### PR TITLE
feat: add actor attribution and optimistic concurrency

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -122,23 +122,57 @@ All errors return a consistent JSON envelope:
 
 ### Status Codes
 
-| Code  | Meaning                                    |
-| ----- | ------------------------------------------ |
-| `200` | Success                                    |
-| `201` | Created                                    |
-| `400` | Bad request — invalid body, missing fields |
-| `401` | Not authenticated                          |
-| `403` | Forbidden — insufficient role              |
-| `404` | Resource not found                         |
-| `409` | Conflict — duplicate, state violation      |
-| `429` | Rate limited                               |
-| `503` | Service degraded (health checks)           |
+| Code  | Meaning                                               |
+| ----- | ----------------------------------------------------- |
+| `200` | Success                                               |
+| `201` | Created                                               |
+| `400` | Bad request — invalid body, missing fields            |
+| `401` | Not authenticated                                     |
+| `403` | Forbidden — insufficient role                         |
+| `404` | Resource not found                                    |
+| `409` | Conflict — duplicate, state violation, stale revision |
+| `429` | Rate limited                                          |
+| `503` | Service degraded (health checks)                      |
 
 ---
 
 ## Tasks
 
 All task routes are mounted at `/api/tasks`.
+
+### Task Revisions and Conflict Handling
+
+Task reads and writes include optimistic-concurrency metadata:
+
+- `GET /api/tasks/:id`, `POST /api/tasks`, and successful task mutations return
+  `ETag: "task:<taskId>:<revision>"`.
+- The same revision is also returned as `X-Resource-Revision`.
+- Clients that edit a loaded task should send `If-Match` with the last ETag, or
+  `X-Resource-Revision` with the last numeric revision.
+- Tasks include `revision`, `createdBy`, and `updatedBy`. Comments include
+  `revision`, `createdBy`, and `updatedBy` when created or edited through the
+  v5 routes.
+
+When the supplied revision is stale, the API returns `409 CONFLICT` and includes
+the latest resource so the client can reload or reapply the edit:
+
+```json
+{
+  "code": "CONFLICT",
+  "message": "task task_20260531_abcd has changed since it was loaded. Reload and retry with the latest revision.",
+  "details": {
+    "resourceType": "task",
+    "resourceId": "task_20260531_abcd",
+    "expectedRevision": 3,
+    "currentRevision": 4,
+    "current": {
+      "id": "task_20260531_abcd",
+      "title": "Latest task title",
+      "revision": 4
+    }
+  }
+}
+```
 
 ### List Tasks
 
@@ -207,6 +241,15 @@ PATCH /api/tasks/:id
 ```
 
 **Body**: Partial task fields to update (title, description, status, priority, assignee, etc.).
+
+**Headers**:
+
+```http
+If-Match: "task:task_20260531_abcd:3"
+```
+
+If the task has been updated since revision `3`, the API returns `409 CONFLICT`
+with the latest task in `details.current`.
 
 ### Delete Task
 
@@ -846,6 +889,11 @@ DELETE /api/tasks/:id/verification/:stepId
 ## Task Comments
 
 Comment threads on tasks — supports adding, editing, and deleting comments. Comments auto-sync to linked GitHub issues.
+
+Comment mutations use the parent task revision. Send the latest task `ETag` in
+`If-Match` when adding, editing, or deleting comments. A stale comment edit
+returns the same `409 CONFLICT` shape documented in [Tasks](#tasks), with the
+latest task and comments in `details.current`.
 
 Mounted at `/api/tasks`.
 

--- a/docs/API-WORKFLOWS.md
+++ b/docs/API-WORKFLOWS.md
@@ -161,6 +161,13 @@ curl http://localhost:3001/api/workflows/feature-dev
 - `404 Not Found` — Workflow not found
 - `403 Forbidden` — No view permission
 
+**Headers**:
+
+```http
+ETag: "workflow:feature-dev:2"
+X-Resource-Revision: 2
+```
+
 **Permissions**: Requires `view` permission.
 
 ---
@@ -242,6 +249,7 @@ Update an existing workflow (auto-increments version).
 ```bash
 curl -X PUT http://localhost:3001/api/workflows/hello-world \
   -H "Content-Type: application/json" \
+  -H 'If-Match: "workflow:hello-world:1"' \
   -d '{
     "id": "hello-world",
     "name": "Hello World Workflow v2",
@@ -296,14 +304,39 @@ curl -X PUT http://localhost:3001/api/workflows/hello-world \
 - `400 Bad Request` — Validation error or ID mismatch
 - `404 Not Found` — Workflow not found
 - `403 Forbidden` — No edit permission
+- `409 Conflict` — Workflow has changed since the supplied `If-Match` revision
 
 **Permissions**: Requires `edit` permission.
 
 **Notes**:
 
 - Version is auto-incremented (ignore `version` in request body)
+- Workflow `version` is also the optimistic-concurrency revision. Read the
+  workflow ETag, then send it back with `If-Match` on update.
+- Workflow definitions include `createdBy`, `updatedBy`, `createdAt`, and
+  `updatedAt` when saved through the API.
 - Active runs continue with their snapshotted version (no interruption)
 - Changes are logged to `.veritas-kanban/workflows/.audit.jsonl`
+
+**Conflict response**:
+
+```json
+{
+  "code": "CONFLICT",
+  "message": "workflow hello-world has changed since it was loaded. Reload and retry with the latest revision.",
+  "details": {
+    "resourceType": "workflow",
+    "resourceId": "hello-world",
+    "expectedRevision": 1,
+    "currentRevision": 2,
+    "current": {
+      "id": "hello-world",
+      "version": 2,
+      "description": "Latest workflow body"
+    }
+  }
+}
+```
 
 ---
 

--- a/server/src/__tests__/activity-service.test.ts
+++ b/server/src/__tests__/activity-service.test.ts
@@ -52,13 +52,17 @@ describe('ActivityService', () => {
         'task_created',
         'task_20260128_abc123',
         'New Feature',
-        { type: 'code', priority: 'high' }
+        { type: 'code', priority: 'high' },
+        'codex',
+        'agent:codex'
       );
 
       expect(activity.id).toMatch(/^activity_/);
       expect(activity.type).toBe('task_created');
       expect(activity.taskId).toBe('task_20260128_abc123');
       expect(activity.taskTitle).toBe('New Feature');
+      expect(activity.agent).toBe('codex');
+      expect(activity.actor).toBe('agent:codex');
       expect(activity.details).toEqual({ type: 'code', priority: 'high' });
       expect(activity.timestamp).toBeDefined();
     });

