### PR TITLE
feat: add SQLite chat repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -949,6 +949,18 @@ YAML and `run.json` persistence layer while retaining file mode as the default.
 | `workflow_audit_events` | Complete workflow audit event JSON plus workflow, action, user, and timestamp data.  |
 | `workflow_runs`         | Complete `WorkflowRun` JSON plus status, task, checkpoint, error, and snapshot JSON. |
 
+## Chat Repository Implementation
+
+Chat sessions, task chat messages, and squad messages move into SQLite when
+`VERITAS_STORAGE=sqlite`. File mode remains the default and keeps the current
+Markdown format for existing local projects.
+
+| Runtime table    | Stored data                                                                     |
+| ---------------- | ------------------------------------------------------------------------------- |
+| `chat_sessions`  | Board and task chat session metadata, scoped by task when present.              |
+| `chat_messages`  | Individual chat messages with session, task, role, agent, model, and timestamp. |
+| `squad_messages` | Squad channel messages with agent, system/event flags, tags, cards, and timing. |
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/src/__tests__/storage/sqlite-chat-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-chat-repositories.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ChatService } from '../../services/chat-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+describe('SQLite chat repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-chat-'));
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('persists board chat, task chat, and squad chat without markdown files', async () => {
+    const chatsDir = path.join(testRoot, 'storage', 'chats');
+    const service = new ChatService({
+      chatsDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const board = await service.createSession({ agent: 'VERITAS', mode: 'build' });
+    const task = await service.createSession({ taskId: 'TASK-1', agent: 'TARS' });
+
+    await service.addMessage(board.id, {
+      role: 'user',
+      content: 'Review the board',
+      model: 'gpt-5',
+    });
+    await service.addMessage(task.id, {
+      role: 'assistant',
+      content: 'Task scoped reply',
+      agent: 'TARS',
+    });
+    await service.sendSquadMessage(
+      {
+        agent: 'TARS',
+        message: 'Task started',
+        tags: ['task'],
+        model: 'claude-sonnet-4',
+        taskTitle: 'TASK-1',
+        duration: '2s',
+        card: { type: 'AdaptiveCard' },
+      },
+      'Tars'
+    );
+    await service.sendSquadMessage({
+      agent: 'CASE',
+      message: 'System note',
+      system: true,
+      event: 'agent.status',
+    });
+
+    const restarted = new ChatService({
+      chatsDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    expect(await restarted.getSession(board.id)).toMatchObject({
+      id: board.id,
+      messages: [expect.objectContaining({ role: 'user', content: 'Review the board' })],
+    });
+    expect(await restarted.getSessionForTask('TASK-1')).toMatchObject({
+      id: task.id,
+      taskId: 'TASK-1',
+      messages: [expect.objectContaining({ role: 'assistant', content: 'Task scoped reply' })],
+    });
+    expect((await restarted.listSessions()).map((session) => session.id)).toEqual([board.id]);
+
+    const squadMessages = await restarted.getSquadMessages();
+    expect(squadMessages).toHaveLength(2);
+    expect(squadMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent: 'TARS',
+          displayName: 'Tars',
+          tags: ['task'],
+          card: { type: 'AdaptiveCard' },
+        }),
+        expect.objectContaining({ agent: 'CASE', system: true, event: 'agent.status' }),
+      ])
+    );
+    expect(await restarted.getSquadMessages({ agent: 'TARS' })).toEqual([
+      expect.objectContaining({ agent: 'TARS', message: 'Task started' }),
+    ]);
+    expect(await restarted.getSquadMessages({ includeSystem: false })).toEqual([
+      expect.objectContaining({ agent: 'TARS' }),
+    ]);
+    expect(await restarted.getSquadMessages({ limit: 1 })).toHaveLength(1);
+
+    await restarted.deleteSession(board.id);
+    expect(await restarted.getSession(board.id)).toBeNull();
+    await expect(fs.access(chatsDir)).rejects.toThrow();
+  });
+});

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -15,6 +15,8 @@ import { withFileLock } from './file-lock.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
 import { createLogger } from '../lib/logger.js';
 import { getChatsDir } from '../utils/paths.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteChatRepository } from '../storage/sqlite/chat-repository.js';
 
 const log = createLogger('chat-service');
 
