### PR TITLE
feat: flag possible duplicate tasks

### DIFF
--- a/docs/features/qmd-search.md
+++ b/docs/features/qmd-search.md
@@ -62,8 +62,11 @@ Open the search dialog from the header search icon or the command palette action
 
 Task results open directly in the board detail panel when the result path maps to a task markdown file.
 
+## Duplicate Detection
+
+The create-task dialog checks active and archived task collections after the title has enough signal. Possible matches are shown inline and can be opened for inspection, but task creation remains available so intentional follow-up work is not blocked.
+
 ## Next v4.1 PRs
 
-- Duplicate detection hints during task creation
 - VERITAS context injection
 - Scheduled QMD update/embed maintenance

--- a/web/src/__tests__/CreateTaskDuplicateDetection.test.tsx
+++ b/web/src/__tests__/CreateTaskDuplicateDetection.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { CreateTaskDialog } from '@/components/task/CreateTaskDialog';
+import { api } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    search: {
+      query: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/hooks/useTaskTypes', () => ({
+  useTaskTypes: () => ({
+    data: [{ id: 'code', label: 'Code', icon: 'Code', order: 0, created: '', updated: '' }],
+  }),
+  getTypeIcon: () => null,
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProjects: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/useSprints', () => ({
+  useSprints: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({ data: { agents: [] } }),
+}));
+
+vi.mock('@/hooks/useTemplateForm', () => ({
+  useTemplateForm: () => ({
+    selectedTemplate: null,
+    templates: [],
+    subtasks: [],
+    customVars: {},
+    requiredCustomVars: [],
+    applyTemplate: vi.fn(),
+    clearTemplate: vi.fn(),
+    removeSubtask: vi.fn(),
+    setCustomVars: vi.fn(),
+    createTasks: vi.fn(),
+    isCreating: false,
+  }),
+}));
+
+const navigateToTaskMock = vi.fn();
+
+vi.mock('@/contexts/ViewContext', () => ({
+  useView: () => ({
+    navigateToTask: navigateToTaskMock,
+  }),
+}));
+
+const queryMock = vi.mocked(api.search.query);
+
+describe('CreateTaskDialog duplicate detection', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    navigateToTaskMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows likely duplicates without blocking task creation', async () => {
+    queryMock.mockResolvedValue({
+      query: 'Search duplicate',
+      backend: 'keyword',
+      degraded: false,
+      elapsedMs: 3,
+      results: [
+        {
+          id: 'tasks/active/task_20260504_match-search-duplicate.md',
+          title: 'Existing Search Duplicate',
+          path: 'tasks/active/task_20260504_match-search-duplicate.md',
+          collection: 'tasks-active',
+          snippet: 'Already covers duplicate detection.',
+          score: 5,
+        },
+      ],
+    });
+
+    const onOpenChange = vi.fn();
+    render(<CreateTaskDialog open onOpenChange={onOpenChange} />);
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Search duplicate' },
+    });
+
+    await waitFor(() => expect(queryMock).toHaveBeenCalledTimes(1));
+    expect(queryMock).toHaveBeenCalledWith({
+      query: 'Search duplicate',
+      backend: 'auto',
+      collections: ['tasks-active', 'tasks-archive'],
+      limit: 5,
+    });
+    expect(await screen.findByText('Existing Search Duplicate')).toBeDefined();
+    expect(
+      (screen.getByRole('button', { name: /^create task$/i }) as HTMLButtonElement).disabled
+    ).toBe(false);
+  });
+
+  it('opens a duplicate result for inspection', async () => {
+    queryMock.mockResolvedValue({
+      query: 'Search duplicate',
+      backend: 'keyword',
+      degraded: false,
+      elapsedMs: 3,
+      results: [
+        {
+          id: 'tasks/archive/task_20260504_match-search-duplicate.md',
+          title: 'Archived Search Duplicate',
+          path: 'tasks/archive/task_20260504_match-search-duplicate.md',
+          collection: 'tasks-archive',
+          snippet: '',
+          score: 4,
+        },
+      ],
+    });
+
+    const onOpenChange = vi.fn();
+    render(<CreateTaskDialog open onOpenChange={onOpenChange} />);
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Search duplicate' },
+    });
+
+    fireEvent.click(await screen.findByText('Archived Search Duplicate'));
+
+    expect(navigateToTaskMock).toHaveBeenCalledWith('task_20260504_match');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/components/search/SearchDialog.tsx
+++ b/web/src/components/search/SearchDialog.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { api, type SearchBackend, type SearchCollection, type SearchResponse } from '@/lib/api';
+import { extractTaskId } from '@/lib/search-utils';
 import { cn } from '@/lib/utils';
 
 const COLLECTIONS: { id: SearchCollection; label: string }[] = [
@@ -38,12 +39,6 @@ interface SearchDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onTaskOpen?: (taskId: string) => void;
-}
-
-function extractTaskId(path: string): string | null {
-  const fileName = path.split('/').pop() ?? '';
-  const match = fileName.match(/^(task_[^./]+?)(?:-[^/]*)?\.md$/);
-  return match?.[1] ?? null;
 }
 
 function collectionIcon(collection: string) {

--- a/web/src/components/task/CreateTaskDialog.tsx
+++ b/web/src/components/task/CreateTaskDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -27,8 +27,21 @@ import { useCreateTaskForm } from '@/hooks/useCreateTaskForm';
 import { BlueprintPreview } from './create/BlueprintPreview';
 import { TemplateVariableInputs } from './create/TemplateVariableInputs';
 import type { TaskPriority } from '@veritas-kanban/shared';
-import { FileText, X, Check, HelpCircle, Info } from 'lucide-react';
+import {
+  AlertTriangle,
+  Check,
+  ExternalLink,
+  FileText,
+  HelpCircle,
+  Info,
+  Loader2,
+  X,
+} from 'lucide-react';
 import { getCategoryIcon } from '@/lib/template-categories';
+import { api, type SearchResult } from '@/lib/api';
+import { extractTaskId } from '@/lib/search-utils';
+import { Badge } from '@/components/ui/badge';
+import { useView } from '@/contexts/ViewContext';
 
 interface CreateTaskDialogProps {
   open: boolean;
@@ -36,6 +49,10 @@ interface CreateTaskDialogProps {
 }
 
 export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) {
+  const { navigateToTask } = useView();
+  const [duplicateResults, setDuplicateResults] = useState<SearchResult[]>([]);
+  const [duplicateError, setDuplicateError] = useState<string | null>(null);
+  const [isCheckingDuplicates, setIsCheckingDuplicates] = useState(false);
   // Consolidated form state via useReducer
   const {
     state: formState,
@@ -120,6 +137,49 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
     ? templates?.find((t) => t.id === selectedTemplate)
     : null;
   const isBlueprint = Boolean(currentTemplate?.blueprint && currentTemplate.blueprint.length > 0);
+
+  useEffect(() => {
+    const query = [title, description].filter(Boolean).join(' ').trim();
+    if (!open || isBlueprint || title.trim().length < 4) {
+      setDuplicateResults([]);
+      setDuplicateError(null);
+      setIsCheckingDuplicates(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsCheckingDuplicates(true);
+    const timer = window.setTimeout(async () => {
+      try {
+        const response = await api.search.query({
+          query,
+          backend: 'auto',
+          collections: ['tasks-active', 'tasks-archive'],
+          limit: 5,
+        });
+
+        if (cancelled) return;
+        const normalizedTitle = title.trim().toLowerCase();
+        setDuplicateResults(
+          response.results
+            .filter((result) => result.title.trim().toLowerCase() !== normalizedTitle)
+            .slice(0, 3)
+        );
+        setDuplicateError(response.degraded ? response.reason || null : null);
+      } catch (err) {
+        if (cancelled) return;
+        setDuplicateResults([]);
+        setDuplicateError(err instanceof Error ? err.message : 'Duplicate check failed');
+      } finally {
+        if (!cancelled) setIsCheckingDuplicates(false);
+      }
+    }, 500);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [description, isBlueprint, open, title]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -269,6 +329,72 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
                     rows={3}
                   />
                 </div>
+
+                {(isCheckingDuplicates || duplicateResults.length > 0 || duplicateError) && (
+                  <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        <AlertTriangle className="h-4 w-4 text-amber-600" aria-hidden="true" />
+                        Possible duplicates
+                      </div>
+                      {isCheckingDuplicates && (
+                        <Loader2
+                          className="h-4 w-4 animate-spin text-muted-foreground"
+                          aria-label="Checking duplicates"
+                        />
+                      )}
+                    </div>
+                    {duplicateResults.length > 0 ? (
+                      <div className="mt-2 space-y-2">
+                        {duplicateResults.map((result) => {
+                          const taskId = extractTaskId(result.path);
+                          return (
+                            <button
+                              key={`${result.collection}:${result.id}`}
+                              type="button"
+                              className="flex w-full items-start gap-2 rounded-md border bg-background px-3 py-2 text-left transition-colors hover:bg-muted/50"
+                              onClick={() => {
+                                if (!taskId) return;
+                                navigateToTask(taskId);
+                                onOpenChange(false);
+                              }}
+                            >
+                              <span className="min-w-0 flex-1">
+                                <span className="flex flex-wrap items-center gap-2">
+                                  <span className="text-sm font-medium">{result.title}</span>
+                                  <Badge variant="secondary">{result.collection}</Badge>
+                                </span>
+                                <span className="mt-1 block break-all text-xs text-muted-foreground">
+                                  {result.path}
+                                </span>
+                                {result.snippet && (
+                                  <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                                    {result.snippet}
+                                  </span>
+                                )}
+                              </span>
+                              {taskId && (
+                                <ExternalLink
+                                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                                  aria-hidden="true"
+                                />
+                              )}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      !isCheckingDuplicates && (
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          No likely task duplicates found.
+                        </p>
+                      )
+                    )}
+                    {duplicateError && (
+                      <p className="mt-2 text-xs text-muted-foreground">{duplicateError}</p>
+                    )}
+                  </div>
+                )}
 
                 <div className="grid grid-cols-2 gap-4">
                   <div className="grid gap-2">

--- a/web/src/lib/search-utils.ts
+++ b/web/src/lib/search-utils.ts
@@ -1,0 +1,5 @@
+export function extractTaskId(path: string): string | null {
+  const fileName = path.split('/').pop() ?? '';
+  const match = fileName.match(/^(task_[^./]+?)(?:-[^/]*)?\.md$/);
+  return match?.[1] ?? null;
+}


### PR DESCRIPTION
## Summary
- check active and archived task collections while creating a new task
- show possible duplicate matches inline without blocking task creation
- let users open a matching task for inspection
- move task path parsing into a shared search utility

## Verification
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/CreateTaskDuplicateDetection.test.tsx`
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/SearchDialog.test.tsx`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm --filter @veritas-kanban/web lint` (passes with existing warnings)

Refs #171
Closes #287