### PR TITLE
feat: add Codex SDK sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1] - 2026-05-06
+
+### Added
+
+- Codex SDK session provider powered by `@openai/codex-sdk`, enabling durable local Codex threads for code-task attempts.
+- Disabled-by-default `codex-sdk` agent profile for teams that want SDK-backed sessions alongside the existing `codex` CLI profile.
+- Codex SDK attempt logging for streamed thread, turn, item, error, and usage events.
+- Codex SDK token telemetry mapping and stop support through abortable SDK turns.
+- `threadId` attempt metadata so SDK session IDs are preserved on active and completed attempts for follow-up workflows.
+
+### Changed
+
+- Updated workspace package versions and README badge from `4.2.0` to `4.2.1`.
+- Documented Codex SDK sessions as implemented while keeping Cloud delegation, workflow steps, review actions, and richer Settings checks in the v4.2 patch train.
+
 ## [4.2.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built for developers who want a visual Kanban board that works with autonomous c
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.2.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.2.1-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/docs/CODEX-INTEGRATION.md
+++ b/docs/CODEX-INTEGRATION.md
@@ -2,7 +2,7 @@
 
 Release target: **Veritas Kanban v4.2**
 
-This roadmap tracks the first-class OpenAI Codex integration work for Veritas Kanban. v4.2 now includes the first real runtime slice: a native `codex` agent backed by local `codex exec` execution. The remaining work expands that foundation into richer SDK sessions, cloud delegation, workflow-engine execution, review automation, and deeper UI.
+This roadmap tracks the first-class OpenAI Codex integration work for Veritas Kanban. v4.2 now includes local `codex exec` execution and SDK-backed local Codex sessions. The remaining work expands that foundation into cloud delegation, workflow-engine execution, review automation, and deeper Settings health checks.
 
 Companion docs:
 
@@ -36,7 +36,18 @@ codex exec --cwd <task-worktree> --sandbox workspace-write --json <prompt>
 
 ### Codex SDK Provider
 
-The SDK path should support long-lived local Codex threads, resumable sessions, and richer follow-up workflows. This remains a planned provider mode so the CLI path stays stable and easy to debug.
+The SDK path supports long-lived local Codex threads, resumable session IDs, and richer follow-up workflows. Veritas starts `@openai/codex-sdk` threads in the task worktree, streams SDK events into attempt logs, emits token telemetry, and persists the SDK `threadId` on the active/completed attempt.
+
+Recommended default shape:
+
+```ts
+const thread = codex.startThread({
+  workingDirectory: '<task-worktree>',
+  sandboxMode: 'workspace-write',
+  approvalPolicy: 'never',
+  networkAccessEnabled: true,
+});
+```
 
 ### Codex Cloud Delegation
 
@@ -44,7 +55,7 @@ Cloud delegation should start through GitHub-native workflows: Veritas can creat
 
 ## Architecture Direction
 
-v4.2 starts with a focused provider seam inside the existing agent service instead of a full rewrite. `codex` agents resolve to the local Codex CLI runner; existing agents keep the OpenClaw request-file behavior. A fuller provider abstraction is still tracked for the next implementation step.
+v4.2 starts with a focused provider seam inside the existing agent service instead of a full rewrite. `codex` agents resolve to the local Codex CLI runner, `codex-sdk` agents resolve to the SDK session runner, and existing agents keep the OpenClaw request-file behavior. A fuller provider abstraction is still tracked for workflow and review execution.
 
 Expected long-term provider capabilities:
 
@@ -61,7 +72,7 @@ The provider abstraction should support:
 
 - OpenClaw compatibility through an OpenClaw provider adapter.
 - Codex CLI through a local process provider.
-- Codex SDK through a thread/session provider.
+- Codex SDK through the implemented thread/session provider.
 - Future providers without route-level branching.
 
 ## Telemetry And Logs

--- a/docs/EXAMPLES-codex-workflows.md
+++ b/docs/EXAMPLES-codex-workflows.md
@@ -89,7 +89,7 @@ Use these recipes as starting points for v4.2 OpenAI Codex workflows in Veritas 
 **Goal:** Continue a Codex task after human feedback without losing context.
 
 1. Start the initial task in SDK provider mode.