--- a/server/src/__tests__/routes/optimistic-concurrency.test.ts
+++ b/server/src/__tests__/routes/optimistic-concurrency.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import type { Task } from '@veritas-kanban/shared';
+import type { AuthenticatedRequest } from '../../middleware/auth.js';
+
+let app: express.Express;
+let testRoot: string;
+let disposeTaskService: (() => void) | undefined;
+let disposeWorkflowService: (() => void) | undefined;
+
+function unwrap<T>(body: unknown): T {
+  if (
+    body &&
+    typeof body === 'object' &&
+    (body as { success?: unknown }).success === true &&
+    'data' in body
+  ) {
+    return (body as { data: T }).data;
+  }
+  return body as T;
+}
+
+interface ApiErrorBody {
+  code: string;
+  message: string;
+  details?: {
+    resourceType?: string;
+    resourceId?: string;
+    expectedRevision?: number;
+    currentRevision?: number;
+    current?: Record<string, unknown>;
+  };
+}
+
+function unwrapError(body: unknown): ApiErrorBody {
+  if (
+    body &&
+    typeof body === 'object' &&
+    (body as { success?: unknown }).success === false &&
+    'error' in body
+  ) {
+    return (body as { error: ApiErrorBody }).error;
+  }
+  return body as ApiErrorBody;
+}
+
+function workflow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'route-concurrency',
+    name: 'Route Concurrency',
+    version: 1,
+    description: 'Initial workflow',
+    agents: [
+      {
+        id: 'agent-1',
+        name: 'Agent 1',
+        role: 'developer',
+        description: 'Handles implementation work',
+      },
+    ],
+    steps: [
+      {
+        id: 'step-1',
+        name: 'Implement',
+        type: 'agent',
+        agent: 'agent-1',
+        input: 'Do the work',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('route-level optimistic concurrency', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-concurrency-'));
+    process.env.VERITAS_DATA_DIR = testRoot;
+    process.env.DATA_DIR = testRoot;
+    process.env.VERITAS_DISABLE_WATCHERS = '1';
+    process.env.VERITAS_TASK_SYNC_FLAP_GUARD_MS = '0';
+
+    const [
+      { taskRoutes },
+      { taskCommentRoutes },
+      { workflowRoutes },
+      taskService,
+      workflowService,
+      { errorHandler },
+    ] = await Promise.all([
+      import('../../routes/tasks.js'),
+      import('../../routes/task-comments.js'),
+      import('../../routes/workflows.js'),
+      import('../../services/task-service.js'),
+      import('../../services/workflow-service.js'),
+      import('../../middleware/error-handler.js'),
+    ]);
+    disposeTaskService = taskService.disposeTaskService;
+    disposeWorkflowService = workflowService.disposeWorkflowService;
+
+    app = express();
+    app.use(express.json());
+    app.use((req: AuthenticatedRequest, _res, next) => {
+      req.auth = {
+        role: 'admin',
+        keyName: 'route-test-admin',
+        isLocalhost: false,
+        userId: 'route-test-user',
+        workspaceId: 'local',
+        actorType: 'user',
+        authMethod: 'session',
+        permissions: ['*'],
+      };
+      next();
+    });
+    app.use('/api/tasks', taskRoutes);
+    app.use('/api/tasks', taskCommentRoutes);
+    app.use('/api/workflows', workflowRoutes);
+    app.use(errorHandler);
+  });
+
+  afterEach(async () => {
+    disposeTaskService?.();
+    disposeWorkflowService?.();
+    delete process.env.VERITAS_DATA_DIR;
+    delete process.env.DATA_DIR;
+    delete process.env.VERITAS_DISABLE_WATCHERS;
+    delete process.env.VERITAS_TASK_SYNC_FLAP_GUARD_MS;
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('rejects stale task updates with current task metadata', async () => {
+    const createRes = await request(app).post('/api/tasks').send({
+      title: 'Concurrent task',
+      type: 'feature',
+      priority: 'high',
+    });
+    expect(createRes.status).toBe(201);
+    const created = unwrap<Task>(createRes.body);
+
+    const loaded = await request(app).get(`/api/tasks/${created.id}`);
+    const firstEtag = loaded.headers.etag as string;
+    expect(firstEtag).toBe(`"task:${created.id}:1"`);
+
+    const firstUpdate = await request(app)
+      .patch(`/api/tasks/${created.id}`)
+      .set('If-Match', firstEtag)
+      .send({ title: 'First client update' });
+    expect(firstUpdate.status).toBe(200);
+    const firstTask = unwrap<Task>(firstUpdate.body);
+    expect(firstTask.revision).toBe(2);
+    expect(firstTask.updatedBy).toBe('user:route-test-user');
+    expect(firstUpdate.headers['x-resource-revision']).toBe('2');
+
+    const staleUpdate = await request(app)
+      .patch(`/api/tasks/${created.id}`)
+      .set('If-Match', firstEtag)
+      .send({ title: 'Second client stale update' });
+    expect(staleUpdate.status).toBe(409);
+    const error = unwrapError(staleUpdate.body);
+    expect(error.code).toBe('CONFLICT');
+    expect(error.details).toMatchObject({
+      resourceType: 'task',
+      resourceId: created.id,
+      expectedRevision: 1,
+      currentRevision: 2,
+    });
+    expect(error.details?.current?.title).toBe('First client update');
+  });
+
+  it('rejects stale comment edits against the parent task revision', async () => {
+    const createRes = await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Comment race', type: 'feature', priority: 'medium' });
+    const task = unwrap<Task>(createRes.body);
+
+    const addRes = await request(app)
+      .post(`/api/tasks/${task.id}/comments`)
+      .set('If-Match', createRes.headers.etag as string)
+      .send({ author: 'Tester', text: 'Original comment' });
+    expect(addRes.status).toBe(201);
+    const withComment = unwrap<Task>(addRes.body);
+    const commentId = withComment.comments?.[0]?.id;
+    expect(commentId).toBeTruthy();
+
+    const loaded = await request(app).get(`/api/tasks/${task.id}`);
+    const editEtag = loaded.headers.etag as string;
+
+    const firstEdit = await request(app)
+      .patch(`/api/tasks/${task.id}/comments/${commentId}`)
+      .set('If-Match', editEtag)
+      .send({ text: 'First edit wins' });
+    expect(firstEdit.status).toBe(200);
+    expect(unwrap<Task>(firstEdit.body).comments?.[0]).toMatchObject({
+      text: 'First edit wins',
+      updatedBy: 'user:route-test-user',
+      revision: 2,
+    });
+
+    const staleEdit = await request(app)
+      .patch(`/api/tasks/${task.id}/comments/${commentId}`)
+      .set('If-Match', editEtag)
+      .send({ text: 'Second edit is stale' });
+    expect(staleEdit.status).toBe(409);
+    const error = unwrapError(staleEdit.body);
+    expect(error.details).toMatchObject({
+      resourceType: 'task',
+      resourceId: task.id,
+      expectedRevision: 2,
+      currentRevision: 3,
+    });
+    const currentComments = error.details?.current?.comments as Array<{ text: string }> | undefined;
+    expect(currentComments?.[0]?.text).toBe('First edit wins');
+  });
+
+  it('rejects stale workflow updates using workflow versions as revisions', async () => {
+    const initialWorkflow = workflow();
+    const createRes = await request(app).post('/api/workflows').send(initialWorkflow);
+    expect(createRes.status).toBe(201);
+
+    const loaded = await request(app).get('/api/workflows/route-concurrency');
+    const workflowEtag = loaded.headers.etag as string;
+    expect(workflowEtag).toBe('"workflow:route-concurrency:1"');
+
+    const firstUpdate = await request(app)
+      .put('/api/workflows/route-concurrency')
+      .set('If-Match', workflowEtag)
+      .send({ ...initialWorkflow, description: 'First workflow update' });
+    expect(firstUpdate.status).toBe(200);
+    expect(firstUpdate.body.version).toBe(2);
+    expect(firstUpdate.headers['x-resource-revision']).toBe('2');
+
+    const staleUpdate = await request(app)
+      .put('/api/workflows/route-concurrency')
+      .set('If-Match', workflowEtag)
+      .send({ ...initialWorkflow, description: 'Second stale workflow update' });
+    expect(staleUpdate.status).toBe(409);
+    const error = unwrapError(staleUpdate.body);
+    expect(error.details).toMatchObject({
+      resourceType: 'workflow',
+      resourceId: 'route-concurrency',
+      expectedRevision: 1,
+      currentRevision: 2,
+    });
+    expect(error.details?.current?.description).toBe('First workflow update');
+  });
+});

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -226,8 +226,9 @@ describe('Tasks Routes (actual module)', () => {
         'status_changed',
         't1',
         'Task',
-        expect.objectContaining({ from: 'todo', status: 'done' }),
-        updatedTask.agent
+        expect.objectContaining({ from: 'todo', status: 'done', actor: 'system:unknown' }),
+        updatedTask.agent,
+        'system:unknown'
       );
     });
 

