### PR TITLE
feat: inject VERITAS retrieval context

### DIFF
--- a/docs/features/qmd-search.md
+++ b/docs/features/qmd-search.md
@@ -66,7 +66,12 @@ Task results open directly in the board detail panel when the result path maps t
 
 The create-task dialog checks active and archived task collections after the title has enough signal. Possible matches are shown inline and can be opened for inspection, but task creation remains available so intentional follow-up work is not blocked.
 
+## VERITAS Context Injection
+
+VERITAS chat sends retrieve compact supporting context from active tasks, archived tasks, and docs before calling the gateway. The original user message is still saved unchanged; retrieved context is appended only to the gateway prompt inside a `<veritas_context>` block with source paths.
+
+Clients can opt out per chat send by passing `includeContext: false`.
+
 ## Next v4.1 PRs
 
-- VERITAS context injection
 - Scheduled QMD update/embed maintenance

--- a/server/src/__tests__/routes/chat.test.ts
+++ b/server/src/__tests__/routes/chat.test.ts
@@ -10,7 +10,7 @@ import express from 'express';
 
 // ── Mock dependencies before importing route ─────────────────────────────────
 
-const { mockChatService } = vi.hoisted(() => ({
+const { mockChatService, mockSendGatewayChat, mockBuildContext } = vi.hoisted(() => ({
   mockChatService: {
     getSession: vi.fn(),
     getSessionForTask: vi.fn(),
@@ -21,6 +21,8 @@ const { mockChatService } = vi.hoisted(() => ({
     sendSquadMessage: vi.fn(),
     getSquadMessages: vi.fn(),
   },
+  mockSendGatewayChat: vi.fn().mockResolvedValue(undefined),
+  mockBuildContext: vi.fn(),
 }));
 
 vi.mock('../../services/chat-service.js', () => ({
@@ -28,8 +30,14 @@ vi.mock('../../services/chat-service.js', () => ({
 }));
 
 vi.mock('../../services/gateway-chat-client.js', () => ({
-  sendGatewayChat: vi.fn().mockResolvedValue(undefined),
+  sendGatewayChat: mockSendGatewayChat,
   loadGatewayToken: vi.fn().mockResolvedValue('token'),
+}));
+
+vi.mock('../../services/veritas-context-service.js', () => ({
+  getVeritasContextService: () => ({
+    buildContext: mockBuildContext,
+  }),
 }));
 
 vi.mock('../../services/broadcast-service.js', () => ({
@@ -111,6 +119,7 @@ describe('Chat Routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBuildContext.mockResolvedValue({ contextBlock: '', results: [], degraded: false });
     app = buildApp(true);
   });
 
@@ -186,6 +195,41 @@ describe('Chat Routes', () => {
     it('accepts valid mode: build', async () => {
       const res = await request(app).post('/send').send({ message: 'hi', mode: 'build' });
       expect(res.status).toBe(200);
+    });
+
+    it('injects retrieval context for VERITAS gateway messages', async () => {
+      mockBuildContext.mockResolvedValue({
+        contextBlock: '<veritas_context>\nRelevant task\n</veritas_context>',
+        results: [],
+        degraded: false,
+      });
+
+      const res = await request(app).post('/send').send({ message: 'what overlaps?' });
+
+      expect(res.status).toBe(200);
+      expect(mockBuildContext).toHaveBeenCalledWith({
+        message: 'what overlaps?',
+        taskId: undefined,
+      });
+      expect(mockSendGatewayChat).toHaveBeenCalledWith(
+        'what overlaps?\n\n<veritas_context>\nRelevant task\n</veritas_context>',
+        'kanban-chat-sess_1',
+        expect.any(Object)
+      );
+    });
+
+    it('skips retrieval context when requested', async () => {
+      const res = await request(app)
+        .post('/send')
+        .send({ message: 'plain chat', includeContext: false });
+
+      expect(res.status).toBe(200);
+      expect(mockBuildContext).not.toHaveBeenCalled();
+      expect(mockSendGatewayChat).toHaveBeenCalledWith(
+        'plain chat',
+        'kanban-chat-sess_1',
+        expect.any(Object)
+      );
     });
 
     it('accepts optional taskId and sessionId', async () => {

--- a/server/src/__tests__/veritas-context-service.test.ts
+++ b/server/src/__tests__/veritas-context-service.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { VeritasContextService } from '../services/veritas-context-service.js';
+
+const searchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../services/search-service.js', () => ({
+  getSearchService: () => ({
+    search: searchMock,
+  }),
+}));
+
+describe('VeritasContextService', () => {
+  beforeEach(() => {
+    searchMock.mockReset();
+  });
+
+  it('formats retrieved tasks and docs as a compact context block', async () => {
+    searchMock.mockResolvedValue({
+      query: 'task_1 duplicate search',
+      backend: 'qmd',
+      degraded: false,
+      elapsedMs: 5,
+      results: [
+        {
+          id: 'tasks/active/task_1.md',
+          title: 'Duplicate task search',
+          path: 'tasks/active/task_1.md',
+          collection: 'tasks-active',
+          snippet: 'Find similar tasks before creating new work.',
+          score: 0.91,
+        },
+      ],
+    });
+
+    const result = await new VeritasContextService().buildContext({
+      taskId: 'task_1',
+      message: 'duplicate search',
+    });
+
+    expect(searchMock).toHaveBeenCalledWith({
+      query: 'task_1 duplicate search',
+      backend: 'auto',
+      collections: ['tasks-active', 'tasks-archive', 'docs'],
+      limit: 4,
+    });
+    expect(result.contextBlock).toContain('<veritas_context>');
+    expect(result.contextBlock).toContain('Duplicate task search');
+    expect(result.contextBlock).toContain('tasks/active/task_1.md');
+  });
+
+  it('returns empty context when retrieval has no matches', async () => {
+    searchMock.mockResolvedValue({
+      query: 'nothing',
+      backend: 'keyword',
+      degraded: false,
+      elapsedMs: 1,
+      results: [],
+    });
+
+    const result = await new VeritasContextService().buildContext({ message: 'nothing' });
+
+    expect(result.contextBlock).toBe('');
+    expect(result.results).toEqual([]);
+  });
+});

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -11,6 +11,7 @@ import { sendGatewayChat, loadGatewayToken } from '../services/gateway-chat-clie
 import { broadcastChatMessage, broadcastSquadMessage } from '../services/broadcast-service.js';
 import { fireSquadWebhook } from '../services/squad-webhook-service.js';
 import { ConfigService } from '../services/config-service.js';
+import { getVeritasContextService } from '../services/veritas-context-service.js';
 import type { ChatSendInput } from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
@@ -33,6 +34,7 @@ const chatSendSchema = z.object({
   agent: z.string().optional(),
   model: z.string().optional(),
   mode: z.enum(['ask', 'build']).optional(),
+  includeContext: z.boolean().optional(),
 });
 
 const squadMessageSchema = z.object({
@@ -121,7 +123,22 @@ router.post(
     // Trigger async AI response via Clawdbot Gateway
     const gatewaySessionKey = `kanban-chat-${sessionId}`;
 
-    sendGatewayChat(input.message, gatewaySessionKey, {
+    const agent = input.agent || session.agent || 'veritas';
+    const shouldInjectContext =
+      input.includeContext !== false && agent.toLowerCase().includes('veritas');
+    let gatewayMessage = input.message;
+
+    if (shouldInjectContext) {
+      const context = await getVeritasContextService().buildContext({
+        message: input.message,
+        taskId: input.taskId || session.taskId || undefined,
+      });
+      if (context.contextBlock) {
+        gatewayMessage = `${input.message}\n\n${context.contextBlock}`;
+      }
+    }
+
+    sendGatewayChat(gatewayMessage, gatewaySessionKey, {
       onDelta: (text) => {
         // Broadcast streaming chunk to kanban WebSocket clients
         broadcastChatMessage(sessionId, {

--- a/server/src/services/veritas-context-service.ts
+++ b/server/src/services/veritas-context-service.ts
@@ -1,0 +1,101 @@
+import { createLogger } from '../lib/logger.js';
+import { getSearchService, type SearchResult } from './search-service.js';
+
+const log = createLogger('veritas-context-service');
+
+export interface VeritasContextRequest {
+  message: string;
+  taskId?: string;
+  limit?: number;
+}
+
+export interface VeritasContextResponse {
+  query: string;
+  contextBlock: string;
+  results: SearchResult[];
+  degraded: boolean;
+  reason?: string;
+}
+
+const DEFAULT_LIMIT = 4;
+const MAX_SNIPPET_LENGTH = 280;
+
+export class VeritasContextService {
+  async buildContext(request: VeritasContextRequest): Promise<VeritasContextResponse> {
+    const query = [request.taskId, request.message].filter(Boolean).join(' ').trim();
+    const limit = Math.min(Math.max(request.limit ?? DEFAULT_LIMIT, 1), 8);
+
+    if (!query) {
+      return {
+        query,
+        contextBlock: '',
+        results: [],
+        degraded: false,
+      };
+    }
+
+    try {
+      const response = await getSearchService().search({
+        query,
+        backend: 'auto',
+        collections: ['tasks-active', 'tasks-archive', 'docs'],
+        limit,
+      });
+
+      const results = response.results.slice(0, limit);
+      return {
+        query,
+        results,
+        degraded: response.degraded,
+        reason: response.reason,
+        contextBlock: this.formatContextBlock(results, response.degraded, response.reason),
+      };
+    } catch (err) {
+      log.warn({ err }, 'Failed to build VERITAS retrieval context');
+      return {
+        query,
+        contextBlock: '',
+        results: [],
+        degraded: true,
+        reason: err instanceof Error ? err.message : 'Context retrieval failed',
+      };
+    }
+  }
+
+  private formatContextBlock(results: SearchResult[], degraded: boolean, reason?: string): string {
+    if (results.length === 0) return '';
+
+    const lines = [
+      '<veritas_context>',
+      'Relevant project context retrieved from tasks and docs. Use as supporting context only; cite paths when relying on it.',
+    ];
+
+    if (degraded) {
+      lines.push(`Retrieval fallback: ${reason || 'keyword search used'}.`);
+    }
+
+    results.forEach((result, index) => {
+      const snippet = result.snippet.replace(/\s+/g, ' ').trim().slice(0, MAX_SNIPPET_LENGTH);
+      lines.push(
+        `${index + 1}. [${result.collection}] ${result.title} (${result.path}, score ${Number(
+          result.score
+        ).toFixed(2)})`
+      );
+      if (snippet) {
+        lines.push(`   ${snippet}`);
+      }
+    });
+
+    lines.push('</veritas_context>');
+    return lines.join('\n');
+  }
+}
+
+let instance: VeritasContextService | null = null;
+
+export function getVeritasContextService(): VeritasContextService {
+  if (!instance) {
+    instance = new VeritasContextService();
+  }
+  return instance;
+}

--- a/shared/src/types/chat.types.ts
+++ b/shared/src/types/chat.types.ts
@@ -38,6 +38,7 @@ export interface ChatSendInput {
   agent?: string; // Override agent
   model?: string; // Override model
   mode?: 'ask' | 'build';
+  includeContext?: boolean; // Set false to skip retrieval context injection
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a VERITAS context service that retrieves compact task/doc context through the search abstraction
- append cited `<veritas_context>` blocks to gateway prompts for VERITAS chat sends
- preserve the original user message in chat history and add per-send `includeContext: false` opt-out
- document context injection behavior

## Verification
- `pnpm --filter @veritas-kanban/server test -- src/__tests__/veritas-context-service.test.ts src/__tests__/routes/chat.test.ts`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm --filter @veritas-kanban/server lint` (passes with existing warnings)

Refs #171
Closes #288