-2. Store the Codex thread ID in attempt provider metadata.
+2. Veritas stores the Codex thread ID in attempt metadata as `threadId`.
 3. Human adds a task comment:
 
    ```text
@@ -108,7 +108,7 @@ Use these recipes as starting points for v4.2 OpenAI Codex workflows in Veritas 
 
 5. Expected outputs:
    - same Codex thread continues
-   - second attempt log references prior thread
+   - attempt log includes `thread.started`, item, turn, and usage events
    - final summary explains the delta from the first pass
 
 ---
@@ -233,7 +233,9 @@ Checklist:
 - [ ] Settings detects installed `codex`.
 - [ ] Settings reports missing/authenticated state correctly.
 - [ ] Mocked Codex CLI provider passes CI.
+- [ ] Mocked Codex SDK provider records `threadId` and token usage.
 - [ ] Real Codex CLI task completes locally.
+- [ ] Real Codex SDK task completes locally when SDK credentials are available.
 - [ ] Attempt log includes final summary and command/file events.
 - [ ] Token usage appears when Codex provides usage data.
 - [ ] Codex review produces findings on a known diff.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -295,20 +295,21 @@ First-class support for autonomous coding agents.
 
 ## OpenAI Codex Integration (v4.2)
 
-v4.2 adds the first runtime slice of first-class OpenAI Codex support: a built-in `codex` agent that can run local `codex exec` attempts in a task worktree and report status, logs, completion, and telemetry through the existing Veritas agent lifecycle.
+v4.2 adds first-class OpenAI Codex support: local `codex exec` attempts plus SDK-backed Codex sessions that run in task worktrees and report status, logs, completion, telemetry, and durable thread IDs through the existing Veritas agent lifecycle.
 
 Implemented:
 
 - **Codex CLI provider** — Runs `codex exec --json` in the task worktree, maps JSONL/stdout/stderr into Veritas attempt logs, records final summaries, and emits run/token telemetry when available.
 - **Codex agent defaults** — Adds a disabled-by-default OpenAI Codex agent profile with `codex exec --sandbox workspace-write --json`.
+- **Codex SDK provider** — Uses `@openai/codex-sdk` to start durable local Codex threads, stream SDK events into attempt logs, persist `threadId` on attempts, and emit token telemetry from completed turns.
 - **Config migration** — Existing configs receive the missing built-in Codex agent without overwriting customized agents.
 
 Still planned:
 
-- **Codex SDK provider** — Uses `@openai/codex-sdk` for durable local threads, follow-up prompts, and richer session control.
 - **Codex Cloud delegation** — Creates GitHub issue/PR delegation prompts for cloud Codex work and links GitHub artifacts back to Veritas tasks.
 - **Codex review actions** — Uses Codex to review task branches, PR diffs, and failed changes.
 - **Workflow Codex steps** — Executes workflow-engine agent steps through the same provider abstraction used by local task starts.
+- **Richer Settings health checks** — Detects Codex install, auth, SDK availability, and profile readiness from Settings.
 
 Planned documentation:
 

--- a/docs/SOP-codex-integration.md
+++ b/docs/SOP-codex-integration.md
@@ -1,6 +1,6 @@
 # SOP: OpenAI Codex Integration
 
-Use this playbook when Veritas Kanban delegates work to OpenAI Codex. v4.2 includes local Codex CLI execution through `codex exec`; SDK sessions, Cloud delegation, and workflow-engine execution remain part of the broader integration track.
+Use this playbook when Veritas Kanban delegates work to OpenAI Codex. v4.2 includes local Codex CLI execution through `codex exec` and SDK-backed local Codex sessions; Cloud delegation, workflow-engine execution, review actions, and richer Settings checks continue through the v4.2 patch train.
 
 ---
 
@@ -25,7 +25,7 @@ Use this playbook when Veritas Kanban delegates work to OpenAI Codex. v4.2 inclu
 | **Codex Review**   | Review task branches, PR diffs, or failed changes | CLI/SDK review action                |
 | **Workflow Codex** | Pipeline steps in Veritas workflow definitions    | Provider-backed workflow step        |
 
-Default for v4.2 is **Codex CLI**. It is easiest to install, debug, mock in CI, and observe through JSONL events.
+Default for v4.2 is **Codex CLI**. Use **Codex SDK** when a task needs a durable local thread ID for follow-up prompts or richer session continuity.
 
 ---
 
@@ -94,23 +94,37 @@ export CODEX_API_KEY="<optional-api-key-for-automation>"
 
 ## Codex SDK Flow
 
-Use SDK mode when the user needs a durable local Codex thread across multiple prompts. This mode is planned, not part of the initial CLI runner:
+Use SDK mode when the user needs a durable local Codex thread across multiple prompts:
 
 ```ts
 import { Codex } from '@openai/codex-sdk';
 
