### PR TITLE
Dev reliability: /api/health + dev:clean + watchdog

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,8 +15,54 @@ Common issues and solutions for Veritas Kanban. Can't find your issue? [Open a D
 - [UI & Frontend](#ui--frontend)
 - [Data & Storage](#data--storage)
 - [Useful Commands](#useful-commands)
+- [Dev Reliability (ports, hangs, and restarts)](#dev-reliability-ports-hangs-and-restarts)
 
 ---
+
+## Dev Reliability (ports, hangs, and restarts)
+
+### Quick fix: clean restart
+
+If the UI is acting hung or the API is returning unexpected 404s, run:
+
+```bash
+pnpm dev:clean
+```
+
+This:
+
+- frees ports **3001** (server) and **3000** (web)
+- kills stale dev watchers for this repo (`tsx watch`, `vite`, `concurrently`)
+- restarts `pnpm dev`
+
+### Check server health
+
+VK provides a canonical health endpoint for tooling:
+
+```bash
+curl -s http://localhost:3001/api/health
+```
+
+Expected: HTTP 200 JSON like:
+
+```json
+{ "ok": true, "service": "veritas-kanban", "version": "1.x.x" }
+```
+
+### Optional: auto-restart watchdog (dev)
+
+If you want VK to auto-restart when unhealthy during dev:
+
+```bash
+pnpm dev:watchdog
+```
+
+Environment variables:
+
+- `WATCHDOG_INTERVAL_SECONDS` (default 30)
+- `WATCHDOG_FAIL_THRESHOLD` (default 3)
+
+> Note: watchdog is for local dev convenience. For production, prefer a real supervisor (pm2/docker) with health checks.
 
 ## Installation & Build
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "packageManager": "pnpm@9.15.4",
   "scripts": {
     "dev": "concurrently -n server,web -c blue,green \"pnpm --filter server dev\" \"pnpm --filter web dev\"",
+    "dev:clean": "bash scripts/dev-clean.sh",
+    "dev:watchdog": "bash scripts/dev-watchdog.sh",
     "build": "pnpm --filter server build && pnpm --filter web build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dev safety rail: kill stale VK dev runners + free ports, then restart.
+#
+# Goals:
+# - Prevent “port capture” (something else bound to :3001 / :3000)
+# - Prevent duplicate watchers (tsx watch / vite / concurrently)
+# - Be SAFE: only target this repo’s processes + the configured ports
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SERVER_PORT="${PORT:-3001}"
+WEB_PORT="${WEB_PORT:-3000}"
+
+echo "[dev-clean] repo=${REPO_ROOT}"
+echo "[dev-clean] ports: server=${SERVER_PORT} web=${WEB_PORT}"
+
+kill_listeners() {
+  local port="$1"
+  local pids
+  pids="$(lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null || true)"
+  if [[ -n "${pids}" ]]; then
+    echo "[dev-clean] killing listeners on :${port}: ${pids}"
+    # shellcheck disable=SC2086
+    kill ${pids} 2>/dev/null || true
+  fi
+}
+
+kill_repo_watchers() {
+  python3 - <<PY
+import os, re, subprocess
+repo=os.environ['REPO_ROOT']
+pat=re.compile(r'(pnpm\s+dev|concurrently|vite(\.js)?(\s|$)|tsx\s+watch)')
+ps=subprocess.check_output(['ps','aux'], text=True).splitlines()[1:]
+kill=[]
+for line in ps:
+    if repo not in line:
+        continue
+    if not pat.search(line):
+        continue
+    try:
+        pid=int(line.split()[1])
+    except Exception:
+        continue
+    # Don't kill the current python process
+    if pid == os.getpid():
+        continue
+    kill.append(pid)
+if kill:
+    print('[dev-clean] killing repo dev watchers:', kill)
+    for pid in kill:
+        try:
+            os.kill(pid, 15)
+        except ProcessLookupError:
+            pass
+else:
+    print('[dev-clean] no repo dev watchers found')
+PY
+}
+
+export REPO_ROOT
+
+kill_listeners "${SERVER_PORT}"
+kill_listeners "${WEB_PORT}"
+
+# Give sockets a moment to release
+sleep 0.5
+
+kill_repo_watchers
+
+sleep 0.5
+
+echo "[dev-clean] starting pnpm dev"
+cd "${REPO_ROOT}"
+exec pnpm dev

--- a/scripts/dev-watchdog.sh
+++ b/scripts/dev-watchdog.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple dev watchdog:
+# - polls http://localhost:${PORT}/api/health
+# - if unhealthy for N consecutive checks, runs `pnpm dev:clean`
+#
+# Intended for macOS launchd or manual terminal use.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${PORT:-3001}"
+INTERVAL_SECONDS="${WATCHDOG_INTERVAL_SECONDS:-30}"
+FAIL_THRESHOLD="${WATCHDOG_FAIL_THRESHOLD:-3}"
+
+URL="http://localhost:${PORT}/api/health"
+
+fails=0
+
+echo "[dev-watchdog] repo=${REPO_ROOT}"
+echo "[dev-watchdog] url=${URL} interval=${INTERVAL_SECONDS}s threshold=${FAIL_THRESHOLD}"
+
+while true; do
+  http_code="$(curl -s -o /dev/null -w '%{http_code}' "${URL}" || true)"
+
+  if [[ "${http_code}" == "200" ]]; then
+    fails=0
+  else
+    fails=$((fails+1))
+    echo "[dev-watchdog] health check failed (http=${http_code}) fails=${fails}/${FAIL_THRESHOLD}"
+  fi
+
+  if [[ "${fails}" -ge "${FAIL_THRESHOLD}" ]]; then
+    echo "[dev-watchdog] unhealthy threshold reached -> restarting via pnpm dev:clean"
+    cd "${REPO_ROOT}"
+    exec pnpm dev:clean
+  fi
+
+  sleep "${INTERVAL_SECONDS}"
+done

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -59,7 +59,7 @@ import attachmentRoutes from './routes/attachments.js';
 import { configRoutes } from './routes/config.js';
 import { agentRoutes } from './routes/agents.js';
 import { cspNonceMiddleware, cspNonceDirective } from './middleware/csp-nonce.js';
-import { healthRouter, setHealthWss } from './routes/health.js';
+import { healthRouter, apiHealthRouter, setHealthWss } from './routes/health.js';
 import { getPrometheusCollector } from './services/metrics/prometheus.js';
 import { metricsCollector } from './middleware/metrics-collector.js';
 
@@ -290,6 +290,9 @@ app.use(express.json({ limit: '1mb' }));
 
 // Health checks (liveness, readiness, deep diagnostics)
 app.use('/health', healthRouter);
+
+// Canonical VK API health signal (unauthenticated; used by dev tooling/watchdogs)
+app.use('/api/health', apiHealthRouter);
 
 // ============================================
 // Prometheus Metrics (unauthenticated, for scraping)


### PR DESCRIPTION
## Summary
Implements the dev reliability improvements proposed in #82:

1) Adds a canonical API health endpoint:
- `GET /api/health` (unauthenticated) → `{ ok, service, version, uptimeMs, timestamp }`
- `GET /api/health/deep` (admin) → same payload as `/health/deep`

2) Adds safe dev restart tooling:
- `pnpm dev:clean` → frees ports 3001/3000, kills stale repo dev watchers, restarts dev
- `pnpm dev:watchdog` → simple polling watchdog that restarts via `dev:clean` after N failures

3) Documents the workflow in `docs/TROUBLESHOOTING.md`.

---

## Why
We hit a failure mode where *something* was bound to port 3001 but it was not the VK API (404: `Cannot GET /api/...`). This PR makes that easy to detect (`/api/health`) and easy to recover from (`dev:clean`), with an optional auto-restart loop (`dev:watchdog`).

---

## How to test

### Health endpoint
```bash
curl -s http://localhost:3001/api/health
```

### Clean restart
```bash
pnpm dev:clean
```

### Watchdog (optional)
```bash
WATCHDOG_INTERVAL_SECONDS=10 WATCHDOG_FAIL_THRESHOLD=2 pnpm dev:watchdog
```

---

## Notes
- `/health/*` endpoints remain for container/orchestrator use. `/api/health` is the canonical signal for dev tooling/watchdogs.
- `dev:clean` is designed to be safe: it targets only ports 3000/3001 and watcher processes scoped to this repo path.
