### PR TITLE
fix: convert successRate from ratio to percentage in SystemHealthBar (#211)

### DIFF
--- a/server/src/routes/system-health.ts
+++ b/server/src/routes/system-health.ts
@@ -127,7 +127,8 @@ async function getOperationsSignal(): Promise<OperationsSignal> {
     const metrics = getMetricsService();
     const runMetrics = await metrics.getRunMetrics('24h');
     const recentRuns = runMetrics.runs;
-    const successRate = runMetrics.runs > 0 ? runMetrics.successRate : 100;
+    // runMetrics.successRate is 0-1 ratio; convert to 0-100 percentage
+    const successRate = runMetrics.runs > 0 ? Math.round(runMetrics.successRate * 100) : 100;
     const failedRuns = runMetrics.failures + runMetrics.errors;
 
     let status: 'ok' | 'warn' | 'critical';


### PR DESCRIPTION
## Summary

Fixes #211 — SystemHealthBar displayed "1% success rate" when all runs succeeded.

## Root Cause

`getRunMetrics()` returns `successRate` as a 0-1 ratio (e.g. `1.0` = 100%), but `getOperationsSignal()` in `system-health.ts` passed it through without converting to a 0-100 percentage. The threshold checks (`< 50`, `< 80`) assume a percentage scale, so `1.0` was flagged as `critical`.

## Fix

One-line change: multiply `runMetrics.successRate` by 100 and round before comparison/display.

## Testing

- Verified locally: `/api/v1/system/health` now returns `successRate: 100` and `status: 'ok'` with 29/29 successful runs.