-const codex = new Codex();
-const thread = codex.startThread();
+const codex = new Codex({ env: { VK_API_URL: 'http://localhost:3001' } });
+const thread = codex.startThread({
+  workingDirectory: '<task-worktree>',
+  sandboxMode: 'workspace-write',
+  approvalPolicy: 'never',
+  networkAccessEnabled: true,
+});
 const result = await thread.run('Implement the Veritas task in the current worktree.');
 ```
 
-Veritas should persist the Codex thread ID in attempt provider metadata so follow-up task comments can continue the same Codex context.
+Veritas persists the Codex thread ID in attempt metadata:
+
+```json
+{
+  "agent": "codex-sdk",
+  "provider": "codex-sdk",
+  "model": "gpt-5.5",
+  "threadId": "thread_..."
+}
+```
 
 ### SDK Session Rules
 
 - Use fresh threads for independent task attempts.
 - Reuse a thread only when the task explicitly needs follow-up work.
-- Store thread IDs in Veritas runtime metadata, not task prose.
+- Store thread IDs in attempt metadata, not task prose.
 - Surface SDK availability errors clearly in Settings and attempt logs.
 
 ---

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
 
   server:
     dependencies:
+      '@openai/codex-sdk':
+        specifier: 0.128.0
+        version: 0.128.0
       '@veritas-kanban/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1062,6 +1065,51 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@openai/codex-sdk@0.128.0':
+    resolution: {integrity: sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ==}
+    engines: {node: '>=18'}
+
+  '@openai/codex@0.128.0':
+    resolution: {integrity: sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.128.0-darwin-arm64':
+    resolution: {integrity: sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.128.0-darwin-x64':
+    resolution: {integrity: sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.128.0-linux-arm64':
+    resolution: {integrity: sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.128.0-linux-x64':
+    resolution: {integrity: sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.128.0-win32-arm64':
+    resolution: {integrity: sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.128.0-win32-x64':
+    resolution: {integrity: sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -6481,6 +6529,37 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@openai/codex-sdk@0.128.0':
+    dependencies:
+      '@openai/codex': 0.128.0
+
+  '@openai/codex@0.128.0':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.128.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.128.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.128.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.128.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.128.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.128.0-win32-x64'
+
+  '@openai/codex@0.128.0-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.128.0-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.128.0-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.128.0-linux-x64':
+    optional: true
+
+  '@openai/codex@0.128.0-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.128.0-win32-x64':
+    optional: true
 
   '@oxc-project/types@0.127.0': {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -16,6 +16,7 @@
     "reset-password": "tsx src/scripts/reset-password.ts"
   },
   "dependencies": {
+    "@openai/codex-sdk": "0.128.0",
     "@veritas-kanban/shared": "workspace:*",
     "ajv": "^8.20.0",
     "bcrypt": "^6.0.0",

--- a/server/src/__tests__/config-service-extended.test.ts
+++ b/server/src/__tests__/config-service-extended.test.ts
@@ -50,6 +50,13 @@ describe('ConfigService', () => {
             provider: 'codex-cli',
             enabled: false,
           }),
+          expect.objectContaining({
+            type: 'codex-sdk',
+            name: 'OpenAI Codex SDK',
+            command: 'codex',
+            provider: 'codex-sdk',
+            enabled: false,
+          }),
         ])
       );
     });
@@ -103,6 +110,11 @@ describe('ConfigService', () => {
             type: 'codex',
             command: 'codex',
             provider: 'codex-cli',
+          }),
+          expect.objectContaining({
+            type: 'codex-sdk',
+            command: 'codex',
+            provider: 'codex-sdk',
           }),
         ])
       );

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -193,6 +193,15 @@ describe('Config Routes (actual module)', () => {
           provider: 'codex-cli',
           model: 'gpt-5.5',
         },
+        {
+          type: 'codex-sdk',
+          name: 'OpenAI Codex SDK',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          provider: 'codex-sdk',
+          model: 'gpt-5.5',
+        },
       ];
       mockConfigService.updateAgents.mockResolvedValue({ agents });
       const res = await request(app).put('/api/config/agents').send(agents);

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -26,7 +26,7 @@ const agentSchema = z.object({
   command: z.string().min(1),
   args: z.array(z.string()),
   enabled: z.boolean(),
-  provider: z.enum(['openclaw', 'codex-cli', 'custom']).optional(),
+  provider: z.enum(['openclaw', 'codex-cli', 'codex-sdk', 'custom']).optional(),
   model: z.string().optional(),
 });
 

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -21,6 +21,7 @@ import { getTelemetryService } from './telemetry-service.js';
 import { getAgentRoutingService } from './agent-routing-service.js';
 import { getBreaker } from './circuit-registry.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
+import type { ThreadEvent } from '@openai/codex-sdk';
 import type {
   Task,
   AgentType,
@@ -38,6 +39,7 @@ const log = createLogger('clawdbot-agent-service');
 const PROJECT_ROOT = path.resolve(process.cwd(), '..');
 const LOGS_DIR = path.join(PROJECT_ROOT, '.veritas-kanban', 'logs');
 const CLAWDBOT_GATEWAY = process.env.CLAWDBOT_GATEWAY || 'http://127.0.0.1:18789';
+type AgentProvider = 'openclaw' | 'codex-cli' | 'codex-sdk';
 
 export interface AgentStatus {
   taskId: string;
@@ -63,7 +65,10 @@ const pendingAgents = new Map<
     agent: AgentType;
     startedAt: string;
     emitter: EventEmitter;
-    provider: 'openclaw' | 'codex-cli';
+    provider: AgentProvider;
+    model?: string;
+    threadId?: string;
+    abortController?: AbortController;
     process?: ChildProcessWithoutNullStreams;
   }
 >();
@@ -147,6 +152,7 @@ export class ClawdbotAgentService {
       startedAt,
       emitter,
       provider,
+      model: agentConfig?.model,
     });
 
     // Validate path segments for log file
@@ -206,6 +212,43 @@ export class ClawdbotAgentService {
         });
         throw new Error(`Failed to start agent via Codex CLI: ${error.message}`);
       }
+
+      return {
+        taskId,
+        attemptId,
+        agent,
+        status: 'running',
+        startedAt,
+      };
+    }
+
+    if (provider === 'codex-sdk') {
+      const abortController = new AbortController();
+      const pending = pendingAgents.get(taskId);
+      if (pending) {
+        pending.abortController = abortController;
+      }
+
+      void this.startCodexSdk(
+        task,
+        agentConfig,
+        taskPrompt,
+        logPath,
+        attemptId,
+        startedAt,
+        emitter,
+        abortController
+      ).catch(async (error: any) => {
+        if (!pendingAgents.has(task.id)) return;
+        await this.appendLog(
+          logPath,
+          `\n## Codex SDK Error\n\n${error.message || 'Codex SDK attempt failed'}\n`
+        );
+        await this.completeAgent(task.id, {
+          success: false,
+          error: error.message || 'Codex SDK attempt failed',
+        });
+      });
 
       return {
         taskId,
@@ -315,6 +358,8 @@ export class ClawdbotAgentService {
         started: pending.startedAt,
         ended: endedAt,
         provider: pending.provider,
+        model: pending.model,
+        threadId: pending.threadId,
       },
     });
 
