### PR TITLE
fix: harden LAN dev access for Vite hosts and CORS origins

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -254,7 +254,24 @@ If you see CORS errors in the browser console, update `CORS_ORIGINS` in `server/
 
 ```bash
 # Add your frontend URL (comma-separated, no trailing slashes)
-CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://your-ip:3000
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://your-ip:3000,http://your-hostname:5173
+```
+
+When using hostname access on LAN (for example `http://manfredclaw:5173`), include that hostname origin explicitly.
+
+### Vite: "Blocked request. This host is not allowed."
+
+If the web dev server rejects LAN hostname access, configure Vite host allowlist in `web/.env`:
+
+```bash
+VITE_HOST=0.0.0.0
+VITE_ALLOWED_HOSTS=your-hostname,your-hostname.local,your-ip
+```
+
+You can allow all hosts for trusted LAN-only environments:
+
+```bash
+VITE_ALLOWED_HOSTS=*
 ```
 
 ### Accessing from another machine on the network
@@ -266,7 +283,16 @@ By default, the server binds to `localhost`. To access from other machines:
 HOST=0.0.0.0
 ```
 
-Update `CORS_ORIGINS` to include the IP/hostname you'll access from.
+Update both CORS and Vite allowlist to include the IP/hostname you'll access from:
+
+```bash
+# server/.env
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://your-ip:3000,http://your-hostname:5173
+
+# web/.env
+VITE_HOST=0.0.0.0
+VITE_ALLOWED_HOSTS=your-hostname,your-hostname.local,your-ip
+```
 
 ---
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,17 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+const viteAllowedHostsEnv = process.env.VITE_ALLOWED_HOSTS?.trim();
+const viteAllowedHosts =
+  viteAllowedHostsEnv && viteAllowedHostsEnv.length > 0
+    ? viteAllowedHostsEnv === '*'
+      ? true
+      : viteAllowedHostsEnv
+          .split(',')
+          .map((host) => host.trim())
+          .filter(Boolean)
+    : undefined;
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -37,7 +48,9 @@ export default defineConfig({
     },
   },
   server: {
+    host: process.env.VITE_HOST || undefined,
     port: 3000,
+    allowedHosts: viteAllowedHosts,
     proxy: {
       '/api': {
         target: 'http://localhost:3001',


### PR DESCRIPTION
## Summary
- add hostname-aware default dev CORS origins in server startup (localhost, 127.0.0.1, system hostname, and .local variant)
- normalize configured/request origins to avoid trailing-slash mismatch in CORS checks
- add configurable Vite LAN host allowlist via VITE_HOST and VITE_ALLOWED_HOSTS
- document LAN/hostname setup to resolve both common errors:
  - Blocked request. This host is not allowed.
  - auth setup HTTP 403 caused by missing hostname origin in CORS_ORIGINS

## Why
When running VK on another machine in the same LAN, a typical flow is to open the UI via hostname (e.g. http://manfredclaw:5173). Two failures are easy to hit:
1. Vite host allowlist blocks the host.
2. Server CORS allowlist does not include hostname origins by default, causing auth setup calls to fail with 403.

This PR keeps production behavior explicit while making dev/LAN setup deterministic and documented.

## Validation
- lint-staged hooks passed during commit (eslint + prettier on changed files)
- pnpm --filter @veritas-kanban/server typecheck and pnpm --filter @veritas-kanban/web typecheck currently fail on unrelated pre-existing workspace issues (missing @veritas-kanban/shared resolution + existing TS errors on main in this checkout), so full typecheck could not be used as a signal for this patch.
