### PR TITLE
fix: resolve #377 — Detect duplicate task/card IDs in board APIs and promote/create flows

### DIFF
--- a/src/api/backlog.ts
+++ b/src/api/backlog.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from 'express';
+import { BacklogItem, BacklogWarning } from '../types/backlog';
+import { getBacklogItems } from '../services/backlogService';
+
+export const getBacklog = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const items: BacklogItem[] = await getBacklogItems();
+    
+    // Check for duplicate IDs and generate warnings
+    const idCounts = new Map<string, number>();
+    const warnings: BacklogWarning[] = [];
+    
+    items.forEach(item => {
+      const count = idCounts.get(item.id) || 0;
+      idCounts.set(item.id, count + 1);
+    });
+    
+    idCounts.forEach((count, id) => {
+      if (count > 1) {
+        warnings.push({
+          type: 'DUPLICATE_ID',
+          itemId: id,
+          message: `Item with ID ${id} appears ${count} times in backlog`
+        });
+      }
+    });
+    
+    res.json({
+      items,
+      warnings
+    });
+  } catch (error) {
+    console.error('Error fetching backlog:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from 'express';
+import { getBoard } from '../services/boardService';
+import { Task } from '../types';
+
+export const getTasks = (req: Request, res: Response) => {
+  try {
+    const board = getBoard();
+    const tasks: Task[] = board.tasks;
+    
+    // Check for duplicate diagnostics
+    const warnings: Array<{id: string, source: string, action: string}> = [];
+    
+    if (board.diagnostics && board.diagnostics.duplicates) {
+      for (const [id, sources] of Object.entries(board.diagnostics.duplicates)) {
+        warnings.push({
+          id,
+          source: sources.join(', '),
+          action: 'Remove duplicate task definitions'
+        });
+      }
+    }
+    
+    res.json({
+      tasks,
+      warnings
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch tasks' });
+  }
+};

--- a/src/board/Board.ts
+++ b/src/board/Board.ts
@@ -1,0 +1,46 @@
+import { Task } from './Task';
+import { Business } from './Business';
+import { Card } from './Card';
+import { Diagnostics } from './Diagnostics';
+
+export class Board {
+  public active: Card[] = [];
+  public backlog: Card[] = [];
+  public archive: Card[] = [];
+  public diagnostics: Diagnostics = new Diagnostics();
+
+  constructor() {}
+
+  public loadBoard(data: any): void {
+    // Load cards into respective arrays
+    this.active = data.active?.map((card: any) => new Card(card)) || [];
+    this.backlog = data.backlog?.map((card: any) => new Card(card)) || [];
+    this.archive = data.archive?.map((card: any) => new Card(card)) || [];
+
+    // Validate for duplicate IDs
+    this.validateDuplicateIds();
+  }
+
+  private validateDuplicateIds(): void {
+    const taskIdMap = new Map<string, string>(); // taskId -> sourceFile
+    const businessIdMap = new Map<string, string>(); // businessId -> sourceFile
+    
+    const allCards = [...this.active, ...this.backlog, ...this.archive];
+    
+    for (const card of allCards) {
+      // Check for duplicate task IDs
+      if (taskIdMap.has(card.task.id)) {
+        this.diagnostics.addDuplicateTaskId(card.task.id, taskIdMap.get(card.task.id)!, card.sourceFile);
+      } else {
+        taskIdMap.set(card.task.id, card.sourceFile);
+      }
+      
+      // Check for duplicate business IDs
+      if (businessIdMap.has(card.business.id)) {
+        this.diagnostics.addDuplicateBusinessId(card.business.id, businessIdMap.get(card.business.id)!, card.sourceFile);
+      } else {
+        businessIdMap.set(card.business.id, card.sourceFile);
+      }
+    }
+  }
+}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,0 +1,50 @@
+import { Command } from 'commander';
+import { readBoard, writeBoard } from '../utils/board';
+import { Board, Task } from '../types';
+
+export const createCommand = new Command()
+  .name('create')
+  .description('Create new tasks or businesses')
+  .option('-t, --task <task>', 'Create a new task')
+  .option('-b, --business <business>', 'Create a new business')
+  .action((options) => {
+    const board = readBoard();
+    
+    if (options.task) {
+      const newTask: Task = {
+        id: options.task.split(':')[0],
+        description: options.task.split(':')[1] || '',
+        status: 'todo',
+        businessId: options.task.split(':')[2] || ''
+      };
+      
+      // Validate no duplicate task IDs
+      if (board.tasks.some(task => task.id === newTask.id)) {
+        console.error(`Error: Task with ID '${newTask.id}' already exists`);
+        process.exit(1);
+      }
+      
+      // Validate business ID exists if specified
+      if (newTask.businessId && !board.businesses.some(business => business.id === newTask.businessId)) {
+        console.error(`Error: Business with ID '${newTask.businessId}' does not exist`);
+        process.exit(1);
+      }
+      
+      board.tasks.push(newTask);
+    }
+    
+    if (options.business) {
+      const businessId = options.business;
+      
+      // Validate no duplicate business IDs
+      if (board.businesses.some(business => business.id === businessId)) {
+        console.error(`Error: Business with ID '${businessId}' already exists`);
+        process.exit(1);
+      }
+      
+      board.businesses.push({ id: businessId });
+    }
+    
+    writeBoard(board);
+    console.log('Created successfully');
+  });

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -1,0 +1,66 @@
+import { Command } from 'commander';
+import { readConfig } from '../config';
+import { Card, loadCards, saveCards } from '../card';
+import { validateCard } from '../validation';
+import { logger } from '../logger';
+
+export function promoteCommand(program: Command) {
+  program
+    .command('promote <id>')
+    .description('Promote a card to the next stage')
+    .action(async (id: string) => {
+      try {
+        const config = readConfig();
+        const cards = loadCards(config.paths.cards);
+        
+        // Find the card to promote
+        const cardIndex = cards.findIndex(card => card.id === id);
+        if (cardIndex === -1) {
+          logger.error(`Card with ID ${id} not found`);
+          process.exit(1);
+        }
+        
+        const card = cards[cardIndex];
+        
+        // Validate card before promotion
+        const validationError = validateCard(card);
+        if (validationError) {
+          logger.error(`Validation error: ${validationError}`);
+          process.exit(1);
+        }
+        
+        // Check for duplicate ID conflicts before promotion
+        const targetPath = config.paths.nextStage;
+        const targetCards = loadCards(targetPath);
+        
+        const duplicateCard = targetCards.find(targetCard => targetCard.id === card.id);
+        if (duplicateCard) {
+          const error = {
+            message: 'Duplicate ID conflict detected',
+            cardId: card.id,
+            sourcePath: config.paths.cards,
+            targetPath: targetPath,
+            conflictingCard: duplicateCard
+          };
+          logger.error(`Promotion failed: ${error.message}`);
+          logger.error(`Card ID: ${error.cardId}`);
+          logger.error(`Source Path: ${error.sourcePath}`);
+          logger.error(`Target Path: ${error.targetPath}`);
+          process.exit(1);
+        }
+        
+        // Perform promotion
+        targetCards.push(card);
+        saveCards(targetCards, targetPath);
+        
+        // Remove from current stage
+        cards.splice(cardIndex, 1);
+        saveCards(cards, config.paths.cards);
+        
+        logger.info(`Card ${id} promoted successfully`);
+      } catch (error) {
+        logger.error('Failed to promote card:', error);
+        process.exit(1);
+      }
+    });
+}


### PR DESCRIPTION
## Summary

fix: resolve #377 — Detect duplicate task/card IDs in board APIs and promote/create flows

## Problem

**Severity**: `Critical` | **File**: `src/board/Board.ts`

Implement logic to detect duplicate task IDs and business IDs when loading boards. This should scan all active/backlog/archive cards and identify conflicts before any operations proceed.

## Solution

Add a validation phase during board initialization that builds maps of task IDs and business IDs to their source files. When duplicates are found, store them in a diagnostics structure that can be accessed by APIs and commands.

## Changes

- `src/board/Board.ts` (new)
- `src/api/tasks.ts` (new)
- `src/api/backlog.ts` (new)
- `src/commands/promote.ts` (new)
- `src/commands/create.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced