### PR TITLE
test: add v5 dual-storage parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Run workspace unit tests
         run: pnpm test:unit
 
+      - name: Run dual-storage parity tests
+        run: pnpm --filter @veritas-kanban/server test -- src/__tests__/storage/dual-storage-parity.test.ts
+
   # ─── Build ───────────────────────────────────────────────────────
   build:
     name: Build

--- a/docs/testing/dual-storage-parity.md
+++ b/docs/testing/dual-storage-parity.md
@@ -1,0 +1,19 @@
+# Dual-storage parity tests
+
+The v5 SQLite rollout keeps file storage and SQLite behavior under the same test fixture until SQLite becomes the default backend.
+
+## Fixture
+
+- Versioned fixture: `server/src/__tests__/fixtures/dual-storage-parity/v5-rich-metadata.json`
+- Current fixture version: `1`
+- Covered data: rich task metadata, comments, subtasks, dependencies, settings, task templates, prompt registry usage, activity, status history, telemetry, task-scoped chat, and one workflow run.
+
+## Test gate
+
+Run the focused parity gate:
+
+```sh
+pnpm --filter @veritas-kanban/server test -- src/__tests__/storage/dual-storage-parity.test.ts
+```
+
+CI runs this gate explicitly after the workspace unit test suite. Add new v5 storage surfaces to the fixture and normalize only nondeterministic fields such as generated IDs, timestamps, and temp paths.

