### PR TITLE
feat: add SQLite provenance queries

### DIFF
--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -1106,6 +1106,22 @@ center search, and export flows.
 | `work_product_versions` | Bounded non-destructive version history for refine, regenerate, restore, and manual updates.                 |
 | `work_product_search`   | FTS index for command-center and search reachability without walking task/comment files.                     |
 
+## Operational Provenance Repository Implementation
+
+SQLite mode also exposes a lightweight operational provenance repository over
+the normalized runtime tables. The repository returns bounded metadata records
+for task or workflow-run context without exposing raw JSON payloads or walking
+legacy files. New v5 surfaces can use these records to populate command center
+results, task work views, run timelines, maintenance screens, and completion
+packets before those surfaces own their final UI.
+
+| Query                      | Indexed records returned                                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `listForTask(taskId)`      | Work products, task deliverables, task attachments, workflow runs, notifications, and task chat messages.                             |
+| `listForRun(sourceRunId)`  | Work products, task deliverables, workflow run metadata, and scheduled deliverable snapshots tied to a source run.                    |
+| `listRecent({ limit })`    | Recent operational artifacts across work products, deliverables, attachments, workflow runs, scheduled runs, notifications, and chat. |
+| Returned provenance fields | Kind, ID, workspace, title, status/subtype, task/run/workflow IDs, agent/model, path/target URL, redaction, timestamps.               |
+
 ## Scheduled Deliverable Repository Implementation
 
 Scheduled deliverables and recurring run history move into SQLite when

