### PR TITLE
test: add v5 permission coverage manifest gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Enforce lint warning budget
         run: pnpm lint:budget
 
+      - name: Check permission coverage
+        run: node scripts/check-permission-coverage.mjs
+
       - name: Type check all packages
         run: pnpm typecheck
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,6 +91,13 @@ context for the v5 RBAC migration:
 New v5 endpoints should prefer explicit permission guards over broad role
 checks. Legacy role guards remain supported while route coverage is migrated.
 
+The v5 authority surface is tracked in
+[`docs/security/permission-coverage.json`](security/permission-coverage.json).
+Run `node scripts/check-permission-coverage.mjs` to fail when a REST route
+prefix, WebSocket event, CLI command, MCP tool, workflow step/action type,
+command palette action, or tracked background job is added without a permission
+classification.
+
 ## Configuration Reference
 
 ### Environment Variables

--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -1,0 +1,1271 @@
+{
+  "version": 1,
+  "lastReviewed": "2026-05-31",
+  "notes": "Authority surface manifest for v5.0. The REST route-map entry is backed by shared/src/utils/api-permissions.ts, and CI compares it against server/src/routes/v1/index.ts.",
+  "surfaces": [
+    {
+      "id": "rest:v1-route-map",
+      "kind": "rest",
+      "classification": "authenticated-write",
+      "permissions": ["route-map"],
+      "source": "shared/src/utils/api-permissions.ts",
+      "denialReason": "REST requests are denied by explicit route permission guards or by the client preflight map."
+    },
+    {
+      "id": "websocket:task:changed",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Task change events require task read access in the event workspace."
+    },
+    {
+      "id": "websocket:chat:delta",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Chat delta events require task read access in the event workspace."
+    },
+    {
+      "id": "websocket:chat:message",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Chat message events require task read access in the event workspace."
+    },
+    {
+      "id": "websocket:chat:error",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Chat error events require task read access in the event workspace."
+    },
+    {
+      "id": "websocket:squad:message",
+      "kind": "websocket",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Squad messages require agent read access."
+    },
+    {
+      "id": "websocket:telemetry:event",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["telemetry:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Telemetry events require telemetry read access."
+    },
+    {
+      "id": "websocket:broadcast:new",
+      "kind": "websocket",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Agent broadcast notifications require agent read access."
+    },
+    {
+      "id": "websocket:workflow:status",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["workflow:read"],
+      "source": "server/src/services/broadcast-service.ts",
+      "denialReason": "Workflow status events require workflow read access."
+    },
+    {
+      "id": "websocket:agent:status",
+      "kind": "websocket",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "server/src/routes/agent-status.ts",
+      "denialReason": "Agent status events require agent read access."
+    },
+    {
+      "id": "websocket:agent:output",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Agent output subscriptions require task read access."
+    },
+    {
+      "id": "websocket:agent:complete",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Agent completion subscriptions require task read access."
+    },
+    {
+      "id": "websocket:agent:error",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Agent error subscriptions require task read access."
+    },
+    {
+      "id": "websocket:chat:subscribed",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Chat subscription confirmations are only sent after task read authorization."
+    },
+    {
+      "id": "websocket:subscribed",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Task output subscription confirmations are only sent after task read authorization."
+    },
+    {
+      "id": "websocket:error",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["workspace:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "WebSocket denial errors are only sent on an authenticated connection."
+    },
+    {
+      "id": "websocket-inbound:chat:subscribe",
+      "kind": "websocket-inbound",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Chat subscriptions require task read access in the requested workspace."
+    },
+    {
+      "id": "websocket-inbound:subscribe",
+      "kind": "websocket-inbound",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Agent output subscriptions require task read access in the requested workspace."
+    },
+    {
+      "id": "workflow-step:agent",
+      "kind": "workflow-step",
+      "classification": "agent-scoped",
+      "permissions": ["workflow:execute", "agent:read"],
+      "source": "shared/src/types/workflow.ts",
+      "denialReason": "Agent workflow steps require workflow execution permission and an allowed agent."
+    },
+    {
+      "id": "workflow-step:loop",
+      "kind": "workflow-step",
+      "classification": "agent-scoped",
+      "permissions": ["workflow:execute", "agent:read"],
+      "source": "shared/src/types/workflow.ts",
+      "denialReason": "Loop workflow steps require workflow execution permission and an allowed agent."
+    },
+    {
+      "id": "workflow-step:gate",
+      "kind": "workflow-step",
+      "classification": "authenticated-write",
+      "permissions": ["workflow:execute"],
+      "source": "shared/src/types/workflow.ts",
+      "denialReason": "Gate workflow steps require workflow execution permission."
+    },
+    {
+      "id": "workflow-step:parallel",
+      "kind": "workflow-step",
+      "classification": "agent-scoped",
+      "permissions": ["workflow:execute", "agent:read"],
+      "source": "shared/src/types/workflow.ts",
+      "denialReason": "Parallel workflow steps require workflow execution permission and allowed agents."
+    },
+    {
+      "id": "transition-gate:require-agent",
+      "kind": "transition-gate",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition gates execute inside an already authorized task status change."
+    },
+    {
+      "id": "transition-gate:require-plan",
+      "kind": "transition-gate",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition gates execute inside an already authorized task status change."
+    },
+    {
+      "id": "transition-gate:require-verification-complete",
+      "kind": "transition-gate",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition gates execute inside an already authorized task status change."
+    },
+    {
+      "id": "transition-gate:require-time-tracked",
+      "kind": "transition-gate",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition gates execute inside an already authorized task status change."
+    },
+    {
+      "id": "transition-gate:require-closing-comment",
+      "kind": "transition-gate",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition gates execute inside an already authorized task status change."
+    },
+    {
+      "id": "transition-gate:require-subtasks-complete",
+      "kind": "transition-gate",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition gates execute inside an already authorized task status change."
+    },
+    {
+      "id": "transition-gate:require-blocker-reason",
+      "kind": "transition-gate",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition gates execute inside an already authorized task status change."
+    },
+    {
+      "id": "transition-action:auto-start-timer",
+      "kind": "transition-action",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition actions execute only after the initiating task transition is authorized."
+    },
+    {
+      "id": "transition-action:auto-stop-timer",
+      "kind": "transition-action",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition actions execute only after the initiating task transition is authorized."
+    },
+    {
+      "id": "transition-action:send-webhook",
+      "kind": "transition-action",
+      "classification": "workspace-admin",
+      "permissions": ["admin:manage"],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "denialReason": "Webhook transition actions can only be configured through admin-guarded transition hook settings."
+    },
+    {
+      "id": "transition-action:send-notification",
+      "kind": "transition-action",
+      "classification": "workspace-admin",
+      "permissions": ["admin:manage"],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "denialReason": "Notification transition actions can only be configured through admin-guarded transition hook settings."
+    },
+    {
+      "id": "transition-action:prompt-lessons-learned",
+      "kind": "transition-action",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition actions execute only after the initiating task transition is authorized."
+    },
+    {
+      "id": "transition-action:log-activity",
+      "kind": "transition-action",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "shared/src/types/transition-hooks.types.ts",
+      "justification": "Transition actions execute only after the initiating task transition is authorized."
+    },
+    {
+      "id": "command-palette:new-task",
+      "kind": "command-palette",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Creating a task through the command palette requires task write access."
+    },
+    {
+      "id": "command-palette:toggle-theme",
+      "kind": "command-palette",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "justification": "Theme switching is a client-local preference and does not call a privileged API."
+    },
+    {
+      "id": "command-palette:open-search",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read", "work_product:read"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Opening semantic search leads to task and work product read APIs."
+    },
+    {
+      "id": "command-palette:move-todo",
+      "kind": "command-palette",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Moving a task to To Do requires task write access."
+    },
+    {
+      "id": "command-palette:move-inprogress",
+      "kind": "command-palette",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Moving a task to In Progress requires task write access."
+    },
+    {
+      "id": "command-palette:move-blocked",
+      "kind": "command-palette",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Moving a task to Blocked requires task write access."
+    },
+    {
+      "id": "command-palette:move-done",
+      "kind": "command-palette",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Moving a task to Done requires task write access."
+    },
+    {
+      "id": "command-palette:nav-up",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Task selection shortcuts are only useful after task read access is granted."
+    },
+    {
+      "id": "command-palette:nav-down",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Task selection shortcuts are only useful after task read access is granted."
+    },
+    {
+      "id": "command-palette:open-task",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "web/src/components/layout/CommandPalette.tsx",
+      "denialReason": "Opening a selected task requires task read access."
+    },
+    {
+      "id": "command-palette:go-board",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Board navigation leads to task read APIs."
+    },
+    {
+      "id": "command-palette:go-activity",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["telemetry:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Activity navigation leads to activity and telemetry read APIs."
+    },
+    {
+      "id": "command-palette:go-backlog",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Backlog navigation leads to task read APIs."
+    },
+    {
+      "id": "command-palette:go-archive",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Archive navigation leads to task read APIs."
+    },
+    {
+      "id": "command-palette:go-templates",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Template navigation leads to settings read APIs."
+    },
+    {
+      "id": "command-palette:go-workflows",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["workflow:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Workflow navigation leads to workflow read APIs."
+    },
+    {
+      "id": "command-palette:go-drift",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["telemetry:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Drift navigation leads to telemetry read APIs."
+    },
+    {
+      "id": "command-palette:go-decisions",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Decision navigation leads to task-linked decision read APIs."
+    },
+    {
+      "id": "command-palette:go-scoring",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["report:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Scoring navigation leads to report read APIs."
+    },
+    {
+      "id": "command-palette:go-policies",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["policy:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Policy navigation leads to policy read APIs."
+    },
+    {
+      "id": "background-job:agent-registry-stale-check",
+      "kind": "background-job",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "server/src/services/agent-registry-service.ts",
+      "justification": "Agent stale checks are server-owned maintenance and are not caller-triggered."
+    },
+    {
+      "id": "background-job:github-sync-poll",
+      "kind": "background-job",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "server/src/services/github-sync-service.ts",
+      "justification": "GitHub sync polling runs from configured server state and is not caller-triggered."
+    },
+    {
+      "id": "background-job:prometheus-event-loop-lag",
+      "kind": "background-job",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "server/src/services/metrics/prometheus.ts",
+      "justification": "Event loop lag sampling records process metrics and is not caller-triggered."
+    },
+    {
+      "id": "background-job:task-github-reconcile",
+      "kind": "background-job",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "server/src/services/task-service.ts",
+      "justification": "Task GitHub reconciliation runs from configured server state and is not caller-triggered."
+    },
+    {
+      "id": "background-job:websocket-heartbeat",
+      "kind": "background-job",
+      "classification": "internal-only",
+      "permissions": [],
+      "source": "server/src/index.ts",
+      "justification": "WebSocket heartbeats maintain authenticated connections and do not expose data."
+    },
+    {
+      "id": "cli:agent-status:agent",
+      "kind": "cli",
+      "classification": "public/setup",
+      "permissions": [],
+      "source": "cli/src/commands/agent-status.ts",
+      "justification": "Parent command only; subcommands carry authorization."
+    },
+    {
+      "id": "cli:agent-status:status",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "cli/src/commands/agent-status.ts",
+      "denialReason": "Agent status reads require agent read access."
+    },
+    {
+      "id": "cli:agent-status:working",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["telemetry:write"],
+      "source": "cli/src/commands/agent-status.ts",
+      "denialReason": "Agent status writes require telemetry write access."
+    },
+    {
+      "id": "cli:agent-status:idle",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["telemetry:write"],
+      "source": "cli/src/commands/agent-status.ts",
+      "denialReason": "Agent status writes require telemetry write access."
+    },
+    {
+      "id": "cli:agent-status:sub-agent",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["telemetry:write"],
+      "source": "cli/src/commands/agent-status.ts",
+      "denialReason": "Agent status writes require telemetry write access."
+    },
+    {
+      "id": "cli:agents:start",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Starting an agent requires task read and task write access."
+    },
+    {
+      "id": "cli:agents:stop",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Stopping an agent requires task read and task write access."
+    },
+    {
+      "id": "cli:agents:agents:pending",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Listing pending agent requests requires agent read access."
+    },
+    {
+      "id": "cli:agents:agents:complete",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Completing an agent request requires task write access."
+    },
+    {
+      "id": "cli:agents:agents:status",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Agent request status requires agent read access."
+    },
+    {
+      "id": "cli:automation:automation:pending",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/automation.ts",
+      "denialReason": "Automation task reads require task read access."
+    },
+    {
+      "id": "cli:automation:automation:running",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/automation.ts",
+      "denialReason": "Automation task reads require task read access."
+    },
+    {
+      "id": "cli:automation:automation:start",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/automation.ts",
+      "denialReason": "Starting automation requires task read and task write access."
+    },
+    {
+      "id": "cli:automation:automation:complete",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/automation.ts",
+      "denialReason": "Completing automation requires task read and task write access."
+    },
+    {
+      "id": "cli:backlog:backlog",
+      "kind": "cli",
+      "classification": "public/setup",
+      "permissions": [],
+      "source": "cli/src/commands/backlog.ts",
+      "justification": "Parent command only; subcommands carry authorization."
+    },
+    {
+      "id": "cli:backlog:list",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/backlog.ts",
+      "denialReason": "Backlog reads require task read access."
+    },
+    {
+      "id": "cli:backlog:add",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/backlog.ts",
+      "denialReason": "Adding backlog items requires task write access."
+    },
+    {
+      "id": "cli:backlog:promote",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/backlog.ts",
+      "denialReason": "Promoting backlog items requires task write access."
+    },
+    {
+      "id": "cli:backlog:demote",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/backlog.ts",
+      "denialReason": "Demoting tasks requires task write access."
+    },
+    {
+      "id": "cli:backlog:delete",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/backlog.ts",
+      "denialReason": "Deleting backlog items requires task write access."
+    },
+    {
+      "id": "cli:backlog:count",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/backlog.ts",
+      "denialReason": "Backlog counts require task read access."
+    },
+    {
+      "id": "cli:comments:comment",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "comment:write"],
+      "source": "cli/src/commands/comments.ts",
+      "denialReason": "Adding comments requires task read and comment write access."
+    },
+    {
+      "id": "cli:github:github",
+      "kind": "cli",
+      "classification": "public/setup",
+      "permissions": [],
+      "source": "cli/src/commands/github.ts",
+      "justification": "Parent command only; subcommands carry authorization."
+    },
+    {
+      "id": "cli:github:sync",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/github.ts",
+      "denialReason": "GitHub sync mutates task state and requires task write access."
+    },
+    {
+      "id": "cli:github:status",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/github.ts",
+      "denialReason": "GitHub sync status requires task read access."
+    },
+    {
+      "id": "cli:github:config",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/github.ts",
+      "denialReason": "GitHub sync config reads and writes require task route access."
+    },
+    {
+      "id": "cli:github:mappings",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/github.ts",
+      "denialReason": "GitHub mappings require task read access."
+    },
+    {
+      "id": "cli:notifications:notify",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["comment:write"],
+      "source": "cli/src/commands/notifications.ts",
+      "denialReason": "Creating notifications requires comment write access."
+    },
+    {
+      "id": "cli:notifications:notify:check",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["comment:write"],
+      "source": "cli/src/commands/notifications.ts",
+      "denialReason": "Notification checks can create notifications and require comment write access."
+    },
+    {
+      "id": "cli:notifications:notify:pending",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "cli/src/commands/notifications.ts",
+      "denialReason": "Pending notification reads require agent read access."
+    },
+    {
+      "id": "cli:notifications:notify:list",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "cli/src/commands/notifications.ts",
+      "denialReason": "Notification lists require agent read access."
+    },
+    {
+      "id": "cli:notifications:notify:clear",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["comment:write"],
+      "source": "cli/src/commands/notifications.ts",
+      "denialReason": "Clearing notifications requires comment write access."
+    },
+    {
+      "id": "cli:projects:project",
+      "kind": "cli",
+      "classification": "public/setup",
+      "permissions": [],
+      "source": "cli/src/commands/projects.ts",
+      "justification": "Parent command only; subcommands carry authorization."
+    },
+    {
+      "id": "cli:projects:list",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "cli/src/commands/projects.ts",
+      "denialReason": "Project reads require settings read access."
+    },
+    {
+      "id": "cli:projects:create",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "cli/src/commands/projects.ts",
+      "denialReason": "Project creation requires settings write access."
+    },
+    {
+      "id": "cli:setup:setup",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/setup.ts",
+      "denialReason": "Setup can create a sample task and requires task write access unless skipped."
+    },
+    {
+      "id": "cli:sprints:sprint",
+      "kind": "cli",
+      "classification": "public/setup",
+      "permissions": [],
+      "source": "cli/src/commands/sprints.ts",
+      "justification": "Parent command only; subcommands carry authorization."
+    },
+    {
+      "id": "cli:sprints:list",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "cli/src/commands/sprints.ts",
+      "denialReason": "Sprint reads require settings read access."
+    },
+    {
+      "id": "cli:sprints:create",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "cli/src/commands/sprints.ts",
+      "denialReason": "Sprint creation requires settings write access."
+    },
+    {
+      "id": "cli:sprints:update",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "cli/src/commands/sprints.ts",
+      "denialReason": "Sprint updates require settings write access."
+    },
+    {
+      "id": "cli:sprints:delete",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "cli/src/commands/sprints.ts",
+      "denialReason": "Sprint deletion requires settings write access."
+    },
+    {
+      "id": "cli:sprints:suggestions",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/sprints.ts",
+      "denialReason": "Archive suggestions require task read access."
+    },
+    {
+      "id": "cli:sprints:close",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/sprints.ts",
+      "denialReason": "Closing a sprint mutates tasks and requires task write access."
+    },
+    {
+      "id": "cli:summary:summary",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["report:read"],
+      "source": "cli/src/commands/summary.ts",
+      "denialReason": "Summary output requires report read access."
+    },
+    {
+      "id": "cli:summary:standup",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["report:read"],
+      "source": "cli/src/commands/summary.ts",
+      "denialReason": "Standup reports require report read access."
+    },
+    {
+      "id": "cli:summary:memory",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["report:read"],
+      "source": "cli/src/commands/summary.ts",
+      "denialReason": "Memory summaries require report read access."
+    },
+    {
+      "id": "cli:tasks:list",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/tasks.ts",
+      "denialReason": "Task lists require task read access."
+    },
+    {
+      "id": "cli:tasks:show",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/tasks.ts",
+      "denialReason": "Task details require task read access."
+    },
+    {
+      "id": "cli:tasks:create",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "cli/src/commands/tasks.ts",
+      "denialReason": "Task creation requires task write access."
+    },
+    {
+      "id": "cli:tasks:update",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/tasks.ts",
+      "denialReason": "Task updates require task read and task write access."
+    },
+    {
+      "id": "cli:tasks:archive",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/tasks.ts",
+      "denialReason": "Task archive operations require task read and task write access."
+    },
+    {
+      "id": "cli:tasks:delete",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/tasks.ts",
+      "denialReason": "Task deletion requires task read and task write access."
+    },
+    {
+      "id": "cli:time:time",
+      "kind": "cli",
+      "classification": "public/setup",
+      "permissions": [],
+      "source": "cli/src/commands/time.ts",
+      "justification": "Parent command only; subcommands carry authorization."
+    },
+    {
+      "id": "cli:time:start",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/time.ts",
+      "denialReason": "Starting timers requires task read and task write access."
+    },
+    {
+      "id": "cli:time:stop",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/time.ts",
+      "denialReason": "Stopping timers requires task read and task write access."
+    },
+    {
+      "id": "cli:time:entry",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/time.ts",
+      "denialReason": "Manual time entries require task read and task write access."
+    },
+    {
+      "id": "cli:time:show",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "cli/src/commands/time.ts",
+      "denialReason": "Time entry display requires task read access."
+    },
+    {
+      "id": "cli:usage:usage",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["report:read"],
+      "source": "cli/src/commands/usage.ts",
+      "denialReason": "Usage reports require report read access."
+    },
+    {
+      "id": "cli:workflow:begin",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write", "telemetry:write"],
+      "source": "cli/src/commands/workflow.ts",
+      "denialReason": "Workflow begin mutates task, timer, and agent status state."
+    },
+    {
+      "id": "cli:workflow:done",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write", "comment:write", "telemetry:write"],
+      "source": "cli/src/commands/workflow.ts",
+      "denialReason": "Workflow completion mutates task, timer, comment, and agent status state."
+    },
+    {
+      "id": "cli:workflow:block",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write", "comment:write"],
+      "source": "cli/src/commands/workflow.ts",
+      "denialReason": "Blocking a task mutates task and comment state."
+    },
+    {
+      "id": "cli:workflow:unblock",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "cli/src/commands/workflow.ts",
+      "denialReason": "Unblocking a task requires task write access."
+    },
+    {
+      "id": "mcp:start_agent",
+      "kind": "mcp",
+      "classification": "agent-scoped",
+      "permissions": ["task:read", "task:write"],
+      "source": "mcp/src/tools/agents.ts",
+      "denialReason": "Starting an agent requires task read and task write access."
+    },
+    {
+      "id": "mcp:stop_agent",
+      "kind": "mcp",
+      "classification": "agent-scoped",
+      "permissions": ["task:read", "task:write"],
+      "source": "mcp/src/tools/agents.ts",
+      "denialReason": "Stopping an agent requires task read and task write access."
+    },
+    {
+      "id": "mcp:list_pending_automation",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "mcp/src/tools/automation.ts",
+      "denialReason": "Listing pending automation requires task read access."
+    },
+    {
+      "id": "mcp:list_running_automation",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "mcp/src/tools/automation.ts",
+      "denialReason": "Listing running automation requires task read access."
+    },
+    {
+      "id": "mcp:start_automation",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "mcp/src/tools/automation.ts",
+      "denialReason": "Starting automation requires task read and task write access."
+    },
+    {
+      "id": "mcp:complete_automation",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "mcp/src/tools/automation.ts",
+      "denialReason": "Completing automation requires task read and task write access."
+    },
+    {
+      "id": "mcp:add_comment",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["comment:write"],
+      "source": "mcp/src/tools/comments.ts",
+      "denialReason": "Adding comments requires comment write access."
+    },
+    {
+      "id": "mcp:list_comments",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "mcp/src/tools/comments.ts",
+      "denialReason": "Listing comments requires task read access."
+    },
+    {
+      "id": "mcp:delete_comment",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["comment:write"],
+      "source": "mcp/src/tools/comments.ts",
+      "denialReason": "Deleting comments requires comment write access."
+    },
+    {
+      "id": "mcp:create_notification",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["comment:write"],
+      "source": "mcp/src/tools/notifications.ts",
+      "denialReason": "Creating notifications requires comment write access."
+    },
+    {
+      "id": "mcp:get_pending_notifications",
+      "kind": "mcp",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "mcp/src/tools/notifications.ts",
+      "denialReason": "Pending notification reads require agent read access."
+    },
+    {
+      "id": "mcp:check_notifications",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["comment:write"],
+      "source": "mcp/src/tools/notifications.ts",
+      "denialReason": "Notification checks can create notifications and require comment write access."
+    },
+    {
+      "id": "mcp:list_projects",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "mcp/src/tools/projects.ts",
+      "denialReason": "Project listing requires settings read access."
+    },
+    {
+      "id": "mcp:get_project",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "mcp/src/tools/projects.ts",
+      "denialReason": "Project details require settings read access."
+    },
+    {
+      "id": "mcp:create_project",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/projects.ts",
+      "denialReason": "Creating projects requires settings write access."
+    },
+    {
+      "id": "mcp:update_project",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/projects.ts",
+      "denialReason": "Updating projects requires settings write access."
+    },
+    {
+      "id": "mcp:delete_project",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/projects.ts",
+      "denialReason": "Deleting projects requires settings write access."
+    },
+    {
+      "id": "mcp:get_project_stats",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "mcp/src/tools/projects.ts",
+      "denialReason": "Project stats require task read access."
+    },
+    {
+      "id": "mcp:reorder_projects",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/projects.ts",
+      "denialReason": "Reordering projects requires settings write access."
+    },
+    {
+      "id": "mcp:list_sprints",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Sprint listing requires settings read access."
+    },
+    {
+      "id": "mcp:get_sprint",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Sprint details require settings read access."
+    },
+    {
+      "id": "mcp:create_sprint",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Creating sprints requires settings write access."
+    },
+    {
+      "id": "mcp:update_sprint",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Updating sprints requires settings write access."
+    },
+    {
+      "id": "mcp:delete_sprint",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Deleting sprints requires settings write access."
+    },
+    {
+      "id": "mcp:can_delete_sprint",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Sprint deletion checks require settings read access."
+    },
+    {
+      "id": "mcp:reorder_sprints",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Reordering sprints requires settings write access."
+    },
+    {
+      "id": "mcp:get_archive_suggestions",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Archive suggestions require task read access."
+    },
+    {
+      "id": "mcp:close_sprint",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "mcp/src/tools/sprints.ts",
+      "denialReason": "Closing a sprint mutates tasks and requires task write access."
+    },
+    {
+      "id": "mcp:get_summary",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["report:read"],
+      "source": "mcp/src/tools/summary.ts",
+      "denialReason": "Summary tools require report read access."
+    },
+    {
+      "id": "mcp:get_memory_summary",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["report:read"],
+      "source": "mcp/src/tools/summary.ts",
+      "denialReason": "Memory summary tools require report read access."
+    },
+    {
+      "id": "mcp:list_tasks",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "mcp/src/tools/tasks.ts",
+      "denialReason": "Task listing requires task read access."
+    },
+    {
+      "id": "mcp:get_task",
+      "kind": "mcp",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "mcp/src/tools/tasks.ts",
+      "denialReason": "Task details require task read access."
+    },
+    {
+      "id": "mcp:create_task",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["task:write"],
+      "source": "mcp/src/tools/tasks.ts",
+      "denialReason": "Task creation requires task write access."
+    },
+    {
+      "id": "mcp:update_task",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "mcp/src/tools/tasks.ts",
+      "denialReason": "Task updates require task read and task write access."
+    },
+    {
+      "id": "mcp:archive_task",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "mcp/src/tools/tasks.ts",
+      "denialReason": "Task archive operations require task read and task write access."
+    },
+    {
+      "id": "mcp:delete_task",
+      "kind": "mcp",
+      "classification": "authenticated-write",
+      "permissions": ["task:read", "task:write"],
+      "source": "mcp/src/tools/tasks.ts",
+      "denialReason": "Task deletion requires task read and task write access."
+    }
+  ]
+}

--- a/scripts/check-permission-coverage.mjs
+++ b/scripts/check-permission-coverage.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const allowedClassifications = new Set([
+  'public/setup',
+  'authenticated-read',
+  'authenticated-write',
+  'agent-scoped',
+  'workspace-admin',
+  'owner-admin',
+  'desktop-only',
+  'internal-only',
+]);
+const justificationRequired = new Set(['public/setup', 'desktop-only', 'internal-only']);
+const permissionRequired = new Set([
+  'authenticated-read',
+  'authenticated-write',
+  'agent-scoped',
+  'workspace-admin',
+  'owner-admin',
+]);
+
+async function readText(relativePath) {
+  return readFile(path.join(root, relativePath), 'utf8');
+}
+
+async function readJson(relativePath) {
+  return JSON.parse(await readText(relativePath));
+}
+
+function matches(source, regex) {
+  return [...source.matchAll(regex)].map((match) => match[1]);
+}
+
+async function discoverUnionType(relativePath, typeName) {
+  const source = await readText(relativePath);
+  const declaration = source.match(new RegExp(`export type ${typeName} =([\\s\\S]*?);`));
+  if (!declaration) {
+    throw new Error(`Could not find ${typeName} declaration in ${relativePath}`);
+  }
+
+  return matches(declaration[1], /'([^']+)'/g);
+}
+
+function firstCommandToken(commandLiteral) {
+  return commandLiteral.split(/[ <[]/, 1)[0];
+}
+
+async function discoverCliCommands() {
+  const commandFiles = [
+    'agent-status',
+    'agents',
+    'automation',
+    'backlog',
+    'comments',
+    'github',
+    'notifications',
+    'projects',
+    'setup',
+    'sprints',
+    'summary',
+    'tasks',
+    'time',
+    'usage',
+    'workflow',
+  ];
+  const ids = [];
+
+  for (const file of commandFiles) {
+    const source = await readText(`cli/src/commands/${file}.ts`);
+    for (const command of matches(source, /\.command\('([^']+)'/g)) {
+      ids.push(`cli:${file}:${firstCommandToken(command)}`);
+    }
+  }
+
+  return ids;
+}
+
+async function discoverMcpTools() {
+  const toolFiles = [
+    'agents',
+    'automation',
+    'comments',
+    'notifications',
+    'projects',
+    'sprints',
+    'summary',
+    'tasks',
+  ];
+  const ids = [];
+
+  for (const file of toolFiles) {
+    const source = await readText(`mcp/src/tools/${file}.ts`);
+    for (const toolName of matches(source, /name:\s*'([^']+)'/g)) {
+      ids.push(`mcp:${toolName}`);
+    }
+  }
+
+  return ids;
+}
+
+async function discoverWebSocketSurfaces() {
+  const sources = [
+    await readText('server/src/services/broadcast-service.ts'),
+    await readText('server/src/routes/agent-status.ts'),
+    await readText('server/src/index.ts'),
+  ].join('\n');
+
+  const outbound = matches(sources, /type:\s*'([^']+)'/g)
+    .filter((type) => type.includes(':') || type === 'error' || type === 'subscribed')
+    .map((type) => `websocket:${type}`);
+  const inbound = matches(sources, /message\.type\s*===\s*'([^']+)'/g).map(
+    (type) => `websocket-inbound:${type}`
+  );
+
+  return [...new Set([...outbound, ...inbound])];
+}
+
+async function discoverWorkflowStepTypes() {
+  const sharedTypes = await discoverUnionType('shared/src/types/workflow.ts', 'StepType');
+  const serverTypes = await discoverUnionType('server/src/types/workflow.ts', 'StepType');
+
+  return [...new Set([...sharedTypes, ...serverTypes])].map((type) => `workflow-step:${type}`);
+}
+
+async function discoverTransitionHookTypes() {
+  const source = 'shared/src/types/transition-hooks.types.ts';
+  const gates = await discoverUnionType(source, 'GateType');
+  const actions = await discoverUnionType(source, 'ActionType');
+
+  return [
+    ...gates.map((type) => `transition-gate:${type}`),
+    ...actions.map((type) => `transition-action:${type}`),
+  ];
+}
+
+async function discoverCommandPaletteActions() {
+  const paletteSource = await readText('web/src/components/layout/CommandPalette.tsx');
+  const viewSource = await readText('web/src/lib/views.ts');
+  const staticCommandIds = matches(paletteSource, /id:\s*'([^']+)'/g);
+  const navigationIds = matches(viewSource, /view:\s*'([^']+)'/g).map((view) => `go-${view}`);
+
+  return [...new Set([...staticCommandIds, ...navigationIds])].map((id) => `command-palette:${id}`);
+}
+
+async function discoverBackgroundJobs() {
+  const jobs = [
+    {
+      id: 'background-job:agent-registry-stale-check',
+      source: 'server/src/services/agent-registry-service.ts',
+      marker: 'setInterval(() => this.checkStaleAgents(), STALE_CHECK_INTERVAL_MS)',
+    },
+    {
+      id: 'background-job:github-sync-poll',
+      source: 'server/src/services/github-sync-service.ts',
+      marker: 'this.pollTimer = setInterval(async () =>',
+    },
+    {
+      id: 'background-job:prometheus-event-loop-lag',
+      source: 'server/src/services/metrics/prometheus.ts',
+      marker: 'this.lagTimer = setInterval(() =>',
+    },
+    {
+      id: 'background-job:task-github-reconcile',
+      source: 'server/src/services/task-service.ts',
+      marker: 'this.taskSyncReconcileInterval = setInterval(() =>',
+    },
+    {
+      id: 'background-job:websocket-heartbeat',
+      source: 'server/src/index.ts',
+      marker: 'const heartbeatInterval = setInterval(() =>',
+    },
+  ];
+
+  for (const job of jobs) {
+    const source = await readText(job.source);
+    if (!source.includes(job.marker)) {
+      throw new Error(`Could not find background job marker for ${job.id}`);
+    }
+  }
+
+  return jobs.map((job) => job.id);
+}
+
+async function assertRestRouteMapCoverage(errors) {
+  const v1Source = await readText('server/src/routes/v1/index.ts');
+  const permissionSource = await readText('shared/src/utils/api-permissions.ts');
+  const serverPrefixes = new Set(
+    matches(v1Source, /v1Router\.use\(\s*['"]([^'"]+)['"]/g).map((prefix) => `/api${prefix}`)
+  );
+  const mappedPrefixes = new Set(matches(permissionSource, /prefix:\s*'([^']+)'/g));
+
+  for (const prefix of serverPrefixes) {
+    if (!mappedPrefixes.has(prefix)) {
+      errors.push(`REST route prefix missing from client permission map: ${prefix}`);
+    }
+  }
+}
+
+function assertManifestShape(manifest, errors) {
+  if (manifest.version !== 1) {
+    errors.push('Manifest version must be 1');
+  }
+  if (!Array.isArray(manifest.surfaces)) {
+    errors.push('Manifest must contain a surfaces array');
+    return new Set();
+  }
+
+  const ids = new Set();
+  for (const surface of manifest.surfaces) {
+    if (!surface.id || typeof surface.id !== 'string') {
+      errors.push(`Manifest surface missing string id: ${JSON.stringify(surface)}`);
+      continue;
+    }
+    if (ids.has(surface.id)) {
+      errors.push(`Duplicate manifest surface id: ${surface.id}`);
+    }
+    ids.add(surface.id);
+
+    if (!allowedClassifications.has(surface.classification)) {
+      errors.push(`Invalid classification for ${surface.id}: ${surface.classification}`);
+    }
+    if (!surface.kind || typeof surface.kind !== 'string') {
+      errors.push(`Surface ${surface.id} is missing kind`);
+    }
+    if (!surface.source || typeof surface.source !== 'string') {
+      errors.push(`Surface ${surface.id} is missing source`);
+    }
+    if (permissionRequired.has(surface.classification) && !surface.permissions?.length) {
+      errors.push(`Surface ${surface.id} requires at least one permission`);
+    }
+    if (justificationRequired.has(surface.classification) && !surface.justification) {
+      errors.push(`Surface ${surface.id} requires a justification`);
+    }
+    if (!surface.denialReason && !justificationRequired.has(surface.classification)) {
+      errors.push(`Surface ${surface.id} is missing denialReason`);
+    }
+  }
+
+  return ids;
+}
+
+async function main() {
+  const errors = [];
+  const manifest = await readJson('docs/security/permission-coverage.json');
+  const manifestIds = assertManifestShape(manifest, errors);
+
+  await assertRestRouteMapCoverage(errors);
+
+  const discoveredIds = [
+    'rest:v1-route-map',
+    ...(await discoverWebSocketSurfaces()),
+    ...(await discoverCliCommands()),
+    ...(await discoverMcpTools()),
+    ...(await discoverWorkflowStepTypes()),
+    ...(await discoverTransitionHookTypes()),
+    ...(await discoverCommandPaletteActions()),
+    ...(await discoverBackgroundJobs()),
+  ];
+
+  for (const id of discoveredIds) {
+    if (!manifestIds.has(id)) {
+      errors.push(`Missing permission manifest entry: ${id}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('Permission coverage check failed:');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Permission coverage manifest covers ${manifestIds.size} classified surfaces.`);
+  console.log(`Checked ${discoveredIds.length} discovered surfaces plus REST route-map parity.`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- adds a v5 permission coverage manifest with classifications, required permissions, denial reasons, and review justifications across REST, WebSocket, CLI, MCP, workflow, transition hook, command palette, and background job surfaces
- adds a Node-based coverage checker that fails when tracked surfaces are missing from the manifest or when REST route prefixes drift from the shared permission map
- wires the checker into CI and documents the manifest gate in the security guide

Closes #420.

## Verification

- `node scripts/check-permission-coverage.mjs`
- `./node_modules/.bin/prettier --check package.json .github/workflows/ci.yml scripts/check-permission-coverage.mjs docs/security/permission-coverage.json docs/security.md`
- `git diff --check`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm audit --prod --audit-level=high` (passes high gate; 3 existing moderate findings)