### PR TITLE
feat: add multi-user identity APIs

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -24,28 +24,29 @@
 11. [Chat & Squad](#chat--squad)
 12. [Agent Status](#agent-status)
 13. [Auth & Diagnostics](#auth--diagnostics)
-14. [Telemetry](#telemetry)
-15. [Health](#health)
-16. [WebSocket](#websocket)
-17. [Task Verification](#task-verification)
-18. [Task Comments](#task-comments)
-19. [Task Subtasks](#task-subtasks)
-20. [Task Deliverables](#task-deliverables)
-21. [Task Archive](#task-archive)
-22. [Attachments](#attachments)
-23. [Agent Permissions](#agent-permissions)
-24. [Agent Routing](#agent-routing)
-25. [Shared Resources](#shared-resources)
-26. [Doc Freshness](#doc-freshness)
-27. [Cost Prediction](#cost-prediction)
-28. [Error Learning](#error-learning)
-29. [Tool Policies](#tool-policies)
-30. [Traces](#traces)
-31. [Audit](#audit)
-32. [Common Workflows](#common-workflows)
-33. [Versioning & Deprecation](#versioning--deprecation)
-34. [Rate Limits](#rate-limits)
-35. [Additional Endpoint Groups](#additional-endpoint-groups)
+14. [Identity & Workspaces](#identity--workspaces)
+15. [Telemetry](#telemetry)
+16. [Health](#health)
+17. [WebSocket](#websocket)
+18. [Task Verification](#task-verification)
+19. [Task Comments](#task-comments)
+20. [Task Subtasks](#task-subtasks)
+21. [Task Deliverables](#task-deliverables)
+22. [Task Archive](#task-archive)
+23. [Attachments](#attachments)
+24. [Agent Permissions](#agent-permissions)
+25. [Agent Routing](#agent-routing)
+26. [Shared Resources](#shared-resources)
+27. [Doc Freshness](#doc-freshness)
+28. [Cost Prediction](#cost-prediction)
+29. [Error Learning](#error-learning)
+30. [Tool Policies](#tool-policies)
+31. [Traces](#traces)
+32. [Audit](#audit)
+33. [Common Workflows](#common-workflows)
+34. [Versioning & Deprecation](#versioning--deprecation)
+35. [Rate Limits](#rate-limits)
+36. [Additional Endpoint Groups](#additional-endpoint-groups)
 
 ---
 
@@ -569,6 +570,60 @@ POST /api/auth/login
   "expiresIn": "24h"
 }
 ```
+
+---
+
+## Identity & Workspaces
+
+v5 adds SQLite-backed identity management for users, workspaces, memberships,
+roles, and invitations. These endpoints are mounted at `/api/identity` and
+`/api/v1/identity`.
+
+| Method   | Path                                                | Description                                      |
+| -------- | --------------------------------------------------- | ------------------------------------------------ |
+| `GET`    | `/api/identity/profile`                             | Current user profile plus workspace memberships. |
+| `GET`    | `/api/identity/workspaces`                          | Workspaces available to the current user.        |
+| `POST`   | `/api/identity/workspaces/switch`                   | Validate/select an active workspace membership.  |
+| `GET`    | `/api/identity/workspaces/:workspaceId/members`     | List active workspace members.                   |
+| `GET`    | `/api/identity/workspaces/:workspaceId/invitations` | List invitations. Requires admin.                |
+| `POST`   | `/api/identity/workspaces/:workspaceId/invitations` | Create an invitation. Requires admin.            |
+| `POST`   | `/api/identity/invitations/accept`                  | Accept an invitation.                            |
+| `POST`   | `/api/auth/invitations/accept`                      | Accept an invitation before login.               |
+| `POST`   | `/api/identity/invitations/:id/revoke`              | Revoke a pending invitation. Requires admin.     |
+| `PATCH`  | `/api/identity/workspaces/:workspaceId/members/:id` | Update a member role. Requires admin.            |
+| `DELETE` | `/api/identity/workspaces/:workspaceId/members/:id` | Remove a member. Requires admin.                 |
+
+### Create Invitation
+
+```http
+POST /api/identity/workspaces/local/invitations
+```
+
+```json
+{
+  "email": "reviewer@example.com",
+  "role": "reviewer"
+}
+```
+
+The response includes the plaintext invitation token once. SQLite stores only
+the token hash.
+
+### Accept Invitation
+
+```http
+POST /api/auth/invitations/accept
+```
+
+```json
+{
+  "token": "plaintext-token-from-invite",
+  "displayName": "Reviewer",
+  "email": "reviewer@example.com"
+}
+```
+
+Membership mutations are recorded in audit and activity history.
 
 ---
 

--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -94,6 +94,20 @@ CREATE TABLE workspace_memberships (
   PRIMARY KEY (workspace_id, user_id)
 );
 
+CREATE TABLE workspace_invitations (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  email TEXT,
+  role TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  invited_by TEXT NOT NULL REFERENCES users(id),
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  accepted_by TEXT REFERENCES users(id),
+  accepted_at TEXT,
+  revoked_at TEXT
+);
+
 CREATE TABLE api_tokens (
   id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
@@ -112,6 +126,8 @@ Important indexes:
 
 ```sql
 CREATE INDEX idx_memberships_user ON workspace_memberships(user_id);
+CREATE INDEX idx_workspace_invitations_workspace_email
+  ON workspace_invitations(workspace_id, email, revoked_at, accepted_at);
 CREATE INDEX idx_api_tokens_workspace ON api_tokens(workspace_id, revoked_at);
 ```
 

--- a/server/src/__tests__/identity-service.test.ts
+++ b/server/src/__tests__/identity-service.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTestSqliteDatabase } from '../storage/sqlite/test-helpers.js';
+import { SqliteIdentityRepository } from '../storage/sqlite/identity-repository.js';
+import { IdentityService, type IdentityActor } from '../services/identity-service.js';
+import { ForbiddenError, ValidationError } from '../middleware/error-handler.js';
+
+function createService() {
+  const fixture = createTestSqliteDatabase();
+  fixture.database.open();
+  const repository = new SqliteIdentityRepository(fixture.database);
+  const audit = vi.fn().mockResolvedValue(undefined);
+  const activity = { logActivity: vi.fn().mockResolvedValue(undefined) };
+  const service = new IdentityService({ repository, audit, activity });
+  const owner = service.ensureOwnerSetup({ displayName: 'Owner' });
+
+  return {
+    fixture,
+    repository,
+    service,
+    audit,
+    activity,
+    ownerActor: {
+      userId: owner.user.id,
+      role: 'owner',
+      displayName: owner.user.displayName,
+    } satisfies IdentityActor,
+  };
+}
+
+describe('IdentityService', () => {
+  it('lets owner/admin create invitations and records audit and activity entries', async () => {
+    const { fixture, service, audit, activity, ownerActor } = createService();
+
+    try {
+      const result = await service.createInvitation(
+        {
+          workspaceId: 'local',
+          email: 'member@example.com',
+          role: 'member',
+        },
+        ownerActor
+      );
+
+      expect(result.token).toHaveLength(64);
+      expect(result.invitation.email).toBe('member@example.com');
+      expect(result.invitation.tokenHash).not.toBe(result.token);
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'identity.invitation.create',
+          resource: 'local',
+        })
+      );
+      expect(activity.logActivity).toHaveBeenCalledWith(
+        'membership_updated',
+        'workspace:local',
+        'Workspace local',
+        expect.objectContaining({ action: 'identity.invitation.create' })
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rejects member and read-only membership management', async () => {
+    const { fixture, service, ownerActor } = createService();
+
+    try {
+      const invitation = await service.createInvitation(
+        {
+          workspaceId: 'local',
+          email: 'member@example.com',
+          role: 'member',
+        },
+        ownerActor
+      );
+      const accepted = await service.acceptInvitation({
+        token: invitation.token,
+        displayName: 'Member',
+      });
+
+      await expect(
+        service.createInvitation(
+          {
+            workspaceId: 'local',
+            email: 'blocked@example.com',
+            role: 'member',
+          },
+          {
+            userId: accepted.user.id,
+            role: 'member',
+            displayName: 'Member',
+          }
+        )
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      await expect(
+        service.createInvitation(
+          {
+            workspaceId: 'local',
+            email: 'blocked@example.com',
+            role: 'read-only',
+          },
+          {
+            userId: accepted.user.id,
+            role: 'read-only',
+            displayName: 'Member',
+          }
+        )
+      ).rejects.toBeInstanceOf(ForbiddenError);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('accepts invitations into active memberships and blocks expired tokens', async () => {
+    const { fixture, service, ownerActor } = createService();
+
+    try {
+      const active = await service.createInvitation(
+        {
+          workspaceId: 'local',
+          email: 'reviewer@example.com',
+          role: 'reviewer',
+        },
+        ownerActor
+      );
+      const accepted = await service.acceptInvitation({
+        token: active.token,
+        displayName: 'Reviewer',
+      });
+      const expired = await service.createInvitation(
+        {
+          workspaceId: 'local',
+          email: 'old@example.com',
+          role: 'member',
+          expiresAt: '2000-01-01T00:00:00.000Z',
+        },
+        ownerActor
+      );
+
+      expect(accepted.membership.role).toBe('reviewer');
+      expect(accepted.invitation.acceptedAt).toBeTruthy();
+      await expect(
+        service.acceptInvitation({
+          token: expired.token,
+          displayName: 'Old Invite',
+        })
+      ).rejects.toBeInstanceOf(ValidationError);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('protects the last owner from demotion or removal', async () => {
+    const { fixture, service, ownerActor } = createService();
+
+    try {
+      await expect(
+        service.updateMemberRole('local', ownerActor.userId, 'admin', ownerActor)
+      ).rejects.toBeInstanceOf(ValidationError);
+      await expect(
+        service.removeMember('local', ownerActor.userId, ownerActor)
+      ).rejects.toBeInstanceOf(ValidationError);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/__tests__/routes/identity.test.ts
+++ b/server/src/__tests__/routes/identity.test.ts
@@ -1,0 +1,85 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import type { AuthenticatedRequest } from '../../middleware/auth.js';
+import { errorHandler } from '../../middleware/error-handler.js';
+import { createIdentityRoutes } from '../../routes/identity.js';
+import { IdentityService } from '../../services/identity-service.js';
+import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+import { SqliteIdentityRepository } from '../../storage/sqlite/identity-repository.js';
+
+function createApp(role: 'admin' | 'agent' | 'read-only' = 'admin') {
+  const fixture = createTestSqliteDatabase();
+  fixture.database.open();
+  const repository = new SqliteIdentityRepository(fixture.database);
+  const service = new IdentityService({
+    repository,
+    audit: vi.fn().mockResolvedValue(undefined),
+    activity: { logActivity: vi.fn().mockResolvedValue(undefined) },
+  });
+  service.ensureOwnerSetup({ displayName: 'Owner' });
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as AuthenticatedRequest).auth = {
+      role,
+      keyName: role,
+      isLocalhost: false,
+    };
+    next();
+  });
+  app.use('/identity', createIdentityRoutes(service));
+  app.use(errorHandler);
+
+  return { app, fixture };
+}
+
+describe('identity routes', () => {
+  it('returns profile and workspace memberships for the current user', async () => {
+    const { app, fixture } = createApp();
+
+    try {
+      const response = await request(app).get('/identity/profile').expect(200);
+
+      expect(response.body.user.id).toBe('local-user');
+      expect(response.body.workspaces[0].workspace.id).toBe('local');
+      expect(response.body.workspaces[0].membership.role).toBe('owner');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('creates and accepts workspace invitations', async () => {
+    const { app, fixture } = createApp();
+
+    try {
+      const invitation = await request(app)
+        .post('/identity/workspaces/local/invitations')
+        .send({ email: 'member@example.com', role: 'member' })
+        .expect(201);
+      const accepted = await request(app)
+        .post('/identity/invitations/accept')
+        .send({ token: invitation.body.token, displayName: 'Member' })
+        .expect(201);
+
+      expect(invitation.body.invitation.tokenHash).not.toBe(invitation.body.token);
+      expect(accepted.body.membership.role).toBe('member');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps read-only callers out of membership mutations', async () => {
+    const { app, fixture } = createApp('read-only');
+
+    try {
+      await request(app)
+        .post('/identity/workspaces/local/invitations')
+        .send({ email: 'member@example.com', role: 'member' })
+        .expect(403);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/__tests__/storage/sqlite-identity-repository.test.ts
+++ b/server/src/__tests__/storage/sqlite-identity-repository.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+import { SqliteIdentityRepository } from '../../storage/sqlite/identity-repository.js';
+import { hashInvitationToken } from '../../services/identity-service.js';
+
+describe('SqliteIdentityRepository', () => {
+  it('seeds the local owner and lists workspace membership details', () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+      const repository = new SqliteIdentityRepository(fixture.database);
+
+      const setup = repository.ensureLocalOwner({
+        displayName: 'Owner',
+        email: 'owner@example.com',
+      });
+      const workspaces = repository.listWorkspacesForUser('local-user');
+      const members = repository.listMembers('local');
+
+      expect(setup.user.displayName).toBe('Owner');
+      expect(setup.workspace.id).toBe('local');
+      expect(setup.membership.role).toBe('owner');
+      expect(workspaces).toHaveLength(1);
+      expect(workspaces[0].membership.role).toBe('owner');
+      expect(members[0].user?.email).toBe('owner@example.com');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('creates, accepts, and revokes workspace invitations', () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+      const repository = new SqliteIdentityRepository(fixture.database);
+      repository.ensureLocalOwner();
+
+      const pending = repository.createInvitation({
+        workspaceId: 'local',
+        email: 'member@example.com',
+        role: 'member',
+        tokenHash: hashInvitationToken('invite-token'),
+        invitedBy: 'local-user',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      const accepted = repository.acceptInvitation({
+        tokenHash: hashInvitationToken('invite-token'),
+        displayName: 'Member',
+      });
+      const revoked = repository.createInvitation({
+        workspaceId: 'local',
+        email: 'reviewer@example.com',
+        role: 'reviewer',
+        tokenHash: hashInvitationToken('revoke-token'),
+        invitedBy: 'local-user',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+
+      expect(pending.acceptedAt).toBeNull();
+      expect(accepted.user.email).toBe('member@example.com');
+      expect(accepted.membership.role).toBe('member');
+      expect(repository.listMembers('local').map((member) => member.role)).toEqual([
+        'owner',
+        'member',
+      ]);
+      expect(repository.revokeInvitation(revoked.id)?.revokedAt).toBeTruthy();
+      expect(repository.listInvitations('local')).toHaveLength(0);
+      expect(repository.listInvitations('local', { includeInactive: true })).toHaveLength(2);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('updates and removes active memberships without deleting history', () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+      const repository = new SqliteIdentityRepository(fixture.database);
+      repository.ensureLocalOwner();
+      const user = repository.createUser({
+        displayName: 'Reviewer',
+        email: 'reviewer@example.com',
+      });
+      repository.createInvitation({
+        workspaceId: 'local',
+        email: 'reviewer@example.com',
+        role: 'reviewer',
+        tokenHash: hashInvitationToken('reviewer-token'),
+        invitedBy: 'local-user',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+      repository.acceptInvitation({ tokenHash: hashInvitationToken('reviewer-token') });
+
+      const updated = repository.updateMembershipRole('local', user.id, 'read-only');
+      const removed = repository.removeMembership('local', user.id);
+
+      expect(updated?.role).toBe('read-only');
+      expect(removed?.status).toBe('removed');
+      expect(repository.listMembers('local').map((member) => member.userId)).not.toContain(user.id);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -16,6 +16,7 @@ import {
 } from '../config/security.js';
 import { authenticate, authorize, type AuthenticatedRequest } from '../middleware/auth.js';
 import { auditLog } from '../services/audit-service.js';
+import { getIdentityService } from '../services/identity-service.js';
 
 const router: IRouter = Router();
 
@@ -45,6 +46,12 @@ const rotateSecretSchema = z
   })
   .optional()
   .default({});
+
+const acceptInvitationSchema = z.object({
+  token: z.string().min(32),
+  displayName: z.string().min(1).max(120).optional(),
+  email: z.string().email().optional(),
+});
 
 // Constants
 const SALT_ROUNDS = process.env.NODE_ENV === 'test' ? 4 : 12;
@@ -237,12 +244,41 @@ router.post(
     // Save config
     saveSecurityConfig(updatedConfig);
 
+    let identity: unknown;
+    if (process.env.VERITAS_STORAGE === 'sqlite') {
+      identity = getIdentityService().ensureOwnerSetup({
+        displayName: 'Local User',
+      });
+    }
+
     // Return recovery key (only time it's shown in plaintext)
     res.json({
       success: true,
       recoveryKey,
+      identity,
       message: 'Password set successfully. Save your recovery key!',
     });
+  })
+);
+
+router.post(
+  '/invitations/accept',
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = acceptInvitationSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Invalid invitation request',
+        code: 'INVALID_INVITATION_REQUEST',
+        details: parsed.error.issues.map((e) => ({
+          path: e.path.join('.'),
+          message: e.message,
+        })),
+      });
+      return;
+    }
+
+    const result = await getIdentityService().acceptInvitation(parsed.data);
+    res.status(201).json(result);
   })
 );
 

--- a/server/src/routes/identity.ts
+++ b/server/src/routes/identity.ts
@@ -1,0 +1,181 @@
+import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { authorize, type AuthenticatedRequest } from '../middleware/auth.js';
+import { ValidationError } from '../middleware/error-handler.js';
+import {
+  getIdentityService,
+  type IdentityActor,
+  type IdentityService,
+} from '../services/identity-service.js';
+import { WORKSPACE_ROLES } from '../storage/sqlite/identity-repository.js';
+
+const roleSchema = z.enum(WORKSPACE_ROLES);
+
+const createInvitationSchema = z.object({
+  email: z.string().email().optional(),
+  role: roleSchema,
+  expiresAt: z.string().datetime().optional(),
+});
+
+const acceptInvitationSchema = z.object({
+  token: z.string().min(32),
+  displayName: z.string().min(1).max(120).optional(),
+  email: z.string().email().optional(),
+});
+
+const updateRoleSchema = z.object({
+  role: roleSchema,
+});
+
+export function createIdentityRoutes(service?: IdentityService): RouterType {
+  const router: RouterType = Router();
+  const serviceForRequest = () => service ?? getIdentityService();
+
+  router.get(
+    '/profile',
+    asyncHandler(async (req, res) => {
+      res.json(serviceForRequest().getProfile(actorFromRequest(req as AuthenticatedRequest)));
+    })
+  );
+
+  router.get(
+    '/workspaces',
+    asyncHandler(async (req, res) => {
+      res.json(serviceForRequest().listWorkspaces(actorFromRequest(req as AuthenticatedRequest)));
+    })
+  );
+
+  router.post(
+    '/workspaces/switch',
+    asyncHandler(async (req, res) => {
+      const schema = z.object({ workspaceId: z.string().min(1) });
+      const { workspaceId } = parseBody(schema, req.body);
+      res.json(
+        serviceForRequest().switchWorkspace(
+          workspaceId,
+          actorFromRequest(req as AuthenticatedRequest)
+        )
+      );
+    })
+  );
+
+  router.get(
+    '/workspaces/:workspaceId/members',
+    asyncHandler(async (req, res) => {
+      res.json(
+        serviceForRequest().listMembers(
+          String(req.params.workspaceId),
+          actorFromRequest(req as AuthenticatedRequest)
+        )
+      );
+    })
+  );
+
+  router.get(
+    '/workspaces/:workspaceId/invitations',
+    authorize('admin'),
+    asyncHandler(async (req, res) => {
+      res.json(
+        serviceForRequest().listInvitations(
+          String(req.params.workspaceId),
+          actorFromRequest(req as AuthenticatedRequest)
+        )
+      );
+    })
+  );
+
+  router.post(
+    '/workspaces/:workspaceId/invitations',
+    authorize('admin'),
+    asyncHandler(async (req, res) => {
+      const body = parseBody(createInvitationSchema, req.body);
+      const result = await serviceForRequest().createInvitation(
+        {
+          workspaceId: String(req.params.workspaceId),
+          email: body.email,
+          role: body.role,
+          expiresAt: body.expiresAt,
+        },
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.status(201).json(result);
+    })
+  );
+
+  router.post(
+    '/invitations/accept',
+    asyncHandler(async (req, res) => {
+      const body = parseBody(acceptInvitationSchema, req.body);
+      const result = await serviceForRequest().acceptInvitation(body);
+      res.status(201).json(result);
+    })
+  );
+
+  router.post(
+    '/invitations/:id/revoke',
+    authorize('admin'),
+    asyncHandler(async (req, res) => {
+      const invitation = await serviceForRequest().revokeInvitation(
+        String(req.params.id),
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.json(invitation);
+    })
+  );
+
+  router.patch(
+    '/workspaces/:workspaceId/members/:userId',
+    authorize('admin'),
+    asyncHandler(async (req, res) => {
+      const body = parseBody(updateRoleSchema, req.body);
+      const membership = await serviceForRequest().updateMemberRole(
+        String(req.params.workspaceId),
+        String(req.params.userId),
+        body.role,
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.json(membership);
+    })
+  );
+
+  router.delete(
+    '/workspaces/:workspaceId/members/:userId',
+    authorize('admin'),
+    asyncHandler(async (req, res) => {
+      const membership = await serviceForRequest().removeMember(
+        String(req.params.workspaceId),
+        String(req.params.userId),
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.json(membership);
+    })
+  );
+
+  return router;
+}
+
+function actorFromRequest(req: AuthenticatedRequest): IdentityActor {
+  const role = req.auth?.role;
+  return {
+    userId: 'local-user',
+    role: role === 'agent' ? 'agent' : role === 'read-only' ? 'read-only' : 'owner',
+    displayName: req.auth?.keyName ?? 'local-user',
+  };
+}
+
+function parseBody<T extends z.ZodTypeAny>(schema: T, body: unknown): z.infer<T> {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw new ValidationError(
+      'Invalid identity request',
+      parsed.error.issues.map((issue) => ({
+        path: issue.path.join('.'),
+        message: issue.message,
+      }))
+    );
+  }
+  return parsed.data;
+}
+
+export const identityRoutes = createIdentityRoutes();

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -84,6 +84,7 @@ import { scoringRoutes } from '../scoring.js';
 import { feedbackRoutes } from '../feedback.js';
 import promptRegistryRoutes from '../prompt-registry.js';
 import { sqlitePortabilityRoutes } from '../sqlite-portability.js';
+import { identityRoutes } from '../identity.js';
 
 const v1Router: IRouter = Router();
 
@@ -184,5 +185,6 @@ v1Router.use('/decisions', decisionRoutes);
 v1Router.use('/feedback', feedbackRoutes);
 v1Router.use('/prompt-registry', promptRegistryRoutes);
 v1Router.use('/sqlite', sqlitePortabilityRoutes);
+v1Router.use('/identity', identityRoutes);
 
 export { v1Router };

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -34,7 +34,8 @@ export type ActivityType =
   | 'observation_added'
   | 'observation_deleted'
   | 'dependency_added'
-  | 'dependency_removed';
+  | 'dependency_removed'
+  | 'membership_updated';
 
 export interface Activity {
   id: string;

--- a/server/src/services/identity-service.ts
+++ b/server/src/services/identity-service.ts
@@ -1,0 +1,347 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { ForbiddenError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { auditLog, type AuditEvent } from './audit-service.js';
+import { ActivityService } from './activity-service.js';
+import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
+import {
+  WORKSPACE_ROLES,
+  SqliteIdentityRepository,
+  type IdentityUser,
+  type WorkspaceIdentity,
+  type WorkspaceInvitation,
+  type WorkspaceMembership,
+  type WorkspaceRole,
+} from '../storage/sqlite/identity-repository.js';
+
+const DEFAULT_INVITATION_TTL_DAYS = 7;
+const MANAGER_ROLES = new Set<WorkspaceRole>(['owner', 'admin']);
+
+export interface IdentityActor {
+  userId: string;
+  role: WorkspaceRole;
+  displayName?: string;
+}
+
+export interface CreateInvitationResult {
+  invitation: WorkspaceInvitation;
+  token: string;
+}
+
+export interface IdentityServiceOptions {
+  repository?: SqliteIdentityRepository;
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+  audit?: (event: AuditEvent) => Promise<void>;
+  activity?: Pick<ActivityService, 'logActivity'>;
+}
+
+export class IdentityService {
+  private readonly repository: SqliteIdentityRepository;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
+  private readonly audit: (event: AuditEvent) => Promise<void>;
+  private readonly activity: Pick<ActivityService, 'logActivity'>;
+
+  constructor(options: IdentityServiceOptions = {}) {
+    if (options.repository) {
+      this.repository = options.repository;
+    } else {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.repository = new SqliteIdentityRepository(this.sqliteDatabase);
+    }
+
+    this.audit = options.audit ?? auditLog;
+    this.activity =
+      options.activity ??
+      new ActivityService({
+        storageType: process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file',
+        sqliteDatabase: options.sqliteDatabase,
+      });
+  }
+
+  ensureOwnerSetup(input: { displayName?: string; email?: string | null } = {}): {
+    user: IdentityUser;
+    workspace: WorkspaceIdentity;
+    membership: WorkspaceMembership;
+  } {
+    return this.repository.ensureLocalOwner(input);
+  }
+
+  getProfile(actor: IdentityActor): {
+    user: IdentityUser;
+    workspaces: Array<{ workspace: WorkspaceIdentity; membership: WorkspaceMembership }>;
+  } {
+    this.ensureOwnerSetup();
+    const user = this.repository.getUser(actor.userId) ?? this.repository.getUser('local-user');
+    if (!user) throw new NotFoundError('User not found');
+
+    return {
+      user,
+      workspaces: this.repository.listWorkspacesForUser(user.id),
+    };
+  }
+
+  listWorkspaces(actor: IdentityActor): Array<{
+    workspace: WorkspaceIdentity;
+    membership: WorkspaceMembership;
+  }> {
+    this.ensureOwnerSetup();
+    return this.repository.listWorkspacesForUser(actor.userId);
+  }
+
+  switchWorkspace(
+    workspaceId: string,
+    actor: IdentityActor
+  ): { workspace: WorkspaceIdentity; membership: WorkspaceMembership } {
+    this.ensureOwnerSetup();
+    const membership = this.repository.getMembership(workspaceId, actor.userId);
+    if (!membership || membership.status !== 'active') {
+      throw new ForbiddenError('No active membership for workspace');
+    }
+
+    const workspace = this.repository.getWorkspace(workspaceId);
+    if (!workspace) throw new NotFoundError('Workspace not found');
+
+    return { workspace, membership };
+  }
+
+  listMembers(workspaceId: string, actor: IdentityActor): WorkspaceMembership[] {
+    this.assertWorkspaceAccess(workspaceId, actor);
+    return this.repository.listMembers(workspaceId);
+  }
+
+  listInvitations(workspaceId: string, actor: IdentityActor): WorkspaceInvitation[] {
+    this.assertCanManageMembers(workspaceId, actor);
+    return this.repository.listInvitations(workspaceId, { includeInactive: true });
+  }
+
+  async createInvitation(
+    input: {
+      workspaceId: string;
+      email?: string | null;
+      role: WorkspaceRole;
+      expiresAt?: string | null;
+    },
+    actor: IdentityActor
+  ): Promise<CreateInvitationResult> {
+    this.assertCanManageMembers(input.workspaceId, actor);
+    this.assertAssignableRole(input.role, actor);
+
+    const token = randomBytes(32).toString('hex');
+    const invitation = this.repository.createInvitation({
+      workspaceId: input.workspaceId,
+      email: input.email,
+      role: input.role,
+      tokenHash: hashInvitationToken(token),
+      invitedBy: actor.userId,
+      expiresAt: input.expiresAt ?? defaultInvitationExpiry(),
+    });
+
+    await this.recordIdentityChange('identity.invitation.create', actor, input.workspaceId, {
+      invitationId: invitation.id,
+      email: invitation.email,
+      role: invitation.role,
+    });
+
+    return { invitation, token };
+  }
+
+  async acceptInvitation(input: {
+    token: string;
+    displayName?: string | null;
+    email?: string | null;
+  }): Promise<{
+    invitation: WorkspaceInvitation;
+    user: IdentityUser;
+    membership: WorkspaceMembership;
+  }> {
+    const tokenHash = hashInvitationToken(input.token);
+    const invitation = this.repository.getInvitationByTokenHash(tokenHash);
+    if (!invitation) throw new NotFoundError('Invitation not found');
+    if (invitation.revokedAt) throw new ValidationError('Invitation has been revoked');
+    if (invitation.acceptedAt) throw new ValidationError('Invitation has already been accepted');
+    if (Date.parse(invitation.expiresAt) <= Date.now()) {
+      throw new ValidationError('Invitation has expired');
+    }
+
+    const result = this.repository.acceptInvitation({
+      tokenHash,
+      displayName: input.displayName,
+      email: input.email,
+    });
+
+    await this.recordIdentityChange(
+      'identity.invitation.accept',
+      {
+        userId: result.user.id,
+        role: result.membership.role,
+        displayName: result.user.displayName,
+      },
+      result.invitation.workspaceId,
+      {
+        invitationId: result.invitation.id,
+        role: result.membership.role,
+      }
+    );
+
+    return result;
+  }
+
+  async revokeInvitation(invitationId: string, actor: IdentityActor): Promise<WorkspaceInvitation> {
+    const existing = this.repository.getInvitation(invitationId);
+    if (!existing) throw new NotFoundError('Invitation not found');
+
+    this.assertCanManageMembers(existing.workspaceId, actor);
+    const invitation = this.repository.revokeInvitation(invitationId);
+    if (!invitation) throw new ValidationError('Invitation cannot be revoked');
+
+    await this.recordIdentityChange('identity.invitation.revoke', actor, invitation.workspaceId, {
+      invitationId,
+    });
+
+    return invitation;
+  }
+
+  async updateMemberRole(
+    workspaceId: string,
+    userId: string,
+    role: WorkspaceRole,
+    actor: IdentityActor
+  ): Promise<WorkspaceMembership> {
+    this.assertCanManageMembers(workspaceId, actor);
+    this.assertAssignableRole(role, actor);
+
+    const existing = this.repository.getMembership(workspaceId, userId);
+    if (!existing || existing.status !== 'active') throw new NotFoundError('Member not found');
+    if (
+      existing.role === 'owner' &&
+      role !== 'owner' &&
+      this.repository.countActiveOwners(workspaceId) <= 1
+    ) {
+      throw new ValidationError('Cannot remove the last workspace owner role');
+    }
+
+    const membership = this.repository.updateMembershipRole(workspaceId, userId, role);
+    if (!membership) throw new NotFoundError('Member not found');
+
+    await this.recordIdentityChange('identity.member.role_update', actor, workspaceId, {
+      userId,
+      previousRole: existing.role,
+      role,
+    });
+
+    return membership;
+  }
+
+  async removeMember(
+    workspaceId: string,
+    userId: string,
+    actor: IdentityActor
+  ): Promise<WorkspaceMembership> {
+    this.assertCanManageMembers(workspaceId, actor);
+
+    const existing = this.repository.getMembership(workspaceId, userId);
+    if (!existing || existing.status !== 'active') throw new NotFoundError('Member not found');
+    if (existing.role === 'owner' && this.repository.countActiveOwners(workspaceId) <= 1) {
+      throw new ValidationError('Cannot remove the last workspace owner');
+    }
+
+    const membership = this.repository.removeMembership(workspaceId, userId);
+    if (!membership) throw new NotFoundError('Member not found');
+
+    await this.recordIdentityChange('identity.member.remove', actor, workspaceId, {
+      userId,
+      role: existing.role,
+    });
+
+    return membership;
+  }
+
+  close(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+  }
+
+  private assertWorkspaceAccess(workspaceId: string, actor: IdentityActor): void {
+    this.ensureOwnerSetup();
+    const membership = this.repository.getMembership(workspaceId, actor.userId);
+    if (!membership || membership.status !== 'active') {
+      throw new ForbiddenError('No active membership for workspace');
+    }
+  }
+
+  private assertCanManageMembers(workspaceId: string, actor: IdentityActor): void {
+    this.assertWorkspaceAccess(workspaceId, actor);
+    const membership = this.repository.getMembership(workspaceId, actor.userId);
+    const effectiveRole = membership?.role ?? actor.role;
+    if (!MANAGER_ROLES.has(effectiveRole)) {
+      throw new ForbiddenError('Only workspace owners and admins can manage members');
+    }
+  }
+
+  private assertAssignableRole(role: WorkspaceRole, actor: IdentityActor): void {
+    if (!WORKSPACE_ROLES.includes(role)) {
+      throw new ValidationError('Invalid workspace role');
+    }
+    if (role === 'owner' && actor.role !== 'owner') {
+      throw new ForbiddenError('Only owners can assign the owner role');
+    }
+  }
+
+  private async recordIdentityChange(
+    action: string,
+    actor: IdentityActor,
+    workspaceId: string,
+    details: Record<string, unknown>
+  ): Promise<void> {
+    await this.audit({
+      action,
+      actor: actor.displayName || actor.userId,
+      resource: workspaceId,
+      details,
+    });
+
+    await this.activity.logActivity(
+      'membership_updated',
+      `workspace:${workspaceId}`,
+      `Workspace ${workspaceId}`,
+      {
+        action,
+        actor: actor.userId,
+        ...details,
+      }
+    );
+  }
+}
+
+let identityService: IdentityService | null = null;
+
+export function getIdentityService(): IdentityService {
+  if (!identityService) {
+    identityService = new IdentityService();
+  }
+  return identityService;
+}
+
+export function resetIdentityServiceForTests(): void {
+  identityService?.close();
+  identityService = null;
+}
+
+export function hashInvitationToken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+export function isWorkspaceRole(value: string): value is WorkspaceRole {
+  return (WORKSPACE_ROLES as readonly string[]).includes(value);
+}
+
+function defaultInvitationExpiry(): string {
+  const expiresAt = new Date();
+  expiresAt.setUTCDate(expiresAt.getUTCDate() + DEFAULT_INVITATION_TTL_DAYS);
+  return expiresAt.toISOString();
+}

--- a/server/src/services/sqlite-portability-service.ts
+++ b/server/src/services/sqlite-portability-service.ts
@@ -46,6 +46,7 @@ const SQLITE_BACKUP_TABLES = [
   'workspaces',
   'users',
   'workspace_memberships',
+  'workspace_invitations',
   'app_config_documents',
   'tasks',
   'task_attachments',

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -79,6 +79,14 @@ export {
 export { SqliteChatRepository } from './sqlite/chat-repository.js';
 export { SqliteNotificationRepository } from './sqlite/notification-repository.js';
 export { SqliteScheduledDeliverablesRepository } from './sqlite/scheduled-deliverables-repository.js';
+export { SqliteIdentityRepository, WORKSPACE_ROLES } from './sqlite/identity-repository.js';
+export type {
+  IdentityUser,
+  WorkspaceIdentity,
+  WorkspaceInvitation,
+  WorkspaceMembership,
+  WorkspaceRole,
+} from './sqlite/identity-repository.js';
 
 // ---------------------------------------------------------------------------
 // Supported backend types (extend this union as new backends are added)

--- a/server/src/storage/sqlite/identity-repository.ts
+++ b/server/src/storage/sqlite/identity-repository.ts
@@ -1,0 +1,672 @@
+import { randomUUID } from 'node:crypto';
+import type { SqliteDatabase } from './database.js';
+
+export const WORKSPACE_ROLES = [
+  'owner',
+  'admin',
+  'member',
+  'reviewer',
+  'read-only',
+  'agent',
+] as const;
+
+export type WorkspaceRole = (typeof WORKSPACE_ROLES)[number];
+
+export const ACTIVE_MEMBERSHIP_STATUS = 'active';
+
+export interface IdentityUser {
+  id: string;
+  displayName: string;
+  email: string | null;
+  handle: string | null;
+  authSubject: string | null;
+  avatarUrl: string | null;
+  disabledAt: string | null;
+  lastSeenAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceIdentity {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  mode: string;
+  createdBy: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceMembership {
+  workspaceId: string;
+  userId: string;
+  role: WorkspaceRole;
+  status: string;
+  invitedBy: string | null;
+  joinedAt: string | null;
+  disabledAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  user?: IdentityUser;
+}
+
+export interface WorkspaceInvitation {
+  id: string;
+  workspaceId: string;
+  email: string | null;
+  role: WorkspaceRole;
+  tokenHash: string;
+  invitedBy: string;
+  createdAt: string;
+  expiresAt: string;
+  acceptedBy: string | null;
+  acceptedAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface CreateUserInput {
+  id?: string;
+  displayName: string;
+  email?: string | null;
+  handle?: string | null;
+  authSubject?: string | null;
+  avatarUrl?: string | null;
+}
+
+export interface CreateInvitationInput {
+  workspaceId: string;
+  email?: string | null;
+  role: WorkspaceRole;
+  tokenHash: string;
+  invitedBy: string;
+  expiresAt: string;
+}
+
+interface UserRow {
+  id: string;
+  display_name: string;
+  email: string | null;
+  handle: string | null;
+  auth_subject: string | null;
+  avatar_url: string | null;
+  disabled_at: string | null;
+  last_seen_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkspaceRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  mode: string;
+  created_by: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MembershipRow {
+  workspace_id: string;
+  user_id: string;
+  role: WorkspaceRole;
+  status: string;
+  invited_by: string | null;
+  joined_at: string | null;
+  disabled_at: string | null;
+  created_at: string;
+  updated_at: string;
+  user_display_name?: string;
+  user_email?: string | null;
+  user_handle?: string | null;
+  user_auth_subject?: string | null;
+  user_avatar_url?: string | null;
+  user_disabled_at?: string | null;
+  user_last_seen_at?: string | null;
+  user_created_at?: string;
+  user_updated_at?: string;
+}
+
+interface InvitationRow {
+  id: string;
+  workspace_id: string;
+  email: string | null;
+  role: WorkspaceRole;
+  token_hash: string;
+  invited_by: string;
+  created_at: string;
+  expires_at: string;
+  accepted_by: string | null;
+  accepted_at: string | null;
+  revoked_at: string | null;
+}
+
+interface CountRow {
+  count: number;
+}
+
+export class SqliteIdentityRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  ensureLocalOwner(input: { displayName?: string; email?: string | null } = {}): {
+    user: IdentityUser;
+    workspace: WorkspaceIdentity;
+    membership: WorkspaceMembership;
+  } {
+    const now = new Date().toISOString();
+    const db = this.database.getConnection();
+
+    db.prepare(
+      `
+        INSERT INTO workspaces (id, slug, name, description, mode, created_by, created_at, updated_at)
+        VALUES ('local', 'local', 'Local Workspace', ?, 'local', 'local-user', ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          mode = COALESCE(workspaces.mode, excluded.mode),
+          updated_at = excluded.updated_at
+      `
+    ).run('Default local workspace used for v5 migration and single-user mode.', now, now);
+
+    db.prepare(
+      `
+        INSERT INTO users (id, display_name, email, created_at, updated_at)
+        VALUES ('local-user', ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          display_name = CASE
+            WHEN ? IS NOT NULL THEN excluded.display_name
+            ELSE users.display_name
+          END,
+          email = COALESCE(excluded.email, users.email),
+          updated_at = excluded.updated_at
+      `
+    ).run(
+      input.displayName ?? 'Local User',
+      input.email ?? null,
+      now,
+      now,
+      input.displayName ?? null
+    );
+
+    db.prepare(
+      `
+        INSERT INTO workspace_memberships (
+          workspace_id, user_id, role, status, joined_at, created_at, updated_at
+        )
+        VALUES ('local', 'local-user', 'owner', 'active', ?, ?, ?)
+        ON CONFLICT(workspace_id, user_id) DO UPDATE SET
+          role = CASE
+            WHEN workspace_memberships.role = 'owner' THEN workspace_memberships.role
+            ELSE excluded.role
+          END,
+          status = 'active',
+          disabled_at = NULL,
+          updated_at = excluded.updated_at
+      `
+    ).run(now, now, now);
+
+    return {
+      user: requireValue(this.getUser('local-user'), 'Local user was not created'),
+      workspace: requireValue(this.getWorkspace('local'), 'Local workspace was not created'),
+      membership: requireValue(
+        this.getMembership('local', 'local-user'),
+        'Local owner membership was not created'
+      ),
+    };
+  }
+
+  createUser(input: CreateUserInput): IdentityUser {
+    const now = new Date().toISOString();
+    const id = input.id ?? `user_${randomUUID()}`;
+
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO users (
+            id, display_name, email, handle, auth_subject, avatar_url, created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            display_name = excluded.display_name,
+            email = COALESCE(excluded.email, users.email),
+            handle = COALESCE(excluded.handle, users.handle),
+            auth_subject = COALESCE(excluded.auth_subject, users.auth_subject),
+            avatar_url = COALESCE(excluded.avatar_url, users.avatar_url),
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        id,
+        input.displayName,
+        input.email ?? null,
+        input.handle ?? null,
+        input.authSubject ?? null,
+        input.avatarUrl ?? null,
+        now,
+        now
+      );
+
+    return requireValue(this.getUser(id), 'User was not created');
+  }
+
+  getUser(id: string): IdentityUser | null {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT * FROM users WHERE id = ?')
+      .get(id) as UserRow | undefined;
+
+    return row ? mapUser(row) : null;
+  }
+
+  getUserByEmail(email: string): IdentityUser | null {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT * FROM users WHERE lower(email) = lower(?)')
+      .get(email) as UserRow | undefined;
+
+    return row ? mapUser(row) : null;
+  }
+
+  getWorkspace(id: string): WorkspaceIdentity | null {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT * FROM workspaces WHERE id = ?')
+      .get(id) as WorkspaceRow | undefined;
+
+    return row ? mapWorkspace(row) : null;
+  }
+
+  listWorkspacesForUser(userId: string): Array<{
+    workspace: WorkspaceIdentity;
+    membership: WorkspaceMembership;
+  }> {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT
+            w.*,
+            m.workspace_id,
+            m.user_id,
+            m.role,
+            m.status,
+            m.invited_by,
+            m.joined_at,
+            m.disabled_at,
+            m.created_at AS membership_created_at,
+            m.updated_at AS membership_updated_at
+          FROM workspace_memberships m
+          JOIN workspaces w ON w.id = m.workspace_id
+          WHERE m.user_id = ? AND m.status = 'active' AND w.archived_at IS NULL
+          ORDER BY w.name ASC
+        `
+      )
+      .all(userId) as unknown as Array<
+      WorkspaceRow & {
+        workspace_id: string;
+        user_id: string;
+        role: WorkspaceRole;
+        status: string;
+        invited_by: string | null;
+        joined_at: string | null;
+        disabled_at: string | null;
+        membership_created_at: string;
+        membership_updated_at: string;
+      }
+    >;
+
+    return rows.map((row) => ({
+      workspace: mapWorkspace(row),
+      membership: {
+        workspaceId: row.workspace_id,
+        userId: row.user_id,
+        role: row.role,
+        status: row.status,
+        invitedBy: row.invited_by,
+        joinedAt: row.joined_at,
+        disabledAt: row.disabled_at,
+        createdAt: row.membership_created_at,
+        updatedAt: row.membership_updated_at,
+      },
+    }));
+  }
+
+  listMembers(workspaceId: string): WorkspaceMembership[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT
+            m.*,
+            u.display_name AS user_display_name,
+            u.email AS user_email,
+            u.handle AS user_handle,
+            u.auth_subject AS user_auth_subject,
+            u.avatar_url AS user_avatar_url,
+            u.disabled_at AS user_disabled_at,
+            u.last_seen_at AS user_last_seen_at,
+            u.created_at AS user_created_at,
+            u.updated_at AS user_updated_at
+          FROM workspace_memberships m
+          JOIN users u ON u.id = m.user_id
+          WHERE m.workspace_id = ? AND m.status = 'active'
+          ORDER BY
+            CASE m.role
+              WHEN 'owner' THEN 0
+              WHEN 'admin' THEN 1
+              WHEN 'member' THEN 2
+              WHEN 'reviewer' THEN 3
+              WHEN 'read-only' THEN 4
+              ELSE 5
+            END,
+            lower(u.display_name) ASC
+        `
+      )
+      .all(workspaceId) as unknown as MembershipRow[];
+
+    return rows.map(mapMembership);
+  }
+
+  getMembership(workspaceId: string, userId: string): WorkspaceMembership | null {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT * FROM workspace_memberships WHERE workspace_id = ? AND user_id = ?')
+      .get(workspaceId, userId) as MembershipRow | undefined;
+
+    return row ? mapMembership(row) : null;
+  }
+
+  createInvitation(input: CreateInvitationInput): WorkspaceInvitation {
+    const now = new Date().toISOString();
+    const id = `inv_${randomUUID()}`;
+
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO workspace_invitations (
+            id, workspace_id, email, role, token_hash, invited_by, created_at, expires_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        id,
+        input.workspaceId,
+        input.email?.trim().toLowerCase() || null,
+        input.role,
+        input.tokenHash,
+        input.invitedBy,
+        now,
+        input.expiresAt
+      );
+
+    return requireValue(this.getInvitation(id), 'Invitation was not created');
+  }
+
+  listInvitations(
+    workspaceId: string,
+    options: { includeInactive?: boolean } = {}
+  ): WorkspaceInvitation[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT *
+          FROM workspace_invitations
+          WHERE workspace_id = ?
+            AND (? = 1 OR (accepted_at IS NULL AND revoked_at IS NULL))
+          ORDER BY created_at DESC
+        `
+      )
+      .all(workspaceId, options.includeInactive ? 1 : 0) as unknown as InvitationRow[];
+
+    return rows.map(mapInvitation);
+  }
+
+  getInvitation(id: string): WorkspaceInvitation | null {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT * FROM workspace_invitations WHERE id = ?')
+      .get(id) as InvitationRow | undefined;
+
+    return row ? mapInvitation(row) : null;
+  }
+
+  getInvitationByTokenHash(tokenHash: string): WorkspaceInvitation | null {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT * FROM workspace_invitations WHERE token_hash = ?')
+      .get(tokenHash) as InvitationRow | undefined;
+
+    return row ? mapInvitation(row) : null;
+  }
+
+  acceptInvitation(input: {
+    tokenHash: string;
+    displayName?: string | null;
+    email?: string | null;
+  }): { invitation: WorkspaceInvitation; user: IdentityUser; membership: WorkspaceMembership } {
+    const invitation = this.getInvitationByTokenHash(input.tokenHash);
+    if (!invitation) {
+      throw new Error('Invitation not found');
+    }
+
+    const now = new Date().toISOString();
+    const email = input.email ?? invitation.email;
+    const existing = email ? this.getUserByEmail(email) : null;
+    const user =
+      existing ??
+      this.createUser({
+        displayName: input.displayName || email || 'Invited User',
+        email,
+      });
+
+    const db = this.database.getConnection();
+    try {
+      db.exec('BEGIN IMMEDIATE;');
+      db.prepare(
+        `
+          INSERT INTO workspace_memberships (
+            workspace_id,
+            user_id,
+            role,
+            status,
+            invited_by,
+            joined_at,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, 'active', ?, ?, ?, ?)
+          ON CONFLICT(workspace_id, user_id) DO UPDATE SET
+            role = excluded.role,
+            status = 'active',
+            invited_by = excluded.invited_by,
+            joined_at = COALESCE(workspace_memberships.joined_at, excluded.joined_at),
+            disabled_at = NULL,
+            updated_at = excluded.updated_at
+        `
+      ).run(invitation.workspaceId, user.id, invitation.role, invitation.invitedBy, now, now, now);
+
+      db.prepare(
+        `
+          UPDATE workspace_invitations
+          SET accepted_by = ?, accepted_at = ?
+          WHERE id = ?
+        `
+      ).run(user.id, now, invitation.id);
+      db.exec('COMMIT;');
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // Preserve the original write error.
+      }
+      throw error;
+    }
+
+    return {
+      invitation: requireValue(
+        this.getInvitation(invitation.id),
+        'Accepted invitation was not updated'
+      ),
+      user: requireValue(this.getUser(user.id), 'Invitation user was not created'),
+      membership: requireValue(
+        this.getMembership(invitation.workspaceId, user.id),
+        'Invitation membership was not created'
+      ),
+    };
+  }
+
+  revokeInvitation(id: string): WorkspaceInvitation | null {
+    const now = new Date().toISOString();
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          UPDATE workspace_invitations
+          SET revoked_at = ?
+          WHERE id = ? AND accepted_at IS NULL AND revoked_at IS NULL
+        `
+      )
+      .run(now, id);
+
+    return result.changes > 0 ? this.getInvitation(id) : null;
+  }
+
+  updateMembershipRole(
+    workspaceId: string,
+    userId: string,
+    role: WorkspaceRole
+  ): WorkspaceMembership | null {
+    const now = new Date().toISOString();
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          UPDATE workspace_memberships
+          SET role = ?, updated_at = ?
+          WHERE workspace_id = ? AND user_id = ? AND status = 'active'
+        `
+      )
+      .run(role, now, workspaceId, userId);
+
+    return result.changes > 0 ? this.getMembership(workspaceId, userId) : null;
+  }
+
+  removeMembership(workspaceId: string, userId: string): WorkspaceMembership | null {
+    const now = new Date().toISOString();
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          UPDATE workspace_memberships
+          SET status = 'removed', disabled_at = ?, updated_at = ?
+          WHERE workspace_id = ? AND user_id = ? AND status = 'active'
+        `
+      )
+      .run(now, now, workspaceId, userId);
+
+    return result.changes > 0 ? this.getMembership(workspaceId, userId) : null;
+  }
+
+  countActiveOwners(workspaceId: string): number {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT COUNT(*) AS count
+          FROM workspace_memberships
+          WHERE workspace_id = ? AND role = 'owner' AND status = 'active'
+        `
+      )
+      .get(workspaceId) as unknown as CountRow;
+
+    return row.count;
+  }
+}
+
+function mapUser(row: UserRow): IdentityUser {
+  return {
+    id: row.id,
+    displayName: row.display_name,
+    email: row.email,
+    handle: row.handle,
+    authSubject: row.auth_subject,
+    avatarUrl: row.avatar_url,
+    disabledAt: row.disabled_at,
+    lastSeenAt: row.last_seen_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapWorkspace(row: WorkspaceRow): WorkspaceIdentity {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    mode: row.mode,
+    createdBy: row.created_by,
+    archivedAt: row.archived_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapMembership(row: MembershipRow): WorkspaceMembership {
+  const membership: WorkspaceMembership = {
+    workspaceId: row.workspace_id,
+    userId: row.user_id,
+    role: row.role,
+    status: row.status,
+    invitedBy: row.invited_by,
+    joinedAt: row.joined_at,
+    disabledAt: row.disabled_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+
+  if (row.user_display_name && row.user_created_at && row.user_updated_at) {
+    membership.user = {
+      id: row.user_id,
+      displayName: row.user_display_name,
+      email: row.user_email ?? null,
+      handle: row.user_handle ?? null,
+      authSubject: row.user_auth_subject ?? null,
+      avatarUrl: row.user_avatar_url ?? null,
+      disabledAt: row.user_disabled_at ?? null,
+      lastSeenAt: row.user_last_seen_at ?? null,
+      createdAt: row.user_created_at,
+      updatedAt: row.user_updated_at,
+    };
+  }
+
+  return membership;
+}
+
+function mapInvitation(row: InvitationRow): WorkspaceInvitation {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    email: row.email,
+    role: row.role,
+    tokenHash: row.token_hash,
+    invitedBy: row.invited_by,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    acceptedBy: row.accepted_by,
+    acceptedAt: row.accepted_at,
+    revokedAt: row.revoked_at,
+  };
+}
+
+function requireValue<T>(value: T | null | undefined, message: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -865,6 +865,90 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
       );
     `,
   },
+  {
+    version: 14,
+    name: '0014_multi_user_identity_foundation',
+    up: `
+      ALTER TABLE users ADD COLUMN handle TEXT;
+      ALTER TABLE users ADD COLUMN auth_subject TEXT;
+      ALTER TABLE users ADD COLUMN avatar_url TEXT;
+      ALTER TABLE users ADD COLUMN disabled_at TEXT;
+      ALTER TABLE users ADD COLUMN last_seen_at TEXT;
+
+      ALTER TABLE workspaces ADD COLUMN mode TEXT NOT NULL DEFAULT 'local';
+      ALTER TABLE workspaces ADD COLUMN created_by TEXT;
+      ALTER TABLE workspaces ADD COLUMN archived_at TEXT;
+
+      ALTER TABLE workspace_memberships RENAME TO workspace_memberships_legacy;
+
+      CREATE TABLE workspace_memberships (
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        role TEXT NOT NULL CHECK (
+          role IN ('owner', 'admin', 'member', 'reviewer', 'read-only', 'agent')
+        ),
+        status TEXT NOT NULL DEFAULT 'active',
+        invited_by TEXT,
+        joined_at TEXT,
+        disabled_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        PRIMARY KEY (workspace_id, user_id)
+      );
+
+      INSERT INTO workspace_memberships (
+        workspace_id,
+        user_id,
+        role,
+        status,
+        joined_at,
+        created_at,
+        updated_at
+      )
+      SELECT
+        workspace_id,
+        user_id,
+        CASE role
+          WHEN 'viewer' THEN 'read-only'
+          ELSE role
+        END,
+        'active',
+        created_at,
+        created_at,
+        created_at
+      FROM workspace_memberships_legacy;
+
+      DROP TABLE workspace_memberships_legacy;
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_memberships_user_id
+        ON workspace_memberships(user_id);
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_memberships_user_status
+        ON workspace_memberships(user_id, status);
+
+      CREATE TABLE workspace_invitations (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        email TEXT,
+        role TEXT NOT NULL CHECK (
+          role IN ('owner', 'admin', 'member', 'reviewer', 'read-only', 'agent')
+        ),
+        token_hash TEXT NOT NULL UNIQUE,
+        invited_by TEXT NOT NULL REFERENCES users(id),
+        created_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        accepted_by TEXT REFERENCES users(id),
+        accepted_at TEXT,
+        revoked_at TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_invitations_workspace_email
+        ON workspace_invitations(workspace_id, email, revoked_at, accepted_at);
+
+      CREATE INDEX IF NOT EXISTS idx_workspace_invitations_token_hash
+        ON workspace_invitations(token_hash);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {


### PR DESCRIPTION
## Summary

- adds the SQLite multi-user identity foundation migration for expanded workspace roles and workspace invitations
- adds SQLite identity repository/service support for local owner setup, workspace/profile reads, invitations, role updates, member removal, audit/activity recording, and invitation acceptance
- adds `/api/identity` and `/api/v1/identity` routes plus unauthenticated `/api/auth/invitations/accept`
- wires SQLite auth setup to ensure the local owner/default workspace exists
- includes identity tables in SQLite portability backups and documents the new identity API surface

Closes #335.

## Verification

- `pnpm --filter @veritas-kanban/server test -- sqlite-identity-repository identity-service routes/identity`
- `pnpm --filter @veritas-kanban/server test -- sqlite-portability-service sqlite-storage routes/auth`
- `pnpm --filter @veritas-kanban/server test -- middleware/auth`
- `pnpm --filter @veritas-kanban/server test -- docker-paths`
- `pnpm --filter @veritas-kanban/server typecheck`
- `./node_modules/.bin/prettier --check docs/API-REFERENCE.md docs/SQLITE-SCHEMA.md server/src/routes/auth.ts server/src/routes/identity.ts server/src/routes/v1/index.ts server/src/services/activity-service.ts server/src/services/identity-service.ts server/src/services/sqlite-portability-service.ts server/src/storage/index.ts server/src/storage/sqlite/identity-repository.ts server/src/storage/sqlite/migrations.ts server/src/__tests__/identity-service.test.ts server/src/__tests__/routes/identity.test.ts server/src/__tests__/storage/sqlite-identity-repository.test.ts`
- `git diff --check`
- `pnpm lint:budget`
- `pnpm audit --prod --audit-level=high`
- `pnpm build`

## Notes

- `pnpm lint:budget` currently reports the existing 707 warnings against the 714-warning budget.
- `pnpm audit --prod --audit-level=high` exits cleanly with 3 moderate advisories reported.
- A full `pnpm test:unit` attempt reached 1,625 passing server tests and timed out on `docker-paths.test.ts`; the isolated `docker-paths` rerun passed.
- This is the management API/data foundation for #335. Broad route-by-route RBAC enforcement remains in #336.
