### PR TITLE
feat: global system health status bar

### DIFF
--- a/server/src/routes/system-health.ts
+++ b/server/src/routes/system-health.ts
@@ -1,0 +1,219 @@
+/**
+ * System Health Aggregator Route
+ *
+ * GET /api/v1/system/health
+ *
+ * Aggregates system health signals (infrastructure, agents, operations)
+ * into a single response for the frontend status bar.
+ *
+ * No auth required — mounted before auth middleware, same pattern as /health/ready.
+ */
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import fs from 'fs/promises';
+import path from 'path';
+import { createLogger } from '../lib/logger.js';
+import { getAgentRegistryService } from '../services/agent-registry-service.js';
+import { getMetricsService } from '../services/metrics/index.js';
+
+const log = createLogger('system-health');
+
+// ─── Types ────────────────────────────────────────────────────
+
+type OverallStatus = 'stable' | 'reviewing' | 'drifting' | 'elevated' | 'alert';
+
+interface SystemSignal {
+  status: 'ok' | 'warn' | 'fail';
+  storage: boolean;
+  disk: boolean;
+  memory: boolean;
+}
+
+interface AgentSignal {
+  status: 'ok' | 'warn' | 'critical';
+  total: number;
+  online: number;
+  offline: number;
+}
+
+interface OperationsSignal {
+  status: 'ok' | 'warn' | 'critical';
+  recentRuns: number;
+  successRate: number;
+  failedRuns: number;
+}
+
+interface SystemHealthResponse {
+  timestamp: string;
+  status: OverallStatus;
+  signals: {
+    system: SystemSignal;
+    agents: AgentSignal;
+    operations: OperationsSignal;
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+function getDataDir(): string {
+  const dataDir = process.env.DATA_DIR || '.veritas-kanban';
+  return path.resolve(process.cwd(), dataDir);
+}
+
+async function checkStorage(): Promise<boolean> {
+  const dataDir = getDataDir();
+  try {
+    await fs.access(dataDir, fs.constants.R_OK | fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkDisk(): Promise<boolean> {
+  const dataDir = getDataDir();
+  try {
+    const stats = await fs.statfs(dataDir);
+    const freeBytes = stats.bfree * stats.bsize;
+    const MIN_FREE_BYTES = 100 * 1024 * 1024; // 100 MB
+    return freeBytes >= MIN_FREE_BYTES;
+  } catch {
+    return false;
+  }
+}
+
+function checkMemory(): boolean {
+  const mem = process.memoryUsage();
+  return mem.heapUsed / mem.heapTotal <= 0.9;
+}
+
+function getSystemSignal(storage: boolean, disk: boolean, memory: boolean): SystemSignal {
+  const anyFail = !storage || !disk;
+  const anyWarn = !memory;
+  const status: 'ok' | 'warn' | 'fail' = anyFail ? 'fail' : anyWarn ? 'warn' : 'ok';
+  return { status, storage, disk, memory };
+}
+
+function getAgentSignal(): AgentSignal {
+  try {
+    const registry = getAgentRegistryService();
+    const agents = registry.list();
+    const total = agents.length;
+    const online = agents.filter(
+      (a) => a.status === 'online' || a.status === 'busy' || a.status === 'idle'
+    ).length;
+    const offline = total - online;
+
+    let status: 'ok' | 'warn' | 'critical';
+    if (total === 0) {
+      status = 'ok'; // No agents registered is not an error
+    } else if (offline === total) {
+      status = 'critical';
+    } else if (offline > 0) {
+      status = 'warn';
+    } else {
+      status = 'ok';
+    }
+
+    return { status, total, online, offline };
+  } catch (err) {
+    log.warn({ err }, 'Failed to read agent registry');
+    return { status: 'ok', total: 0, online: 0, offline: 0 };
+  }
+}
+
+async function getOperationsSignal(): Promise<OperationsSignal> {
+  try {
+    const metrics = getMetricsService();
+    const runMetrics = await metrics.getRunMetrics('24h');
+    const recentRuns = runMetrics.runs;
+    const successRate = runMetrics.runs > 0 ? runMetrics.successRate : 100;
+    const failedRuns = runMetrics.failures + runMetrics.errors;
+
+    let status: 'ok' | 'warn' | 'critical';
+    if (successRate < 50) {
+      status = 'critical';
+    } else if (successRate < 80 || failedRuns > 5) {
+      status = 'warn';
+    } else {
+      status = 'ok';
+    }
+
+    return { status, recentRuns, successRate, failedRuns };
+  } catch (err) {
+    log.warn({ err }, 'Failed to read operations metrics');
+    return { status: 'ok', recentRuns: 0, successRate: 100, failedRuns: 0 };
+  }
+}
+
+/**
+ * Determine overall status from individual signals.
+ *
+ *   stable   = all signals ok
+ *   reviewing = 1 warning signal
+ *   drifting  = 2+ warnings or any agent offline
+ *   elevated  = any critical signal
+ *   alert     = system fail or successRate < 50%
+ */
+function determineOverallStatus(
+  system: SystemSignal,
+  agents: AgentSignal,
+  operations: OperationsSignal
+): OverallStatus {
+  // Alert: system failure or very low success rate
+  if (system.status === 'fail' || operations.successRate < 50) {
+    return 'alert';
+  }
+
+  // Elevated: any critical signal
+  if (agents.status === 'critical' || operations.status === 'critical') {
+    return 'elevated';
+  }
+
+  // Count warnings
+  const warnings = [system.status, agents.status, operations.status].filter(
+    (s) => s === 'warn'
+  ).length;
+
+  // Drifting: 2+ warnings or any agent offline
+  if (warnings >= 2 || agents.offline > 0) {
+    return 'drifting';
+  }
+
+  // Reviewing: 1 warning
+  if (warnings === 1) {
+    return 'reviewing';
+  }
+
+  return 'stable';
+}
+
+// ─── Router ───────────────────────────────────────────────────
+
+const router = Router();
+
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const [storage, disk] = await Promise.all([checkStorage(), checkDisk()]);
+    const memory = checkMemory();
+
+    const system = getSystemSignal(storage, disk, memory);
+    const agents = getAgentSignal();
+    const operations = await getOperationsSignal();
+
+    const status = determineOverallStatus(system, agents, operations);
+
+    const response: SystemHealthResponse = {
+      timestamp: new Date().toISOString(),
+      status,
+      signals: { system, agents, operations },
+    };
+
+    res.json(response);
+  } catch (err) {
+    log.error({ err }, 'Failed to aggregate system health');
+    res.status(500).json({ status: 'unknown', error: 'Failed to aggregate health' });
+  }
+});
+
+export { router as systemHealthRouter };

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -73,6 +73,7 @@ import delegationRoutes from '../delegation.js';
 import { workflowRoutes } from '../workflows.js';
 import toolPolicyRoutes from '../tool-policies.js';
 import { integrationsRoutes } from '../integrations.js';
+import { systemHealthRouter } from '../system-health.js';
 
 const v1Router: IRouter = Router();
 
@@ -161,5 +162,6 @@ v1Router.use('/delegation', delegationRoutes);
 v1Router.use('/workflows', workflowRoutes);
 v1Router.use('/tool-policies', toolPolicyRoutes);
 v1Router.use('/integrations', integrationsRoutes);
+v1Router.use('/system/health', systemHealthRouter);
 
 export { v1Router };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import { SkipToContent } from './components/shared/SkipToContent';
 import { LiveAnnouncerProvider } from './components/shared/LiveAnnouncer';
 import { FloatingChat } from './components/chat/FloatingChat';
+import { SystemHealthBar } from './components/layout/SystemHealthBar';
 
 // Lazy-load ActivityFeed and BacklogPage to keep initial bundle small
 const ActivityFeed = lazy(() =>
@@ -146,6 +147,7 @@ function AppContent() {
                 <div className="min-h-screen bg-background">
                   <SkipToContent />
                   <Header />
+                  <SystemHealthBar />
                   <main id="main-content" className="mx-auto px-14 py-6" tabIndex={-1}>
                     <ErrorBoundary level="section">
                       <MainContent />

--- a/web/src/components/layout/SystemHealthBar.tsx
+++ b/web/src/components/layout/SystemHealthBar.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import {
+  CheckCircle2,
+  Eye,
+  TrendingDown,
+  AlertTriangle,
+  AlertOctagon,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from 'lucide-react';
+import { useSystemHealth, type OverallStatus } from '@/hooks/useSystemHealth';
+
+// ─── Status Configuration ─────────────────────────────────────
+
+const STATUS_CONFIG: Record<
+  OverallStatus,
+  {
+    icon: typeof CheckCircle2;
+    label: string;
+    barClass: string;
+    iconClass: string;
+  }
+> = {
+  stable: {
+    icon: CheckCircle2,
+    label: 'Stable',
+    barClass: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+    iconClass: 'text-emerald-600 dark:text-emerald-400',
+  },
+  reviewing: {
+    icon: Eye,
+    label: 'Reviewing',
+    barClass: 'bg-blue-500/10 text-blue-700 dark:text-blue-400',
+    iconClass: 'text-blue-600 dark:text-blue-400',
+  },
+  drifting: {
+    icon: TrendingDown,
+    label: 'Drifting',
+    barClass: 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    iconClass: 'text-amber-600 dark:text-amber-400',
+  },
+  elevated: {
+    icon: AlertTriangle,
+    label: 'Elevated',
+    barClass: 'bg-orange-500/10 text-orange-700 dark:text-orange-400',
+    iconClass: 'text-orange-600 dark:text-orange-400',
+  },
+  alert: {
+    icon: AlertOctagon,
+    label: 'Alert',
+    barClass: 'bg-red-500/10 text-red-700 dark:text-red-400',
+    iconClass: 'text-red-600 dark:text-red-400',
+  },
+};
+
+// ─── Signal Status Dot ────────────────────────────────────────
+
+function SignalDot({ status }: { status: 'ok' | 'warn' | 'fail' | 'critical' }) {
+  const dotColor =
+    status === 'ok' ? 'bg-emerald-500' : status === 'warn' ? 'bg-amber-500' : 'bg-red-500';
+  return <span className={`inline-block h-2 w-2 rounded-full ${dotColor}`} />;
+}
+
+// ─── Component ────────────────────────────────────────────────
+
+/**
+ * A thin, persistent bar below the header showing aggregated system health.
+ * Click to expand a detail panel with per-signal breakdown.
+ */
+export function SystemHealthBar() {
+  const [expanded, setExpanded] = useState(false);
+  const { data, isLoading, isError } = useSystemHealth();
+
+  // Don't render anything while loading or on error
+  if (isLoading && !data) {
+    return (
+      <div
+        className="flex h-7 items-center justify-center border-b border-border bg-muted/30 text-xs text-muted-foreground"
+        role="status"
+        aria-label="Loading system health"
+      >
+        <Loader2 className="mr-1.5 h-3 w-3 animate-spin" aria-hidden="true" />
+        Checking system health...
+      </div>
+    );
+  }
+
+  if (isError && !data) {
+    return null;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const config = STATUS_CONFIG[data.status];
+  const StatusIcon = config.icon;
+  const { system, agents, operations } = data.signals;
+
+  // Build summary text
+  const summaryParts: string[] = [];
+  if (agents.total > 0) {
+    summaryParts.push(`${agents.online} agent${agents.online !== 1 ? 's' : ''} online`);
+  }
+  if (operations.recentRuns > 0) {
+    summaryParts.push(`${Math.round(operations.successRate)}% success rate`);
+  }
+  const summary = summaryParts.join(' \u00B7 ');
+
+  const ToggleIcon = expanded ? ChevronUp : ChevronDown;
+
+  return (
+    <div className={`border-b border-border ${config.barClass}`}>
+      {/* Main bar */}
+      <button
+        className="flex h-7 w-full items-center justify-center gap-2 px-4 text-xs cursor-pointer select-none transition-colors hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-controls="system-health-details"
+        aria-label={`System health: ${config.label}. ${summary}. Click to ${expanded ? 'collapse' : 'expand'} details.`}
+      >
+        <StatusIcon className={`h-3.5 w-3.5 ${config.iconClass}`} aria-hidden="true" />
+        <span className="font-medium">{config.label}</span>
+        {summary && (
+          <>
+            <span className="opacity-40" aria-hidden="true">
+              |
+            </span>
+            <span className="opacity-75">{summary}</span>
+          </>
+        )}
+        <ToggleIcon className="ml-1 h-3 w-3 opacity-50" aria-hidden="true" />
+      </button>
+
+      {/* Detail panel */}
+      {expanded && (
+        <div
+          id="system-health-details"
+          className="border-t border-border/50 px-4 py-3"
+          role="region"
+          aria-label="System health details"
+        >
+          <div className="mx-auto grid max-w-2xl grid-cols-3 gap-4 text-xs">
+            {/* System signal */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-1.5 font-medium">
+                <SignalDot status={system.status} />
+                Infrastructure
+              </div>
+              <ul className="space-y-0.5 text-muted-foreground" aria-label="Infrastructure checks">
+                <li>Storage: {system.storage ? 'OK' : 'Fail'}</li>
+                <li>Disk: {system.disk ? 'OK' : 'Fail'}</li>
+                <li>Memory: {system.memory ? 'OK' : 'High'}</li>
+              </ul>
+            </div>
+
+            {/* Agents signal */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-1.5 font-medium">
+                <SignalDot status={agents.status} />
+                Agents
+              </div>
+              <ul className="space-y-0.5 text-muted-foreground" aria-label="Agent status">
+                <li>Total: {agents.total}</li>
+                <li>Online: {agents.online}</li>
+                <li>Offline: {agents.offline}</li>
+              </ul>
+            </div>
+
+            {/* Operations signal */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-1.5 font-medium">
+                <SignalDot status={operations.status} />
+                Operations
+              </div>
+              <ul className="space-y-0.5 text-muted-foreground" aria-label="Operations metrics">
+                <li>Recent runs: {operations.recentRuns}</li>
+                <li>Success rate: {Math.round(operations.successRate)}%</li>
+                <li>Failed: {operations.failedRuns}</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useSystemHealth.ts
+++ b/web/src/hooks/useSystemHealth.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { useWebSocketStatus } from '@/contexts/WebSocketContext';
+import { apiFetch } from '@/lib/api/helpers';
+
+// ─── Types ────────────────────────────────────────────────────
+
+export type OverallStatus = 'stable' | 'reviewing' | 'drifting' | 'elevated' | 'alert';
+
+export interface SystemSignal {
+  status: 'ok' | 'warn' | 'fail';
+  storage: boolean;
+  disk: boolean;
+  memory: boolean;
+}
+
+export interface AgentSignal {
+  status: 'ok' | 'warn' | 'critical';
+  total: number;
+  online: number;
+  offline: number;
+}
+
+export interface OperationsSignal {
+  status: 'ok' | 'warn' | 'critical';
+  recentRuns: number;
+  successRate: number;
+  failedRuns: number;
+}
+
+export interface SystemHealth {
+  timestamp: string;
+  status: OverallStatus;
+  signals: {
+    system: SystemSignal;
+    agents: AgentSignal;
+    operations: OperationsSignal;
+  };
+}
+
+/**
+ * Fetches aggregated system health for the status bar.
+ * Polls every 30s when WebSocket is connected, 60s otherwise.
+ */
+export function useSystemHealth() {
+  const { isConnected } = useWebSocketStatus();
+
+  return useQuery({
+    queryKey: ['system', 'health'],
+    queryFn: () => apiFetch<SystemHealth>('/api/v1/system/health'),
+    refetchInterval: isConnected ? 30_000 : 60_000,
+    staleTime: 15_000,
+    placeholderData: (previousData) => previousData,
+  });
+}


### PR DESCRIPTION
## Summary

Implements #185 — a persistent status bar below the header showing aggregated system health at a glance.

### What's included

**Backend: `GET /api/v1/system/health`** (`server/src/routes/system-health.ts`)
- Aggregates three signal categories from existing services:
  - **System**: storage writable, disk >100MB free, heap usage <90%
  - **Agents**: online/offline counts from `AgentRegistryService`
  - **Operations**: recent run count + success rate from `MetricsService`
- Computes overall status: `stable` → `reviewing` → `drifting` → `elevated` → `alert`
- No auth required (same pattern as `/health/ready`)

**Frontend: `SystemHealthBar` component** (`web/src/components/layout/SystemHealthBar.tsx`)
- 28px thin bar with color-coded background per status level (green/blue/amber/orange/red)
- Shows: icon + status label + summary text (agents online, success rate)
- Click to expand 3-column detail panel showing per-signal breakdown
- Full accessibility: ARIA labels, `aria-expanded`, `aria-controls`, screen-reader lists
- Dark mode support via Tailwind `dark:` variants

**Hook: `useSystemHealth`** (`web/src/hooks/useSystemHealth.ts`)
- `@tanstack/react-query` with `apiFetch` helper
- Polls every 30s (WS connected) or 60s (disconnected), 15s stale time

**Integration**: Inserted between `<Header />` and `<main>` in `App.tsx`

### Design decisions

- **No new service** — aggregates from existing `AgentRegistryService` and `MetricsService` to avoid duplication
- **Status thresholds** match the 5-state model from the issue (stable/reviewing/drifting/elevated/alert)
- **Expandable detail panel** avoids cluttering the bar while keeping drill-down accessible

## Test plan

- [ ] Verify bar appears below header on all views (board, activity, backlog, archive)
- [ ] Verify color transitions: stop agents → bar turns amber/orange
- [ ] Verify expand/collapse works with keyboard (Enter/Space)
- [ ] Verify dark mode styling
- [ ] Screen reader: verify ARIA labels announce status correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>