--- a/server/src/__tests__/fixtures/dual-storage-parity/v5-rich-metadata.json
+++ b/server/src/__tests__/fixtures/dual-storage-parity/v5-rich-metadata.json
@@ -1,0 +1,314 @@
+{
+  "version": 1,
+  "timestamps": {
+    "created": "2026-05-31T12:00:00.000Z",
+    "updated": "2026-05-31T12:05:00.000Z",
+    "completed": "2026-05-31T12:30:00.000Z"
+  },
+  "task": {
+    "title": "v5 parity-rich storage task",
+    "description": "Exercise v5 task metadata across both storage backends. Search token: parity-rich.",
+    "type": "feature",
+    "status": "blocked",
+    "priority": "critical",
+    "project": "v5",
+    "sprint": "v5.0",
+    "agents": ["codex", "veritas"],
+    "git": {
+      "repo": "BradGroux/veritas-kanban",
+      "branch": "v5-dual-storage-parity-tests",
+      "baseBranch": "main",
+      "worktreePath": "/tmp/veritas-parity",
+      "prNumber": 349,
+      "prUrl": "https://github.com/BradGroux/veritas-kanban/pull/349"
+    },
+    "github": {
+      "issueNumber": 349,
+      "repo": "BradGroux/veritas-kanban",
+      "url": "https://github.com/BradGroux/veritas-kanban/issues/349"
+    },
+    "attempt": {
+      "id": "attempt_v5_parity_1",
+      "agent": "codex",
+      "status": "running",
+      "started": "2026-05-31T12:01:00.000Z",
+      "provider": "openai",
+      "model": "gpt-5",
+      "threadId": "thread_v5_parity"
+    },
+    "attempts": [
+      {
+        "id": "attempt_v5_parity_0",
+        "agent": "veritas",
+        "status": "complete",
+        "started": "2026-05-31T11:30:00.000Z",
+        "ended": "2026-05-31T11:45:00.000Z",
+        "provider": "local",
+        "model": "veritas"
+      }
+    ],
+    "reviewScores": [10, 9, 10, 9],
+    "review": {
+      "decision": "changes-requested",
+      "decidedAt": "2026-05-31T12:10:00.000Z",
+      "summary": "Fixture keeps storage parity visible before SQLite becomes default."
+    },
+    "subtasks": [
+      {
+        "id": "subtask_parity_fixture",
+        "title": "Seed parity fixture",
+        "completed": true,
+        "created": "2026-05-31T12:00:00.000Z",
+        "acceptanceCriteria": ["fixture is versioned", "both storage modes reload it"],
+        "criteriaChecked": [true, true]
+      },
+      {
+        "id": "subtask_parity_ci",
+        "title": "Run parity gate in CI",
+        "completed": false,
+        "created": "2026-05-31T12:02:00.000Z",
+        "acceptanceCriteria": ["CI has explicit parity step"],
+        "criteriaChecked": [false]
+      }
+    ],
+    "autoCompleteOnSubtasks": true,
+    "verificationSteps": [
+      {
+        "id": "verify_parity_file",
+        "description": "File storage reload preserves rich metadata",
+        "checked": true,
+        "checkedAt": "2026-05-31T12:20:00.000Z"
+      },
+      {
+        "id": "verify_parity_sqlite",
+        "description": "SQLite storage reload preserves rich metadata",
+        "checked": true,
+        "checkedAt": "2026-05-31T12:21:00.000Z"
+      }
+    ],
+    "dependencies": {
+      "depends_on": ["task_v5_migration_fixture"],
+      "blocks": ["task_v5_sqlite_default"]
+    },
+    "blockedBy": ["task_v5_migration_fixture"],
+    "blockedReason": {
+      "category": "prerequisite",
+      "note": "Waiting for migration fixture comparison to stay green."
+    },
+    "automation": {
+      "sessionKey": "session_v5_parity",
+      "spawnedAt": "2026-05-31T12:04:00.000Z",
+      "completedAt": "2026-05-31T12:29:00.000Z",
+      "result": "Fixture executed without drift."
+    },
+    "timeTracking": {
+      "entries": [
+        {
+          "id": "time_v5_parity_1",
+          "startTime": "2026-05-31T12:00:00.000Z",
+          "endTime": "2026-05-31T12:25:00.000Z",
+          "duration": 1500,
+          "description": "Build parity fixture",
+          "manual": true
+        }
+      ],
+      "totalSeconds": 1500,
+      "isRunning": false
+    },
+    "comments": [
+      {
+        "id": "comment_v5_parity_1",
+        "author": "Brad",
+        "text": "Keep file and SQLite behavior identical until cutover.",
+        "timestamp": "2026-05-31T12:06:00.000Z"
+      }
+    ],
+    "observations": [
+      {
+        "id": "obs_v5_parity_1",
+        "type": "decision",
+        "content": "Use one fixture to exercise broad task metadata instead of narrow CRUD only.",
+        "score": 9,
+        "timestamp": "2026-05-31T12:07:00.000Z",
+        "agent": "codex"
+      }
+    ],
+    "attachments": [
+      {
+        "id": "att_v5_parity_1",
+        "filename": "parity-report.md",
+        "originalName": "Parity Report.md",
+        "mimeType": "text/markdown",
+        "size": 2048,
+        "uploaded": "2026-05-31T12:08:00.000Z",
+        "workspaceId": "local",
+        "sessionId": "session_v5_parity",
+        "uploadedBy": "codex",
+        "sha256": "7df6f9f3f3f832b90e5f20cf44c0ce67a751d3b8b0f98c49bdac5fdc97359a72",
+        "storagePath": "tasks/attachments/task_v5_parity/parity-report.md",
+        "validationStatus": "valid",
+        "retentionStatus": "active",
+        "cleanupEligible": false
+      }
+    ],
+    "deliverables": [
+      {
+        "id": "deliverable_v5_parity_1",
+        "title": "Dual-storage parity report",
+        "type": "report",
+        "path": "docs/testing/dual-storage-parity.md",
+        "status": "attached",
+        "agent": "codex",
+        "model": "gpt-5",
+        "workspaceId": "local",
+        "sourceRunId": "run_v5_parity",
+        "version": 1,
+        "created": "2026-05-31T12:09:00.000Z",
+        "updated": "2026-05-31T12:10:00.000Z",
+        "description": "Documents the parity fixture and CI gate.",
+        "redaction": {
+          "level": "standard",
+          "containsSensitiveContent": false,
+          "notes": ["fixture-only data"]
+        }
+      }
+    ],
+    "position": 349,
+    "costPrediction": {
+      "estimatedCost": 4.25,
+      "confidence": "high",
+      "sampleSize": 12,
+      "factors": {
+        "baseCost": 2.5,
+        "typeMultiplier": 1.2,
+        "priorityMultiplier": 1.5,
+        "complexityMultiplier": 1.1,
+        "projectAdjustment": 0.25
+      },
+      "predictedAt": "2026-05-31T12:03:00.000Z"
+    },
+    "actualCost": 3.75,
+    "lessonsLearned": "Parity fixtures should fail before backend-specific drift reaches the UI.",
+    "lessonTags": ["sqlite", "parity", "v5"],
+    "checkpoint": {
+      "step": 2,
+      "state": {
+        "fixture": "v5-rich-metadata",
+        "storageModes": ["file", "sqlite"]
+      },
+      "timestamp": "2026-05-31T12:11:00.000Z",
+      "resumeCount": 1
+    },
+    "runMode": "qa",
+    "qaGate": {
+      "required": true,
+      "passed": false
+    }
+  },
+  "settingsPatch": {
+    "board": {
+      "showDashboard": true,
+      "cardDensity": "compact",
+      "showPriorityIndicators": true
+    },
+    "tasks": {
+      "enableDependencies": true,
+      "enableAttachments": true,
+      "enableComments": true,
+      "defaultPriority": "high",
+      "requireDeliverableForDone": false
+    },
+    "telemetry": {
+      "enabled": true,
+      "retentionDays": 45,
+      "enableTraces": true,
+      "enableActivityTracking": true
+    },
+    "enforcement": {
+      "reviewGate": false,
+      "closingComments": false,
+      "autoTelemetry": true,
+      "autoTimeTracking": false
+    }
+  },
+  "taskTemplate": {
+    "name": "v5 parity fixture template",
+    "description": "Creates a task with rich metadata for storage parity checks.",
+    "category": "qa",
+    "taskDefaults": {
+      "type": "feature",
+      "priority": "high",
+      "project": "v5",
+      "descriptionTemplate": "Use {{project}} parity fixture data.",
+      "agent": "codex"
+    },
+    "subtaskTemplates": [
+      {
+        "title": "Verify {{project}} storage reload",
+        "order": 1
+      }
+    ],
+    "blueprint": [
+      {
+        "refId": "parity-task",
+        "title": "Run {{project}} parity checks",
+        "taskDefaults": {
+          "type": "feature",
+          "priority": "high",
+          "project": "v5",
+          "descriptionTemplate": "Run both storage modes.",
+          "agent": "codex"
+        },
+        "subtaskTemplates": [
+          {
+            "title": "Collect snapshots",
+            "order": 1
+          }
+        ]
+      }
+    ]
+  },
+  "promptTemplate": {
+    "name": "v5 parity review prompt",
+    "description": "Summarizes parity drift for a task.",
+    "category": "evaluation",
+    "content": "Review {{task_title}} in {{project}} and report storage drift."
+  },
+  "workflow": {
+    "id": "v5-parity-workflow",
+    "name": "v5 Parity Workflow",
+    "version": 1,
+    "description": "Minimal workflow run used by the dual-storage parity gate.",
+    "variables": {
+      "ready": "true"
+    },
+    "agents": [
+      {
+        "id": "verifier",
+        "name": "Verifier",
+        "role": "qa",
+        "description": "Validates the storage parity gate."
+      }
+    ],
+    "steps": [
+      {
+        "id": "qa-gate",
+        "name": "QA Gate",
+        "type": "gate",
+        "condition": "ready == \"true\""
+      }
+    ]
+  },
+  "chatMessages": [
+    {
+      "role": "user",
+      "content": "Compare file and SQLite output for the parity fixture."
+    },
+    {
+      "role": "assistant",
+      "content": "Both storage modes should return the same normalized task, settings, chat, and workflow data.",
+      "agent": "codex",
+      "model": "gpt-5"
+    }
+  ]
+}

