### PR TITLE
fix: Squad chat panel not scrollable (#224)

### DIFF
--- a/web/src/components/chat/SquadChatPanel.tsx
+++ b/web/src/components/chat/SquadChatPanel.tsx
@@ -204,7 +204,7 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
         </div>
 
         {/* Messages */}
-        <ScrollArea className="flex-1 px-4" onScrollCapture={handleScroll} ref={scrollAreaRef}>
+        <ScrollArea className="flex-1 min-h-0 px-4" onScrollCapture={handleScroll} ref={scrollAreaRef}>
           <div className="py-4 space-y-3">
             {isLoading && (
               <div className="text-center text-muted-foreground py-8">


### PR DESCRIPTION
Closes #224

## Problem
Squad chat panel doesn't scroll when messages overflow the container.

## Root Cause
In a flex column layout, `flex-1` children default to `min-height: auto`, which prevents them from shrinking below their content height. The ScrollArea never gets constrained, so the Radix scroll viewport has no reason to scroll.

## Fix
Add `min-h-0` (Tailwind for `min-height: 0`) to the ScrollArea component. This allows the flex item to shrink to the available space, enabling overflow scrolling.

One-line change.