### PR TITLE
feat: add QMD index maintenance

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1472,9 +1472,10 @@ QMD-ready retrieval across task markdown and docs. The endpoint uses the configu
 
 Mounted at `/api/search`.
 
-| Method | Path          | Description                                     |
-| ------ | ------------- | ----------------------------------------------- |
-| `POST` | `/api/search` | Search task and docs collections with one query |
+| Method | Path                        | Description                                     |
+| ------ | --------------------------- | ----------------------------------------------- |
+| `POST` | `/api/search`               | Search task and docs collections with one query |
+| `POST` | `/api/search/index/refresh` | Refresh QMD collections and embeddings          |
 
 ### Search Collections
 
@@ -1520,8 +1521,36 @@ POST /api/search
 
 ```bash
 npm install -g @tobilu/qmd
-scripts/qmd/setup-veritas-qmd.sh
+pnpm qmd:setup
 VERITAS_SEARCH_BACKEND=qmd pnpm dev
+```
+
+### QMD Index Refresh
+
+```
+POST /api/search/index/refresh
+```
+
+**Body**:
+
+```json
+{
+  "embed": true
+}
+```
+
+Set `embed` to `false` to run only `qmd update`.
+
+**Response** `200`:
+
+```json
+{
+  "backend": "qmd",
+  "updated": true,
+  "embedded": true,
+  "elapsedMs": 982,
+  "commands": ["update", "embed"]
+}
 ```
 
 ---

--- a/docs/features/qmd-search.md
+++ b/docs/features/qmd-search.md
@@ -32,7 +32,7 @@ Install QMD and create the initial collections:
 
 ```bash
 npm install -g @tobilu/qmd
-scripts/qmd/setup-veritas-qmd.sh
+pnpm qmd:setup
 ```
 
 Then start VK with QMD enabled:
@@ -40,6 +40,14 @@ Then start VK with QMD enabled:
 ```bash
 VERITAS_SEARCH_BACKEND=qmd pnpm dev
 ```
+
+Refresh the index after larger task/doc changes:
+
+```bash
+pnpm qmd:refresh
+```
+
+Set `VERITAS_QMD_SKIP_EMBED=true` to run `qmd update` without `qmd embed`.
 
 ## API
 
@@ -72,6 +80,10 @@ VERITAS chat sends retrieve compact supporting context from active tasks, archiv
 
 Clients can opt out per chat send by passing `includeContext: false`.
 
+## Index Maintenance
+
+The authenticated API exposes `POST /api/search/index/refresh` for operators and automation. Send `{ "embed": false }` to update collections without recomputing embeddings.
+
 ## Next v4.1 PRs
 
-- Scheduled QMD update/embed maintenance
+- Add deployment-specific schedules as needed with `pnpm qmd:refresh` or `POST /api/search/index/refresh`.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "clean": "pnpm -r clean && rm -rf node_modules",
     "audit": "pnpm audit --prod",
     "audit:all": "pnpm audit",
+    "qmd:setup": "bash scripts/qmd/setup-veritas-qmd.sh",
+    "qmd:refresh": "bash scripts/qmd/refresh-veritas-qmd.sh",
     "seed": "bash scripts/seed.sh",
     "prepare": "husky",
     "demo": "docker compose -f demo/docker-compose.demo.yml up --build"

--- a/scripts/qmd/refresh-veritas-qmd.sh
+++ b/scripts/qmd/refresh-veritas-qmd.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+QMD_BIN="${QMD_BIN:-qmd}"
+SKIP_EMBED="${VERITAS_QMD_SKIP_EMBED:-false}"
+
+if ! command -v "$QMD_BIN" >/dev/null 2>&1; then
+  echo "qmd CLI not found. Install with: npm install -g @tobilu/qmd" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+"$QMD_BIN" update
+
+if [[ "$SKIP_EMBED" != "true" ]]; then
+  "$QMD_BIN" embed
+fi

--- a/server/src/__tests__/routes/search.test.ts
+++ b/server/src/__tests__/routes/search.test.ts
@@ -4,11 +4,15 @@ import request from 'supertest';
 import { searchRoutes } from '../../routes/search.js';
 import { errorHandler } from '../../middleware/error-handler.js';
 
-const mockSearch = vi.hoisted(() => vi.fn());
+const { mockSearch, mockRefreshIndex } = vi.hoisted(() => ({
+  mockSearch: vi.fn(),
+  mockRefreshIndex: vi.fn(),
+}));
 
 vi.mock('../../services/search-service.js', () => ({
   getSearchService: () => ({
     search: mockSearch,
+    refreshIndex: mockRefreshIndex,
   }),
 }));
 
@@ -51,5 +55,21 @@ describe('searchRoutes', () => {
     const res = await request(app).post('/api/search').send({ query: '' });
     expect(res.status).toBe(400);
     expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/search/index/refresh refreshes the qmd index', async () => {
+    mockRefreshIndex.mockResolvedValue({
+      backend: 'qmd',
+      updated: true,
+      embedded: false,
+      elapsedMs: 8,
+      commands: ['update'],
+    });
+
+    const res = await request(app).post('/api/search/index/refresh').send({ embed: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ backend: 'qmd', updated: true, embedded: false });
+    expect(mockRefreshIndex).toHaveBeenCalledWith({ embed: false });
   });
 });

--- a/server/src/__tests__/search-service.test.ts
+++ b/server/src/__tests__/search-service.test.ts
@@ -95,4 +95,45 @@ describe('SearchService', () => {
       collection: 'tasks-active',
     });
   });
