### PR TITLE
feat: add SQLite notification repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -961,6 +961,18 @@ Markdown format for existing local projects.
 | `chat_messages`  | Individual chat messages with session, task, role, agent, model, and timestamp. |
 | `squad_messages` | Squad channel messages with agent, system/event flags, tags, cards, and timing. |
 
+## Notification Repository Implementation
+
+Notification inbox records and thread subscriptions move into SQLite when
+`VERITAS_STORAGE=sqlite`. The notification service keeps the same mention,
+assignment, delivery, and subscription behavior while replacing
+`notifications.json` and `thread-subscriptions.json` in SQLite mode.
+
+| Runtime table          | Stored data                                                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| `notifications`        | Complete notification JSON plus task, target, source, type, read state, target URL, and dedupe key. |
+| `thread_subscriptions` | Complete subscription JSON keyed by workspace, task, and subscribed agent.                          |
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/src/__tests__/notification-service.test.ts
+++ b/server/src/__tests__/notification-service.test.ts
@@ -292,6 +292,8 @@ describe('NotificationService', () => {
       expect(notif.targetAgent).toBe('system');
       expect(notif.fromAgent).toBe('system');
       expect(notif.content).toBe('The build failed on task ABC-123');
+      expect(notif.type).toBe('error');
+      expect(notif.title).toBe('Build Failed');
       expect(notif.delivered).toBe(false);
     });
   });

--- a/server/src/__tests__/storage/sqlite-notification-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-notification-repositories.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { NotificationService } from '../../services/notification-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+describe('SQLite notification repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-notifications-'));
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('persists notification inbox records and thread subscriptions without JSON files', async () => {
+    const dataDir = path.join(testRoot, 'data');
+    const service = new NotificationService({
+      dataDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const created = await service.processComment({
+      taskId: 'TASK-1',
+      fromAgent: 'alice',
+      content: '@bob @all please review',
+      allAgents: ['alice', 'bob', 'case'],
+    });
+    await service.notifyAssignment('TASK-2', ['bob', 'alice'], 'alice');
+    await service.createNotification({
+      type: 'system_alert',
+      title: 'System Alert',
+      message: 'System alert',
+      taskId: 'TASK-3',
+      taskTitle: 'Review production deploy',
+      project: 'veritas-kanban',
+      targetUrl: '/tasks/TASK-3',
+      dedupeKey: 'system_alert:TASK-3',
+      source: { service: 'sqlite-notification-test', retry: 0, userVisible: true },
+    });
+    await service.markDelivered(created[0].id);
+
+    const restarted = new NotificationService({
+      dataDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const bobNotifications = await restarted.getNotifications({ agent: 'bob' });
+    expect(bobNotifications).toHaveLength(2);
+    expect(bobNotifications).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          taskId: 'TASK-1',
+          targetAgent: 'bob',
+          type: 'mention',
+          delivered: true,
+          deliveredAt: expect.any(String),
+        }),
+        expect.objectContaining({
+          taskId: 'TASK-2',
+          targetAgent: 'bob',
+          type: 'assignment',
+          delivered: false,
+        }),
+      ])
+    );
+    expect(await restarted.getNotifications({ agent: 'case', undelivered: true })).toEqual([
+      expect.objectContaining({ taskId: 'TASK-1', targetAgent: 'case' }),
+    ]);
+    expect(await restarted.getAllNotifications({ undelivered: true })).toHaveLength(3);
+    expect(await restarted.getAllNotifications()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          taskId: 'TASK-3',
+          targetAgent: 'system',
+          type: 'system_alert',
+          title: 'System Alert',
+          taskTitle: 'Review production deploy',
+          project: 'veritas-kanban',
+          targetUrl: '/tasks/TASK-3',
+          dedupeKey: 'system_alert:TASK-3',
+          source: { service: 'sqlite-notification-test', retry: 0, userVisible: true },
+        }),
+      ])
+    );
+
+    const subscriptions = await restarted.getSubscriptions('TASK-1');
+    expect(subscriptions.map((subscription) => subscription.agent).sort()).toEqual([
+      'alice',
+      'bob',
+      'case',
+    ]);
+
+    const stats = await restarted.getStats();
+    expect(stats.totalNotifications).toBe(4);
+    expect(stats.byAgent.bob).toMatchObject({ total: 2, undelivered: 1 });
+    expect(stats.byType).toMatchObject({ assignment: 1, mention: 2, system_alert: 1 });
+
+    await expect(fs.access(path.join(dataDir, 'notifications.json'))).rejects.toThrow();
+    await expect(fs.access(path.join(dataDir, 'thread-subscriptions.json'))).rejects.toThrow();
+  });
+});

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -50,6 +50,11 @@ router.post(
       taskId: z.string().optional(),
       taskTitle: z.string().optional(),
       project: z.string().optional(),
+      targetUrl: z.string().optional(),
+      dedupeKey: z.string().optional(),
+      source: z
+        .record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+        .optional(),
     });
 
     const data = schema.parse(req.body);

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -9,12 +9,16 @@ import { createLogger } from '../lib/logger.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { withFileLock } from './file-lock.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteNotificationRepository } from '../storage/sqlite/notification-repository.js';
 
 const DATA_DIR = process.env.DATA_DIR || path.join(process.cwd(), '..', '.veritas-kanban');
 
 const log = createLogger('notifications');
 
 // ─── Types ───────────────────────────────────────────────────────
