### PR TITLE
fix: align Veritas with Hermes runtime truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,5 +76,6 @@ VERITAS_ADMIN_KEY=
 # TELEMETRY_COMPRESS_DAYS=7
 
 # ── External Services ────────────────────────────────────────
-# Clawdbot gateway URL (default: http://127.0.0.1:18789)
-# CLAWDBOT_GATEWAY=http://127.0.0.1:18789
+# Hermes gateway URL (default: http://127.0.0.1:18789)
+# HERMES_GATEWAY=http://127.0.0.1:18789
+# Legacy compatibility alias also accepted: CLAWDBOT_GATEWAY

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tasks/attachments/
 tasks/archive-attachments/
 .veritas-kanban/*
 !.veritas-kanban/.gitkeep
+server/storage/
 
 # Historical broken config data (should never have been tracked)
 .veritas-kanban.broken/

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -82,7 +82,7 @@ export function registerAgentCommands(program: Command): void {
   // Get pending agent requests (for Veritas to process)
   program
     .command('agents:pending')
-    .description('List pending agent requests waiting for Clawdbot to process')
+    .description('List pending agent requests waiting for Hermes to process')
     .option('--json', 'Output as JSON')
     .action(async (options) => {
       try {
@@ -135,7 +135,7 @@ export function registerAgentCommands(program: Command): void {
       }
     });
 
-  // Complete an agent request (called by Clawdbot after sub-agent finishes)
+  // Complete an agent request (called by Hermes after sub-agent finishes)
   program
     .command('agents:complete <taskId>')
     .description('Mark an agent request as complete')

--- a/cli/src/commands/automation.ts
+++ b/cli/src/commands/automation.ts
@@ -59,7 +59,7 @@ export function registerAutomationCommands(program: Command): void {
     .command('automation:start <id>')
     .alias('as')
     .description('Start an automation task via Veritas sub-agent')
-    .option('-s, --session <key>', 'Clawdbot session key')
+    .option('-s, --session <key>', 'Hermes session key')
     .option('--json', 'Output as JSON')
     .action(async (id, options) => {
       try {

--- a/mcp/src/tools/automation.ts
+++ b/mcp/src/tools/automation.ts
@@ -43,7 +43,7 @@ export const automationTools = [
         },
         sessionKey: {
           type: 'string',
-          description: 'Clawdbot session key (optional)',
+          description: 'Hermes session key (optional)',
         },
       },
       required: ['id'],
@@ -100,13 +100,15 @@ export async function handleAutomationTool(name: string, args: any): Promise<any
         };
       }
 
-      const result = await api<{ taskId: string; attemptId: string; title: string; description: string }>(
-        `/api/automation/${task.id}/start`,
-        {
-          method: 'POST',
-          body: JSON.stringify({ sessionKey }),
-        }
-      );
+      const result = await api<{
+        taskId: string;
+        attemptId: string;
+        title: string;
+        description: string;
+      }>(`/api/automation/${task.id}/start`, {
+        method: 'POST',
+        body: JSON.stringify({ sessionKey }),
+      });
 
       return {
         content: [

--- a/server/.env.example
+++ b/server/.env.example
@@ -80,10 +80,11 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,h
 # INTEGRATION
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Clawdbot gateway URL for AI agent orchestration
-# CLAWDBOT_GATEWAY=http://127.0.0.1:18789
+# Hermes gateway URL for AI agent orchestration
+# HERMES_GATEWAY=http://127.0.0.1:18789
+# Legacy compatibility alias also accepted: CLAWDBOT_GATEWAY
 
-# Webhook URL for pushing task/chat events to an external service (e.g. Clawdbot Gateway).
+# Webhook URL for pushing task/chat events to an external service (e.g. Hermes gateway).
 # Overrides the webhookUrl value in notification settings if set.
 # VERITAS_WEBHOOK_URL=http://127.0.0.1:18789/webhook
 

--- a/server/src/__tests__/config/env.test.ts
+++ b/server/src/__tests__/config/env.test.ts
@@ -177,6 +177,7 @@ describe('envSchema', () => {
         expect(result.data.VERITAS_API_KEYS).toBe('');
         expect(result.data.RATE_LIMIT_MAX).toBe(300);
         expect(result.data.CSP_REPORT_ONLY).toBe(false);
+        expect(result.data.HERMES_GATEWAY).toBe('http://127.0.0.1:18789');
         expect(result.data.CLAWDBOT_GATEWAY).toBe('http://127.0.0.1:18789');
       }
     });
@@ -275,19 +276,32 @@ describe('envSchema', () => {
     });
   });
 
-  describe('CLAWDBOT_GATEWAY', () => {
-    it('should accept a valid URL', () => {
+  describe('HERMES_GATEWAY / CLAWDBOT_GATEWAY', () => {
+    it('should accept the Hermes-native gateway URL and mirror it to the compatibility alias', () => {
+      const result = envSchema.safeParse({
+        VERITAS_ADMIN_KEY: 'test-key',
+        HERMES_GATEWAY: 'http://127.0.0.1:18789',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.HERMES_GATEWAY).toBe('http://127.0.0.1:18789');
+        expect(result.data.CLAWDBOT_GATEWAY).toBe('http://127.0.0.1:18789');
+      }
+    });
+
+    it('should accept the legacy compatibility alias and normalize it to HERMES_GATEWAY', () => {
       const result = envSchema.safeParse({
         VERITAS_ADMIN_KEY: 'test-key',
         CLAWDBOT_GATEWAY: 'http://192.168.1.100:18789',
       });
       expect(result.success).toBe(true);
       if (result.success) {
+        expect(result.data.HERMES_GATEWAY).toBe('http://192.168.1.100:18789');
         expect(result.data.CLAWDBOT_GATEWAY).toBe('http://192.168.1.100:18789');
       }
     });
 
-    it('should reject an invalid URL', () => {
+    it('should reject an invalid legacy compatibility URL', () => {
       const result = envSchema.safeParse({
         VERITAS_ADMIN_KEY: 'test-key',
         CLAWDBOT_GATEWAY: 'not-a-url',

--- a/server/src/__tests__/routes/agent-status-coverage.test.ts
+++ b/server/src/__tests__/routes/agent-status-coverage.test.ts
@@ -11,7 +11,20 @@ vi.mock('../../services/status-history-service.js', () => ({
   },
 }));
 
-import { agentStatusRoutes, updateAgentStatus, getAgentStatus, initAgentStatus } from '../../routes/agent-status.js';
+const mockRegistryAgents = vi.hoisted(() => ({ value: [] as any[] }));
+
+vi.mock('../../services/agent-registry-service.js', () => ({
+  getAgentRegistryService: () => ({
+    list: () => mockRegistryAgents.value,
+  }),
+}));
+
+import {
+  agentStatusRoutes,
+  updateAgentStatus,
+  getAgentStatus,
+  initAgentStatus,
+} from '../../routes/agent-status.js';
 import { errorHandler } from '../../middleware/error-handler.js';
 
 describe('Agent Status Routes (actual module)', () => {
@@ -19,6 +32,7 @@ describe('Agent Status Routes (actual module)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRegistryAgents.value = [];
     updateAgentStatus({ status: 'idle', subAgentCount: 0 });
     app = express();
     app.use(express.json());
@@ -32,6 +46,36 @@ describe('Agent Status Routes (actual module)', () => {
     expect(res.body.status).toBe('idle');
   });
 
+  it('GET / should expose registry agents through the legacy status endpoint', async () => {
+    mockRegistryAgents.value = [
+      {
+        id: 'hermes-agent',
+        name: 'HermesAgent',
+        status: 'busy',
+        registeredAt: '2026-05-09T08:00:00.000Z',
+        lastHeartbeat: '2026-05-09T08:01:00.000Z',
+        currentTaskId: 'task_1',
+        currentTaskTitle: 'Clean repo',
+        capabilities: [],
+      },
+    ];
+
+    const res = await request(app).get('/api/agent/status');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('sub-agent');
+    expect(res.body.subAgentCount).toBe(1);
+    expect(res.body.activeAgents).toEqual([
+      {
+        agent: 'HermesAgent',
+        status: 'working',
+        taskId: 'task_1',
+        taskTitle: 'Clean repo',
+        startedAt: '2026-05-09T08:01:00.000Z',
+      },
+    ]);
+  });
+
   it('GET / should return flattened activeTask', async () => {
     updateAgentStatus({ status: 'working', activeTask: { id: 't1', title: 'Test' } });
     const res = await request(app).get('/api/agent/status');
@@ -40,13 +84,17 @@ describe('Agent Status Routes (actual module)', () => {
   });
 
   it('POST / should update to working', async () => {
-    const res = await request(app).post('/api/agent/status').send({ status: 'working', activeTask: { id: 't1' } });
+    const res = await request(app)
+      .post('/api/agent/status')
+      .send({ status: 'working', activeTask: { id: 't1' } });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('working');
   });
 
   it('POST / should update sub-agent count', async () => {
-    const res = await request(app).post('/api/agent/status').send({ status: 'sub-agent', subAgentCount: 3 });
+    const res = await request(app)
+      .post('/api/agent/status')
+      .send({ status: 'sub-agent', subAgentCount: 3 });
     expect(res.body.subAgentCount).toBe(3);
   });
 
@@ -58,7 +106,9 @@ describe('Agent Status Routes (actual module)', () => {
   });
 
   it('POST / should set error message', async () => {
-    const res = await request(app).post('/api/agent/status').send({ status: 'error', errorMessage: 'Failed' });
+    const res = await request(app)
+      .post('/api/agent/status')
+      .send({ status: 'error', errorMessage: 'Failed' });
     expect(res.body.errorMessage).toBe('Failed');
   });
 

--- a/server/src/__tests__/squad-webhook-service.test.ts
+++ b/server/src/__tests__/squad-webhook-service.test.ts
@@ -84,7 +84,7 @@ describe('squad webhook service', () => {
     });
   });
 
-  it('fires OpenClaw wake call and validates url', async () => {
+  it('fires Hermes gateway wake call and validates url', async () => {
     fetchSpy.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
     const mod = await import('../services/squad-webhook-service.js');
 
@@ -100,9 +100,9 @@ describe('squad webhook service', () => {
         enabled: true,
         notifyOnHuman: true,
         notifyOnAgent: true,
-        mode: 'openclaw',
-        openclawGatewayUrl: 'https://gateway.test',
-        openclawGatewayToken: 'token',
+        mode: 'hermes',
+        hermesGatewayUrl: 'https://gateway.test',
+        hermesGatewayToken: 'token',
       } as any
     );
 
@@ -115,7 +115,7 @@ describe('squad webhook service', () => {
     });
   });
 
-  it('skips invalid OpenClaw or incomplete config and tolerates failed responses', async () => {
+  it('skips invalid Hermes gateway or incomplete config and tolerates failed responses', async () => {
     const mod = await import('../services/squad-webhook-service.js');
     const msg = {
       id: 'm1',
@@ -128,16 +128,16 @@ describe('squad webhook service', () => {
       enabled: true,
       notifyOnHuman: true,
       notifyOnAgent: true,
-      mode: 'openclaw',
+      mode: 'hermes',
     } as any);
     mockValidateWebhookUrl.mockReturnValue({ valid: false, reason: 'ssrf' });
     await mod.fireSquadWebhook(msg, {
       enabled: true,
       notifyOnHuman: true,
       notifyOnAgent: true,
-      mode: 'openclaw',
-      openclawGatewayUrl: 'https://bad.test',
-      openclawGatewayToken: 'token',
+      mode: 'hermes',
+      hermesGatewayUrl: 'https://bad.test',
+      hermesGatewayToken: 'token',
     } as any);
     expect(fetchSpy).not.toHaveBeenCalled();
 

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -44,7 +44,7 @@ const booleanString = z
     return val === 'true';
   });
 
-export const envSchema = z.object({
+const baseEnvSchema = z.object({
   // ── Server ──────────────────────────────────────────────────────────
   /** HTTP port the server listens on */
   PORT: portSchema.default('3001'),
