### PR TITLE
[codex] Fix task popout spacing and harden webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-05-04
+
 ### Fixed
 
+- Restored task detail side-popout spacing after the shadcn/ui v4 sheet padding change
+- Prevented task detail tabs from being squeezed in code-task popouts by allowing horizontal tab overflow
 - Mass archive failure caused by missing `/api/tasks/bulk-archive-by-ids` endpoint
 - MIME validation test fixtures now use valid PNG IHDR chunks (#266)
 - Status history tests isolated from real state
@@ -22,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Required `N8N_WEBHOOK_SECRET` for unauthenticated n8n webhook requests
+- Hardened n8n webhook secret comparison, attachment type checks, filename sanitization, and path containment
+- Patched high and moderate dependency advisories for `@xmldom/xmldom`, `hono`, `postcss`, and `sanitize-html`
 - Hardened localhost bypass and broadcast frontmatter parsing (#242)
 - Startup init failures now fatal with shutdown timeouts (#241)
 - Config cache stampede prevention and corrupted activity file logging (#240)
@@ -1372,7 +1379,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.0...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.1...HEAD
+[4.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v3.3.3...v4.0.0
 [3.3.3]: https://github.com/BradGroux/veritas-kanban/compare/v3.3.2...v3.3.3
 [1.4.1]: https://github.com/BradGroux/veritas-kanban/compare/v1.4.0...v1.4.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built for developers who want a visual Kanban board that works with autonomous c
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.0.1-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -297,7 +297,7 @@ Veritas Kanban is neither. It's the **visual command center for agentic work** �
 | **YAML workflow pipelines**     |      ✅ Loops, gates, parallel      |     ⚠️ Code-defined only     |          ❌           |
 | **Real-time agent dashboard**   |    ✅ Status, model attribution     |              ❌              |          ❌           |
 | **Agent communication**         | ✅ Squad Chat with lifecycle events |       ⚠️ Internal only       |          ❌           |
-| **MCP server**                  |             ✅ 33+ tools            |              ❌              |          ❌           |
+| **MCP server**                  |            ✅ 33+ tools             |              ❌              |          ❌           |
 | **CLI**                         |          ✅ Full lifecycle          |              ❌              |      ⚠️ Limited       |
 | **Git worktrees + code review** |             ✅ Built-in             |              ❌              |          ❌           |
 | **Task persistence**            |          ✅ Markdown files          |         ❌ In-memory         |      ✅ Database      |
@@ -673,19 +673,19 @@ pnpm test:e2e   # E2E tests (Playwright)
 
 ## 📚 Documentation
 
-| Document                                   | Description                      |
-| ------------------------------------------ | -------------------------------- |
-| [Features](docs/FEATURES.md)               | Complete feature reference       |
-| [API Reference](docs/API-REFERENCE.md)     | Auth, endpoints, WebSocket docs  |
-| [CLI Guide](docs/CLI-GUIDE.md)             | Comprehensive CLI usage guide    |
+| Document                                       | Description                                  |
+| ---------------------------------------------- | -------------------------------------------- |
+| [Features](docs/FEATURES.md)                   | Complete feature reference                   |
+| [API Reference](docs/API-REFERENCE.md)         | Auth, endpoints, WebSocket docs              |
+| [CLI Guide](docs/CLI-GUIDE.md)                 | Comprehensive CLI usage guide                |
 | [Self-Hosting Guide](docs/guides/SELF_HOST.md) | Production deployment, reverse proxy, Docker |
-| [Deployment](docs/DEPLOYMENT.md)           | Docker, bare metal, env config   |
-| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common issues & solutions        |
-| [Contributing](CONTRIBUTING.md)            | How to contribute, PR guidelines |
-| [Security Policy](SECURITY.md)             | Vulnerability reporting          |
-| [Code of Conduct](CODE_OF_CONDUCT.md)      | Community guidelines             |
-| [Changelog](CHANGELOG.md)                  | Release history                  |
-| [Sprint Docs](docs/)                       | Sprint planning & audit reports  |
+| [Deployment](docs/DEPLOYMENT.md)               | Docker, bare metal, env config               |
+| [Troubleshooting](docs/TROUBLESHOOTING.md)     | Common issues & solutions                    |
+| [Contributing](CONTRIBUTING.md)                | How to contribute, PR guidelines             |
+| [Security Policy](SECURITY.md)                 | Vulnerability reporting                      |
+| [Code of Conduct](CODE_OF_CONDUCT.md)          | Community guidelines                         |
+| [Changelog](CHANGELOG.md)                      | Release history                              |
+| [Sprint Docs](docs/)                           | Sprint planning & audit reports              |
 
 ---
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",
@@ -59,7 +59,9 @@
   },
   "pnpm": {
     "overrides": {
-      "hono": ">=4.12.2",
+      "@xmldom/xmldom": ">=0.8.13",
+      "hono": ">=4.12.14",
+      "postcss": ">=8.5.10",
       "qs": "^6.14.2",
       "minimatch": ">=10.2.3",
       "path-to-regexp": ">=8.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.2'
+  '@xmldom/xmldom': '>=0.8.13'
+  hono: '>=4.12.14'
+  postcss: '>=8.5.10'
   qs: ^6.14.2
   minimatch: '>=10.2.3'
   path-to-regexp: '>=8.4.0'
@@ -84,8 +86,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       hono:
-        specifier: '>=4.12.2'
-        version: 4.12.12
+        specifier: '>=4.12.14'
+        version: 4.12.16
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -169,8 +171,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       sanitize-html:
-        specifier: ^2.17.2
-        version: 2.17.2
+        specifier: ^2.17.3
+        version: 2.17.3
       simple-git:
         specifier: ^3.36.0
         version: 3.36.0
@@ -354,7 +356,7 @@ importers:
         version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       recharts:
         specifier: ^3.8.1
-        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1)
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@17.0.2)(react@19.2.5)(redux@5.0.1)
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2
@@ -403,7 +405,7 @@ importers:
         version: 5.2.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       autoprefixer:
         specifier: ^10.5.0
-        version: 10.5.0(postcss@8.5.9)
+        version: 10.5.0(postcss@8.5.13)
       eslint:
         specifier: ^9.17.0
         version: 9.38.0(jiti@2.6.1)
@@ -411,8 +413,8 @@ importers:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@1.8.0)
       postcss:
-        specifier: ^8.5.9
-        version: 8.5.9
+        specifier: '>=8.5.10'
+        version: 8.5.13
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.2
@@ -1224,7 +1226,7 @@ packages:
       }
     engines: { node: '>=18.14.1' }
     peerDependencies:
-      hono: '>=4.12.2'
+      hono: '>=4.12.14'
 
   '@humanfs/core@0.19.1':
     resolution:
@@ -3339,12 +3341,12 @@ packages:
         integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==,
       }
 
-  '@xmldom/xmldom@0.8.12':
+  '@xmldom/xmldom@0.9.10':
     resolution:
       {
-        integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==,
+        integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==,
       }
-    engines: { node: '>=10.0.0' }
+    engines: { node: '>=14.6' }
 
   accepts@2.0.0:
     resolution:
@@ -3609,7 +3611,7 @@ packages:
     engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   available-typed-arrays@1.0.7:
     resolution:
@@ -5437,10 +5439,10 @@ packages:
       }
     engines: { node: '>=12.0.0' }
 