--- a/server/src/config/swagger.ts
+++ b/server/src/config/swagger.ts
@@ -58,9 +58,16 @@ const options: swaggerJsdoc.Options = {
             sprint: { type: 'string', example: 'Sprint 3' },
             created: { type: 'string', format: 'date-time' },
             updated: { type: 'string', format: 'date-time' },
+            revision: { type: 'number', example: 3 },
+            createdBy: { type: 'string', example: 'user:local-user' },
+            updatedBy: { type: 'string', example: 'agent:planner' },
             subtasks: {
               type: 'array',
               items: { $ref: '#/components/schemas/Subtask' },
+            },
+            comments: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/Comment' },
             },
             blockedBy: {
               type: 'array',
@@ -144,6 +151,7 @@ const options: swaggerJsdoc.Options = {
             priority: { type: 'string', enum: ['low', 'medium', 'high'] },
             project: { type: 'string' },
             sprint: { type: 'string' },
+            expectedRevision: { type: 'number' },
             blockedBy: { type: 'array', items: { type: 'string' } },
             blockedReason: { $ref: '#/components/schemas/BlockedReason' },
             reviewScores: {
@@ -206,6 +214,19 @@ const options: swaggerJsdoc.Options = {
             line: { type: 'number' },
             content: { type: 'string' },
             created: { type: 'string', format: 'date-time' },
+          },
+        },
+        Comment: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            author: { type: 'string' },
+            text: { type: 'string' },
+            timestamp: { type: 'string', format: 'date-time' },
+            revision: { type: 'number' },
+            createdBy: { type: 'string' },
+            updatedBy: { type: 'string' },
+            updated: { type: 'string', format: 'date-time' },
           },
         },
         PaginatedResponse: {

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -29,8 +29,8 @@ export class ValidationError extends AppError {
 }
 
 export class ConflictError extends AppError {
-  constructor(message: string) {
-    super(409, message, 'CONFLICT');
+  constructor(message: string, details?: unknown) {
+    super(409, message, 'CONFLICT', details);
   }
 }
 

--- a/server/src/routes/task-comments.ts
+++ b/server/src/routes/task-comments.ts
@@ -8,6 +8,8 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { sanitizeCommentText, sanitizeAuthor } from '../utils/sanitize.js';
 import { broadcastTaskChange } from '../services/broadcast-service.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../utils/concurrency.js';
 
 const router: RouterType = Router();
 const taskService = getTaskService();
@@ -39,16 +41,27 @@ router.post(
     if (!task) {
       throw new NotFoundError('Task not found');
     }
+    assertFreshRevision(req, 'task', task.id, task);
+    const actor = actorFromRequest(req as AuthenticatedRequest);
 
     const comment = {
       id: `comment_${randomUUID()}`,
       author,
       text,
       timestamp: new Date().toISOString(),
+      revision: 1,
+      createdBy: actor,
+      updatedBy: actor,
     };
 
     const comments = [...(task.comments || []), comment];
-    const updatedTask = await taskService.updateTask(req.params.id as string, { comments });
+    const updatedTask = await taskService.updateTask(req.params.id as string, {
+      comments,
+      updatedBy: actor,
+    });
+    if (!updatedTask) {
+      throw new NotFoundError('Task not found');
+    }
 
     // Log activity
     await activityService.logActivity(
@@ -58,8 +71,10 @@ router.post(
       {
         author,
         preview: text.slice(0, 50) + (text.length > 50 ? '...' : ''),
+        actor,
       },
-      task.agent
+      task.agent,
+      actor
     );
 
     // Broadcast update to all connected WebSocket clients
@@ -74,6 +89,7 @@ router.post(
         });
     }
 
+    setRevisionHeaders(res, 'task', updatedTask.id, updatedTask);
     res.status(201).json(updatedTask);
   })
 );
@@ -98,8 +114,10 @@ router.patch(
     if (!task) {
       throw new NotFoundError('Task not found');
     }
+    assertFreshRevision(req, 'task', task.id, task);
+    const actor = actorFromRequest(req as AuthenticatedRequest);
 
-    const comments = task.comments || [];
+    const comments = [...(task.comments || [])];
     const commentIndex = comments.findIndex(
       (c: { id: string; author: string; text: string; timestamp: string }) =>
         c.id === (req.params.commentId as string)
@@ -112,13 +130,23 @@ router.patch(
       ...comments[commentIndex],
       text,
       timestamp: comments[commentIndex].timestamp, // preserve original timestamp
+      updated: new Date().toISOString(),
+      updatedBy: actor,
+      revision: (comments[commentIndex]?.revision ?? 1) + 1,
     };
 
-    const updatedTask = await taskService.updateTask(req.params.id as string, { comments });
+    const updatedTask = await taskService.updateTask(req.params.id as string, {
+      comments,
+      updatedBy: actor,
+    });
+    if (!updatedTask) {
+      throw new NotFoundError('Task not found');
+    }
 
     // Broadcast update to all connected WebSocket clients
     broadcastTaskChange('updated', req.params.id as string);
 
+    setRevisionHeaders(res, 'task', updatedTask.id, updatedTask);
     res.json(updatedTask);
   })
 );
