### PR TITLE
feat: add SQLite operational history repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -843,9 +843,9 @@ Runtime settings:
 | `VERITAS_DATA_DIR`    | project/runtime default   | Controls the runtime directory used by defaults. |
 
 SQLite mode owns database open/close, PRAGMAs, migration tracking, task
-persistence, settings, managed lists, task templates, and prompt registry
-persistence. File storage remains the default until the migration/import path is
-complete.
+persistence, settings, managed lists, task templates, prompt registry,
+activity/status history, and telemetry persistence. File storage remains the
+default until the migration/import path is complete.
 
 ## Task Repository Implementation
 
@@ -887,6 +887,24 @@ children into the broader target schema above.
 `VERITAS_STORAGE=sqlite`, so the existing REST/UI routes continue to use the
 same service contracts in both storage modes. File-backed behavior remains
 unchanged when `VERITAS_STORAGE=file`.
+
+## Operational Repository Implementation
+
+The first operational repository pass moves append-heavy runtime data into
+SQLite tables with JSON payload columns plus query indexes. This keeps the v4
+service contracts intact while preventing SQLite mode from writing operational
+state back to `.veritas-kanban/*.json` or telemetry NDJSON files.
+
+| Runtime table      | Stored data                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| `activity_events`  | Complete activity entries plus type, task, agent, and created-time columns.              |
+| `status_history`   | Complete status transition entries plus previous/new status and task columns.            |
+| `telemetry_events` | Complete telemetry events plus type, task, project, token, duration, and result columns. |
+
+`ActivityService`, `StatusHistoryService`, and `TelemetryService` select these
+SQLite repositories when `VERITAS_STORAGE=sqlite`. File storage still forces the
+file-backed services to `storageType='file'`, so explicit file mode cannot be
+accidentally flipped by the environment.
 
 ## Migration Numbering
 