--- a/server/src/__tests__/storage/sqlite-provenance-repository.test.ts
+++ b/server/src/__tests__/storage/sqlite-provenance-repository.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import type { Task } from '@veritas-kanban/shared';
+import type { WorkflowRun } from '../../types/workflow.js';
+import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+import { SqliteTaskRepository } from '../../storage/sqlite/task-repository.js';
+import { SqliteWorkProductRepository } from '../../storage/sqlite/work-product-repository.js';
+import { SqliteWorkflowRunRepository } from '../../storage/sqlite/workflow-repositories.js';
+import { SqliteNotificationRepository } from '../../storage/sqlite/notification-repository.js';
+import { SqliteChatRepository } from '../../storage/sqlite/chat-repository.js';
+import { SqliteScheduledDeliverablesRepository } from '../../storage/sqlite/scheduled-deliverables-repository.js';
+import { SqliteOperationalProvenanceRepository } from '../../storage/sqlite/provenance-repository.js';
+
+describe('SQLite operational provenance repository', () => {
+  it('indexes task and run provenance without returning raw JSON payloads', async () => {
+    const fixture = createTestSqliteDatabase();
+    fixture.database.open();
+
+    try {
+      const now = '2026-05-31T08:00:00.000Z';
+      const taskRepository = new SqliteTaskRepository(fixture.database);
+      const workProducts = new SqliteWorkProductRepository(fixture.database);
+      const workflowRuns = new SqliteWorkflowRunRepository(fixture.database);
+      const notifications = new SqliteNotificationRepository(fixture.database);
+      const chat = new SqliteChatRepository(fixture.database);
+      const scheduled = new SqliteScheduledDeliverablesRepository(fixture.database);
+      const provenance = new SqliteOperationalProvenanceRepository(fixture.database);
+
+      const task: Task = {
+        id: 'task_provenance_1',
+        title: 'Ship provenance APIs',
+        description: 'Expose SQLite provenance rows for v5 surfaces.',
+        type: 'feature',
+        status: 'in-progress',
+        priority: 'high',
+        created: now,
+        updated: '2026-05-31T08:02:00.000Z',
+        attachments: [
+          {
+            id: 'att_1',
+            filename: 'evidence.md',
+            originalName: 'Evidence.md',
+            mimeType: 'text/markdown',
+            size: 1200,
+            uploaded: '2026-05-31T08:01:00.000Z',
+            uploadedBy: 'codex',
+            storagePath: 'tasks/attachments/task_provenance_1/evidence.md',
+            validationStatus: 'valid',
+            cleanupEligible: true,
+          },
+        ],
+        deliverables: [
+          {
+            id: 'deliv_1',
+            title: 'Completion packet',
+            type: 'report',
+            status: 'attached',
+            path: 'docs/completion.md',
+            agent: 'codex',
+            model: 'gpt-5',
+            sourceRunId: 'run_provenance_1',
+            redaction: { level: 'standard' },
+            created: '2026-05-31T08:03:00.000Z',
+          },
+        ],
+      };
+
+      await taskRepository.create(task);
+      workProducts.save(
+        {
+          id: 'wp_1',
+          workspaceId: 'local',
+          kind: 'summary',
+          title: 'Run handoff',
+          status: 'active',
+          render: {
+            schemaVersion: 1,
+            kind: 'summary',
+            summary: 'Ready for review.',
+          },
+          version: 1,
+          taskId: task.id,
+          sourceRunId: 'run_provenance_1',
+          agent: 'codex',
+          model: 'gpt-5',
+          redaction: { level: 'strict' },
+          createdAt: '2026-05-31T08:04:00.000Z',
+          updatedAt: '2026-05-31T08:04:00.000Z',
+        },
+        'Ready for review.'
+      );
+
+      const run: WorkflowRun = {
+        id: 'run_provenance_1',
+        workflowId: 'wf_release',
+        workflowVersion: 1,
+        taskId: task.id,
+        status: 'completed',
+        currentStep: 'handoff',
+        context: {},
+        startedAt: '2026-05-31T08:05:00.000Z',
+        completedAt: '2026-05-31T08:06:00.000Z',
+        steps: [],
+      };
+      workflowRuns.save(run);
+
+      notifications.saveNotifications([
+        {
+          id: 'notif_1',
+          taskId: task.id,
+          targetAgent: 'reviewer',
+          fromAgent: 'codex',
+          content: 'Review the completion packet.',
+          type: 'review',
+          title: 'Review needed',
+          taskTitle: task.title,
+          targetUrl: `/tasks/${task.id}`,
+          delivered: false,
+          createdAt: '2026-05-31T08:07:00.000Z',
+        },
+      ]);
+      chat.saveSession({
+        id: 'chat_1',
+        taskId: task.id,
+        title: 'Task handoff',
+        agent: 'codex',
+        model: 'gpt-5',
+        mode: 'build',
+        created: '2026-05-31T08:08:00.000Z',
+        updated: '2026-05-31T08:08:00.000Z',
+        messages: [
+          {
+            id: 'msg_1',
+            role: 'assistant',
+            content: 'Completion packet is attached.',
+            agent: 'codex',
+            model: 'gpt-5',
+            timestamp: '2026-05-31T08:08:00.000Z',
+          },
+        ],
+      });
+      scheduled.saveRuns([
+        {
+          id: 'sched_run_1',
+          deliverableId: 'weekly_qa',
+          status: 'success',
+          outputFile: 'docs/weekly-qa.md',
+          summary: 'Weekly QA snapshot',
+          sourceRunId: 'run_provenance_1',
+          workflowId: 'wf_release',
+          runAt: '2026-05-31T08:09:00.000Z',
+        },
+      ]);
+
+      const taskRecords = provenance.listForTask(task.id);
+      expect(taskRecords.map((record) => record.kind)).toEqual([
+        'chat-message',
+        'notification',
+        'workflow-run',
+        'work-product',
+        'task-deliverable',
+        'task-attachment',
+      ]);
+      expect(taskRecords.find((record) => record.id === 'wp_1')).toMatchObject({
+        kind: 'work-product',
+        sourceRunId: 'run_provenance_1',
+        redactionLevel: 'strict',
+        agent: 'codex',
+        model: 'gpt-5',
+      });
+      expect(taskRecords.find((record) => record.id === 'att_1')).toMatchObject({
+        kind: 'task-attachment',
+        contentType: 'text/markdown',
+        cleanupEligible: true,
+        path: 'tasks/attachments/task_provenance_1/evidence.md',
+      });
+
+      const runRecords = provenance.listForRun('run_provenance_1');
+      expect(runRecords.map((record) => record.kind)).toEqual([
+        'scheduled-deliverable-run',
+        'workflow-run',
+        'work-product',
+        'task-deliverable',
+      ]);
+      expect(
+        runRecords.find((record) => record.kind === 'scheduled-deliverable-run')
+      ).toMatchObject({
+        id: 'sched_run_1',
+        workflowId: 'wf_release',
+        path: 'docs/weekly-qa.md',
+      });
+
+      const rawRecord = taskRecords[0] as unknown as Record<string, unknown>;
+      expect(rawRecord.product_json).toBeUndefined();
+      expect(rawRecord.deliverable_json).toBeUndefined();
+      expect(rawRecord.message_json).toBeUndefined();
+      expect(rawRecord.notification_json).toBeUndefined();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/storage/sqlite/provenance-repository.ts
+++ b/server/src/storage/sqlite/provenance-repository.ts
@@ -1,0 +1,324 @@
+import type { SQLInputValue } from 'node:sqlite';
+import type { SqliteDatabase } from './database.js';
+
+export type SqliteOperationalProvenanceKind =
+  | 'work-product'
+  | 'task-deliverable'
+  | 'task-attachment'
+  | 'workflow-run'
+  | 'scheduled-deliverable-run'
+  | 'notification'
+  | 'chat-message';
+
+export interface SqliteOperationalProvenanceRecord {
+  kind: SqliteOperationalProvenanceKind;
+  id: string;
+  workspaceId: string;
+  title: string;
+  status?: string;
+  subtype?: string;
+  taskId?: string;
+  sourceRunId?: string;
+  workflowId?: string;
+  agent?: string;
+  model?: string;
+  path?: string;
+  targetUrl?: string;
+  contentType?: string;
+  redactionLevel?: string;
+  cleanupEligible?: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+interface ProvenanceRow {
+  kind: SqliteOperationalProvenanceKind;
+  id: string;
+  workspace_id: string;
+  title: string | null;
+  status: string | null;
+  subtype: string | null;
+  task_id: string | null;
+  source_run_id: string | null;
+  workflow_id: string | null;
+  agent: string | null;
+  model: string | null;
+  path: string | null;
+  target_url: string | null;
+  content_type: string | null;
+  redaction_json: string | null;
+  cleanup_eligible: number | null;
+  created_at: string;
+  updated_at: string | null;
+  sort_at: string;
+}
+
+export class SqliteOperationalProvenanceRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  listForTask(
+    taskId: string,
+    options: { limit?: number } = {}
+  ): SqliteOperationalProvenanceRecord[] {
+    return this.query(this.baseQuery('task'), [taskId, taskId, taskId, taskId, taskId, taskId], {
+      limit: options.limit,
+    });
+  }
+
+  listForRun(
+    sourceRunId: string,
+    options: { limit?: number } = {}
+  ): SqliteOperationalProvenanceRecord[] {
+    return this.query(this.baseQuery('run'), [sourceRunId, sourceRunId, sourceRunId, sourceRunId], {
+      limit: options.limit,
+    });
+  }
+
+  listRecent(options: { limit?: number } = {}): SqliteOperationalProvenanceRecord[] {
+    return this.query(this.baseQuery('recent'), [], options);
+  }
+
+  private query(
+    sql: string,
+    params: SQLInputValue[],
+    options: { limit?: number }
+  ): SqliteOperationalProvenanceRecord[] {
+    const limit = Math.min(Math.max(options.limit ?? 100, 1), 500);
+    const rows = this.database
+      .getConnection()
+      .prepare(sql)
+      .all(...params, limit) as unknown as ProvenanceRow[];
+
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  private baseQuery(mode: 'task' | 'run' | 'recent'): string {
+    const taskFilter = mode === 'task';
+    const runFilter = mode === 'run';
+
+    return `
+      SELECT *
+      FROM (
+        SELECT
+          'work-product' AS kind,
+          id,
+          workspace_id,
+          title,
+          status,
+          kind AS subtype,
+          task_id,
+          source_run_id,
+          NULL AS workflow_id,
+          agent,
+          model,
+          NULL AS path,
+          NULL AS target_url,
+          NULL AS content_type,
+          redaction_json,
+          NULL AS cleanup_eligible,
+          created_at,
+          updated_at,
+          updated_at AS sort_at
+        FROM work_products
+        WHERE deleted_at IS NULL
+          ${taskFilter ? 'AND task_id = ?' : ''}
+          ${runFilter ? 'AND source_run_id = ?' : ''}
+
+        UNION ALL
+
+        SELECT
+          'task-deliverable' AS kind,
+          id,
+          workspace_id,
+          title,
+          status,
+          type AS subtype,
+          task_id,
+          source_run_id,
+          NULL AS workflow_id,
+          agent,
+          model,
+          path,
+          NULL AS target_url,
+          NULL AS content_type,
+          redaction_json,
+          NULL AS cleanup_eligible,
+          created_at,
+          updated_at,
+          COALESCE(updated_at, created_at) AS sort_at
+        FROM task_deliverables
+        WHERE deleted_at IS NULL
+          ${taskFilter ? 'AND task_id = ?' : ''}
+          ${runFilter ? 'AND source_run_id = ?' : ''}
+
+        UNION ALL
+
+        SELECT
+          'task-attachment' AS kind,
+          id,
+          workspace_id,
+          original_name AS title,
+          validation_status AS status,
+          mime_type AS subtype,
+          task_id,
+          NULL AS source_run_id,
+          NULL AS workflow_id,
+          uploaded_by AS agent,
+          NULL AS model,
+          storage_path AS path,
+          NULL AS target_url,
+          mime_type AS content_type,
+          NULL AS redaction_json,
+          cleanup_eligible,
+          uploaded_at AS created_at,
+          NULL AS updated_at,
+          uploaded_at AS sort_at
+        FROM task_attachments
+        WHERE deleted_at IS NULL
+          ${taskFilter ? 'AND task_id = ?' : runFilter ? 'AND 0' : ''}
+
+        UNION ALL
+
+        SELECT
+          'workflow-run' AS kind,
+          id,
+          workspace_id,
+          workflow_id AS title,
+          status,
+          current_step AS subtype,
+          task_id,
+          id AS source_run_id,
+          workflow_id,
+          NULL AS agent,
+          NULL AS model,
+          NULL AS path,
+          NULL AS target_url,
+          NULL AS content_type,
+          NULL AS redaction_json,
+          NULL AS cleanup_eligible,
+          started_at AS created_at,
+          completed_at AS updated_at,
+          COALESCE(completed_at, last_checkpoint, started_at) AS sort_at
+        FROM workflow_runs
+        WHERE 1 = 1
+          ${taskFilter ? 'AND task_id = ?' : ''}
+          ${runFilter ? 'AND id = ?' : ''}
+
+        UNION ALL
+
+        SELECT
+          'scheduled-deliverable-run' AS kind,
+          id,
+          workspace_id,
+          COALESCE(summary, deliverable_id) AS title,
+          status,
+          deliverable_id AS subtype,
+          NULL AS task_id,
+          source_run_id,
+          workflow_id,
+          NULL AS agent,
+          NULL AS model,
+          output_file AS path,
+          NULL AS target_url,
+          NULL AS content_type,
+          NULL AS redaction_json,
+          NULL AS cleanup_eligible,
+          run_at AS created_at,
+          NULL AS updated_at,
+          run_at AS sort_at
+        FROM scheduled_deliverable_runs
+        WHERE 1 = 1
+          ${taskFilter ? 'AND 0' : ''}
+          ${runFilter ? 'AND source_run_id = ?' : ''}
+
+        UNION ALL
+
+        SELECT
+          'notification' AS kind,
+          id,
+          workspace_id,
+          COALESCE(title, task_title, content) AS title,
+          CASE WHEN delivered = 1 THEN 'delivered' ELSE 'unread' END AS status,
+          type AS subtype,
+          task_id,
+          NULL AS source_run_id,
+          NULL AS workflow_id,
+          from_agent AS agent,
+          NULL AS model,
+          NULL AS path,
+          target_url,
+          NULL AS content_type,
+          NULL AS redaction_json,
+          NULL AS cleanup_eligible,
+          created_at,
+          delivered_at AS updated_at,
+          COALESCE(delivered_at, created_at) AS sort_at
+        FROM notifications
+        WHERE 1 = 1
+          ${taskFilter ? 'AND task_id = ?' : runFilter ? 'AND 0' : ''}
+
+        UNION ALL
+
+        SELECT
+          'chat-message' AS kind,
+          id,
+          workspace_id,
+          COALESCE(agent, role) || ' message' AS title,
+          role AS status,
+          session_id AS subtype,
+          task_id,
+          NULL AS source_run_id,
+          NULL AS workflow_id,
+          agent,
+          model,
+          NULL AS path,
+          NULL AS target_url,
+          NULL AS content_type,
+          NULL AS redaction_json,
+          NULL AS cleanup_eligible,
+          created_at,
+          NULL AS updated_at,
+          created_at AS sort_at
+        FROM chat_messages
+        WHERE 1 = 1
+          ${taskFilter ? 'AND task_id = ?' : runFilter ? 'AND 0' : ''}
+      )
+      ORDER BY datetime(sort_at) DESC, kind ASC, id ASC
+      LIMIT ?
+    `;
+  }
+
+  private mapRow(row: ProvenanceRow): SqliteOperationalProvenanceRecord {
+    return {
+      kind: row.kind,
+      id: row.id,
+      workspaceId: row.workspace_id,
+      title: row.title ?? row.id,
+      status: row.status ?? undefined,
+      subtype: row.subtype ?? undefined,
+      taskId: row.task_id ?? undefined,
+      sourceRunId: row.source_run_id ?? undefined,
+      workflowId: row.workflow_id ?? undefined,
+      agent: row.agent ?? undefined,
+      model: row.model ?? undefined,
+      path: row.path ?? undefined,
+      targetUrl: row.target_url ?? undefined,
+      contentType: row.content_type ?? undefined,
+      redactionLevel: this.redactionLevel(row.redaction_json),
+      cleanupEligible: row.cleanup_eligible === null ? undefined : row.cleanup_eligible === 1,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at ?? undefined,
+    };
+  }
+
+  private redactionLevel(redactionJson: string | null): string | undefined {
+    if (!redactionJson) return undefined;
+
+    try {
+      const parsed = JSON.parse(redactionJson) as { level?: unknown };
+      return typeof parsed.level === 'string' ? parsed.level : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -9,6 +9,7 @@ import { SqlitePromptRegistryRepository } from './prompt-registry-repository.js'
 import { SqliteActivityRepository } from './activity-repository.js';
 import { SqliteStatusHistoryRepository } from './status-history-repository.js';
 import { SqliteTelemetryRepository } from './telemetry-repository.js';
+import { SqliteOperationalProvenanceRepository } from './provenance-repository.js';
 import { createDefaultConfig, normalizeAppConfig } from '../../services/config-service.js';
 
 export interface SqliteStorageOptions {
@@ -25,6 +26,7 @@ export class SqliteStorageProvider implements StorageProvider {
   readonly statusHistory: SqliteStatusHistoryRepository;
   readonly managedLists: SqliteManagedListProvider;
   readonly telemetry: SqliteTelemetryRepository;
+  readonly provenance: SqliteOperationalProvenanceRepository;
 
   private readonly sqlite: SqliteDatabase;
 
@@ -42,6 +44,7 @@ export class SqliteStorageProvider implements StorageProvider {
     this.statusHistory = new SqliteStatusHistoryRepository(this.sqlite);
     this.managedLists = new SqliteManagedListProvider(this.sqlite);
     this.telemetry = new SqliteTelemetryRepository(this.sqlite);
+    this.provenance = new SqliteOperationalProvenanceRepository(this.sqlite);
   }
 
   getDatabase(): SqliteDatabase {


### PR DESCRIPTION
## Summary

- adds a SQLite operational provenance repository with bounded task, run, and recent artifact queries
- exposes lightweight provenance metadata for work products, task deliverables, attachments, workflow runs, scheduled run snapshots, notifications, and task chat messages without returning raw JSON payloads
- wires the provenance repository into the SQLite storage provider
- documents the query surface in the SQLite schema guide

Closes #332.

## Verification

- `./node_modules/.bin/vitest run server/src/__tests__/storage/sqlite-provenance-repository.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm lint:budget`
- `pnpm audit --prod --audit-level=high`
- `pnpm build`
- `./node_modules/.bin/prettier --check docs/SQLITE-SCHEMA.md server/src/__tests__/storage/sqlite-provenance-repository.test.ts server/src/storage/sqlite/provenance-repository.ts server/src/storage/sqlite/sqlite-storage.ts`
- `git diff --check`

## Notes

- Production audit still reports the existing 3 moderate advisories; the high-severity gate passes.
- Local server-package Vitest shim was stale after dependency churn, so the focused test was run through the current root Vitest binary.