### PR TITLE
[codex] Add Codex CLI agent execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Codex Integration SOP with operational guidance for CLI, SDK, Cloud, MCP, telemetry mapping, reviews, workflow steps, escalation, and release validation (#310)
 - Codex workflow examples for local feature work, Codex review, SDK follow-up sessions, workflow pipelines, Cloud delegation, MCP-first board maintenance, and release QA (#310)
 - Codex-specific AGENTS.md guidance and MCP setup instructions for Veritas-aware Codex work (#310)
-- Planned v4.2 Codex feature reference in `docs/FEATURES.md` (#310)
+- Codex feature reference in `docs/FEATURES.md`, updated to distinguish implemented CLI support from planned SDK, Cloud, review, and workflow modes (#310)
+- Built-in `codex` agent profile backed by local `codex exec --sandbox workspace-write --json`
+- Local Codex CLI execution path for code-task attempts, including process launch in the task worktree, attempt logs, final summary capture, completion handling, stop support, and run/token telemetry mapping
+- Config migration that appends missing built-in agents, including Codex, to existing configs without overwriting customized agents
 
 ### Changed
 

--- a/docs/CODEX-INTEGRATION.md
+++ b/docs/CODEX-INTEGRATION.md
@@ -2,7 +2,7 @@
 
 Release target: **Veritas Kanban v4.2**
 
-This roadmap tracks the first-class OpenAI Codex integration work for Veritas Kanban. The goal is not to treat Codex as a generic custom command. v4.2 should make Codex a native Veritas agent provider across local task execution, workflow runs, reviews, telemetry, MCP, and release documentation.
+This roadmap tracks the first-class OpenAI Codex integration work for Veritas Kanban. v4.2 now includes the first real runtime slice: a native `codex` agent backed by local `codex exec` execution. The remaining work expands that foundation into richer SDK sessions, cloud delegation, workflow-engine execution, review automation, and deeper UI.
 
 Companion docs:
 
@@ -26,7 +26,7 @@ Veritas Kanban should become the local-first command center for Codex-backed sof
 
 ### Codex CLI Provider
 
-The first implementation path should use `codex exec` because it is designed for automation and can emit JSONL events. Veritas should launch it inside the task worktree, stream progress into attempt logs, parse usage and file-change events, and complete the task from the final Codex result.
+The first implementation path uses `codex exec` because it is designed for automation and can emit JSONL events. Veritas launches it inside the task worktree, streams progress into attempt logs, parses usage events, and completes the task from the final Codex result.
 
 Recommended default shape:
 
@@ -36,7 +36,7 @@ codex exec --cwd <task-worktree> --sandbox workspace-write --json <prompt>
 
 ### Codex SDK Provider
 
-The SDK path should support long-lived local Codex threads, resumable sessions, and richer follow-up workflows. This should be a separate provider mode so the CLI path remains stable and easy to debug.
+The SDK path should support long-lived local Codex threads, resumable sessions, and richer follow-up workflows. This remains a planned provider mode so the CLI path stays stable and easy to debug.
 
 ### Codex Cloud Delegation
 
@@ -44,9 +44,9 @@ Cloud delegation should start through GitHub-native workflows: Veritas can creat
 
 ## Architecture Direction
 
-v4.2 should introduce an agent provider abstraction instead of expanding the current OpenClaw-specific service with Codex branches.
+v4.2 starts with a focused provider seam inside the existing agent service instead of a full rewrite. `codex` agents resolve to the local Codex CLI runner; existing agents keep the OpenClaw request-file behavior. A fuller provider abstraction is still tracked for the next implementation step.
 
-Expected provider capabilities:
+Expected long-term provider capabilities:
 
 - `start`
 - `stop`
@@ -134,7 +134,7 @@ The v4.2 docs should land with the implementation, not after it. Required docume
 
 v4.2 is done when:
 
-- Codex can complete a Veritas code task from the UI.
+- Codex can complete a Veritas code task from the UI or API through the local CLI provider.
 - Codex can run as a workflow-engine agent step.
 - Codex logs, final output, and token usage appear in Veritas attempt and telemetry surfaces.
 - Codex setup has first-class Settings UX and docs.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -23,7 +23,7 @@ For a quick overview, see the [README](../README.md#-what-makes-veritas-kanban-d
 ### AI Agents
 
 - [Agent Integration](#agent-integration)
-- [OpenAI Codex Integration](#openai-codex-integration-planned-v42)
+- [OpenAI Codex Integration](#openai-codex-integration-v42)
 - [Multi-Agent System](#multi-agent-system)
 - [Squad Chat](#squad-chat)
 - [Agent Registry & Dashboard](#agent-registry--dashboard)
@@ -293,13 +293,18 @@ First-class support for autonomous coding agents.
 
 ---
 
-## OpenAI Codex Integration (Planned v4.2)
+## OpenAI Codex Integration (v4.2)
 
-v4.2 plans first-class OpenAI Codex support across local task execution, SDK-backed sessions, cloud delegation, MCP setup, workflow execution, review automation, and telemetry.
+v4.2 adds the first runtime slice of first-class OpenAI Codex support: a built-in `codex` agent that can run local `codex exec` attempts in a task worktree and report status, logs, completion, and telemetry through the existing Veritas agent lifecycle.
 
-Planned provider modes:
+Implemented:
 
-- **Codex CLI provider** — Runs `codex exec --json` in the task worktree, maps JSONL events into Veritas attempt logs, and records final summaries.
+- **Codex CLI provider** — Runs `codex exec --json` in the task worktree, maps JSONL/stdout/stderr into Veritas attempt logs, records final summaries, and emits run/token telemetry when available.
+- **Codex agent defaults** — Adds a disabled-by-default OpenAI Codex agent profile with `codex exec --sandbox workspace-write --json`.
+- **Config migration** — Existing configs receive the missing built-in Codex agent without overwriting customized agents.
+
+Still planned:
+
 - **Codex SDK provider** — Uses `@openai/codex-sdk` for durable local threads, follow-up prompts, and richer session control.
 - **Codex Cloud delegation** — Creates GitHub issue/PR delegation prompts for cloud Codex work and links GitHub artifacts back to Veritas tasks.
 - **Codex review actions** — Uses Codex to review task branches, PR diffs, and failed changes.

--- a/docs/SOP-codex-integration.md
+++ b/docs/SOP-codex-integration.md
@@ -1,6 +1,6 @@
 # SOP: OpenAI Codex Integration
 
-Use this playbook when Veritas Kanban delegates work to OpenAI Codex. It covers the intended v4.2 lifecycle for local Codex CLI runs, Codex SDK sessions, Codex Cloud delegation, telemetry, reviews, and workflow-engine execution.
+Use this playbook when Veritas Kanban delegates work to OpenAI Codex. v4.2 includes local Codex CLI execution through `codex exec`; SDK sessions, Cloud delegation, and workflow-engine execution remain part of the broader integration track.
 
 ---
 
@@ -25,7 +25,7 @@ Use this playbook when Veritas Kanban delegates work to OpenAI Codex. It covers 
 | **Codex Review**   | Review task branches, PR diffs, or failed changes | CLI/SDK review action                |
 | **Workflow Codex** | Pipeline steps in Veritas workflow definitions    | Provider-backed workflow step        |
 
-Default for v4.2 should be **Codex CLI**. It is easiest to install, debug, mock in CI, and observe through JSONL events.
+Default for v4.2 is **Codex CLI**. It is easiest to install, debug, mock in CI, and observe through JSONL events.
 
 ---
 
@@ -65,7 +65,7 @@ export VK_API_KEY="<agent-role-key-if-auth-required>"
 export CODEX_API_KEY="<optional-api-key-for-automation>"
 ```
 
-### Expected Veritas Behavior
+### Veritas Behavior
 
 1. Resolve the selected agent to a provider: `codex-cli`.
 2. Create an attempt with provider metadata:
@@ -94,7 +94,7 @@ export CODEX_API_KEY="<optional-api-key-for-automation>"
 
 ## Codex SDK Flow
 
-Use SDK mode when the user needs a durable local Codex thread across multiple prompts:
+Use SDK mode when the user needs a durable local Codex thread across multiple prompts. This mode is planned, not part of the initial CLI runner:
 
 ```ts
 import { Codex } from '@openai/codex-sdk';

--- a/server/src/__tests__/config-service-extended.test.ts
+++ b/server/src/__tests__/config-service-extended.test.ts
@@ -41,6 +41,17 @@ describe('ConfigService', () => {
       expect(config.repos).toEqual([]);
       expect(config.agents).toBeDefined();
       expect(config.agents.length).toBeGreaterThan(0);
+      expect(config.agents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'codex',
+            name: 'OpenAI Codex',
+            command: 'codex',
+            provider: 'codex-cli',
+            enabled: false,
+          }),
+        ])
+      );
     });
 
     it('should create config file with defaults when missing', async () => {
@@ -64,6 +75,37 @@ describe('ConfigService', () => {
       expect(config.repos).toHaveLength(1);
       expect(config.repos[0].name).toBe('test-repo');
       expect(config.defaultAgent).toBe('amp');
+    });
+
+    it('should add missing built-in agents to existing config', async () => {
+      await fs.writeFile(
+        configFile,
+        JSON.stringify({
+          repos: [],
+          agents: [
+            {
+              type: 'claude-code',
+              name: 'My Claude',
+              command: 'claude',
+              args: [],
+              enabled: true,
+            },
+          ],
+          defaultAgent: 'claude-code',
+        })
+      );
+
+      const config = await service.getConfig();
+      expect(config.agents.find((agent) => agent.type === 'claude-code')?.name).toBe('My Claude');
+      expect(config.agents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'codex',
+            command: 'codex',
+            provider: 'codex-cli',
+          }),
+        ])
+      );
     });
 
     it('should use cache on subsequent calls', async () => {

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -182,6 +182,24 @@ describe('Config Routes (actual module)', () => {
       expect(res.status).toBe(200);
     });
 
+    it('should accept Codex provider metadata', async () => {
+      const agents = [
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: ['exec', '--sandbox', 'workspace-write', '--json'],
+          enabled: true,
+          provider: 'codex-cli',
+          model: 'gpt-5.5',
+        },
+      ];
+      mockConfigService.updateAgents.mockResolvedValue({ agents });
+      const res = await request(app).put('/api/config/agents').send(agents);
+      expect(res.status).toBe(200);
+      expect(mockConfigService.updateAgents).toHaveBeenCalledWith(agents);
+    });
+
     it('should reject invalid agent data', async () => {
       const res = await request(app)
         .put('/api/config/agents')

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -26,6 +26,8 @@ const agentSchema = z.object({
   command: z.string().min(1),
   args: z.array(z.string()),
   enabled: z.boolean(),
+  provider: z.enum(['openclaw', 'codex-cli', 'custom']).optional(),
+  model: z.string().optional(),
 });
 
 const setDefaultAgentSchema = z.object({

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -11,15 +11,27 @@
  */
 
 import { EventEmitter } from 'events';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { nanoid } from 'nanoid';
 import fs from 'fs/promises';
 import path from 'path';
 import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
+import { getTelemetryService } from './telemetry-service.js';
 import { getAgentRoutingService } from './agent-routing-service.js';
 import { getBreaker } from './circuit-registry.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
-import type { Task, AgentType, TaskAttempt, AttemptStatus } from '@veritas-kanban/shared';
+import type {
+  Task,
+  AgentType,
+  AgentConfig,
+  TaskAttempt,
+  AttemptStatus,
+  RunStartedEvent,
+  RunCompletedEvent,
+  RunErrorEvent,
+  TokenTelemetryEvent,
+} from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 const log = createLogger('clawdbot-agent-service');
 
@@ -51,6 +63,8 @@ const pendingAgents = new Map<
     agent: AgentType;
     startedAt: string;
     emitter: EventEmitter;
+    provider: 'openclaw' | 'codex-cli';
+    process?: ChildProcessWithoutNullStreams;
   }
 >();
 
@@ -114,6 +128,9 @@ export class ClawdbotAgentService {
       agent = agentType;
     }
 
+    const agentConfig = this.resolveAgentConfig(config.agents, agent);
+    const provider = this.resolveAgentProvider(agentConfig, agent);
+
     // Create attempt
     const attemptId = `attempt_${nanoid(8)}`;
     const startedAt = new Date().toISOString();
@@ -129,6 +146,7 @@ export class ClawdbotAgentService {
       agent,
       startedAt,
       emitter,
+      provider,
     });
 
     // Validate path segments for log file
@@ -149,12 +167,54 @@ export class ClawdbotAgentService {
       agent,
       status: 'running',
       started: startedAt,
+      provider,
+      model: agentConfig?.model,
     };
 
     await this.taskService.updateTask(taskId, {
       status: 'in-progress',
       attempt,
     });
+
+    const telemetry = getTelemetryService();
+    await telemetry.emit<RunStartedEvent>({
+      type: 'run.started',
+      taskId,
+      attemptId,
+      agent,
+      model: agentConfig?.model,
+      project: task.project,
+    });
+
+    if (provider === 'codex-cli') {
+      try {
+        this.startCodexCli(task, agentConfig, taskPrompt, logPath, attemptId, startedAt, emitter);
+      } catch (error: any) {
+        pendingAgents.delete(taskId);
+        await this.taskService.updateTask(taskId, {
+          status: 'todo',
+          attempt: { ...attempt, status: 'failed', ended: new Date().toISOString() },
+        });
+        await telemetry.emit<RunErrorEvent>({
+          type: 'run.error',
+          taskId,
+          attemptId,
+          agent,
+          project: task.project,
+          error: error.message || 'Failed to start Codex CLI',
+          stackTrace: error.stack,
+        });
+        throw new Error(`Failed to start agent via Codex CLI: ${error.message}`);
+      }
+
+      return {
+        taskId,
+        attemptId,
+        agent,
+        status: 'running',
+        startedAt,
+      };
+    }
 
     // Send request to Clawdbot main session (wrapped in circuit breaker)
     // This will be picked up by Veritas who will spawn the actual sub-agent
@@ -168,7 +228,16 @@ export class ClawdbotAgentService {
         status: 'todo',
         attempt: { ...attempt, status: 'failed', ended: new Date().toISOString() },
       });
-      throw new Error(`Failed to start agent via Clawdbot: ${error.message}`);
+      await telemetry.emit<RunErrorEvent>({
+        type: 'run.error',
+        taskId,
+        attemptId,
+        agent,
+        project: task.project,
+        error: error.message || 'Failed to start OpenClaw request',
+        stackTrace: error.stack,
+      });
+      throw new Error(`Failed to start agent via OpenClaw: ${error.message}`);
     }
 
     return {
@@ -234,6 +303,7 @@ export class ClawdbotAgentService {
     const { attemptId, emitter } = pending;
     const endedAt = new Date().toISOString();
     const status: AttemptStatus = result.success ? 'complete' : 'failed';
+    const durationMs = new Date(endedAt).getTime() - new Date(pending.startedAt).getTime();
 
     // Update task
     await this.taskService.updateTask(taskId, {
@@ -244,6 +314,7 @@ export class ClawdbotAgentService {
         status,
         started: pending.startedAt,
         ended: endedAt,
+        provider: pending.provider,
       },
     });
 
@@ -254,6 +325,18 @@ export class ClawdbotAgentService {
 
     // Emit completion
     emitter.emit('complete', { status, summary });
+
+    const task = await this.taskService.getTask(taskId);
+    await getTelemetryService().emit<RunCompletedEvent>({
+      type: 'run.completed',
+      taskId,
+      attemptId,
+      agent: pending.agent,
+      project: task?.project,
+      durationMs,
+      success: result.success,
+      error: result.error,
+    });
 
     // Clean up
     pendingAgents.delete(taskId);
@@ -283,11 +366,269 @@ export class ClawdbotAgentService {
       throw new Error('No agent running for this task');
     }
 
+    if (pending.provider === 'codex-cli' && pending.process && !pending.process.killed) {
+      pending.process.kill('SIGTERM');
+    }
+
     // Mark as failed/stopped
     await this.completeAgent(taskId, {
       success: false,
       error: 'Stopped by user',
     });
+  }
+
+  private resolveAgentConfig(agents: AgentConfig[], agent: AgentType): AgentConfig | undefined {
+    return agents.find((a) => a.type === agent);
+  }
+
+  private resolveAgentProvider(
+    agentConfig: AgentConfig | undefined,
+    agent: AgentType
+  ): 'openclaw' | 'codex-cli' {
+    if (agentConfig?.provider === 'codex-cli') return 'codex-cli';
+    if (agent === 'codex') return 'codex-cli';
+    if (agentConfig?.command === 'codex') return 'codex-cli';
+    return 'openclaw';
+  }
+
+  private startCodexCli(
+    task: Task,
+    agentConfig: AgentConfig | undefined,
+    prompt: string,
+    logPath: string,
+    attemptId: string,
+    startedAt: string,
+    emitter: EventEmitter
+  ): void {
+    const worktreePath = this.expandPath(task.git?.worktreePath || '');
+    if (!worktreePath) {
+      throw new Error('Task worktree path is required for Codex CLI');
+    }
+
+    const command = agentConfig?.command || 'codex';
+    const args = this.buildCodexArgs(agentConfig, prompt, logPath, attemptId);
+    const child = spawn(command, args, {
+      cwd: worktreePath,
+      env: {
+        ...process.env,
+        VK_API_URL: process.env.VK_API_URL || 'http://localhost:3001',
+      },
+      shell: false,
+    });
+
+    const pending = pendingAgents.get(task.id);
+    if (pending) {
+      pending.process = child;
+    }
+
+    void this.appendLog(
+      logPath,
+      `\n## Codex CLI\n\n**Command:** \`${[command, ...args.map((a) => (a === prompt ? '<prompt>' : a))].join(' ')}\`\n**PID:** ${child.pid ?? 'unknown'}\n\n`
+    );
+
+    let stdoutBuffer = '';
+    let stderrBuffer = '';
+    let finalSummary = '';
+    let tokenUsage:
+      | { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string }
+      | undefined;
+
+    child.stdout.setEncoding('utf-8');
+    child.stdout.on('data', (chunk: string) => {
+      stdoutBuffer += chunk;
+      const lines = stdoutBuffer.split(/\r?\n/);
+      stdoutBuffer = lines.pop() || '';
+      for (const line of lines) {
+        const parsed = this.handleCodexJsonLine(line, logPath);
+        if (parsed.summary) finalSummary = parsed.summary;
+        if (parsed.usage) tokenUsage = parsed.usage;
+      }
+    });
+
+    child.stderr.setEncoding('utf-8');
+    child.stderr.on('data', (chunk: string) => {
+      stderrBuffer += chunk;
+      void this.appendLog(logPath, `\n### stderr\n\n\`\`\`\n${chunk.trimEnd()}\n\`\`\`\n`);
+    });
+
+    child.on('error', (error) => {
+      void this.appendLog(logPath, `\n## Codex Process Error\n\n${error.message}\n`);
+      emitter.emit('error', error);
+    });
+
+    child.on('close', (code, signal) => {
+      void (async () => {
+        if (stdoutBuffer.trim()) {
+          const parsed = this.handleCodexJsonLine(stdoutBuffer, logPath);
+          if (parsed.summary) finalSummary = parsed.summary;
+          if (parsed.usage) tokenUsage = parsed.usage;
+        }
+
+        const finalPath = this.getCodexFinalPath(logPath, attemptId);
+        finalSummary ||= await this.readOptionalFile(finalPath);
+        finalSummary ||=
+          code === 0 ? 'Codex completed without a final summary.' : stderrBuffer.trim();
+
+        if (tokenUsage) {
+          await getTelemetryService().emit<TokenTelemetryEvent>({
+            type: 'run.tokens',
+            taskId: task.id,
+            attemptId,
+            agent: agentConfig?.type || 'codex',
+            project: task.project,
+            inputTokens: tokenUsage.inputTokens,
+            outputTokens: tokenUsage.outputTokens,
+            totalTokens: tokenUsage.totalTokens,
+            model: tokenUsage.model || agentConfig?.model,
+          });
+        }
+
+        await this.appendLog(
+          logPath,
+          `\n## Codex Exit\n\n**Exit code:** ${code ?? 'none'}\n**Signal:** ${signal ?? 'none'}\n**Duration:** ${Date.now() - new Date(startedAt).getTime()}ms\n`
+        );
+
+        await this.completeAgent(task.id, {
+          success: code === 0,
+          summary: finalSummary,
+          error: code === 0 ? undefined : finalSummary || `Codex exited with code ${code}`,
+        });
+      })().catch((error) => {
+        log.error({ err: error, taskId: task.id }, 'Failed to finalize Codex attempt');
+      });
+    });
+  }
+
+  private buildCodexArgs(
+    agentConfig: AgentConfig | undefined,
+    prompt: string,
+    logPath: string,
+    attemptId: string
+  ): string[] {
+    const configured = agentConfig?.args?.length ? [...agentConfig.args] : ['exec'];
+    const args = configured.includes('exec') ? configured : ['exec', ...configured];
+    if (!args.includes('--sandbox')) args.push('--sandbox', 'workspace-write');
+    if (!args.includes('--json')) args.push('--json');
+    if (!args.includes('--output-last-message')) {
+      args.push('--output-last-message', this.getCodexFinalPath(logPath, attemptId));
+    }
+    args.push(prompt);
+    return args;
+  }
+
+  private getCodexFinalPath(logPath: string, attemptId: string): string {
+    return path.join(path.dirname(logPath), `${attemptId}.codex-final.md`);
+  }
+
+  private handleCodexJsonLine(
+    line: string,
+    logPath: string
+  ): {
+    summary?: string;
+    usage?: { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string };
+  } {
+    const trimmed = line.trim();
+    if (!trimmed) return {};
+
+    try {
+      const event = JSON.parse(trimmed) as Record<string, unknown>;
+      const type = String(event.type || event.event || 'codex.event');
+      const summary = this.extractCodexSummary(event);
+      const usage = this.extractCodexUsage(event);
+      void this.appendLog(
+        logPath,
+        `\n### ${type}\n\n${summary ? `${summary}\n\n` : ''}<details><summary>Raw event</summary>\n\n\`\`\`json\n${JSON.stringify(event, null, 2)}\n\`\`\`\n\n</details>\n`
+      );
+      return { summary, usage };
+    } catch {
+      void this.appendLog(logPath, `\n### stdout\n\n\`\`\`\n${trimmed}\n\`\`\`\n`);
+      return { summary: trimmed };
+    }
+  }
+
+  private extractCodexSummary(event: unknown): string | undefined {
+    const seen = new Set<unknown>();
+    const visit = (value: unknown): string | undefined => {
+      if (!value || typeof value !== 'object') return undefined;
+      if (seen.has(value)) return undefined;
+      seen.add(value);
+      const record = value as Record<string, unknown>;
+      for (const key of [
+        'final_response',
+        'finalMessage',
+        'final_message',
+        'message',
+        'text',
+        'output',
+      ]) {
+        const candidate = record[key];
+        if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+      }
+      for (const child of Object.values(record)) {
+        const result = visit(child);
+        if (result) return result;
+      }
+      return undefined;
+    };
+    return visit(event);
+  }
+
+  private extractCodexUsage(
+    event: unknown
+  ):
+    | { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string }
+    | undefined {
+    const seen = new Set<unknown>();
+    const visit = (value: unknown): Record<string, unknown> | undefined => {
+      if (!value || typeof value !== 'object') return undefined;
+      if (seen.has(value)) return undefined;
+      seen.add(value);
+      const record = value as Record<string, unknown>;
+      const input =
+        record.input_tokens ?? record.inputTokens ?? record.prompt_tokens ?? record.promptTokens;
+      const output =
+        record.output_tokens ??
+        record.outputTokens ??
+        record.completion_tokens ??
+        record.completionTokens;
+      if (typeof input === 'number' && typeof output === 'number') return record;
+      for (const child of Object.values(record)) {
+        const result = visit(child);
+        if (result) return result;
+      }
+      return undefined;
+    };
+
+    const usage = visit(event);
+    if (!usage) return undefined;
+    const input = (usage.input_tokens ??
+      usage.inputTokens ??
+      usage.prompt_tokens ??
+      usage.promptTokens) as number;
+    const output = (usage.output_tokens ??
+      usage.outputTokens ??
+      usage.completion_tokens ??
+      usage.completionTokens) as number;
+    const total = usage.total_tokens ?? usage.totalTokens;
+    return {
+      inputTokens: input,
+      outputTokens: output,
+      totalTokens: typeof total === 'number' ? total : input + output,
+      model: typeof usage.model === 'string' ? usage.model : undefined,
+    };
+  }
+
+  private async appendLog(logPath: string, content: string): Promise<void> {
+    ensureWithinBase(this.logsDir, logPath);
+    await fs.appendFile(logPath, content, 'utf-8');
+  }
+
+  private async readOptionalFile(filePath: string): Promise<string> {
+    try {
+      return (await fs.readFile(filePath, 'utf-8')).trim();
+    } catch {
+      return '';
+    }
   }
 
   /**
@@ -424,7 +765,7 @@ If you encounter errors, call with \`success: false\` and include the error mess
     const header = `# Agent Log: ${task.title}
 
 **Task ID:** ${task.id}
-**Agent:** ${agent} (via Clawdbot)
+**Agent:** ${agent}
 **Started:** ${new Date().toISOString()}
 **Worktree:** ${task.git?.worktreePath}
 
@@ -436,7 +777,7 @@ ${prompt}
 
 ## Progress
 
-*Agent is working via Clawdbot sub-agent...*
+*Agent is working...*
 
 `;
     await fs.writeFile(logPath, header, 'utf-8');

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -54,6 +54,14 @@ const DEFAULT_CONFIG: AppConfig = {
       args: [],
       enabled: false,
     },
+    {
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      args: ['exec', '--sandbox', 'workspace-write', '--json'],
+      enabled: false,
+      provider: 'codex-cli',
+    },
   ],
   defaultAgent: 'claude-code',
 };
@@ -210,6 +218,7 @@ export class ConfigService {
       const raw = JSON.parse(content) as AppConfig;
       // Auto-merge feature defaults for backward compatibility
       raw.features = deepMergeDefaults(raw.features || {}, DEFAULT_FEATURE_SETTINGS);
+      raw.agents = this.mergeDefaultAgents(raw.agents || []);
       this.config = raw;
       this.cacheTimestamp = Date.now();
       this.setupWatcher();
@@ -223,6 +232,12 @@ export class ConfigService {
       }
       throw error;
     }
+  }
+
+  private mergeDefaultAgents(agents: AgentConfig[]): AgentConfig[] {
+    const existingTypes = new Set(agents.map((agent) => agent.type));
+    const missingDefaults = DEFAULT_CONFIG.agents.filter((agent) => !existingTypes.has(agent.type));
+    return [...agents, ...missingDefaults];
   }
 
   async getFeatureSettings(): Promise<FeatureSettings> {

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -22,6 +22,8 @@ export interface AgentConfig {
   command: string;
   args: string[];
   enabled: boolean;
+  provider?: 'openclaw' | 'codex-cli' | 'custom';
+  model?: string;
 }
 
 // ============ Agent Routing Types ============

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -15,7 +15,7 @@ export interface QaGateState {
   passedBy?: string; // Who approved (e.g. 'human', agent slug, user name)
 }
 /** Built-in agent types. Custom agents use any string slug. */
-export type BuiltInAgentType = 'claude-code' | 'amp' | 'copilot' | 'gemini' | 'veritas';
+export type BuiltInAgentType = 'claude-code' | 'amp' | 'copilot' | 'gemini' | 'codex' | 'veritas';
 export type AgentType = BuiltInAgentType | (string & {});
 export type AttemptStatus = 'pending' | 'running' | 'complete' | 'failed';
 export type BlockedCategory = 'waiting-on-feedback' | 'technical-snag' | 'prerequisite' | 'other';
@@ -40,6 +40,8 @@ export interface TaskAttempt {
   status: AttemptStatus;
   started?: string;
   ended?: string;
+  provider?: string;
+  model?: string;
 }
 
 export interface Subtask {

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -927,6 +927,8 @@ function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps)
         .split(/\s+/)
         .filter((a) => a),
       enabled: agent?.enabled ?? true,
+      provider: agent?.provider,
+      model: agent?.model,
     });
   };
 


### PR DESCRIPTION
## Description

Adds the actual v4.2 Codex runtime integration: a built-in Codex agent profile backed by local `codex exec` execution through the existing Veritas agent lifecycle.

## What changed

- Adds `codex` as a built-in agent type.
- Adds default disabled OpenAI Codex agent config: `codex exec --sandbox workspace-write --json`.
- Adds `provider` and `model` metadata to agent config and task attempts.
- Starts Codex CLI attempts inside the task worktree for code tasks.
- Streams Codex JSONL/stdout/stderr into attempt logs.
- Captures final Codex summary through `--output-last-message` when available.
- Emits `run.started`, `run.completed`, `run.error`, and `run.tokens` telemetry where available.
- Supports stopping running Codex attempts by terminating the child process.
- Migrates existing configs by appending missing built-in agents, including Codex, without overwriting customized agents.
- Preserves provider/model fields when editing agents in Settings.
- Updates docs/changelog from planning-only language to implemented CLI support plus remaining planned modes.

## Testing

```bash
pnpm --filter @veritas-kanban/shared build
pnpm --filter @veritas-kanban/server typecheck
pnpm --filter @veritas-kanban/web typecheck
pnpm --filter @veritas-kanban/server test -- config-service-extended.test.ts config-coverage.test.ts
pnpm build
```

Build completed with existing Vite chunk-size/dynamic-import warnings.

