### PR TITLE
feat: add SQLite configuration repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -842,9 +842,9 @@ Runtime settings:
 | `VERITAS_SQLITE_PATH` | `{runtimeDir}/veritas.db` | Overrides the SQLite database file location.     |
 | `VERITAS_DATA_DIR`    | project/runtime default   | Controls the runtime directory used by defaults. |
 
-SQLite mode currently owns database open/close, PRAGMAs, and migration
-tracking while repository parity is implemented in the following provider
-issues. File storage remains the default until the migration/import path is
+SQLite mode owns database open/close, PRAGMAs, migration tracking, task
+persistence, settings, managed lists, task templates, and prompt registry
+persistence. File storage remains the default until the migration/import path is
 complete.
 
 ## Task Repository Implementation
@@ -865,6 +865,28 @@ Task storage states replace filesystem moves:
 
 `task_search` is maintained by SQLite repository writes so title/description
 search can use FTS5 in SQLite mode.
+
+## Configuration Repository Implementation
+
+The first settings and registry repository pass uses JSON document tables with
+indexed metadata columns. This keeps v4 payloads lossless while the later
+multi-user work normalizes repositories, agents, integrations, and template
+children into the broader target schema above.
+
+| Runtime table          | Stored data                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `app_config_documents` | Full `AppConfig` document keyed by `app_config`, with default feature merge. |
+| `managed_list_items`   | Projects, sprints, task types, and other managed lists by `list_name`.       |
+| `task_templates`       | Complete `TaskTemplate` JSON plus name/category index columns.               |
+| `prompt_templates`     | Complete `PromptTemplate` JSON plus category/current-version columns.        |
+| `prompt_versions`      | Version snapshots for prompt template content and changelogs.                |
+| `prompt_usage`         | Usage records for prompt stats, token averages, and last-used timestamps.    |
+
+`ConfigService`, `ManagedListService`, `TemplateService`, and
+`PromptRegistryService` select these SQLite repositories when
+`VERITAS_STORAGE=sqlite`, so the existing REST/UI routes continue to use the
+same service contracts in both storage modes. File-backed behavior remains
+unchanged when `VERITAS_STORAGE=file`.
 
 ## Migration Numbering
 

