### PR TITLE
feat: add multi-user workspace UX

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { TaskConfigProvider } from './contexts/TaskConfigContext';
 import { WebSocketStatusProvider } from './contexts/WebSocketContext';
 import { ViewProvider, useView } from './contexts/ViewContext';
 import { AuthProvider } from './hooks/useAuth';
+import { IdentityProvider } from './hooks/useIdentity';
 import { AuthGuard } from './components/auth';
 import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import { SkipToContent } from './components/shared/SkipToContent';
@@ -179,19 +180,21 @@ function AppContent() {
           <BulkActionsProvider>
             <TaskConfigProvider>
               <ViewProvider>
-                <div className="min-h-screen bg-background">
-                  <SkipToContent />
-                  <Header />
-                  <SystemHealthBar />
-                  <main id="main-content" className="mx-auto px-14 py-6" tabIndex={-1}>
-                    <ErrorBoundary level="section">
-                      <MainContent />
-                    </ErrorBoundary>
-                  </main>
-                  <Toaster />
-                  <CommandPalette />
-                  <FloatingChat />
-                </div>
+                <IdentityProvider>
+                  <div className="min-h-screen bg-background">
+                    <SkipToContent />
+                    <Header />
+                    <SystemHealthBar />
+                    <main id="main-content" className="mx-auto px-14 py-6" tabIndex={-1}>
+                      <ErrorBoundary level="section">
+                        <MainContent />
+                      </ErrorBoundary>
+                    </main>
+                    <Toaster />
+                    <CommandPalette />
+                    <FloatingChat />
+                  </div>
+                </IdentityProvider>
               </ViewProvider>
             </TaskConfigProvider>
           </BulkActionsProvider>

--- a/web/src/__tests__/multi-user-tab.test.tsx
+++ b/web/src/__tests__/multi-user-tab.test.tsx
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from './test-utils';
+import { IdentityProvider } from '@/hooks/useIdentity';
+import { MultiUserTab } from '@/components/settings/tabs/MultiUserTab';
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+}
+
+const ownerProfile = {
+  user: {
+    id: 'local-user',
+    displayName: 'Local User',
+    email: 'local@example.com',
+    handle: null,
+    authSubject: null,
+    avatarUrl: null,
+    disabledAt: null,
+    lastSeenAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  workspaces: [
+    {
+      workspace: {
+        id: 'local',
+        slug: 'local',
+        name: 'Local Workspace',
+        description: 'Default workspace',
+        mode: 'local',
+        createdBy: 'local-user',
+        archivedAt: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+      membership: {
+        workspaceId: 'local',
+        userId: 'local-user',
+        role: 'owner',
+        status: 'active',
+        invitedBy: null,
+        joinedAt: '2026-01-01T00:00:00.000Z',
+        disabledAt: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    },
+  ],
+};
+
+const authContext = {
+  role: 'admin',
+  keyName: 'session',
+  isLocalhost: true,
+  userId: 'local-user',
+  workspaceId: 'local',
+  actorType: 'user',
+  authMethod: 'session',
+  tokenName: undefined,
+  permissions: ['*'],
+};
+
+function renderMultiUserTab() {
+  return renderWithProviders(
+    <IdentityProvider>
+      <MultiUserTab />
+    </IdentityProvider>
+  );
+}
+
+describe('MultiUserTab', () => {
+  afterEach(() => {
+    window.localStorage?.clear?.();
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders workspace members, invitations, and current API context for owners', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/api/auth/context')) return jsonResponse(authContext);
+        if (url.endsWith('/api/identity/profile')) return jsonResponse(ownerProfile);
+        if (url.endsWith('/api/identity/workspaces/local/members')) {
+          return jsonResponse([
+            {
+              ...ownerProfile.workspaces[0].membership,
+              user: ownerProfile.user,
+            },
+          ]);
+        }
+        if (url.endsWith('/api/identity/workspaces/local/invitations')) {
+          return jsonResponse([
+            {
+              id: 'inv_expired',
+              workspaceId: 'local',
+              email: 'expired@example.com',
+              role: 'reviewer',
+              tokenHash: 'hash',
+              invitedBy: 'local-user',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              expiresAt: '2026-01-02T00:00:00.000Z',
+              acceptedBy: null,
+              acceptedAt: null,
+              revokedAt: null,
+            },
+          ]);
+        }
+        return jsonResponse({ error: `Unexpected ${url}` }, 404);
+      })
+    );
+
+    renderMultiUserTab();
+
+    expect(await screen.findByText('Local Workspace')).toBeDefined();
+    expect(await screen.findByText('Local User')).toBeDefined();
+    expect(await screen.findByText('expired@example.com')).toBeDefined();
+    expect(screen.getByText('Expired')).toBeDefined();
+    expect(screen.getAllByText('session').length).toBeGreaterThan(0);
+  });
+
+  it('shows invite permission state for read-only workspace members', async () => {
+    const readOnlyProfile = {
+      ...ownerProfile,
+      workspaces: [
+        {
+          ...ownerProfile.workspaces[0],
+          membership: {
+            ...ownerProfile.workspaces[0].membership,
+            role: 'read-only',
+          },
+        },
+      ],
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/api/auth/context')) {
+          return jsonResponse({
+            ...authContext,
+            role: 'read-only',
+            permissions: ['workspace:read', 'task:read', 'settings:read'],
+          });
+        }
+        if (url.endsWith('/api/identity/profile')) return jsonResponse(readOnlyProfile);
+        if (url.endsWith('/api/identity/workspaces/local/members')) {
+          return jsonResponse([
+            {
+              ...readOnlyProfile.workspaces[0].membership,
+              user: readOnlyProfile.user,
+            },
+          ]);
+        }
+        return jsonResponse([]);
+      })
+    );
+
+    renderMultiUserTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Read-only')).toBeDefined();
+      expect(
+        screen.getByText('Owner or admin permission is required to view and send invitations.')
+      ).toBeDefined();
+    });
+  });
+});

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -24,6 +24,7 @@ import { ArchiveSuggestionBanner } from './ArchiveSuggestionBanner';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import { useLiveAnnouncer } from '@/components/shared/LiveAnnouncer';
 import { useView } from '@/contexts/ViewContext';
+import { useIdentity } from '@/hooks/useIdentity';
 
 // Lazy-load Dashboard to split recharts + d3 (~800KB) out of main bundle
 const Dashboard = lazy(() =>
@@ -49,6 +50,8 @@ export function KanbanBoard() {
   const { data: tasks, isLoading, error } = useTasks();
   const { settings: featureSettings } = useFeatureSettings();
   const { announce } = useLiveAnnouncer();
+  const { hasPermission } = useIdentity();
+  const canWriteTasks = hasPermission('task:write');
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailPanelMounted, setDetailPanelMounted] = useState(false);
@@ -167,10 +170,14 @@ export function KanbanBoard() {
     (taskId: string, status: TaskStatus) => {
       const task = filteredTasks.find((t) => t.id === taskId);
       const columnName = COLUMNS.find((c) => c.id === status)?.title || status;
+      if (!canWriteTasks) {
+        announce(`Task ${task?.title || taskId} cannot be moved with the current permissions`);
+        return;
+      }
       updateTask.mutate({ id: taskId, input: { status } });
       announce(`Task ${task?.title || taskId} moved to ${columnName}`);
     },
-    [updateTask, filteredTasks, announce]
+    [announce, canWriteTasks, filteredTasks, updateTask]
   );
 
   // Register callbacks with keyboard context (refs, so no need for useEffect)
@@ -192,9 +199,11 @@ export function KanbanBoard() {
     tasksByStatus,
     columns: COLUMNS,
     onStatusChange: (taskId, status) => {
+      if (!canWriteTasks) return;
       updateTask.mutate({ id: taskId, input: { status } });
     },
     onReorder: (taskIds) => {
+      if (!canWriteTasks) return;
       reorderTasks.mutate(taskIds);
     },
   });
