### PR TITLE
fix(api): resolve promise handling issues causing crashes and data loss

### DIFF
--- a/server/src/services/file-lock.ts
+++ b/server/src/services/file-lock.ts
@@ -49,9 +49,12 @@ async function enqueue(key: string, timeout: number): Promise<() => void> {
 
   if (result === timedOut) {
     // We timed out. We can't just disappear — the next waiter is chained
-    // on `myTurn`. Pass through: when `previous` resolves, immediately
+    // on `myTurn`. Pass through: when `previous` settles, immediately
     // release so the chain doesn't stall.
-    previous.then(() => release());
+    previous.then(
+      () => release(),
+      () => release()
+    );
     throw new Error('in-process queue timeout');
   }
 

--- a/server/src/services/gateway-chat-client.ts
+++ b/server/src/services/gateway-chat-client.ts
@@ -49,6 +49,7 @@ export async function sendGatewayChat(
 
   return new Promise((resolve, reject) => {
     let connected = false;
+    let settled = false;
     let responseText = '';
     let responseUsage: Record<string, unknown> | undefined;
     let connectTimer: ReturnType<typeof setTimeout>;
@@ -66,21 +67,33 @@ export async function sendGatewayChat(
       }
     };
 
+    const safeReject = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    };
+
+    const safeResolve = (value: ChatResponse) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
     connectTimer = setTimeout(() => {
       if (!connected) {
-        cleanup();
         const err = 'Gateway connection timeout';
         callbacks?.onError?.(err);
-        reject(new Error(err));
+        safeReject(new Error(err));
       }
     }, CONNECT_TIMEOUT_MS);
 
     ws.on('error', (err) => {
       log.error({ err: err.message }, 'Gateway WebSocket error');
-      cleanup();
       const errMsg = `Gateway connection failed: ${err.message}`;
       callbacks?.onError?.(errMsg);
-      reject(new Error(errMsg));
+      safeReject(new Error(errMsg));
     });
 
     ws.on('message', (data) => {
@@ -123,10 +136,9 @@ export async function sendGatewayChat(
 
         // Start response timeout
         responseTimer = setTimeout(() => {
-          cleanup();
           const err = 'Gateway response timeout';
           callbacks?.onError?.(err);
-          reject(new Error(err));
+          safeReject(new Error(err));
         }, RESPONSE_TIMEOUT_MS);
 
         ws.send(
@@ -152,11 +164,10 @@ export async function sendGatewayChat(
 
       // Handle errors
       if (msg.type === 'res' && !msg.ok) {
-        cleanup();
         const errMsg = msg.error?.message || 'Unknown gateway error';
         log.error({ error: msg.error }, 'Gateway error');
         callbacks?.onError?.(errMsg);
-        reject(new Error(errMsg));
+        safeReject(new Error(errMsg));
         return;
       }
 
@@ -206,27 +217,24 @@ export async function sendGatewayChat(
           };
 
           log.info({ sessionKey, textLength: responseText.length }, 'Chat response complete');
-          cleanup();
           callbacks?.onFinal?.(response);
-          resolve(response);
+          safeResolve(response);
           return;
         }
 
         if (payload.state === 'error') {
-          cleanup();
           const errMsg = payload.errorMessage || 'Chat error';
           callbacks?.onError?.(errMsg);
-          reject(new Error(errMsg));
+          safeReject(new Error(errMsg));
           return;
         }
 
         if (payload.state === 'aborted') {
-          cleanup();
           const response: ChatResponse = {
             text: responseText || '(response aborted)',
           };
           callbacks?.onFinal?.(response);
-          resolve(response);
+          safeResolve(response);
           return;
         }
       }
@@ -234,7 +242,7 @@ export async function sendGatewayChat(
 
     ws.on('close', () => {
       if (!connected) {
-        reject(new Error('Gateway WebSocket closed before connecting'));
+        safeReject(new Error('Gateway WebSocket closed before connecting'));
       }
     });
   });

--- a/server/src/services/status-history-service.ts
+++ b/server/src/services/status-history-service.ts
@@ -40,11 +40,16 @@ export class StatusHistoryService {
   private historyFile: string;
   private readonly MAX_ENTRIES = 5000; // Keep more entries for historical analysis
   private lastEntry: StatusHistoryEntry | null = null;
+  private initPromise: Promise<void>;
 
   constructor() {
     this.historyFile = join(process.cwd(), '.veritas-kanban', 'status-history.json');
-    this.ensureDir();
-    this.loadLastEntry();
+    this.initPromise = this.init();
+  }
+
+  private async init(): Promise<void> {
+    await this.ensureDir();
+    await this.loadLastEntry();
   }
 
   private async ensureDir(): Promise<void> {
@@ -65,7 +70,7 @@ export class StatusHistoryService {
   }
 
   async getHistory(limit: number = 100, offset: number = 0): Promise<StatusHistoryEntry[]> {
-    await this.ensureDir();
+    await this.initPromise;
 
     if (!(await fileExists(this.historyFile))) {
       return [];
@@ -88,7 +93,7 @@ export class StatusHistoryService {
     taskTitle?: string,
     subAgentCount?: number
   ): Promise<StatusHistoryEntry> {
-    await this.ensureDir();
+    await this.initPromise;
 
     const now = new Date();
     const timestamp = now.toISOString();
@@ -269,7 +274,7 @@ export class StatusHistoryService {
   }
 
   async clearHistory(): Promise<void> {
-    await this.ensureDir();
+    await this.initPromise;
     await writeFile(this.historyFile, '[]', 'utf-8');
     this.lastEntry = null;
   }

--- a/server/src/services/telemetry-service.ts
+++ b/server/src/services/telemetry-service.ts
@@ -147,14 +147,12 @@ export class TelemetryService {
       );
     }
 
+    // Capture the event to write — don't rely on queue ordering at execution time
+    const eventToWrite = this.pendingWrites.shift()!;
+
     // Queue the write to prevent concurrent file access issues
     const writePromise = this.writeQueue
-      .then(() => {
-        const eventToWrite = this.pendingWrites.shift();
-        if (eventToWrite) {
-          return this.writeEvent(eventToWrite);
-        }
-      })
+      .then(() => this.writeEvent(eventToWrite))
       .catch((err) => {
         log.error({ err: err }, '[Telemetry] Failed to write event');
       });


### PR DESCRIPTION
## Summary

- **gateway-chat-client**: Add `settled` flag to prevent multiple resolve/reject on the same promise from concurrent timeout, error, and close events
- **file-lock**: Add rejection handler on `previous.then()` in timeout path to prevent unhandled rejections when predecessor fails
- **telemetry-service**: Capture event reference at enqueue time instead of shifting from queue at write time, preventing event loss under concurrency
- **status-history-service**: Await async init before any public method runs, preventing race when `logStatusChange` is called before `loadLastEntry` completes

## Test plan

- [x] Server builds cleanly
- [ ] Manual: verify gateway chat still works end-to-end
- [ ] Manual: verify telemetry events are written without gaps under load
- [ ] Manual: verify status history is correct after rapid status changes on startup

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)