+
+  it('refreshes qmd index and embeddings', async () => {
+    execFileMock.mockImplementation((_bin, _args, _options, callback) => {
+      callback(null, '', '');
+    });
+
+    const result = await new SearchService().refreshIndex();
+
+    expect(result).toMatchObject({
+      backend: 'qmd',
+      updated: true,
+      embedded: true,
+      commands: ['update', 'embed'],
+    });
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      1,
+      'qmd',
+      ['update'],
+      expect.objectContaining({ cwd: root }),
+      expect.any(Function)
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'qmd',
+      ['embed'],
+      expect.objectContaining({ cwd: root }),
+      expect.any(Function)
+    );
+  });
+
+  it('can refresh qmd index without embedding', async () => {
+    execFileMock.mockImplementation((_bin, _args, _options, callback) => {
+      callback(null, '', '');
+    });
+
+    const result = await new SearchService().refreshIndex({ embed: false });
+
+    expect(result.embedded).toBe(false);
+    expect(result.commands).toEqual(['update']);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -19,6 +19,12 @@ const SearchBodySchema = z.object({
   minScore: z.number().min(0).max(1).optional(),
 });
 
+const RefreshBodySchema = z
+  .object({
+    embed: z.boolean().optional(),
+  })
+  .optional();
+
 router.post(
   '/',
   asyncHandler(async (req, res) => {
@@ -42,6 +48,25 @@ router.post(
       backend: body.backend as SearchBackend | undefined,
       minScore: body.minScore,
     });
+    res.json(result);
+  })
+);
+
+router.post(
+  '/index/refresh',
+  asyncHandler(async (req, res) => {
+    const parsed = RefreshBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new ValidationError(
+        'Validation failed',
+        parsed.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        }))
+      );
+    }
+
+    const result = await getSearchService().refreshIndex({ embed: parsed.data?.embed });
     res.json(result);
   })
 );

--- a/server/src/services/search-service.ts
+++ b/server/src/services/search-service.ts
@@ -35,6 +35,14 @@ export interface SearchResponse {
   results: SearchResult[];
 }
 
+export interface SearchIndexRefreshResponse {
+  backend: 'qmd';
+  updated: boolean;
+  embedded: boolean;
+  elapsedMs: number;
+  commands: string[];
+}
+
 interface SearchSource {
   collection: SearchCollection;
   dir: string;
@@ -107,6 +115,33 @@ class SearchService {
     };
   }
 
+  async refreshIndex(options: { embed?: boolean } = {}): Promise<SearchIndexRefreshResponse> {
+    const started = Date.now();
+    const embed = options.embed ?? true;
+    const commands = ['update'];
+
+    await this.runQmdCommand(
+      ['update'],
+      Number(process.env.VERITAS_QMD_REFRESH_TIMEOUT_MS || 60_000)
+    );
+
+    if (embed) {
+      commands.push('embed');
+      await this.runQmdCommand(
+        ['embed'],
+        Number(process.env.VERITAS_QMD_REFRESH_TIMEOUT_MS || 60_000)
+      );
+    }
+
+    return {
+      backend: 'qmd',
+      updated: true,
+      embedded: embed,
+      elapsedMs: Date.now() - started,
+      commands,
+    };
+  }
+
   private defaultBackend(): SearchBackend {
     const configured = process.env.VERITAS_SEARCH_BACKEND;
     if (configured === 'qmd' || configured === 'auto' || configured === 'keyword') {
@@ -119,7 +154,6 @@ class SearchService {
     query: string,
     options: { limit: number; collections: SearchCollection[]; minScore?: number }
   ): Promise<SearchResult[]> {
-    const bin = process.env.VERITAS_QMD_BIN || 'qmd';
     const args = ['query', query, '--json', '-n', String(options.limit)];
 
     if (options.minScore !== undefined) {
@@ -130,13 +164,23 @@ class SearchService {
       args.push('--collections', options.collections.join(','));
     }
 
-    const stdout = await new Promise<string>((resolve, reject) => {
+    const stdout = await this.runQmdCommand(
+      args,
+      Number(process.env.VERITAS_QMD_TIMEOUT_MS || 10_000)
+    );
+
+    return this.normalizeQmdResults(stdout, options.limit);
+  }
+
+  private async runQmdCommand(args: string[], timeout: number): Promise<string> {
+    const bin = process.env.VERITAS_QMD_BIN || 'qmd';
+    return new Promise<string>((resolve, reject) => {
       execFile(
         bin,
         args,
         {
           cwd: this.projectRoot(),
-          timeout: Number(process.env.VERITAS_QMD_TIMEOUT_MS || 10_000),
+          timeout,
           maxBuffer: 2 * 1024 * 1024,
         },
         (error, stdoutValue) => {
@@ -148,8 +192,6 @@ class SearchService {
         }
       );
     });
-
-    return this.normalizeQmdResults(stdout, options.limit);
   }
 
   private normalizeQmdResults(stdout: string, limit: number): SearchResult[] {


### PR DESCRIPTION
## Summary
- add `pnpm qmd:setup` and `pnpm qmd:refresh` operator commands
- add an authenticated `POST /api/search/index/refresh` endpoint for update/embed refreshes
- support refresh without embeddings via `embed: false` or `VERITAS_QMD_SKIP_EMBED=true`
- update API and feature docs for setup, refresh, and scheduling

## Verification
- `pnpm --filter @veritas-kanban/server test -- src/__tests__/search-service.test.ts src/__tests__/routes/search.test.ts`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm --filter @veritas-kanban/server lint` (passes with existing warnings)

Refs #171
Closes #289