@@ -236,6 +245,8 @@ export function KanbanBoard() {
             variant="ghost"
             size="sm"
             onClick={toggleSelecting}
+            disabled={!canWriteTasks}
+            title={canWriteTasks ? 'Select tasks' : 'Task write permission required'}
             className="text-muted-foreground shrink-0"
           >
             <CheckSquare className="h-4 w-4 mr-1" />
@@ -254,7 +265,7 @@ export function KanbanBoard() {
             className="col-span-4"
             aria-label={`Kanban board, ${filteredTasks.length} tasks`}
           >
-            {featureSettings.board.enableDragAndDrop ? (
+            {featureSettings.board.enableDragAndDrop && canWriteTasks ? (
               <DndContext
                 sensors={sensors}
                 collisionDetection={collisionDetection}
@@ -335,6 +346,7 @@ export function KanbanBoard() {
             task={currentSelectedTask}
             open={detailOpen}
             onOpenChange={handleDetailClose}
+            readOnly={!canWriteTasks}
           />
         </Suspense>
       )}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -21,12 +21,14 @@ import { Button } from '@/components/ui/button';
 // ActivitySidebar removed — merged into ActivityFeed (GH-66)
 // ArchiveSidebar removed — replaced with full-page ArchivePage
 import { UserMenu } from './UserMenu';
+import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 import { WebSocketIndicator } from '@/components/shared/WebSocketIndicator';
 import { lazy, Suspense, useState, useCallback } from 'react';
 import { useKeyboard } from '@/hooks/useKeyboard';
 import { useView } from '@/contexts/ViewContext';
 import { useBacklogCount } from '@/hooks/useBacklog';
 import { useTheme } from '@/hooks/useTheme';
+import { useIdentity } from '@/hooks/useIdentity';
 import { Badge } from '@/components/ui/badge';
 import { NAVIGATION_VIEWS, type ViewIcon } from '@/lib/views';
 
@@ -89,6 +91,9 @@ export function Header() {
   const { view, setView, navigateToTask } = useView();
   const { data: backlogCount = 0 } = useBacklogCount();
   const { theme, setTheme } = useTheme();
+  const { hasPermission } = useIdentity();
+  const canCreateTask = hasPermission('task:write');
+  const canOpenSettings = hasPermission('settings:read') || hasPermission('admin:manage');
 
   const markPanelLoaded = useCallback((panel: LazyPanel) => {
     setLoadedPanels((current) => {
@@ -131,6 +136,12 @@ export function Header() {
     setSettingsOpen(true);
   }, [markPanelLoaded]);
 
+  const openIdentitySettings = useCallback(() => {
+    markPanelLoaded('settings');
+    setSettingsTab('multi-user');
+    setSettingsOpen(true);
+  }, [markPanelLoaded]);
+
   // Register the create dialog and chat panel openers with keyboard context (refs, no useEffect needed)
   setOpenCreateDialog(openCreateDialog);
   setOpenChatPanel(openChatPanel);
@@ -152,11 +163,19 @@ export function Header() {
               <h1 className="text-lg font-semibold">Veritas Kanban</h1>
             </button>
             <div className="h-4 w-px bg-border" aria-hidden="true" />
+            <WorkspaceSwitcher />
+            <div className="hidden md:block h-4 w-px bg-border" aria-hidden="true" />
             <WebSocketIndicator />
           </div>
 
           <div className="flex items-center gap-2" role="toolbar" aria-label="Board actions">
-            <Button variant="default" size="sm" onClick={openCreateDialog}>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={openCreateDialog}
+              disabled={!canCreateTask}
+              title={canCreateTask ? 'New Task' : 'Task write permission required'}
+            >
               <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
               New Task
             </Button>
@@ -208,8 +227,9 @@ export function Header() {
               variant="ghost"
               size="icon"
               onClick={openSettingsDialog}
+              disabled={!canOpenSettings}
               aria-label="Settings"
-              title="Settings"
+              title={canOpenSettings ? 'Settings' : 'Settings permission required'}
             >
               <Settings className="h-4 w-4" aria-hidden="true" />
             </Button>
@@ -226,7 +246,10 @@ export function Header() {
                 <Sun className="h-4 w-4" aria-hidden="true" />
               )}
             </Button>
-            <UserMenu onOpenSecuritySettings={openSecuritySettings} />
+            <UserMenu
+              onOpenSecuritySettings={openSecuritySettings}
+              onOpenIdentitySettings={openIdentitySettings}
+            />
             <Button
               variant="ghost"
               size="sm"

--- a/web/src/components/layout/UserMenu.tsx
+++ b/web/src/components/layout/UserMenu.tsx
@@ -1,31 +1,36 @@
-import { useState, useEffect } from 'react';
-import { Lock, LogOut, Shield, Clock, ChevronDown } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { Building2, Clock, ChevronDown, KeyRound, Lock, LogOut, Shield, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useAuth } from '@/hooks/useAuth';
+import { useIdentity } from '@/hooks/useIdentity';
 
 interface UserMenuProps {
   onOpenSecuritySettings?: () => void;
+  onOpenIdentitySettings?: () => void;
 }
 
-export function UserMenu({ onOpenSecuritySettings }: UserMenuProps) {
+export function UserMenu({ onOpenSecuritySettings, onOpenIdentitySettings }: UserMenuProps) {
   const { status, logout } = useAuth();
+  const { activeMembership, activeWorkspace, authContext, profile, canManageMembers } =
+    useIdentity();
   const [open, setOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   // Format session expiry
   const formatExpiry = (expiry: string | null) => {
     if (!expiry) return 'No expiry';
-    
+
     const expiryDate = new Date(expiry);
     const now = new Date();
     const diffMs = expiryDate.getTime() - now.getTime();
-    
+
     if (diffMs <= 0) return 'Expired';
-    
+
     const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
     const diffDays = Math.floor(diffHours / 24);
-    
+
     if (diffDays > 0) {
       return `${diffDays}d ${diffHours % 24}h remaining`;
     }
@@ -33,34 +38,39 @@ export function UserMenu({ onOpenSecuritySettings }: UserMenuProps) {
       const diffMins = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
       return `${diffHours}h ${diffMins}m remaining`;
     }
-    
+
     const diffMins = Math.floor(diffMs / (1000 * 60));
     return `${diffMins}m remaining`;
   };
+
+  const handleLogout = useCallback(async () => {
+    setIsLoggingOut(true);
+    await logout();
+    setOpen(false);
+    // Page will redirect via AuthGuard
+  }, [logout]);
 
   // Keyboard shortcut: Cmd/Ctrl+Shift+L for logout
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
         e.preventDefault();
-        handleLogout();
+        void handleLogout();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
-
-  const handleLogout = async () => {
-    setIsLoggingOut(true);
-    await logout();
-    setOpen(false);
-    // Page will redirect via AuthGuard
-  };
+  }, [handleLogout]);
 
   const handleSecurityClick = () => {
     setOpen(false);
     onOpenSecuritySettings?.();
+  };
+
+  const handleIdentityClick = () => {
+    setOpen(false);
+    onOpenIdentitySettings?.();
   };
 
   // Don't render if not authenticated
@@ -68,33 +78,68 @@ export function UserMenu({ onOpenSecuritySettings }: UserMenuProps) {
     return null;
   }
 
+  const displayName = profile?.user.displayName ?? authContext?.keyName ?? 'Local user';
+  const role = activeMembership?.role ?? authContext?.role ?? 'admin';
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="gap-2"
-          title="Session menu"
-        >
+        <Button variant="ghost" size="sm" className="gap-2" title="Session menu">
           <Lock className="h-4 w-4 text-emerald-500" />
-          <span className="text-xs text-muted-foreground hidden sm:inline">Secured</span>
+          <span className="text-xs text-muted-foreground hidden sm:inline">{displayName}</span>
           <ChevronDown className="h-3 w-3 text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 p-0" align="end">
+      <PopoverContent className="w-72 p-0" align="end">
         <div className="p-3 border-b border-border">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Lock className="h-4 w-4 text-emerald-500" />
-            Logged In
+          <div className="flex items-start gap-2">
+            <div className="mt-0.5 rounded-full bg-primary/10 p-1.5 text-primary">
+              <User className="h-4 w-4" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-medium">{displayName}</div>
+              <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                <Badge variant="secondary" className="capitalize">
+                  {role}
+                </Badge>
+                {authContext?.authMethod && (
+                  <Badge variant="outline" className="capitalize">
+                    {authContext.authMethod}
+                  </Badge>
+                )}
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+          <div className="flex items-center gap-2 mt-3 text-xs text-muted-foreground">
             <Clock className="h-3 w-3" />
             {formatExpiry(status.sessionExpiry)}
           </div>
+          {activeWorkspace && (
+            <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+              <Building2 className="h-3 w-3" />
+              <span className="truncate">{activeWorkspace.name}</span>
+            </div>
+          )}
+          {authContext?.tokenName && (
+            <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+              <KeyRound className="h-3 w-3" />
+              <span className="truncate">{authContext.tokenName}</span>
+            </div>
+          )}
         </div>
-        
+
         <div className="p-1">
+          <button
+            onClick={handleIdentityClick}
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-accent transition-colors"
+          >
+            <Building2 className="h-4 w-4" />
+            Members & Permissions
+            {!canManageMembers && (
+              <span className="ml-auto text-xs text-muted-foreground">View</span>
+            )}
+          </button>
+
           <button
             onClick={handleSecurityClick}
             className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-accent transition-colors"
@@ -102,7 +147,7 @@ export function UserMenu({ onOpenSecuritySettings }: UserMenuProps) {
             <Shield className="h-4 w-4" />
             Security Settings
           </button>
-          
+
           <button
             onClick={handleLogout}
             disabled={isLoggingOut}

--- a/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Building2, Loader2 } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { useIdentity } from '@/hooks/useIdentity';
+
+export function WorkspaceSwitcher() {
+  const { activeWorkspace, activeMembership, activeWorkspaceId, workspaces, switchWorkspace } =
+    useIdentity();
+  const [isSwitching, setIsSwitching] = useState(false);
+
+  if (workspaces.length === 0) {
+    return (
+      <div className="hidden md:flex items-center gap-2 text-xs text-muted-foreground">
+        <Building2 className="h-4 w-4" aria-hidden="true" />
+        Workspace unavailable
+      </div>
+    );
+  }
+
+  const handleSwitch = async (workspaceId: string) => {
+    if (workspaceId === activeWorkspaceId) return;
+    setIsSwitching(true);
+    try {
+      await switchWorkspace(workspaceId);
+    } finally {
+      setIsSwitching(false);
+    }
+  };
+
+  return (
+    <div className="hidden md:flex items-center gap-2">
+      <Select value={activeWorkspaceId ?? undefined} onValueChange={handleSwitch}>
+        <SelectTrigger
+          className="h-8 w-[190px] bg-background/60"
+          aria-label="Workspace"
+          disabled={isSwitching}
+        >
+          <Building2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <SelectValue placeholder={activeWorkspace?.name ?? 'Workspace'} />
+          {isSwitching && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
+        </SelectTrigger>
+        <SelectContent align="start">
+          {workspaces.map(({ workspace, membership }) => (
+            <SelectItem key={workspace.id} value={workspace.id}>
+              <span className="flex min-w-0 items-center gap-2">
+                <span className="truncate">{workspace.name}</span>
+                <span className="text-xs text-muted-foreground">{membership.role}</span>
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {activeMembership && (
+        <Badge variant="secondary" className="hidden lg:inline-flex capitalize">
+          {activeMembership.role}
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,5 +1,11 @@
 import { useState, useRef, useCallback, lazy, Suspense, useEffect } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   Select,
   SelectContent,
@@ -21,6 +27,7 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
+import { useIdentity } from '@/hooks/useIdentity';
 import { useToast } from '@/hooks/useToast';
 import {
   Settings2,
@@ -39,8 +46,10 @@ import {
   CheckCircle2,
   Boxes,
   BookOpen,
+  UserCog,
 } from 'lucide-react';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import type { ClientAuthPermission } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
 import { SettingsErrorBoundary } from './shared';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -79,6 +88,9 @@ const LazySharedResourcesTab = lazy(() =>
 const LazyDocFreshnessTab = lazy(() =>
   import('./tabs/DocFreshnessTab').then((m) => ({ default: m.DocFreshnessTab }))
 );
+const LazyMultiUserTab = lazy(() =>
+  import('./tabs/MultiUserTab').then((m) => ({ default: m.MultiUserTab }))
+);
 
 // ============ Tab Skeleton ============
 
@@ -110,28 +122,36 @@ type TabId =
   | 'enforcement'
   | 'shared-resources'
   | 'doc-freshness'
+  | 'multi-user'
   | 'manage';
 
 interface TabDef {
   id: TabId;
   label: string;
   icon: React.ElementType;
+  requiredPermission?: ClientAuthPermission;
 }
 
 const TABS: TabDef[] = [
   { id: 'general', label: 'General', icon: Settings2 },
   { id: 'board', label: 'Board', icon: Layout },
   { id: 'tasks', label: 'Tasks', icon: ListTodo },
-  { id: 'agents', label: 'Agents', icon: Cpu },
-  { id: 'data', label: 'Data', icon: Database },
+  { id: 'agents', label: 'Agents', icon: Cpu, requiredPermission: 'agent:read' },
+  { id: 'data', label: 'Data', icon: Database, requiredPermission: 'backup:read' },
   { id: 'notifications', label: 'Notifications', icon: Bell },
-  { id: 'security', label: 'Security', icon: Shield },
-  { id: 'delegation', label: 'Delegation', icon: Plane },
-  { id: 'tool-policies', label: 'Tool Policies', icon: Lock },
-  { id: 'enforcement', label: 'Enforcement', icon: CheckCircle2 },
+  { id: 'security', label: 'Security', icon: Shield, requiredPermission: 'settings:read' },
+  { id: 'multi-user', label: 'Multi-user', icon: UserCog, requiredPermission: 'workspace:read' },
+  { id: 'delegation', label: 'Delegation', icon: Plane, requiredPermission: 'agent:read' },
+  { id: 'tool-policies', label: 'Tool Policies', icon: Lock, requiredPermission: 'policy:read' },
+  {
+    id: 'enforcement',
+    label: 'Enforcement',
+    icon: CheckCircle2,
+    requiredPermission: 'policy:read',
+  },
   { id: 'shared-resources', label: 'Shared Resources', icon: Boxes },
   { id: 'doc-freshness', label: 'Doc Freshness', icon: BookOpen },
-  { id: 'manage', label: 'Manage', icon: Archive },
+  { id: 'manage', label: 'Manage', icon: Archive, requiredPermission: 'backup:read' },
 ];
 
 // ============ Settings Dialog Props ============
@@ -146,13 +166,27 @@ interface SettingsDialogProps {
 
 export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialogProps) {
   const [activeTab, setActiveTab] = useState<TabId>('general');
+  const { hasPermission } = useIdentity();
+  const canWriteSettings = hasPermission('settings:write');
+  const canUseTab = useCallback(
+    (tab: TabDef) => !tab.requiredPermission || hasPermission(tab.requiredPermission),
+    [hasPermission]
+  );
 
   // Set active tab when defaultTab changes
   useEffect(() => {
-    if (defaultTab && TABS.some((t) => t.id === defaultTab)) {
+    const requestedTab = TABS.find((t) => t.id === defaultTab);
+    if (requestedTab && canUseTab(requestedTab)) {
       setActiveTab(defaultTab as TabId);
     }
-  }, [defaultTab]);
+  }, [canUseTab, defaultTab]);
+
+  useEffect(() => {
+    const currentTab = TABS.find((tab) => tab.id === activeTab);
+    if (currentTab && !canUseTab(currentTab)) {
+      setActiveTab(TABS.find(canUseTab)?.id ?? 'general');
+    }
+  }, [activeTab, canUseTab]);
   const { settings: currentSettings } = useFeatureSettings();
   const { debouncedUpdate } = useDebouncedFeatureUpdate();
   const settingsFileInputRef = useRef<HTMLInputElement>(null);
@@ -224,7 +258,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
           duration: Infinity,
         });
       }
-      const validPatch: Record<string, any> = {};
+      const validPatch: Record<string, unknown> = {};
       for (const key of importedKeys) {
         if (validSections.includes(key)) {
           validPatch[key] = imported[key];
@@ -268,18 +302,19 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      const currentIndex = TABS.findIndex((t) => t.id === activeTab);
+      const availableTabs = TABS.filter(canUseTab);
+      const currentIndex = availableTabs.findIndex((t) => t.id === activeTab);
       if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
         e.preventDefault();
-        const next = (currentIndex + 1) % TABS.length;
-        setActiveTab(TABS[next].id);
+        const next = (currentIndex + 1) % availableTabs.length;
+        setActiveTab(availableTabs[next].id);
       } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
         e.preventDefault();
-        const prev = (currentIndex - 1 + TABS.length) % TABS.length;
-        setActiveTab(TABS[prev].id);
+        const prev = (currentIndex - 1 + availableTabs.length) % availableTabs.length;
+        setActiveTab(availableTabs[prev].id);
       }
     },
-    [activeTab]
+    [activeTab, canUseTab]
   );
 
   const renderTab = () => {
@@ -320,6 +355,11 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
             <LazySecurityTab />
           </SettingsErrorBoundary>
         )}
+        {activeTab === 'multi-user' && (
+          <SettingsErrorBoundary tabName="Multi-user">
+            <LazyMultiUserTab />
+          </SettingsErrorBoundary>
+        )}
         {activeTab === 'delegation' && (
           <SettingsErrorBoundary tabName="Delegation">
             <LazyDelegationTab />
@@ -357,6 +397,9 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[800px] h-[85vh] p-0 overflow-hidden">
+        <DialogDescription className="sr-only">
+          Manage board, task, data, security, and workspace settings.
+        </DialogDescription>
         <ErrorBoundary level="section">
           <div className="flex h-full min-h-0">
             {/* Sidebar Tabs — hidden on narrow screens, shown as dropdown instead */}
@@ -382,11 +425,16 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
                       aria-controls="settings-tab-content"
                       tabIndex={activeTab === tab.id ? 0 : -1}
                       onClick={() => setActiveTab(tab.id)}
+                      disabled={!canUseTab(tab)}
+                      title={
+                        canUseTab(tab) ? tab.label : `${tab.requiredPermission} permission required`
+                      }
                       className={cn(
                         'w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors text-left',
                         activeTab === tab.id
                           ? 'bg-background shadow-sm font-medium'
-                          : 'text-muted-foreground hover:bg-background/50 hover:text-foreground'
+                          : 'text-muted-foreground hover:bg-background/50 hover:text-foreground',
+                        !canUseTab(tab) && 'cursor-not-allowed opacity-45 hover:bg-transparent'
                       )}
                     >
                       <Icon className="h-4 w-4 flex-shrink-0" />
@@ -416,6 +464,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
                 </button>
                 <button
                   onClick={() => settingsFileInputRef.current?.click()}
+                  disabled={!canWriteSettings}
                   aria-label="Import settings from JSON file"
                   className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-xs text-muted-foreground hover:bg-background/50 hover:text-foreground transition-colors text-left"
                 >
@@ -424,7 +473,10 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
                 </button>
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
-                    <button className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-xs text-red-400 hover:bg-red-500/10 transition-colors text-left">
+                    <button
+                      disabled={!canWriteSettings}
+                      className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-xs text-red-400 hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-45 transition-colors text-left"
+                    >
                       <RotateCcw className="h-3.5 w-3.5 flex-shrink-0" />
                       Reset All
                     </button>
@@ -459,7 +511,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
                 </SelectTrigger>
                 <SelectContent>
                   {TABS.map((tab) => (
-                    <SelectItem key={tab.id} value={tab.id}>
+                    <SelectItem key={tab.id} value={tab.id} disabled={!canUseTab(tab)}>
                       {tab.label}
                     </SelectItem>
                   ))}

--- a/web/src/components/settings/tabs/MultiUserTab.tsx
+++ b/web/src/components/settings/tabs/MultiUserTab.tsx
@@ -1,0 +1,515 @@
+import { useMemo, useState } from 'react';
+import type { FormEvent, ReactNode } from 'react';
+import {
+  AlertTriangle,
+  Building2,
+  CheckCircle2,
+  Clipboard,
+  KeyRound,
+  MailPlus,
+  Shield,
+  Trash2,
+  Users,
+  type LucideIcon,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/hooks/useToast';
+import {
+  WORKSPACE_ROLES,
+  useCreateWorkspaceInvitation,
+  useIdentity,
+  useRemoveWorkspaceMember,
+  useRevokeWorkspaceInvitation,
+  useUpdateWorkspaceMemberRole,
+  useWorkspaceInvitations,
+  useWorkspaceMembers,
+  type WorkspaceRole,
+} from '@/hooks/useIdentity';
+import type { WorkspaceInvitation, WorkspaceMembership } from '@/lib/api/identity';
+
+const ROLE_LABELS: Record<WorkspaceRole, string> = {
+  owner: 'Owner',
+  admin: 'Admin',
+  member: 'Member',
+  reviewer: 'Reviewer',
+  'read-only': 'Read-only',
+  agent: 'Agent',
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return 'Never';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value));
+}
+
+function invitationStatus(invitation: WorkspaceInvitation) {
+  if (invitation.acceptedAt) return { label: 'Accepted', variant: 'secondary' as const };
+  if (invitation.revokedAt) return { label: 'Revoked', variant: 'destructive' as const };
+  if (Date.parse(invitation.expiresAt) <= Date.now()) {
+    return { label: 'Expired', variant: 'outline' as const };
+  }
+  return { label: 'Pending', variant: 'secondary' as const };
+}
+
+function memberName(member: WorkspaceMembership) {
+  return member.user?.displayName ?? member.userId;
+}
+
+function Section({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: LucideIcon;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">{title}</h3>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function PermissionEmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+      <Shield className="mt-0.5 h-4 w-4" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+export function MultiUserTab() {
+  const {
+    activeMembership,
+    activeWorkspace,
+    authContext,
+    canManageMembers,
+    error,
+    hasPermission,
+    isLoading,
+    profile,
+    switchWorkspace,
+    workspaces,
+  } = useIdentity();
+  const { toast } = useToast();
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<WorkspaceRole>('member');
+  const [inviteExpiresAt, setInviteExpiresAt] = useState('');
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+
+  const workspaceId = activeWorkspace?.id ?? null;
+  const membersQuery = useWorkspaceMembers(workspaceId);
+  const invitationsQuery = useWorkspaceInvitations(workspaceId, canManageMembers);
+  const createInvitation = useCreateWorkspaceInvitation(workspaceId);
+  const updateMemberRole = useUpdateWorkspaceMemberRole(workspaceId);
+  const removeMember = useRemoveWorkspaceMember(workspaceId);
+  const revokeInvitation = useRevokeWorkspaceInvitation(workspaceId);
+
+  const roleOptions = useMemo(
+    () =>
+      activeMembership?.role === 'owner'
+        ? WORKSPACE_ROLES
+        : WORKSPACE_ROLES.filter((role) => role !== 'owner'),
+    [activeMembership?.role]
+  );
+
+  const canWriteSettings = hasPermission('settings:write');
+  const canManageApiTokens = hasPermission('admin:manage');
+  const members = membersQuery.data ?? [];
+  const invitations = invitationsQuery.data ?? [];
+
+  const handleCreateInvitation = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!workspaceId) return;
+    setCreatedToken(null);
+
+    try {
+      const result = await createInvitation.mutateAsync({
+        email: inviteEmail.trim() || undefined,
+        role: inviteRole,
+        expiresAt: inviteExpiresAt ? new Date(inviteExpiresAt).toISOString() : undefined,
+      });
+      setCreatedToken(result.token);
+      setInviteEmail('');
+      setInviteExpiresAt('');
+      toast({
+        title: 'Invitation created',
+        description: result.invitation.email ?? 'One-time invitation token is ready.',
+      });
+    } catch (err) {
+      toast({
+        title: 'Invitation failed',
+        description: err instanceof Error ? err.message : 'Unable to create invitation.',
+        duration: Infinity,
+      });
+    }
+  };
+
+  const handleCopyToken = async () => {
+    if (!createdToken || !navigator.clipboard) return;
+    await navigator.clipboard.writeText(createdToken);
+    toast({ title: 'Invitation token copied', duration: 2500 });
+  };
+
+  const handleRoleChange = async (member: WorkspaceMembership, role: WorkspaceRole) => {
+    try {
+      await updateMemberRole.mutateAsync({ userId: member.userId, role });
+      toast({ title: 'Role updated', description: `${memberName(member)} is now ${role}.` });
+    } catch (err) {
+      toast({
+        title: 'Role update failed',
+        description: err instanceof Error ? err.message : 'Unable to update member role.',
+        duration: Infinity,
+      });
+    }
+  };
+
+  const handleRemoveMember = async (member: WorkspaceMembership) => {
+    try {
+      await removeMember.mutateAsync(member.userId);
+      toast({ title: 'Member removed', description: memberName(member) });
+    } catch (err) {
+      toast({
+        title: 'Remove failed',
+        description: err instanceof Error ? err.message : 'Unable to remove member.',
+        duration: Infinity,
+      });
+    }
+  };
+
+  const handleRevokeInvitation = async (invitation: WorkspaceInvitation) => {
+    try {
+      await revokeInvitation.mutateAsync(invitation.id);
+      toast({ title: 'Invitation revoked', description: invitation.email ?? invitation.id });
+    } catch (err) {
+      toast({
+        title: 'Revoke failed',
+        description: err instanceof Error ? err.message : 'Unable to revoke invitation.',
+        duration: Infinity,
+      });
+    }
+  };
+
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading workspace access...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-start gap-2 rounded-md border border-destructive/40 p-3 text-sm">
+        <AlertTriangle className="mt-0.5 h-4 w-4 text-destructive" aria-hidden="true" />
+        <div>
+          <div className="font-medium text-destructive">Unable to load identity data</div>
+          <div className="text-muted-foreground">{error.message}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!activeWorkspace || !activeMembership) {
+    return <PermissionEmptyState message="No active workspace membership is available." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Section title="Workspace" icon={Building2}>
+        <div className="grid gap-3 rounded-md border p-3 sm:grid-cols-[1fr_auto]">
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="truncate font-medium">{activeWorkspace.name}</div>
+              <Badge variant="secondary" className="capitalize">
+                {activeMembership.role}
+              </Badge>
+              <Badge variant="outline" className="capitalize">
+                {activeWorkspace.mode}
+              </Badge>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {activeWorkspace.description ?? 'Workspace access is active.'}
+            </div>
+          </div>
+          <Select value={activeWorkspace.id} onValueChange={(value) => void switchWorkspace(value)}>
+            <SelectTrigger className="w-full sm:w-56" aria-label="Active workspace">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {workspaces.map(({ workspace, membership }) => (
+                <SelectItem key={workspace.id} value={workspace.id}>
+                  {workspace.name} ({membership.role})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </Section>
+
+      <Section title="Members" icon={Users}>
+        {membersQuery.isLoading ? (
+          <div className="text-sm text-muted-foreground">Loading members...</div>
+        ) : members.length === 0 ? (
+          <PermissionEmptyState message="No active members were returned for this workspace." />
+        ) : (
+          <div className="overflow-hidden rounded-md border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Member</th>
+                  <th className="px-3 py-2 text-left font-medium">Role</th>
+                  <th className="px-3 py-2 text-left font-medium">Joined</th>
+                  <th className="px-3 py-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {members.map((member) => {
+                  const isSelf = member.userId === profile?.user.id;
+                  const canEditMember =
+                    canManageMembers &&
+                    (activeMembership.role === 'owner' || member.role !== 'owner');
+                  return (
+                    <tr key={member.userId} className="border-t">
+                      <td className="px-3 py-2">
+                        <div className="font-medium">{memberName(member)}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {member.user?.email ?? member.userId}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2">
+                        <Select
+                          value={member.role}
+                          onValueChange={(role) =>
+                            void handleRoleChange(member, role as WorkspaceRole)
+                          }
+                          disabled={!canEditMember}
+                        >
+                          <SelectTrigger
+                            className="h-8 w-36"
+                            aria-label={`Role for ${memberName(member)}`}
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {roleOptions.map((role) => (
+                              <SelectItem key={role} value={role}>
+                                {ROLE_LABELS[role]}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {formatDate(member.joinedAt)}
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => void handleRemoveMember(member)}
+                          disabled={!canEditMember || isSelf}
+                          title={
+                            isSelf
+                              ? 'Cannot remove your own active session'
+                              : canEditMember
+                                ? 'Remove member'
+                                : 'Owner or admin permission required'
+                          }
+                        >
+                          <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                        </Button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Section>
+
+      <Section title="Invitations" icon={MailPlus}>
+        {!canManageMembers ? (
+          <PermissionEmptyState message="Owner or admin permission is required to view and send invitations." />
+        ) : (
+          <div className="space-y-3">
+            <form
+              className="grid gap-3 rounded-md border p-3 sm:grid-cols-2"
+              onSubmit={handleCreateInvitation}
+            >
+              <div className="grid gap-1.5 sm:col-span-2">
+                <Label htmlFor="invite-email">Email</Label>
+                <Input
+                  id="invite-email"
+                  type="email"
+                  value={inviteEmail}
+                  onChange={(event) => setInviteEmail(event.target.value)}
+                  placeholder="person@example.com"
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>Role</Label>
+                <Select
+                  value={inviteRole}
+                  onValueChange={(role) => setInviteRole(role as WorkspaceRole)}
+                >
+                  <SelectTrigger aria-label="Invitation role">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {roleOptions.map((role) => (
+                      <SelectItem key={role} value={role}>
+                        {ROLE_LABELS[role]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="invite-expires">Expires</Label>
+                <Input
+                  id="invite-expires"
+                  type="datetime-local"
+                  value={inviteExpiresAt}
+                  onChange={(event) => setInviteExpiresAt(event.target.value)}
+                />
+              </div>
+              <div className="flex items-end sm:col-span-2 sm:justify-end">
+                <Button
+                  type="submit"
+                  disabled={createInvitation.isPending}
+                  className="w-full sm:w-auto"
+                >
+                  <MailPlus className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Send
+                </Button>
+              </div>
+            </form>
+
+            {createdToken && (
+              <div className="grid gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500" aria-hidden="true" />
+                  One-time invitation token
+                </div>
+                <div className="flex gap-2">
+                  <Input value={createdToken} readOnly className="font-mono text-xs" />
+                  <Button type="button" variant="outline" onClick={() => void handleCopyToken()}>
+                    <Clipboard className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {invitationsQuery.isLoading ? (
+              <div className="text-sm text-muted-foreground">Loading invitations...</div>
+            ) : invitations.length === 0 ? (
+              <PermissionEmptyState message="No invitations have been created for this workspace." />
+            ) : (
+              <div className="space-y-2">
+                {invitations.map((invitation) => {
+                  const status = invitationStatus(invitation);
+                  const canRevoke = status.label === 'Pending';
+                  return (
+                    <div
+                      key={invitation.id}
+                      className="flex items-center justify-between gap-3 rounded-md border p-3"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="truncate font-medium">
+                            {invitation.email ?? invitation.id}
+                          </span>
+                          <Badge variant={status.variant}>{status.label}</Badge>
+                          <Badge variant="outline">{ROLE_LABELS[invitation.role]}</Badge>
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          Expires {formatDate(invitation.expiresAt)}
+                        </div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => void handleRevokeInvitation(invitation)}
+                        disabled={!canRevoke || revokeInvitation.isPending}
+                      >
+                        Revoke
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </Section>
+
+      <Section title="API Access" icon={KeyRound}>
+        <div className="space-y-3 rounded-md border p-3">
+          <div className="grid gap-2 text-sm sm:grid-cols-3">
+            <div>
+              <div className="text-xs uppercase text-muted-foreground">Auth method</div>
+              <div className="font-medium">{authContext?.authMethod ?? 'unknown'}</div>
+            </div>
+            <div>
+              <div className="text-xs uppercase text-muted-foreground">Actor</div>
+              <div className="font-medium">{authContext?.actorType ?? 'unknown'}</div>
+            </div>
+            <div>
+              <div className="text-xs uppercase text-muted-foreground">Token</div>
+              <div className="font-medium">{authContext?.tokenName ?? 'session'}</div>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {(authContext?.permissions ?? []).slice(0, 10).map((permission) => (
+              <Badge key={permission} variant="outline" className="font-mono text-[11px]">
+                {permission}
+              </Badge>
+            ))}
+            {(authContext?.permissions?.length ?? 0) > 10 && (
+              <Badge variant="secondary">+{(authContext?.permissions?.length ?? 0) - 10}</Badge>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled
+              title={
+                canManageApiTokens
+                  ? 'Scoped token API is not available yet'
+                  : 'Admin manage permission required'
+              }
+            >
+              <KeyRound className="mr-2 h-4 w-4" aria-hidden="true" />
+              Create Token
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              Scoped token issuance is held until the SQLite token repository/API lands.
+            </span>
+          </div>
+          {!canWriteSettings && (
+            <PermissionEmptyState message="Settings write permission is required before token policy changes can be made." />
+          )}
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/web/src/components/settings/tabs/index.ts
+++ b/web/src/components/settings/tabs/index.ts
@@ -4,6 +4,7 @@ export { TasksTab } from './TasksTab';
 export { AgentsTab } from './AgentsTab';
 export { DataTab } from './DataTab';
 export { NotificationsTab } from './NotificationsTab';
+export { MultiUserTab } from './MultiUserTab';
 export { ManageTab } from './ManageTab';
 export { EnforcementTab } from './EnforcementTab';
 export { SharedResourcesTab } from './SharedResourcesTab';

--- a/web/src/components/task/GitSection.tsx
+++ b/web/src/components/task/GitSection.tsx
@@ -5,6 +5,7 @@ import { GitBranch, Loader2, AlertCircle } from 'lucide-react';
 import type { Task, TaskGit } from '@veritas-kanban/shared';
 import { GitSelectionForm } from './git/GitSelectionForm';
 import { WorktreeStatus } from './git/WorktreeStatus';
+import { useIdentity } from '@/hooks/useIdentity';
 
 interface GitSectionProps {
   task: Task;
@@ -13,13 +14,15 @@ interface GitSectionProps {
 
 export function GitSection({ task, onGitChange }: GitSectionProps) {
   const { data: config, isLoading: configLoading } = useConfig();
+  const { hasPermission } = useIdentity();
+  const canEditTaskGit = hasPermission('task:write');
 
   const handleClearGit = () => {
     onGitChange(undefined);
   };
 
   // Don't allow editing if worktree exists
-  const isLocked = !!task.git?.worktreePath;
+  const isLocked = !!task.git?.worktreePath || !canEditTaskGit;
   const selectedRepo = task.git?.repo;
 
   if (configLoading) {
@@ -65,13 +68,19 @@ export function GitSection({ task, onGitChange }: GitSectionProps) {
             size="sm"
             className="h-6 text-xs"
             onClick={handleClearGit}
+            disabled={!canEditTaskGit}
           >
             Clear
           </Button>
         )}
       </div>
 
-      <GitSelectionForm task={task} onGitChange={onGitChange} />
+      {!canEditTaskGit && (
+        <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+          Task write permission is required to change Git settings.
+        </div>
+      )}
+      <GitSelectionForm task={task} onGitChange={onGitChange} disabled={!canEditTaskGit} />
       <WorktreeStatus task={task} />
     </div>
   );

--- a/web/src/components/task/git/GitSelectionForm.tsx
+++ b/web/src/components/task/git/GitSelectionForm.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils';
 interface GitSelectionFormProps {
   task: Task;
   onGitChange: (git: Partial<TaskGit> | undefined) => void;
+  disabled?: boolean;
 }
 
 function slugify(text: string): string {
@@ -26,7 +27,7 @@ function slugify(text: string): string {
     .slice(0, 40);
 }
 
-export function GitSelectionForm({ task, onGitChange }: GitSelectionFormProps) {
+export function GitSelectionForm({ task, onGitChange, disabled = false }: GitSelectionFormProps) {
   const { data: config } = useConfig();
   const [selectedRepo, setSelectedRepo] = useState<string>(task.git?.repo || '');
   const [baseBranch, setBaseBranch] = useState<string>(task.git?.baseBranch || '');
@@ -63,7 +64,7 @@ export function GitSelectionForm({ task, onGitChange }: GitSelectionFormProps) {
       setFeatureBranch(task.git.branch || '');
       setAutoGenerateBranch(!task.git.branch);
     }
-  }, [task.id, task.git?.repo, task.git?.baseBranch, task.git?.branch]); // Re-sync when task or git config changes
+  }, [task.id, task.git]); // Re-sync when task or git config changes
 
   // Update parent when values change
   const handleRepoChange = (repo: string) => {
@@ -99,7 +100,7 @@ export function GitSelectionForm({ task, onGitChange }: GitSelectionFormProps) {
   };
 
   // Don't allow editing if worktree exists
-  const isLocked = !!task.git?.worktreePath;
+  const isLocked = !!task.git?.worktreePath || disabled;
 
   return (
     <div className="grid gap-3 p-3 rounded-md border bg-muted/30">

--- a/web/src/components/workflows/WorkflowsPage.tsx
+++ b/web/src/components/workflows/WorkflowsPage.tsx
@@ -18,6 +18,7 @@ import { useToast } from '@/hooks/useToast';
 import { Skeleton } from '@/components/ui/skeleton';
 import { WorkflowRunList } from './WorkflowRunList';
 import { WorkflowDashboard } from './WorkflowDashboard';
+import { useIdentity } from '@/hooks/useIdentity';
 
 interface WorkflowsPageProps {
   onBack: () => void;
@@ -40,6 +41,8 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [showDashboard, setShowDashboard] = useState(false);
   const { toast } = useToast();
+  const { hasPermission } = useIdentity();
+  const canExecuteWorkflows = hasPermission('workflow:execute');
 
   // Fetch workflows on mount
   useEffect(() => {
@@ -74,6 +77,9 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
 
   const handleStartRun = async (workflowId: string) => {
     try {
+      if (!canExecuteWorkflows) {
+        throw new Error('Workflow execute permission required');
+      }
       const response = await fetch(`${API_BASE}/workflows/${workflowId}/runs`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -157,6 +163,7 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
               workflow={workflow}
               onStartRun={() => handleStartRun(workflow.id)}
               onViewRuns={() => setSelectedWorkflowId(workflow.id)}
+              canStartRun={canExecuteWorkflows}
             />
           ))}
         </div>
@@ -169,9 +176,10 @@ interface WorkflowCardProps {
   workflow: Workflow;
   onStartRun: () => void;
   onViewRuns: () => void;
+  canStartRun: boolean;
 }
 
-function WorkflowCard({ workflow, onStartRun, onViewRuns }: WorkflowCardProps) {
+function WorkflowCard({ workflow, onStartRun, onViewRuns, canStartRun }: WorkflowCardProps) {
   return (
     <div className="p-6 rounded-lg border bg-card hover:bg-accent/50 transition-colors">
       <div className="flex items-start justify-between gap-4">
@@ -205,7 +213,12 @@ function WorkflowCard({ workflow, onStartRun, onViewRuns }: WorkflowCardProps) {
         </div>
 
         <div className="flex flex-col gap-2 shrink-0">
-          <Button size="sm" onClick={onStartRun}>
+          <Button
+            size="sm"
+            onClick={onStartRun}
+            disabled={!canStartRun}
+            title={canStartRun ? 'Start run' : 'Workflow execute permission required'}
+          >
             <Play className="h-3 w-3 mr-1" />
             Start Run
           </Button>

--- a/web/src/hooks/useIdentity.tsx
+++ b/web/src/hooks/useIdentity.tsx
@@ -1,0 +1,332 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  hasClientPermission,
+  type ClientAuthContext,
+  type ClientAuthPermission,
+} from '@veritas-kanban/shared';
+import {
+  identityApi,
+  type CreateInvitationInput,
+  type IdentityProfile,
+  type WorkspaceIdentity,
+  type WorkspaceMembership,
+  type WorkspaceRole,
+} from '@/lib/api/identity';
+
+const ACTIVE_WORKSPACE_STORAGE_KEY = 'veritas-kanban.active-workspace-id';
+
+const ALL_PERMISSIONS: readonly ClientAuthPermission[] = [
+  '*',
+  'workspace:read',
+  'task:read',
+  'task:write',
+  'comment:write',
+  'workflow:read',
+  'workflow:write',
+  'workflow:execute',
+  'work_product:read',
+  'work_product:write',
+  'report:read',
+  'telemetry:read',
+  'telemetry:write',
+  'agent:read',
+  'agent:write',
+  'settings:read',
+  'settings:write',
+  'policy:read',
+  'policy:write',
+  'backup:read',
+  'backup:write',
+  'admin:manage',
+];
+
+const WORKSPACE_ROLE_PERMISSIONS: Record<WorkspaceRole, readonly ClientAuthPermission[]> = {
+  owner: ALL_PERMISSIONS,
+  admin: ALL_PERMISSIONS.filter((permission) => permission !== '*'),
+  member: [
+    'workspace:read',
+    'task:read',
+    'task:write',
+    'comment:write',
+    'workflow:read',
+    'workflow:execute',
+    'work_product:read',
+    'work_product:write',
+    'report:read',
+    'telemetry:read',
+    'agent:read',
+    'settings:read',
+  ],
+  reviewer: [
+    'workspace:read',
+    'task:read',
+    'comment:write',
+    'workflow:read',
+    'work_product:read',
+    'report:read',
+    'telemetry:read',
+    'agent:read',
+    'settings:read',
+    'policy:read',
+  ],
+  'read-only': [
+    'workspace:read',
+    'task:read',
+    'workflow:read',
+    'work_product:read',
+    'report:read',
+    'telemetry:read',
+    'agent:read',
+    'settings:read',
+    'policy:read',
+    'backup:read',
+  ],
+  agent: [
+    'workspace:read',
+    'task:read',
+    'task:write',
+    'comment:write',
+    'workflow:read',
+    'workflow:execute',
+    'work_product:read',
+    'work_product:write',
+    'report:read',
+    'telemetry:write',
+    'agent:read',
+  ],
+};
+
+interface IdentityContextValue {
+  authContext: ClientAuthContext | null;
+  profile: IdentityProfile | null;
+  workspaces: IdentityProfile['workspaces'];
+  activeWorkspace: WorkspaceIdentity | null;
+  activeMembership: WorkspaceMembership | null;
+  activeWorkspaceId: string | null;
+  isLoading: boolean;
+  error: Error | null;
+  canManageMembers: boolean;
+  hasPermission: (permission: ClientAuthPermission) => boolean;
+  switchWorkspace: (workspaceId: string) => Promise<void>;
+}
+
+const permissiveFallback: IdentityContextValue = {
+  authContext: null,
+  profile: null,
+  workspaces: [],
+  activeWorkspace: null,
+  activeMembership: null,
+  activeWorkspaceId: null,
+  isLoading: false,
+  error: null,
+  canManageMembers: true,
+  hasPermission: () => true,
+  switchWorkspace: async () => {},
+};
+
+const IdentityContext = createContext<IdentityContextValue | null>(null);
+
+function readStoredWorkspaceId(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(ACTIVE_WORKSPACE_STORAGE_KEY);
+}
+
+function storeWorkspaceId(workspaceId: string): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(ACTIVE_WORKSPACE_STORAGE_KEY, workspaceId);
+}
+
+function workspaceRoleAllows(role: WorkspaceRole | undefined, permission: ClientAuthPermission) {
+  if (!role) return true;
+  const permissions = WORKSPACE_ROLE_PERMISSIONS[role] ?? [];
+  return permissions.includes('*') || permissions.includes(permission);
+}
+
+function requireWorkspaceId(workspaceId: string | null | undefined): string {
+  if (!workspaceId) {
+    throw new Error('Workspace is required');
+  }
+  return workspaceId;
+}
+
+export function IdentityProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(readStoredWorkspaceId);
+
+  const authQuery = useQuery({
+    queryKey: ['auth', 'context'],
+    queryFn: identityApi.getAuthContext,
+    retry: false,
+  });
+
+  const profileQuery = useQuery({
+    queryKey: ['identity', 'profile'],
+    queryFn: identityApi.getProfile,
+    retry: false,
+  });
+
+  const workspaces = useMemo(() => profileQuery.data?.workspaces ?? [], [profileQuery.data]);
+
+  useEffect(() => {
+    if (workspaces.length === 0) return;
+    const selected = activeWorkspaceId
+      ? workspaces.some((entry) => entry.workspace.id === activeWorkspaceId)
+      : false;
+    if (!selected) {
+      const nextWorkspaceId = workspaces[0].workspace.id;
+      setActiveWorkspaceId(nextWorkspaceId);
+      storeWorkspaceId(nextWorkspaceId);
+    }
+  }, [activeWorkspaceId, workspaces]);
+
+  const switchMutation = useMutation({
+    mutationFn: identityApi.switchWorkspace,
+    onSuccess: async (result) => {
+      setActiveWorkspaceId(result.workspace.id);
+      storeWorkspaceId(result.workspace.id);
+      await queryClient.invalidateQueries({ queryKey: ['identity'] });
+    },
+  });
+
+  const activeEntry = useMemo(() => {
+    if (workspaces.length === 0) return null;
+    return workspaces.find((entry) => entry.workspace.id === activeWorkspaceId) ?? workspaces[0];
+  }, [activeWorkspaceId, workspaces]);
+
+  const authContext = authQuery.data ?? null;
+  const activeMembership = activeEntry?.membership ?? null;
+
+  const hasPermission = useCallback(
+    (permission: ClientAuthPermission) => {
+      const authAllows = authContext ? hasClientPermission(authContext, permission) : true;
+      return authAllows && workspaceRoleAllows(activeMembership?.role, permission);
+    },
+    [activeMembership?.role, authContext]
+  );
+
+  const value = useMemo<IdentityContextValue>(
+    () => ({
+      authContext,
+      profile: profileQuery.data ?? null,
+      workspaces,
+      activeWorkspace: activeEntry?.workspace ?? null,
+      activeMembership,
+      activeWorkspaceId: activeEntry?.workspace.id ?? activeWorkspaceId,
+      isLoading: authQuery.isLoading || profileQuery.isLoading,
+      error: (authQuery.error as Error | null) ?? (profileQuery.error as Error | null) ?? null,
+      canManageMembers: hasPermission('admin:manage'),
+      hasPermission,
+      switchWorkspace: async (workspaceId: string) => {
+        await switchMutation.mutateAsync(workspaceId);
+      },
+    }),
+    [
+      activeEntry,
+      activeMembership,
+      activeWorkspaceId,
+      authContext,
+      authQuery.error,
+      authQuery.isLoading,
+      hasPermission,
+      profileQuery.data,
+      profileQuery.error,
+      profileQuery.isLoading,
+      switchMutation,
+      workspaces,
+    ]
+  );
+
+  return <IdentityContext.Provider value={value}>{children}</IdentityContext.Provider>;
+}
+
+export function useIdentity(): IdentityContextValue {
+  return useContext(IdentityContext) ?? permissiveFallback;
+}
+
+export function useWorkspaceMembers(workspaceId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['identity', 'workspaces', workspaceId, 'members'],
+    queryFn: () => identityApi.listMembers(requireWorkspaceId(workspaceId)),
+    enabled: !!workspaceId,
+  });
+}
+
+export function useWorkspaceInvitations(
+  workspaceId: string | null | undefined,
+  canManageMembers: boolean
+) {
+  return useQuery({
+    queryKey: ['identity', 'workspaces', workspaceId, 'invitations'],
+    queryFn: () => identityApi.listInvitations(requireWorkspaceId(workspaceId)),
+    enabled: !!workspaceId && canManageMembers,
+  });
+}
+
+export function useCreateWorkspaceInvitation(workspaceId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateInvitationInput) =>
+      identityApi.createInvitation(requireWorkspaceId(workspaceId), input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['identity', 'workspaces', workspaceId, 'invitations'],
+      });
+    },
+  });
+}
+
+export function useUpdateWorkspaceMemberRole(workspaceId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ userId, role }: { userId: string; role: WorkspaceRole }) =>
+      identityApi.updateMemberRole(requireWorkspaceId(workspaceId), userId, role),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['identity', 'workspaces', workspaceId, 'members'],
+        }),
+        queryClient.invalidateQueries({ queryKey: ['identity', 'profile'] }),
+      ]);
+    },
+  });
+}
+
+export function useRemoveWorkspaceMember(workspaceId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: string) =>
+      identityApi.removeMember(requireWorkspaceId(workspaceId), userId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['identity', 'workspaces', workspaceId, 'members'],
+      });
+    },
+  });
+}
+
+export function useRevokeWorkspaceInvitation(workspaceId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: identityApi.revokeInvitation,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['identity', 'workspaces', workspaceId, 'invitations'],
+      });
+    },
+  });
+}
+
+export { WORKSPACE_ROLES, type WorkspaceRole } from '@/lib/api/identity';

--- a/web/src/lib/api/identity.ts
+++ b/web/src/lib/api/identity.ts
@@ -1,0 +1,159 @@
+import type { ClientAuthContext, ClientAuthPermission } from '@veritas-kanban/shared';
+import { apiFetch } from './helpers';
+
+export const WORKSPACE_ROLES = [
+  'owner',
+  'admin',
+  'member',
+  'reviewer',
+  'read-only',
+  'agent',
+] as const;
+
+export type WorkspaceRole = (typeof WORKSPACE_ROLES)[number];
+
+export interface IdentityUser {
+  id: string;
+  displayName: string;
+  email: string | null;
+  handle: string | null;
+  authSubject: string | null;
+  avatarUrl: string | null;
+  disabledAt: string | null;
+  lastSeenAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceIdentity {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  mode: string;
+  createdBy: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceMembership {
+  workspaceId: string;
+  userId: string;
+  role: WorkspaceRole;
+  status: string;
+  invitedBy: string | null;
+  joinedAt: string | null;
+  disabledAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  user?: IdentityUser;
+}
+
+export interface WorkspaceInvitation {
+  id: string;
+  workspaceId: string;
+  email: string | null;
+  role: WorkspaceRole;
+  tokenHash: string;
+  invitedBy: string;
+  createdAt: string;
+  expiresAt: string;
+  acceptedBy: string | null;
+  acceptedAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface IdentityProfile {
+  user: IdentityUser;
+  workspaces: Array<{
+    workspace: WorkspaceIdentity;
+    membership: WorkspaceMembership;
+  }>;
+}
+
+export interface CreateInvitationInput {
+  email?: string;
+  role: WorkspaceRole;
+  expiresAt?: string;
+}
+
+export interface CreateInvitationResult {
+  invitation: WorkspaceInvitation;
+  token: string;
+}
+
+export interface ApiTokenSummary {
+  name: string;
+  authMethod: string;
+  tokenName?: string;
+  permissions: ClientAuthPermission[];
+}
+
+export const identityApi = {
+  getAuthContext: () => apiFetch<ClientAuthContext>('/api/auth/context'),
+
+  getProfile: () => apiFetch<IdentityProfile>('/api/identity/profile'),
+
+  listWorkspaces: () => apiFetch<IdentityProfile['workspaces']>('/api/identity/workspaces'),
+
+  switchWorkspace: (workspaceId: string) =>
+    apiFetch<{ workspace: WorkspaceIdentity; membership: WorkspaceMembership }>(
+      '/api/identity/workspaces/switch',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspaceId }),
+      }
+    ),
+
+  listMembers: (workspaceId: string) =>
+    apiFetch<WorkspaceMembership[]>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/members`
+    ),
+
+  listInvitations: (workspaceId: string) =>
+    apiFetch<WorkspaceInvitation[]>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/invitations`
+    ),
+
+  createInvitation: (workspaceId: string, input: CreateInvitationInput) =>
+    apiFetch<CreateInvitationResult>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/invitations`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    ),
+
+  revokeInvitation: (invitationId: string) =>
+    apiFetch<WorkspaceInvitation>(
+      `/api/identity/invitations/${encodeURIComponent(invitationId)}/revoke`,
+      {
+        method: 'POST',
+      }
+    ),
+
+  updateMemberRole: (workspaceId: string, userId: string, role: WorkspaceRole) =>
+    apiFetch<WorkspaceMembership>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/members/${encodeURIComponent(
+        userId
+      )}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role }),
+      }
+    ),
+
+  removeMember: (workspaceId: string, userId: string) =>
+    apiFetch<WorkspaceMembership>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/members/${encodeURIComponent(
+        userId
+      )}`,
+      {
+        method: 'DELETE',
+      }
+    ),
+};

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -15,6 +15,7 @@ import { chatApi } from './chat';
 import { decisionsApi } from './decisions';
 import { scoringApi } from './scoring';
 import { searchApi } from './search';
+import { identityApi } from './identity';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -40,6 +41,7 @@ export const api = {
   decisions: decisionsApi,
   scoring: scoringApi,
   search: searchApi,
+  identity: identityApi,
 };
 
 export type {
@@ -111,3 +113,14 @@ export type {
   DecisionWithChain,
   DecisionListFilters,
 } from '@veritas-kanban/shared';
+
+export type {
+  IdentityProfile,
+  IdentityUser,
+  WorkspaceIdentity,
+  WorkspaceInvitation,
+  WorkspaceMembership,
+  WorkspaceRole,
+  CreateInvitationInput,
+  CreateInvitationResult,
+} from './identity';


### PR DESCRIPTION
## Summary

- adds identity API client/hooks and an app-level identity provider for auth context, active workspace selection, and role-aware permissions
- adds a header workspace switcher and richer session menu with profile, workspace, role, and API context
- adds a Multi-user settings tab for workspace members, invitations, role edits, invite tokens, and current API access
- applies permission-aware disabled states across task creation, board movement/bulk selection, settings tabs/import/reset, workflow runs, and Git settings
- tracks scoped API token issuance separately in #457 because it needs repository, hashing, auth middleware, and audit work

Closes #338.

## Verification

- `pnpm --filter @veritas-kanban/web test -- src/__tests__/multi-user-tab.test.tsx src/__tests__/KanbanBoard.test.tsx`
- `pnpm --filter @veritas-kanban/web test`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `git diff --check`
- Browser smoke: app shell, workspace switcher, Multi-user settings tab, invite form layout, and settings accessibility warning check at `http://127.0.0.1:3000`

## Notes

- The API Access panel shows the current auth context in this slice. Token creation stays disabled until #457 lands the backing token lifecycle.