### PR TITLE
fix(security): enforce HS256 algorithm in JWT verification

### DIFF
--- a/server/src/__tests__/jwt-rotation.test.ts
+++ b/server/src/__tests__/jwt-rotation.test.ts
@@ -334,7 +334,7 @@ describe('JWT Secret Rotation', () => {
       let verified = false;
       for (const secret of secrets) {
         try {
-          jwt.verify(token, secret);
+          jwt.verify(token, secret, { algorithms: ['HS256'] });
           verified = true;
           break;
         } catch {
@@ -364,7 +364,7 @@ describe('JWT Secret Rotation', () => {
 
       // Token signed with current secret should verify with it
       const token = jwt.sign({ type: 'session' }, signingSecret, { expiresIn: '24h' });
-      const decoded = jwt.verify(token, 'new-secret');
+      const decoded = jwt.verify(token, 'new-secret', { algorithms: ['HS256'] });
       expect(decoded).toBeDefined();
     });
   });

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -244,7 +244,7 @@ function verifyJwtToken(token: string): { valid: boolean; error?: string } {
 
   for (const secret of secrets) {
     try {
-      jwt.verify(token, secret);
+      jwt.verify(token, secret, { algorithms: ['HS256'] });
       return { valid: true };
     } catch (err) {
       lastError = err as Error;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -126,7 +126,9 @@ router.get(
     const token = req.cookies?.veritas_session;
     if (token && !needsSetup) {
       try {
-        const decoded = jwt.verify(token, getJwtSecret()) as jwt.JwtPayload;
+        const decoded = jwt.verify(token, getJwtSecret(), {
+          algorithms: ['HS256'],
+        }) as jwt.JwtPayload;
         authenticated = true;
         if (decoded.exp) {
           sessionExpiry = new Date(decoded.exp * 1000).toISOString();


### PR DESCRIPTION
## Summary

- Adds explicit `algorithms: ['HS256']` to all `jwt.verify()` calls in `auth.ts` middleware, `auth.ts` routes, and JWT rotation tests
- Prevents algorithm confusion attacks (CVE-2015-9235) where an attacker switches the JWT algorithm header to bypass signature verification

## Test plan

- [x] All 16 JWT rotation tests pass
- [x] Server builds cleanly (`tsc --noEmit`)
- [ ] Manual: verify login flow still works with existing session tokens
- [ ] Manual: verify tokens signed with non-HS256 algorithms are rejected

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)