### PR TITLE
fix(security): harden localhost bypass and broadcast frontmatter parsing

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -155,13 +155,9 @@ function isLocalhostRequest(req: Request | IncomingMessage): boolean {
     : undefined;
   let remoteAddr: string;
 
+  // In production, never allow localhost bypass regardless of config
   if (process.env.NODE_ENV === 'production') {
-    const config = getAuthConfig();
-    if (config.allowLocalhostBypass) {
-      log.warn(
-        'Localhost bypass is enabled in production; consider disabling VERITAS_AUTH_LOCALHOST_BYPASS.'
-      );
-    }
+    return false;
   }
 
   if ('socket' in req && req.socket) {

--- a/server/src/services/broadcast-storage-service.ts
+++ b/server/src/services/broadcast-storage-service.ts
@@ -68,11 +68,19 @@ function parseBroadcastFile(content: string, id: string): Broadcast {
     } else if (trimmedKey === 'from') {
       frontmatter.from = value;
     } else if (trimmedKey === 'tags') {
-      frontmatter.tags = JSON.parse(value);
+      try {
+        frontmatter.tags = JSON.parse(value);
+      } catch {
+        frontmatter.tags = [];
+      }
     } else if (trimmedKey === 'createdAt') {
       frontmatter.createdAt = value;
     } else if (trimmedKey === 'readBy') {
-      frontmatter.readBy = JSON.parse(value);
+      try {
+        frontmatter.readBy = JSON.parse(value);
+      } catch {
+        frontmatter.readBy = [];
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **auth**: Disable localhost bypass entirely in production mode (`NODE_ENV=production`) instead of just logging a warning — prevents misconfigured deployments from allowing unauthenticated access
- **broadcast-storage**: Wrap `JSON.parse()` for `tags` and `readBy` frontmatter fields in try-catch, defaulting to empty arrays on parse failure instead of crashing the route handler

## Test plan

- [x] Server builds cleanly
- [ ] Manual: set `NODE_ENV=production` and `VERITAS_AUTH_LOCALHOST_BYPASS=true` — verify localhost requests are rejected
- [ ] Manual: create a broadcast file with malformed tags JSON — verify the route returns the broadcast with empty tags instead of 500

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)