### PR TITLE
feat(squad-chat): Add Adaptive Card support to squad messages

### DIFF
--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -44,6 +44,7 @@ const squadMessageSchema = z.object({
   event: z.enum(['agent.spawned', 'agent.completed', 'agent.failed', 'agent.status']).optional(),
   taskTitle: z.string().optional(),
   duration: z.string().optional(),
+  card: z.record(z.unknown()).optional(), // Adaptive Card v1.5 JSON
 });
 
 /**
@@ -271,6 +272,7 @@ router.post(
         event: validatedInput.event,
         taskTitle: validatedInput.taskTitle,
         duration: validatedInput.duration,
+        card: validatedInput.card,
       },
       displayName
     );

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -361,6 +361,7 @@ export class ChatService {
       event?: 'agent.spawned' | 'agent.completed' | 'agent.failed' | 'agent.status';
       taskTitle?: string;
       duration?: string;
+      card?: Record<string, unknown>;
     },
     displayName?: string
   ): Promise<SquadMessage> {
@@ -379,6 +380,7 @@ export class ChatService {
       event: input.event,
       taskTitle: input.taskTitle,
       duration: input.duration,
+      ...(input.card && { card: input.card }),
     };
 
     // Store as daily markdown file: squad/YYYY-MM-DD.md

--- a/server/src/services/squad-webhook-service.ts
+++ b/server/src/services/squad-webhook-service.ts
@@ -21,6 +21,7 @@ interface WebhookPayload {
     message: string;
     tags?: string[];
     timestamp: string;
+    card?: Record<string, unknown>;
   };
   isHuman: boolean;
 }
@@ -148,6 +149,7 @@ async function fireGenericWebhook(
       message: message.message,
       tags: message.tags,
       timestamp: message.timestamp,
+      ...(message.card && { card: message.card }),
     },
     isHuman,
   };

--- a/shared/src/types/chat.types.ts
+++ b/shared/src/types/chat.types.ts
@@ -56,6 +56,7 @@ export interface SquadMessage {
   event?: 'agent.spawned' | 'agent.completed' | 'agent.failed' | 'agent.status'; // Event type for system messages
   taskTitle?: string; // Task title for system messages
   duration?: string; // Duration string for completed/failed events (e.g., "2m 44s")
+  card?: Record<string, unknown>; // Adaptive Card v1.5 JSON for rich Teams rendering
 }
 
 /**
@@ -70,4 +71,5 @@ export interface SquadMessageInput {
   event?: 'agent.spawned' | 'agent.completed' | 'agent.failed' | 'agent.status';
   taskTitle?: string;
   duration?: string;
+  card?: Record<string, unknown>; // Adaptive Card v1.5 JSON for rich Teams rendering
 }


### PR DESCRIPTION
Closes #213

## What

Adds an optional `card` field (`Record<string, unknown>`) to the squad chat API, enabling Adaptive Card v1.5 JSON payloads to flow through the full squad chat pipeline.

## Why

7 n8n workflows were upgraded today with Adaptive Card code nodes that generate rich Teams cards (tables, severity badges, action buttons, Digital Meld branding). The squad chat API needed to accept and forward the `card` field for these to render in Teams.

## Changes

| File | Change |
|------|--------|
| `shared/src/types/chat.types.ts` | Added `card?` to `SquadMessage` + `SquadMessageInput` |
| `server/src/routes/chat.ts` | Added `card` to zod schema + route handler passthrough |
| `server/src/services/chat-service.ts` | Added `card` to input type + spread into message object |
| `server/src/services/squad-webhook-service.ts` | Added `card` to webhook payload type + passthrough |

## Pipeline flow

```
POST /api/chat/squad (card in body)
  → zod validates card as Record<string, unknown>
  → chatService.sendSquadMessage stores message + card
  → Response includes card ✅
  → broadcastSquadMessage sends card via WebSocket ✅
  → fireSquadWebhook includes card in payload ✅
```

## Testing

```bash
curl -X POST http://localhost:3001/api/chat/squad \
  -H 'Content-Type: application/json' \
  -d '{"agent":"test","message":"test","card":{"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"Works!"}]},"model":"test"}'
# → data.card is present in response ✅
```

4 files changed, 8 insertions. Zero breaking changes — field is optional.