--- a/server/src/__tests__/storage/dual-storage-parity.test.ts
+++ b/server/src/__tests__/storage/dual-storage-parity.test.ts
@@ -318,13 +318,18 @@ async function collectChatSnapshot(mode: StorageMode, fixture: DualStorageFixtur
 async function collectWorkflowSnapshot(mode: StorageMode, fixture: DualStorageFixture) {
   const root = await createTempRoot(mode);
   const sqliteDatabase = createOptionalSqlite(mode, root, 'workflow.db');
+  const workflowsDir = path.join(root, '.veritas-kanban', 'workflows');
+  const runsDir = path.join(root, '.veritas-kanban', 'workflow-runs');
+  await fs.mkdir(workflowsDir, { recursive: true });
+  await fs.mkdir(runsDir, { recursive: true });
+
   const workflowService = new WorkflowService({
-    workflowsDir: path.join(root, '.veritas-kanban', 'workflows'),
+    workflowsDir,
     storageType: mode,
     sqliteDatabase,
   });
   const runService = new WorkflowRunService({
-    runsDir: path.join(root, '.veritas-kanban', 'workflow-runs'),
+    runsDir,
     workflowService,
     storageType: mode,
     sqliteDatabase,
@@ -360,7 +365,7 @@ async function collectWorkflowSnapshot(mode: StorageMode, fixture: DualStorageFi
 
 async function waitForRun(service: WorkflowRunService, runId: string): Promise<WorkflowRun> {
   for (let attempt = 0; attempt < 50; attempt++) {
-    const run = await service.getRun(runId);
+    const run = await readRunWhenAvailable(service, runId);
     if (run && run.status !== 'running') {
       return run;
     }
@@ -368,6 +373,30 @@ async function waitForRun(service: WorkflowRunService, runId: string): Promise<W
   }
 
   throw new Error(`Workflow run ${runId} did not finish`);
+}
+
+async function readRunWhenAvailable(
+  service: WorkflowRunService,
+  runId: string
+): Promise<WorkflowRun | null> {
+  try {
+    return await service.getRun(runId);
+  } catch (error) {
+    if (error instanceof SyntaxError || isMissingFileError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: string }).code === 'ENOENT'
+  );
 }
 
 function normalizeWorkflowRun(run: WorkflowRun) {

--- a/server/src/__tests__/storage/dual-storage-parity.test.ts
+++ b/server/src/__tests__/storage/dual-storage-parity.test.ts
@@ -1,0 +1,590 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type {
+  CreatePromptTemplateInput,
+  CreateTemplateInput,
+  FeatureSettings,
+  Task,
+} from '@veritas-kanban/shared';
+import { ChatService } from '../../services/chat-service.js';
+import { TaskService } from '../../services/task-service.js';
+import { TelemetryService } from '../../services/telemetry-service.js';
+import { WorkflowRunService } from '../../services/workflow-run-service.js';
+import { WorkflowService } from '../../services/workflow-service.js';
+import {
+  FileStorageProvider,
+  SqliteDatabase,
+  SqliteStorageProvider,
+  type FileStorageOptions,
+  type StorageProvider,
+} from '../../storage/index.js';
+import type { WorkflowDefinition, WorkflowRun } from '../../types/workflow.js';
+
+type StorageMode = 'file' | 'sqlite';
+
+interface DualStorageFixture {
+  version: number;
+  timestamps: {
+    created: string;
+    updated: string;
+    completed: string;
+  };
+  task: Omit<Task, 'id' | 'created' | 'updated'>;
+  settingsPatch: Partial<FeatureSettings>;
+  taskTemplate: CreateTemplateInput;
+  promptTemplate: CreatePromptTemplateInput;
+  workflow: WorkflowDefinition;
+  chatMessages: Array<{
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+    agent?: string;
+    model?: string;
+  }>;
+}
+
+const fixturePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../fixtures/dual-storage-parity/v5-rich-metadata.json'
+);
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const tasks = cleanupTasks.splice(0);
+  await Promise.allSettled(tasks.map((cleanup) => cleanup()));
+});
+
+describe('dual-storage parity', () => {
+  it('keeps rich task, settings, template, prompt, activity, status, and telemetry data aligned', async () => {
+    const fixture = await loadFixture();
+
+    await expectStorageParity((mode) => collectProviderSnapshot(mode, fixture));
+  });
+
+  it('keeps archive lifecycle semantics aligned', async () => {
+    const fixture = await loadFixture();
+
+    await expectStorageParity((mode) => collectArchiveSnapshot(mode, fixture));
+  });
+
+  it('keeps task-scoped chat history aligned', async () => {
+    const fixture = await loadFixture();
+
+    await expectStorageParity((mode) => collectChatSnapshot(mode, fixture));
+  });
+
+  it('keeps workflow definitions and a completed workflow run aligned', async () => {
+    const fixture = await loadFixture();
+
+    await expectStorageParity((mode) => collectWorkflowSnapshot(mode, fixture));
+  });
+});
+
+async function expectStorageParity<T>(collector: (mode: StorageMode) => Promise<T>) {
+  const fileSnapshot = await collector('file');
+  const sqliteSnapshot = await collector('sqlite');
+
+  expect(sqliteSnapshot).toEqual(fileSnapshot);
+}
+
+async function collectProviderSnapshot(mode: StorageMode, fixture: DualStorageFixture) {
+  const harness = await createProviderHarness(mode);
+
+  try {
+    const created = await harness.provider.tasks.create({
+      id: 'task_v5_parity_seed',
+      title: fixture.task.title,
+      description: fixture.task.description,
+      type: fixture.task.type,
+      status: 'todo',
+      priority: fixture.task.priority,
+      project: fixture.task.project,
+      sprint: fixture.task.sprint,
+      created: fixture.timestamps.created,
+      updated: fixture.timestamps.created,
+    });
+
+    await harness.provider.tasks.update(created.id, fixture.task);
+    await harness.reopen();
+
+    const task = await harness.provider.tasks.findById(created.id);
+    const searchResults = await harness.provider.tasks.search('parity-rich');
+    const settings = await harness.provider.settings.update(fixture.settingsPatch);
+    const taskTemplate = await harness.provider.templates.createTemplate(fixture.taskTemplate);
+    const promptTemplate = await harness.provider.promptRegistry.createTemplate(
+      fixture.promptTemplate
+    );
+    const promptPreview = await harness.provider.promptRegistry.renderPreview({
+      templateId: promptTemplate.id,
+      sampleVariables: {
+        task_title: fixture.task.title,
+        project: fixture.task.project ?? '',
+      },
+    });
+
+    await harness.provider.promptRegistry.recordUsage(
+      promptTemplate.id,
+      'codex',
+      promptPreview.renderedPrompt,
+      'gpt-5',
+      42,
+      24
+    );
+    const promptUsage = await harness.provider.promptRegistry.getUsageRecords(promptTemplate.id);
+    const promptStats = await harness.provider.promptRegistry.getStats(promptTemplate.id);
+
+    const activity = await harness.provider.activities.logActivity(
+      'comment_added',
+      created.id,
+      fixture.task.title,
+      { comments: fixture.task.comments?.length ?? 0 },
+      'codex'
+    );
+    const status = await harness.provider.statusHistory.logStatusChange(
+      'idle',
+      'working',
+      created.id,
+      fixture.task.title,
+      fixture.task.agents?.length
+    );
+    await harness.provider.telemetry.emit({
+      type: 'task.created',
+      taskId: created.id,
+      project: fixture.task.project,
+      status: 'todo',
+      timestamp: fixture.timestamps.created,
+    });
+    await harness.provider.telemetry.emit({
+      type: 'run.completed',
+      taskId: created.id,
+      project: fixture.task.project,
+      agent: 'codex',
+      success: true,
+      durationMs: 1500,
+      timestamp: fixture.timestamps.completed,
+    });
+    const telemetry = (await harness.provider.telemetry.getTaskEvents(created.id)).filter((event) =>
+      [fixture.timestamps.created, fixture.timestamps.completed].includes(event.timestamp)
+    );
+
+    return {
+      task: normalizeTask(task),
+      search: searchResults.map((result) => normalizeTask(result)),
+      settings: normalizeSettings(settings),
+      taskTemplate: normalizeTaskTemplate(taskTemplate),
+      promptTemplate: {
+        name: promptTemplate.name,
+        description: promptTemplate.description,
+        category: promptTemplate.category,
+        content: promptTemplate.content,
+        variables: promptTemplate.variables,
+        preview: promptPreview,
+        usage: promptUsage.map((usage) => ({
+          templateId: '<prompt>',
+          usedBy: usage.usedBy,
+          renderedPrompt: usage.renderedPrompt,
+          model: usage.model,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+        })),
+        stats: promptStats
+          ? {
+              totalUsages: promptStats.totalUsages,
+              totalVersions: promptStats.totalVersions,
+              lastUsed: Boolean(promptStats.lastUsedAt),
+              mostFrequentUser: promptStats.mostFrequentUser,
+              averageTokensPerUsage: promptStats.averageTokensPerUsage,
+            }
+          : null,
+      },
+      activity: {
+        type: activity.type,
+        taskId: '<task>',
+        taskTitle: activity.taskTitle,
+        agent: activity.agent,
+        details: activity.details,
+      },
+      status: {
+        previousStatus: status.previousStatus,
+        newStatus: status.newStatus,
+        taskId: '<task>',
+        taskTitle: status.taskTitle,
+        subAgentCount: status.subAgentCount,
+      },
+      telemetry: telemetry
+        .map((event) => ({
+          type: event.type,
+          taskId: '<task>',
+          project: event.project,
+          timestamp: event.timestamp,
+          status: 'status' in event ? event.status : undefined,
+          agent: 'agent' in event ? event.agent : undefined,
+          success: 'success' in event ? event.success : undefined,
+          durationMs: 'durationMs' in event ? event.durationMs : undefined,
+        }))
+        .sort((a, b) => a.type.localeCompare(b.type)),
+    };
+  } finally {
+    await harness.dispose();
+  }
+}
+
+async function collectArchiveSnapshot(mode: StorageMode, fixture: DualStorageFixture) {
+  const root = await createTempRoot(mode);
+  const telemetryService = new TelemetryService({
+    telemetryDir: path.join(root, '.veritas-kanban', 'telemetry'),
+    config: { enabled: true },
+  });
+  const taskService = new TaskService({
+    tasksDir: path.join(root, 'tasks', 'active'),
+    archiveDir: path.join(root, 'tasks', 'archive'),
+    telemetryService,
+    storageType: mode,
+    sqliteConnectionOptions:
+      mode === 'sqlite'
+        ? { databasePath: path.join(root, '.veritas-kanban', 'archive.db') }
+        : undefined,
+  });
+
+  try {
+    const created = await taskService.createTask({
+      title: fixture.task.title,
+      description: fixture.task.description,
+      type: fixture.task.type,
+      priority: fixture.task.priority,
+      project: fixture.task.project,
+      sprint: fixture.task.sprint,
+      agent: fixture.task.agent,
+      subtasks: fixture.task.subtasks,
+      blockedBy: fixture.task.blockedBy,
+    });
+    await taskService.updateTask(created.id, fixture.task);
+
+    expect(await taskService.archiveTask(created.id)).toBe(true);
+
+    const activeTask = await taskService.getTask(created.id);
+    const archivedTasks = await taskService.listArchivedTasks();
+    const archivedTask = await taskService.getArchivedTask(created.id);
+
+    return {
+      activeTask,
+      archivedTasks: archivedTasks.map((task) => normalizeTask(task)),
+      archivedTask: normalizeTask(archivedTask),
+    };
+  } finally {
+    taskService.dispose();
+    telemetryService.dispose();
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function collectChatSnapshot(mode: StorageMode, fixture: DualStorageFixture) {
+  const root = await createTempRoot(mode);
+  const sqliteDatabase = createOptionalSqlite(mode, root, 'chat.db');
+  const service = new ChatService({
+    chatsDir: path.join(root, '.veritas-kanban', 'chats'),
+    storageType: mode,
+    sqliteDatabase,
+  });
+
+  try {
+    const session = await service.createSession({
+      taskId: 'task_v5_parity_chat',
+      agent: 'codex',
+      mode: 'build',
+    });
+
+    for (const message of fixture.chatMessages) {
+      await service.addMessage(session.id, message);
+    }
+
+    const fetched = await service.getSessionForTask('task_v5_parity_chat');
+    const listed = await service.listSessions();
+
+    return {
+      session: normalizeChatSession(fetched),
+      listed: listed.map(normalizeChatSession),
+    };
+  } finally {
+    service.dispose();
+    sqliteDatabase?.close();
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function collectWorkflowSnapshot(mode: StorageMode, fixture: DualStorageFixture) {
+  const root = await createTempRoot(mode);
+  const sqliteDatabase = createOptionalSqlite(mode, root, 'workflow.db');
+  const workflowService = new WorkflowService({
+    workflowsDir: path.join(root, '.veritas-kanban', 'workflows'),
+    storageType: mode,
+    sqliteDatabase,
+  });
+  const runService = new WorkflowRunService({
+    runsDir: path.join(root, '.veritas-kanban', 'workflow-runs'),
+    workflowService,
+    storageType: mode,
+    sqliteDatabase,
+  });
+
+  try {
+    await workflowService.saveWorkflow(fixture.workflow);
+    const started = await runService.startRun(fixture.workflow.id, undefined, {
+      fixtureVersion: fixture.version,
+    });
+    const completed = await waitForRun(runService, started.id);
+    const workflows = await workflowService.listWorkflowsMetadata();
+    const runs = await runService.listRunsMetadata({ workflowId: fixture.workflow.id });
+
+    return {
+      workflows,
+      run: normalizeWorkflowRun(completed),
+      runs: runs.map((run) => ({
+        workflowId: run.workflowId,
+        workflowVersion: run.workflowVersion,
+        taskId: run.taskId,
+        status: run.status,
+        error: run.error,
+      })),
+    };
+  } finally {
+    runService.dispose();
+    workflowService.dispose();
+    sqliteDatabase?.close();
+    await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function waitForRun(service: WorkflowRunService, runId: string): Promise<WorkflowRun> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const run = await service.getRun(runId);
+    if (run && run.status !== 'running') {
+      return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  throw new Error(`Workflow run ${runId} did not finish`);
+}
+
+function normalizeWorkflowRun(run: WorkflowRun) {
+  return {
+    workflowId: run.workflowId,
+    workflowVersion: run.workflowVersion,
+    status: run.status,
+    currentStep: run.currentStep,
+    context: {
+      ready: run.context.ready,
+      fixtureVersion: run.context.fixtureVersion,
+    },
+    steps: run.steps.map((step) => ({
+      stepId: step.stepId,
+      status: step.status,
+      retries: step.retries,
+      hasOutput: Boolean(step.output),
+      error: step.error,
+    })),
+    error: run.error,
+  };
+}
+
+function normalizeChatSession(session: Awaited<ReturnType<ChatService['getSessionForTask']>>) {
+  if (!session) {
+    return null;
+  }
+
+  return {
+    id: session.taskId ? 'task_<task>' : '<session>',
+    taskId: session.taskId ? '<task>' : undefined,
+    title: session.taskId ? 'Task <task>' : session.title,
+    agent: session.agent,
+    model: session.model,
+    mode: session.mode,
+    messages: session.messages.map((message) => ({
+      role: message.role,
+      content: message.content,
+      agent: message.agent,
+      model: message.model,
+    })),
+  };
+}
+
+function normalizeSettings(settings: FeatureSettings) {
+  return {
+    board: {
+      showDashboard: settings.board.showDashboard,
+      cardDensity: settings.board.cardDensity,
+      showPriorityIndicators: settings.board.showPriorityIndicators,
+    },
+    tasks: {
+      enableDependencies: settings.tasks.enableDependencies,
+      enableAttachments: settings.tasks.enableAttachments,
+      enableComments: settings.tasks.enableComments,
+      defaultPriority: settings.tasks.defaultPriority,
+      requireDeliverableForDone: settings.tasks.requireDeliverableForDone,
+    },
+    telemetry: settings.telemetry,
+    enforcement: {
+      reviewGate: settings.enforcement.reviewGate,
+      closingComments: settings.enforcement.closingComments,
+      autoTelemetry: settings.enforcement.autoTelemetry,
+      autoTimeTracking: settings.enforcement.autoTimeTracking,
+    },
+  };
+}
+
+function normalizeTaskTemplate(template: Awaited<StorageProvider['templates']['createTemplate']>) {
+  return {
+    name: template.name,
+    description: template.description,
+    category: template.category,
+    version: template.version,
+    taskDefaults: template.taskDefaults,
+    subtaskTemplates: template.subtaskTemplates,
+    blueprint: template.blueprint,
+  };
+}
+
+function normalizeTask(task: Task | null) {
+  if (!task) {
+    return null;
+  }
+
+  return {
+    title: task.title,
+    description: task.description,
+    type: task.type,
+    status: task.status,
+    priority: task.priority,
+    project: task.project,
+    sprint: task.sprint,
+    agent: task.agent,
+    agents: task.agents,
+    git: normalizeGit(task.git),
+    github: task.github,
+    attempt: task.attempt,
+    attempts: task.attempts,
+    reviewScores: task.reviewScores,
+    review: task.review,
+    subtasks: task.subtasks,
+    autoCompleteOnSubtasks: task.autoCompleteOnSubtasks,
+    verificationSteps: task.verificationSteps,
+    dependencies: task.dependencies,
+    blockedBy: task.blockedBy,
+    blockedReason: task.blockedReason,
+    automation: task.automation,
+    timeTracking: task.timeTracking,
+    comments: task.comments,
+    observations: task.observations,
+    attachments: task.attachments,
+    deliverables: task.deliverables,
+    position: task.position,
+    costPrediction: task.costPrediction,
+    actualCost: task.actualCost,
+    lessonsLearned: task.lessonsLearned,
+    lessonTags: task.lessonTags,
+    checkpoint: task.checkpoint,
+    runMode: task.runMode,
+    qaGate: task.qaGate,
+  };
+}
+
+function normalizeGit(git: Task['git']) {
+  if (!git) {
+    return undefined;
+  }
+
+  return {
+    ...git,
+    worktreePath: '<worktree>',
+  };
+}
+
+async function createProviderHarness(mode: StorageMode) {
+  const root = await createTempRoot(mode);
+  let provider = await openProvider(mode, root);
+
+  return {
+    get provider() {
+      return provider;
+    },
+    async reopen() {
+      await provider.shutdown();
+      provider = await openProvider(mode, root);
+    },
+    async dispose() {
+      await provider.shutdown().catch(() => {});
+      await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+    },
+  };
+}
+
+async function openProvider(mode: StorageMode, root: string): Promise<StorageProvider> {
+  const provider =
+    mode === 'file'
+      ? new FileStorageProvider(fileStorageOptionsFor(root))
+      : new SqliteStorageProvider({
+          database: {
+            databasePath: path.join(root, '.veritas-kanban', 'provider.db'),
+          },
+        });
+
+  await provider.initialize();
+  return provider;
+}
+
+function fileStorageOptionsFor(root: string): FileStorageOptions {
+  const runtimeDir = path.join(root, '.veritas-kanban');
+
+  return {
+    taskServiceOptions: {
+      tasksDir: path.join(root, 'tasks', 'active'),
+      archiveDir: path.join(root, 'tasks', 'archive'),
+    },
+    configServiceOptions: {
+      configDir: runtimeDir,
+      configFile: path.join(runtimeDir, 'config.json'),
+    },
+    telemetryServiceOptions: {
+      telemetryDir: path.join(runtimeDir, 'telemetry'),
+      config: { enabled: true },
+    },
+    activityServiceOptions: {
+      activityFile: path.join(runtimeDir, 'activity.json'),
+    },
+    statusHistoryServiceOptions: {
+      historyFile: path.join(runtimeDir, 'status-history.json'),
+    },
+    templateServiceOptions: {
+      templatesDir: path.join(runtimeDir, 'templates'),
+    },
+    promptRegistryServiceOptions: {
+      templatesDir: path.join(runtimeDir, 'prompt-templates'),
+      versionsDir: path.join(runtimeDir, 'prompt-versions'),
+      usageDir: path.join(runtimeDir, 'prompt-usage'),
+    },
+  };
+}
+
+function createOptionalSqlite(mode: StorageMode, root: string, filename: string) {
+  if (mode !== 'sqlite') {
+    return undefined;
+  }
+
+  return new SqliteDatabase({
+    databasePath: path.join(root, '.veritas-kanban', filename),
+  });
+}
+
+async function createTempRoot(mode: StorageMode) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `veritas-${mode}-parity-`));
+  cleanupTasks.push(() => fs.rm(root, { recursive: true, force: true }).catch(() => {}));
+  return root;
+}
+
+async function loadFixture(): Promise<DualStorageFixture> {
+  return JSON.parse(await fs.readFile(fixturePath, 'utf-8')) as DualStorageFixture;
+}

--- a/server/src/services/prompt-registry-service.ts
+++ b/server/src/services/prompt-registry-service.ts
@@ -22,6 +22,9 @@ import { SqlitePromptRegistryRepository } from '../storage/sqlite/prompt-registr
 const log = createLogger('prompt-registry-service');
 
 export interface PromptRegistryServiceOptions {
+  templatesDir?: string;
+  versionsDir?: string;
+  usageDir?: string;
   storageType?: 'file' | 'sqlite';
   sqliteDatabase?: SqliteDatabase;
   sqliteConnectionOptions?: SqliteConnectionOptions;
@@ -35,9 +38,11 @@ export class PromptRegistryService {
   private sqliteDatabase: SqliteDatabase | null = null;
 
   constructor(options: PromptRegistryServiceOptions = {}) {
-    this.templatesDir = join(process.cwd(), '.veritas-kanban', 'prompt-templates');
-    this.versionsDir = join(process.cwd(), '.veritas-kanban', 'prompt-versions');
-    this.usageDir = join(process.cwd(), '.veritas-kanban', 'prompt-usage');
+    this.templatesDir =
+      options.templatesDir || join(process.cwd(), '.veritas-kanban', 'prompt-templates');
+    this.versionsDir =
+      options.versionsDir || join(process.cwd(), '.veritas-kanban', 'prompt-versions');
+    this.usageDir = options.usageDir || join(process.cwd(), '.veritas-kanban', 'prompt-usage');
     const storageType =
       options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -469,6 +469,7 @@ export class TaskService {
         project: data.project,
         sprint: data.sprint,
         agent: data.agent,
+        agents: data.agents,
         created: data.created || new Date().toISOString(),
         updated: data.updated || new Date().toISOString(),
         git: data.git,
@@ -488,12 +489,16 @@ export class TaskService {
         observations: data.observations,
         attachments: data.attachments,
         position: data.position,
+        costPrediction: data.costPrediction,
+        actualCost: data.actualCost,
         lessonsLearned: data.lessonsLearned,
         lessonTags: data.lessonTags,
         checkpoint: data.checkpoint,
         verificationSteps: data.verificationSteps,
         deliverables: data.deliverables,
         dependencies: data.dependencies,
+        runMode: data.runMode,
+        qaGate: data.qaGate,
       };
     } catch (error) {
       log.error({ err: error, filename }, 'Failed to parse task file');

--- a/server/src/services/template-service.ts
+++ b/server/src/services/template-service.ts
@@ -15,6 +15,7 @@ import { SqliteTemplateRepository } from '../storage/sqlite/template-repository.
 const log = createLogger('template-service');
 
 export interface TemplateServiceOptions {
+  templatesDir?: string;
   storageType?: 'file' | 'sqlite';
   sqliteDatabase?: SqliteDatabase;
   sqliteConnectionOptions?: SqliteConnectionOptions;
@@ -26,7 +27,7 @@ export class TemplateService {
   private sqliteDatabase: SqliteDatabase | null = null;
 
   constructor(options: TemplateServiceOptions = {}) {
-    this.templatesDir = join(process.cwd(), '.veritas-kanban', 'templates');
+    this.templatesDir = options.templatesDir || join(process.cwd(), '.veritas-kanban', 'templates');
     const storageType =
       options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -49,7 +49,7 @@ export class WorkflowRunService {
     const resolvedOptions = typeof options === 'string' ? { runsDir: options } : options;
     this.runsDir = resolvedOptions.runsDir || getWorkflowRunsDir();
     this.workflowService = resolvedOptions.workflowService ?? getWorkflowService();
-    this.stepExecutor = new WorkflowStepExecutor();
+    this.stepExecutor = new WorkflowStepExecutor(resolvedOptions.runsDir);
     const storageType =
       resolvedOptions.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 

--- a/server/src/storage/sqlite/chat-repository.ts
+++ b/server/src/storage/sqlite/chat-repository.ts
@@ -263,7 +263,7 @@ export class SqliteChatRepository {
           FROM chat_messages
           WHERE workspace_id = 'local'
             AND session_id = ?
-          ORDER BY datetime(created_at) ASC, id ASC
+          ORDER BY datetime(created_at) ASC, rowid ASC
         `
       )
       .all(sessionId) as unknown as ChatMessageRow[];


### PR DESCRIPTION
## Summary

- adds a versioned v5 dual-storage parity fixture and focused parity test suite for file and SQLite storage
- covers rich task metadata, archive behavior, comments/chat history, settings/templates, prompt usage, telemetry/activity/status history, and one workflow run
- wires an explicit CI parity step so SQLite drift fails before cutover
- fixes two drift points found by the gate: file-mode reload of newer task metadata and SQLite chat message ordering for same-millisecond messages

Closes #349.

## Verification

- VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/vitest run server/src/__tests__/storage/dual-storage-parity.test.ts
- node_modules/.bin/prettier --check touched files
- pnpm --filter @veritas-kanban/server typecheck
- git diff --check
- pnpm lint:budget
- pnpm build
- pnpm audit --prod --audit-level=high