--- a/server/src/__tests__/storage/sqlite-config-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-config-repositories.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { DEFAULT_FEATURE_SETTINGS, type ManagedListItem } from '@veritas-kanban/shared';
+import { ConfigService } from '../../services/config-service.js';
+import { ManagedListService } from '../../services/managed-list-service.js';
+import { TemplateService } from '../../services/template-service.js';
+import { PromptRegistryService } from '../../services/prompt-registry-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+interface TestListItem extends ManagedListItem {
+  color?: string;
+}
+
+describe('SQLite configuration repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-config-'));
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('stores ConfigService settings in SQLite without creating config JSON files', async () => {
+    const configFile = path.join(testRoot, '.veritas-kanban', 'config.json');
+    const service = new ConfigService({
+      configDir: path.dirname(configFile),
+      configFile,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const defaults = await service.getFeatureSettings();
+    expect(defaults).toEqual(DEFAULT_FEATURE_SETTINGS);
+
+    const updated = await service.updateFeatureSettings({
+      board: { showDashboard: false },
+      tasks: { enableTimeTracking: false },
+    });
+
+    expect(updated.board.showDashboard).toBe(false);
+    expect(updated.board.showArchiveSuggestions).toBe(
+      DEFAULT_FEATURE_SETTINGS.board.showArchiveSuggestions
+    );
+    expect(updated.tasks.enableTimeTracking).toBe(false);
+
+    const secondService = new ConfigService({
+      configDir: path.dirname(configFile),
+      configFile,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+    expect((await secondService.getFeatureSettings()).board.showDashboard).toBe(false);
+    await expect(fs.access(configFile)).rejects.toThrow();
+  });
+
+  it('supports managed list defaults, CRUD, delete safety, and reorder in SQLite', async () => {
+    const service = new ManagedListService<TestListItem>({
+      filename: 'test-items.json',
+      configDir: path.join(testRoot, '.veritas-kanban'),
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+      defaults: [
+        {
+          id: 'default-1',
+          label: 'Default One',
+          order: 0,
+          isDefault: true,
+          created: '2026-01-01T00:00:00.000Z',
+          updated: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      referenceCounter: async (id: string) => (id === 'default-1' ? 2 : 0),
+    });
+
+    expect((await service.list()).map((item) => item.id)).toEqual(['default-1']);
+    const created = await service.create({ label: 'Created Item', color: 'blue' });
+    expect(created.id).toContain('created-item');
+    expect(created.order).toBe(1);
+
+    const hidden = await service.update(created.id, { isHidden: true });
+    expect(hidden?.isHidden).toBe(true);
+    expect((await service.list()).map((item) => item.id)).toEqual(['default-1']);
+    expect(await service.list(true)).toHaveLength(2);
+
+    expect(await service.canDelete('default-1')).toMatchObject({
+      allowed: false,
+      referenceCount: 2,
+      isDefault: true,
+    });
+    expect(await service.delete('default-1')).toEqual({ deleted: false, referenceCount: 2 });
+    expect(await service.delete('default-1', true)).toEqual({ deleted: true });
+
+    await service.update(created.id, { isHidden: false });
+    const reordered = await service.reorder([created.id]);
+    expect(reordered[0].id).toBe(created.id);
+    expect(reordered[0].order).toBe(0);
+  });
+
+  it('stores task templates in SQLite with v1 update semantics', async () => {
+    const service = new TemplateService({
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const created = await service.createTemplate({
+      name: 'SQLite Template',
+      description: 'Stored in SQLite',
+      category: 'feature',
+      taskDefaults: {
+        type: 'code',
+        priority: 'medium',
+        descriptionTemplate: 'Build {{feature}}',
+      },
+      subtaskTemplates: [{ title: 'Review {{feature}}', order: 0 }],
+    });
+
+    expect(created.id).toMatch(/^template_sqlite-template_/);
+    expect(await service.getTemplate(created.id)).toEqual(created);
+
+    const updated = await service.updateTemplate(created.id, {
+      name: 'Updated SQLite Template',
+      taskDefaults: { priority: 'high' },
+    });
+    expect(updated?.taskDefaults.type).toBe('code');
+    expect(updated?.taskDefaults.priority).toBe('high');
+    expect((await service.getTemplates()).map((template) => template.name)).toEqual([
+      'Updated SQLite Template',
+    ]);
+
+    expect(await service.deleteTemplate(created.id)).toBe(true);
+    expect(await service.getTemplate(created.id)).toBeNull();
+  });
+
+  it('stores prompt templates, versions, usage, stats, and preview rendering in SQLite', async () => {
+    const service = new PromptRegistryService({
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const created = await service.createTemplate({
+      name: 'SQLite Prompt',
+      category: 'agent',
+      content: 'Hello {{ name }} from {{team}}',
+    });
+    expect(created.variables).toEqual(['name', 'team']);
+    expect(
+      (await service.getVersionHistory(created.id)).map((version) => version.versionNumber)
+    ).toEqual([1]);
+
+    await expect(service.updateTemplate(created.id, { content: 'Hello {{name}}' })).rejects.toThrow(
+      /changelog is required/
+    );
+
+    const updated = await service.updateTemplate(created.id, {
+      content: 'Hello {{name}} from {{team}} in {{env}}',
+      changelog: 'Add environment variable',
+    });
+    expect(updated?.currentVersionId).toBe(`${created.id}_v2`);
+    expect(
+      (await service.getVersionHistory(created.id)).map((version) => version.versionNumber)
+    ).toEqual([2, 1]);
+
+    await service.recordUsage(created.id, 'brad', 'Hello Brad', 'gpt', 10, 5);
+    const stats = await service.getStats(created.id);
+    expect(stats).toMatchObject({
+      templateId: created.id,
+      totalUsages: 1,
+      totalVersions: 2,
+      mostFrequentUser: 'brad',
+      averageTokensPerUsage: 15,
+    });
+
+    const preview = await service.renderPreview({
+      templateId: created.id,
+      sampleVariables: { name: 'Brad', team: 'Veritas' },
+    });
+    expect(preview.renderedPrompt).toBe('Hello Brad from Veritas in {{env}}');
+    expect(preview.unmatchedVariables).toEqual(['env']);
+
+    expect(await service.deleteTemplate(created.id)).toBe(true);
+    expect(await service.getTemplate(created.id)).toBeNull();
+    expect(await service.getVersionHistory(created.id)).toEqual([]);
+    expect(await service.getUsageRecords(created.id)).toEqual([]);
+  });
+});

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -11,6 +11,8 @@ import type {
 } from '@veritas-kanban/shared';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import { withFileLock } from './file-lock.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteSettingsRepository } from '../storage/sqlite/settings-repository.js';
 
 /** How long cached config stays valid before re-reading from disk */
 const CACHE_TTL_MS = 60_000; // 60 seconds
@@ -82,6 +84,30 @@ const DEFAULT_CONFIG: AppConfig = {
   defaultAgent: 'claude-code',
 };
 
+export function createDefaultConfig(): AppConfig {
+  return normalizeAppConfig({
+    ...cloneJson(DEFAULT_CONFIG),
+    features: cloneJson(DEFAULT_FEATURE_SETTINGS),
+  });
+}
+
+export function normalizeAppConfig(config: AppConfig): AppConfig {
+  const normalized = cloneJson(config);
+  normalized.features = deepMergeDefaults(normalized.features || {}, DEFAULT_FEATURE_SETTINGS);
+  normalized.agents = mergeDefaultAgents(normalized.agents || []);
+  return normalized;
+}
+
+function mergeDefaultAgents(agents: AgentConfig[]): AgentConfig[] {
+  const existingTypes = new Set(agents.map((agent) => agent.type));
+  const missingDefaults = DEFAULT_CONFIG.agents.filter((agent) => !existingTypes.has(agent.type));
+  return [...agents, ...cloneJson(missingDefaults)];
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
 /**
  * Keys that could lead to prototype pollution and must be rejected
  */
@@ -149,6 +175,9 @@ function deepMergeDefaults<T extends object>(target: Partial<T>, defaults: T): T
 export interface ConfigServiceOptions {
   configDir?: string;
   configFile?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 export class ConfigService {
@@ -159,10 +188,26 @@ export class ConfigService {
   private lastWriteTime: number = 0;
   private watcher: FSWatcher | null = null;
   private pendingRead: Promise<AppConfig> | null = null;
+  private sqliteDatabase: SqliteDatabase | null = null;
+  private sqliteSettings: SqliteSettingsRepository | null = null;
+  private ownsSqliteDatabase = false;
 
   constructor(options: ConfigServiceOptions = {}) {
     this.configDir = options.configDir || CONFIG_DIR;
     this.configFile = options.configFile || CONFIG_FILE;
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.sqliteSettings = new SqliteSettingsRepository(this.sqliteDatabase, {
+        defaultConfig: createDefaultConfig(),
+        normalizeConfig: normalizeAppConfig,
+      });
+    }
   }
 
   /** Check whether the in-memory cache is still usable */
@@ -206,6 +251,11 @@ export class ConfigService {
   /** Release file-watcher and clear cache (call on shutdown) */
   dispose(): void {
     this.closeWatcher();
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+    this.sqliteDatabase = null;
+    this.sqliteSettings = null;
     this.invalidateCache();
   }
 
@@ -219,11 +269,24 @@ export class ConfigService {
     // Prevent cache stampede: coalesce concurrent reads into a single disk read
     if (this.pendingRead) return this.pendingRead;
 
-    this.pendingRead = this.readConfigFromDisk().finally(() => {
+    this.pendingRead = (
+      this.sqliteSettings ? this.readConfigFromSqlite() : this.readConfigFromDisk()
+    ).finally(() => {
       this.pendingRead = null;
     });
 
     return this.pendingRead;
+  }
+
+  private async readConfigFromSqlite(): Promise<AppConfig> {
+    if (!this.sqliteSettings) {
+      throw new Error('SQLite settings repository is not configured');
+    }
+
+    const config = await this.sqliteSettings.getConfig();
+    this.config = normalizeAppConfig(config);
+    this.cacheTimestamp = Date.now();
+    return this.config;
   }
 
   private async readConfigFromDisk(): Promise<AppConfig> {
@@ -233,27 +296,19 @@ export class ConfigService {
       const content = await fs.readFile(this.configFile, 'utf-8');
       const raw = JSON.parse(content) as AppConfig;
       // Auto-merge feature defaults for backward compatibility
-      raw.features = deepMergeDefaults(raw.features || {}, DEFAULT_FEATURE_SETTINGS);
-      raw.agents = this.mergeDefaultAgents(raw.agents || []);
-      this.config = raw;
+      this.config = normalizeAppConfig(raw);
       this.cacheTimestamp = Date.now();
       this.setupWatcher();
       return this.config;
     } catch (error: any) {
       if (error.code === 'ENOENT') {
         // Create default config with features
-        const config = { ...DEFAULT_CONFIG, features: DEFAULT_FEATURE_SETTINGS };
+        const config = createDefaultConfig();
         await this.saveConfig(config);
         return config;
       }
       throw error;
     }
-  }
-
-  private mergeDefaultAgents(agents: AgentConfig[]): AgentConfig[] {
-    const existingTypes = new Set(agents.map((agent) => agent.type));
-    const missingDefaults = DEFAULT_CONFIG.agents.filter((agent) => !existingTypes.has(agent.type));
-    return [...agents, ...missingDefaults];
   }
 
   async getFeatureSettings(): Promise<FeatureSettings> {
@@ -293,6 +348,14 @@ export class ConfigService {
   }
 
   async saveConfig(config: AppConfig): Promise<void> {
+    if (this.sqliteSettings) {
+      const normalized = normalizeAppConfig(config);
+      await this.sqliteSettings.saveConfig(normalized);
+      this.config = normalized;
+      this.cacheTimestamp = Date.now();
+      return;
+    }
+
     await this.ensureConfigDir();
     this.lastWriteTime = Date.now();
     await withFileLock(this.configFile, async () => {

--- a/server/src/services/managed-list-service.ts
+++ b/server/src/services/managed-list-service.ts
@@ -5,6 +5,9 @@ import { nanoid } from 'nanoid';
 import type { ManagedListItem } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { withFileLock } from './file-lock.js';
+import type { ManagedListRepository } from '../storage/interfaces.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteManagedListRepository } from '../storage/sqlite/managed-list-repository.js';
 const log = createLogger('managed-list-service');
 
 export interface ManagedListServiceConfig<T extends ManagedListItem> {
@@ -12,6 +15,9 @@ export interface ManagedListServiceConfig<T extends ManagedListItem> {
   configDir: string;
   defaults: T[];
   referenceCounter?: (id: string) => Promise<number>;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 export class ManagedListService<T extends ManagedListItem> {
@@ -19,17 +25,32 @@ export class ManagedListService<T extends ManagedListItem> {
   private filePath: string;
   private defaults: T[];
   private referenceCounter?: (id: string) => Promise<number>;
+  private repository: ManagedListRepository<T> | null = null;
+  private sqliteDatabase: SqliteDatabase | null = null;
 
   constructor(config: ManagedListServiceConfig<T>) {
     this.filePath = join(config.configDir, config.filename);
     this.defaults = config.defaults;
     this.referenceCounter = config.referenceCounter;
+    const storageType =
+      config.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        config.sqliteDatabase ?? new SqliteDatabase(config.sqliteConnectionOptions);
+      this.sqliteDatabase.open();
+      this.repository = new SqliteManagedListRepository(this.sqliteDatabase, config);
+    }
   }
 
   /**
    * Initialize service: ensure config dir exists and seed file if missing
    */
   async init(): Promise<void> {
+    if (this.repository) {
+      return this.repository.init();
+    }
+
     const configDir = this.filePath.substring(0, this.filePath.lastIndexOf('/'));
 
     await mkdir(configDir, { recursive: true });
@@ -79,6 +100,10 @@ export class ManagedListService<T extends ManagedListItem> {
    * List all items, optionally including hidden items
    */
   async list(includeHidden = false): Promise<T[]> {
+    if (this.repository) {
+      return this.repository.list(includeHidden);
+    }
+
     await this.init();
 
     let result = [...this.items];
@@ -94,6 +119,10 @@ export class ManagedListService<T extends ManagedListItem> {
    * Get a single item by ID
    */
   async get(id: string): Promise<T | null> {
+    if (this.repository) {
+      return this.repository.get(id);
+    }
+
     await this.init();
     return this.items.find((item) => item.id === id) || null;
   }
@@ -102,6 +131,10 @@ export class ManagedListService<T extends ManagedListItem> {
    * Create a new item
    */
   async create(input: Omit<T, 'order' | 'created' | 'updated'> & { id?: string }): Promise<T> {
+    if (this.repository) {
+      return this.repository.create(input);
+    }
+
     await this.init();
 
     const now = new Date().toISOString();
@@ -137,6 +170,10 @@ export class ManagedListService<T extends ManagedListItem> {
    * Skips ID generation — caller provides the full item
    */
   async seedItem(item: T): Promise<T> {
+    if (this.repository) {
+      return this.repository.seedItem(item);
+    }
+
     this.items.push(item);
     await this.save();
     return item;
@@ -146,6 +183,10 @@ export class ManagedListService<T extends ManagedListItem> {
    * Update an existing item
    */
   async update(id: string, patch: Partial<T>): Promise<T | null> {
+    if (this.repository) {
+      return this.repository.update(id, patch);
+    }
+
     await this.init();
 
     const index = this.items.findIndex((item) => item.id === id);
@@ -170,6 +211,10 @@ export class ManagedListService<T extends ManagedListItem> {
   async canDelete(
     id: string
   ): Promise<{ allowed: boolean; referenceCount: number; isDefault: boolean }> {
+    if (this.repository) {
+      return this.repository.canDelete(id);
+    }
+
     await this.init();
 
     const item = this.items.find((item) => item.id === id);
@@ -191,6 +236,10 @@ export class ManagedListService<T extends ManagedListItem> {
    * Delete an item
    */
   async delete(id: string, force = false): Promise<{ deleted: boolean; referenceCount?: number }> {
+    if (this.repository) {
+      return this.repository.delete(id, force);
+    }
+
     await this.init();
 
     const item = this.items.find((item) => item.id === id);
@@ -216,6 +265,10 @@ export class ManagedListService<T extends ManagedListItem> {
    * Reorder items by providing ordered IDs
    */
   async reorder(orderedIds: string[]): Promise<T[]> {
+    if (this.repository) {
+      return this.repository.reorder(orderedIds);
+    }
+
     await this.init();
 
     // Create a map of id -> new order

--- a/server/src/services/prompt-registry-service.ts
+++ b/server/src/services/prompt-registry-service.ts
@@ -15,19 +15,38 @@ import type {
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
+import type { PromptRegistryRepository } from '../storage/interfaces.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqlitePromptRegistryRepository } from '../storage/sqlite/prompt-registry-repository.js';
 
 const log = createLogger('prompt-registry-service');
+
+export interface PromptRegistryServiceOptions {
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+}
 
 export class PromptRegistryService {
   private templatesDir: string;
   private versionsDir: string;
   private usageDir: string;
+  private repository: PromptRegistryRepository | null = null;
+  private sqliteDatabase: SqliteDatabase | null = null;
 
-  constructor() {
+  constructor(options: PromptRegistryServiceOptions = {}) {
     this.templatesDir = join(process.cwd(), '.veritas-kanban', 'prompt-templates');
     this.versionsDir = join(process.cwd(), '.veritas-kanban', 'prompt-versions');
     this.usageDir = join(process.cwd(), '.veritas-kanban', 'prompt-usage');
-    this.ensureDirs();
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.sqliteDatabase.open();
+      this.repository = new SqlitePromptRegistryRepository(this.sqliteDatabase);
+    }
   }
 
   private async ensureDirs() {
@@ -136,6 +155,10 @@ export class PromptRegistryService {
    * Get all templates
    */
   async getTemplates(): Promise<PromptTemplate[]> {
+    if (this.repository) {
+      return this.repository.getTemplates();
+    }
+
     await this.ensureDirs();
 
     const files = await readdir(this.templatesDir);
@@ -160,6 +183,10 @@ export class PromptRegistryService {
    * Get single template by ID
    */
   async getTemplate(id: string): Promise<PromptTemplate | null> {
+    if (this.repository) {
+      return this.repository.getTemplate(id);
+    }
+
     const path = this.templatePath(id);
 
     if (!(await fileExists(path))) {
@@ -180,6 +207,10 @@ export class PromptRegistryService {
    * Create a new prompt template
    */
   async createTemplate(input: CreatePromptTemplateInput): Promise<PromptTemplate> {
+    if (this.repository) {
+      return this.repository.createTemplate(input);
+    }
+
     await this.ensureDirs();
 
     const id = `prompt_${this.slugify(input.name)}_${Date.now()}`;
@@ -224,7 +255,14 @@ export class PromptRegistryService {
   /**
    * Update a prompt template
    */
-  async updateTemplate(id: string, input: UpdatePromptTemplateInput): Promise<PromptTemplate | null> {
+  async updateTemplate(
+    id: string,
+    input: UpdatePromptTemplateInput
+  ): Promise<PromptTemplate | null> {
+    if (this.repository) {
+      return this.repository.updateTemplate(id, input);
+    }
+
     const existing = await this.getTemplate(id);
     if (!existing) return null;
 
@@ -284,6 +322,10 @@ export class PromptRegistryService {
    * Delete a prompt template
    */
   async deleteTemplate(id: string): Promise<boolean> {
+    if (this.repository) {
+      return this.repository.deleteTemplate(id);
+    }
+
     const path = this.templatePath(id);
 
     if (!(await fileExists(path))) {
@@ -313,6 +355,10 @@ export class PromptRegistryService {
    * Get version history for a template
    */
   async getVersionHistory(templateId: string): Promise<PromptVersion[]> {
+    if (this.repository) {
+      return this.repository.getVersionHistory(templateId);
+    }
+
     await this.ensureDirs();
 
     const files = await readdir(this.versionsDir);
@@ -344,6 +390,17 @@ export class PromptRegistryService {
     inputTokens?: number,
     outputTokens?: number
   ): Promise<PromptUsage> {
+    if (this.repository) {
+      return this.repository.recordUsage(
+        templateId,
+        usedBy,
+        renderedPrompt,
+        model,
+        inputTokens,
+        outputTokens
+      );
+    }
+
     await this.ensureDirs();
 
     const now = new Date().toISOString();
@@ -383,6 +440,10 @@ export class PromptRegistryService {
    * Get usage records for a template
    */
   async getUsageRecords(templateId: string): Promise<PromptUsage[]> {
+    if (this.repository) {
+      return this.repository.getUsageRecords(templateId);
+    }
+
     const usageFile = this.usagePath(templateId);
 
     if (!(await fileExists(usageFile))) {
@@ -402,6 +463,10 @@ export class PromptRegistryService {
    * Get statistics for a template
    */
   async getStats(templateId: string): Promise<PromptStats | null> {
+    if (this.repository) {
+      return this.repository.getStats(templateId);
+    }
+
     const template = await this.getTemplate(templateId);
     if (!template) return null;
 
@@ -411,7 +476,8 @@ export class PromptRegistryService {
     // Calculate stats
     const totalUsages = usageRecords.length;
     const totalVersions = versions.length;
-    const lastUsedAt = usageRecords.length > 0 ? usageRecords[usageRecords.length - 1].usedAt : undefined;
+    const lastUsedAt =
+      usageRecords.length > 0 ? usageRecords[usageRecords.length - 1].usedAt : undefined;
 
     // Find most frequent user
     const userMap = new Map<string, number>();
@@ -423,11 +489,15 @@ export class PromptRegistryService {
     const mostFrequentUser = Array.from(userMap.entries()).sort((a, b) => b[1] - a[1])[0]?.[0];
 
     // Calculate average tokens
-    const tokensRecords = usageRecords.filter((r) => r.inputTokens !== undefined || r.outputTokens !== undefined);
+    const tokensRecords = usageRecords.filter(
+      (r) => r.inputTokens !== undefined || r.outputTokens !== undefined
+    );
     const averageTokensPerUsage =
       tokensRecords.length > 0
-        ? tokensRecords.reduce((sum, r) => sum + ((r.inputTokens ?? 0) + (r.outputTokens ?? 0)), 0) /
-          tokensRecords.length
+        ? tokensRecords.reduce(
+            (sum, r) => sum + ((r.inputTokens ?? 0) + (r.outputTokens ?? 0)),
+            0
+          ) / tokensRecords.length
         : undefined;
 
     return {
@@ -445,6 +515,10 @@ export class PromptRegistryService {
    * Get statistics for all templates
    */
   async getAllStats(): Promise<PromptStats[]> {
+    if (this.repository) {
+      return this.repository.getAllStats();
+    }
+
     const templates = await this.getTemplates();
     const stats: PromptStats[] = [];
 
@@ -462,6 +536,10 @@ export class PromptRegistryService {
    * Render preview with sample variables
    */
   async renderPreview(request: RenderPreviewRequest): Promise<RenderPreviewResponse> {
+    if (this.repository) {
+      return this.repository.renderPreview(request);
+    }
+
     const template = await this.getTemplate(request.templateId);
     if (!template) {
       throw new Error(`Template ${request.templateId} not found`);

--- a/server/src/services/template-service.ts
+++ b/server/src/services/template-service.ts
@@ -9,14 +9,33 @@ import type {
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
+import type { TemplateRepository } from '../storage/interfaces.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteTemplateRepository } from '../storage/sqlite/template-repository.js';
 const log = createLogger('template-service');
+
+export interface TemplateServiceOptions {
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+}
 
 export class TemplateService {
   private templatesDir: string;
+  private repository: TemplateRepository | null = null;
+  private sqliteDatabase: SqliteDatabase | null = null;
 
-  constructor() {
+  constructor(options: TemplateServiceOptions = {}) {
     this.templatesDir = join(process.cwd(), '.veritas-kanban', 'templates');
-    this.ensureDir();
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.sqliteDatabase.open();
+      this.repository = new SqliteTemplateRepository(this.sqliteDatabase);
+    }
   }
 
   private async ensureDir() {
@@ -96,6 +115,10 @@ export class TemplateService {
   }
 
   async getTemplates(): Promise<TaskTemplate[]> {
+    if (this.repository) {
+      return this.repository.getTemplates();
+    }
+
     await this.ensureDir();
 
     const files = await readdir(this.templatesDir);
@@ -118,6 +141,10 @@ export class TemplateService {
   }
 
   async getTemplate(id: string): Promise<TaskTemplate | null> {
+    if (this.repository) {
+      return this.repository.getTemplate(id);
+    }
+
     const path = this.templatePath(id);
 
     if (!(await fileExists(path))) {
@@ -135,6 +162,10 @@ export class TemplateService {
   }
 
   async createTemplate(input: CreateTemplateInput): Promise<TaskTemplate> {
+    if (this.repository) {
+      return this.repository.createTemplate(input);
+    }
+
     await this.ensureDir();
 
     const id = `template_${this.slugify(input.name)}_${Date.now()}`;
@@ -163,6 +194,10 @@ export class TemplateService {
   }
 
   async updateTemplate(id: string, input: UpdateTemplateInput): Promise<TaskTemplate | null> {
+    if (this.repository) {
+      return this.repository.updateTemplate(id, input);
+    }
+
     const existing = await this.getTemplate(id);
     if (!existing) return null;
 
@@ -191,6 +226,10 @@ export class TemplateService {
   }
 
   async deleteTemplate(id: string): Promise<boolean> {
+    if (this.repository) {
+      return this.repository.deleteTemplate(id);
+    }
+
     const path = this.templatePath(id);
 
     if (!(await fileExists(path))) {

--- a/server/src/storage/file-storage.ts
+++ b/server/src/storage/file-storage.ts
@@ -14,6 +14,14 @@ import type {
   CreateTemplateInput,
   UpdateTemplateInput,
   ManagedListItem,
+  PromptStats,
+  PromptTemplate,
+  PromptUsage,
+  PromptVersion,
+  CreatePromptTemplateInput,
+  UpdatePromptTemplateInput,
+  RenderPreviewRequest,
+  RenderPreviewResponse,
   TelemetryEvent,
   TelemetryEventType,
   TelemetryConfig,
@@ -26,6 +34,7 @@ import type {
   StorageProvider,
   ActivityRepository,
   TemplateRepository,
+  PromptRegistryRepository,
   StatusHistoryRepository,
   ManagedListRepository,
   ManagedListProvider,
@@ -34,7 +43,11 @@ import type {
 import { TaskService, type TaskServiceOptions } from '../services/task-service.js';
 import { ConfigService, type ConfigServiceOptions } from '../services/config-service.js';
 import { ActivityService, type Activity, type ActivityType } from '../services/activity-service.js';
-import { TemplateService } from '../services/template-service.js';
+import { TemplateService, type TemplateServiceOptions } from '../services/template-service.js';
+import {
+  PromptRegistryService,
+  type PromptRegistryServiceOptions,
+} from '../services/prompt-registry-service.js';
 import {
   StatusHistoryService,
   type StatusHistoryEntry,
@@ -185,6 +198,75 @@ export class FileTemplateRepository implements TemplateRepository {
 
   async deleteTemplate(id: string): Promise<boolean> {
     return this.service.deleteTemplate(id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FilePromptRegistryRepository
+// ---------------------------------------------------------------------------
+
+export class FilePromptRegistryRepository implements PromptRegistryRepository {
+  constructor(private readonly service: PromptRegistryService) {}
+
+  async getTemplates(): Promise<PromptTemplate[]> {
+    return this.service.getTemplates();
+  }
+
+  async getTemplate(id: string): Promise<PromptTemplate | null> {
+    return this.service.getTemplate(id);
+  }
+
+  async createTemplate(input: CreatePromptTemplateInput): Promise<PromptTemplate> {
+    return this.service.createTemplate(input);
+  }
+
+  async updateTemplate(
+    id: string,
+    input: UpdatePromptTemplateInput
+  ): Promise<PromptTemplate | null> {
+    return this.service.updateTemplate(id, input);
+  }
+
+  async deleteTemplate(id: string): Promise<boolean> {
+    return this.service.deleteTemplate(id);
+  }
+
+  async getVersionHistory(templateId: string): Promise<PromptVersion[]> {
+    return this.service.getVersionHistory(templateId);
+  }
+
+  async recordUsage(
+    templateId: string,
+    usedBy?: string,
+    renderedPrompt?: string,
+    model?: string,
+    inputTokens?: number,
+    outputTokens?: number
+  ): Promise<PromptUsage> {
+    return this.service.recordUsage(
+      templateId,
+      usedBy,
+      renderedPrompt,
+      model,
+      inputTokens,
+      outputTokens
+    );
+  }
+
+  async getUsageRecords(templateId: string): Promise<PromptUsage[]> {
+    return this.service.getUsageRecords(templateId);
+  }
+
+  async getStats(templateId: string): Promise<PromptStats | null> {
+    return this.service.getStats(templateId);
+  }
+
+  async getAllStats(): Promise<PromptStats[]> {
+    return this.service.getAllStats();
+  }
+
+  async renderPreview(request: RenderPreviewRequest): Promise<RenderPreviewResponse> {
+    return this.service.renderPreview(request);
   }
 }
 
@@ -379,6 +461,8 @@ export class FileTelemetryRepository implements TelemetryRepository {
 export interface FileStorageOptions {
   taskServiceOptions?: TaskServiceOptions;
   configServiceOptions?: ConfigServiceOptions;
+  templateServiceOptions?: TemplateServiceOptions;
+  promptRegistryServiceOptions?: PromptRegistryServiceOptions;
   telemetryServiceOptions?: TelemetryServiceOptions;
 }
 
@@ -387,6 +471,7 @@ export class FileStorageProvider implements StorageProvider {
   readonly settings: FileSettingsRepository;
   readonly activities: FileActivityRepository;
   readonly templates: FileTemplateRepository;
+  readonly promptRegistry: FilePromptRegistryRepository;
   readonly statusHistory: FileStatusHistoryRepository;
   readonly managedLists: FileManagedListProvider;
   readonly telemetry: FileTelemetryRepository;
@@ -395,6 +480,7 @@ export class FileStorageProvider implements StorageProvider {
   private configService: ConfigService;
   private activityService: ActivityService;
   private templateService: TemplateService;
+  private promptRegistryService: PromptRegistryService;
   private statusHistoryService: StatusHistoryService;
   private telemetryService: TelemetryService;
 
@@ -403,17 +489,29 @@ export class FileStorageProvider implements StorageProvider {
 
     this.taskService = new TaskService({
       ...(options.taskServiceOptions || {}),
+      storageType: 'file',
       telemetryService: this.telemetryService,
     });
-    this.configService = new ConfigService(options.configServiceOptions);
+    this.configService = new ConfigService({
+      ...(options.configServiceOptions || {}),
+      storageType: 'file',
+    });
     this.activityService = new ActivityService();
-    this.templateService = new TemplateService();
+    this.templateService = new TemplateService({
+      ...(options.templateServiceOptions || {}),
+      storageType: 'file',
+    });
+    this.promptRegistryService = new PromptRegistryService({
+      ...(options.promptRegistryServiceOptions || {}),
+      storageType: 'file',
+    });
     this.statusHistoryService = new StatusHistoryService();
 
     this.tasks = new FileTaskRepository(this.taskService);
     this.settings = new FileSettingsRepository(this.configService);
     this.activities = new FileActivityRepository(this.activityService);
     this.templates = new FileTemplateRepository(this.templateService);
+    this.promptRegistry = new FilePromptRegistryRepository(this.promptRegistryService);
     this.statusHistory = new FileStatusHistoryRepository(this.statusHistoryService);
     this.managedLists = new FileManagedListProvider();
     this.telemetry = new FileTelemetryRepository(this.telemetryService);

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -18,6 +18,7 @@ export type {
   SettingsRepository,
   ActivityRepository,
   TemplateRepository,
+  PromptRegistryRepository,
   StatusHistoryRepository,
   ManagedListRepository,
   ManagedListProvider,
@@ -30,6 +31,7 @@ export {
   FileSettingsRepository,
   FileActivityRepository,
   FileTemplateRepository,
+  FilePromptRegistryRepository,
   FileStatusHistoryRepository,
   FileManagedListRepository,
   FileManagedListProvider,
@@ -49,6 +51,13 @@ export { SqliteStorageProvider } from './sqlite/sqlite-storage.js';
 export type { SqliteStorageOptions } from './sqlite/sqlite-storage.js';
 export { SqliteTaskRepository } from './sqlite/task-repository.js';
 export type { TaskStorageState } from './sqlite/task-repository.js';
+export { SqliteSettingsRepository } from './sqlite/settings-repository.js';
+export {
+  SqliteManagedListProvider,
+  SqliteManagedListRepository,
+} from './sqlite/managed-list-repository.js';
+export { SqliteTemplateRepository } from './sqlite/template-repository.js';
+export { SqlitePromptRegistryRepository } from './sqlite/prompt-registry-repository.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -19,6 +19,14 @@ import type {
   TelemetryConfig,
   TelemetryQueryOptions,
   AnyTelemetryEvent,
+  PromptTemplate,
+  PromptVersion,
+  PromptUsage,
+  PromptStats,
+  CreatePromptTemplateInput,
+  UpdatePromptTemplateInput,
+  RenderPreviewRequest,
+  RenderPreviewResponse,
 } from '@veritas-kanban/shared';
 import type { Activity, ActivityType } from '../services/activity-service.js';
 import type {
@@ -104,6 +112,41 @@ export interface TemplateRepository {
 
   /** Delete a template by ID. Returns true if deleted, false if not found. */
   deleteTemplate(id: string): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt Registry Repository
+// ---------------------------------------------------------------------------
+
+export interface PromptRegistryRepository {
+  getTemplates(): Promise<PromptTemplate[]>;
+
+  getTemplate(id: string): Promise<PromptTemplate | null>;
+
+  createTemplate(input: CreatePromptTemplateInput): Promise<PromptTemplate>;
+
+  updateTemplate(id: string, input: UpdatePromptTemplateInput): Promise<PromptTemplate | null>;
+
+  deleteTemplate(id: string): Promise<boolean>;
+
+  getVersionHistory(templateId: string): Promise<PromptVersion[]>;
+
+  recordUsage(
+    templateId: string,
+    usedBy?: string,
+    renderedPrompt?: string,
+    model?: string,
+    inputTokens?: number,
+    outputTokens?: number
+  ): Promise<PromptUsage>;
+
+  getUsageRecords(templateId: string): Promise<PromptUsage[]>;
+
+  getStats(templateId: string): Promise<PromptStats | null>;
+
+  getAllStats(): Promise<PromptStats[]>;
+
+  renderPreview(request: RenderPreviewRequest): Promise<RenderPreviewResponse>;
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +282,7 @@ export interface StorageProvider {
   readonly settings: SettingsRepository;
   readonly activities: ActivityRepository;
   readonly templates: TemplateRepository;
+  readonly promptRegistry: PromptRegistryRepository;
   readonly statusHistory: StatusHistoryRepository;
   readonly managedLists: ManagedListProvider;
   readonly telemetry: TelemetryRepository;

--- a/server/src/storage/sqlite/managed-list-repository.ts
+++ b/server/src/storage/sqlite/managed-list-repository.ts
@@ -1,0 +1,306 @@
+import { nanoid } from 'nanoid';
+import type { ManagedListItem } from '@veritas-kanban/shared';
+import type { ManagedListProvider, ManagedListRepository } from '../interfaces.js';
+import type { ManagedListServiceConfig } from '../../services/managed-list-service.js';
+import type { SqliteDatabase } from './database.js';
+
+interface ManagedListRow {
+  item_json: string;
+}
+
+export class SqliteManagedListRepository<
+  T extends ManagedListItem,
+> implements ManagedListRepository<T> {
+  private readonly listName: string;
+  private readonly defaults: T[];
+  private readonly referenceCounter?: (id: string) => Promise<number>;
+
+  constructor(
+    private readonly database: SqliteDatabase,
+    config: ManagedListServiceConfig<T>
+  ) {
+    this.listName = config.filename.replace(/\.[^.]+$/, '');
+    this.defaults = config.defaults;
+    this.referenceCounter = config.referenceCounter;
+  }
+
+  async init(): Promise<void> {
+    const count = this.database
+      .getConnection()
+      .prepare('SELECT COUNT(*) AS count FROM managed_list_items WHERE list_name = ?')
+      .get(this.listName) as { count: number };
+
+    if (count.count === 0 && this.defaults.length > 0) {
+      this.transaction(() => {
+        for (const item of this.defaults) {
+          this.insertItem(item);
+        }
+      });
+    }
+  }
+
+  async list(includeHidden = false): Promise<T[]> {
+    await this.init();
+
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT item_json
+          FROM managed_list_items
+          WHERE list_name = ?
+            AND (? = 1 OR is_hidden = 0)
+          ORDER BY order_index ASC, item_id ASC
+        `
+      )
+      .all(this.listName, includeHidden ? 1 : 0) as unknown as ManagedListRow[];
+
+    return rows.map((row) => this.parseItem(row));
+  }
+
+  async get(id: string): Promise<T | null> {
+    await this.init();
+
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT item_json
+          FROM managed_list_items
+          WHERE list_name = ?
+            AND item_id = ?
+        `
+      )
+      .get(this.listName, id) as ManagedListRow | undefined;
+
+    return row ? this.parseItem(row) : null;
+  }
+
+  async create(input: Omit<T, 'order' | 'created' | 'updated'> & { id?: string }): Promise<T> {
+    await this.init();
+
+    const now = new Date().toISOString();
+    const id =
+      input.id || `${this.slugify((input as Pick<ManagedListItem, 'label'>).label)}-${nanoid(6)}`;
+
+    if (await this.get(id)) {
+      throw new Error(`Item with id '${id}' already exists`);
+    }
+
+    const maxOrder = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT MAX(order_index) AS maxOrder
+          FROM managed_list_items
+          WHERE list_name = ?
+        `
+      )
+      .get(this.listName) as { maxOrder: number | null };
+
+    const item = {
+      ...input,
+      id,
+      order: (maxOrder.maxOrder ?? -1) + 1,
+      created: now,
+      updated: now,
+    } as T;
+
+    this.insertItem(item);
+    return item;
+  }
+
+  async seedItem(item: T): Promise<T> {
+    await this.init();
+    this.insertItem(item);
+    return item;
+  }
+
+  async update(id: string, patch: Partial<T>): Promise<T | null> {
+    await this.init();
+
+    const existing = await this.get(id);
+    if (!existing) return null;
+
+    const updated = {
+      ...existing,
+      ...patch,
+      id,
+      updated: new Date().toISOString(),
+    } as T;
+
+    this.upsertItem(updated);
+    return updated;
+  }
+
+  async canDelete(
+    id: string
+  ): Promise<{ allowed: boolean; referenceCount: number; isDefault: boolean }> {
+    await this.init();
+
+    const item = await this.get(id);
+    if (!item) {
+      return { allowed: false, referenceCount: 0, isDefault: false };
+    }
+
+    const referenceCount = this.referenceCounter ? await this.referenceCounter(id) : 0;
+    return {
+      allowed: referenceCount === 0,
+      referenceCount,
+      isDefault: item.isDefault ?? false,
+    };
+  }
+
+  async delete(id: string, force = false): Promise<{ deleted: boolean; referenceCount?: number }> {
+    await this.init();
+
+    const item = await this.get(id);
+    if (!item) {
+      return { deleted: false };
+    }
+
+    if (!force && this.referenceCounter) {
+      const referenceCount = await this.referenceCounter(id);
+      if (referenceCount > 0) {
+        return { deleted: false, referenceCount };
+      }
+    }
+
+    const result = this.database
+      .getConnection()
+      .prepare('DELETE FROM managed_list_items WHERE list_name = ? AND item_id = ?')
+      .run(this.listName, id);
+
+    return { deleted: result.changes > 0 };
+  }
+
+  async reorder(orderedIds: string[]): Promise<T[]> {
+    await this.init();
+
+    const orderMap = new Map<string, number>();
+    orderedIds.forEach((id, index) => {
+      orderMap.set(id, index);
+    });
+
+    const items = await this.list(true);
+    const now = new Date().toISOString();
+
+    this.transaction(() => {
+      for (const item of items) {
+        const newOrder = orderMap.get(item.id);
+        if (newOrder !== undefined) {
+          this.upsertItem({
+            ...item,
+            order: newOrder,
+            updated: now,
+          });
+        }
+      }
+    });
+
+    return this.list(true);
+  }
+
+  private insertItem(item: T): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO managed_list_items (
+            list_name,
+            item_id,
+            item_json,
+            order_index,
+            is_default,
+            is_hidden,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        this.listName,
+        item.id,
+        JSON.stringify(item),
+        item.order,
+        item.isDefault ? 1 : 0,
+        item.isHidden ? 1 : 0,
+        item.created,
+        item.updated
+      );
+  }
+
+  private upsertItem(item: T): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO managed_list_items (
+            list_name,
+            item_id,
+            item_json,
+            order_index,
+            is_default,
+            is_hidden,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(list_name, item_id) DO UPDATE SET
+            item_json = excluded.item_json,
+            order_index = excluded.order_index,
+            is_default = excluded.is_default,
+            is_hidden = excluded.is_hidden,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        this.listName,
+        item.id,
+        JSON.stringify(item),
+        item.order,
+        item.isDefault ? 1 : 0,
+        item.isHidden ? 1 : 0,
+        item.created,
+        item.updated
+      );
+  }
+
+  private parseItem(row: ManagedListRow): T {
+    return JSON.parse(row.item_json) as T;
+  }
+
+  private slugify(label: string): string {
+    return label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+
+  private transaction<TValue>(callback: () => TValue): TValue {
+    const db = this.database.getConnection();
+
+    try {
+      db.exec('BEGIN IMMEDIATE;');
+      const result = callback();
+      db.exec('COMMIT;');
+      return result;
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // Preserve the original failure.
+      }
+      throw error;
+    }
+  }
+}
+
+export class SqliteManagedListProvider implements ManagedListProvider {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  create<T extends ManagedListItem>(config: ManagedListServiceConfig<T>): ManagedListRepository<T> {
+    return new SqliteManagedListRepository(this.database, config);
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -102,6 +102,82 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
       );
     `,
   },
+  {
+    version: 4,
+    name: '0004_configuration_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS app_config_documents (
+        key TEXT PRIMARY KEY,
+        document_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS managed_list_items (
+        list_name TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        item_json TEXT NOT NULL,
+        order_index INTEGER NOT NULL,
+        is_default INTEGER NOT NULL DEFAULT 0,
+        is_hidden INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (list_name, item_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_managed_list_items_order
+        ON managed_list_items(list_name, order_index);
+
+      CREATE TABLE IF NOT EXISTS task_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        category TEXT,
+        template_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_task_templates_name
+        ON task_templates(name);
+
+      CREATE TABLE IF NOT EXISTS prompt_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        category TEXT NOT NULL,
+        current_version_id TEXT NOT NULL,
+        template_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_prompt_templates_category_name
+        ON prompt_templates(category, name);
+
+      CREATE TABLE IF NOT EXISTS prompt_versions (
+        id TEXT PRIMARY KEY,
+        template_id TEXT NOT NULL,
+        version_number INTEGER NOT NULL,
+        version_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (template_id, version_number)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_prompt_versions_template
+        ON prompt_versions(template_id, version_number DESC);
+
+      CREATE TABLE IF NOT EXISTS prompt_usage (
+        id TEXT PRIMARY KEY,
+        template_id TEXT NOT NULL,
+        used_at TEXT NOT NULL,
+        used_by TEXT,
+        model TEXT,
+        usage_json TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_prompt_usage_template_used
+        ON prompt_usage(template_id, used_at);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/prompt-registry-repository.ts
+++ b/server/src/storage/sqlite/prompt-registry-repository.ts
@@ -1,0 +1,408 @@
+import type {
+  CreatePromptTemplateInput,
+  PromptStats,
+  PromptTemplate,
+  PromptUsage,
+  PromptVersion,
+  RenderPreviewRequest,
+  RenderPreviewResponse,
+  UpdatePromptTemplateInput,
+} from '@veritas-kanban/shared';
+import type { PromptRegistryRepository } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+
+interface PromptTemplateRow {
+  template_json: string;
+}
+
+interface PromptVersionRow {
+  version_json: string;
+}
+
+interface PromptUsageRow {
+  usage_json: string;
+}
+
+export class SqlitePromptRegistryRepository implements PromptRegistryRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async getTemplates(): Promise<PromptTemplate[]> {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT template_json
+          FROM prompt_templates
+          ORDER BY name COLLATE NOCASE ASC
+        `
+      )
+      .all() as unknown as PromptTemplateRow[];
+
+    return rows.map((row) => JSON.parse(row.template_json) as PromptTemplate);
+  }
+
+  async getTemplate(id: string): Promise<PromptTemplate | null> {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT template_json FROM prompt_templates WHERE id = ?')
+      .get(id) as PromptTemplateRow | undefined;
+
+    return row ? (JSON.parse(row.template_json) as PromptTemplate) : null;
+  }
+
+  async createTemplate(input: CreatePromptTemplateInput): Promise<PromptTemplate> {
+    const id = `prompt_${this.slugify(input.name)}_${Date.now()}`;
+    const now = new Date().toISOString();
+    const variables = this.extractVariables(input.content);
+
+    const template: PromptTemplate = {
+      id,
+      name: input.name,
+      description: input.description,
+      category: input.category,
+      content: input.content,
+      variables,
+      created: now,
+      updated: now,
+      currentVersionId: `${id}_v1`,
+    };
+
+    const version: PromptVersion = {
+      id: `${id}_v1`,
+      templateId: id,
+      versionNumber: 1,
+      content: input.content,
+      changelog: 'Initial version',
+      createdAt: now,
+    };
+
+    this.transaction(() => {
+      this.upsertTemplate(template);
+      this.insertVersion(version);
+    });
+
+    return template;
+  }
+
+  async updateTemplate(
+    id: string,
+    input: UpdatePromptTemplateInput
+  ): Promise<PromptTemplate | null> {
+    const existing = await this.getTemplate(id);
+    if (!existing) return null;
+
+    const now = new Date().toISOString();
+    const contentChanged = input.content !== undefined && input.content !== existing.content;
+    if (contentChanged && !input.changelog) {
+      throw new Error('changelog is required when updating template content');
+    }
+
+    const variables = contentChanged
+      ? this.extractVariables(input.content ?? '')
+      : existing.variables;
+
+    let updated: PromptTemplate | null = null;
+
+    this.transaction(() => {
+      let newVersionId = existing.currentVersionId;
+
+      if (contentChanged) {
+        const row = this.database
+          .getConnection()
+          .prepare(
+            `
+              SELECT MAX(version_number) AS maxVersion
+              FROM prompt_versions
+              WHERE template_id = ?
+            `
+          )
+          .get(id) as { maxVersion: number | null };
+
+        const nextVersionNumber = (row.maxVersion ?? 0) + 1;
+        const newVersion: PromptVersion = {
+          id: `${id}_v${nextVersionNumber}`,
+          templateId: id,
+          versionNumber: nextVersionNumber,
+          content: input.content ?? existing.content,
+          changelog: input.changelog ?? '',
+          createdAt: now,
+        };
+
+        this.insertVersion(newVersion);
+        newVersionId = newVersion.id;
+      }
+
+      updated = {
+        ...existing,
+        name: input.name ?? existing.name,
+        description: input.description ?? existing.description,
+        category: input.category ?? existing.category,
+        content: input.content ?? existing.content,
+        variables,
+        updated: now,
+        currentVersionId: newVersionId,
+      };
+
+      this.upsertTemplate(updated);
+    });
+
+    return updated;
+  }
+
+  async deleteTemplate(id: string): Promise<boolean> {
+    const existing = await this.getTemplate(id);
+    if (!existing) return false;
+
+    this.transaction(() => {
+      const db = this.database.getConnection();
+      db.prepare('DELETE FROM prompt_usage WHERE template_id = ?').run(id);
+      db.prepare('DELETE FROM prompt_versions WHERE template_id = ?').run(id);
+      db.prepare('DELETE FROM prompt_templates WHERE id = ?').run(id);
+    });
+
+    return true;
+  }
+
+  async getVersionHistory(templateId: string): Promise<PromptVersion[]> {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT version_json
+          FROM prompt_versions
+          WHERE template_id = ?
+          ORDER BY version_number DESC
+        `
+      )
+      .all(templateId) as unknown as PromptVersionRow[];
+
+    return rows.map((row) => JSON.parse(row.version_json) as PromptVersion);
+  }
+
+  async recordUsage(
+    templateId: string,
+    usedBy?: string,
+    renderedPrompt?: string,
+    model?: string,
+    inputTokens?: number,
+    outputTokens?: number
+  ): Promise<PromptUsage> {
+    const now = new Date().toISOString();
+    const usage: PromptUsage = {
+      id: `usage_${templateId}_${Date.now()}`,
+      templateId,
+      usedAt: now,
+      usedBy,
+      renderedPrompt,
+      model,
+      inputTokens,
+      outputTokens,
+    };
+
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO prompt_usage (
+            id,
+            template_id,
+            used_at,
+            used_by,
+            model,
+            usage_json
+          )
+          VALUES (?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(usage.id, templateId, now, usedBy ?? null, model ?? null, JSON.stringify(usage));
+
+    return usage;
+  }
+
+  async getUsageRecords(templateId: string): Promise<PromptUsage[]> {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT usage_json
+          FROM prompt_usage
+          WHERE template_id = ?
+          ORDER BY used_at ASC
+        `
+      )
+      .all(templateId) as unknown as PromptUsageRow[];
+
+    return rows.map((row) => JSON.parse(row.usage_json) as PromptUsage);
+  }
+
+  async getStats(templateId: string): Promise<PromptStats | null> {
+    const template = await this.getTemplate(templateId);
+    if (!template) return null;
+
+    const versions = await this.getVersionHistory(templateId);
+    const usageRecords = await this.getUsageRecords(templateId);
+    const lastUsedAt =
+      usageRecords.length > 0 ? usageRecords[usageRecords.length - 1].usedAt : undefined;
+
+    const userMap = new Map<string, number>();
+    for (const record of usageRecords) {
+      if (record.usedBy) {
+        userMap.set(record.usedBy, (userMap.get(record.usedBy) || 0) + 1);
+      }
+    }
+    const mostFrequentUser = Array.from(userMap.entries()).sort((a, b) => b[1] - a[1])[0]?.[0];
+
+    const tokenRecords = usageRecords.filter(
+      (record) => record.inputTokens !== undefined || record.outputTokens !== undefined
+    );
+    const averageTokensPerUsage =
+      tokenRecords.length > 0
+        ? tokenRecords.reduce(
+            (sum, record) => sum + (record.inputTokens ?? 0) + (record.outputTokens ?? 0),
+            0
+          ) / tokenRecords.length
+        : undefined;
+
+    return {
+      templateId,
+      templateName: template.name,
+      totalUsages: usageRecords.length,
+      totalVersions: versions.length,
+      lastUsedAt,
+      mostFrequentUser,
+      averageTokensPerUsage,
+    };
+  }
+
+  async getAllStats(): Promise<PromptStats[]> {
+    const templates = await this.getTemplates();
+    const stats = await Promise.all(templates.map((template) => this.getStats(template.id)));
+
+    return stats
+      .filter((templateStats): templateStats is PromptStats => templateStats !== null)
+      .sort((a, b) => b.totalUsages - a.totalUsages);
+  }
+
+  async renderPreview(request: RenderPreviewRequest): Promise<RenderPreviewResponse> {
+    const template = await this.getTemplate(request.templateId);
+    if (!template) {
+      throw new Error(`Template ${request.templateId} not found`);
+    }
+
+    return this.renderTemplate(template.content, request.sampleVariables);
+  }
+
+  renderTemplate(content: string, variables: Record<string, string>): RenderPreviewResponse {
+    let rendered = content;
+    const unmatchedVariables = new Set<string>();
+
+    for (const variableName of this.extractVariables(content)) {
+      const value = variables[variableName];
+      if (value !== undefined) {
+        rendered = rendered.replace(new RegExp(`\\{\\{${variableName}\\}\\}`, 'g'), value);
+      } else {
+        unmatchedVariables.add(variableName);
+      }
+    }
+
+    return {
+      renderedPrompt: rendered,
+      unmatchedVariables: Array.from(unmatchedVariables).sort(),
+    };
+  }
+
+  private upsertTemplate(template: PromptTemplate): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO prompt_templates (
+            id,
+            name,
+            category,
+            current_version_id,
+            template_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            category = excluded.category,
+            current_version_id = excluded.current_version_id,
+            template_json = excluded.template_json,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        template.id,
+        template.name,
+        template.category,
+        template.currentVersionId,
+        JSON.stringify(template),
+        template.created,
+        template.updated
+      );
+  }
+
+  private insertVersion(version: PromptVersion): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO prompt_versions (
+            id,
+            template_id,
+            version_number,
+            version_json,
+            created_at
+          )
+          VALUES (?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        version.id,
+        version.templateId,
+        version.versionNumber,
+        JSON.stringify(version),
+        version.createdAt
+      );
+  }
+
+  private extractVariables(content: string): string[] {
+    const regex = /\{\{([^}]+)\}\}/g;
+    const variables = new Set<string>();
+    let match;
+
+    while ((match = regex.exec(content)) !== null) {
+      variables.add(match[1].trim());
+    }
+
+    return Array.from(variables).sort();
+  }
+
+  private slugify(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+
+  private transaction<T>(callback: () => T): T {
+    const db = this.database.getConnection();
+
+    try {
+      db.exec('BEGIN IMMEDIATE;');
+      const result = callback();
+      db.exec('COMMIT;');
+      return result;
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // Preserve the original failure.
+      }
+      throw error;
+    }
+  }
+}

--- a/server/src/storage/sqlite/settings-repository.ts
+++ b/server/src/storage/sqlite/settings-repository.ts
@@ -1,0 +1,124 @@
+import type { AppConfig, FeatureSettings } from '@veritas-kanban/shared';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import type { SettingsRepository } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+
+const APP_CONFIG_KEY = 'app_config';
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+interface ConfigRow {
+  document_json: string;
+}
+
+export interface SqliteSettingsRepositoryOptions {
+  defaultConfig: AppConfig;
+  normalizeConfig?: (config: AppConfig) => AppConfig;
+}
+
+export class SqliteSettingsRepository implements SettingsRepository {
+  constructor(
+    private readonly database: SqliteDatabase,
+    private readonly options: SqliteSettingsRepositoryOptions
+  ) {}
+
+  async get(): Promise<FeatureSettings> {
+    const config = await this.getConfig();
+    return config.features ?? DEFAULT_FEATURE_SETTINGS;
+  }
+
+  async update(settings: Partial<FeatureSettings>): Promise<FeatureSettings> {
+    if (hasDangerousKeys(settings)) {
+      throw new Error('Invalid input: dangerous keys detected');
+    }
+
+    const config = await this.getConfig();
+    const current = config.features ?? DEFAULT_FEATURE_SETTINGS;
+    const merged = mergeFeatureSettings(current, settings);
+
+    await this.saveConfig({
+      ...config,
+      features: merged,
+    });
+
+    return merged;
+  }
+
+  async getConfig(): Promise<AppConfig> {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT document_json FROM app_config_documents WHERE key = ?')
+      .get(APP_CONFIG_KEY) as ConfigRow | undefined;
+
+    if (!row) {
+      const defaultConfig = this.normalize(cloneJson(this.options.defaultConfig));
+      await this.saveConfig(defaultConfig);
+      return defaultConfig;
+    }
+
+    return this.normalize(JSON.parse(row.document_json) as AppConfig);
+  }
+
+  async saveConfig(config: AppConfig): Promise<void> {
+    if (hasDangerousKeys(config)) {
+      throw new Error('Invalid input: dangerous keys detected');
+    }
+
+    const normalized = this.normalize(config);
+    const now = new Date().toISOString();
+    const documentJson = JSON.stringify(normalized);
+
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO app_config_documents (key, document_json, created_at, updated_at)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(key) DO UPDATE SET
+            document_json = excluded.document_json,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(APP_CONFIG_KEY, documentJson, now, now);
+  }
+
+  private normalize(config: AppConfig): AppConfig {
+    return this.options.normalizeConfig ? this.options.normalizeConfig(config) : config;
+  }
+}
+
+function mergeFeatureSettings(
+  current: FeatureSettings,
+  patch: Partial<FeatureSettings>
+): FeatureSettings {
+  const merged = { ...current } as unknown as Record<string, Record<string, unknown>>;
+
+  for (const section of Object.keys(patch)) {
+    const patchSection = (patch as Record<string, unknown>)[section];
+    if (typeof patchSection === 'object' && patchSection !== null && !Array.isArray(patchSection)) {
+      merged[section] = {
+        ...(merged[section] || {}),
+        ...(patchSection as Record<string, unknown>),
+      };
+    } else {
+      merged[section] = patchSection as Record<string, unknown>;
+    }
+  }
+
+  return merged as unknown as FeatureSettings;
+}
+
+function hasDangerousKeys(obj: unknown): boolean {
+  if (obj === null || typeof obj !== 'object') return false;
+  if (Array.isArray(obj)) return obj.some(hasDangerousKeys);
+
+  for (const key of Object.keys(obj)) {
+    if (DANGEROUS_KEYS.has(key)) return true;
+    if (hasDangerousKeys((obj as Record<string, unknown>)[key])) return true;
+  }
+
+  return false;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -2,6 +2,11 @@ import type { StorageProvider } from '../interfaces.js';
 import { FileStorageProvider, type FileStorageOptions } from '../file-storage.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from './database.js';
 import { SqliteTaskRepository } from './task-repository.js';
+import { SqliteSettingsRepository } from './settings-repository.js';
+import { SqliteManagedListProvider } from './managed-list-repository.js';
+import { SqliteTemplateRepository } from './template-repository.js';
+import { SqlitePromptRegistryRepository } from './prompt-registry-repository.js';
+import { createDefaultConfig, normalizeAppConfig } from '../../services/config-service.js';
 
 export interface SqliteStorageOptions {
   database?: SqliteConnectionOptions;
@@ -10,11 +15,12 @@ export interface SqliteStorageOptions {
 
 export class SqliteStorageProvider implements StorageProvider {
   readonly tasks: SqliteTaskRepository;
-  readonly settings: StorageProvider['settings'];
+  readonly settings: SqliteSettingsRepository;
   readonly activities: StorageProvider['activities'];
-  readonly templates: StorageProvider['templates'];
+  readonly templates: SqliteTemplateRepository;
+  readonly promptRegistry: SqlitePromptRegistryRepository;
   readonly statusHistory: StorageProvider['statusHistory'];
-  readonly managedLists: StorageProvider['managedLists'];
+  readonly managedLists: SqliteManagedListProvider;
   readonly telemetry: StorageProvider['telemetry'];
 
   private readonly sqlite: SqliteDatabase;
@@ -22,16 +28,28 @@ export class SqliteStorageProvider implements StorageProvider {
 
   constructor(options: SqliteStorageOptions = {}) {
     this.sqlite = new SqliteDatabase(options.database);
-    this.fileProvider = new FileStorageProvider(options.fileStorageOptions);
+    this.fileProvider = new FileStorageProvider({
+      ...(options.fileStorageOptions || {}),
+      taskServiceOptions: {
+        ...(options.fileStorageOptions?.taskServiceOptions || {}),
+        storageType: 'file',
+      },
+      configServiceOptions: {
+        ...(options.fileStorageOptions?.configServiceOptions || {}),
+        storageType: 'file',
+      },
+    });
 
-    // Repository parity lands incrementally in #330+. Until then, SQLite mode
-    // owns task persistence while remaining repositories delegate to files.
     this.tasks = new SqliteTaskRepository(this.sqlite);
-    this.settings = this.fileProvider.settings;
+    this.settings = new SqliteSettingsRepository(this.sqlite, {
+      defaultConfig: createDefaultConfig(),
+      normalizeConfig: normalizeAppConfig,
+    });
     this.activities = this.fileProvider.activities;
-    this.templates = this.fileProvider.templates;
+    this.templates = new SqliteTemplateRepository(this.sqlite);
+    this.promptRegistry = new SqlitePromptRegistryRepository(this.sqlite);
     this.statusHistory = this.fileProvider.statusHistory;
-    this.managedLists = this.fileProvider.managedLists;
+    this.managedLists = new SqliteManagedListProvider(this.sqlite);
     this.telemetry = this.fileProvider.telemetry;
   }
 

--- a/server/src/storage/sqlite/template-repository.ts
+++ b/server/src/storage/sqlite/template-repository.ts
@@ -1,0 +1,156 @@
+import type {
+  CreateTemplateInput,
+  TaskTemplate,
+  UpdateTemplateInput,
+} from '@veritas-kanban/shared';
+import type { TemplateRepository } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+
+interface TemplateRow {
+  template_json: string;
+}
+
+export class SqliteTemplateRepository implements TemplateRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async getTemplates(): Promise<TaskTemplate[]> {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT template_json
+          FROM task_templates
+          ORDER BY name COLLATE NOCASE ASC
+        `
+      )
+      .all() as unknown as TemplateRow[];
+
+    return rows.map((row) => this.migrateTemplate(JSON.parse(row.template_json)));
+  }
+
+  async getTemplate(id: string): Promise<TaskTemplate | null> {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT template_json FROM task_templates WHERE id = ?')
+      .get(id) as TemplateRow | undefined;
+
+    return row ? this.migrateTemplate(JSON.parse(row.template_json)) : null;
+  }
+
+  async createTemplate(input: CreateTemplateInput): Promise<TaskTemplate> {
+    const id = `template_${this.slugify(input.name)}_${Date.now()}`;
+    const now = new Date().toISOString();
+
+    const template: TaskTemplate = {
+      id,
+      name: input.name,
+      description: input.description,
+      category: input.category,
+      version: 1,
+      taskDefaults: input.taskDefaults,
+      subtaskTemplates: input.subtaskTemplates,
+      blueprint: input.blueprint,
+      created: now,
+      updated: now,
+    };
+
+    this.upsertTemplate(template);
+    return template;
+  }
+
+  async updateTemplate(id: string, input: UpdateTemplateInput): Promise<TaskTemplate | null> {
+    const existing = await this.getTemplate(id);
+    if (!existing) return null;
+
+    const updated: TaskTemplate = {
+      ...existing,
+      name: input.name ?? existing.name,
+      description: input.description ?? existing.description,
+      category: input.category ?? existing.category,
+      version: existing.version,
+      taskDefaults: {
+        ...existing.taskDefaults,
+        ...input.taskDefaults,
+      },
+      subtaskTemplates: input.subtaskTemplates ?? existing.subtaskTemplates,
+      blueprint: input.blueprint ?? existing.blueprint,
+      updated: new Date().toISOString(),
+    };
+
+    this.upsertTemplate(updated);
+    return updated;
+  }
+
+  async deleteTemplate(id: string): Promise<boolean> {
+    const result = this.database
+      .getConnection()
+      .prepare('DELETE FROM task_templates WHERE id = ?')
+      .run(id);
+
+    return result.changes > 0;
+  }
+
+  private upsertTemplate(template: TaskTemplate): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO task_templates (
+            id,
+            name,
+            category,
+            template_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            category = excluded.category,
+            template_json = excluded.template_json,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        template.id,
+        template.name,
+        template.category ?? null,
+        JSON.stringify(template),
+        template.created,
+        template.updated
+      );
+  }
+
+  private migrateTemplate(data: unknown): TaskTemplate {
+    const template = data as TaskTemplate;
+    if (template.version === 1) {
+      return template;
+    }
+
+    return {
+      id: template.id,
+      name: template.name,
+      description: template.description,
+      version: 1,
+      taskDefaults: {
+        type: template.taskDefaults?.type,
+        priority: template.taskDefaults?.priority,
+        project: template.taskDefaults?.project,
+        descriptionTemplate: template.taskDefaults?.descriptionTemplate,
+        agent: undefined,
+      },
+      category: undefined,
+      subtaskTemplates: undefined,
+      blueprint: undefined,
+      created: template.created,
+      updated: template.updated,
+    };
+  }
+
+  private slugify(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+}


### PR DESCRIPTION
## Summary

- adds SQLite migration/table support for app config, managed lists, task templates, prompt templates, prompt versions, and prompt usage
- wires ConfigService, ManagedListService, TemplateService, and PromptRegistryService into SQLite mode while preserving file-backed behavior
- exposes repository/provider implementations and documents the runtime schema
- adds SQLite configuration repository coverage and removes file-backed template constructor directory races

Closes #331.

## Verification

- `./node_modules/.bin/prettier --check docs/SQLITE-SCHEMA.md server/src/services/config-service.ts server/src/services/managed-list-service.ts server/src/services/prompt-registry-service.ts server/src/services/template-service.ts server/src/storage/file-storage.ts server/src/storage/index.ts server/src/storage/interfaces.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/sqlite-storage.ts server/src/storage/sqlite/managed-list-repository.ts server/src/storage/sqlite/prompt-registry-repository.ts server/src/storage/sqlite/settings-repository.ts server/src/storage/sqlite/template-repository.ts server/src/__tests__/storage/sqlite-config-repositories.test.ts`
- `./node_modules/.bin/eslint server/src/services/config-service.ts server/src/services/managed-list-service.ts server/src/services/prompt-registry-service.ts server/src/services/template-service.ts server/src/storage/file-storage.ts server/src/storage/index.ts server/src/storage/interfaces.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/sqlite-storage.ts server/src/storage/sqlite/managed-list-repository.ts server/src/storage/sqlite/prompt-registry-repository.ts server/src/storage/sqlite/settings-repository.ts server/src/storage/sqlite/template-repository.ts server/src/__tests__/storage/sqlite-config-repositories.test.ts --quiet`
- `pnpm --filter @veritas-kanban/server test -- src/__tests__/prompt-registry-service.test.ts src/__tests__/template-service.test.ts src/__tests__/storage/sqlite-config-repositories.test.ts`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- Live SQLite API smoke for `/api/settings/features`, `/api/projects`, `/api/templates`, `/api/prompt-registry`, prompt versions, prompt usage, prompt stats, and schema row counts