### PR TITLE
feat(mcp): project management tools (reimplements #151)

### DIFF
--- a/mcp/src/__tests__/project-tools.test.ts
+++ b/mcp/src/__tests__/project-tools.test.ts
@@ -1,0 +1,360 @@
+/**
+ * MCP Project Tools — Unit Tests
+ *
+ * Tests tool definitions, Zod validation, and mocked API calls.
+ * Does NOT require a running server — all API calls are mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { projectTools, handleProjectTool } from '../tools/projects.js';
+
+// Mock the API module
+vi.mock('../utils/api.js', () => ({
+  api: vi.fn(),
+}));
+
+import { api } from '../utils/api.js';
+const mockApi = vi.mocked(api);
+
+// Helper: parse JSON from tool response content
+function parseToolResponse(result: any): any {
+  const text = result.content[0].text;
+  const jsonStart = text.indexOf('{');
+  const jsonArrayStart = text.indexOf('[');
+  const start =
+    jsonStart === -1
+      ? jsonArrayStart
+      : jsonArrayStart === -1
+        ? jsonStart
+        : Math.min(jsonStart, jsonArrayStart);
+  if (start === -1) return text;
+  return JSON.parse(text.substring(start));
+}
+
+describe('Project MCP Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Tool Definitions ───────────────────────────────────────────────────────
+
+  describe('Tool definitions', () => {
+    it('should export 7 project tools', () => {
+      expect(projectTools).toHaveLength(7);
+    });
+
+    it('should have correct tool names', () => {
+      const names = projectTools.map((t) => t.name);
+      expect(names).toContain('list_projects');
+      expect(names).toContain('get_project');
+      expect(names).toContain('create_project');
+      expect(names).toContain('update_project');
+      expect(names).toContain('delete_project');
+      expect(names).toContain('get_project_stats');
+      expect(names).toContain('reorder_projects');
+    });
+
+    it('should require id for get_project', () => {
+      const tool = projectTools.find((t) => t.name === 'get_project');
+      expect(tool?.inputSchema.required).toContain('id');
+    });
+
+    it('should require label for create_project', () => {
+      const tool = projectTools.find((t) => t.name === 'create_project');
+      expect(tool?.inputSchema.required).toContain('label');
+    });
+
+    it('should require id for update_project', () => {
+      const tool = projectTools.find((t) => t.name === 'update_project');
+      expect(tool?.inputSchema.required).toContain('id');
+    });
+
+    it('should require id for delete_project', () => {
+      const tool = projectTools.find((t) => t.name === 'delete_project');
+      expect(tool?.inputSchema.required).toContain('id');
+    });
+
+    it('should have force as optional on delete_project', () => {
+      const tool = projectTools.find((t) => t.name === 'delete_project');
+      expect(tool?.inputSchema.properties.force).toBeDefined();
+      expect(tool?.inputSchema.properties.force.type).toBe('boolean');
+      expect(tool?.inputSchema.required).not.toContain('force');
+    });
+
+    it('should require id for get_project_stats', () => {
+      const tool = projectTools.find((t) => t.name === 'get_project_stats');
+      expect(tool?.inputSchema.required).toContain('id');
+    });
+
+    it('should require orderedIds for reorder_projects', () => {
+      const tool = projectTools.find((t) => t.name === 'reorder_projects');
+      expect(tool?.inputSchema.required).toContain('orderedIds');
+    });
+  });
+
+  // ─── Zod Validation ─────────────────────────────────────────────────────────
+
+  describe('Zod color validation', () => {
+    it('should accept valid Tailwind color segments in create_project', async () => {
+      const mockProject = { id: 'proj-1', label: 'Test', color: 'green-500' };
+      mockApi.mockResolvedValueOnce(mockProject);
+
+      const result = await handleProjectTool('create_project', {
+        label: 'Test',
+        color: 'green-500',
+      });
+      expect(result.content[0].text).toContain('Test');
+    });
+
+    it('should accept valid 3-digit Tailwind color segments', async () => {
+      const mockProject = { id: 'proj-2', label: 'Test2', color: 'red-100' };
+      mockApi.mockResolvedValueOnce(mockProject);
+
+      const result = await handleProjectTool('create_project', {
+        label: 'Test2',
+        color: 'red-100',
+      });
+      expect(result.content[0].text).toContain('Test2');
+    });
+
+    it('should reject invalid color format (full bg- prefix)', async () => {
+      await expect(
+        handleProjectTool('create_project', {
+          label: 'Test',
+          color: 'bg-green-500',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject invalid color format (no number)', async () => {
+      await expect(
+        handleProjectTool('create_project', {
+          label: 'Test',
+          color: 'green',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject invalid color format (uppercase)', async () => {
+      await expect(
+        handleProjectTool('create_project', {
+          label: 'Test',
+          color: 'Green-500',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should allow color to be omitted (optional)', async () => {
+      const mockProject = { id: 'proj-3', label: 'No color' };
+      mockApi.mockResolvedValueOnce(mockProject);
+
+      const result = await handleProjectTool('create_project', {
+        label: 'No color',
+      });
+      expect(result.content[0].text).toContain('No color');
+    });
+  });
+
+  // ─── list_projects ───────────────────────────────────────────────────────────
+
+  describe('list_projects', () => {
+    it('should call GET /api/projects', async () => {
+      const mockProjects = [{ id: 'p1', label: 'Alpha' }];
+      mockApi.mockResolvedValueOnce(mockProjects);
+
+      const result = await handleProjectTool('list_projects', {});
+      expect(mockApi).toHaveBeenCalledWith('/api/projects');
+      const data = parseToolResponse(result);
+      expect(Array.isArray(data)).toBe(true);
+    });
+
+    it('should pass includeHidden query param when true', async () => {
+      mockApi.mockResolvedValueOnce([]);
+      await handleProjectTool('list_projects', { includeHidden: true });
+      expect(mockApi).toHaveBeenCalledWith('/api/projects?includeHidden=true');
+    });
+
+    it('should accept undefined args', async () => {
+      mockApi.mockResolvedValueOnce([]);
+      const result = await handleProjectTool('list_projects', undefined);
+      expect(result.content[0].type).toBe('text');
+    });
+  });
+
+  // ─── get_project ─────────────────────────────────────────────────────────────
+
+  describe('get_project', () => {
+    it('should call GET /api/projects/:id', async () => {
+      const mockProject = { id: 'proj-abc', label: 'My Project' };
+      mockApi.mockResolvedValueOnce(mockProject);
+
+      const result = await handleProjectTool('get_project', { id: 'proj-abc' });
+      expect(mockApi).toHaveBeenCalledWith('/api/projects/proj-abc');
+      const data = parseToolResponse(result);
+      expect(data.id).toBe('proj-abc');
+    });
+
+    it('should throw when id is missing', async () => {
+      await expect(handleProjectTool('get_project', {})).rejects.toThrow();
+    });
+  });
+
+  // ─── create_project ──────────────────────────────────────────────────────────
+
+  describe('create_project', () => {
+    it('should POST to /api/projects', async () => {
+      const mockProject = { id: 'new-1', label: 'New Project', description: 'A test project' };
+      mockApi.mockResolvedValueOnce(mockProject);
+
+      const result = await handleProjectTool('create_project', {
+        label: 'New Project',
+        description: 'A test project',
+      });
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/projects',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(result.content[0].text).toContain('Project created: New Project');
+    });
+
+    it('should throw when label is missing', async () => {
+      await expect(handleProjectTool('create_project', {})).rejects.toThrow();
+    });
+  });
+
+  // ─── update_project ──────────────────────────────────────────────────────────
+
+  describe('update_project', () => {
+    it('should PATCH /api/projects/:id', async () => {
+      const mockProject = { id: 'proj-1', label: 'Updated Label' };
+      mockApi.mockResolvedValueOnce(mockProject);
+
+      const result = await handleProjectTool('update_project', {
+        id: 'proj-1',
+        label: 'Updated Label',
+      });
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/projects/proj-1',
+        expect.objectContaining({ method: 'PATCH' })
+      );
+      expect(result.content[0].text).toContain('Project updated: Updated Label');
+    });
+
+    it('should throw when id is missing', async () => {
+      await expect(handleProjectTool('update_project', { label: 'x' })).rejects.toThrow();
+    });
+  });
+
+  // ─── delete_project ──────────────────────────────────────────────────────────
+
+  describe('delete_project', () => {
+    it('should DELETE /api/projects/:id', async () => {
+      mockApi.mockResolvedValueOnce(undefined);
+
+      const result = await handleProjectTool('delete_project', { id: 'proj-del' });
+      expect(mockApi).toHaveBeenCalledWith('/api/projects/proj-del', { method: 'DELETE' });
+      expect(result.content[0].text).toContain('deleted');
+    });
+
+    it('should append ?force=true when force flag is set', async () => {
+      mockApi.mockResolvedValueOnce(undefined);
+
+      await handleProjectTool('delete_project', { id: 'proj-x', force: true });
+      expect(mockApi).toHaveBeenCalledWith('/api/projects/proj-x?force=true', { method: 'DELETE' });
+    });
+
+    it('should throw when id is missing', async () => {
+      await expect(handleProjectTool('delete_project', {})).rejects.toThrow();
+    });
+  });
+
+  // ─── get_project_stats ───────────────────────────────────────────────────────
+
+  describe('get_project_stats', () => {
+    it('should aggregate tasks by status', async () => {
+      const mockTasks = {
+        success: true,
+        data: [
+          { id: 't1', status: 'todo', project: 'proj-1' },
+          { id: 't2', status: 'in-progress', project: 'proj-1' },
+          { id: 't3', status: 'todo', project: 'proj-1' },
+          { id: 't4', status: 'done', project: 'proj-1' },
+        ],
+      };
+      mockApi.mockResolvedValueOnce(mockTasks);
+
+      const result = await handleProjectTool('get_project_stats', { id: 'proj-1' });
+      const stats = parseToolResponse(result);
+
+      expect(stats.projectId).toBe('proj-1');
+      expect(stats.total).toBe(4);
+      expect(stats.byStatus.todo).toBe(2);
+      expect(stats.byStatus['in-progress']).toBe(1);
+      expect(stats.byStatus.done).toBe(1);
+    });
+
+    it('should handle empty task list', async () => {
+      mockApi.mockResolvedValueOnce({ success: true, data: [] });
+
+      const result = await handleProjectTool('get_project_stats', { id: 'empty-proj' });
+      const stats = parseToolResponse(result);
+
+      expect(stats.total).toBe(0);
+      expect(stats.byStatus).toEqual({});
+    });
+
+    it('should handle plain array response', async () => {
+      mockApi.mockResolvedValueOnce([
+        { id: 't1', status: 'todo' },
+        { id: 't2', status: 'todo' },
+      ]);
+
+      const result = await handleProjectTool('get_project_stats', { id: 'proj-2' });
+      const stats = parseToolResponse(result);
+
+      expect(stats.total).toBe(2);
+      expect(stats.byStatus.todo).toBe(2);
+    });
+
+    it('should throw when id is missing', async () => {
+      await expect(handleProjectTool('get_project_stats', {})).rejects.toThrow();
+    });
+  });
+
+  // ─── reorder_projects ────────────────────────────────────────────────────────
+
+  describe('reorder_projects', () => {
+    it('should POST to /api/projects/reorder', async () => {
+      const mockProjects = [
+        { id: 'p2', label: 'B', order: 1 },
+        { id: 'p1', label: 'A', order: 2 },
+      ];
+      mockApi.mockResolvedValueOnce(mockProjects);
+
+      const result = await handleProjectTool('reorder_projects', {
+        orderedIds: ['p2', 'p1'],
+      });
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/projects/reorder',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(result.content[0].text).toContain('Projects reordered');
+    });
+
+    it('should throw when orderedIds is missing', async () => {
+      await expect(handleProjectTool('reorder_projects', {})).rejects.toThrow();
+    });
+  });
+
+  // ─── Error handling ──────────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('should throw for unknown project tool', async () => {
+      await expect(handleProjectTool('nonexistent_tool', {})).rejects.toThrow(
+        'Unknown project tool'
+      );
+    });
+  });
+});

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -21,6 +21,7 @@ import { notificationTools, handleNotificationTool } from './tools/notifications
 import { summaryTools, handleSummaryTool } from './tools/summary.js';
 import { sprintTools, handleSprintTool } from './tools/sprints.js';
 import { commentTools, handleCommentTool } from './tools/comments.js';
+import { projectTools, handleProjectTool } from './tools/projects.js';
 
 // Create MCP server
 const server = new Server(
@@ -45,6 +46,7 @@ const allTools = [
   ...summaryTools,
   ...sprintTools,
   ...commentTools,
+  ...projectTools,
 ];
 
 // List available tools
@@ -80,6 +82,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
     if (commentTools.some((t) => t.name === name)) {
       return await handleCommentTool(name, args);
+    }
+    if (projectTools.some((t) => t.name === name)) {
+      return await handleProjectTool(name, args);
     }
 
     return {

--- a/mcp/src/tools/projects.ts
+++ b/mcp/src/tools/projects.ts
@@ -1,0 +1,323 @@
+import { z } from 'zod';
+import { api } from '../utils/api.js';
+
+// Local response types
+interface ProjectConfig {
+  id: string;
+  label: string;
+  description?: string;
+  color?: string;
+  order?: number;
+  isHidden?: boolean;
+  created?: string;
+  updated?: string;
+}
+
+interface Task {
+  id: string;
+  status: string;
+  project?: string;
+  [key: string]: any;
+}
+
+interface ProjectStats {
+  projectId: string;
+  total: number;
+  byStatus: Record<string, number>;
+}
+
+// Tailwind color class validation: e.g. bg-green-500, text-red-200
+const tailwindColorRegex = /^[a-z]+-\d{2,3}$/;
+
+// Tool input schemas
+const ListProjectsSchema = z.object({
+  includeHidden: z.boolean().optional(),
+});
+
+const ProjectIdSchema = z.object({
+  id: z.string().min(1),
+});
+
+const CreateProjectSchema = z.object({
+  label: z.string().min(1),
+  description: z.string().optional(),
+  color: z
+    .string()
+    .optional()
+    .refine(
+      (val) => val === undefined || tailwindColorRegex.test(val),
+      { message: 'color must be a valid Tailwind class segment like "green-500" or "red-200"' }
+    ),
+});
+
+const UpdateProjectSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  color: z
+    .string()
+    .optional()
+    .refine(
+      (val) => val === undefined || tailwindColorRegex.test(val),
+      { message: 'color must be a valid Tailwind class segment like "green-500" or "red-200"' }
+    ),
+  isHidden: z.boolean().optional(),
+});
+
+const DeleteProjectSchema = z.object({
+  id: z.string().min(1),
+  force: z.boolean().optional(),
+});
+
+const ReorderProjectsSchema = z.object({
+  orderedIds: z.array(z.string()),
+});
+
+export const projectTools = [
+  {
+    name: 'list_projects',
+    description: 'List all projects. Use includeHidden to show hidden projects.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        includeHidden: {
+          type: 'boolean',
+          description: 'Include hidden projects in the list',
+        },
+      },
+    },
+  },
+  {
+    name: 'get_project',
+    description: 'Get details of a specific project by ID',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Project ID',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'create_project',
+    description: 'Create a new project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        label: {
+          type: 'string',
+          description: 'Project name/label',
+        },
+        description: {
+          type: 'string',
+          description: 'Project description',
+        },
+        color: {
+          type: 'string',
+          description:
+            'Tailwind color class segment (e.g. "green-500", "red-200"). Must match pattern [a-z]+-\\d{2,3}.',
+        },
+      },
+      required: ['label'],
+    },
+  },
+  {
+    name: 'update_project',
+    description: 'Update an existing project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Project ID',
+        },
+        label: {
+          type: 'string',
+          description: 'New project name',
+        },
+        description: {
+          type: 'string',
+          description: 'New description',
+        },
+        color: {
+          type: 'string',
+          description:
+            'New Tailwind color class segment (e.g. "green-500", "red-200"). Must match pattern [a-z]+-\\d{2,3}.',
+        },
+        isHidden: {
+          type: 'boolean',
+          description: 'Hide or show the project',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'delete_project',
+    description:
+      'Delete a project. Use force=true to delete even if tasks are assigned to this project.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Project ID',
+        },
+        force: {
+          type: 'boolean',
+          description: 'Force delete even if tasks reference this project',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'get_project_stats',
+    description:
+      'Get task counts per status for a project. Returns total count and breakdown by status.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Project ID',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'reorder_projects',
+    description:
+      'Reorder projects by providing an array of project IDs in the desired order',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        orderedIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Array of project IDs in desired order',
+        },
+      },
+      required: ['orderedIds'],
+    },
+  },
+];
+
+export async function handleProjectTool(name: string, args: any): Promise<any> {
+  switch (name) {
+    case 'list_projects': {
+      const params = ListProjectsSchema.parse(args || {});
+      const query = params.includeHidden ? '?includeHidden=true' : '';
+      const projects = await api<ProjectConfig[]>(`/api/projects${query}`);
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(projects, null, 2) }],
+      };
+    }
+
+    case 'get_project': {
+      const { id } = ProjectIdSchema.parse(args);
+      const project = await api<ProjectConfig>(`/api/projects/${id}`);
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(project, null, 2) }],
+      };
+    }
+
+    case 'create_project': {
+      const params = CreateProjectSchema.parse(args);
+      const project = await api<ProjectConfig>('/api/projects', {
+        method: 'POST',
+        body: JSON.stringify(params),
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Project created: ${project.label}\n${JSON.stringify(project, null, 2)}`,
+          },
+        ],
+      };
+    }
+
+    case 'update_project': {
+      const { id, ...updates } = UpdateProjectSchema.parse(args);
+      const project = await api<ProjectConfig>(`/api/projects/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(updates),
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Project updated: ${project.label}\n${JSON.stringify(project, null, 2)}`,
+          },
+        ],
+      };
+    }
+
+    case 'delete_project': {
+      const { id, force } = DeleteProjectSchema.parse(args);
+      const query = force ? '?force=true' : '';
+      await api(`/api/projects/${id}${query}`, { method: 'DELETE' });
+
+      return {
+        content: [{ type: 'text', text: `Project deleted: ${id}` }],
+      };
+    }
+
+    case 'get_project_stats': {
+      const { id } = ProjectIdSchema.parse(args);
+      const tasks = await api<{ data?: Task[]; success?: boolean } | Task[]>(
+        `/api/tasks?project=${id}`
+      );
+
+      // Handle both array response and wrapped {data: [...]} response
+      const taskList: Task[] = Array.isArray(tasks)
+        ? tasks
+        : (tasks as any).data ?? [];
+
+      const byStatus: Record<string, number> = {};
+      for (const task of taskList) {
+        const status = task.status ?? 'unknown';
+        byStatus[status] = (byStatus[status] ?? 0) + 1;
+      }
+
+      const stats: ProjectStats = {
+        projectId: id,
+        total: taskList.length,
+        byStatus,
+      };
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(stats, null, 2) }],
+      };
+    }
+
+    case 'reorder_projects': {
+      const { orderedIds } = ReorderProjectsSchema.parse(args);
+      const projects = await api<ProjectConfig[]>('/api/projects/reorder', {
+        method: 'POST',
+        body: JSON.stringify({ orderedIds }),
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Projects reordered\n${JSON.stringify(projects, null, 2)}`,
+          },
+        ],
+      };
+    }
+
+    default:
+      throw new Error(`Unknown project tool: ${name}`);
+  }
+}


### PR DESCRIPTION
## Summary

Reimplements the project management tools from the closed PR #151 (original contribution by @hekr4jivs), with conflict resolution and two additional tools.

## Changes

### `mcp/src/tools/projects.ts` (new)
Full CRUD + extras:
- **`list_projects`** — List all projects, with optional `includeHidden` filter
- **`get_project`** — Get a project by ID
- **`create_project`** — Create with label, description, and color (Tailwind class segment validated via `^[a-z]+-\d{2,3}$`)
- **`update_project`** — PATCH fields by ID
- **`delete_project`** — Delete with optional `force` flag for projects with tasks
- **`get_project_stats`** _(NEW — not in #151)_ — Aggregates task counts per status via `GET /api/tasks?project={id}`
- **`reorder_projects`** _(NEW — not in #151)_ — Reorders projects via `POST /api/projects/reorder`

### `mcp/src/__tests__/project-tools.test.ts` (new)
34 unit tests — all mocked, no running server required:
- Tool definitions (count, names, required fields)
- Zod color validation (valid/invalid formats)
- Mocked API calls for all 7 tools
- Error handling

### `mcp/src/index.ts` (modified)
- Imports `projectTools` and `handleProjectTool`
- Adds to `allTools` array
- Adds routing in `CallToolRequestSchema` handler

## Credit

Original implementation by @hekr4jivs in PR #151. This PR resolves the merge conflicts and adds `get_project_stats` and `reorder_projects` as improvements.

## Test Results

All 34 new tests pass. Pre-existing failures in `server/src/__tests__` are unrelated to this PR (present on `main` before these changes).