### PR TITLE
feat: add SQLite audit and policy repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -922,6 +922,19 @@ only the persistence backend switches when `VERITAS_STORAGE=sqlite`.
 | `drift_alerts`        | Complete `DriftAlert` JSON plus agent, metric, severity, and acknowledged columns.     |
 | `drift_baselines`     | Complete `DriftBaseline` JSON plus agent and metric columns.                           |
 
+## Audit And Policy Repository Implementation
+
+The audit/policy repository pass moves immutable audit log entries, governance
+policies, and role-based tool policies into SQLite when `VERITAS_STORAGE=sqlite`.
+Audit entries retain the existing SHA-256 hash chain semantics; policy services
+keep the same validation, preset seeding, and evaluation behavior.
+
+| Runtime table    | Stored data                                                                       |
+| ---------------- | --------------------------------------------------------------------------------- |
+| `audit_entries`  | Complete audit entry JSON plus action, actor, resource, integrity, and timestamp. |
+| `agent_policies` | Complete `AgentPolicy` JSON plus name, type, enabled, response, and preset data.  |
+| `tool_policies`  | Complete `ToolPolicy` JSON plus role and indexed allow/deny JSON columns.         |
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/src/__tests__/storage/sqlite-audit-policy-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-audit-policy-repositories.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { PolicyService } from '../../services/policy-service.js';
+import { ToolPolicyService } from '../../services/tool-policy-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+describe('SQLite audit and policy repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-audit-policy-'));
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('stores agent policies in SQLite without creating policy files', async () => {
+    const policiesDir = path.join(testRoot, 'storage', 'policies');
+    const service = new PolicyService({
+      policiesDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+    await service.waitForInit();
+
+    expect((await service.listPolicies()).map((policy) => policy.preset).sort()).toEqual([
+      'balanced',
+      'permissive',
+      'strict',
+    ]);
+
+    await service.createPolicy({
+      id: 'block-force-push',
+      name: 'Block Force Push',
+      type: 'block-action-type',
+      enabled: true,
+      scope: {
+        agents: ['codex'],
+        projects: ['core'],
+        actionTypes: [],
+      },
+      responseAction: 'block',
+      config: {
+        actionTypes: ['git.force-push'],
+      },
+    });
+
+    const result = await service.evaluatePolicies({
+      agent: 'codex',
+      project: 'core',
+      actionType: 'git.force-push',
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.blockedBy).toEqual(['block-force-push']);
+
+    const existing = await service.getPolicy('block-force-push');
+    if (!existing) {
+      throw new Error('Expected policy to exist before update');
+    }
+
+    const updated = await service.updatePolicy('block-force-push', {
+      ...existing,
+      enabled: false,
+    });
+    expect(updated.enabled).toBe(false);
+
+    await service.deletePolicy('block-force-push');
+    expect(await service.getPolicy('block-force-push')).toBeNull();
+    await expect(fs.access(policiesDir)).rejects.toThrow();
+  });
+
+  it('stores tool policies in SQLite without creating policy files', async () => {
+    const policiesDir = path.join(testRoot, 'storage', 'tool-policies');
+    const service = new ToolPolicyService({
+      policiesDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+    await service.waitForInit();
+
+    expect((await service.getToolPolicy('developer'))?.allowed).toEqual(['*']);
+
+    await service.savePolicy({
+      role: 'Sandboxed',
+      allowed: ['Read'],
+      denied: ['exec'],
+      description: 'Restricted test role',
+    });
+
+    expect(await service.validateToolAccess('sandboxed', 'Read')).toBe(true);
+    expect(await service.validateToolAccess('sandboxed', 'exec')).toBe(false);
+    expect(await service.getToolFilterForRole('sandboxed')).toEqual({
+      allowed: ['Read'],
+      denied: ['exec'],
+    });
+
+    const roles = (await service.listPolicies()).map((policy) => policy.role);
+    expect(roles).toEqual(expect.arrayContaining(['developer', 'sandboxed']));
+
+    await service.deletePolicy('sandboxed');
+    expect(await service.getToolPolicy('sandboxed')).toBeNull();
+    await expect(fs.access(policiesDir)).rejects.toThrow();
+  });
+});
+
+describe('SQLite audit log repository', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-audit-'));
+    process.env.VERITAS_STORAGE = 'sqlite';
+    process.env.VERITAS_SQLITE_PATH = fixture.databasePath;
+    process.env.DATA_DIR = testRoot;
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    const mod = await import('../../services/audit-service.js');
+    mod._resetAuditState();
+    delete process.env.VERITAS_STORAGE;
+    delete process.env.VERITAS_SQLITE_PATH;
+    delete process.env.DATA_DIR;
+    vi.resetModules();
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('stores audit entries in SQLite with hash-chain verification and recent reads', async () => {
+    const mod = await import('../../services/audit-service.js');
+    mod._resetAuditState();
+
+    await mod.auditLog({
+      action: 'auth.login',
+      actor: 'admin',
+      resource: 'session',
+      details: { ip: '127.0.0.1' },
+    });
+    await mod.auditLog({ action: 'task.create', actor: 'admin', resource: 'task_1' });
+    await mod.auditLog({ action: 'settings.update', actor: 'admin', resource: 'theme' });
+
+    expect(mod.getCurrentAuditLogPath()).toBe('sqlite://audit/current');
+    expect(await mod.verifyAuditLog(mod.getCurrentAuditLogPath())).toEqual({
+      valid: true,
+      entries: 3,
+    });
+
+    const recent = await mod.readRecentAuditEntries(2);
+    expect(recent.map((entry) => entry.action)).toEqual(['settings.update', 'task.create']);
+
+    mod._resetAuditState();
+    await mod.auditLog({ action: 'after-restart', actor: 'system' });
+    expect(await mod.verifyAuditLog(mod.getCurrentAuditLogPath())).toEqual({
+      valid: true,
+      entries: 4,
+    });
+
+    await expect(fs.access(path.join(testRoot, '.veritas-kanban', 'audit'))).rejects.toThrow();
+  });
+});

--- a/server/src/services/audit-service.ts
+++ b/server/src/services/audit-service.ts
@@ -13,6 +13,8 @@ import path from 'path';
 import crypto from 'crypto';
 import readline from 'readline';
 import { createLogger } from '../lib/logger.js';
+import { SqliteDatabase } from '../storage/sqlite/database.js';
+import { SqliteAuditRepository } from '../storage/sqlite/audit-policy-repositories.js';
 
 const log = createLogger('audit');
 
@@ -54,6 +56,7 @@ export interface VerifyResult {
 import { getAuditDir } from '../utils/paths.js';
 
 const AUDIT_DIR = getAuditDir();
+const SQLITE_AUDIT_LOG_PATH = 'sqlite://audit/current';
 
 // ---------------------------------------------------------------------------
 // Internal State
@@ -68,6 +71,8 @@ let writeQueue: Promise<void> = Promise.resolve();
 /** Cached current log file path (invalidated on month change). */
 let currentMonth = '';
 let currentLogPath = '';
+let sqliteDatabase: SqliteDatabase | null = null;
+let auditRepository: SqliteAuditRepository | null = null;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -80,6 +85,10 @@ function sha256(data: string): string {
 
 /** Build the log file path for a given date. */
 function logFilePath(date: Date = new Date()): string {
+  if (isSqliteAuditEnabled()) {
+    return SQLITE_AUDIT_LOG_PATH;
+  }
+
   const yyyy = date.getFullYear();
   const mm = String(date.getMonth() + 1).padStart(2, '0');
   const month = `${yyyy}-${mm}`;
@@ -97,11 +106,31 @@ async function ensureAuditDir(): Promise<void> {
   await fs.mkdir(AUDIT_DIR, { recursive: true });
 }
 
+function isSqliteAuditEnabled(): boolean {
+  return process.env.VERITAS_STORAGE === 'sqlite';
+}
+
+function getAuditRepository(): SqliteAuditRepository {
+  if (!auditRepository) {
+    sqliteDatabase = new SqliteDatabase();
+    sqliteDatabase.open();
+    auditRepository = new SqliteAuditRepository(sqliteDatabase);
+  }
+
+  return auditRepository;
+}
+
 /**
  * Read the last line of the current log file to seed `lastHash`.
  * Called once on first write (or after month rotation).
  */
 async function seedLastHash(filePath: string): Promise<void> {
+  if (isSqliteAuditEnabled() || filePath === SQLITE_AUDIT_LOG_PATH) {
+    const lastLine = getAuditRepository().getLastEntryLine();
+    lastHash = lastLine ? sha256(lastLine) : '';
+    return;
+  }
+
   try {
     const content = await fs.readFile(filePath, 'utf8');
     const lines = content.trimEnd().split('\n').filter(Boolean);
@@ -145,9 +174,10 @@ export function auditLog(event: AuditEvent): Promise<void> {
 }
 
 async function writeEntry(event: AuditEvent): Promise<void> {
-  await ensureAuditDir();
-
   const filePath = logFilePath();
+  if (!isSqliteAuditEnabled()) {
+    await ensureAuditDir();
+  }
 
   // Seed lastHash from disk on first write or month rotation
   if (seededForPath !== filePath) {
@@ -165,7 +195,11 @@ async function writeEntry(event: AuditEvent): Promise<void> {
   };
 
   const line = JSON.stringify(entry);
-  await fs.appendFile(filePath, line + '\n', 'utf8');
+  if (isSqliteAuditEnabled()) {
+    getAuditRepository().save(entry, line);
+  } else {
+    await fs.appendFile(filePath, line + '\n', 'utf8');
+  }
 
   // Update the running hash
   lastHash = sha256(line);
@@ -178,6 +212,10 @@ async function writeEntry(event: AuditEvent): Promise<void> {
  * Returns a result indicating whether the chain is intact.
  */
 export async function verifyAuditLog(filePath: string): Promise<VerifyResult> {
+  if (isSqliteAuditEnabled() || filePath === SQLITE_AUDIT_LOG_PATH) {
+    return getAuditRepository().verify();
+  }
+
   // Check if file exists
   try {
     await fs.access(filePath);
@@ -251,6 +289,10 @@ export async function verifyAuditLog(filePath: string): Promise<VerifyResult> {
  */
 export async function readRecentAuditEntries(limit = 100): Promise<AuditEntry[]> {
   const filePath = logFilePath();
+  if (isSqliteAuditEnabled()) {
+    return getAuditRepository().readRecent(limit) as AuditEntry[];
+  }
+
   let content: string;
   try {
     content = await fs.readFile(filePath, 'utf8');
@@ -284,4 +326,7 @@ export function _resetAuditState(): void {
   currentLogPath = '';
   seededForPath = '';
   writeQueue = Promise.resolve();
+  auditRepository = null;
+  sqliteDatabase?.close();
+  sqliteDatabase = null;
 }

--- a/server/src/services/policy-service.ts
+++ b/server/src/services/policy-service.ts
@@ -12,6 +12,8 @@ import { ConflictError, NotFoundError, ValidationError } from '../middleware/err
 import { policySchema } from '../schemas/policy-schemas.js';
 import { getPoliciesDir } from '../utils/paths.js';
 import { safeFetch } from '../utils/url-validation.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteAgentPolicyRepository } from '../storage/sqlite/audit-policy-repositories.js';
 
 const log = createLogger('policy-service');
 const PRESET_TIMESTAMP = new Date().toISOString();
@@ -83,22 +85,48 @@ const DECISION_PRIORITY: Record<PolicyEvaluationResult['decision'], number> = {
 
 export class PolicyService {
   private readonly policiesDir: string;
+  private readonly repository: SqliteAgentPolicyRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
   private readonly cache = new Map<string, AgentPolicy>();
   private readonly rateLimitState = new Map<string, number[]>();
   private initPromise: Promise<void> | null = null;
 
-  constructor(policiesDir = getPoliciesDir()) {
-    this.policiesDir = policiesDir;
+  constructor(options: string | PolicyServiceOptions = {}) {
+    const resolvedOptions = typeof options === 'string' ? { policiesDir: options } : options;
+    this.policiesDir = resolvedOptions.policiesDir ?? getPoliciesDir();
+    const storageType =
+      resolvedOptions.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        resolvedOptions.sqliteDatabase ??
+        new SqliteDatabase(resolvedOptions.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !resolvedOptions.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteAgentPolicyRepository(this.sqliteDatabase);
+    }
+
     this.initPromise = this.init();
   }
 
   async init(): Promise<void> {
+    if (this.repository) {
+      for (const policy of DEFAULT_PRESET_POLICIES) {
+        if (!this.repository.get(policy.id)) {
+          this.repository.save(policy);
+        }
+      }
+      this.loadPoliciesFromRepository();
+      return;
+    }
+
     await mkdir(this.policiesDir, { recursive: true });
 
     const files = (await readdir(this.policiesDir)).filter((file) => file.endsWith('.json'));
     if (files.length === 0) {
       for (const policy of DEFAULT_PRESET_POLICIES) {
-        await this.writePolicyFile(policy);
+        await this.writePolicy(policy);
       }
     }
 
@@ -124,6 +152,15 @@ export class PolicyService {
       return cached;
     }
 
+    if (this.repository) {
+      this.validatePolicyId(id);
+      const policy = this.repository.get(id);
+      if (policy) {
+        this.cache.set(policy.id, policy);
+      }
+      return policy;
+    }
+
     const filePath = this.getPolicyFilePath(id);
     if (!(await fileExists(filePath))) {
       return null;
@@ -142,7 +179,7 @@ export class PolicyService {
     if (this.cache.has(normalized.id)) {
       throw new ConflictError(`Policy already exists: ${normalized.id}`);
     }
-    await this.writePolicyFile(normalized);
+    await this.writePolicy(normalized);
     this.cache.set(normalized.id, normalized);
     return normalized;
   }
@@ -167,7 +204,7 @@ export class PolicyService {
       false
     );
 
-    await this.writePolicyFile(normalized);
+    await this.writePolicy(normalized);
     this.cache.set(normalized.id, normalized);
     return normalized;
   }
@@ -179,10 +216,15 @@ export class PolicyService {
       throw new NotFoundError(`Policy not found: ${id}`);
     }
 
-    const filePath = this.getPolicyFilePath(id);
-    if (await fileExists(filePath)) {
-      await unlink(filePath);
+    if (this.repository) {
+      this.repository.delete(id);
+    } else {
+      const filePath = this.getPolicyFilePath(id);
+      if (await fileExists(filePath)) {
+        await unlink(filePath);
+      }
     }
+
     this.cache.delete(id);
     for (const key of Array.from(this.rateLimitState.keys())) {
       if (key.startsWith(`${id}:`)) {
@@ -238,6 +280,13 @@ export class PolicyService {
     }
   }
 
+  private loadPoliciesFromRepository(): void {
+    this.cache.clear();
+    for (const policy of this.repository?.list() ?? []) {
+      this.cache.set(policy.id, policy);
+    }
+  }
+
   private normalizePolicy(policy: AgentPolicy, isCreate: boolean): AgentPolicy {
     const now = new Date().toISOString();
     const normalized = policySchema.parse({
@@ -257,7 +306,13 @@ export class PolicyService {
     return normalized;
   }
 
-  private async writePolicyFile(policy: AgentPolicy): Promise<void> {
+  private async writePolicy(policy: AgentPolicy): Promise<void> {
+    if (this.repository) {
+      this.repository.save(policy);
+      log.info({ policyId: policy.id, type: policy.type }, 'Policy saved');
+      return;
+    }
+
     const filePath = this.getPolicyFilePath(policy.id);
     await mkdir(path.dirname(filePath), { recursive: true });
     await writeFile(filePath, `${JSON.stringify(policy, null, 2)}\n`, 'utf8');
@@ -265,10 +320,14 @@ export class PolicyService {
   }
 
   private getPolicyFilePath(id: string): string {
+    this.validatePolicyId(id);
+    return path.join(this.policiesDir, `${id}.json`);
+  }
+
+  private validatePolicyId(id: string): void {
     if (!/^[a-z0-9][a-z0-9-_]*$/.test(id)) {
       throw new ValidationError('Invalid policy id');
     }
-    return path.join(this.policiesDir, `${id}.json`);
   }
 
   private scopeMatches(policy: AgentPolicy, input: PolicyEvaluationRequest): boolean {
@@ -493,6 +552,19 @@ export class PolicyService {
     if (action === 'warn') return 'warn';
     return 'allow';
   }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+  }
+}
+
+export interface PolicyServiceOptions {
+  policiesDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 let policyService: PolicyService | null = null;

--- a/server/src/services/tool-policy-service.ts
+++ b/server/src/services/tool-policy-service.ts
@@ -12,6 +12,8 @@ import type { ToolPolicy } from '../types/workflow.js';
 import { ValidationError } from '../types/workflow.js';
 import { getToolPoliciesDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteToolPolicyRepository } from '../storage/sqlite/audit-policy-repositories.js';
 
 const log = createLogger('tool-policy-service');
 
@@ -124,9 +126,25 @@ export class ToolPolicyService {
   private policiesDir: string;
   private cache: Map<string, ToolPolicy> = new Map();
   private initPromise: Promise<void> | null = null;
+  private readonly repository: SqliteToolPolicyRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
 
-  constructor(policiesDir?: string) {
-    this.policiesDir = policiesDir || getToolPoliciesDir();
+  constructor(options: string | ToolPolicyServiceOptions = {}) {
+    const resolvedOptions = typeof options === 'string' ? { policiesDir: options } : options;
+    this.policiesDir = resolvedOptions.policiesDir || getToolPoliciesDir();
+    const storageType =
+      resolvedOptions.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        resolvedOptions.sqliteDatabase ??
+        new SqliteDatabase(resolvedOptions.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !resolvedOptions.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteToolPolicyRepository(this.sqliteDatabase);
+    }
+
     // Load defaults into cache synchronously (no I/O)
     this.loadDefaultsToCache();
     // Initialize async operations (directory creation, file persistence)
@@ -149,6 +167,16 @@ export class ToolPolicyService {
    */
   private async initializeAsync(): Promise<void> {
     try {
+      if (this.repository) {
+        for (const policy of DEFAULT_POLICIES) {
+          if (!this.repository.get(policy.role)) {
+            this.repository.save(policy);
+          }
+        }
+        this.loadRepositoryPoliciesToCache();
+        return;
+      }
+
       // Ensure directory exists
       await fs.mkdir(this.policiesDir, { recursive: true });
 
@@ -182,12 +210,22 @@ export class ToolPolicyService {
    * Get policy for a specific role
    */
   async getToolPolicy(role: string): Promise<ToolPolicy | null> {
+    await this.waitForInit();
+
     const normalizedRole = role.trim().toLowerCase();
 
     // Check cache first
     if (this.cache.has(normalizedRole)) {
       const cachedPolicy = this.cache.get(normalizedRole);
       if (cachedPolicy) return cachedPolicy;
+    }
+
+    if (this.repository) {
+      const policy = this.repository.get(normalizedRole);
+      if (policy) {
+        this.cache.set(normalizedRole, policy);
+      }
+      return policy;
     }
 
     // Try loading from disk
@@ -219,6 +257,14 @@ export class ToolPolicyService {
    * List all tool policies
    */
   async listPolicies(): Promise<ToolPolicy[]> {
+    await this.waitForInit();
+
+    if (this.repository) {
+      const policies = this.repository.list();
+      log.info({ count: policies.length }, 'Listed tool policies');
+      return policies;
+    }
+
     const files = await fs.readdir(this.policiesDir).catch(() => []);
     const policies: ToolPolicy[] = [];
 
@@ -243,14 +289,17 @@ export class ToolPolicyService {
    * @throws ValidationError if policy validation fails or policy limit is reached
    */
   async savePolicy(policy: ToolPolicy): Promise<void> {
+    await this.waitForInit();
     this.validatePolicy(policy);
 
     const normalizedRole = policy.role.trim().toLowerCase();
 
     // Check if we're at the limit for custom policies
     if (!this.cache.has(normalizedRole)) {
-      const files = await fs.readdir(this.policiesDir).catch(() => []);
-      const policyCount = files.filter((f) => f.endsWith('.json')).length;
+      const policyCount = this.repository
+        ? this.repository.list().length
+        : (await fs.readdir(this.policiesDir).catch(() => [])).filter((f) => f.endsWith('.json'))
+            .length;
 
       if (policyCount >= MAX_POLICIES) {
         throw new ValidationError(
@@ -259,8 +308,12 @@ export class ToolPolicyService {
       }
     }
 
-    const filePath = path.join(this.policiesDir, `${normalizedRole}.json`);
-    await fs.writeFile(filePath, JSON.stringify(policy, null, 2), 'utf-8');
+    if (this.repository) {
+      this.repository.save(policy);
+    } else {
+      const filePath = path.join(this.policiesDir, `${normalizedRole}.json`);
+      await fs.writeFile(filePath, JSON.stringify(policy, null, 2), 'utf-8');
+    }
 
     // Update cache
     this.cache.set(normalizedRole, policy);
@@ -275,6 +328,7 @@ export class ToolPolicyService {
    * @throws ValidationError if attempting to delete a default policy
    */
   async deletePolicy(role: string): Promise<void> {
+    await this.waitForInit();
     const normalizedRole = role.trim().toLowerCase();
 
     // Prevent deletion of default policies
@@ -284,8 +338,12 @@ export class ToolPolicyService {
       );
     }
 
-    const filePath = path.join(this.policiesDir, `${normalizedRole}.json`);
-    await fs.unlink(filePath);
+    if (this.repository) {
+      this.repository.delete(normalizedRole);
+    } else {
+      const filePath = path.join(this.policiesDir, `${normalizedRole}.json`);
+      await fs.unlink(filePath);
+    }
     this.cache.delete(normalizedRole);
 
     log.info({ role: normalizedRole }, 'Tool policy deleted');
@@ -424,7 +482,29 @@ export class ToolPolicyService {
   clearCache(): void {
     this.cache.clear();
     this.loadDefaultsToCache();
+    if (this.repository) {
+      this.loadRepositoryPoliciesToCache();
+    }
   }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+  }
+
+  private loadRepositoryPoliciesToCache(): void {
+    for (const policy of this.repository?.list() ?? []) {
+      this.cache.set(policy.role.trim().toLowerCase(), policy);
+    }
+  }
+}
+
+export interface ToolPolicyServiceOptions {
+  policiesDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 // Singleton

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -67,6 +67,11 @@ export {
   SqliteFeedbackRepository,
   SqliteScoringRepository,
 } from './sqlite/governance-repositories.js';
+export {
+  SqliteAgentPolicyRepository,
+  SqliteAuditRepository,
+  SqliteToolPolicyRepository,
+} from './sqlite/audit-policy-repositories.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/audit-policy-repositories.ts
+++ b/server/src/storage/sqlite/audit-policy-repositories.ts
@@ -1,0 +1,320 @@
+import crypto from 'crypto';
+import type { AgentPolicy } from '@veritas-kanban/shared';
+import type { ToolPolicy } from '../../types/workflow.js';
+import type { SqliteDatabase } from './database.js';
+
+export interface SqliteAuditEntry {
+  timestamp: string;
+  action: string;
+  actor: string;
+  resource?: string;
+  details?: Record<string, unknown>;
+  integrity: string;
+}
+
+export interface SqliteAuditVerifyResult {
+  valid: boolean;
+  entries: number;
+  firstBroken?: number;
+}
+
+interface AuditRow {
+  entry_json: string;
+}
+
+interface AgentPolicyRow {
+  policy_json: string;
+}
+
+interface ToolPolicyRow {
+  policy_json: string;
+}
+
+function sha256(data: string): string {
+  return crypto.createHash('sha256').update(data, 'utf8').digest('hex');
+}
+
+export class SqliteAuditRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  getLastEntryLine(): string | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT entry_json
+          FROM audit_entries
+          WHERE workspace_id = 'local'
+          ORDER BY id DESC
+          LIMIT 1
+        `
+      )
+      .get() as AuditRow | undefined;
+
+    return row?.entry_json ?? null;
+  }
+
+  save(entry: SqliteAuditEntry, line: string): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO audit_entries (
+            workspace_id,
+            action,
+            actor,
+            resource,
+            integrity,
+            entry_json,
+            created_at
+          )
+          VALUES ('local', ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        entry.action,
+        entry.actor,
+        entry.resource ?? null,
+        entry.integrity,
+        line,
+        entry.timestamp
+      );
+  }
+
+  readRecent(limit = 100): SqliteAuditEntry[] {
+    const effectiveLimit = Math.min(Math.max(limit, 1), 10_000);
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT entry_json
+          FROM audit_entries
+          WHERE workspace_id = 'local'
+          ORDER BY id DESC
+          LIMIT ?
+        `
+      )
+      .all(effectiveLimit) as unknown as AuditRow[];
+
+    return rows.map((row) => JSON.parse(row.entry_json) as SqliteAuditEntry);
+  }
+
+  verify(): SqliteAuditVerifyResult {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT entry_json
+          FROM audit_entries
+          WHERE workspace_id = 'local'
+          ORDER BY id ASC
+        `
+      )
+      .all() as unknown as AuditRow[];
+
+    let previousHash = '';
+    let totalEntries = 0;
+
+    for (let index = 0; index < rows.length; index += 1) {
+      const line = rows[index].entry_json;
+      totalEntries += 1;
+
+      let entry: SqliteAuditEntry;
+      try {
+        entry = JSON.parse(line) as SqliteAuditEntry;
+      } catch {
+        return { valid: false, entries: totalEntries, firstBroken: index };
+      }
+
+      if (entry.integrity !== previousHash) {
+        return { valid: false, entries: totalEntries, firstBroken: index };
+      }
+
+      previousHash = sha256(line);
+    }
+
+    return { valid: true, entries: totalEntries };
+  }
+}
+
+export class SqliteAgentPolicyRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  list(): AgentPolicy[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT policy_json
+          FROM agent_policies
+          WHERE workspace_id = 'local'
+          ORDER BY name ASC, id ASC
+        `
+      )
+      .all() as unknown as AgentPolicyRow[];
+
+    return rows.map((row) => JSON.parse(row.policy_json) as AgentPolicy);
+  }
+
+  get(id: string): AgentPolicy | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT policy_json
+          FROM agent_policies
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(id) as AgentPolicyRow | undefined;
+
+    return row ? (JSON.parse(row.policy_json) as AgentPolicy) : null;
+  }
+
+  save(policy: AgentPolicy): void {
+    const now = new Date().toISOString();
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO agent_policies (
+            id,
+            workspace_id,
+            name,
+            type,
+            enabled,
+            response_action,
+            preset,
+            policy_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            type = excluded.type,
+            enabled = excluded.enabled,
+            response_action = excluded.response_action,
+            preset = excluded.preset,
+            policy_json = excluded.policy_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        policy.id,
+        policy.name,
+        policy.type,
+        policy.enabled ? 1 : 0,
+        policy.responseAction,
+        policy.preset ?? null,
+        JSON.stringify(policy),
+        policy.createdAt ?? now,
+        policy.updatedAt ?? now
+      );
+  }
+
+  delete(id: string): boolean {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM agent_policies
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .run(id);
+
+    return Number(result.changes) > 0;
+  }
+}
+
+export class SqliteToolPolicyRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  list(): ToolPolicy[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT policy_json
+          FROM tool_policies
+          WHERE workspace_id = 'local'
+          ORDER BY role ASC
+        `
+      )
+      .all() as unknown as ToolPolicyRow[];
+
+    return rows.map((row) => JSON.parse(row.policy_json) as ToolPolicy);
+  }
+
+  get(role: string): ToolPolicy | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT policy_json
+          FROM tool_policies
+          WHERE workspace_id = 'local'
+            AND role = ?
+        `
+      )
+      .get(role) as ToolPolicyRow | undefined;
+
+    return row ? (JSON.parse(row.policy_json) as ToolPolicy) : null;
+  }
+
+  save(policy: ToolPolicy): void {
+    const normalizedPolicy: ToolPolicy = {
+      ...policy,
+      role: policy.role.trim().toLowerCase(),
+    };
+    const now = new Date().toISOString();
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO tool_policies (
+            role,
+            workspace_id,
+            allowed_json,
+            denied_json,
+            policy_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?)
+          ON CONFLICT(role) DO UPDATE SET
+            allowed_json = excluded.allowed_json,
+            denied_json = excluded.denied_json,
+            policy_json = excluded.policy_json,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        normalizedPolicy.role,
+        JSON.stringify(normalizedPolicy.allowed),
+        JSON.stringify(normalizedPolicy.denied),
+        JSON.stringify(normalizedPolicy),
+        now,
+        now
+      );
+  }
+
+  delete(role: string): boolean {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM tool_policies
+          WHERE workspace_id = 'local'
+            AND role = ?
+        `
+      )
+      .run(role);
+
+    return Number(result.changes) > 0;
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -388,6 +388,66 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON drift_baselines(agent_id, metric);
     `,
   },
+  {
+    version: 7,
+    name: '0007_audit_policy_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS audit_entries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        action TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        resource TEXT,
+        integrity TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_audit_entries_workspace_created
+        ON audit_entries(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_audit_entries_actor_created
+        ON audit_entries(actor, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_audit_entries_action_created
+        ON audit_entries(action, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS agent_policies (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        enabled INTEGER NOT NULL,
+        response_action TEXT NOT NULL,
+        preset TEXT,
+        policy_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_agent_policies_workspace_name
+        ON agent_policies(workspace_id, name);
+
+      CREATE INDEX IF NOT EXISTS idx_agent_policies_type_enabled
+        ON agent_policies(type, enabled);
+
+      CREATE TABLE IF NOT EXISTS tool_policies (
+        role TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        allowed_json TEXT NOT NULL,
+        denied_json TEXT NOT NULL,
+        policy_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_tool_policies_workspace_role
+        ON tool_policies(workspace_id, role);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {


### PR DESCRIPTION
## Summary

- adds v7 SQLite tables and repositories for audit entries, agent policies, and tool policies
- routes audit logging, policy service, and tool policy service to SQLite when configured while preserving file-backed defaults
- keeps audit hash-chain verification and recent-entry reads working in SQLite mode
- adds SQLite coverage for audit persistence, agent policy CRUD/evaluation, tool policy CRUD/access filters, and no file writes
- documents the audit/policy tables in the SQLite schema notes

Part of #332.

## Verification

- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-audit-policy-repositories.test.ts`
- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-audit-policy-repositories.test.ts src/__tests__/services/audit-service.test.ts src/__tests__/services/policy-service.test.ts`
- `./node_modules/.bin/eslint server/src/__tests__/storage/sqlite-audit-policy-repositories.test.ts server/src/services/audit-service.ts server/src/services/policy-service.ts server/src/services/tool-policy-service.ts server/src/storage/index.ts server/src/storage/sqlite/audit-policy-repositories.ts server/src/storage/sqlite/migrations.ts --quiet`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Notes

- This is a partial #332 slice. Workflow, chat, broadcast, notification, work product, upload, and scheduled-run repositories remain separate work.