@@ -131,6 +159,8 @@ router.delete(
     if (!task) {
       throw new NotFoundError('Task not found');
     }
+    assertFreshRevision(req, 'task', task.id, task);
+    const actor = actorFromRequest(req as AuthenticatedRequest);
 
     const comments = task.comments || [];
     const filtered = comments.filter(
@@ -143,7 +173,11 @@ router.delete(
 
     const updatedTask = await taskService.updateTask(req.params.id as string, {
       comments: filtered,
+      updatedBy: actor,
     });
+    if (!updatedTask) {
+      throw new NotFoundError('Task not found');
+    }
 
     await activityService.logActivity(
       'comment_deleted',
@@ -151,13 +185,16 @@ router.delete(
       task.title,
       {
         commentId: req.params.commentId as string,
+        actor,
       },
-      task.agent
+      task.agent,
+      actor
     );
 
     // Broadcast update to all connected WebSocket clients
     broadcastTaskChange('updated', task.id);
 
+    setRevisionHeaders(res, 'task', updatedTask.id, updatedTask);
     res.json(updatedTask);
   })
 );

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -7,7 +7,7 @@ import { getBlockingService } from '../services/blocking-service.js';
 import { getGitHubSyncService } from '../services/github-sync-service.js';
 import { getDelegationService } from '../services/delegation-service.js';
 import { getProgressService } from '../services/progress-service.js';
-import type { CreateTaskInput, UpdateTaskInput, Task, TaskSummary } from '@veritas-kanban/shared';
+import type { CreateTaskInput, UpdateTaskInput, TaskSummary } from '@veritas-kanban/shared';
 import { broadcastTaskChange } from '../services/broadcast-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
@@ -16,6 +16,7 @@ import { setLastModified } from '../middleware/cache-control.js';
 import { sanitizeTaskFields } from '../utils/sanitize.js';
 import { auditLog } from '../services/audit-service.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../utils/concurrency.js';
 
 const router: RouterType = Router();
 const taskService = getTaskService();
@@ -151,6 +152,7 @@ const updateTaskSchema = z.object({
   plan: z.string().optional(),
   automation: automationSchema,
   position: z.number().optional(),
+  expectedRevision: z.number().int().min(0).optional(),
 });
 
 // Progress schemas
@@ -500,6 +502,7 @@ router.get(
       throw new NotFoundError('Task not found');
     }
     setLastModified(res, task.updated || task.created);
+    setRevisionHeaders(res, 'task', task.id, task);
     res.json(task);
   })
 );
@@ -560,6 +563,9 @@ router.post(
     }
     // Sanitize user-provided text fields to prevent stored XSS
     sanitizeTaskFields(input);
+    const authReq = req as AuthenticatedRequest;
+    const actor = actorFromRequest(authReq);
+    input = { ...input, createdBy: actor, updatedBy: actor };
     const task = await taskService.createTask(input);
     broadcastTaskChange('created', task.id);
 
@@ -572,19 +578,21 @@ router.post(
         type: task.type,
         priority: task.priority,
         project: task.project,
+        actor,
       },
-      task.agent
+      task.agent,
+      actor
     );
 
     // Audit log
-    const authReq = req as AuthenticatedRequest;
     await auditLog({
       action: 'task.create',
-      actor: authReq.auth?.keyName || 'unknown',
+      actor,
       resource: task.id,
       details: { title: task.title, type: task.type, priority: task.priority },
     });
 
+    setRevisionHeaders(res, 'task', task.id, task);
     res.status(201).json(task);
   })
 );
@@ -650,11 +658,15 @@ router.patch(
     if (!oldTask) {
       throw new NotFoundError('Task not found');
     }
+    assertFreshRevision(req, 'task', oldTask.id, oldTask);
+
+    const authReq = req as AuthenticatedRequest;
+    const actor = actorFromRequest(authReq);
+    input = { ...input, updatedBy: actor };
 
     // Check delegation if moving to 'done'
     if (input.status === 'done' && oldTask.status !== 'done') {
-      const authReq = req as AuthenticatedRequest;
-      const agentName = authReq.auth?.keyName || 'unknown';
+      const agentName = authReq.auth?.keyName || actor;
 
       const delegationCheck = await delegationService.canApprove(agentName, {
         id: oldTask.id,
@@ -681,8 +693,10 @@ router.patch(
             status: 'done',
             delegated: true,
             delegateAgent: agentName,
+            actor,
           },
-          agentName
+          agentName,
+          actor
         );
       }
       // If delegation check fails, no special handling — the request proceeds normally
@@ -723,8 +737,10 @@ router.patch(
         {
           from: oldTask.status,
           status: input.status,
+          actor,
         },
-        task.agent
+        task.agent,
+        actor
       );
 
       // Outbound sync: push status change to linked GitHub issue (fire-and-forget)
@@ -736,9 +752,17 @@ router.patch(
           });
       }
     } else {
-      await activityService.logActivity('task_updated', task.id, task.title, undefined, task.agent);
+      await activityService.logActivity(
+        'task_updated',
+        task.id,
+        task.title,
+        { actor },
+        task.agent,
+        actor
+      );
     }
 
+    setRevisionHeaders(res, 'task', task.id, task);
     res.json(task);
   })
 );
@@ -778,14 +802,24 @@ router.delete(
 
     // Log activity
     if (task) {
-      await activityService.logActivity('task_deleted', task.id, task.title, undefined, task.agent);
+      const authReqDel = req as AuthenticatedRequest;
+      const actor = actorFromRequest(authReqDel);
+      await activityService.logActivity(
+        'task_deleted',
+        task.id,
+        task.title,
+        { actor },
+        task.agent,
+        actor
+      );
     }
 
     // Audit log
     const authReqDel = req as AuthenticatedRequest;
+    const actor = actorFromRequest(authReqDel);
     await auditLog({
       action: 'task.delete',
-      actor: authReqDel.auth?.keyName || 'unknown',
+      actor,
       resource: req.params.id as string,
       details: task ? { title: task.title } : undefined,
     });

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -13,6 +13,7 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { NotFoundError, ValidationError, BadRequestError } from '../middleware/error-handler.js';
 import { checkWorkflowPermission, assertWorkflowPermission } from '../middleware/workflow-auth.js';
 import { diffWorkflows } from '../utils/workflow-diff.js';
+import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../utils/concurrency.js';
 
 const router = Router();
 const workflowService = getWorkflowService();
@@ -50,6 +51,10 @@ const workflowCreateSchema = z.object({
   steps: z.array(z.unknown()).min(1).max(50),
   variables: z.record(z.string(), z.unknown()).optional(),
   schemas: z.record(z.string(), z.unknown()).optional(),
+  createdBy: z.string().optional(),
+  updatedBy: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
 });
 
 // ==================== Workflow CRUD Routes ====================
@@ -97,6 +102,7 @@ router.get(
     // Check view permission
     await assertWorkflowPermission(workflowId, userId, 'view');
 
+    setRevisionHeaders(res, 'workflow', workflow.id, workflow.version);
     res.json(workflow);
   })
 );
