### PR TITLE
fix: Express 5 wildcard route compatibility

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -496,7 +496,8 @@ if (process.env.NODE_ENV === 'production') {
   );
 
   // SPA fallback: serve index.html for any non-API route
-  app.get('*', (_req, res, next) => {
+  // Express 5 / path-to-regexp v8+ requires named wildcards (fixes #150)
+  app.get('{*path}', (_req, res, next) => {
     // Don't serve index.html for API routes or WebSocket
     if (_req.path.startsWith('/api') || _req.path.startsWith('/ws') || _req.path === '/health') {
       return next();


### PR DESCRIPTION
## Summary
Fixes #150 — Express 5 path-to-regexp breaking change

## Problem
Express 5 uses `path-to-regexp@8+` which no longer accepts bare `*` wildcards:
```
TypeError: Missing parameter name at index 1: *
```

## Solution
Updated the SPA catch-all route from:
```typescript
app.get('*', handler)
```
to:
```typescript
app.get('{*path}', handler)
```

This uses the new named wildcard syntax required by path-to-regexp v8+.

## Testing
- [x] Build passes
- [x] Server starts without path-to-regexp errors (tested locally)