### PR TITLE
feat: Add webhook notifications for Clawdbot Gateway integration

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -80,6 +80,13 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,h
 # Clawdbot gateway URL for AI agent orchestration
 # CLAWDBOT_GATEWAY=http://127.0.0.1:18789
 
+# Webhook URL for pushing task/chat events to an external service (e.g. Clawdbot Gateway).
+# Overrides the webhookUrl value in notification settings if set.
+# VERITAS_WEBHOOK_URL=http://127.0.0.1:18789/webhook
+
+# Secret for signing webhook payloads (HMAC-SHA256). Sent in X-Webhook-Signature header.
+# VERITAS_WEBHOOK_SECRET=your-webhook-secret-here
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # RATE LIMITING
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/server/src/__tests__/clawdbot-webhook-service.test.ts
+++ b/server/src/__tests__/clawdbot-webhook-service.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Clawdbot Webhook Service Tests
+ *
+ * Tests payload formatting, HMAC signing, delivery logic, and retry behaviour.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  signPayload,
+  setWebhookUrl,
+  getWebhookUrl,
+  deliverWebhook,
+  notifyTaskChange,
+  notifyChatMessage,
+  type WebhookTaskPayload,
+  type WebhookChatPayload,
+} from '../services/clawdbot-webhook-service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capture calls to global fetch. */
+function mockFetch(response: { ok: boolean; status?: number } = { ok: true, status: 200 }) {
+  const fn = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClawdbotWebhookService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Clear env overrides
+    delete process.env.VERITAS_WEBHOOK_URL;
+    delete process.env.VERITAS_WEBHOOK_SECRET;
+    setWebhookUrl(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  // -------------------------------------------------------------------------
+  // Configuration
+  // -------------------------------------------------------------------------
+
+  describe('getWebhookUrl()', () => {
+    it('returns undefined when nothing is configured', () => {
+      expect(getWebhookUrl()).toBeUndefined();
+    });
+
+    it('returns settings-based URL when set', () => {
+      setWebhookUrl('https://example.com/hook');
+      expect(getWebhookUrl()).toBe('https://example.com/hook');
+    });
+
+    it('env var takes precedence over settings', () => {
+      setWebhookUrl('https://settings.example.com/hook');
+      process.env.VERITAS_WEBHOOK_URL = 'https://env.example.com/hook';
+      expect(getWebhookUrl()).toBe('https://env.example.com/hook');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Signing
+  // -------------------------------------------------------------------------
+
+  describe('signPayload()', () => {
+    it('produces a valid HMAC-SHA256 hex digest', () => {
+      const sig = signPayload('{"test":true}', 'secret123');
+      expect(sig).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('produces deterministic output', () => {
+      const a = signPayload('hello', 'key');
+      const b = signPayload('hello', 'key');
+      expect(a).toBe(b);
+    });
+
+    it('differs for different secrets', () => {
+      const a = signPayload('hello', 'key1');
+      const b = signPayload('hello', 'key2');
+      expect(a).not.toBe(b);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Delivery
+  // -------------------------------------------------------------------------
+
+  describe('deliverWebhook()', () => {
+    const samplePayload: WebhookTaskPayload = {
+      event: 'task:created',
+      taskId: 'task_123',
+      taskTitle: 'Test task',
+      timestamp: '2025-01-01T00:00:00.000Z',
+    };
+
+    it('does nothing when no webhook URL is configured', async () => {
+      const fetchSpy = mockFetch();
+      await deliverWebhook(samplePayload);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('POSTs JSON to the configured URL', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = mockFetch();
+
+      await deliverWebhook(samplePayload);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toBe('https://hook.test/endpoint');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+
+      const body = JSON.parse(opts.body);
+      expect(body.event).toBe('task:created');
+      expect(body.taskId).toBe('task_123');
+    });
+
+    it('includes X-Webhook-Signature when secret is set', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      process.env.VERITAS_WEBHOOK_SECRET = 'my-secret';
+      const fetchSpy = mockFetch();
+
+      await deliverWebhook(samplePayload);
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers['X-Webhook-Signature']).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('does NOT include X-Webhook-Signature when no secret', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = mockFetch();
+
+      await deliverWebhook(samplePayload);
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers['X-Webhook-Signature']).toBeUndefined();
+    });
+
+    it('retries once after 2 s on failure', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = mockFetch({ ok: false, status: 500 });
+
+      await deliverWebhook(samplePayload);
+
+      // First call already happened
+      expect(fetchSpy).toHaveBeenCalledOnce();
+
+      // Advance timers to trigger the retry
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries once on fetch error (network failure)', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await deliverWebhook(samplePayload);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+
+      // Advance timers to trigger the retry
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT retry on success', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = mockFetch({ ok: true });
+
+      await deliverWebhook(samplePayload);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+
+      // Advance timers — no retry should fire
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Payload formatting helpers
+  // -------------------------------------------------------------------------
+
+  describe('notifyTaskChange()', () => {
+    it('formats a task payload and calls deliverWebhook', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = mockFetch();
+
+      notifyTaskChange('created', 'task_abc', {
+        title: 'My Task',
+        status: 'in-progress',
+        previousStatus: 'todo',
+        assignee: 'agent',
+        project: 'proj_1',
+      });
+
+      // Allow the promise to resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        event: 'task:created',
+        taskId: 'task_abc',
+        taskTitle: 'My Task',
+        status: 'in-progress',
+        previousStatus: 'todo',
+        assignee: 'agent',
+        project: 'proj_1',
+      });
+      expect(body.timestamp).toBeDefined();
+    });
+
+    it('works without optional context', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = mockFetch();
+
+      notifyTaskChange('deleted', 'task_xyz');
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.event).toBe('task:deleted');
+      expect(body.taskId).toBe('task_xyz');
+    });
+  });
+
+  describe('notifyChatMessage()', () => {
+    it('formats a chat payload and calls deliverWebhook', async () => {
+      setWebhookUrl('https://hook.test/endpoint');
+      const fetchSpy = mockFetch();
+
+      notifyChatMessage('session_1', 'chat:message', 'Hello world');
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const body: WebhookChatPayload = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        event: 'chat:message',
+        chatSessionId: 'session_1',
+        message: 'Hello world',
+      });
+      expect(body.timestamp).toBeDefined();
+    });
+  });
+});

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -77,6 +77,7 @@ const NotificationSettingsSchema = z
     onAgentFailure: z.boolean().optional(),
     onReviewNeeded: z.boolean().optional(),
     channel: z.string().max(200).optional(),
+    webhookUrl: z.string().url().optional(),
   })
   .strict()
   .optional();

--- a/server/src/services/clawdbot-webhook-service.ts
+++ b/server/src/services/clawdbot-webhook-service.ts
@@ -1,0 +1,212 @@
+/**
+ * Clawdbot Webhook Service
+ *
+ * Sends task and chat events to a configured webhook URL (e.g. Clawdbot Gateway)
+ * so an AI agent can react in real-time instead of polling.
+ *
+ * Features:
+ * - Non-blocking fire-and-forget delivery
+ * - Single retry after 2 seconds on failure
+ * - Optional HMAC-SHA256 payload signing
+ * - Env var override for webhook URL and secret
+ */
+
+import crypto from 'crypto';
+import { createLogger } from '../lib/logger.js';
+import type { TaskChangeType } from './broadcast-service.js';
+
+const log = createLogger('webhook');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WebhookTaskPayload {
+  event:
+    | 'task:created'
+    | 'task:updated'
+    | 'task:deleted'
+    | 'task:archived'
+    | 'task:restored'
+    | 'task:reordered';
+  taskId?: string;
+  taskTitle?: string;
+  status?: string;
+  previousStatus?: string;
+  assignee?: string;
+  project?: string;
+  timestamp: string;
+}
+
+export interface WebhookChatPayload {
+  event: 'chat:message' | 'chat:delta' | 'chat:error';
+  chatSessionId: string;
+  message?: string;
+  timestamp: string;
+}
+
+export type WebhookPayload = WebhookTaskPayload | WebhookChatPayload;
+
+export interface TaskContext {
+  title?: string;
+  status?: string;
+  previousStatus?: string;
+  assignee?: string;
+  project?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration helpers
+// ---------------------------------------------------------------------------
+
+/** Cached settings-based webhook URL (set via setWebhookUrl). */
+let settingsWebhookUrl: string | undefined;
+
+/**
+ * Allow the settings layer (or tests) to provide a webhook URL at runtime.
+ */
+export function setWebhookUrl(url: string | undefined): void {
+  settingsWebhookUrl = url;
+}
+
+/**
+ * Resolve the effective webhook URL.
+ * Env var takes precedence over the settings value.
+ */
+export function getWebhookUrl(): string | undefined {
+  return process.env.VERITAS_WEBHOOK_URL || settingsWebhookUrl;
+}
+
+/**
+ * Return the signing secret (env var only).
+ */
+function getWebhookSecret(): string | undefined {
+  return process.env.VERITAS_WEBHOOK_SECRET;
+}
+
+// ---------------------------------------------------------------------------
+// Signing
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute HMAC-SHA256 hex digest for the given body using the webhook secret.
+ */
+export function signPayload(body: string, secret: string): string {
+  return crypto.createHmac('sha256', secret).update(body).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Delivery (fire-and-forget with 1 retry)
+// ---------------------------------------------------------------------------
+
+/**
+ * POST a JSON payload to `url`.  Returns true on 2xx, false otherwise.
+ */
+async function postPayload(url: string, body: string, secret?: string): Promise<boolean> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'VeritasKanban-Webhook/1.0',
+  };
+
+  if (secret) {
+    headers['X-Webhook-Signature'] = signPayload(body, secret);
+  }
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body,
+    signal: AbortSignal.timeout(10_000), // 10 s hard timeout per attempt
+  });
+
+  return res.ok;
+}
+
+/**
+ * Deliver `payload` to the configured webhook URL.
+ * Non-blocking: failures are logged, never thrown.
+ * On first failure, retries once after 2 seconds.
+ */
+export async function deliverWebhook(payload: WebhookPayload): Promise<void> {
+  const url = getWebhookUrl();
+  if (!url) return; // webhook not configured — silently skip
+
+  const body = JSON.stringify(payload);
+  const secret = getWebhookSecret();
+
+  try {
+    const ok = await postPayload(url, body, secret);
+    if (ok) {
+      log.debug({ event: payload.event }, 'Webhook delivered');
+      return;
+    }
+    log.warn({ event: payload.event }, 'Webhook delivery failed, retrying in 2 s');
+  } catch (err) {
+    log.warn({ err, event: payload.event }, 'Webhook delivery error, retrying in 2 s');
+  }
+
+  // --- single retry after 2 s ---
+  setTimeout(async () => {
+    try {
+      const ok = await postPayload(url, body, secret);
+      if (!ok) {
+        log.error({ event: payload.event }, 'Webhook retry failed (non-2xx)');
+      } else {
+        log.debug({ event: payload.event }, 'Webhook delivered on retry');
+      }
+    } catch (err) {
+      log.error({ err, event: payload.event }, 'Webhook retry error');
+    }
+  }, 2_000);
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers for callers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fire a webhook for a task change event.
+ * Called from broadcast-service after the WebSocket broadcast.
+ */
+export function notifyTaskChange(
+  changeType: TaskChangeType,
+  taskId?: string,
+  context?: TaskContext
+): void {
+  const payload: WebhookTaskPayload = {
+    event: `task:${changeType}` as WebhookTaskPayload['event'],
+    taskId,
+    taskTitle: context?.title,
+    status: context?.status,
+    previousStatus: context?.previousStatus,
+    assignee: context?.assignee,
+    project: context?.project,
+    timestamp: new Date().toISOString(),
+  };
+
+  // Fire-and-forget
+  deliverWebhook(payload).catch(() => {
+    /* already logged inside deliverWebhook */
+  });
+}
+
+/**
+ * Fire a webhook for a chat event.
+ * Called from broadcast-service after the WebSocket broadcast.
+ */
+export function notifyChatMessage(
+  sessionId: string,
+  eventType: 'chat:message' | 'chat:delta' | 'chat:error',
+  message?: string
+): void {
+  const payload: WebhookChatPayload = {
+    event: eventType,
+    chatSessionId: sessionId,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+
+  deliverWebhook(payload).catch(() => {
+    /* already logged inside deliverWebhook */
+  });
+}


### PR DESCRIPTION
## Summary

Add a webhook notification system that pushes task and chat events to a configured URL (e.g. Clawdbot Gateway) so an AI agent can react to board changes in real-time instead of polling.

> **Note:** This is a POC and for reference only at the moment.

cc @matthewdorman

## Changes

### New: `server/src/services/clawdbot-webhook-service.ts`
- Fire-and-forget webhook delivery with non-blocking semantics
- Single retry after 2 seconds on failure
- Optional HMAC-SHA256 payload signing (`X-Webhook-Signature` header)
- `VERITAS_WEBHOOK_URL` env var overrides settings-based URL
- `VERITAS_WEBHOOK_SECRET` env var for payload signing

### Modified: `server/src/services/broadcast-service.ts`
- After WebSocket broadcasts, also fires webhook notifications
- `broadcastTaskChange()` now accepts optional `TaskContext` for enriched payloads
- `broadcastChatMessage()` forwards chat events to webhook

### Modified: `server/src/schemas/feature-settings-schema.ts`
- Added `webhookUrl` (optional URL) to `NotificationSettingsSchema`

### Modified: `server/.env.example`
- Added `VERITAS_WEBHOOK_URL` and `VERITAS_WEBHOOK_SECRET` with documentation

### New: `server/src/__tests__/clawdbot-webhook-service.test.ts`
- 16 tests covering configuration, HMAC signing, delivery, retry logic, and payload formatting

## Example Webhook Payload

### Task Event
```json
{
  "event": "task:created",
  "taskId": "task_20250130_abc123",
  "taskTitle": "Implement login page",
  "status": "in-progress",
  "previousStatus": "todo",
  "assignee": "agent",
  "project": "proj_frontend",
  "timestamp": "2025-01-30T12:00:00.000Z"
}
```

### Chat Event
```json
{
  "event": "chat:message",
  "chatSessionId": "session_xyz",
  "message": "Can you update the task status?",
  "timestamp": "2025-01-30T12:01:00.000Z"
}
```