### PR TITLE
fix: add missing requireDeliverableForDone to settings schema (reimplements #130)

### DIFF
--- a/server/src/__tests__/routes/misc-routes-coverage.test.ts
+++ b/server/src/__tests__/routes/misc-routes-coverage.test.ts
@@ -317,6 +317,65 @@ describe('Settings Routes', () => {
       .send({ telemetry: { enabled: false } });
     expect(res.status).toBe(500);
   });
+
+  it('PATCH /features should accept requireDeliverableForDone', async () => {
+    const fullSettings = {
+      telemetry: { enabled: true, retentionDays: 30, enableTraces: false, enableActivityTracking: true },
+      tasks: {
+        enableTimeTracking: true,
+        enableSubtaskAutoComplete: true,
+        enableDependencies: true,
+        enableAttachments: true,
+        attachmentMaxFileSize: 10000000,
+        attachmentMaxPerTask: 20,
+        attachmentMaxTotalSize: 50000000,
+        enableComments: true,
+        defaultPriority: 'medium',
+        autoSaveDelayMs: 500,
+        requireDeliverableForDone: true,
+      },
+      hooks: { enabled: false },
+      enforcement: { squadChat: false },
+    };
+    mockConfigServiceForSettings.updateFeatureSettings.mockResolvedValue(fullSettings);
+    const res = await request(app)
+      .patch('/api/settings/features')
+      .send({ tasks: { requireDeliverableForDone: true } });
+    expect(res.status).toBe(200);
+  });
+
+  it('PATCH /features should accept requireDeliverableForDone set to false', async () => {
+    const fullSettings = {
+      telemetry: { enabled: true, retentionDays: 30, enableTraces: false, enableActivityTracking: true },
+      tasks: {
+        enableTimeTracking: true,
+        enableSubtaskAutoComplete: true,
+        enableDependencies: true,
+        enableAttachments: true,
+        attachmentMaxFileSize: 10000000,
+        attachmentMaxPerTask: 20,
+        attachmentMaxTotalSize: 50000000,
+        enableComments: true,
+        defaultPriority: 'medium',
+        autoSaveDelayMs: 500,
+        requireDeliverableForDone: false,
+      },
+      hooks: { enabled: false },
+      enforcement: { squadChat: false },
+    };
+    mockConfigServiceForSettings.updateFeatureSettings.mockResolvedValue(fullSettings);
+    const res = await request(app)
+      .patch('/api/settings/features')
+      .send({ tasks: { requireDeliverableForDone: false } });
+    expect(res.status).toBe(200);
+  });
+
+  it('PATCH /features should reject unknown tasks fields (strict mode)', async () => {
+    const res = await request(app)
+      .patch('/api/settings/features')
+      .send({ tasks: { unknownField: true } });
+    expect(res.status).toBe(400);
+  });
 });
 
 describe('Digest Routes', () => {

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -74,6 +74,7 @@ const TaskBehaviorSettingsSchema = z
     enableComments: z.boolean().optional(),
     defaultPriority: z.enum(['none', 'low', 'medium', 'high', 'critical']).optional(),
     autoSaveDelayMs: z.number().int().min(200).max(5000).optional(),
+    requireDeliverableForDone: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

The `requireDeliverableForDone` field is used in `task-service.ts` and the UI (`TasksTab.tsx`) but was absent from the Zod validation schema. Due to `.strict()` mode on `TaskBehaviorSettingsSchema`, any PATCH to `/api/settings/features` containing this field was silently rejected with a 400 error — meaning the UI toggle had no effect.

## Changes

- **`server/src/schemas/feature-settings-schema.ts`**: Added `requireDeliverableForDone: z.boolean().optional()` to `TaskBehaviorSettingsSchema` after `autoSaveDelayMs`
- **`server/src/__tests__/routes/misc-routes-coverage.test.ts`**: Added 3 tests:
  - PATCH /features accepts `requireDeliverableForDone: true`
  - PATCH /features accepts `requireDeliverableForDone: false`
  - PATCH /features still rejects unknown fields (strict mode preserved)

## Audit

Audited all settings fields used in `server/src/services/`, `web/src/`, and `shared/src/types/` against the Zod schemas. `requireDeliverableForDone` was the only missing field.

## Testing

- `pnpm lint`: 0 errors (617 pre-existing warnings)
- `pnpm test`: All new tests pass; 1 pre-existing failure in `metrics-helpers.test.ts` unrelated to this change

## Credits

This reimplements the fix originally contributed by @TylonHH in PR #130, which went stale. The CORS and Vite config changes from #130 were already merged to main; only the schema fix was missing.

Closes the bug introduced by strict schema validation missing this field.

Co-authored-by: TylonHH <TylonHH@users.noreply.github.com>