### PR TITLE
fix(api): prevent config cache stampede and log corrupted activity files

### DIFF
--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -174,8 +174,8 @@ export class ActivityService {
         try {
           const content = await readFile(this.activityFile, 'utf-8');
           activities = JSON.parse(content);
-        } catch {
-          // Intentionally silent: corrupted file — reset to empty list
+        } catch (err) {
+          log.warn({ err }, 'Corrupted activity file — resetting to empty list');
           activities = [];
         }
       }

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -134,6 +134,7 @@ export class ConfigService {
   private cacheTimestamp: number = 0;
   private lastWriteTime: number = 0;
   private watcher: FSWatcher | null = null;
+  private pendingRead: Promise<AppConfig> | null = null;
 
   constructor(options: ConfigServiceOptions = {}) {
     this.configDir = options.configDir || CONFIG_DIR;
@@ -191,6 +192,17 @@ export class ConfigService {
   async getConfig(): Promise<AppConfig> {
     if (this.isCacheValid()) return this.config!;
 
+    // Prevent cache stampede: coalesce concurrent reads into a single disk read
+    if (this.pendingRead) return this.pendingRead;
+
+    this.pendingRead = this.readConfigFromDisk().finally(() => {
+      this.pendingRead = null;
+    });
+
+    return this.pendingRead;
+  }
+
+  private async readConfigFromDisk(): Promise<AppConfig> {
     await this.ensureConfigDir();
 
     try {


### PR DESCRIPTION
## Summary

- **config-service**: Coalesce concurrent `getConfig()` calls into a single disk read via `pendingRead` promise, preventing cache stampede when multiple requests hit an expired cache simultaneously
- **activity-service**: Log warning when corrupted activity file is encountered instead of silently resetting to empty array

## Test plan

- [x] Server builds cleanly
- [ ] Manual: concurrent API requests should only trigger one config file read
- [ ] Manual: corrupt the activity file and verify warning appears in logs

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)