### PR TITLE
feat: add QMD search UI

### DIFF
--- a/docs/features/qmd-search.md
+++ b/docs/features/qmd-search.md
@@ -56,9 +56,14 @@ curl -X POST http://localhost:3001/api/search \
 
 The response includes `backend`, `degraded`, and optional `reason` fields so clients can show whether QMD or fallback search served the request.
 
+## App UI
+
+Open the search dialog from the header search icon or the command palette action named **Search Tasks and Docs**. The dialog can query active tasks, archived tasks, and docs, and it shows whether the response came from QMD or keyword fallback.
+
+Task results open directly in the board detail panel when the result path maps to a task markdown file.
+
 ## Next v4.1 PRs
 
-- Search UI
 - Duplicate detection hints during task creation
 - VERITAS context injection
 - Scheduled QMD update/embed maintenance

--- a/web/src/__tests__/SearchDialog.test.tsx
+++ b/web/src/__tests__/SearchDialog.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SearchDialog, extractTaskId } from '@/components/search';
+import { api } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    search: {
+      query: vi.fn(),
+    },
+  },
+}));
+
+const queryMock = vi.mocked(api.search.query);
+
+describe('SearchDialog', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('extracts task ids from task markdown paths', () => {
+    expect(extractTaskId('tasks/active/task_20260504_abc123-build-search.md')).toBe(
+      'task_20260504_abc123'
+    );
+    expect(extractTaskId('docs/features/qmd-search.md')).toBeNull();
+  });
+
+  it('searches selected collections and renders fallback status', async () => {
+    queryMock.mockResolvedValue({
+      query: 'qmd',
+      backend: 'keyword',
+      degraded: true,
+      reason: 'qmd unavailable',
+      elapsedMs: 4,
+      results: [
+        {
+          id: 'tasks/active/task_20260504_abc123-build-search.md',
+          title: 'Build search UI',
+          path: 'tasks/active/task_20260504_abc123-build-search.md',
+          collection: 'tasks-active',
+          snippet: 'Search active tasks, archive, and docs.',
+          score: 4,
+        },
+      ],
+    });
+
+    render(<SearchDialog open onOpenChange={vi.fn()} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/search task titles/i), 'qmd');
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    await waitFor(() => expect(queryMock).toHaveBeenCalledTimes(1));
+    expect(queryMock).toHaveBeenCalledWith({
+      query: 'qmd',
+      backend: 'auto',
+      collections: ['tasks-active', 'tasks-archive', 'docs'],
+      limit: 12,
+    });
+    expect(await screen.findByText('Build search UI')).toBeDefined();
+    expect(screen.getByText('Fallback')).toBeDefined();
+    expect(screen.getByText('qmd unavailable')).toBeDefined();
+  });
+
+  it('opens task results through the supplied navigation callback', async () => {
+    const onTaskOpen = vi.fn();
+    const onOpenChange = vi.fn();
+    queryMock.mockResolvedValue({
+      query: 'task',
+      backend: 'keyword',
+      degraded: false,
+      elapsedMs: 2,
+      results: [
+        {
+          id: 'tasks/active/task_20260504_abc123-build-search.md',
+          title: 'Build search UI',
+          path: 'tasks/active/task_20260504_abc123-build-search.md',
+          collection: 'tasks-active',
+          snippet: '',
+          score: 2,
+        },
+      ],
+    });
+
+    render(<SearchDialog open onOpenChange={onOpenChange} onTaskOpen={onTaskOpen} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/search task titles/i), 'task');
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    fireEvent.click(await screen.findByText('Build search UI'));
+
+    expect(onTaskOpen).toHaveBeenCalledWith('task_20260504_abc123');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/components/layout/CommandPalette.tsx
+++ b/web/src/components/layout/CommandPalette.tsx
@@ -15,9 +15,11 @@ import {
   Keyboard,
   Activity,
   GitBranch,
+  Sparkles,
 } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { cn } from '@/lib/utils';
+import { SearchDialog } from '@/components/search';
 
 interface CommandItem {
   id: string;
@@ -31,13 +33,14 @@ interface CommandItem {
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
   const { openCreateDialog, isHelpOpen } = useKeyboard();
-  const { setView } = useView();
+  const { setView, navigateToTask } = useView();
   const { theme, setTheme } = useTheme();
 
   const commands: CommandItem[] = useMemo(
@@ -59,6 +62,14 @@ export function CommandPalette() {
         category: 'Actions',
         action: () => setTheme(theme === 'dark' ? 'light' : 'dark'),
         keywords: ['theme', 'dark', 'light', 'mode', 'appearance'],
+      },
+      {
+        id: 'open-search',
+        label: 'Search Tasks and Docs',
+        icon: <Sparkles className="h-4 w-4" />,
+        category: 'Actions',
+        action: () => setSearchOpen(true),
+        keywords: ['qmd', 'semantic', 'retrieval', 'docs', 'archive'],
       },
 
       // Navigation
@@ -268,75 +279,83 @@ export function CommandPalette() {
   let flatIndex = -1;
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="max-w-[520px] p-0 gap-0 overflow-hidden" onKeyDown={handleKeyDown}>
-        {/* Search input */}
-        <div className="flex items-center gap-3 px-4 border-b">
-          <Search className="h-4 w-4 text-muted-foreground shrink-0" />
-          <input
-            ref={inputRef}
-            value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setSelectedIndex(0);
-            }}
-            placeholder="Type a command or search..."
-            aria-label="Search commands"
-            className="flex-1 h-12 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-          />
-          <kbd className="hidden sm:inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
-            ESC
-          </kbd>
-        </div>
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="max-w-[520px] p-0 gap-0 overflow-hidden"
+          onKeyDown={handleKeyDown}
+        >
+          {/* Search input */}
+          <div className="flex items-center gap-3 px-4 border-b">
+            <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelectedIndex(0);
+              }}
+              placeholder="Type a command or search..."
+              aria-label="Search commands"
+              className="flex-1 h-12 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+            <kbd className="hidden sm:inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
+              ESC
+            </kbd>
+          </div>
 
-        {/* Results */}
-        <div ref={listRef} className="max-h-[320px] overflow-y-auto p-2">
-          {filtered.length === 0 ? (
-            <div className="py-6 text-center text-sm text-muted-foreground">No commands found</div>
-          ) : (
-            grouped.map((group) => (
-              <div key={group.category}>
-                <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-                  {group.category}
-                </div>
-                {group.items.map((cmd) => {
-                  flatIndex++;
-                  const idx = flatIndex;
-                  return (
-                    <button
-                      key={cmd.id}
-                      data-index={idx}
-                      className={cn(
-                        'flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm transition-colors',
-                        idx === selectedIndex
-                          ? 'bg-primary/10 text-primary'
-                          : 'text-foreground hover:bg-muted/50'
-                      )}
-                      onClick={() => runCommand(cmd)}
-                      onMouseEnter={() => setSelectedIndex(idx)}
-                    >
-                      <span
-                        className={cn(
-                          'shrink-0',
-                          idx === selectedIndex ? 'text-primary' : 'text-muted-foreground'
-                        )}
-                      >
-                        {cmd.icon}
-                      </span>
-                      <span className="flex-1 text-left">{cmd.label}</span>
-                      {cmd.shortcut && (
-                        <kbd className="ml-auto hidden sm:inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
-                          {cmd.shortcut}
-                        </kbd>
-                      )}
-                    </button>
-                  );
-                })}
+          {/* Results */}
+          <div ref={listRef} className="max-h-[320px] overflow-y-auto p-2">
+            {filtered.length === 0 ? (
+              <div className="py-6 text-center text-sm text-muted-foreground">
+                No commands found
               </div>
-            ))
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+            ) : (
+              grouped.map((group) => (
+                <div key={group.category}>
+                  <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                    {group.category}
+                  </div>
+                  {group.items.map((cmd) => {
+                    flatIndex++;
+                    const idx = flatIndex;
+                    return (
+                      <button
+                        key={cmd.id}
+                        data-index={idx}
+                        className={cn(
+                          'flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm transition-colors',
+                          idx === selectedIndex
+                            ? 'bg-primary/10 text-primary'
+                            : 'text-foreground hover:bg-muted/50'
+                        )}
+                        onClick={() => runCommand(cmd)}
+                        onMouseEnter={() => setSelectedIndex(idx)}
+                      >
+                        <span
+                          className={cn(
+                            'shrink-0',
+                            idx === selectedIndex ? 'text-primary' : 'text-muted-foreground'
+                          )}
+                        >
+                          {cmd.icon}
+                        </span>
+                        <span className="flex-1 text-left">{cmd.label}</span>
+                        {cmd.shortcut && (
+                          <kbd className="ml-auto hidden sm:inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
+                            {cmd.shortcut}
+                          </kbd>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+      <SearchDialog open={searchOpen} onOpenChange={setSearchOpen} onTaskOpen={navigateToTask} />
+    </>
   );
 }

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -22,6 +22,7 @@ import { SettingsDialog } from '@/components/settings/SettingsDialog';
 // ArchiveSidebar removed — replaced with full-page ArchivePage
 import { ChatPanel } from '@/components/chat/ChatPanel';
 import { SquadChatPanel } from '@/components/chat/SquadChatPanel';
+import { SearchDialog } from '@/components/search';
 import { UserMenu } from './UserMenu';
 import { WebSocketIndicator } from '@/components/shared/WebSocketIndicator';
 import { useState, useCallback } from 'react';
@@ -35,12 +36,13 @@ export function Header() {
   const [createOpen, setCreateOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<string | undefined>();
+  const [searchOpen, setSearchOpen] = useState(false);
   // activityOpen removed — sidebar merged into feed (GH-66)
   // archiveOpen removed — archive is now a full page view
   const [chatOpen, setChatOpen] = useState(false);
   const [squadChatOpen, setSquadChatOpen] = useState(false);
   const { setOpenCreateDialog, setOpenChatPanel } = useKeyboard();
-  const { view, setView } = useView();
+  const { view, setView, navigateToTask } = useView();
   const { data: backlogCount = 0 } = useBacklogCount();
   const { theme, setTheme } = useTheme();
 
@@ -171,6 +173,15 @@ export function Header() {
             <Button
               variant="ghost"
               size="icon"
+              onClick={() => setSearchOpen(true)}
+              aria-label="Search"
+              title="Search"
+            >
+              <Search className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={() => setSquadChatOpen(true)}
               aria-label="Squad Chat"
               title="Squad Chat — Agent communication"
@@ -230,6 +241,7 @@ export function Header() {
       />
       <ChatPanel open={chatOpen} onOpenChange={setChatOpen} />
       <SquadChatPanel open={squadChatOpen} onOpenChange={setSquadChatOpen} />
+      <SearchDialog open={searchOpen} onOpenChange={setSearchOpen} onTaskOpen={navigateToTask} />
     </header>
   );
 }

--- a/web/src/components/search/SearchDialog.tsx
+++ b/web/src/components/search/SearchDialog.tsx
@@ -1,0 +1,250 @@
+import { useMemo, useState } from 'react';
+import { Archive, FileText, Loader2, Search, ShieldAlert, Sparkles } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { api, type SearchBackend, type SearchCollection, type SearchResponse } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+const COLLECTIONS: { id: SearchCollection; label: string }[] = [
+  { id: 'tasks-active', label: 'Active' },
+  { id: 'tasks-archive', label: 'Archive' },
+  { id: 'docs', label: 'Docs' },
+];
+
+const BACKENDS: { id: SearchBackend; label: string }[] = [
+  { id: 'auto', label: 'Auto' },
+  { id: 'keyword', label: 'Keyword' },
+  { id: 'qmd', label: 'QMD' },
+];
+
+interface SearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onTaskOpen?: (taskId: string) => void;
+}
+
+function extractTaskId(path: string): string | null {
+  const fileName = path.split('/').pop() ?? '';
+  const match = fileName.match(/^(task_[^./]+?)(?:-[^/]*)?\.md$/);
+  return match?.[1] ?? null;
+}
+
+function collectionIcon(collection: string) {
+  if (collection === 'docs') return FileText;
+  if (collection === 'tasks-archive') return Archive;
+  return Search;
+}
+
+export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogProps) {
+  const [query, setQuery] = useState('');
+  const [backend, setBackend] = useState<SearchBackend>('auto');
+  const [collections, setCollections] = useState<SearchCollection[]>(
+    COLLECTIONS.map((collection) => collection.id)
+  );
+  const [response, setResponse] = useState<SearchResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const trimmedQuery = query.trim();
+  const canSearch = trimmedQuery.length > 0 && collections.length > 0 && !isSearching;
+
+  const resultCount = response?.results.length ?? 0;
+  const statusLabel = useMemo(() => {
+    if (!response) return null;
+    const noun = resultCount === 1 ? 'result' : 'results';
+    return `${resultCount} ${noun} from ${response.backend}`;
+  }, [response, resultCount]);
+
+  const runSearch = async () => {
+    if (!canSearch) return;
+
+    setIsSearching(true);
+    setError(null);
+    try {
+      const nextResponse = await api.search.query({
+        query: trimmedQuery,
+        backend,
+        collections,
+        limit: 12,
+      });
+      setResponse(nextResponse);
+    } catch (err) {
+      setResponse(null);
+      setError(err instanceof Error ? err.message : 'Search failed');
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const toggleCollection = (collection: SearchCollection, checked: boolean) => {
+    setCollections((current) => {
+      if (checked) return Array.from(new Set([...current, collection]));
+      return current.filter((item) => item !== collection);
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl gap-0 overflow-hidden p-0">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
+            Search Tasks and Docs
+          </DialogTitle>
+          <DialogDescription>
+            Find active work, archived decisions, and project documentation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 px-5 py-4">
+          <form
+            className="flex flex-col gap-3 sm:flex-row"
+            onSubmit={(event) => {
+              event.preventDefault();
+              runSearch();
+            }}
+          >
+            <div className="relative min-w-0 flex-1">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search task titles, descriptions, notes, docs..."
+                className="pl-9"
+                autoFocus
+              />
+            </div>
+            <Select value={backend} onValueChange={(value) => setBackend(value as SearchBackend)}>
+              <SelectTrigger className="w-full sm:w-32" aria-label="Search backend">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {BACKENDS.map((item) => (
+                  <SelectItem key={item.id} value={item.id}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button type="submit" disabled={!canSearch} className="gap-2">
+              {isSearching ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Search className="h-4 w-4" aria-hidden="true" />
+              )}
+              Search
+            </Button>
+          </form>
+
+          <div className="flex flex-wrap items-center gap-3">
+            {COLLECTIONS.map((collection) => (
+              <Label
+                key={collection.id}
+                className="flex h-8 items-center gap-2 rounded-md border px-3 text-sm font-normal"
+              >
+                <Checkbox
+                  checked={collections.includes(collection.id)}
+                  onCheckedChange={(checked) => toggleCollection(collection.id, checked === true)}
+                />
+                {collection.label}
+              </Label>
+            ))}
+            {response?.degraded && (
+              <Badge variant="outline" className="gap-1 border-amber-500/40 text-amber-700">
+                <ShieldAlert className="h-3 w-3" aria-hidden="true" />
+                Fallback
+              </Badge>
+            )}
+            {statusLabel && <span className="text-sm text-muted-foreground">{statusLabel}</span>}
+          </div>
+
+          {error && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="max-h-[460px] overflow-y-auto rounded-md border">
+            {!response && !error ? (
+              <div className="px-4 py-10 text-center text-sm text-muted-foreground">
+                Search across task markdown and docs.
+              </div>
+            ) : response && response.results.length === 0 ? (
+              <div className="px-4 py-10 text-center text-sm text-muted-foreground">
+                No matches found.
+              </div>
+            ) : (
+              response?.results.map((result) => {
+                const Icon = collectionIcon(result.collection);
+                const taskId = result.collection.startsWith('tasks')
+                  ? extractTaskId(result.path)
+                  : null;
+
+                return (
+                  <button
+                    key={`${result.collection}:${result.id}`}
+                    type="button"
+                    className={cn(
+                      'flex w-full gap-3 border-b px-4 py-3 text-left transition-colors last:border-b-0',
+                      taskId ? 'hover:bg-muted/60' : 'cursor-default'
+                    )}
+                    onClick={() => {
+                      if (!taskId) return;
+                      onTaskOpen?.(taskId);
+                      onOpenChange(false);
+                    }}
+                  >
+                    <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 flex-1">
+                      <span className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium text-foreground">{result.title}</span>
+                        <Badge variant="secondary">{result.collection}</Badge>
+                      </span>
+                      <span className="mt-1 block break-all text-xs text-muted-foreground">
+                        {result.path}
+                      </span>
+                      {result.snippet && (
+                        <span className="mt-2 block text-sm leading-6 text-muted-foreground">
+                          {result.snippet}
+                        </span>
+                      )}
+                    </span>
+                    <span className="text-xs tabular-nums text-muted-foreground">
+                      {Number(result.score).toFixed(2)}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          {response?.degraded && response.reason && (
+            <p className="text-xs text-muted-foreground">{response.reason}</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { extractTaskId };

--- a/web/src/components/search/index.ts
+++ b/web/src/components/search/index.ts
@@ -1,0 +1,1 @@
+export { SearchDialog, extractTaskId } from './SearchDialog';

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -42,7 +42,13 @@ export const api = {
   search: searchApi,
 };
 
-export type { SearchRequest, SearchResponse, SearchResult } from './search';
+export type {
+  SearchBackend,
+  SearchCollection,
+  SearchRequest,
+  SearchResponse,
+  SearchResult,
+} from './search';
 
 // Re-export managed list helper
 export { managedList } from './managed-list';


### PR DESCRIPTION
## Summary
- add a header and command-palette search dialog for tasks, archives, and docs
- expose backend and collection controls with degraded/fallback status
- open task markdown results directly in the board detail flow
- update QMD search docs for the app UI

## Verification
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/SearchDialog.test.tsx`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm --filter @veritas-kanban/web lint` (passes with existing warnings)

Refs #171
Closes #286