### PR TITLE
feat: migrate shared primitives to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -39,6 +39,18 @@ Current shared primitive usage:
 | `toast`/`toaster`                 | Radix Toast wrapper and app-level notification surface | 1 import     |
 | `data-table`                      | Custom table wrapper                                   | 1 import     |
 
+Shared primitive migration progress:
+
+- Mantine-backed compatibility wrappers are now active for `button`, `badge`,
+  `input`, `textarea`, `checkbox`, `switch`, `label`, `skeleton`,
+  `scroll-area`, and the app-level `toaster` delivery path.
+- Temporary Radix holdouts remain for compound/focus-heavy APIs: `select`,
+  `dialog`, `sheet`, `alert-dialog`, `popover`, `tooltip`, and `tabs`.
+- The holdouts stay intentionally until their feature surfaces can be migrated
+  with visual and keyboard/focus checks in the same PR. New v5 surfaces should
+  prefer Mantine primitives directly unless they need one of the compatibility
+  wrappers above.
+
 High-traffic feature surfaces:
 
 | Area                 | Representative files                                                                 | Migration class      |
@@ -176,6 +188,8 @@ Foundation verification currently covers:
 - required v5 status semantics: blocked, needs review, running, done, failed,
   warning, policy denied, and destructive
 - reduced-motion, focus ring, auto contrast, and breakpoint defaults
+- Mantine-backed shared primitives for buttons, badges, text fields,
+  checkbox/switch controls, labels, skeletons, scroll areas, and notifications
 
 ## Migration Order
 
