### PR TITLE
feat: add REST route permission guards

### DIFF
--- a/server/src/__tests__/middleware/auth.test.ts
+++ b/server/src/__tests__/middleware/auth.test.ts
@@ -22,6 +22,7 @@ import {
   authenticate,
   authorize,
   authorizePermission,
+  authorizePermissionByMethod,
   authorizeWrite,
   authenticateWebSocket,
   validateWebSocketOrigin,
@@ -448,6 +449,57 @@ describe('Auth Middleware', () => {
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'FORBIDDEN' }));
+    });
+
+    it('should select read permissions for safe HTTP methods', () => {
+      const middleware = authorizePermissionByMethod({
+        read: 'settings:read',
+        write: 'settings:write',
+      });
+      const req = mockRequest({ method: 'GET' }) as AuthenticatedRequest;
+      req.auth = { role: 'read-only', isLocalhost: false };
+      const res = mockResponse();
+      const next = mockNext();
+
+      middleware(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should select write permissions for mutating HTTP methods', () => {
+      const middleware = authorizePermissionByMethod({
+        read: 'settings:read',
+        write: 'settings:write',
+      });
+      const req = mockRequest({ method: 'PATCH' }) as AuthenticatedRequest;
+      req.auth = { role: 'agent', isLocalhost: false };
+      const res = mockResponse();
+      const next = mockNext();
+
+      middleware(req, res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({ required: ['settings:write'] }),
+        })
+      );
+    });
+
+    it('should honor method and path permission overrides', () => {
+      const middleware = authorizePermissionByMethod({
+        read: 'workflow:read',
+        write: 'workflow:write',
+        overrides: [
+          { methods: ['POST'], path: /^\/workflow-1\/runs\/?$/, permissions: 'workflow:execute' },
+        ],
+      });
+      const req = mockRequest({ method: 'POST', path: '/workflow-1/runs' }) as AuthenticatedRequest;
+      req.auth = { role: 'agent', isLocalhost: false };
+      const res = mockResponse();
+      const next = mockNext();
+
+      middleware(req, res, next);
+      expect(next).toHaveBeenCalled();
     });
   });
 

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { NextFunction, Response } from 'express';
+import type { AuthenticatedRequest } from '../../middleware/auth.js';
+import {
+  activityAccess,
+  policyAccess,
+  scoringAccess,
+  searchAccess,
+  settingsAccess,
+  workflowAccess,
+} from '../../routes/v1/permissions.js';
+
+type AccessGuard = (req: AuthenticatedRequest, res: Response, next: NextFunction) => void;
+
+function mockRequest(method: string, path: string): AuthenticatedRequest {
+  return {
+    method,
+    path,
+    auth: { role: 'agent', isLocalhost: false },
+  } as unknown as AuthenticatedRequest;
+}
+
+function mockResponse(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+function runGuard(handler: AccessGuard, req: AuthenticatedRequest) {
+  const res = mockResponse();
+  const next = vi.fn() as NextFunction;
+  handler(req, res, next);
+  return { res, next };
+}
+
+describe('v1 REST permission guard presets', () => {
+  it('blocks agent keys from settings mutations at the route boundary', () => {
+    const { res, next } = runGuard(settingsAccess, mockRequest('PATCH', '/features'));
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'FORBIDDEN',
+        details: expect.objectContaining({
+          required: ['settings:write'],
+          currentRole: 'agent',
+        }),
+      })
+    );
+  });
+
+  it('requires admin permission for destructive telemetry maintenance routes', () => {
+    const { res, next } = runGuard(activityAccess, mockRequest('DELETE', '/'));
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          required: ['admin:manage'],
+          currentRole: 'agent',
+        }),
+      })
+    );
+  });
+
+  it('keeps read-like search POSTs available while guarding index refresh', () => {
+    expect(runGuard(searchAccess, mockRequest('POST', '/')).next).toHaveBeenCalled();
+
+    const { res, next } = runGuard(searchAccess, mockRequest('POST', '/index/refresh'));
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['settings:write'] }),
+      })
+    );
+  });
+
+  it('keeps policy evaluation available to agent keys without opening policy mutations', () => {
+    expect(runGuard(policyAccess, mockRequest('POST', '/evaluate')).next).toHaveBeenCalled();
+
+    const { res, next } = runGuard(policyAccess, mockRequest('POST', '/'));
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['policy:read'] }),
+      })
+    );
+  });
+
+  it('separates workflow execution from workflow authoring permissions', () => {
+    expect(
+      runGuard(workflowAccess, mockRequest('POST', '/workflow-1/runs')).next
+    ).toHaveBeenCalled();
+
+    const { res, next } = runGuard(workflowAccess, mockRequest('POST', '/'));
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['workflow:write'] }),
+      })
+    );
+  });
+
+  it('keeps scoring evaluation read-like while guarding scoring profile mutations', () => {
+    expect(runGuard(scoringAccess, mockRequest('POST', '/evaluate')).next).toHaveBeenCalled();
+
+    const { res, next } = runGuard(scoringAccess, mockRequest('POST', '/profiles'));
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['settings:write'] }),
+      })
+    );
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -515,6 +515,57 @@ export function authorizePermission(...allowedPermissions: AuthPermission[]) {
   };
 }
 
