### PR TITLE
Fix notification CLI routes and Squad Chat sender list

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1084,8 +1084,11 @@ Priority-based persistent notification system with agent-specific delivery and r
 | ----------------------------- | ------ | --------------------------------------- |
 | `/api/notifications`          | POST   | Create a notification                   |
 | `/api/notifications`          | GET    | List notifications (filterable)         |
-| `/api/notifications/:id/read` | POST   | Mark notification as read               |
-| `/api/notifications/pending`  | GET    | Get unsent notifications (Teams format) |
+| `/api/notifications/:id/delivered` | POST   | Mark notification as delivered          |
+| `/api/notifications/delivered-all` | POST   | Mark all notifications delivered for an agent |
+| `/api/notifications/pending`       | GET    | Get undelivered notifications in Teams-compatible format |
+| `/api/notifications/mark-sent`     | POST   | Mark a batch of notifications delivered |
+| `/api/notifications/check`         | POST   | Check for notifications; returns a safe no-op result when no scanner is configured |
 
 ---
 

--- a/docs/features/squad-chat.md
+++ b/docs/features/squad-chat.md
@@ -104,16 +104,20 @@ Posts to a custom HTTP endpoint with the following payload:
 
 ```json
 {
-  "event": "squad_message",
-  "timestamp": "2026-02-07T15:41:10.774Z",
-  "agent": "Human",
-  "message": "Check this out!",
-  "isHuman": true,
-  "system": false
+  "event": "squad.message",
+  "message": {
+    "id": "msg_abc123",
+    "agent": "Human",
+    "displayName": "Coby",
+    "message": "Check this out!",
+    "tags": ["example"],
+    "timestamp": "2026-02-07T15:41:10.774Z"
+  },
+  "isHuman": true
 }
 ```
 
-Includes `X-Webhook-Signature` header with HMAC-SHA256 signature using the configured secret.
+Includes `X-VK-Signature` header with HMAC-SHA256 signature using the configured secret.
 
 ### OpenClaw Direct Mode
 
@@ -192,7 +196,7 @@ curl -X POST http://localhost:3001/api/chat/squad \
 
 ### Human Oversight
 
