### PR TITLE
feat: add v5 auth permission context

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -70,6 +70,15 @@ VK supports three authentication methods. All are optional when running locally 
 | `agent`     | Read/write tasks, time tracking, observations, chat, telemetry   |
 | `read-only` | Read-only access to all GET endpoints                            |
 
+### v5 Permission Context
+
+Protected REST handlers and WebSocket connections receive a shared auth context:
+`role`, `userId`, `workspaceId`, `actorType`, `authMethod`, `tokenName`, and
+role-derived `permissions`. Existing endpoints still accept the compatibility
+roles above, but new v5 route work should declare the specific permission it
+requires, such as `task:read`, `task:write`, `workflow:execute`, or
+`admin:manage`.
+
 ### Localhost Bypass
 
 When `VERITAS_AUTH_LOCALHOST_BYPASS=true`, requests from `127.0.0.1` / `::1` are authenticated automatically with the role set by `VERITAS_AUTH_LOCALHOST_ROLE` (default: `read-only`).

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -640,6 +640,11 @@ export VK_API_KEY=your-api-key-here
 
 If you're running locally with localhost auth bypass enabled, read commands may work without a key. Write commands need `VK_API_KEY` unless `VERITAS_AUTH_LOCALHOST_ROLE` is set to `agent` or `admin`. Prefer an `agent` role key for CLI automation.
 
