### PR TITLE
chore: bump version to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-05-04
+
+### Added
+
+- QMD-backed search foundation with keyword fallback across active tasks, archived tasks, and docs (#290)
+- In-app search dialog with backend and collection controls, fallback status, and task-result navigation (#291)
+- Duplicate detection hints in the create-task dialog using active and archived task retrieval (#292)
+- VERITAS chat context injection with compact, cited `<veritas_context>` blocks and per-message opt-out (#293)
+- QMD index maintenance commands and API refresh endpoint:
+  - `pnpm qmd:setup`
+  - `pnpm qmd:refresh`
+  - `POST /api/search/index/refresh` (#294)
+
+### Changed
+
+- Documented the v4.1 QMD setup, search UI, duplicate detection, VERITAS context injection, and index maintenance workflows
+- Updated package versions from `4.0.1` to `4.1.0`
+
 ## [4.0.1] - 2026-05-04
 
 ### Fixed
@@ -1379,7 +1397,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.1...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.1...v4.1.0
 [4.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v3.3.3...v4.0.0
 [3.3.3]: https://github.com/BradGroux/veritas-kanban/compare/v3.3.2...v3.3.3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built for developers who want a visual Kanban board that works with autonomous c
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.0.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.1.0-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -760,7 +760,6 @@ See the [open issues](https://github.com/BradGroux/veritas-kanban/issues) for wh
 
 ### Backlog
 
-- [QMD Retrieval for Veritas Kanban](https://github.com/BradGroux/veritas-kanban/issues/171) — v4.1 staged track for task/docs search, duplicate detection, context injection, and index maintenance
 - [WCAG 2.1 AA accessibility](https://github.com/BradGroux/veritas-kanban/issues/1) — Full keyboard navigation, screen reader support, color contrast
 - [Example video](https://github.com/BradGroux/veritas-kanban/issues/68) — Hosted walkthrough video on YouTube or Vimeo
 

--- a/docs/features/qmd-search.md
+++ b/docs/features/qmd-search.md
@@ -1,10 +1,10 @@
-# QMD Search Foundation
+# QMD Retrieval
 
-Veritas Kanban v4.1 adds the first slice of QMD-backed retrieval: a server-side search abstraction and `POST /api/search` endpoint. QMD is optional; if it is unavailable, VK falls back to built-in keyword search across markdown files.
+Veritas Kanban v4.1 adds QMD-backed retrieval for task/docs search, duplicate detection, and VERITAS chat context. QMD is optional; if it is unavailable, VK falls back to built-in keyword search across markdown files.
 
 ## Collections
 
-The foundation searches these collections:
+Retrieval searches these collections:
 
 - `tasks-active` — `tasks/active/**/*.md`
 - `tasks-archive` — `tasks/archive/**/*.md`
@@ -84,6 +84,6 @@ Clients can opt out per chat send by passing `includeContext: false`.
 
 The authenticated API exposes `POST /api/search/index/refresh` for operators and automation. Send `{ "embed": false }` to update collections without recomputing embeddings.
 
-## Next v4.1 PRs
+## Scheduling
 
-- Add deployment-specific schedules as needed with `pnpm qmd:refresh` or `POST /api/search/index/refresh`.
+Add deployment-specific schedules as needed with `pnpm qmd:refresh` or `POST /api/search/index/refresh`.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump root, server, web, shared, and MCP package versions to `4.1.0`
- update the README version badge and remove the completed v4.1 QMD backlog item
- add the `4.1.0` changelog entry and update compare links
- refresh QMD retrieval docs to describe the shipped v4.1 feature set

## Verification
- `pnpm install --lockfile-only`
- `pnpm typecheck`