### PR TITLE
feat: add SQLite governance repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -906,6 +906,22 @@ SQLite repositories when `VERITAS_STORAGE=sqlite`. File storage still forces the
 file-backed services to `storageType='file'`, so explicit file mode cannot be
 accidentally flipped by the environment.
 
+## Governance Repository Implementation
+
+The first governance repository pass moves JSON-backed decisions, feedback,
+scoring, and drift data into SQLite document tables with indexed query columns.
+The domain services keep their existing APIs, validation, and analytics logic;
+only the persistence backend switches when `VERITAS_STORAGE=sqlite`.
+
+| Runtime table         | Stored data                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `decision_records`    | Complete `DecisionRecord` JSON plus agent, task, parent, confidence, and risk columns. |
+| `feedback_records`    | Complete `Feedback` JSON plus task, agent, rating, sentiment, and resolved columns.    |
+| `scoring_profiles`    | Complete `ScoringProfile` JSON plus name and built-in metadata.                        |
+| `scoring_evaluations` | Complete `EvaluationResult` JSON plus profile, agent, task, and score columns.         |
+| `drift_alerts`        | Complete `DriftAlert` JSON plus agent, metric, severity, and acknowledged columns.     |
+| `drift_baselines`     | Complete `DriftBaseline` JSON plus agent and metric columns.                           |
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/src/__tests__/storage/sqlite-governance-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-governance-repositories.test.ts
@@ -1,0 +1,311 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import type { AnyTelemetryEvent } from '@veritas-kanban/shared';
+import { DecisionService } from '../../services/decision-service.js';
+import { DriftService } from '../../services/drift-service.js';
+import { FeedbackService } from '../../services/feedback-service.js';
+import { ScoringService } from '../../services/scoring-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+const getEventsMock = vi.fn<() => Promise<AnyTelemetryEvent[]>>();
+
+vi.mock('../../services/telemetry-service.js', () => ({
+  getTelemetryService: () => ({
+    getEvents: getEventsMock,
+  }),
+}));
+
+function atDay(day: string, hour: number): string {
+  return `${day}T${String(hour).padStart(2, '0')}:00:00.000Z`;
+}
+
+function driftEvents(agent: string): AnyTelemetryEvent[] {
+  return [
+    {
+      id: '1',
+      type: 'run.started',
+      timestamp: atDay('2025-01-01', 9),
+      taskId: 'task_1',
+      agent,
+    },
+    {
+      id: '2',
+      type: 'run.completed',
+      timestamp: atDay('2025-01-01', 10),
+      taskId: 'task_1',
+      agent,
+      success: true,
+      durationMs: 1000,
+    },
+    {
+      id: '3',
+      type: 'run.tokens',
+      timestamp: atDay('2025-01-01', 10),
+      taskId: 'task_1',
+      agent,
+      inputTokens: 50,
+      outputTokens: 50,
+      totalTokens: 100,
+      cost: 0.1,
+    },
+    {
+      id: '4',
+      type: 'run.started',
+      timestamp: atDay('2025-01-02', 9),
+      taskId: 'task_2',
+      agent,
+    },
+    {
+      id: '5',
+      type: 'run.completed',
+      timestamp: atDay('2025-01-02', 10),
+      taskId: 'task_2',
+      agent,
+      success: true,
+      durationMs: 1000,
+    },
+    {
+      id: '6',
+      type: 'run.tokens',
+      timestamp: atDay('2025-01-02', 10),
+      taskId: 'task_2',
+      agent,
+      inputTokens: 50,
+      outputTokens: 50,
+      totalTokens: 100,
+      cost: 0.1,
+    },
+    {
+      id: '7',
+      type: 'run.started',
+      timestamp: atDay('2025-01-03', 9),
+      taskId: 'task_3',
+      agent,
+    },
+    {
+      id: '8',
+      type: 'run.completed',
+      timestamp: atDay('2025-01-03', 10),
+      taskId: 'task_3',
+      agent,
+      success: true,
+      durationMs: 1000,
+    },
+    {
+      id: '9',
+      type: 'run.tokens',
+      timestamp: atDay('2025-01-03', 10),
+      taskId: 'task_3',
+      agent,
+      inputTokens: 50,
+      outputTokens: 50,
+      totalTokens: 100,
+      cost: 0.1,
+    },
+    {
+      id: '10',
+      type: 'run.started',
+      timestamp: atDay('2025-01-04', 9),
+      taskId: 'task_4',
+      agent,
+    },
+    {
+      id: '11',
+      type: 'run.completed',
+      timestamp: atDay('2025-01-04', 12),
+      taskId: 'task_4',
+      agent,
+      success: false,
+      durationMs: 6000,
+    },
+    {
+      id: '12',
+      type: 'run.tokens',
+      timestamp: atDay('2025-01-04', 12),
+      taskId: 'task_4',
+      agent,
+      inputTokens: 400,
+      outputTokens: 300,
+      totalTokens: 700,
+      cost: 0.9,
+    },
+  ] as AnyTelemetryEvent[];
+}
+
+describe('SQLite governance repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-governance-'));
+    getEventsMock.mockReset();
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('stores decisions in SQLite with filtering, chains, and assumption updates', async () => {
+    const decisionsDir = path.join(testRoot, 'storage', 'decisions');
+    const service = new DecisionService({
+      decisionsDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const root = await service.create({
+      inputContext: 'root context',
+      outputAction: 'root action',
+      assumptions: ['traffic stays low'],
+      confidenceLevel: 0.8,
+      riskScore: 0.2,
+      agentId: 'codex',
+      taskId: 'task_1',
+      timestamp: '2026-03-01T00:00:00.000Z',
+    });
+    const child = await service.create({
+      inputContext: 'child context',
+      outputAction: 'child action',
+      confidenceLevel: 0.9,
+      riskScore: 0.1,
+      parentDecisionId: root.id,
+      agentId: 'codex',
+      taskId: 'task_1',
+      timestamp: '2026-03-02T00:00:00.000Z',
+    });
+
+    expect((await service.list({ minConfidence: 0.85 })).map((decision) => decision.id)).toEqual([
+      child.id,
+    ]);
+    expect((await service.getChain(child.id)).map((decision) => decision.id)).toEqual([
+      root.id,
+      child.id,
+    ]);
+
+    const updated = await service.updateAssumption(root.id, 0, {
+      status: 'validated',
+      note: 'checked',
+    });
+    expect(updated.assumptions[0].status).toBe('validated');
+    await expect(fs.access(decisionsDir)).rejects.toThrow();
+  });
+
+  it('stores feedback in SQLite with analytics and unresolved helpers', async () => {
+    const feedbackDir = path.join(testRoot, 'storage', 'feedback');
+    const service = new FeedbackService({
+      feedbackDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const positive = await service.create({
+      taskId: 'task_1',
+      agent: 'codex',
+      rating: 5,
+      comment: 'Great and helpful',
+      categories: ['quality', 'ux'],
+    });
+    const negative = await service.create({
+      taskId: 'task_2',
+      agent: 'amp',
+      rating: 2,
+      comment: 'Broken and confusing',
+      categories: ['accuracy'],
+    });
+    await service.update(negative.id, { resolved: true });
+
+    expect((await service.list({ agent: 'codex' })).map((item) => item.id)).toEqual([positive.id]);
+    expect((await service.listUnresolved()).map((item) => item.id)).toEqual([positive.id]);
+
+    const analytics = await service.getAnalytics();
+    expect(analytics.totalFeedback).toBe(2);
+    expect(analytics.sentimentBreakdown).toEqual({ positive: 1, neutral: 0, negative: 1 });
+    expect(analytics.unresolvedCount).toBe(1);
+
+    expect(await service.delete(positive.id)).toBe(true);
+    expect(await service.get(positive.id)).toBeNull();
+    await expect(fs.access(feedbackDir)).rejects.toThrow();
+  });
+
+  it('stores scoring profiles and evaluation history in SQLite', async () => {
+    const profilesDir = path.join(testRoot, 'storage', 'scoring');
+    const evaluationsDir = path.join(testRoot, 'storage', 'evaluations');
+    const service = new ScoringService({
+      profilesDir,
+      evaluationsDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    expect((await service.listProfiles()).map((profile) => profile.id)).toEqual(
+      expect.arrayContaining(['code-quality', 'task-efficiency', 'convention-compliance'])
+    );
+
+    const profile = await service.createProfile({
+      name: 'SQLite Score',
+      compositeMethod: 'weightedAvg',
+      scorers: [
+        {
+          id: 'mentions-tests',
+          name: 'Mentions tests',
+          type: 'KeywordContains',
+          weight: 1,
+          target: 'output',
+          keywords: ['tested'],
+          matchMode: 'any',
+        },
+      ],
+    });
+
+    const result = await service.evaluate({
+      profileId: profile.id,
+      agent: 'codex',
+      taskId: 'task_1',
+      output: 'tested and verified',
+    });
+
+    expect(result.compositeScore).toBe(1);
+    expect((await service.getHistory({ profileId: profile.id })).map((item) => item.id)).toEqual([
+      result.id,
+    ]);
+
+    await expect(fs.access(profilesDir)).rejects.toThrow();
+    await expect(fs.access(evaluationsDir)).rejects.toThrow();
+  });
+
+  it('stores drift alerts and baselines in SQLite', async () => {
+    const alertsDir = path.join(testRoot, 'storage', 'drift', 'alerts');
+    const baselinesDir = path.join(testRoot, 'storage', 'drift', 'baselines');
+    const service = new DriftService({
+      alertsDir,
+      baselinesDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+    getEventsMock.mockResolvedValue(driftEvents('codex'));
+
+    const analysis = await service.analyzeAgent('codex');
+    expect(analysis.alerts.length).toBeGreaterThan(0);
+    expect(analysis.baselines.length).toBeGreaterThan(0);
+
+    const firstAlert = analysis.alerts[0];
+    const acknowledged = await service.acknowledgeAlert(firstAlert.id);
+    expect(acknowledged?.acknowledged).toBe(true);
+    expect(await service.listAlerts({ agentId: 'codex', acknowledged: true })).toHaveLength(1);
+
+    const reset = await service.resetBaselines('codex');
+    expect(reset.deleted).toBeGreaterThan(0);
+    expect(await service.listBaselines({ agentId: 'codex' })).toEqual([]);
+
+    await expect(fs.access(alertsDir)).rejects.toThrow();
+    await expect(fs.access(baselinesDir)).rejects.toThrow();
+  });
+});

--- a/server/src/services/decision-service.ts
+++ b/server/src/services/decision-service.ts
@@ -11,13 +11,40 @@ import { BadRequestError, NotFoundError } from '../middleware/error-handler.js';
 import { fileExists, mkdir, readFile, readdir, writeFile } from '../storage/fs-helpers.js';
 import { getDecisionsDir } from '../utils/paths.js';
 import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteDecisionRepository } from '../storage/sqlite/governance-repositories.js';
 
 const log = createLogger('decision-service');
 
+export interface DecisionServiceOptions {
+  decisionsDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+}
+
 export class DecisionService {
-  private readonly decisionsDir = getDecisionsDir();
+  private readonly decisionsDir: string;
+  private readonly repository: SqliteDecisionRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
+
+  constructor(options: DecisionServiceOptions = {}) {
+    this.decisionsDir = options.decisionsDir ?? getDecisionsDir();
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteDecisionRepository(this.sqliteDatabase);
+    }
+  }
 
   private async ensureDir(): Promise<void> {
+    if (this.repository) return;
     await mkdir(this.decisionsDir, { recursive: true });
   }
 
@@ -39,6 +66,10 @@ export class DecisionService {
   }
 
   private async readDecision(id: string): Promise<DecisionRecord | null> {
+    if (this.repository) {
+      return this.repository.getById(id);
+    }
+
     const filePath = this.getDecisionPath(id);
     if (!(await fileExists(filePath))) {
       return null;
@@ -49,6 +80,11 @@ export class DecisionService {
   }
 
   private async writeDecision(decision: DecisionRecord): Promise<void> {
+    if (this.repository) {
+      await this.repository.save(decision);
+      return;
+    }
+
     await this.ensureDir();
     await writeFile(this.getDecisionPath(decision.id), JSON.stringify(decision, null, 2), 'utf8');
   }
@@ -81,6 +117,10 @@ export class DecisionService {
   }
 
   async list(filters: DecisionListFilters = {}): Promise<DecisionRecord[]> {
+    if (this.repository) {
+      return this.repository.list(filters);
+    }
+
     await this.ensureDir();
     const files = await readdir(this.decisionsDir);
     const decisions = await Promise.all(
@@ -168,6 +208,12 @@ export class DecisionService {
 
     await this.writeDecision(decision);
     return decision;
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
   }
 }
 

--- a/server/src/services/drift-service.ts
+++ b/server/src/services/drift-service.ts
@@ -15,6 +15,8 @@ import { fileExists, mkdir, readdir, readFile, rm, writeFile } from '../storage/
 import { getDriftAlertsDir, getDriftBaselinesDir } from '../utils/paths.js';
 import { getTelemetryService } from './telemetry-service.js';
 import { createLogger } from '../lib/logger.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteDriftRepository } from '../storage/sqlite/governance-repositories.js';
 
 const log = createLogger('drift-service');
 
@@ -51,22 +53,39 @@ interface DailyAggregate {
   errors: number;
 }
 
-interface DriftServiceOptions {
+export interface DriftServiceOptions {
   alertsDir?: string;
   baselinesDir?: string;
   configs?: DriftConfig[];
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 export class DriftService {
   private readonly alertsDir: string;
   private readonly baselinesDir: string;
   private readonly configs: Map<DriftMetric, DriftConfig>;
+  private readonly repository: SqliteDriftRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
 
   constructor(options: DriftServiceOptions = {}) {
     this.alertsDir = options.alertsDir ?? getDriftAlertsDir();
     this.baselinesDir = options.baselinesDir ?? getDriftBaselinesDir();
     const configs = options.configs ?? DEFAULT_CONFIGS;
     this.configs = new Map(configs.map((config) => [config.metric, config]));
+
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteDriftRepository(this.sqliteDatabase);
+    }
   }
 
   async listAlerts(
@@ -77,6 +96,10 @@ export class DriftService {
       acknowledged?: boolean;
     } = {}
   ): Promise<DriftAlert[]> {
+    if (this.repository) {
+      return this.repository.listAlerts(filters);
+    }
+
     const alerts = await this.readCollection<DriftAlert>(this.alertsDir);
     return alerts
       .filter((alert) => {
@@ -92,6 +115,15 @@ export class DriftService {
   }
 
   async acknowledgeAlert(id: string): Promise<DriftAlert | null> {
+    if (this.repository) {
+      const alert = await this.repository.getAlert(id);
+      if (!alert) return null;
+
+      const updated: DriftAlert = { ...alert, acknowledged: true };
+      await this.repository.saveAlert(updated);
+      return updated;
+    }
+
     const filePath = path.join(this.alertsDir, `${id}.json`);
     if (!(await fileExists(filePath))) {
       return null;
@@ -106,6 +138,10 @@ export class DriftService {
   async listBaselines(
     filters: { agentId?: string; metric?: DriftMetric } = {}
   ): Promise<DriftBaseline[]> {
+    if (this.repository) {
+      return this.repository.listBaselines(filters);
+    }
+
     const baselines = await this.readCollection<DriftBaseline>(this.baselinesDir);
     return baselines
       .filter((baseline) => {
@@ -117,6 +153,10 @@ export class DriftService {
   }
 
   async resetBaselines(agentId: string, metric?: DriftMetric): Promise<{ deleted: number }> {
+    if (this.repository) {
+      return this.repository.resetBaselines(agentId, metric);
+    }
+
     await mkdir(this.baselinesDir, { recursive: true });
     const files = await readdir(this.baselinesDir).catch(() => [] as string[]);
     const matching = files.filter((file) => {
@@ -379,11 +419,21 @@ export class DriftService {
   }
 
   private async saveAlert(alert: DriftAlert): Promise<void> {
+    if (this.repository) {
+      await this.repository.saveAlert(alert);
+      return;
+    }
+
     await mkdir(this.alertsDir, { recursive: true });
     await this.writeJson(path.join(this.alertsDir, `${alert.id}.json`), alert);
   }
 
   private async saveBaseline(baseline: DriftBaseline): Promise<void> {
+    if (this.repository) {
+      await this.repository.saveBaseline(baseline);
+      return;
+    }
+
     await mkdir(this.baselinesDir, { recursive: true });
     const file = `${this.toFileSegment(baseline.agentId)}__${baseline.metric}.json`;
     await this.writeJson(path.join(this.baselinesDir, file), baseline);
@@ -413,6 +463,12 @@ export class DriftService {
 
   private async writeJson(filePath: string, value: unknown): Promise<void> {
     await writeFile(filePath, JSON.stringify(value, null, 2), 'utf-8');
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
   }
 }
 

--- a/server/src/services/feedback-service.ts
+++ b/server/src/services/feedback-service.ts
@@ -16,7 +16,8 @@ import { fileExists, mkdir, readdir, readFile, unlink, writeFile } from '../stor
 import { withFileLock } from './file-lock.js';
 import { createLogger } from '../lib/logger.js';
 import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
-import { NotFoundError } from '../middleware/error-handler.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteFeedbackRepository } from '../storage/sqlite/governance-repositories.js';
 
 const log = createLogger('feedback-service');
 
@@ -118,10 +119,35 @@ export function detectSentiment(text: string): Sentiment {
 
 // ─── Service ──────────────────────────────────────────────────────────────────
 
+export interface FeedbackServiceOptions {
+  feedbackDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+}
+
 export class FeedbackService {
-  private readonly feedbackDir = join(process.cwd(), 'storage', 'feedback');
+  private readonly feedbackDir: string;
+  private readonly repository: SqliteFeedbackRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
+
+  constructor(options: FeedbackServiceOptions = {}) {
+    this.feedbackDir = options.feedbackDir ?? join(process.cwd(), 'storage', 'feedback');
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteFeedbackRepository(this.sqliteDatabase);
+    }
+  }
 
   private async ensureDirs(): Promise<void> {
+    if (this.repository) return;
     await mkdir(this.feedbackDir, { recursive: true });
   }
 
@@ -142,6 +168,10 @@ export class FeedbackService {
   }
 
   async list(query: FeedbackQuery = {}): Promise<Feedback[]> {
+    if (this.repository) {
+      return this.repository.list(query);
+    }
+
     await this.ensureDirs();
 
     const files = await readdir(this.feedbackDir);
@@ -167,6 +197,10 @@ export class FeedbackService {
   }
 
   async get(id: string): Promise<Feedback | null> {
+    if (this.repository) {
+      return this.repository.get(id);
+    }
+
     await this.ensureDirs();
     const filePath = this.feedbackPath(id);
     if (!(await fileExists(filePath))) return null;
@@ -193,10 +227,14 @@ export class FeedbackService {
       updatedAt: now,
     };
 
-    const filePath = this.feedbackPath(id);
-    await withFileLock(filePath, async () => {
-      await writeFile(filePath, JSON.stringify(feedback, null, 2), 'utf-8');
-    });
+    if (this.repository) {
+      await this.repository.save(feedback);
+    } else {
+      const filePath = this.feedbackPath(id);
+      await withFileLock(filePath, async () => {
+        await writeFile(filePath, JSON.stringify(feedback, null, 2), 'utf-8');
+      });
+    }
 
     log.info({ id, taskId: input.taskId, sentiment }, 'Feedback created');
     return feedback;
@@ -216,21 +254,26 @@ export class FeedbackService {
       createdAt: existing.createdAt,
       updatedAt: new Date().toISOString(),
       // Re-run sentiment if comment changed
-      sentiment:
-        input.comment !== undefined
-          ? detectSentiment(input.comment)
-          : existing.sentiment,
+      sentiment: input.comment !== undefined ? detectSentiment(input.comment) : existing.sentiment,
     };
 
-    const filePath = this.feedbackPath(id);
-    await withFileLock(filePath, async () => {
-      await writeFile(filePath, JSON.stringify(updated, null, 2), 'utf-8');
-    });
+    if (this.repository) {
+      await this.repository.save(updated);
+    } else {
+      const filePath = this.feedbackPath(id);
+      await withFileLock(filePath, async () => {
+        await writeFile(filePath, JSON.stringify(updated, null, 2), 'utf-8');
+      });
+    }
 
     return updated;
   }
 
   async delete(id: string): Promise<boolean> {
+    if (this.repository) {
+      return this.repository.delete(id);
+    }
+
     await this.ensureDirs();
     const filePath = this.feedbackPath(id);
     if (!(await fileExists(filePath))) return false;
@@ -243,9 +286,7 @@ export class FeedbackService {
 
     const totalFeedback = allItems.length;
     const averageRating =
-      totalFeedback > 0
-        ? allItems.reduce((sum, item) => sum + item.rating, 0) / totalFeedback
-        : 0;
+      totalFeedback > 0 ? allItems.reduce((sum, item) => sum + item.rating, 0) / totalFeedback : 0;
 
     // Rating distribution (1–5)
     const ratingCounts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
@@ -341,6 +382,12 @@ export class FeedbackService {
 
   async listUnresolved(limit = 100): Promise<Feedback[]> {
     return this.list({ resolved: false, limit });
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
   }
 }
 

--- a/server/src/services/scoring-service.ts
+++ b/server/src/services/scoring-service.ts
@@ -18,6 +18,8 @@ import { withFileLock } from './file-lock.js';
 import { createLogger } from '../lib/logger.js';
 import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
 import { NotFoundError } from '../middleware/error-handler.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteScoringRepository } from '../storage/sqlite/governance-repositories.js';
 
 const log = createLogger('scoring-service');
 
@@ -172,14 +174,42 @@ const BUILT_IN_PROFILES: Array<Omit<ScoringProfile, 'created' | 'updated'>> = [
   },
 ];
 
+export interface ScoringServiceOptions {
+  profilesDir?: string;
+  evaluationsDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+}
+
 export class ScoringService {
-  private readonly profilesDir = join(process.cwd(), 'storage', 'scoring');
-  private readonly evaluationsDir = join(process.cwd(), 'storage', 'evaluations');
+  private readonly profilesDir: string;
+  private readonly evaluationsDir: string;
+  private readonly repository: SqliteScoringRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
   private builtInsSeeded = false;
 
+  constructor(options: ScoringServiceOptions = {}) {
+    this.profilesDir = options.profilesDir ?? join(process.cwd(), 'storage', 'scoring');
+    this.evaluationsDir = options.evaluationsDir ?? join(process.cwd(), 'storage', 'evaluations');
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteScoringRepository(this.sqliteDatabase);
+    }
+  }
+
   private async ensureDirs(): Promise<void> {
-    await mkdir(this.profilesDir, { recursive: true });
-    await mkdir(this.evaluationsDir, { recursive: true });
+    if (!this.repository) {
+      await mkdir(this.profilesDir, { recursive: true });
+      await mkdir(this.evaluationsDir, { recursive: true });
+    }
     await this.seedBuiltIns();
   }
 
@@ -187,15 +217,25 @@ export class ScoringService {
     if (this.builtInsSeeded) return;
 
     for (const profile of BUILT_IN_PROFILES) {
-      const filePath = this.profilePath(profile.id);
-      if (await fileExists(filePath)) continue;
+      const existing = this.repository
+        ? await this.repository.getProfile(profile.id)
+        : await fileExists(this.profilePath(profile.id));
+      if (existing) continue;
 
       const now = new Date().toISOString();
-      await writeFile(
-        filePath,
-        JSON.stringify({ ...profile, created: now, updated: now }, null, 2),
-        'utf-8'
-      );
+      const seededProfile: ScoringProfile = {
+        ...profile,
+        created: now,
+        updated: now,
+      };
+
+      if (this.repository) {
+        await this.repository.saveProfile(seededProfile);
+        continue;
+      }
+
+      const filePath = this.profilePath(profile.id);
+      await writeFile(filePath, JSON.stringify(seededProfile, null, 2), 'utf-8');
     }
 
     this.builtInsSeeded = true;
@@ -236,6 +276,10 @@ export class ScoringService {
   async listProfiles(): Promise<ScoringProfile[]> {
     await this.ensureDirs();
 
+    if (this.repository) {
+      return this.repository.listProfiles();
+    }
+
     const files = await readdir(this.profilesDir);
     const profiles = await Promise.all(
       files
@@ -255,6 +299,10 @@ export class ScoringService {
 
   async getProfile(id: string): Promise<ScoringProfile | null> {
     await this.ensureDirs();
+
+    if (this.repository) {
+      return this.repository.getProfile(id);
+    }
 
     const filePath = this.profilePath(id);
     if (!(await fileExists(filePath))) return null;
@@ -277,10 +325,14 @@ export class ScoringService {
       updated: now,
     };
 
-    const filePath = this.profilePath(id);
-    await withFileLock(filePath, async () => {
-      await writeFile(filePath, JSON.stringify(profile, null, 2), 'utf-8');
-    });
+    if (this.repository) {
+      await this.repository.saveProfile(profile);
+    } else {
+      const filePath = this.profilePath(id);
+      await withFileLock(filePath, async () => {
+        await writeFile(filePath, JSON.stringify(profile, null, 2), 'utf-8');
+      });
+    }
 
     return profile;
   }
@@ -305,10 +357,14 @@ export class ScoringService {
       updated: new Date().toISOString(),
     };
 
-    const filePath = this.profilePath(id);
-    await withFileLock(filePath, async () => {
-      await writeFile(filePath, JSON.stringify(updated, null, 2), 'utf-8');
-    });
+    if (this.repository) {
+      await this.repository.saveProfile(updated);
+    } else {
+      const filePath = this.profilePath(id);
+      await withFileLock(filePath, async () => {
+        await writeFile(filePath, JSON.stringify(updated, null, 2), 'utf-8');
+      });
+    }
 
     return updated;
   }
@@ -320,6 +376,10 @@ export class ScoringService {
     if (!existing) return false;
     if (existing.builtIn) {
       throw new Error('Built-in scoring profiles cannot be deleted');
+    }
+
+    if (this.repository) {
+      return this.repository.deleteProfile(id);
     }
 
     await unlink(this.profilePath(id));
@@ -538,16 +598,24 @@ export class ScoringService {
       created: new Date().toISOString(),
     };
 
-    const filePath = this.evaluationPath(result.id);
-    await withFileLock(filePath, async () => {
-      await writeFile(filePath, JSON.stringify(result, null, 2), 'utf-8');
-    });
+    if (this.repository) {
+      await this.repository.saveEvaluation(result);
+    } else {
+      const filePath = this.evaluationPath(result.id);
+      await withFileLock(filePath, async () => {
+        await writeFile(filePath, JSON.stringify(result, null, 2), 'utf-8');
+      });
+    }
 
     return result;
   }
 
   async getHistory(query: EvaluationHistoryQuery = {}): Promise<EvaluationResult[]> {
     await this.ensureDirs();
+
+    if (this.repository) {
+      return this.repository.getHistory(query);
+    }
 
     const files = await readdir(this.evaluationsDir);
     const limit = query.limit ?? 200;
@@ -564,6 +632,12 @@ export class ScoringService {
       .filter((result) => !query.taskId || result.taskId === query.taskId)
       .sort((a, b) => b.created.localeCompare(a.created))
       .slice(0, limit);
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
   }
 }
 

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -61,6 +61,12 @@ export { SqlitePromptRegistryRepository } from './sqlite/prompt-registry-reposit
 export { SqliteActivityRepository } from './sqlite/activity-repository.js';
 export { SqliteStatusHistoryRepository } from './sqlite/status-history-repository.js';
 export { SqliteTelemetryRepository } from './sqlite/telemetry-repository.js';
+export {
+  SqliteDecisionRepository,
+  SqliteDriftRepository,
+  SqliteFeedbackRepository,
+  SqliteScoringRepository,
+} from './sqlite/governance-repositories.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/governance-repositories.ts
+++ b/server/src/storage/sqlite/governance-repositories.ts
@@ -1,0 +1,613 @@
+import type { SQLInputValue } from 'node:sqlite';
+import type {
+  DecisionListFilters,
+  DecisionRecord,
+  DriftAlert,
+  DriftBaseline,
+  DriftMetric,
+  DriftSeverity,
+  EvaluationHistoryQuery,
+  EvaluationResult,
+  Feedback,
+  FeedbackQuery,
+  ScoringProfile,
+} from '@veritas-kanban/shared';
+import type { SqliteDatabase } from './database.js';
+
+interface DecisionRow {
+  decision_json: string;
+}
+
+interface FeedbackRow {
+  feedback_json: string;
+}
+
+interface ScoringProfileRow {
+  profile_json: string;
+}
+
+interface EvaluationRow {
+  evaluation_json: string;
+}
+
+interface DriftAlertRow {
+  payload_json: string;
+}
+
+interface DriftBaselineRow {
+  payload_json: string;
+}
+
+export class SqliteDecisionRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async save(decision: DecisionRecord): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO decision_records (
+            id,
+            workspace_id,
+            agent_id,
+            task_id,
+            parent_decision_id,
+            confidence_level,
+            risk_score,
+            decision_json,
+            created_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            task_id = excluded.task_id,
+            parent_decision_id = excluded.parent_decision_id,
+            confidence_level = excluded.confidence_level,
+            risk_score = excluded.risk_score,
+            decision_json = excluded.decision_json,
+            created_at = excluded.created_at
+        `
+      )
+      .run(
+        decision.id,
+        decision.agentId ?? null,
+        decision.taskId ?? null,
+        decision.parentDecisionId ?? null,
+        decision.confidenceLevel,
+        decision.riskScore,
+        JSON.stringify(decision),
+        decision.timestamp
+      );
+  }
+
+  async getById(id: string): Promise<DecisionRecord | null> {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT decision_json
+          FROM decision_records
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(id) as DecisionRow | undefined;
+
+    return row ? (JSON.parse(row.decision_json) as DecisionRecord) : null;
+  }
+
+  async list(filters: DecisionListFilters = {}): Promise<DecisionRecord[]> {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+
+    if (filters.agent) {
+      clauses.push('agent_id = ?');
+      params.push(filters.agent);
+    }
+    if (filters.startTime) {
+      clauses.push('created_at >= ?');
+      params.push(filters.startTime);
+    }
+    if (filters.endTime) {
+      clauses.push('created_at <= ?');
+      params.push(filters.endTime);
+    }
+    if (filters.minConfidence !== undefined) {
+      clauses.push('confidence_level >= ?');
+      params.push(filters.minConfidence);
+    }
+    if (filters.maxConfidence !== undefined) {
+      clauses.push('confidence_level <= ?');
+      params.push(filters.maxConfidence);
+    }
+    if (filters.minRisk !== undefined) {
+      clauses.push('risk_score >= ?');
+      params.push(filters.minRisk);
+    }
+    if (filters.maxRisk !== undefined) {
+      clauses.push('risk_score <= ?');
+      params.push(filters.maxRisk);
+    }
+
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT decision_json
+          FROM decision_records
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY datetime(created_at) DESC, id DESC
+        `
+      )
+      .all(...params) as unknown as DecisionRow[];
+
+    return rows.map((row) => JSON.parse(row.decision_json) as DecisionRecord);
+  }
+}
+
+export class SqliteFeedbackRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async list(query: FeedbackQuery = {}): Promise<Feedback[]> {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+
+    if (query.taskId) {
+      clauses.push('task_id = ?');
+      params.push(query.taskId);
+    }
+    if (query.agent) {
+      clauses.push('agent = ?');
+      params.push(query.agent);
+    }
+    if (query.sentiment) {
+      clauses.push('sentiment = ?');
+      params.push(query.sentiment);
+    }
+    if (query.resolved !== undefined) {
+      clauses.push('resolved = ?');
+      params.push(query.resolved ? 1 : 0);
+    }
+    if (query.since) {
+      clauses.push('created_at >= ?');
+      params.push(query.since);
+    }
+    if (query.until) {
+      clauses.push('created_at <= ?');
+      params.push(query.until);
+    }
+
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT feedback_json
+          FROM feedback_records
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY datetime(created_at) DESC, id DESC
+        `
+      )
+      .all(...params) as unknown as FeedbackRow[];
+
+    const limit = query.limit ?? 500;
+    return rows
+      .map((row) => JSON.parse(row.feedback_json) as Feedback)
+      .filter((item) => !query.category || item.categories.includes(query.category))
+      .slice(0, limit);
+  }
+
+  async get(id: string): Promise<Feedback | null> {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT feedback_json
+          FROM feedback_records
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(id) as FeedbackRow | undefined;
+
+    return row ? (JSON.parse(row.feedback_json) as Feedback) : null;
+  }
+
+  async save(feedback: Feedback): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO feedback_records (
+            id,
+            workspace_id,
+            task_id,
+            agent,
+            rating,
+            sentiment,
+            resolved,
+            categories_json,
+            feedback_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            task_id = excluded.task_id,
+            agent = excluded.agent,
+            rating = excluded.rating,
+            sentiment = excluded.sentiment,
+            resolved = excluded.resolved,
+            categories_json = excluded.categories_json,
+            feedback_json = excluded.feedback_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        feedback.id,
+        feedback.taskId,
+        feedback.agent ?? null,
+        feedback.rating,
+        feedback.sentiment,
+        feedback.resolved ? 1 : 0,
+        JSON.stringify(feedback.categories),
+        JSON.stringify(feedback),
+        feedback.createdAt,
+        feedback.updatedAt
+      );
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM feedback_records
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .run(id);
+
+    return result.changes > 0;
+  }
+}
+
+export class SqliteScoringRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async listProfiles(): Promise<ScoringProfile[]> {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT profile_json
+          FROM scoring_profiles
+          WHERE workspace_id = 'local'
+          ORDER BY built_in DESC, name ASC
+        `
+      )
+      .all() as unknown as ScoringProfileRow[];
+
+    return rows.map((row) => JSON.parse(row.profile_json) as ScoringProfile);
+  }
+
+  async getProfile(id: string): Promise<ScoringProfile | null> {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT profile_json
+          FROM scoring_profiles
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(id) as ScoringProfileRow | undefined;
+
+    return row ? (JSON.parse(row.profile_json) as ScoringProfile) : null;
+  }
+
+  async saveProfile(profile: ScoringProfile): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO scoring_profiles (
+            id,
+            workspace_id,
+            name,
+            built_in,
+            profile_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            built_in = excluded.built_in,
+            profile_json = excluded.profile_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        profile.id,
+        profile.name,
+        profile.builtIn ? 1 : 0,
+        JSON.stringify(profile),
+        profile.created,
+        profile.updated
+      );
+  }
+
+  async deleteProfile(id: string): Promise<boolean> {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM scoring_profiles
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .run(id);
+
+    return result.changes > 0;
+  }
+
+  async saveEvaluation(result: EvaluationResult): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO scoring_evaluations (
+            id,
+            workspace_id,
+            profile_id,
+            agent,
+            task_id,
+            composite_score,
+            evaluation_json,
+            created_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        result.id,
+        result.profileId,
+        result.agent ?? null,
+        result.taskId ?? null,
+        result.compositeScore,
+        JSON.stringify(result),
+        result.created
+      );
+  }
+
+  async getHistory(query: EvaluationHistoryQuery = {}): Promise<EvaluationResult[]> {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+
+    if (query.profileId) {
+      clauses.push('profile_id = ?');
+      params.push(query.profileId);
+    }
+    if (query.agent) {
+      clauses.push('agent = ?');
+      params.push(query.agent);
+    }
+    if (query.taskId) {
+      clauses.push('task_id = ?');
+      params.push(query.taskId);
+    }
+
+    const effectiveLimit = Math.min(Math.max(query.limit ?? 200, 1), 10_000);
+    params.push(effectiveLimit);
+
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT evaluation_json
+          FROM scoring_evaluations
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY datetime(created_at) DESC, id DESC
+          LIMIT ?
+        `
+      )
+      .all(...params) as unknown as EvaluationRow[];
+
+    return rows.map((row) => JSON.parse(row.evaluation_json) as EvaluationResult);
+  }
+}
+
+export class SqliteDriftRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async listAlerts(
+    filters: {
+      agentId?: string;
+      metric?: DriftMetric;
+      severity?: DriftSeverity;
+      acknowledged?: boolean;
+    } = {}
+  ): Promise<DriftAlert[]> {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+
+    if (filters.agentId) {
+      clauses.push('agent_id = ?');
+      params.push(filters.agentId);
+    }
+    if (filters.metric) {
+      clauses.push('metric = ?');
+      params.push(filters.metric);
+    }
+    if (filters.severity) {
+      clauses.push('severity = ?');
+      params.push(filters.severity);
+    }
+    if (filters.acknowledged !== undefined) {
+      clauses.push('acknowledged = ?');
+      params.push(filters.acknowledged ? 1 : 0);
+    }
+
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT payload_json
+          FROM drift_alerts
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY datetime(created_at) DESC, id DESC
+        `
+      )
+      .all(...params) as unknown as DriftAlertRow[];
+
+    return rows.map((row) => JSON.parse(row.payload_json) as DriftAlert);
+  }
+
+  async getAlert(id: string): Promise<DriftAlert | null> {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT payload_json
+          FROM drift_alerts
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(id) as DriftAlertRow | undefined;
+
+    return row ? (JSON.parse(row.payload_json) as DriftAlert) : null;
+  }
+
+  async saveAlert(alert: DriftAlert): Promise<void> {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO drift_alerts (
+            id,
+            workspace_id,
+            agent_id,
+            metric,
+            severity,
+            acknowledged,
+            payload_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            metric = excluded.metric,
+            severity = excluded.severity,
+            acknowledged = excluded.acknowledged,
+            payload_json = excluded.payload_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        alert.id,
+        alert.agentId,
+        alert.metric,
+        alert.severity,
+        alert.acknowledged ? 1 : 0,
+        JSON.stringify(alert),
+        alert.timestamp,
+        new Date().toISOString()
+      );
+  }
+
+  async listBaselines(
+    filters: { agentId?: string; metric?: DriftMetric } = {}
+  ): Promise<DriftBaseline[]> {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+
+    if (filters.agentId) {
+      clauses.push('agent_id = ?');
+      params.push(filters.agentId);
+    }
+    if (filters.metric) {
+      clauses.push('metric = ?');
+      params.push(filters.metric);
+    }
+
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT payload_json
+          FROM drift_baselines
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY agent_id ASC, metric ASC
+        `
+      )
+      .all(...params) as unknown as DriftBaselineRow[];
+
+    return rows.map((row) => JSON.parse(row.payload_json) as DriftBaseline);
+  }
+
+  async saveBaseline(baseline: DriftBaseline): Promise<void> {
+    const id = this.baselineId(baseline.agentId, baseline.metric);
+    const now = new Date().toISOString();
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO drift_baselines (
+            id,
+            workspace_id,
+            agent_id,
+            metric,
+            payload_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?)
+          ON CONFLICT(workspace_id, agent_id, metric) DO UPDATE SET
+            payload_json = excluded.payload_json,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        id,
+        baseline.agentId,
+        baseline.metric,
+        JSON.stringify(baseline),
+        baseline.windowStart,
+        now
+      );
+  }
+
+  async resetBaselines(agentId: string, metric?: DriftMetric): Promise<{ deleted: number }> {
+    const clauses = ["workspace_id = 'local'", 'agent_id = ?'];
+    const params: SQLInputValue[] = [agentId];
+
+    if (metric) {
+      clauses.push('metric = ?');
+      params.push(metric);
+    }
+
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM drift_baselines
+          WHERE ${clauses.join(' AND ')}
+        `
+      )
+      .run(...params);
+
+    return { deleted: Number(result.changes) };
+  }
+
+  private baselineId(agentId: string, metric: DriftMetric): string {
+    return `${agentId}__${metric}`;
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -262,6 +262,132 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON telemetry_events(project_id, created_at DESC);
     `,
   },
+  {
+    version: 6,
+    name: '0006_governance_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS decision_records (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        agent_id TEXT,
+        task_id TEXT,
+        parent_decision_id TEXT,
+        confidence_level REAL NOT NULL,
+        risk_score REAL NOT NULL,
+        decision_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_decision_records_workspace_created
+        ON decision_records(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_decision_records_agent_created
+        ON decision_records(agent_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_decision_records_task_created
+        ON decision_records(task_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS feedback_records (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        task_id TEXT NOT NULL,
+        agent TEXT,
+        rating INTEGER NOT NULL,
+        sentiment TEXT NOT NULL,
+        resolved INTEGER NOT NULL DEFAULT 0,
+        categories_json TEXT NOT NULL,
+        feedback_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_feedback_records_workspace_created
+        ON feedback_records(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_feedback_records_task_created
+        ON feedback_records(task_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_feedback_records_agent_created
+        ON feedback_records(agent, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_feedback_records_sentiment_created
+        ON feedback_records(sentiment, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS scoring_profiles (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        built_in INTEGER NOT NULL DEFAULT 0,
+        profile_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_scoring_profiles_workspace_name
+        ON scoring_profiles(workspace_id, name);
+
+      CREATE TABLE IF NOT EXISTS scoring_evaluations (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        profile_id TEXT NOT NULL,
+        agent TEXT,
+        task_id TEXT,
+        composite_score REAL NOT NULL,
+        evaluation_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_scoring_evaluations_profile_created
+        ON scoring_evaluations(profile_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_scoring_evaluations_agent_created
+        ON scoring_evaluations(agent, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_scoring_evaluations_task_created
+        ON scoring_evaluations(task_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS drift_alerts (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        agent_id TEXT NOT NULL,
+        metric TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        acknowledged INTEGER NOT NULL DEFAULT 0,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_drift_alerts_workspace_created
+        ON drift_alerts(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_drift_alerts_agent_created
+        ON drift_alerts(agent_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_drift_alerts_metric_created
+        ON drift_alerts(metric, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS drift_baselines (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        agent_id TEXT NOT NULL,
+        metric TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (workspace_id, agent_id, metric)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_drift_baselines_agent_metric
+        ON drift_baselines(agent_id, metric);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {


### PR DESCRIPTION
## Summary

- adds v6 SQLite governance tables and repositories for decisions, feedback, scoring, and drift data
- routes DecisionService, FeedbackService, ScoringService, and DriftService to SQLite when configured while preserving file-backed defaults
- adds SQLite coverage for decision chains, feedback analytics, scoring history, drift alerts and baselines, and no file writes
- documents the governance repository tables in the SQLite schema notes

Part of #332.

## Verification

- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-governance-repositories.test.ts`
- `pnpm typecheck`
- `./node_modules/.bin/eslint server/src/__tests__/storage/sqlite-governance-repositories.test.ts server/src/services/decision-service.ts server/src/services/feedback-service.ts server/src/services/scoring-service.ts server/src/services/drift-service.ts server/src/storage/index.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/governance-repositories.ts --quiet`
- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-governance-repositories.test.ts src/__tests__/decision-service.test.ts src/__tests__/feedback-service.test.ts src/__tests__/scoring-service.test.ts src/__tests__/drift-service.test.ts`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Notes

- This is a partial #332 slice. Audit, policy, workflow, chat, broadcast, notification, work product, upload, and scheduled-run repositories remain separate work.