### PR TITLE
feat: add Codex settings health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.5] - 2026-05-06
+
+### Added
+
+- Codex Settings health endpoint at `GET /api/settings/codex/health`.
+- Server-side checks for Codex CLI installation, CLI version, `codex login status`, Codex SDK import availability, and Codex CLI/SDK/Cloud agent profile readiness.
+- Settings Agents tab Codex Health panel with refresh, readiness badges, version/auth details, and actionable recommendations.
+- Frontend API and hook support for Codex health checks.
+- Route coverage for the Codex Settings health endpoint.
+
+### Changed
+
+- Updated workspace package versions and README badge from `4.2.4` to `4.2.5`.
+- Documented richer Codex Settings health checks as implemented, completing the requested v4.2 patch train.
+
 ## [4.2.4] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built for developers who want a visual Kanban board that works with autonomous c
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-4.2.4-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.2.5-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/docs/CODEX-INTEGRATION.md
+++ b/docs/CODEX-INTEGRATION.md
@@ -2,7 +2,7 @@
 
 Release target: **Veritas Kanban v4.2**
 
-This roadmap tracks the first-class OpenAI Codex integration work for Veritas Kanban. v4.2 now includes local `codex exec` execution, SDK-backed local Codex sessions, GitHub-native Codex Cloud delegation, Codex-backed workflow-engine steps, and Codex review actions. The remaining work expands that foundation into deeper Settings health checks.
+This roadmap tracks the first-class OpenAI Codex integration work for Veritas Kanban. v4.2 now includes local `codex exec` execution, SDK-backed local Codex sessions, GitHub-native Codex Cloud delegation, Codex-backed workflow-engine steps, Codex review actions, and richer Settings health checks.
 
 Companion docs:
 
