### PR TITLE
fix: build shared package before server and web

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "concurrently -n server,web -c blue,green \"pnpm --filter server dev\" \"pnpm --filter web dev\"",
     "dev:clean": "bash scripts/dev-clean.sh",
     "dev:watchdog": "bash scripts/dev-watchdog.sh",
-    "build": "pnpm --filter server build && pnpm --filter web build",
+    "build": "pnpm --filter shared build && pnpm --filter server build && pnpm --filter web build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "pnpm -r typecheck",


### PR DESCRIPTION
## Summary
- build the shared workspace package before server and web in the root build pipeline
- prevent stale `@veritas-kanban/shared` dist types from breaking fresh v4.0.0 builds

## Why
The root build script skipped `shared`, but both `server` and `web` resolve `@veritas-kanban/shared` from `shared/dist`. On a fresh checkout or after cleaning `shared/dist`, `pnpm build` failed with missing shared exports and downstream TypeScript noise.

## Verification
- ran `pnpm --filter shared clean`
- ran `pnpm build`
- verified shared, server, and web all build successfully
