### PR TITLE
feat: add SQLite task repository parity

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -847,6 +847,25 @@ tracking while repository parity is implemented in the following provider
 issues. File storage remains the default until the migration/import path is
 complete.
 
+## Task Repository Implementation
+
+The first SQLite task repository stores the complete shared `Task` payload as
+JSON while also maintaining indexed columns for board and API access patterns:
+`status`, `priority`, `type`, `project`, `sprint`, `position`, timestamps, and
+storage state. This keeps all existing task fields round-trippable while later
+migrations can normalize high-value child collections without losing data.
+
+Task storage states replace filesystem moves:
+
+| State      | Meaning                                      |
+| ---------- | -------------------------------------------- |
+| `active`   | Visible on the active board.                 |
+| `archived` | Hidden from active lists, restorable later.  |
+| `backlog`  | Reserved for the backlog provider migration. |
+
+`task_search` is maintained by SQLite repository writes so title/description
+search can use FTS5 in SQLite mode.
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/src/__tests__/routes/tasks-sqlite.test.ts
+++ b/server/src/__tests__/routes/tasks-sqlite.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { TaskService } from '../../services/task-service.js';
+import { TelemetryService } from '../../services/telemetry-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+describe('Tasks Routes with SQLite TaskService', () => {
+  let app: express.Express;
+  let fixture: TestSqliteDatabase;
+  let taskService: TaskService;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-routes-sqlite-'));
+
+    taskService = new TaskService({
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+      tasksDir: path.join(testRoot, 'tasks', 'active'),
+      archiveDir: path.join(testRoot, 'tasks', 'archive'),
+      telemetryService: new TelemetryService({
+        telemetryDir: path.join(testRoot, 'telemetry'),
+        config: { enabled: false },
+      }),
+    });
+
+    const router = express.Router();
+    router.get('/', async (_req, res) => {
+      res.json(await taskService.listTasks());
+    });
+    router.post('/', async (req, res) => {
+      res.status(201).json(await taskService.createTask(req.body));
+    });
+    router.patch('/:id', async (req, res) => {
+      const task = await taskService.updateTask(req.params.id, req.body);
+      if (!task) {
+        res.status(404).json({ error: 'Task not found' });
+        return;
+      }
+      res.json(task);
+    });
+    router.delete('/:id', async (req, res) => {
+      const deleted = await taskService.deleteTask(req.params.id);
+      if (!deleted) {
+        res.status(404).json({ error: 'Task not found' });
+        return;
+      }
+      res.status(204).send();
+    });
+    router.post('/reorder', async (req, res) => {
+      res.json({ updated: (await taskService.reorderTasks(req.body.orderedIds)).length });
+    });
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/tasks', router);
+    app.use(errorHandler);
+  });
+
+  afterEach(async () => {
+    taskService.dispose();
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('returns equivalent CRUD responses without task markdown files', async () => {
+    const createRes = await request(app).post('/api/tasks').send({
+      title: 'SQLite API task',
+      description: 'Created through the API route shape',
+      type: 'feature',
+      priority: 'high',
+      project: 'veritas',
+    });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.title).toBe('SQLite API task');
+    expect(createRes.body.status).toBe('todo');
+
+    const patchRes = await request(app)
+      .patch(`/api/tasks/${createRes.body.id}`)
+      .send({ title: 'Updated SQLite API task', position: 2 });
+
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.title).toBe('Updated SQLite API task');
+    expect(patchRes.body.position).toBe(2);
+
+    const listRes = await request(app).get('/api/tasks');
+    expect(listRes.status).toBe(200);
+    expect(listRes.body).toHaveLength(1);
+
+    const deleteRes = await request(app).delete(`/api/tasks/${createRes.body.id}`);
+    expect(deleteRes.status).toBe(204);
+
+    const emptyListRes = await request(app).get('/api/tasks');
+    expect(emptyListRes.body).toEqual([]);
+
+    await expect(fs.readdir(path.join(testRoot, 'tasks', 'active'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('supports reorder responses with SQLite-backed position updates', async () => {
+    const first = await taskService.createTask({ title: 'First' });
+    const second = await taskService.createTask({ title: 'Second' });
+
+    const reorderRes = await request(app)
+      .post('/api/tasks/reorder')
+      .send({ orderedIds: [second.id, first.id] });
+
+    expect(reorderRes.status).toBe(200);
+    expect(reorderRes.body.updated).toBe(2);
+    expect((await taskService.getTask(second.id))?.position).toBe(0);
+    expect((await taskService.getTask(first.id))?.position).toBe(1);
+  });
+});

--- a/server/src/__tests__/storage/sqlite-task-repository.test.ts
+++ b/server/src/__tests__/storage/sqlite-task-repository.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import type { Task } from '@veritas-kanban/shared';
+import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+import { SqliteTaskRepository } from '../../storage/sqlite/task-repository.js';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  const now = new Date().toISOString();
+  return {
+    id: `task_20260530_${Math.random().toString(36).slice(2, 8)}`,
+    title: 'SQLite Task',
+    description: 'Persisted in SQLite',
+    type: 'code',
+    status: 'todo',
+    priority: 'medium',
+    created: now,
+    updated: now,
+    ...overrides,
+  };
+}
+
+describe('SqliteTaskRepository', () => {
+  it('persists and reads full task JSON with indexed fields', async () => {
+    const fixture = createTestSqliteDatabase();
+    const task = makeTask({
+      title: 'Full fidelity task',
+      description: 'Includes nested task details',
+      project: 'veritas',
+      sprint: 'v5',
+      github: { issueNumber: 330, repo: 'BradGroux/veritas-kanban' },
+      subtasks: [
+        {
+          id: 'subtask-1',
+          title: 'Wire repository',
+          completed: false,
+          created: new Date().toISOString(),
+          acceptanceCriteria: ['CRUD works'],
+          criteriaChecked: [false],
+        },
+      ],
+      comments: [
+        {
+          id: 'comment-1',
+          author: 'tester',
+          text: 'Preserve comments',
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      observations: [
+        {
+          id: 'observation-1',
+          type: 'decision',
+          content: 'Use JSON payload plus indexed columns',
+          score: 8,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      deliverables: [
+        {
+          id: 'deliverable-1',
+          title: 'Patch',
+          type: 'code',
+          status: 'attached',
+          created: new Date().toISOString(),
+        },
+      ],
+      verificationSteps: [
+        {
+          id: 'verify-1',
+          description: 'Run tests',
+          checked: false,
+        },
+      ],
+      timeTracking: {
+        entries: [],
+        totalSeconds: 120,
+        isRunning: false,
+      },
+      position: 3,
+    });
+
+    try {
+      fixture.database.open();
+      const repo = new SqliteTaskRepository(fixture.database);
+
+      await repo.create(task);
+
+      expect(await repo.findById(task.id)).toEqual(task);
+      expect(await repo.findAll()).toEqual([task]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('updates, archives, restores, and deletes active tasks without file moves', async () => {
+    const fixture = createTestSqliteDatabase();
+    const task = makeTask({ title: 'Lifecycle task' });
+
+    try {
+      fixture.database.open();
+      const repo = new SqliteTaskRepository(fixture.database);
+
+      await repo.create(task);
+      const updated = await repo.update(task.id, { title: 'Updated lifecycle task', position: 1 });
+
+      expect(updated.title).toBe('Updated lifecycle task');
+      expect(updated.position).toBe(1);
+
+      expect(await repo.archive(task.id)).toBe(true);
+      expect(await repo.findById(task.id)).toBeNull();
+      expect((await repo.listArchived()).map((archived) => archived.id)).toEqual([task.id]);
+
+      const restored = await repo.restore(task.id);
+      expect(restored?.status).toBe('done');
+      expect(await repo.findArchivedById(task.id)).toBeNull();
+      expect(await repo.findById(task.id)).toEqual(restored);
+
+      await repo.delete(task.id);
+      expect(await repo.findById(task.id)).toBeNull();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('uses FTS-backed search for active task title and description', async () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+      const repo = new SqliteTaskRepository(fixture.database);
+
+      const matching = makeTask({
+        title: 'FTS search target',
+        description: 'Contains the uncommon persistence-token phrase',
+      });
+      const nonMatching = makeTask({
+        title: 'Different task',
+        description: 'No matching content',
+      });
+
+      await repo.create(matching);
+      await repo.create(nonMatching);
+
+      const results = await repo.search('persistence-token');
+
+      expect(results.map((task) => task.id)).toEqual([matching.id]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/__tests__/task-service-sqlite.test.ts
+++ b/server/src/__tests__/task-service-sqlite.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { TaskService } from '../services/task-service.js';
+import { TelemetryService } from '../services/telemetry-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../storage/sqlite/test-helpers.js';
+
+describe('TaskService SQLite mode', () => {
+  let fixture: TestSqliteDatabase;
+  let service: TaskService;
+  let testRoot: string;
+  let tasksDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-task-service-sqlite-'));
+    tasksDir = path.join(testRoot, 'tasks', 'active');
+    archiveDir = path.join(testRoot, 'tasks', 'archive');
+
+    service = new TaskService({
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+      tasksDir,
+      archiveDir,
+      telemetryService: new TelemetryService({
+        telemetryDir: path.join(testRoot, 'telemetry'),
+        config: { enabled: false },
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    service.dispose();
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('creates, lists, updates, and reorders tasks through SQLite persistence', async () => {
+    const first = await service.createTask({
+      title: 'First SQLite task',
+      description: 'Stored in sqlite',
+      type: 'feature',
+      priority: 'high',
+      project: 'veritas',
+      sprint: 'v5',
+    });
+    const second = await service.createTask({ title: 'Second SQLite task' });
+
+    const updated = await service.updateTask(first.id, {
+      title: 'Updated SQLite task',
+      position: 9,
+      comments: [
+        {
+          id: 'comment-1',
+          author: 'tester',
+          text: 'SQLite comment',
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    });
+
+    expect(updated?.title).toBe('Updated SQLite task');
+    expect(updated?.comments?.[0]?.text).toBe('SQLite comment');
+
+    const reordered = await service.reorderTasks([second.id, first.id]);
+    expect(reordered).toHaveLength(2);
+
+    const tasks = await service.listTasks();
+    expect(tasks.map((task) => task.id).sort()).toEqual([first.id, second.id].sort());
+
+    await expect(fs.readdir(tasksDir)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('archives, lists archived tasks, restores, and deletes without task files', async () => {
+    const task = await service.createTask({ title: 'Archive SQLite task' });
+
+    expect(await service.archiveTask(task.id)).toBe(true);
+    expect(await service.getTask(task.id)).toBeNull();
+
+    const archived = await service.listArchivedTasks();
+    expect(archived.map((archivedTask) => archivedTask.id)).toEqual([task.id]);
+
+    const restored = await service.restoreTask(task.id);
+    expect(restored?.id).toBe(task.id);
+    expect(restored?.status).toBe('done');
+    expect(await service.listArchivedTasks()).toEqual([]);
+
+    expect(await service.deleteTask(task.id)).toBe(true);
+    expect(await service.getTask(task.id)).toBeNull();
+    await expect(fs.readdir(archiveDir)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -31,6 +31,8 @@ import {
   type TaskSyncContext,
 } from './agent-registry-service.js';
 import { getTasksActiveDir, getTasksArchiveDir } from '../utils/paths.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteTaskRepository } from '../storage/sqlite/task-repository.js';
 
 const log = createLogger('task-cache');
 const TASK_SYNC_CONTEXT: TaskSyncContext = createTaskSyncToken('task-service');
@@ -71,6 +73,9 @@ export interface TaskServiceOptions {
   tasksDir?: string;
   archiveDir?: string;
   telemetryService?: TelemetryService;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 /** Ignore file-watcher events within this window after our own writes */
@@ -80,6 +85,9 @@ export class TaskService {
   private tasksDir: string;
   private archiveDir: string;
   private telemetry: TelemetryService;
+  private sqliteDatabase: SqliteDatabase | null = null;
+  private sqliteTasks: SqliteTaskRepository | null = null;
+  private sqliteMutationQueue: Promise<unknown> = Promise.resolve();
 
   // ============ In-Memory Cache ============
   private cache: Map<string, Task> = new Map();
@@ -95,7 +103,18 @@ export class TaskService {
     this.tasksDir = options.tasksDir || DEFAULT_TASKS_DIR;
     this.archiveDir = options.archiveDir || DEFAULT_ARCHIVE_DIR;
     this.telemetry = options.telemetryService || getTelemetryService();
-    this.ensureDirectories();
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.sqliteDatabase.open();
+      this.sqliteTasks = new SqliteTaskRepository(this.sqliteDatabase);
+    } else {
+      this.ensureDirectories();
+    }
+
     this.startTaskSyncReconciler();
   }
 
@@ -106,6 +125,8 @@ export class TaskService {
    * Safe to call multiple times; only the first call does work.
    */
   private async initCache(): Promise<void> {
+    if (this.sqliteTasks) return;
+
     if (this.cacheInitialized) return;
 
     // Prevent concurrent initialization (e.g. parallel listTasks + getTask)
@@ -209,6 +230,15 @@ export class TaskService {
     return deleted;
   }
 
+  private runSqliteMutation<T>(callback: () => Promise<T>): Promise<T> {
+    const run = this.sqliteMutationQueue.then(callback, callback);
+    this.sqliteMutationQueue = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
   /** Get a task from the cache */
   private cacheGet(id: string): Task | undefined {
     const task = this.cache.get(id);
@@ -264,6 +294,9 @@ export class TaskService {
       clearInterval(this.taskSyncReconcileInterval);
       this.taskSyncReconcileInterval = null;
     }
+    this.sqliteDatabase?.close();
+    this.sqliteDatabase = null;
+    this.sqliteTasks = null;
     this.cache.clear();
     this.cacheInitialized = false;
     this.cacheLoading = null;
@@ -519,6 +552,10 @@ export class TaskService {
   }
 
   async listTasks(): Promise<Task[]> {
+    if (this.sqliteTasks) {
+      return this.sqliteTasks.findAll();
+    }
+
     await this.initCache();
     return this.cacheList();
   }
@@ -551,6 +588,10 @@ export class TaskService {
   }
 
   async getTask(id: string): Promise<Task | null> {
+    if (this.sqliteTasks) {
+      return this.sqliteTasks.findById(id);
+    }
+
     await this.initCache();
     return this.cacheGet(id) ?? null;
   }
@@ -589,17 +630,22 @@ export class TaskService {
       }
     }
 
-    const filename = this.taskToFilename(task);
-    const filepath = path.join(this.tasksDir, filename);
-    const content = this.taskToMarkdown(task);
+    if (this.sqliteTasks) {
+      const sqliteTasks = this.sqliteTasks;
+      await this.runSqliteMutation(() => sqliteTasks.create(task));
+    } else {
+      const filename = this.taskToFilename(task);
+      const filepath = path.join(this.tasksDir, filename);
+      const content = this.taskToMarkdown(task);
 
-    await withFileLock(filepath, async () => {
-      this.markWrite();
-      await fs.writeFile(filepath, content, 'utf-8');
-    });
+      await withFileLock(filepath, async () => {
+        this.markWrite();
+        await fs.writeFile(filepath, content, 'utf-8');
+      });
 
-    // Write-through: update cache immediately
-    this.cache.set(task.id, task);
+      // Write-through: update cache immediately
+      this.cache.set(task.id, task);
+    }
 
     // Emit telemetry event
     await this.telemetry.emit<TaskTelemetryEvent>({
@@ -640,12 +686,22 @@ export class TaskService {
     const filepath = path.join(this.tasksDir, newFilename);
 
     let updatedTask!: Task;
+    const runMutation = async (callback: () => Promise<void>): Promise<void> => {
+      if (this.sqliteTasks) {
+        await this.runSqliteMutation(callback);
+        return;
+      }
 
-    await withFileLock(filepath, async () => {
+      await withFileLock(filepath, callback);
+    };
+
+    await runMutation(async () => {
       // Re-read from cache inside the lock to get the latest state.
       // This prevents concurrent writes (e.g., debounced field save vs.
       // timer start) from overwriting each other's changes.
-      const freshTask = this.cacheGet(id) ?? task;
+      const freshTask = this.sqliteTasks
+        ? ((await this.sqliteTasks.findById(id)) ?? task)
+        : (this.cacheGet(id) ?? task);
 
       const previousStatus = freshTask.status;
       const statusChanged = input.status !== undefined && input.status !== previousStatus;
@@ -812,17 +868,21 @@ export class TaskService {
         updated: new Date().toISOString(),
       };
 
-      const content = this.taskToMarkdown(updatedTask);
-      this.markWrite();
+      if (this.sqliteTasks) {
+        await this.sqliteTasks.replaceActive(updatedTask);
+      } else {
+        const content = this.taskToMarkdown(updatedTask);
+        this.markWrite();
 
-      if (oldFilename !== newFilename) {
-        // Intentionally silent: old file may already be gone after rename
-        await fs.unlink(path.join(this.tasksDir, oldFilename)).catch(() => {});
+        if (oldFilename !== newFilename) {
+          // Intentionally silent: old file may already be gone after rename
+          await fs.unlink(path.join(this.tasksDir, oldFilename)).catch(() => {});
+        }
+        await fs.writeFile(filepath, content, 'utf-8');
+
+        // Write-through: update cache immediately (inside lock for consistency)
+        this.cache.set(updatedTask.id, updatedTask);
       }
-      await fs.writeFile(filepath, content, 'utf-8');
-
-      // Write-through: update cache immediately (inside lock for consistency)
-      this.cache.set(updatedTask.id, updatedTask);
 
       // Emit telemetry event if status changed
       if (statusChanged) {
@@ -944,6 +1004,11 @@ export class TaskService {
     const task = await this.getTask(id);
     if (!task) return false;
 
+    if (this.sqliteTasks) {
+      const sqliteTasks = this.sqliteTasks;
+      return this.runSqliteMutation(() => sqliteTasks.deleteActive(id));
+    }
+
     // Find ALL files on disk with this task ID (handles orphaned slug variations)
     const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
     if (allFilenames.length === 0) {
@@ -977,6 +1042,25 @@ export class TaskService {
   async archiveTask(id: string): Promise<boolean> {
     const task = await this.getTask(id);
     if (!task) return false;
+
+    if (this.sqliteTasks) {
+      const sqliteTasks = this.sqliteTasks;
+      const archived = await this.runSqliteMutation(() => sqliteTasks.archive(id));
+      if (!archived) return false;
+
+      await this.telemetry.emit<TaskTelemetryEvent>({
+        type: 'task.archived',
+        taskId: task.id,
+        project: task.project,
+        status: task.status,
+      });
+
+      fireHook('onArchived', task).catch((err) => {
+        log.warn({ taskId: task.id }, 'onArchived hook failed: %s', err);
+      });
+
+      return true;
+    }
 
     // Find ALL files on disk with this task ID (handles orphaned slug variations)
     const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
@@ -1028,6 +1112,10 @@ export class TaskService {
   }
 
   async listArchivedTasks(): Promise<Task[]> {
+    if (this.sqliteTasks) {
+      return this.sqliteTasks.listArchived();
+    }
+
     await this.ensureDirectories();
 
     const files = await fs.readdir(this.archiveDir);
@@ -1052,11 +1140,30 @@ export class TaskService {
   }
 
   async getArchivedTask(id: string): Promise<Task | null> {
+    if (this.sqliteTasks) {
+      return this.sqliteTasks.findArchivedById(id);
+    }
+
     const tasks = await this.listArchivedTasks();
     return tasks.find((t) => t.id === id) || null;
   }
 
   async restoreTask(id: string): Promise<Task | null> {
+    if (this.sqliteTasks) {
+      const sqliteTasks = this.sqliteTasks;
+      const restoredTask = await this.runSqliteMutation(() => sqliteTasks.restore(id));
+      if (!restoredTask) return null;
+
+      await this.telemetry.emit<TaskTelemetryEvent>({
+        type: 'task.restored',
+        taskId: restoredTask.id,
+        project: restoredTask.project,
+        status: restoredTask.status,
+      });
+
+      return restoredTask;
+    }
+
     const task = await this.getArchivedTask(id);
     if (!task) return null;
 

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -47,6 +47,8 @@ export { SQLITE_BASE_MIGRATIONS, sortedMigrations } from './sqlite/migrations.js
 export type { SqliteMigration } from './sqlite/migrations.js';
 export { SqliteStorageProvider } from './sqlite/sqlite-storage.js';
 export type { SqliteStorageOptions } from './sqlite/sqlite-storage.js';
+export { SqliteTaskRepository } from './sqlite/task-repository.js';
+export type { TaskStorageState } from './sqlite/task-repository.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -57,6 +57,51 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
       VALUES ('local', 'local-user', 'owner');
     `,
   },
+  {
+    version: 3,
+    name: '0003_task_repository_foundation',
+    up: `
+      CREATE TABLE IF NOT EXISTS tasks (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        storage_state TEXT NOT NULL DEFAULT 'active'
+          CHECK (storage_state IN ('active', 'archived', 'backlog')),
+        title TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        priority TEXT NOT NULL,
+        project TEXT,
+        sprint TEXT,
+        position INTEGER,
+        task_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        archived_at TEXT,
+        deleted_at TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_tasks_workspace_state_updated
+        ON tasks(workspace_id, storage_state, updated_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_tasks_status_position
+        ON tasks(status, position);
+
+      CREATE INDEX IF NOT EXISTS idx_tasks_project
+        ON tasks(project);
+
+      CREATE INDEX IF NOT EXISTS idx_tasks_sprint
+        ON tasks(sprint);
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS task_search USING fts5(
+        task_id UNINDEXED,
+        title,
+        description,
+        tokenize='porter unicode61'
+      );
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -1,6 +1,7 @@
 import type { StorageProvider } from '../interfaces.js';
 import { FileStorageProvider, type FileStorageOptions } from '../file-storage.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from './database.js';
+import { SqliteTaskRepository } from './task-repository.js';
 
 export interface SqliteStorageOptions {
   database?: SqliteConnectionOptions;
@@ -8,7 +9,7 @@ export interface SqliteStorageOptions {
 }
 
 export class SqliteStorageProvider implements StorageProvider {
-  readonly tasks: StorageProvider['tasks'];
+  readonly tasks: SqliteTaskRepository;
   readonly settings: StorageProvider['settings'];
   readonly activities: StorageProvider['activities'];
   readonly templates: StorageProvider['templates'];
@@ -24,8 +25,8 @@ export class SqliteStorageProvider implements StorageProvider {
     this.fileProvider = new FileStorageProvider(options.fileStorageOptions);
 
     // Repository parity lands incrementally in #330+. Until then, SQLite mode
-    // owns the database lifecycle while delegating existing behavior to files.
-    this.tasks = this.fileProvider.tasks;
+    // owns task persistence while remaining repositories delegate to files.
+    this.tasks = new SqliteTaskRepository(this.sqlite);
     this.settings = this.fileProvider.settings;
     this.activities = this.fileProvider.activities;
     this.templates = this.fileProvider.templates;

--- a/server/src/storage/sqlite/task-repository.ts
+++ b/server/src/storage/sqlite/task-repository.ts
@@ -1,0 +1,329 @@
+import type { Task } from '@veritas-kanban/shared';
+import type { TaskRepository } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+
+export type TaskStorageState = 'active' | 'archived' | 'backlog';
+
+interface TaskRow {
+  task_json: string;
+}
+
+export class SqliteTaskRepository implements TaskRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async findAll(): Promise<Task[]> {
+    return this.listByState('active');
+  }
+
+  async findById(id: string): Promise<Task | null> {
+    return this.findByState(id, 'active');
+  }
+
+  async create(task: Task): Promise<Task> {
+    this.save(task, 'active');
+    return task;
+  }
+
+  async update(id: string, updates: Partial<Task>): Promise<Task> {
+    const existing = await this.findById(id);
+    if (!existing) {
+      throw new Error(`Task not found: ${id}`);
+    }
+
+    const updated = {
+      ...existing,
+      ...updates,
+      updated: updates.updated ?? new Date().toISOString(),
+    };
+    this.save(updated, 'active');
+    return updated;
+  }
+
+  async delete(id: string): Promise<void> {
+    const deleted = await this.deleteActive(id);
+    if (!deleted) {
+      throw new Error(`Task not found: ${id}`);
+    }
+  }
+
+  async search(query: string): Promise<Task[]> {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return this.findAll();
+    }
+
+    const db = this.database.getConnection();
+    const likeQuery = `%${trimmed.toLowerCase()}%`;
+
+    try {
+      const ftsQuery = this.toFtsQuery(trimmed);
+      const rows = db
+        .prepare(
+          `
+            SELECT t.task_json
+            FROM tasks t
+            WHERE t.storage_state = 'active'
+              AND t.deleted_at IS NULL
+              AND (
+                lower(t.id) LIKE ?
+                OR t.id IN (
+                  SELECT task_id
+                  FROM task_search
+                  WHERE task_search MATCH ?
+                )
+              )
+            ORDER BY datetime(t.updated_at) DESC
+          `
+        )
+        .all(likeQuery, ftsQuery) as unknown as TaskRow[];
+
+      return rows.map((row) => this.parseTask(row));
+    } catch {
+      const rows = db
+        .prepare(
+          `
+            SELECT task_json
+            FROM tasks
+            WHERE storage_state = 'active'
+              AND deleted_at IS NULL
+              AND (
+                lower(id) LIKE ?
+                OR lower(title) LIKE ?
+                OR lower(description) LIKE ?
+              )
+            ORDER BY datetime(updated_at) DESC
+          `
+        )
+        .all(likeQuery, likeQuery, likeQuery) as unknown as TaskRow[];
+
+      return rows.map((row) => this.parseTask(row));
+    }
+  }
+
+  async listArchived(): Promise<Task[]> {
+    return this.listByState('archived');
+  }
+
+  async findArchivedById(id: string): Promise<Task | null> {
+    return this.findByState(id, 'archived');
+  }
+
+  async replaceActive(task: Task): Promise<Task> {
+    this.save(task, 'active');
+    return task;
+  }
+
+  async deleteActive(id: string): Promise<boolean> {
+    const db = this.database.getConnection();
+    const result = this.transaction(() => {
+      this.deleteSearchRow(id);
+      return db.prepare("DELETE FROM tasks WHERE id = ? AND storage_state = 'active';").run(id);
+    });
+
+    return result.changes > 0;
+  }
+
+  async archive(id: string): Promise<boolean> {
+    const existing = await this.findById(id);
+    if (!existing) {
+      return false;
+    }
+
+    this.save(existing, 'archived', new Date().toISOString());
+    return true;
+  }
+
+  async restore(id: string): Promise<Task | null> {
+    const existing = await this.findArchivedById(id);
+    if (!existing) {
+      return null;
+    }
+
+    const restored = {
+      ...existing,
+      status: 'done' as const,
+      updated: new Date().toISOString(),
+    };
+    this.save(restored, 'active', null);
+    return restored;
+  }
+
+  async listBacklog(): Promise<Task[]> {
+    return this.listByState('backlog');
+  }
+
+  async moveToBacklog(id: string): Promise<Task | null> {
+    const existing = await this.findById(id);
+    if (!existing) {
+      return null;
+    }
+
+    this.save(existing, 'backlog');
+    return existing;
+  }
+
+  async promoteBacklog(id: string): Promise<Task | null> {
+    const existing = await this.findByState(id, 'backlog');
+    if (!existing) {
+      return null;
+    }
+
+    const activeTask = {
+      ...existing,
+      status: 'todo' as const,
+      updated: new Date().toISOString(),
+    };
+    this.save(activeTask, 'active');
+    return activeTask;
+  }
+
+  private listByState(state: TaskStorageState): Task[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT task_json
+          FROM tasks
+          WHERE storage_state = ?
+            AND deleted_at IS NULL
+          ORDER BY datetime(updated_at) DESC
+        `
+      )
+      .all(state) as unknown as TaskRow[];
+
+    return rows.map((row) => this.parseTask(row));
+  }
+
+  private findByState(id: string, state: TaskStorageState): Task | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT task_json
+          FROM tasks
+          WHERE id = ?
+            AND storage_state = ?
+            AND deleted_at IS NULL
+        `
+      )
+      .get(id, state) as TaskRow | undefined;
+
+    return row ? this.parseTask(row) : null;
+  }
+
+  private save(task: Task, state: TaskStorageState, archivedAt?: string | null): void {
+    const db = this.database.getConnection();
+    const taskJson = JSON.stringify(task);
+    const archivedValue = state === 'archived' ? (archivedAt ?? new Date().toISOString()) : null;
+
+    this.transaction(() => {
+      db.prepare(
+        `
+          INSERT INTO tasks (
+            id,
+            workspace_id,
+            storage_state,
+            title,
+            description,
+            type,
+            status,
+            priority,
+            project,
+            sprint,
+            position,
+            task_json,
+            created_at,
+            updated_at,
+            archived_at,
+            deleted_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+          ON CONFLICT(id) DO UPDATE SET
+            storage_state = excluded.storage_state,
+            title = excluded.title,
+            description = excluded.description,
+            type = excluded.type,
+            status = excluded.status,
+            priority = excluded.priority,
+            project = excluded.project,
+            sprint = excluded.sprint,
+            position = excluded.position,
+            task_json = excluded.task_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            archived_at = excluded.archived_at,
+            deleted_at = NULL
+        `
+      ).run(
+        task.id,
+        state,
+        task.title,
+        task.description ?? '',
+        task.type,
+        task.status,
+        task.priority,
+        task.project ?? null,
+        task.sprint ?? null,
+        task.position ?? null,
+        taskJson,
+        task.created,
+        task.updated,
+        archivedValue
+      );
+
+      this.upsertSearchRow(task, state);
+    });
+  }
+
+  private upsertSearchRow(task: Task, state: TaskStorageState): void {
+    this.deleteSearchRow(task.id);
+
+    if (state !== 'active') {
+      return;
+    }
+
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO task_search (task_id, title, description)
+          VALUES (?, ?, ?)
+        `
+      )
+      .run(task.id, task.title, task.description ?? '');
+  }
+
+  private deleteSearchRow(taskId: string): void {
+    this.database.getConnection().prepare('DELETE FROM task_search WHERE task_id = ?;').run(taskId);
+  }
+
+  private parseTask(row: TaskRow): Task {
+    return JSON.parse(row.task_json) as Task;
+  }
+
+  private toFtsQuery(query: string): string {
+    return query
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((term) => `"${term.replace(/"/g, '""')}"`)
+      .join(' ');
+  }
+
+  private transaction<T>(callback: () => T): T {
+    const db = this.database.getConnection();
+
+    try {
+      db.exec('BEGIN IMMEDIATE;');
+      const result = callback();
+      db.exec('COMMIT;');
+      return result;
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // Preserve the original failure.
+      }
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- adds the v5 SQLite task table, indexed task columns, and FTS5 task_search migration
- adds SqliteTaskRepository for full task JSON persistence plus active/archive/backlog state helpers
- wires TaskService SQLite mode for create/list/read/update/delete/archive/restore/reorder without task markdown writes
- preserves serialized task mutations in SQLite mode and adds repository, service, and route-shape coverage
- documents the task repository storage strategy in the SQLite schema guide

Closes #330.

## Verification

- `./node_modules/.bin/prettier --check docs/SQLITE-SCHEMA.md server/src/services/task-service.ts server/src/storage/index.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/sqlite-storage.ts server/src/storage/sqlite/task-repository.ts server/src/__tests__/storage/sqlite-task-repository.test.ts server/src/__tests__/task-service-sqlite.test.ts server/src/__tests__/routes/tasks-sqlite.test.ts`
- `./node_modules/.bin/eslint server/src/services/task-service.ts server/src/storage/index.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/sqlite-storage.ts server/src/storage/sqlite/task-repository.ts server/src/__tests__/storage/sqlite-task-repository.test.ts server/src/__tests__/task-service-sqlite.test.ts server/src/__tests__/routes/tasks-sqlite.test.ts --quiet`
- `pnpm lint`
- `pnpm lint:budget`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/server test -- src/__tests__/storage/sqlite-task-repository.test.ts src/__tests__/task-service-sqlite.test.ts src/__tests__/routes/tasks-sqlite.test.ts`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- live SQLite API smoke: POST/GET `/api/tasks` with `VERITAS_STORAGE=sqlite`, verified only `veritas.db` was created under the data dir

## Notes

- The production audit gate reports 3 moderate vulnerabilities and no high/critical failures.
- A stricter touched-file `--max-warnings=0` lint check was not used as a gate because `task-service.ts` already carries warning debt; the repo lint budget remains at 713 warnings.