### PR TITLE
test(server): stabilize workflow run service setup

### DIFF
--- a/server/src/__tests__/workflow-run-service.test.ts
+++ b/server/src/__tests__/workflow-run-service.test.ts
@@ -57,6 +57,7 @@ describe('WorkflowRunService', () => {
   beforeEach(async () => {
     vi.resetModules();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workflow-run-'));
+    await fs.mkdir(path.join(tmpDir, '.veritas-kanban', 'workflows'), { recursive: true });
     mockLoadWorkflow.mockResolvedValue(makeWorkflow());
     mockListWorkflowsMetadata.mockResolvedValue([
       { id: 'wf-1', name: 'Workflow One' },


### PR DESCRIPTION
## What this does\n- rebuilds the salvageable workflow test fix from stale PR #258 on top of current main\n- pre-creates the workflow directory in test setup to avoid ENOENT races during workflow run setup\n\n## Why\nThe prior branches (#258, #259, #271) went stale and conflicted with main. This keeps the useful test fix and drops the stale branch baggage.\n\n## Replaces\n- #258\n- #259\n- #271\n\n## Validation\n- pnpm --filter @veritas-kanban/server test -- src/__tests__/workflow-run-service.test.ts src/__tests__/workflow-service.test.ts src/__tests__/delegation-service.test.ts