@@ -108,9 +114,15 @@ router.post(
   '/',
   asyncHandler(async (req: AuthenticatedRequest, res) => {
     const userId = getUserId(req);
+    const actor = actorFromRequest(req);
+    const now = new Date().toISOString();
 
     // Validate input
     const workflow = workflowCreateSchema.parse(req.body) as WorkflowDefinition;
+    workflow.createdBy = workflow.createdBy ?? actor;
+    workflow.updatedBy = actor;
+    workflow.createdAt = workflow.createdAt ?? now;
+    workflow.updatedAt = now;
 
     // Save workflow
     await workflowService.saveWorkflow(workflow);
@@ -135,6 +147,7 @@ router.post(
       workflowVersion: workflow.version,
     });
 
+    setRevisionHeaders(res, 'workflow', workflow.id, workflow.version);
     res.status(201).json({ success: true, workflowId: workflow.id });
   })
 );
@@ -147,6 +160,8 @@ router.put(
   asyncHandler(async (req: AuthenticatedRequest, res) => {
     const urlWorkflowId = getStringParam(req.params.id);
     const userId = getUserId(req);
+    const actor = actorFromRequest(req);
+    const now = new Date().toISOString();
 
     // Validate input
     const workflow = workflowCreateSchema.parse(req.body) as WorkflowDefinition;
@@ -163,7 +178,16 @@ router.put(
 
     // Load previous version for versioning and change tracking
     const previousVersion = await workflowService.loadWorkflow(workflow.id);
+    if (!previousVersion) {
+      throw new NotFoundError(`Workflow ${workflow.id} not found`);
+    }
+    assertFreshRevision(req, 'workflow', workflow.id, previousVersion, previousVersion);
+
     workflow.version = (previousVersion?.version || 0) + 1;
+    workflow.createdBy = previousVersion.createdBy;
+    workflow.createdAt = previousVersion.createdAt;
+    workflow.updatedBy = actor;
+    workflow.updatedAt = now;
 
     // Save workflow
     await workflowService.saveWorkflow(workflow);
@@ -178,6 +202,7 @@ router.put(
       changes: diffWorkflows(previousVersion, workflow),
     });
 
+    setRevisionHeaders(res, 'workflow', workflow.id, workflow.version);
     res.json({ success: true, version: workflow.version });
   })
 );

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -43,6 +43,7 @@ export interface Activity {
   taskId: string;
   taskTitle: string;
   agent?: string;
+  actor?: string;
   details?: Record<string, unknown>;
   timestamp: string;
 }
@@ -181,10 +182,11 @@ export class ActivityService {
     taskId: string,
     taskTitle: string,
     details?: Record<string, unknown>,
-    agent?: string
+    agent?: string,
+    actor?: string
   ): Promise<Activity> {
     if (this.repository) {
-      return this.repository.logActivity(type, taskId, taskTitle, details, agent);
+      return this.repository.logActivity(type, taskId, taskTitle, details, agent, actor);
     }
 
     await this.ensureDir();
@@ -195,6 +197,7 @@ export class ActivityService {
       taskId,
       taskTitle,
       ...(agent && { agent }),
+      ...(actor && { actor }),
       details,
       timestamp: new Date().toISOString(),
     };

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -618,6 +618,9 @@ export class TaskService {
       blockedBy: input.blockedBy, // Include dependencies from blueprint
       created: now,
       updated: now,
+      revision: 1,
+      createdBy: input.createdBy,
+      updatedBy: input.updatedBy ?? input.createdBy,
     };
 
     // Validate agent ref against registry (#157)
@@ -680,6 +683,7 @@ export class TaskService {
       git: gitUpdate,
       github: githubUpdate,
       blockedReason: blockedReasonUpdate,
+      expectedRevision: _expectedRevision,
       ...restInput
     } = input;
 
@@ -870,6 +874,7 @@ export class TaskService {
           : checkpointUpdate !== undefined
             ? checkpointUpdate
             : freshTask.checkpoint,
+        revision: (typeof freshTask.revision === 'number' ? freshTask.revision : 1) + 1,
         updated: new Date().toISOString(),
       };
 

--- a/server/src/services/workflow-service.ts
+++ b/server/src/services/workflow-service.ts
@@ -468,3 +468,11 @@ export function getWorkflowService(): WorkflowService {
   }
   return workflowServiceInstance;
 }
+
+/** Dispose and reset the singleton (useful for tests and shutdown). */
+export function disposeWorkflowService(): void {
+  if (workflowServiceInstance) {
+    workflowServiceInstance.dispose();
+    workflowServiceInstance = null;
+  }
+}

