### PR TITLE
feat: add SQLite migration recovery drills

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ Current planning lives in GitHub, not in a stale README checklist:
 - [Open issues](https://github.com/BradGroux/veritas-kanban/issues)
 - [v5.0 roadmap issues](https://github.com/BradGroux/veritas-kanban/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease%3Av5.0)
 - [v5.0 SQLite schema and migration strategy](docs/SQLITE-SCHEMA.md)
+- [v5.0 SQLite migration recovery drill](docs/MIGRATION-RECOVERY.md)
 - [Release history](CHANGELOG.md)
 
 Use issues for current work and the changelog for shipped work.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2567,7 +2567,8 @@ POST /api/v1/sqlite/migration/dry-run
 ```json
 {
   "sourceRoot": "/path/to/project",
-  "sqlitePath": "/path/to/.veritas-kanban/veritas.db"
+  "sqlitePath": "/path/to/.veritas-kanban/veritas.db",
+  "journalPath": "/path/to/.veritas-kanban/sqlite-migration-journal.json"
 }
 ```
 
@@ -2583,12 +2584,43 @@ POST /api/v1/sqlite/migration/run
 {
   "sourceRoot": "/path/to/project",
   "sqlitePath": "/path/to/.veritas-kanban/veritas.db",
-  "backupDir": "/path/to/pre-migration-backup"
+  "backupDir": "/path/to/pre-migration-backup",
+  "journalPath": "/path/to/.veritas-kanban/sqlite-migration-journal.json"
 }
 ```
 
 Creates a timestamped source backup, imports supported file-backed data into
 SQLite, and returns a migration report.
+
+#### Migration Recovery State
+
+```
+GET /api/v1/sqlite/migration/recovery?sourceRoot=/path/to/project&sqlitePath=/path/to/.veritas-kanban/veritas.db
+```
+
+Returns the latest migration journal, safe-mode recommendation, backup
+restore availability, source-file availability, SQLite readability, next
+actions, and artifacts to preserve for support.
+
+#### Restore Pre-Migration Backup
+
+```
+POST /api/v1/sqlite/migration/restore-backup
+```
+
+```json
+{
+  "backupPath": "/path/to/pre-migration-backup",
+  "targetRoot": "/path/to/project",
+  "journalPath": "/path/to/.veritas-kanban/sqlite-migration-journal.json",
+  "replaceExisting": true,
+  "dryRun": false
+}
+```
+
+Restores the file-backed `tasks/` and `.veritas-kanban/` content from the
+pre-migration backup. Non-empty targets require `replaceExisting: true`; use
+`dryRun: true` to verify the paths and file count before overwriting.
 
 #### Export Backup Bundle
 

--- a/docs/MIGRATION-RECOVERY.md
+++ b/docs/MIGRATION-RECOVERY.md
@@ -1,0 +1,86 @@
+# v5 SQLite Migration Recovery
+
+This document defines the v5 file-to-SQLite rollback and failed-upgrade drill.
+
+## Recovery Contract
+
+The v5 migration must never leave a project in a state where neither file
+storage nor SQLite can be opened. The file-backed source remains the recovery
+source of truth until the migrated SQLite database is accepted.
+
+Every non-dry-run migration writes a JSON journal at
+`.veritas-kanban/sqlite-migration-journal.json` unless an explicit
+`journalPath` is supplied. The journal records:
+
+- source root, target SQLite path, temporary SQLite path, and backup path
+- started and updated timestamps
+- current stage and completed stages
+- scanned/written/skipped entity counts
+- warnings for malformed source records, duplicate task IDs, missing attachment
+  files, and backup copy issues
+- failure name, message, and failed stage when migration fails
+- safe-mode recommendation, next actions, and artifacts to preserve
+
+## Failure Behavior
+
+Migration stages are checkpointed as `scan-source`, `create-backup`,
+`open-sqlite`, `write-sqlite`, `promote-database`, and `completed`.
+
+If migration fails:
+
+1. Keep the app on file storage.
+2. Treat the project as `file-readonly` until a backup or retry path is chosen.
+3. Preserve the journal, pre-migration backup, failed SQLite database, and any
+   temporary SQLite files.
+4. Show the failed stage, backup path, and next action to the admin.
+5. Retry migration only after preserving the failed artifacts.
+
+Interrupted migrations that were writing a new SQLite database use a temporary
+database path and promote it only after writes and checkpointing complete. A
+failed temporary database is removed after journaling the failure.
+
+## Restore Drill
+
+The rollback drill restores the file-backed state from the pre-migration backup:
+
+```text
+POST /api/v1/sqlite/migration/restore-backup
+```
+
+Recommended sequence:
+
+1. Call restore with `dryRun: true` and confirm the target root and restored
+   file count.
+2. Stop the app or keep it in recovery mode.
+3. Restore with `replaceExisting: true`.
+4. Boot with `VERITAS_STORAGE=file`.
+5. Verify board, task detail, search, workflow, chat, and admin settings.
+6. Preserve the failed SQLite database and journal until the incident is closed.
+
+The restore endpoint only restores `tasks/` and `.veritas-kanban/` from the
+pre-migration backup. It does not attempt destructive SQLite down migrations.
+
+## Downgrade Policy
+
+For pre-GA v5 testing, schema `down` migrations may exist to support developer
+iteration and controlled drills.
+
+For GA users, rollback means restoring the pre-migration file-backed backup.
+Indefinite downgrade from all future v5 SQLite schema versions is unsupported.
+If an older app sees a newer SQLite database, it must refuse normal startup,
+report the schema version, and direct the admin to restore the pre-migration
+backup or use a compatible newer app.
+
+## Support Bundle Contents
+
+When support is needed, preserve:
+
+- migration journal
+- migration report response
+- pre-migration backup manifest
+- failed SQLite database, WAL, and SHM files
+- temporary SQLite database if one remains
+- server logs around the migration window
+- redacted config and environment summary
+
+Do not include plaintext secrets, API tokens, cookies, or private keys.

--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -1168,7 +1168,7 @@ Rollback is safety-first because v5 upgrades existing file-backed projects.
    migrated in a manifest and keep them for rollback/export until the user
    explicitly cleans them up.
 3. If any import step fails, rollback the SQLite transaction, keep the backup,
-   write a migration report, and leave the app on file storage.
+   write a migration journal/report, and leave the app on file storage.
 4. If a shipped schema migration fails after v5 adoption, stop startup before
    mutating data further and show the failed migration version.
 5. `down` migrations may be used during development and pre-GA testing. For GA
@@ -1177,17 +1177,23 @@ Rollback is safety-first because v5 upgrades existing file-backed projects.
 6. Any migration that changes sensitive fields must prove redaction behavior in
    the migration report.
 
+Operational drills, support bundle contents, safe-mode behavior, and the GA
+downgrade policy are defined in
+[v5 SQLite Migration Recovery](MIGRATION-RECOVERY.md).
+
 ## Migration and Backup API
 
 v5 exposes an admin-only portability surface under `/api/sqlite` so upgrades can
 be rehearsed, reported, and reversed without deleting source files.
 
-| Endpoint                             | Purpose                                                                                                                                                               |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POST /api/sqlite/migration/dry-run` | Scan file-backed data and return entity counts, warnings, skipped files, and parse errors without creating or mutating the SQLite database.                           |
-| `POST /api/sqlite/migration/run`     | Create a timestamped pre-migration backup, import supported file-backed data into SQLite, preserve existing source files, and return the same migration report shape. |
-| `POST /api/sqlite/export`            | Write a backup bundle containing raw SQLite table snapshots plus human-readable task Markdown, config JSON, and workflow YAML.                                        |
-| `POST /api/sqlite/import`            | Restore a backup bundle into a fresh or explicitly replaced SQLite database and rebuild derived search indexes.                                                       |
+| Endpoint                                    | Purpose                                                                                                                                                         |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/sqlite/migration/dry-run`        | Scan file-backed data and return entity counts, warnings, skipped files, and parse errors without creating or mutating the SQLite database.                     |
+| `POST /api/sqlite/migration/run`            | Create a timestamped pre-migration backup, import supported file-backed data into SQLite, preserve existing source files, write a journal, and return a report. |
+| `GET /api/sqlite/migration/recovery`        | Read the latest migration journal and return safe mode, source/SQLite readability, backup restore availability, next actions, and artifacts to preserve.        |
+| `POST /api/sqlite/migration/restore-backup` | Restore the file-backed `tasks/` and `.veritas-kanban/` state from a pre-migration backup after a dry-run check or explicit replacement request.                |
+| `POST /api/sqlite/export`                   | Write a backup bundle containing raw SQLite table snapshots plus human-readable task Markdown, config JSON, and workflow YAML.                                  |
+| `POST /api/sqlite/import`                   | Restore a backup bundle into a fresh or explicitly replaced SQLite database and rebuild derived search indexes.                                                 |
 
 The initial migration path imports active, archived, and backlog task Markdown;
 settings; task templates; prompt templates, versions, and usage; activity;
@@ -1201,10 +1207,10 @@ Manual recovery is intentionally boring:
 
 1. Keep `VERITAS_STORAGE=file` if dry-run or migration warnings are unacceptable.
 2. If `/api/sqlite/migration/run` fails, leave the app on file storage, inspect
-   the returned warnings, and fix or remove the malformed source files.
-3. If a migrated database behaves incorrectly, stop the server, point
-   `VERITAS_SQLITE_PATH` at a new database or restore the previous database file,
-   and keep the timestamped backup created under `.veritas-kanban/backups/`.
+   the returned recovery state, and fix or remove malformed source files.
+3. If a migrated database behaves incorrectly, stop the server, restore the
+   pre-migration backup, and boot with `VERITAS_STORAGE=file` before retrying
+   SQLite.
 4. To verify portability, export the SQLite database, import the bundle into a
    fresh database path, then smoke the board, search, workflows, chat, and task
    detail APIs before switching the live path.

--- a/server/src/__tests__/sqlite-portability-service.test.ts
+++ b/server/src/__tests__/sqlite-portability-service.test.ts
@@ -239,6 +239,7 @@ describe('SqlitePortabilityService', () => {
 
     const service = new SqlitePortabilityService();
     const sqlitePath = path.join(testRoot, 'migration.db');
+    const journalPath = path.join(runtimeDir, 'sqlite-migration-journal.json');
     const dryRun = await service.migrateFilesToSqlite({ sourceRoot, sqlitePath, dryRun: true });
 
     expect(dryRun.dryRun).toBe(true);
@@ -247,9 +248,31 @@ describe('SqlitePortabilityService', () => {
     expect(dryRun.warnings.some((warning) => warning.entity === 'tasks.active')).toBe(true);
     expect(dryRun.warnings.some((warning) => warning.entity === 'telemetry')).toBe(true);
 
-    const report = await service.migrateFilesToSqlite({ sourceRoot, sqlitePath });
+    const report = await service.migrateFilesToSqlite({ sourceRoot, sqlitePath, journalPath });
     expect(report.backupPath).toBeTruthy();
     expect(await exists(path.join(report.backupPath!, 'backup-manifest.json'))).toBe(true);
+    expect(
+      await exists(
+        path.join(report.backupPath!, '.veritas-kanban', 'sqlite-migration-journal.json')
+      )
+    ).toBe(false);
+    const journal = await service.readMigrationJournal(journalPath);
+    expect(journal?.status).toBe('completed');
+    expect(journal?.backupPath).toBe(report.backupPath);
+    expect(journal?.completedStages).toEqual(
+      expect.arrayContaining(['scan-source', 'create-backup', 'open-sqlite', 'write-sqlite'])
+    );
+    expect(journal?.counts.find((count) => count.entity === 'tasks.active')?.written).toBe(1);
+
+    const recovery = await service.getMigrationRecoveryState({
+      sourceRoot,
+      sqlitePath,
+      journalPath,
+    });
+    expect(recovery.safeMode).toBe('normal');
+    expect(recovery.canRestoreBackup).toBe(true);
+    expect(recovery.canOpenSourceFiles).toBe(true);
+    expect(recovery.canOpenSqlite).toBe(true);
 
     const database = new SqliteDatabase({ databasePath: sqlitePath });
     database.open();
@@ -279,6 +302,164 @@ describe('SqlitePortabilityService', () => {
     } finally {
       database.close();
     }
+  });
+
+  it('records failed migration recovery state and supports rerun to a fresh database', async () => {
+    const service = new SqlitePortabilityService();
+    const { sourceRoot, taskId, runtimeDir } = await createMinimalLegacyProject(
+      testRoot,
+      'failed',
+      'task_20260531_fail1'
+    );
+    const sqlitePath = path.join(testRoot, 'corrupt.db');
+    const journalPath = path.join(runtimeDir, 'sqlite-migration-journal.json');
+    await fs.writeFile(sqlitePath, 'not a sqlite database', 'utf-8');
+
+    await expect(
+      service.migrateFilesToSqlite({ sourceRoot, sqlitePath, journalPath })
+    ).rejects.toThrow();
+
+    const journal = await service.readMigrationJournal(journalPath);
+    expect(journal?.status).toBe('failed');
+    expect(journal?.failure?.stage).toBe('open-sqlite');
+    expect(journal?.completedStages).not.toContain('open-sqlite');
+    expect(journal?.backupPath).toBeTruthy();
+    expect(journal?.recovery.safeMode).toBe('file-readonly');
+    expect(await exists(path.join(sourceRoot, 'tasks', 'active'))).toBe(true);
+    expect(
+      await exists(
+        path.join(journal!.backupPath!, '.veritas-kanban', 'sqlite-migration-journal.json')
+      )
+    ).toBe(false);
+
+    const recovery = await service.getMigrationRecoveryState({
+      sourceRoot,
+      sqlitePath,
+      journalPath,
+    });
+    expect(recovery.canOpenSourceFiles).toBe(true);
+    expect(recovery.canOpenSqlite).toBe(false);
+    expect(recovery.canRestoreBackup).toBe(true);
+    expect(recovery.nextActions.join(' ')).toContain('file storage');
+
+    const rerunPath = path.join(testRoot, 'rerun.db');
+    await service.migrateFilesToSqlite({ sourceRoot, sqlitePath: rerunPath });
+    const rerunDb = new SqliteDatabase({ databasePath: rerunPath });
+    rerunDb.open();
+    try {
+      const task = await new SqliteTaskRepository(rerunDb).findById(taskId);
+      expect(task?.title).toBe('Minimal failed task');
+    } finally {
+      rerunDb.close();
+    }
+  });
+
+  it('restores a pre-migration backup over the file tree and records restored recovery state', async () => {
+    const service = new SqlitePortabilityService();
+    const { sourceRoot, activeDir, runtimeDir, taskId } = await createMinimalLegacyProject(
+      testRoot,
+      'restore',
+      'task_20260531_restore1'
+    );
+    const sqlitePath = path.join(testRoot, 'restore.db');
+    const journalPath = path.join(runtimeDir, 'sqlite-migration-journal.json');
+    const report = await service.migrateFilesToSqlite({ sourceRoot, sqlitePath, journalPath });
+
+    await writeTask(activeDir, {
+      id: taskId,
+      title: 'Mutated task',
+      description: 'This should be replaced by the backup.',
+      type: 'feature',
+      status: 'todo',
+      priority: 'high',
+      created: '2026-05-31T12:00:00.000Z',
+      updated: '2026-05-31T13:00:00.000Z',
+    });
+
+    await expect(
+      service.restorePreMigrationBackup({ backupPath: report.backupPath!, targetRoot: sourceRoot })
+    ).rejects.toThrow(/replaceExisting=true/);
+
+    const dryRun = await service.restorePreMigrationBackup({
+      backupPath: report.backupPath!,
+      targetRoot: sourceRoot,
+      dryRun: true,
+    });
+    expect(dryRun.filesRestored).toBeGreaterThan(0);
+
+    const restore = await service.restorePreMigrationBackup({
+      backupPath: report.backupPath!,
+      targetRoot: sourceRoot,
+      journalPath,
+      replaceExisting: true,
+    });
+    expect(restore.filesRestored).toBeGreaterThan(0);
+
+    const activeFiles = await fs.readdir(activeDir);
+    const restoredTaskFile = activeFiles.find((file) => file.startsWith(`${taskId}-`));
+    expect(restoredTaskFile).toBeTruthy();
+    const restoredTask = matter(
+      await fs.readFile(path.join(activeDir, restoredTaskFile!), 'utf-8')
+    );
+    expect(restoredTask.data.title).toBe('Minimal restore task');
+    expect(restoredTask.content).toContain('Original restore body');
+
+    const journal = await service.readMigrationJournal(journalPath);
+    expect(journal?.status).toBe('restored');
+    expect(journal?.recovery.safeMode).toBe('file-readonly');
+  });
+
+  it('warns about duplicate task ids and missing attachment files before migration', async () => {
+    const service = new SqlitePortabilityService();
+    const { sourceRoot, activeDir, backlogDir, taskId } = await createMinimalLegacyProject(
+      testRoot,
+      'warnings',
+      'task_20260531_warn1'
+    );
+    await writeTask(activeDir, {
+      id: taskId,
+      title: 'Task with missing attachment',
+      description: 'Attachment metadata points at a missing file.',
+      type: 'feature',
+      status: 'todo',
+      priority: 'high',
+      created: '2026-05-31T12:00:00.000Z',
+      updated: '2026-05-31T12:00:00.000Z',
+      attachments: [
+        {
+          id: 'att_missing',
+          filename: 'missing.txt',
+          originalName: 'missing.txt',
+          mimeType: 'text/plain',
+          size: 12,
+          uploaded: '2026-05-31T12:00:00.000Z',
+          storagePath: 'tasks/attachments/task_20260531_warn1/missing.txt',
+        },
+      ],
+    });
+    await writeTask(backlogDir, {
+      id: taskId,
+      title: 'Duplicate task id',
+      description: 'This duplicate should be called out before migration.',
+      type: 'task',
+      status: 'todo',
+      priority: 'medium',
+      created: '2026-05-31T12:00:00.000Z',
+      updated: '2026-05-31T12:00:00.000Z',
+    });
+
+    const report = await service.migrateFilesToSqlite({
+      sourceRoot,
+      sqlitePath: path.join(testRoot, 'warnings.db'),
+      dryRun: true,
+    });
+
+    expect(report.warnings.some((warning) => warning.message.includes('Duplicate task id'))).toBe(
+      true
+    );
+    expect(
+      report.warnings.some((warning) => warning.message.includes('Attachment file not found'))
+    ).toBe(true);
   });
 
   it('exports a SQLite backup bundle and imports it into a fresh database', async () => {
@@ -349,6 +530,53 @@ describe('SqlitePortabilityService', () => {
     }
   });
 });
+
+async function createMinimalLegacyProject(
+  testRoot: string,
+  name: string,
+  taskId: string
+): Promise<{
+  sourceRoot: string;
+  runtimeDir: string;
+  activeDir: string;
+  backlogDir: string;
+  taskId: string;
+}> {
+  const sourceRoot = path.join(testRoot, `project-${name}`);
+  const runtimeDir = path.join(sourceRoot, '.veritas-kanban');
+  const activeDir = path.join(sourceRoot, 'tasks', 'active');
+  const archiveDir = path.join(sourceRoot, 'tasks', 'archive');
+  const backlogDir = path.join(sourceRoot, 'tasks', 'backlog');
+  const now = '2026-05-31T12:00:00.000Z';
+
+  await fs.mkdir(activeDir, { recursive: true });
+  await fs.mkdir(archiveDir, { recursive: true });
+  await fs.mkdir(backlogDir, { recursive: true });
+  await fs.mkdir(runtimeDir, { recursive: true });
+
+  await writeTask(activeDir, {
+    id: taskId,
+    title: `Minimal ${name} task`,
+    description: `Original ${name} body`,
+    type: 'feature',
+    status: 'todo',
+    priority: 'high',
+    created: now,
+    updated: now,
+  });
+
+  await fs.writeFile(
+    path.join(runtimeDir, 'config.json'),
+    JSON.stringify({
+      repos: [{ name, path: sourceRoot, defaultBranch: 'main' }],
+      agents: [],
+      defaultAgent: 'codex',
+    }),
+    'utf-8'
+  );
+
+  return { sourceRoot, runtimeDir, activeDir, backlogDir, taskId };
+}
 
 async function writeTask(dir: string, task: Task): Promise<void> {
   const { description, ...frontmatter } = task;

--- a/server/src/routes/sqlite-portability.ts
+++ b/server/src/routes/sqlite-portability.ts
@@ -13,6 +13,7 @@ const migrationSchema = z.object({
   sourceRoot: pathSchema.optional(),
   sqlitePath: pathSchema,
   backupDir: pathSchema.optional(),
+  journalPath: pathSchema.optional(),
 });
 
 const exportSchema = z.object({
@@ -24,6 +25,20 @@ const importSchema = z.object({
   sqlitePath: pathSchema,
   bundleDir: pathSchema,
   replaceExisting: z.boolean().optional(),
+});
+
+const recoveryQuerySchema = z.object({
+  sourceRoot: pathSchema.optional(),
+  sqlitePath: pathSchema.optional(),
+  journalPath: pathSchema.optional(),
+});
+
+const restoreBackupSchema = z.object({
+  backupPath: pathSchema,
+  targetRoot: pathSchema.optional(),
+  journalPath: pathSchema.optional(),
+  replaceExisting: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
 });
 
 function parseBody<T>(schema: z.ZodType<T>, body: unknown): T {
@@ -56,6 +71,26 @@ router.post(
       ...input,
       dryRun: false,
     });
+    res.json(report);
+  })
+);
+
+router.get(
+  '/migration/recovery',
+  authorize('admin'),
+  asyncHandler(async (req, res) => {
+    const input = parseBody(recoveryQuerySchema, req.query);
+    const state = await getSqlitePortabilityService().getMigrationRecoveryState(input);
+    res.json(state);
+  })
+);
+
+router.post(
+  '/migration/restore-backup',
+  authorize('admin'),
+  asyncHandler(async (req, res) => {
+    const input = parseBody(restoreBackupSchema, req.body);
+    const report = await getSqlitePortabilityService().restorePreMigrationBackup(input);
     res.json(report);
   })
 );

--- a/server/src/services/sqlite-portability-service.ts
+++ b/server/src/services/sqlite-portability-service.ts
@@ -134,6 +134,7 @@ export interface FileToSqliteMigrationOptions {
   sqlitePath: string;
   dryRun?: boolean;
   backupDir?: string;
+  journalPath?: string;
 }
 
 export interface SqliteBackupExportOptions {
@@ -145,6 +146,78 @@ export interface SqliteBackupImportOptions {
   sqlitePath: string;
   bundleDir: string;
   replaceExisting?: boolean;
+}
+
+export type SqliteMigrationStage =
+  | 'scan-source'
+  | 'create-backup'
+  | 'open-sqlite'
+  | 'write-sqlite'
+  | 'promote-database'
+  | 'completed'
+  | 'failed';
+
+export interface SqliteMigrationJournal {
+  formatVersion: 1;
+  operation: 'file-to-sqlite';
+  status: 'running' | 'completed' | 'failed' | 'restored';
+  startedAt: string;
+  updatedAt: string;
+  sourceRoot: string;
+  sqlitePath: string;
+  backupPath?: string;
+  tempSqlitePath?: string;
+  currentStage: SqliteMigrationStage;
+  completedStages: SqliteMigrationStage[];
+  counts: SqlitePortabilityEntityCount[];
+  warnings: SqlitePortabilityWarning[];
+  failure?: {
+    stage: SqliteMigrationStage;
+    name: string;
+    message: string;
+  };
+  recovery: {
+    safeMode: 'file-readonly' | 'sqlite-readonly' | 'normal';
+    nextActions: string[];
+    preserveArtifacts: string[];
+  };
+}
+
+export interface SqliteMigrationRecoveryState {
+  journalPath: string;
+  journal: SqliteMigrationJournal | null;
+  safeMode: SqliteMigrationJournal['recovery']['safeMode'];
+  canRestoreBackup: boolean;
+  canOpenSourceFiles: boolean;
+  canOpenSqlite: boolean;
+  nextActions: string[];
+  preserveArtifacts: string[];
+}
+
+export interface SqliteMigrationRecoveryOptions {
+  sourceRoot?: string;
+  sqlitePath?: string;
+  journalPath?: string;
+}
+
+export interface RestorePreMigrationBackupOptions {
+  backupPath: string;
+  targetRoot?: string;
+  journalPath?: string;
+  replaceExisting?: boolean;
+  dryRun?: boolean;
+}
+
+export interface RestorePreMigrationBackupReport {
+  operation: 'restore-pre-migration-backup';
+  dryRun: boolean;
+  startedAt: string;
+  completedAt: string;
+  backupPath: string;
+  targetRoot: string;
+  restoredPaths: string[];
+  filesRestored: number;
+  warnings: SqlitePortabilityWarning[];
 }
 
 interface LegacyPaths {
@@ -202,13 +275,30 @@ export class SqlitePortabilityService {
     const paths = this.resolveLegacyPaths(options.sourceRoot);
     const warnings: SqlitePortabilityWarning[] = [];
     const legacy = await this.readLegacyData(paths, warnings);
-    const counts = this.buildLegacyCounts(legacy, dryRun ? 0 : undefined);
+    const counts = this.buildLegacyCounts(legacy, 0);
+    const journalPath = dryRun
+      ? undefined
+      : this.resolveMigrationJournalPath(paths, options.journalPath);
+    let journal = journalPath
+      ? this.createMigrationJournal({
+          startedAt,
+          sourceRoot: paths.sourceRoot,
+          sqlitePath: path.resolve(options.sqlitePath),
+          journalPath,
+          counts,
+          warnings,
+        })
+      : null;
 
     let backupPath: string | undefined;
     let database: SqliteDatabase | null = null;
     let tempSqlitePath: string | null = null;
 
     try {
+      if (journalPath && journal) {
+        journal = await this.writeMigrationJournal(journalPath, journal, 'scan-source');
+      }
+
       if (!dryRun) {
         const sqlitePath = path.resolve(options.sqlitePath);
         const sqliteExists = await this.exists(sqlitePath);
@@ -217,18 +307,53 @@ export class SqlitePortabilityService {
           : `${sqlitePath}.tmp-${Date.now().toString(36)}`;
 
         backupPath = await this.createPreMigrationBackup(paths, options.backupDir, warnings);
+        if (journalPath && journal) {
+          journal.backupPath = backupPath;
+          journal.warnings = warnings;
+          journal = await this.writeMigrationJournal(journalPath, journal, 'create-backup');
+        }
+
         tempSqlitePath = sqliteExists ? null : writeSqlitePath;
+        if (journalPath && journal) {
+          journal.tempSqlitePath = tempSqlitePath ?? undefined;
+        }
+
         await fs.mkdir(path.dirname(writeSqlitePath), { recursive: true });
         database = new SqliteDatabase({ databasePath: writeSqlitePath });
+        if (journalPath && journal) {
+          journal = await this.writeMigrationJournal(journalPath, journal, 'open-sqlite', {
+            completeStage: false,
+          });
+        }
         database.open();
+        if (journalPath && journal) {
+          journal = await this.writeMigrationJournal(journalPath, journal, 'open-sqlite');
+          journal = await this.writeMigrationJournal(journalPath, journal, 'write-sqlite', {
+            completeStage: false,
+          });
+        }
         await this.writeLegacyData(database, legacy);
+        if (journalPath && journal) {
+          journal = await this.writeMigrationJournal(journalPath, journal, 'write-sqlite');
+        }
+
         database.getConnection().exec('PRAGMA wal_checkpoint(FULL);');
         database.close();
         database = null;
 
         if (tempSqlitePath) {
+          if (journalPath && journal) {
+            journal.tempSqlitePath = tempSqlitePath;
+            journal = await this.writeMigrationJournal(journalPath, journal, 'promote-database', {
+              completeStage: false,
+            });
+          }
           await this.promoteTempDatabase(tempSqlitePath, sqlitePath);
           tempSqlitePath = null;
+          if (journalPath && journal) {
+            journal.tempSqlitePath = undefined;
+            journal = await this.writeMigrationJournal(journalPath, journal, 'promote-database');
+          }
         }
 
         for (const count of counts) {
@@ -236,7 +361,7 @@ export class SqlitePortabilityService {
         }
       }
 
-      return {
+      const report: SqlitePortabilityReport = {
         operation: 'file-to-sqlite',
         dryRun,
         startedAt,
@@ -247,6 +372,17 @@ export class SqlitePortabilityService {
         counts,
         warnings,
       };
+
+      if (journalPath && journal) {
+        await this.completeMigrationJournal(journalPath, journal, report);
+      }
+
+      return report;
+    } catch (error) {
+      if (journalPath && journal) {
+        await this.failMigrationJournal(journalPath, journal, error);
+      }
+      throw error;
     } finally {
       database?.close();
       if (tempSqlitePath) {
@@ -358,6 +494,125 @@ export class SqlitePortabilityService {
     }
   }
 
+  async readMigrationJournal(journalPath: string): Promise<SqliteMigrationJournal | null> {
+    if (!(await this.exists(journalPath))) {
+      return null;
+    }
+
+    return JSON.parse(await fs.readFile(journalPath, 'utf-8')) as SqliteMigrationJournal;
+  }
+
+  async getMigrationRecoveryState(
+    options: SqliteMigrationRecoveryOptions = {}
+  ): Promise<SqliteMigrationRecoveryState> {
+    const paths = this.resolveLegacyPaths(options.sourceRoot);
+    const journalPath = this.resolveMigrationJournalPath(paths, options.journalPath);
+    const journal = await this.readMigrationJournal(journalPath);
+    const sqlitePath = options.sqlitePath ?? journal?.sqlitePath;
+    const canOpenSourceFiles = await this.exists(paths.sourceRoot);
+    const canOpenSqlite = sqlitePath ? await this.canOpenSqlite(sqlitePath) : false;
+    const canRestoreBackup = journal?.backupPath ? await this.exists(journal.backupPath) : false;
+    const fallback = this.buildRecoveryPlan({
+      status: journal?.status ?? 'failed',
+      sourceRoot: paths.sourceRoot,
+      sqlitePath: sqlitePath ? path.resolve(sqlitePath) : undefined,
+      backupPath: journal?.backupPath,
+      journalPath,
+      failureStage: journal?.failure?.stage ?? journal?.currentStage ?? 'failed',
+    });
+
+    return {
+      journalPath,
+      journal,
+      safeMode: journal?.recovery.safeMode ?? fallback.safeMode,
+      canRestoreBackup,
+      canOpenSourceFiles,
+      canOpenSqlite,
+      nextActions: journal?.recovery.nextActions ?? fallback.nextActions,
+      preserveArtifacts: journal?.recovery.preserveArtifacts ?? fallback.preserveArtifacts,
+    };
+  }
+
+  async restorePreMigrationBackup(
+    options: RestorePreMigrationBackupOptions
+  ): Promise<RestorePreMigrationBackupReport> {
+    const startedAt = new Date().toISOString();
+    const backupPath = path.resolve(options.backupPath);
+    const warnings: SqlitePortabilityWarning[] = [];
+    const manifest = await this.readBackupManifest(backupPath);
+    const targetRoot = path.resolve(options.targetRoot ?? manifest.sourceRoot);
+    const journalPath = path.resolve(
+      options.journalPath ??
+        path.join(targetRoot, '.veritas-kanban', 'sqlite-migration-journal.json')
+    );
+    const journal = await this.readMigrationJournal(journalPath);
+    const dryRun = options.dryRun === true;
+    const restoredPaths: string[] = [];
+    let filesRestored = 0;
+
+    const restoreTargets = [
+      {
+        source: path.join(backupPath, 'tasks'),
+        target: path.join(targetRoot, 'tasks'),
+      },
+      {
+        source: path.join(backupPath, '.veritas-kanban'),
+        target: path.join(targetRoot, '.veritas-kanban'),
+      },
+    ];
+
+    for (const restoreTarget of restoreTargets) {
+      const files = await this.countRecursiveFiles(restoreTarget.source);
+      if (files === 0) {
+        continue;
+      }
+      filesRestored += files;
+      restoredPaths.push(restoreTarget.target);
+
+      if (dryRun) {
+        continue;
+      }
+
+      if (!options.replaceExisting) {
+        await this.assertRestoreTargetIsClear(restoreTarget.target);
+      } else {
+        await fs.rm(restoreTarget.target, { recursive: true, force: true });
+      }
+
+      await this.copyBackupSource(restoreTarget.source, restoreTarget.target, [], warnings);
+    }
+
+    if (!dryRun && journal) {
+      const restored: SqliteMigrationJournal = {
+        ...journal,
+        status: 'restored',
+        updatedAt: new Date().toISOString(),
+        recovery: this.buildRecoveryPlan({
+          status: 'restored',
+          sourceRoot: targetRoot,
+          sqlitePath: journal.sqlitePath,
+          backupPath,
+          tempSqlitePath: journal.tempSqlitePath,
+          journalPath,
+          failureStage: journal.failure?.stage ?? journal.currentStage,
+        }),
+      };
+      await this.writeJson(journalPath, restored);
+    }
+
+    return {
+      operation: 'restore-pre-migration-backup',
+      dryRun,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      backupPath,
+      targetRoot,
+      restoredPaths,
+      filesRestored,
+      warnings,
+    };
+  }
+
   private resolveLegacyPaths(sourceRoot?: string): LegacyPaths {
     if (!sourceRoot) {
       const runtimeDir = getRuntimeDir();
@@ -412,6 +667,7 @@ export class SqlitePortabilityService {
       archived: await this.readTasks(paths.tasksArchiveDir, 'tasks.archived', warnings),
       backlog: await this.readTasks(paths.tasksBacklogDir, 'tasks.backlog', warnings),
     };
+    await this.validateTaskMigrationInputs(paths, tasks, warnings);
 
     const config = await this.readJsonFile<AppConfig>(paths.configFile, 'settings', warnings);
     const taskTemplates = await this.readMatterDirectory<TaskTemplate>(
@@ -600,6 +856,7 @@ export class SqlitePortabilityService {
     for (const entry of entries) {
       if (
         entry.name === 'backups' ||
+        entry.name === 'sqlite-migration-journal.json' ||
         entry.name === 'veritas.db' ||
         entry.name === 'veritas.db-shm' ||
         entry.name === 'veritas.db-wal'
@@ -644,6 +901,310 @@ export class SqlitePortabilityService {
     await fs.rm(tempSqlitePath, { force: true }).catch(() => {});
     await fs.rm(`${tempSqlitePath}-wal`, { force: true }).catch(() => {});
     await fs.rm(`${tempSqlitePath}-shm`, { force: true }).catch(() => {});
+  }
+
+  private resolveMigrationJournalPath(paths: LegacyPaths, journalPath?: string): string {
+    return path.resolve(
+      journalPath ?? path.join(paths.runtimeDir, 'sqlite-migration-journal.json')
+    );
+  }
+
+  private createMigrationJournal(input: {
+    startedAt: string;
+    sourceRoot: string;
+    sqlitePath: string;
+    journalPath?: string;
+    counts: SqlitePortabilityEntityCount[];
+    warnings: SqlitePortabilityWarning[];
+  }): SqliteMigrationJournal {
+    const recovery = this.buildRecoveryPlan({
+      status: 'running',
+      sourceRoot: input.sourceRoot,
+      sqlitePath: input.sqlitePath,
+      journalPath: input.journalPath,
+      failureStage: 'scan-source',
+    });
+
+    return {
+      formatVersion: 1,
+      operation: 'file-to-sqlite',
+      status: 'running',
+      startedAt: input.startedAt,
+      updatedAt: input.startedAt,
+      sourceRoot: input.sourceRoot,
+      sqlitePath: input.sqlitePath,
+      currentStage: 'scan-source',
+      completedStages: [],
+      counts: input.counts,
+      warnings: input.warnings,
+      recovery,
+    };
+  }
+
+  private async writeMigrationJournal(
+    journalPath: string,
+    journal: SqliteMigrationJournal,
+    completedStage: SqliteMigrationStage,
+    options: { completeStage?: boolean } = {}
+  ): Promise<SqliteMigrationJournal> {
+    const nextCompleted = new Set(journal.completedStages);
+    if (completedStage !== 'failed' && options.completeStage !== false) {
+      nextCompleted.add(completedStage);
+    }
+
+    const nextJournal: SqliteMigrationJournal = {
+      ...journal,
+      updatedAt: new Date().toISOString(),
+      currentStage: completedStage,
+      completedStages: Array.from(nextCompleted),
+      recovery: this.buildRecoveryPlan({
+        status: journal.status,
+        sourceRoot: journal.sourceRoot,
+        sqlitePath: journal.sqlitePath,
+        backupPath: journal.backupPath,
+        journalPath,
+        failureStage: completedStage,
+      }),
+    };
+
+    await this.writeJson(journalPath, nextJournal);
+    return nextJournal;
+  }
+
+  private async completeMigrationJournal(
+    journalPath: string,
+    journal: SqliteMigrationJournal,
+    report: SqlitePortabilityReport
+  ): Promise<void> {
+    const completed: SqliteMigrationJournal = {
+      ...journal,
+      status: 'completed',
+      updatedAt: report.completedAt,
+      backupPath: report.backupPath,
+      tempSqlitePath: undefined,
+      currentStage: 'completed',
+      completedStages: Array.from(new Set([...journal.completedStages, 'completed'])),
+      counts: report.counts,
+      warnings: report.warnings,
+      failure: undefined,
+      recovery: this.buildRecoveryPlan({
+        status: 'completed',
+        sourceRoot: journal.sourceRoot,
+        sqlitePath: journal.sqlitePath,
+        backupPath: report.backupPath,
+        journalPath,
+        failureStage: 'completed',
+      }),
+    };
+
+    await this.writeJson(journalPath, completed);
+  }
+
+  private async failMigrationJournal(
+    journalPath: string,
+    journal: SqliteMigrationJournal,
+    error: unknown
+  ): Promise<void> {
+    const failure = {
+      stage: journal.currentStage,
+      name: error instanceof Error ? error.name : 'Error',
+      message: error instanceof Error ? error.message : String(error),
+    };
+    const failed: SqliteMigrationJournal = {
+      ...journal,
+      status: 'failed',
+      updatedAt: new Date().toISOString(),
+      currentStage: 'failed',
+      completedStages: Array.from(new Set([...journal.completedStages, 'failed'])),
+      failure,
+      recovery: this.buildRecoveryPlan({
+        status: 'failed',
+        sourceRoot: journal.sourceRoot,
+        sqlitePath: journal.sqlitePath,
+        backupPath: journal.backupPath,
+        tempSqlitePath: journal.tempSqlitePath,
+        journalPath,
+        failureStage: failure.stage,
+      }),
+    };
+
+    await this.writeJson(journalPath, failed);
+  }
+
+  private buildRecoveryPlan(input: {
+    status: SqliteMigrationJournal['status'];
+    sourceRoot: string;
+    sqlitePath?: string;
+    backupPath?: string;
+    tempSqlitePath?: string;
+    journalPath?: string;
+    failureStage: SqliteMigrationStage;
+  }): SqliteMigrationJournal['recovery'] {
+    if (input.status === 'completed') {
+      return {
+        safeMode: 'normal',
+        nextActions: [
+          'Continue with SQLite storage after verifying the migrated database.',
+          'Keep the pre-migration backup until the v5 upgrade is accepted.',
+        ],
+        preserveArtifacts: [input.backupPath, input.sqlitePath].filter(
+          (artifact): artifact is string => Boolean(artifact)
+        ),
+      };
+    }
+
+    if (input.status === 'restored') {
+      return {
+        safeMode: 'file-readonly',
+        nextActions: [
+          'Boot with file storage and verify the restored project before retrying migration.',
+          'Preserve the failed SQLite database and migration journal for support review.',
+        ],
+        preserveArtifacts: [input.backupPath, input.sqlitePath, input.tempSqlitePath].filter(
+          (artifact): artifact is string => Boolean(artifact)
+        ),
+      };
+    }
+
+    return {
+      safeMode: 'file-readonly',
+      nextActions: [
+        'Boot with file storage in read-only recovery mode.',
+        input.backupPath
+          ? 'Offer restore from the pre-migration backup or export the failed SQLite artifacts.'
+          : 'Create a manual file-system backup before retrying migration.',
+        'Retry migration only after preserving the failed journal and target database.',
+      ],
+      preserveArtifacts: [
+        input.backupPath,
+        input.sqlitePath,
+        input.tempSqlitePath,
+        input.journalPath ??
+          path.join(input.sourceRoot, '.veritas-kanban', 'sqlite-migration-journal.json'),
+      ].filter((artifact): artifact is string => Boolean(artifact)),
+    };
+  }
+
+  private async readBackupManifest(backupPath: string): Promise<{ sourceRoot: string }> {
+    const manifestPath = path.join(backupPath, 'backup-manifest.json');
+    if (!(await this.exists(manifestPath))) {
+      throw new Error(`Pre-migration backup manifest not found: ${manifestPath}`);
+    }
+
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8')) as {
+      sourceRoot?: unknown;
+    };
+    if (typeof manifest.sourceRoot !== 'string' || !manifest.sourceRoot.trim()) {
+      throw new Error(`Pre-migration backup manifest is missing sourceRoot: ${manifestPath}`);
+    }
+
+    return { sourceRoot: manifest.sourceRoot };
+  }
+
+  private async assertRestoreTargetIsClear(target: string): Promise<void> {
+    if (!(await this.exists(target))) {
+      return;
+    }
+
+    const entries = await fs.readdir(target);
+    if (entries.length > 0) {
+      throw new Error(
+        `Restore target is not empty: ${target}. Rerun with replaceExisting=true to overwrite.`
+      );
+    }
+  }
+
+  private async countRecursiveFiles(root: string): Promise<number> {
+    if (!(await this.exists(root))) {
+      return 0;
+    }
+
+    const entries = await fs.readdir(root, { withFileTypes: true });
+    let count = 0;
+    for (const entry of entries) {
+      const fullPath = path.join(root, entry.name);
+      if (entry.isDirectory()) {
+        count += await this.countRecursiveFiles(fullPath);
+      } else if (entry.isFile()) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  private async canOpenSqlite(sqlitePath: string): Promise<boolean> {
+    if (!(await this.exists(sqlitePath))) {
+      return false;
+    }
+
+    const database = new SqliteDatabase({ databasePath: sqlitePath, applyMigrations: false });
+    try {
+      database.open();
+      return true;
+    } catch {
+      return false;
+    } finally {
+      database.close();
+    }
+  }
+
+  private async validateTaskMigrationInputs(
+    paths: LegacyPaths,
+    tasks: ParsedTaskSet,
+    warnings: SqlitePortabilityWarning[]
+  ): Promise<void> {
+    const seen = new Map<string, SqlitePortabilityEntity>();
+    const groups: Array<{
+      entity: Extract<SqlitePortabilityEntity, `tasks.${string}`>;
+      tasks: Task[];
+    }> = [
+      { entity: 'tasks.active', tasks: tasks.active },
+      { entity: 'tasks.archived', tasks: tasks.archived },
+      { entity: 'tasks.backlog', tasks: tasks.backlog },
+    ];
+
+    for (const group of groups) {
+      for (const task of group.tasks) {
+        const previousEntity = seen.get(task.id);
+        if (previousEntity) {
+          warnings.push({
+            entity: group.entity,
+            source: task.id,
+            message: `Duplicate task id already seen in ${previousEntity}`,
+          });
+        } else {
+          seen.set(task.id, group.entity);
+        }
+
+        await this.validateTaskAttachments(paths.sourceRoot, group.entity, task, warnings);
+      }
+    }
+  }
+
+  private async validateTaskAttachments(
+    sourceRoot: string,
+    entity: Extract<SqlitePortabilityEntity, `tasks.${string}`>,
+    task: Task,
+    warnings: SqlitePortabilityWarning[]
+  ): Promise<void> {
+    for (const attachment of task.attachments ?? []) {
+      const storagePath =
+        typeof attachment.storagePath === 'string' && attachment.storagePath.trim()
+          ? attachment.storagePath
+          : path.join('tasks', 'attachments', task.id, attachment.filename);
+      const attachmentPath = path.isAbsolute(storagePath)
+        ? storagePath
+        : path.join(sourceRoot, storagePath);
+
+      if (!(await this.exists(attachmentPath))) {
+        warnings.push({
+          entity,
+          source: attachmentPath,
+          message: `Attachment file not found for task ${task.id}: ${attachment.filename}`,
+        });
+      }
+    }
   }
 
   private async readTasks(


### PR DESCRIPTION
## Summary

- adds migration journals, recovery-state reporting, and restore-from-pre-migration-backup service support
- exposes admin recovery and restore endpoints for SQLite migration rollback drills
- documents the v5 recovery contract, downgrade policy, and support bundle contents
- expands portability tests for completed journals, corrupt target failure recovery, rerun, restore, duplicate IDs, and missing attachment files

Closes #419.

## Verification

- `VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/vitest run server/src/__tests__/sqlite-portability-service.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm build`
- `pnpm lint:budget`
- `pnpm audit --prod --audit-level=high`
- `node_modules/.bin/prettier --check server/src/services/sqlite-portability-service.ts server/src/routes/sqlite-portability.ts server/src/__tests__/sqlite-portability-service.test.ts docs/API-REFERENCE.md docs/SQLITE-SCHEMA.md docs/MIGRATION-RECOVERY.md README.md`
- `git diff --check`

## Notes

- `pnpm audit --prod --audit-level=high` passes the high-severity gate and still reports 3 moderate existing vulnerabilities.
- `pnpm lint:budget` passed with 705 warnings under the 714 warning budget.