@@ -109,8 +109,20 @@ export const envSchema = z.object({
   TELEMETRY_COMPRESS_DAYS: positiveIntString,
 
   // ── External Services ───────────────────────────────────────────────
-  /** Clawdbot gateway URL */
-  CLAWDBOT_GATEWAY: z.string().url().optional().default('http://127.0.0.1:18789'),
+  /** Hermes gateway URL. Prefer this over legacy CLAWDBOT_GATEWAY. */
+  HERMES_GATEWAY: z.string().url().optional(),
+
+  /** Legacy compatibility alias for Hermes gateway URL */
+  CLAWDBOT_GATEWAY: z.string().url().optional(),
+});
+
+export const envSchema = baseEnvSchema.transform((env) => {
+  const hermesGateway = env.HERMES_GATEWAY ?? env.CLAWDBOT_GATEWAY ?? 'http://127.0.0.1:18789';
+  return {
+    ...env,
+    HERMES_GATEWAY: hermesGateway,
+    CLAWDBOT_GATEWAY: env.CLAWDBOT_GATEWAY ?? hermesGateway,
+  };
 });
 
 // ---------------------------------------------------------------------------
@@ -165,7 +177,7 @@ export function validateEnv(): Env {
   _env = result.data;
 
   // Log which env vars are configured (names only, never values)
-  const configuredVars = Object.keys(envSchema.shape)
+  const configuredVars = Object.keys(baseEnvSchema.shape)
     .filter((key) => process.env[key] !== undefined && process.env[key] !== '')
     .sort();
 

--- a/server/src/routes/agent-status.ts
+++ b/server/src/routes/agent-status.ts
@@ -9,6 +9,10 @@ import {
   statusHistoryService,
   type AgentStatusState as HistoryStatusState,
 } from '../services/status-history-service.js';
+import {
+  getAgentRegistryService,
+  type RegisteredAgent,
+} from '../services/agent-registry-service.js';
 import { createLogger } from '../lib/logger.js';
 const log = createLogger('agent-status');
 
@@ -203,6 +207,45 @@ export function getAgentStatus(): AgentStatus {
   return { ...currentStatus };
 }
 
+function registryStatusToAgentStatus(status: RegisteredAgent['status']): AgentStatusState {
+  switch (status) {
+    case 'busy':
+      return 'working';
+    case 'offline':
+      return 'idle';
+    case 'online':
+    case 'idle':
+    default:
+      return 'thinking';
+  }
+}
+
+/**
+ * Build a Hermes-native registry-backed view for the legacy global status endpoint.
+ *
+ * `/api/agent/status` predates the agent registry and is kept as a compatibility
+ * alias for existing clients. Prefer registry data when the legacy status payload
+ * has no activeAgents so HermesAgent/Hermes-native registrations remain visible
+ * without requiring OpenClaw-era callers to POST global status separately.
+ */
+function getRegistryActiveAgents(): ActiveAgent[] {
+  try {
+    return getAgentRegistryService()
+      .list()
+      .filter((agent) => agent.status !== 'offline')
+      .map((agent) => ({
+        agent: agent.name || agent.id,
+        status: registryStatusToAgentStatus(agent.status),
+        taskId: agent.currentTaskId,
+        taskTitle: agent.currentTaskTitle,
+        startedAt: agent.lastHeartbeat || agent.registeredAt,
+      }));
+  } catch (err) {
+    log.warn({ err }, '[AgentStatus] Could not read registry-backed compatibility status');
+    return [];
+  }
+}
+
 // Validation schema for POST
 const activeAgentSchema = z.object({
   agent: z.string(),
@@ -232,11 +275,17 @@ router.get(
   '/',
   asyncHandler(async (_req, res) => {
     const { activeTask, errorMessage, activeAgents, ...rest } = currentStatus;
+    const registryActiveAgents = activeAgents?.length ? [] : getRegistryActiveAgents();
+    const effectiveActiveAgents = activeAgents?.length ? activeAgents : registryActiveAgents;
+    const effectiveStatus =
+      rest.status === 'idle' && effectiveActiveAgents.length > 0 ? 'sub-agent' : rest.status;
     res.json({
       ...rest,
+      status: effectiveStatus,
       activeTask: activeTask?.id,
       activeTaskTitle: activeTask?.title,
-      activeAgents: activeAgents || [],
+      subAgentCount: Math.max(rest.subAgentCount, effectiveActiveAgents.length),
+      activeAgents: effectiveActiveAgents,
       error: errorMessage,
     });
   })

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,6 +1,6 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
-import { ClawdbotAgentService, clawdbotAgentService } from '../services/clawdbot-agent-service.js';
+import { HermesAgentService, hermesAgentService } from '../services/clawdbot-agent-service.js';
 import { getTelemetryService } from '../services/telemetry-service.js';
 import { getTaskService } from '../services/task-service.js';
 import type { AgentType, TokenTelemetryEvent } from '@veritas-kanban/shared';
@@ -31,7 +31,7 @@ const reportTokensSchema = z.object({
   agent: AgentTypeSchema.optional(),
 });
 
-// POST /api/agents/:taskId/start - Start agent on task (delegates to Clawdbot)
+// POST /api/agents/:taskId/start - Start agent on task (delegates to Hermes)
 router.post(
   '/:taskId/start',
   asyncHandler(async (req, res) => {
@@ -44,12 +44,12 @@ router.post(
       }
       throw error;
     }
-    const status = await clawdbotAgentService.startAgent(req.params.taskId as string, agent);
+    const status = await hermesAgentService.startAgent(req.params.taskId as string, agent);
     res.status(201).json(status);
   })
 );
 
-// POST /api/agents/:taskId/complete - Callback from Clawdbot when agent finishes
+// POST /api/agents/:taskId/complete - Callback from Hermes when agent finishes
 router.post(
   '/:taskId/complete',
   asyncHandler(async (req, res) => {
@@ -65,7 +65,7 @@ router.post(
       throw err;
     }
 
-    await clawdbotAgentService.completeAgent(req.params.taskId as string, {
+    await hermesAgentService.completeAgent(req.params.taskId as string, {
       success,
       summary,
       error,
@@ -78,7 +78,7 @@ router.post(
 router.post(
   '/:taskId/stop',
   asyncHandler(async (req, res) => {
-    await clawdbotAgentService.stopAgent(req.params.taskId as string);
+    await hermesAgentService.stopAgent(req.params.taskId as string);
     res.json({ stopped: true });
   })
 );
@@ -87,7 +87,7 @@ router.post(
 router.get(
   '/:taskId/status',
   asyncHandler(async (req, res) => {
-    const status = clawdbotAgentService.getAgentStatus(req.params.taskId as string);
+    const status = hermesAgentService.getAgentStatus(req.params.taskId as string);
     if (!status) {
       return res.json({ running: false });
     }
@@ -99,7 +99,7 @@ router.get(
 router.get(
   '/pending',
   asyncHandler(async (_req, res) => {
-    const requests = await clawdbotAgentService.listPendingRequests();
+    const requests = await hermesAgentService.listPendingRequests();
     res.json(requests);
   })
 );
@@ -108,7 +108,7 @@ router.get(
 router.get(
   '/:taskId/attempts',
   asyncHandler(async (req, res) => {
-    const attempts = await clawdbotAgentService.listAttempts(req.params.taskId as string);
+    const attempts = await hermesAgentService.listAttempts(req.params.taskId as string);
     res.json(attempts);
   })
 );
@@ -117,7 +117,7 @@ router.get(
 router.get(
   '/:taskId/attempts/:attemptId/log',
   asyncHandler(async (req, res) => {
-    const log = await clawdbotAgentService.getAttemptLog(
+    const log = await hermesAgentService.getAttemptLog(
       req.params.taskId as string,
       req.params.attemptId as string
     );
@@ -187,4 +187,4 @@ router.post(
 );
 
 // Export service for WebSocket use
-export { router as agentRoutes, clawdbotAgentService as agentService };
+export { router as agentRoutes, hermesAgentService as agentService };

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -120,7 +120,7 @@ router.post(
       message: 'Message sent — agent response incoming',
     });
 
-    // Trigger async AI response via Clawdbot Gateway
+    // Trigger async AI response via the Hermes gateway
     const gatewaySessionKey = `kanban-chat-${sessionId}`;
 
     const agent = input.agent || session.agent || 'veritas';

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -202,11 +202,13 @@ const DocFreshnessSettingsSchema = z
 const SquadWebhookSettingsSchema = z
   .object({
     enabled: z.boolean().optional(),
-    mode: z.enum(['webhook', 'openclaw']).optional(),
+    mode: z.enum(['webhook', 'hermes', 'openclaw']).optional(),
     // Generic webhook fields
     url: z.string().url().max(500).optional(),
     secret: z.string().min(16).max(128).optional(),
-    // OpenClaw fields
+    // Hermes gateway fields; openclaw* names remain accepted as legacy compatibility aliases.
+    hermesGatewayUrl: z.string().url().max(500).optional(),
+    hermesGatewayToken: z.string().min(16).max(128).optional(),
     openclawGatewayUrl: z.string().url().max(500).optional(),
     openclawGatewayToken: z.string().min(16).max(128).optional(),
     // Common fields

--- a/server/src/services/circuit-registry.ts
+++ b/server/src/services/circuit-registry.ts
@@ -76,7 +76,7 @@ getBreaker('github', {
   monitorWindow: 60_000,
 });
 
-// Clawdbot agent service — may be down if Clawdbot gateway is offline
+// Hermes agent service — may be down if the Hermes gateway is offline
 getBreaker('agent', {
   failureThreshold: 3,
   resetTimeout: 20_000,

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -1,13 +1,14 @@
 /**
- * ClawdbotAgentService - Delegates agent work to Clawdbot's sessions_spawn
+ * HermesAgentService - delegates agent work to Hermes sub-agents
  *
  * Instead of managing PTY processes directly, this service:
- * 1. Sends a task request to the main Veritas session
- * 2. Veritas spawns a sub-agent with proper PTY handling
+ * 1. Sends a task request to the main Hermes/Veritas session
+ * 2. Hermes spawns a sub-agent with proper PTY handling
  * 3. Sub-agent works in the task's worktree
  * 4. On completion, Veritas calls back to update the task
  *
- * This keeps agent management simple and leverages Clawdbot's existing infrastructure.
+ * This keeps agent management simple and leverages Hermes infrastructure.
+ * Legacy Clawdbot export names remain compatibility aliases only.
  */
 
 import { EventEmitter } from 'events';
@@ -25,7 +26,12 @@ const log = createLogger('clawdbot-agent-service');
 
 const PROJECT_ROOT = path.resolve(process.cwd(), '..');
 const LOGS_DIR = path.join(PROJECT_ROOT, '.veritas-kanban', 'logs');
-const CLAWDBOT_GATEWAY = process.env.CLAWDBOT_GATEWAY || 'http://127.0.0.1:18789';
+const HERMES_GATEWAY =
+  process.env.HERMES_GATEWAY ||
+  process.env.HERMES_GATEWAY_URL ||
+  process.env.CLAWDBOT_GATEWAY ||
+  'http://127.0.0.1:18789';
+void HERMES_GATEWAY;
 
 export interface AgentStatus {
   taskId: string;
@@ -54,7 +60,7 @@ const pendingAgents = new Map<
   }
 >();
 
-export class ClawdbotAgentService {
+export class HermesAgentService {
   private configService: ConfigService;
   private taskService: TaskService;
   private logsDir: string;
@@ -75,7 +81,7 @@ export class ClawdbotAgentService {
   }
 
   /**
-   * Start an agent on a task by delegating to Clawdbot
+   * Start an agent on a task by delegating to Hermes
    */
   async startAgent(taskId: string, agentType?: AgentType): Promise<AgentStatus> {
     // Get task
@@ -108,7 +114,7 @@ export class ClawdbotAgentService {
       agent = result.agent;
       routingReason = result.reason;
       log.info(
-        `[ClawdbotAgent] Routing resolved agent for task ${taskId}: ${agent} (${routingReason})`
+        `[HermesAgent] Routing resolved agent for task ${taskId}: ${agent} (${routingReason})`
       );
     } else {
       agent = agentType;
@@ -135,7 +141,7 @@ export class ClawdbotAgentService {
     validatePathSegment(taskId);
     validatePathSegment(attemptId);
 
-    // Build the task prompt for Clawdbot
+    // Build the task prompt for Hermes
     const worktreePath = this.expandPath(task.git.worktreePath);
     const taskPrompt = this.buildTaskPrompt(task, worktreePath, attemptId);
 
@@ -156,11 +162,11 @@ export class ClawdbotAgentService {
       attempt,
     });
 
-    // Send request to Clawdbot main session (wrapped in circuit breaker)
-    // This will be picked up by Veritas who will spawn the actual sub-agent
+    // Send request to Hermes main session (wrapped in circuit breaker)
+    // This will be picked up by Veritas/Hermes who will spawn the actual sub-agent
     const agentBreaker = getBreaker('agent');
     try {
-      await agentBreaker.execute(() => this.sendToClawdbot(taskPrompt, taskId, attemptId));
+      await agentBreaker.execute(() => this.sendToHermes(taskPrompt, taskId, attemptId));
     } catch (error: any) {
       // Clean up on failure
       pendingAgents.delete(taskId);
@@ -168,7 +174,7 @@ export class ClawdbotAgentService {
         status: 'todo',
         attempt: { ...attempt, status: 'failed', ended: new Date().toISOString() },
       });
-      throw new Error(`Failed to start agent via Clawdbot: ${error.message}`);
+      throw new Error(`Failed to start agent via Hermes: ${error.message}`);
     }
 
     return {
@@ -181,10 +187,10 @@ export class ClawdbotAgentService {
   }
 
   /**
-   * Send task request to Clawdbot main session
-   * Uses the webchat API endpoint
+   * Send task request to Hermes main session.
+   * Uses the file-backed request queue monitored by Veritas/Hermes.
    */
-  private async sendToClawdbot(prompt: string, taskId: string, attemptId: string): Promise<void> {
+  private async sendToHermes(prompt: string, taskId: string, attemptId: string): Promise<void> {
     // Validate path segments to prevent directory traversal
     validatePathSegment(taskId);
     validatePathSegment(attemptId);
@@ -212,14 +218,14 @@ export class ClawdbotAgentService {
       )
     );
 
-    log.info(`[ClawdbotAgent] Wrote agent request for task ${taskId} to ${requestFile}`);
+    log.info(`[HermesAgent] Wrote agent request for task ${taskId} to ${requestFile}`);
     log.info(
-      `[ClawdbotAgent] Veritas should pick this up on next heartbeat or you can trigger manually`
+      `[HermesAgent] Veritas/Hermes should pick this up on next heartbeat or you can trigger manually`
     );
   }
 
   /**
-   * Handle completion callback from Clawdbot sub-agent
+   * Handle completion callback from Hermes sub-agent
    */
   async completeAgent(
     taskId: string,
@@ -227,7 +233,7 @@ export class ClawdbotAgentService {
   ): Promise<void> {
     const pending = pendingAgents.get(taskId);
     if (!pending) {
-      log.warn(`[ClawdbotAgent] Received completion for unknown task ${taskId}`);
+      log.warn(`[HermesAgent] Received completion for unknown task ${taskId}`);
       return;
     }
 
@@ -271,7 +277,7 @@ export class ClawdbotAgentService {
       // Ignore if already deleted
     }
 
-    log.info(`[ClawdbotAgent] Task ${taskId} completed with status: ${status}`);
+    log.info(`[HermesAgent] Task ${taskId} completed with status: ${status}`);
   }
 
   /**
@@ -424,7 +430,7 @@ If you encounter errors, call with \`success: false\` and include the error mess
     const header = `# Agent Log: ${task.title}
 
 **Task ID:** ${task.id}
-**Agent:** ${agent} (via Clawdbot)
+**Agent:** ${agent} (via Hermes)
 **Started:** ${new Date().toISOString()}
 **Worktree:** ${task.git?.worktreePath}
 
@@ -436,12 +442,14 @@ ${prompt}
 
 ## Progress
 
-*Agent is working via Clawdbot sub-agent...*
+*Agent is working via Hermes sub-agent...*
 
 `;
     await fs.writeFile(logPath, header, 'utf-8');
   }
 }
 
-// Export singleton
-export const clawdbotAgentService = new ClawdbotAgentService();
+// Export singleton with Hermes-native name plus legacy compatibility aliases.
+export const hermesAgentService = new HermesAgentService();
+export const clawdbotAgentService = hermesAgentService;
+export { HermesAgentService as ClawdbotAgentService };

--- a/server/src/services/clawdbot-webhook-service.ts
+++ b/server/src/services/clawdbot-webhook-service.ts
@@ -1,7 +1,7 @@
 /**
- * Clawdbot Webhook Service
+ * Hermes Webhook Service
  *
- * Sends task and chat events to a configured webhook URL (e.g. Clawdbot Gateway)
+ * Sends task and chat events to a configured webhook URL (e.g. Hermes gateway)
  * so an AI agent can react in real-time instead of polling.
  *
  * Features:

--- a/server/src/services/gateway-chat-client.ts
+++ b/server/src/services/gateway-chat-client.ts
@@ -1,7 +1,8 @@
 /**
  * Gateway Chat Client
  *
- * Connects to the Clawdbot Gateway WebSocket to proxy chat messages.
+ * Connects to the Hermes Gateway WebSocket to proxy chat messages.
+ * Legacy Clawdbot/OpenClaw env names remain compatibility aliases only.
  * Handles authentication, message sending, and response collection.
  */
 
@@ -11,7 +12,11 @@ import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('gateway-chat');
 
-const GATEWAY_URL = process.env.CLAWDBOT_GATEWAY || 'http://127.0.0.1:18789';
+const GATEWAY_URL =
+  process.env.HERMES_GATEWAY ||
+  process.env.HERMES_GATEWAY_URL ||
+  process.env.CLAWDBOT_GATEWAY ||
+  'http://127.0.0.1:18789';
 const PROTOCOL_VERSION = 3;
 const CONNECT_TIMEOUT_MS = 10_000;
 const RESPONSE_TIMEOUT_MS = 120_000; // 2 minutes for AI response
@@ -21,7 +26,7 @@ let cachedToken: string | null = null;
 
 function getToken(): string {
   if (cachedToken) return cachedToken;
-  return process.env.CLAWDBOT_GATEWAY_TOKEN || '';
+  return process.env.HERMES_GATEWAY_TOKEN || process.env.CLAWDBOT_GATEWAY_TOKEN || '';
 }
 
 interface ChatResponse {
@@ -37,7 +42,7 @@ interface StreamCallbacks {
 }
 
 /**
- * Send a message to the Clawdbot Gateway and collect the response.
+ * Send a message to the Hermes Gateway and collect the response.
  * Opens a temporary WebSocket connection for each request.
  */
 export async function sendGatewayChat(
@@ -253,21 +258,52 @@ export async function sendGatewayChat(
  */
 export async function loadGatewayToken(): Promise<string> {
   if (cachedToken) return cachedToken;
+  if (process.env.HERMES_GATEWAY_TOKEN) {
+    cachedToken = process.env.HERMES_GATEWAY_TOKEN;
+    return cachedToken;
+  }
   if (process.env.CLAWDBOT_GATEWAY_TOKEN) {
     cachedToken = process.env.CLAWDBOT_GATEWAY_TOKEN;
+    process.env.HERMES_GATEWAY_TOKEN = cachedToken;
     return cachedToken;
   }
 
   try {
     const fs = await import('fs/promises');
     const path = await import('path');
+    const envPaths = [
+      path.join(process.env.HOME || '', '.hermes', '.env'),
+      path.join(process.env.HOME || '', '.hermes', 'profiles', 'default', '.env'),
+    ];
+    for (const envPath of envPaths) {
+      try {
+        const rawEnv = await fs.readFile(envPath, 'utf-8');
+        const token = rawEnv
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .find(
+            (line) =>
+              line.startsWith('HERMES_GATEWAY_TOKEN=') || line.startsWith('CLAWDBOT_GATEWAY_TOKEN=')
+          )
+          ?.replace(/^[^=]+=/, '')
+          .replace(/^['"]|['"]$/g, '');
+        if (token) {
+          cachedToken = token;
+          process.env.HERMES_GATEWAY_TOKEN = token;
+          return token;
+        }
+      } catch {
+        // Try the next Hermes env path before falling back to legacy config.
+      }
+    }
+
     const configPath = path.join(process.env.HOME || '', '.clawdbot', 'clawdbot.json');
     const raw = await fs.readFile(configPath, 'utf-8');
     const config = JSON.parse(raw);
     const token = config?.gateway?.auth?.token;
     if (token) {
       cachedToken = token;
-      process.env.CLAWDBOT_GATEWAY_TOKEN = token;
+      process.env.HERMES_GATEWAY_TOKEN = token;
       return token;
     }
   } catch (err: any) {

--- a/server/src/services/squad-webhook-service.ts
+++ b/server/src/services/squad-webhook-service.ts
@@ -53,22 +53,26 @@ export async function fireSquadWebhook(
   }
 
   // Route based on mode
-  if (settings.mode === 'openclaw') {
-    await fireOpenClawWake(message, settings);
+  if (settings.mode === 'hermes' || settings.mode === 'openclaw') {
+    await fireHermesGatewayWake(message, settings);
   } else {
     await fireGenericWebhook(message, settings, isHuman);
   }
 }
 
 /**
- * Fire an OpenClaw gateway wake call
+ * Fire a Hermes gateway wake call. The openclaw* settings names are retained
+ * only as legacy compatibility aliases while stored settings migrate.
  */
-async function fireOpenClawWake(
+async function fireHermesGatewayWake(
   message: SquadMessage,
   settings: SquadWebhookSettings
 ): Promise<void> {
-  if (!settings.openclawGatewayUrl || !settings.openclawGatewayToken) {
-    log.warn('OpenClaw mode enabled but gatewayUrl or gatewayToken missing');
+  const gatewayUrl = settings.hermesGatewayUrl || settings.openclawGatewayUrl;
+  const gatewayToken = settings.hermesGatewayToken || settings.openclawGatewayToken;
+
+  if (!gatewayUrl || !gatewayToken) {
+    log.warn('Hermes gateway mode enabled but gatewayUrl or gatewayToken missing');
     return;
   }
 
@@ -84,7 +88,7 @@ async function fireOpenClawWake(
     },
   };
 
-  const url = `${settings.openclawGatewayUrl}/tools/invoke`;
+  const url = `${gatewayUrl}/tools/invoke`;
 
   // Validate URL to prevent SSRF attacks
   const validation = validateWebhookUrl(url);
@@ -101,7 +105,7 @@ async function fireOpenClawWake(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${settings.openclawGatewayToken}`,
+        Authorization: `Bearer ${gatewayToken}`,
       },
       body: JSON.stringify(payload),
       signal: controller.signal,
@@ -112,17 +116,17 @@ async function fireOpenClawWake(
     if (!response.ok) {
       log.warn(
         { status: response.status, statusText: response.statusText, url },
-        'OpenClaw wake call returned non-2xx status'
+        'Hermes gateway wake call returned non-2xx status'
       );
       return;
     }
 
-    log.info({ messageId: message.id, displayName }, 'OpenClaw wake call fired successfully');
+    log.info({ messageId: message.id, displayName }, 'Hermes gateway wake call fired successfully');
   } catch (err: any) {
     if (err.name === 'AbortError') {
-      log.warn({ url }, 'OpenClaw wake call timed out after 5 seconds');
+      log.warn({ url }, 'Hermes gateway wake call timed out after 5 seconds');
     } else {
-      log.error({ err: err.message, url }, 'OpenClaw wake call failed');
+      log.error({ err: err.message, url }, 'Hermes gateway wake call failed');
     }
   }
 }

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -318,15 +318,17 @@ export interface DelegationScope {
 /** Squad webhook settings */
 export interface SquadWebhookSettings {
   enabled: boolean;
-  mode: 'webhook' | 'openclaw'; // 'webhook' = generic HTTP POST, 'openclaw' = gateway wake
+  mode: 'webhook' | 'hermes' | 'openclaw'; // 'webhook' = generic HTTP POST, 'hermes' = gateway wake; 'openclaw' remains a legacy compatibility alias
   // Generic webhook fields:
   url?: string; // Where to POST notifications
   secret?: string; // Optional HMAC signing secret for verification
   notifyOnHuman: boolean; // Fire webhook when human posts (default: true)
   notifyOnAgent: boolean; // Fire webhook when agent posts (default: false)
-  // OpenClaw fields:
-  openclawGatewayUrl?: string; // e.g., "http://127.0.0.1:18789"
-  openclawGatewayToken?: string; // Auth token
+  // Hermes gateway fields; openclaw* names remain accepted as legacy compatibility aliases.
+  hermesGatewayUrl?: string; // e.g., "http://127.0.0.1:18789"
+  hermesGatewayToken?: string; // Auth token
+  openclawGatewayUrl?: string; // Legacy alias for hermesGatewayUrl
+  openclawGatewayToken?: string; // Legacy alias for hermesGatewayToken
 }
 
 /** All feature settings combined */
@@ -453,6 +455,8 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     url: '',
     notifyOnHuman: true,
     notifyOnAgent: false,
+    hermesGatewayUrl: '',
+    hermesGatewayToken: '',
     openclawGatewayUrl: '',
     openclawGatewayToken: '',
   },

--- a/web/src/__tests__/useWebSocket.test.ts
+++ b/web/src/__tests__/useWebSocket.test.ts
@@ -84,6 +84,21 @@ describe('useWebSocket', () => {
     expect(result.current.lastMessage).toEqual({ type: 'task_updated', taskId: '123' });
   });
 
+  it('keeps a quiet but open connection connected', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://test/ws' }));
+
+    act(() => {
+      ws.latest.simulateOpen();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(result.current.connectionState).toBe('connected');
+    expect(ws.instances).toHaveLength(1);
+  });
+
   it('send() sends JSON to the WebSocket', () => {
     const { result } = renderHook(() => useWebSocket({ url: 'ws://test/ws' }));
 

--- a/web/src/components/board/FilterBar.tsx
+++ b/web/src/components/board/FilterBar.tsx
@@ -13,6 +13,41 @@ import type { Task, TaskType } from '@veritas-kanban/shared';
 import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useConfig } from '@/hooks/useConfig';
+import { useGlobalAgentStatus } from '@/hooks/useGlobalAgentStatus';
+
+function formatAgentLabel(agent: string): string {
+  return agent
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => (part.length <= 3 ? part.toUpperCase() : part[0].toUpperCase() + part.slice(1)))
+    .join(' ');
+}
+
+function normalizeAgentKey(agent: string): string {
+  return agent.trim().toLowerCase();
+}
+
+interface AgentOption {
+  value: string;
+  label: string;
+}
+
+function addAgentOption(
+  agents: Map<string, AgentOption>,
+  value: string | null | undefined,
+  label?: string | null
+): void {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue) return;
+
+  const key = normalizeAgentKey(trimmedValue);
+  if (!agents.has(key)) {
+    agents.set(key, {
+      value: trimmedValue,
+      label: label?.trim() || formatAgentLabel(trimmedValue),
+    });
+  }
+}
 
 export interface FilterState {
   search: string;
@@ -27,11 +62,23 @@ interface FilterBarProps {
   onFiltersChange: (filters: FilterState) => void;
 }
 
-export function FilterBar({ filters, onFiltersChange }: FilterBarProps) {
+export function FilterBar({ tasks, filters, onFiltersChange }: FilterBarProps) {
   const { data: taskTypes = [], isLoading: typesLoading } = useTaskTypes();
   const { data: projects = [], isLoading: projectsLoading } = useProjects();
   const { data: config } = useConfig();
-  const agents = config?.agents || [];
+  const { data: agentStatus } = useGlobalAgentStatus();
+  const agents = new Map<string, AgentOption>();
+  for (const agent of config?.agents || []) {
+    addAgentOption(agents, agent.type, agent.name);
+  }
+  for (const activeAgent of agentStatus?.activeAgents || []) {
+    addAgentOption(agents, activeAgent.agent, activeAgent.agent);
+  }
+  for (const task of tasks) {
+    if (task.agent && task.agent !== 'auto') {
+      addAgentOption(agents, task.agent);
+    }
+  }
 
   // Count active filters
   const activeFilterCount = [filters.search, filters.project, filters.type, filters.agent].filter(
@@ -138,9 +185,9 @@ export function FilterBar({ filters, onFiltersChange }: FilterBarProps) {
           <SelectItem value="all">All Agents</SelectItem>
           <SelectItem value="auto">Auto (routing)</SelectItem>
           <SelectItem value="unassigned">Unassigned</SelectItem>
-          {agents.map((a) => (
-            <SelectItem key={a.type} value={a.type}>
-              {a.name}
+          {[...agents.values()].map((agent) => (
+            <SelectItem key={agent.value} value={agent.value}>
+              {agent.label}
             </SelectItem>
           ))}
         </SelectContent>

--- a/web/src/components/settings/tabs/NotificationsTab.tsx
+++ b/web/src/components/settings/tabs/NotificationsTab.tsx
@@ -94,7 +94,7 @@ export function NotificationsTab() {
       <div className="space-y-4">
         <SectionHeader title="Squad Chat Webhook" />
         <p className="text-sm text-muted-foreground -mt-2">
-          Fire HTTP webhooks or OpenClaw wake calls when squad messages are posted
+          Fire HTTP webhooks or Hermes gateway wake calls when squad messages are posted
         </p>
         <div className="divide-y">
           <ToggleRow
@@ -114,7 +114,8 @@ export function NotificationsTab() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="webhook">Generic Webhook</SelectItem>
-                    <SelectItem value="openclaw">OpenClaw Direct</SelectItem>
+                    <SelectItem value="hermes">Hermes Gateway</SelectItem>
+                    <SelectItem value="openclaw">Legacy Gateway Alias</SelectItem>
                   </SelectContent>
                 </Select>
               </SettingRow>
@@ -148,15 +149,19 @@ export function NotificationsTab() {
                 </>
               )}
 
-              {webhookMode === 'openclaw' && (
+              {(webhookMode === 'hermes' || webhookMode === 'openclaw') && (
                 <>
                   <SettingRow
                     label="Gateway URL"
-                    description="OpenClaw gateway endpoint (e.g., http://127.0.0.1:18789)"
+                    description="Hermes gateway endpoint (e.g., http://127.0.0.1:18789)"
                   >
                     <Input
-                      value={settings.squadWebhook?.openclawGatewayUrl ?? ''}
-                      onChange={(e) => updateSquadWebhook('openclawGatewayUrl', e.target.value)}
+                      value={
+                        settings.squadWebhook?.hermesGatewayUrl ??
+                        settings.squadWebhook?.openclawGatewayUrl ??
+                        ''
+                      }
+                      onChange={(e) => updateSquadWebhook('hermesGatewayUrl', e.target.value)}
                       placeholder="http://127.0.0.1:18789"
                       className="w-96 h-8 text-xs"
                       type="url"
@@ -164,11 +169,15 @@ export function NotificationsTab() {
                   </SettingRow>
                   <SettingRow
                     label="Gateway Token"
-                    description="OpenClaw gateway authorization token"
+                    description="Hermes gateway authorization token"
                   >
                     <Input
-                      value={settings.squadWebhook?.openclawGatewayToken ?? ''}
-                      onChange={(e) => updateSquadWebhook('openclawGatewayToken', e.target.value)}
+                      value={
+                        settings.squadWebhook?.hermesGatewayToken ??
+                        settings.squadWebhook?.openclawGatewayToken ??
+                        ''
+                      }
+                      onChange={(e) => updateSquadWebhook('hermesGatewayToken', e.target.value)}
                       placeholder="your-gateway-token"
                       className="w-96 h-8 text-xs"
                       type="password"

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -55,8 +55,6 @@ export interface UseWebSocketReturn {
 const BACKOFF_BASE_MS = 1000;
 /** Maximum backoff delay (ms). */
 const BACKOFF_MAX_MS = 30_000;
-/** If no message received within this time, assume dead and reconnect (ms). */
-const KEEPALIVE_TIMEOUT_MS = 45_000;
 /** Default maximum number of reconnect attempts before giving up. */
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 20;
 
@@ -96,7 +94,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const keepaliveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const mountedRef = useRef(true);
   /** True when user explicitly called disconnect() — suppresses auto-reconnect. */
@@ -126,27 +123,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     }
   }, []);
 
-  const clearKeepaliveTimeout = useCallback(() => {
-    if (keepaliveTimeoutRef.current) {
-      clearTimeout(keepaliveTimeoutRef.current);
-      keepaliveTimeoutRef.current = null;
-    }
-  }, []);
-
-  /**
-   * Reset the keepalive timer. Called on every incoming message (or open).
-   * If no message arrives within KEEPALIVE_TIMEOUT_MS, force-close to trigger reconnect.
-   */
-  const resetKeepaliveTimeout = useCallback(() => {
-    clearKeepaliveTimeout();
-    keepaliveTimeoutRef.current = setTimeout(() => {
-      if (!mountedRef.current) return;
-      // No data received for 45s — assume dead, force reconnect
-      console.warn('[WebSocket] Keepalive timeout — no data in 45s, reconnecting');
-      wsRef.current?.close(4000, 'Keepalive timeout');
-    }, KEEPALIVE_TIMEOUT_MS);
-  }, [clearKeepaliveTimeout]);
-
   // ---- Connect / Reconnect ----
 
   const connect = useCallback(() => {
@@ -173,7 +149,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       reconnectAttemptsRef.current = 0;
       setReconnectAttempt(0);
       onConnectedRef.current?.();
-      resetKeepaliveTimeout();
 
       // Send subscription message if provided
       if (onOpenRef.current) {
@@ -183,8 +158,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
     ws.onmessage = (event) => {
       if (!mountedRef.current) return;
-      // Reset keepalive on every received message
-      resetKeepaliveTimeout();
       try {
         const message = JSON.parse(event.data) as WebSocketMessage;
         setLastMessage(message);
@@ -196,7 +169,6 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 
     ws.onclose = () => {
       if (!mountedRef.current) return;
-      clearKeepaliveTimeout();
       wsRef.current = null;
       onDisconnectedRef.current?.();
 
@@ -232,25 +204,17 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       onErrorRef.current?.(error);
       // onclose will fire after onerror — reconnect logic lives there
     };
-  }, [
-    url,
-    autoReconnect,
-    maxReconnectAttempts,
-    clearReconnectTimeout,
-    clearKeepaliveTimeout,
-    resetKeepaliveTimeout,
-  ]);
+  }, [url, autoReconnect, maxReconnectAttempts, clearReconnectTimeout]);
 
   const disconnect = useCallback(() => {
     intentionalDisconnectRef.current = true;
     clearReconnectTimeout();
-    clearKeepaliveTimeout();
     reconnectAttemptsRef.current = 0;
     setReconnectAttempt(0);
     wsRef.current?.close(1000, 'Client disconnect');
     wsRef.current = null;
     setConnectionState('disconnected');
-  }, [clearReconnectTimeout, clearKeepaliveTimeout]);
+  }, [clearReconnectTimeout]);
 
   const send = useCallback((message: WebSocketMessage) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -269,11 +233,10 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     return () => {
       mountedRef.current = false;
       clearReconnectTimeout();
-      clearKeepaliveTimeout();
       wsRef.current?.close();
       wsRef.current = null;
     };
-  }, [autoConnect, connect, clearReconnectTimeout, clearKeepaliveTimeout]);
+  }, [autoConnect, connect, clearReconnectTimeout]);
 
   return {
     isConnected: connectionState === 'connected',

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,6 +14,11 @@ const viteAllowedHosts =
           .filter(Boolean)
     : undefined;
 
+const apiProxyTarget = process.env.VITE_API_PROXY_TARGET || 'http://localhost:3001';
+const wsProxyTarget =
+  process.env.VITE_WS_PROXY_TARGET ||
+  apiProxyTarget.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
+
 export default defineConfig({
   // Support deployment under a sub-path (e.g., VITE_BASE_PATH=/kanban/)
   base: process.env.VITE_BASE_PATH || '/',
@@ -35,10 +40,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (
-            id.includes('node_modules/react/') ||
-            id.includes('node_modules/react-dom/')
-          ) {
+          if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom/')) {
             return 'vendor-react';
           }
           if (
@@ -71,11 +73,12 @@ export default defineConfig({
     allowedHosts: viteAllowedHosts,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: apiProxyTarget,
         changeOrigin: true,
       },
       '/ws': {
-        target: 'ws://localhost:3001',
+        target: wsProxyTarget,
+        changeOrigin: true,
         ws: true,
       },
     },


### PR DESCRIPTION
## Summary
- Align Veritas runtime truth with Hermes-era agent status and gateway configuration while preserving legacy compatibility aliases.
- Populate the board agent filter from live agent status, task data, and config-backed agents with case-insensitive dedupe.
- Fix websocket false-negative disconnects by removing the frontend quiet-socket idle timeout and adding regression coverage.
- Ignore generated `server/storage/*` runtime artifacts while preserving `.gitkeep`.

## Verification
- Web typecheck passed.
- Focused websocket regression test passed.
- Full web test suite passed.
- Shared build passed.
- Server typecheck passed.
- Focused server route/service tests passed.
- Live Brave UI smoke passed: agent dropdown populated, duplicate labels absent, authenticated websocket connected, progress note visible.
- `git diff --check` clean.
- Static diff scan found no credential values; one env-name reference was manually verified as a false positive.

## Notes
- This PR is opened from fork `asperty567/veritas-kanban` because the authenticated GitHub account lacks direct push permission to `BradGroux/veritas-kanban`.
- A related Mission Control repo change exists separately at `/Users/admin/Projects/mission-control-production/app/lib/agent-runtime-truth.ts` and is not included in this Veritas PR.
