### PR TITLE
Clarify setup paths and integration auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Created by **Brad Groux** — CEO of [Digital Meld](https://digitalmeld.io), and
 
 ## ⚡ Quickstart
 
-Want to take the easy way out? Ask your agent (like [OpenClaw](https://github.com/openclaw/openclaw)):
+Start with the local board. OpenClaw, MCP, Squad Chat webhooks, notifications, workflows, and governance gates are optional layers you can turn on later. See [Setup Paths](docs/SETUP-PATHS.md) for the board-only, CLI, MCP, OpenClaw, and self-hosted paths.
+
+Want to take the easy way out? Ask your agent:
 
 ```
-Clone and set up veritas-kanban locally. Install dependencies with pnpm, copy the .env.example, and start the dev server. Verify it's running at localhost:3000.
+Clone and set up veritas-kanban locally using the board-only setup path first. Install dependencies with pnpm, copy server/.env.example to server/.env, and start the dev server. Verify the UI at localhost:3000 and the API health endpoint at localhost:3001/api/health. Do not configure OpenClaw, MCP, Squad Chat webhooks, workflows, or notifications unless I explicitly ask for that layer.
 ```
 
 Want to do it yourself? Get up and running in under 5 minutes:
@@ -60,6 +62,7 @@ Open [http://localhost:3000](http://localhost:3000) — that's it. The board aut
 ## 📚 Documentation Map
 
 - [MCP Server Guide](docs/mcp/README.md) — 36 tools, architecture, quickstart, tool catalog, security model, troubleshooting.
+- [Setup Paths](docs/SETUP-PATHS.md) — board-only, CLI, MCP, OpenClaw, and self-hosted paths without mixing optional layers into first-run setup.
 - [OpenAI Codex Integration Roadmap](docs/CODEX-INTEGRATION.md) — v4.3 plan for local Codex execution, SDK sessions, cloud delegation, MCP setup, workflows, telemetry, and release QA.
 - [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) — authority model, HermesAgent roster, QA evidence gate, and GitHub-backed task templates.
 - [Codex Integration SOP](docs/SOP-codex-integration.md) & [Codex Workflow Examples](docs/EXAMPLES-codex-workflows.md) — operational playbooks for using Codex as a first-class Veritas agent.
@@ -112,7 +115,7 @@ Open [http://localhost:3000](http://localhost:3000) — that's it. The board aut
 
 ### 🤖 Agent Orchestration
 
-Spawn autonomous coding agents on tasks. Track them in real-time with the multi-agent dashboard — status indicators, expandable agent cards, model attribution. Squad Chat gives agents a shared communication channel with system lifecycle events (spawned, completed, failed). Assign multiple agents per task, set permission levels (Intern/Specialist/Lead), and let them coordinate.
+Spawn autonomous coding agents on tasks when you choose to connect an agent runner. Track them in real-time with the multi-agent dashboard — status indicators, expandable agent cards, model attribution. Squad Chat gives agents a shared local communication channel with system lifecycle events (spawned, completed, failed). Assign multiple agents per task, set permission levels (Intern/Specialist/Lead), and let them coordinate.
 
 ![Agent orchestration](assets/demo-overview.gif)
 
@@ -182,7 +185,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **Platform-agnostic API** — REST endpoints work with any agentic platform
 - **HermesAgent support** — v4.3 documents HermesAgent/Hermes Gateway as the active control plane, with Veritas as the GitHub-backed source of truth
 - **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, and MCP setup
-- **Built-in OpenClaw support** — Native integration with [OpenClaw](https://github.com/openclaw/openclaw)
+- **Optional OpenClaw support** — Native integration with [OpenClaw](https://github.com/openclaw/openclaw) when you want OpenClaw to execute or wake agents
 - **Squad Chat** — Real-time agent-to-agent communication with WebSocket updates, system lifecycle events, model attribution per message, and configurable display names
 - **@Mention notifications** — @agent-name parsing in comments, thread subscriptions
 - **Broadcast Notifications** — Priority-based persistent notifications with read receipts and agent-specific delivery
@@ -196,7 +199,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **Task Deliverables** — First-class deliverable objects with type/status tracking (code, documentation, data, etc.)
 - **Efficient Polling** — `/api/changes?since=...` endpoint with ETag support for optimized agent polling
 - **Approval Delegation** — Vacation mode with scoped approval delegation and automatic routing
-- **OpenClaw Integration** — Direct gateway wake for real-time squad chat notifications and agent orchestration
+- **OpenClaw Integration** — Optional direct gateway wake for real-time squad chat notifications and agent orchestration
 - **Reverse Proxy Ready** — Deploy behind nginx, Caddy, Traefik, or any reverse proxy with `TRUST_PROXY`
 - **Multiple attempts** — Retry with different agents, preserve history
 - **Running indicator** — Visual feedback when agents are working
@@ -545,9 +548,9 @@ All commands support `--json` for scripting and machine consumption.
 
 ## 🤖 Agent Integration
 
-Veritas Kanban works with any agentic platform that can make HTTP calls. The REST API covers the full task lifecycle — create, update, track time, complete.
+Veritas Kanban works with any agentic platform that can make HTTP calls. The REST API covers the full task lifecycle — create, update, track time, complete. No agent runner is required for board-only use.
 
-Built and tested with [OpenClaw](https://github.com/openclaw/openclaw) (formerly Clawdbot/Moltbot), which provides native orchestration via `sessions_spawn`. The built-in agent service targets OpenClaw — PRs welcome for adapters to other platforms.
+Built and tested with [OpenClaw](https://github.com/openclaw/openclaw) (formerly Clawdbot/Moltbot), which provides native orchestration via `sessions_spawn`. OpenClaw is optional. Use it when you want VK to hand work to OpenClaw or wake OpenClaw from Squad Chat events.
 
 v4.3 also documents the Codex and Hermes operating model:
 
@@ -634,14 +637,17 @@ vk agents:pending
       "command": "node",
       "args": ["/path/to/veritas-kanban/mcp/dist/index.js"],
       "env": {
-        "VK_API_URL": "http://localhost:3001"
+        "VK_API_URL": "http://localhost:3001",
+        "VK_API_KEY": "your-agent-api-key"
       }
     }
   }
 }
 ```
 
-**After adding the config, restart OpenClaw:**
+`VK_API_KEY` is required for write tools unless localhost auth bypass grants an `agent` or `admin` role. Prefer an `agent` role key over the admin key.
+
+**After adding the config, restart your MCP client. For OpenClaw:**
 
 ```bash
 openclaw gateway restart
@@ -651,8 +657,8 @@ Verify discovery with `openclaw mcp list`. See [Troubleshooting](docs/TROUBLESHO
 
 **Troubleshooting MCP connection issues:**
 
-- **Always restart OpenClaw after MCP config changes** — MCP servers are discovered at startup
-- **Verify tools are available:** Run `openclaw mcp list` to confirm 26 Veritas Kanban tools appear
+- **Always restart the MCP client after MCP config changes** — MCP servers are discovered at startup
+- **Verify tools are available:** Run `openclaw mcp list` to confirm 36 Veritas Kanban tools appear
 - **When reporting issues, provide:**
   - OpenClaw version (`openclaw --version`)
   - VK version and health (`curl http://localhost:3001/api/health`)

--- a/cli/src/utils/api.ts
+++ b/cli/src/utils/api.ts
@@ -1,2 +1,2 @@
 // Re-export shared API client
-export { api, createApiClient, API_BASE } from '@veritas-kanban/shared';
+export { api, createApiClient, API_BASE, buildApiHeaders } from '@veritas-kanban/shared';

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -51,14 +51,20 @@ cd veritas-kanban
 # Install dependencies
 pnpm install
 
-# Link the CLI globally
-cd cli && npm link
+# Build shared code and the CLI before linking
+pnpm --filter @veritas-kanban/shared build
+pnpm --filter @veritas-kanban/cli build
+
+# Link the CLI globally from the CLI package
+cd cli
+npm link
 ```
 
 After linking, the `vk` command is available globally in your terminal.
 
 ```bash
 vk --help
+vk setup
 ```
 
 > **Prerequisite:** The Veritas Kanban server must be running for CLI commands to work.
@@ -632,7 +638,7 @@ export VK_API_URL=https://kanban.example.com
 export VK_API_KEY=your-api-key-here
 ```
 
-If you're running locally with localhost auth bypass enabled (the default), you may not need an API key for most operations.
+If you're running locally with localhost auth bypass enabled, read commands may work without a key. Write commands need `VK_API_KEY` unless `VERITAS_AUTH_LOCALHOST_ROLE` is set to `agent` or `admin`. Prefer an `agent` role key for CLI automation.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -432,14 +432,14 @@ Automated staleness detection for project documentation with real-time tracking 
 
 ## Squad Chat
 
-Real-time agent-to-agent communication channel for multi-agent collaboration. Shipped in v2.0.
+Real-time agent-to-agent communication channel for multi-agent collaboration. Shipped in v2.0. Optional for first-run setup.
 
 - **WebSocket-powered chat** — Messages broadcast in real time to all connected clients
 - **System lifecycle events** — Automatic events for agent spawned, completed, and failed transitions
-- **Model attribution** — Each message tagged with the sending agent's model for provenance tracking
+- **Model attribution** — Messages can include the sending agent's model for provenance tracking
 - **Configurable display names** — Agents set custom display names for chat identity
-- **Squad Chat Webhook** — Configurable webhooks for external integration; supports generic HTTP and OpenClaw Direct modes
-- **OpenClaw Direct gateway wake** — Real-time squad chat notifications pushed to OpenClaw gateway for agent orchestration
+- **Squad Chat Webhook** — Optional webhooks for external integration; supports generic HTTP and OpenClaw Direct modes
+- **OpenClaw Direct gateway wake** — Optional real-time squad chat notifications pushed to OpenClaw gateway for agent orchestration
 - **Searchable history** — Browse and search past squad chat messages
 
 ### API Endpoints
@@ -1069,7 +1069,7 @@ Added in v3.3.3. At-a-glance enforcement status visible on the dashboard.
 
 ## Broadcast Notifications
 
-Priority-based persistent notification system with agent-specific delivery and read receipts. Shipped in v2.0.
+Notification and broadcast features provide local visibility and optional delivery channels. Shipped in v2.0.
 
 - **Priority levels** — Notifications carry priority (low, normal, high, urgent) for triage
 - **Agent-specific delivery** — Target notifications to specific agents or broadcast to all
@@ -1077,18 +1077,22 @@ Priority-based persistent notification system with agent-specific delivery and r
 - **Persistent storage** — Notifications persisted to disk, survive server restarts
 - **Notification queue** — Unsent notifications queued for batch delivery
 - **Per-event toggles** — Enable/disable notification types in Settings → Notifications
+- **Broadcast messages** — Durable system-wide messages at `/api/broadcasts` with `info`, `action-required`, and `urgent` priorities
 
 ### API Endpoints
 
-| Endpoint                      | Method | Description                             |
-| ----------------------------- | ------ | --------------------------------------- |
-| `/api/notifications`          | POST   | Create a notification                   |
-| `/api/notifications`          | GET    | List notifications (filterable)         |
-| `/api/notifications/:id/delivered` | POST   | Mark notification as delivered          |
-| `/api/notifications/delivered-all` | POST   | Mark all notifications delivered for an agent |
-| `/api/notifications/pending`       | GET    | Get undelivered notifications in Teams-compatible format |
-| `/api/notifications/mark-sent`     | POST   | Mark a batch of notifications delivered |
+| Endpoint                           | Method | Description                                                                        |
+| ---------------------------------- | ------ | ---------------------------------------------------------------------------------- |
+| `/api/notifications`               | POST   | Create a notification                                                              |
+| `/api/notifications`               | GET    | List notifications (filterable)                                                    |
+| `/api/notifications/:id/delivered` | POST   | Mark notification as delivered                                                     |
+| `/api/notifications/delivered-all` | POST   | Mark all notifications delivered for an agent                                      |
+| `/api/notifications/pending`       | GET    | Get undelivered notifications in Teams-compatible format                           |
+| `/api/notifications/mark-sent`     | POST   | Mark a batch of notifications delivered                                            |
 | `/api/notifications/check`         | POST   | Check for notifications; returns a safe no-op result when no scanner is configured |
+| `/api/broadcasts`                  | POST   | Create a durable broadcast message                                                 |
+| `/api/broadcasts`                  | GET    | List broadcast messages                                                            |
+| `/api/broadcasts/:id/read`         | PATCH  | Mark a broadcast read for an agent                                                 |
 
 ---
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -4,12 +4,14 @@
 
 Whether you are standing up the board for yourself or for a fleet of agents, this guide walks you from zero ➝ working board ➝ agents picking up work. Each section is short, copy/paste friendly, and mirrors how we run Veritas Kanban internally.
 
+If you are evaluating VK for the first time, start with the board-only path. MCP, OpenClaw, Squad Chat webhooks, notification delivery, workflow gates, and governance policies are optional layers. The setup paths are broken out in [Setup Paths](SETUP-PATHS.md).
+
 ---
 
 ## Table of Contents
 
 1. [Prerequisites (30 seconds)](#prerequisites-30-seconds)
-2. [Installation & Setup Wizard (manual today, guided tomorrow)](#installation--setup-wizard-manual-today-guided-tomorrow)
+2. [Installation & Setup Wizard](#installation--setup-wizard)
 3. [Create Your First Task (UI path)](#create-your-first-task-ui-path)
 4. [Create Your First Task (API/CLI path)](#create-your-first-task-apicli-path)
 5. [Connect an Agent + Agent Pickup Checklist](#connect-an-agent--agent-pickup-checklist)
@@ -39,7 +41,7 @@ That's it. No database, no extra services.
 
 ### Quick Start with `vk setup`
 
-After cloning and starting the server, run the setup wizard to verify your environment:
+After cloning and starting the server, run the setup wizard to verify your environment. If the `vk` command is not installed yet, finish the manual setup first and then build/link the CLI from the CLI guide.
 
 ```bash
 vk setup
@@ -130,11 +132,16 @@ curl -X POST http://localhost:3001/api/tasks \
 ### CLI (after `cd cli && npm link`)
 
 ```bash
+pnpm --filter @veritas-kanban/shared build
+pnpm --filter @veritas-kanban/cli build
+cd cli
+npm link
+export VK_API_URL=http://localhost:3001
 vk create "Wire up MCP server" --type feature --priority high
 vk list --status todo
 ```
 
-CLI commands fully mirror the API and are the fastest way to script agent workflows.
+CLI commands fully mirror the API and are the fastest way to script agent workflows. Write commands need `VK_API_KEY` unless localhost bypass grants an `agent` or `admin` role.
 
 ![CLI workflow demo](../assets/demo-drag_drop.gif)
 
@@ -149,16 +156,21 @@ Agents interact through HTTP + WebSocket; nothing is hard-coded to a particular 
    VERITAS_API_KEYS=my-agent:super-secret-key:agent,ops:another-key:admin
    ```
 2. **Restart** `pnpm dev` so the key loads.
-3. **Create an agent request** (UI → Start Agent) or drop a JSON file in `.veritas-kanban/agent-requests/`.
-4. **Watch pending agents** in the UI or via CLI:
+3. **Export the key** for CLI, MCP, or agent scripts:
+   ```bash
+   export VK_API_URL=http://localhost:3001
+   export VK_API_KEY=super-secret-key
+   ```
+4. **Create an agent request** (UI → Start Agent) or drop a JSON file in `.veritas-kanban/agent-requests/`.
+5. **Watch pending agents** in the UI or via CLI:
    ```bash
    vk agents:pending
    ```
-5. **Agent workflow** (example prompt to OpenClaw):
+6. **Agent workflow** (example prompt to an agent runner):
    ```
    Hey Veritas, pick up task <ID>. Set status to in-progress, start the timer, do the work, then call `vk done <id> "summary"` when finished. Use cross-model review if you wrote code.
    ```
-6. **Agent completion**
+7. **Agent completion**
    - Verify `tasks/active/...` reflects status/time tracking
    - Check `.veritas-kanban/logs/agents.log` for run details
    - Confirm UI Agent Status indicator flips back to **Idle**

--- a/docs/SETUP-PATHS.md
+++ b/docs/SETUP-PATHS.md
@@ -1,0 +1,133 @@
+# Setup Paths
+
+> Credit: `@cob-ai` helped surface the setup friction that led to this guide.
+
+Veritas Kanban starts as a local board. The agent, MCP, OpenClaw, Squad Chat, notification, workflow, and governance layers are optional. Add them only when you need that capability.
+
+## Pick Your Path
+
+| Path                | Use this when                                                   | Required setup                                                         |
+| ------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Board only          | You want a local Kanban board and UI                            | `pnpm install`, `cp server/.env.example server/.env`, `pnpm dev`       |
+| Board plus CLI      | You want shell commands for tasks                               | Board setup, build/link CLI, `VK_API_URL`, optional `VK_API_KEY`       |
+| Board plus MCP      | You want an assistant to read or update board state through MCP | Board setup, build MCP server, configure MCP client env                |
+| Board plus OpenClaw | You want OpenClaw to run or wake agents                         | Board setup, OpenClaw config, optional browser relay or direct webhook |
+| Self-hosted         | You want remote access                                          | Production env, reverse proxy, auth keys, backups                      |
+
+## Minimal Local Setup
+
+```bash
+git clone https://github.com/BradGroux/veritas-kanban.git
+cd veritas-kanban
+pnpm install
+cp server/.env.example server/.env
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000). The API runs on [http://localhost:3001](http://localhost:3001).
+
+For a low-friction local start, these are the important server values:
+
+```bash
+VERITAS_AUTH_ENABLED=true
+VERITAS_AUTH_LOCALHOST_BYPASS=true
+VERITAS_AUTH_LOCALHOST_ROLE=read-only
+```
+
+This is enough for the board and read-only local API checks. Write-capable CLI and MCP actions need either an API key or a broader localhost role.
+
+## CLI Setup
+
+```bash
+pnpm --filter @veritas-kanban/shared build
+pnpm --filter @veritas-kanban/cli build
+cd cli
+npm link
+```
+
+Then point the CLI at the API:
+
+```bash
+export VK_API_URL=http://localhost:3001
+```
+
+For write commands, create an agent key in `server/.env`:
+
+```bash
+VERITAS_API_KEYS=local-agent:replace-with-a-long-secret:agent
+```
+
+Restart the server and export the same key:
+
+```bash
+export VK_API_KEY=replace-with-a-long-secret
+vk setup
+```
+
+## MCP Setup
+
+Build the MCP server:
+
+```bash
+pnpm --filter @veritas-kanban/shared build
+pnpm --filter @veritas-kanban/mcp build
+```
+
+Local MCP clients should pass both URL and key when the agent will write:
+
+```json
+{
+  "mcpServers": {
+    "veritas-kanban": {
+      "command": "node",
+      "args": ["/absolute/path/to/veritas-kanban/mcp/dist/index.js"],
+      "env": {
+        "VK_API_URL": "http://localhost:3001",
+        "VK_API_KEY": "replace-with-a-long-secret"
+      }
+    }
+  }
+}
+```
+
+Read-only localhost calls may work without `VK_API_KEY`. Write tools need `VK_API_KEY` unless `VERITAS_AUTH_LOCALHOST_ROLE` is set to `agent` or `admin`.
+
+## Optional Layers
+
+### OpenClaw
+
+OpenClaw is not required to run Veritas Kanban. Use it when you want OpenClaw to execute tasks, route agent work, use the browser relay, or receive direct wake events.
+
+### Squad Chat
+
+Squad Chat is a local shared message log for agents. It does not automatically wake an external agent process unless you also configure an external runner, webhook, or OpenClaw Direct path.
+
+### Notifications And Broadcasts
+
+These are separate surfaces:
+
+- Notifications are per-recipient task and system events.
+- Broadcasts are persistent system-wide messages at `/api/broadcasts`.
+- Squad Chat Webhook is an optional outbound wake/delivery mechanism for chat messages.
+
+### Workflows And Governance
+
+Workflow engine, gates, policies, cross-model review, and approval rules are production guardrails. They are useful, but they are not part of first-run setup.
+
+## Assistant-Safe Setup Prompt
+
+Use this when asking an assistant to install or configure VK:
+
+```text
+Set up Veritas Kanban from the official repo and docs only. Start with the board-only local path first. Do not configure OpenClaw, MCP, Squad Chat webhooks, workflow gates, or notification delivery unless I explicitly ask for that layer. After the board runs, verify localhost:3000 and localhost:3001/api/health. If configuring CLI or MCP writes, use VK_API_URL and VK_API_KEY exactly as documented.
+```
+
+## Quick Troubleshooting
+
+| Symptom                                            | Likely cause                                  | Fix                                                                                                          |
+| -------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `vk` command exists but cannot import shared files | CLI linked before shared/CLI build            | Run `pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/cli build`, then link again |
+| MCP reads work but writes fail                     | No write-capable API key                      | Add `VERITAS_API_KEYS` in `server/.env`, restart, set `VK_API_KEY` in MCP client env                         |
+| Assistant says OpenClaw is required                | Setup path confusion                          | Start with board-only setup. OpenClaw is optional                                                            |
+| Squad Chat posts save but no agent wakes           | Local chat works, outbound runner is missing  | Configure OpenClaw Direct or another webhook runner only if wake behavior is needed                          |
+| Notification test does nothing external            | External delivery is disabled or unconfigured | Configure notification channels or use local broadcasts for in-app visibility                                |

--- a/docs/SOP-squad-chat.md
+++ b/docs/SOP-squad-chat.md
@@ -9,18 +9,20 @@ Squad chat is the real-time communication channel for agents and the orchestrato
 ## Prerequisites
 
 - Veritas Kanban server running (squad chat endpoint at `localhost:3001/api/chat/squad`)
-- Agent name and model name (required fields for every post)
+- Agent name and message (required fields for every post)
+- Model name is recommended so the UI can show which model posted the message
+- Write-capable API key unless localhost bypass grants an `agent` or `admin` role
 - For sub-agents without the `squad-post.sh` script: direct curl access
 
 ## Concepts
 
-| Term | Definition |
-|------|------------|
-| **Squad chat** | Persistent message channel shared across all agents and the VK web UI |
-| **Agent** | Name of the posting agent (e.g., `VERITAS`, `TARS`, `CASE`) |
-| **Model** | The LLM powering the agent (e.g., `claude-sonnet-4-6`, `gpt-5.1`) — stored and displayed on the message |
-| **Tags** | Freeform labels for filtering messages by task or feature (e.g., `["docs-v4", "cleanup"]`) |
-| **System events** | Automated events (agent spawned, task completed) that the server pushes to squad chat |
+| Term              | Definition                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------- |
+| **Squad chat**    | Persistent message channel shared across all agents and the VK web UI                                   |
+| **Agent**         | Name of the posting agent (e.g., `VERITAS`, `TARS`, `CASE`)                                             |
+| **Model**         | The LLM powering the agent (e.g., `claude-sonnet-4-6`, `gpt-5.1`) — stored and displayed on the message |
+| **Tags**          | Freeform labels for filtering messages by task or feature (e.g., `["docs-v4", "cleanup"]`)              |
+| **System events** | Automated events (agent spawned, task completed) that the server pushes to squad chat                   |
 
 ## Step-by-Step: Post to Squad Chat
 
@@ -37,6 +39,7 @@ Format: `squad-post.sh <AGENT> "<MESSAGE>" [TAG]`
 ```bash
 curl -s -X POST http://localhost:3001/api/chat/squad \
   -H 'Content-Type: application/json' \
+  -H "X-API-Key: $VK_API_KEY" \
   -d '{
     "agent": "TARS",
     "message": "Step 3/7: CHANGELOG.md v4.0.0 entry written",
@@ -45,7 +48,8 @@ curl -s -X POST http://localhost:3001/api/chat/squad \
   }'
 ```
 
-**Required fields:** `agent`, `message`, `model`  
+**Required fields:** `agent`, `message`
+**Recommended:** `model`
 **Optional:** `tags` (array of strings)
 
 ## The Narration Protocol (Mandatory)
@@ -54,14 +58,14 @@ Squad chat is how multi-agent work stays visible. **Post at every major step** �
 
 ### When to post
 
-| Trigger | Post |
-|---------|------|
-| Starting a multi-step task | `Starting [task title] — [N] steps`  |
-| Completing a major step | `Step N/Total: [what was done]` |
-| Encountering an error | `⚠️ Error on step N: [what failed and what I'm doing about it]` |
-| Completing the full task | `[Task title] complete — [brief summary of what changed]` |
-| Spawning a sub-agent | `Spawning [AgentName] for [subtask]` |
-| Sub-agent completes | `[AgentName] done: [result summary]` |
+| Trigger                    | Post                                                            |
+| -------------------------- | --------------------------------------------------------------- |
+| Starting a multi-step task | `Starting [task title] — [N] steps`                             |
+| Completing a major step    | `Step N/Total: [what was done]`                                 |
+| Encountering an error      | `⚠️ Error on step N: [what failed and what I'm doing about it]` |
+| Completing the full task   | `[Task title] complete — [brief summary of what changed]`       |
+| Spawning a sub-agent       | `Spawning [AgentName] for [subtask]`                            |
+| Sub-agent completes        | `[AgentName] done: [result summary]`                            |
 
 ### What makes a good squad post
 
@@ -102,13 +106,13 @@ curl -s "http://localhost:3001/api/chat/squad?since=2026-03-21T14:00:00Z"
 
 Use consistent tags so messages are filterable by project or task:
 
-| Pattern | Example | Use For |
-|---------|---------|---------|
-| Project name | `rubicon` | All work on a specific project |
-| Task type | `docs-v4`, `security`, `cleanup` | Ongoing task category |
-| Sprint | `sprint-12` | Sprint-scoped work |
-| Feature | `policy-engine` | Specific feature work |
-| System | `health`, `drift`, `heartbeat` | Monitoring and system events |
+| Pattern      | Example                          | Use For                        |
+| ------------ | -------------------------------- | ------------------------------ |
+| Project name | `rubicon`                        | All work on a specific project |
+| Task type    | `docs-v4`, `security`, `cleanup` | Ongoing task category          |
+| Sprint       | `sprint-12`                      | Sprint-scoped work             |
+| Feature      | `policy-engine`                  | Specific feature work          |
+| System       | `health`, `drift`, `heartbeat`   | Monitoring and system events   |
 
 ## Sub-Agent Template Block
 
@@ -118,9 +122,10 @@ Every `sessions_spawn` task prompt must include this block so sub-agents can pos
 SQUAD CHAT (mandatory — post at every major step):
 curl -s -X POST http://localhost:3001/api/chat/squad \
   -H 'Content-Type: application/json' \
+  -H "X-API-Key: $VK_API_KEY" \
   -d '{"agent":"<AGENT_NAME>","message":"<STEP_DESCRIPTION>","model":"<MODEL_NAME>","tags":["<TASK_TAG>"]}'
 Post when: starting work, each major milestone, completion, and errors.
-The "model" field is REQUIRED — the server stores and displays it automatically.
+The "model" field is recommended — the server stores and displays it automatically when provided.
 ```
 
 ## Heartbeat Protocol
@@ -131,6 +136,7 @@ Every heartbeat must post start and end messages:
 # Heartbeat start
 curl -s -X POST http://localhost:3001/api/chat/squad \
   -H 'Content-Type: application/json' \
+  -H "X-API-Key: $VK_API_KEY" \
   -d '{"agent":"VERITAS","message":"Heartbeat: checking email, calendar, drift alerts","model":"claude-sonnet-4-6","tags":["heartbeat"]}'
 
 # ... do the checks ...
@@ -138,25 +144,27 @@ curl -s -X POST http://localhost:3001/api/chat/squad \
 # Heartbeat end
 curl -s -X POST http://localhost:3001/api/chat/squad \
   -H 'Content-Type: application/json' \
+  -H "X-API-Key: $VK_API_KEY" \
   -d '{"agent":"VERITAS","message":"Heartbeat complete — 2 unread emails, Guide Energy meeting at 3pm, all drift ok","model":"claude-sonnet-4-6","tags":["heartbeat"]}'
 ```
 
 ## API Endpoints Used
 
-| Method | Path | Purpose |
-|--------|------|---------|
+| Method | Path              | Purpose                      |
+| ------ | ----------------- | ---------------------------- |
 | `POST` | `/api/chat/squad` | Post a message to squad chat |
-| `GET` | `/api/chat/squad` | List messages (filterable) |
+| `GET`  | `/api/chat/squad` | List messages (filterable)   |
 
 ## Common Issues / Troubleshooting
 
-| Issue | Cause | Fix |
-|-------|-------|-----|
-| `400` on POST | Missing required fields | Ensure `agent`, `message`, and `model` are all present |
-| Messages not appearing in UI | WebSocket disconnected | Refresh the browser; check that the VK server is running |
-| Squad chat panel scroll broken | Known issue (fixed in v4.0, PR #225) | Upgrade to v4.0.0+ if on an older version |
-| Sub-agent posts missing | Sub-agent prompt didn't include the squad chat block | Add the template block to every `sessions_spawn` prompt |
-| Model field blank in UI | `model` field omitted from POST body | Always include `"model": "<model-name>"` — it's required |
+| Issue                          | Cause                                                | Fix                                                                        |
+| ------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| `400` on POST                  | Missing required fields                              | Ensure `agent` and `message` are present                                   |
+| `401` or `403` on POST         | Missing key or read-only local role                  | Set `VK_API_KEY` or grant localhost an `agent` role for local-only testing |
+| Messages not appearing in UI   | WebSocket disconnected                               | Refresh the browser; check that the VK server is running                   |
+| Squad chat panel scroll broken | Known issue (fixed in v4.0, PR #225)                 | Upgrade to v4.0.0+ if on an older version                                  |
+| Sub-agent posts missing        | Sub-agent prompt didn't include the squad chat block | Add the template block to every `sessions_spawn` prompt                    |
+| Model field blank in UI        | `model` field omitted from POST body                 | Include `"model": "<model-name>"` when model attribution matters           |
 
 ## Related Docs
 

--- a/docs/SQUAD-CHAT-PROTOCOL.md
+++ b/docs/SQUAD-CHAT-PROTOCOL.md
@@ -1,10 +1,10 @@
 # Squad Chat Protocol
 
-Squad chat is the **glass box** — the real-time visibility layer that lets humans see what agents are doing. If work is happening and squad chat is quiet, transparency has failed.
+Squad chat is the **glass box** — the real-time visibility layer that lets humans see what agents are doing. It is optional for first-run board setup, but when an agent workflow opts into squad chat, the chat log should stay current.
 
-## Rule: Every Agent Posts to Squad Chat
+## Rule: Participating Agents Post to Squad Chat
 
-**Non-negotiable.** Every agent (human or AI) posts to squad chat when:
+Every participating agent (human or AI) posts to squad chat when:
 
 1. **Starting work** — What you're about to do
 2. **Milestones** — Major progress (e.g., "Chapter 3 of 9 complete")
@@ -28,6 +28,7 @@ Squad chat is the **glass box** — the real-time visibility layer that lets hum
 ```bash
 curl -s -X POST "http://localhost:3001/api/chat/squad" \
   -H 'Content-Type: application/json' \
+  -H "X-API-Key: $VK_API_KEY" \
   -d '{
     "agent": "YOUR_NAME",
     "message": "Your update here",
@@ -40,10 +41,11 @@ curl -s -X POST "http://localhost:3001/api/chat/squad" \
 
 The script supports these env vars for non-default configurations:
 
-| Variable  | Default     | Description     |
-| --------- | ----------- | --------------- |
-| `VK_HOST` | `localhost` | Server hostname |
-| `VK_PORT` | `3001`      | Server port     |
+| Variable     | Default     | Description                                      |
+| ------------ | ----------- | ------------------------------------------------ |
+| `VK_HOST`    | `localhost` | Server hostname                                  |
+| `VK_PORT`    | `3001`      | Server port                                      |
+| `VK_API_KEY` | _(none)_    | API key for write-capable authenticated requests |
 
 ### API Details
 
@@ -51,7 +53,7 @@ The script supports these env vars for non-default configurations:
 - **Port:** 3001 (Express) or 3000 (Vite proxy)
 - **Body:** `{ "agent": string, "message": string, "tags"?: string[], "model"?: string }`
 - **Response:** `201 Created` with the message object `{ id, agent, message, tags, model, timestamp }`
-- **Auth:** None required (localhost only). If exposing externally, protect behind auth.
+- **Auth:** `X-API-Key` required for write access unless localhost bypass grants a write-capable role.
 
 ### Troubleshooting
 
@@ -97,6 +99,7 @@ SQUAD CHAT (mandatory): Post updates to squad chat as YOUR_NAME throughout your 
 Use this command for regular updates:
   curl -s -X POST "http://localhost:3001/api/chat/squad" \
     -H 'Content-Type: application/json' \
+    -H "X-API-Key: $VK_API_KEY" \
     -d '{"agent":"YOUR_NAME","message":"YOUR UPDATE","tags":["relevant","tags"],"model":"YOUR_MODEL"}'
 
 Post when you: (1) start work, (2) hit milestones, (3) complete, (4) find issues.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -393,6 +393,36 @@ docker compose up -d
    ```
 3. For agents running in Docker/containers, use `host.docker.internal:3001` instead of `localhost:3001`
 
+### `vk` command exists but fails to start
+
+The CLI depends on the built shared package. If `npm link` ran before the packages were built, rebuild and relink:
+
+```bash
+pnpm --filter @veritas-kanban/shared build
+pnpm --filter @veritas-kanban/cli build
+cd cli
+npm link
+```
+
+### CLI or MCP can read but cannot write
+
+Localhost bypass commonly grants `read-only` access. Create an agent key in `server/.env`, restart the server, and pass the key to the CLI or MCP client:
+
+```bash
+VERITAS_API_KEYS=local-agent:replace-with-a-long-secret:agent
+```
+
+```bash
+export VK_API_URL=http://localhost:3001
+export VK_API_KEY=replace-with-a-long-secret
+```
+
+For MCP, put `VK_API_KEY` in the MCP server env block. Avoid using the admin key unless you need admin-only endpoints.
+
+### Assistant says OpenClaw is required
+
+OpenClaw is optional. Use the board-only path in [Setup Paths](SETUP-PATHS.md), then add OpenClaw only if you want OpenClaw to execute tasks, use the browser relay, or receive Squad Chat wake events.
+
 ### Agent names/models — is it hardcoded?
 
 **No.** The agent system is platform-agnostic. The board doesn't call LLMs directly — it provides a REST API that any agent can call. Whether you're using Claude, GPT, Kimi, Gemini, Llama, or a custom model, if your agent can make HTTP requests, it can drive the board.
@@ -411,7 +441,7 @@ Verify the MCP server config in your Claude Desktop settings:
       "args": ["/path/to/veritas-kanban/mcp/dist/index.js"],
       "env": {
         "VK_API_URL": "http://localhost:3001",
-        "VK_API_KEY": "your-admin-key"
+        "VK_API_KEY": "your-agent-key"
       }
     }
   }
@@ -452,7 +482,7 @@ After restarting, confirm that Veritas Kanban was successfully discovered and al
 openclaw mcp list
 
 # Expected output should include:
-# veritas-kanban | 26 tools | http://localhost:3001
+# veritas-kanban | 36 tools | http://localhost:3001
 
 # View available tools from Veritas Kanban
 openclaw mcp tools veritas-kanban
@@ -468,12 +498,26 @@ openclaw mcp describe veritas-kanban vk_list_tasks
 - Build the MCP server if missing: `cd mcp && pnpm build`
 - Check OpenClaw logs for startup errors: `~/.openclaw/logs/mcp.log`
 
-**If the tool count is wrong (not 26 tools):**
+**If the tool count is wrong (not 36 tools):**
 
 - MCP server may have started but failed to initialize properly
 - Check VK API is accessible: `curl http://localhost:3001/api/health`
 - Verify API key is set in MCP config env vars
 - Review MCP server logs for initialization errors
+
+**If reads work but write tools return `401` or `403`:**
+
+- Confirm `VK_API_KEY` is set in the MCP client env block
+- Confirm the same key is present in `VERITAS_API_KEYS` with the `agent` role
+- Restart both `pnpm dev` and the MCP client after env changes
+
+### Squad Chat posts save but no agent wakes
+
+Squad Chat stores local messages and streams them to connected UI clients. It does not wake an external process by itself. Configure Settings -> Notifications -> Squad Chat Webhook only when you want outbound delivery through a generic webhook or OpenClaw Direct.
+
+### Notifications do not send externally
+
+Notification delivery channels are optional. Local notifications, broadcasts, and Squad Chat can work while external webhook delivery is disabled. Use `/api/broadcasts` for durable system-wide messages and verify delivery-specific settings before expecting an external wake or push.
 
 **3. Gather diagnostics bundle when reporting issues**
 

--- a/docs/features/broadcasts.md
+++ b/docs/features/broadcasts.md
@@ -46,7 +46,7 @@ curl -s -X POST http://localhost:3001/api/broadcasts \
 
 ```json
 {
-  "id": "bcast_abc123",
+  "id": "4b5fb0b6-9b6e-47b3-bd24-2f088980ccf7",
   "message": "Deploy finished. Review RF-042 before closing the release.",
   "priority": "action-required",
   "from": "release-bot",
@@ -85,7 +85,7 @@ curl -s "http://localhost:3001/api/broadcasts?priority=urgent&since=2026-03-21T1
 ## Mark Read
 
 ```bash
-curl -s -X PATCH http://localhost:3001/api/broadcasts/bcast_abc123/read \
+curl -s -X PATCH http://localhost:3001/api/broadcasts/4b5fb0b6-9b6e-47b3-bd24-2f088980ccf7/read \
   -H "Content-Type: application/json" \
   -H "X-API-Key: YOUR_KEY" \
   -d '{ "agent": "TARS" }'

--- a/docs/features/broadcasts.md
+++ b/docs/features/broadcasts.md
@@ -1,298 +1,120 @@
-# Broadcast Notifications
+# Broadcasts
 
-Priority-based persistent notifications with read receipts and agent-specific delivery tracking.
+Persistent, system-wide messages for agent coordination and operator visibility.
 
 ## Overview
 
-Broadcast Notifications provide a system-wide notification mechanism for important announcements, agent completions, and critical events. Unlike ephemeral toast notifications, broadcasts persist until explicitly dismissed and track read receipts per agent.
+Broadcasts are stored server-side and can be read by agents or UI clients. They are different from notification delivery channels and different from Squad Chat:
 
-## Features
-
-- **Priority levels** — Info, warning, error, critical
-- **Persistent display** — Notifications remain until dismissed
-- **Read receipts** — Track which agents/users have seen each notification
-- **Agent filtering** — Target specific agents or broadcast to all
-- **Auto-dismiss** — Optional expiration time for time-sensitive notifications
-- **Rich content** — Markdown support for formatting
-- **Action buttons** — Optional call-to-action buttons with links
+- Broadcasts use `/api/broadcasts` and are durable until removed from storage.
+- Notifications use `/api/notifications` for recipient-specific task and system events.
+- Squad Chat uses the chat endpoints and optional webhook delivery for agent conversation and wake behavior.
 
 ## API Endpoints
 
-### Create Broadcast
+| Method  | Path                       | Description                        |
+| ------- | -------------------------- | ---------------------------------- |
+| `POST`  | `/api/broadcasts`          | Create a broadcast                 |
+| `GET`   | `/api/broadcasts`          | List broadcasts with filters       |
+| `GET`   | `/api/broadcasts/:id`      | Get one broadcast                  |
+| `PATCH` | `/api/broadcasts/:id/read` | Mark a broadcast read for an agent |
+
+## Create A Broadcast
 
 ```bash
-# Info notification
-curl -X POST http://localhost:3001/api/notifications/broadcast \
+curl -s -X POST http://localhost:3001/api/broadcasts \
   -H "Content-Type: application/json" \
   -H "X-API-Key: YOUR_KEY" \
   -d '{
-    "title": "Deployment Complete",
-    "message": "Version 2.0.0 has been deployed successfully.",
-    "priority": "info"
-  }'
-
-# Warning notification with expiration
-curl -X POST http://localhost:3001/api/notifications/broadcast \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "title": "Maintenance Window",
-    "message": "Database maintenance scheduled for 2 AM tonight. Expect 30 minutes downtime.",
-    "priority": "warning",
-    "expiresAt": "2026-02-08T02:30:00Z"
-  }'
-
-# Critical notification with action button
-curl -X POST http://localhost:3001/api/notifications/broadcast \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "title": "Security Alert",
-    "message": "Critical security patch required. Please update immediately.",
-    "priority": "critical",
-    "actionLabel": "View Patch Notes",
-    "actionUrl": "https://example.com/security-patch"
-  }'
-
-# Agent-specific notification
-curl -X POST http://localhost:3001/api/notifications/broadcast \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "title": "Task Assignment",
-    "message": "TARS, you have been assigned to RF-042.",
-    "priority": "info",
-    "targetAgents": ["TARS"]
+    "message": "Deploy finished. Review RF-042 before closing the release.",
+    "priority": "action-required",
+    "from": "release-bot",
+    "tags": ["release", "review"]
   }'
 ```
 
-### Get Broadcasts
+### Request Schema
 
-```bash
-# Get all active broadcasts
-curl http://localhost:3001/api/notifications/broadcast \
-  -H "X-API-Key: YOUR_KEY"
+| Field      | Type     | Required | Description                                                |
+| ---------- | -------- | -------- | ---------------------------------------------------------- |
+| `message`  | string   | Yes      | Broadcast content, max 5000 characters                     |
+| `priority` | enum     | No       | `info`, `action-required`, or `urgent`. Defaults to `info` |
+| `from`     | string   | No       | Agent or system name, max 100 characters                   |
+| `tags`     | string[] | No       | Up to 20 tags, max 50 characters each                      |
 
-# Get broadcasts for specific agent
-curl "http://localhost:3001/api/notifications/broadcast?agent=TARS" \
-  -H "X-API-Key: YOUR_KEY"
-
-# Include dismissed broadcasts
-curl "http://localhost:3001/api/notifications/broadcast?includeDismissed=true" \
-  -H "X-API-Key: YOUR_KEY"
-```
-
-### Mark as Read
-
-```bash
-curl -X POST http://localhost:3001/api/notifications/broadcast/{id}/read \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "agent": "TARS"
-  }'
-```
-
-### Dismiss Broadcast
-
-```bash
-# Dismiss for specific agent
-curl -X POST http://localhost:3001/api/notifications/broadcast/{id}/dismiss \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "agent": "TARS"
-  }'
-
-# Dismiss globally (requires admin role)
-curl -X DELETE http://localhost:3001/api/notifications/broadcast/{id} \
-  -H "X-API-Key: ADMIN_KEY"
-```
-
-## Request Schema
-
-### Create Broadcast
-
-| Field          | Type     | Required | Description                                     |
-| -------------- | -------- | -------- | ----------------------------------------------- |
-| `title`        | string   | ✅       | Notification title                              |
-| `message`      | string   | ✅       | Notification message (supports markdown)        |
-| `priority`     | enum     | ✅       | `info`, `warning`, `error`, `critical`          |
-| `targetAgents` | string[] | ❌       | Agent IDs to notify (omit for broadcast to all) |
-| `expiresAt`    | ISO 8601 | ❌       | Auto-dismiss timestamp                          |
-| `actionLabel`  | string   | ❌       | Call-to-action button text                      |
-| `actionUrl`    | string   | ❌       | Call-to-action button URL                       |
-
-## Response Schema
-
-### Broadcast Object
+### Response
 
 ```json
 {
-  "id": "bc_abc123",
-  "title": "Deployment Complete",
-  "message": "Version 2.0.0 has been deployed successfully.",
-  "priority": "info",
-  "createdAt": "2026-02-07T15:00:00Z",
-  "createdBy": "VERITAS",
-  "targetAgents": null,
-  "expiresAt": null,
-  "actionLabel": null,
-  "actionUrl": null,
-  "readBy": [
-    {
-      "agent": "TARS",
-      "timestamp": "2026-02-07T15:05:00Z"
-    }
-  ],
-  "dismissedBy": []
+  "id": "bcast_abc123",
+  "message": "Deploy finished. Review RF-042 before closing the release.",
+  "priority": "action-required",
+  "from": "release-bot",
+  "tags": ["release", "review"],
+  "createdAt": "2026-03-21T15:00:00.000Z",
+  "readBy": []
 }
 ```
 
-## Priority Levels
-
-| Priority   | Color  | Icon | Use Case                           |
-| ---------- | ------ | ---- | ---------------------------------- |
-| `info`     | Blue   | ℹ️   | General announcements, completions |
-| `warning`  | Yellow | ⚠️   | Maintenance windows, deprecations  |
-| `error`    | Red    | ❌   | Task failures, integration errors  |
-| `critical` | Red    | 🚨   | Security alerts, system failures   |
-
-## Frontend Display
-
-Broadcasts appear at the top of the board (sticky header) with the following behavior:
-
-- **Stacking** — Multiple broadcasts stack vertically
-- **Priority sorting** — Critical notifications appear first
-- **Dismiss button** — Individual dismiss per agent
-- **Action button** — Opens link in new tab (if configured)
-- **Auto-hide** — Broadcasts past `expiresAt` auto-dismiss
-- **Persistence** — Survives page reloads until manually dismissed
-
-## Common Use Cases
-
-### Deployment Announcements
+## List Broadcasts
 
 ```bash
-curl -X POST http://localhost:3001/api/notifications/broadcast \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "title": "New Features Available",
-    "message": "Squad Chat and Broadcast Notifications are now live! Check the docs for usage.",
-    "priority": "info",
-    "actionLabel": "View Docs",
-    "actionUrl": "http://localhost:3000/docs"
-  }'
+# Latest broadcasts
+curl -s "http://localhost:3001/api/broadcasts?limit=10" \
+  -H "X-API-Key: YOUR_KEY"
+
+# Unread broadcasts for one agent
+curl -s "http://localhost:3001/api/broadcasts?agent=TARS&unread=true" \
+  -H "X-API-Key: YOUR_KEY"
+
+# Urgent broadcasts since a known timestamp
+curl -s "http://localhost:3001/api/broadcasts?priority=urgent&since=2026-03-21T12:00:00.000Z" \
+  -H "X-API-Key: YOUR_KEY"
 ```
 
-### Agent Task Completion
+### Query Parameters
+
+| Parameter  | Description                                                    |
+| ---------- | -------------------------------------------------------------- |
+| `since`    | ISO timestamp. Returns broadcasts created after this timestamp |
+| `unread`   | `true` to return only unread broadcasts. Requires `agent`      |
+| `agent`    | Agent name used for unread filtering                           |
+| `priority` | `info`, `action-required`, or `urgent`                         |
+| `limit`    | Positive integer, max 1000                                     |
+
+## Mark Read
 
 ```bash
-curl -X POST http://localhost:3001/api/notifications/broadcast \
+curl -s -X PATCH http://localhost:3001/api/broadcasts/bcast_abc123/read \
   -H "Content-Type: application/json" \
   -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "title": "Task RF-042 Complete",
-    "message": "TARS completed the API refactor. Ready for review.",
-    "priority": "info",
-    "actionLabel": "Review Changes",
-    "actionUrl": "http://localhost:3000/tasks/RF-042"
-  }'
+  -d '{ "agent": "TARS" }'
 ```
 
-### Critical Security Alerts
+## Agent Polling Pattern
+
+Agents should check unread broadcasts at startup and between work loops:
 
 ```bash
-curl -X POST http://localhost:3001/api/notifications/broadcast \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "title": "Security Patch Required",
-    "message": "CVE-2026-1234 affects dependencies. Update immediately.",
-    "priority": "critical",
-    "actionLabel": "View Details",
-    "actionUrl": "https://nvd.nist.gov/vuln/detail/CVE-2026-1234"
-  }'
+curl -s "http://localhost:3001/api/broadcasts?agent=TARS&unread=true&limit=25" \
+  -H "X-API-Key: YOUR_KEY"
 ```
 
-### Maintenance Windows
-
-```bash
-curl -X POST http://localhost:3001/api/notifications/broadcast \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{
-    "title": "Scheduled Maintenance",
-    "message": "Database backup and migration starting at 2 AM. Expected duration: 30 minutes.",
-    "priority": "warning",
-    "expiresAt": "2026-02-08T02:30:00Z"
-  }'
-```
+After processing a broadcast, mark it read so it does not reappear for that agent.
 
 ## Storage
 
-Broadcasts are stored in `.veritas-kanban/notifications/broadcasts.json`:
-
-```json
-[
-  {
-    "id": "bc_abc123",
-    "title": "Deployment Complete",
-    "message": "Version 2.0.0 deployed.",
-    "priority": "info",
-    "createdAt": "2026-02-07T15:00:00Z",
-    "createdBy": "VERITAS",
-    "readBy": [{ "agent": "TARS", "timestamp": "2026-02-07T15:05:00Z" }],
-    "dismissedBy": []
-  }
-]
-```
-
-## Agent Integration
-
-Agents should poll for broadcasts on startup and periodically:
-
-```bash
-# Check for unread broadcasts
-BROADCASTS=$(curl -s "http://localhost:3001/api/notifications/broadcast?agent=TARS" \
-  -H "X-API-Key: YOUR_KEY")
-
-# Mark as read after displaying
-curl -X POST http://localhost:3001/api/notifications/broadcast/{id}/read \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{ "agent": "TARS" }'
-```
-
-Agents can dismiss broadcasts after acknowledging:
-
-```bash
-curl -X POST http://localhost:3001/api/notifications/broadcast/{id}/dismiss \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: YOUR_KEY" \
-  -d '{ "agent": "TARS" }'
-```
+Broadcast records are stored as markdown-backed runtime data under `.veritas-kanban/broadcasts/`.
 
 ## Security Notes
 
-- All endpoints require authentication
-- Read/dismiss operations validate agent identity
-- Global dismiss requires admin role
-- Action URLs are validated as proper URLs
-- Markdown content is sanitized to prevent XSS
-
-## Best Practices
-
-1. **Use priority appropriately** — Critical should be rare and urgent
-2. **Set expiration for time-sensitive notifications** — Avoid stale maintenance alerts
-3. **Target specific agents when possible** — Reduce noise
-4. **Include action buttons for follow-up** — Make it easy to respond
-5. **Keep messages concise** — Broadcasts should fit in a sticky header
-6. **Use markdown sparingly** — Bold for emphasis, links for references
+- `POST /api/broadcasts` and `PATCH /api/broadcasts/:id/read` require write-capable auth unless localhost bypass grants a write role.
+- Use an `agent` role API key for automation.
+- Do not put secrets, private keys, or credentials in broadcast messages.
 
 ## Related Documentation
 
-- [Squad Chat](squad-chat.md) — Real-time agent communication
-- [@Mention Notifications](#) — Task-specific agent notifications
-- [Agent Registry](#) — Agent discovery and heartbeat tracking
+- [Squad Chat](squad-chat.md) - shared local agent conversation
+- [SOP Broadcasts](../SOP-broadcasts.md) - operator playbook
+- [CLI Guide](../CLI-GUIDE.md) - shell-driven automation
+- [API Reference](../API-REFERENCE.md) - endpoint catalog

--- a/docs/features/squad-chat.md
+++ b/docs/features/squad-chat.md
@@ -4,7 +4,7 @@ Real-time agent-to-agent communication panel with WebSocket updates and system m
 
 ## Overview
 
-Squad Chat provides a dedicated communication channel for AI agents working on your board. Agents can coordinate, share status updates, and post completion summaries. The panel includes system messages that automatically log agent events (spawned, completed, failed, status updates).
+Squad Chat provides a dedicated communication channel for AI agents working on your board. Agents can coordinate, share status updates, and post completion summaries. The panel includes system messages that automatically log agent events (spawned, completed, failed, status updates). Squad Chat is optional for first-run setup and does not require OpenClaw unless you want OpenClaw Direct wake behavior.
 
 ## Features
 
@@ -26,7 +26,8 @@ curl -X POST http://localhost:3001/api/chat/squad \
   -H "X-API-Key: YOUR_KEY" \
   -d '{
     "agent": "TARS",
-    "message": "Completed the API refactor. All tests passing."
+    "message": "Completed the API refactor. All tests passing.",
+    "model": "claude-sonnet-4.5"
   }'
 
 # System message (agent event)
@@ -121,7 +122,7 @@ Includes `X-VK-Signature` header with HMAC-SHA256 signature using the configured
 
 ### OpenClaw Direct Mode
 
-Calls the OpenClaw gateway's `/tools/invoke` endpoint to wake the main agent:
+Optional. Calls the OpenClaw gateway's `/tools/invoke` endpoint to wake the main agent:
 
 ```bash
 POST {gatewayUrl}/tools/invoke

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -165,6 +165,7 @@ Local development:
 ```bash
 codex mcp add veritas-kanban \
   --env VK_API_URL=http://localhost:3001 \
+  --env VK_API_KEY=your-agent-api-key \
   -- node /absolute/path/to/veritas-kanban/mcp/dist/index.js
 ```
 
@@ -205,6 +206,7 @@ When running VK behind a reverse proxy (nginx/Caddy):
 ```
 
 > **Important:** In production, always set `VK_API_KEY` so the MCP server authenticates with the VK API. Without it, requests rely on localhost bypass (which won't work remotely).
+> **Local writes:** Read-only localhost calls may work without `VK_API_KEY`, but write tools need a key unless `VERITAS_AUTH_LOCALHOST_ROLE` is set to `agent` or `admin`.
 
 ---
 
@@ -676,7 +678,7 @@ Resources are useful for MCP clients that support resource browsing (e.g., Claud
 
 ### Token Boundaries
 
-- API keys are passed via the `Authorization: Bearer <key>` header.
+- API keys are passed via the `X-API-Key` header by the shared VK API client. The server also accepts `Authorization: Bearer <key>` for direct HTTP callers.
 - The MCP server reads `VK_API_KEY` from its environment and includes it in every HTTP request to VK.
 - Keys never appear in MCP tool inputs/outputs — they stay in the transport layer.
 
@@ -716,7 +718,7 @@ All tool errors return:
 
 ```bash
 # Run MCP server with stderr visible (it logs to stderr)
-VK_API_URL=http://localhost:3001 node mcp/dist/index.js
+VK_API_URL=http://localhost:3001 VK_API_KEY=your-agent-api-key node mcp/dist/index.js
 
 # Test a specific tool via stdin
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_tasks","arguments":{}}}' | \

--- a/mcp/src/__tests__/project-tools.test.ts
+++ b/mcp/src/__tests__/project-tools.test.ts
@@ -75,8 +75,9 @@ describe('Project MCP Tools', () => {
 
     it('should have force as optional on delete_project', () => {
       const tool = projectTools.find((t) => t.name === 'delete_project');
-      expect(tool?.inputSchema.properties.force).toBeDefined();
-      expect(tool?.inputSchema.properties.force.type).toBe('boolean');
+      const force = tool?.inputSchema.properties.force;
+      expect(force).toBeDefined();
+      expect(force?.type).toBe('boolean');
       expect(tool?.inputSchema.required).not.toContain('force');
     });
 

--- a/mcp/src/__tests__/sprint-tools.test.ts
+++ b/mcp/src/__tests__/sprint-tools.test.ts
@@ -69,8 +69,9 @@ describe('Sprint MCP Tools', () => {
 
     it('should have force as optional on delete_sprint', () => {
       const tool = sprintTools.find((t) => t.name === 'delete_sprint');
-      expect(tool?.inputSchema.properties.force).toBeDefined();
-      expect(tool?.inputSchema.properties.force.type).toBe('boolean');
+      const force = tool?.inputSchema.properties.force;
+      expect(force).toBeDefined();
+      expect(force?.type).toBe('boolean');
       // force is NOT in required — it's optional
       expect(tool?.inputSchema.required).not.toContain('force');
     });

--- a/mcp/src/tools/summary.ts
+++ b/mcp/src/tools/summary.ts
@@ -1,4 +1,4 @@
-import { api, API_BASE } from '../utils/api.js';
+import { api, API_BASE, buildApiHeaders } from '../utils/api.js';
 
 export const summaryTools = [
   {
@@ -11,7 +11,8 @@ export const summaryTools = [
   },
   {
     name: 'get_memory_summary',
-    description: 'Get task summary formatted for memory files (completed tasks, active high-priority, project progress)',
+    description:
+      'Get task summary formatted for memory files (completed tasks, active high-priority, project progress)',
     inputSchema: {
       type: 'object',
       properties: {
@@ -35,7 +36,9 @@ export async function handleSummaryTool(name: string, args: any): Promise<any> {
 
     case 'get_memory_summary': {
       const hours = (args as { hours?: number })?.hours || 24;
-      const res = await fetch(`${API_BASE}/api/summary/memory?hours=${hours}`);
+      const res = await fetch(`${API_BASE}/api/summary/memory?hours=${hours}`, {
+        headers: buildApiHeaders(),
+      });
       const markdown = await res.text();
       return {
         content: [{ type: 'text', text: markdown }],

--- a/mcp/src/tools/summary.ts
+++ b/mcp/src/tools/summary.ts
@@ -40,6 +40,9 @@ export async function handleSummaryTool(name: string, args: any): Promise<any> {
         headers: buildApiHeaders(),
       });
       const markdown = await res.text();
+      if (!res.ok) {
+        throw new Error(markdown || `API error: ${res.status}`);
+      }
       return {
         content: [{ type: 'text', text: markdown }],
       };

--- a/mcp/src/utils/api.ts
+++ b/mcp/src/utils/api.ts
@@ -1,2 +1,2 @@
 // Re-export shared API client
-export { api, createApiClient, API_BASE } from '@veritas-kanban/shared';
+export { api, createApiClient, API_BASE, buildApiHeaders } from '@veritas-kanban/shared';

--- a/shared/src/utils/api-client.ts
+++ b/shared/src/utils/api-client.ts
@@ -18,36 +18,41 @@ function getEnv(name: string): string | undefined {
 }
 
 function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
+  const normalized: Record<string, string> = {};
+
   if (!headers) {
-    return {};
+    return normalized;
   }
 
   if (typeof Headers !== 'undefined' && headers instanceof Headers) {
-    const normalized: Record<string, string> = {};
     headers.forEach((value, key) => {
-      normalized[key] = value;
+      normalized[key.toLowerCase()] = value;
     });
     return normalized;
   }
 
   if (Array.isArray(headers)) {
-    return Object.fromEntries(headers);
+    for (const [key, value] of headers) {
+      normalized[key.toLowerCase()] = value;
+    }
+    return normalized;
   }
 
-  return { ...(headers as Record<string, string>) };
+  for (const [key, value] of Object.entries(headers as Record<string, string>)) {
+    normalized[key.toLowerCase()] = value;
+  }
+
+  return normalized;
 }
 
 export function buildApiHeaders(headers?: HeadersInit, apiKey = getEnv('VK_API_KEY')) {
   const normalized = normalizeHeaders(headers);
-  const hasAuthHeader = Object.keys(normalized).some((key) => {
-    const lower = key.toLowerCase();
-    return lower === 'authorization' || lower === 'x-api-key';
-  });
+  const hasAuthHeader = 'authorization' in normalized || 'x-api-key' in normalized;
 
   return {
-    'Content-Type': 'application/json',
+    'content-type': 'application/json',
     ...normalized,
-    ...(apiKey && !hasAuthHeader ? { 'X-API-Key': apiKey } : {}),
+    ...(apiKey && !hasAuthHeader ? { 'x-api-key': apiKey } : {}),
   };
 }
 

--- a/shared/src/utils/api-client.ts
+++ b/shared/src/utils/api-client.ts
@@ -13,19 +13,54 @@ interface ApiEnvelope<T> {
   meta?: Record<string, unknown>;
 }
 
+function getEnv(name: string): string | undefined {
+  return typeof process !== 'undefined' ? process.env?.[name] : undefined;
+}
+
+function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    const normalized: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      normalized[key] = value;
+    });
+    return normalized;
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return { ...(headers as Record<string, string>) };
+}
+
+export function buildApiHeaders(headers?: HeadersInit, apiKey = getEnv('VK_API_KEY')) {
+  const normalized = normalizeHeaders(headers);
+  const hasAuthHeader = Object.keys(normalized).some((key) => {
+    const lower = key.toLowerCase();
+    return lower === 'authorization' || lower === 'x-api-key';
+  });
+
+  return {
+    'Content-Type': 'application/json',
+    ...normalized,
+    ...(apiKey && !hasAuthHeader ? { 'X-API-Key': apiKey } : {}),
+  };
+}
+
 /**
  * Create an API client instance
  * @param baseUrl - Base URL for the API (default: http://localhost:3001)
  * @returns API client function
  */
-export function createApiClient(baseUrl = DEFAULT_BASE) {
+export function createApiClient(baseUrl = DEFAULT_BASE, apiKey = getEnv('VK_API_KEY')) {
   return async function api<T>(path: string, options?: RequestInit): Promise<T> {
     const res = await fetch(`${baseUrl}${path}`, {
       ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...options?.headers,
-      },
+      headers: buildApiHeaders(options?.headers, apiKey),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- Add a board-first setup paths guide with explicit optional layers and @cob-ai credit.
- Align README, Getting Started, CLI, MCP, Squad Chat, broadcasts, and troubleshooting docs around minimal setup, auth, and external wake behavior.
- Make shared CLI/MCP API calls honor VK_API_KEY and include auth headers for the direct MCP memory summary fetch.
- Fix two MCP test type assertions that blocked the package build under strict TypeScript.

## Tracker
- Created #384, #385, #386, and #387 for the remaining docs work.
- Expanded #343, #352, #367, #368, #370, and #341 for v5 setup and diagnostics scope.
- Added @cob-ai credit to #376, #378, #379, #380, and #381.

## Verification
- pnpm exec prettier --check README.md docs/SETUP-PATHS.md docs/CLI-GUIDE.md docs/FEATURES.md docs/GETTING-STARTED.md docs/SOP-squad-chat.md docs/SQUAD-CHAT-PROTOCOL.md docs/TROUBLESHOOTING.md docs/features/broadcasts.md docs/features/squad-chat.md docs/mcp/README.md shared/src/utils/api-client.ts mcp/src/tools/summary.ts mcp/src/utils/api.ts cli/src/utils/api.ts mcp/src/__tests__/project-tools.test.ts mcp/src/__tests__/sprint-tools.test.ts
- git diff --check
- pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/cli build && pnpm --filter @veritas-kanban/mcp build

## Notes
- `pnpm exec vitest run mcp/src/__tests__/project-tools.test.ts mcp/src/__tests__/sprint-tools.test.ts` still requires a running local VK API for sprint lifecycle coverage and fails with ECONNREFUSED when localhost:3001 is not running.