-  hono@4.12.12:
+  hono@4.12.16:
     resolution:
       {
-        integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==,
+        integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==,
       }
     engines: { node: '>=16.9.0' }
 
@@ -7461,10 +7463,10 @@ packages:
         integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
       }
 
-  postcss@8.5.9:
+  postcss@8.5.13:
     resolution:
       {
-        integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==,
+        integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -8004,10 +8006,10 @@ packages:
         integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==,
       }
 
-  sanitize-html@2.17.2:
+  sanitize-html@2.17.3:
     resolution:
       {
-        integrity: sha512-EnffJUl46VE9uvZ0XeWzObHLurClLlT12gsOk1cHyP2Ol1P0BnBnsXmShlBmWVJM+dKieQI68R0tsPY5m/B+Jg==,
+        integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==,
       }
 
   saxes@5.0.1:
@@ -8995,6 +8997,7 @@ packages:
       {
         integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@7.0.2:
@@ -9899,9 +9902,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.12)':
+  '@hono/node-server@1.19.14(hono@4.12.16)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.16
 
   '@humanfs/core@0.19.1': {}
 
@@ -9973,7 +9976,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.12)
+      '@hono/node-server': 1.19.14(hono@4.12.16)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9983,7 +9986,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.16
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -11409,7 +11412,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.9.10': {}
 
   accepts@2.0.0:
     dependencies:
