### PR TITLE
Fix Docker startup when cwd is / (fixes #62)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,9 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: veritas-kanban
+    working_dir: /app
     ports:
-      - "3001:3001"
+      - '3001:3001'
     environment:
       - NODE_ENV=production
       - PORT=3001
@@ -28,7 +29,7 @@ services:
       - kanban-data:/app/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/health"]
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3001/health']
       interval: 30s
       timeout: 5s
       retries: 3

--- a/server/src/__tests__/docker-paths.test.ts
+++ b/server/src/__tests__/docker-paths.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('paths: Docker DATA_DIR support', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('uses DATA_DIR as storage root for tasks and runtime state', async () => {
+    process.env.DATA_DIR = '/app/data';
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/app/server');
+
+    const paths = await import('../utils/paths.js');
+
+    expect(paths.getTasksActiveDir()).toBe('/app/data/tasks/active');
+    expect(paths.getTasksArchiveDir()).toBe('/app/data/tasks/archive');
+    expect(paths.getRuntimeDir()).toBe('/app/data/.veritas-kanban');
+  });
+
+  it('TaskService defaults to DATA_DIR-backed task directories when set', async () => {
+    process.env.DATA_DIR = '/app/data';
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/app/server');
+
+    const { TaskService } = await import('../services/task-service.js');
+    const svc = new TaskService();
+
+    // Private fields — ok for regression test
+    expect((svc as any).tasksDir).toBe('/app/data/tasks/active');
+    expect((svc as any).archiveDir).toBe('/app/data/tasks/archive');
+  });
+});

--- a/server/src/utils/paths.ts
+++ b/server/src/utils/paths.ts
@@ -1,0 +1,121 @@
+import path from 'path';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+/**
+ * Walk upward from a starting directory looking for a marker file.
+ * Returns the directory containing the marker, or null.
+ */
+function findUp(startDir: string, markerFile: string, maxDepth = 8): string | null {
+  let dir = path.resolve(startDir);
+
+  for (let i = 0; i < maxDepth; i++) {
+    if (existsSync(path.join(dir, markerFile))) return dir;
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the monorepo root.
+ *
+ * - In dev, server often runs with cwd=server/, so root is one level up.
+ * - In Docker, cwd is typically /app, but some environments can start with cwd=/.
+ *
+ * IMPORTANT: We do not trust cwd alone — in containers it can be surprising.
+ */
+export function getProjectRoot(): string {
+  // 1) CWD-based search (dev + most runtimes)
+  const fromCwd = findUp(process.cwd(), 'pnpm-workspace.yaml');
+  if (fromCwd) return fromCwd;
+
+  // 2) Module-based search (robust in Docker / odd cwd situations)
+  // Works in ESM: resolve the directory containing this module.
+  try {
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    const fromModule = findUp(moduleDir, 'pnpm-workspace.yaml');
+    if (fromModule) return fromModule;
+  } catch {
+    // ignore — fallback below
+  }
+
+  // 3) Last resort
+  return process.cwd();
+}
+
+/**
+ * Storage root for persistent data.
+ *
+ * When DATA_DIR or VERITAS_DATA_DIR is set (e.g. Docker), we treat that as the base
+ * directory for ALL persisted data.
+ */
+export function getStorageRoot(): string {
+  const env = process.env.DATA_DIR || process.env.VERITAS_DATA_DIR;
+  if (env && env.trim().length > 0) {
+    return path.resolve(env);
+  }
+
+  const root = getProjectRoot();
+
+  // Guardrail: avoid silently using filesystem root as a storage base.
+  // This is the failure mode behind issue #62 (mkdir '/tasks' → EACCES).
+  if (root === '/') {
+    throw new Error(
+      'Storage root resolved to "/". Set DATA_DIR (recommended for Docker) or run from the repo root.'
+    );
+  }
+
+  return root;
+}
+
+/**
+ * Runtime config/state directory.
+ *
+ * Local-first layout keeps runtime files under <projectRoot>/.veritas-kanban.
+ * In Docker, we keep them under <DATA_DIR>/.veritas-kanban so they live on the volume.
+ */
+export function getRuntimeDir(): string {
+  return path.join(getStorageRoot(), '.veritas-kanban');
+}
+
+// Tasks
+export function getTasksActiveDir(): string {
+  return path.join(getStorageRoot(), 'tasks', 'active');
+}
+
+export function getTasksArchiveDir(): string {
+  return path.join(getStorageRoot(), 'tasks', 'archive');
+}
+
+export function getTasksBacklogDir(): string {
+  return path.join(getStorageRoot(), 'tasks', 'backlog');
+}
+
+export function getTasksAttachmentsDir(): string {
+  return path.join(getStorageRoot(), 'tasks', 'attachments');
+}
+
+// Telemetry / traces
+export function getTelemetryDir(): string {
+  return path.join(getRuntimeDir(), 'telemetry');
+}
+
+export function getTracesDir(): string {
+  return path.join(getRuntimeDir(), 'traces');
+}
+
+export function getLogsDir(): string {
+  return path.join(getRuntimeDir(), 'logs');
+}
+
+export function getWorktreesDir(): string {
+  return path.join(getRuntimeDir(), 'worktrees');
+}
+
+export function getTemplatesDir(): string {
+  return path.join(getRuntimeDir(), 'templates');
+}


### PR DESCRIPTION
Fixes #62\n\n### Problem\nSome Docker/Compose environments start the process with cwd=/. Our path resolver treated that as the project root, causing storage paths like /tasks and runtime dir /.veritas-kanban, which fails under non-root containers (EACCES mkdir '/tasks').\n\n### Changes\n- Harden project root detection: search upward from cwd *and* from the module location (import.meta.url) for pnpm-workspace.yaml.\n- Add guardrail to prevent resolving storage root to '/' without DATA_DIR.\n- Add docker compose working_dir: /app.\n- Add regression test covering Docker DATA_DIR + task/runtime dirs.