### PR TITLE
feat: add SQLite storage foundation

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -827,6 +827,26 @@ CREATE VIRTUAL TABLE docs_search USING fts5(
 Search rows are maintained by repository writes in the first implementation. SQL
 triggers can be added later if repository-level maintenance becomes fragile.
 
+## Runtime Foundation
+
+The v5 foundation uses Node's built-in `node:sqlite` `DatabaseSync` API for the
+server runtime. That keeps SQLite support dependency-free on the required Node
+22.22+ runtime and avoids native package installation during local setup,
+Docker builds, and CI.
+
+Runtime settings:
+
+| Setting               | Default                   | Purpose                                          |
+| --------------------- | ------------------------- | ------------------------------------------------ |
+| `VERITAS_STORAGE`     | `file`                    | Selects `file` or `sqlite` storage mode.         |
+| `VERITAS_SQLITE_PATH` | `{runtimeDir}/veritas.db` | Overrides the SQLite database file location.     |
+| `VERITAS_DATA_DIR`    | project/runtime default   | Controls the runtime directory used by defaults. |
+
+SQLite mode currently owns database open/close, PRAGMAs, and migration
+tracking while repository parity is implemented in the following provider
+issues. File storage remains the default until the migration/import path is
+complete.
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/.env.example
+++ b/server/.env.example
@@ -70,6 +70,12 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,h
 # Data directory for tasks, config, logs (default: .veritas-kanban in project root)
 # VERITAS_DATA_DIR=.veritas-kanban
 
+# Storage backend: file | sqlite (default: file)
+# VERITAS_STORAGE=file
+
+# SQLite database path when VERITAS_STORAGE=sqlite (default: runtime dir / veritas.db)
+# VERITAS_SQLITE_PATH=.veritas-kanban/veritas.db
+
 # Telemetry retention: days to keep event files before deletion (default: 30)
 # TELEMETRY_RETENTION_DAYS=30
 

--- a/server/src/__tests__/config/env.test.ts
+++ b/server/src/__tests__/config/env.test.ts
@@ -175,6 +175,7 @@ describe('envSchema', () => {
         expect(result.data.VERITAS_AUTH_LOCALHOST_BYPASS).toBe(false);
         expect(result.data.VERITAS_AUTH_LOCALHOST_ROLE).toBe('read-only');
         expect(result.data.VERITAS_API_KEYS).toBe('');
+        expect(result.data.VERITAS_STORAGE).toBe('file');
         expect(result.data.RATE_LIMIT_MAX).toBe(300);
         expect(result.data.CSP_REPORT_ONLY).toBe(false);
         expect(result.data.CLAWDBOT_GATEWAY).toBe('http://127.0.0.1:18789');
@@ -275,6 +276,40 @@ describe('envSchema', () => {
     });
   });
 
+  describe('VERITAS_STORAGE', () => {
+    it('should accept file storage', () => {
+      const result = envSchema.safeParse({
+        VERITAS_ADMIN_KEY: 'test-key',
+        VERITAS_STORAGE: 'file',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.VERITAS_STORAGE).toBe('file');
+      }
+    });
+
+    it('should accept sqlite storage and path override', () => {
+      const result = envSchema.safeParse({
+        VERITAS_ADMIN_KEY: 'test-key',
+        VERITAS_STORAGE: 'sqlite',
+        VERITAS_SQLITE_PATH: '/tmp/veritas-test.db',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.VERITAS_STORAGE).toBe('sqlite');
+        expect(result.data.VERITAS_SQLITE_PATH).toBe('/tmp/veritas-test.db');
+      }
+    });
+
+    it('should reject unsupported storage backends', () => {
+      const result = envSchema.safeParse({
+        VERITAS_ADMIN_KEY: 'test-key',
+        VERITAS_STORAGE: 'postgres',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('CLAWDBOT_GATEWAY', () => {
     it('should accept a valid URL', () => {
       const result = envSchema.safeParse({
@@ -320,9 +355,9 @@ describe('validateEnv', () => {
   beforeEach(() => {
     // Save and clear process.env
     originalEnv = { ...process.env };
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number | string | null) => {
       throw new Error('process.exit called');
-    }) as any);
+    }) as typeof process.exit);
   });
 
   afterEach(() => {

--- a/server/src/__tests__/storage/sqlite-database.test.ts
+++ b/server/src/__tests__/storage/sqlite-database.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'fs';
+import type { SqliteMigration } from '../../storage/index.js';
+import { SqliteDatabase } from '../../storage/index.js';
+import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+
+describe('SqliteDatabase', () => {
+  it('opens a file database, applies safe pragmas, and closes cleanly', () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+      const db = fixture.database.getConnection();
+
+      const foreignKeys = db.prepare('PRAGMA foreign_keys;').get() as { foreign_keys: number };
+      const journalMode = db.prepare('PRAGMA journal_mode;').get() as { journal_mode: string };
+
+      expect(existsSync(fixture.databasePath)).toBe(true);
+      expect(foreignKeys.foreign_keys).toBe(1);
+      expect(journalMode.journal_mode).toBe('wal');
+
+      fixture.database.close();
+      expect(fixture.database.isOpen()).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('runs migrations in version order and records schema_migrations rows', () => {
+    const migrations: SqliteMigration[] = [
+      {
+        version: 2,
+        name: '0002_insert_probe',
+        up: "INSERT INTO migration_probe (id, name) VALUES (1, 'ordered');",
+      },
+      {
+        version: 1,
+        name: '0001_create_probe',
+        up: 'CREATE TABLE migration_probe (id INTEGER PRIMARY KEY, name TEXT NOT NULL);',
+      },
+    ];
+    const fixture = createTestSqliteDatabase({ migrations });
+
+    try {
+      fixture.database.open();
+      const db = fixture.database.getConnection();
+      const appliedRows = db
+        .prepare('SELECT version, name FROM schema_migrations ORDER BY version ASC;')
+        .all() as Array<{ version: number; name: string }>;
+      const probeRow = db.prepare('SELECT name FROM migration_probe WHERE id = 1;').get() as {
+        name: string;
+      };
+
+      expect(appliedRows.map((row) => row.version)).toEqual([1, 2]);
+      expect(appliedRows.map((row) => row.name)).toEqual([
+        '0001_create_probe',
+        '0002_insert_probe',
+      ]);
+      expect(probeRow.name).toBe('ordered');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('skips already-applied migrations on rerun', () => {
+    const migrations: SqliteMigration[] = [
+      {
+        version: 1,
+        name: '0001_create_and_insert_probe',
+        up: `
+          CREATE TABLE migration_probe (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+          INSERT INTO migration_probe (id, name) VALUES (1, 'once');
+        `,
+      },
+    ];
+    const fixture = createTestSqliteDatabase({ migrations });
+
+    try {
+      fixture.database.open();
+      fixture.database.runMigrations(migrations);
+
+      const db = fixture.database.getConnection();
+      const migrationCount = db
+        .prepare('SELECT COUNT(*) AS count FROM schema_migrations;')
+        .get() as {
+        count: number;
+      };
+      const dataCount = db.prepare('SELECT COUNT(*) AS count FROM migration_probe;').get() as {
+        count: number;
+      };
+
+      expect(migrationCount.count).toBe(1);
+      expect(dataCount.count).toBe(1);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rejects an already-applied version when the migration content changes', () => {
+    const initialMigration: SqliteMigration = {
+      version: 1,
+      name: '0001_create_probe',
+      up: 'CREATE TABLE migration_probe (id INTEGER PRIMARY KEY);',
+    };
+    const changedMigration: SqliteMigration = {
+      version: 1,
+      name: '0001_create_probe',
+      up: 'CREATE TABLE migration_probe (id INTEGER PRIMARY KEY, name TEXT);',
+    };
+    const fixture = createTestSqliteDatabase({ migrations: [initialMigration] });
+
+    try {
+      fixture.database.open();
+
+      expect(() => fixture.database.runMigrations([changedMigration])).toThrow(
+        'already applied with different content'
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rolls back failed migrations without recording them as applied', () => {
+    const migrations: SqliteMigration[] = [
+      {
+        version: 1,
+        name: '0001_failing_probe',
+        up: `
+          CREATE TABLE rollback_probe (id INTEGER PRIMARY KEY);
+          INSERT INTO missing_table (id) VALUES (1);
+        `,
+      },
+    ];
+    const fixture = createTestSqliteDatabase({ migrations });
+
+    try {
+      expect(() => fixture.database.open()).toThrow('SQLite migration 1');
+
+      const db = fixture.database.getConnection();
+      const rollbackProbe = db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'rollback_probe';")
+        .get();
+      const appliedRows = db.prepare('SELECT version FROM schema_migrations;').all();
+
+      expect(rollbackProbe).toBeUndefined();
+      expect(appliedRows).toHaveLength(0);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('makes close idempotent and guards access after close', () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+      expect(fixture.database.isOpen()).toBe(true);
+
+      fixture.database.close();
+      fixture.database.close();
+
+      expect(fixture.database.isOpen()).toBe(false);
+      expect(() => fixture.database.getConnection()).toThrow('SQLite database is not open');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('creates isolated test database helpers', () => {
+    const first = createTestSqliteDatabase({ applyMigrations: false });
+    const second = createTestSqliteDatabase({ applyMigrations: false });
+
+    try {
+      expect(first.databasePath).not.toBe(second.databasePath);
+      expect(first.rootDir).not.toBe(second.rootDir);
+
+      first.database.open();
+      second.database.open();
+
+      first.database.getConnection().exec('CREATE TABLE only_first (id INTEGER PRIMARY KEY);');
+      const tableInSecond = second.database
+        .getConnection()
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'only_first';")
+        .get();
+
+      expect(tableInSecond).toBeUndefined();
+    } finally {
+      first.cleanup();
+      second.cleanup();
+    }
+  });
+
+  it('uses the configured path when a database path is provided', () => {
+    const fixture = createTestSqliteDatabase({ applyMigrations: false });
+
+    try {
+      const db = new SqliteDatabase({
+        databasePath: fixture.databasePath,
+        applyMigrations: false,
+      });
+
+      db.open();
+      expect(db.databasePath).toBe(fixture.databasePath);
+      db.close();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/__tests__/storage/sqlite-storage.test.ts
+++ b/server/src/__tests__/storage/sqlite-storage.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  getStorage,
+  getStorageTypeFromEnv,
+  initStorage,
+  shutdownStorage,
+  SqliteStorageProvider,
+  type FileStorageOptions,
+} from '../../storage/index.js';
+
+function fileStorageOptionsFor(testRoot: string): FileStorageOptions {
+  return {
+    taskServiceOptions: {
+      tasksDir: path.join(testRoot, 'tasks', 'active'),
+      archiveDir: path.join(testRoot, 'tasks', 'archive'),
+    },
+    configServiceOptions: {
+      configDir: path.join(testRoot, '.veritas-kanban'),
+      configFile: path.join(testRoot, '.veritas-kanban', 'config.json'),
+    },
+    telemetryServiceOptions: {
+      telemetryDir: path.join(testRoot, '.veritas-kanban', 'telemetry'),
+    },
+  };
+}
+
+describe('SqliteStorageProvider', () => {
+  let testRoot: string;
+
+  beforeEach(async () => {
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-provider-'));
+  });
+
+  afterEach(async () => {
+    await shutdownStorage();
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('opens, migrates, delegates repositories, and closes the SQLite connection', async () => {
+    const provider = new SqliteStorageProvider({
+      database: {
+        databasePath: path.join(testRoot, '.veritas-kanban', 'veritas.db'),
+      },
+      fileStorageOptions: fileStorageOptionsFor(testRoot),
+    });
+
+    await provider.initialize();
+
+    const db = provider.getDatabase().getConnection();
+    const localWorkspace = db.prepare("SELECT id FROM workspaces WHERE id = 'local';").get() as {
+      id: string;
+    };
+    const tasks = await provider.tasks.findAll();
+
+    expect(provider.getDatabase().isOpen()).toBe(true);
+    expect(localWorkspace.id).toBe('local');
+    expect(Array.isArray(tasks)).toBe(true);
+
+    await provider.shutdown();
+    expect(provider.getDatabase().isOpen()).toBe(false);
+  });
+
+  it('can be selected through the storage factory', async () => {
+    await initStorage('sqlite', {
+      database: {
+        databasePath: path.join(testRoot, '.veritas-kanban', 'factory.db'),
+      },
+      fileStorageOptions: fileStorageOptionsFor(testRoot),
+    });
+
+    const storage = getStorage();
+
+    expect(storage).toBeInstanceOf(SqliteStorageProvider);
+  });
+
+  it('parses storage backend env selection', () => {
+    expect(getStorageTypeFromEnv({ VERITAS_STORAGE: 'sqlite' })).toBe('sqlite');
+    expect(getStorageTypeFromEnv({ VERITAS_STORAGE: 'file' })).toBe('file');
+    expect(getStorageTypeFromEnv({})).toBe('file');
+    expect(() => getStorageTypeFromEnv({ VERITAS_STORAGE: 'postgres' })).toThrow(
+      'Unsupported VERITAS_STORAGE value'
+    );
+  });
+});

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -79,6 +79,12 @@ export const envSchema = z.object({
   /** Root directory for data storage */
   VERITAS_DATA_DIR: z.string().optional(),
 
+  /** Storage backend: file remains the default until the v5 migration completes */
+  VERITAS_STORAGE: z.enum(['file', 'sqlite']).optional().default('file'),
+
+  /** SQLite database file path when VERITAS_STORAGE=sqlite */
+  VERITAS_SQLITE_PATH: z.string().optional(),
+
   // ── CORS ────────────────────────────────────────────────────────────
   /** Comma-separated list of allowed CORS origins */
   CORS_ORIGINS: z.string().optional(),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,6 +58,7 @@ import { cspNonceMiddleware, cspNonceDirective } from './middleware/csp-nonce.js
 import { healthRouter, apiHealthRouter, setHealthWss } from './routes/health.js';
 import { getPrometheusCollector } from './services/metrics/prometheus.js';
 import { metricsCollector } from './middleware/metrics-collector.js';
+import { getStorageTypeFromEnv, initStorage, shutdownStorage } from './storage/index.js';
 
 const log = createLogger('server');
 
@@ -526,6 +527,7 @@ app.use(errorHandler);
 
 // Module-level config service instance (shared with shutdown handler)
 let configService: ConfigService | null = null;
+let storageInitialized = false;
 
 // Initialize services on startup
 (async () => {
@@ -560,6 +562,13 @@ let configService: ConfigService | null = null;
     syncSettingsToServices(featureSettings);
     await getTelemetryService().init();
     await getPolicyService().waitForInit();
+
+    const storageType = getStorageTypeFromEnv();
+    if (storageType === 'sqlite') {
+      await initStorage('sqlite');
+      storageInitialized = true;
+      log.info('SQLite storage initialized');
+    }
   } catch (err) {
     log.fatal({ err }, 'Failed to initialize services — server cannot start safely');
     process.exit(1);
@@ -966,6 +975,12 @@ async function gracefulShutdown(signal: string) {
       configService.dispose();
       configService = null;
       log.info('Config service disposed');
+    }
+
+    if (storageInitialized) {
+      await shutdownStorage();
+      storageInitialized = false;
+      log.info('Storage provider shut down');
     }
   } catch (err) {
     log.error({ err }, 'Error during service disposal');

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -4,13 +4,14 @@
  * Usage:
  *   import { initStorage, getStorage } from './storage/index.js';
  *
- *   await initStorage('file');          // call once at startup
+ *   await initStorage();                // call once at startup
  *   const storage = getStorage();       // anywhere in the app
  *   const tasks   = await storage.tasks.findAll();
  */
 
 import type { StorageProvider } from './interfaces.js';
 import { FileStorageProvider, type FileStorageOptions } from './file-storage.js';
+import { SqliteStorageProvider, type SqliteStorageOptions } from './sqlite/sqlite-storage.js';
 
 export type {
   TaskRepository,
@@ -35,26 +36,53 @@ export {
   FileTelemetryRepository,
 } from './file-storage.js';
 export type { FileStorageOptions } from './file-storage.js';
+export {
+  DEFAULT_SQLITE_FILENAME,
+  SqliteDatabase,
+  calculateMigrationChecksum,
+  resolveSqliteDatabasePath,
+} from './sqlite/database.js';
+export type { SqliteConnectionOptions } from './sqlite/database.js';
+export { SQLITE_BASE_MIGRATIONS, sortedMigrations } from './sqlite/migrations.js';
+export type { SqliteMigration } from './sqlite/migrations.js';
+export { SqliteStorageProvider } from './sqlite/sqlite-storage.js';
+export type { SqliteStorageOptions } from './sqlite/sqlite-storage.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)
 // ---------------------------------------------------------------------------
-export type StorageType = 'file';
+export type StorageType = 'file' | 'sqlite';
+type StorageOptions = FileStorageOptions | SqliteStorageOptions;
 
 // ---------------------------------------------------------------------------
 // Module-level singleton
 // ---------------------------------------------------------------------------
 let activeProvider: StorageProvider | null = null;
 
+export function getStorageTypeFromEnv(env: NodeJS.ProcessEnv = process.env): StorageType {
+  const storageType = env.VERITAS_STORAGE?.trim() || 'file';
+
+  if (storageType === 'file' || storageType === 'sqlite') {
+    return storageType;
+  }
+
+  throw new Error(`Unsupported VERITAS_STORAGE value: ${storageType}`);
+}
+
+export function getSqlitePathFromEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const sqlitePath = env.VERITAS_SQLITE_PATH?.trim();
+  return sqlitePath && sqlitePath.length > 0 ? sqlitePath : undefined;
+}
+
 /**
  * Initialise the storage layer.
  *
- * @param type    Backend type – currently only `'file'`.
+ * @param type    Backend type.
  * @param options Backend-specific options forwarded to the provider.
  */
 export async function initStorage(
-  type: StorageType = 'file',
-  options?: FileStorageOptions
+  type: StorageType = getStorageTypeFromEnv(),
+  options?: StorageOptions
 ): Promise<void> {
   // Shut down any previously-active provider
   if (activeProvider) {
@@ -64,7 +92,10 @@ export async function initStorage(
 
   switch (type) {
     case 'file':
-      activeProvider = new FileStorageProvider(options);
+      activeProvider = new FileStorageProvider(options as FileStorageOptions | undefined);
+      break;
+    case 'sqlite':
+      activeProvider = new SqliteStorageProvider(options as SqliteStorageOptions | undefined);
       break;
     default: {
       // Exhaustive check – compile error if a new StorageType is added
@@ -75,6 +106,15 @@ export async function initStorage(
   }
 
   await activeProvider.initialize();
+}
+
+export async function shutdownStorage(): Promise<void> {
+  if (!activeProvider) {
+    return;
+  }
+
+  await activeProvider.shutdown();
+  activeProvider = null;
 }
 
 /**

--- a/server/src/storage/sqlite/database.ts
+++ b/server/src/storage/sqlite/database.ts
@@ -1,0 +1,191 @@
+import { createHash } from 'crypto';
+import { mkdirSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { DatabaseSync } from 'node:sqlite';
+import { getRuntimeDir } from '../../utils/paths.js';
+import { SQLITE_BASE_MIGRATIONS, sortedMigrations, type SqliteMigration } from './migrations.js';
+
+export const DEFAULT_SQLITE_FILENAME = 'veritas.db';
+
+export interface SqliteConnectionOptions {
+  databasePath?: string;
+  migrations?: readonly SqliteMigration[];
+  applyMigrations?: boolean;
+}
+
+interface AppliedMigrationRow {
+  version: number;
+  name: string;
+  checksum: string;
+}
+
+export function resolveSqliteDatabasePath(explicitPath?: string): string {
+  const configuredPath = explicitPath ?? process.env.VERITAS_SQLITE_PATH;
+
+  if (configuredPath && configuredPath.trim().length > 0) {
+    const trimmed = configuredPath.trim();
+    return trimmed === ':memory:' ? trimmed : resolve(trimmed);
+  }
+
+  return join(getRuntimeDir(), DEFAULT_SQLITE_FILENAME);
+}
+
+export function calculateMigrationChecksum(migration: SqliteMigration): string {
+  const normalizedSql = migration.up.replace(/\r\n/g, '\n').trim();
+  return createHash('sha256')
+    .update(`${migration.version}:${migration.name}:${normalizedSql}`)
+    .digest('hex');
+}
+
+export class SqliteDatabase {
+  readonly databasePath: string;
+
+  private db: DatabaseSync | null = null;
+  private readonly migrations: readonly SqliteMigration[];
+  private readonly applyMigrations: boolean;
+
+  constructor(options: SqliteConnectionOptions = {}) {
+    this.databasePath = resolveSqliteDatabasePath(options.databasePath);
+    this.migrations = options.migrations ?? SQLITE_BASE_MIGRATIONS;
+    this.applyMigrations = options.applyMigrations ?? true;
+  }
+
+  open(): DatabaseSync {
+    if (this.db) {
+      return this.db;
+    }
+
+    if (!this.isMemoryDatabase()) {
+      mkdirSync(dirname(this.databasePath), { recursive: true });
+    }
+
+    this.db = new DatabaseSync(this.databasePath);
+    this.applyPragmas();
+
+    if (this.applyMigrations) {
+      this.runMigrations();
+    }
+
+    return this.db;
+  }
+
+  getConnection(): DatabaseSync {
+    if (!this.db) {
+      throw new Error('SQLite database is not open. Call open() first.');
+    }
+
+    return this.db;
+  }
+
+  isOpen(): boolean {
+    return this.db !== null;
+  }
+
+  runMigrations(migrations: readonly SqliteMigration[] = this.migrations): void {
+    const db = this.getConnection();
+    this.ensureSchemaMigrationsTable();
+
+    const appliedByVersion = this.getAppliedMigrations();
+
+    for (const migration of sortedMigrations(migrations)) {
+      const applied = appliedByVersion.get(migration.version);
+      const checksum = calculateMigrationChecksum(migration);
+
+      if (applied) {
+        if (applied.checksum !== checksum || applied.name !== migration.name) {
+          throw new Error(
+            `SQLite migration ${migration.version} was already applied with different content`
+          );
+        }
+        continue;
+      }
+
+      this.applyMigration(db, migration, checksum);
+      appliedByVersion.set(migration.version, {
+        version: migration.version,
+        name: migration.name,
+        checksum,
+      });
+    }
+  }
+
+  close(): void {
+    if (!this.db) {
+      return;
+    }
+
+    this.db.close();
+    this.db = null;
+  }
+
+  private applyPragmas(): void {
+    const db = this.getConnection();
+    db.exec('PRAGMA foreign_keys = ON;');
+    db.exec('PRAGMA busy_timeout = 5000;');
+
+    if (!this.isMemoryDatabase()) {
+      db.exec('PRAGMA journal_mode = WAL;');
+    }
+  }
+
+  private ensureSchemaMigrationsTable(): void {
+    this.getConnection().exec(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        checksum TEXT NOT NULL,
+        applied_at TEXT NOT NULL,
+        execution_ms INTEGER NOT NULL,
+        rolled_back_at TEXT
+      );
+    `);
+  }
+
+  private getAppliedMigrations(): Map<number, AppliedMigrationRow> {
+    const rows = this.getConnection()
+      .prepare(
+        `
+          SELECT version, name, checksum
+          FROM schema_migrations
+          WHERE rolled_back_at IS NULL
+          ORDER BY version ASC
+        `
+      )
+      .all() as unknown as AppliedMigrationRow[];
+
+    return new Map(rows.map((row) => [row.version, row]));
+  }
+
+  private applyMigration(db: DatabaseSync, migration: SqliteMigration, checksum: string): void {
+    const startedAt = Date.now();
+
+    try {
+      db.exec('BEGIN IMMEDIATE;');
+      db.exec(migration.up);
+
+      const executionMs = Date.now() - startedAt;
+      db.prepare(
+        `
+          INSERT INTO schema_migrations (version, name, checksum, applied_at, execution_ms)
+          VALUES (?, ?, ?, ?, ?)
+        `
+      ).run(migration.version, migration.name, checksum, new Date().toISOString(), executionMs);
+
+      db.exec('COMMIT;');
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // The original migration error is the actionable failure.
+      }
+
+      throw new Error(`SQLite migration ${migration.version} (${migration.name}) failed`, {
+        cause: error,
+      });
+    }
+  }
+
+  private isMemoryDatabase(): boolean {
+    return this.databasePath === ':memory:';
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -1,0 +1,64 @@
+export interface SqliteMigration {
+  version: number;
+  name: string;
+  up: string;
+}
+
+export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
+  {
+    version: 1,
+    name: '0001_initial_workspace_foundation',
+    up: `
+      CREATE TABLE IF NOT EXISTS workspaces (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL UNIQUE,
+        name TEXT NOT NULL,
+        description TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL,
+        email TEXT UNIQUE,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS workspace_memberships (
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        role TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member', 'viewer')),
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        PRIMARY KEY (workspace_id, user_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_memberships_user_id
+        ON workspace_memberships(user_id);
+    `,
+  },
+  {
+    version: 2,
+    name: '0002_seed_local_workspace',
+    up: `
+      INSERT OR IGNORE INTO workspaces (id, slug, name, description)
+      VALUES (
+        'local',
+        'local',
+        'Local Workspace',
+        'Default local workspace used for v5 migration and single-user mode.'
+      );
+
+      INSERT OR IGNORE INTO users (id, display_name, email)
+      VALUES ('local-user', 'Local User', NULL);
+
+      INSERT OR IGNORE INTO workspace_memberships (workspace_id, user_id, role)
+      VALUES ('local', 'local-user', 'owner');
+    `,
+  },
+];
+
+export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {
+  return [...migrations].sort((a, b) => a.version - b.version);
+}

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -1,0 +1,53 @@
+import type { StorageProvider } from '../interfaces.js';
+import { FileStorageProvider, type FileStorageOptions } from '../file-storage.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from './database.js';
+
+export interface SqliteStorageOptions {
+  database?: SqliteConnectionOptions;
+  fileStorageOptions?: FileStorageOptions;
+}
+
+export class SqliteStorageProvider implements StorageProvider {
+  readonly tasks: StorageProvider['tasks'];
+  readonly settings: StorageProvider['settings'];
+  readonly activities: StorageProvider['activities'];
+  readonly templates: StorageProvider['templates'];
+  readonly statusHistory: StorageProvider['statusHistory'];
+  readonly managedLists: StorageProvider['managedLists'];
+  readonly telemetry: StorageProvider['telemetry'];
+
+  private readonly sqlite: SqliteDatabase;
+  private readonly fileProvider: FileStorageProvider;
+
+  constructor(options: SqliteStorageOptions = {}) {
+    this.sqlite = new SqliteDatabase(options.database);
+    this.fileProvider = new FileStorageProvider(options.fileStorageOptions);
+
+    // Repository parity lands incrementally in #330+. Until then, SQLite mode
+    // owns the database lifecycle while delegating existing behavior to files.
+    this.tasks = this.fileProvider.tasks;
+    this.settings = this.fileProvider.settings;
+    this.activities = this.fileProvider.activities;
+    this.templates = this.fileProvider.templates;
+    this.statusHistory = this.fileProvider.statusHistory;
+    this.managedLists = this.fileProvider.managedLists;
+    this.telemetry = this.fileProvider.telemetry;
+  }
+
+  getDatabase(): SqliteDatabase {
+    return this.sqlite;
+  }
+
+  async initialize(): Promise<void> {
+    this.sqlite.open();
+    await this.fileProvider.initialize();
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      await this.fileProvider.shutdown();
+    } finally {
+      this.sqlite.close();
+    }
+  }
+}

--- a/server/src/storage/sqlite/test-helpers.ts
+++ b/server/src/storage/sqlite/test-helpers.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SqliteDatabase, type SqliteConnectionOptions } from './database.js';
+
+export interface TestSqliteDatabase {
+  database: SqliteDatabase;
+  databasePath: string;
+  rootDir: string;
+  cleanup(): void;
+}
+
+export function createTestSqliteDatabase(
+  options: Omit<SqliteConnectionOptions, 'databasePath'> = {}
+): TestSqliteDatabase {
+  const rootDir = mkdtempSync(join(tmpdir(), 'veritas-sqlite-'));
+  const databasePath = join(rootDir, 'veritas-test.db');
+  const database = new SqliteDatabase({
+    ...options,
+    databasePath,
+  });
+
+  return {
+    database,
+    databasePath,
+    rootDir,
+    cleanup() {
+      database.close();
+      rmSync(rootDir, { recursive: true, force: true });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- adds a dependency-free Node `node:sqlite` database foundation with safe PRAGMAs, schema_migrations tracking, checksum validation, and transactional migration rollback
- adds the SQLite storage provider shell, lifecycle shutdown, and isolated SQLite test helpers while file repositories remain the default behavior
- wires `VERITAS_STORAGE=file|sqlite` plus `VERITAS_SQLITE_PATH` through env validation, docs, and server startup/shutdown

Closes #329.

## Verification

- `./node_modules/.bin/prettier --check docs/SQLITE-SCHEMA.md server/src/config/env.ts server/src/index.ts server/src/storage/index.ts server/src/storage/sqlite/database.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/sqlite-storage.ts server/src/storage/sqlite/test-helpers.ts server/src/__tests__/config/env.test.ts server/src/__tests__/storage/sqlite-database.test.ts server/src/__tests__/storage/sqlite-storage.test.ts`
- `./node_modules/.bin/eslint server/src --ext .ts --quiet`
- `pnpm --filter @veritas-kanban/server test -- src/__tests__/storage/sqlite-database.test.ts src/__tests__/storage/sqlite-storage.test.ts src/__tests__/config/env.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`
- SQLite startup smoke with `VERITAS_STORAGE=sqlite` against a fresh temp data dir and `/api/health` returning ok

## Notes

- File storage remains the default until the provider parity and migration/import issues land. SQLite mode currently owns database lifecycle and migrations, then delegates existing repositories to file storage.