@@ -369,6 +414,9 @@ export class ClawdbotAgentService {
     if (pending.provider === 'codex-cli' && pending.process && !pending.process.killed) {
       pending.process.kill('SIGTERM');
     }
+    if (pending.provider === 'codex-sdk') {
+      pending.abortController?.abort();
+    }
 
     // Mark as failed/stopped
     await this.completeAgent(taskId, {
@@ -384,7 +432,8 @@ export class ClawdbotAgentService {
   private resolveAgentProvider(
     agentConfig: AgentConfig | undefined,
     agent: AgentType
-  ): 'openclaw' | 'codex-cli' {
+  ): AgentProvider {
+    if (agentConfig?.provider === 'codex-sdk') return 'codex-sdk';
     if (agentConfig?.provider === 'codex-cli') return 'codex-cli';
     if (agent === 'codex') return 'codex-cli';
     if (agentConfig?.command === 'codex') return 'codex-cli';
@@ -520,6 +569,92 @@ export class ClawdbotAgentService {
     return path.join(path.dirname(logPath), `${attemptId}.codex-final.md`);
   }
 
+  private async startCodexSdk(
+    task: Task,
+    agentConfig: AgentConfig | undefined,
+    prompt: string,
+    logPath: string,
+    attemptId: string,
+    startedAt: string,
+    emitter: EventEmitter,
+    abortController: AbortController
+  ): Promise<void> {
+    const worktreePath = this.expandPath(task.git?.worktreePath || '');
+    if (!worktreePath) {
+      throw new Error('Task worktree path is required for Codex SDK');
+    }
+
+    const { Codex } = await import('@openai/codex-sdk');
+    const codex = new Codex({
+      codexPathOverride:
+        agentConfig?.command && agentConfig.command !== 'codex' ? agentConfig.command : undefined,
+      env: this.buildCodexEnv(),
+    });
+
+    const thread = codex.startThread({
+      workingDirectory: worktreePath,
+      skipGitRepoCheck: true,
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'never',
+      networkAccessEnabled: true,
+      model: agentConfig?.model,
+    });
+
+    await this.appendLog(
+      logPath,
+      `\n## Codex SDK\n\n**Worktree:** \`${worktreePath}\`\n**Model:** ${agentConfig?.model || 'default'}\n\n`
+    );
+
+    const streamed = await thread.runStreamed(prompt, { signal: abortController.signal });
+    let finalSummary = '';
+    let failureMessage = '';
+    let tokenUsage:
+      | { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string }
+      | undefined;
+
+    for await (const event of streamed.events) {
+      const parsed = this.handleCodexEvent(event, logPath);
+      if (parsed.summary) finalSummary = parsed.summary;
+      if (parsed.usage) tokenUsage = parsed.usage;
+
+      if (event.type === 'thread.started') {
+        await this.recordCodexThread(task, attemptId, event.thread_id);
+      }
+      if (event.type === 'turn.failed') {
+        failureMessage = event.error.message;
+      }
+      if (event.type === 'error') {
+        failureMessage = event.message;
+      }
+    }
+
+    if (tokenUsage) {
+      await getTelemetryService().emit<TokenTelemetryEvent>({
+        type: 'run.tokens',
+        taskId: task.id,
+        attemptId,
+        agent: agentConfig?.type || 'codex-sdk',
+        project: task.project,
+        inputTokens: tokenUsage.inputTokens,
+        outputTokens: tokenUsage.outputTokens,
+        totalTokens: tokenUsage.totalTokens,
+        model: tokenUsage.model || agentConfig?.model,
+      });
+    }
+
+    await this.appendLog(
+      logPath,
+      `\n## Codex SDK Complete\n\n**Duration:** ${Date.now() - new Date(startedAt).getTime()}ms\n`
+    );
+
+    await this.completeAgent(task.id, {
+      success: !failureMessage,
+      summary: finalSummary || failureMessage || 'Codex SDK completed without a final summary.',
+      error: failureMessage || undefined,
+    });
+    emitter.emit('sdk.complete', { taskId: task.id, attemptId });
+  }
+
   private handleCodexJsonLine(
     line: string,
     logPath: string
@@ -532,18 +667,58 @@ export class ClawdbotAgentService {
 
     try {
       const event = JSON.parse(trimmed) as Record<string, unknown>;
-      const type = String(event.type || event.event || 'codex.event');
-      const summary = this.extractCodexSummary(event);
-      const usage = this.extractCodexUsage(event);
-      void this.appendLog(
-        logPath,
-        `\n### ${type}\n\n${summary ? `${summary}\n\n` : ''}<details><summary>Raw event</summary>\n\n\`\`\`json\n${JSON.stringify(event, null, 2)}\n\`\`\`\n\n</details>\n`
-      );
-      return { summary, usage };
+      return this.handleCodexEvent(event, logPath);
     } catch {
       void this.appendLog(logPath, `\n### stdout\n\n\`\`\`\n${trimmed}\n\`\`\`\n`);
       return { summary: trimmed };
     }
+  }
+
+  private handleCodexEvent(
+    event: ThreadEvent | Record<string, unknown>,
+    logPath: string
+  ): {
+    summary?: string;
+    usage?: { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string };
+  } {
+    const record = event as Record<string, unknown>;
+    const type = String(record.type || record.event || 'codex.event');
+    const summary = this.extractCodexSummary(record);
+    const usage = this.extractCodexUsage(record);
+    void this.appendLog(
+      logPath,
+      `\n### ${type}\n\n${summary ? `${summary}\n\n` : ''}<details><summary>Raw event</summary>\n\n\`\`\`json\n${JSON.stringify(record, null, 2)}\n\`\`\`\n\n</details>\n`
+    );
+    return { summary, usage };
+  }
+
+  private async recordCodexThread(task: Task, attemptId: string, threadId: string): Promise<void> {
+    const pending = pendingAgents.get(task.id);
+    if (pending) {
+      pending.threadId = threadId;
+    }
+
+    await this.taskService.updateTask(task.id, {
+      status: 'in-progress',
+      attempt: {
+        id: attemptId,
+        agent: pending?.agent || 'codex-sdk',
+        status: 'running',
+        started: pending?.startedAt,
+        provider: pending?.provider || 'codex-sdk',
+        model: pending?.model,
+        threadId,
+      },
+    });
+  }
+
+  private buildCodexEnv(): Record<string, string> {
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (typeof value === 'string') env[key] = value;
+    }
+    env.VK_API_URL = process.env.VK_API_URL || 'http://localhost:3001';
+    return env;
   }
 
   private extractCodexSummary(event: unknown): string | undefined {

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -62,6 +62,14 @@ const DEFAULT_CONFIG: AppConfig = {
       enabled: false,
       provider: 'codex-cli',
     },
+    {
+      type: 'codex-sdk',
+      name: 'OpenAI Codex SDK',
+      command: 'codex',
+      args: [],
+      enabled: false,
+      provider: 'codex-sdk',
+    },
   ],
   defaultAgent: 'claude-code',
 };

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -22,7 +22,7 @@ export interface AgentConfig {
   command: string;
   args: string[];
   enabled: boolean;
-  provider?: 'openclaw' | 'codex-cli' | 'custom';
+  provider?: 'openclaw' | 'codex-cli' | 'codex-sdk' | 'custom';
   model?: string;
 }
 

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -42,6 +42,7 @@ export interface TaskAttempt {
   ended?: string;
   provider?: string;
   model?: string;
+  threadId?: string;
 }
 
 export interface Subtask {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Ships v4.2.1 Codex SDK sessions.

- Add @openai/codex-sdk as a server dependency and introduce a disabled-by-default `codex-sdk` agent profile
- Run SDK-backed Codex attempts in task worktrees with streamed event logs, abort/stop support, and token telemetry
- Persist SDK `threadId` on task attempts for future follow-up/resume workflows
- Update provider schemas/types, config defaults/migration tests, docs, changelog, README badge, and package versions to 4.2.1

Closes #301

## Validation

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/server test -- config-service-extended.test.ts config-coverage.test.ts`
- `pnpm build`