### PR TITLE
feat: add SQLite workflow repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -935,6 +935,20 @@ keep the same validation, preset seeding, and evaluation behavior.
 | `agent_policies` | Complete `AgentPolicy` JSON plus name, type, enabled, response, and preset data.  |
 | `tool_policies`  | Complete `ToolPolicy` JSON plus role and indexed allow/deny JSON columns.         |
 
+## Workflow Repository Implementation
+
+Workflow definitions, ACLs, audit events, run state, and workflow snapshots move
+into SQLite when `VERITAS_STORAGE=sqlite`. The workflow execution engine keeps
+its existing state machine and retry/block/resume behavior; SQLite replaces the
+YAML and `run.json` persistence layer while retaining file mode as the default.
+
+| Runtime table           | Stored data                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| `workflow_definitions`  | Complete `WorkflowDefinition` JSON plus name, version, and description columns.      |
+| `workflow_acls`         | Complete `WorkflowACL` JSON keyed by workflow.                                       |
+| `workflow_audit_events` | Complete workflow audit event JSON plus workflow, action, user, and timestamp data.  |
+| `workflow_runs`         | Complete `WorkflowRun` JSON plus status, task, checkpoint, error, and snapshot JSON. |
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/src/__tests__/storage/sqlite-workflow-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-workflow-repositories.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { WorkflowDefinition, WorkflowRun } from '../../types/workflow.js';
+import { WorkflowRunService } from '../../services/workflow-run-service.js';
+import { WorkflowService } from '../../services/workflow-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+function workflow(): WorkflowDefinition {
+  return {
+    id: 'wf-sqlite',
+    name: 'SQLite Workflow',
+    version: 2,
+    description: 'Workflow persisted in SQLite',
+    variables: { project: 'core' },
+    agents: [
+      {
+        id: 'agent-1',
+        name: 'Agent One',
+        role: 'developer',
+        description: 'Test agent',
+      },
+    ],
+    steps: [
+      {
+        id: 'step-1',
+        name: 'Step One',
+        type: 'agent',
+        agent: 'agent-1',
+        input: 'do the work',
+        on_fail: { retry: 1, retry_delay_ms: 1 },
+      },
+    ],
+  };
+}
+
+function run(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  return {
+    id: 'run_1234567890_abcdef',
+    workflowId: 'wf-sqlite',
+    workflowVersion: 2,
+    taskId: 'task_1',
+    status: 'running',
+    currentStep: 'step-1',
+    context: { started: true },
+    startedAt: '2026-03-01T00:00:00.000Z',
+    steps: [{ stepId: 'step-1', status: 'running', retries: 1 }],
+    ...overrides,
+  };
+}
+
+describe('SQLite workflow repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-workflow-'));
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('stores workflow definitions, ACLs, and workflow audit events in SQLite', async () => {
+    const workflowsDir = path.join(testRoot, 'storage', 'workflows');
+    const service = new WorkflowService({
+      workflowsDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const definition = workflow();
+    await service.saveWorkflow(definition);
+
+    expect(await service.loadWorkflow(definition.id)).toEqual(definition);
+    expect(await service.listWorkflowsMetadata()).toEqual([
+      {
+        id: definition.id,
+        name: definition.name,
+        version: definition.version,
+        description: definition.description,
+      },
+    ]);
+
+    await service.saveACL({
+      workflowId: definition.id,
+      owner: 'brad',
+      editors: ['brad'],
+      viewers: ['team'],
+      executors: ['agent'],
+      isPublic: false,
+    });
+    expect(await service.loadACL(definition.id)).toMatchObject({ owner: 'brad' });
+
+    await service.auditChange({
+      timestamp: '2026-03-01T00:00:00.000Z',
+      userId: 'brad',
+      action: 'edit',
+      workflowId: definition.id,
+      workflowVersion: definition.version,
+    });
+
+    await service.deleteWorkflow(definition.id);
+    expect(await service.loadWorkflow(definition.id)).toBeNull();
+    await expect(fs.access(workflowsDir)).rejects.toThrow();
+  });
+
+  it('stores workflow run state, checkpoints, filters, and snapshots in SQLite', async () => {
+    const runsDir = path.join(testRoot, 'storage', 'workflow-runs');
+    const workflowService = new WorkflowService({
+      workflowsDir: path.join(testRoot, 'storage', 'workflows'),
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+    const runService = new WorkflowRunService({
+      runsDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+      workflowService,
+    });
+    const internals = runService as unknown as {
+      saveRun(value: WorkflowRun): Promise<void>;
+      snapshotWorkflow(runId: string, definition: WorkflowDefinition): Promise<void>;
+    };
+
+    const definition = workflow();
+    await workflowService.saveWorkflow(definition);
+
+    const running = run();
+    await internals.saveRun(running);
+    await internals.snapshotWorkflow(running.id, definition);
+
+    const completed = run({
+      status: 'completed',
+      completedAt: '2026-03-01T00:05:00.000Z',
+      steps: [
+        {
+          stepId: 'step-1',
+          status: 'completed',
+          retries: 1,
+          output: '/tmp/step-1.json',
+        },
+      ],
+    });
+    await internals.saveRun(completed);
+
+    expect(await runService.getRun(completed.id)).toMatchObject({
+      id: completed.id,
+      status: 'completed',
+      lastCheckpoint: expect.any(String),
+    });
+    expect((await runService.listRuns({ taskId: 'task_1' })).map((item) => item.id)).toEqual([
+      completed.id,
+    ]);
+    expect(await runService.listRunsMetadata({ workflowId: 'wf-sqlite' })).toEqual([
+      expect.objectContaining({
+        id: completed.id,
+        workflowId: 'wf-sqlite',
+        taskId: 'task_1',
+        status: 'completed',
+        completedAt: '2026-03-01T00:05:00.000Z',
+      }),
+    ]);
+
+    await expect(fs.access(runsDir)).rejects.toThrow();
+  });
+});

--- a/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
+++ b/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { WorkflowDefinition } from '../../types/workflow.js';
+import { WorkflowService } from '../../services/workflow-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+const mockExecuteStep = vi.fn();
+const mockBroadcastWorkflowStatus = vi.fn();
+const mockGetTask = vi.fn();
+
+vi.mock('../../services/workflow-step-executor.js', () => ({
+  WorkflowStepExecutor: class {
+    executeStep = mockExecuteStep;
+  },
+}));
+
+vi.mock('../../services/broadcast-service.js', () => ({
+  broadcastWorkflowStatus: mockBroadcastWorkflowStatus,
+}));
+
+vi.mock('../../services/task-service.js', () => ({
+  getTaskService: () => ({ getTask: mockGetTask }),
+}));
+
+function workflow(): WorkflowDefinition {
+  return {
+    id: 'wf-sqlite-execution',
+    name: 'SQLite Execution Workflow',
+    version: 1,
+    description: 'Workflow execution persisted in SQLite',
+    variables: { project: 'core' },
+    agents: [
+      {
+        id: 'agent-1',
+        name: 'Agent One',
+        role: 'developer',
+        description: 'Test agent',
+      },
+    ],
+    steps: [
+      {
+        id: 'retryable',
+        name: 'Retryable',
+        type: 'agent',
+        agent: 'agent-1',
+        input: 'retry once',
+        on_fail: { retry: 1 },
+      },
+      {
+        id: 'approval',
+        name: 'Approval',
+        type: 'agent',
+        agent: 'agent-1',
+        input: 'requires approval',
+        on_fail: { escalate_to: 'human', escalate_message: 'Needs approval' },
+      },
+    ],
+  };
+}
+
+describe('SQLite workflow run execution', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+  let workflowService: WorkflowService;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-workflow-execution-'));
+    workflowService = new WorkflowService({
+      workflowsDir: path.join(testRoot, 'storage', 'workflows'),
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+    mockGetTask.mockResolvedValue(null);
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('starts, retries, blocks, resumes, and completes runs in SQLite mode', async () => {
+    const { WorkflowRunService } = await import('../../services/workflow-run-service.js');
+    const definition = workflow();
+    const runsDir = path.join(testRoot, 'storage', 'workflow-runs');
+    const runService = new WorkflowRunService({
+      runsDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+      workflowService,
+    });
+    const counts: Record<string, number> = {};
+
+    await workflowService.saveWorkflow(definition);
+    mockExecuteStep.mockImplementation(async (step: { id: string }) => {
+      counts[step.id] = (counts[step.id] || 0) + 1;
+      if (step.id === 'retryable' && counts[step.id] === 1) {
+        throw new Error('transient failure');
+      }
+      if (step.id === 'approval' && counts[step.id] === 1) {
+        throw new Error('approval required');
+      }
+      return {
+        output: { done: step.id },
+        outputPath: `/tmp/${step.id}.json`,
+      };
+    });
+
+    const run = await runService.startRun(definition.id);
+    await vi.waitFor(async () => {
+      const saved = await runService.getRun(run.id);
+      expect(saved?.status).toBe('blocked');
+      expect(saved?.error).toBe('Needs approval');
+    });
+
+    const blocked = await runService.getRun(run.id);
+    expect(blocked?.steps.find((step) => step.stepId === 'retryable')).toMatchObject({
+      status: 'completed',
+      retries: 1,
+    });
+    expect(blocked?.steps.find((step) => step.stepId === 'approval')).toMatchObject({
+      status: 'failed',
+      error: 'approval required',
+    });
+
+    await runService.resumeRun(run.id, { approved: true });
+    await vi.waitFor(async () => {
+      const saved = await runService.getRun(run.id);
+      expect(saved?.status).toBe('completed');
+      expect(saved?.completedAt).toEqual(expect.any(String));
+      expect(saved?.context.approved).toBe(true);
+    });
+
+    expect(await runService.listRunsMetadata({ status: 'completed' })).toEqual([
+      expect.objectContaining({
+        id: run.id,
+        workflowId: definition.id,
+        status: 'completed',
+      }),
+    ]);
+    expect(counts).toEqual({ retryable: 2, approval: 2 });
+    expect(mockBroadcastWorkflowStatus).toHaveBeenCalled();
+    await expect(fs.access(runsDir)).rejects.toThrow();
+  });
+});

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -13,6 +13,8 @@ import { getWorkflowRunsDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
 import { broadcastWorkflowStatus } from './broadcast-service.js';
 import { getTaskService } from './task-service.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteWorkflowRunRepository } from '../storage/sqlite/workflow-repositories.js';
 
 const log = createLogger('workflow-run');
 
@@ -39,12 +41,30 @@ export class WorkflowRunService {
   private runsDir: string;
   private workflowService: ReturnType<typeof getWorkflowService>;
   private stepExecutor: WorkflowStepExecutor;
+  private readonly repository: SqliteWorkflowRunRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
 
-  constructor(runsDir?: string) {
-    this.runsDir = runsDir || getWorkflowRunsDir();
-    this.workflowService = getWorkflowService();
+  constructor(options: string | WorkflowRunServiceOptions = {}) {
+    const resolvedOptions = typeof options === 'string' ? { runsDir: options } : options;
+    this.runsDir = resolvedOptions.runsDir || getWorkflowRunsDir();
+    this.workflowService = resolvedOptions.workflowService ?? getWorkflowService();
     this.stepExecutor = new WorkflowStepExecutor();
-    this.ensureDirectories();
+    const storageType =
+      resolvedOptions.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        resolvedOptions.sqliteDatabase ??
+        new SqliteDatabase(resolvedOptions.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !resolvedOptions.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteWorkflowRunRepository(this.sqliteDatabase);
+    }
+
+    if (!this.repository) {
+      this.ensureDirectories();
+    }
   }
 
   private async ensureDirectories(): Promise<void> {
@@ -343,6 +363,10 @@ export class WorkflowRunService {
    */
   async getRun(runId: string): Promise<WorkflowRun | null> {
     const safeRunId = this.normalizeRunId(runId);
+    if (this.repository) {
+      return this.repository.get(safeRunId);
+    }
+
     const runPath = path.join(this.runsDir, safeRunId, 'run.json');
 
     try {
@@ -362,6 +386,10 @@ export class WorkflowRunService {
     workflowId?: string;
     status?: string;
   }): Promise<WorkflowRun[]> {
+    if (this.repository) {
+      return this.repository.list(filters);
+    }
+
     const runDirs = await fs.readdir(this.runsDir).catch(() => []);
     const runs: WorkflowRun[] = [];
 
@@ -418,6 +446,12 @@ export class WorkflowRunService {
       >
     >
   > {
+    if (this.repository) {
+      const metadata = this.repository.listMetadata(filters);
+      log.info({ count: metadata.length }, 'Listed run metadata');
+      return metadata;
+    }
+
     const runDirs = await fs.readdir(this.runsDir).catch(() => []);
     const metadata: Array<
       Pick<
@@ -662,11 +696,16 @@ export class WorkflowRunService {
    * Phase 2: Updates lastCheckpoint timestamp on every save
    */
   private async saveRun(run: WorkflowRun): Promise<void> {
-    const runDir = path.join(this.runsDir, run.id);
-    await fs.mkdir(runDir, { recursive: true });
-
     // Update checkpoint timestamp
     run.lastCheckpoint = new Date().toISOString();
+
+    if (this.repository) {
+      this.repository.save(run);
+      return;
+    }
+
+    const runDir = path.join(this.runsDir, run.id);
+    await fs.mkdir(runDir, { recursive: true });
 
     const runPath = path.join(runDir, 'run.json');
     await fs.writeFile(runPath, JSON.stringify(run, null, 2), 'utf-8');
@@ -676,6 +715,11 @@ export class WorkflowRunService {
    * Snapshot workflow YAML into run directory (for version immutability)
    */
   private async snapshotWorkflow(runId: string, workflow: WorkflowDefinition): Promise<void> {
+    if (this.repository) {
+      this.repository.saveWorkflowSnapshot(runId, workflow);
+      return;
+    }
+
     const runDir = path.join(this.runsDir, runId);
     await fs.mkdir(runDir, { recursive: true });
 
@@ -683,6 +727,20 @@ export class WorkflowRunService {
     const yaml = await import('yaml');
     await fs.writeFile(snapshotPath, yaml.stringify(workflow), 'utf-8');
   }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+  }
+}
+
+export interface WorkflowRunServiceOptions {
+  runsDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+  workflowService?: ReturnType<typeof getWorkflowService>;
 }
 
 // Singleton

--- a/server/src/services/workflow-service.ts
+++ b/server/src/services/workflow-service.ts
@@ -10,6 +10,8 @@ import type { WorkflowDefinition, WorkflowACL, WorkflowAuditEvent } from '../typ
 import { ValidationError } from '../types/workflow.js';
 import { getWorkflowsDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteWorkflowDefinitionRepository } from '../storage/sqlite/workflow-repositories.js';
 
 const log = createLogger('workflow-service');
 const WORKFLOW_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/;
@@ -26,10 +28,28 @@ const MAX_RETRY_DELAY_MS = 300000; // 5 minutes max delay
 export class WorkflowService {
   private workflowsDir: string;
   private cache: Map<string, WorkflowDefinition> = new Map();
+  private readonly repository: SqliteWorkflowDefinitionRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
 
-  constructor(workflowsDir?: string) {
-    this.workflowsDir = workflowsDir || getWorkflowsDir();
-    this.ensureDirectories();
+  constructor(options: string | WorkflowServiceOptions = {}) {
+    const resolvedOptions = typeof options === 'string' ? { workflowsDir: options } : options;
+    this.workflowsDir = resolvedOptions.workflowsDir || getWorkflowsDir();
+    const storageType =
+      resolvedOptions.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        resolvedOptions.sqliteDatabase ??
+        new SqliteDatabase(resolvedOptions.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !resolvedOptions.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteWorkflowDefinitionRepository(this.sqliteDatabase);
+    }
+
+    if (!this.repository) {
+      this.ensureDirectories();
+    }
   }
 
   private async ensureDirectories(): Promise<void> {
@@ -66,6 +86,16 @@ export class WorkflowService {
       return this.cache.get(normalizedId)!;
     }
 
+    if (this.repository) {
+      const workflow = this.repository.get(normalizedId);
+      if (workflow) {
+        this.validateWorkflow(workflow);
+        this.cache.set(normalizedId, workflow);
+        log.info({ workflowId: normalizedId, version: workflow.version }, 'Workflow loaded');
+      }
+      return workflow;
+    }
+
     const filePath = path.join(this.workflowsDir, `${normalizedId}.yml`);
 
     try {
@@ -95,6 +125,15 @@ export class WorkflowService {
    * List all available workflows (full definitions)
    */
   async listWorkflows(): Promise<WorkflowDefinition[]> {
+    if (this.repository) {
+      const workflows = this.repository.list();
+      for (const workflow of workflows) {
+        this.cache.set(workflow.id, workflow);
+      }
+      log.info({ count: workflows.length }, 'Listed workflows');
+      return workflows;
+    }
+
     const files = await fs.readdir(this.workflowsDir).catch(() => []);
     const workflows: WorkflowDefinition[] = [];
 
@@ -119,6 +158,12 @@ export class WorkflowService {
   async listWorkflowsMetadata(): Promise<
     Array<Pick<WorkflowDefinition, 'id' | 'name' | 'version' | 'description'>>
   > {
+    if (this.repository) {
+      const metadata = this.repository.listMetadata();
+      log.info({ count: metadata.length }, 'Listed workflow metadata');
+      return metadata;
+    }
+
     const files = await fs.readdir(this.workflowsDir).catch(() => []);
     const metadata: Array<Pick<WorkflowDefinition, 'id' | 'name' | 'version' | 'description'>> = [];
 
@@ -155,6 +200,20 @@ export class WorkflowService {
     this.validateWorkflow(workflow);
 
     const normalizedId = this.normalizeWorkflowId(workflow.id);
+
+    if (this.repository) {
+      if (!this.repository.get(normalizedId) && this.repository.count() >= MAX_WORKFLOWS) {
+        throw new ValidationError(
+          `Maximum workflow limit (${MAX_WORKFLOWS}) reached. Delete unused workflows before creating new ones.`
+        );
+      }
+
+      this.repository.save(workflow);
+      this.cache.set(normalizedId, workflow);
+      log.info({ workflowId: normalizedId, version: workflow.version }, 'Workflow saved');
+      return;
+    }
+
     const filePath = path.join(this.workflowsDir, `${normalizedId}.yml`);
 
     // Check if this is a new workflow (not an update)
@@ -187,6 +246,13 @@ export class WorkflowService {
    */
   async deleteWorkflow(id: string): Promise<void> {
     const normalizedId = this.normalizeWorkflowId(id);
+    if (this.repository) {
+      this.repository.delete(normalizedId);
+      this.cache.delete(normalizedId);
+      log.info({ workflowId: normalizedId }, 'Workflow deleted');
+      return;
+    }
+
     const filePath = path.join(this.workflowsDir, `${normalizedId}.yml`);
     await fs.unlink(filePath);
     this.cache.delete(normalizedId);
@@ -311,6 +377,10 @@ export class WorkflowService {
    * Load workflow ACL (access control list)
    */
   async loadACL(workflowId: string): Promise<WorkflowACL | null> {
+    if (this.repository) {
+      return this.repository.getAcl(workflowId);
+    }
+
     const aclPath = path.join(this.workflowsDir, '.acl.json');
 
     try {
@@ -327,6 +397,12 @@ export class WorkflowService {
    * Save workflow ACL
    */
   async saveACL(acl: WorkflowACL): Promise<void> {
+    if (this.repository) {
+      this.repository.saveAcl(acl);
+      log.info({ workflowId: acl.workflowId }, 'Workflow ACL saved');
+      return;
+    }
+
     const aclPath = path.join(this.workflowsDir, '.acl.json');
 
     let acls: Record<string, WorkflowACL> = {};
@@ -349,6 +425,12 @@ export class WorkflowService {
    * Audit workflow changes
    */
   async auditChange(event: WorkflowAuditEvent): Promise<void> {
+    if (this.repository) {
+      this.repository.appendAuditEvent(event);
+      log.info({ event }, 'Workflow audit event logged');
+      return;
+    }
+
     const auditPath = path.join(this.workflowsDir, '.audit.jsonl');
     const line = JSON.stringify(event) + '\n';
     await fs.appendFile(auditPath, line, 'utf-8');
@@ -362,6 +444,19 @@ export class WorkflowService {
   clearCache(): void {
     this.cache.clear();
   }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+  }
+}
+
+export interface WorkflowServiceOptions {
+  workflowsDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 // Singleton

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -72,6 +72,10 @@ export {
   SqliteAuditRepository,
   SqliteToolPolicyRepository,
 } from './sqlite/audit-policy-repositories.js';
+export {
+  SqliteWorkflowDefinitionRepository,
+  SqliteWorkflowRunRepository,
+} from './sqlite/workflow-repositories.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -448,6 +448,77 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON tool_policies(workspace_id, role);
     `,
   },
+  {
+    version: 8,
+    name: '0008_workflow_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS workflow_definitions (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        description TEXT,
+        workflow_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_definitions_workspace_name
+        ON workflow_definitions(workspace_id, name);
+
+      CREATE TABLE IF NOT EXISTS workflow_acls (
+        workflow_id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        acl_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS workflow_audit_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        workflow_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        event_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_audit_events_workflow_created
+        ON workflow_audit_events(workflow_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS workflow_runs (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        workflow_id TEXT NOT NULL,
+        workflow_version INTEGER NOT NULL,
+        task_id TEXT,
+        status TEXT NOT NULL,
+        current_step TEXT,
+        run_json TEXT NOT NULL,
+        workflow_snapshot_json TEXT,
+        started_at TEXT NOT NULL,
+        completed_at TEXT,
+        last_checkpoint TEXT,
+        error TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_runs_workspace_started
+        ON workflow_runs(workspace_id, started_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_started
+        ON workflow_runs(workflow_id, started_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_runs_task_started
+        ON workflow_runs(task_id, started_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_runs_status_started
+        ON workflow_runs(status, started_at DESC);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/workflow-repositories.ts
+++ b/server/src/storage/sqlite/workflow-repositories.ts
@@ -1,0 +1,401 @@
+import type { SQLInputValue } from 'node:sqlite';
+import type {
+  WorkflowACL,
+  WorkflowAuditEvent,
+  WorkflowDefinition,
+  WorkflowRun,
+} from '../../types/workflow.js';
+import type { SqliteDatabase } from './database.js';
+
+type WorkflowMetadata = Pick<WorkflowDefinition, 'id' | 'name' | 'version' | 'description'>;
+type WorkflowRunMetadata = Pick<
+  WorkflowRun,
+  | 'id'
+  | 'workflowId'
+  | 'workflowVersion'
+  | 'taskId'
+  | 'status'
+  | 'startedAt'
+  | 'completedAt'
+  | 'error'
+>;
+
+interface WorkflowDefinitionRow {
+  workflow_json: string;
+}
+
+interface WorkflowMetadataRow {
+  id: string;
+  name: string;
+  version: number;
+  description: string | null;
+}
+
+interface WorkflowAclRow {
+  acl_json: string;
+}
+
+interface WorkflowRunRow {
+  run_json: string;
+}
+
+interface WorkflowRunMetadataRow {
+  id: string;
+  workflow_id: string;
+  workflow_version: number;
+  task_id: string | null;
+  status: WorkflowRun['status'];
+  started_at: string;
+  completed_at: string | null;
+  error: string | null;
+}
+
+export class SqliteWorkflowDefinitionRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  count(): number {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT COUNT(*) AS count
+          FROM workflow_definitions
+          WHERE workspace_id = 'local'
+        `
+      )
+      .get() as { count: number } | undefined;
+
+    return row?.count ?? 0;
+  }
+
+  get(id: string): WorkflowDefinition | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT workflow_json
+          FROM workflow_definitions
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(id) as WorkflowDefinitionRow | undefined;
+
+    return row ? (JSON.parse(row.workflow_json) as WorkflowDefinition) : null;
+  }
+
+  list(): WorkflowDefinition[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT workflow_json
+          FROM workflow_definitions
+          WHERE workspace_id = 'local'
+          ORDER BY name ASC, id ASC
+        `
+      )
+      .all() as unknown as WorkflowDefinitionRow[];
+
+    return rows.map((row) => JSON.parse(row.workflow_json) as WorkflowDefinition);
+  }
+
+  listMetadata(): WorkflowMetadata[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT id, name, version, description
+          FROM workflow_definitions
+          WHERE workspace_id = 'local'
+          ORDER BY name ASC, id ASC
+        `
+      )
+      .all() as unknown as WorkflowMetadataRow[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      version: row.version,
+      description: row.description ?? '',
+    }));
+  }
+
+  save(workflow: WorkflowDefinition): void {
+    const now = new Date().toISOString();
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO workflow_definitions (
+            id,
+            workspace_id,
+            name,
+            version,
+            description,
+            workflow_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            version = excluded.version,
+            description = excluded.description,
+            workflow_json = excluded.workflow_json,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        workflow.id,
+        workflow.name,
+        workflow.version,
+        workflow.description ?? null,
+        JSON.stringify(workflow),
+        now,
+        now
+      );
+  }
+
+  delete(id: string): boolean {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM workflow_definitions
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .run(id);
+
+    return Number(result.changes) > 0;
+  }
+
+  getAcl(workflowId: string): WorkflowACL | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT acl_json
+          FROM workflow_acls
+          WHERE workspace_id = 'local'
+            AND workflow_id = ?
+        `
+      )
+      .get(workflowId) as WorkflowAclRow | undefined;
+
+    return row ? (JSON.parse(row.acl_json) as WorkflowACL) : null;
+  }
+
+  saveAcl(acl: WorkflowACL): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO workflow_acls (
+            workflow_id,
+            workspace_id,
+            acl_json,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?)
+          ON CONFLICT(workflow_id) DO UPDATE SET
+            acl_json = excluded.acl_json,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(acl.workflowId, JSON.stringify(acl), new Date().toISOString());
+  }
+
+  appendAuditEvent(event: WorkflowAuditEvent): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO workflow_audit_events (
+            workspace_id,
+            workflow_id,
+            action,
+            user_id,
+            event_json,
+            created_at
+          )
+          VALUES ('local', ?, ?, ?, ?, ?)
+        `
+      )
+      .run(event.workflowId, event.action, event.userId, JSON.stringify(event), event.timestamp);
+  }
+}
+
+export class SqliteWorkflowRunRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  get(runId: string): WorkflowRun | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT run_json
+          FROM workflow_runs
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(runId) as WorkflowRunRow | undefined;
+
+    return row ? (JSON.parse(row.run_json) as WorkflowRun) : null;
+  }
+
+  list(filters: { taskId?: string; workflowId?: string; status?: string } = {}): WorkflowRun[] {
+    const rows = this.queryRunRows(filters);
+    return rows.map((row) => JSON.parse(row.run_json) as WorkflowRun);
+  }
+
+  listMetadata(
+    filters: { taskId?: string; workflowId?: string; status?: string } = {}
+  ): WorkflowRunMetadata[] {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+
+    if (filters.taskId) {
+      clauses.push('task_id = ?');
+      params.push(filters.taskId);
+    }
+    if (filters.workflowId) {
+      clauses.push('workflow_id = ?');
+      params.push(filters.workflowId);
+    }
+    if (filters.status) {
+      clauses.push('status = ?');
+      params.push(filters.status);
+    }
+
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT
+            id,
+            workflow_id,
+            workflow_version,
+            task_id,
+            status,
+            started_at,
+            completed_at,
+            error
+          FROM workflow_runs
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY datetime(started_at) DESC, id DESC
+        `
+      )
+      .all(...params) as unknown as WorkflowRunMetadataRow[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      workflowId: row.workflow_id,
+      workflowVersion: row.workflow_version,
+      taskId: row.task_id ?? undefined,
+      status: row.status,
+      startedAt: row.started_at,
+      completedAt: row.completed_at ?? undefined,
+      error: row.error ?? undefined,
+    }));
+  }
+
+  save(run: WorkflowRun): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO workflow_runs (
+            id,
+            workspace_id,
+            workflow_id,
+            workflow_version,
+            task_id,
+            status,
+            current_step,
+            run_json,
+            started_at,
+            completed_at,
+            last_checkpoint,
+            error
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            workflow_id = excluded.workflow_id,
+            workflow_version = excluded.workflow_version,
+            task_id = excluded.task_id,
+            status = excluded.status,
+            current_step = excluded.current_step,
+            run_json = excluded.run_json,
+            started_at = excluded.started_at,
+            completed_at = excluded.completed_at,
+            last_checkpoint = excluded.last_checkpoint,
+            error = excluded.error
+        `
+      )
+      .run(
+        run.id,
+        run.workflowId,
+        run.workflowVersion,
+        run.taskId ?? null,
+        run.status,
+        run.currentStep ?? null,
+        JSON.stringify(run),
+        run.startedAt,
+        run.completedAt ?? null,
+        run.lastCheckpoint ?? null,
+        run.error ?? null
+      );
+  }
+
+  saveWorkflowSnapshot(runId: string, workflow: WorkflowDefinition): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          UPDATE workflow_runs
+          SET workflow_snapshot_json = ?
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .run(JSON.stringify(workflow), runId);
+  }
+
+  private queryRunRows(filters: {
+    taskId?: string;
+    workflowId?: string;
+    status?: string;
+  }): WorkflowRunRow[] {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+
+    if (filters.taskId) {
+      clauses.push('task_id = ?');
+      params.push(filters.taskId);
+    }
+    if (filters.workflowId) {
+      clauses.push('workflow_id = ?');
+      params.push(filters.workflowId);
+    }
+    if (filters.status) {
+      clauses.push('status = ?');
+      params.push(filters.status);
+    }
+
+    return this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT run_json
+          FROM workflow_runs
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY datetime(started_at) DESC, id DESC
+        `
+      )
+      .all(...params) as unknown as WorkflowRunRow[];
+  }
+}


### PR DESCRIPTION
## Summary

- adds SQLite tables and repositories for workflow definitions, ACLs, audit events, run state, and workflow snapshots
- wires workflow definition and run services into SQLite mode while keeping file mode as the default
- adds SQLite repository tests plus an execution-path test for start, retry, block, resume, and complete behavior
- documents the workflow repository schema mapping

Part of #332.

## Verification

- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-workflow-repositories.test.ts src/__tests__/storage/sqlite-workflow-run-execution.test.ts src/__tests__/workflow-service.test.ts src/__tests__/workflow-run-service.test.ts`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Notes

- The production audit currently reports only moderate vulnerabilities.