### PR TITLE
feat: add SQLite scheduled deliverable repositories

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -973,6 +973,18 @@ assignment, delivery, and subscription behavior while replacing
 | `notifications`        | Complete notification JSON plus task, target, source, type, read state, target URL, and dedupe key. |
 | `thread_subscriptions` | Complete subscription JSON keyed by workspace, task, and subscribed agent.                          |
 
+## Scheduled Deliverable Repository Implementation
+
+Scheduled deliverables and recurring run history move into SQLite when
+`VERITAS_STORAGE=sqlite`. Run rows keep stable output snapshots separate from
+live workflow execution state so dashboards and completion packets can read
+bounded historical results without traversing workflow-run directories.
+
+| Runtime table                | Stored data                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| `scheduled_deliverables`     | Complete scheduled deliverable JSON plus schedule, agent, output path, tags, and next run.   |
+| `scheduled_deliverable_runs` | Complete run JSON plus source workflow/run IDs, status, output, duration, and snapshot JSON. |
+
 ## Migration Numbering
 
 Migrations live under the future SQLite package as paired SQL files:

--- a/server/src/__tests__/storage/sqlite-scheduled-deliverables-repository.test.ts
+++ b/server/src/__tests__/storage/sqlite-scheduled-deliverables-repository.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ScheduledDeliverablesService } from '../../services/scheduled-deliverables-service.js';
+import {
+  createTestSqliteDatabase,
+  type TestSqliteDatabase,
+} from '../../storage/sqlite/test-helpers.js';
+
+describe('SQLite scheduled deliverable repositories', () => {
+  let fixture: TestSqliteDatabase;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    fixture = createTestSqliteDatabase();
+    fixture.database.open();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sqlite-scheduled-'));
+  });
+
+  afterEach(async () => {
+    fixture.cleanup();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('persists scheduled deliverables and stable run snapshots without JSON files', async () => {
+    const dataDir = path.join(testRoot, 'data');
+    const service = new ScheduledDeliverablesService({
+      dataDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    const deliverable = await service.create({
+      name: 'Weekly QA Packet',
+      description: 'Summarize completed QA runs.',
+      schedule: 'weekly',
+      agent: 'codex',
+      outputPath: 'docs/reports/weekly-qa.md',
+      tags: ['qa', 'weekly'],
+    });
+    await service.create({
+      name: 'Paused Report',
+      description: 'Disabled report fixture.',
+      schedule: 'daily',
+      enabled: false,
+      tags: ['paused'],
+    });
+    await service.recordRun({
+      deliverableId: deliverable.id,
+      status: 'success',
+      outputFile: 'docs/reports/weekly-qa-2026-05-31.md',
+      summary: 'Three runs completed, no release blockers.',
+      durationMs: 1234,
+      sourceRunId: 'run_20260531_weekly_qa',
+      workflowId: 'workflow_weekly_qa',
+      snapshotMetadata: { reviewed: true, completedRuns: 3, releaseBlockers: 0 },
+    });
+
+    const restarted = new ScheduledDeliverablesService({
+      dataDir,
+      storageType: 'sqlite',
+      sqliteDatabase: fixture.database,
+    });
+
+    expect(await restarted.list({ enabled: true, agent: 'codex', tag: 'weekly' })).toEqual([
+      expect.objectContaining({
+        id: deliverable.id,
+        name: 'Weekly QA Packet',
+        totalRuns: 1,
+        lastRunAt: expect.any(String),
+        nextRunAt: expect.any(String),
+      }),
+    ]);
+    expect(await restarted.list({ enabled: false })).toEqual([
+      expect.objectContaining({ name: 'Paused Report' }),
+    ]);
+
+    const detail = await restarted.get(deliverable.id);
+    expect(detail?.recentRuns).toEqual([
+      expect.objectContaining({
+        deliverableId: deliverable.id,
+        status: 'success',
+        sourceRunId: 'run_20260531_weekly_qa',
+        workflowId: 'workflow_weekly_qa',
+        snapshot: expect.objectContaining({
+          status: 'success',
+          capturedAt: expect.any(String),
+          outputFile: 'docs/reports/weekly-qa-2026-05-31.md',
+          summary: 'Three runs completed, no release blockers.',
+          metadata: { reviewed: true, completedRuns: 3, releaseBlockers: 0 },
+        }),
+      }),
+    ]);
+    await expect(fs.access(path.join(dataDir, 'scheduled-deliverables.json'))).rejects.toThrow();
+    await expect(fs.access(path.join(dataDir, 'deliverable-runs.json'))).rejects.toThrow();
+  });
+});

--- a/server/src/routes/scheduled-deliverables.ts
+++ b/server/src/routes/scheduled-deliverables.ts
@@ -23,8 +23,9 @@ router.get(
   asyncHandler(async (req, res) => {
     const service = getScheduledDeliverablesService();
     const deliverables = await service.list({
-      enabled: req.query.enabled === 'true' ? true : req.query.enabled === 'false' ? false : undefined,
-      agent: String(req.query.agent || ""),
+      enabled:
+        req.query.enabled === 'true' ? true : req.query.enabled === 'false' ? false : undefined,
+      agent: String(req.query.agent || ''),
       tag: req.query.tag as string,
     });
     res.json(deliverables);
@@ -103,6 +104,11 @@ router.post(
       summary: z.string().optional(),
       durationMs: z.number().optional(),
       error: z.string().optional(),
+      sourceRunId: z.string().optional(),
+      workflowId: z.string().optional(),
+      snapshotMetadata: z
+        .record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+        .optional(),
     });
     const data = schema.parse(req.body);
     const service = getScheduledDeliverablesService();

--- a/server/src/services/scheduled-deliverables-service.ts
+++ b/server/src/services/scheduled-deliverables-service.ts
@@ -3,13 +3,13 @@
  *
  * Manages recurring agent workflows and their outputs.
  * Think: daily pulses, weekly audits, scheduled reports.
- *
- * Inspired by @nateherk's Klouse scheduled deliverables view.
  */
 
 import { createLogger } from '../lib/logger.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import { SqliteScheduledDeliverablesRepository } from '../storage/sqlite/scheduled-deliverables-repository.js';
 const DATA_DIR = process.env.DATA_DIR || path.join(process.cwd(), '..', '.veritas-kanban');
 
 const log = createLogger('deliverables');
@@ -61,39 +61,94 @@ export interface DeliverableRun {
   durationMs?: number;
   /** Error message if failed */
   error?: string;
+  /** Source workflow run captured into this scheduled result */
+  sourceRunId?: string;
+  /** Workflow definition that produced the result */
+  workflowId?: string;
+  /** Stable result snapshot for dashboards and completion packets */
+  snapshot?: DeliverableRunSnapshot;
   /** Run timestamp */
   runAt: string;
 }
 
+export interface DeliverableRunSnapshot {
+  status: DeliverableRun['status'];
+  capturedAt: string;
+  sourceRunId?: string;
+  workflowId?: string;
+  outputFile?: string;
+  summary?: string;
+  durationMs?: number;
+  error?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface ScheduledDeliverablesServiceOptions {
+  dataDir?: string;
+  deliverablesFile?: string;
+  runsFile?: string;
+  storageType?: 'file' | 'sqlite';
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+  runRetentionLimit?: number;
+}
+
 // ─── Service ─────────────────────────────────────────────────────
 
-class ScheduledDeliverablesService {
+export class ScheduledDeliverablesService {
   private deliverables: Deliverable[] = [];
   private runs: DeliverableRun[] = [];
   private loaded = false;
+  private readonly deliverablesFile: string;
+  private readonly runsFile: string;
+  private readonly runRetentionLimit: number;
+  private readonly repository: SqliteScheduledDeliverablesRepository | null = null;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
 
-  private get deliverablesPath(): string {
-    return path.join(DATA_DIR, 'scheduled-deliverables.json');
-  }
+  constructor(options: ScheduledDeliverablesServiceOptions = {}) {
+    const dataDir = options.dataDir ?? DATA_DIR;
+    this.deliverablesFile =
+      options.deliverablesFile ?? path.join(dataDir, 'scheduled-deliverables.json');
+    this.runsFile = options.runsFile ?? path.join(dataDir, 'deliverable-runs.json');
+    this.runRetentionLimit = options.runRetentionLimit ?? 500;
+    const storageType =
+      options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 
-  private get runsPath(): string {
-    return path.join(DATA_DIR, 'deliverable-runs.json');
+    if (storageType === 'sqlite') {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteScheduledDeliverablesRepository(this.sqliteDatabase);
+    }
   }
 
   private async ensureLoaded(): Promise<void> {
     if (this.loaded) return;
+    if (this.repository) {
+      this.deliverables = this.repository.loadDeliverables();
+      this.runs = this.repository.loadRuns();
+      if (this.runs.length > this.runRetentionLimit) {
+        this.runs = this.runs.slice(-this.runRetentionLimit);
+        this.repository.saveRuns(this.runs);
+      }
+      this.loaded = true;
+      return;
+    }
+
     try {
-      const data = await fs.readFile(this.deliverablesPath, 'utf-8');
+      const data = await fs.readFile(this.deliverablesFile, 'utf-8');
       this.deliverables = JSON.parse(data);
     } catch {
       this.deliverables = [];
     }
     try {
-      const data = await fs.readFile(this.runsPath, 'utf-8');
+      const data = await fs.readFile(this.runsFile, 'utf-8');
       this.runs = JSON.parse(data);
       // Keep only last 500 runs
-      if (this.runs.length > 500) {
-        this.runs = this.runs.slice(-500);
+      if (this.runs.length > this.runRetentionLimit) {
+        this.runs = this.runs.slice(-this.runRetentionLimit);
       }
     } catch {
       this.runs = [];
@@ -102,11 +157,23 @@ class ScheduledDeliverablesService {
   }
 
   private async saveDeliverables(): Promise<void> {
-    await fs.writeFile(this.deliverablesPath, JSON.stringify(this.deliverables, null, 2));
+    if (this.repository) {
+      this.repository.saveDeliverables(this.deliverables);
+      return;
+    }
+
+    await fs.mkdir(path.dirname(this.deliverablesFile), { recursive: true });
+    await fs.writeFile(this.deliverablesFile, JSON.stringify(this.deliverables, null, 2));
   }
 
   private async saveRuns(): Promise<void> {
-    await fs.writeFile(this.runsPath, JSON.stringify(this.runs, null, 2));
+    if (this.repository) {
+      this.repository.saveRuns(this.runs);
+      return;
+    }
+
+    await fs.mkdir(path.dirname(this.runsFile), { recursive: true });
+    await fs.writeFile(this.runsFile, JSON.stringify(this.runs, null, 2));
   }
 
   /**
@@ -125,7 +192,8 @@ class ScheduledDeliverablesService {
   }): Promise<Deliverable> {
     await this.ensureLoaded();
 
-    const scheduleDesc = params.scheduleDescription || this.describeSchedule(params.schedule, params.cronExpr);
+    const scheduleDesc =
+      params.scheduleDescription || this.describeSchedule(params.schedule, params.cronExpr);
 
     const deliverable: Deliverable = {
       id: `del_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
@@ -151,14 +219,31 @@ class ScheduledDeliverablesService {
   /**
    * Update a deliverable.
    */
-  async update(id: string, update: Partial<Pick<Deliverable, 'name' | 'description' | 'schedule' | 'cronExpr' | 'scheduleDescription' | 'enabled' | 'agent' | 'outputPath' | 'tags'>>): Promise<Deliverable | null> {
+  async update(
+    id: string,
+    update: Partial<
+      Pick<
+        Deliverable,
+        | 'name'
+        | 'description'
+        | 'schedule'
+        | 'cronExpr'
+        | 'scheduleDescription'
+        | 'enabled'
+        | 'agent'
+        | 'outputPath'
+        | 'tags'
+      >
+    >
+  ): Promise<Deliverable | null> {
     await this.ensureLoaded();
     const del = this.deliverables.find((d) => d.id === id);
     if (!del) return null;
 
     Object.assign(del, update);
     if (update.schedule || update.cronExpr) {
-      del.scheduleDescription = update.scheduleDescription || this.describeSchedule(del.schedule, del.cronExpr);
+      del.scheduleDescription =
+        update.scheduleDescription || this.describeSchedule(del.schedule, del.cronExpr);
     }
 
     await this.saveDeliverables();
@@ -187,8 +272,23 @@ class ScheduledDeliverablesService {
     summary?: string;
     durationMs?: number;
     error?: string;
+    sourceRunId?: string;
+    workflowId?: string;
+    snapshotMetadata?: Record<string, string | number | boolean | null>;
   }): Promise<DeliverableRun> {
     await this.ensureLoaded();
+    const runAt = new Date().toISOString();
+    const snapshot: DeliverableRunSnapshot = {
+      status: params.status,
+      capturedAt: runAt,
+      sourceRunId: params.sourceRunId,
+      workflowId: params.workflowId,
+      outputFile: params.outputFile,
+      summary: params.summary,
+      durationMs: params.durationMs,
+      error: params.error,
+      metadata: params.snapshotMetadata,
+    };
 
     const run: DeliverableRun = {
       id: `run_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
@@ -198,7 +298,10 @@ class ScheduledDeliverablesService {
       summary: params.summary,
       durationMs: params.durationMs,
       error: params.error,
-      runAt: new Date().toISOString(),
+      sourceRunId: params.sourceRunId,
+      workflowId: params.workflowId,
+      snapshot,
+      runAt,
     };
 
     this.runs.push(run);
@@ -219,7 +322,11 @@ class ScheduledDeliverablesService {
   /**
    * List all deliverables.
    */
-  async list(filters?: { enabled?: boolean; agent?: string; tag?: string }): Promise<Deliverable[]> {
+  async list(filters?: {
+    enabled?: boolean;
+    agent?: string;
+    tag?: string;
+  }): Promise<Deliverable[]> {
     await this.ensureLoaded();
 
     let results = [...this.deliverables];
@@ -239,7 +346,9 @@ class ScheduledDeliverablesService {
   /**
    * Get a specific deliverable with its recent runs.
    */
-  async get(id: string): Promise<{ deliverable: Deliverable; recentRuns: DeliverableRun[] } | null> {
+  async get(
+    id: string
+  ): Promise<{ deliverable: Deliverable; recentRuns: DeliverableRun[] } | null> {
     await this.ensureLoaded();
     const deliverable = this.deliverables.find((d) => d.id === id);
     if (!deliverable) return null;
@@ -263,15 +372,26 @@ class ScheduledDeliverablesService {
       .slice(0, limit);
   }
 
+  dispose(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+  }
+
   // ─── Private ─────────────────────────────────────────────────
 
   private describeSchedule(schedule: DeliverableSchedule, cronExpr?: string): string {
     switch (schedule) {
-      case 'daily': return 'Every day';
-      case 'weekly': return 'Every week';
-      case 'biweekly': return 'Every 2 weeks';
-      case 'monthly': return 'Every month';
-      case 'custom': return cronExpr ? `Cron: ${cronExpr}` : 'Custom schedule';
+      case 'daily':
+        return 'Every day';
+      case 'weekly':
+        return 'Every week';
+      case 'biweekly':
+        return 'Every 2 weeks';
+      case 'monthly':
+        return 'Every month';
+      case 'custom':
+        return cronExpr ? `Cron: ${cronExpr}` : 'Custom schedule';
     }
   }
 
@@ -280,11 +400,21 @@ class ScheduledDeliverablesService {
     const next = new Date(lastRun);
 
     switch (del.schedule) {
-      case 'daily': next.setDate(next.getDate() + 1); break;
-      case 'weekly': next.setDate(next.getDate() + 7); break;
-      case 'biweekly': next.setDate(next.getDate() + 14); break;
-      case 'monthly': next.setMonth(next.getMonth() + 1); break;
-      default: next.setDate(next.getDate() + 1); break;
+      case 'daily':
+        next.setDate(next.getDate() + 1);
+        break;
+      case 'weekly':
+        next.setDate(next.getDate() + 7);
+        break;
+      case 'biweekly':
+        next.setDate(next.getDate() + 14);
+        break;
+      case 'monthly':
+        next.setMonth(next.getMonth() + 1);
+        break;
+      default:
+        next.setDate(next.getDate() + 1);
+        break;
     }
 
     return next.toISOString();

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -78,6 +78,7 @@ export {
 } from './sqlite/workflow-repositories.js';
 export { SqliteChatRepository } from './sqlite/chat-repository.js';
 export { SqliteNotificationRepository } from './sqlite/notification-repository.js';
+export { SqliteScheduledDeliverablesRepository } from './sqlite/scheduled-deliverables-repository.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -648,6 +648,68 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON thread_subscriptions(task_id, agent);
     `,
   },
+  {
+    version: 11,
+    name: '0011_scheduled_deliverable_repositories',
+    up: `
+      CREATE TABLE IF NOT EXISTS scheduled_deliverables (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        schedule TEXT NOT NULL,
+        cron_expr TEXT,
+        schedule_description TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        agent TEXT,
+        output_path TEXT,
+        tags_json TEXT NOT NULL,
+        deliverable_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        last_run_at TEXT,
+        next_run_at TEXT,
+        total_runs INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_scheduled_deliverables_enabled_next_run
+        ON scheduled_deliverables(enabled, next_run_at);
+
+      CREATE INDEX IF NOT EXISTS idx_scheduled_deliverables_agent_enabled
+        ON scheduled_deliverables(agent, enabled);
+
+      CREATE TABLE IF NOT EXISTS scheduled_deliverable_runs (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        deliverable_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        output_file TEXT,
+        summary TEXT,
+        duration_ms INTEGER,
+        error TEXT,
+        source_run_id TEXT,
+        workflow_id TEXT,
+        snapshot_json TEXT,
+        run_json TEXT NOT NULL,
+        run_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_scheduled_deliverable_runs_deliverable_run
+        ON scheduled_deliverable_runs(deliverable_id, run_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_scheduled_deliverable_runs_status_run
+        ON scheduled_deliverable_runs(status, run_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_scheduled_deliverable_runs_source_run
+        ON scheduled_deliverable_runs(source_run_id)
+        WHERE source_run_id IS NOT NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_scheduled_deliverable_runs_workflow_run
+        ON scheduled_deliverable_runs(workflow_id, run_at DESC)
+        WHERE workflow_id IS NOT NULL;
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/scheduled-deliverables-repository.ts
+++ b/server/src/storage/sqlite/scheduled-deliverables-repository.ts
@@ -1,0 +1,156 @@
+import type { Deliverable, DeliverableRun } from '../../services/scheduled-deliverables-service.js';
+import type { SqliteDatabase } from './database.js';
+
+interface DeliverableRow {
+  deliverable_json: string;
+}
+
+interface DeliverableRunRow {
+  run_json: string;
+}
+
+export class SqliteScheduledDeliverablesRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  loadDeliverables(): Deliverable[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT deliverable_json
+          FROM scheduled_deliverables
+          WHERE workspace_id = 'local'
+          ORDER BY lower(name) ASC, id ASC
+        `
+      )
+      .all() as unknown as DeliverableRow[];
+
+    return rows.map((row) => JSON.parse(row.deliverable_json) as Deliverable);
+  }
+
+  saveDeliverables(deliverables: Deliverable[]): void {
+    const db = this.database.getConnection();
+
+    db.exec('BEGIN IMMEDIATE;');
+    try {
+      db.prepare("DELETE FROM scheduled_deliverables WHERE workspace_id = 'local'").run();
+
+      const insertDeliverable = db.prepare(
+        `
+          INSERT INTO scheduled_deliverables (
+            id,
+            workspace_id,
+            name,
+            description,
+            schedule,
+            cron_expr,
+            schedule_description,
+            enabled,
+            agent,
+            output_path,
+            tags_json,
+            deliverable_json,
+            created_at,
+            last_run_at,
+            next_run_at,
+            total_runs
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      );
+
+      for (const deliverable of deliverables) {
+        insertDeliverable.run(
+          deliverable.id,
+          deliverable.name,
+          deliverable.description,
+          deliverable.schedule,
+          deliverable.cronExpr ?? null,
+          deliverable.scheduleDescription,
+          deliverable.enabled ? 1 : 0,
+          deliverable.agent ?? null,
+          deliverable.outputPath ?? null,
+          JSON.stringify(deliverable.tags),
+          JSON.stringify(deliverable),
+          deliverable.createdAt,
+          deliverable.lastRunAt ?? null,
+          deliverable.nextRunAt ?? null,
+          deliverable.totalRuns
+        );
+      }
+
+      db.exec('COMMIT;');
+    } catch (error) {
+      db.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+
+  loadRuns(): DeliverableRun[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT run_json
+          FROM scheduled_deliverable_runs
+          WHERE workspace_id = 'local'
+          ORDER BY datetime(run_at) ASC, id ASC
+        `
+      )
+      .all() as unknown as DeliverableRunRow[];
+
+    return rows.map((row) => JSON.parse(row.run_json) as DeliverableRun);
+  }
+
+  saveRuns(runs: DeliverableRun[]): void {
+    const db = this.database.getConnection();
+
+    db.exec('BEGIN IMMEDIATE;');
+    try {
+      db.prepare("DELETE FROM scheduled_deliverable_runs WHERE workspace_id = 'local'").run();
+
+      const insertRun = db.prepare(
+        `
+          INSERT INTO scheduled_deliverable_runs (
+            id,
+            workspace_id,
+            deliverable_id,
+            status,
+            output_file,
+            summary,
+            duration_ms,
+            error,
+            source_run_id,
+            workflow_id,
+            snapshot_json,
+            run_json,
+            run_at
+          )
+          VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      );
+
+      for (const run of runs) {
+        insertRun.run(
+          run.id,
+          run.deliverableId,
+          run.status,
+          run.outputFile ?? null,
+          run.summary ?? null,
+          run.durationMs ?? null,
+          run.error ?? null,
+          run.sourceRunId ?? null,
+          run.workflowId ?? null,
+          run.snapshot ? JSON.stringify(run.snapshot) : null,
+          JSON.stringify(run),
+          run.runAt
+        );
+      }
+
+      db.exec('COMMIT;');
+    } catch (error) {
+      db.exec('ROLLBACK;');
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- adds SQLite tables and repository storage for scheduled deliverables and recurring run history
- wires ScheduledDeliverablesService into SQLite mode while preserving JSON file mode and configurable file paths
- captures stable scheduled-run snapshots with source workflow/run IDs, output metadata, summary, duration, and audit-safe snapshot metadata
- adds restart-style SQLite coverage for schedules, filters, run history, snapshots, and no JSON-file writes
- documents the scheduled deliverable repository schema mapping

Part of #332.

## Verification

- `pnpm --filter @veritas-kanban/server test -- --run src/__tests__/storage/sqlite-scheduled-deliverables-repository.test.ts`
- `pnpm typecheck`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`
- `git diff --cached --check`

## Notes

- The production audit currently reports only moderate vulnerabilities.