@@ -142,6 +142,16 @@ POST /api/diff/<taskId>/codex-review
   "save": true
 }
 ```
+
+## Settings Health
+
+Settings exposes Codex readiness through a dedicated health check:
+
+```http
+GET /api/settings/codex/health
+```
+
+The response reports Codex CLI install/version/auth state, SDK import availability, Codex agent profile readiness, enabled Codex profiles, and recommendations.
 
 ## MCP And Project Instructions
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -295,7 +295,7 @@ First-class support for autonomous coding agents.
 
 ## OpenAI Codex Integration (v4.2)
 
-v4.2 adds first-class OpenAI Codex support: local `codex exec` attempts, SDK-backed Codex sessions, GitHub-native Codex Cloud delegation, Codex-backed workflow-engine steps, and Codex review actions through the existing Veritas task lifecycle.
+v4.2 adds first-class OpenAI Codex support: local `codex exec` attempts, SDK-backed Codex sessions, GitHub-native Codex Cloud delegation, Codex-backed workflow-engine steps, Codex review actions, and Settings health checks through the existing Veritas task lifecycle.
 
 Implemented:
 
@@ -305,11 +305,8 @@ Implemented:
 - **Codex Cloud delegation** — Creates scoped `@codex` GitHub issue/PR prompts, records cloud attempt metadata, and links the GitHub artifact back to the Veritas task.
 - **Workflow Codex steps** — Executes workflow-engine agent steps through Codex SDK streaming, writes step outputs, and stores Codex thread IDs in workflow session context.
 - **Codex review actions** — Reviews task branch diffs in read-only Codex SDK mode, maps structured findings to Veritas review comments, and stores review decisions.
+- **Codex Settings health** — Checks Codex CLI install/auth state, SDK availability, and Codex CLI/SDK/Cloud profile readiness from Settings.
 - **Config migration** — Existing configs receive the missing built-in Codex agent without overwriting customized agents.
-
-Still planned:
-
-- **Richer Settings health checks** — Detects Codex install, auth, SDK availability, and profile readiness from Settings.
 
 Planned documentation:
 

--- a/docs/SOP-codex-integration.md
+++ b/docs/SOP-codex-integration.md
@@ -1,6 +1,6 @@
 # SOP: OpenAI Codex Integration
 
-Use this playbook when Veritas Kanban delegates work to OpenAI Codex. v4.2 includes local Codex CLI execution through `codex exec`, SDK-backed local Codex sessions, GitHub-native Codex Cloud delegation, workflow-engine Codex steps, and Codex review actions; richer Settings checks continue through the v4.2 patch train.
+Use this playbook when Veritas Kanban delegates work to OpenAI Codex. v4.2 includes local Codex CLI execution through `codex exec`, SDK-backed local Codex sessions, GitHub-native Codex Cloud delegation, workflow-engine Codex steps, Codex review actions, and richer Settings health checks.
 
 ---
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/server/src/__tests__/routes/settings-codex-health.test.ts
+++ b/server/src/__tests__/routes/settings-codex-health.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+const { mockCodexHealthService } = vi.hoisted(() => ({
+  mockCodexHealthService: {
+    getHealth: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/codex-health-service.js', () => ({
+  CodexHealthService: function () {
+    return mockCodexHealthService;
+  },
+}));
+
+vi.mock('../../services/config-service.js', () => ({
+  ConfigService: function () {
+    return {
+      getFeatureSettings: vi.fn(),
+      updateFeatureSettings: vi.fn(),
+    };
+  },
+}));
+
+import { settingsRoutes } from '../../routes/settings.js';
+
+describe('Settings Codex health route', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/settings', settingsRoutes);
+    app.use(errorHandler);
+  });
+
+  it('returns Codex install/auth/profile health', async () => {
+    mockCodexHealthService.getHealth.mockResolvedValue({
+      checkedAt: '2026-05-06T00:00:00.000Z',
+      cli: { installed: true, authenticated: true, version: 'codex-cli 0.128.0' },
+      sdk: { available: true },
+      agents: { codexCli: true, codexSdk: true, codexCloud: true, enabled: ['codex'] },
+      ready: { cli: true, sdk: true, cloud: true, overall: true },
+      recommendations: [],
+    });
+
+    const response = await request(app).get('/api/settings/codex/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.ready.overall).toBe(true);
+    expect(mockCodexHealthService.getHealth).toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,5 +1,6 @@
 import { Router, type Router as RouterType } from 'express';
 import { ConfigService } from '../services/config-service.js';
+import { CodexHealthService } from '../services/codex-health-service.js';
 import { getTelemetryService } from '../services/telemetry-service.js';
 import { getAttachmentService } from '../services/attachment-service.js';
 import { setEnforcementSettings, setHooksSettings } from '../services/hook-service.js';
@@ -13,6 +14,7 @@ import { authorize, type AuthenticatedRequest } from '../middleware/auth.js';
 
 const router: RouterType = Router();
 const configService = new ConfigService();
+const codexHealthService = new CodexHealthService();
 
 /**
  * Sync feature settings to affected server-side services.
@@ -66,6 +68,15 @@ router.get(
   asyncHandler(async (_req, res) => {
     const features = await configService.getFeatureSettings();
     res.json(sanitizeFeatureSettings(features));
+  })
+);
+
+// GET /api/settings/codex/health — checks Codex install/auth/SDK/profile readiness
+router.get(
+  '/codex/health',
+  asyncHandler(async (_req, res) => {
+    const health = await codexHealthService.getHealth();
+    res.json(health);
   })
 );
 

--- a/server/src/services/codex-health-service.ts
+++ b/server/src/services/codex-health-service.ts
@@ -1,0 +1,133 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { ConfigService } from './config-service.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface CodexHealthStatus {
+  checkedAt: string;
+  cli: {
+    installed: boolean;
+    path?: string;
+    version?: string;
+    authenticated: boolean;
+    authMode?: string;
+    error?: string;
+  };
+  sdk: {
+    available: boolean;
+    error?: string;
+  };
+  agents: {
+    codexCli: boolean;
+    codexSdk: boolean;
+    codexCloud: boolean;
+    enabled: string[];
+  };
+  ready: {
+    cli: boolean;
+    sdk: boolean;
+    cloud: boolean;
+    overall: boolean;
+  };
+  recommendations: string[];
+}
+
+export class CodexHealthService {
+  private configService: ConfigService;
+
+  constructor() {
+    this.configService = new ConfigService();
+  }
+
+  async getHealth(): Promise<CodexHealthStatus> {
+    const [cli, sdk, config] = await Promise.all([
+      this.checkCli(),
+      this.checkSdk(),
+      this.configService.getConfig(),
+    ]);
+
+    const codexCli = config.agents.some((agent) => agent.provider === 'codex-cli');
+    const codexSdk = config.agents.some((agent) => agent.provider === 'codex-sdk');
+    const codexCloud = config.agents.some((agent) => agent.provider === 'codex-cloud');
+    const enabled = config.agents
+      .filter((agent) => agent.enabled && String(agent.provider || '').startsWith('codex'))
+      .map((agent) => agent.type);
+
+    const ready = {
+      cli: cli.installed && cli.authenticated && codexCli,
+      sdk: cli.installed && cli.authenticated && sdk.available && codexSdk,
+      cloud: cli.installed && cli.authenticated && codexCloud,
+      overall: false,
+    };
+    ready.overall = ready.cli || ready.sdk || ready.cloud;
+
+    return {
+      checkedAt: new Date().toISOString(),
+      cli,
+      sdk,
+      agents: { codexCli, codexSdk, codexCloud, enabled },
+      ready,
+      recommendations: this.buildRecommendations(cli, sdk, {
+        codexCli,
+        codexSdk,
+        codexCloud,
+      }),
+    };
+  }
+
+  private async checkCli(): Promise<CodexHealthStatus['cli']> {
+    try {
+      const { stdout: path } = await execFileAsync('which', ['codex']);
+      const version = await execFileAsync('codex', ['--version'])
+        .then(({ stdout }) => stdout.trim())
+        .catch(() => undefined);
+      const login = await execFileAsync('codex', ['login', 'status'])
+        .then(({ stdout, stderr }) => `${stdout}${stderr}`.trim())
+        .catch((error: Error) => error.message);
+
+      const authenticated = /logged in/i.test(login);
+      return {
+        installed: true,
+        path: path.trim(),
+        version,
+        authenticated,
+        authMode: authenticated ? login.split(/\r?\n/)[0] : undefined,
+        error: authenticated ? undefined : login,
+      };
+    } catch (error: any) {
+      return {
+        installed: false,
+        authenticated: false,
+        error: error.message || 'Codex CLI is not installed',
+      };
+    }
+  }
+
+  private async checkSdk(): Promise<CodexHealthStatus['sdk']> {
+    try {
+      await import('@openai/codex-sdk');
+      return { available: true };
+    } catch (error: any) {
+      return { available: false, error: error.message || 'Codex SDK is not available' };
+    }
+  }
+
+  private buildRecommendations(
+    cli: CodexHealthStatus['cli'],
+    sdk: CodexHealthStatus['sdk'],
+    agents: { codexCli: boolean; codexSdk: boolean; codexCloud: boolean }
+  ): string[] {
+    const recommendations: string[] = [];
+    if (!cli.installed)
+      recommendations.push('Install the Codex CLI and ensure `codex` is on PATH.');
+    if (cli.installed && !cli.authenticated)
+      recommendations.push('Run `codex login` to authenticate.');
+    if (!sdk.available)
+      recommendations.push('Install server dependencies so `@openai/codex-sdk` is available.');
+    if (!agents.codexCli) recommendations.push('Add the default Codex CLI agent profile.');
+    if (!agents.codexSdk) recommendations.push('Add the default Codex SDK agent profile.');
+    if (!agents.codexCloud) recommendations.push('Add the default Codex Cloud agent profile.');
+    return recommendations;
+  }
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -22,7 +22,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { useConfig, useUpdateAgents } from '@/hooks/useConfig';
+import { useCodexHealth, useConfig, useUpdateAgents } from '@/hooks/useConfig';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { useRoutingConfig, useUpdateRoutingConfig } from '@/hooks/useRouting';
 import {
@@ -36,6 +36,7 @@ import {
   ChevronDown,
   ChevronUp,
   Loader2,
+  RefreshCw,
 } from 'lucide-react';
 import type {
   AgentConfig,
@@ -43,12 +44,18 @@ import type {
   RoutingRule,
   AgentRoutingConfig,
 } from '@veritas-kanban/shared';
+import type { CodexHealthStatus } from '@/lib/api';
 import { DEFAULT_FEATURE_SETTINGS, DEFAULT_ROUTING_CONFIG } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
 import { ToggleRow, NumberRow, SectionHeader, SaveIndicator } from '../shared';
 
 export function AgentsTab() {
   const { data: config, isLoading } = useConfig();
+  const {
+    data: codexHealth,
+    isFetching: isCodexHealthFetching,
+    refetch: refetchCodexHealth,
+  } = useCodexHealth();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
   const updateAgents = useUpdateAgents();
@@ -147,6 +154,12 @@ export function AgentsTab() {
         )}
       </div>
 
+      <CodexHealthPanel
+        health={codexHealth}
+        isFetching={isCodexHealthFetching}
+        onRefresh={() => refetchCodexHealth()}
+      />
+
       {/* Agent Behavior */}
       <div className="space-y-4">
         <div className="flex items-center justify-between">
@@ -198,6 +211,76 @@ export function AgentsTab() {
 
       {/* Agent Routing Rules */}
       <RoutingRulesSection agents={config?.agents || []} />
+    </div>
+  );
+}
+
+function CodexHealthPanel({
+  health,
+  isFetching,
+  onRefresh,
+}: {
+  health?: CodexHealthStatus;
+  isFetching: boolean;
+  onRefresh: () => void;
+}) {
+  const statusBadge = (ready: boolean, label: string) => (
+    <Badge variant={ready ? 'default' : 'secondary'} className="gap-1">
+      {ready ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
+      {label}
+    </Badge>
+  );
+
+  return (
+    <div className="rounded-md border bg-card p-3 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">Codex Health</h3>
+          <p className="text-xs text-muted-foreground">
+            {health?.checkedAt
+              ? `Checked ${new Date(health.checkedAt).toLocaleTimeString()}`
+              : 'Checking Codex readiness'}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onRefresh}
+          disabled={isFetching}
+          aria-label="Refresh Codex health"
+        >
+          {isFetching ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {statusBadge(!!health?.cli.installed, 'CLI installed')}
+        {statusBadge(!!health?.cli.authenticated, 'Authenticated')}
+        {statusBadge(!!health?.sdk.available, 'SDK available')}
+        {statusBadge(!!health?.ready.cli, 'CLI profile')}
+        {statusBadge(!!health?.ready.sdk, 'SDK profile')}
+        {statusBadge(!!health?.ready.cloud, 'Cloud profile')}
+      </div>
+
+      {health?.cli.version && (
+        <div className="text-xs text-muted-foreground">
+          {health.cli.version}
+          {health.cli.authMode ? ` · ${health.cli.authMode}` : ''}
+        </div>
+      )}
+
+      {health?.recommendations.length ? (
+        <ul className="space-y-1 text-xs text-muted-foreground">
+          {health.recommendations.map((recommendation) => (
+            <li key={recommendation}>{recommendation}</li>
+          ))}
+        </ul>
+      ) : null}
     </div>
   );
 }

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -9,6 +9,14 @@ export function useConfig() {
   });
 }
 
+export function useCodexHealth() {
+  return useQuery({
+    queryKey: ['settings', 'codex-health'],
+    queryFn: api.settings.getCodexHealth,
+    staleTime: 30 * 1000,
+  });
+}
+
 export function useRepos() {
   return useQuery({
     queryKey: ['config', 'repos'],

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -16,6 +16,11 @@ export const settingsApi = {
     return handleResponse<FeatureSettings>(response);
   },
 
+  getCodexHealth: async (): Promise<CodexHealthStatus> => {
+    const response = await fetch(`${API_BASE}/settings/codex/health`);
+    return handleResponse<CodexHealthStatus>(response);
+  },
+
   updateFeatures: async (patch: Partial<FeatureSettings>): Promise<FeatureSettings> => {
     const response = await fetch(`${API_BASE}/settings/features`, {
       credentials: 'include',
@@ -26,6 +31,35 @@ export const settingsApi = {
     return handleResponse<FeatureSettings>(response);
   },
 };
+
+export interface CodexHealthStatus {
+  checkedAt: string;
+  cli: {
+    installed: boolean;
+    path?: string;
+    version?: string;
+    authenticated: boolean;
+    authMode?: string;
+    error?: string;
+  };
+  sdk: {
+    available: boolean;
+    error?: string;
+  };
+  agents: {
+    codexCli: boolean;
+    codexSdk: boolean;
+    codexCloud: boolean;
+    enabled: string[];
+  };
+  ready: {
+    cli: boolean;
+    sdk: boolean;
+    cloud: boolean;
+    overall: boolean;
+  };
+  recommendations: string[];
+}
 
 export const configApi = {
   get: async (): Promise<AppConfig> => {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -56,6 +56,7 @@ export { managedList } from './managed-list';
 // Re-export all types from each module
 export type { ArchiveSuggestion } from './tasks';
 export type { BacklogListResponse, BacklogFilterOptions } from './backlog';
+export type { CodexHealthStatus } from './config';
 
 export type {
   AgentStatus,


### PR DESCRIPTION
## Summary

Ships v4.2.5 richer Codex Settings health checks.

- Add `GET /api/settings/codex/health` for Codex CLI install/version/auth, SDK availability, and profile readiness
- Add Settings > Agents Codex Health panel with refresh, readiness badges, auth/version details, and recommendations
- Add frontend API/hook support and route coverage
- Update docs, changelog, README badge, and workspace package versions

Closes #303

## Validation

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server test -- settings-codex-health.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm build`