### PR TITLE
fix: use dynamic host for WebSocket URL in dev mode

### DIFF
--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -62,8 +62,7 @@ const DEFAULT_MAX_RECONNECT_ATTEMPTS = 20;
 
 function getDefaultWsUrl(): string {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const isDev = ['3000', '5173'].includes(window.location.port);
-  return isDev ? `${protocol}//localhost:3001/ws` : `${protocol}//${window.location.host}/ws`;
+  return `${protocol}//${window.location.host}/ws`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- The `getDefaultWsUrl()` function in `useWebSocket.ts` hardcodes `ws://localhost:3001/ws` when running on dev ports (3000/5173). This breaks WebSocket connections when the app is accessed from a non-localhost address (e.g., Tailscale IP, LAN IP), because the browser tries to reach `localhost:3001` on the client machine rather than the server.
- Since Vite already proxies `/ws` to `ws://localhost:3001`, the frontend can simply use `window.location.host` in all cases. This makes WebSocket work regardless of how the app is accessed.

## Additional setup notes encountered
- `@veritas-kanban/shared` must be built (`pnpm --filter shared build`) before `pnpm dev`, otherwise Vite fails to resolve `@veritas-kanban/shared` and the page loads blank. Consider adding a `prebuild`/`predev` script to automate this.
- `.env.example` needs to be copied to `server/.env` (not just the repo root) for the server to pick it up via `dotenv/config`.

## Test plan
- [ ] Run `pnpm dev` and open the app from a non-localhost address (e.g., LAN IP or Tailscale IP)
- [ ] Verify WebSocket connects successfully (no "Connection lost" banner)
- [ ] Verify it still works from `localhost:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)