@@ -11591,13 +11594,13 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.5.0(postcss@8.5.9):
+  autoprefixer@10.5.0(postcss@8.5.13):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001788
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.9
+      postcss: 8.5.13
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -12780,7 +12783,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.12: {}
+  hono@4.12.16: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -13365,7 +13368,7 @@ snapshots:
 
   mammoth@1.12.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.9.10
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7
@@ -14073,7 +14076,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.9:
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -14326,7 +14329,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1):
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@17.0.2)(react@19.2.5)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
       clsx: 2.1.1
@@ -14336,7 +14339,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
@@ -14527,14 +14530,14 @@ snapshots:
     dependencies:
       truncate-utf8-bytes: 1.0.2
 
-  sanitize-html@2.17.2:
+  sanitize-html@2.17.3:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
       htmlparser2: 10.1.0
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
-      postcss: 8.5.9
+      postcss: 8.5.13
 
   saxes@5.0.1:
     dependencies:
@@ -14633,7 +14636,7 @@ snapshots:
       node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.9
+      postcss: 8.5.13
       postcss-selector-parser: 7.1.1
       prompts: 2.4.2
       recast: 0.23.11
@@ -15231,7 +15234,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.13
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -38,7 +38,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "sanitize-filename": "^1.6.4",
-    "sanitize-html": "^2.17.2",
+    "sanitize-html": "^2.17.3",
     "simple-git": "^3.36.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/server/src/__tests__/routes/webhook-n8n.test.ts
