### PR TITLE
fix(server): unblock dependency/observation routes by tightening types

### DIFF
--- a/server/src/routes/task-observations.ts
+++ b/server/src/routes/task-observations.ts
@@ -171,7 +171,7 @@ observationSearchRouter.get(
     }
 
     const queryLower = query.toLowerCase();
-    const allTasks = await taskService.getAllTasks();
+    const allTasks = await taskService.listTasks();
 
     // NOTE: Full-text search should be replaced with a proper index (e.g., SQLite FTS5)
     // when task count exceeds ~500 for better performance.

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1143,6 +1143,9 @@ router.post(
     const { depends_on, blocks } = input;
     const targetId = depends_on || blocks;
     const type: 'depends_on' | 'blocks' = depends_on ? 'depends_on' : 'blocks';
+    if (!targetId) {
+      throw new ValidationError('Either depends_on or blocks is required');
+    }
 
     const task = await taskService.addDependency(taskId, targetId, type);
 
@@ -1443,7 +1446,7 @@ router.post(
     const updatedTask = await taskService.updateTask(taskId, { checkpoint });
 
     // Broadcast change
-    broadcastTaskChange('updated', updatedTask);
+    broadcastTaskChange('updated', updatedTask.id);
 
     res.json({ success: true, checkpoint });
   })
@@ -1510,7 +1513,7 @@ router.delete(
     const updatedTask = await taskService.updateTask(taskId, { checkpoint: undefined });
 
     // Broadcast change
-    broadcastTaskChange('updated', updatedTask);
+    broadcastTaskChange('updated', updatedTask.id);
 
     res.json({ success: true });
   })

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -26,7 +26,11 @@ export type ActivityType =
   | 'comment_deleted'
   | 'deliverable_added'
   | 'deliverable_updated'
-  | 'deliverable_deleted';
+  | 'deliverable_deleted'
+  | 'observation_added'
+  | 'observation_deleted'
+  | 'dependency_added'
+  | 'dependency_removed';
 
 export interface Activity {
   id: string;


### PR DESCRIPTION
## Summary
This PR addresses a cluster of server-side type regressions that break `@veritas-kanban/server` builds in current main snapshots.

## Changes
- Add missing `ActivityType` variants used by routes:
  - `observation_added`, `observation_deleted`
  - `dependency_added`, `dependency_removed`
- Replace non-existent `taskService.getAllTasks()` with `taskService.listTasks()` in observation search route.
- Guard `targetId` before calling `addDependency` to avoid passing `string | undefined`.
- Fix checkpoint route broadcasts to pass task ID (`updatedTask.id`) instead of a task object.

## Why
These are low-risk consistency fixes that align route usage with existing service contracts and remove avoidable TypeScript failures from active codepaths.

## Validation
- `eslint --fix` and `prettier --write` ran via repository pre-commit hooks during commit.
- Functional impact is minimal and isolated to route typing/shape correctness.