+For v5, issue dedicated CLI keys instead of sharing the admin key. Routine
+automation should use an `agent` role key; read-only dashboards and reporting
+scripts should use `read-only`. Reserve the admin key for setup, migration,
+backup/import, and policy operations.
+
 ### Read/Write Smoke Check
 
 Use this check after linking `vk` and exporting `VK_API_URL`/`VK_API_KEY`. It proves the CLI can both read from and write to the configured VK server.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -711,6 +711,7 @@ Resources are useful for MCP clients that support resource browsing (e.g., Claud
 - API keys are passed via the `X-API-Key` header by the shared VK API client. The server also accepts `Authorization: Bearer <key>` for direct HTTP callers.
 - The MCP server reads `VK_API_KEY` from its environment and includes it in every HTTP request to VK.
 - Keys never appear in MCP tool inputs/outputs — they stay in the transport layer.
+- v5 auth context classifies MCP calls with `actorType=agent`, `authMethod=api-key`, the configured token name, and role-derived permissions. Future MCP tools should request the narrowest server permission that matches the operation.
 
 ### What the MCP Server Cannot Do
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -73,6 +73,24 @@ const ws = new WebSocket('ws://localhost:3001/ws?api_key=your-api-key');
 - **agent**: Can read/write tasks, run agents, manage worktrees. Intended for AI agents like [OpenClaw](https://github.com/openclaw/openclaw)
 - **read-only**: Can only perform GET requests. Suitable for dashboards and monitoring
 
+### v5 Auth Context
+
+Authenticated REST requests and WebSocket connections now carry a shared auth
+context for the v5 RBAC migration:
+
+| Field         | Description                                               |
+| ------------- | --------------------------------------------------------- |
+| `role`        | Current compatibility role: `admin`, `agent`, `read-only` |
+| `userId`      | Local fallback user ID until persisted users are enforced |
+| `workspaceId` | Local fallback workspace ID until workspace scoping lands |
+| `actorType`   | `user`, `agent`, `service`, or `localhost-bypass`         |
+| `authMethod`  | `disabled`, `session`, `api-key`, or `localhost-bypass`   |
+| `tokenName`   | API key name when authenticated with a configured key     |
+| `permissions` | Role-derived permission list used by new route guards     |
+
+New v5 endpoints should prefer explicit permission guards over broad role
+checks. Legacy role guards remain supported while route coverage is migrated.
+
 ## Configuration Reference
 
 ### Environment Variables

--- a/server/src/__tests__/middleware/auth.test.ts
+++ b/server/src/__tests__/middleware/auth.test.ts
@@ -21,10 +21,12 @@ vi.mock('../../config/security.js', () => ({
 import {
   authenticate,
   authorize,
+  authorizePermission,
   authorizeWrite,
   authenticateWebSocket,
   validateWebSocketOrigin,
   generateApiKey,
+  hasPermission,
   isAuthRequired,
   getAuthStatus,
   getAuthConfig,
@@ -164,6 +166,10 @@ describe('Auth Middleware', () => {
       authenticate(req, res, next);
       expect(next).toHaveBeenCalled();
       expect(req.auth?.role).toBe('admin');
+      expect(req.auth?.actorType).toBe('service');
+      expect(req.auth?.authMethod).toBe('disabled');
+      expect(req.auth?.workspaceId).toBe('local');
+      expect(req.auth?.permissions).toEqual(['*']);
     });
 
     it('should authenticate via API key in X-API-Key header', () => {
@@ -178,6 +184,9 @@ describe('Auth Middleware', () => {
       expect(next).toHaveBeenCalled();
       expect(req.auth?.role).toBe('admin');
       expect(req.auth?.keyName).toBe('admin');
+      expect(req.auth?.authMethod).toBe('api-key');
+      expect(req.auth?.tokenName).toBe('admin');
+      expect(req.auth?.actorType).toBe('service');
     });
 
     it('should authenticate via Bearer token in Authorization header', () => {
@@ -205,6 +214,13 @@ describe('Auth Middleware', () => {
       expect(next).toHaveBeenCalled();
       expect(req.auth?.role).toBe('agent');
       expect(req.auth?.keyName).toBe('myagent');
+      expect(req.auth?.actorType).toBe('agent');
+      expect(req.auth?.authMethod).toBe('api-key');
+      expect(req.auth?.tokenName).toBe('myagent');
+      expect(req.auth?.userId).toBe('local-user');
+      expect(req.auth?.workspaceId).toBe('local');
+      expect(req.auth?.permissions).toContain('task:write');
+      expect(req.auth?.permissions).not.toContain('admin:manage');
     });
 
     it('should allow localhost bypass with read-only role by default', () => {
@@ -220,6 +236,10 @@ describe('Auth Middleware', () => {
       expect(req.auth?.role).toBe('read-only');
       expect(req.auth?.keyName).toBe('localhost-bypass');
       expect(req.auth?.isLocalhost).toBe(true);
+      expect(req.auth?.actorType).toBe('localhost-bypass');
+      expect(req.auth?.authMethod).toBe('localhost-bypass');
+      expect(req.auth?.permissions).toContain('task:read');
+      expect(req.auth?.permissions).not.toContain('task:write');
     });
 
     it('should allow localhost bypass with admin role when explicitly configured', () => {
@@ -302,6 +322,9 @@ describe('Auth Middleware', () => {
       expect(next).toHaveBeenCalled();
       expect(req.auth?.role).toBe('admin');
       expect(req.auth?.keyName).toBe('session');
+      expect(req.auth?.actorType).toBe('user');
+      expect(req.auth?.authMethod).toBe('session');
+      expect(req.auth?.workspaceId).toBe('local');
     });
 
     it('should fall back to API key when JWT is invalid', () => {
@@ -386,6 +409,45 @@ describe('Auth Middleware', () => {
       authenticate(req, res, next);
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
+    });
+  });
+
+  // === permission helpers ===
+  describe('permission helpers', () => {
+    it('should allow admin for any permission', () => {
+      expect(hasPermission({ role: 'admin' }, 'admin:manage')).toBe(true);
+      expect(hasPermission({ role: 'admin', permissions: [] }, 'task:write')).toBe(true);
+    });
+
+    it('should evaluate role-derived permissions when permissions are absent', () => {
+      expect(hasPermission({ role: 'agent' }, 'task:write')).toBe(true);
+      expect(hasPermission({ role: 'agent' }, 'admin:manage')).toBe(false);
+      expect(hasPermission({ role: 'read-only' }, 'task:read')).toBe(true);
+      expect(hasPermission({ role: 'read-only' }, 'task:write')).toBe(false);
+    });
+
+    it('should allow explicit permission middleware matches', () => {
+      const middleware = authorizePermission('task:write');
+      const req = mockRequest() as AuthenticatedRequest;
+      req.auth = { role: 'agent', isLocalhost: false };
+      const res = mockResponse();
+      const next = mockNext();
+
+      middleware(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should reject explicit permission middleware misses', () => {
+      const middleware = authorizePermission('admin:manage');
+      const req = mockRequest() as AuthenticatedRequest;
+      req.auth = { role: 'agent', isLocalhost: false };
+      const res = mockResponse();
+      const next = mockNext();
+
+      middleware(req, res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'FORBIDDEN' }));
     });
   });
 
@@ -538,6 +600,8 @@ describe('Auth Middleware', () => {
       const result = authenticateWebSocket(req);
       expect(result.authenticated).toBe(true);
       expect(result.role).toBe('admin');
+      expect(result.authMethod).toBe('disabled');
+      expect(result.permissions).toEqual(['*']);
     });
 
     it('should authenticate via API key in query parameter', () => {
@@ -551,6 +615,27 @@ describe('Auth Middleware', () => {
       const result = authenticateWebSocket(req);
       expect(result.authenticated).toBe(true);
       expect(result.role).toBe('admin');
+      expect(result.authMethod).toBe('api-key');
+      expect(result.tokenName).toBe('admin');
+    });
+
+    it('should authenticate WebSocket API keys with v5 auth context', () => {
+      process.env.VERITAS_API_KEYS = 'myagent:ws-agent-key:agent';
+      const req = {
+        headers: { authorization: 'Bearer ws-agent-key', host: 'localhost:3001' },
+        url: '/ws',
+        socket: { remoteAddress: '192.168.1.100' },
+      } as unknown as IncomingMessage;
+
+      const result = authenticateWebSocket(req);
+      expect(result.authenticated).toBe(true);
+      expect(result.role).toBe('agent');
+      expect(result.actorType).toBe('agent');
+      expect(result.authMethod).toBe('api-key');
+      expect(result.tokenName).toBe('myagent');
+      expect(result.workspaceId).toBe('local');
+      expect(result.permissions).toContain('task:write');
+      expect(result.permissions).not.toContain('admin:manage');
     });
 
     it('should authenticate via JWT cookie', () => {
@@ -575,6 +660,8 @@ describe('Auth Middleware', () => {
       const result = authenticateWebSocket(req);
       expect(result.authenticated).toBe(true);
       expect(result.role).toBe('admin');
+      expect(result.authMethod).toBe('session');
+      expect(result.actorType).toBe('user');
     });
 
     it('should allow localhost bypass for WebSocket with read-only role by default', () => {
@@ -589,6 +676,8 @@ describe('Auth Middleware', () => {
       expect(result.authenticated).toBe(true);
       expect(result.role).toBe('read-only');
       expect(result.keyName).toBe('localhost-bypass');
+      expect(result.authMethod).toBe('localhost-bypass');
+      expect(result.actorType).toBe('localhost-bypass');
     });
 
     it('should allow WebSocket localhost bypass with admin when configured', () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -681,6 +681,12 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
     role: authResult.role,
     keyName: authResult.keyName,
     isLocalhost: authResult.isLocalhost,
+    userId: authResult.userId,
+    workspaceId: authResult.workspaceId,
+    actorType: authResult.actorType,
+    authMethod: authResult.authMethod,
+    tokenName: authResult.tokenName,
+    permissions: authResult.permissions,
   };
 
   // ---- Heartbeat: mark alive on connect and on pong ----

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -11,6 +11,31 @@ const log = createLogger('auth');
 // === Types ===
 
 export type AuthRole = 'admin' | 'read-only' | 'agent';
+export type AuthMethod = 'disabled' | 'session' | 'api-key' | 'localhost-bypass';
+export type AuthActorType = 'user' | 'agent' | 'service' | 'localhost-bypass';
+export type AuthPermission =
+  | '*'
+  | 'workspace:read'
+  | 'task:read'
+  | 'task:write'
+  | 'comment:write'
+  | 'workflow:read'
+  | 'workflow:write'
+  | 'workflow:execute'
+  | 'work_product:read'
+  | 'work_product:write'
+  | 'report:read'
+  | 'telemetry:read'
+  | 'telemetry:write'
+  | 'agent:read'
+  | 'agent:write'
+  | 'settings:read'
+  | 'settings:write'
+  | 'policy:read'
+  | 'policy:write'
+  | 'backup:read'
+  | 'backup:write'
+  | 'admin:manage';
 
 export interface AuthConfig {
   /** Enable authentication (default: true) */
@@ -37,11 +62,95 @@ export interface ApiKeyConfig {
 }
 
 export interface AuthenticatedRequest extends Request {
-  auth?: {
-    role: AuthRole;
-    keyName?: string;
-    isLocalhost: boolean;
+  auth?: AuthContext;
+}
+
+const DEFAULT_WORKSPACE_ID = 'local';
+const DEFAULT_USER_ID = 'local-user';
+
+export interface AuthContext {
+  role: AuthRole;
+  keyName?: string;
+  isLocalhost: boolean;
+  userId?: string;
+  workspaceId?: string;
+  actorType?: AuthActorType;
+  authMethod?: AuthMethod;
+  tokenName?: string;
+  permissions?: AuthPermission[];
+}
+
+const ROLE_PERMISSIONS: Record<AuthRole, readonly AuthPermission[]> = {
+  admin: ['*'],
+  agent: [
+    'workspace:read',
+    'task:read',
+    'task:write',
+    'comment:write',
+    'workflow:read',
+    'workflow:execute',
+    'work_product:read',
+    'work_product:write',
+    'report:read',
+    'telemetry:write',
+    'agent:read',
+  ],
+  'read-only': [
+    'workspace:read',
+    'task:read',
+    'workflow:read',
+    'work_product:read',
+    'report:read',
+    'telemetry:read',
+    'agent:read',
+    'settings:read',
+    'policy:read',
+    'backup:read',
+  ],
+};
+
+function permissionsForRole(role: AuthRole): AuthPermission[] {
+  return [...ROLE_PERMISSIONS[role]];
+}
+
+function actorTypeFor(role: AuthRole, authMethod: AuthMethod): AuthActorType {
+  if (authMethod === 'localhost-bypass') return 'localhost-bypass';
+  if (role === 'agent') return 'agent';
+  return authMethod === 'session' ? 'user' : 'service';
+}
+
+function buildAuthContext(input: {
+  role: AuthRole;
+  keyName?: string;
+  isLocalhost: boolean;
+  authMethod: AuthMethod;
+}): NonNullable<AuthenticatedRequest['auth']> {
+  return {
+    role: input.role,
+    keyName: input.keyName,
+    isLocalhost: input.isLocalhost,
+    userId: DEFAULT_USER_ID,
+    workspaceId: DEFAULT_WORKSPACE_ID,
+    actorType: actorTypeFor(input.role, input.authMethod),
+    authMethod: input.authMethod,
+    tokenName: input.authMethod === 'api-key' ? input.keyName : undefined,
+    permissions: permissionsForRole(input.role),
   };
+}
+
+function permissionListFor(auth: Pick<AuthContext, 'role' | 'permissions'>): AuthPermission[] {
+  return auth.permissions ?? permissionsForRole(auth.role);
+}
+
+export function hasPermission(
+  auth: Pick<AuthContext, 'role' | 'permissions'> | undefined,
+  permission: AuthPermission
+): boolean {
+  if (!auth) return false;
+  if (auth.role === 'admin') return true;
+
+  const permissions = permissionListFor(auth);
+  return permissions.includes('*') || permissions.includes(permission);
 }
 
 // === Configuration ===
@@ -283,7 +392,7 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
 
   // Auth disabled via env var - allow all requests
   if (!config.enabled && !passwordAuthEnabled) {
-    req.auth = { role: 'admin', isLocalhost };
+    req.auth = buildAuthContext({ role: 'admin', isLocalhost, authMethod: 'disabled' });
     return next();
   }
 
@@ -291,7 +400,12 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
   if (passwordAuthEnabled) {
     const jwtResult = verifyJwtCookie(req);
     if (jwtResult.valid) {
-      req.auth = { role: 'admin', keyName: 'session', isLocalhost };
+      req.auth = buildAuthContext({
+        role: 'admin',
+        keyName: 'session',
+        isLocalhost,
+        authMethod: 'session',
+      });
       return next();
     }
   }
@@ -301,18 +415,24 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
   if (apiKey) {
     const validation = validateApiKey(apiKey, config);
     if (validation.valid) {
-      req.auth = {
+      req.auth = buildAuthContext({
         role: validation.role!,
         keyName: validation.name,
         isLocalhost,
-      };
+        authMethod: 'api-key',
+      });
       return next();
     }
   }
 
   // 3. Localhost bypass (dev mode) — role is configurable (default: read-only)
   if (config.allowLocalhostBypass && isLocalhost) {
-    req.auth = { role: config.localhostRole, keyName: 'localhost-bypass', isLocalhost };
+    req.auth = buildAuthContext({
+      role: config.localhostRole,
+      keyName: 'localhost-bypass',
+      isLocalhost,
+      authMethod: 'localhost-bypass',
+    });
     return next();
   }
 
@@ -363,6 +483,39 @@ export function authorize(...allowedRoles: AuthRole[]) {
 }
 
 /**
+ * Authorization middleware factory - requires at least one specific permission.
+ *
+ * Existing callers can keep using role checks while v5 route work moves toward
+ * explicit permission requirements.
+ */
+export function authorizePermission(...allowedPermissions: AuthPermission[]) {
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    if (!req.auth) {
+      res.status(401).json({
+        code: 'AUTH_REQUIRED',
+        message: 'Authentication required',
+      });
+      return;
+    }
+
+    if (!allowedPermissions.some((permission) => hasPermission(req.auth, permission))) {
+      res.status(403).json({
+        code: 'FORBIDDEN',
+        message: 'Insufficient permissions',
+        details: {
+          required: allowedPermissions,
+          currentRole: req.auth.role,
+          currentPermissions: permissionListFor(req.auth),
+        },
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
  * Middleware that allows read operations for read-only users
  * but requires admin for write operations
  */
@@ -402,6 +555,12 @@ export interface WebSocketAuthResult {
   role?: AuthRole;
   keyName?: string;
   isLocalhost: boolean;
+  userId?: string;
+  workspaceId?: string;
+  actorType?: AuthActorType;
+  authMethod?: AuthMethod;
+  tokenName?: string;
+  permissions?: AuthPermission[];
   error?: string;
 }
 
@@ -436,7 +595,10 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
 
   // Auth disabled via env var
   if (!config.enabled && !passwordAuthEnabled) {
-    return { authenticated: true, role: 'admin', isLocalhost };
+    return {
+      authenticated: true,
+      ...buildAuthContext({ role: 'admin', isLocalhost, authMethod: 'disabled' }),
+    };
   }
 
   // 1. Check JWT cookie (supports rotated secrets)
@@ -445,7 +607,15 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
     if (token) {
       const result = verifyJwtToken(token);
       if (result.valid) {
-        return { authenticated: true, role: 'admin', keyName: 'session', isLocalhost };
+        return {
+          authenticated: true,
+          ...buildAuthContext({
+            role: 'admin',
+            keyName: 'session',
+            isLocalhost,
+            authMethod: 'session',
+          }),
+        };
       }
       // Token invalid or expired, continue to other auth methods
     }
@@ -458,9 +628,12 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
     if (validation.valid) {
       return {
         authenticated: true,
-        role: validation.role,
-        keyName: validation.name,
-        isLocalhost,
+        ...buildAuthContext({
+          role: validation.role!,
+          keyName: validation.name,
+          isLocalhost,
+          authMethod: 'api-key',
+        }),
       };
     }
   }
@@ -469,9 +642,12 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
   if (config.allowLocalhostBypass && isLocalhost) {
     return {
       authenticated: true,
-      role: config.localhostRole,
-      keyName: 'localhost-bypass',
-      isLocalhost,
+      ...buildAuthContext({
+        role: config.localhostRole,
+        keyName: 'localhost-bypass',
+        isLocalhost,
+        authMethod: 'localhost-bypass',
+      }),
     };
   }
 
@@ -488,11 +664,7 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
  * Attach auth info to WebSocket for later use
  */
 export interface AuthenticatedWebSocket extends WebSocket {
-  auth?: {
-    role: AuthRole;
-    keyName?: string;
-    isLocalhost: boolean;
-  };
+  auth?: AuthContext;
 }
 
 // === Origin Validation ===


### PR DESCRIPTION
## Summary

- adds a shared v5 auth context for REST requests and WebSocket connections
- adds role-derived permission sets plus an explicit `authorizePermission` guard for upcoming route migrations
- documents scoped CLI and MCP token expectations for v5 RBAC work

Refs #336.

## Verification

- `pnpm --filter @veritas-kanban/server test -- middleware/auth`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Notes

- This is a compatibility groundwork slice for #336. It does not complete route-by-route permission enforcement, workspace filtering, or agent token scoping.