+const READ_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+type PermissionInput = AuthPermission | AuthPermission[];
+
+export interface MethodPermissionOverride {
+  methods?: string[];
+  path?: RegExp;
+  permissions: PermissionInput;
+}
+
+export interface MethodPermissionConfig {
+  read: PermissionInput;
+  write?: PermissionInput;
+  overrides?: MethodPermissionOverride[];
+}
+
+function normalizePermissions(permissions: PermissionInput): AuthPermission[] {
+  return Array.isArray(permissions) ? permissions : [permissions];
+}
+
+/**
+ * Authorization middleware factory - selects explicit permissions by method.
+ *
+ * REST route groups can use this at mount time to require read permissions for
+ * safe methods and write/execute permissions for mutating methods, with narrow
+ * path overrides for read-like POST endpoints.
+ */
+export function authorizePermissionByMethod(config: MethodPermissionConfig) {
+  const readPermissions = normalizePermissions(config.read);
+  const writePermissions = normalizePermissions(config.write ?? config.read);
+  const overrides = config.overrides ?? [];
+
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    const override = overrides.find((candidate) => {
+      const methodMatches =
+        !candidate.methods ||
+        candidate.methods.some((method) => method.toUpperCase() === req.method.toUpperCase());
+      const pathMatches = !candidate.path || candidate.path.test(req.path);
+      return methodMatches && pathMatches;
+    });
+
+    const requiredPermissions = override
+      ? normalizePermissions(override.permissions)
+      : READ_METHODS.has(req.method)
+        ? readPermissions
+        : writePermissions;
+
+    authorizePermission(...requiredPermissions)(req, res, next);
+  };
+}
+
 /**
  * Middleware that allows read operations for read-only users
  * but requires admin for write operations

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -16,6 +16,36 @@
  */
 import { Router, type IRouter, type Request } from 'express';
 import { readRateLimit, writeRateLimit, uploadRateLimit } from '../../middleware/rate-limit.js';
+import {
+  activityAccess,
+  adminAccess,
+  agentSelfServiceAccess,
+  agentStatusAccess,
+  agentTaskAccess,
+  backupAccess,
+  broadcastAccess,
+  configAccess,
+  costPredictionAccess,
+  delegationAccess,
+  feedbackAccess,
+  notificationAccess,
+  policyAccess,
+  promptRegistryAccess,
+  reportAccess,
+  reportRoutesAccess,
+  scoringAccess,
+  searchAccess,
+  settingsAccess,
+  statusHistoryAccess,
+  taskAccess,
+  taskCommentAccess,
+  taskReadAccess,
+  telemetryAccess,
+  transcriptAccess,
+  workflowAccess,
+  workProductAccess,
+  workspaceAccess,
+} from './permissions.js';
 
 // Task routes (order-sensitive — see note above)
 import { taskArchiveRoutes } from '../task-archive.js';
