### PR TITLE
fix(web): clean up observation panel hook refs and strict unused checks

### DIFF
--- a/web/src/components/task/DependenciesSection.tsx
+++ b/web/src/components/task/DependenciesSection.tsx
@@ -22,6 +22,7 @@ interface DependenciesSectionProps {
 }
 
 export function DependenciesSection({ task, onBlockedByChange }: DependenciesSectionProps) {
+  void onBlockedByChange;
   const { data: allTasks } = useTasks();
   const [isAddingDependsOn, setIsAddingDependsOn] = useState(false);
   const [isAddingBlocks, setIsAddingBlocks] = useState(false);

--- a/web/src/components/task/ObservationsSection.tsx
+++ b/web/src/components/task/ObservationsSection.tsx
@@ -65,6 +65,7 @@ function ObservationItem({
   taskId: string;
   onDelete: (observationId: string) => Promise<void>;
 }) {
+  void taskId;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const handleDelete = async () => {

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -64,6 +64,8 @@ export function TaskDetailPanel({
   const [applyTemplateOpen, setApplyTemplateOpen] = useState(false);
   const [taskChatOpen, setTaskChatOpen] = useState(false);
   const [workflowOpen, setWorkflowOpen] = useState(false);
+  const addObservation = useAddObservation();
+  const deleteObservation = useDeleteObservation();
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -126,7 +126,7 @@ export function useUpdateTask() {
       }
     },
     // Handle validation errors with detailed toast messages
-    onError: (error: Error & { code?: string; details?: unknown }, { input }) => {
+    onError: (error: Error & { code?: string; details?: unknown }) => {
       // Extract enforcement gate error details
       const details = error.details as
         | Array<{ code: string; message: string; path: string[] }>


### PR DESCRIPTION
## Summary
Small frontend compile-safety cleanup based on local integration findings.

## Changes
- Wire `useAddObservation` / `useDeleteObservation` hooks in `TaskDetailPanel` before use.
- Mark intentionally passthrough props as used to satisfy strict no-unused checks:
  - `onBlockedByChange` in `DependenciesSection`
  - `taskId` in `ObservationItem`
- Remove unused destructured mutation arg in `useUpdateTask` error handler.

## Why
These are narrow, low-risk fixes that reduce strict TypeScript/lint breakage in the task detail + observations flow.

## Validation
- `eslint --fix` and `prettier --write` ran via repository pre-commit hooks during commit.