-Humans can check progress and provide guidance:
+Humans can check progress and provide guidance. Squad Chat is a shared coordination log; posting a message does not automatically wake an agent or produce a reply unless a webhook/OpenClaw/orchestrator consumer is configured to watch the chat and respond:
 
 ```bash
 curl -X POST http://localhost:3001/api/chat/squad \

--- a/server/src/__tests__/routes/notifications-coverage.test.ts
+++ b/server/src/__tests__/routes/notifications-coverage.test.ts
@@ -30,17 +30,21 @@ import { errorHandler } from '../../middleware/error-handler.js';
 describe('Notification Routes', () => {
   let app: express.Express;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    app = express();
-    app.use(express.json());
-    // Simulate authenticated admin user for route tests
-    app.use((req: any, _res: any, next: any) => {
-      req.auth = { role: 'admin', keyName: 'test-admin', isLocalhost: true };
+  function buildApp(role: 'admin' | 'agent' = 'admin'): express.Express {
+    const testApp = express();
+    testApp.use(express.json());
+    testApp.use((req: any, _res: any, next: any) => {
+      req.auth = { role, keyName: `test-${role}`, isLocalhost: true };
       next();
     });
-    app.use('/api/notifications', notificationRoutes);
-    app.use(errorHandler);
+    testApp.use('/api/notifications', notificationRoutes);
+    testApp.use(errorHandler);
+    return testApp;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
   });
 
   describe('GET /api/notifications', () => {
@@ -203,9 +207,11 @@ describe('Notification Routes', () => {
     it('should mark pending notifications sent through the CLI alias', async () => {
       mockNotificationService.markManyDelivered.mockResolvedValue(2);
 
-      const res = await request(app).post('/api/notifications/mark-sent').send({
-        ids: ['n1', 'n2'],
-      });
+      const res = await request(app)
+        .post('/api/notifications/mark-sent')
+        .send({
+          ids: ['n1', 'n2'],
+        });
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true, count: 2 });
@@ -232,6 +238,69 @@ describe('Notification Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true, count: 4 });
       expect(mockNotificationService.clearNotifications).toHaveBeenCalled();
+    });
+  });
+
+  describe('global notification authorization', () => {
+    beforeEach(() => {
+      app = buildApp('agent');
+    });
+
+    it('should allow agent-scoped notification reads for agent keys', async () => {
+      mockNotificationService.getNotifications.mockResolvedValue([
+        { id: 'n1', targetAgent: 'alice', delivered: false },
+      ]);
+
+      const res = await request(app).get('/api/notifications?agent=alice');
+
+      expect(res.status).toBe(200);
+      expect(mockNotificationService.getNotifications).toHaveBeenCalledWith({
+        agent: 'alice',
+        undelivered: false,
+        taskId: '',
+        limit: undefined,
+      });
+    });
+
+    it('should reject global notification reads for agent keys', async () => {
+      const res = await request(app).get('/api/notifications');
+
+      expect(res.status).toBe(403);
+      expect(mockNotificationService.getAllNotifications).not.toHaveBeenCalled();
+    });
+
+    it('should reject global notification creation for agent keys', async () => {
+      const res = await request(app).post('/api/notifications').send({
+        message: 'Hello from CLI',
+      });
+
+      expect(res.status).toBe(403);
+      expect(mockNotificationService.createNotification).not.toHaveBeenCalled();
+    });
+
+    it('should reject pending notification export for agent keys', async () => {
+      const res = await request(app).get('/api/notifications/pending');
+
+      expect(res.status).toBe(403);
+      expect(mockNotificationService.getAllNotifications).not.toHaveBeenCalled();
+    });
+
+    it('should reject global mark-sent for agent keys', async () => {
+      const res = await request(app)
+        .post('/api/notifications/mark-sent')
+        .send({
+          ids: ['n1'],
+        });
+
+      expect(res.status).toBe(403);
+      expect(mockNotificationService.markManyDelivered).not.toHaveBeenCalled();
+    });
+
+    it('should reject global notification clearing for agent keys', async () => {
+      const res = await request(app).delete('/api/notifications');
+
+      expect(res.status).toBe(403);
+      expect(mockNotificationService.clearNotifications).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/__tests__/routes/notifications-coverage.test.ts
+++ b/server/src/__tests__/routes/notifications-coverage.test.ts
@@ -7,12 +7,16 @@ import express from 'express';
 
 const { mockNotificationService } = vi.hoisted(() => ({
   mockNotificationService: {
+    createNotification: vi.fn(),
+    getAllNotifications: vi.fn(),
     getNotifications: vi.fn(),
     getStats: vi.fn(),
     getSubscriptions: vi.fn(),
     processComment: vi.fn(),
     markDelivered: vi.fn(),
+    markManyDelivered: vi.fn(),
     markAllDelivered: vi.fn(),
+    clearNotifications: vi.fn(),
   },
 }));
 
@@ -40,6 +44,33 @@ describe('Notification Routes', () => {
   });
 
   describe('GET /api/notifications', () => {
+    it('should list all notifications when no agent is provided', async () => {
+      mockNotificationService.getAllNotifications.mockResolvedValue([
+        { id: 'n1', targetAgent: 'system', delivered: false },
+      ]);
+
+      const res = await request(app).get('/api/notifications');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(mockNotificationService.getAllNotifications).toHaveBeenCalledWith({
+        undelivered: false,
+      });
+    });
+
+    it('should list undelivered notifications for CLI unsent compatibility', async () => {
+      mockNotificationService.getAllNotifications.mockResolvedValue([
+        { id: 'n1', targetAgent: 'system', delivered: false },
+      ]);
+
+      const res = await request(app).get('/api/notifications?unsent=true');
+
+      expect(res.status).toBe(200);
+      expect(mockNotificationService.getAllNotifications).toHaveBeenCalledWith({
+        undelivered: true,
+      });
+    });
+
     it('should get notifications for an agent', async () => {
       mockNotificationService.getNotifications.mockResolvedValue([
         { id: 'n1', targetAgent: 'alice', delivered: false },
@@ -57,10 +88,33 @@ describe('Notification Routes', () => {
       });
     });
 
-    it('should require agent parameter', async () => {
-      const res = await request(app).get('/api/notifications');
-      expect(res.status).toBe(400);
-      expect(res.body.error).toContain('agent');
+    it('should create CLI notifications', async () => {
+      mockNotificationService.createNotification.mockResolvedValue({
+        id: 'n1',
+        type: 'mention',
+        title: 'Notification',
+      });
+
+      const res = await request(app).post('/api/notifications').send({
+        type: 'info',
+        title: 'Notification',
+        message: 'Hello from CLI',
+        taskId: 'TASK-1',
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBe('n1');
+      expect(mockNotificationService.createNotification).toHaveBeenCalledWith({
+        type: 'info',
+        title: 'Notification',
+        message: 'Hello from CLI',
+        taskId: 'TASK-1',
+      });
+    });
+
+    it('should reject CLI notification creation without a message', async () => {
+      const res = await request(app).post('/api/notifications').send({ title: 'Missing body' });
+      expect(res.status).toBe(500);
     });
 
     it('should filter by undelivered', async () => {
@@ -117,6 +171,67 @@ describe('Notification Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.totalNotifications).toBe(10);
       expect(res.body.undelivered).toBe(3);
+    });
+  });
+
+  describe('CLI compatibility endpoints', () => {
+    it('should return pending notifications formatted for Teams', async () => {
+      mockNotificationService.getAllNotifications.mockResolvedValue([
+        {
+          id: 'n1',
+          type: 'mention',
+          content: 'Review TASK-1',
+          createdAt: '2026-05-13T12:00:00.000Z',
+        },
+      ]);
+
+      const res = await request(app).get('/api/notifications/pending');
+
+      expect(res.status).toBe(200);
+      expect(res.body.count).toBe(1);
+      expect(res.body.messages[0]).toEqual({
+        id: 'n1',
+        type: 'mention',
+        text: 'Review TASK-1',
+        timestamp: '2026-05-13T12:00:00.000Z',
+      });
+      expect(mockNotificationService.getAllNotifications).toHaveBeenCalledWith({
+        undelivered: true,
+      });
+    });
+
+    it('should mark pending notifications sent through the CLI alias', async () => {
+      mockNotificationService.markManyDelivered.mockResolvedValue(2);
+
+      const res = await request(app).post('/api/notifications/mark-sent').send({
+        ids: ['n1', 'n2'],
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true, count: 2 });
+      expect(mockNotificationService.markManyDelivered).toHaveBeenCalledWith(['n1', 'n2']);
+    });
+
+    it('should reject mark-sent without ids', async () => {
+      const res = await request(app).post('/api/notifications/mark-sent').send({});
+      expect(res.status).toBe(500);
+    });
+
+    it('should return a safe no-op notify check result', async () => {
+      const res = await request(app).post('/api/notifications/check');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ checked: 0, created: 0 });
+    });
+
+    it('should clear notifications for the CLI clear command', async () => {
+      mockNotificationService.clearNotifications.mockResolvedValue(4);
+
+      const res = await request(app).delete('/api/notifications');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true, count: 4 });
+      expect(mockNotificationService.clearNotifications).toHaveBeenCalled();
     });
   });
 

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -1,7 +1,12 @@
 /**
  * Notification API Routes
  *
- * GET    /api/notifications              — Get notifications for an agent
+ * GET    /api/notifications              — Get notifications
+ * POST   /api/notifications              — Create a notification
+ * POST   /api/notifications/check        — CLI compatibility no-op check
+ * GET    /api/notifications/pending      — CLI compatibility pending notifications
+ * POST   /api/notifications/mark-sent    — CLI compatibility delivered marker
+ * DELETE /api/notifications              — Clear notifications
  * POST   /api/notifications/:id/delivered — Mark as delivered
  * POST   /api/notifications/delivered-all — Mark all as delivered for an agent
  * POST   /api/notifications/process      — Process a comment for @mentions
@@ -18,6 +23,29 @@ import { NotFoundError } from '../middleware/error-handler.js';
 const router: RouterType = Router();
 
 /**
+ * POST /api/notifications
+ * Create a notification directly.
+ */
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const schema = z.object({
+      type: z.string().optional(),
+      title: z.string().optional(),
+      message: z.string().min(1),
+      taskId: z.string().optional(),
+      taskTitle: z.string().optional(),
+      project: z.string().optional(),
+    });
+
+    const data = schema.parse(req.body);
+    const service = getNotificationService();
+    const notification = await service.createNotification(data);
+    res.status(201).json(notification);
+  })
+);
+
+/**
  * GET /api/notifications?agent=<name>&undelivered=true&taskId=<id>&limit=<n>
  */
 router.get(
@@ -25,7 +53,12 @@ router.get(
   asyncHandler(async (req, res) => {
     const agent = String(req.query.agent || "");
     if (!agent) {
-      return res.status(400).json({ error: 'agent query parameter required' });
+      const service = getNotificationService();
+      const notifications = await service.getAllNotifications({
+        undelivered: req.query.undelivered === 'true' || req.query.unsent === 'true',
+        limit: req.query.limit ? Number(String(req.query.limit)) : undefined,
+      });
+      return res.json(notifications);
     }
 
     const service = getNotificationService();
@@ -37,6 +70,68 @@ router.get(
     });
 
     res.json(notifications);
+  })
+);
+
+/**
+ * POST /api/notifications/check
+ * Compatibility endpoint for the CLI's notify:check command. The current
+ * server does not synthesize task notifications here, so this is explicit
+ * no-op behavior instead of a 404.
+ */
+router.post(
+  '/check',
+  asyncHandler(async (_req, res) => {
+    res.json({ checked: 0, created: 0 });
+  })
+);
+
+/**
+ * GET /api/notifications/pending
+ * Compatibility endpoint for CLI Teams formatting.
+ */
+router.get(
+  '/pending',
+  asyncHandler(async (_req, res) => {
+    const service = getNotificationService();
+    const notifications = await service.getAllNotifications({ undelivered: true });
+    res.json({
+      count: notifications.length,
+      messages: notifications.map((notification) => ({
+        id: notification.id,
+        type: notification.type,
+        text: notification.content,
+        timestamp: notification.createdAt,
+      })),
+    });
+  })
+);
+
+/**
+ * POST /api/notifications/mark-sent
+ * Compatibility endpoint for the CLI's --mark-sent flag.
+ */
+router.post(
+  '/mark-sent',
+  asyncHandler(async (req, res) => {
+    const schema = z.object({ ids: z.array(z.string().min(1)).min(1) });
+    const { ids } = schema.parse(req.body);
+    const service = getNotificationService();
+    const count = await service.markManyDelivered(ids);
+    res.json({ success: true, count });
+  })
+);
+
+/**
+ * DELETE /api/notifications
+ * Compatibility endpoint for CLI clear.
+ */
+router.delete(
+  '/',
+  asyncHandler(async (_req, res) => {
+    const service = getNotificationService();
+    const count = await service.clearNotifications();
+    res.json({ success: true, count });
   })
 );
 

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -14,13 +14,26 @@
  * GET    /api/notifications/subscriptions/:taskId — Thread subscriptions
  */
 
-import { Router, type Router as RouterType } from 'express';
+import { Router, type NextFunction, type Response, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { getNotificationService } from '../services/notification-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError } from '../middleware/error-handler.js';
+import { authorize, type AuthenticatedRequest } from '../middleware/auth.js';
 
 const router: RouterType = Router();
+const requireAdmin = authorize('admin');
+
+function requireAdminForGlobalNotifications(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  if (req.query.agent) {
+    return next();
+  }
+  return requireAdmin(req, res, next);
+}
 
 /**
  * POST /api/notifications
@@ -28,6 +41,7 @@ const router: RouterType = Router();
  */
 router.post(
   '/',
+  requireAdmin,
   asyncHandler(async (req, res) => {
     const schema = z.object({
       type: z.string().optional(),
@@ -50,8 +64,9 @@ router.post(
  */
 router.get(
   '/',
+  requireAdminForGlobalNotifications,
   asyncHandler(async (req, res) => {
-    const agent = String(req.query.agent || "");
+    const agent = String(req.query.agent || '');
     if (!agent) {
       const service = getNotificationService();
       const notifications = await service.getAllNotifications({
@@ -65,7 +80,7 @@ router.get(
     const notifications = await service.getNotifications({
       agent,
       undelivered: req.query.undelivered === 'true',
-      taskId: String(req.query.taskId || ""),
+      taskId: String(req.query.taskId || ''),
       limit: req.query.limit ? Number(String(req.query.limit)) : undefined,
     });
 
@@ -92,6 +107,7 @@ router.post(
  */
 router.get(
   '/pending',
+  requireAdmin,
   asyncHandler(async (_req, res) => {
     const service = getNotificationService();
     const notifications = await service.getAllNotifications({ undelivered: true });
@@ -113,6 +129,7 @@ router.get(
  */
 router.post(
   '/mark-sent',
+  requireAdmin,
   asyncHandler(async (req, res) => {
     const schema = z.object({ ids: z.array(z.string().min(1)).min(1) });
     const { ids } = schema.parse(req.body);
@@ -128,6 +145,7 @@ router.post(
  */
 router.delete(
   '/',
+  requireAdmin,
   asyncHandler(async (_req, res) => {
     const service = getNotificationService();
     const count = await service.clearNotifications();

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -239,6 +239,33 @@ export class NotificationService {
   }
 
   /**
+   * Get notifications across all agents.
+   *
+   * Used by the CLI notification commands, which predate the agent-scoped
+   * route shape.
+   */
+  async getAllNotifications(filters: {
+    undelivered?: boolean;
+    limit?: number;
+  } = {}): Promise<Notification[]> {
+    await this.ensureLoaded();
+
+    let results = [...this.notifications];
+
+    if (filters.undelivered) {
+      results = results.filter((n) => !n.delivered);
+    }
+
+    results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+    if (filters.limit) {
+      results = results.slice(0, filters.limit);
+    }
+
+    return results;
+  }
+
+  /**
    * Mark a notification as delivered.
    */
   async markDelivered(notificationId: string): Promise<boolean> {
@@ -251,6 +278,27 @@ export class NotificationService {
     notification.deliveredAt = new Date().toISOString();
     await this.saveNotifications();
     return true;
+  }
+
+  /**
+   * Mark multiple notifications as delivered.
+   */
+  async markManyDelivered(notificationIds: string[]): Promise<number> {
+    await this.ensureLoaded();
+
+    const ids = new Set(notificationIds);
+    const now = new Date().toISOString();
+    let count = 0;
+    for (const notification of this.notifications) {
+      if (ids.has(notification.id) && !notification.delivered) {
+        notification.delivered = true;
+        notification.deliveredAt = now;
+        count++;
+      }
+    }
+
+    if (count > 0) await this.saveNotifications();
+    return count;
   }
 
   /**
@@ -300,6 +348,18 @@ export class NotificationService {
     this.notifications.push(notification);
     await this.saveNotifications();
     return notification;
+  }
+
+  /**
+   * Clear all notifications.
+   */
+  async clearNotifications(): Promise<number> {
+    await this.ensureLoaded();
+
+    const count = this.notifications.length;
+    this.notifications = [];
+    if (count > 0) await this.saveNotifications();
+    return count;
   }
 
   /**

--- a/web/src/__tests__/SquadChatPanel.test.tsx
+++ b/web/src/__tests__/SquadChatPanel.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from './test-utils';
+import { SquadChatPanel } from '@/components/chat/SquadChatPanel';
+
+vi.mock('@/hooks/useChat', () => ({
+  useSquadMessages: () => ({ data: [], isLoading: false }),
+  useSendSquadMessage: () => ({ mutate: vi.fn(), isPending: false }),
+  useSquadStream: () => ({ newMessage: null }),
+}));
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSetting: () => 'Coby',
+}));
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({
+    data: {
+      agents: [
+        { type: 'codex', name: 'OpenAI Codex', enabled: true },
+        { type: 'claude-code', name: 'Claude Code Opus 4.7 Reviewer', enabled: true },
+        { type: 'amp', name: 'Amp', enabled: false },
+      ],
+    },
+  }),
+}));
+
+describe('SquadChatPanel', () => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+  const originalHasPointerCapture = Element.prototype.hasPointerCapture;
+  const originalSetPointerCapture = Element.prototype.setPointerCapture;
+  const originalReleasePointerCapture = Element.prototype.releasePointerCapture;
+
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.hasPointerCapture = vi.fn(() => false);
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
+
+  afterAll(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    Element.prototype.hasPointerCapture = originalHasPointerCapture;
+    Element.prototype.setPointerCapture = originalSetPointerCapture;
+    Element.prototype.releasePointerCapture = originalReleasePointerCapture;
+  });
+
+  afterEach(() => cleanup());
+
+  it('uses configured enabled agents for the sender selector instead of the demo roster', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<SquadChatPanel open={true} onOpenChange={vi.fn()} />);
+
+    const [filterSelector, senderSelector] = screen.getAllByRole('combobox');
+    expect(filterSelector).toBeDefined();
+
+    await user.click(senderSelector);
+
+    expect(await screen.findByText('OpenAI Codex')).toBeDefined();
+    expect(screen.getByText('Claude Code Opus 4.7 Reviewer')).toBeDefined();
+    expect(screen.queryByText('Amp')).toBeNull();
+    expect(screen.queryByText('TARS')).toBeNull();
+  });
+});

--- a/web/src/components/chat/SquadChatPanel.tsx
+++ b/web/src/components/chat/SquadChatPanel.tsx
@@ -36,19 +36,33 @@ const agentColors: Record<string, string> = {
   Marvin: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
 };
 
+function readIncludeSystemPreference(): boolean {
+  try {
+    const saved = window.localStorage.getItem('squadChat.includeSystem');
+    return saved === null ? true : saved === 'true';
+  } catch {
+    return true;
+  }
+}
+
+function writeIncludeSystemPreference(includeSystem: boolean): void {
+  try {
+    window.localStorage.setItem('squadChat.includeSystem', includeSystem.toString());
+  } catch {
+    // Ignore storage failures in restricted browser/test environments.
+  }
+}
+
 export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
   const humanDisplayName = useFeatureSetting('general', 'humanDisplayName');
   const { data: config } = useConfig();
 
   // Load includeSystem preference from localStorage
-  const [includeSystem, setIncludeSystem] = useState<boolean>(() => {
-    const saved = localStorage.getItem('squadChat.includeSystem');
-    return saved === null ? true : saved === 'true'; // Default to true
-  });
+  const [includeSystem, setIncludeSystem] = useState<boolean>(readIncludeSystemPreference);
 
   // Save includeSystem preference to localStorage
   useEffect(() => {
-    localStorage.setItem('squadChat.includeSystem', includeSystem.toString());
+    writeIncludeSystemPreference(includeSystem);
   }, [includeSystem]);
 
   // Available senders: human first, then the enabled configured agents.
@@ -199,7 +213,11 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
         </div>
 
         {/* Messages */}
-        <ScrollArea className="flex-1 min-h-0 px-4" onScrollCapture={handleScroll} ref={scrollAreaRef}>
+        <ScrollArea
+          className="flex-1 min-h-0 px-4"
+          onScrollCapture={handleScroll}
+          ref={scrollAreaRef}
+        >
           <div className="py-4 space-y-3">
             {isLoading && (
               <div className="text-center text-muted-foreground py-8">

--- a/web/src/components/chat/SquadChatPanel.tsx
+++ b/web/src/components/chat/SquadChatPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/select';
 import { Send, Loader2, Users, Filter, Settings2 } from 'lucide-react';
 import { useSquadMessages, useSendSquadMessage, useSquadStream } from '@/hooks/useChat';
+import { useConfig } from '@/hooks/useConfig';
 import { useFeatureSetting } from '@/hooks/useFeatureSettings';
 import type { SquadMessage } from '@veritas-kanban/shared';
 
@@ -37,6 +38,7 @@ const agentColors: Record<string, string> = {
 
 export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
   const humanDisplayName = useFeatureSetting('general', 'humanDisplayName');
+  const { data: config } = useConfig();
 
   // Load includeSystem preference from localStorage
   const [includeSystem, setIncludeSystem] = useState<boolean>(() => {
@@ -49,20 +51,13 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
     localStorage.setItem('squadChat.includeSystem', includeSystem.toString());
   }, [includeSystem]);
 
-  // Available agents for the selector (Human display name is dynamic)
-  const availableAgents = [
-    humanDisplayName, // Human user first (from settings)
-    'VERITAS',
-    'TARS',
-    'CASE',
-    'Ava',
-    'R2-D2',
-    'K-2SO',
-    'MAX',
-    'Johnny 5',
-    'Bishop',
-    'Marvin',
-  ];
+  // Available senders: human first, then the enabled configured agents.
+  const availableAgents = Array.from(
+    new Set([
+      humanDisplayName || 'Human',
+      ...(config?.agents ?? []).filter((agent) => agent.enabled).map((agent) => agent.name),
+    ])
+  );
 
   const [message, setMessage] = useState('');
   const [selectedAgent, setSelectedAgent] = useState(humanDisplayName || 'Human'); // Human user default (from settings)


### PR DESCRIPTION
## Summary

- Restore server compatibility for documented `vk notify:*` CLI flows (`pending`, `check`, `mark-sent`, list/create/clear).
- Change Squad Chat sender options to use the configured enabled agents instead of hardcoded demo names.
- Clarify Squad Chat docs: chat messages are coordination log entries and only wake/reply via a configured webhook/OpenClaw/orchestrator consumer.
- Align generic Squad Chat webhook docs with the actual nested `squad.message` payload and `X-VK-Signature` header.

## Validation

Run in the local checkout with dependencies installed:

- `pnpm --filter server test -- notification`
- `pnpm --filter web test -- SquadChatPanel`
- `pnpm --filter web typecheck`
- `pnpm --filter server typecheck`

## Notes

This PR keeps the changes generic to Veritas Kanban. WCP-specific runtime config, prompt registry files, and Obsidian notes are not included.