@@ -100,15 +130,15 @@ v1Router.use((req: Request, _res, next) => {
 });
 
 // ── Task routes (order-sensitive) ────────────────────────────
-v1Router.use('/tasks', taskArchiveRoutes);
-v1Router.use('/tasks', taskTimeRoutes);
-v1Router.use('/tasks', taskRoutes);
-v1Router.use('/tasks', taskCommentRoutes);
-v1Router.use('/tasks', taskObservationRoutes);
-v1Router.use('/tasks', taskSubtaskRoutes);
-v1Router.use('/tasks', taskVerificationRoutes);
-v1Router.use('/tasks', taskDeliverableRoutes);
-v1Router.use('/tasks', taskWorkProductRoutes);
+v1Router.use('/tasks', taskAccess, taskArchiveRoutes);
+v1Router.use('/tasks', taskAccess, taskTimeRoutes);
+v1Router.use('/tasks', taskAccess, taskRoutes);
+v1Router.use('/tasks', taskCommentAccess, taskCommentRoutes);
+v1Router.use('/tasks', taskAccess, taskObservationRoutes);
+v1Router.use('/tasks', taskAccess, taskSubtaskRoutes);
+v1Router.use('/tasks', taskAccess, taskVerificationRoutes);
+v1Router.use('/tasks', taskAccess, taskDeliverableRoutes);
+v1Router.use('/tasks', workProductAccess, taskWorkProductRoutes);
 
 // Attachment routes get the stricter upload rate limit (20 req/min)
 // applied BEFORE the route handler for upload (POST) requests.
@@ -121,70 +151,71 @@ v1Router.use(
     }
     next();
   },
+  taskAccess,
   attachmentRoutes
 );
 
 // ── Backlog routes ───────────────────────────────────────────
-v1Router.use('/backlog', backlogRoutes);
+v1Router.use('/backlog', taskAccess, backlogRoutes);
 
 // ── Observation search ───────────────────────────────────────
-v1Router.use('/observations', observationSearchRouter);
+v1Router.use('/observations', taskReadAccess, observationSearchRouter);
 
 // ── Feature routes ───────────────────────────────────────────