--- a/server/src/storage/file-storage.ts
+++ b/server/src/storage/file-storage.ts
@@ -165,9 +165,10 @@ export class FileActivityRepository implements ActivityRepository {
     taskId: string,
     taskTitle: string,
     details?: Record<string, unknown>,
-    agent?: string
+    agent?: string,
+    actor?: string
   ): Promise<Activity> {
-    return this.service.logActivity(type, taskId, taskTitle, details, agent);
+    return this.service.logActivity(type, taskId, taskTitle, details, agent, actor);
   }
 
   async clearActivities(): Promise<void> {

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -86,7 +86,8 @@ export interface ActivityRepository {
     taskId: string,
     taskTitle: string,
     details?: Record<string, unknown>,
-    agent?: string
+    agent?: string,
+    actor?: string
   ): Promise<Activity>;
 
   /** Delete all activity entries. */

--- a/server/src/storage/sqlite/activity-repository.ts
+++ b/server/src/storage/sqlite/activity-repository.ts
@@ -34,7 +34,8 @@ export class SqliteActivityRepository implements ActivityRepository {
     taskId: string,
     taskTitle: string,
     details?: Record<string, unknown>,
-    agent?: string
+    agent?: string,
+    actor?: string
   ): Promise<Activity> {
     const activity: Activity = {
       id: `activity_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
@@ -42,6 +43,7 @@ export class SqliteActivityRepository implements ActivityRepository {
       taskId,
       taskTitle,
       ...(agent && { agent }),
+      ...(actor && { actor }),
       details,
       timestamp: new Date().toISOString(),
     };

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -17,6 +17,10 @@ export interface WorkflowDefinition {
   steps: WorkflowStep[];
   variables?: Record<string, unknown>;
   schemas?: Record<string, unknown>;
+  createdBy?: string;
+  updatedBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface WorkflowConfig {

--- a/server/src/utils/concurrency.ts
+++ b/server/src/utils/concurrency.ts
@@ -1,0 +1,133 @@
+import type { Request, Response } from 'express';
+import { ConflictError } from '../middleware/error-handler.js';
+import type { AuthContext, AuthenticatedRequest } from '../middleware/auth.js';
+
+export interface RevisionedResource {
+  revision?: number;
+  version?: number;
+}
+
+export interface RevisionConflictDetails {
+  resourceType: string;
+  resourceId: string;
+  expectedRevision: number;
+  currentRevision: number;
+  current: unknown;
+}
+
+function parseRevisionValue(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '*') {
+    return undefined;
+  }
+
+  const normalized = trimmed.replace(/^W\//, '').replace(/^"|"$/g, '');
+  const direct = Number.parseInt(normalized, 10);
+  if (/^\d+$/.test(normalized) && Number.isInteger(direct)) {
+    return direct;
+  }
+
+  const revisionSegment = normalized.match(/:(\d+)$/);
+  if (!revisionSegment?.[1]) {
+    return undefined;
+  }
+
+  const revision = Number.parseInt(revisionSegment[1], 10);
+  return Number.isInteger(revision) ? revision : undefined;
+}
+
+export function actorFromRequest(req: AuthenticatedRequest): string {
+  const auth: AuthContext | undefined = req.auth;
+  if (!auth) {
+    return 'system:unknown';
+  }
+
+  const actorType = auth.actorType ?? (auth.role === 'agent' ? 'agent' : 'service');
+  const actorId =
+    actorType === 'user'
+      ? auth.userId || auth.keyName || auth.tokenName
+      : actorType === 'localhost-bypass'
+        ? auth.keyName || auth.userId || 'localhost'
+        : auth.tokenName || auth.keyName || auth.userId;
+
+  return `${actorType}:${actorId || 'unknown'}`;
+}
+
+export function resourceRevision(resource: RevisionedResource | null | undefined): number {
+  const revision = resource?.revision ?? resource?.version;
+  return typeof revision === 'number' && Number.isInteger(revision) && revision >= 0 ? revision : 1;
+}
+
+export function revisionEtag(resourceType: string, resourceId: string, revision: number): string {
+  return `"${resourceType}:${resourceId}:${revision}"`;
+}
+
+export function setRevisionHeaders(
+  res: Response,
+  resourceType: string,
+  resourceId: string,
+  resource: RevisionedResource | number
+): void {
+  const revision = typeof resource === 'number' ? resource : resourceRevision(resource);
+  res.setHeader('ETag', revisionEtag(resourceType, resourceId, revision));
+  res.setHeader('X-Resource-Revision', String(revision));
+}
+
+export function expectedRevisionFromRequest(req: Request): number | undefined {
+  const ifMatch = req.header('if-match');
+  if (ifMatch) {
+    for (const candidate of ifMatch.split(',')) {
+      const revision = parseRevisionValue(candidate);
+      if (revision !== undefined) {
+        return revision;
+      }
+    }
+  }
+
+  const headerRevision = parseRevisionValue(req.header('x-resource-revision'));
+  if (headerRevision !== undefined) {
+    return headerRevision;
+  }
+
+  const body = req.body as Record<string, unknown> | undefined;
+  return parseRevisionValue(body?.expectedRevision);
+}
+
+export function assertFreshRevision(
+  req: Request,
+  resourceType: string,
+  resourceId: string,
+  current: RevisionedResource,
+  currentPayload: unknown = current
+): void {
+  const expectedRevision = expectedRevisionFromRequest(req);
+  if (expectedRevision === undefined) {
+    return;
+  }
+
+  const currentRevision = resourceRevision(current);
+  if (expectedRevision === currentRevision) {
+    return;
+  }
+
+  const details: RevisionConflictDetails = {
+    resourceType,
+    resourceId,
+    expectedRevision,
+    currentRevision,
+    current: currentPayload,
+  };
+
+  throw new ConflictError(
+    `${resourceType} ${resourceId} has changed since it was loaded. Reload and retry with the latest revision.`,
+    details
+  );
+}

--- a/shared/src/types/task.types.d.ts
+++ b/shared/src/types/task.types.d.ts
@@ -65,6 +65,10 @@ export interface Comment {
   author: string;
   text: string;
   timestamp: string;
+  revision?: number;
+  createdBy?: string;
+  updatedBy?: string;
+  updated?: string;
 }
 export type AttachmentValidationStatus = 'valid' | 'invalid' | 'skipped' | 'unknown';
 export type AttachmentRetentionStatus = 'active' | 'archived' | 'deleted' | 'expired';
@@ -131,6 +135,9 @@ export interface Task {
   sprint?: string;
   created: string;
   updated: string;
+  revision?: number;
+  createdBy?: string;
+  updatedBy?: string;
   agent?: AgentType | 'auto';
   agents?: AgentType[];
   git?: TaskGit;
@@ -194,6 +201,8 @@ export interface CreateTaskInput {
   priority?: TaskPriority;
   project?: string;
   sprint?: string;
+  createdBy?: string;
+  updatedBy?: string;
   agent?: AgentType | 'auto';
   agents?: AgentType[];
   subtasks?: Subtask[];
@@ -207,6 +216,8 @@ export interface UpdateTaskInput {
   priority?: TaskPriority;
   project?: string;
   sprint?: string;
+  expectedRevision?: number;
+  updatedBy?: string;
   agent?: AgentType | 'auto';
   agents?: AgentType[];
   git?: Partial<TaskGit>;

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -91,6 +91,10 @@ export interface Comment {
   author: string;
   text: string;
   timestamp: string;
+  revision?: number;
+  createdBy?: string;
+  updatedBy?: string;
+  updated?: string;
 }
 
 export type ObservationType = 'decision' | 'blocker' | 'insight' | 'context';
@@ -212,6 +216,9 @@ export interface Task {
   sprint?: string;
   created: string;
   updated: string;
+  revision?: number;
+  createdBy?: string;
+  updatedBy?: string;
 
   // Agent assignment — "auto" uses routing engine, or a specific agent slug
   agent?: AgentType | 'auto';
@@ -344,6 +351,8 @@ export interface CreateTaskInput {
   priority?: TaskPriority;
   project?: string;
   sprint?: string;
+  createdBy?: string;
+  updatedBy?: string;
   agent?: AgentType | 'auto'; // Pre-assign an agent (or "auto" for routing engine)
   agents?: AgentType[]; // Multi-agent assignment
   subtasks?: Subtask[]; // Can be provided when creating from a template
@@ -360,6 +369,8 @@ export interface UpdateTaskInput {
   priority?: TaskPriority;
   project?: string;
   sprint?: string;
+  expectedRevision?: number;
+  updatedBy?: string;
   agent?: AgentType | 'auto';
   agents?: AgentType[];
   git?: Partial<TaskGit>;

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -15,6 +15,10 @@ export interface WorkflowDefinition {
   steps: WorkflowStep[];
   variables?: Record<string, unknown>;
   schemas?: Record<string, unknown>;
+  createdBy?: string;
+  updatedBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface WorkflowConfig {

--- a/web/src/__tests__/api-helpers.test.ts
+++ b/web/src/__tests__/api-helpers.test.ts
@@ -83,6 +83,24 @@ describe('handleResponse', () => {
     await expect(handleResponse(jsonResponse(body, 500))).rejects.toThrow('Internal Server Error');
   });
 
+  it('preserves code and details for non-envelope errors', async () => {
+    const body = {
+      code: 'CONFLICT',
+      message: 'Task changed',
+      details: { currentRevision: 4 },
+    };
+
+    try {
+      await handleResponse(jsonResponse(body, 409));
+      expect.fail('Should have thrown');
+    } catch (err: unknown) {
+      const e = err as Error & { code?: string; details?: unknown };
+      expect(e.message).toBe('Task changed');
+      expect(e.code).toBe('CONFLICT');
+      expect(e.details).toEqual({ currentRevision: 4 });
+    }
+  });
+
   it('uses HTTP status for non-ok non-envelope response without error string', async () => {
     const body = { some: 'data' };
     await expect(handleResponse(jsonResponse(body, 502))).rejects.toThrow('HTTP 502');

--- a/web/src/__tests__/api-tasks.test.ts
+++ b/web/src/__tests__/api-tasks.test.ts
@@ -113,6 +113,40 @@ describe('tasksApi', () => {
     expect(result.status).toBe('done');
   });
 
+  it('update() sends If-Match and strips expectedRevision from the JSON body', async () => {
+    const updated = createMockTask({ id: 'u1', title: 'Updated' });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => envelope(updated),
+    } as Response);
+
+    await tasksApi.update('u1', { title: 'Updated', expectedRevision: 7 });
+    expect(fetch).toHaveBeenCalledWith('http://test-api/tasks/u1', {
+      credentials: 'include',
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'If-Match': '"task:u1:7"' },
+      body: JSON.stringify({ title: 'Updated' }),
+    });
+  });
+
+  it('addComment() sends the parent task revision when provided', async () => {
+    const updated = createMockTask({ id: 'task-1' });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => envelope(updated),
+    } as Response);
+
+    await tasksApi.addComment('task-1', 'Tester', 'Comment body', 3);
+    expect(fetch).toHaveBeenCalledWith('http://test-api/tasks/task-1/comments', {
+      credentials: 'include',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'If-Match': '"task:task-1:3"' },
+      body: JSON.stringify({ author: 'Tester', text: 'Comment body' }),
+    });
+  });
+
   it('delete() calls DELETE /tasks/:id', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,

--- a/web/src/hooks/useDebouncedSave.ts
+++ b/web/src/hooks/useDebouncedSave.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useUpdateTask } from './useTasks';
+import { isRevisionConflict, useUpdateTask } from './useTasks';
 import { useToast } from '@/hooks/useToast';
 import { useFeatureSetting } from '@/hooks/useFeatureSettings';
 import type { Task } from '@veritas-kanban/shared';
@@ -73,10 +73,16 @@ export function useDebouncedSave(task: Task | null) {
             });
           },
           onError: (error) => {
+            if (isRevisionConflict(error)) {
+              return;
+            }
             toastRef.current({
               variant: 'destructive',
               title: 'Failed to save changes',
-              description: error instanceof Error ? error.message : 'Please try again',
+              description:
+                typeof (error as { message?: unknown }).message === 'string'
+                  ? (error as { message: string }).message
+                  : 'Please try again',
             });
           },
         }

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -23,6 +23,67 @@ function patchTaskInCaches(queryClient: QueryClient, task: Task): void {
   queryClient.setQueryData(['tasks', task.id], task);
 }
 
+type ApiMutationError = Error & { code?: string; details?: unknown };
+
+function cachedTaskRevision(queryClient: QueryClient, taskId: string): number | undefined {
+  const detailTask = queryClient.getQueryData<Task>(['tasks', taskId]);
+  if (typeof detailTask?.revision === 'number') {
+    return detailTask.revision;
+  }
+
+  const listTask = queryClient.getQueryData<Task[]>(['tasks'])?.find((task) => task.id === taskId);
+  return typeof listTask?.revision === 'number' ? listTask.revision : undefined;
+}
+
+function conflictCurrentTask(error: ApiMutationError): Task | undefined {
+  const details = error.details as { current?: unknown } | undefined;
+  const current = details?.current;
+  if (
+    current &&
+    typeof current === 'object' &&
+    'id' in current &&
+    typeof (current as { id?: unknown }).id === 'string'
+  ) {
+    return current as Task;
+  }
+  return undefined;
+}
+
+export function isRevisionConflict(error: unknown): error is ApiMutationError {
+  return (
+    error instanceof Error &&
+    (error as ApiMutationError).code === 'CONFLICT' &&
+    typeof (error as ApiMutationError).details === 'object'
+  );
+}
+
+function handleRevisionConflict(
+  queryClient: QueryClient,
+  error: ApiMutationError,
+  taskId: string
+): boolean {
+  if (!isRevisionConflict(error)) {
+    return false;
+  }
+
+  const current = conflictCurrentTask(error);
+  if (current) {
+    patchTaskInCaches(queryClient, current);
+  }
+
+  queryClient.invalidateQueries({ queryKey: ['tasks'] });
+  queryClient.invalidateQueries({ queryKey: ['tasks', taskId] });
+
+  toast({
+    title: 'Task changed elsewhere',
+    description: 'Loaded the latest task. Review your edit and save again.',
+    variant: 'destructive',
+    duration: 10000,
+  });
+
+  return true;
+}
+
 /**
  * Polling intervals based on WebSocket connection state.
  * - Connected: 60s safety-net polling (WS delivers real-time updates)
@@ -112,7 +173,7 @@ export function useUpdateTask() {
 
   return useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateTaskInput }) =>
-      api.tasks.update(id, input),
+      api.tasks.update(id, input, cachedTaskRevision(queryClient, id)),
     // On success, merge the server response with the current cache.
     // Preserve timeTracking from the cache if it wasn't part of this update,
     // since concurrent timer mutations (start/stop) may have already patched
@@ -145,7 +206,11 @@ export function useUpdateTask() {
       }
     },
     // Handle validation errors with detailed toast messages
-    onError: (error: Error & { code?: string; details?: unknown }) => {
+    onError: (error: Error & { code?: string; details?: unknown }, { id }) => {
+      if (handleRevisionConflict(queryClient, error, id)) {
+        return;
+      }
+
       // Extract enforcement gate error details
       const details = error.details as
         | Array<{ code: string; message: string; path: string[] }>
@@ -483,9 +548,12 @@ export function useAddComment() {
 
   return useMutation({
     mutationFn: ({ taskId, author, text }: { taskId: string; author: string; text: string }) =>
-      api.tasks.addComment(taskId, author, text),
+      api.tasks.addComment(taskId, author, text, cachedTaskRevision(queryClient, taskId)),
     onSuccess: (task) => {
       patchTaskInCaches(queryClient, task);
+    },
+    onError: (error, { taskId }) => {
+      handleRevisionConflict(queryClient, error as ApiMutationError, taskId);
     },
   });
 }
@@ -502,9 +570,12 @@ export function useEditComment() {
       taskId: string;
       commentId: string;
       text: string;
-    }) => api.tasks.editComment(taskId, commentId, text),
+    }) => api.tasks.editComment(taskId, commentId, text, cachedTaskRevision(queryClient, taskId)),
     onSuccess: (task) => {
       patchTaskInCaches(queryClient, task);
+    },
+    onError: (error, { taskId }) => {
+      handleRevisionConflict(queryClient, error as ApiMutationError, taskId);
     },
   });
 }
@@ -514,9 +585,12 @@ export function useDeleteComment() {
 
   return useMutation({
     mutationFn: ({ taskId, commentId }: { taskId: string; commentId: string }) =>
-      api.tasks.deleteComment(taskId, commentId),
+      api.tasks.deleteComment(taskId, commentId, cachedTaskRevision(queryClient, taskId)),
     onSuccess: (task) => {
       patchTaskInCaches(queryClient, task);
+    },
+    onError: (error, { taskId }) => {
+      handleRevisionConflict(queryClient, error as ApiMutationError, taskId);
     },
   });
 }

--- a/web/src/lib/api/helpers.ts
+++ b/web/src/lib/api/helpers.ts
@@ -59,10 +59,18 @@ export async function handleResponse<T>(response: Response): Promise<T> {
   // Non-envelope response (e.g., legacy or non-API endpoint)
   if (!response.ok) {
     const errBody = body as Record<string, unknown> | null;
-    throw new Error(
+    const err = new Error(
       (errBody && typeof errBody.error === 'string' ? errBody.error : null) ||
+        (errBody && typeof errBody.message === 'string' ? errBody.message : null) ||
         `HTTP ${response.status}`
-    );
+    ) as Error & { code?: string; details?: unknown };
+    if (errBody && typeof errBody.code === 'string') {
+      err.code = errBody.code;
+    }
+    if (errBody && 'details' in errBody) {
+      err.details = errBody.details;
+    }
+    throw err;
   }
 
   return body as T;

--- a/web/src/lib/api/tasks.ts
+++ b/web/src/lib/api/tasks.ts
@@ -30,12 +30,17 @@ export const tasksApi = {
     return handleResponse<Task>(response);
   },
 
-  update: async (id: string, input: UpdateTaskInput): Promise<Task> => {
+  update: async (id: string, input: UpdateTaskInput, expectedRevision?: number): Promise<Task> => {
+    const { expectedRevision: bodyExpectedRevision, ...body } = input;
+    const revision = expectedRevision ?? bodyExpectedRevision;
     const response = await fetch(`${API_BASE}/tasks/${id}`, {
       credentials: 'include',
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(input),
+      headers: {
+        'Content-Type': 'application/json',
+        ...(typeof revision === 'number' ? { 'If-Match': `"task:${id}:${revision}"` } : {}),
+      },
+      body: JSON.stringify(body),
     });
     return handleResponse<Task>(response);
   },
@@ -170,30 +175,58 @@ export const tasksApi = {
     return handleResponse<Task>(response);
   },
 
-  addComment: async (taskId: string, author: string, text: string): Promise<Task> => {
+  addComment: async (
+    taskId: string,
+    author: string,
+    text: string,
+    expectedRevision?: number
+  ): Promise<Task> => {
     const response = await fetch(`${API_BASE}/tasks/${taskId}/comments`, {
       credentials: 'include',
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(typeof expectedRevision === 'number'
+          ? { 'If-Match': `"task:${taskId}:${expectedRevision}"` }
+          : {}),
+      },
       body: JSON.stringify({ author, text }),
     });
     return handleResponse<Task>(response);
   },
 
-  editComment: async (taskId: string, commentId: string, text: string): Promise<Task> => {
+  editComment: async (
+    taskId: string,
+    commentId: string,
+    text: string,
+    expectedRevision?: number
+  ): Promise<Task> => {
     const response = await fetch(`${API_BASE}/tasks/${taskId}/comments/${commentId}`, {
       credentials: 'include',
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(typeof expectedRevision === 'number'
+          ? { 'If-Match': `"task:${taskId}:${expectedRevision}"` }
+          : {}),
+      },
       body: JSON.stringify({ text }),
     });
     return handleResponse<Task>(response);
   },
 
-  deleteComment: async (taskId: string, commentId: string): Promise<Task> => {
+  deleteComment: async (
+    taskId: string,
+    commentId: string,
+    expectedRevision?: number
+  ): Promise<Task> => {
     const response = await fetch(`${API_BASE}/tasks/${taskId}/comments/${commentId}`, {
       credentials: 'include',
       method: 'DELETE',
+      headers:
+        typeof expectedRevision === 'number'
+          ? { 'If-Match': `"task:${taskId}:${expectedRevision}"` }
+          : undefined,
     });
     return handleResponse<Task>(response);
   },


### PR DESCRIPTION
## Summary

- adds revision metadata and actor attribution for task, comment, activity, and workflow mutations
- returns ETag and X-Resource-Revision metadata for task and workflow reads/writes
- rejects stale task, comment, and workflow writes with a structured 409 conflict payload containing the current resource
- wires the web task/comment mutation path to send cached revisions and reload on conflicts
- documents the task/comment/workflow conflict contract in the API docs and Swagger schema

Closes #337.

## Verification

- `VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/vitest run server/src/__tests__/routes/optimistic-concurrency.test.ts server/src/__tests__/activity-service.test.ts`
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/api-tasks.test.ts src/__tests__/api-helpers.test.ts src/__tests__/useTasks-patchCache.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm build`
- `pnpm lint:budget`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`

## Notes

- `pnpm lint:budget` passes with the existing warning budget at 704 warnings.
- `pnpm audit --prod --audit-level=high` passes the high-severity gate; the existing 3 moderate findings remain.