### PR TITLE
fix: isolate status history tests from real state

### DIFF
--- a/server/src/__tests__/status-history-service.test.ts
+++ b/server/src/__tests__/status-history-service.test.ts
@@ -20,9 +20,7 @@ describe('StatusHistoryService', () => {
     await fs.mkdir(configDir, { recursive: true });
     historyFile = path.join(configDir, 'status-history.json');
 
-    // Create service and override private fields
-    service = new StatusHistoryService();
-    (service as any).historyFile = historyFile;
+    service = new StatusHistoryService({ historyFile });
   });
 
   afterEach(async () => {

--- a/server/src/services/status-history-service.ts
+++ b/server/src/services/status-history-service.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { fileExists } from '../storage/fs-helpers.js';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { createLogger } from '../lib/logger.js';
 import { withFileLock } from './file-lock.js';
 const log = createLogger('status-history-service');
@@ -36,36 +36,39 @@ export interface StatusPeriod {
   taskTitle?: string;
 }
 
+export interface StatusHistoryServiceOptions {
+  historyFile?: string;
+}
+
 export class StatusHistoryService {
   private historyFile: string;
   private readonly MAX_ENTRIES = 5000; // Keep more entries for historical analysis
   private lastEntry: StatusHistoryEntry | null = null;
   private initPromise: Promise<void>;
 
-  constructor() {
-    this.historyFile = join(process.cwd(), '.veritas-kanban', 'status-history.json');
-    this.initPromise = this.init();
-  }
-
-  private async init(): Promise<void> {
-    await this.ensureDir();
-    await this.loadLastEntry();
+  constructor(options: StatusHistoryServiceOptions = {}) {
+    this.historyFile =
+      options.historyFile || join(process.cwd(), '.veritas-kanban', 'status-history.json');
+    this.initPromise = this.ensureDir();
   }
 
   private async ensureDir(): Promise<void> {
-    const dir = join(process.cwd(), '.veritas-kanban');
-    await mkdir(dir, { recursive: true });
+    await mkdir(dirname(this.historyFile), { recursive: true });
   }
 
-  private async loadLastEntry(): Promise<void> {
+  private async getLastEntry(): Promise<StatusHistoryEntry | null> {
+    if (this.lastEntry) {
+      return this.lastEntry;
+    }
+
     try {
       const entries = await this.getHistory(1);
-      if (entries.length > 0) {
-        this.lastEntry = entries[0];
-      }
+      this.lastEntry = entries[0] ?? null;
+      return this.lastEntry;
     } catch {
       // Intentionally silent: history file may not exist on first run
       this.lastEntry = null;
+      return null;
     }
   }
 
@@ -100,8 +103,9 @@ export class StatusHistoryService {
 
     // Calculate duration of previous status
     let durationMs: number | undefined;
-    if (this.lastEntry) {
-      const lastTime = new Date(this.lastEntry.timestamp).getTime();
+    const previousEntry = await this.getLastEntry();
+    if (previousEntry) {
+      const lastTime = new Date(previousEntry.timestamp).getTime();
       durationMs = now.getTime() - lastTime;
     }
 


### PR DESCRIPTION
## Summary
- remove constructor-triggered async file I/O from `StatusHistoryService`
- allow injecting `historyFile` so tests can target an isolated temp file from instantiation
- lazily load `lastEntry` only when a write actually needs it

## Why
The unit test was mutating a private path after construction while the service constructor had already started async reads against the real `server/.veritas-kanban/status-history.json`. That is brittle and can surface as CI-only hangs/timeouts depending on runner state.

## Verification
- `cd server && VERITAS_DISABLE_WATCHERS=1 ../node_modules/.bin/vitest run src/__tests__/status-history-service.test.ts --reporter=verbose`
- `cd server && VERITAS_DISABLE_WATCHERS=1 npx -y node@20 /Users/bradgroux/Projects/veritas-kanban/node_modules/.pnpm/vitest@4.0.18_@types+node@25.4.0_jiti@2.6.1_jsdom@29.0.0_@noble+hashes@1.8.0__lightningcss@1._44r25orifossko45wuewzhqn2u/node_modules/vitest/vitest.mjs run src/__tests__/status-history-service.test.ts --reporter=verbose`

## Notes
- Repo-wide server typecheck is currently red for unrelated shared export drift; this PR stays narrowly scoped to the flaky status-history-service path.

Closes #245
VK Task: task_20260322_sCi5Cb