-v1Router.use('/config', configRoutes);
-v1Router.use('/changes', changesRoutes); // Efficient agent polling endpoint
-v1Router.use('/chat', chatRoutes); // Chat interface - must be before agent routes
-v1Router.use('/agents/register', agentRegistryRoutes); // Before agentRoutes (/:taskId catches "register")
-v1Router.use('/agents/permissions', agentPermissionRoutes);
-v1Router.use('/agents', agentRoutingRoutes); // Must be before agentRoutes (/:taskId would match "route"/"routing")
-v1Router.use('/agents', agentRoutes);
-v1Router.use('/diff', diffRoutes);
-v1Router.use('/automation', automationRoutes);
-v1Router.use('/summary', summaryRoutes);
-v1Router.use('/notifications', notificationRoutes);
-v1Router.use('/broadcasts', broadcastRoutes);
-v1Router.use('/templates', templateRoutes);
-v1Router.use('/task-types', taskTypeRoutes);
-v1Router.use('/projects', projectRoutes);
-v1Router.use('/sprints', sprintRoutes);
-v1Router.use('/activity', activityRoutes);
-v1Router.use('/github', githubRoutes);
-v1Router.use('/preview', previewRoutes);
-v1Router.use('/conflicts', conflictRoutes);
-v1Router.use('/telemetry', telemetryRoutes);
-v1Router.use('/metrics', metricsRoutes);
-v1Router.use('/analytics', analyticsRoutes);
-v1Router.use('/traces', tracesRoutes);
-v1Router.use('/drift', driftRoutes);
-v1Router.use('/settings', settingsRoutes);
-v1Router.use('/settings/transition-hooks', transitionHooksRoutes);
-v1Router.use('/agent/status', agentStatusRoutes);
-v1Router.use('/cost-prediction', costPredictionRoutes);
-v1Router.use('/deliverables', scheduledDeliverablesRoutes);
-v1Router.use('/reports', reportRoutes);
-v1Router.use('/doc-freshness', docFreshnessRoutes);
-v1Router.use('/docs', docsRoutes);
-v1Router.use('/errors', errorLearningRoutes);
-v1Router.use('/search', searchRoutes);
-v1Router.use('/work-products', workProductRoutes);
-v1Router.use('/hooks', lifecycleHooksRoutes);
-v1Router.use('/shared-resources', sharedResourcesRoutes);
-v1Router.use('/status-history', statusHistoryRoutes);
-v1Router.use('/digest', digestRoutes);
-v1Router.use('/audit', auditRoutes);
-v1Router.use('/lessons', lessonsRoutes);
-v1Router.use('/delegation', delegationRoutes);
-v1Router.use('/workflows', workflowRoutes);
-v1Router.use('/tool-policies', toolPolicyRoutes);
-v1Router.use('/policies', policyRoutes);
-v1Router.use('/integrations', integrationsRoutes);
-v1Router.use('/transcripts', transcriptRoutes);
-v1Router.use('/scoring', scoringRoutes);
-v1Router.use('/system/health', systemHealthRouter);
-v1Router.use('/decisions', decisionRoutes);
-v1Router.use('/feedback', feedbackRoutes);
-v1Router.use('/prompt-registry', promptRegistryRoutes);
-v1Router.use('/sqlite', sqlitePortabilityRoutes);
-v1Router.use('/identity', identityRoutes);
+v1Router.use('/config', configAccess, configRoutes);
+v1Router.use('/changes', taskReadAccess, changesRoutes); // Efficient agent polling endpoint
+v1Router.use('/chat', taskCommentAccess, chatRoutes); // Chat interface - must be before agent routes
+v1Router.use('/agents/register', agentSelfServiceAccess, agentRegistryRoutes); // Before agentRoutes (/:taskId catches "register")
+v1Router.use('/agents/permissions', agentSelfServiceAccess, agentPermissionRoutes);
+v1Router.use('/agents', agentSelfServiceAccess, agentRoutingRoutes); // Must be before agentRoutes (/:taskId would match "route"/"routing")
+v1Router.use('/agents', agentTaskAccess, agentRoutes);
+v1Router.use('/diff', taskReadAccess, diffRoutes);
+v1Router.use('/automation', taskAccess, automationRoutes);
+v1Router.use('/summary', reportAccess, summaryRoutes);
+v1Router.use('/notifications', notificationAccess, notificationRoutes);
+v1Router.use('/broadcasts', broadcastAccess, broadcastRoutes);
+v1Router.use('/templates', settingsAccess, templateRoutes);
+v1Router.use('/task-types', settingsAccess, taskTypeRoutes);
+v1Router.use('/projects', settingsAccess, projectRoutes);
+v1Router.use('/sprints', settingsAccess, sprintRoutes);
+v1Router.use('/activity', activityAccess, activityRoutes);
+v1Router.use('/github', taskAccess, githubRoutes);
+v1Router.use('/preview', taskReadAccess, previewRoutes);
+v1Router.use('/conflicts', taskAccess, conflictRoutes);
+v1Router.use('/telemetry', telemetryAccess, telemetryRoutes);
+v1Router.use('/metrics', reportAccess, metricsRoutes);
+v1Router.use('/analytics', reportAccess, analyticsRoutes);
+v1Router.use('/traces', telemetryAccess, tracesRoutes);
+v1Router.use('/drift', telemetryAccess, driftRoutes);
+v1Router.use('/settings/transition-hooks', adminAccess, transitionHooksRoutes);
+v1Router.use('/settings', settingsAccess, settingsRoutes);
+v1Router.use('/agent/status', agentStatusAccess, agentStatusRoutes);
+v1Router.use('/cost-prediction', costPredictionAccess, costPredictionRoutes);
+v1Router.use('/deliverables', taskAccess, scheduledDeliverablesRoutes);
+v1Router.use('/reports', reportRoutesAccess, reportRoutes);
+v1Router.use('/doc-freshness', settingsAccess, docFreshnessRoutes);
+v1Router.use('/docs', settingsAccess, docsRoutes);
+v1Router.use('/errors', telemetryAccess, errorLearningRoutes);
+v1Router.use('/search', searchAccess, searchRoutes);
+v1Router.use('/work-products', workProductAccess, workProductRoutes);
+v1Router.use('/hooks', settingsAccess, lifecycleHooksRoutes);
+v1Router.use('/shared-resources', settingsAccess, sharedResourcesRoutes);
+v1Router.use('/status-history', statusHistoryAccess, statusHistoryRoutes);
+v1Router.use('/digest', reportAccess, digestRoutes);
+v1Router.use('/audit', adminAccess, auditRoutes);
+v1Router.use('/lessons', taskReadAccess, lessonsRoutes);
+v1Router.use('/delegation', delegationAccess, delegationRoutes);
+v1Router.use('/workflows', workflowAccess, workflowRoutes);
+v1Router.use('/tool-policies', policyAccess, toolPolicyRoutes);
+v1Router.use('/policies', policyAccess, policyRoutes);
+v1Router.use('/integrations', settingsAccess, integrationsRoutes);
+v1Router.use('/transcripts', transcriptAccess, transcriptRoutes);
+v1Router.use('/scoring', scoringAccess, scoringRoutes);
+v1Router.use('/system/health', workspaceAccess, systemHealthRouter);
+v1Router.use('/decisions', taskAccess, decisionRoutes);
+v1Router.use('/feedback', feedbackAccess, feedbackRoutes);
+v1Router.use('/prompt-registry', promptRegistryAccess, promptRegistryRoutes);
+v1Router.use('/sqlite', backupAccess, sqlitePortabilityRoutes);
+v1Router.use('/identity', workspaceAccess, identityRoutes);
 
 export { v1Router };

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -1,0 +1,71 @@
+import {
+  authorizePermissionByMethod,
+  type AuthPermission,
+  type MethodPermissionOverride,
+} from '../../middleware/auth.js';
+
+type PermissionSpec = AuthPermission | AuthPermission[];
+
+function routeAccess(
+  read: PermissionSpec,
+  write: PermissionSpec = read,
+  overrides: MethodPermissionOverride[] = []
+) {
+  return authorizePermissionByMethod({ read, write, overrides });
+}
+
+export const taskAccess = routeAccess('task:read', 'task:write');
+export const taskReadAccess = routeAccess('task:read', 'task:read');
+export const taskCommentAccess = routeAccess('task:read', 'comment:write');
+export const workProductAccess = routeAccess('work_product:read', 'work_product:write');
+export const settingsAccess = routeAccess('settings:read', 'settings:write');
+export const adminAccess = routeAccess('admin:manage', 'admin:manage');
+export const agentSelfServiceAccess = routeAccess('agent:read', 'agent:read');
+export const agentTaskAccess = routeAccess('agent:read', 'task:write');
+export const agentStatusAccess = routeAccess('agent:read', 'telemetry:write');
+export const reportAccess = routeAccess('report:read', 'report:read');
+export const telemetryAccess = routeAccess('telemetry:read', 'telemetry:write');
+export const policyAccess = routeAccess('policy:read', 'policy:read', [
+  { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
+]);
+export const backupAccess = routeAccess('backup:read', 'backup:write');
+export const workspaceAccess = routeAccess('workspace:read', 'admin:manage');
+export const notificationAccess = routeAccess('agent:read', 'comment:write');
+export const broadcastAccess = routeAccess('task:read', 'comment:write');
+export const activityAccess = routeAccess('telemetry:read', 'admin:manage');
+export const costPredictionAccess = routeAccess('report:read', 'task:write');
+export const statusHistoryAccess = routeAccess('telemetry:read', 'admin:manage');
+export const delegationAccess = routeAccess('agent:read', 'admin:manage');
+export const transcriptAccess = routeAccess('workspace:read', 'workflow:execute');
+export const feedbackAccess = routeAccess('report:read', 'comment:write');
+
+export const configAccess = routeAccess('settings:read', 'settings:write', [
+  { methods: ['POST'], path: /^\/repos\/validate\/?$/, permissions: 'settings:read' },
+]);
+
+export const searchAccess = routeAccess('task:read', 'settings:write', [
+  { methods: ['POST'], path: /^\/?$/, permissions: ['task:read', 'work_product:read'] },
+]);
+
+export const workflowAccess = routeAccess('workflow:read', 'workflow:write', [
+  { methods: ['POST'], path: /^\/[^/]+\/runs\/?$/, permissions: 'workflow:execute' },
+  { methods: ['POST'], path: /^\/runs\/[^/]+\/resume\/?$/, permissions: 'workflow:execute' },
+  {
+    methods: ['POST'],
+    path: /^\/runs\/[^/]+\/steps\/[^/]+\/(approve|reject)\/?$/,
+    permissions: 'workflow:execute',
+  },
+]);
+
+export const reportRoutesAccess = routeAccess('report:read', 'settings:write', [
+  { methods: ['POST'], path: /^\/generate\/?$/, permissions: 'report:read' },
+]);
+
+export const scoringAccess = routeAccess('report:read', 'settings:write', [
+  { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: 'report:read' },
+]);
+
+export const promptRegistryAccess = routeAccess('settings:read', 'settings:write', [
+  { methods: ['POST'], path: /^\/[^/]+\/render-preview\/?$/, permissions: 'settings:read' },
+  { methods: ['POST'], path: /^\/[^/]+\/record-usage\/?$/, permissions: 'telemetry:write' },
+]);

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -26,7 +26,7 @@ function getStringParam(param: string | string[] | undefined): string {
 
 // Helper to get user ID from request
 function getUserId(req: AuthenticatedRequest): string {
-  return req.auth?.keyName || 'unknown';
+  return req.auth?.userId || req.auth?.keyName || 'unknown';
 }
 
 // Validation schemas


### PR DESCRIPTION
## Summary

- adds method/path-aware permission middleware for explicit REST read, write, and execute requirements
- maps the v1 route registry to permission presets across task, settings, agent, telemetry, report, policy, workflow, backup, and workspace surfaces
- preserves read-like POST behavior for search, workflow execution, report/scoring generation, policy evaluation, and prompt preview/usage routes
- uses v5 auth user IDs for workflow ACL checks when available
- adds focused coverage for permission selection and v1 route preset behavior

Refs #336.

## Verification

- `./node_modules/.bin/vitest run server/src/__tests__/middleware/auth.test.ts server/src/__tests__/routes/v1-permission-guards.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm lint:budget` (708 warnings, budget 714)
- `pnpm audit --prod --audit-level=high` (3 moderate advisories, high gate passes)
- `pnpm build`
- `./node_modules/.bin/prettier --check server/src/middleware/auth.ts server/src/routes/v1/index.ts server/src/routes/v1/permissions.ts server/src/__tests__/middleware/auth.test.ts server/src/__tests__/routes/v1-permission-guards.test.ts server/src/routes/workflows.ts`
- `git diff --check`

## Notes

- This is the REST route-guard slice for #336. WebSocket event filtering and scoped CLI/MCP execution enforcement remain separate follow-up slices.