### PR TITLE
fix: build shared before typecheck to prevent export drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "pnpm --filter shared build && pnpm --filter server build && pnpm --filter web build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",
     "test": "vitest run",
     "test:unit": "pnpm -r --workspace-concurrency=1 test",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary

Aligns the root `typecheck` script with CI by building `@veritas-kanban/shared` before running recursive typecheck.

## Problem

The root `typecheck` script ran `pnpm -r typecheck` without building shared first. Since `shared/dist/` is gitignored, 7 newer type module files (drift, decision, evaluation, policy, prompt-registry, system-health, feedback) were missing from dist, causing 80+ TS2305 errors in server typecheck.

## Change

```diff
- "typecheck": "pnpm -r typecheck",
+ "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",
```

One-line change. Matches what CI already does.

## Verification

- `npx tsc --project server/tsconfig.json --noEmit` → 0 errors (was 80+)
- `pnpm --filter shared typecheck` → clean
- `pnpm --filter server typecheck` → clean
- `pnpm --filter cli typecheck` → clean

Closes #247
VK: task_20260322_l9Qj-A