@@ -25,18 +27,37 @@ const DEFAULT_SQUAD_DIR = path.join(DEFAULT_CHATS_DIR, 'squad');
 
 export interface ChatServiceOptions {
   chatsDir?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
 }
 
 export class ChatService {
   private chatsDir: string;
   private sessionsDir: string;
   private squadDir: string;
+  private readonly repository: SqliteChatRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
 
   constructor(options: ChatServiceOptions = {}) {
     this.chatsDir = options.chatsDir || DEFAULT_CHATS_DIR;
     this.sessionsDir = path.join(this.chatsDir, 'sessions');
     this.squadDir = path.join(this.chatsDir, 'squad');
-    this.ensureDirectories();
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
+
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteChatRepository(this.sqliteDatabase);
+    }
+
+    if (!this.repository) {
+      this.ensureDirectories();
+    }
   }
 
   private async ensureDirectories(): Promise<void> {
@@ -176,6 +197,15 @@ export class ChatService {
     // Try to find the session file (could be task-scoped or board-level)
     // First check if it's a task-scoped session
     const taskMatch = sessionId.match(/^task_(.+)$/);
+    if (this.repository) {
+      if (taskMatch) {
+        validatePathSegment(taskMatch[1]);
+      } else {
+        validatePathSegment(sessionId);
+      }
+      return this.repository.getSession(sessionId);
+    }
+
     if (taskMatch) {
       const taskId = taskMatch[1];
       const filePath = this.getSessionPath(sessionId, taskId);
@@ -205,6 +235,11 @@ export class ChatService {
    * Get the session for a specific task
    */
   async getSessionForTask(taskId: string): Promise<ChatSession | null> {
+    if (this.repository) {
+      validatePathSegment(taskId);
+      return this.repository.getSessionForTask(taskId);
+    }
+
     const filePath = this.getSessionPath(`task_${taskId}`, taskId);
 
     try {
@@ -220,6 +255,10 @@ export class ChatService {
    * List all sessions (board-level only)
    */
   async listSessions(): Promise<ChatSession[]> {
+    if (this.repository) {
+      return this.repository.listBoardSessions();
+    }
+
     try {
       const files = await fs.readdir(this.sessionsDir);
       const sessions: ChatSession[] = [];
@@ -250,6 +289,10 @@ export class ChatService {
     agent: string;
     mode?: 'ask' | 'build';
   }): Promise<ChatSession> {
+    if (input.taskId) {
+      validatePathSegment(input.taskId);
+    }
+
     const sessionId = input.taskId ? `task_${input.taskId}` : this.generateSessionId();
     const now = new Date().toISOString();
 
@@ -263,6 +306,12 @@ export class ChatService {
       created: now,
       updated: now,
     };
+
+    if (this.repository) {
+      this.repository.saveSession(session);
+      log.info({ sessionId, taskId: input.taskId }, 'Created chat session');
+      return session;
+    }
 
     const filePath = this.getSessionPath(sessionId, input.taskId);
     const content = this.serializeSession(session);
@@ -292,6 +341,26 @@ export class ChatService {
     // Determine file path - need to check both task-scoped and board-level paths
     const taskMatch = sessionId.match(/^task_(.+)$/);
     const taskId = taskMatch ? taskMatch[1] : undefined;
+    if (this.repository) {
+      if (taskId) {
+        validatePathSegment(taskId);
+      } else {
+        validatePathSegment(sessionId);
+      }
+
+      const session = await this.repository.getSession(sessionId);
+      if (!session) {
+        throw new Error(`Session ${sessionId} not found`);
+      }
+
+      session.messages.push(newMessage);
+      session.updated = newMessage.timestamp;
+      this.repository.saveSession(session);
+
+      log.debug({ sessionId, messageId: newMessage.id, role: newMessage.role }, 'Added message');
+      return newMessage;
+    }
+
     const filePath = this.getSessionPath(sessionId, taskId);
 
     await withFileLock(filePath, async () => {
@@ -320,6 +389,22 @@ export class ChatService {
     // Determine file path - need to check both task-scoped and board-level paths
     const taskMatch = sessionId.match(/^task_(.+)$/);
     const taskId = taskMatch ? taskMatch[1] : undefined;
+    if (this.repository) {
+      if (taskId) {
+        validatePathSegment(taskId);
+      } else {
+        validatePathSegment(sessionId);
+      }
+
+      if (!this.repository.deleteSession(sessionId)) {
+        log.info({ sessionId }, 'Chat session already deleted or never existed');
+        return;
+      }
+
+      log.info({ sessionId }, 'Deleted chat session');
+      return;
+    }
+
     const filePath = this.getSessionPath(sessionId, taskId);
 
     await withFileLock(filePath, async () => {
@@ -383,6 +468,21 @@ export class ChatService {
       ...(input.card && { card: input.card }),
     };
 
+    if (this.repository) {
+      this.repository.appendSquadMessage(squadMessage);
+      log.info(
+        {
+          messageId,
+          agent: input.agent,
+          tags: input.tags,
+          model: input.model,
+          system: input.system,
+        },
+        'Squad message sent'
+      );
+      return squadMessage;
+    }
+
     // Store as daily markdown file: squad/YYYY-MM-DD.md
     const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
     const filePath = path.join(this.squadDir, `${date}.md`);
@@ -433,6 +533,10 @@ export class ChatService {
       includeSystem?: boolean;
     } = {}
   ): Promise<SquadMessage[]> {
+    if (this.repository) {
+      return this.repository.listSquadMessages(options);
+    }
+
     const messages: SquadMessage[] = [];
     const includeSystem = options.includeSystem !== false; // Default to true
     const sinceTimestamp = options.since ? Date.parse(options.since) : null;
@@ -561,6 +665,12 @@ export class ChatService {
     } catch (err: any) {
       if (err.code === 'ENOENT') return [];
       throw err;
+    }
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
     }
   }
 }

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -76,6 +76,7 @@ export {
   SqliteWorkflowDefinitionRepository,
   SqliteWorkflowRunRepository,
 } from './sqlite/workflow-repositories.js';
+export { SqliteChatRepository } from './sqlite/chat-repository.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/chat-repository.ts
+++ b/server/src/storage/sqlite/chat-repository.ts
@@ -1,0 +1,273 @@
+import type { SQLInputValue } from 'node:sqlite';
+import type { ChatMessage, ChatSession, SquadMessage } from '@veritas-kanban/shared';
+import type { SqliteDatabase } from './database.js';
+
+interface ChatSessionRow {
+  id: string;
+  session_json: string;
+}
+
+interface ChatMessageRow {
+  message_json: string;
+}
+
+interface SquadMessageRow {
+  message_json: string;
+}
+
+export class SqliteChatRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  getSession(sessionId: string): ChatSession | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT id, session_json
+          FROM chat_sessions
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .get(sessionId) as ChatSessionRow | undefined;
+
+    return row ? this.hydrateSession(row) : null;
+  }
+
+  getSessionForTask(taskId: string): ChatSession | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT id, session_json
+          FROM chat_sessions
+          WHERE workspace_id = 'local'
+            AND task_id = ?
+        `
+      )
+      .get(taskId) as ChatSessionRow | undefined;
+
+    return row ? this.hydrateSession(row) : null;
+  }
+
+  listBoardSessions(): ChatSession[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT id, session_json
+          FROM chat_sessions
+          WHERE workspace_id = 'local'
+            AND task_id IS NULL
+          ORDER BY datetime(updated_at) DESC, id DESC
+        `
+      )
+      .all() as unknown as ChatSessionRow[];
+
+    return rows.map((row) => this.hydrateSession(row));
+  }
+
+  saveSession(session: ChatSession): void {
+    const db = this.database.getConnection();
+
+    db.exec('BEGIN IMMEDIATE;');
+    try {
+      db.prepare(
+        `
+          INSERT INTO chat_sessions (
+            id,
+            workspace_id,
+            task_id,
+            title,
+            agent,
+            model,
+            mode,
+            session_json,
+            created_at,
+            updated_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            task_id = excluded.task_id,
+            title = excluded.title,
+            agent = excluded.agent,
+            model = excluded.model,
+            mode = excluded.mode,
+            session_json = excluded.session_json,
+            updated_at = excluded.updated_at
+        `
+      ).run(
+        session.id,
+        session.taskId ?? null,
+        session.title,
+        session.agent,
+        session.model ?? null,
+        session.mode,
+        JSON.stringify({ ...session, messages: [] }),
+        session.created,
+        session.updated
+      );
+
+      db.prepare("DELETE FROM chat_messages WHERE workspace_id = 'local' AND session_id = ?").run(
+        session.id
+      );
+
+      const insertMessage = db.prepare(
+        `
+          INSERT INTO chat_messages (
+            id,
+            workspace_id,
+            session_id,
+            task_id,
+            role,
+            agent,
+            model,
+            message_json,
+            created_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?)
+        `
+      );
+
+      for (const message of session.messages) {
+        insertMessage.run(
+          message.id,
+          session.id,
+          session.taskId ?? null,
+          message.role,
+          message.agent ?? null,
+          message.model ?? null,
+          JSON.stringify(message),
+          message.timestamp
+        );
+      }
+
+      db.exec('COMMIT;');
+    } catch (error) {
+      db.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+
+  deleteSession(sessionId: string): boolean {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          DELETE FROM chat_sessions
+          WHERE workspace_id = 'local'
+            AND id = ?
+        `
+      )
+      .run(sessionId);
+
+    return Number(result.changes) > 0;
+  }
+
+  appendSquadMessage(message: SquadMessage): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO squad_messages (
+            id,
+            workspace_id,
+            agent,
+            display_name,
+            message,
+            tags_json,
+            timestamp,
+            model,
+            is_system,
+            event,
+            task_title,
+            duration,
+            card_json,
+            message_json
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        message.id,
+        message.agent,
+        message.displayName ?? null,
+        message.message,
+        message.tags ? JSON.stringify(message.tags) : null,
+        message.timestamp,
+        message.model ?? null,
+        message.system ? 1 : 0,
+        message.event ?? null,
+        message.taskTitle ?? null,
+        message.duration ?? null,
+        message.card ? JSON.stringify(message.card) : null,
+        JSON.stringify(message)
+      );
+  }
+
+  listSquadMessages(
+    options: {
+      since?: string;
+      agent?: string;
+      limit?: number;
+      includeSystem?: boolean;
+    } = {}
+  ): SquadMessage[] {
+    const clauses = ["workspace_id = 'local'"];
+    const params: SQLInputValue[] = [];
+    const sinceTimestamp =
+      options.since && !Number.isNaN(Date.parse(options.since)) ? options.since : null;
+
+    if (sinceTimestamp) {
+      clauses.push('timestamp >= ?');
+      params.push(sinceTimestamp);
+    }
+    if (options.agent) {
+      clauses.push('agent = ?');
+      params.push(options.agent);
+    }
+    if (options.includeSystem === false) {
+      clauses.push('is_system = 0');
+    }
+
+    const limit = options.limit && options.limit > 0 ? Math.floor(options.limit) : null;
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT message_json
+          FROM squad_messages
+          WHERE ${clauses.join(' AND ')}
+          ORDER BY datetime(timestamp) ${limit ? 'DESC' : 'ASC'}, id ${limit ? 'DESC' : 'ASC'}
+          ${limit ? 'LIMIT ?' : ''}
+        `
+      )
+      .all(...(limit ? [...params, limit] : params)) as unknown as SquadMessageRow[];
+
+    const messages = rows.map((row) => JSON.parse(row.message_json) as SquadMessage);
+    return limit ? messages.reverse() : messages;
+  }
+
+  private hydrateSession(row: ChatSessionRow): ChatSession {
+    const session = JSON.parse(row.session_json) as ChatSession;
+    session.messages = this.listMessages(row.id);
+    return session;
+  }
+
+  private listMessages(sessionId: string): ChatMessage[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT message_json
+          FROM chat_messages
+          WHERE workspace_id = 'local'
+            AND session_id = ?
+          ORDER BY datetime(created_at) ASC, id ASC
+        `
+      )
+      .all(sessionId) as unknown as ChatMessageRow[];
+
+    return rows.map((row) => JSON.parse(row.message_json) as ChatMessage);
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -519,6 +519,78 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON workflow_runs(status, started_at DESC);
     `,
   },
+  {
+    version: 9,
+    name: '0009_chat_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS chat_sessions (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        task_id TEXT,
+        title TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        model TEXT,
+        mode TEXT NOT NULL,
+        session_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_sessions_task
+        ON chat_sessions(task_id)
+        WHERE task_id IS NOT NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_chat_sessions_workspace_updated
+        ON chat_sessions(workspace_id, updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS chat_messages (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        session_id TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+        task_id TEXT,
+        role TEXT NOT NULL,
+        agent TEXT,
+        model TEXT,
+        message_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_chat_messages_session_created
+        ON chat_messages(session_id, created_at ASC);
+
+      CREATE INDEX IF NOT EXISTS idx_chat_messages_task_created
+        ON chat_messages(task_id, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS squad_messages (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        agent TEXT NOT NULL,
+        display_name TEXT,
+        message TEXT NOT NULL,
+        tags_json TEXT,
+        timestamp TEXT NOT NULL,
+        model TEXT,
+        is_system INTEGER NOT NULL DEFAULT 0,
+        event TEXT,
+        task_title TEXT,
+        duration TEXT,
+        card_json TEXT,
+        message_json TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_squad_messages_workspace_timestamp
+        ON squad_messages(workspace_id, timestamp DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_squad_messages_agent_timestamp
+        ON squad_messages(agent, timestamp DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_squad_messages_event_timestamp
+        ON squad_messages(event, timestamp DESC);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {


### PR DESCRIPTION
## Summary

- adds SQLite tables and repositories for board chat sessions, task chat messages, and squad chat messages
- wires ChatService into SQLite mode while leaving Markdown file mode as the default
- adds restart-style SQLite coverage proving board chat, task chat, and squad chat persist without markdown files
- documents the chat repository schema mapping

Part of #332.

## Verification

- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-chat-repositories.test.ts src/__tests__/chat-service.test.ts src/__tests__/routes/chat.test.ts`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Notes

- The production audit currently reports only moderate vulnerabilities.