### PR TITLE
fix: correct false cycle detection in dependency API (#188)

### DIFF
--- a/server/src/__tests__/dependency-cycle.test.ts
+++ b/server/src/__tests__/dependency-cycle.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Dependency Cycle Detection Tests (Issue #188)
+ *
+ * Verifies that cycle detection in TaskService.addDependency() works correctly:
+ * - Allows valid dependencies between unrelated tasks
+ * - Detects real cycles (direct and transitive)
+ * - Handles both depends_on and blocks relationship types
+ * - Does NOT false-positive on valid graphs that mix relationship types (#188)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TaskService } from '../services/task-service.js';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+describe('Dependency cycle detection', () => {
+  let service: TaskService;
+  let tmpDir: string;
+  let tasksDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-cycle-test-'));
+    tasksDir = path.join(tmpDir, 'tasks');
+    archiveDir = path.join(tmpDir, 'archive');
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.mkdir(archiveDir, { recursive: true });
+    service = new TaskService({ tasksDir, archiveDir });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function createSimpleTask(title: string) {
+    return service.createTask({ title, project: 'test' });
+  }
+
+  it('allows a dependency between two unrelated tasks', async () => {
+    const a = await createSimpleTask('Task A');
+    const b = await createSimpleTask('Task B');
+
+    const result = await service.addDependency(a.id, b.id, 'depends_on');
+    expect(result.dependencies?.depends_on).toContain(b.id);
+  });
+
+  it('detects a direct cycle: A depends_on B, then B depends_on A', async () => {
+    const a = await createSimpleTask('Task A');
+    const b = await createSimpleTask('Task B');
+
+    await service.addDependency(a.id, b.id, 'depends_on');
+
+    await expect(service.addDependency(b.id, a.id, 'depends_on')).rejects.toThrow(/cycle/i);
+  });
+
+  it('detects a transitive cycle: A→B→C, then C→A', async () => {
+    const a = await createSimpleTask('Task A');
+    const b = await createSimpleTask('Task B');
+    const c = await createSimpleTask('Task C');
+
+    await service.addDependency(a.id, b.id, 'depends_on');
+    await service.addDependency(b.id, c.id, 'depends_on');
+
+    await expect(service.addDependency(c.id, a.id, 'depends_on')).rejects.toThrow(/cycle/i);
+  });
+
+  it('detects a cycle through blocks: A blocks B, then B blocks A', async () => {
+    const a = await createSimpleTask('Task A');
+    const b = await createSimpleTask('Task B');
+
+    // A blocks B  ⟹  stored as A.blocks=[B], B.depends_on=[A]
+    await service.addDependency(a.id, b.id, 'blocks');
+
+    // B blocks A  ⟹  would mean B.blocks=[A], A.depends_on=[B]
+    // Combined: A depends_on B AND B depends_on A → cycle
+    await expect(service.addDependency(b.id, a.id, 'blocks')).rejects.toThrow(/cycle/i);
+  });
+
+  it('allows a complex DAG with no cycle (diamond shape)', async () => {
+    // A→B, A→C, B→D, C→D  (diamond, no cycle)
+    const a = await createSimpleTask('Task A');
+    const b = await createSimpleTask('Task B');
+    const c = await createSimpleTask('Task C');
+    const d = await createSimpleTask('Task D');
+
+    await service.addDependency(a.id, b.id, 'depends_on');
+    await service.addDependency(a.id, c.id, 'depends_on');
+    await service.addDependency(b.id, d.id, 'depends_on');
+
+    const result = await service.addDependency(c.id, d.id, 'depends_on');
+    expect(result.dependencies?.depends_on).toContain(d.id);
+  });
+
+  it('does not false-positive when depends_on and blocks edges cross (issue #188)', async () => {
+    // C depends_on D, and D blocks E.
+    // This is NOT a cycle — they are separate valid relationships.
+    // Adding E depends_on C should succeed because there is no actual depends_on cycle.
+    //
+    // Old bug: DFS mixed depends_on + blocks edges, creating a false path C→D→E,
+    // causing checkForCycle(E, C, ...) to incorrectly return true.
+    const c = await createSimpleTask('Task C');
+    const d = await createSimpleTask('Task D');
+    const e = await createSimpleTask('Task E');
+
+    // C depends_on D: C is blocked by D
+    await service.addDependency(c.id, d.id, 'depends_on');
+
+    // D blocks E: D must be done before E (E depends_on D stored on D's side as blocks)
+    await service.addDependency(d.id, e.id, 'blocks');
+
+    // E depends_on C should be valid — no actual depends_on cycle exists
+    const result = await service.addDependency(e.id, c.id, 'depends_on');
+    expect(result.dependencies?.depends_on).toContain(c.id);
+  });
+
+  it('still detects real cycle when an unrelated blocks edge is present', async () => {
+    // A depends_on B, B depends_on A — real depends_on cycle.
+    // An unrelated blocks edge (X blocks A) should not affect detection.
+    const a = await createSimpleTask('Task A');
+    const b = await createSimpleTask('Task B');
+    const x = await createSimpleTask('Task X');
+
+    await service.addDependency(a.id, b.id, 'depends_on');
+    // Add an unrelated blocks edge
+    await service.addDependency(x.id, a.id, 'blocks');
+
+    await expect(service.addDependency(b.id, a.id, 'depends_on')).rejects.toThrow(/cycle/i);
+  });
+});

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -1301,20 +1301,30 @@ export class TaskService {
       throw new NotFoundError(`Target task ${targetId} not found`);
     }
 
-    // Initialize dependencies if needed
-    const dependencies = task.dependencies || { depends_on: [], blocks: [] };
-    const targetDependencies = targetTask.dependencies || { depends_on: [], blocks: [] };
+    // Deep-copy dependencies so we never mutate the cache entries in place.
+    // Mutating in-place before the final cycle check can corrupt the cache,
+    // causing checkForCycle to see the not-yet-committed edges and mis-detect cycles.
+    const dependencies = {
+      depends_on: [...(task.dependencies?.depends_on || [])],
+      blocks: [...(task.dependencies?.blocks || [])],
+    };
+    const targetDependencies = {
+      depends_on: [...(targetTask.dependencies?.depends_on || [])],
+      blocks: [...(targetTask.dependencies?.blocks || [])],
+    };
 
     // Check for cycle BEFORE any updates
     if (type === 'depends_on') {
-      // If we're adding A depends_on B, check if B (or its ancestors) already depend on A
-      const hasCycle = await this.checkForCycle(targetId, taskId);
+      // Adding A depends_on B: check if B already transitively depends_on A (would form a cycle).
+      const hasCycle = await this.checkForCycle(targetId, taskId, 'depends_on');
       if (hasCycle) {
         throw new ValidationError('Adding this dependency would create a cycle');
       }
     } else {
-      // If we're adding A blocks B, check if A (or its ancestors) already depend on B
-      const hasCycle = await this.checkForCycle(taskId, targetId);
+      // Adding A blocks B: check if B already transitively blocks A (would form a cycle).
+      // Both relationships form a directed graph in the same order, so the same DFS
+      // direction applies: start from target (B) and see if A is reachable via blocks edges.
+      const hasCycle = await this.checkForCycle(targetId, taskId, 'blocks');
       if (hasCycle) {
         throw new ValidationError('Adding this dependency would create a cycle');
       }
@@ -1356,8 +1366,8 @@ export class TaskService {
     // between our initial check and now
     const finalCycleCheck =
       type === 'depends_on'
-        ? await this.checkForCycle(targetId, taskId)
-        : await this.checkForCycle(taskId, targetId);
+        ? await this.checkForCycle(targetId, taskId, 'depends_on')
+        : await this.checkForCycle(targetId, taskId, 'blocks');
 
     if (finalCycleCheck) {
       // Rollback the target task update
@@ -1417,11 +1427,18 @@ export class TaskService {
   }
 
   /**
-   * Check if adding a dependency would create a cycle
-   * Performs DFS to detect cycles, traversing BOTH depends_on and blocks relationships
-   * Uses batch loading to avoid N+1 queries
+   * Check if adding a dependency would create a cycle.
+   * Performs DFS following only edges of `direction` type (depends_on or blocks).
+   * Mixing relationship types during traversal produces false positives — e.g.
+   * C depends_on D and D blocks E is a valid DAG, but traversing C→D→E through
+   * mixed edge types would incorrectly report a cycle when checking E depends_on C.
+   * Uses batch loading to avoid N+1 queries.
    */
-  private async checkForCycle(startId: string, targetId: string): Promise<boolean> {
+  private async checkForCycle(
+    startId: string,
+    targetId: string,
+    direction: 'depends_on' | 'blocks'
+  ): Promise<boolean> {
     // Load all tasks once for batch processing (performance optimization)
     const allTasks = await this.listTasks();
     const taskMap = new Map(allTasks.map((t) => [t.id, t]));
@@ -1448,12 +1465,9 @@ export class TaskService {
         continue;
       }
 
-      // Traverse BOTH depends_on and blocks relationships
-      // A cycle can occur through either relationship type
-      const nextIds = [
-        ...(currentTask.dependencies.depends_on || []),
-        ...(currentTask.dependencies.blocks || []),
-      ];
+      // Only follow edges of the same relationship type being added.
+      // This prevents false positives from mixed depends_on/blocks traversal.
+      const nextIds = currentTask.dependencies[direction] || [];
 
       for (const nextId of nextIds) {
         if (!visited.has(nextId)) {


### PR DESCRIPTION
## Summary

Fixes #188 — false positive cycle detection when `depends_on` and `blocks` relationship edges are mixed during DFS traversal.

## Root Cause

The `checkForCycle` method traversed **both** `depends_on` and `blocks` edges during its DFS. This created false paths across unrelated relationship types. For example:

- C `depends_on` D (valid)
- D `blocks` E (valid)
- Adding E `depends_on` C → **incorrectly rejected** as a cycle

The DFS would traverse C→D (via `depends_on`) then D→E (via `blocks`), finding E, and falsely concluding a cycle existed when adding `E depends_on C`.

## Additional bug fixed

A second bug was discovered during investigation: dependency objects were **mutated in place** before the final race-condition cycle check. This corrupted the in-memory cache, causing the final check to see pre-committed edges and mis-detect cycles on valid graphs.

## Changes

### `server/src/services/task-service.ts`
- `checkForCycle` now accepts a `direction: 'depends_on' | 'blocks'` parameter and only traverses edges of that type
- Deep-copy dependency objects before mutation to prevent cache corruption
- Fix `blocks` cycle detection direction: mirror the same start-from-target DFS pattern used for `depends_on`

### `server/src/__tests__/dependency-cycle.test.ts` (new file)
7 test cases covering:
- Basic dependency between unrelated tasks
- Direct cycle detection (A→B, B→A)
- Transitive cycle detection (A→B→C→A)
- Blocks cycle detection
- Diamond DAG (valid, no cycle)
- **The #188 false positive scenario** (cross-type edges)
- Real cycle with an unrelated blocks edge present

## Testing

```
Tests: 7 passed (7) — dependency-cycle.test.ts
Full suite: 1362 passed, 2 pre-existing failures (unrelated to this change)
```