@@ -204,11 +218,16 @@ Target issue: `v5.0 UI: Migrate shared primitives, forms, and overlays to Mantin
 
 Migration batches:
 
-1. Basic controls: button, badge, input, label, textarea, skeleton
-2. Form controls: select, checkbox, switch, number-like inputs
-3. Overlays: dialog, alert dialog, sheet/drawer, popover, tooltip
-4. Navigation modes: tabs, segmented controls, command/search shell
-5. Feedback: toast/notifications, loading/error banners
+1. Basic controls: button, badge, input, label, textarea, skeleton. Completed
+   for the compatibility layer; feature surfaces can now use these wrappers
+   while preserving current imports.
+2. Form controls: checkbox and switch completed for the compatibility layer;
+   select and number-like inputs remain for feature-surface migration PRs.
+3. Feedback: toast delivery now routes through Mantine notifications.
+4. Overlays: dialog, alert dialog, sheet/drawer, popover, tooltip. Still Radix
+   holdouts until each surface has visual and focus QA.
+5. Navigation modes: tabs, segmented controls, command/search shell. Tabs remain
+   a Radix holdout; new mode controls should use Mantine directly.
 
 Use compatibility wrappers only when they reduce churn. Each wrapper must have a
 removal target and should not hide incompatible behavior.

--- a/web/src/__tests__/CreateTaskDuplicateDetection.test.tsx
+++ b/web/src/__tests__/CreateTaskDuplicateDetection.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { CreateTaskDialog } from '@/components/task/CreateTaskDialog';
 import { api } from '@/lib/api';
+import { renderWithProviders } from './test-utils';
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -85,7 +86,7 @@ describe('CreateTaskDialog duplicate detection', () => {
     });
 
     const onOpenChange = vi.fn();
-    render(<CreateTaskDialog open onOpenChange={onOpenChange} />);
+    renderWithProviders(<CreateTaskDialog open onOpenChange={onOpenChange} />);
 
     fireEvent.change(screen.getByLabelText('Title'), {
       target: { value: 'Search duplicate' },
@@ -123,7 +124,7 @@ describe('CreateTaskDialog duplicate detection', () => {
     });
 
     const onOpenChange = vi.fn();
-    render(<CreateTaskDialog open onOpenChange={onOpenChange} />);
+    renderWithProviders(<CreateTaskDialog open onOpenChange={onOpenChange} />);
 
     fireEvent.change(screen.getByLabelText('Title'), {
       target: { value: 'Search duplicate' },

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -4,10 +4,10 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, cleanup } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 import { KanbanBoard } from '@/components/board/KanbanBoard';
-import { createMockTask } from './test-utils';
+import { createMockTask, renderWithProviders } from './test-utils';
 import type { Task } from '@veritas-kanban/shared';
 
 // ── Mocks ────────────────────────────────────────────────────
@@ -168,11 +168,7 @@ function renderBoard() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <KanbanBoard />
-    </QueryClientProvider>
-  );
+  return renderWithProviders(<KanbanBoard />, { queryClient });
 }
 
 afterEach(() => {

--- a/web/src/__tests__/SearchDialog.test.tsx
+++ b/web/src/__tests__/SearchDialog.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SearchDialog, extractTaskId } from '@/components/search';
 import { api } from '@/lib/api';
+import { renderWithProviders } from './test-utils';
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -49,7 +50,7 @@ describe('SearchDialog', () => {
       ],
     });
 
-    render(<SearchDialog open onOpenChange={vi.fn()} />);
+    renderWithProviders(<SearchDialog open onOpenChange={vi.fn()} />);
 
     await userEvent.type(screen.getByPlaceholderText(/search task titles/i), 'qmd');
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
@@ -86,7 +87,7 @@ describe('SearchDialog', () => {
       ],
     });
 
-    render(<SearchDialog open onOpenChange={onOpenChange} onTaskOpen={onTaskOpen} />);
+    renderWithProviders(<SearchDialog open onOpenChange={onOpenChange} onTaskOpen={onTaskOpen} />);
 
     await userEvent.type(screen.getByPlaceholderText(/search task titles/i), 'task');
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { notifications } from '@mantine/notifications';
+import { renderWithProviders } from './test-utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { Toaster } from '@/components/ui/toaster';
+import { toast } from '@/hooks/useToast';
+
+function ToggleProbe() {
+  const [checked, setChecked] = React.useState(false);
+  const [enabled, setEnabled] = React.useState(false);
+
+  return (
+    <div>
+      <Checkbox
+        aria-label="Done"
+        checked={checked}
+        onCheckedChange={(nextChecked) => setChecked(nextChecked === true)}
+      />
+      <span data-testid="checkbox-state">{String(checked)}</span>
+
+      <Switch
+        aria-label="Enabled"
+        checked={enabled}
+        onCheckedChange={(nextEnabled) => setEnabled(nextEnabled)}
+      />
+      <span data-testid="switch-state">{String(enabled)}</span>
+    </div>
+  );
+}
+
+function ToastProbe() {
+  return (
+    <Button
+      onClick={() =>
+        toast({
+          title: 'Saved',
+          description: 'Mantine notification bridge is active.',
+        })
+      }
+    >
+      Notify
+    </Button>
+  );
+}
+
+describe('Mantine-backed shared UI primitives', () => {
+  afterEach(() => {
+    notifications.clean();
+    cleanup();
+  });
+
+  it('renders the common control wrappers through Mantine with legacy data slots', () => {
+    renderWithProviders(
+      <div>
+        <Button>Save</Button>
+        <Button size="icon" aria-label="Refresh">
+          R
+        </Button>
+        <Badge variant="secondary">Ready</Badge>
+        <Label htmlFor="name">Name</Label>
+        <Input id="name" aria-label="Name" placeholder="Task name" />
+        <Textarea aria-label="Notes" placeholder="Task notes" />
+        <Skeleton data-testid="loading-row" className="h-8 w-full" />
+        <ScrollArea data-testid="scroll-area" className="h-24">
+          <div>Scrollable content</div>
+        </ScrollArea>
+      </div>
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' }).getAttribute('data-slot')).toBe('button');
+    expect(screen.getByRole('button', { name: 'Refresh' }).getAttribute('data-slot')).toBe(
+      'button'
+    );
+    expect(screen.getByText('Ready').closest('[data-slot="badge"]')).toBeDefined();
+    expect(screen.getByLabelText('Name').getAttribute('data-slot')).toBe('input');
+    expect(screen.getByLabelText('Notes')).toBeDefined();
+    expect(screen.getByTestId('loading-row').getAttribute('data-slot')).toBe('skeleton');
+    expect(screen.getByTestId('scroll-area').getAttribute('data-slot')).toBe('scroll-area');
+  });
+
+  it('preserves checkbox and switch onCheckedChange compatibility', () => {
+    renderWithProviders(<ToggleProbe />);
+
+    fireEvent.click(screen.getByLabelText('Done'));
+    fireEvent.click(screen.getByLabelText('Enabled'));
+
+    expect(screen.getByTestId('checkbox-state').textContent).toBe('true');
+    expect(screen.getByTestId('switch-state').textContent).toBe('true');
+  });
+
+  it('routes legacy toast calls through Mantine notifications', async () => {
+    renderWithProviders(
+      <>
+        <Toaster />
+        <ToastProbe />
+      </>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Notify' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeDefined();
+      expect(screen.getByText('Mantine notification bridge is active.')).toBeDefined();
+    });
+  });
+});

--- a/web/src/__tests__/test-utils.tsx
+++ b/web/src/__tests__/test-utils.tsx
@@ -85,6 +85,17 @@ function ensureMantineBrowserApis() {
     });
   }
 
+  if (typeof window.ResizeObserver !== 'function') {
+    Object.defineProperty(window, 'ResizeObserver', {
+      configurable: true,
+      value: class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    });
+  }
+
   try {
     window.localStorage.getItem('__veritas_test_probe__');
   } catch {

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Badge as MantineBadge, type BadgeProps as MantineBadgeProps } from '@mantine/core';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from 'radix-ui';
 
@@ -24,20 +25,42 @@ const badgeVariants = cva(
   }
 );
 
+const mantineBadgeVariant = {
+  default: 'filled',
+  secondary: 'light',
+  destructive: 'light',
+  outline: 'outline',
+  ghost: 'transparent',
+  link: 'transparent',
+} as const satisfies Record<
+  NonNullable<VariantProps<typeof badgeVariants>['variant']>,
+  MantineBadgeProps['variant']
+>;
+
 function Badge({
   className,
   variant = 'default',
   asChild = false,
   ...props
 }: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : 'span';
+  const resolvedVariant = variant ?? 'default';
+  const classes = cn(badgeVariants({ variant: resolvedVariant }), className);
+  const color = resolvedVariant === 'destructive' ? 'red' : undefined;
+
+  if (asChild) {
+    return (
+      <Slot.Root data-slot="badge" data-variant={resolvedVariant} className={classes} {...props} />
+    );
+  }
 
   return (
-    <Comp
+    <MantineBadge
       data-slot="badge"
-      data-variant={variant}
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
+      data-variant={resolvedVariant}
+      variant={mantineBadgeVariant[resolvedVariant]}
+      color={color}
+      className={classes}
+      {...(props as Omit<MantineBadgeProps, 'ref'>)}
     />
   );
 }

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -1,4 +1,10 @@
 import * as React from 'react';
+import {
+  ActionIcon as MantineActionIcon,
+  Button as MantineButton,
+  type ActionIconProps as MantineActionIconProps,
+  type ButtonProps as MantineButtonProps,
+} from '@mantine/core';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from 'radix-ui';
 
@@ -41,6 +47,36 @@ const buttonVariants = cva(
   }
 );
 
+const mantineButtonVariant = {
+  default: 'filled',
+  outline: 'outline',
+  secondary: 'light',
+  ghost: 'subtle',
+  destructive: 'light',
+  link: 'transparent',
+} as const satisfies Record<
+  NonNullable<VariantProps<typeof buttonVariants>['variant']>,
+  MantineButtonProps['variant']
+>;
+
+const mantineButtonSize = {
+  default: 'sm',
+  xs: 'xs',
+  sm: 'xs',
+  lg: 'md',
+  icon: 'sm',
+  'icon-xs': 'xs',
+  'icon-sm': 'xs',
+  'icon-lg': 'md',
+} as const satisfies Record<NonNullable<VariantProps<typeof buttonVariants>['size']>, string>;
+
+const mantineActionIconSize = {
+  icon: 32,
+  'icon-xs': 24,
+  'icon-sm': 28,
+  'icon-lg': 36,
+} as const;
+
 function Button({
   className,
   variant = 'default',
@@ -51,15 +87,50 @@ function Button({
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : 'button';
+  const resolvedVariant = variant ?? 'default';
+  const resolvedSize = size ?? 'default';
+  const classes = cn(buttonVariants({ variant: resolvedVariant, size: resolvedSize, className }));
+  const color = resolvedVariant === 'destructive' ? 'red' : undefined;
+
+  if (asChild) {
+    return (
+      <Slot.Root
+        data-slot="button"
+        data-variant={resolvedVariant}
+        data-size={resolvedSize}
+        className={classes}
+        {...props}
+      />
+    );
+  }
+
+  if (resolvedSize.startsWith('icon')) {
+    const actionIconProps = props as MantineActionIconProps & React.ComponentProps<'button'>;
+
+    return (
+      <MantineActionIcon
+        data-slot="button"
+        data-variant={resolvedVariant}
+        data-size={resolvedSize}
+        variant={mantineButtonVariant[resolvedVariant]}
+        color={color}
+        size={mantineActionIconSize[resolvedSize as keyof typeof mantineActionIconSize]}
+        className={classes}
+        {...actionIconProps}
+      />
+    );
+  }
 
   return (
-    <Comp
+    <MantineButton
       data-slot="button"
-      data-variant={variant}
-      data-size={size}
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
+      data-variant={resolvedVariant}
+      data-size={resolvedSize}
+      variant={mantineButtonVariant[resolvedVariant]}
+      color={color}
+      size={mantineButtonSize[resolvedSize]}
+      className={classes}
+      {...(props as MantineButtonProps & React.ComponentProps<'button'>)}
     />
   );
 }

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,26 +1,56 @@
 import * as React from 'react';
-import { Checkbox as CheckboxPrimitive } from 'radix-ui';
+import {
+  Checkbox as MantineCheckbox,
+  type CheckboxProps as MantineCheckboxProps,
+} from '@mantine/core';
 
 import { cn } from '@/lib/utils';
-import { CheckIcon } from 'lucide-react';
 
-function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+type CheckedState = boolean | 'indeterminate';
+
+type CheckboxProps = Omit<
+  MantineCheckboxProps,
+  'checked' | 'defaultChecked' | 'onChange' | 'classNames'
+> & {
+  checked?: CheckedState;
+  defaultChecked?: CheckedState;
+  onCheckedChange?: (checked: CheckedState) => void;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+};
+
+function Checkbox({
+  className,
+  checked,
+  defaultChecked,
+  onCheckedChange,
+  onChange,
+  ...props
+}: CheckboxProps) {
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event);
+      onCheckedChange?.(event.currentTarget.checked);
+    },
+    [onChange, onCheckedChange]
+  );
+
   return (
-    <CheckboxPrimitive.Root
+    <MantineCheckbox
       data-slot="checkbox"
-      className={cn(
-        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
-        className
-      )}
+      checked={checked === 'indeterminate' ? false : checked}
+      defaultChecked={defaultChecked === 'indeterminate' ? false : defaultChecked}
+      indeterminate={checked === 'indeterminate' || defaultChecked === 'indeterminate'}
+      onChange={handleChange}
+      className={className}
+      classNames={{
+        root: 'inline-flex',
+        body: 'items-center',
+        input: cn(
+          'peer size-4 cursor-pointer rounded-[4px] border-input transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50'
+        ),
+      }}
       {...props}
-    >
-      <CheckboxPrimitive.Indicator
-        data-slot="checkbox-indicator"
-        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
-      >
-        <CheckIcon />
-      </CheckboxPrimitive.Indicator>
-    </CheckboxPrimitive.Root>
+    />
   );
 }
 

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
+import { Input as MantineInput, type InputProps as MantineInputProps } from '@mantine/core';
 
 import { cn } from '@/lib/utils';
 
 function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
-    <input
+    <MantineInput
       type={type}
       data-slot="input"
       className={cn(
         'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className
       )}
-      {...props}
+      {...(props as MantineInputProps & React.ComponentProps<'input'>)}
     />
   );
 }

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { Label as LabelPrimitive } from 'radix-ui';
+import { Box } from '@mantine/core';
 
 import { cn } from '@/lib/utils';
 
-function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<'label'>) {
   return (
-    <LabelPrimitive.Root
+    <Box
+      component="label"
       data-slot="label"
       className={cn(
         'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',

--- a/web/src/components/ui/scroll-area.tsx
+++ b/web/src/components/ui/scroll-area.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import * as React from 'react';
-import { ScrollArea as ScrollAreaPrimitive } from 'radix-ui';
+import {
+  ScrollArea as MantineScrollArea,
+  type ScrollAreaProps as MantineScrollAreaProps,
+} from '@mantine/core';
 
 import { cn } from '@/lib/utils';
 
@@ -9,47 +12,21 @@ function ScrollArea({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<'div'> & MantineScrollAreaProps) {
   return (
-    <ScrollAreaPrimitive.Root
+    <MantineScrollArea
       data-slot="scroll-area"
+      type="auto"
       className={cn('relative', className)}
       {...props}
     >
-      <ScrollAreaPrimitive.Viewport
-        data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
-      >
-        {children}
-      </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
-      <ScrollAreaPrimitive.Corner />
-    </ScrollAreaPrimitive.Root>
+      {children}
+    </MantineScrollArea>
   );
 }
 
-function ScrollBar({
-  className,
-  orientation = 'vertical',
-  ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
-  return (
-    <ScrollAreaPrimitive.ScrollAreaScrollbar
-      data-slot="scroll-area-scrollbar"
-      data-orientation={orientation}
-      orientation={orientation}
-      className={cn(
-        'flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent',
-        className
-      )}
-      {...props}
-    >
-      <ScrollAreaPrimitive.ScrollAreaThumb
-        data-slot="scroll-area-thumb"
-        className="relative flex-1 rounded-full bg-border"
-      />
-    </ScrollAreaPrimitive.ScrollAreaScrollbar>
-  );
+function ScrollBar({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="scroll-area-scrollbar" className={cn('hidden', className)} {...props} />;
 }
 
 export { ScrollArea, ScrollBar };

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -1,11 +1,16 @@
+import {
+  Skeleton as MantineSkeleton,
+  type SkeletonProps as MantineSkeletonProps,
+} from '@mantine/core';
+
 import { cn } from '@/lib/utils';
 
 function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div
+    <MantineSkeleton
       data-slot="skeleton"
       className={cn('animate-pulse rounded-md bg-muted', className)}
-      {...props}
+      {...(props as MantineSkeletonProps & React.ComponentProps<'div'>)}
     />
   );
 }

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,32 +1,40 @@
 'use client';
 
 import * as React from 'react';
-import { Switch as SwitchPrimitive } from 'radix-ui';
+import { Switch as MantineSwitch, type SwitchProps as MantineSwitchProps } from '@mantine/core';
 
 import { cn } from '@/lib/utils';
 
-function Switch({
-  className,
-  size = 'default',
-  ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+type SwitchProps = Omit<MantineSwitchProps, 'onChange' | 'size' | 'classNames'> & {
   size?: 'sm' | 'default';
-}) {
+  onCheckedChange?: (checked: boolean) => void;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+};
+
+function Switch({ className, size = 'default', onCheckedChange, onChange, ...props }: SwitchProps) {
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event);
+      onCheckedChange?.(event.currentTarget.checked);
+    },
+    [onChange, onCheckedChange]
+  );
+
   return (
-    <SwitchPrimitive.Root
+    <MantineSwitch
       data-slot="switch"
       data-size={size}
-      className={cn(
-        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
-        className
-      )}
+      size={size === 'sm' ? 'xs' : 'sm'}
+      onChange={handleChange}
+      className={className}
+      classNames={{
+        root: 'inline-flex',
+        track: cn(
+          'cursor-pointer border-transparent transition-all focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50'
+        ),
+      }}
       {...props}
-    >
-      <SwitchPrimitive.Thumb
-        data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
-      />
-    </SwitchPrimitive.Root>
+    />
   );
 }
 

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -1,16 +1,22 @@
 import * as React from 'react';
+import {
+  Textarea as MantineTextarea,
+  type TextareaProps as MantineTextareaProps,
+} from '@mantine/core';
 
 import { cn } from '@/lib/utils';
 
 function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
-    <textarea
+    <MantineTextarea
       data-slot="textarea"
-      className={cn(
-        'flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
-        className
-      )}
-      {...props}
+      classNames={{
+        input: cn(
+          'flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+          className
+        ),
+      }}
+      {...(props as MantineTextareaProps & React.ComponentProps<'textarea'>)}
     />
   );
 }

--- a/web/src/components/ui/toast.tsx
+++ b/web/src/components/ui/toast.tsx
@@ -1,99 +1,110 @@
 import * as React from 'react';
-import * as ToastPrimitives from '@radix-ui/react-toast';
+import { Notification } from '@mantine/core';
 import { cn } from '@/lib/utils';
-import { X } from 'lucide-react';
 
-const ToastProvider = ToastPrimitives.Provider;
+function ToastProvider({ children }: { children?: React.ReactNode }) {
+  return <>{children}</>;
+}
 
-const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
-    ref={ref}
-    className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
-      className
-    )}
-    {...props}
-  />
-));
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+const ToastViewport = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="toast-viewport"
+      className={cn('fixed right-4 bottom-4 z-[100] hidden', className)}
+      {...props}
+    />
+  )
+);
+ToastViewport.displayName = 'ToastViewport';
 
 const Toast = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>
->(({ className, ...props }, ref) => {
-  return (
-    <ToastPrimitives.Root
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<'div'> & {
+    variant?: 'default' | 'destructive';
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    duration?: number;
+  }
+>(
+  (
+    {
+      className,
+      variant = 'default',
+      open: _open,
+      onOpenChange: _onOpenChange,
+      duration: _duration,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Notification
+        ref={ref}
+        data-slot="toast"
+        color={variant === 'destructive' ? 'red' : 'veritas'}
+        className={cn('pointer-events-auto', className)}
+        {...props}
+      />
+    );
+  }
+);
+Toast.displayName = 'Toast';
+
+const ToastAction = React.forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<'button'>>(
+  ({ className, ...props }, ref) => (
+    <button
       ref={ref}
+      data-slot="toast-action"
       className={cn(
-        'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-4 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
-        'bg-background border-border',
+        'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring disabled:pointer-events-none disabled:opacity-50',
         className
       )}
       {...props}
     />
-  );
-});
-Toast.displayName = ToastPrimitives.Root.displayName;
+  )
+);
+ToastAction.displayName = 'ToastAction';
 
-const ToastAction = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Action>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Action
-    ref={ref}
-    className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
-      className
-    )}
-    {...props}
-  />
-));
-ToastAction.displayName = ToastPrimitives.Action.displayName;
+const ToastClose = React.forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<'button'>>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+        className
+      )}
+      data-slot="toast-close"
+      type="button"
+      {...props}
+    />
+  )
+);
+ToastClose.displayName = 'ToastClose';
 
-const ToastClose = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Close>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Close
-    ref={ref}
-    className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
-      className
-    )}
-    toast-close=""
-    {...props}
-  >
-    <X className="h-4 w-4" />
-  </ToastPrimitives.Close>
-));
-ToastClose.displayName = ToastPrimitives.Close.displayName;
+const ToastTitle = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="toast-title"
+      className={cn('text-sm font-semibold', className)}
+      {...props}
+    />
+  )
+);
+ToastTitle.displayName = 'ToastTitle';
 
-const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Title>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Title
-    ref={ref}
-    className={cn('text-sm font-semibold', className)}
-    {...props}
-  />
-));
-ToastTitle.displayName = ToastPrimitives.Title.displayName;
-
-const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Description>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description
-    ref={ref}
-    className={cn('text-sm opacity-90', className)}
-    {...props}
-  />
-));
-ToastDescription.displayName = ToastPrimitives.Description.displayName;
+const ToastDescription = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="toast-description"
+      className={cn('text-sm opacity-90', className)}
+      {...props}
+    />
+  )
+);
+ToastDescription.displayName = 'ToastDescription';
 
 type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 

--- a/web/src/components/ui/toaster.tsx
+++ b/web/src/components/ui/toaster.tsx
@@ -1,33 +1,64 @@
-import {
-  Toast,
-  ToastClose,
-  ToastDescription,
-  ToastProvider,
-  ToastTitle,
-  ToastViewport,
-} from '@/components/ui/toast';
+import * as React from 'react';
+import { Stack, Text } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import { useToast } from '@/hooks/useToast';
 
 export function Toaster() {
-  const { toasts } = useToast();
+  const { toasts, dismiss } = useToast();
+  const activeToastIds = React.useRef(new Set<string>());
+  const dismissRef = React.useRef(dismiss);
 
-  return (
-    <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
-        return (
-          <Toast key={id} {...props}>
-            <div className="grid gap-1">
-              {title && <ToastTitle>{title}</ToastTitle>}
-              {description && (
-                <ToastDescription>{description}</ToastDescription>
-              )}
-            </div>
-            {action}
-            <ToastClose />
-          </Toast>
-        );
-      })}
-      <ToastViewport />
-    </ToastProvider>
-  );
+  React.useEffect(() => {
+    dismissRef.current = dismiss;
+  }, [dismiss]);
+
+  React.useEffect(() => {
+    const nextIds = new Set(toasts.map((toast) => toast.id));
+
+    for (const id of Array.from(activeToastIds.current)) {
+      if (!nextIds.has(id)) {
+        notifications.hide(id);
+        activeToastIds.current.delete(id);
+      }
+    }
+
+    for (const toast of toasts) {
+      if (toast.open === false) {
+        notifications.hide(toast.id);
+        activeToastIds.current.delete(toast.id);
+        continue;
+      }
+
+      const message =
+        toast.description || toast.action ? (
+          <Stack gap={6}>
+            {toast.description ? (
+              <Text size="sm" c="dimmed">
+                {toast.description}
+              </Text>
+            ) : null}
+            {toast.action}
+          </Stack>
+        ) : null;
+
+      const notification = {
+        id: toast.id,
+        title: toast.title,
+        message,
+        color: toast.variant === 'destructive' ? 'red' : 'veritas',
+        autoClose: toast.duration ?? 5000,
+        withCloseButton: true,
+        onClose: () => dismissRef.current(toast.id),
+      };
+
+      if (activeToastIds.current.has(toast.id)) {
+        notifications.update(notification);
+      } else {
+        notifications.show(notification);
+      }
+      activeToastIds.current.add(toast.id);
+    }
+  }, [toasts]);
+
+  return null;
 }


### PR DESCRIPTION
## Summary

- migrates low-risk shared UI wrappers to Mantine-backed compatibility components: button, badge, input, textarea, checkbox, switch, label, skeleton, scroll area
- routes existing toast() calls through Mantine notifications and removes Radix Toast from the app-level toaster path
- adds shared primitive regression coverage and provider/test environment shims
- documents temporary Radix holdouts for compound and focus-heavy APIs

Refs #416.

## Verification

- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web test -- mantine-ui-primitives`
- `pnpm --filter @veritas-kanban/web test`
- `pnpm lint:budget`
- `pnpm audit --prod --audit-level=high`
- `pnpm build`
- `./node_modules/.bin/prettier --check docs/UI-MANTINE-MIGRATION.md web/src/__tests__/CreateTaskDuplicateDetection.test.tsx web/src/__tests__/KanbanBoard.test.tsx web/src/__tests__/SearchDialog.test.tsx web/src/__tests__/test-utils.tsx web/src/__tests__/mantine-ui-primitives.test.tsx web/src/components/ui/badge.tsx web/src/components/ui/button.tsx web/src/components/ui/checkbox.tsx web/src/components/ui/input.tsx web/src/components/ui/label.tsx web/src/components/ui/scroll-area.tsx web/src/components/ui/skeleton.tsx web/src/components/ui/switch.tsx web/src/components/ui/textarea.tsx web/src/components/ui/toast.tsx web/src/components/ui/toaster.tsx`
- `git diff --check`
- Browser smoke: `http://127.0.0.1:3000/` rendered setup with Mantine styles, button/input slots, notification root, no overflow, and no new console errors

## Notes

- #416 remains open for select, dialog, sheet/drawer, alert-dialog, popover, tooltip, tabs, number-like inputs, and focus/visual QA.
- Production audit still reports existing 3 moderate advisories; the high-severity gate passes.
- Bundle movement: vendor-mantine JS 179.22 kB / 54.12 kB gzip, index JS 205.43 kB / 58.98 kB gzip, vendor-radix JS 62.22 kB / 19.00 kB gzip.