### PR TITLE
feat: add configurable board columns

### DIFF
--- a/cli/src/commands/summary.ts
+++ b/cli/src/commands/summary.ts
@@ -22,10 +22,9 @@ export function registerSummaryCommands(program: Command): void {
         console.log(chalk.bold('\n📊 Veritas Kanban Summary\n'));
 
         console.log(chalk.dim('Status:'));
-        console.log(`  To Do:       ${summary.byStatus.todo}`);
-        console.log(`  In Progress: ${summary.byStatus['in-progress']}`);
-        console.log(`  Blocked:     ${summary.byStatus.blocked}`);
-        console.log(`  Done:        ${summary.byStatus.done}`);
+        Object.entries(summary.byStatus).forEach(([status, count]) => {
+          console.log(`  ${status}: ${count}`);
+        });
 
         const projects = Object.entries(summary.byProject) as [
           string,

--- a/docs/BOARD-MANAGER-ARCHITECTURE.md
+++ b/docs/BOARD-MANAGER-ARCHITECTURE.md
@@ -1,0 +1,167 @@
+# Board Manager Architecture — Example Approval Workflow
+
+Status: design/spec only. This document describes an optional automation pattern; it does not install or require any persistent scheduler.
+
+This document describes an example short-lived board manager that uses configurable board columns and service-level workflow gates. It is not intended to hard-code a personal workflow into Veritas. The concrete names below are example operator/worker roles; downstream teams can rename roles, columns, and dispatch mechanisms to match their own environment.
+
+For the generic configurable-column model, see [Configurable Board Columns](CONFIGURABLE-BOARD-COLUMNS.md).
+
+## Example Board Workflow
+
+Configured board columns, in order:
+
+1. `triage` — **Triage**: raw capture. New tasks default here after this board configuration is applied.
+2. `todo` — **To Do**: operator review / approval queue. Existing `todo` tasks remain here.
+3. `ready` — **Ready**: approved, assigned, worker-actionable.
+4. `in-progress` — **In Progress**: worker has claimed/started.
+5. `blocked` — **Blocked**: worker needs input, dependency, access, or decision.
+6. `done` — **Done**: completed with deliverable/comment/verification.
+
+These columns preserve a local locked workflow semantics: raw intake must be shaped before approval; approved work must be assigned before execution; blocked work must carry visible blocker context; done work must leave evidence.
+
+## Example Role Responsibilities
+
+### Intake / Enrichment Role
+
+The intake role owns Triage enrichment. For each `triage` card it adds or verifies:
+
+- clarified objective
+- context/background
+- acceptance criteria / definition of done
+- suggested worker type
+- expected artifact/output
+- risks, blockers, and open questions
+
+After enrichment, the intake role moves the card to `todo`, not `ready`.
+
+### Operator / Approver Role
+
+The operator reviews `todo` cards. Approved/assigned cards are manually moved to `ready`.
+
+### Worker Roles
+
+Example worker roster:
+
+- `librarian`
+- `implementer`
+- `researcher`
+- `writer`
+- `ops`
+
+Workers do **not** need to poll Veritas. In this architecture, a worker receives one assigned task, does that task, returns a result, and stops.
+
+## Assignment Field
+
+Prefer the existing visible `agent` field when it maps cleanly to the target worker. Otherwise use `assignedWorker`, a lightweight task field for board-manager assignment. The UI exposes `assignedWorker` as **Assigned Worker** with the example roster above.
+
+## Transition Gates
+
+Hard blocks are preferred over warnings for this approval workflow.
+
+### `todo` -> `ready`
+
+Block unless:
+
+- assigned worker exists (`assignedWorker` or usable `agent`)
+- acceptance criteria / definition of done exists in the description or subtask acceptance criteria
+
+### `in-progress` / active work -> `done`
+
+Block unless:
+
+- completion comment exists
+- deliverable/artifact is attached or recorded
+- verification note exists, either via checked verification step or comment text
+
+### Any -> `blocked`
+
+Block unless a concrete blocker is recorded via `blockedReason.note` or a blocker-style visible comment. Blocked notifications are immediate only for high-priority/urgent work; otherwise they are comment/digest material.
+
+## Board Manager Lifecycle
+
+The board manager is intentionally short-lived and idempotent. A production deployment could trigger it periodically, but this patch does **not** install or require any persistent scheduler.
+
+One run:
+
+1. acquire local lock
+2. health check Veritas/API/config/state
+3. load structured local state
+4. reconcile active work first
+   - inspect active run/session IDs
+   - reconcile stale/finished workers
+   - write visible comments and status transitions
+5. triage/enrichment dispatch
+   - dispatch intake/enrichment role for eligible `triage` cards
+   - worker returns enrichment and stops
+   - manager comments and moves enriched cards to `todo`
+6. ready pickup
+   - choose `ready` cards within concurrency limits
+   - infer worker readiness from active run state, not worker polling
+   - dispatch worker directly
+   - record run/session IDs in local state and visible Veritas comment
+   - move task to `in-progress`
+7. release lock and exit
+
+## State and Recovery
+
+Use two recovery surfaces:
+
+- visible Veritas comments/status transitions for human audit and partial recovery
+- structured local state for manager idempotency and worker-run reconciliation
+
+Suggested local state shape:
+
+```json
+{
+  "activeRuns": {
+    "task_YYYYMMDD_xxxxxx": {
+      "worker": "implementer",
+      "sessionId": "...",
+      "runId": "...",
+      "status": "running",
+      "startedAt": "2026-05-13T00:00:00.000Z",
+      "lastSeenAt": "2026-05-13T00:00:00.000Z"
+    }
+  },
+  "lastManagerRunAt": "2026-05-13T00:00:00.000Z"
+}
+```
+
+Concurrency defaults:
+
+- one active task per worker
+- max 3 active worker tasks globally
+
+## Manual Run Affordance
+
+Practical command shape for a future implementation:
+
+```bash
+pnpm --filter server board-manager:run-once
+```
+
+or a repo script wrapper:
+
+```bash
+pnpm board-manager:run-now
+```
+
+The command should run the exact short-lived lifecycle above once, then exit with a clear status code.
+
+## Upstream/Fork Framing
+
+This document is best treated as an example architecture layered on top of configurable board columns, not as a core requirement for all Veritas users. The reusable upstream pieces are:
+
+- configured board columns
+- server-validated status transitions
+- first-class blocked reason support
+- visible assignment metadata
+- service-level gates that cannot be bypassed by alternate clients
+
+The environment-specific pieces are:
+
+- worker names and dispatch implementation
+- scheduler choice
+- local state file location
+- notification policy
+- exact gate rules beyond the currently implemented service checks

--- a/docs/CONFIGURABLE-BOARD-COLUMNS.md
+++ b/docs/CONFIGURABLE-BOARD-COLUMNS.md
@@ -1,0 +1,163 @@
+# Configurable Board Columns
+
+Status: proposal / branch documentation for configurable task-status columns.
+
+## Problem
+
+Veritas historically assumed a small, fixed board lifecycle. That works for simple task tracking, but it becomes limiting when teams want to model a real operating process, for example:
+
+- an intake lane before work is approved
+- a ready/approved queue before agents or humans start work
+- a blocked lane with required blocker context
+- custom status labels that match an existing team workflow
+- keyboard shortcuts, counts, drag/drop, and API validation that all use the same column model
+
+When the board layout is hard-coded, the UI, task service, CLI/API clients, metrics, and tests can drift from each other. Configurable columns make the board lifecycle explicit in feature settings instead of scattering status assumptions across the app.
+
+For AI-assisted workflows, configurable columns also turn the board into a durable coordination layer instead of leaving work trapped in one conversational thread. A typical operating loop becomes:
+
+> Capture rough work → enrich it into executable tasks → approve/assign it → execute it → record evidence on the card
+
+That separation lets humans capture incomplete work quickly, lets task-shaping agents clarify it later, and lets execution agents pick up only approved work with visible progress, blockers, deliverables, and verification.
+
+## Feature
+
+Board columns are configured from `features.board.columns` and rendered in that configured order. Each column has:
+
+- `id`: the task status value stored on tasks
+- `title`: the human-readable column title shown in the board UI
+
+New tasks use `features.board.defaultStatus` when no status is provided. If `defaultStatus` is missing from the configured columns, the server falls back to the first configured column, then to `todo` as a final safety fallback.
+
+The default branch configuration in this work is:
+
+```json
+{
+  "features": {
+    "board": {
+      "columns": [
+        { "id": "triage", "title": "Triage" },
+        { "id": "todo", "title": "To Do" },
+        { "id": "ready", "title": "Ready" },
+        { "id": "in-progress", "title": "In Progress" },
+        { "id": "blocked", "title": "Blocked" },
+        { "id": "done", "title": "Done" }
+      ],
+      "defaultStatus": "triage"
+    }
+  }
+}
+```
+
+## Configuration Model
+
+The configuration lives under feature settings:
+
+```ts
+interface BoardColumnConfig {
+  id: TaskStatus;
+  title: string;
+}
+
+interface BoardSettings {
+  columns: BoardColumnConfig[];
+  defaultStatus: TaskStatus;
+}
+```
+
+Validation rules:
+
+- `columns` is optional in PATCH payloads, but resolves to defaults when omitted.
+- `columns` must contain 1-12 entries when provided.
+- `column.id` must be 1-50 characters.
+- `column.id` must be lowercase alphanumeric with dashes: `^[a-z0-9][a-z0-9-]*$`.
+- `column.title` must be 1-50 characters.
+- `defaultStatus` must use the same slug format as a column ID.
+
+`TaskStatus` remains string-extensible, so custom status IDs can flow through shared types without requiring a source-code enum edit for every workflow.
+
+## UI Behavior
+
+The board renders from the configured column list:
+
+- columns appear in `features.board.columns` order
+- loading skeletons use the same configured column count
+- drag/drop accepts configured status IDs
+- task grouping uses configured status IDs
+- task counts and sidebar views can address custom status IDs through generic count records
+- number-key shortcuts map to the current column order instead of a fixed 1-4 set
+- column names in move announcements resolve from configured titles
+
+Settings -> Board & Display includes a **Board Columns** section for editing visible workflow columns. The current UI supports adding columns before/after existing columns and editing column titles/status IDs. Existing task statuses are not automatically rewritten when a column ID is changed.
+
+## Server Validation
+
+The task service treats configured columns as the authoritative set of active task statuses.
+
+On task creation:
+
+- if the request includes `status`, it must match a configured column ID
+- if the request omits `status`, the server uses the configured default status
+- if the configured default is invalid or missing, the first configured column is used
+- an unconfigured status returns `ValidationError` with `INVALID_STATUS`
+
+On task update/status change:
+
+- requested status changes must match a configured column ID
+- invalid status updates are rejected before writing task files
+- service-level validation applies to PATCH, bulk update, CLI/MCP, and future automation paths that call `TaskService.updateTask`
+
+This keeps UI drag/drop, API clients, and automation clients behind the same guardrail.
+
+## Workflow Gates
+
+This branch also includes service-level workflow gates that assume a six-column approval workflow:
+
+- `todo` -> `ready` requires an assigned worker (`assignedWorker` or usable `agent`) and acceptance criteria / definition of done.
+- entering `blocked` requires a first-class blocked reason with category and note.
+
+These gates are intentionally enforced in the task service rather than only in the UI, so bulk updates and automated clients cannot bypass them.
+
+For an upstream contribution, treat these as a first implementation of configurable workflow enforcement, not as the only possible policy model. Future work could make gate rules themselves configurable, for example by declaring required fields per transition.
+
+## Backward Compatibility
+
+Config loading still deep-merges feature settings with `DEFAULT_FEATURE_SETTINGS`, so existing installations that do not define `features.board.columns` receive the default columns automatically.
+
+Task files remain Markdown with YAML frontmatter. Existing task status values are preserved on disk; this feature does not rewrite existing tasks during config load.
+
+Compatibility considerations:
+
+- Existing tasks whose statuses match configured column IDs continue to appear in the board.
+- Existing tasks with statuses that are no longer configured are preserved, but they may not appear in visible board columns until the status is re-added or the task is migrated.
+- API/CLI callers that hard-code old status values must be updated if an installation removes or renames those columns.
+- Default migrations should prefer additive column changes over destructive renames.
+
+## Migration / Default Behavior
+
+Recommended migration path for existing installs:
+
+1. Load current settings; if `features.board.columns` is absent, use defaults.
+2. Add new columns without removing legacy statuses first.
+3. Move or bulk-update existing tasks into the new workflow intentionally.
+4. Only remove old columns after no active tasks use those status IDs.
+5. Keep `defaultStatus` aligned with an existing configured column.
+
+For fresh installs, the default six-column workflow starts new tasks in `triage`.
+
+For conservative upstream rollout, maintainers may choose to keep the historical four-column default (`todo`, `in-progress`, `blocked`, `done`) and document the six-column workflow as an example configuration. The implementation supports either default.
+
+## Limitations
+
+Current limitations / follow-ups:
+
+- Workflow gates are not yet fully configurable; the current gates target the `todo` -> `ready` and `blocked` transitions.
+- The board settings UI does not automatically migrate task statuses when a column ID changes.
+- Removing or renaming a column can hide tasks with the old status from the visible board until migrated or reconfigured.
+- Some documentation and examples may still mention the historical four-column workflow and should be updated as part of final upstream polish.
+- External integrations should discover configured columns from settings rather than assuming a fixed status list.
+
+## Related Documentation
+
+- [Board Manager Architecture](BOARD-MANAGER-ARCHITECTURE.md) — example automation architecture using configurable columns and service-level gates.
+- [Configurable Board Columns PR Notes](PR-CONFIGURABLE-BOARD-COLUMNS.md) — upstream PR framing and rollout checklist.

--- a/docs/CONFIGURABLE-BOARD-COLUMNS.md
+++ b/docs/CONFIGURABLE-BOARD-COLUMNS.md
@@ -90,6 +90,8 @@ The board renders from the configured column list:
 
 Settings -> Board & Display includes a **Board Columns** section for editing visible workflow columns. The current UI supports adding columns before/after existing columns and editing column titles/status IDs. Existing task statuses are not automatically rewritten when a column ID is changed.
 
+Because the Board & Display tab can become taller than the viewport once dashboard toggles and column editing controls are shown together, the settings dialog itself must remain vertically scrollable. Do not wrap this tab in a fixed-height clipped container without a working scroll path; otherwise lower controls such as Drag & Drop and Done Column Metrics can become unreachable.
+
 ## Server Validation
 
 The task service treats configured columns as the authoritative set of active task statuses.
@@ -153,6 +155,7 @@ Current limitations / follow-ups:
 
 - Workflow gates are not yet fully configurable; the current gates target the `todo` -> `ready` and `blocked` transitions.
 - The board settings UI does not automatically migrate task statuses when a column ID changes.
+- The board settings UI depends on the settings dialog preserving vertical scroll for long tabs.
 - Removing or renaming a column can hide tasks with the old status from the visible board until migrated or reconfigured.
 - Some documentation and examples may still mention the historical four-column workflow and should be updated as part of final upstream polish.
 - External integrations should discover configured columns from settings rather than assuming a fixed status list.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,8 +85,8 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 | ![Main board view](../assets/scr-main_overview_1.png) | ![Board with tasks](../assets/scr-main_overview_2.png) |
 | ![Board columns](../assets/scr-main_overview_3.png)   | ![Board dark mode](../assets/scr-main_overview_4.png)  |
 
-- **Kanban columns** — Four default columns: To Do, In Progress, Blocked, Done
-- **Drag-and-drop** — Move tasks between columns with [@dnd-kit](https://dndkit.com/); reorder within columns; custom collision detection (pointerWithin + rectIntersection fallback) for reliable cross-column moves; tooltips suppressed during drag; local state management for real-time column updates
+- **Kanban columns** — Configurable board columns and default task status via Settings → Board & Display. See [Configurable Board Columns](CONFIGURABLE-BOARD-COLUMNS.md).
+- **Drag-and-drop** — Move tasks between configured columns with [@dnd-kit](https://dndkit.com/); reorder within columns; custom collision detection (pointerWithin + rectIntersection fallback) for reliable cross-column moves; tooltips suppressed during drag; local state management for real-time column updates
 
   ![Drag-and-drop demo](../assets/demo-drag_drop.gif)
 

--- a/docs/PR-CONFIGURABLE-BOARD-COLUMNS.md
+++ b/docs/PR-CONFIGURABLE-BOARD-COLUMNS.md
@@ -1,0 +1,185 @@
+# PR: Configurable Board Columns + Workflow Gates
+
+Status: draft PR framing for upstream or fork contribution.
+
+## Summary
+
+This change makes kanban board columns configurable through feature settings and routes board rendering, keyboard moves, drag/drop, task creation, and task status validation through the same configured column model.
+
+It also adds service-level workflow gates for approval-oriented boards:
+
+- `todo` -> `ready` requires an assigned worker and acceptance criteria / definition of done.
+- entering `blocked` requires a structured blocked reason.
+
+## Why
+
+Fixed board columns are too rigid for teams that use Veritas as an operating board rather than a simple todo list. Common workflows need intake, approval, ready-for-worker, active, blocked, and done states. If those statuses are hard-coded in each UI/service surface, behavior drifts and automation can bypass process rules.
+
+Configurable columns provide one source of truth for active task statuses. Server-side validation ensures UI, API, CLI, MCP, bulk updates, and future automation paths agree on which statuses are valid.
+
+This is especially useful for AI-assisted task orchestration because it moves work out of a single chat thread and onto durable cards. Teams can separate raw intake, task enrichment, human approval, active execution, blockers, and completion evidence while keeping the same status model across UI and API surfaces.
+
+## User-Facing Changes
+
+- Board columns render from `features.board.columns`.
+- New tasks default to `features.board.defaultStatus` when no status is provided.
+- Settings -> Board & Display includes a **Board Columns** editor.
+- Keyboard number shortcuts map to configured column order.
+- Loading skeletons, board grid width, drag/drop targets, and column titles follow the configured board.
+- Invalid status moves are rejected with a clear validation error.
+- Approval workflow gates can block moves that lack required context.
+
+Default six-column example:
+
+1. Triage
+2. To Do
+3. Ready
+4. In Progress
+5. Blocked
+6. Done
+
+## Technical Changes
+
+Shared/config:
+
+- Adds `BoardColumnConfig` and `BoardSettings.columns` / `BoardSettings.defaultStatus` to feature settings.
+- Keeps `TaskStatus` string-extensible so custom workflow IDs are type-compatible.
+- Updates default feature settings to include board columns and default status.
+- Expands status labels for common six-column statuses.
+
+Server:
+
+- Validates create/update statuses against configured board columns.
+- Uses configured default status for task creation.
+- Falls back safely if default status is missing from configured columns.
+- Enforces workflow gates in `TaskService.updateTask` so API, bulk, CLI/MCP, and automation paths share the same rules.
+- Updates migration/summary/metrics/service logic to handle configurable statuses.
+
+Web:
+
+- Renders board columns from feature settings.
+- Updates drag/drop, keyboard shortcuts, task grouping, loading skeleton, sidebar/counts, and board settings UI to respect configured columns.
+- Exposes `assignedWorker` and blocked reason fields needed by workflow gates.
+
+Tests:
+
+- Adds/updates service tests for configurable statuses and workflow gates.
+- Updates frontend tests/mocks around dynamic columns.
+- Updates task/service/storage/migration/summary coverage for the expanded default workflow.
+
+Docs:
+
+- Adds generic configurable board columns documentation.
+- Frames the board manager as an example automation architecture rather than an environment-specific requirement.
+
+## Validation
+
+Branch validation already performed before this packaging pass:
+
+- Configurable board columns branch validates.
+- Existing code/test changes are present on branch `zora/configurable-board-columns`.
+
+Documentation packaging validation to run before commit/PR:
+
+```bash
+# Generic framing sanity: no environment-specific labels should appear outside this checklist.
+rg -n "environment-specific-label-placeholder" docs/CONFIGURABLE-BOARD-COLUMNS.md docs/PR-CONFIGURABLE-BOARD-COLUMNS.md docs/BOARD-MANAGER-ARCHITECTURE.md
+rg -n "CONFIGURABLE-BOARD-COLUMNS|PR-CONFIGURABLE-BOARD-COLUMNS|Board Manager Architecture" docs
+rg -n "[[:blank:]]$" docs/CONFIGURABLE-BOARD-COLUMNS.md docs/PR-CONFIGURABLE-BOARD-COLUMNS.md docs/BOARD-MANAGER-ARCHITECTURE.md
+
+git diff --check
+```
+
+Suggested full validation before upstream PR, if code has changed after this doc pass:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @veritas-kanban/shared build
+pnpm --filter @veritas-kanban/server test
+pnpm --filter @veritas-kanban/server typecheck
+pnpm --filter @veritas-kanban/server build
+pnpm --filter @veritas-kanban/web typecheck
+pnpm --filter @veritas-kanban/web build
+git diff --check
+```
+
+Run the shared build before server tests in clean checkouts where `shared/dist` is absent. Use the repository's current canonical test commands if they differ.
+
+Observed non-blocking validation warnings during local packaging:
+
+- `pnpm --filter @veritas-kanban/web build` emits existing Vite warnings about large chunks and an ineffective dynamic import involving `src/lib/api/index.ts`. The build still succeeds.
+- `pnpm --filter @veritas-kanban/server test` emitted a Node `MaxListenersExceededWarning` during one local post-commit validation run. The full server test suite still passed.
+
+These warnings were not introduced as failing conditions by this branch, but they should be visible to maintainers during PR review.
+
+Additional local validation evidence after packaging:
+
+- Re-applied the package in a clean local validation copy.
+- Re-ran validation: shared build, full server suite (105 files / 1557 tests), server typecheck/build, web typecheck/build, and `git diff --check` all passed.
+- Verified API health, web UI response, configured six-column board order, default `triage` status, and transition gate behavior in a local runtime smoke test.
+- Smoke-created tasks were deleted after verification.
+
+## Compatibility
+
+Backward-compatible defaults:
+
+- Existing configs without `features.board.columns` get defaults through feature-settings merge.
+- Existing task files are not rewritten during config load.
+- Existing status values remain valid if those IDs remain configured.
+
+Potentially breaking behavior:
+
+- If an installation removes or renames a column, tasks with the old status may no longer render in visible board columns until migrated or the column is restored.
+- API/CLI clients that assume fixed statuses must discover configured columns or align with the instance configuration.
+- The six-column default changes where new tasks land (`triage`) compared with older four-column defaults (`todo`). Upstream maintainers may choose to keep the historical default and document six columns as an opt-in example.
+
+## Risks
+
+- Hidden fixed-status assumptions may remain in older docs, tests, screenshots, or integrations.
+- Current workflow gates are hard-coded to specific transitions; this is useful for the included approval workflow but should become configurable for broad upstream use.
+- Column ID edits in settings do not migrate existing tasks, which can make old-status tasks disappear from the rendered board until handled.
+- Custom status IDs may need careful handling in metrics, summaries, exports, and external integrations.
+
+## Screenshots / GIFs
+
+Add before PR submission:
+
+- [ ] Settings -> Board & Display -> Board Columns editor
+- [ ] Board showing six configured columns
+- [ ] Drag/drop or keyboard move into a configured column
+- [ ] Validation error for an invalid or gated move
+- [ ] Task detail showing Assigned Worker / Blocked Reason fields
+
+## Rollout Notes
+
+Recommended rollout for maintainers:
+
+1. Decide whether the upstream default should remain the historical four-column board or move to the six-column workflow.
+2. If preserving maximum compatibility, ship configurable columns first with the historical default and include six-column configuration as an example.
+3. Add a release note warning that removing/renaming columns does not migrate existing task statuses automatically.
+4. Encourage API/CLI/MCP clients to read configured board columns instead of hard-coding statuses.
+5. Consider a follow-up issue for configurable transition gates.
+
+## Suggested PR Description
+
+```markdown
+## What
+
+Adds configurable kanban board columns through feature settings and uses that configuration across board rendering, drag/drop, keyboard shortcuts, task creation, and task status validation. Also adds service-level workflow gates for approval-oriented boards.
+
+## Why
+
+Teams use Veritas with different operating workflows. Making columns configurable avoids hard-coded status drift and gives UI/API/automation clients one source of truth for valid task statuses.
+
+## Validation
+
+- [ ] Server tests
+- [ ] Web tests
+- [ ] Typecheck
+- [ ] `git diff --check`
+- [ ] Manual UI smoke: configure columns, create task, drag/drop, keyboard move, invalid move validation
+
+## Compatibility
+
+Existing configs receive defaults. Existing task files are preserved. Installations that remove/rename statuses should migrate tasks or keep legacy columns visible until no active tasks use them.
+```

--- a/docs/PR-CONFIGURABLE-BOARD-COLUMNS.md
+++ b/docs/PR-CONFIGURABLE-BOARD-COLUMNS.md
@@ -145,6 +145,7 @@ Potentially breaking behavior:
 Add before PR submission:
 
 - [ ] Settings -> Board & Display -> Board Columns editor
+- [ ] Settings -> Board & Display remains vertically scrollable; lower controls such as Drag & Drop and Done Column Metrics are reachable after the Board Columns editor is visible
 - [ ] Board showing six configured columns
 - [ ] Drag/drop or keyboard move into a configured column
 - [ ] Validation error for an invalid or gated move

--- a/mcp/src/tools/tasks.ts
+++ b/mcp/src/tools/tasks.ts
@@ -5,7 +5,7 @@ import { Task } from '../utils/types.js';
 
 // Tool input schemas
 const ListTasksSchema = z.object({
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']).optional(),
+  status: z.string().min(1).optional(),
   type: z.enum(['code', 'research', 'content', 'automation']).optional(),
   project: z.string().optional(),
   sprint: z.string().optional(),
@@ -24,7 +24,7 @@ const UpdateTaskSchema = z.object({
   id: z.string().min(1),
   title: z.string().optional(),
   description: z.string().optional(),
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']).optional(),
+  status: z.string().min(1).optional(),
   type: z.enum(['code', 'research', 'content', 'automation']).optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
   project: z.string().optional(),
@@ -44,7 +44,6 @@ export const taskTools = [
       properties: {
         status: {
           type: 'string',
-          enum: ['todo', 'in-progress', 'blocked', 'done'],
           description: 'Filter by task status',
         },
         type: {
@@ -133,7 +132,6 @@ export const taskTools = [
         },
         status: {
           type: 'string',
-          enum: ['todo', 'in-progress', 'blocked', 'done'],
           description: 'New status',
         },
         type: {

--- a/server/src/__tests__/approval-workflow-gates.test.ts
+++ b/server/src/__tests__/approval-workflow-gates.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import { TaskService } from '../services/task-service.js';
+import { ConfigService } from '../services/config-service.js';
+
+function buildSettings() {
+  return {
+    ...DEFAULT_FEATURE_SETTINGS,
+    board: {
+      ...DEFAULT_FEATURE_SETTINGS.board,
+      columns: [
+        { id: 'triage', title: 'Triage' },
+        { id: 'todo', title: 'To Do' },
+        { id: 'ready', title: 'Ready' },
+        { id: 'in-progress', title: 'In Progress' },
+        { id: 'blocked', title: 'Blocked' },
+        { id: 'done', title: 'Done' },
+      ],
+      // Keep the default aligned with older route/service tests if this prototype mock is ever
+      // observed cross-file during Vitest's parallel execution.
+      defaultStatus: 'todo',
+    },
+    tasks: {
+      ...DEFAULT_FEATURE_SETTINGS.tasks,
+      requireDeliverableForDone: false,
+    },
+    enforcement: {
+      ...DEFAULT_FEATURE_SETTINGS.enforcement,
+      reviewGate: false,
+      closingComments: false,
+      autoTelemetry: false,
+      autoTimeTracking: false,
+    },
+  } as typeof DEFAULT_FEATURE_SETTINGS;
+}
+
+describe('approval workflow gates', () => {
+  let service: TaskService;
+  let testRoot: string;
+  let tasksDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    const uniqueSuffix = Math.random().toString(36).substring(7);
+    testRoot = path.join(os.tmpdir(), `veritas-test-hermes-gates-${uniqueSuffix}`);
+    tasksDir = path.join(testRoot, 'active');
+    archiveDir = path.join(testRoot, 'archive');
+
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.mkdir(archiveDir, { recursive: true });
+
+    vi.spyOn(ConfigService.prototype, 'getFeatureSettings').mockResolvedValue(buildSettings());
+    service = new TaskService({ tasksDir, archiveDir });
+  });
+
+  afterEach(async () => {
+    service?.dispose();
+    vi.restoreAllMocks();
+    if (testRoot) {
+      await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('blocks To Do → Ready without an assigned worker and acceptance criteria', async () => {
+    const task = await service.createTask({ title: 'Shape unassigned work', status: 'todo' });
+
+    await expect(service.updateTask(task.id, { status: 'ready' })).rejects.toMatchObject({
+      message:
+        'To Do → Ready requires an assigned worker and acceptance criteria/definition of done',
+      details: expect.arrayContaining([
+        expect.objectContaining({ code: 'ASSIGNED_WORKER_REQUIRED', path: ['assignedWorker'] }),
+        expect.objectContaining({ code: 'ACCEPTANCE_CRITERIA_REQUIRED', path: ['subtasks'] }),
+      ]),
+    });
+  });
+
+  it('allows To Do → Ready with an assigned worker and Definition of Done', async () => {
+    const task = await service.createTask({ title: 'Ready shaped work', status: 'todo' });
+
+    const updated = await service.updateTask(task.id, {
+      status: 'ready',
+      assignedWorker: 'hermes:spark',
+      description: 'Definition of Done:\n- User can verify the finished artifact.',
+    });
+
+    expect(updated.status).toBe('ready');
+    expect(updated.assignedWorker).toBe('hermes:spark');
+  });
+
+  it('blocks transitions into Blocked without a first-class blocked reason', async () => {
+    const task = await service.createTask({
+      title: 'Blocked without context',
+      status: 'in-progress',
+    });
+
+    await expect(service.updateTask(task.id, { status: 'blocked' })).rejects.toMatchObject({
+      message: 'Blocked tasks require a first-class blocked reason',
+      details: expect.arrayContaining([
+        expect.objectContaining({ code: 'BLOCKED_REASON_REQUIRED', path: ['blockedReason'] }),
+      ]),
+    });
+  });
+
+  it('allows transitions into Blocked with category and note', async () => {
+    const task = await service.createTask({ title: 'Blocked with context', status: 'in-progress' });
+
+    const updated = await service.updateTask(task.id, {
+      status: 'blocked',
+      blockedReason: {
+        category: 'technical-snag',
+        note: 'Waiting for a reproducible fixture from the failing environment.',
+      },
+    });
+
+    expect(updated.status).toBe('blocked');
+    expect(updated.blockedReason).toEqual({
+      category: 'technical-snag',
+      note: 'Waiting for a reproducible fixture from the failing environment.',
+    });
+  });
+
+  it('blocks transitions into Done without completion comment, deliverable, and verification evidence', async () => {
+    const task = await service.createTask({
+      title: 'Done without evidence',
+      status: 'in-progress',
+    });
+
+    await expect(service.updateTask(task.id, { status: 'done' })).rejects.toMatchObject({
+      message:
+        'Done requires a completion comment, deliverable/artifact, and verification note/check',
+      details: expect.arrayContaining([
+        expect.objectContaining({ code: 'COMPLETION_COMMENT_REQUIRED', path: ['comments'] }),
+        expect.objectContaining({ code: 'DELIVERABLE_REQUIRED', path: ['deliverables'] }),
+        expect.objectContaining({
+          code: 'VERIFICATION_NOTE_REQUIRED',
+          path: ['verificationSteps'],
+        }),
+      ]),
+    });
+  });
+
+  it('allows transitions into Done with completion comment, deliverable, and checked verification step', async () => {
+    const task = await service.createTask({ title: 'Done with evidence', status: 'in-progress' });
+
+    const updated = await service.updateTask(task.id, {
+      status: 'done',
+      comments: [
+        {
+          id: 'comment_complete',
+          author: 'hermes:scribe',
+          text: 'Completed implementation and handoff summary for reviewer.',
+          timestamp: '2026-05-13T12:00:00.000Z',
+        },
+      ],
+      deliverables: [
+        {
+          id: 'deliverable_patch',
+          title: 'Implementation patch',
+          type: 'code',
+          path: 'server/src/services/task-service.ts',
+          status: 'attached',
+          created: '2026-05-13T12:00:00.000Z',
+        },
+      ],
+      verificationSteps: [
+        {
+          id: 'verification_targeted_tests',
+          description: 'Targeted service tests pass',
+          checked: true,
+          checkedAt: '2026-05-13T12:05:00.000Z',
+        },
+      ],
+    });
+
+    expect(updated.status).toBe('done');
+    expect(updated.deliverables).toHaveLength(1);
+    expect(updated.verificationSteps?.[0]?.checked).toBe(true);
+  });
+});

--- a/server/src/__tests__/enforcement.test.ts
+++ b/server/src/__tests__/enforcement.test.ts
@@ -5,7 +5,41 @@ import os from 'os';
 import { TaskService } from '../services/task-service.js';
 import { ConfigService } from '../services/config-service.js';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import type { UpdateTaskInput } from '@veritas-kanban/shared';
 import { reviewScoresSchema } from '../routes/tasks.js';
+
+const DONE_EVIDENCE = {
+  comments: [
+    {
+      id: 'comment_done_evidence',
+      author: 'test-agent',
+      text: 'Completed implementation summary and handoff for this test task.',
+      timestamp: '2026-05-13T12:00:00.000Z',
+    },
+  ],
+  deliverables: [
+    {
+      id: 'deliverable_done_evidence',
+      title: 'Test artifact',
+      type: 'artifact',
+      path: 'server/src/__tests__/enforcement.test.ts',
+      status: 'attached',
+      created: '2026-05-13T12:00:00.000Z',
+    },
+  ],
+  verificationSteps: [
+    {
+      id: 'verification_done_evidence',
+      description: 'Evidence fixture checked',
+      checked: true,
+      checkedAt: '2026-05-13T12:00:00.000Z',
+    },
+  ],
+} as const;
+
+function doneInput(overrides: Partial<UpdateTaskInput> = {}): UpdateTaskInput {
+  return { status: 'done', ...DONE_EVIDENCE, ...overrides };
+}
 
 function buildSettings(overrides: Partial<typeof DEFAULT_FEATURE_SETTINGS> = {}) {
   return {
@@ -49,7 +83,7 @@ describe('Enforcement gates', () => {
     service = new TaskService({ tasksDir, archiveDir });
 
     const task = await service.createTask({ title: 'Review gate disabled' });
-    const updated = await service.updateTask(task.id, { status: 'done' });
+    const updated = await service.updateTask(task.id, doneInput());
 
     expect(updated.status).toBe('done');
   });
@@ -62,7 +96,7 @@ describe('Enforcement gates', () => {
 
     const task = await service.createTask({ title: 'Review gate enabled', type: 'code' });
 
-    await expect(service.updateTask(task.id, { status: 'done' })).rejects.toThrow(
+    await expect(service.updateTask(task.id, doneInput())).rejects.toThrow(
       /Review Gate.*requires all four review scores/
     );
   });
@@ -83,8 +117,8 @@ describe('Enforcement gates', () => {
     });
 
     // Should complete without review scores
-    const updatedContent = await service.updateTask(contentTask.id, { status: 'done' });
-    const updatedResearch = await service.updateTask(researchTask.id, { status: 'done' });
+    const updatedContent = await service.updateTask(contentTask.id, doneInput());
+    const updatedResearch = await service.updateTask(researchTask.id, doneInput());
 
     expect(updatedContent.status).toBe('done');
     expect(updatedResearch.status).toBe('done');
@@ -97,7 +131,7 @@ describe('Enforcement gates', () => {
     service = new TaskService({ tasksDir, archiveDir });
 
     const task = await service.createTask({ title: 'Closing comments disabled' });
-    const updated = await service.updateTask(task.id, { status: 'done' });
+    const updated = await service.updateTask(task.id, doneInput());
 
     expect(updated.status).toBe('done');
   });
@@ -110,9 +144,7 @@ describe('Enforcement gates', () => {
 
     const task = await service.createTask({ title: 'Closing comments enabled' });
 
-    await expect(service.updateTask(task.id, { status: 'done' })).rejects.toThrow(
-      /Closing Comments:/
-    );
+    await expect(service.updateTask(task.id, doneInput())).rejects.toThrow(/Closing Comments:/);
   });
 
   it('skips enforcement when enforcement settings are missing', async () => {
@@ -123,7 +155,7 @@ describe('Enforcement gates', () => {
     service = new TaskService({ tasksDir, archiveDir });
 
     const task = await service.createTask({ title: 'No enforcement settings' });
-    const updated = await service.updateTask(task.id, { status: 'done' });
+    const updated = await service.updateTask(task.id, doneInput());
 
     expect(updated.status).toBe('done');
   });
@@ -137,7 +169,7 @@ describe('Enforcement gates', () => {
 
     const task = await service.createTask({ title: 'Auto telemetry enabled' });
     await service.updateTask(task.id, { status: 'in-progress' });
-    await service.updateTask(task.id, { status: 'done' });
+    await service.updateTask(task.id, doneInput());
 
     expect(telemetry.emit).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'run.started', taskId: task.id })
@@ -177,10 +209,10 @@ describe('Enforcement gates', () => {
 
     const task = await service.createTask({ title: 'Auto time tracking enabled' });
     await service.updateTask(task.id, { status: 'in-progress' });
-    await service.updateTask(task.id, {
-      status: 'done',
-      timeTracking: { entries: [], totalSeconds: 0, isRunning: true },
-    });
+    await service.updateTask(
+      task.id,
+      doneInput({ timeTracking: { entries: [], totalSeconds: 0, isRunning: true } })
+    );
 
     expect(startSpy).toHaveBeenCalled();
     expect(stopSpy).toHaveBeenCalled();

--- a/server/src/__tests__/migration-service.test.ts
+++ b/server/src/__tests__/migration-service.test.ts
@@ -5,8 +5,42 @@ import os from 'os';
 import { MigrationService } from '../services/migration-service.js';
 import { TaskService } from '../services/task-service.js';
 import { ConfigService } from '../services/config-service.js';
-import type { TaskStatus } from '@veritas-kanban/shared';
+import type { BlockedReason, TaskStatus, UpdateTaskInput } from '@veritas-kanban/shared';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+
+const BLOCKED_REASON: BlockedReason = {
+  category: 'other',
+  note: 'Blocked in migration test fixture.',
+};
+
+const DONE_EVIDENCE: Pick<UpdateTaskInput, 'comments' | 'deliverables' | 'verificationSteps'> = {
+  comments: [
+    {
+      id: 'comment_done_evidence',
+      author: 'test-agent',
+      text: 'Completed migration test task and verification summary.',
+      timestamp: '2026-05-13T12:00:00.000Z',
+    },
+  ],
+  deliverables: [
+    {
+      id: 'deliverable_done_evidence',
+      title: 'Migration test artifact',
+      type: 'artifact',
+      path: 'server/src/__tests__/migration-service.test.ts',
+      status: 'attached',
+      created: '2026-05-13T12:00:00.000Z',
+    },
+  ],
+  verificationSteps: [
+    {
+      id: 'verification_done_evidence',
+      description: 'Migration test evidence checked',
+      checked: true,
+      checkedAt: '2026-05-13T12:00:00.000Z',
+    },
+  ],
+};
 
 describe('MigrationService', () => {
   let taskService: TaskService;
@@ -94,6 +128,10 @@ This task has the legacy review status.
       const tasks = await taskService.listTasks();
       expect(tasks).toHaveLength(1);
       expect(tasks[0].status).toBe('blocked');
+      expect(tasks[0].blockedReason).toEqual({
+        category: 'other',
+        note: 'Migrated from legacy review status after review column removal.',
+      });
     });
 
     it('should not modify tasks with non-review statuses', async () => {
@@ -105,10 +143,13 @@ This task has the legacy review status.
       await taskService.updateTask(inProgressTask.id, { status: 'in-progress' });
 
       const blockedTask = await taskService.createTask({ title: 'Blocked Task' });
-      await taskService.updateTask(blockedTask.id, { status: 'blocked' });
+      await taskService.updateTask(blockedTask.id, {
+        status: 'blocked',
+        blockedReason: BLOCKED_REASON,
+      });
 
       const doneTask = await taskService.createTask({ title: 'Done Task' });
-      await taskService.updateTask(doneTask.id, { status: 'done' });
+      await taskService.updateTask(doneTask.id, { status: 'done', ...DONE_EVIDENCE });
 
       // Run migrations
       await migrationService.runMigrations();
@@ -218,6 +259,10 @@ This archived task has the legacy review status.
       const archivedTasks = await taskService.listArchivedTasks();
       expect(archivedTasks).toHaveLength(1);
       expect(archivedTasks[0].status).toBe('blocked');
+      expect(archivedTasks[0].blockedReason).toEqual({
+        category: 'other',
+        note: 'Migrated from legacy review status after review column removal.',
+      });
     });
   });
 });

--- a/server/src/__tests__/routes/task-agent-sync.integration.test.ts
+++ b/server/src/__tests__/routes/task-agent-sync.integration.test.ts
@@ -76,7 +76,7 @@ describe('Task ↔ Agent registry sync (route-level integration)', () => {
     expect(created.status).toBe(201);
     const createdTask = unwrap<{ id: string; status: string }>(created.body);
     expect(createdTask.id).toMatch(/^task_/);
-    expect(createdTask.status).toBe('todo');
+    expect(createdTask.status).toBe('triage');
 
     // 3) Move task to in-progress => registry should reflect busy + currentTaskId.
     const toInProgress = await request(app)
@@ -94,7 +94,35 @@ describe('Task ↔ Agent registry sync (route-level integration)', () => {
     // Test forces flap guard to 0ms (VERITAS_TASK_SYNC_FLAP_GUARD_MS) for deterministic timing.
     const toDone = await request(app)
       .patch(`/api/tasks/${createdTask.id}`)
-      .send({ status: 'done' });
+      .send({
+        status: 'done',
+        comments: [
+          {
+            id: 'comment_done_evidence',
+            author: agentId,
+            text: 'Completed route sync smoke task and handoff summary.',
+            timestamp: '2026-05-13T12:00:00.000Z',
+          },
+        ],
+        deliverables: [
+          {
+            id: 'deliverable_done_evidence',
+            title: 'Route sync smoke artifact',
+            type: 'artifact',
+            path: 'server/src/__tests__/routes/task-agent-sync.integration.test.ts',
+            status: 'attached',
+            created: '2026-05-13T12:00:00.000Z',
+          },
+        ],
+        verificationSteps: [
+          {
+            id: 'verification_done_evidence',
+            description: 'Route sync smoke task verified',
+            checked: true,
+            checkedAt: '2026-05-13T12:00:00.000Z',
+          },
+        ],
+      });
     expect(toDone.status).toBe(200);
 
     const agentIdle = await request(app).get(`/api/agents/register/${agentId}`);

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -231,7 +231,7 @@ describe('Tasks Routes (actual module)', () => {
       );
     });
 
-    it('should check blocking when moving to in-progress', async () => {
+    it('should allow moving to in-progress through task service', async () => {
       const oldTask = { id: 't1', status: 'todo', title: 'Task', blockedBy: ['t2'] };
       mockTaskService.getTask.mockResolvedValue(oldTask);
       mockTaskService.listTasks.mockResolvedValue([oldTask]);
@@ -242,7 +242,7 @@ describe('Tasks Routes (actual module)', () => {
       expect(res.status).toBe(200);
     });
 
-    it('should reject blocked task moving to in-progress', async () => {
+    it('should delegate dependency validation to task service when moving to in-progress', async () => {
       const oldTask = { id: 't1', status: 'todo', title: 'Task', blockedBy: ['t2'] };
       mockTaskService.getTask.mockResolvedValue(oldTask);
       mockTaskService.listTasks.mockResolvedValue([oldTask]);
@@ -252,7 +252,8 @@ describe('Tasks Routes (actual module)', () => {
       });
 
       const res = await request(app).patch('/api/tasks/t1').send({ status: 'in-progress' });
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
+      expect(mockTaskService.updateTask).toHaveBeenCalledWith('t1', { status: 'in-progress' });
     });
 
     it('should auto-clear blockedReason when moving out of blocked', async () => {

--- a/server/src/__tests__/routes/tasks.test.ts
+++ b/server/src/__tests__/routes/tasks.test.ts
@@ -25,26 +25,26 @@ describe('Tasks Routes', () => {
     testRoot = path.join(os.tmpdir(), `veritas-test-routes-${uniqueSuffix}`);
     tasksDir = path.join(testRoot, 'active');
     archiveDir = path.join(testRoot, 'archive');
-    
+
     await fs.mkdir(tasksDir, { recursive: true });
     await fs.mkdir(archiveDir, { recursive: true });
-    
+
     // Create TaskService with test directories
     taskService = new TaskService({ tasksDir, archiveDir });
-    
+
     // Create app with mocked routes
     app = express();
     app.use(express.json());
-    
+
     // Create a router that uses our test TaskService
     const router = express.Router();
-    
+
     // GET /api/tasks - List all tasks
     router.get('/', async (_req, res) => {
       const tasks = await taskService.listTasks();
       res.json(tasks);
     });
-    
+
     // POST /api/tasks - Create task
     router.post('/', async (req, res) => {
       try {
@@ -54,7 +54,7 @@ describe('Tasks Routes', () => {
         res.status(400).json({ error: error.message });
       }
     });
-    
+
     // GET /api/tasks/:id - Get single task
     router.get('/:id', async (req, res) => {
       const task = await taskService.getTask(req.params.id);
@@ -63,7 +63,7 @@ describe('Tasks Routes', () => {
       }
       res.json(task);
     });
-    
+
     // PATCH /api/tasks/:id - Update task
     router.patch('/:id', async (req, res) => {
       const task = await taskService.updateTask(req.params.id, req.body);
@@ -72,7 +72,7 @@ describe('Tasks Routes', () => {
       }
       res.json(task);
     });
-    
+
     // DELETE /api/tasks/:id - Delete task
     router.delete('/:id', async (req, res) => {
       const success = await taskService.deleteTask(req.params.id);
@@ -81,7 +81,7 @@ describe('Tasks Routes', () => {
       }
       res.status(204).send();
     });
-    
+
     // POST /api/tasks/reorder - Reorder tasks
     router.post('/reorder', async (req, res) => {
       const { orderedIds } = req.body;
@@ -91,7 +91,7 @@ describe('Tasks Routes', () => {
       const updated = await taskService.reorderTasks(orderedIds);
       res.json({ updated: updated.length });
     });
-    
+
     app.use('/api/tasks', router);
     app.use(errorHandler);
   });
@@ -105,7 +105,7 @@ describe('Tasks Routes', () => {
   describe('GET /api/tasks', () => {
     it('should return empty array when no tasks exist', async () => {
       const res = await request(app).get('/api/tasks');
-      
+
       expect(res.status).toBe(200);
       expect(res.body).toEqual([]);
     });
@@ -113,9 +113,9 @@ describe('Tasks Routes', () => {
     it('should return all tasks', async () => {
       await taskService.createTask({ title: 'Task 1' });
       await taskService.createTask({ title: 'Task 2' });
-      
+
       const res = await request(app).get('/api/tasks');
-      
+
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(2);
       expect(res.body.map((t: any) => t.title)).toContain('Task 1');
@@ -125,30 +125,26 @@ describe('Tasks Routes', () => {
 
   describe('POST /api/tasks', () => {
     it('should create a task with minimal fields', async () => {
-      const res = await request(app)
-        .post('/api/tasks')
-        .send({ title: 'New Task' });
-      
+      const res = await request(app).post('/api/tasks').send({ title: 'New Task' });
+
       expect(res.status).toBe(201);
       expect(res.body.title).toBe('New Task');
       expect(res.body.id).toMatch(/^task_/);
-      expect(res.body.status).toBe('todo');
+      expect(res.body.status).toBe('triage');
       expect(res.body.priority).toBe('medium');
       expect(res.body.type).toBe('code');
     });
 
     it('should create a task with all fields', async () => {
-      const res = await request(app)
-        .post('/api/tasks')
-        .send({
-          title: 'Full Task',
-          description: 'Detailed description',
-          type: 'research',
-          priority: 'high',
-          project: 'test-project',
-          sprint: 'US-100',
-        });
-      
+      const res = await request(app).post('/api/tasks').send({
+        title: 'Full Task',
+        description: 'Detailed description',
+        type: 'research',
+        priority: 'high',
+        project: 'test-project',
+        sprint: 'US-100',
+      });
+
       expect(res.status).toBe(201);
       expect(res.body.title).toBe('Full Task');
       expect(res.body.description).toBe('Detailed description');
@@ -162,9 +158,9 @@ describe('Tasks Routes', () => {
   describe('GET /api/tasks/:id', () => {
     it('should return a task by id', async () => {
       const task = await taskService.createTask({ title: 'Fetch Me' });
-      
+
       const res = await request(app).get(`/api/tasks/${task.id}`);
-      
+
       expect(res.status).toBe(200);
       expect(res.body.id).toBe(task.id);
       expect(res.body.title).toBe('Fetch Me');
@@ -172,7 +168,7 @@ describe('Tasks Routes', () => {
 
     it('should return 404 for non-existent task', async () => {
       const res = await request(app).get('/api/tasks/nonexistent_id');
-      
+
       expect(res.status).toBe(404);
     });
   });
@@ -180,15 +176,13 @@ describe('Tasks Routes', () => {
   describe('PATCH /api/tasks/:id', () => {
     it('should update task fields', async () => {
       const task = await taskService.createTask({ title: 'Original' });
-      
-      const res = await request(app)
-        .patch(`/api/tasks/${task.id}`)
-        .send({
-          title: 'Updated',
-          status: 'in-progress',
-          priority: 'high',
-        });
-      
+
+      const res = await request(app).patch(`/api/tasks/${task.id}`).send({
+        title: 'Updated',
+        status: 'in-progress',
+        priority: 'high',
+      });
+
       expect(res.status).toBe(200);
       expect(res.body.title).toBe('Updated');
       expect(res.body.status).toBe('in-progress');
@@ -199,7 +193,7 @@ describe('Tasks Routes', () => {
       const res = await request(app)
         .patch('/api/tasks/nonexistent_id')
         .send({ title: 'Will Fail' });
-      
+
       expect(res.status).toBe(404);
     });
 
@@ -209,11 +203,9 @@ describe('Tasks Routes', () => {
         description: 'Original Desc',
         priority: 'low',
       });
-      
-      const res = await request(app)
-        .patch(`/api/tasks/${task.id}`)
-        .send({ priority: 'high' });
-      
+
+      const res = await request(app).patch(`/api/tasks/${task.id}`).send({ priority: 'high' });
+
       expect(res.status).toBe(200);
       expect(res.body.title).toBe('Original Title');
       expect(res.body.description).toBe('Original Desc');
@@ -224,11 +216,11 @@ describe('Tasks Routes', () => {
   describe('DELETE /api/tasks/:id', () => {
     it('should delete a task', async () => {
       const task = await taskService.createTask({ title: 'Delete Me' });
-      
+
       const res = await request(app).delete(`/api/tasks/${task.id}`);
-      
+
       expect(res.status).toBe(204);
-      
+
       // Verify task is gone
       const tasks = await taskService.listTasks();
       expect(tasks).toHaveLength(0);
@@ -236,7 +228,7 @@ describe('Tasks Routes', () => {
 
     it('should return 404 for non-existent task', async () => {
       const res = await request(app).delete('/api/tasks/nonexistent_id');
-      
+
       expect(res.status).toBe(404);
     });
   });
@@ -246,35 +238,31 @@ describe('Tasks Routes', () => {
       const task1 = await taskService.createTask({ title: 'Task 1' });
       const task2 = await taskService.createTask({ title: 'Task 2' });
       const task3 = await taskService.createTask({ title: 'Task 3' });
-      
+
       const res = await request(app)
         .post('/api/tasks/reorder')
         .send({ orderedIds: [task3.id, task1.id, task2.id] });
-      
+
       expect(res.status).toBe(200);
       expect(res.body.updated).toBe(3);
-      
+
       // Verify positions
       const tasks = await taskService.listTasks();
-      const taskMap = new Map(tasks.map(t => [t.id, t]));
+      const taskMap = new Map(tasks.map((t) => [t.id, t]));
       expect(taskMap.get(task3.id)?.position).toBe(0);
       expect(taskMap.get(task1.id)?.position).toBe(1);
       expect(taskMap.get(task2.id)?.position).toBe(2);
     });
 
     it('should reject empty orderedIds', async () => {
-      const res = await request(app)
-        .post('/api/tasks/reorder')
-        .send({ orderedIds: [] });
-      
+      const res = await request(app).post('/api/tasks/reorder').send({ orderedIds: [] });
+
       expect(res.status).toBe(400);
     });
 
     it('should reject missing orderedIds', async () => {
-      const res = await request(app)
-        .post('/api/tasks/reorder')
-        .send({});
-      
+      const res = await request(app).post('/api/tasks/reorder').send({});
+
       expect(res.status).toBe(400);
     });
   });

--- a/server/src/__tests__/storage/file-storage.test.ts
+++ b/server/src/__tests__/storage/file-storage.test.ts
@@ -125,7 +125,7 @@ describe('FileStorageProvider', () => {
       expect(created).toBeDefined();
       expect(created.id).toMatch(/^task_/);
       expect(created.title).toBe('Created via storage');
-      expect(created.status).toBe('todo');
+      expect(created.status).toBe('triage');
     });
 
     it('findById returns the created task', async () => {

--- a/server/src/__tests__/summary-service.test.ts
+++ b/server/src/__tests__/summary-service.test.ts
@@ -33,10 +33,7 @@ describe('SummaryService', () => {
     it('should return empty summary for empty task list', () => {
       const result = service.getOverallSummary([]);
       expect(result.total).toBe(0);
-      expect(result.byStatus.todo).toBe(0);
-      expect(result.byStatus['in-progress']).toBe(0);
-      expect(result.byStatus.blocked).toBe(0);
-      expect(result.byStatus.done).toBe(0);
+      expect(result.byStatus).toEqual({});
       expect(result.highPriority).toHaveLength(0);
       expect(Object.keys(result.byProject)).toHaveLength(0);
     });

--- a/server/src/__tests__/task-service.test.ts
+++ b/server/src/__tests__/task-service.test.ts
@@ -174,7 +174,7 @@ updated: '2026-01-26T10:00:00.000Z'
       expect(task.title).toBe('New Task');
       expect(task.description).toBe('Task description here');
       expect(task.type).toBe('research');
-      expect(task.status).toBe('todo');
+      expect(task.status).toBe('triage');
       expect(task.priority).toBe('high');
       expect(task.project).toBe('my-project');
       expect(task.sprint).toBe('US-900');
@@ -192,7 +192,7 @@ updated: '2026-01-26T10:00:00.000Z'
       expect(task.title).toBe('Minimal');
       expect(task.type).toBe('code'); // default
       expect(task.priority).toBe('medium'); // default
-      expect(task.status).toBe('todo'); // default
+      expect(task.status).toBe('triage'); // configured default
     });
 
     it('should generate proper slugs for filenames', async () => {

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -35,6 +35,12 @@ const reviewCommentSchema = z.object({
 
 export const reviewScoresSchema = z.array(z.number().int().min(0).max(10)).length(4);
 
+const taskStatusSchema = z
+  .string()
+  .min(1)
+  .max(50)
+  .regex(/^[a-z0-9][a-z0-9-]*$/, 'Status must be lowercase alphanumeric with dashes');
+
 const createTaskSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().optional().default(''),
@@ -43,8 +49,10 @@ const createTaskSchema = z.object({
   project: z.string().optional(),
   sprint: z.string().optional(),
   agent: z.string().max(50).optional(), // "auto" | agent type slug
+  assignedWorker: z.string().max(100).optional(),
   reviewScores: reviewScoresSchema.optional(),
   reviewComments: z.array(reviewCommentSchema).optional(),
+  status: taskStatusSchema.optional(),
 });
 
 const gitSchema = z
@@ -133,11 +141,12 @@ const updateTaskSchema = z.object({
   title: z.string().min(1).max(200).optional(),
   description: z.string().optional(),
   type: z.string().optional(),
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']).optional(),
+  status: taskStatusSchema.optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
   project: z.string().optional(),
   sprint: z.string().optional(),
   agent: z.string().max(50).optional(),
+  assignedWorker: z.string().max(100).optional(),
   git: gitSchema,
   github: githubSchema,
   attempt: attemptSchema,
@@ -148,6 +157,40 @@ const updateTaskSchema = z.object({
   autoCompleteOnSubtasks: z.boolean().optional(),
   blockedBy: z.array(z.string()).optional(),
   blockedReason: blockedReasonSchema,
+  comments: z
+    .array(
+      z.object({
+        id: z.string(),
+        author: z.string(),
+        text: z.string(),
+        timestamp: z.string(),
+      })
+    )
+    .optional(),
+  verificationSteps: z
+    .array(
+      z.object({
+        id: z.string(),
+        description: z.string(),
+        checked: z.boolean(),
+        checkedAt: z.string().optional(),
+      })
+    )
+    .optional(),
+  deliverables: z
+    .array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        type: z.enum(['document', 'code', 'report', 'artifact', 'other']),
+        path: z.string().optional(),
+        status: z.enum(['pending', 'attached', 'reviewed', 'accepted']),
+        agent: z.string().optional(),
+        created: z.string(),
+        description: z.string().optional(),
+      })
+    )
+    .optional(),
   plan: z.string().optional(),
   automation: automationSchema,
   position: z.number().optional(),
@@ -309,6 +352,8 @@ router.get(
           type: task.type,
           project: task.project,
           sprint: task.sprint,
+          agent: task.agent,
+          assignedWorker: task.assignedWorker,
           created: task.created,
           updated: task.updated,
           subtasks: task.subtasks,
@@ -419,20 +464,14 @@ router.get(
 
     // Get all active tasks and count by status
     const tasks = await taskService.listTasks();
-    const counts = {
+    const counts: Record<string, number> = {
       backlog: 0,
-      todo: 0,
-      'in-progress': 0,
-      blocked: 0,
-      done: 0,
       archived: 0,
     };
 
     // Count active tasks by status
     for (const task of tasks) {
-      if (task.status in counts) {
-        counts[task.status as keyof typeof counts]++;
-      }
+      counts[task.status] = (counts[task.status] ?? 0) + 1;
     }
 
     // Get backlog count
@@ -687,16 +726,6 @@ router.patch(
       }
       // If delegation check fails, no special handling — the request proceeds normally
       // (human users can still approve, or API keys with admin/agent role)
-    }
-
-    // Check if trying to move blocked task to in-progress
-    if (input.status === 'in-progress' && oldTask.status === 'todo' && oldTask.blockedBy?.length) {
-      const allTasks = await taskService.listTasks();
-      const { allowed, blockers } = blockingService.canMoveToInProgress(oldTask, allTasks);
-
-      if (!allowed) {
-        throw new ValidationError('Task is blocked', { blockedBy: blockers });
-      }
     }
 
     // Auto-clear blockedReason when task moves out of blocked status
@@ -978,7 +1007,7 @@ const bulkUpdateSchema = z.object({
     .array(z.string())
     .min(1, 'At least one task ID is required')
     .max(100, 'Maximum 100 tasks per bulk operation'),
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']),
+  status: taskStatusSchema,
 });
 
 const bulkArchiveSchema = z.object({
@@ -992,7 +1021,7 @@ const bulkArchiveSchema = z.object({
 router.post(
   '/bulk-update',
   asyncHandler(async (req, res) => {
-    let input: { ids: string[]; status: 'todo' | 'in-progress' | 'blocked' | 'done' };
+    let input: { ids: string[]; status: string };
     try {
       input = bulkUpdateSchema.parse(req.body);
     } catch (error) {

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -19,6 +19,17 @@ const GeneralSettingsSchema = z
   .strict()
   .optional();
 
+const BoardColumnSchema = z
+  .object({
+    id: z
+      .string()
+      .min(1)
+      .max(50)
+      .regex(/^[a-z0-9][a-z0-9-]*$/, 'Column ID must be lowercase alphanumeric with dashes'),
+    title: z.string().min(1).max(50),
+  })
+  .strict();
+
 const DashboardWidgetSettingsSchema = z
   .object({
     showTokenUsage: z.boolean().optional(),
@@ -47,6 +58,13 @@ const BoardSettingsSchema = z
     showSprintBadges: z.boolean().optional(),
     enableDragAndDrop: z.boolean().optional(),
     showDoneMetrics: z.boolean().optional(),
+    columns: z.array(BoardColumnSchema).min(1).max(12).optional(),
+    defaultStatus: z
+      .string()
+      .min(1)
+      .max(50)
+      .regex(/^[a-z0-9][a-z0-9-]*$/)
+      .optional(),
     dashboardWidgets: DashboardWidgetSettingsSchema,
   })
   .strict()

--- a/server/src/services/agent-registry-service.ts
+++ b/server/src/services/agent-registry-service.ts
@@ -80,7 +80,7 @@ export interface TaskSyncUpdate {
   agentRef: string;
   taskId: string;
   taskTitle?: string;
-  taskStatus: 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
+  taskStatus: string;
 }
 
 export interface TaskSyncContext {
@@ -113,7 +113,7 @@ export function isValidSyncToken(context: TaskSyncContext): boolean {
 export interface TaskSyncSnapshot {
   id: string;
   title?: string;
-  status: 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
+  status: string;
   agent?: string;
 }
 

--- a/server/src/services/metrics/task-metrics.ts
+++ b/server/src/services/metrics/task-metrics.ts
@@ -3,7 +3,7 @@
  */
 import fs from 'fs/promises';
 import path from 'path';
-import type { TaskStatus, BlockedCategory } from '@veritas-kanban/shared';
+import type { BlockedCategory } from '@veritas-kanban/shared';
 import { TaskService } from '../task-service.js';
 import { PROJECT_ROOT } from './helpers.js';
 import type {
@@ -51,13 +51,7 @@ export async function computeTaskMetrics(
   }
 
   // Count by status
-  const byStatus: Record<TaskStatus, number> = {
-    todo: 0,
-    'in-progress': 0,
-    blocked: 0,
-    done: 0,
-    cancelled: 0,
-  };
+  const byStatus: Record<string, number> = {};
 
   // Count by blocked reason
   const byBlockedReason: Record<BlockedCategory | 'unspecified', number> = {
@@ -69,7 +63,7 @@ export async function computeTaskMetrics(
   };
 
   for (const task of filteredActive) {
-    byStatus[task.status]++;
+    byStatus[task.status] = (byStatus[task.status] ?? 0) + 1;
 
     // Count blocked reasons for blocked tasks
     if (task.status === 'blocked') {
@@ -83,7 +77,7 @@ export async function computeTaskMetrics(
 
   const archived = filteredArchived.length;
   const total = filteredActive.length + archived;
-  const completed = byStatus['done'] + archived;
+  const completed = (byStatus['done'] ?? 0) + archived;
 
   return {
     byStatus,

--- a/server/src/services/metrics/types.ts
+++ b/server/src/services/metrics/types.ts
@@ -3,7 +3,6 @@
  * All metric interfaces and type aliases used across the metrics modules.
  */
 import type {
-  TaskStatus,
   BlockedCategory,
   TelemetryEventType,
   AnyTelemetryEvent,
@@ -27,7 +26,7 @@ export type MetricsPeriod =
   | 'custom';
 
 export interface TaskMetrics {
-  byStatus: Record<TaskStatus, number>;
+  byStatus: Record<string, number>;
   byBlockedReason: Record<BlockedCategory | 'unspecified', number>;
   total: number;
   completed: number; // done + archived

--- a/server/src/services/migration-service.ts
+++ b/server/src/services/migration-service.ts
@@ -1,5 +1,5 @@
 import { TaskService } from './task-service.js';
-import type { TaskStatus } from '@veritas-kanban/shared';
+import type { BlockedReason, TaskStatus } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 const log = createLogger('migration-service');
 
@@ -7,6 +7,11 @@ const log = createLogger('migration-service');
  * One-time data migrations that run on server startup.
  * Each migration should be idempotent (safe to run multiple times).
  */
+const LEGACY_REVIEW_BLOCKED_REASON: BlockedReason = {
+  category: 'other',
+  note: 'Migrated from legacy review status after review column removal.',
+};
+
 export class MigrationService {
   private taskService: TaskService;
 
@@ -42,7 +47,10 @@ export class MigrationService {
     const activeTasks = await this.taskService.listTasks();
     for (const task of activeTasks) {
       if (isReviewStatus(task.status)) {
-        await this.taskService.updateTask(task.id, { status: 'blocked' });
+        await this.taskService.updateTask(task.id, {
+          status: 'blocked',
+          blockedReason: LEGACY_REVIEW_BLOCKED_REASON,
+        });
         migratedCount++;
       }
     }
@@ -77,7 +85,10 @@ export class MigrationService {
     await this.taskService.restoreTask(taskId);
 
     // Update status (restoreTask sets status to 'done', so we need to correct it)
-    await this.taskService.updateTask(taskId, { status: 'blocked' });
+    await this.taskService.updateTask(taskId, {
+      status: 'blocked',
+      blockedReason: LEGACY_REVIEW_BLOCKED_REASON,
+    });
 
     // Re-archive
     await this.taskService.archiveTask(taskId);

--- a/server/src/services/summary-service.ts
+++ b/server/src/services/summary-service.ts
@@ -9,12 +9,7 @@ import type { Task, Comment } from '@veritas-kanban/shared';
 import { formatDuration, formatDate } from '@veritas-kanban/shared';
 import type { Activity } from './activity-service.js';
 
-export interface StatusCounts {
-  todo: number;
-  'in-progress': number;
-  blocked: number;
-  done: number;
-}
+export type StatusCounts = Record<string, number>;
 
 export interface ProjectStats {
   total: number;
@@ -71,12 +66,10 @@ export class SummaryService {
    * Get overall task summary with status counts, project breakdown, and high-priority items
    */
   getOverallSummary(tasks: Task[]): OverallSummary {
-    const byStatus: StatusCounts = {
-      todo: tasks.filter((t) => t.status === 'todo').length,
-      'in-progress': tasks.filter((t) => t.status === 'in-progress').length,
-      blocked: tasks.filter((t) => t.status === 'blocked').length,
-      done: tasks.filter((t) => t.status === 'done').length,
-    };
+    const byStatus: StatusCounts = {};
+    tasks.forEach((task) => {
+      byStatus[task.status] = (byStatus[task.status] ?? 0) + 1;
+    });
 
     const byProject: Record<string, ProjectStats> = {};
     tasks.forEach((task) => {

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -436,6 +436,7 @@ export class TaskService {
         project: data.project,
         sprint: data.sprint,
         agent: data.agent,
+        assignedWorker: data.assignedWorker,
         created: data.created || new Date().toISOString(),
         updated: data.updated || new Date().toISOString(),
         git: data.git,
@@ -471,7 +472,7 @@ export class TaskService {
   private syncAgentRegistryForStatusTransition(task: Task): void {
     if (!task.agent) return;
 
-    if (!['todo', 'in-progress', 'blocked', 'done', 'cancelled'].includes(task.status)) return;
+    if (!task.status) return;
 
     const registry = getAgentRegistryService();
     registry.syncFromTask(
@@ -557,17 +558,35 @@ export class TaskService {
 
   async createTask(input: CreateTaskInput): Promise<Task> {
     const now = new Date().toISOString();
+    const configService = new ConfigService();
+    const settings = await configService.getFeatureSettings();
+    const configuredStatuses = new Set(settings.board.columns.map((column) => column.id));
+    const defaultStatus = configuredStatuses.has(settings.board.defaultStatus)
+      ? settings.board.defaultStatus
+      : (settings.board.columns[0]?.id ?? 'todo');
+    const requestedStatus = input.status ?? defaultStatus;
+
+    if (!configuredStatuses.has(requestedStatus)) {
+      throw new ValidationError(`Unknown task status: ${requestedStatus}`, [
+        {
+          code: 'INVALID_STATUS',
+          message: `Status "${requestedStatus}" is not configured as a board column`,
+          path: ['status'],
+        },
+      ]);
+    }
 
     const task: Task = {
       id: this.generateId(),
       title: input.title,
       description: input.description || '',
       type: input.type || 'code',
-      status: 'todo',
+      status: requestedStatus,
       priority: input.priority || 'medium',
       project: input.project,
       sprint: input.sprint,
       agent: input.agent, // Pre-assigned agent (or "auto" for routing)
+      assignedWorker: input.assignedWorker,
       subtasks: input.subtasks, // Include subtasks from template
       blockedBy: input.blockedBy, // Include dependencies from blueprint
       created: now,
@@ -654,6 +673,129 @@ export class TaskService {
       if (statusChanged) {
         const configService = new ConfigService();
         settings = await configService.getFeatureSettings();
+        const configuredStatuses = new Set(settings.board.columns.map((column) => column.id));
+        if (input.status && !configuredStatuses.has(input.status)) {
+          throw new ValidationError(`Unknown task status: ${input.status}`, [
+            {
+              code: 'INVALID_STATUS',
+              message: `Status "${input.status}" is not configured as a board column`,
+              path: ['status'],
+            },
+          ]);
+        }
+      }
+
+      // Locked approval workflow gates before allowing status change.
+      // Keep these in the service so PATCH, bulk-update, CLI/MCP, and future board-manager
+      // paths enforce the same rules.
+      if (statusChanged && input.status) {
+        if (input.status === 'ready' && previousStatus === 'todo') {
+          const nextAssignedWorker =
+            input.assignedWorker ?? freshTask.assignedWorker ?? freshTask.agent;
+          const nextDescription = input.description ?? freshTask.description ?? '';
+          const nextSubtasks = input.subtasks ?? freshTask.subtasks ?? [];
+          const hasAcceptanceCriteria =
+            /(?:acceptance criteria|definition of done)\s*:?/i.test(nextDescription) ||
+            nextSubtasks.some((subtask) =>
+              (subtask.acceptanceCriteria ?? []).some((criterion) => criterion.trim().length > 0)
+            );
+          const readyGateDetails = [];
+
+          if (!nextAssignedWorker?.trim()) {
+            readyGateDetails.push({
+              code: 'ASSIGNED_WORKER_REQUIRED',
+              message: 'Add Assigned Worker in Details → Metadata → Assigned Worker.',
+              path: ['assignedWorker'],
+            });
+          }
+
+          if (!hasAcceptanceCriteria) {
+            readyGateDetails.push({
+              code: 'ACCEPTANCE_CRITERIA_REQUIRED',
+              message:
+                'Add acceptance criteria in Details → Subtasks → Add Acceptance Criteria, or add a “Definition of Done” section in Description.',
+              path: ['subtasks'],
+            });
+          }
+
+          if (readyGateDetails.length > 0) {
+            throw new ValidationError(
+              'To Do → Ready requires an assigned worker and acceptance criteria/definition of done',
+              readyGateDetails
+            );
+          }
+        }
+
+        if (input.status === 'blocked' && previousStatus !== 'blocked') {
+          const nextBlockedReason = input.blockedReason ?? freshTask.blockedReason;
+          const hasBlockedReason =
+            !!nextBlockedReason?.category && !!nextBlockedReason.note?.trim();
+
+          if (!hasBlockedReason) {
+            throw new ValidationError('Blocked tasks require a first-class blocked reason', [
+              {
+                code: 'BLOCKED_REASON_REQUIRED',
+                message:
+                  'Add Blocked Reason in Details → Blocked Reason: choose a category and write the blocker note. If the UI cannot show the field until after the failed move, retry the move after adding the note.',
+                path: ['blockedReason'],
+              },
+            ]);
+          }
+        }
+
+        if (input.status === 'done' && previousStatus !== 'done') {
+          const nextComments = input.comments ?? freshTask.comments ?? [];
+          const nextDeliverables = input.deliverables ?? freshTask.deliverables ?? [];
+          const nextVerification = input.verificationSteps ?? freshTask.verificationSteps ?? [];
+          const hasCompletionComment = nextComments.some((comment) =>
+            /complete|completed|done|delivered|summary|handoff/i.test(comment.text)
+          );
+          const hasVerificationNote =
+            nextVerification.some((step) => step.checked) ||
+            nextComments.some((comment) =>
+              /verified|verification|tested|validated|checked|not run|not tested/i.test(
+                comment.text
+              )
+            );
+
+          if (!hasCompletionComment || nextDeliverables.length === 0 || !hasVerificationNote) {
+            throw new ValidationError(
+              'Done requires a completion comment, deliverable/artifact, and verification note/check',
+              [
+                ...(!hasCompletionComment
+                  ? [
+                      {
+                        code: 'COMPLETION_COMMENT_REQUIRED',
+                        message:
+                          'Add a completion comment in Details → Comments summarizing what was completed.',
+                        path: ['comments'],
+                      },
+                    ]
+                  : []),
+                ...(nextDeliverables.length === 0
+                  ? [
+                      {
+                        code: 'DELIVERABLE_REQUIRED',
+                        message:
+                          'Add a deliverable/artifact in Details → Deliverables with the file, branch, PR, URL, or output location.',
+                        path: ['deliverables'],
+                      },
+                    ]
+                  : []),
+                ...(!hasVerificationNote
+                  ? [
+                      {
+                        code: 'VERIFICATION_NOTE_REQUIRED',
+                        message:
+                          'Add a verification note in Details → Comments, or check a step in Details → Done Criteria.',
+                        path: ['verificationSteps'],
+                      },
+                    ]
+                  : []),
+              ]
+            );
+          }
+        }
       }
 
       // Validate transition hooks (quality gates) before allowing status change

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -1,6 +1,6 @@
 // Config Types
 
-import type { AgentType, TaskPriority } from './task.types.js';
+import type { AgentType, TaskPriority, TaskStatus } from './task.types.js';
 import type { TelemetryConfig } from './telemetry.types.js';
 
 export interface DevServerConfig {
@@ -181,6 +181,11 @@ export interface GeneralSettings {
 }
 
 /** Board display settings */
+export interface BoardColumnConfig {
+  id: TaskStatus;
+  title: string;
+}
+
 export interface BoardSettings {
   showDashboard: boolean;
   showArchiveSuggestions: boolean;
@@ -190,6 +195,8 @@ export interface BoardSettings {
   showSprintBadges: boolean;
   enableDragAndDrop: boolean;
   showDoneMetrics: boolean;
+  columns: BoardColumnConfig[];
+  defaultStatus: TaskStatus;
   dashboardWidgets: DashboardWidgetSettings;
 }
 
@@ -363,6 +370,15 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     showSprintBadges: true,
     enableDragAndDrop: true,
     showDoneMetrics: true,
+    columns: [
+      { id: 'triage', title: 'Triage' },
+      { id: 'todo', title: 'To Do' },
+      { id: 'ready', title: 'Ready' },
+      { id: 'in-progress', title: 'In Progress' },
+      { id: 'blocked', title: 'Blocked' },
+      { id: 'done', title: 'Done' },
+    ],
+    defaultStatus: 'triage',
     dashboardWidgets: {
       showTokenUsage: true,
       showRunDuration: true,

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -1,7 +1,15 @@
 // Task Types
 
 export type TaskType = string;
-export type TaskStatus = 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
+export type TaskStatus =
+  | 'triage'
+  | 'todo'
+  | 'ready'
+  | 'in-progress'
+  | 'blocked'
+  | 'done'
+  | 'cancelled'
+  | (string & {});
 export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
 
 /** Run mode controls the review/QA strategy for a task. */
@@ -191,6 +199,8 @@ export interface Task {
 
   // Agent assignment — "auto" uses routing engine, or a specific agent slug
   agent?: AgentType | 'auto';
+  // Optional visible worker assignment used when agent routing is unavailable or unsuitable
+  assignedWorker?: string;
   // Multi-agent assignment — multiple agents collaborating on a task
   agents?: AgentType[];
 
@@ -321,11 +331,13 @@ export interface CreateTaskInput {
   project?: string;
   sprint?: string;
   agent?: AgentType | 'auto'; // Pre-assign an agent (or "auto" for routing engine)
+  assignedWorker?: string; // Optional visible worker assignment used by board-manager workflows
   agents?: AgentType[]; // Multi-agent assignment
   subtasks?: Subtask[]; // Can be provided when creating from a template
   blockedBy?: string[]; // Can be provided when creating from a blueprint
   reviewScores?: [number, number, number, number]; // Optional 4x10 scores
   reviewComments?: ReviewComment[]; // Optional review comments
+  status?: TaskStatus; // Optional initial board column/status (defaults to configured default)
 }
 
 export interface UpdateTaskInput {
@@ -337,6 +349,7 @@ export interface UpdateTaskInput {
   project?: string;
   sprint?: string;
   agent?: AgentType | 'auto';
+  assignedWorker?: string;
   agents?: AgentType[];
   git?: Partial<TaskGit>;
   github?: TaskGitHub;
@@ -397,6 +410,7 @@ export interface TaskSummary {
   project?: string;
   sprint?: string;
   agent?: AgentType | 'auto';
+  assignedWorker?: string;
   created: string;
   updated: string;
   subtasks?: Subtask[];

--- a/shared/src/utils/constants.ts
+++ b/shared/src/utils/constants.ts
@@ -16,7 +16,9 @@ export const PRIORITY_LABELS: Record<string, string> = {
  * Task status labels
  */
 export const STATUS_LABELS: Record<string, string> = {
+  triage: 'Triage',
   todo: 'To Do',
+  ready: 'Ready',
   'in-progress': 'In Progress',
   done: 'Done',
   blocked: 'Blocked',

--- a/web/src/components/board/BoardLoadingSkeleton.tsx
+++ b/web/src/components/board/BoardLoadingSkeleton.tsx
@@ -1,18 +1,16 @@
 import { Skeleton } from '@/components/ui/skeleton';
-import type { TaskStatus } from '@veritas-kanban/shared';
-
-interface Column {
-  id: TaskStatus;
-  title: string;
-}
+import type { BoardColumnConfig } from '@veritas-kanban/shared';
 
 interface BoardLoadingSkeletonProps {
-  columns: Column[];
+  columns: BoardColumnConfig[];
 }
 
 export function BoardLoadingSkeleton({ columns }: BoardLoadingSkeletonProps) {
   return (
-    <div className="grid grid-cols-4 gap-4">
+    <div
+      className="grid gap-4 overflow-x-auto"
+      style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(16rem, 1fr))` }}
+    >
       {columns.map((column) => (
         <div
           key={column.id}

--- a/web/src/components/board/BoardSidebar.tsx
+++ b/web/src/components/board/BoardSidebar.tsx
@@ -12,6 +12,7 @@ import { useRealtimeAgentStatus } from '@/hooks/useAgentStatus';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { api, Activity } from '@/lib/api';
 import { useTaskCounts } from '@/hooks/useTaskCounts';
+import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import { useView } from '@/contexts/ViewContext';
 import {
   Clock,
@@ -22,9 +23,6 @@ import {
   Cpu,
   Inbox,
   ListTodo,
-  Play,
-  Ban,
-  CheckCircle,
   Archive,
   ExternalLink,
   GitBranch,
@@ -33,6 +31,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { BudgetCard } from '@/components/dashboard/BudgetCard';
 import { MultiAgentPanel } from './MultiAgentPanel';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 
 // ─── Agent State Types ───────────────────────────────────────────────
 
@@ -388,6 +387,10 @@ interface BoardSidebarProps {
 export function BoardSidebar({ onTaskClick }: BoardSidebarProps) {
   const { setView } = useView();
   const { data: counts } = useTaskCounts(); // Use new counts endpoint for sidebar counters
+  const { settings: featureSettings } = useFeatureSettings();
+  const columns = featureSettings.board.columns?.length
+    ? featureSettings.board.columns
+    : DEFAULT_FEATURE_SETTINGS.board.columns;
 
   return (
     <div className="flex flex-col gap-4">
@@ -402,29 +405,14 @@ export function BoardSidebar({ onTaskClick }: BoardSidebarProps) {
             value={counts?.backlog || 0}
             icon={<Inbox className="h-3.5 w-3.5" />}
           />
-          <Counter
-            label="To Do"
-            value={counts?.todo || 0}
-            icon={<ListTodo className="h-3.5 w-3.5" />}
-          />
-          <Counter
-            label="In Progress"
-            value={counts?.['in-progress'] || 0}
-            icon={<Play className="h-3.5 w-3.5" />}
-            color="text-blue-500"
-          />
-          <Counter
-            label="Blocked"
-            value={counts?.blocked || 0}
-            icon={<Ban className="h-3.5 w-3.5" />}
-            color="text-red-500"
-          />
-          <Counter
-            label="Done"
-            value={counts?.done || 0}
-            icon={<CheckCircle className="h-3.5 w-3.5" />}
-            color="text-green-500"
-          />
+          {columns.map((column) => (
+            <Counter
+              key={column.id}
+              label={column.title}
+              value={counts?.[column.id] || 0}
+              icon={<ListTodo className="h-3.5 w-3.5" />}
+            />
+          ))}
           <Counter
             label="Archived"
             value={counts?.archived || 0}

--- a/web/src/components/board/BulkActionsBar.tsx
+++ b/web/src/components/board/BulkActionsBar.tsx
@@ -17,34 +17,8 @@ import { useBulkActions } from '@/hooks/useBulkActions';
 import { useDeleteTask, useBulkUpdate, useBulkArchiveByIds } from '@/hooks/useTasks';
 import { useBulkDemote } from '@/hooks/useBacklog';
 import { cn } from '@/lib/utils';
-import type { Task, TaskStatus } from '@veritas-kanban/shared';
-
-const STATUS_BUTTONS: { id: TaskStatus; label: string; color: string; activeColor: string }[] = [
-  {
-    id: 'todo',
-    label: 'Todo',
-    color: 'border-slate-400 text-slate-600',
-    activeColor: 'bg-slate-500 text-white border-slate-500',
-  },
-  {
-    id: 'in-progress',
-    label: 'In Progress',
-    color: 'border-blue-400 text-blue-600',
-    activeColor: 'bg-blue-500 text-white border-blue-500',
-  },
-  {
-    id: 'blocked',
-    label: 'Blocked',
-    color: 'border-red-400 text-red-600',
-    activeColor: 'bg-red-500 text-white border-red-500',
-  },
-  {
-    id: 'done',
-    label: 'Done',
-    color: 'border-green-400 text-green-600',
-    activeColor: 'bg-green-500 text-white border-green-500',
-  },
-];
+import { DEFAULT_FEATURE_SETTINGS, type Task, type TaskStatus } from '@veritas-kanban/shared';
+import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 
 interface BulkActionsBarProps {
   tasks: Task[];
@@ -59,6 +33,10 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
   const deleteTask = useDeleteTask();
   const bulkArchiveByIds = useBulkArchiveByIds();
   const bulkDemote = useBulkDemote();
+  const { settings: featureSettings } = useFeatureSettings();
+  const columns = featureSettings.board.columns?.length
+    ? featureSettings.board.columns
+    : DEFAULT_FEATURE_SETTINGS.board.columns;
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -66,20 +44,19 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
 
   // Group task IDs by status
   const taskIdsByStatus = useMemo(() => {
-    const map: Record<TaskStatus, string[]> = {
-      todo: [],
-      'in-progress': [],
-      blocked: [],
-      done: [],
-      cancelled: [],
-    };
+    const map = columns.reduce(
+      (acc, column) => {
+        acc[column.id] = [];
+        return acc;
+      },
+      {} as Record<TaskStatus, string[]>
+    );
     for (const task of tasks) {
-      if (map[task.status]) {
-        map[task.status].push(task.id);
-      }
+      if (!map[task.status]) map[task.status] = [];
+      map[task.status].push(task.id);
     }
     return map;
-  }, [tasks]);
+  }, [tasks, columns]);
 
   const allTaskIds = useMemo(() => tasks.map((t) => t.id), [tasks]);
   const selectedCount = selectedIds.size;
@@ -113,10 +90,9 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
     setIsProcessing(true);
     try {
       const ids = Array.from(selectedIds);
-      // Type assertion since BulkActionsBar only allows the 4 valid statuses
       const result = await bulkUpdate.mutateAsync({
         ids,
-        status: moveTarget as 'todo' | 'in-progress' | 'blocked' | 'done',
+        status: moveTarget,
       });
 
       if (result.failed.length > 0) {
@@ -265,8 +241,11 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
 
           {/* Status filter buttons */}
           <div className="flex items-center gap-1.5 ml-1">
-            {STATUS_BUTTONS.map(({ id, label, color, activeColor }) => {
-              const count = taskIdsByStatus[id].length;
+            {columns.map(({ id, title }) => {
+              const count = taskIdsByStatus[id]?.length ?? 0;
+              const label = title;
+              const color = 'border-slate-400 text-slate-600';
+              const activeColor = 'bg-slate-500 text-white border-slate-500';
               if (count === 0) return null;
               const fullySelected = isStatusFullySelected(id);
               const partiallySelected = isStatusPartiallySelected(id);
@@ -305,16 +284,17 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
                   <ArrowRight className="h-4 w-4" />
                   <span>
                     {moveTarget
-                      ? (STATUS_BUTTONS.find((s) => s.id === moveTarget)?.label ?? 'Move to...')
+                      ? (columns.find((s) => s.id === moveTarget)?.title ?? 'Move to...')
                       : 'Move to...'}
                   </span>
                 </div>
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="todo">To Do</SelectItem>
-                <SelectItem value="in-progress">In Progress</SelectItem>
-                <SelectItem value="blocked">Blocked</SelectItem>
-                <SelectItem value="done">Done</SelectItem>
+                {columns.map((column) => (
+                  <SelectItem key={column.id} value={column.id}>
+                    {column.title}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
 

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -3,7 +3,7 @@ import { useBoardDragDrop } from '@/hooks/useBoardDragDrop';
 import { KanbanColumn } from './KanbanColumn';
 import { BoardLoadingSkeleton } from './BoardLoadingSkeleton';
 import { TaskDetailPanel } from '@/components/task/TaskDetailPanel';
-import type { TaskStatus, Task } from '@veritas-kanban/shared';
+import { DEFAULT_FEATURE_SETTINGS, type TaskStatus, type Task } from '@veritas-kanban/shared';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
@@ -32,13 +32,6 @@ const Dashboard = lazy(() =>
     default: mod.Dashboard,
   }))
 );
-
-const COLUMNS: { id: TaskStatus; title: string }[] = [
-  { id: 'todo', title: 'To Do' },
-  { id: 'in-progress', title: 'In Progress' },
-  { id: 'blocked', title: 'Blocked' },
-  { id: 'done', title: 'Done' },
-];
 
 export function KanbanBoard() {
   const { data: tasks, isLoading, error } = useTasks();
@@ -99,13 +92,21 @@ export function KanbanBoard() {
     window.history.replaceState({}, '', newUrl);
   }, [filters]);
 
+  const columns = featureSettings.board.columns?.length
+    ? featureSettings.board.columns
+    : DEFAULT_FEATURE_SETTINGS.board.columns;
+
+  const gridTemplateColumns = {
+    gridTemplateColumns: `repeat(${columns.length}, minmax(16rem, 1fr))`,
+  };
+
   // Filter tasks
   const filteredTasks = useMemo(() => {
     return tasks ? filterTasks(tasks, filters) : [];
   }, [tasks, filters]);
 
   // Group filtered tasks by status
-  const tasksByStatus = useTasksByStatus(filteredTasks);
+  const tasksByStatus = useTasksByStatus(filteredTasks, columns);
 
   // Register filtered tasks with keyboard context
   useEffect(() => {
@@ -155,11 +156,11 @@ export function KanbanBoard() {
   const handleMoveTask = useCallback(
     (taskId: string, status: TaskStatus) => {
       const task = filteredTasks.find((t) => t.id === taskId);
-      const columnName = COLUMNS.find((c) => c.id === status)?.title || status;
+      const columnName = columns.find((c) => c.id === status)?.title || status;
       updateTask.mutate({ id: taskId, input: { status } });
       announce(`Task ${task?.title || taskId} moved to ${columnName}`);
     },
-    [updateTask, filteredTasks, announce]
+    [updateTask, filteredTasks, announce, columns]
   );
 
   // Register callbacks with keyboard context (refs, so no need for useEffect)
@@ -179,7 +180,7 @@ export function KanbanBoard() {
   } = useBoardDragDrop({
     tasks: filteredTasks,
     tasksByStatus,
-    columns: COLUMNS,
+    columns,
     onStatusChange: (taskId, status) => {
       updateTask.mutate({ id: taskId, input: { status } });
     },
@@ -202,7 +203,7 @@ export function KanbanBoard() {
     : null;
 
   if (isLoading) {
-    return <BoardLoadingSkeleton columns={COLUMNS} />;
+    return <BoardLoadingSkeleton columns={columns} />;
   }
 
   if (error) {
@@ -251,13 +252,18 @@ export function KanbanBoard() {
                 onDragOver={handleDragOver}
                 onDragEnd={handleDragEnd}
               >
-                <div className="grid grid-cols-4 gap-4" role="group" aria-label="Kanban columns">
-                  {COLUMNS.map((column) => (
+                <div
+                  className="grid gap-4 overflow-x-auto"
+                  style={gridTemplateColumns}
+                  role="group"
+                  aria-label="Kanban columns"
+                >
+                  {columns.map((column) => (
                     <KanbanColumn
                       key={column.id}
                       id={column.id}
                       title={column.title}
-                      tasks={liveTasksByStatus[column.id]}
+                      tasks={liveTasksByStatus[column.id] ?? []}
                       allTasks={filteredTasks}
                       onTaskClick={handleTaskClick}
                       selectedTaskId={selectedTaskId}
@@ -271,13 +277,18 @@ export function KanbanBoard() {
                 </DragOverlay>
               </DndContext>
             ) : (
-              <div className="grid grid-cols-4 gap-4" role="group" aria-label="Kanban columns">
-                {COLUMNS.map((column) => (
+              <div
+                className="grid gap-4 overflow-x-auto"
+                style={gridTemplateColumns}
+                role="group"
+                aria-label="Kanban columns"
+              >
+                {columns.map((column) => (
                   <KanbanColumn
                     key={column.id}
                     id={column.id}
                     title={column.title}
-                    tasks={tasksByStatus[column.id]}
+                    tasks={tasksByStatus[column.id] ?? []}
                     allTasks={filteredTasks}
                     onTaskClick={handleTaskClick}
                     selectedTaskId={selectedTaskId}

--- a/web/src/components/board/KanbanColumn.tsx
+++ b/web/src/components/board/KanbanColumn.tsx
@@ -20,8 +20,10 @@ interface KanbanColumnProps {
   isDragActive?: boolean;
 }
 
-const columnColors: Record<TaskStatus, string> = {
+const columnColors: Record<string, string> = {
+  triage: 'border-t-zinc-500',
   todo: 'border-t-slate-500',
+  ready: 'border-t-amber-500',
   'in-progress': 'border-t-blue-500',
   blocked: 'border-t-red-500',
   done: 'border-t-green-500',
@@ -66,7 +68,7 @@ export function KanbanColumn({
       aria-roledescription="kanban column"
       className={cn(
         'flex flex-col rounded-lg bg-muted/50 border-t-2 transition-all',
-        columnColors[id],
+        columnColors[id] ?? 'border-t-slate-400',
         isOver && 'ring-2 ring-primary/50 bg-muted/70'
       )}
     >

--- a/web/src/components/dashboard/TasksDrillDown.tsx
+++ b/web/src/components/dashboard/TasksDrillDown.tsx
@@ -14,7 +14,7 @@ interface TasksDrillDownProps {
 }
 
 const statusConfig: Record<
-  TaskStatus,
+  string,
   {
     icon: React.ReactNode;
     color: string;
@@ -79,14 +79,10 @@ export function TasksDrillDown({
 
   // Group by status for summary
   const statusCounts = useMemo(() => {
-    const counts: Record<TaskStatus, number> = {
-      todo: 0,
-      'in-progress': 0,
-      blocked: 0,
-      done: 0,
-      cancelled: 0,
-    };
-    filteredTasks.forEach((t) => counts[t.status]++);
+    const counts: Record<string, number> = {};
+    filteredTasks.forEach((t) => {
+      counts[t.status] = (counts[t.status] ?? 0) + 1;
+    });
     return counts;
   }, [filteredTasks]);
 
@@ -105,7 +101,11 @@ export function TasksDrillDown({
       {/* Summary Stats */}
       <div className="flex gap-2 flex-wrap">
         {Object.entries(statusCounts).map(([status, count]) => {
-          const config = statusConfig[status as TaskStatus];
+          const config = statusConfig[status] ?? {
+            icon: <ListTodo className="h-4 w-4" />,
+            color: 'text-muted-foreground',
+            label: status,
+          };
           return (
             <Badge
               key={status}
@@ -147,7 +147,11 @@ function TaskRow({
   projects?: Array<{ id: string; label: string }>;
   onClick?: () => void;
 }) {
-  const config = statusConfig[task.status];
+  const config = statusConfig[task.status] ?? {
+    icon: <ListTodo className="h-4 w-4" />,
+    color: 'text-muted-foreground',
+    label: task.status,
+  };
   const projectLabel = task.project
     ? projects.find((p) => p.id === task.project)?.label || task.project
     : null;

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -18,7 +18,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { useToast } from '@/hooks/useToast';
@@ -356,11 +355,11 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[800px] h-[85vh] p-0 overflow-hidden">
+      <DialogContent className="sm:max-w-[800px] max-h-[85vh] p-0 overflow-y-auto">
         <ErrorBoundary level="section">
-          <div className="flex h-full min-h-0">
+          <div className="flex min-h-0">
             {/* Sidebar Tabs — hidden on narrow screens, shown as dropdown instead */}
-            <div className="hidden sm:flex flex-col w-48 border-r bg-muted/30 py-4">
+            <div className="hidden sm:sticky sm:top-0 sm:flex flex-col w-48 shrink-0 self-start max-h-[85vh] border-r bg-muted/30 py-4">
               <div className="px-4 pb-3">
                 <h2 className="text-sm font-semibold">Settings</h2>
               </div>
@@ -468,22 +467,22 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
             </div>
 
             {/* Content */}
-            <div className="flex-1 flex flex-col min-w-0 min-h-0">
+            <div className="flex-1 flex flex-col min-w-0">
               <DialogHeader className="px-6 py-4 border-b sm:hidden">
                 <DialogTitle>Settings</DialogTitle>
               </DialogHeader>
-              <ScrollArea className="flex-1 min-h-0">
+              <div className="min-w-0">
                 <div
                   id="settings-tab-content"
                   ref={contentAreaRef}
-                  className="px-6 py-4"
+                  className="px-6 pt-4 pb-8 min-w-0"
                   role="tabpanel"
                   tabIndex={-1}
                   aria-labelledby={`tab-${activeTab}`}
                 >
                   {renderTab()}
                 </div>
-              </ScrollArea>
+              </div>
             </div>
           </div>
         </ErrorBoundary>

--- a/web/src/components/settings/tabs/BoardTab.tsx
+++ b/web/src/components/settings/tabs/BoardTab.tsx
@@ -5,16 +5,78 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
-import { DEFAULT_FEATURE_SETTINGS, type DashboardWidgetSettings } from '@veritas-kanban/shared';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type BoardColumnConfig,
+  type DashboardWidgetSettings,
+} from '@veritas-kanban/shared';
 import { SettingRow, ToggleRow, SectionHeader, SaveIndicator } from '../shared';
+
+function slugifyColumnTitle(title: string): string {
+  return (
+    title
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'column'
+  ).slice(0, 50);
+}
+
+function makeUniqueColumnId(base: string, columns: BoardColumnConfig[]): string {
+  const existing = new Set(columns.map((column) => column.id));
+  let id = slugifyColumnTitle(base);
+  let suffix = 2;
+  while (existing.has(id)) {
+    id = `${slugifyColumnTitle(base)}-${suffix}`;
+    suffix += 1;
+  }
+  return id;
+}
 
 export function BoardTab() {
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const board = settings.board ?? DEFAULT_FEATURE_SETTINGS.board;
+  const columns = board.columns?.length ? board.columns : DEFAULT_FEATURE_SETTINGS.board.columns;
+  const defaultStatus = columns.some((column) => column.id === board.defaultStatus)
+    ? board.defaultStatus
+    : columns[0]?.id;
 
   const update = (key: string, value: any) => {
     debouncedUpdate({ board: { [key]: value } });
+  };
+
+  const updateColumns = (nextColumns: BoardColumnConfig[]) => {
+    debouncedUpdate({
+      board: {
+        columns: nextColumns,
+        defaultStatus: nextColumns.some((column) => column.id === defaultStatus)
+          ? defaultStatus
+          : nextColumns[0]?.id,
+      },
+    });
+  };
+
+  const insertColumn = (index: number) => {
+    const id = makeUniqueColumnId('new-column', columns);
+    const nextColumns = [...columns];
+    nextColumns.splice(index, 0, { id, title: 'New Column' });
+    updateColumns(nextColumns);
+  };
+
+  const updateColumnTitle = (index: number, title: string) => {
+    updateColumns(columns.map((column, i) => (i === index ? { ...column, title } : column)));
+  };
+
+  const updateColumnId = (index: number, id: string) => {
+    const normalizedId = slugifyColumnTitle(id);
+    updateColumns(
+      columns.map((column, i) => (i === index ? { ...column, id: normalizedId } : column))
+    );
   };
 
   const resetBoard = () => {
@@ -92,6 +154,68 @@ export function BoardTab() {
           }
           onCheckedChange={(v) => update('showArchiveSuggestions', v)}
         />
+        <div className="py-3 space-y-3">
+          <div>
+            <Label className="text-sm font-medium">Board Columns</Label>
+            <p className="text-xs text-muted-foreground">
+              Configure visible workflow columns. Existing task statuses are preserved.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 overflow-x-auto pb-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 shrink-0"
+              aria-label="Add column before first column"
+              onClick={() => insertColumn(0)}
+            >
+              +
+            </Button>
+            {columns.map((column, index) => (
+              <div key={`${column.id}-${index}`} className="flex items-center gap-2 shrink-0">
+                <div className="rounded-md border bg-background p-2 space-y-2 w-44">
+                  <Input
+                    value={column.title}
+                    aria-label={`Column ${index + 1} title`}
+                    onChange={(event) => updateColumnTitle(index, event.target.value)}
+                    className="h-8"
+                  />
+                  <Input
+                    value={column.id}
+                    aria-label={`Column ${index + 1} status ID`}
+                    onChange={(event) => updateColumnId(index, event.target.value)}
+                    className="h-8 font-mono text-xs"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 shrink-0"
+                  aria-label={`Add column after ${column.title || column.id}`}
+                  onClick={() => insertColumn(index + 1)}
+                >
+                  +
+                </Button>
+              </div>
+            ))}
+          </div>
+          <SettingRow label="Default Column" description="New tasks are created in this column">
+            <Select value={defaultStatus} onValueChange={(v) => update('defaultStatus', v)}>
+              <SelectTrigger className="w-40 h-8">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {columns.map((column) => (
+                  <SelectItem key={column.id} value={column.id}>
+                    {column.title}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+        </div>
         <SettingRow label="Card Density" description="Compact cards use less space">
           <Select
             value={settings.board?.cardDensity ?? DEFAULT_FEATURE_SETTINGS.board.cardDensity}

--- a/web/src/components/task/BlockedReasonSection.tsx
+++ b/web/src/components/task/BlockedReasonSection.tsx
@@ -17,39 +17,43 @@ interface BlockedReasonSectionProps {
   readOnly?: boolean;
 }
 
-const BLOCKED_CATEGORIES: { value: BlockedCategory; label: string; icon: React.ReactNode; description: string }[] = [
-  { 
-    value: 'waiting-on-feedback', 
-    label: 'Waiting on Feedback', 
+const BLOCKED_CATEGORIES: {
+  value: BlockedCategory;
+  label: string;
+  icon: React.ReactNode;
+  description: string;
+}[] = [
+  {
+    value: 'waiting-on-feedback',
+    label: 'Waiting on Feedback',
     icon: <MessageSquare className="h-4 w-4" />,
     description: 'Blocked waiting for input from someone',
   },
-  { 
-    value: 'technical-snag', 
-    label: 'Technical Snag', 
+  {
+    value: 'technical-snag',
+    label: 'Technical Snag',
     icon: <Wrench className="h-4 w-4" />,
     description: 'Blocked by a technical issue or bug',
   },
-  { 
-    value: 'prerequisite', 
-    label: 'Prerequisite', 
+  {
+    value: 'prerequisite',
+    label: 'Prerequisite',
     icon: <Link2 className="h-4 w-4" />,
     description: 'Blocked by another task that must complete first',
   },
-  { 
-    value: 'other', 
-    label: 'Other', 
+  {
+    value: 'other',
+    label: 'Other',
     icon: <HelpCircle className="h-4 w-4" />,
     description: 'Blocked for another reason',
   },
 ];
 
-export function BlockedReasonSection({ task, onUpdate, readOnly = false }: BlockedReasonSectionProps) {
-  // Only show when status is blocked
-  if (task.status !== 'blocked') {
-    return null;
-  }
-
+export function BlockedReasonSection({
+  task,
+  onUpdate,
+  readOnly = false,
+}: BlockedReasonSectionProps) {
   const currentCategory = task.blockedReason?.category;
   const currentNote = task.blockedReason?.note || '';
 
@@ -76,7 +80,7 @@ export function BlockedReasonSection({ task, onUpdate, readOnly = false }: Block
   };
 
   const getCategoryInfo = (category: BlockedCategory) => {
-    return BLOCKED_CATEGORIES.find(c => c.value === category);
+    return BLOCKED_CATEGORIES.find((c) => c.value === category);
   };
 
   return (
@@ -85,6 +89,11 @@ export function BlockedReasonSection({ task, onUpdate, readOnly = false }: Block
         <Ban className="h-4 w-4 text-red-500" />
         <Label className="text-muted-foreground font-medium">Blocked Reason</Label>
       </div>
+      {task.status !== 'blocked' && !readOnly && (
+        <p className="text-xs text-muted-foreground">
+          Required before moving to Blocked. Choose a category and add the concrete blocker note.
+        </p>
+      )}
 
       {readOnly ? (
         <div className="bg-red-500/10 border border-red-500/20 rounded-md p-3 space-y-2">
@@ -109,7 +118,7 @@ export function BlockedReasonSection({ task, onUpdate, readOnly = false }: Block
             onValueChange={(value) => handleCategoryChange(value as BlockedCategory)}
           >
             <SelectTrigger className="w-full">
-              <SelectValue placeholder="Why is this task blocked?" />
+              <SelectValue placeholder="Choose blocker category..." />
             </SelectTrigger>
             <SelectContent>
               {BLOCKED_CATEGORIES.map((cat) => (
@@ -126,7 +135,7 @@ export function BlockedReasonSection({ task, onUpdate, readOnly = false }: Block
           <Textarea
             value={currentNote}
             onChange={(e) => handleNoteChange(e.target.value)}
-            placeholder="Add details about what's blocking this task..."
+            placeholder="What exactly is blocking this, and what is needed next?"
             rows={2}
             className="resize-none text-sm"
           />

--- a/web/src/components/task/CommentsSection.tsx
+++ b/web/src/components/task/CommentsSection.tsx
@@ -283,7 +283,7 @@ export function CommentsSection({ task }: CommentsSectionProps) {
               value={text}
               onChange={setText}
               onKeyDown={handleKeyDown}
-              placeholder="Add a comment... (supports Markdown, Cmd/Ctrl+Enter to submit)"
+              placeholder="Add a comment... For Done, include completion summary and verification note. Cmd/Ctrl+Enter to submit."
               minHeight={100}
               maxHeight={240}
               disabled={isAdding}
@@ -293,7 +293,7 @@ export function CommentsSection({ task }: CommentsSectionProps) {
               value={text}
               onChange={(e) => setText(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder="Add a comment... (Cmd/Ctrl+Enter to submit)"
+              placeholder="Add a comment... For Done, include completion summary and verification note. Cmd/Ctrl+Enter to submit."
               className="text-sm min-h-[80px] resize-none"
               disabled={isAdding}
             />

--- a/web/src/components/task/DeliverablesSection.tsx
+++ b/web/src/components/task/DeliverablesSection.tsx
@@ -335,7 +335,7 @@ export function DeliverablesSection({ task }: DeliverablesSectionProps) {
             <Input
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g., API Documentation"
+              placeholder="e.g., PR #123, branch name, report, exported file"
               className="text-sm h-8"
               autoFocus
             />
@@ -356,11 +356,11 @@ export function DeliverablesSection({ task }: DeliverablesSectionProps) {
             </Select>
           </div>
           <div>
-            <Label className="text-xs">Path / URL (optional)</Label>
+            <Label className="text-xs">Path / URL / branch / PR (optional)</Label>
             <Input
               value={path}
               onChange={(e) => setPath(e.target.value)}
-              placeholder="https://... or /path/to/file"
+              placeholder="https://..., /path/to/file, branch-name, or PR #"
               className="text-sm h-8"
             />
           </div>
@@ -369,7 +369,7 @@ export function DeliverablesSection({ task }: DeliverablesSectionProps) {
             <Textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="Add details about this deliverable..."
+              placeholder="What output should the operator/reviewer inspect?"
               className="text-sm min-h-[60px] resize-none"
             />
           </div>

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -17,6 +17,7 @@ import {
   Zap,
   MessageSquare,
   Wrench,
+  UserRound,
   Link2,
   HelpCircle,
   Play,
@@ -238,6 +239,8 @@ export const TaskCard = memo(function TaskCard({
   }, [taskTypes, task.type]);
 
   // Memoize project info
+  const assignedWorker = task.assignedWorker ?? task.agent;
+
   const { projectColor, projectLabel } = useMemo(
     () => ({
       projectColor: task.project ? getProjectColor(projects, task.project) : 'bg-muted',
@@ -478,6 +481,12 @@ export const TaskCard = memo(function TaskCard({
                   )}
                 >
                   {task.priority}
+                </span>
+              )}
+              {assignedWorker && (
+                <span className="text-xs px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400 flex items-center gap-1">
+                  <UserRound className="h-3 w-3" />
+                  {assignedWorker}
                 </span>
               )}
               {/* Attachment indicator */}

--- a/web/src/components/task/VerificationSection.tsx
+++ b/web/src/components/task/VerificationSection.tsx
@@ -146,7 +146,7 @@ export function VerificationSection({ task }: VerificationSectionProps) {
           value={newDescription}
           onChange={(e) => setNewDescription(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Add verification step..."
+          placeholder="Add verification step or note (e.g., web build passed, smoke test not run — reason)..."
           className="text-sm"
           disabled={isAdding}
         />

--- a/web/src/components/task/detail/TaskDetailsTab.tsx
+++ b/web/src/components/task/detail/TaskDetailsTab.tsx
@@ -111,18 +111,16 @@ export function TaskDetailsTab({
       {/* Metadata Section */}
       <TaskMetadataSection task={task} onUpdate={onUpdate} readOnly={readOnly} />
 
-      {/* Blocked Reason (shown when status is blocked) */}
-      {task.status === 'blocked' && (
-        <div className="border-t pt-4">
-          <BlockedReasonSection
-            task={task}
-            onUpdate={(blockedReason: BlockedReason | undefined) =>
-              onUpdate('blockedReason', blockedReason)
-            }
-            readOnly={readOnly}
-          />
-        </div>
-      )}
+      {/* Blocked Reason */}
+      <div className="border-t pt-4">
+        <BlockedReasonSection
+          task={task}
+          onUpdate={(blockedReason: BlockedReason | undefined) =>
+            onUpdate('blockedReason', blockedReason)
+          }
+          readOnly={readOnly}
+        />
+      </div>
 
       {/* Checkpoint Status (shown when checkpoint exists) */}
       {task.checkpoint && (
@@ -175,6 +173,10 @@ export function TaskDetailsTab({
 
       {/* Subtasks */}
       <div className="border-t pt-4">
+        <p className="mb-3 text-xs text-muted-foreground">
+          Ready gate: add acceptance criteria here, or add a “Definition of Done” section in the
+          description.
+        </p>
         <SubtasksSection
           task={task}
           onAutoCompleteChange={(value) => onUpdate('autoCompleteOnSubtasks', value || undefined)}
@@ -183,6 +185,9 @@ export function TaskDetailsTab({
 
       {/* Verification / Done Criteria */}
       <div className="border-t pt-4">
+        <p className="mb-3 text-xs text-muted-foreground">
+          Done gate: check a verification step here, or add a verification note in Comments.
+        </p>
         <VerificationSection task={task} />
       </div>
 
@@ -205,12 +210,19 @@ export function TaskDetailsTab({
 
       {/* Deliverables */}
       <div className="border-t pt-4">
+        <p className="mb-3 text-xs text-muted-foreground">
+          Done gate: record the branch, PR, file path, URL, or output location before moving to
+          Done.
+        </p>
         <DeliverablesSection task={task} />
       </div>
 
       {/* Comments */}
       {taskSettings.enableComments && (
         <div className="border-t pt-4">
+          <p className="mb-3 text-xs text-muted-foreground">
+            Done gate: add a completion summary and, if needed, a verification note here.
+          </p>
           <CommentsSection task={task} />
         </div>
       )}

--- a/web/src/components/task/detail/TaskMetadataSection.tsx
+++ b/web/src/components/task/detail/TaskMetadataSection.tsx
@@ -13,21 +13,19 @@ import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
 import { useConfig } from '@/hooks/useConfig';
-import type { Task, TaskStatus, TaskPriority, AgentType } from '@veritas-kanban/shared';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type Task,
+  type TaskStatus,
+  type TaskPriority,
+  type AgentType,
+} from '@veritas-kanban/shared';
 
 interface TaskMetadataSectionProps {
   task: Task;
   onUpdate: <K extends keyof Task>(field: K, value: Task[K]) => void;
   readOnly?: boolean;
 }
-
-const statusLabels: Record<TaskStatus, string> = {
-  todo: 'To Do',
-  'in-progress': 'In Progress',
-  blocked: 'Blocked',
-  done: 'Done',
-  cancelled: 'Cancelled',
-};
 
 const priorityLabels: Record<TaskPriority, string> = {
   low: 'Low',
@@ -46,6 +44,13 @@ export function TaskMetadataSection({
   const { data: sprints = [] } = useSprints();
   const { data: config } = useConfig();
   const enabledAgents = config?.agents.filter((a) => a.enabled) || [];
+  const columns = config?.features?.board?.columns?.length
+    ? config.features.board.columns
+    : DEFAULT_FEATURE_SETTINGS.board.columns;
+  const currentStatusLabel =
+    columns.find((column) => column.id === task.status)?.title ?? task.status;
+  const currentWorker = task.assignedWorker ?? task.agent ?? '';
+  const workerOptions = ['librarian', 'implementer', 'researcher', 'writer', 'ops'];
   const [showNewProject, setShowNewProject] = useState(false);
   const [newProjectName, setNewProjectName] = useState('');
 
@@ -61,7 +66,7 @@ export function TaskMetadataSection({
           <Label className="text-muted-foreground">Status</Label>
           {readOnly ? (
             <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md">
-              {statusLabels[task.status]}
+              {currentStatusLabel}
             </div>
           ) : (
             <Select value={task.status} onValueChange={(v) => onUpdate('status', v as TaskStatus)}>
@@ -69,9 +74,9 @@ export function TaskMetadataSection({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {Object.entries(statusLabels).map(([value, label]) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
+                {columns.map((column) => (
+                  <SelectItem key={column.id} value={column.id}>
+                    {column.title}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -213,8 +218,8 @@ export function TaskMetadataSection({
         )}
       </div>
 
-      {/* Sprint & Agent */}
-      <div className="grid grid-cols-2 gap-4">
+      {/* Sprint, Assignment & Agent */}
+      <div className="grid grid-cols-3 gap-4">
         <div className="space-y-2">
           <Label className="text-muted-foreground">Sprint</Label>
           {readOnly ? (
@@ -238,6 +243,37 @@ export function TaskMetadataSection({
                     {s.label}
                   </SelectItem>
                 ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-muted-foreground">Assigned Worker</Label>
+          {readOnly ? (
+            <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md">
+              {currentWorker || 'Unassigned'}
+            </div>
+          ) : (
+            <Select
+              value={currentWorker || '__none__'}
+              onValueChange={(value) =>
+                onUpdate('assignedWorker', value === '__none__' ? undefined : value)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Unassigned" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">Unassigned</SelectItem>
+                {workerOptions.map((worker) => (
+                  <SelectItem key={worker} value={worker}>
+                    {worker}
+                  </SelectItem>
+                ))}
+                {currentWorker && !workerOptions.includes(currentWorker) && (
+                  <SelectItem value={currentWorker}>{currentWorker}</SelectItem>
+                )}
               </SelectContent>
             </Select>
           )}

--- a/web/src/hooks/useBoardDragDrop.ts
+++ b/web/src/hooks/useBoardDragDrop.ts
@@ -11,12 +11,12 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
-import type { Task, TaskStatus } from '@veritas-kanban/shared';
+import type { BoardColumnConfig, Task, TaskStatus } from '@veritas-kanban/shared';
 
 interface UseBoardDragDropOptions {
   tasks: Task[];
   tasksByStatus: Record<TaskStatus, Task[]>;
-  columns: { id: TaskStatus; title: string }[];
+  columns: BoardColumnConfig[];
   onStatusChange: (taskId: string, status: TaskStatus) => void;
   onReorder: (taskIds: string[], onSuccess?: () => void) => void;
 }
@@ -132,8 +132,8 @@ export function useBoardDragDrop({
         if (!overColumn || activeColumn === overColumn) return prev;
 
         // Move the task from source to destination
-        const sourceTasks = prev[activeColumn];
-        const destTasks = prev[overColumn];
+        const sourceTasks = prev[activeColumn] ?? [];
+        const destTasks = prev[overColumn] ?? [];
         const activeIndex = sourceTasks.findIndex((t) => t.id === activeId);
         if (activeIndex === -1) return prev;
 
@@ -188,8 +188,8 @@ export function useBoardDragDrop({
 
       if (originalColumn === finalColumn && !columnIds.includes(overId as TaskStatus)) {
         // Same column — check for reorder
-        const columnTasks = finalState[finalColumn];
-        const origColumnTasks = tasksByStatus[originalColumn];
+        const columnTasks = finalState[finalColumn] ?? [];
+        const origColumnTasks = tasksByStatus[originalColumn] ?? [];
         const oldIndex = origColumnTasks.findIndex((t: Task) => t.id === activeId);
         const newIndex = columnTasks.findIndex((t: Task) => t.id === activeId);
 
@@ -202,7 +202,7 @@ export function useBoardDragDrop({
         onStatusChange(activeId, finalColumn);
 
         // Send the new order for the destination column
-        const newOrder = finalState[finalColumn].map((t: Task) => t.id);
+        const newOrder = (finalState[finalColumn] ?? []).map((t: Task) => t.id);
         onReorder(newOrder);
       }
     },

--- a/web/src/hooks/useKeyboard.tsx
+++ b/web/src/hooks/useKeyboard.tsx
@@ -8,8 +8,14 @@ import {
   useRef,
   type ReactNode,
 } from 'react';
-import type { Task, TaskStatus } from '@veritas-kanban/shared';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type BoardColumnConfig,
+  type Task,
+  type TaskStatus,
+} from '@veritas-kanban/shared';
 import { toast } from './useToast';
+import { useFeatureSettings } from './useFeatureSettings';
 
 interface KeyboardContextValue {
   // Dialog triggers
@@ -36,19 +42,21 @@ interface KeyboardContextValue {
   setOnMoveTask: (fn: (taskId: string, status: TaskStatus) => void) => void;
 }
 
-const KeyboardContext = createContext<KeyboardContextValue | null>(null);
+function getColumnForShortcut(key: string, columns: BoardColumnConfig[]): TaskStatus | null {
+  const index = Number.parseInt(key, 10) - 1;
+  return Number.isInteger(index) && index >= 0 && index < columns.length ? columns[index].id : null;
+}
 
-const STATUS_MAP: Record<string, TaskStatus> = {
-  '1': 'todo',
-  '2': 'in-progress',
-  '3': 'blocked',
-  '4': 'done',
-};
+const KeyboardContext = createContext<KeyboardContextValue | null>(null);
 
 export function KeyboardProvider({ children }: { children: ReactNode }) {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
+  const { settings: featureSettings } = useFeatureSettings();
+  const columns = featureSettings.board.columns?.length
+    ? featureSettings.board.columns
+    : DEFAULT_FEATURE_SETTINGS.board.columns;
 
   // Use refs for callbacks to avoid re-render loops
   const openCreateDialogRef = useRef<(() => void) | null>(null);
@@ -90,14 +98,14 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
 
   // Get flat list of tasks sorted by column then position
   const getTaskList = useCallback(() => {
-    const statusOrder: TaskStatus[] = ['todo', 'in-progress', 'blocked', 'done'];
+    const statusOrder = columns.map((column) => column.id);
     return [...tasks].sort((a, b) => {
       const aIndex = statusOrder.indexOf(a.status);
       const bIndex = statusOrder.indexOf(b.status);
       if (aIndex !== bIndex) return aIndex - bIndex;
       return a.title.localeCompare(b.title);
     });
-  }, [tasks]);
+  }, [tasks, columns]);
 
   // Keyboard event handler
   useEffect(() => {
@@ -177,9 +185,21 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
         case '2':
         case '3':
         case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9': {
           e.preventDefault();
+          const newStatus = getColumnForShortcut(e.key, columns);
+          if (!newStatus) {
+            toast({
+              title: 'No column for shortcut',
+              description: `Column ${e.key} is not configured on this board`,
+            });
+            return;
+          }
           if (selectedTaskId && onMoveTaskRef.current) {
-            const newStatus = STATUS_MAP[e.key];
             onMoveTaskRef.current(selectedTaskId, newStatus);
           } else {
             // Show toast when no task is selected
@@ -189,12 +209,13 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
             });
           }
           break;
+        }
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [getTaskList, selectedTaskId, isHelpOpen, openCreateDialog, openChatPanel]);
+  }, [getTaskList, selectedTaskId, isHelpOpen, openCreateDialog, openChatPanel, columns]);
 
   const value = useMemo<KeyboardContextValue>(
     () => ({

--- a/web/src/hooks/useTaskCounts.ts
+++ b/web/src/hooks/useTaskCounts.ts
@@ -2,12 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api/helpers';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 
-export interface TaskCounts {
+export interface TaskCounts extends Record<string, number> {
   backlog: number;
-  todo: number;
-  'in-progress': number;
-  blocked: number;
-  done: number;
   archived: number;
 }
 

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -2,7 +2,12 @@ import { useQuery, useMutation, useQueryClient, QueryClient } from '@tanstack/re
 import { api } from '@/lib/api';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { toast } from '@/hooks/useToast';
-import type { Task, CreateTaskInput, UpdateTaskInput } from '@veritas-kanban/shared';
+import type {
+  BoardColumnConfig,
+  Task,
+  CreateTaskInput,
+  UpdateTaskInput,
+} from '@veritas-kanban/shared';
 
 /**
  * Patch a single task in both the list cache (['tasks']) and the individual
@@ -76,7 +81,7 @@ export function useCreateTask() {
         title: input.title,
         description: input.description || '',
         type: (input.type || 'code') as Task['type'],
-        status: 'todo',
+        status: input.status || 'triage',
         priority: input.priority || 'medium',
         project: input.project,
         sprint: input.sprint,
@@ -157,6 +162,39 @@ export function useUpdateTask() {
 
         // Map gate codes to user-friendly titles and actionable guidance
         const gateInfo: Record<string, { title: string; guidance: string }> = {
+          ASSIGNED_WORKER_REQUIRED: {
+            title: '🧭 Ready Gate Blocked',
+            guidance: 'Open the task → Details → Metadata → Assigned Worker.',
+          },
+          ACCEPTANCE_CRITERIA_REQUIRED: {
+            title: '🧭 Ready Gate Blocked',
+            guidance:
+              'Open the task → Details → Subtasks → Add Acceptance Criteria, or add a “Definition of Done” section in Description.',
+          },
+          BLOCKED_REASON_REQUIRED: {
+            title: '🚧 Blocked Reason Required',
+            guidance:
+              'Open the task → set status to Blocked → Details → Blocked Reason. Choose a category and add the blocker note, then retry the move if needed.',
+          },
+          BLOCKER_COMMENT_REQUIRED: {
+            title: '🚧 Blocked Reason Required',
+            guidance:
+              'Use the first-class Blocked Reason field: choose a category and add the blocker note.',
+          },
+          COMPLETION_COMMENT_REQUIRED: {
+            title: '✅ Done Gate Blocked',
+            guidance: 'Open the task → Details → Comments. Add a short completion summary.',
+          },
+          DELIVERABLE_REQUIRED: {
+            title: '📦 Deliverable Required',
+            guidance:
+              'Open the task → Details → Deliverables. Add the file, branch, PR, URL, or output location.',
+          },
+          VERIFICATION_NOTE_REQUIRED: {
+            title: '🧪 Verification Required',
+            guidance:
+              'Open the task → Details → Done Criteria and check a step, or add a verification note in Comments.',
+          },
           REVIEW_GATE: {
             title: '🔒 Review Gate Blocked',
             guidance: 'Add all four review scores (10/10/10/10) before completing this task.',
@@ -165,10 +203,6 @@ export function useUpdateTask() {
             title: '💬 Closing Comments Required',
             guidance:
               'Add a review comment with a deliverable summary (≥20 chars) before completing.',
-          },
-          DELIVERABLE_REQUIRED: {
-            title: '📦 Deliverable Required',
-            guidance: 'Attach at least one deliverable before marking this task as done.',
           },
           ORCHESTRATOR_DELEGATION: {
             title: '🤖 Delegation Required',
@@ -274,13 +308,8 @@ export function useBulkUpdate() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      ids,
-      status,
-    }: {
-      ids: string[];
-      status: 'todo' | 'in-progress' | 'blocked' | 'done';
-    }) => api.tasks.bulkUpdate(ids, status),
+    mutationFn: ({ ids, status }: { ids: string[]; status: Task['status'] }) =>
+      api.tasks.bulkUpdate(ids, status),
     onMutate: async ({ ids, status }) => {
       // Cancel outgoing refetches
       await queryClient.cancelQueries({ queryKey: ['tasks'] });
@@ -576,24 +605,24 @@ function sortByPosition(tasks: Task[]): Task[] {
   });
 }
 
-export function useTasksByStatus(tasks: Task[] | undefined) {
-  if (!tasks) {
-    return {
-      todo: [],
-      'in-progress': [],
-      blocked: [],
-      done: [],
-      cancelled: [],
-    };
-  }
+export function useTasksByStatus(tasks: Task[] | undefined, columns?: BoardColumnConfig[]) {
+  const statuses = columns?.map((column) => column.id) ?? [
+    'triage',
+    'todo',
+    'ready',
+    'in-progress',
+    'blocked',
+    'done',
+    'cancelled',
+  ];
 
-  return {
-    todo: sortByPosition(tasks.filter((t) => t.status === 'todo')),
-    'in-progress': sortByPosition(tasks.filter((t) => t.status === 'in-progress')),
-    blocked: sortByPosition(tasks.filter((t) => t.status === 'blocked')),
-    done: sortByPosition(tasks.filter((t) => t.status === 'done')),
-    cancelled: sortByPosition(tasks.filter((t) => t.status === 'cancelled')),
-  };
+  return statuses.reduce(
+    (grouped, status) => {
+      grouped[status] = sortByPosition((tasks ?? []).filter((t) => t.status === status));
+      return grouped;
+    },
+    {} as Record<Task['status'], Task[]>
+  );
 }
 
 // Check if a task is blocked by incomplete dependencies

--- a/web/src/lib/api/tasks.ts
+++ b/web/src/lib/api/tasks.ts
@@ -312,7 +312,7 @@ export const tasksApi = {
 
   bulkUpdate: async (
     ids: string[],
-    status: 'todo' | 'in-progress' | 'blocked' | 'done'
+    status: Task['status']
   ): Promise<{ updated: string[]; count: number; failed: string[] }> => {
     const response = await fetch(`${API_BASE}/tasks/bulk-update`, {
       credentials: 'include',


### PR DESCRIPTION
# PR: Configurable Board Columns + Workflow Gates

Status: draft PR framing for upstream or fork contribution.

## Summary

This change makes kanban board columns configurable through feature settings and routes board rendering, keyboard moves, drag/drop, task creation, and task status validation through the same configured column model.

It also adds service-level workflow gates for approval-oriented boards:

- `todo` -> `ready` requires an assigned worker and acceptance criteria / definition of done.
- entering `blocked` requires a structured blocked reason.

## Why

Fixed board columns are too rigid for teams that use Veritas as an operating board rather than a simple todo list. Common workflows need intake, approval, ready-for-worker, active, blocked, and done states. If those statuses are hard-coded in each UI/service surface, behavior drifts and automation can bypass process rules.

Configurable columns provide one source of truth for active task statuses. Server-side validation ensures UI, API, CLI, MCP, bulk updates, and future automation paths agree on which statuses are valid.

This is especially useful for AI-assisted task orchestration because it moves work out of a single chat thread and onto durable cards. Teams can separate raw intake, task enrichment, human approval, active execution, blockers, and completion evidence while keeping the same status model across UI and API surfaces.

## User-Facing Changes

- Board columns render from `features.board.columns`.
- New tasks default to `features.board.defaultStatus` when no status is provided.
- Settings -> Board & Display includes a **Board Columns** editor.
- Keyboard number shortcuts map to configured column order.
- Loading skeletons, board grid width, drag/drop targets, and column titles follow the configured board.
- Invalid status moves are rejected with a clear validation error.
- Approval workflow gates can block moves that lack required context.

Default six-column example:

1. Triage
2. To Do
3. Ready
4. In Progress
5. Blocked
6. Done

## Technical Changes

Shared/config:

- Adds `BoardColumnConfig` and `BoardSettings.columns` / `BoardSettings.defaultStatus` to feature settings.
- Keeps `TaskStatus` string-extensible so custom workflow IDs are type-compatible.
- Updates default feature settings to include board columns and default status.
- Expands status labels for common six-column statuses.

Server:

- Validates create/update statuses against configured board columns.
- Uses configured default status for task creation.
- Falls back safely if default status is missing from configured columns.
- Enforces workflow gates in `TaskService.updateTask` so API, bulk, CLI/MCP, and automation paths share the same rules.
- Updates migration/summary/metrics/service logic to handle configurable statuses.

Web:

- Renders board columns from feature settings.
- Updates drag/drop, keyboard shortcuts, task grouping, loading skeleton, sidebar/counts, and board settings UI to respect configured columns.
- Exposes `assignedWorker` and blocked reason fields needed by workflow gates.

Tests:

- Adds/updates service tests for configurable statuses and workflow gates.
- Updates frontend tests/mocks around dynamic columns.
- Updates task/service/storage/migration/summary coverage for the expanded default workflow.

Docs:

- Adds generic configurable board columns documentation.
- Frames the board manager as an example automation architecture rather than an environment-specific requirement.

## Validation

Branch validation already performed before this packaging pass:

- Configurable board columns branch validates.
- Existing code/test changes are present on branch `zora/configurable-board-columns`.

Documentation packaging validation to run before commit/PR:

```bash
# Generic framing sanity: no environment-specific labels should appear outside this checklist.
rg -n "environment-specific-label-placeholder" docs/CONFIGURABLE-BOARD-COLUMNS.md docs/PR-CONFIGURABLE-BOARD-COLUMNS.md docs/BOARD-MANAGER-ARCHITECTURE.md
rg -n "CONFIGURABLE-BOARD-COLUMNS|PR-CONFIGURABLE-BOARD-COLUMNS|Board Manager Architecture" docs
rg -n "[[:blank:]]$" docs/CONFIGURABLE-BOARD-COLUMNS.md docs/PR-CONFIGURABLE-BOARD-COLUMNS.md docs/BOARD-MANAGER-ARCHITECTURE.md

git diff --check
```

Suggested full validation before upstream PR, if code has changed after this doc pass:

```bash
pnpm install --frozen-lockfile
pnpm --filter @veritas-kanban/shared build
pnpm --filter @veritas-kanban/server test
pnpm --filter @veritas-kanban/server typecheck
pnpm --filter @veritas-kanban/server build
pnpm --filter @veritas-kanban/web typecheck
pnpm --filter @veritas-kanban/web build
git diff --check
```

Run the shared build before server tests in clean checkouts where `shared/dist` is absent. Use the repository's current canonical test commands if they differ.

Observed non-blocking validation warnings during local packaging:

- `pnpm --filter @veritas-kanban/web build` emits existing Vite warnings about large chunks and an ineffective dynamic import involving `src/lib/api/index.ts`. The build still succeeds.
- `pnpm --filter @veritas-kanban/server test` emitted a Node `MaxListenersExceededWarning` during one local post-commit validation run. The full server test suite still passed.

These warnings were not introduced as failing conditions by this branch, but they should be visible to maintainers during PR review.

Additional local validation evidence after packaging:

- Re-applied the package in a clean local validation copy.
- Re-ran validation: shared build, full server suite (105 files / 1557 tests), server typecheck/build, web typecheck/build, and `git diff --check` all passed.
- Verified API health, web UI response, configured six-column board order, default `triage` status, and transition gate behavior in a local runtime smoke test.
- Smoke-created tasks were deleted after verification.

## Compatibility

Backward-compatible defaults:

- Existing configs without `features.board.columns` get defaults through feature-settings merge.
- Existing task files are not rewritten during config load.
- Existing status values remain valid if those IDs remain configured.

Potentially breaking behavior:

- If an installation removes or renames a column, tasks with the old status may no longer render in visible board columns until migrated or the column is restored.
- API/CLI clients that assume fixed statuses must discover configured columns or align with the instance configuration.
- The six-column default changes where new tasks land (`triage`) compared with older four-column defaults (`todo`). Upstream maintainers may choose to keep the historical default and document six columns as an opt-in example.

## Risks

- Hidden fixed-status assumptions may remain in older docs, tests, screenshots, or integrations.
- Current workflow gates are hard-coded to specific transitions; this is useful for the included approval workflow but should become configurable for broad upstream use.
- Column ID edits in settings do not migrate existing tasks, which can make old-status tasks disappear from the rendered board until handled.
- Custom status IDs may need careful handling in metrics, summaries, exports, and external integrations.

## Screenshots / GIFs

Add before PR submission:

- [ ] Settings -> Board & Display -> Board Columns editor
- [ ] Board showing six configured columns
- [ ] Drag/drop or keyboard move into a configured column
- [ ] Validation error for an invalid or gated move
- [ ] Task detail showing Assigned Worker / Blocked Reason fields

## Rollout Notes

Recommended rollout for maintainers:

1. Decide whether the upstream default should remain the historical four-column board or move to the six-column workflow.
2. If preserving maximum compatibility, ship configurable columns first with the historical default and include six-column configuration as an example.
3. Add a release note warning that removing/renaming columns does not migrate existing task statuses automatically.
4. Encourage API/CLI/MCP clients to read configured board columns instead of hard-coding statuses.
5. Consider a follow-up issue for configurable transition gates.

## Suggested PR Description

```markdown
## What

Adds configurable kanban board columns through feature settings and uses that configuration across board rendering, drag/drop, keyboard shortcuts, task creation, and task status validation. Also adds service-level workflow gates for approval-oriented boards.

## Why

Teams use Veritas with different operating workflows. Making columns configurable avoids hard-coded status drift and gives UI/API/automation clients one source of truth for valid task statuses.

## Validation

- [ ] Server tests
- [ ] Web tests
- [ ] Typecheck
- [ ] `git diff --check`
- [ ] Manual UI smoke: configure columns, create task, drag/drop, keyboard move, invalid move validation

## Compatibility

Existing configs receive defaults. Existing task files are preserved. Installations that remove/rename statuses should migrate tasks or keep legacy columns visible until no active tasks use them.
```
