### PR TITLE
fix(server): broadcast WebSocket events on comment mutations

### DIFF
--- a/server/src/routes/task-comments.ts
+++ b/server/src/routes/task-comments.ts
@@ -7,6 +7,7 @@ import { getGitHubSyncService } from '../services/github-sync-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { sanitizeCommentText, sanitizeAuthor } from '../utils/sanitize.js';
+import { broadcastTaskChange } from '../services/broadcast-service.js';
 
 const router: RouterType = Router();
 const taskService = getTaskService();
@@ -61,6 +62,9 @@ router.post(
       task.agent
     );
 
+    // Broadcast update to all connected WebSocket clients
+    broadcastTaskChange('updated', task.id);
+
     // Outbound sync: post comment to linked GitHub issue (fire-and-forget)
     if (task.github) {
       getGitHubSyncService()
@@ -111,6 +115,10 @@ router.patch(
     };
 
     const updatedTask = await taskService.updateTask(req.params.id as string, { comments });
+
+    // Broadcast update to all connected WebSocket clients
+    broadcastTaskChange('updated', req.params.id as string);
+
     res.json(updatedTask);
   })
 );
@@ -146,6 +154,9 @@ router.delete(
       },
       task.agent
     );
+
+    // Broadcast update to all connected WebSocket clients
+    broadcastTaskChange('updated', task.id);
 
     res.json(updatedTask);
   })


### PR DESCRIPTION
## Summary

Comment add/edit/delete operations (`task-comments.ts`) update tasks via `taskService.updateTask()` but don't broadcast to WebSocket clients. Other connected users see stale comment data until they manually refresh.

- Added `broadcastTaskChange('updated', taskId)` to POST, PATCH, and DELETE comment endpoints
- Follows the same pattern used in `tasks.ts` (lines 564, 711, 773)

## Motivation

We deployed Veritas behind Traefik for a 5-agent team. Comments are the primary async coordination mechanism — agents post status updates, blockers, and handoff notes as comments. Without WebSocket broadcasts, the dashboard and other agents' views are stale until refresh.

## Changes

| File | Change |
|------|--------|
| `server/src/routes/task-comments.ts` | Import `broadcastTaskChange`, call it on add/edit/delete |

## Test plan

- [ ] Add a comment via API while another client is connected via WebSocket
- [ ] Verify the WebSocket client receives a `task:changed` event with `changeType: 'updated'`
- [ ] Edit and delete comments — same verification
- [ ] Existing task-comments tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)