### PR TITLE
Fix content-disposition v2 import

### DIFF
--- a/server/src/routes/attachments.ts
+++ b/server/src/routes/attachments.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import type { Router as RouterType } from 'express';
 import multer from 'multer';
 import { basename } from 'node:path';
-import { create as contentDisposition } from 'content-disposition';
+import * as contentDisposition from 'content-disposition';
 import { getTaskService } from '../services/task-service.js';
 import { getAttachmentService } from '../services/attachment-service.js';
 import { getTextExtractionService } from '../services/text-extraction-service.js';
@@ -163,7 +163,10 @@ router.get(
     const downloadName = basename(attachment.originalName.replace(/\\/g, '/'));
 
     res.setHeader('Content-Type', attachment.mimeType);
-    res.setHeader('Content-Disposition', contentDisposition(downloadName, { type: 'attachment' }));
+    res.setHeader(
+      'Content-Disposition',
+      contentDisposition.create(downloadName, { type: 'attachment' })
+    );
     res.sendFile(filepath);
   })
 );


### PR DESCRIPTION
## Summary
- Replace the named ESM import of `content-disposition` with a namespace import.
- Call `contentDisposition.create(...)`, matching the v2 CommonJS package exports and TypeScript declarations.

## Why
After the dependency bump to `content-disposition@2.0.0`, local server startup failed with:

```text
SyntaxError: The requested module 'content-disposition' does not provide an export named 'create'
```

A default import also type-checks incorrectly against v2 because the default namespace object is not callable.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`

Note: local Node is `v22.17.0`, so pnpm prints the repo engine warning for `>=22.22.1`, but the build completes successfully.