### PR TITLE
feat(cli+mcp): add sprint management commands and task --sprint flags

### DIFF
--- a/cli/src/commands/sprints.ts
+++ b/cli/src/commands/sprints.ts
@@ -1,0 +1,237 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { api } from '../utils/api.js';
+import type { Task } from '../utils/types.js';
+
+interface Sprint {
+  id: string;
+  label: string;
+  description?: string;
+  order: number;
+  isHidden?: boolean;
+  created: string;
+  updated: string;
+}
+
+interface ArchiveSuggestion {
+  sprint: string;
+  taskCount: number;
+  tasks: Task[];
+}
+
+interface ArchiveResult {
+  archived: number;
+  taskIds: string[];
+}
+
+export function registerSprintCommands(program: Command): void {
+  const sprint = program.command('sprint').description('Sprint management commands');
+
+  // List sprints
+  sprint
+    .command('list')
+    .alias('ls')
+    .description('List all sprints')
+    .option('--hidden', 'Include hidden sprints')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const params = new URLSearchParams();
+        if (options.hidden) params.append('includeHidden', 'true');
+
+        const url = `/api/sprints${params.toString() ? `?${params.toString()}` : ''}`;
+        const sprints = await api<Sprint[]>(url);
+
+        if (options.json) {
+          console.log(JSON.stringify(sprints, null, 2));
+        } else if (sprints.length === 0) {
+          console.log(chalk.dim('No sprints found'));
+        } else {
+          console.log(chalk.bold('\nSprints\n'));
+          console.log(chalk.dim('-'.repeat(50)));
+          sprints.forEach((s) => {
+            let line = `  ${chalk.cyan(s.label)}`;
+            if (s.isHidden) {
+              line += chalk.dim(' [hidden]');
+            }
+            console.log(line);
+            if (s.description) {
+              console.log(chalk.dim(`    ${s.description}`));
+            }
+          });
+          console.log(chalk.dim('-'.repeat(50)));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // Create sprint
+  sprint
+    .command('create <label>')
+    .description('Create a new sprint')
+    .option('-d, --description <desc>', 'Sprint description')
+    .option('--json', 'Output as JSON')
+    .action(async (label, options) => {
+      try {
+        const body: Record<string, string> = { label };
+        if (options.description) body.description = options.description;
+
+        const result = await api<Sprint>('/api/sprints', {
+          method: 'POST',
+          body: JSON.stringify(body),
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(chalk.green(`✓ Sprint created: ${label}`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // Update sprint
+  sprint
+    .command('update <id>')
+    .description('Update a sprint')
+    .option('-l, --label <label>', 'New sprint name')
+    .option('-d, --description <desc>', 'Sprint description')
+    .option('--hide', 'Hide sprint from listings')
+    .option('--show', 'Show hidden sprint')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const body: Record<string, unknown> = {};
+        if (options.label) body.label = options.label;
+        if (options.description) body.description = options.description;
+        if (options.hide) body.isHidden = true;
+        if (options.show) body.isHidden = false;
+
+        if (Object.keys(body).length === 0) {
+          console.error(chalk.red('Error: No update options provided'));
+          process.exit(1);
+        }
+
+        const result = await api<Sprint>(`/api/sprints/${id}`, {
+          method: 'PATCH',
+          body: JSON.stringify(body),
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(chalk.green(`✓ Sprint updated: ${result.label}`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // Delete sprint
+  sprint
+    .command('delete <id>')
+    .alias('rm')
+    .description('Delete a sprint')
+    .option('-y, --yes', 'Skip confirmation')
+    .option('-f, --force', 'Force delete even if tasks reference this sprint')
+    .action(async (id, options) => {
+      try {
+        if (!options.yes) {
+          const readline = await import('node:readline/promises');
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          const answer = await rl.question('Are you sure you want to delete this sprint? (y/N) ');
+          rl.close();
+          if (answer.toLowerCase() !== 'y' && answer.toLowerCase() !== 'yes') {
+            console.log('Cancelled');
+            return;
+          }
+        }
+
+        const params = new URLSearchParams();
+        if (options.force) params.append('force', 'true');
+
+        const url = `/api/sprints/${id}${params.toString() ? `?${params.toString()}` : ''}`;
+        await api(url, { method: 'DELETE' });
+        console.log(chalk.green('✓ Sprint deleted'));
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // Show sprints ready to archive
+  sprint
+    .command('suggestions')
+    .description('Show sprints ready to archive (all tasks done)')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const suggestions = await api<ArchiveSuggestion[]>('/api/tasks/archive/suggestions');
+
+        if (options.json) {
+          console.log(JSON.stringify(suggestions, null, 2));
+        } else if (suggestions.length === 0) {
+          console.log(chalk.dim('No sprints ready to archive'));
+        } else {
+          console.log(chalk.bold('\nSprints Ready to Archive\n'));
+          console.log(chalk.dim('-'.repeat(50)));
+          suggestions.forEach((s) => {
+            console.log(`  ${chalk.cyan(s.sprint)}`);
+            console.log(chalk.dim(`    ${s.taskCount} task(s) completed, ready to close`));
+          });
+          console.log(chalk.dim('-'.repeat(50)));
+          console.log(chalk.dim(`\nUse 'vk sprint close <id>' to archive tasks`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // Close sprint (archive all done tasks)
+  sprint
+    .command('close <id>')
+    .description('Archive all done tasks in a sprint')
+    .option('-y, --yes', 'Skip confirmation')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        if (!options.yes) {
+          const readline = await import('node:readline/promises');
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          const answer = await rl.question(
+            `Are you sure you want to archive all done tasks in sprint "${id}"? (y/N) `
+          );
+          rl.close();
+          if (answer.toLowerCase() !== 'y' && answer.toLowerCase() !== 'yes') {
+            console.log('Cancelled');
+            return;
+          }
+        }
+
+        const result = await api<ArchiveResult>(`/api/tasks/archive/sprint/${id}`, {
+          method: 'POST',
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(chalk.green(`✓ Archived ${result.archived} task(s) from sprint "${id}"`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -14,6 +14,7 @@ export function registerTaskCommands(program: Command): void {
     .option('-s, --status <status>', 'Filter by status (todo, in-progress, blocked, done)')
     .option('-t, --type <type>', 'Filter by type (code, research, content, automation)')
     .option('-p, --project <project>', 'Filter by project')
+    .option('-S, --sprint <sprint>', 'Filter by sprint')
     .option('-v, --verbose', 'Show more details')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
@@ -29,6 +30,9 @@ export function registerTaskCommands(program: Command): void {
         }
         if (options.project) {
           filtered = filtered.filter((t: Task) => t.project === options.project);
+        }
+        if (options.sprint) {
+          filtered = filtered.filter((t: Task) => t.sprint === options.sprint);
         }
 
         if (options.json) {
@@ -86,6 +90,7 @@ export function registerTaskCommands(program: Command): void {
     .description('Create a new task')
     .option('-t, --type <type>', 'Task type (code, research, content, automation)', 'code')
     .option('-p, --project <project>', 'Project name')
+    .option('-S, --sprint <sprint>', 'Sprint name or ID')
     .option('-d, --description <desc>', 'Task description')
     .option('--priority <priority>', 'Priority (low, medium, high)', 'medium')
     .option('--json', 'Output as JSON')
@@ -97,6 +102,7 @@ export function registerTaskCommands(program: Command): void {
             title,
             type: options.type,
             project: options.project,
+            sprint: options.sprint,
             description: options.description || '',
             priority: options.priority,
           }),
@@ -121,6 +127,7 @@ export function registerTaskCommands(program: Command): void {
     .option('-s, --status <status>', 'New status')
     .option('-t, --type <type>', 'New type')
     .option('-p, --project <project>', 'New project')
+    .option('-S, --sprint <sprint>', 'Sprint name or ID')
     .option('--priority <priority>', 'New priority')
     .option('--title <title>', 'New title')
     .option('--json', 'Output as JSON')
@@ -137,6 +144,7 @@ export function registerTaskCommands(program: Command): void {
         if (options.status) updates.status = options.status;
         if (options.type) updates.type = options.type;
         if (options.project) updates.project = options.project;
+        if (options.sprint) updates.sprint = options.sprint;
         if (options.priority) updates.priority = options.priority;
         if (options.title) updates.title = options.title;
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -14,6 +14,7 @@ import { registerProjectCommands } from './commands/projects.js';
 import { registerWorkflowCommands } from './commands/workflow.js';
 import { registerSetupCommands } from './commands/setup.js';
 import { registerUsageCommands } from './commands/usage.js';
+import { registerSprintCommands } from './commands/sprints.js';
 
 const program = new Command();
 
@@ -37,5 +38,6 @@ registerProjectCommands(program);
 registerWorkflowCommands(program);
 registerSetupCommands(program);
 registerUsageCommands(program);
+registerSprintCommands(program);
 
 program.parse();

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -19,6 +19,7 @@ import { agentTools, handleAgentTool } from './tools/agents.js';
 import { automationTools, handleAutomationTool } from './tools/automation.js';
 import { notificationTools, handleNotificationTool } from './tools/notifications.js';
 import { summaryTools, handleSummaryTool } from './tools/summary.js';
+import { sprintTools, handleSprintTool } from './tools/sprints.js';
 
 // Create MCP server
 const server = new Server(
@@ -41,6 +42,7 @@ const allTools = [
   ...automationTools,
   ...notificationTools,
   ...summaryTools,
+  ...sprintTools,
 ];
 
 // List available tools
@@ -70,6 +72,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
     if (summaryTools.some((t) => t.name === name)) {
       return await handleSummaryTool(name, args);
+    }
+    if (sprintTools.some((t) => t.name === name)) {
+      return await handleSprintTool(name, args);
     }
 
     return {

--- a/mcp/src/tools/sprints.ts
+++ b/mcp/src/tools/sprints.ts
@@ -1,0 +1,319 @@
+import { z } from 'zod';
+import { api } from '../utils/api.js';
+import type { SprintConfig, Task } from '../utils/types.js';
+
+// Local response types
+interface ArchiveSuggestion {
+  sprint: string;
+  taskCount: number;
+  tasks: Task[];
+}
+
+interface ArchiveResult {
+  archived: number;
+  taskIds: string[];
+}
+
+interface CanDeleteResult {
+  canDelete: boolean;
+  referenceCount?: number;
+}
+
+// Tool input schemas
+const ListSprintsSchema = z.object({
+  includeHidden: z.boolean().optional(),
+});
+
+const SprintIdSchema = z.object({
+  id: z.string().min(1),
+});
+
+const CreateSprintSchema = z.object({
+  label: z.string().min(1),
+  description: z.string().optional(),
+});
+
+const UpdateSprintSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  isHidden: z.boolean().optional(),
+});
+
+const DeleteSprintSchema = z.object({
+  id: z.string().min(1),
+  force: z.boolean().optional(),
+});
+
+const ReorderSprintsSchema = z.object({
+  orderedIds: z.array(z.string()),
+});
+
+export const sprintTools = [
+  {
+    name: 'list_sprints',
+    description: 'List all sprints. Use includeHidden to show hidden sprints.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        includeHidden: {
+          type: 'boolean',
+          description: 'Include hidden sprints in the list',
+        },
+      },
+    },
+  },
+  {
+    name: 'get_sprint',
+    description: 'Get details of a specific sprint by ID',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Sprint ID',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'create_sprint',
+    description: 'Create a new sprint',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        label: {
+          type: 'string',
+          description: 'Sprint name/label',
+        },
+        description: {
+          type: 'string',
+          description: 'Sprint description',
+        },
+      },
+      required: ['label'],
+    },
+  },
+  {
+    name: 'update_sprint',
+    description: 'Update an existing sprint',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Sprint ID',
+        },
+        label: {
+          type: 'string',
+          description: 'New sprint name',
+        },
+        description: {
+          type: 'string',
+          description: 'New description',
+        },
+        isHidden: {
+          type: 'boolean',
+          description: 'Hide or show the sprint',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'delete_sprint',
+    description: 'Delete a sprint. Use force=true to delete even if tasks reference this sprint.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Sprint ID',
+        },
+        force: {
+          type: 'boolean',
+          description: 'Force delete even if tasks reference this sprint',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'can_delete_sprint',
+    description: 'Check if a sprint can be deleted and get reference count',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Sprint ID',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'reorder_sprints',
+    description: 'Reorder sprints by providing an array of sprint IDs in the desired order',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        orderedIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Array of sprint IDs in desired order',
+        },
+      },
+      required: ['orderedIds'],
+    },
+  },
+  {
+    name: 'get_archive_suggestions',
+    description: 'Get sprints that are ready to archive (all tasks completed)',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'close_sprint',
+    description: 'Archive all completed tasks in a sprint',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Sprint ID',
+        },
+      },
+      required: ['id'],
+    },
+  },
+];
+
+export async function handleSprintTool(name: string, args: any): Promise<any> {
+  switch (name) {
+    case 'list_sprints': {
+      const params = ListSprintsSchema.parse(args || {});
+      const query = params.includeHidden ? '?includeHidden=true' : '';
+      const sprints = await api<SprintConfig[]>(`/api/sprints${query}`);
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(sprints, null, 2) }],
+      };
+    }
+
+    case 'get_sprint': {
+      const { id } = SprintIdSchema.parse(args);
+      const sprint = await api<SprintConfig>(`/api/sprints/${id}`);
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(sprint, null, 2) }],
+      };
+    }
+
+    case 'create_sprint': {
+      const params = CreateSprintSchema.parse(args);
+      const sprint = await api<SprintConfig>('/api/sprints', {
+        method: 'POST',
+        body: JSON.stringify(params),
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Sprint created: ${sprint.label}\n${JSON.stringify(sprint, null, 2)}`,
+          },
+        ],
+      };
+    }
+
+    case 'update_sprint': {
+      const { id, ...updates } = UpdateSprintSchema.parse(args);
+      const sprint = await api<SprintConfig>(`/api/sprints/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(updates),
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Sprint updated: ${sprint.label}\n${JSON.stringify(sprint, null, 2)}`,
+          },
+        ],
+      };
+    }
+
+    case 'delete_sprint': {
+      const { id, force } = DeleteSprintSchema.parse(args);
+      const query = force ? '?force=true' : '';
+      await api(`/api/sprints/${id}${query}`, { method: 'DELETE' });
+
+      return {
+        content: [{ type: 'text', text: `Sprint deleted: ${id}` }],
+      };
+    }
+
+    case 'can_delete_sprint': {
+      const { id } = SprintIdSchema.parse(args);
+      const result = await api<CanDeleteResult>(`/api/sprints/${id}/can-delete`);
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+
+    case 'reorder_sprints': {
+      const { orderedIds } = ReorderSprintsSchema.parse(args);
+      const sprints = await api<SprintConfig[]>('/api/sprints/reorder', {
+        method: 'POST',
+        body: JSON.stringify({ orderedIds }),
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Sprints reordered\n${JSON.stringify(sprints, null, 2)}`,
+          },
+        ],
+      };
+    }
+
+    case 'get_archive_suggestions': {
+      const suggestions = await api<ArchiveSuggestion[]>('/api/tasks/archive/suggestions');
+
+      if (suggestions.length === 0) {
+        return {
+          content: [{ type: 'text', text: 'No sprints ready to archive' }],
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(suggestions, null, 2) }],
+      };
+    }
+
+    case 'close_sprint': {
+      const { id } = SprintIdSchema.parse(args);
+      const result = await api<ArchiveResult>(`/api/tasks/archive/sprint/${id}`, {
+        method: 'POST',
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Archived ${result.archived} task(s) from sprint\n${JSON.stringify(result, null, 2)}`,
+          },
+        ],
+      };
+    }
+
+    default:
+      throw new Error(`Unknown sprint tool: ${name}`);
+  }
+}

--- a/mcp/src/tools/tasks.ts
+++ b/mcp/src/tools/tasks.ts
@@ -8,6 +8,7 @@ const ListTasksSchema = z.object({
   status: z.enum(['todo', 'in-progress', 'blocked', 'done']).optional(),
   type: z.enum(['code', 'research', 'content', 'automation']).optional(),
   project: z.string().optional(),
+  sprint: z.string().optional(),
 });
 
 const CreateTaskSchema = z.object({
@@ -16,6 +17,7 @@ const CreateTaskSchema = z.object({
   type: z.enum(['code', 'research', 'content', 'automation']).default('code'),
   priority: z.enum(['low', 'medium', 'high']).default('medium'),
   project: z.string().optional(),
+  sprint: z.string().optional(),
 });
 
 const UpdateTaskSchema = z.object({
@@ -26,6 +28,7 @@ const UpdateTaskSchema = z.object({
   type: z.enum(['code', 'research', 'content', 'automation']).optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
   project: z.string().optional(),
+  sprint: z.string().optional(),
 });
 
 const TaskIdSchema = z.object({
@@ -52,6 +55,10 @@ export const taskTools = [
         project: {
           type: 'string',
           description: 'Filter by project name',
+        },
+        sprint: {
+          type: 'string',
+          description: 'Filter by sprint ID',
         },
       },
     },
@@ -98,6 +105,10 @@ export const taskTools = [
           type: 'string',
           description: 'Project name',
         },
+        sprint: {
+          type: 'string',
+          description: 'Sprint ID',
+        },
       },
       required: ['title'],
     },
@@ -138,6 +149,10 @@ export const taskTools = [
         project: {
           type: 'string',
           description: 'New project',
+        },
+        sprint: {
+          type: 'string',
+          description: 'New sprint ID',
         },
       },
       required: ['id'],
@@ -187,6 +202,9 @@ export async function handleTaskTool(name: string, args: any): Promise<any> {
       }
       if (params.project) {
         tasks = tasks.filter((t) => t.project === params.project);
+      }
+      if (params.sprint) {
+        tasks = tasks.filter((t) => t.sprint === params.sprint);
       }
 
       return {

--- a/mcp/src/utils/types.ts
+++ b/mcp/src/utils/types.ts
@@ -1,2 +1,2 @@
 // Re-export shared types
-export type { Task } from '@veritas-kanban/shared';
+export type { Task, SprintConfig } from '@veritas-kanban/shared';


### PR DESCRIPTION
## Description

Adds sprint management to the CLI and MCP surfaces, enabling both human operators and AI agents to manage sprints from the command line.

This is a **scoped successor** to #80 by @mariozig — thank you Mario for the excellent implementation and thorough testing! 🙏 This PR extracts only the CLI/MCP sprint features from that broader PR to keep the changeset small and reviewable.

## What's Included

### CLI Sprint Commands
- `vk sprint list` — List all sprints (with `--hidden`, `--json` flags)
- `vk sprint create` — Create sprints with optional description
- `vk sprint update` — Update label, description, visibility
- `vk sprint delete` — Delete sprints (with `--force` for non-empty)
- `vk sprint close` — Archive completed tasks in a sprint
- `vk sprint suggestions` — Show sprints ready to archive

### Task Sprint Integration
- `vk list -S <sprint>` — Filter tasks by sprint
- `vk create -S <sprint>` — Assign tasks to sprint on creation
- `vk update -S <sprint>` — Move tasks between sprints

### MCP Sprint Tools
- `list_sprints`, `create_sprint`, `update_sprint`, `delete_sprint`
- `close_sprint`, `sprint_suggestions`
- Sprint field added to `list_tasks`, `create_task`, `update_task`

## What's NOT Included (from #80)
- Server/API route changes (sprint routes already exist on main)
- Web UI changes
- Documentation/README changes
- Refactoring/binary files
- Type definition changes (sprint field already in shared types)

## Testing
- ✅ CLI typecheck passes (`tsc --noEmit`)
- ✅ MCP typecheck passes (`tsc --noEmit`)
- ✅ Lint/format passes (lint-staged)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

Closes: Scoped replacement for #80