--- a/server/src/__tests__/storage/sqlite-operational-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-operational-repositories.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import type {
+  RunCompletedEvent,
+  TaskTelemetryEvent,
+  TokenTelemetryEvent,
+} from '@veritas-kanban/shared';
+import { ActivityService } from '../../services/activity-service.js';
+import { StatusHistoryService } from '../../services/status-history-service.js';
+import { TelemetryService } from '../../services/telemetry-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+describe('SQLite operational repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-operational-'));
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('stores activities in SQLite and preserves ActivityService filtering helpers', async () => {
+    const activityFile = path.join(testRoot, '.veritas-kanban', 'activity.json');
+    const service = new ActivityService({
+      activityFile,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const started = await service.logActivity(
+      'agent_started',
+      'task_1',
+      'First task',
+      { attemptId: 'attempt_1' },
+      'codex'
+    );
+    const updated = await service.logActivity('task_updated', 'task_2', 'Second task');
+
+    expect((await service.getActivities(10)).map((activity) => activity.id).sort()).toEqual(
+      [started.id, updated.id].sort()
+    );
+    expect(await service.countActivities({ agent: 'codex' })).toBe(1);
+    expect((await service.getActivities(10, { type: 'task_updated' }))[0].id).toBe(updated.id);
+    expect((await service.getActivities(10, { taskId: 'task_1' }))[0]).toMatchObject({
+      id: started.id,
+      details: { attemptId: 'attempt_1' },
+      agent: 'codex',
+    });
+    expect(await service.getDistinctAgents()).toEqual(['codex']);
+    expect(await service.getDistinctTypes()).toEqual(['agent_started', 'task_updated']);
+
+    await service.clearActivities();
+
+    expect(await service.getActivities()).toEqual([]);
+    await expect(fs.access(activityFile)).rejects.toThrow();
+  });
+
+  it('stores status history in SQLite and computes summaries without status-history JSON', async () => {
+    const historyFile = path.join(testRoot, '.veritas-kanban', 'status-history.json');
+    const service = new StatusHistoryService({
+      historyFile,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const started = await service.logStatusChange('idle', 'working', 'task_1', 'First task', 1);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const stopped = await service.logStatusChange('working', 'idle', 'task_1', 'First task');
+
+    const history = await service.getHistory(10);
+    expect(history.map((entry) => entry.id)).toEqual([stopped.id, started.id]);
+    expect(stopped.durationMs).toBeGreaterThanOrEqual(0);
+
+    const range = await service.getHistoryByDateRange(
+      new Date(Date.now() - 1000).toISOString(),
+      new Date(Date.now() + 1000).toISOString()
+    );
+    expect(range).toHaveLength(2);
+
+    const today = new Date().toISOString().split('T')[0];
+    const daily = await service.getDailySummary(today);
+    expect(daily.date).toBe(today);
+    expect(daily.transitions).toBe(2);
+    expect(daily.periods.length).toBeGreaterThanOrEqual(1);
+    expect(await service.getWeeklySummary()).toHaveLength(7);
+
+    await service.clearHistory();
+
+    expect(await service.getHistory()).toEqual([]);
+    await expect(fs.access(historyFile)).rejects.toThrow();
+  });
+
+  it('stores telemetry in SQLite with query, export, config, and duration parity', async () => {
+    const telemetryDir = path.join(testRoot, '.veritas-kanban', 'telemetry');
+    const service = new TelemetryService({
+      telemetryDir,
+      config: { enabled: true, retention: 7 },
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const completed = await service.emit<RunCompletedEvent>({
+      type: 'run.completed',
+      taskId: 'task_1',
+      project: 'veritas',
+      agent: 'codex',
+      durationMs: 604800001,
+      exitCode: 0,
+      success: true,
+      attemptId: 'attempt_1',
+    });
+    const tokens = await service.emit<TokenTelemetryEvent>({
+      type: 'run.tokens',
+      taskId: 'task_1',
+      project: 'veritas',
+      agent: 'codex',
+      inputTokens: 100,
+      outputTokens: 25,
+      cacheTokens: 10,
+      totalTokens: 135,
+      model: 'gpt.5',
+      attemptId: 'attempt_1',
+    });
+
+    expect(completed.durationMs).toBe(604800000);
+    expect(await service.countEvents(['run.completed', 'run.tokens'])).toBe(2);
+    expect((await service.getEvents({ type: 'run.completed' })).map((event) => event.id)).toEqual([
+      completed.id,
+    ]);
+    expect(
+      (await service.getEvents({ project: 'veritas' })).map((event) => event.id).sort()
+    ).toEqual([completed.id, tokens.id].sort());
+    expect((await service.getTaskEvents('task_1')).map((event) => event.id).sort()).toEqual(
+      [completed.id, tokens.id].sort()
+    );
+
+    const bulk = await service.getBulkTaskEvents(['task_1'], 1);
+    expect(bulk.get('task_1')).toHaveLength(1);
+    expect(await service.exportAsJson({ taskId: 'task_1' })).toContain('run.completed');
+    expect(await service.exportAsCsv({ taskId: 'task_1' })).toContain('run.tokens');
+
+    service.configure({ enabled: false });
+    const disabled = await service.emit<TaskTelemetryEvent>({
+      type: 'task.created',
+      taskId: 'task_2',
+    });
+    expect(disabled.id).toMatch(/^disabled_/);
+    expect(await service.countEvents(['run.completed', 'run.tokens', 'task.created'])).toBe(2);
+
+    await service.clear();
+
+    expect(await service.getEvents()).toEqual([]);
+    await expect(fs.access(telemetryDir)).rejects.toThrow();
+  });
+});

--- a/server/src/__tests__/storage/sqlite-storage.test.ts
+++ b/server/src/__tests__/storage/sqlite-storage.test.ts
@@ -8,6 +8,9 @@ import {
   initStorage,
   shutdownStorage,
   SqliteStorageProvider,
+  SqliteActivityRepository,
+  SqliteStatusHistoryRepository,
+  SqliteTelemetryRepository,
   type FileStorageOptions,
 } from '../../storage/index.js';
 
@@ -23,6 +26,12 @@ function fileStorageOptionsFor(testRoot: string): FileStorageOptions {
     },
     telemetryServiceOptions: {
       telemetryDir: path.join(testRoot, '.veritas-kanban', 'telemetry'),
+    },
+    activityServiceOptions: {
+      activityFile: path.join(testRoot, '.veritas-kanban', 'activity.json'),
+    },
+    statusHistoryServiceOptions: {
+      historyFile: path.join(testRoot, '.veritas-kanban', 'status-history.json'),
     },
   };
 }
@@ -58,6 +67,9 @@ describe('SqliteStorageProvider', () => {
     expect(provider.getDatabase().isOpen()).toBe(true);
     expect(localWorkspace.id).toBe('local');
     expect(Array.isArray(tasks)).toBe(true);
+    expect(provider.activities).toBeInstanceOf(SqliteActivityRepository);
+    expect(provider.statusHistory).toBeInstanceOf(SqliteStatusHistoryRepository);
+    expect(provider.telemetry).toBeInstanceOf(SqliteTelemetryRepository);
 
     await provider.shutdown();
     expect(provider.getDatabase().isOpen()).toBe(false);

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -4,6 +4,9 @@ import { join } from 'path';
 import { createLogger } from '../lib/logger.js';
 import { withFileLock } from './file-lock.js';
 import { getDataDir } from '../utils/paths.js';
+import type { ActivityRepository } from '../storage/interfaces.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteActivityRepository } from '../storage/sqlite/activity-repository.js';
 const log = createLogger('activity-service');
 
 export type ActivityType =
@@ -51,13 +54,32 @@ export interface ActivityFilters {
   until?: string;
 }
 
+export interface ActivityServiceOptions {
+  activityFile?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+}
+
 export class ActivityService {
   private activityFile: string;
   private readonly MAX_ACTIVITIES = 5000; // Increased from 1000 for longer history
+  private repository: ActivityRepository | null = null;
+  private sqliteDatabase: SqliteDatabase | null = null;
+  private ownsSqliteDatabase = false;
 
-  constructor() {
-    this.activityFile = join(getDataDir(), 'activity.json');
-    this.ensureDir();
+  constructor(options: ActivityServiceOptions = {}) {
+    this.activityFile = options.activityFile || join(getDataDir(), 'activity.json');
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteActivityRepository(this.sqliteDatabase);
+    }
   }
 
   private async ensureDir() {
@@ -69,6 +91,10 @@ export class ActivityService {
    * Load all activities from disk (already sorted newest-first).
    */
   private async loadAll(): Promise<Activity[]> {
+    if (this.repository) {
+      return this.repository.getActivities(this.MAX_ACTIVITIES);
+    }
+
     await this.ensureDir();
 
     if (!(await fileExists(this.activityFile))) {
@@ -156,6 +182,10 @@ export class ActivityService {
     details?: Record<string, unknown>,
     agent?: string
   ): Promise<Activity> {
+    if (this.repository) {
+      return this.repository.logActivity(type, taskId, taskTitle, details, agent);
+    }
+
     await this.ensureDir();
 
     const activity: Activity = {
@@ -197,8 +227,21 @@ export class ActivityService {
   }
 
   async clearActivities(): Promise<void> {
+    if (this.repository) {
+      await this.repository.clearActivities();
+      return;
+    }
+
     await this.ensureDir();
     await writeFile(this.activityFile, '[]', 'utf-8');
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+    this.sqliteDatabase = null;
+    this.repository = null;
   }
 }
 

--- a/server/src/services/status-history-service.ts
+++ b/server/src/services/status-history-service.ts
@@ -3,6 +3,9 @@ import { fileExists } from '../storage/fs-helpers.js';
 import { dirname, join } from 'path';
 import { createLogger } from '../lib/logger.js';
 import { withFileLock } from './file-lock.js';
+import type { StatusHistoryRepository } from '../storage/interfaces.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteStatusHistoryRepository } from '../storage/sqlite/status-history-repository.js';
 const log = createLogger('status-history-service');
 
 export type AgentStatusState = 'idle' | 'working' | 'thinking' | 'sub-agent' | 'error';
@@ -38,6 +41,9 @@ export interface StatusPeriod {
 
 export interface StatusHistoryServiceOptions {
   historyFile?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 export class StatusHistoryService {
@@ -45,11 +51,26 @@ export class StatusHistoryService {
   private readonly MAX_ENTRIES = 5000; // Keep more entries for historical analysis
   private lastEntry: StatusHistoryEntry | null = null;
   private initPromise: Promise<void>;
+  private repository: StatusHistoryRepository | null = null;
+  private sqliteDatabase: SqliteDatabase | null = null;
+  private ownsSqliteDatabase = false;
 
   constructor(options: StatusHistoryServiceOptions = {}) {
     this.historyFile =
       options.historyFile || join(process.cwd(), '.veritas-kanban', 'status-history.json');
-    this.initPromise = this.ensureDir();
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteStatusHistoryRepository(this.sqliteDatabase);
+      this.initPromise = Promise.resolve();
+    } else {
+      this.initPromise = this.ensureDir();
+    }
   }
 
   private async ensureDir(): Promise<void> {
@@ -73,6 +94,10 @@ export class StatusHistoryService {
   }
 
   async getHistory(limit: number = 100, offset: number = 0): Promise<StatusHistoryEntry[]> {
+    if (this.repository) {
+      return this.repository.getHistory(limit, offset);
+    }
+
     await this.initPromise;
 
     if (!(await fileExists(this.historyFile))) {
@@ -96,6 +121,22 @@ export class StatusHistoryService {
     taskTitle?: string,
     subAgentCount?: number
   ): Promise<StatusHistoryEntry> {
+    if (this.repository) {
+      const entry = await this.repository.logStatusChange(
+        previousStatus,
+        newStatus,
+        taskId,
+        taskTitle,
+        subAgentCount
+      );
+
+      log.info(
+        `[StatusHistory] ${previousStatus} → ${newStatus}${taskId ? ` (task: ${taskId})` : ''}`
+      );
+
+      return entry;
+    }
+
     await this.initPromise;
 
     const now = new Date();
@@ -149,6 +190,10 @@ export class StatusHistoryService {
   }
 
   async getHistoryByDateRange(startDate: string, endDate: string): Promise<StatusHistoryEntry[]> {
+    if (this.repository) {
+      return this.repository.getHistoryByDateRange(startDate, endDate);
+    }
+
     const entries = await this.getHistory(this.MAX_ENTRIES);
     const start = new Date(startDate).getTime();
     const end = new Date(endDate).getTime();
@@ -160,6 +205,10 @@ export class StatusHistoryService {
   }
 
   async getDailySummary(date?: string): Promise<DailySummary> {
+    if (this.repository) {
+      return this.repository.getDailySummary(date);
+    }
+
     const targetDate = date || new Date().toISOString().split('T')[0];
     const startOfDay = new Date(`${targetDate}T00:00:00.000Z`);
     const endOfDay = new Date(`${targetDate}T23:59:59.999Z`);
@@ -264,6 +313,10 @@ export class StatusHistoryService {
   }
 
   async getWeeklySummary(): Promise<DailySummary[]> {
+    if (this.repository) {
+      return this.repository.getWeeklySummary();
+    }
+
     const summaries: DailySummary[] = [];
     const today = new Date();
 
@@ -278,8 +331,23 @@ export class StatusHistoryService {
   }
 
   async clearHistory(): Promise<void> {
+    if (this.repository) {
+      await this.repository.clearHistory();
+      this.lastEntry = null;
+      return;
+    }
+
     await this.initPromise;
     await writeFile(this.historyFile, '[]', 'utf-8');
+    this.lastEntry = null;
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+    this.sqliteDatabase = null;
+    this.repository = null;
     this.lastEntry = null;
   }
 }

--- a/server/src/services/telemetry-service.ts
+++ b/server/src/services/telemetry-service.ts
@@ -14,6 +14,9 @@ import type {
   AnyTelemetryEvent,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
+import type { TelemetryRepository } from '../storage/interfaces.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteTelemetryRepository } from '../storage/sqlite/telemetry-repository.js';
 const log = createLogger('telemetry-service');
 
 // Default paths - resolve via shared paths helper (respects DATA_DIR/VERITAS_DATA_DIR)
@@ -28,6 +31,9 @@ const DEFAULT_CONFIG: TelemetryConfig = {
 export interface TelemetryServiceOptions {
   telemetryDir?: string;
   config?: Partial<TelemetryConfig>;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 /**
@@ -44,6 +50,9 @@ export class TelemetryService {
   private writeQueue: Promise<void> = Promise.resolve();
   private pendingWrites: Array<TelemetryEvent> = [];
   private readonly MAX_QUEUE_SIZE = 10000;
+  private repository: TelemetryRepository | null = null;
+  private sqliteDatabase: SqliteDatabase | null = null;
+  private ownsSqliteDatabase = false;
 
   constructor(options: TelemetryServiceOptions = {}) {
     this.telemetryDir = options.telemetryDir || TELEMETRY_DIR;
@@ -66,6 +75,19 @@ export class TelemetryService {
         ? { retention: envRetentionParsed }
         : {}),
     };
+
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteTelemetryRepository(this.sqliteDatabase, {
+        config: this.config,
+      });
+    }
   }
 
   /**
@@ -73,6 +95,12 @@ export class TelemetryService {
    */
   async init(): Promise<void> {
     if (this.initialized) return;
+
+    if (this.repository) {
+      await this.repository.init();
+      this.initialized = true;
+      return;
+    }
 
     await fs.mkdir(this.telemetryDir, { recursive: true });
     await this.cleanupOldEvents();
@@ -84,12 +112,17 @@ export class TelemetryService {
    */
   configure(config: Partial<TelemetryConfig>): void {
     this.config = { ...this.config, ...config };
+    this.repository?.configure(config);
   }
 
   /**
    * Get current configuration
    */
   getConfig(): TelemetryConfig {
+    if (this.repository) {
+      return this.repository.getConfig();
+    }
+
     return { ...this.config };
   }
 
@@ -97,6 +130,10 @@ export class TelemetryService {
    * Check if telemetry is enabled
    */
   isEnabled(): boolean {
+    if (this.repository) {
+      return this.repository.isEnabled();
+    }
+
     return this.config.enabled;
   }
 
@@ -109,6 +146,11 @@ export class TelemetryService {
   async emit<T extends TelemetryEvent>(
     event: Omit<T, 'id' | 'timestamp'> & { timestamp?: string }
   ): Promise<T> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.emit(event);
+    }
+
     if (!this.config.enabled) {
       // Return a fake event when disabled
       return {
@@ -169,6 +211,11 @@ export class TelemetryService {
    * Wait for any pending writes to complete
    */
   async flush(): Promise<void> {
+    if (this.repository) {
+      await this.repository.flush();
+      return;
+    }
+
     await this.writeQueue;
   }
 
@@ -176,6 +223,11 @@ export class TelemetryService {
    * Query events with optional filters
    */
   async getEvents(options: TelemetryQueryOptions = {}): Promise<AnyTelemetryEvent[]> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.getEvents(options);
+    }
+
     await this.init();
 
     const { type, since, until, taskId, project, limit } = options;
@@ -219,6 +271,11 @@ export class TelemetryService {
    * Get events for a specific task
    */
   async getTaskEvents(taskId: string): Promise<AnyTelemetryEvent[]> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.getTaskEvents(taskId);
+    }
+
     return this.getEvents({ taskId });
   }
 
@@ -230,6 +287,11 @@ export class TelemetryService {
     taskIds: string[],
     perTaskLimit: number = 200
   ): Promise<Map<string, AnyTelemetryEvent[]>> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.getBulkTaskEvents(taskIds, perTaskLimit);
+    }
+
     if (taskIds.length === 0) {
       return new Map();
     }
@@ -275,6 +337,11 @@ export class TelemetryService {
    * Get events within a time period
    */
   async getEventsSince(since: string): Promise<AnyTelemetryEvent[]> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.getEventsSince(since);
+    }
+
     return this.getEvents({ since });
   }
 
@@ -286,6 +353,11 @@ export class TelemetryService {
     since?: string,
     until?: string
   ): Promise<number> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.countEvents(type, since, until);
+    }
+
     const events = await this.getEvents({ type, since, until });
     return events.length;
   }
@@ -294,6 +366,11 @@ export class TelemetryService {
    * Delete all events (for testing/reset)
    */
   async clear(): Promise<void> {
+    if (this.repository) {
+      await this.repository.clear();
+      return;
+    }
+
     await this.init();
     const files = await fs.readdir(this.telemetryDir);
 
@@ -308,6 +385,11 @@ export class TelemetryService {
    * Export events as JSON
    */
   async exportAsJson(options: TelemetryQueryOptions = {}): Promise<string> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.exportAsJson(options);
+    }
+
     const events = await this.getEvents(options);
     return JSON.stringify(events, null, 2);
   }
@@ -316,6 +398,11 @@ export class TelemetryService {
    * Export events as CSV
    */
   async exportAsCsv(options: TelemetryQueryOptions = {}): Promise<string> {
+    if (this.repository) {
+      await this.init();
+      return this.repository.exportAsCsv(options);
+    }
+
     const events = await this.getEvents(options);
 
     if (events.length === 0) {
@@ -565,6 +652,15 @@ export class TelemetryService {
     const gzPath = filepath + '.gz';
     await pipeline(createReadStream(filepath), createGzip(), createWriteStream(gzPath));
     await fs.unlink(filepath);
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+    this.sqliteDatabase = null;
+    this.repository = null;
+    this.initialized = false;
   }
 }
 

--- a/server/src/storage/file-storage.ts
+++ b/server/src/storage/file-storage.ts
@@ -42,7 +42,12 @@ import type {
 } from './interfaces.js';
 import { TaskService, type TaskServiceOptions } from '../services/task-service.js';
 import { ConfigService, type ConfigServiceOptions } from '../services/config-service.js';
-import { ActivityService, type Activity, type ActivityType } from '../services/activity-service.js';
+import {
+  ActivityService,
+  type Activity,
+  type ActivityType,
+  type ActivityServiceOptions,
+} from '../services/activity-service.js';
 import { TemplateService, type TemplateServiceOptions } from '../services/template-service.js';
 import {
   PromptRegistryService,
@@ -53,6 +58,7 @@ import {
   type StatusHistoryEntry,
   type DailySummary,
   type AgentStatusState,
+  type StatusHistoryServiceOptions,
 } from '../services/status-history-service.js';
 import { ManagedListService } from '../services/managed-list-service.js';
 import { TelemetryService, type TelemetryServiceOptions } from '../services/telemetry-service.js';
@@ -397,7 +403,9 @@ export class FileTelemetryRepository implements TelemetryRepository {
     return this.service.init();
   }
 
-  async emit<T extends TelemetryEvent>(event: Omit<T, 'id' | 'timestamp'>): Promise<T> {
+  async emit<T extends TelemetryEvent>(
+    event: Omit<T, 'id' | 'timestamp'> & { timestamp?: string }
+  ): Promise<T> {
     return this.service.emit(event);
   }
 
@@ -409,8 +417,11 @@ export class FileTelemetryRepository implements TelemetryRepository {
     return this.service.getTaskEvents(taskId);
   }
 
-  async getBulkTaskEvents(taskIds: string[]): Promise<Map<string, AnyTelemetryEvent[]>> {
-    return this.service.getBulkTaskEvents(taskIds);
+  async getBulkTaskEvents(
+    taskIds: string[],
+    perTaskLimit?: number
+  ): Promise<Map<string, AnyTelemetryEvent[]>> {
+    return this.service.getBulkTaskEvents(taskIds, perTaskLimit);
   }
 
   async getEventsSince(since: string): Promise<AnyTelemetryEvent[]> {
@@ -461,8 +472,10 @@ export class FileTelemetryRepository implements TelemetryRepository {
 export interface FileStorageOptions {
   taskServiceOptions?: TaskServiceOptions;
   configServiceOptions?: ConfigServiceOptions;
+  activityServiceOptions?: ActivityServiceOptions;
   templateServiceOptions?: TemplateServiceOptions;
   promptRegistryServiceOptions?: PromptRegistryServiceOptions;
+  statusHistoryServiceOptions?: StatusHistoryServiceOptions;
   telemetryServiceOptions?: TelemetryServiceOptions;
 }
 
@@ -485,7 +498,10 @@ export class FileStorageProvider implements StorageProvider {
   private telemetryService: TelemetryService;
 
   constructor(options: FileStorageOptions = {}) {
-    this.telemetryService = new TelemetryService(options.telemetryServiceOptions);
+    this.telemetryService = new TelemetryService({
+      ...(options.telemetryServiceOptions || {}),
+      storageType: 'file',
+    });
 
     this.taskService = new TaskService({
       ...(options.taskServiceOptions || {}),
@@ -496,7 +512,10 @@ export class FileStorageProvider implements StorageProvider {
       ...(options.configServiceOptions || {}),
       storageType: 'file',
     });
-    this.activityService = new ActivityService();
+    this.activityService = new ActivityService({
+      ...(options.activityServiceOptions || {}),
+      storageType: 'file',
+    });
     this.templateService = new TemplateService({
       ...(options.templateServiceOptions || {}),
       storageType: 'file',
@@ -505,7 +524,10 @@ export class FileStorageProvider implements StorageProvider {
       ...(options.promptRegistryServiceOptions || {}),
       storageType: 'file',
     });
-    this.statusHistoryService = new StatusHistoryService();
+    this.statusHistoryService = new StatusHistoryService({
+      ...(options.statusHistoryServiceOptions || {}),
+      storageType: 'file',
+    });
 
     this.tasks = new FileTaskRepository(this.taskService);
     this.settings = new FileSettingsRepository(this.configService);
@@ -527,5 +549,8 @@ export class FileStorageProvider implements StorageProvider {
     await this.telemetry.flush().catch(() => {});
     this.taskService.dispose();
     this.configService.dispose();
+    this.activityService.dispose();
+    this.statusHistoryService.dispose();
+    this.telemetryService.dispose();
   }
 }

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -58,6 +58,9 @@ export {
 } from './sqlite/managed-list-repository.js';
 export { SqliteTemplateRepository } from './sqlite/template-repository.js';
 export { SqlitePromptRegistryRepository } from './sqlite/prompt-registry-repository.js';
+export { SqliteActivityRepository } from './sqlite/activity-repository.js';
+export { SqliteStatusHistoryRepository } from './sqlite/status-history-repository.js';
+export { SqliteTelemetryRepository } from './sqlite/telemetry-repository.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -230,7 +230,9 @@ export interface TelemetryRepository {
   init(): Promise<void>;
 
   /** Emit a telemetry event. */
-  emit<T extends TelemetryEvent>(event: Omit<T, 'id' | 'timestamp'>): Promise<T>;
+  emit<T extends TelemetryEvent>(
+    event: Omit<T, 'id' | 'timestamp'> & { timestamp?: string }
+  ): Promise<T>;
 
   /** Query events with optional filters. */
   getEvents(options?: TelemetryQueryOptions): Promise<AnyTelemetryEvent[]>;
@@ -239,7 +241,10 @@ export interface TelemetryRepository {
   getTaskEvents(taskId: string): Promise<AnyTelemetryEvent[]>;
 
   /** Batch-query events for multiple tasks. */
-  getBulkTaskEvents(taskIds: string[]): Promise<Map<string, AnyTelemetryEvent[]>>;
+  getBulkTaskEvents(
+    taskIds: string[],
+    perTaskLimit?: number
+  ): Promise<Map<string, AnyTelemetryEvent[]>>;
 
   /** Get events since a given timestamp. */
   getEventsSince(since: string): Promise<AnyTelemetryEvent[]>;

--- a/server/src/storage/sqlite/activity-repository.ts
+++ b/server/src/storage/sqlite/activity-repository.ts
@@ -1,0 +1,127 @@
+import type { ActivityRepository } from '../interfaces.js';
+import type { Activity, ActivityType } from '../../services/activity-service.js';
+import type { SqliteDatabase } from './database.js';
+
+const MAX_ACTIVITIES = 5000;
+
+interface ActivityRow {
+  activity_json: string;
+}
+
+export class SqliteActivityRepository implements ActivityRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async getActivities(limit = 50): Promise<Activity[]> {
+    const effectiveLimit = Math.min(Math.max(limit, 1), MAX_ACTIVITIES);
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT activity_json
+          FROM activity_events
+          WHERE workspace_id = 'local'
+          ORDER BY datetime(created_at) DESC, id DESC
+          LIMIT ?
+        `
+      )
+      .all(effectiveLimit) as unknown as ActivityRow[];
+
+    return rows.map((row) => JSON.parse(row.activity_json) as Activity);
+  }
+
+  async logActivity(
+    type: ActivityType,
+    taskId: string,
+    taskTitle: string,
+    details?: Record<string, unknown>,
+    agent?: string
+  ): Promise<Activity> {
+    const activity: Activity = {
+      id: `activity_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
+      type,
+      taskId,
+      taskTitle,
+      ...(agent && { agent }),
+      details,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.transaction(() => {
+      this.database
+        .getConnection()
+        .prepare(
+          `
+            INSERT INTO activity_events (
+              id,
+              workspace_id,
+              type,
+              task_id,
+              task_title,
+              agent,
+              details_json,
+              activity_json,
+              created_at
+            )
+            VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          activity.id,
+          activity.type,
+          activity.taskId,
+          activity.taskTitle,
+          activity.agent ?? null,
+          activity.details ? JSON.stringify(activity.details) : null,
+          JSON.stringify(activity),
+          activity.timestamp
+        );
+
+      this.trimOldActivities();
+    });
+
+    return activity;
+  }
+
+  async clearActivities(): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare("DELETE FROM activity_events WHERE workspace_id = 'local'")
+      .run();
+  }
+
+  private trimOldActivities(): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+        DELETE FROM activity_events
+        WHERE id IN (
+          SELECT id
+          FROM activity_events
+          WHERE workspace_id = 'local'
+          ORDER BY datetime(created_at) DESC, id DESC
+          LIMIT -1 OFFSET ?
+        )
+      `
+      )
+      .run(MAX_ACTIVITIES);
+  }
+
+  private transaction<T>(callback: () => T): T {
+    const db = this.database.getConnection();
+
+    try {
+      db.exec('BEGIN IMMEDIATE;');
+      const result = callback();
+      db.exec('COMMIT;');
+      return result;
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // Preserve the original failure.
+      }
+      throw error;
+    }
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -178,6 +178,90 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON prompt_usage(template_id, used_at);
     `,
   },
+  {
+    version: 5,
+    name: '0005_operational_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS activity_events (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        type TEXT NOT NULL,
+        task_id TEXT,
+        task_title TEXT,
+        agent TEXT,
+        details_json TEXT,
+        activity_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_activity_workspace_created
+        ON activity_events(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_activity_task_created
+        ON activity_events(task_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_activity_type_created
+        ON activity_events(type, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS status_history (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        previous_status TEXT NOT NULL,
+        new_status TEXT NOT NULL,
+        task_id TEXT,
+        task_title TEXT,
+        sub_agent_count INTEGER,
+        duration_ms INTEGER,
+        entry_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_status_history_workspace_created
+        ON status_history(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_status_history_task_created
+        ON status_history(task_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS telemetry_events (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        type TEXT NOT NULL,
+        task_id TEXT,
+        project_id TEXT,
+        agent TEXT,
+        model TEXT,
+        attempt_id TEXT,
+        success INTEGER,
+        duration_ms INTEGER,
+        exit_code INTEGER,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        cache_tokens INTEGER,
+        total_tokens INTEGER,
+        cost REAL,
+        error TEXT,
+        stack_trace TEXT,
+        session_key TEXT,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_workspace_created
+        ON telemetry_events(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_type_created
+        ON telemetry_events(workspace_id, type, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_task_created
+        ON telemetry_events(task_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_project_created
+        ON telemetry_events(project_id, created_at DESC);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -1,11 +1,14 @@
 import type { StorageProvider } from '../interfaces.js';
-import { FileStorageProvider, type FileStorageOptions } from '../file-storage.js';
+import type { FileStorageOptions } from '../file-storage.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from './database.js';
 import { SqliteTaskRepository } from './task-repository.js';
 import { SqliteSettingsRepository } from './settings-repository.js';
 import { SqliteManagedListProvider } from './managed-list-repository.js';
 import { SqliteTemplateRepository } from './template-repository.js';
 import { SqlitePromptRegistryRepository } from './prompt-registry-repository.js';
+import { SqliteActivityRepository } from './activity-repository.js';
+import { SqliteStatusHistoryRepository } from './status-history-repository.js';
+import { SqliteTelemetryRepository } from './telemetry-repository.js';
 import { createDefaultConfig, normalizeAppConfig } from '../../services/config-service.js';
 
 export interface SqliteStorageOptions {
@@ -16,41 +19,29 @@ export interface SqliteStorageOptions {
 export class SqliteStorageProvider implements StorageProvider {
   readonly tasks: SqliteTaskRepository;
   readonly settings: SqliteSettingsRepository;
-  readonly activities: StorageProvider['activities'];
+  readonly activities: SqliteActivityRepository;
   readonly templates: SqliteTemplateRepository;
   readonly promptRegistry: SqlitePromptRegistryRepository;
-  readonly statusHistory: StorageProvider['statusHistory'];
+  readonly statusHistory: SqliteStatusHistoryRepository;
   readonly managedLists: SqliteManagedListProvider;
-  readonly telemetry: StorageProvider['telemetry'];
+  readonly telemetry: SqliteTelemetryRepository;
 
   private readonly sqlite: SqliteDatabase;
-  private readonly fileProvider: FileStorageProvider;
 
   constructor(options: SqliteStorageOptions = {}) {
     this.sqlite = new SqliteDatabase(options.database);
-    this.fileProvider = new FileStorageProvider({
-      ...(options.fileStorageOptions || {}),
-      taskServiceOptions: {
-        ...(options.fileStorageOptions?.taskServiceOptions || {}),
-        storageType: 'file',
-      },
-      configServiceOptions: {
-        ...(options.fileStorageOptions?.configServiceOptions || {}),
-        storageType: 'file',
-      },
-    });
 
     this.tasks = new SqliteTaskRepository(this.sqlite);
     this.settings = new SqliteSettingsRepository(this.sqlite, {
       defaultConfig: createDefaultConfig(),
       normalizeConfig: normalizeAppConfig,
     });
-    this.activities = this.fileProvider.activities;
+    this.activities = new SqliteActivityRepository(this.sqlite);
     this.templates = new SqliteTemplateRepository(this.sqlite);
     this.promptRegistry = new SqlitePromptRegistryRepository(this.sqlite);
-    this.statusHistory = this.fileProvider.statusHistory;
+    this.statusHistory = new SqliteStatusHistoryRepository(this.sqlite);
     this.managedLists = new SqliteManagedListProvider(this.sqlite);
-    this.telemetry = this.fileProvider.telemetry;
+    this.telemetry = new SqliteTelemetryRepository(this.sqlite);
   }
 
   getDatabase(): SqliteDatabase {
@@ -59,14 +50,11 @@ export class SqliteStorageProvider implements StorageProvider {
 
   async initialize(): Promise<void> {
     this.sqlite.open();
-    await this.fileProvider.initialize();
+    await this.telemetry.init();
   }
 
   async shutdown(): Promise<void> {
-    try {
-      await this.fileProvider.shutdown();
-    } finally {
-      this.sqlite.close();
-    }
+    await this.telemetry.flush().catch(() => {});
+    this.sqlite.close();
   }
 }

--- a/server/src/storage/sqlite/status-history-repository.ts
+++ b/server/src/storage/sqlite/status-history-repository.ts
@@ -1,0 +1,296 @@
+import type { StatusHistoryRepository } from '../interfaces.js';
+import type {
+  AgentStatusState,
+  DailySummary,
+  StatusHistoryEntry,
+  StatusPeriod,
+} from '../../services/status-history-service.js';
+import type { SqliteDatabase } from './database.js';
+
+const MAX_ENTRIES = 5000;
+
+interface StatusHistoryRow {
+  entry_json: string;
+}
+
+export class SqliteStatusHistoryRepository implements StatusHistoryRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async getHistory(limit = 100, offset = 0): Promise<StatusHistoryEntry[]> {
+    const effectiveLimit = Math.min(Math.max(limit, 1), MAX_ENTRIES);
+    const effectiveOffset = Math.max(offset, 0);
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT entry_json
+          FROM status_history
+          WHERE workspace_id = 'local'
+          ORDER BY datetime(created_at) DESC, id DESC
+          LIMIT ? OFFSET ?
+        `
+      )
+      .all(effectiveLimit, effectiveOffset) as unknown as StatusHistoryRow[];
+
+    return rows.map((row) => JSON.parse(row.entry_json) as StatusHistoryEntry);
+  }
+
+  async logStatusChange(
+    previousStatus: AgentStatusState,
+    newStatus: AgentStatusState,
+    taskId?: string,
+    taskTitle?: string,
+    subAgentCount?: number
+  ): Promise<StatusHistoryEntry> {
+    const now = new Date();
+    const timestamp = now.toISOString();
+    const previousEntry = await this.getLastEntry();
+    const durationMs = previousEntry
+      ? now.getTime() - new Date(previousEntry.timestamp).getTime()
+      : undefined;
+
+    const entry: StatusHistoryEntry = {
+      id: `status_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
+      timestamp,
+      previousStatus,
+      newStatus,
+      taskId,
+      taskTitle,
+      subAgentCount,
+      durationMs,
+    };
+
+    this.transaction(() => {
+      this.database
+        .getConnection()
+        .prepare(
+          `
+            INSERT INTO status_history (
+              id,
+              workspace_id,
+              previous_status,
+              new_status,
+              task_id,
+              task_title,
+              sub_agent_count,
+              duration_ms,
+              entry_json,
+              created_at
+            )
+            VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          entry.id,
+          entry.previousStatus,
+          entry.newStatus,
+          entry.taskId ?? null,
+          entry.taskTitle ?? null,
+          entry.subAgentCount ?? null,
+          entry.durationMs ?? null,
+          JSON.stringify(entry),
+          entry.timestamp
+        );
+
+      this.trimOldEntries();
+    });
+
+    return entry;
+  }
+
+  async getHistoryByDateRange(startDate: string, endDate: string): Promise<StatusHistoryEntry[]> {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT entry_json
+          FROM status_history
+          WHERE workspace_id = 'local'
+            AND created_at >= ?
+            AND created_at <= ?
+          ORDER BY datetime(created_at) DESC, id DESC
+        `
+      )
+      .all(startDate, endDate) as unknown as StatusHistoryRow[];
+
+    return rows.map((row) => JSON.parse(row.entry_json) as StatusHistoryEntry);
+  }
+
+  async getDailySummary(date?: string): Promise<DailySummary> {
+    const targetDate = date || new Date().toISOString().split('T')[0];
+    const startOfDay = new Date(`${targetDate}T00:00:00.000Z`);
+    const endOfDay = new Date(`${targetDate}T23:59:59.999Z`);
+
+    const entries = await this.getHistoryByDateRange(
+      startOfDay.toISOString(),
+      endOfDay.toISOString()
+    );
+
+    const chronological = [...entries].reverse();
+    let activeMs = 0;
+    let idleMs = 0;
+    let errorMs = 0;
+    const periods: StatusPeriod[] = [];
+
+    for (let i = 0; i < chronological.length; i++) {
+      const entry = chronological[i];
+      const nextEntry = chronological[i + 1];
+      const endTime = nextEntry ? new Date(nextEntry.timestamp) : this.getOpenPeriodEnd(endOfDay);
+      const startTime = new Date(entry.timestamp);
+      const durationMs = endTime.getTime() - startTime.getTime();
+
+      if (durationMs <= 0) {
+        continue;
+      }
+
+      if (entry.newStatus === 'idle') {
+        idleMs += durationMs;
+      } else if (entry.newStatus === 'error') {
+        errorMs += durationMs;
+      } else {
+        activeMs += durationMs;
+      }
+
+      periods.push({
+        status: entry.newStatus,
+        startTime: entry.timestamp,
+        endTime: endTime.toISOString(),
+        durationMs,
+        taskId: entry.taskId,
+        taskTitle: entry.taskTitle,
+      });
+    }
+
+    if (chronological.length === 0) {
+      const lastBeforeDay = await this.getLastEntryBefore(startOfDay.toISOString());
+      const durationMs = this.applyCarryForwardPeriod(periods, lastBeforeDay, startOfDay, endOfDay);
+
+      if (durationMs > 0 && lastBeforeDay) {
+        if (lastBeforeDay.newStatus === 'idle') {
+          idleMs = durationMs;
+        } else if (lastBeforeDay.newStatus === 'error') {
+          errorMs = durationMs;
+        } else {
+          activeMs = durationMs;
+        }
+      }
+    }
+
+    return {
+      date: targetDate,
+      activeMs,
+      idleMs,
+      errorMs,
+      transitions: entries.length,
+      periods,
+    };
+  }
+
+  async getWeeklySummary(): Promise<DailySummary[]> {
+    const summaries: DailySummary[] = [];
+    const today = new Date();
+
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(today);
+      date.setDate(date.getDate() - i);
+      summaries.push(await this.getDailySummary(date.toISOString().split('T')[0]));
+    }
+
+    return summaries;
+  }
+
+  async clearHistory(): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare("DELETE FROM status_history WHERE workspace_id = 'local'")
+      .run();
+  }
+
+  private async getLastEntry(): Promise<StatusHistoryEntry | null> {
+    const rows = await this.getHistory(1);
+    return rows[0] ?? null;
+  }
+
+  private async getLastEntryBefore(timestamp: string): Promise<StatusHistoryEntry | null> {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT entry_json
+          FROM status_history
+          WHERE workspace_id = 'local'
+            AND created_at < ?
+          ORDER BY datetime(created_at) DESC, id DESC
+          LIMIT 1
+        `
+      )
+      .get(timestamp) as StatusHistoryRow | undefined;
+
+    return row ? (JSON.parse(row.entry_json) as StatusHistoryEntry) : null;
+  }
+
+  private getOpenPeriodEnd(endOfDay: Date): Date {
+    const now = new Date();
+    return now < endOfDay ? now : endOfDay;
+  }
+
+  private applyCarryForwardPeriod(
+    periods: StatusPeriod[],
+    entry: StatusHistoryEntry | null,
+    startOfDay: Date,
+    endOfDay: Date
+  ): number {
+    if (!entry) return 0;
+
+    const effectiveEnd = this.getOpenPeriodEnd(endOfDay);
+    const durationMs = effectiveEnd.getTime() - startOfDay.getTime();
+    if (durationMs <= 0) return 0;
+
+    periods.push({
+      status: entry.newStatus,
+      startTime: startOfDay.toISOString(),
+      endTime: effectiveEnd.toISOString(),
+      durationMs,
+      taskId: entry.taskId,
+      taskTitle: entry.taskTitle,
+    });
+
+    return durationMs;
+  }
+
+  private trimOldEntries(): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+        DELETE FROM status_history
+        WHERE id IN (
+          SELECT id
+          FROM status_history
+          WHERE workspace_id = 'local'
+          ORDER BY datetime(created_at) DESC, id DESC
+          LIMIT -1 OFFSET ?
+        )
+      `
+      )
+      .run(MAX_ENTRIES);
+  }
+
+  private transaction<T>(callback: () => T): T {
+    const db = this.database.getConnection();
+
+    try {
+      db.exec('BEGIN IMMEDIATE;');
+      const result = callback();
+      db.exec('COMMIT;');
+      return result;
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // Preserve the original failure.
+      }
+      throw error;
+    }
+  }
+}

--- a/server/src/storage/sqlite/telemetry-repository.ts
+++ b/server/src/storage/sqlite/telemetry-repository.ts
@@ -1,0 +1,379 @@
+import { nanoid } from 'nanoid';
+import type { SQLInputValue } from 'node:sqlite';
+import type {
+  AnyTelemetryEvent,
+  TelemetryConfig,
+  TelemetryEvent,
+  TelemetryEventType,
+  TelemetryQueryOptions,
+} from '@veritas-kanban/shared';
+import type { TelemetryRepository } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+import { createLogger } from '../../lib/logger.js';
+
+const log = createLogger('sqlite-telemetry-repository');
+const DEFAULT_CONFIG: TelemetryConfig = {
+  enabled: true,
+  retention: 30,
+  traces: false,
+};
+const MAX_DURATION_MS = 604800000;
+
+interface TelemetryRow {
+  payload_json: string;
+}
+
+interface TelemetryCountRow {
+  count: number;
+}
+
+export interface SqliteTelemetryRepositoryOptions {
+  config?: Partial<TelemetryConfig>;
+}
+
+export class SqliteTelemetryRepository implements TelemetryRepository {
+  private config: TelemetryConfig;
+
+  constructor(
+    private readonly database: SqliteDatabase,
+    options: SqliteTelemetryRepositoryOptions = {}
+  ) {
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...options.config,
+    };
+  }
+
+  async init(): Promise<void> {
+    await this.cleanupOldEvents();
+  }
+
+  async emit<T extends TelemetryEvent>(
+    event: Omit<T, 'id' | 'timestamp'> & { timestamp?: string }
+  ): Promise<T> {
+    if (!this.config.enabled) {
+      return {
+        ...event,
+        id: `disabled_${nanoid(8)}`,
+        timestamp: event.timestamp ?? new Date().toISOString(),
+      } as T;
+    }
+
+    const mutableEvent = event as T & { durationMs?: number };
+    if (typeof mutableEvent.durationMs === 'number' && mutableEvent.durationMs > MAX_DURATION_MS) {
+      log.warn(
+        { originalDuration: mutableEvent.durationMs, cappedDuration: MAX_DURATION_MS },
+        'durationMs exceeds 7 days, capping to maximum'
+      );
+      mutableEvent.durationMs = MAX_DURATION_MS;
+    }
+
+    const fullEvent = {
+      ...event,
+      id: `evt_${nanoid(12)}`,
+      timestamp: event.timestamp ?? new Date().toISOString(),
+    } as T;
+
+    this.insertEvent(fullEvent as unknown as AnyTelemetryEvent);
+    return fullEvent;
+  }
+
+  async getEvents(options: TelemetryQueryOptions = {}): Promise<AnyTelemetryEvent[]> {
+    const { sql, params } = this.buildEventQuery(options, false);
+    const rows = this.database
+      .getConnection()
+      .prepare(sql)
+      .all(...params) as unknown as TelemetryRow[];
+
+    return rows.map((row) => JSON.parse(row.payload_json) as AnyTelemetryEvent);
+  }
+
+  async getTaskEvents(taskId: string): Promise<AnyTelemetryEvent[]> {
+    return this.getEvents({ taskId });
+  }
+
+  async getBulkTaskEvents(
+    taskIds: string[],
+    perTaskLimit = 200
+  ): Promise<Map<string, AnyTelemetryEvent[]>> {
+    const result = new Map<string, AnyTelemetryEvent[]>();
+    for (const taskId of taskIds) {
+      result.set(taskId, []);
+    }
+
+    if (taskIds.length === 0) {
+      return result;
+    }
+
+    const effectivePerTaskLimit = Math.min(Math.max(perTaskLimit, 1), 1000);
+    const placeholders = taskIds.map(() => '?').join(', ');
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT payload_json
+          FROM telemetry_events
+          WHERE workspace_id = 'local'
+            AND task_id IN (${placeholders})
+          ORDER BY datetime(created_at) DESC, id DESC
+        `
+      )
+      .all(...taskIds) as unknown as TelemetryRow[];
+
+    for (const row of rows) {
+      const event = JSON.parse(row.payload_json) as AnyTelemetryEvent;
+      if (!event.taskId) continue;
+
+      const bucket = result.get(event.taskId);
+      if (!bucket || bucket.length >= effectivePerTaskLimit) continue;
+
+      bucket.push(event);
+    }
+
+    return result;
+  }
+
+  async getEventsSince(since: string): Promise<AnyTelemetryEvent[]> {
+    return this.getEvents({ since });
+  }
+
+  async countEvents(
+    type: TelemetryEventType | TelemetryEventType[],
+    since?: string,
+    until?: string
+  ): Promise<number> {
+    const { sql, params } = this.buildEventQuery({ type, since, until }, true);
+    const row = this.database
+      .getConnection()
+      .prepare(sql)
+      .get(...params) as unknown as TelemetryCountRow;
+    return row.count;
+  }
+
+  async clear(): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare("DELETE FROM telemetry_events WHERE workspace_id = 'local'")
+      .run();
+  }
+
+  async flush(): Promise<void> {
+    return;
+  }
+
+  async exportAsJson(options: TelemetryQueryOptions = {}): Promise<string> {
+    const events = await this.getEvents(options);
+    return JSON.stringify(events, null, 2);
+  }
+
+  async exportAsCsv(options: TelemetryQueryOptions = {}): Promise<string> {
+    const events = await this.getEvents(options);
+
+    if (events.length === 0) {
+      return 'id,type,timestamp,taskId,project,agent,success,durationMs,inputTokens,outputTokens,cacheTokens,cost,error\n';
+    }
+
+    const headers = [
+      'id',
+      'type',
+      'timestamp',
+      'taskId',
+      'project',
+      'agent',
+      'success',
+      'durationMs',
+      'inputTokens',
+      'outputTokens',
+      'cacheTokens',
+      'cost',
+      'error',
+    ];
+
+    const rows = events.map((event) => {
+      const fields = event as unknown as Record<string, unknown>;
+      const row: Record<string, string> = {
+        id: this.escapeCsvField(event.id),
+        type: this.escapeCsvField(event.type),
+        timestamp: this.escapeCsvField(event.timestamp),
+        taskId: this.escapeCsvField(event.taskId || ''),
+        project: this.escapeCsvField(event.project || ''),
+        agent: this.escapeCsvField(String(fields.agent ?? '')),
+        success: this.escapeCsvField(String(fields.success ?? '')),
+        durationMs: this.escapeCsvField(String(fields.durationMs ?? '')),
+        inputTokens: this.escapeCsvField(String(fields.inputTokens ?? '')),
+        outputTokens: this.escapeCsvField(String(fields.outputTokens ?? '')),
+        cacheTokens: this.escapeCsvField(String(fields.cacheTokens ?? '')),
+        cost: this.escapeCsvField(String(fields.cost ?? '')),
+        error: this.escapeCsvField(String(fields.error ?? '')),
+      };
+      return headers.map((header) => row[header]).join(',');
+    });
+
+    return [headers.join(','), ...rows].join('\n');
+  }
+
+  configure(config: Partial<TelemetryConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  getConfig(): TelemetryConfig {
+    return { ...this.config };
+  }
+
+  isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  private insertEvent(event: AnyTelemetryEvent): void {
+    const fields = event as unknown as Record<string, unknown>;
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO telemetry_events (
+            id,
+            workspace_id,
+            type,
+            task_id,
+            project_id,
+            agent,
+            model,
+            attempt_id,
+            success,
+            duration_ms,
+            exit_code,
+            input_tokens,
+            output_tokens,
+            cache_tokens,
+            total_tokens,
+            cost,
+            error,
+            stack_trace,
+            session_key,
+            payload_json,
+            created_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        event.id,
+        event.type,
+        event.taskId ?? null,
+        event.project ?? null,
+        this.optionalString(fields.agent),
+        this.optionalString(fields.model),
+        this.optionalString(fields.attemptId),
+        typeof fields.success === 'boolean' ? (fields.success ? 1 : 0) : null,
+        this.optionalNumber(fields.durationMs),
+        this.optionalNumber(fields.exitCode),
+        this.optionalNumber(fields.inputTokens),
+        this.optionalNumber(fields.outputTokens),
+        this.optionalNumber(fields.cacheTokens),
+        this.optionalNumber(fields.totalTokens),
+        this.optionalNumber(fields.cost),
+        this.optionalString(fields.error),
+        this.optionalString(fields.stackTrace),
+        this.optionalString(fields.sessionKey),
+        JSON.stringify(event),
+        event.timestamp
+      );
+  }
+
+  private buildEventQuery(
+    options: TelemetryQueryOptions,
+    countOnly: boolean
+  ): { sql: string; params: SQLInputValue[] } {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+    const types = options.type
+      ? Array.isArray(options.type)
+        ? options.type
+        : [options.type]
+      : null;
+
+    if (types && types.length > 0) {
+      clauses.push(`type IN (${types.map(() => '?').join(', ')})`);
+      params.push(...types);
+    }
+
+    if (options.since) {
+      clauses.push('created_at >= ?');
+      params.push(options.since);
+    }
+
+    if (options.until) {
+      clauses.push('created_at <= ?');
+      params.push(options.until);
+    }
+
+    if (options.taskId) {
+      clauses.push('task_id = ?');
+      params.push(options.taskId);
+    }
+
+    if (options.project) {
+      clauses.push('project_id = ?');
+      params.push(options.project);
+    }
+
+    if (countOnly) {
+      return {
+        sql: `
+          SELECT COUNT(*) AS count
+          FROM telemetry_events
+          WHERE ${clauses.join(' AND ')}
+        `,
+        params,
+      };
+    }
+
+    const effectiveLimit = Math.min(Math.max(options.limit ?? 1000, 1), 10_000);
+    params.push(effectiveLimit);
+
+    return {
+      sql: `
+        SELECT payload_json
+        FROM telemetry_events
+        WHERE ${clauses.join(' AND ')}
+        ORDER BY datetime(created_at) DESC, id DESC
+        LIMIT ?
+      `,
+      params,
+    };
+  }
+
+  private async cleanupOldEvents(): Promise<void> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - this.config.retention);
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM telemetry_events
+          WHERE workspace_id = 'local'
+            AND created_at < ?
+        `
+      )
+      .run(cutoff.toISOString());
+  }
+
+  private optionalString(value: unknown): string | null {
+    return typeof value === 'string' ? value : null;
+  }
+
+  private optionalNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  }
+
+  private escapeCsvField(field: string): string {
+    let sanitized = field;
+    if (/^[=+\-@]/.test(sanitized)) {
+      sanitized = `'${sanitized}`;
+    }
+    if (sanitized.includes(',') || sanitized.includes('"') || sanitized.includes('\n')) {
+      return `"${sanitized.replace(/"/g, '""')}"`;
+    }
+    return sanitized;
+  }
+}


### PR DESCRIPTION
## Summary

- adds SQLite migration/table support for activity events, status history, and telemetry events
- wires ActivityService, StatusHistoryService, TelemetryService, and SqliteStorageProvider to use SQLite repositories in sqlite mode
- keeps file storage explicitly file-backed and adds regression coverage that sqlite mode does not create JSON/NDJSON operational files
- documents the operational repository slice in the v5 SQLite schema plan

Part of #332.

## Verification

- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-operational-repositories.test.ts src/__tests__/storage/sqlite-storage.test.ts`
- `pnpm typecheck`
- `./node_modules/.bin/eslint server/src/__tests__/storage/sqlite-storage.test.ts server/src/__tests__/storage/sqlite-operational-repositories.test.ts server/src/services/activity-service.ts server/src/services/status-history-service.ts server/src/services/telemetry-service.ts server/src/storage/file-storage.ts server/src/storage/index.ts server/src/storage/interfaces.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/sqlite-storage.ts server/src/storage/sqlite/activity-repository.ts server/src/storage/sqlite/status-history-repository.ts server/src/storage/sqlite/telemetry-repository.ts --quiet`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Notes

- This PR covers the activity, status history, and telemetry checkboxes from #332. Audit/policy/decision/feedback/scoring/drift, workflow run state, chat, notifications, uploads, and durable work products remain in #332 or follow-up slices.