### PR TITLE
Fix squad chat lifecycle enforcement

### DIFF
--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -102,6 +102,7 @@ curl -X PATCH http://localhost:3001/api/settings/features \
 
 - Squad chat endpoint configured
 - Agent context available
+- No per-hook `squadChat` flag. This is controlled by the global `enforcement.squadChat` setting.
 
 **Example:**
 When a task moves to `in-progress`, squad chat automatically receives:

--- a/server/src/__tests__/hook-service.test.ts
+++ b/server/src/__tests__/hook-service.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendSquadMessage = vi.fn();
+
+vi.mock('../services/chat-service.js', () => ({
+  getChatService: () => ({
+    sendSquadMessage,
+  }),
+}));
+
+describe('hook-service squad chat enforcement', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    sendSquadMessage.mockReset();
+  });
+
+  it('posts lifecycle events to squad chat when enforcement.squadChat is enabled', async () => {
+    const { fireHook, setEnforcementSettings, setHooksSettings } =
+      await import('../services/hook-service.js');
+
+    setHooksSettings({ enabled: false });
+    setEnforcementSettings({
+      squadChat: true,
+      reviewGate: false,
+      closingComments: false,
+      autoTelemetry: false,
+      autoTimeTracking: false,
+      orchestratorDelegation: false,
+      orchestratorAgent: '',
+    });
+
+    await fireHook(
+      'onStarted',
+      {
+        id: 'task_123',
+        title: 'Test task',
+        status: 'in-progress',
+        project: 'Setup',
+        agent: 'codex',
+      },
+      'todo'
+    );
+
+    expect(sendSquadMessage).toHaveBeenCalledWith({
+      agent: 'CODEX',
+      message: 'Started working on: Test task',
+      tags: ['task-lifecycle', 'Setup'],
+      system: true,
+      event: 'agent.status',
+      taskTitle: 'Test task',
+    });
+  });
+
+  it('does not post lifecycle events to squad chat when enforcement.squadChat is disabled', async () => {
+    const { fireHook, setEnforcementSettings, setHooksSettings } =
+      await import('../services/hook-service.js');
+
+    setHooksSettings({
+      enabled: true,
+      onStarted: {
+        enabled: true,
+      },
+    });
+    setEnforcementSettings({
+      squadChat: false,
+      reviewGate: false,
+      closingComments: false,
+      autoTelemetry: false,
+      autoTimeTracking: false,
+      orchestratorDelegation: false,
+      orchestratorAgent: '',
+    });
+
+    await fireHook(
+      'onStarted',
+      {
+        id: 'task_123',
+        title: 'Test task',
+        status: 'in-progress',
+        project: 'Setup',
+        agent: 'codex',
+      },
+      'todo'
+    );
+
+    expect(sendSquadMessage).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/hook-service.ts
+++ b/server/src/services/hook-service.ts
@@ -35,7 +35,6 @@ export interface HookConfig {
   webhook?: string;
   notify?: boolean;
   logActivity?: boolean;
-  squadChat?: boolean;
 }
 
 export interface HooksSettings {
@@ -112,15 +111,18 @@ export async function fireHook(
   previousStatus?: string
 ): Promise<void> {
   const settings = cachedSettings;
+  const squadChatEnabled = cachedEnforcement?.squadChat === true;
+  const hooksEnabled = settings?.enabled === true;
 
-  // Check if hooks are globally enabled
-  if (!settings?.enabled) {
+  // Nothing to do if both lifecycle hooks and squad chat enforcement are disabled.
+  if (!hooksEnabled && !squadChatEnabled) {
     return;
   }
 
   // Get the specific hook config
-  const hookConfig = settings[event];
-  if (!hookConfig?.enabled) {
+  const hookConfig = settings?.[event];
+  const hookEnabled = hooksEnabled && hookConfig?.enabled === true;
+  if (!hookEnabled && !squadChatEnabled) {
     return;
   }
 
@@ -138,21 +140,23 @@ export async function fireHook(
   log.info({ event, taskId: task.id }, 'Firing hook');
 
   // Fire webhook if configured
-  if (hookConfig.webhook) {
+  if (hookEnabled && hookConfig?.webhook) {
     fireWebhook(hookConfig.webhook, payload).catch((err) => {
       log.warn({ event, taskId: task.id, error: err.message }, 'Webhook delivery failed');
     });
   }
 
-  // Fire squad chat if configured
-  if (hookConfig.squadChat && (cachedEnforcement?.squadChat ?? true)) {
+  // Fire squad chat when the enforcement toggle is enabled. This is intentionally
+  // independent of per-hook settings because enforcement.squadChat is the public
+  // setting documented for lifecycle squad-chat posts.
+  if (squadChatEnabled) {
     fireSquadChat(event, task, previousStatus).catch((err) => {
       log.warn({ event, taskId: task.id, error: err.message }, 'Squad chat post failed');
     });
   }
 
   // Fire notification if configured
-  if (hookConfig.notify) {
+  if (hookEnabled && hookConfig?.notify) {
     fireNotification(event, payload).catch((err) => {
       log.warn({ event, taskId: task.id, error: err.message }, 'Notification creation failed');
     });


### PR DESCRIPTION
## Summary

Fixes lifecycle Squad Chat auto-posting so the documented `enforcement.squadChat` setting actually controls Squad Chat lifecycle posts.

Before this change, `fireHook()` required both:

- global/per-event lifecycle hook config, and
- an undocumented per-hook `squadChat` flag

That made the public `enforcement.squadChat` toggle misleading because the normal hook schema/types/docs do not expose a per-hook `squadChat` option.

## Changes

- Treat `enforcement.squadChat` as the source of truth for Squad Chat lifecycle posts.
- Keep normal hook settings responsible for webhook / notification behavior.
- Remove the internal-only `HookConfig.squadChat` field from the service interface.
- Add focused unit coverage for enabled/disabled Squad Chat enforcement.
- Clarify the enforcement doc that no per-hook `squadChat` flag is required.

## Validation

- `pnpm exec vitest run server/src/__tests__/hook-service.test.ts server/src/__tests__/settings-service.test.ts`
- `pnpm --filter server typecheck`
- `pnpm --filter server build`
- `pnpm build`
- `VERITAS_DISABLE_WATCHERS=1 pnpm exec vitest run --no-file-parallelism --maxWorkers=1`

Note: a plain full-suite `pnpm test` run hit macOS `EMFILE: too many open files, watch` even though all assertions passed. Re-running with `VERITAS_DISABLE_WATCHERS=1` passed all 122 files / 1763 tests.