+++ b/server/src/__tests__/routes/webhook-n8n.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+async function createApp() {
+  const { webhookN8nRouter } = await import('../../routes/webhook-n8n.js');
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+  app.use('/api/webhook', webhookN8nRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('n8n webhook route', () => {
+  let attachmentDir: string;
+  let originalSecret: string | undefined;
+  let originalAttachmentDir: string | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    attachmentDir = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-webhook-'));
+    originalSecret = process.env.N8N_WEBHOOK_SECRET;
+    originalAttachmentDir = process.env.CLAWD_ATTACHMENT_DIR;
+    process.env.CLAWD_ATTACHMENT_DIR = attachmentDir;
+  });
+
+  afterEach(async () => {
+    vi.resetModules();
+    if (originalSecret === undefined) {
+      delete process.env.N8N_WEBHOOK_SECRET;
+    } else {
+      process.env.N8N_WEBHOOK_SECRET = originalSecret;
+    }
+    if (originalAttachmentDir === undefined) {
+      delete process.env.CLAWD_ATTACHMENT_DIR;
+    } else {
+      process.env.CLAWD_ATTACHMENT_DIR = originalAttachmentDir;
+    }
+    await fs.rm(attachmentDir, { recursive: true, force: true });
+  });
+
+  it('rejects requests when the webhook secret is not configured', async () => {
+    delete process.env.N8N_WEBHOOK_SECRET;
+    const app = await createApp();
+
+    const res = await request(app).post('/api/webhook/n8n').send({ type: 'email-directive' });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('Webhook secret is not configured');
+  });
+
+  it('rejects requests with an invalid webhook secret', async () => {
+    process.env.N8N_WEBHOOK_SECRET = 'correct-secret';
+    const app = await createApp();
+
+    const res = await request(app)
+      .post('/api/webhook/n8n')
+      .set('x-webhook-secret', 'wrong-secret')
+      .send({ type: 'email-directive' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('sanitizes generated filenames and skips mismatched attachment types', async () => {
+    process.env.N8N_WEBHOOK_SECRET = 'correct-secret';
+    const app = await createApp();
+
+    const res = await request(app)
+      .post('/api/webhook/n8n')
+      .set('x-webhook-secret', 'correct-secret')
+      .send({
+        type: 'email-directive',
+        from: '../../operator@example.com',
+        subject: 'Directive',
+        directive: 'Review this',
+        timestamp: '2026-05-03T12:00:00.000Z',
+        attachments: [
+          {
+            filename: '../notes.txt',
+            mimeType: 'text/plain',
+            data: Buffer.from('hello').toString('base64'),
+          },
+          {
+            filename: 'invoice.exe',
+            mimeType: 'text/plain',
+            data: Buffer.from('nope').toString('base64'),
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.saved).toHaveLength(1);
+    expect(res.body.skipped).toEqual(['invoice.exe']);
+
+    const files = await fs.readdir(attachmentDir);
+    expect(files).toHaveLength(2);
+    expect(files.every((file) => !file.includes('..') && !file.includes('/'))).toBe(true);
+  });
+});

--- a/server/src/routes/webhook-n8n.ts
+++ b/server/src/routes/webhook-n8n.ts
@@ -10,6 +10,7 @@
  */
 import { Router, Request, Response } from 'express';
 import type { Router as RouterType } from 'express';
+import crypto from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
 import { asyncHandler } from '../middleware/async-handler.js';
@@ -33,6 +34,42 @@ const ATTACHMENT_DIR =
 
 const WEBHOOK_SECRET = process.env.N8N_WEBHOOK_SECRET;
 
+function safeCompareSecret(provided: string | string[] | undefined, expected: string): boolean {
+  if (typeof provided !== 'string') return false;
+
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+
+  return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+function sanitizePathSegment(value: string | undefined, fallback: string): string {
+  const sanitized = (value || fallback)
+    .replace(/[/\\]/g, '_')
+    .replace(/[^a-zA-Z0-9._\-() ]/g, '_')
+    .replace(/\.{2,}/g, '.')
+    .slice(0, 120);
+
+  return sanitized || fallback;
+}
+
+function ensureWithinAttachmentDir(filePath: string): void {
+  const base = path.resolve(ATTACHMENT_DIR);
+  const resolved = path.resolve(filePath);
+
+  if (resolved !== base && !resolved.startsWith(base + path.sep)) {
+    throw new Error('Invalid attachment path');
+  }
+}
+
+function formatTimestampForFilename(timestamp: string | undefined): string {
+  const date = timestamp ? new Date(timestamp) : new Date();
+  const safeDate = Number.isNaN(date.getTime()) ? new Date() : date;
+
+  return safeDate.toISOString().replace(/[:.]/g, '-').slice(0, 19);
+}
+
 /**
  * POST /api/webhook/n8n
  * Body: { type: 'email-directive', from, subject, directive, messageId, timestamp, attachments? }
@@ -41,13 +78,15 @@ const WEBHOOK_SECRET = process.env.N8N_WEBHOOK_SECRET;
 router.post(
   '/n8n',
   asyncHandler(async (req: Request, res: Response) => {
-    // Optional shared-secret check
-    if (WEBHOOK_SECRET) {
-      const provided = req.headers['x-webhook-secret'];
-      if (provided !== WEBHOOK_SECRET) {
-        res.status(401).json({ ok: false, error: 'Unauthorized' });
-        return;
-      }
+    if (!WEBHOOK_SECRET) {
+      res.status(503).json({ ok: false, error: 'Webhook secret is not configured' });
+      return;
+    }
+
+    const provided = req.headers['x-webhook-secret'];
+    if (!safeCompareSecret(provided, WEBHOOK_SECRET)) {
+      res.status(401).json({ ok: false, error: 'Unauthorized' });
+      return;
     }
 
     const body = req.body as {
@@ -74,31 +113,30 @@ router.post(
 
     for (const att of body.attachments || []) {
       const ext = path.extname(att.filename).toLowerCase();
-      if (!ALLOWED_EXTENSIONS.has(ext) && !ALLOWED_MIME_TYPES.has(att.mimeType)) {
+      if (!ALLOWED_EXTENSIONS.has(ext) || !ALLOWED_MIME_TYPES.has(att.mimeType)) {
         skipped.push(att.filename);
         continue;
       }
 
-      // Sanitize filename
-      const safeName = att.filename.replace(/[^a-zA-Z0-9._\-() ]/g, '_');
-      const ts = new Date(body.timestamp || Date.now())
-        .toISOString()
-        .replace(/[:.]/g, '-')
-        .slice(0, 19);
-      const destName = `${ts}_${body.from?.split('@')[0] || 'unknown'}_${safeName}`;
+      const safeName = sanitizePathSegment(att.filename, 'attachment');
+      const safeSender = sanitizePathSegment(body.from?.split('@')[0], 'unknown');
+      const ts = formatTimestampForFilename(body.timestamp);
+      const destName = `${ts}_${safeSender}_${safeName}`;
       const destPath = path.join(ATTACHMENT_DIR, destName);
+      ensureWithinAttachmentDir(destPath);
 
       await fs.writeFile(destPath, Buffer.from(att.data, 'base64'));
       saved.push(destName);
     }
 
     // Write a sidecar .json summary for each email-directive
-    const metaName = `${new Date(body.timestamp || Date.now())
-      .toISOString()
-      .replace(/[:.]/g, '-')
-      .slice(0, 19)}_${body.from?.split('@')[0] || 'unknown'}_directive.json`;
+    const safeSender = sanitizePathSegment(body.from?.split('@')[0], 'unknown');
+    const metaName = `${formatTimestampForFilename(body.timestamp)}_${safeSender}_directive.json`;
+    const metaPath = path.join(ATTACHMENT_DIR, metaName);
+    ensureWithinAttachmentDir(metaPath);
+
     await fs.writeFile(
-      path.join(ATTACHMENT_DIR, metaName),
+      metaPath,
       JSON.stringify(
         {
           type: 'email-directive',

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -90,10 +90,10 @@ export function TaskDetailPanel({
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
-        className="w-[700px] sm:max-w-[700px] overflow-hidden flex flex-col"
+        className="w-[700px] sm:max-w-[700px] overflow-hidden flex flex-col p-0"
         aria-label={`Task details: ${localTask.title}`}
       >
-        <SheetHeader className="space-y-1 flex-shrink-0">
+        <SheetHeader className="space-y-1 flex-shrink-0 border-b px-6 py-4 pr-12">
           <div className="flex items-center gap-2 text-muted-foreground">
             {TypeIconComponent && <TypeIconComponent className="h-4 w-4" />}
             <span className="text-xs uppercase tracking-wide">{typeLabel} Task</span>
@@ -123,7 +123,7 @@ export function TaskDetailPanel({
         </SheetHeader>
 
         {/* Action buttons above tabs */}
-        <div className="grid grid-cols-3 gap-2 mt-4 flex-shrink-0">
+        <div className="grid grid-cols-3 gap-2 px-6 pt-4 flex-shrink-0">
           <Button
             variant="outline"
             size="sm"
@@ -176,57 +176,53 @@ export function TaskDetailPanel({
         <Tabs
           value={activeTab}
           onValueChange={setActiveTab}
-          className="flex-1 flex flex-col overflow-hidden mt-3"
+          className="flex-1 flex flex-col overflow-hidden px-6 pt-3 pb-6"
         >
-          <TabsList
-            className={`grid w-full flex-shrink-0 ${isCodeTask ? (taskSettings.enableAttachments ? 'grid-cols-9' : 'grid-cols-8') : taskSettings.enableAttachments ? 'grid-cols-5' : 'grid-cols-4'}`}
-          >
-            <TabsTrigger value="details">Details</TabsTrigger>
-            <TabsTrigger value="progress" className="flex items-center gap-1">
+          <TabsList className="w-full flex-shrink-0 justify-start overflow-x-auto">
+            <TabsTrigger value="details" className="flex-none px-3">
+              Details
+            </TabsTrigger>
+            <TabsTrigger value="progress" className="flex-none px-3">
               <NotebookPen className="h-3 w-3" />
               Progress
             </TabsTrigger>
-            <TabsTrigger value="observations" className="flex items-center gap-1">
+            <TabsTrigger value="observations" className="flex-none px-3">
               <Eye className="h-3 w-3" />
               Observations
             </TabsTrigger>
             {taskSettings.enableAttachments && (
-              <TabsTrigger value="attachments" className="flex items-center gap-1">
+              <TabsTrigger value="attachments" className="flex-none px-3">
                 <Paperclip className="h-3 w-3" />
                 Attachments
               </TabsTrigger>
             )}
             {isCodeTask && (
               <>
-                <TabsTrigger value="git" className="flex items-center gap-1">
+                <TabsTrigger value="git" className="flex-none px-3">
                   <GitBranch className="h-3 w-3" />
                   Git
                 </TabsTrigger>
-                <TabsTrigger value="agent" className="flex items-center gap-1">
+                <TabsTrigger value="agent" className="flex-none px-3">
                   <Bot className="h-3 w-3" />
                   Agent
                 </TabsTrigger>
-                <TabsTrigger
-                  value="changes"
-                  disabled={!hasWorktree}
-                  className="flex items-center gap-1"
-                >
+                <TabsTrigger value="changes" disabled={!hasWorktree} className="flex-none px-3">
                   <FileDiff className="h-3 w-3" />
                   Changes
                 </TabsTrigger>
-                <TabsTrigger value="review" className="flex items-center gap-1">
+                <TabsTrigger value="review" className="flex-none px-3">
                   <ClipboardCheck className="h-3 w-3" />
                   Review
                 </TabsTrigger>
               </>
             )}
-            <TabsTrigger value="metrics" className="flex items-center gap-1">
+            <TabsTrigger value="metrics" className="flex-none px-3">
               <BarChart3 className="h-3 w-3" />
               Metrics
             </TabsTrigger>
           </TabsList>
 
-          <div className="flex-1 overflow-y-auto mt-4">
+          <div className="flex-1 overflow-y-auto mt-4 pr-1">
             {/* Details Tab */}
             <TabsContent value="details" className="mt-0">
               <TaskDetailsTab


### PR DESCRIPTION
## Summary
- restore task detail side-popout padding and make crowded task tabs horizontally scrollable
- harden the unauthenticated n8n webhook with required secret validation, constant-time comparison, safer attachment filtering, filename sanitization, and path containment
- bump release/package metadata to 4.0.1 and patch dependency advisories for @xmldom/xmldom, hono, postcss, and sanitize-html

## Validation
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server test -- src/__tests__/routes/webhook-n8n.test.ts
- pnpm --filter @veritas-kanban/web build
- pnpm --filter @veritas-kanban/server build
- pnpm audit --prod (one remaining moderate advisory: exceljs@4.4.0 -> uuid@8.3.2)

## Notes
The remaining audit item is transitive through exceljs and requires an upstream-compatible dependency update rather than a simple major-version override.