### PR TITLE
feat: add SQLite task artifact metadata

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -233,6 +233,7 @@ CREATE TABLE task_observations (
 
 CREATE TABLE task_attachments (
   id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   filename TEXT NOT NULL,
   original_name TEXT NOT NULL,
@@ -242,18 +243,30 @@ CREATE TABLE task_attachments (
   storage_path TEXT NOT NULL,
   uploaded_at TEXT NOT NULL,
   uploaded_by TEXT,
+  session_id TEXT,
+  validation_status TEXT NOT NULL DEFAULT 'unknown',
+  validation_error TEXT,
+  retention_status TEXT NOT NULL DEFAULT 'active',
+  cleanup_eligible INTEGER NOT NULL DEFAULT 0,
+  attachment_json TEXT NOT NULL,
   deleted_at TEXT
 );
 
 CREATE TABLE task_deliverables (
   id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
   type TEXT NOT NULL,
   status TEXT NOT NULL,
   path TEXT,
   agent TEXT,
+  model TEXT,
+  source_run_id TEXT,
   description TEXT,
+  version_number INTEGER NOT NULL DEFAULT 1,
+  redaction_json TEXT,
+  deliverable_json TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT,
   deleted_at TEXT
@@ -308,8 +321,23 @@ CREATE INDEX idx_tasks_github ON tasks(github_repo, github_issue_number);
 CREATE INDEX idx_task_attempts_task ON task_attempts(task_id, started_at DESC);
 CREATE INDEX idx_task_comments_task ON task_comments(task_id, created_at);
 CREATE INDEX idx_task_observations_task ON task_observations(task_id, created_at DESC);
-CREATE INDEX idx_task_attachments_task ON task_attachments(task_id, uploaded_at DESC);
-CREATE INDEX idx_task_deliverables_task ON task_deliverables(task_id, created_at DESC);
+CREATE INDEX idx_task_attachments_task_uploaded ON task_attachments(task_id, uploaded_at DESC);
+CREATE INDEX idx_task_attachments_workspace_cleanup
+  ON task_attachments(workspace_id, cleanup_eligible, uploaded_at DESC)
+  WHERE deleted_at IS NULL;
+CREATE INDEX idx_task_attachments_mime_uploaded
+  ON task_attachments(workspace_id, mime_type, uploaded_at DESC)
+  WHERE deleted_at IS NULL;
+CREATE INDEX idx_task_deliverables_task_created ON task_deliverables(task_id, created_at DESC);
+CREATE INDEX idx_task_deliverables_workspace_type_status
+  ON task_deliverables(workspace_id, type, status, created_at DESC)
+  WHERE deleted_at IS NULL;
+CREATE INDEX idx_task_deliverables_agent_created
+  ON task_deliverables(agent, created_at DESC)
+  WHERE agent IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX idx_task_deliverables_source_run
+  ON task_deliverables(source_run_id)
+  WHERE source_run_id IS NOT NULL;
 CREATE INDEX idx_task_dependencies_depends ON task_dependencies(depends_on_task_id);
 ```
 
@@ -973,6 +1001,21 @@ assignment, delivery, and subscription behavior while replacing
 | `notifications`        | Complete notification JSON plus task, target, source, type, read state, target URL, and dedupe key. |
 | `thread_subscriptions` | Complete subscription JSON keyed by workspace, task, and subscribed agent.                          |
 
+## Task Artifact Metadata Implementation
+
+Task attachments and task deliverables keep their full JSON inside `tasks` for
+API parity, and SQLite mode mirrors high-value metadata into child tables during
+the same repository transaction. Attachments store validation, size, hash,
+retention, workspace, session, and cleanup fields while leaving binary blobs on
+disk. Deliverables store typed artifact metadata, source run/model provenance,
+redaction hints, and a current version number for task detail, timeline,
+completion packet, dashboard, and migration queries.
+
+| Runtime table       | Stored data                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `task_attachments`  | File metadata, MIME validation result, hash/path, owner/session, retention, and cleanup data. |
+| `task_deliverables` | Typed work-product metadata, source run/model, redaction hints, and full deliverable JSON.    |
+
 ## Scheduled Deliverable Repository Implementation
 
 Scheduled deliverables and recurring run history move into SQLite when
@@ -1107,8 +1150,8 @@ workspace screens without destructive schema rewrites.
    migrations.
 2. Implement TaskRepository parity against this schema.
 3. Move settings, managed lists, templates, and prompt registry repositories.
-4. Move telemetry, activity, audit, workflow, chat, and notification
-   repositories.
+4. Move telemetry, activity, audit, workflow, chat, notification, attachment
+   metadata, and task deliverable metadata repositories.
 5. Add file-to-database migration, Markdown export/import, and rollback drills.
 6. Turn on SQLite as the default storage backend for fresh v5 installs after
    parity and migration tests pass.

--- a/server/src/__tests__/storage/sqlite-task-repository.test.ts
+++ b/server/src/__tests__/storage/sqlite-task-repository.test.ts
@@ -3,6 +3,36 @@ import type { Task } from '@veritas-kanban/shared';
 import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
 import { SqliteTaskRepository } from '../../storage/sqlite/task-repository.js';
 
+interface CountRow {
+  count: number;
+}
+
+interface AttachmentRow {
+  id: string;
+  task_id: string;
+  workspace_id: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string | null;
+  storage_path: string;
+  validation_status: string;
+  retention_status: string;
+  cleanup_eligible: number;
+}
+
+interface DeliverableRow {
+  id: string;
+  task_id: string;
+  workspace_id: string;
+  type: string;
+  status: string;
+  agent: string | null;
+  model: string | null;
+  source_run_id: string | null;
+  version_number: number;
+  redaction_json: string | null;
+}
+
 function makeTask(overrides: Partial<Task> = {}): Task {
   const now = new Date().toISOString();
   return {
@@ -86,6 +116,134 @@ describe('SqliteTaskRepository', () => {
 
       expect(await repo.findById(task.id)).toEqual(task);
       expect(await repo.findAll()).toEqual([task]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('syncs attachment and deliverable metadata into normalized SQLite tables', async () => {
+    const fixture = createTestSqliteDatabase();
+    const task = makeTask({
+      title: 'Artifact metadata task',
+      attachments: [
+        {
+          id: 'att-1',
+          filename: 'att-1_report.pdf',
+          originalName: 'report.pdf',
+          mimeType: 'application/pdf',
+          size: 4096,
+          uploaded: '2026-05-30T12:00:00.000Z',
+          workspaceId: 'local',
+          sessionId: 'session-1',
+          uploadedBy: 'tester',
+          sha256: 'abc123',
+          storagePath: 'tasks/attachments/task-1/att-1_report.pdf',
+          validationStatus: 'valid',
+          retentionStatus: 'active',
+          cleanupEligible: false,
+        },
+      ],
+      deliverables: [
+        {
+          id: 'deliverable-1',
+          title: 'Completion packet',
+          type: 'report',
+          status: 'attached',
+          agent: 'codex',
+          model: 'gpt-5',
+          sourceRunId: 'run-1',
+          version: 3,
+          created: '2026-05-30T12:05:00.000Z',
+          updated: '2026-05-30T12:06:00.000Z',
+          description: 'Verified artifact',
+          redaction: {
+            level: 'standard',
+            containsSensitiveContent: false,
+            notes: ['paths redacted'],
+          },
+        },
+      ],
+    });
+
+    try {
+      fixture.database.open();
+      const repo = new SqliteTaskRepository(fixture.database);
+
+      await repo.create(task);
+
+      const db = fixture.database.getConnection();
+      const attachment = db
+        .prepare(
+          `
+            SELECT id, task_id, workspace_id, mime_type, size_bytes, sha256, storage_path,
+                   validation_status, retention_status, cleanup_eligible
+            FROM task_attachments
+            WHERE task_id = ?
+          `
+        )
+        .get(task.id) as AttachmentRow | undefined;
+      expect(attachment).toEqual({
+        id: 'att-1',
+        task_id: task.id,
+        workspace_id: 'local',
+        mime_type: 'application/pdf',
+        size_bytes: 4096,
+        sha256: 'abc123',
+        storage_path: 'tasks/attachments/task-1/att-1_report.pdf',
+        validation_status: 'valid',
+        retention_status: 'active',
+        cleanup_eligible: 0,
+      });
+
+      const deliverable = db
+        .prepare(
+          `
+            SELECT id, task_id, workspace_id, type, status, agent, model, source_run_id,
+                   version_number, redaction_json
+            FROM task_deliverables
+            WHERE task_id = ?
+          `
+        )
+        .get(task.id) as DeliverableRow | undefined;
+      expect(deliverable).toEqual({
+        id: 'deliverable-1',
+        task_id: task.id,
+        workspace_id: 'local',
+        type: 'report',
+        status: 'attached',
+        agent: 'codex',
+        model: 'gpt-5',
+        source_run_id: 'run-1',
+        version_number: 3,
+        redaction_json: JSON.stringify(task.deliverables?.[0]?.redaction),
+      });
+
+      await repo.update(task.id, {
+        attachments: [],
+        deliverables: [
+          {
+            ...(task.deliverables?.[0] as NonNullable<Task['deliverables']>[number]),
+            status: 'reviewed',
+            version: 4,
+          },
+        ],
+      });
+
+      const attachmentCount = db
+        .prepare('SELECT COUNT(*) AS count FROM task_attachments WHERE task_id = ?')
+        .get(task.id) as CountRow;
+      expect(attachmentCount.count).toBe(0);
+
+      const updatedDeliverable = db
+        .prepare(
+          `
+            SELECT status, version_number
+            FROM task_deliverables
+            WHERE task_id = ?
+          `
+        )
+        .get(task.id) as Pick<DeliverableRow, 'status' | 'version_number'> | undefined;
+      expect(updatedDeliverable).toEqual({ status: 'reviewed', version_number: 4 });
     } finally {
       fixture.cleanup();
     }

--- a/server/src/routes/task-deliverables.ts
+++ b/server/src/routes/task-deliverables.ts
@@ -53,8 +53,13 @@ router.post(
       path: body.path,
       status: 'pending',
       agent: body.agent,
+      model: body.model,
+      workspaceId: 'local',
+      sourceRunId: body.sourceRunId,
+      version: 1,
       created: new Date().toISOString(),
       description: body.description,
+      redaction: body.redaction,
     };
 
     const deliverables = [...(task.deliverables || []), deliverable];
@@ -115,9 +120,12 @@ router.patch(
     }
 
     // Update deliverable with provided fields
+    const currentDeliverable = deliverables[deliverableIndex] as Deliverable;
     deliverables[deliverableIndex] = {
-      ...deliverables[deliverableIndex],
+      ...currentDeliverable,
       ...body,
+      updated: new Date().toISOString(),
+      version: (currentDeliverable.version ?? 1) + 1,
     };
 
     const updatedTask = await taskService.updateTask(req.params.id as string, { deliverables });

--- a/server/src/schemas/deliverable-schemas.ts
+++ b/server/src/schemas/deliverable-schemas.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 
+const RedactionSchema = z.object({
+  level: z.enum(['none', 'standard', 'strict']).optional(),
+  containsSensitiveContent: z.boolean().optional(),
+  notes: z.array(z.string().max(500)).max(20).optional(),
+});
+
 /**
  * POST /api/tasks/:id/deliverables - Add a deliverable
  */
@@ -9,6 +15,9 @@ export const AddDeliverableBodySchema = z.object({
   path: z.string().max(500).optional(),
   description: z.string().max(1000).optional(),
   agent: z.string().max(100).optional(),
+  model: z.string().max(100).optional(),
+  sourceRunId: z.string().max(200).optional(),
+  redaction: RedactionSchema.optional(),
 });
 
 export type AddDeliverableBody = z.infer<typeof AddDeliverableBodySchema>;
@@ -23,6 +32,9 @@ export const UpdateDeliverableBodySchema = z.object({
   status: z.enum(['pending', 'attached', 'reviewed', 'accepted']).optional(),
   description: z.string().max(1000).optional(),
   agent: z.string().max(100).optional(),
+  model: z.string().max(100).optional(),
+  sourceRunId: z.string().max(200).optional(),
+  redaction: RedactionSchema.optional(),
 });
 
 export type UpdateDeliverableBody = z.infer<typeof UpdateDeliverableBodySchema>;

--- a/server/src/services/attachment-service.ts
+++ b/server/src/services/attachment-service.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { createHash } from 'node:crypto';
 import { nanoid } from 'nanoid';
 import mime from 'mime-types';
 import type { Attachment, AttachmentLimits } from '@veritas-kanban/shared';
@@ -199,6 +200,12 @@ export class AttachmentService {
       mimeType: validatedMime,
       size: file.size,
       uploaded: new Date().toISOString(),
+      workspaceId: 'local',
+      sha256: createHash('sha256').update(file.buffer).digest('hex'),
+      storagePath: path.posix.join('tasks', 'attachments', this.sanitizeTaskId(taskId), filename),
+      validationStatus: 'valid',
+      retentionStatus: 'active',
+      cleanupEligible: false,
     };
 
     return attachment;

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -904,6 +904,9 @@ export class ClawdbotAgentService {
         path: file,
         status: 'attached',
         agent,
+        workspaceId: 'local',
+        sourceRunId: attemptId,
+        version: 1,
         created,
         description: `Codex event artifact from attempt ${attemptId}`,
       });

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -710,6 +710,80 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         WHERE workflow_id IS NOT NULL;
     `,
   },
+  {
+    version: 12,
+    name: '0012_task_artifact_metadata',
+    up: `
+      CREATE TABLE IF NOT EXISTS task_attachments (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+        filename TEXT NOT NULL,
+        original_name TEXT NOT NULL,
+        mime_type TEXT NOT NULL,
+        size_bytes INTEGER NOT NULL,
+        sha256 TEXT,
+        storage_path TEXT NOT NULL,
+        uploaded_at TEXT NOT NULL,
+        uploaded_by TEXT,
+        session_id TEXT,
+        validation_status TEXT NOT NULL DEFAULT 'unknown',
+        validation_error TEXT,
+        retention_status TEXT NOT NULL DEFAULT 'active',
+        cleanup_eligible INTEGER NOT NULL DEFAULT 0,
+        attachment_json TEXT NOT NULL,
+        deleted_at TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_task_attachments_task_uploaded
+        ON task_attachments(task_id, uploaded_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_task_attachments_workspace_cleanup
+        ON task_attachments(workspace_id, cleanup_eligible, uploaded_at DESC)
+        WHERE deleted_at IS NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_task_attachments_mime_uploaded
+        ON task_attachments(workspace_id, mime_type, uploaded_at DESC)
+        WHERE deleted_at IS NULL;
+
+      CREATE TABLE IF NOT EXISTS task_deliverables (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+        title TEXT NOT NULL,
+        type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        path TEXT,
+        agent TEXT,
+        model TEXT,
+        source_run_id TEXT,
+        description TEXT,
+        version_number INTEGER NOT NULL DEFAULT 1,
+        redaction_json TEXT,
+        deliverable_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT,
+        deleted_at TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_task_deliverables_task_created
+        ON task_deliverables(task_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_task_deliverables_workspace_type_status
+        ON task_deliverables(workspace_id, type, status, created_at DESC)
+        WHERE deleted_at IS NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_task_deliverables_agent_created
+        ON task_deliverables(agent, created_at DESC)
+        WHERE agent IS NOT NULL AND deleted_at IS NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_task_deliverables_source_run
+        ON task_deliverables(source_run_id)
+        WHERE source_run_id IS NOT NULL;
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/task-repository.ts
+++ b/server/src/storage/sqlite/task-repository.ts
@@ -1,4 +1,4 @@
-import type { Task } from '@veritas-kanban/shared';
+import type { Attachment, Deliverable, Task } from '@veritas-kanban/shared';
 import type { TaskRepository } from '../interfaces.js';
 import type { SqliteDatabase } from './database.js';
 
@@ -116,6 +116,7 @@ export class SqliteTaskRepository implements TaskRepository {
   async deleteActive(id: string): Promise<boolean> {
     const db = this.database.getConnection();
     const result = this.transaction(() => {
+      this.deleteArtifactRows(id);
       this.deleteSearchRow(id);
       return db.prepare("DELETE FROM tasks WHERE id = ? AND storage_state = 'active';").run(id);
     });
@@ -272,7 +273,128 @@ export class SqliteTaskRepository implements TaskRepository {
       );
 
       this.upsertSearchRow(task, state);
+      this.syncArtifactRows(task);
     });
+  }
+
+  private syncArtifactRows(task: Task): void {
+    this.deleteArtifactRows(task.id);
+
+    const attachments = task.attachments ?? [];
+    if (attachments.length > 0) {
+      this.insertAttachmentRows(task, attachments);
+    }
+
+    const deliverables = task.deliverables ?? [];
+    if (deliverables.length > 0) {
+      this.insertDeliverableRows(task, deliverables);
+    }
+  }
+
+  private insertAttachmentRows(task: Task, attachments: Attachment[]): void {
+    const db = this.database.getConnection();
+    const statement = db.prepare(
+      `
+        INSERT INTO task_attachments (
+          id,
+          workspace_id,
+          task_id,
+          filename,
+          original_name,
+          mime_type,
+          size_bytes,
+          sha256,
+          storage_path,
+          uploaded_at,
+          uploaded_by,
+          session_id,
+          validation_status,
+          validation_error,
+          retention_status,
+          cleanup_eligible,
+          attachment_json,
+          deleted_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      `
+    );
+
+    for (const attachment of attachments) {
+      statement.run(
+        attachment.id,
+        this.workspaceIdFor(task, attachment.workspaceId),
+        task.id,
+        attachment.filename,
+        attachment.originalName,
+        attachment.mimeType,
+        attachment.size,
+        attachment.sha256 ?? null,
+        this.attachmentStoragePath(task.id, attachment),
+        attachment.uploaded,
+        attachment.uploadedBy ?? null,
+        attachment.sessionId ?? null,
+        attachment.validationStatus ?? 'unknown',
+        attachment.validationError ?? null,
+        attachment.retentionStatus ?? 'active',
+        attachment.cleanupEligible === true ? 1 : 0,
+        JSON.stringify(attachment)
+      );
+    }
+  }
+
+  private insertDeliverableRows(task: Task, deliverables: Deliverable[]): void {
+    const db = this.database.getConnection();
+    const statement = db.prepare(
+      `
+        INSERT INTO task_deliverables (
+          id,
+          workspace_id,
+          task_id,
+          title,
+          type,
+          status,
+          path,
+          agent,
+          model,
+          source_run_id,
+          description,
+          version_number,
+          redaction_json,
+          deliverable_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      `
+    );
+
+    for (const deliverable of deliverables) {
+      statement.run(
+        deliverable.id,
+        this.workspaceIdFor(task, deliverable.workspaceId),
+        task.id,
+        deliverable.title,
+        deliverable.type,
+        deliverable.status,
+        deliverable.path ?? null,
+        deliverable.agent ?? null,
+        deliverable.model ?? null,
+        deliverable.sourceRunId ?? null,
+        deliverable.description ?? null,
+        this.deliverableVersion(deliverable),
+        this.optionalJson(deliverable.redaction),
+        JSON.stringify(deliverable),
+        deliverable.created,
+        deliverable.updated ?? null
+      );
+    }
+  }
+
+  private deleteArtifactRows(taskId: string): void {
+    const db = this.database.getConnection();
+    db.prepare('DELETE FROM task_deliverables WHERE task_id = ?;').run(taskId);
+    db.prepare('DELETE FROM task_attachments WHERE task_id = ?;').run(taskId);
   }
 
   private upsertSearchRow(task: Task, state: TaskStorageState): void {
@@ -299,6 +421,29 @@ export class SqliteTaskRepository implements TaskRepository {
 
   private parseTask(row: TaskRow): Task {
     return JSON.parse(row.task_json) as Task;
+  }
+
+  private workspaceIdFor(task: Task, explicitWorkspaceId?: string): string {
+    return explicitWorkspaceId ?? (task as Task & { workspaceId?: string }).workspaceId ?? 'local';
+  }
+
+  private attachmentStoragePath(taskId: string, attachment: Attachment): string {
+    if (attachment.storagePath && attachment.storagePath.trim().length > 0) {
+      return attachment.storagePath;
+    }
+
+    const taskPathSegment = taskId.replace(/[^a-zA-Z0-9_-]/g, '');
+    return ['tasks', 'attachments', taskPathSegment, attachment.filename].join('/');
+  }
+
+  private deliverableVersion(deliverable: Deliverable): number {
+    return Number.isInteger(deliverable.version) && (deliverable.version ?? 0) > 0
+      ? (deliverable.version as number)
+      : 1;
+  }
+
+  private optionalJson(value: unknown): string | null {
+    return value === undefined ? null : JSON.stringify(value);
   }
 
   private toFtsQuery(query: string): string {

--- a/shared/src/types/task.types.d.ts
+++ b/shared/src/types/task.types.d.ts
@@ -66,6 +66,8 @@ export interface Comment {
   text: string;
   timestamp: string;
 }
+export type AttachmentValidationStatus = 'valid' | 'invalid' | 'skipped' | 'unknown';
+export type AttachmentRetentionStatus = 'active' | 'archived' | 'deleted' | 'expired';
 export interface Attachment {
   id: string;
   filename: string;
@@ -73,9 +75,23 @@ export interface Attachment {
   mimeType: string;
   size: number;
   uploaded: string;
+  workspaceId?: string;
+  sessionId?: string;
+  uploadedBy?: string;
+  sha256?: string;
+  storagePath?: string;
+  validationStatus?: AttachmentValidationStatus;
+  validationError?: string;
+  retentionStatus?: AttachmentRetentionStatus;
+  cleanupEligible?: boolean;
 }
 export type DeliverableType = 'document' | 'code' | 'report' | 'artifact' | 'other';
 export type DeliverableStatus = 'pending' | 'attached' | 'reviewed' | 'accepted';
+export interface DeliverableRedaction {
+  level?: 'none' | 'standard' | 'strict';
+  containsSensitiveContent?: boolean;
+  notes?: string[];
+}
 export interface Deliverable {
   id: string;
   title: string;
@@ -83,8 +99,14 @@ export interface Deliverable {
   path?: string;
   status: DeliverableStatus;
   agent?: string;
+  model?: string;
+  workspaceId?: string;
+  sourceRunId?: string;
+  version?: number;
   created: string;
+  updated?: string;
   description?: string;
+  redaction?: DeliverableRedaction;
 }
 export interface AttachmentLimits {
   maxFileSize: number;

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -104,6 +104,9 @@ export interface Observation {
   agent?: string; // Which agent recorded this
 }
 
+export type AttachmentValidationStatus = 'valid' | 'invalid' | 'skipped' | 'unknown';
+export type AttachmentRetentionStatus = 'active' | 'archived' | 'deleted' | 'expired';
+
 export interface Attachment {
   id: string;
   filename: string; // Sanitized filename stored on disk
@@ -111,10 +114,25 @@ export interface Attachment {
   mimeType: string;
   size: number; // File size in bytes
   uploaded: string; // ISO timestamp
+  workspaceId?: string;
+  sessionId?: string;
+  uploadedBy?: string;
+  sha256?: string;
+  storagePath?: string;
+  validationStatus?: AttachmentValidationStatus;
+  validationError?: string;
+  retentionStatus?: AttachmentRetentionStatus;
+  cleanupEligible?: boolean;
 }
 
 export type DeliverableType = 'document' | 'code' | 'report' | 'artifact' | 'other';
 export type DeliverableStatus = 'pending' | 'attached' | 'reviewed' | 'accepted';
+
+export interface DeliverableRedaction {
+  level?: 'none' | 'standard' | 'strict';
+  containsSensitiveContent?: boolean;
+  notes?: string[];
+}
 
 export interface Deliverable {
   id: string;
@@ -123,8 +141,14 @@ export interface Deliverable {
   path?: string; // File path or URL
   status: DeliverableStatus;
   agent?: string; // Who produced it
+  model?: string;
+  workspaceId?: string;
+  sourceRunId?: string;
+  version?: number;
   created: string; // ISO timestamp
+  updated?: string;
   description?: string;
+  redaction?: DeliverableRedaction;
 }
 
 export interface AttachmentLimits {


### PR DESCRIPTION
## Summary

- adds SQLite migration 0012 for normalized task attachment and task deliverable metadata
- mirrors attachment validation, hash/path, retention, owner/session, and cleanup fields from task JSON into queryable SQLite rows
- adds deliverable provenance fields for model/source run/redaction/version metadata and stores them in SQLite
- updates task artifact schema docs and adds repository coverage for child row sync

Part of #332.

## Verification

- `pnpm --filter @veritas-kanban/server test -- sqlite-task-repository`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm --filter @veritas-kanban/server test`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `./node_modules/.bin/prettier --check docs/SQLITE-SCHEMA.md server/src/__tests__/storage/sqlite-task-repository.test.ts server/src/routes/task-deliverables.ts server/src/schemas/deliverable-schemas.ts server/src/services/attachment-service.ts server/src/services/clawdbot-agent-service.ts server/src/storage/sqlite/migrations.ts server/src/storage/sqlite/task-repository.ts shared/src/types/task.types.ts shared/src/types/task.types.d.ts`
- `git diff --check`

## Notes

- Attachment binary blobs remain on disk; this slice persists metadata in SQLite for query, migration, backup/import, and cleanup workflows.