+
+export type NotificationSourceMetadata = Record<string, string | number | boolean | null>;
 
 export interface Notification {
   id: string;
@@ -27,7 +31,19 @@ export interface Notification {
   /** The comment/content containing the mention */
   content: string;
   /** Type of notification */
-  type: 'mention' | 'assignment' | 'status_change' | 'reply';
+  type: string;
+  /** Optional display title for direct notifications */
+  title?: string;
+  /** Optional human-readable task title */
+  taskTitle?: string;
+  /** Optional project or workspace label */
+  project?: string;
+  /** Optional link target for UI/API consumers */
+  targetUrl?: string;
+  /** Optional caller-provided dedupe key */
+  dedupeKey?: string;
+  /** Audit-safe source metadata, not raw event payloads */
+  source?: NotificationSourceMetadata;
   /** Has the notification been delivered/read? */
   delivered: boolean;
   /** ISO timestamp when delivered */
@@ -51,6 +67,15 @@ export interface NotificationStats {
   byType: Record<string, number>;
 }
 
+export interface NotificationServiceOptions {
+  dataDir?: string;
+  notificationsFile?: string;
+  subscriptionsFile?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+}
+
 // ─── Mention Parser ──────────────────────────────────────────────
 
 /** Extract @mentions from text. Supports @agent-name and @all */
@@ -72,25 +97,46 @@ export class NotificationService {
   private notifications: Notification[] = [];
   private subscriptions: ThreadSubscription[] = [];
   private loaded = false;
+  private readonly notificationsFile: string;
+  private readonly subscriptionsFile: string;
+  private readonly repository: SqliteNotificationRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
 
-  private get notificationsPath(): string {
-    return path.join(DATA_DIR, 'notifications.json');
-  }
+  constructor(options: NotificationServiceOptions = {}) {
+    const dataDir = options.dataDir ?? DATA_DIR;
+    this.notificationsFile = options.notificationsFile ?? path.join(dataDir, 'notifications.json');
+    this.subscriptionsFile =
+      options.subscriptionsFile ?? path.join(dataDir, 'thread-subscriptions.json');
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 
-  private get subscriptionsPath(): string {
-    return path.join(DATA_DIR, 'thread-subscriptions.json');
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteNotificationRepository(this.sqliteDatabase);
+    }
   }
 
   private async ensureLoaded(): Promise<void> {
     if (this.loaded) return;
+    if (this.repository) {
+      this.notifications = this.repository.loadNotifications();
+      this.subscriptions = this.repository.loadSubscriptions();
+      this.loaded = true;
+      return;
+    }
+
     try {
-      const nData = await fs.readFile(this.notificationsPath, 'utf-8');
+      const nData = await fs.readFile(this.notificationsFile, 'utf-8');
       this.notifications = JSON.parse(nData);
     } catch {
       this.notifications = [];
     }
     try {
-      const sData = await fs.readFile(this.subscriptionsPath, 'utf-8');
+      const sData = await fs.readFile(this.subscriptionsFile, 'utf-8');
       this.subscriptions = JSON.parse(sData);
     } catch {
       this.subscriptions = [];
@@ -99,14 +145,24 @@ export class NotificationService {
   }
 
   private async saveNotifications(): Promise<void> {
-    await withFileLock(this.notificationsPath, async () => {
-      await fs.writeFile(this.notificationsPath, JSON.stringify(this.notifications, null, 2));
+    if (this.repository) {
+      this.repository.saveNotifications(this.notifications);
+      return;
+    }
+
+    await withFileLock(this.notificationsFile, async () => {
+      await fs.writeFile(this.notificationsFile, JSON.stringify(this.notifications, null, 2));
     });
   }
 
   private async saveSubscriptions(): Promise<void> {
-    await withFileLock(this.subscriptionsPath, async () => {
-      await fs.writeFile(this.subscriptionsPath, JSON.stringify(this.subscriptions, null, 2));
+    if (this.repository) {
+      this.repository.saveSubscriptions(this.subscriptions);
+      return;
+    }
+
+    await withFileLock(this.subscriptionsFile, async () => {
+      await fs.writeFile(this.subscriptionsFile, JSON.stringify(this.subscriptions, null, 2));
     });
   }
 
@@ -244,10 +300,12 @@ export class NotificationService {
    * Used by the CLI notification commands, which predate the agent-scoped
    * route shape.
    */
-  async getAllNotifications(filters: {
-    undelivered?: boolean;
-    limit?: number;
-  } = {}): Promise<Notification[]> {
+  async getAllNotifications(
+    filters: {
+      undelivered?: boolean;
+      limit?: number;
+    } = {}
+  ): Promise<Notification[]> {
     await this.ensureLoaded();
 
     let results = [...this.notifications];
@@ -331,6 +389,9 @@ export class NotificationService {
     taskId?: string;
     taskTitle?: string;
     project?: string;
+    targetUrl?: string;
+    dedupeKey?: string;
+    source?: NotificationSourceMetadata;
   }): Promise<Notification> {
     await this.ensureLoaded();
 
@@ -340,7 +401,13 @@ export class NotificationService {
       targetAgent: 'system',
       fromAgent: 'system',
       content: params.message,
-      type: 'mention',
+      type: params.type || 'system',
+      title: params.title,
+      taskTitle: params.taskTitle,
+      project: params.project,
+      targetUrl: params.targetUrl,
+      dedupeKey: params.dedupeKey,
+      source: params.source,
       delivered: false,
       createdAt: new Date().toISOString(),
     };
@@ -419,6 +486,12 @@ export class NotificationService {
   async getSubscriptions(taskId: string): Promise<ThreadSubscription[]> {
     await this.ensureLoaded();
     return this.subscriptions.filter((s) => s.taskId === taskId);
+  }
+
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
   }
 }
 

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -77,6 +77,7 @@ export {
   SqliteWorkflowRunRepository,
 } from './sqlite/workflow-repositories.js';
 export { SqliteChatRepository } from './sqlite/chat-repository.js';
+export { SqliteNotificationRepository } from './sqlite/notification-repository.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -591,6 +591,63 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON squad_messages(event, timestamp DESC);
     `,
   },
+  {
+    version: 10,
+    name: '0010_notification_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS notifications (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        task_id TEXT NOT NULL,
+        target_agent TEXT NOT NULL,
+        from_agent TEXT NOT NULL,
+        type TEXT NOT NULL,
+        delivered INTEGER NOT NULL DEFAULT 0,
+        delivered_at TEXT,
+        content TEXT NOT NULL,
+        title TEXT,
+        task_title TEXT,
+        project TEXT,
+        target_url TEXT,
+        dedupe_key TEXT,
+        source_json TEXT,
+        notification_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_notifications_agent_delivered_created
+        ON notifications(target_agent, delivered, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_notifications_task_created
+        ON notifications(task_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_notifications_type_created
+        ON notifications(type, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_notifications_dedupe_key
+        ON notifications(dedupe_key)
+        WHERE dedupe_key IS NOT NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_notifications_project_created
+        ON notifications(project, created_at DESC)
+        WHERE project IS NOT NULL;
+
+      CREATE TABLE IF NOT EXISTS thread_subscriptions (
+        task_id TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        reason TEXT NOT NULL,
+        subscription_json TEXT NOT NULL,
+        subscribed_at TEXT NOT NULL,
+        PRIMARY KEY (workspace_id, task_id, agent)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_thread_subscriptions_task
+        ON thread_subscriptions(task_id, agent);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/notification-repository.ts
+++ b/server/src/storage/sqlite/notification-repository.ts
@@ -1,0 +1,144 @@
+import type { Notification, ThreadSubscription } from '../../services/notification-service.js';
+import type { SqliteDatabase } from './database.js';
+
+interface NotificationRow {
+  notification_json: string;
+}
+
+interface ThreadSubscriptionRow {
+  subscription_json: string;
+}
+
+export class SqliteNotificationRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  loadNotifications(): Notification[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT notification_json
+          FROM notifications
+          WHERE workspace_id = 'local'
+          ORDER BY datetime(created_at) ASC, id ASC
+        `
+      )
+      .all() as unknown as NotificationRow[];
+
+    return rows.map((row) => JSON.parse(row.notification_json) as Notification);
+  }
+
+  saveNotifications(notifications: Notification[]): void {
+    const db = this.database.getConnection();
+
+    db.exec('BEGIN IMMEDIATE;');
+    try {
+      db.prepare("DELETE FROM notifications WHERE workspace_id = 'local'").run();
+
+      const insertNotification = db.prepare(
+        `
+          INSERT INTO notifications (
+            id,
+            workspace_id,
+            task_id,
+            target_agent,
+            from_agent,
+            type,
+            delivered,
+            delivered_at,
+            content,
+            title,
+            task_title,
+            project,
+            target_url,
+            dedupe_key,
+            source_json,
+            notification_json,
+            created_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      );
+
+      for (const notification of notifications) {
+        insertNotification.run(
+          notification.id,
+          notification.taskId,
+          notification.targetAgent,
+          notification.fromAgent,
+          notification.type,
+          notification.delivered ? 1 : 0,
+          notification.deliveredAt ?? null,
+          notification.content,
+          notification.title ?? null,
+          notification.taskTitle ?? null,
+          notification.project ?? null,
+          notification.targetUrl ?? null,
+          notification.dedupeKey ?? null,
+          notification.source ? JSON.stringify(notification.source) : null,
+          JSON.stringify(notification),
+          notification.createdAt
+        );
+      }
+
+      db.exec('COMMIT;');
+    } catch (error) {
+      db.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+
+  loadSubscriptions(): ThreadSubscription[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT subscription_json
+          FROM thread_subscriptions
+          WHERE workspace_id = 'local'
+          ORDER BY datetime(subscribed_at) ASC, task_id ASC, agent ASC
+        `
+      )
+      .all() as unknown as ThreadSubscriptionRow[];
+
+    return rows.map((row) => JSON.parse(row.subscription_json) as ThreadSubscription);
+  }
+
+  saveSubscriptions(subscriptions: ThreadSubscription[]): void {
+    const db = this.database.getConnection();
+
+    db.exec('BEGIN IMMEDIATE;');
+    try {
+      db.prepare("DELETE FROM thread_subscriptions WHERE workspace_id = 'local'").run();
+
+      const insertSubscription = db.prepare(
+        `
+          INSERT INTO thread_subscriptions (
+            task_id,
+            agent,
+            workspace_id,
+            reason,
+            subscription_json,
+            subscribed_at
+          )
+          VALUES (?, ?, 'local', ?, ?, ?)
+        `
+      );
+
+      for (const subscription of subscriptions) {
+        insertSubscription.run(
+          subscription.taskId,
+          subscription.agent,
+          subscription.reason,
+          JSON.stringify(subscription),
+          subscription.subscribedAt
+        );
+      }
+
+      db.exec('COMMIT;');
+    } catch (error) {
+      db.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- adds SQLite tables and repository storage for notification inbox records and thread subscriptions
- wires NotificationService into SQLite mode while preserving JSON file mode and existing file-path test options
- preserves direct notification metadata including type, title, task title, project, target URL, dedupe key, and source metadata
- adds restart-style SQLite coverage for mentions, assignments, direct notifications, delivered state, stats, and subscriptions
- documents the notification repository schema mapping

Part of #332.

## Verification

- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-notification-repositories.test.ts src/__tests__/notification-service.test.ts src/__tests__/failure-alert-service.test.ts src/__tests__/routes/notifications-coverage.test.ts`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`
- `git diff --cached --check`

## Notes

- The production audit currently reports only moderate vulnerabilities.