### PR TITLE
Add scoped API token management

### DIFF
--- a/server/src/__tests__/api-token-service.test.ts
+++ b/server/src/__tests__/api-token-service.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ForbiddenError, NotFoundError } from '../middleware/error-handler.js';
+import {
+  ApiTokenService,
+  hashApiTokenSecret,
+  type CreateApiTokenResult,
+} from '../services/api-token-service.js';
+import { createTestSqliteDatabase } from '../storage/sqlite/test-helpers.js';
+import { SqliteApiTokenRepository } from '../storage/sqlite/api-token-repository.js';
+import { SqliteIdentityRepository } from '../storage/sqlite/identity-repository.js';
+import type { IdentityActor } from '../services/identity-service.js';
+
+function createService() {
+  const fixture = createTestSqliteDatabase();
+  fixture.database.open();
+  const identityRepository = new SqliteIdentityRepository(fixture.database);
+  const tokenRepository = new SqliteApiTokenRepository(fixture.database);
+  const audit = vi.fn().mockResolvedValue(undefined);
+  const activity = { logActivity: vi.fn().mockResolvedValue(undefined) };
+  const service = new ApiTokenService({
+    identityRepository,
+    tokenRepository,
+    audit,
+    activity,
+  });
+  const owner = identityRepository.ensureLocalOwner({ displayName: 'Owner' });
+  const ownerActor = {
+    userId: owner.user.id,
+    role: 'owner',
+    displayName: owner.user.displayName,
+    permissions: ['*'],
+  } satisfies IdentityActor;
+
+  return {
+    fixture,
+    identityRepository,
+    tokenRepository,
+    service,
+    audit,
+    activity,
+    ownerActor,
+  };
+}
+
+describe('ApiTokenService', () => {
+  it('creates scoped tokens, stores only a hash, and validates the secret', async () => {
+    const { fixture, service, tokenRepository, audit, activity, ownerActor } = createService();
+
+    try {
+      const result = await service.createToken(
+        {
+          workspaceId: 'local',
+          name: 'CLI worker',
+          scopes: ['workspace:read', 'task:read'],
+        },
+        ownerActor
+      );
+
+      const authRecord = tokenRepository.getForAuthByHash(hashApiTokenSecret(result.secret));
+      const validation = service.validateSecret(result.secret);
+
+      expect(result.secret).toMatch(/^vk_pat_/);
+      expect(authRecord?.tokenHash).not.toBe(result.secret);
+      expect(authRecord?.scopes).toEqual(['workspace:read', 'task:read']);
+      expect(validation.valid).toBe(true);
+      expect(validation.auth).toMatchObject({
+        role: 'read-only',
+        userId: 'local-user',
+        workspaceId: 'local',
+        tokenName: 'CLI worker',
+        permissions: ['workspace:read', 'task:read'],
+      });
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'identity.api_token.create', resource: 'local' })
+      );
+      expect(activity.logActivity).toHaveBeenCalledWith(
+        'membership_updated',
+        'workspace:local',
+        'Workspace local',
+        expect.objectContaining({ action: 'identity.api_token.create' })
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rejects token scopes that exceed the current actor permission boundary', async () => {
+    const { fixture, service, ownerActor } = createService();
+
+    try {
+      const scopedActor = {
+        ...ownerActor,
+        role: 'admin',
+        permissions: ['admin:manage', 'task:read'],
+      } satisfies IdentityActor;
+
+      await expect(
+        service.createToken(
+          {
+            workspaceId: 'local',
+            name: 'Escalation attempt',
+            scopes: ['task:write'],
+          },
+          scopedActor
+        )
+      ).rejects.toBeInstanceOf(ForbiddenError);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rejects revoked, expired, and disabled-actor tokens during validation', async () => {
+    const { fixture, service, ownerActor } = createService();
+
+    try {
+      const active = await service.createToken(
+        {
+          workspaceId: 'local',
+          name: 'Revoked worker',
+          scopes: ['workspace:read'],
+        },
+        ownerActor
+      );
+      const expired = await service.createToken(
+        {
+          workspaceId: 'local',
+          name: 'Expired worker',
+          scopes: ['workspace:read'],
+          expiresAt: '2000-01-01T00:00:00.000Z',
+        },
+        ownerActor
+      );
+
+      await service.revokeToken(active.token.id, ownerActor);
+
+      expect(service.validateSecret(active.secret).valid).toBe(false);
+      expect(service.validateSecret(expired.secret).valid).toBe(false);
+
+      const stillActive = await service.createToken(
+        {
+          workspaceId: 'local',
+          name: 'Disabled owner worker',
+          scopes: ['workspace:read'],
+        },
+        ownerActor
+      );
+      fixture.database
+        .getConnection()
+        .prepare('UPDATE users SET disabled_at = ? WHERE id = ?')
+        .run(new Date().toISOString(), ownerActor.userId);
+
+      expect(service.validateSecret(stillActive.secret).valid).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('does not revoke tokens through the wrong workspace path', async () => {
+    const { fixture, service, ownerActor } = createService();
+
+    try {
+      const result: CreateApiTokenResult = await service.createToken(
+        {
+          workspaceId: 'local',
+          name: 'Workspace bound worker',
+          scopes: ['workspace:read'],
+        },
+        ownerActor
+      );
+
+      await expect(
+        service.revokeToken(result.token.id, ownerActor, 'other-workspace')
+      ).rejects.toBeInstanceOf(NotFoundError);
+      expect(service.validateSecret(result.secret).valid).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/__tests__/middleware/auth.test.ts
+++ b/server/src/__tests__/middleware/auth.test.ts
@@ -35,6 +35,11 @@ import {
 } from '../../middleware/auth.js';
 import { getSecurityConfig, getValidJwtSecrets } from '../../config/security.js';
 import jwt from 'jsonwebtoken';
+import { ApiTokenService, resetApiTokenServiceForTests } from '../../services/api-token-service.js';
+import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+import { SqliteApiTokenRepository } from '../../storage/sqlite/api-token-repository.js';
+import { SqliteIdentityRepository } from '../../storage/sqlite/identity-repository.js';
+import type { IdentityActor } from '../../services/identity-service.js';
 
 // Helper to create a mock Express request
 function mockRequest(overrides: Partial<Request> = {}): Request {
@@ -73,6 +78,7 @@ describe('Auth Middleware', () => {
     delete process.env.VERITAS_AUTH_LOCALHOST_ROLE;
     delete process.env.VERITAS_ADMIN_KEY;
     delete process.env.VERITAS_API_KEYS;
+    delete process.env.VERITAS_SQLITE_PATH;
     process.env.NODE_ENV = 'development';
 
     // Reset mocks
@@ -83,6 +89,7 @@ describe('Auth Middleware', () => {
   });
 
   afterEach(() => {
+    resetApiTokenServiceForTests();
     process.env = { ...originalEnv };
     vi.restoreAllMocks();
   });
@@ -222,6 +229,56 @@ describe('Auth Middleware', () => {
       expect(req.auth?.workspaceId).toBe('local');
       expect(req.auth?.permissions).toContain('task:write');
       expect(req.auth?.permissions).not.toContain('admin:manage');
+    });
+
+    it('should authenticate via SQLite scoped API token', async () => {
+      const fixture = createTestSqliteDatabase();
+      fixture.database.open();
+      process.env.VERITAS_SQLITE_PATH = fixture.databasePath;
+
+      const identityRepository = new SqliteIdentityRepository(fixture.database);
+      const tokenRepository = new SqliteApiTokenRepository(fixture.database);
+      const service = new ApiTokenService({
+        identityRepository,
+        tokenRepository,
+        audit: vi.fn().mockResolvedValue(undefined),
+        activity: { logActivity: vi.fn().mockResolvedValue(undefined) },
+      });
+      const owner = identityRepository.ensureLocalOwner({ displayName: 'Owner' });
+      const ownerActor = {
+        userId: owner.user.id,
+        role: 'owner',
+        displayName: owner.user.displayName,
+        permissions: ['*'],
+      } satisfies IdentityActor;
+      const scoped = await service.createToken(
+        {
+          workspaceId: 'local',
+          name: 'Scoped worker',
+          scopes: ['workspace:read', 'task:read'],
+        },
+        ownerActor
+      );
+      resetApiTokenServiceForTests();
+
+      try {
+        const req = mockRequest({
+          headers: { authorization: `Bearer ${scoped.secret}` },
+          socket: { remoteAddress: '192.168.1.100' } as any,
+          ip: '192.168.1.100',
+        }) as AuthenticatedRequest;
+        const res = mockResponse();
+        const next = mockNext();
+
+        authenticate(req, res, next);
+        expect(next).toHaveBeenCalled();
+        expect(req.auth?.role).toBe('read-only');
+        expect(req.auth?.keyName).toBe('Scoped worker');
+        expect(req.auth?.workspaceId).toBe('local');
+        expect(req.auth?.permissions).toEqual(['workspace:read', 'task:read']);
+      } finally {
+        fixture.cleanup();
+      }
     });
 
     it('should allow localhost bypass with read-only role by default', () => {
@@ -688,6 +745,53 @@ describe('Auth Middleware', () => {
       expect(result.workspaceId).toBe('local');
       expect(result.permissions).toContain('task:write');
       expect(result.permissions).not.toContain('admin:manage');
+    });
+
+    it('should authenticate WebSocket scoped API tokens from the query parameter', async () => {
+      const fixture = createTestSqliteDatabase();
+      fixture.database.open();
+      process.env.VERITAS_SQLITE_PATH = fixture.databasePath;
+
+      const identityRepository = new SqliteIdentityRepository(fixture.database);
+      const tokenRepository = new SqliteApiTokenRepository(fixture.database);
+      const service = new ApiTokenService({
+        identityRepository,
+        tokenRepository,
+        audit: vi.fn().mockResolvedValue(undefined),
+        activity: { logActivity: vi.fn().mockResolvedValue(undefined) },
+      });
+      const owner = identityRepository.ensureLocalOwner({ displayName: 'Owner' });
+      const scoped = await service.createToken(
+        {
+          workspaceId: 'local',
+          name: 'WebSocket reader',
+          scopes: ['workspace:read', 'task:read'],
+        },
+        {
+          userId: owner.user.id,
+          role: 'owner',
+          displayName: owner.user.displayName,
+          permissions: ['*'],
+        }
+      );
+      resetApiTokenServiceForTests();
+
+      try {
+        const req = {
+          headers: { host: 'localhost:3001' },
+          url: `/ws?api_key=${encodeURIComponent(scoped.secret)}`,
+          socket: { remoteAddress: '192.168.1.100' },
+        } as unknown as IncomingMessage;
+
+        const result = authenticateWebSocket(req);
+        expect(result.authenticated).toBe(true);
+        expect(result.role).toBe('read-only');
+        expect(result.tokenName).toBe('WebSocket reader');
+        expect(result.workspaceId).toBe('local');
+        expect(result.permissions).toEqual(['workspace:read', 'task:read']);
+      } finally {
+        fixture.cleanup();
+      }
     });
 
     it('should authenticate via JWT cookie', () => {

--- a/server/src/__tests__/routes/identity.test.ts
+++ b/server/src/__tests__/routes/identity.test.ts
@@ -4,16 +4,25 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AuthenticatedRequest } from '../../middleware/auth.js';
 import { errorHandler } from '../../middleware/error-handler.js';
 import { createIdentityRoutes } from '../../routes/identity.js';
+import { ApiTokenService } from '../../services/api-token-service.js';
 import { IdentityService } from '../../services/identity-service.js';
 import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+import { SqliteApiTokenRepository } from '../../storage/sqlite/api-token-repository.js';
 import { SqliteIdentityRepository } from '../../storage/sqlite/identity-repository.js';
 
 function createApp(role: 'admin' | 'agent' | 'read-only' = 'admin') {
   const fixture = createTestSqliteDatabase();
   fixture.database.open();
   const repository = new SqliteIdentityRepository(fixture.database);
+  const tokenRepository = new SqliteApiTokenRepository(fixture.database);
   const service = new IdentityService({
     repository,
+    audit: vi.fn().mockResolvedValue(undefined),
+    activity: { logActivity: vi.fn().mockResolvedValue(undefined) },
+  });
+  const apiTokenService = new ApiTokenService({
+    identityRepository: repository,
+    tokenRepository,
     audit: vi.fn().mockResolvedValue(undefined),
     activity: { logActivity: vi.fn().mockResolvedValue(undefined) },
   });
@@ -26,10 +35,13 @@ function createApp(role: 'admin' | 'agent' | 'read-only' = 'admin') {
       role,
       keyName: role,
       isLocalhost: false,
+      userId: 'local-user',
+      workspaceId: 'local',
+      permissions: role === 'admin' ? ['*'] : ['workspace:read'],
     };
     next();
   });
-  app.use('/identity', createIdentityRoutes(service));
+  app.use('/identity', createIdentityRoutes(service, apiTokenService));
   app.use(errorHandler);
 
   return { app, fixture };
@@ -78,6 +90,40 @@ describe('identity routes', () => {
         .post('/identity/workspaces/local/invitations')
         .send({ email: 'member@example.com', role: 'member' })
         .expect(403);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('creates, lists, rotates, and revokes scoped API tokens without exposing hashes', async () => {
+    const { app, fixture } = createApp();
+
+    try {
+      const created = await request(app)
+        .post('/identity/workspaces/local/api-tokens')
+        .send({ name: 'CLI worker', scopes: ['workspace:read', 'task:read'] })
+        .expect(201);
+
+      expect(created.body.secret).toMatch(/^vk_pat_/);
+      expect(created.body.token.name).toBe('CLI worker');
+      expect(created.body.token.tokenHash).toBeUndefined();
+
+      const listed = await request(app).get('/identity/workspaces/local/api-tokens').expect(200);
+      expect(listed.body).toHaveLength(1);
+      expect(listed.body[0].tokenHash).toBeUndefined();
+
+      const rotated = await request(app)
+        .post(`/identity/workspaces/local/api-tokens/${created.body.token.id}/rotate`)
+        .send()
+        .expect(201);
+      expect(rotated.body.secret).toMatch(/^vk_pat_/);
+      expect(rotated.body.secret).not.toBe(created.body.secret);
+
+      const revoked = await request(app)
+        .post(`/identity/workspaces/local/api-tokens/${rotated.body.token.id}/revoke`)
+        .send()
+        .expect(200);
+      expect(revoked.body.revokedAt).toBeTruthy();
     } finally {
       fixture.cleanup();
     }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { getSecurityConfig, getJwtSecret, getValidJwtSecrets } from '../config/security.js';
 import { createLogger } from '../lib/logger.js';
+import { validateScopedApiToken } from '../services/api-token-service.js';
 
 const log = createLogger('auth');
 
@@ -336,6 +337,27 @@ function validateApiKey(
   return { valid: false };
 }
 
+function validateDatabaseApiToken(
+  apiKey: string,
+  req: Request | IncomingMessage,
+  isLocalhost: boolean
+): AuthContext | null {
+  try {
+    const validation = validateScopedApiToken(apiKey, requestRemoteAddress(req));
+    return validation.valid && validation.auth ? { ...validation.auth, isLocalhost } : null;
+  } catch (error) {
+    log.warn({ err: error }, 'Scoped API token validation failed');
+    return null;
+  }
+}
+
+function requestRemoteAddress(req: Request | IncomingMessage): string | null {
+  if ('socket' in req && req.socket) {
+    return req.socket.remoteAddress ?? null;
+  }
+  return 'ip' in req ? ((req as Request).ip ?? null) : null;
+}
+
 // === JWT Verification ===
 
 /**
@@ -423,6 +445,12 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
       });
       return next();
     }
+
+    const scopedAuth = validateDatabaseApiToken(apiKey, req, isLocalhost);
+    if (scopedAuth) {
+      req.auth = scopedAuth;
+      return next();
+    }
   }
 
   // 3. Localhost bypass (dev mode) — role is configurable (default: read-only)
@@ -463,6 +491,10 @@ export function authorize(...allowedRoles: AuthRole[]) {
 
     // Admin can do everything
     if (req.auth.role === 'admin') {
+      return next();
+    }
+
+    if (allowedRoles.includes('admin') && hasPermission(req.auth, 'admin:manage')) {
       return next();
     }
 
@@ -685,6 +717,14 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
           isLocalhost,
           authMethod: 'api-key',
         }),
+      };
+    }
+
+    const scopedAuth = validateDatabaseApiToken(apiKey, req, isLocalhost);
+    if (scopedAuth) {
+      return {
+        authenticated: true,
+        ...scopedAuth,
       };
     }
   }

--- a/server/src/routes/identity.ts
+++ b/server/src/routes/identity.ts
@@ -1,8 +1,17 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { asyncHandler } from '../middleware/async-handler.js';
-import { authorize, type AuthenticatedRequest } from '../middleware/auth.js';
+import {
+  authorizePermission,
+  type AuthenticatedRequest,
+  type AuthPermission,
+} from '../middleware/auth.js';
 import { ValidationError } from '../middleware/error-handler.js';
+import {
+  getApiTokenService,
+  SCOPED_API_TOKEN_PERMISSIONS,
+  type ApiTokenService,
+} from '../services/api-token-service.js';
 import {
   getIdentityService,
   type IdentityActor,
@@ -28,9 +37,19 @@ const updateRoleSchema = z.object({
   role: roleSchema,
 });
 
-export function createIdentityRoutes(service?: IdentityService): RouterType {
+const createApiTokenSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  scopes: z.array(z.enum(SCOPED_API_TOKEN_PERMISSIONS)).min(1),
+  expiresAt: z.string().datetime().optional().nullable(),
+});
+
+export function createIdentityRoutes(
+  service?: IdentityService,
+  apiTokenService?: ApiTokenService
+): RouterType {
   const router: RouterType = Router();
   const serviceForRequest = () => service ?? getIdentityService();
+  const tokenServiceForRequest = () => apiTokenService ?? getApiTokenService();
 
   router.get(
     '/profile',
@@ -74,7 +93,7 @@ export function createIdentityRoutes(service?: IdentityService): RouterType {
 
   router.get(
     '/workspaces/:workspaceId/invitations',
-    authorize('admin'),
+    authorizePermission('admin:manage'),
     asyncHandler(async (req, res) => {
       res.json(
         serviceForRequest().listInvitations(
@@ -87,7 +106,7 @@ export function createIdentityRoutes(service?: IdentityService): RouterType {
 
   router.post(
     '/workspaces/:workspaceId/invitations',
-    authorize('admin'),
+    authorizePermission('admin:manage'),
     asyncHandler(async (req, res) => {
       const body = parseBody(createInvitationSchema, req.body);
       const result = await serviceForRequest().createInvitation(
@@ -114,7 +133,7 @@ export function createIdentityRoutes(service?: IdentityService): RouterType {
 
   router.post(
     '/invitations/:id/revoke',
-    authorize('admin'),
+    authorizePermission('admin:manage'),
     asyncHandler(async (req, res) => {
       const invitation = await serviceForRequest().revokeInvitation(
         String(req.params.id),
@@ -126,7 +145,7 @@ export function createIdentityRoutes(service?: IdentityService): RouterType {
 
   router.patch(
     '/workspaces/:workspaceId/members/:userId',
-    authorize('admin'),
+    authorizePermission('admin:manage'),
     asyncHandler(async (req, res) => {
       const body = parseBody(updateRoleSchema, req.body);
       const membership = await serviceForRequest().updateMemberRole(
@@ -141,7 +160,7 @@ export function createIdentityRoutes(service?: IdentityService): RouterType {
 
   router.delete(
     '/workspaces/:workspaceId/members/:userId',
-    authorize('admin'),
+    authorizePermission('admin:manage'),
     asyncHandler(async (req, res) => {
       const membership = await serviceForRequest().removeMember(
         String(req.params.workspaceId),
@@ -152,15 +171,74 @@ export function createIdentityRoutes(service?: IdentityService): RouterType {
     })
   );
 
+  router.get(
+    '/workspaces/:workspaceId/api-tokens',
+    authorizePermission('admin:manage'),
+    asyncHandler(async (req, res) => {
+      res.json(
+        tokenServiceForRequest().listTokens(
+          String(req.params.workspaceId),
+          actorFromRequest(req as AuthenticatedRequest)
+        )
+      );
+    })
+  );
+
+  router.post(
+    '/workspaces/:workspaceId/api-tokens',
+    authorizePermission('admin:manage'),
+    asyncHandler(async (req, res) => {
+      const body = parseBody(createApiTokenSchema, req.body);
+      const result = await tokenServiceForRequest().createToken(
+        {
+          workspaceId: String(req.params.workspaceId),
+          name: body.name,
+          scopes: body.scopes as AuthPermission[],
+          expiresAt: body.expiresAt,
+        },
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.status(201).json(result);
+    })
+  );
+
+  router.post(
+    '/workspaces/:workspaceId/api-tokens/:tokenId/revoke',
+    authorizePermission('admin:manage'),
+    asyncHandler(async (req, res) => {
+      const token = await tokenServiceForRequest().revokeToken(
+        String(req.params.tokenId),
+        actorFromRequest(req as AuthenticatedRequest),
+        String(req.params.workspaceId)
+      );
+      res.json(token);
+    })
+  );
+
+  router.post(
+    '/workspaces/:workspaceId/api-tokens/:tokenId/rotate',
+    authorizePermission('admin:manage'),
+    asyncHandler(async (req, res) => {
+      const result = await tokenServiceForRequest().rotateToken(
+        String(req.params.tokenId),
+        actorFromRequest(req as AuthenticatedRequest),
+        String(req.params.workspaceId)
+      );
+      res.status(201).json(result);
+    })
+  );
+
   return router;
 }
 
 function actorFromRequest(req: AuthenticatedRequest): IdentityActor {
   const role = req.auth?.role;
+  const userId = req.auth?.userId ?? 'local-user';
   return {
-    userId: 'local-user',
+    userId,
     role: role === 'agent' ? 'agent' : role === 'read-only' ? 'read-only' : 'owner',
-    displayName: req.auth?.keyName ?? 'local-user',
+    displayName: req.auth?.tokenName ?? req.auth?.keyName ?? userId,
+    permissions: req.auth?.permissions,
   };
 }
 

--- a/server/src/services/api-token-service.ts
+++ b/server/src/services/api-token-service.ts
@@ -1,0 +1,353 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { AuthContext, AuthPermission, AuthRole } from '../middleware/auth.js';
+import { ForbiddenError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { auditLog, type AuditEvent } from './audit-service.js';
+import { ActivityService } from './activity-service.js';
+import {
+  SqliteDatabase,
+  resolveSqliteDatabasePath,
+  type SqliteConnectionOptions,
+} from '../storage/sqlite/database.js';
+import {
+  SqliteApiTokenRepository,
+  type ApiTokenRecord,
+} from '../storage/sqlite/api-token-repository.js';
+import {
+  SqliteIdentityRepository,
+  type WorkspaceMembership,
+  type WorkspaceRole,
+} from '../storage/sqlite/identity-repository.js';
+import type { IdentityActor } from './identity-service.js';
+
+const TOKEN_SECRET_PREFIX = 'vk_pat_';
+const TOKEN_PREFIX_LENGTH = 16;
+const MANAGER_ROLES = new Set<WorkspaceRole>(['owner', 'admin']);
+const WRITE_PERMISSIONS = new Set<AuthPermission>([
+  'task:write',
+  'comment:write',
+  'workflow:write',
+  'workflow:execute',
+  'work_product:write',
+  'telemetry:write',
+  'agent:write',
+  'settings:write',
+  'policy:write',
+  'backup:write',
+  'admin:manage',
+]);
+
+export const SCOPED_API_TOKEN_PERMISSIONS = [
+  'workspace:read',
+  'task:read',
+  'task:write',
+  'comment:write',
+  'workflow:read',
+  'workflow:write',
+  'workflow:execute',
+  'work_product:read',
+  'work_product:write',
+  'report:read',
+  'telemetry:read',
+  'telemetry:write',
+  'agent:read',
+  'agent:write',
+  'settings:read',
+  'settings:write',
+  'policy:read',
+  'policy:write',
+  'backup:read',
+  'backup:write',
+  'admin:manage',
+] as const satisfies readonly AuthPermission[];
+
+const SCOPED_API_TOKEN_PERMISSION_SET = new Set<AuthPermission>(SCOPED_API_TOKEN_PERMISSIONS);
+
+export interface CreateApiTokenResult {
+  token: ApiTokenRecord;
+  secret: string;
+}
+
+export interface ApiTokenServiceOptions {
+  tokenRepository?: SqliteApiTokenRepository;
+  identityRepository?: SqliteIdentityRepository;
+  sqliteDatabase?: SqliteDatabase;
+  sqliteConnectionOptions?: SqliteConnectionOptions;
+  audit?: (event: AuditEvent) => Promise<void>;
+  activity?: Pick<ActivityService, 'logActivity'>;
+}
+
+export interface ScopedApiTokenValidationResult {
+  valid: boolean;
+  auth?: AuthContext;
+}
+
+export class ApiTokenService {
+  private readonly tokenRepository: SqliteApiTokenRepository;
+  private readonly identityRepository: SqliteIdentityRepository;
+  private readonly sqliteDatabase: SqliteDatabase | null = null;
+  private readonly ownsSqliteDatabase: boolean = false;
+  private readonly audit: (event: AuditEvent) => Promise<void>;
+  private readonly activity: Pick<ActivityService, 'logActivity'>;
+
+  constructor(options: ApiTokenServiceOptions = {}) {
+    if (options.tokenRepository && options.identityRepository) {
+      this.tokenRepository = options.tokenRepository;
+      this.identityRepository = options.identityRepository;
+    } else {
+      this.sqliteDatabase =
+        options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
+      this.ownsSqliteDatabase = !options.sqliteDatabase;
+      this.sqliteDatabase.open();
+      this.tokenRepository =
+        options.tokenRepository ?? new SqliteApiTokenRepository(this.sqliteDatabase);
+      this.identityRepository =
+        options.identityRepository ?? new SqliteIdentityRepository(this.sqliteDatabase);
+    }
+
+    this.audit = options.audit ?? auditLog;
+    this.activity =
+      options.activity ??
+      new ActivityService({
+        storageType: process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file',
+        sqliteDatabase: options.sqliteDatabase,
+      });
+  }
+
+  listTokens(workspaceId: string, actor: IdentityActor): ApiTokenRecord[] {
+    this.assertCanManageTokens(workspaceId, actor);
+    return this.tokenRepository.listByWorkspace(workspaceId);
+  }
+
+  async createToken(
+    input: {
+      workspaceId: string;
+      name: string;
+      scopes: AuthPermission[];
+      expiresAt?: string | null;
+    },
+    actor: IdentityActor
+  ): Promise<CreateApiTokenResult> {
+    this.assertCanManageTokens(input.workspaceId, actor);
+    const scopes = this.normalizeScopes(input.scopes, actor);
+    const secret = generateApiTokenSecret();
+    const token = this.tokenRepository.create({
+      workspaceId: input.workspaceId,
+      name: input.name,
+      tokenPrefix: secret.slice(0, TOKEN_PREFIX_LENGTH),
+      tokenHash: hashApiTokenSecret(secret),
+      scopes,
+      createdBy: actor.userId,
+      expiresAt: input.expiresAt ?? null,
+    });
+
+    await this.recordTokenChange('identity.api_token.create', actor, input.workspaceId, {
+      tokenId: token.id,
+      tokenName: token.name,
+      scopes,
+      expiresAt: token.expiresAt,
+    });
+
+    return { token, secret };
+  }
+
+  async revokeToken(
+    tokenId: string,
+    actor: IdentityActor,
+    expectedWorkspaceId?: string
+  ): Promise<ApiTokenRecord> {
+    const existing = this.tokenRepository.get(tokenId);
+    if (!existing) throw new NotFoundError('API token not found');
+    if (expectedWorkspaceId && existing.workspaceId !== expectedWorkspaceId) {
+      throw new NotFoundError('API token not found');
+    }
+    this.assertCanManageTokens(existing.workspaceId, actor);
+
+    const token = this.tokenRepository.revoke(tokenId, actor.userId);
+    if (!token) throw new ValidationError('API token cannot be revoked');
+
+    await this.recordTokenChange('identity.api_token.revoke', actor, token.workspaceId, {
+      tokenId,
+      tokenName: token.name,
+    });
+
+    return token;
+  }
+
+  async rotateToken(
+    tokenId: string,
+    actor: IdentityActor,
+    expectedWorkspaceId?: string
+  ): Promise<CreateApiTokenResult> {
+    const existing = this.tokenRepository.get(tokenId);
+    if (!existing) throw new NotFoundError('API token not found');
+    if (expectedWorkspaceId && existing.workspaceId !== expectedWorkspaceId) {
+      throw new NotFoundError('API token not found');
+    }
+    this.assertCanManageTokens(existing.workspaceId, actor);
+    this.normalizeScopes(existing.scopes, actor);
+
+    if (!existing.revokedAt) {
+      this.tokenRepository.revoke(tokenId, actor.userId);
+    }
+
+    const result = await this.createToken(
+      {
+        workspaceId: existing.workspaceId,
+        name: existing.name,
+        scopes: existing.scopes,
+        expiresAt: existing.expiresAt,
+      },
+      actor
+    );
+
+    await this.recordTokenChange('identity.api_token.rotate', actor, existing.workspaceId, {
+      previousTokenId: tokenId,
+      tokenId: result.token.id,
+      tokenName: result.token.name,
+    });
+
+    return result;
+  }
+
+  validateSecret(secret: string, ipAddress?: string | null): ScopedApiTokenValidationResult {
+    if (!isScopedApiTokenSecret(secret)) return { valid: false };
+
+    const token = this.tokenRepository.getForAuthByHash(hashApiTokenSecret(secret));
+    if (!token) return { valid: false };
+    if (token.revokedAt) return { valid: false };
+    if (token.expiresAt && Date.parse(token.expiresAt) <= Date.now()) return { valid: false };
+    if (token.creatorDisabledAt) return { valid: false };
+    if (token.workspaceArchivedAt) return { valid: false };
+    if (token.membershipStatus !== 'active' || token.membershipDisabledAt) return { valid: false };
+
+    this.tokenRepository.recordUse(token.id, ipAddress);
+
+    return {
+      valid: true,
+      auth: {
+        role: roleForScopes(token.scopes),
+        keyName: token.name,
+        isLocalhost: false,
+        userId: token.createdBy,
+        workspaceId: token.workspaceId,
+        actorType: 'service',
+        authMethod: 'api-key',
+        tokenName: token.name,
+        permissions: token.scopes,
+      },
+    };
+  }
+
+  close(): void {
+    if (this.ownsSqliteDatabase) {
+      this.sqliteDatabase?.close();
+    }
+  }
+
+  private assertCanManageTokens(workspaceId: string, actor: IdentityActor): WorkspaceMembership {
+    this.identityRepository.ensureLocalOwner();
+    const membership = this.identityRepository.getMembership(workspaceId, actor.userId);
+    if (!membership || membership.status !== 'active' || membership.disabledAt) {
+      throw new ForbiddenError('No active membership for workspace');
+    }
+
+    if (!MANAGER_ROLES.has(membership.role)) {
+      throw new ForbiddenError('Only workspace owners and admins can manage API tokens');
+    }
+
+    return membership;
+  }
+
+  private normalizeScopes(scopes: AuthPermission[], actor: IdentityActor): AuthPermission[] {
+    const uniqueScopes = [...new Set(scopes)];
+    if (uniqueScopes.length === 0) {
+      throw new ValidationError('At least one API token scope is required');
+    }
+
+    const invalid = uniqueScopes.filter((scope) => !SCOPED_API_TOKEN_PERMISSION_SET.has(scope));
+    if (invalid.length > 0) {
+      throw new ValidationError('Invalid API token scope', { invalid });
+    }
+
+    const actorPermissions = actor.permissions ?? [];
+    const actorHasAll = actorPermissions.includes('*') || actor.role === 'owner';
+    if (!actorHasAll) {
+      const denied = uniqueScopes.filter((scope) => !actorPermissions.includes(scope));
+      if (denied.length > 0) {
+        throw new ForbiddenError('API token scopes exceed the current actor permissions', {
+          denied,
+        });
+      }
+    }
+
+    return uniqueScopes;
+  }
+
+  private async recordTokenChange(
+    action: string,
+    actor: IdentityActor,
+    workspaceId: string,
+    details: Record<string, unknown>
+  ): Promise<void> {
+    await this.audit({
+      action,
+      actor: actor.displayName || actor.userId,
+      resource: workspaceId,
+      details,
+    });
+
+    await this.activity.logActivity(
+      'membership_updated',
+      `workspace:${workspaceId}`,
+      `Workspace ${workspaceId}`,
+      {
+        action,
+        actor: actor.userId,
+        ...details,
+      }
+    );
+  }
+}
+
+let apiTokenService: ApiTokenService | null = null;
+let apiTokenServicePath: string | null = null;
+
+export function getApiTokenService(): ApiTokenService {
+  const databasePath = resolveSqliteDatabasePath();
+  if (!apiTokenService || apiTokenServicePath !== databasePath) {
+    apiTokenService?.close();
+    apiTokenService = new ApiTokenService({ sqliteConnectionOptions: { databasePath } });
+    apiTokenServicePath = databasePath;
+  }
+  return apiTokenService;
+}
+
+export function resetApiTokenServiceForTests(): void {
+  apiTokenService?.close();
+  apiTokenService = null;
+  apiTokenServicePath = null;
+}
+
+export function validateScopedApiToken(
+  secret: string,
+  ipAddress?: string | null
+): ScopedApiTokenValidationResult {
+  if (!isScopedApiTokenSecret(secret)) return { valid: false };
+  return getApiTokenService().validateSecret(secret, ipAddress);
+}
+
+export function generateApiTokenSecret(): string {
+  return `${TOKEN_SECRET_PREFIX}${randomBytes(32).toString('base64url')}`;
+}
+
+export function hashApiTokenSecret(secret: string): string {
+  return createHash('sha256').update(secret, 'utf8').digest('hex');
+}
+
+export function isScopedApiTokenSecret(secret: string): boolean {
+  return secret.startsWith(TOKEN_SECRET_PREFIX);
+}
+
+function roleForScopes(scopes: readonly AuthPermission[]): AuthRole {
+  return scopes.some((scope) => WRITE_PERMISSIONS.has(scope)) ? 'agent' : 'read-only';
+}

--- a/server/src/services/identity-service.ts
+++ b/server/src/services/identity-service.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { ForbiddenError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import type { AuthPermission } from '../middleware/auth.js';
 import { auditLog, type AuditEvent } from './audit-service.js';
 import { ActivityService } from './activity-service.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
@@ -20,6 +21,7 @@ export interface IdentityActor {
   userId: string;
   role: WorkspaceRole;
   displayName?: string;
+  permissions?: AuthPermission[];
 }
 
 export interface CreateInvitationResult {

--- a/server/src/storage/sqlite/api-token-repository.ts
+++ b/server/src/storage/sqlite/api-token-repository.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from 'node:crypto';
+import type { AuthPermission } from '../../middleware/auth.js';
+import type { SqliteDatabase } from './database.js';
+
+export interface ApiTokenRecord {
+  id: string;
+  workspaceId: string;
+  name: string;
+  tokenPrefix: string;
+  scopes: AuthPermission[];
+  createdBy: string;
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  revokedBy: string | null;
+  lastUsedAt: string | null;
+  lastUsedIp: string | null;
+}
+
+export interface ApiTokenAuthRecord extends ApiTokenRecord {
+  tokenHash: string;
+  creatorDisabledAt: string | null;
+  membershipRole: string | null;
+  membershipStatus: string | null;
+  membershipDisabledAt: string | null;
+  workspaceArchivedAt: string | null;
+}
+
+export interface CreateApiTokenInput {
+  workspaceId: string;
+  name: string;
+  tokenPrefix: string;
+  tokenHash: string;
+  scopes: AuthPermission[];
+  createdBy: string;
+  expiresAt?: string | null;
+}
+
+interface ApiTokenRow {
+  id: string;
+  workspace_id: string;
+  name: string;
+  token_prefix: string;
+  token_hash: string;
+  scopes_json: string;
+  created_by: string;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  revoked_by: string | null;
+  last_used_at: string | null;
+  last_used_ip: string | null;
+  creator_disabled_at?: string | null;
+  membership_role?: string | null;
+  membership_status?: string | null;
+  membership_disabled_at?: string | null;
+  workspace_archived_at?: string | null;
+}
+
+export class SqliteApiTokenRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  create(input: CreateApiTokenInput): ApiTokenRecord {
+    const id = `token_${randomUUID()}`;
+    const now = new Date().toISOString();
+
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          INSERT INTO api_tokens (
+            id,
+            workspace_id,
+            name,
+            token_prefix,
+            token_hash,
+            scopes_json,
+            created_by,
+            created_at,
+            expires_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        id,
+        input.workspaceId,
+        input.name.trim(),
+        input.tokenPrefix,
+        input.tokenHash,
+        JSON.stringify(input.scopes),
+        input.createdBy,
+        now,
+        input.expiresAt ?? null
+      );
+
+    return requireValue(this.get(id), 'API token was not created');
+  }
+
+  listByWorkspace(workspaceId: string): ApiTokenRecord[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT *
+          FROM api_tokens
+          WHERE workspace_id = ?
+          ORDER BY created_at DESC
+        `
+      )
+      .all(workspaceId) as unknown as ApiTokenRow[];
+
+    return rows.map(mapApiToken);
+  }
+
+  get(id: string): ApiTokenRecord | null {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT * FROM api_tokens WHERE id = ?')
+      .get(id) as ApiTokenRow | undefined;
+
+    return row ? mapApiToken(row) : null;
+  }
+
+  getForAuthByHash(tokenHash: string): ApiTokenAuthRecord | null {
+    const row = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT
+            t.*,
+            u.disabled_at AS creator_disabled_at,
+            m.role AS membership_role,
+            m.status AS membership_status,
+            m.disabled_at AS membership_disabled_at,
+            w.archived_at AS workspace_archived_at
+          FROM api_tokens t
+          JOIN users u ON u.id = t.created_by
+          JOIN workspaces w ON w.id = t.workspace_id
+          LEFT JOIN workspace_memberships m
+            ON m.workspace_id = t.workspace_id
+           AND m.user_id = t.created_by
+          WHERE t.token_hash = ?
+        `
+      )
+      .get(tokenHash) as ApiTokenRow | undefined;
+
+    return row
+      ? {
+          ...mapApiToken(row),
+          tokenHash: row.token_hash,
+          creatorDisabledAt: row.creator_disabled_at ?? null,
+          membershipRole: row.membership_role ?? null,
+          membershipStatus: row.membership_status ?? null,
+          membershipDisabledAt: row.membership_disabled_at ?? null,
+          workspaceArchivedAt: row.workspace_archived_at ?? null,
+        }
+      : null;
+  }
+
+  revoke(id: string, revokedBy: string): ApiTokenRecord | null {
+    const now = new Date().toISOString();
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `
+          UPDATE api_tokens
+          SET revoked_at = ?, revoked_by = ?
+          WHERE id = ? AND revoked_at IS NULL
+        `
+      )
+      .run(now, revokedBy, id);
+
+    return result.changes > 0 ? this.get(id) : null;
+  }
+
+  recordUse(id: string, ipAddress?: string | null): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `
+          UPDATE api_tokens
+          SET last_used_at = ?, last_used_ip = ?
+          WHERE id = ?
+        `
+      )
+      .run(new Date().toISOString(), ipAddress ?? null, id);
+  }
+}
+
+function mapApiToken(row: ApiTokenRow): ApiTokenRecord {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    name: row.name,
+    tokenPrefix: row.token_prefix,
+    scopes: parseScopes(row.scopes_json),
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    revokedBy: row.revoked_by,
+    lastUsedAt: row.last_used_at,
+    lastUsedIp: row.last_used_ip,
+  };
+}
+
+function parseScopes(value: string): AuthPermission[] {
+  const parsed = JSON.parse(value) as unknown;
+  return Array.isArray(parsed)
+    ? (parsed.filter((item) => typeof item === 'string') as AuthPermission[])
+    : [];
+}
+
+function requireValue<T>(value: T | null | undefined, message: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -949,6 +949,36 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON workspace_invitations(token_hash);
     `,
   },
+  {
+    version: 15,
+    name: '0015_scoped_api_tokens',
+    up: `
+      CREATE TABLE api_tokens (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        token_prefix TEXT NOT NULL,
+        token_hash TEXT NOT NULL UNIQUE,
+        scopes_json TEXT NOT NULL,
+        created_by TEXT NOT NULL REFERENCES users(id),
+        created_at TEXT NOT NULL,
+        expires_at TEXT,
+        revoked_at TEXT,
+        revoked_by TEXT REFERENCES users(id),
+        last_used_at TEXT,
+        last_used_ip TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_workspace_created
+        ON api_tokens(workspace_id, created_at DESC);
+
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_hash
+        ON api_tokens(token_hash);
+
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_active
+        ON api_tokens(workspace_id, revoked_at, expires_at);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/web/src/__tests__/multi-user-tab.test.tsx
+++ b/web/src/__tests__/multi-user-tab.test.tsx
@@ -114,6 +114,24 @@ describe('MultiUserTab', () => {
             },
           ]);
         }
+        if (url.endsWith('/api/identity/workspaces/local/api-tokens')) {
+          return jsonResponse([
+            {
+              id: 'token_cli',
+              workspaceId: 'local',
+              name: 'CLI worker',
+              tokenPrefix: 'vk_pat_abcd1234',
+              scopes: ['workspace:read', 'task:read'],
+              createdBy: 'local-user',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              expiresAt: null,
+              revokedAt: null,
+              revokedBy: null,
+              lastUsedAt: null,
+              lastUsedIp: null,
+            },
+          ]);
+        }
         return jsonResponse({ error: `Unexpected ${url}` }, 404);
       })
     );
@@ -123,7 +141,9 @@ describe('MultiUserTab', () => {
     expect(await screen.findByText('Local Workspace')).toBeDefined();
     expect(await screen.findByText('Local User')).toBeDefined();
     expect(await screen.findByText('expired@example.com')).toBeDefined();
+    expect(await screen.findByText('CLI worker')).toBeDefined();
     expect(screen.getByText('Expired')).toBeDefined();
+    expect(screen.getByText('Active')).toBeDefined();
     expect(screen.getAllByText('session').length).toBeGreaterThan(0);
   });
 

--- a/web/src/components/settings/tabs/MultiUserTab.tsx
+++ b/web/src/components/settings/tabs/MultiUserTab.tsx
@@ -7,6 +7,7 @@ import {
   Clipboard,
   KeyRound,
   MailPlus,
+  RefreshCw,
   Shield,
   Trash2,
   Users,
@@ -14,6 +15,7 @@ import {
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -25,17 +27,23 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/useToast';
 import {
+  SCOPED_API_TOKEN_PERMISSIONS,
   WORKSPACE_ROLES,
+  useCreateWorkspaceApiToken,
   useCreateWorkspaceInvitation,
   useIdentity,
   useRemoveWorkspaceMember,
+  useRevokeWorkspaceApiToken,
   useRevokeWorkspaceInvitation,
+  useRotateWorkspaceApiToken,
   useUpdateWorkspaceMemberRole,
+  useWorkspaceApiTokens,
   useWorkspaceInvitations,
   useWorkspaceMembers,
   type WorkspaceRole,
 } from '@/hooks/useIdentity';
-import type { WorkspaceInvitation, WorkspaceMembership } from '@/lib/api/identity';
+import type { ClientAuthPermission } from '@veritas-kanban/shared';
+import type { ApiTokenSummary, WorkspaceInvitation, WorkspaceMembership } from '@/lib/api/identity';
 
 const ROLE_LABELS: Record<WorkspaceRole, string> = {
   owner: 'Owner',
@@ -65,8 +73,20 @@ function invitationStatus(invitation: WorkspaceInvitation) {
   return { label: 'Pending', variant: 'secondary' as const };
 }
 
+function tokenStatus(token: ApiTokenSummary) {
+  if (token.revokedAt) return { label: 'Revoked', variant: 'destructive' as const };
+  if (token.expiresAt && Date.parse(token.expiresAt) <= Date.now()) {
+    return { label: 'Expired', variant: 'outline' as const };
+  }
+  return { label: 'Active', variant: 'secondary' as const };
+}
+
 function memberName(member: WorkspaceMembership) {
   return member.user?.displayName ?? member.userId;
+}
+
+function permissionLabel(permission: ClientAuthPermission) {
+  return permission.replace(':', ' ');
 }
 
 function Section({
@@ -116,14 +136,26 @@ export function MultiUserTab() {
   const [inviteRole, setInviteRole] = useState<WorkspaceRole>('member');
   const [inviteExpiresAt, setInviteExpiresAt] = useState('');
   const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [apiTokenName, setApiTokenName] = useState('');
+  const [apiTokenExpiresAt, setApiTokenExpiresAt] = useState('');
+  const [apiTokenScopes, setApiTokenScopes] = useState<ClientAuthPermission[]>([
+    'workspace:read',
+    'task:read',
+  ]);
+  const [createdApiTokenSecret, setCreatedApiTokenSecret] = useState<string | null>(null);
 
   const workspaceId = activeWorkspace?.id ?? null;
+  const canManageApiTokens = hasPermission('admin:manage');
   const membersQuery = useWorkspaceMembers(workspaceId);
   const invitationsQuery = useWorkspaceInvitations(workspaceId, canManageMembers);
+  const apiTokensQuery = useWorkspaceApiTokens(workspaceId, canManageApiTokens);
   const createInvitation = useCreateWorkspaceInvitation(workspaceId);
+  const createApiToken = useCreateWorkspaceApiToken(workspaceId);
   const updateMemberRole = useUpdateWorkspaceMemberRole(workspaceId);
   const removeMember = useRemoveWorkspaceMember(workspaceId);
   const revokeInvitation = useRevokeWorkspaceInvitation(workspaceId);
+  const revokeApiToken = useRevokeWorkspaceApiToken(workspaceId);
+  const rotateApiToken = useRotateWorkspaceApiToken(workspaceId);
 
   const roleOptions = useMemo(
     () =>
@@ -133,10 +165,13 @@ export function MultiUserTab() {
     [activeMembership?.role]
   );
 
-  const canWriteSettings = hasPermission('settings:write');
-  const canManageApiTokens = hasPermission('admin:manage');
   const members = membersQuery.data ?? [];
   const invitations = invitationsQuery.data ?? [];
+  const apiTokens = apiTokensQuery.data ?? [];
+  const selectableTokenScopes = useMemo(
+    () => SCOPED_API_TOKEN_PERMISSIONS.filter((permission) => hasPermission(permission)),
+    [hasPermission]
+  );
 
   const handleCreateInvitation = async (event: FormEvent) => {
     event.preventDefault();
@@ -169,6 +204,44 @@ export function MultiUserTab() {
     if (!createdToken || !navigator.clipboard) return;
     await navigator.clipboard.writeText(createdToken);
     toast({ title: 'Invitation token copied', duration: 2500 });
+  };
+
+  const handleCreateApiToken = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!workspaceId) return;
+    setCreatedApiTokenSecret(null);
+
+    try {
+      const result = await createApiToken.mutateAsync({
+        name: apiTokenName.trim(),
+        scopes: apiTokenScopes,
+        expiresAt: apiTokenExpiresAt ? new Date(apiTokenExpiresAt).toISOString() : null,
+      });
+      setCreatedApiTokenSecret(result.secret);
+      setApiTokenName('');
+      setApiTokenExpiresAt('');
+      toast({ title: 'API token created', description: result.token.name });
+    } catch (err) {
+      toast({
+        title: 'API token failed',
+        description: err instanceof Error ? err.message : 'Unable to create API token.',
+        duration: Infinity,
+      });
+    }
+  };
+
+  const handleToggleApiScope = (permission: ClientAuthPermission, checked: boolean) => {
+    setApiTokenScopes((current) =>
+      checked
+        ? [...new Set([...current, permission])]
+        : current.filter((scope) => scope !== permission)
+    );
+  };
+
+  const handleCopyApiToken = async () => {
+    if (!createdApiTokenSecret || !navigator.clipboard) return;
+    await navigator.clipboard.writeText(createdApiTokenSecret);
+    toast({ title: 'API token copied', duration: 2500 });
   };
 
   const handleRoleChange = async (member: WorkspaceMembership, role: WorkspaceRole) => {
@@ -205,6 +278,33 @@ export function MultiUserTab() {
       toast({
         title: 'Revoke failed',
         description: err instanceof Error ? err.message : 'Unable to revoke invitation.',
+        duration: Infinity,
+      });
+    }
+  };
+
+  const handleRevokeApiToken = async (token: ApiTokenSummary) => {
+    try {
+      await revokeApiToken.mutateAsync(token.id);
+      toast({ title: 'API token revoked', description: token.name });
+    } catch (err) {
+      toast({
+        title: 'Revoke failed',
+        description: err instanceof Error ? err.message : 'Unable to revoke API token.',
+        duration: Infinity,
+      });
+    }
+  };
+
+  const handleRotateApiToken = async (token: ApiTokenSummary) => {
+    try {
+      const result = await rotateApiToken.mutateAsync(token.id);
+      setCreatedApiTokenSecret(result.secret);
+      toast({ title: 'API token rotated', description: token.name });
+    } catch (err) {
+      toast({
+        title: 'Rotate failed',
+        description: err instanceof Error ? err.message : 'Unable to rotate API token.',
         duration: Infinity,
       });
     }
@@ -487,26 +587,151 @@ export function MultiUserTab() {
               <Badge variant="secondary">+{(authContext?.permissions?.length ?? 0) - 10}</Badge>
             )}
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              disabled
-              title={
-                canManageApiTokens
-                  ? 'Scoped token API is not available yet'
-                  : 'Admin manage permission required'
-              }
-            >
-              <KeyRound className="mr-2 h-4 w-4" aria-hidden="true" />
-              Create Token
-            </Button>
-            <span className="text-xs text-muted-foreground">
-              Scoped token issuance is held until the SQLite token repository/API lands.
-            </span>
-          </div>
-          {!canWriteSettings && (
-            <PermissionEmptyState message="Settings write permission is required before token policy changes can be made." />
+          {!canManageApiTokens ? (
+            <PermissionEmptyState message="Owner or admin permission is required to create and manage scoped API tokens." />
+          ) : (
+            <div className="space-y-3">
+              <form className="grid gap-3 rounded-md border p-3" onSubmit={handleCreateApiToken}>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="api-token-name">Name</Label>
+                    <Input
+                      id="api-token-name"
+                      value={apiTokenName}
+                      onChange={(event) => setApiTokenName(event.target.value)}
+                      placeholder="Automation worker"
+                    />
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="api-token-expires">Expires</Label>
+                    <Input
+                      id="api-token-expires"
+                      type="datetime-local"
+                      value={apiTokenExpiresAt}
+                      onChange={(event) => setApiTokenExpiresAt(event.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className="grid gap-2">
+                  <Label>Scopes</Label>
+                  <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {selectableTokenScopes.map((permission) => {
+                      const id = `api-scope-${permission}`;
+                      return (
+                        <label
+                          key={permission}
+                          htmlFor={id}
+                          className="flex items-center gap-2 rounded-md border px-2.5 py-2 text-xs"
+                        >
+                          <Checkbox
+                            id={id}
+                            checked={apiTokenScopes.includes(permission)}
+                            onCheckedChange={(checked) =>
+                              handleToggleApiScope(permission, checked === true)
+                            }
+                          />
+                          <span className="font-mono">{permissionLabel(permission)}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="flex justify-end">
+                  <Button
+                    type="submit"
+                    disabled={
+                      createApiToken.isPending ||
+                      apiTokenName.trim().length === 0 ||
+                      apiTokenScopes.length === 0
+                    }
+                    className="w-full sm:w-auto"
+                  >
+                    <KeyRound className="mr-2 h-4 w-4" aria-hidden="true" />
+                    Create
+                  </Button>
+                </div>
+              </form>
+
+              {createdApiTokenSecret && (
+                <div className="grid gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <CheckCircle2 className="h-4 w-4 text-emerald-500" aria-hidden="true" />
+                    One-time API token
+                  </div>
+                  <div className="flex gap-2">
+                    <Input value={createdApiTokenSecret} readOnly className="font-mono text-xs" />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => void handleCopyApiToken()}
+                    >
+                      <Clipboard className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {apiTokensQuery.isLoading ? (
+                <div className="text-sm text-muted-foreground">Loading API tokens...</div>
+              ) : apiTokens.length === 0 ? (
+                <PermissionEmptyState message="No scoped API tokens have been created for this workspace." />
+              ) : (
+                <div className="space-y-2">
+                  {apiTokens.map((token) => {
+                    const status = tokenStatus(token);
+                    const isActive = status.label === 'Active';
+                    return (
+                      <div key={token.id} className="rounded-md border p-3">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="truncate font-medium">{token.name}</span>
+                              <Badge variant={status.variant}>{status.label}</Badge>
+                              <Badge variant="outline" className="font-mono">
+                                {token.tokenPrefix}...
+                              </Badge>
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              Created {formatDate(token.createdAt)} · Last used{' '}
+                              {formatDate(token.lastUsedAt)} · Expires {formatDate(token.expiresAt)}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => void handleRotateApiToken(token)}
+                              disabled={rotateApiToken.isPending}
+                              title="Rotate token"
+                            >
+                              <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => void handleRevokeApiToken(token)}
+                              disabled={!isActive || revokeApiToken.isPending}
+                              title="Revoke token"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                            </Button>
+                          </div>
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          {token.scopes.map((scope) => (
+                            <Badge key={scope} variant="outline" className="font-mono text-[11px]">
+                              {scope}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
           )}
         </div>
       </Section>

--- a/web/src/hooks/useIdentity.tsx
+++ b/web/src/hooks/useIdentity.tsx
@@ -15,6 +15,7 @@ import {
 } from '@veritas-kanban/shared';
 import {
   identityApi,
+  type CreateApiTokenInput,
   type CreateInvitationInput,
   type IdentityProfile,
   type WorkspaceIdentity,
@@ -24,7 +25,7 @@ import {
 
 const ACTIVE_WORKSPACE_STORAGE_KEY = 'veritas-kanban.active-workspace-id';
 
-const ALL_PERMISSIONS: readonly ClientAuthPermission[] = [
+export const ALL_PERMISSIONS: readonly ClientAuthPermission[] = [
   '*',
   'workspace:read',
   'task:read',
@@ -48,6 +49,10 @@ const ALL_PERMISSIONS: readonly ClientAuthPermission[] = [
   'backup:write',
   'admin:manage',
 ];
+
+export const SCOPED_API_TOKEN_PERMISSIONS = ALL_PERMISSIONS.filter(
+  (permission) => permission !== '*'
+);
 
 const WORKSPACE_ROLE_PERMISSIONS: Record<WorkspaceRole, readonly ClientAuthPermission[]> = {
   owner: ALL_PERMISSIONS,
@@ -271,6 +276,17 @@ export function useWorkspaceInvitations(
   });
 }
 
+export function useWorkspaceApiTokens(
+  workspaceId: string | null | undefined,
+  canManageApiTokens: boolean
+) {
+  return useQuery({
+    queryKey: ['identity', 'workspaces', workspaceId, 'api-tokens'],
+    queryFn: () => identityApi.listApiTokens(requireWorkspaceId(workspaceId)),
+    enabled: !!workspaceId && canManageApiTokens,
+  });
+}
+
 export function useCreateWorkspaceInvitation(workspaceId: string | null | undefined) {
   const queryClient = useQueryClient();
 
@@ -280,6 +296,48 @@ export function useCreateWorkspaceInvitation(workspaceId: string | null | undefi
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: ['identity', 'workspaces', workspaceId, 'invitations'],
+      });
+    },
+  });
+}
+
+export function useCreateWorkspaceApiToken(workspaceId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateApiTokenInput) =>
+      identityApi.createApiToken(requireWorkspaceId(workspaceId), input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['identity', 'workspaces', workspaceId, 'api-tokens'],
+      });
+    },
+  });
+}
+
+export function useRevokeWorkspaceApiToken(workspaceId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (tokenId: string) =>
+      identityApi.revokeApiToken(requireWorkspaceId(workspaceId), tokenId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['identity', 'workspaces', workspaceId, 'api-tokens'],
+      });
+    },
+  });
+}
+
+export function useRotateWorkspaceApiToken(workspaceId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (tokenId: string) =>
+      identityApi.rotateApiToken(requireWorkspaceId(workspaceId), tokenId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['identity', 'workspaces', workspaceId, 'api-tokens'],
       });
     },
   });

--- a/web/src/lib/api/identity.ts
+++ b/web/src/lib/api/identity.ts
@@ -84,10 +84,29 @@ export interface CreateInvitationResult {
 }
 
 export interface ApiTokenSummary {
+  id: string;
+  workspaceId: string;
   name: string;
-  authMethod: string;
-  tokenName?: string;
-  permissions: ClientAuthPermission[];
+  tokenPrefix: string;
+  scopes: ClientAuthPermission[];
+  createdBy: string;
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  revokedBy: string | null;
+  lastUsedAt: string | null;
+  lastUsedIp: string | null;
+}
+
+export interface CreateApiTokenInput {
+  name: string;
+  scopes: ClientAuthPermission[];
+  expiresAt?: string | null;
+}
+
+export interface CreateApiTokenResult {
+  token: ApiTokenSummary;
+  secret: string;
 }
 
 export const identityApi = {
@@ -130,6 +149,41 @@ export const identityApi = {
   revokeInvitation: (invitationId: string) =>
     apiFetch<WorkspaceInvitation>(
       `/api/identity/invitations/${encodeURIComponent(invitationId)}/revoke`,
+      {
+        method: 'POST',
+      }
+    ),
+
+  listApiTokens: (workspaceId: string) =>
+    apiFetch<ApiTokenSummary[]>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/api-tokens`
+    ),
+
+  createApiToken: (workspaceId: string, input: CreateApiTokenInput) =>
+    apiFetch<CreateApiTokenResult>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/api-tokens`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    ),
+
+  revokeApiToken: (workspaceId: string, tokenId: string) =>
+    apiFetch<ApiTokenSummary>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/api-tokens/${encodeURIComponent(
+        tokenId
+      )}/revoke`,
+      {
+        method: 'POST',
+      }
+    ),
+
+  rotateApiToken: (workspaceId: string, tokenId: string) =>
+    apiFetch<CreateApiTokenResult>(
+      `/api/identity/workspaces/${encodeURIComponent(workspaceId)}/api-tokens/${encodeURIComponent(
+        tokenId
+      )}/rotate`,
       {
         method: 'POST',
       }


### PR DESCRIPTION
## Summary

- Add SQLite-backed scoped API tokens with hashed secrets, workspace binding, expiry, revoke, rotate, last-used metadata, and actor-aware audit/activity events.
- Validate scoped database tokens in HTTP and WebSocket auth without granting wildcard admin behavior.
- Replace the placeholder Multi-user API Access panel with real token list/create/revoke/rotate UI and one-time secret display.

Closes #457.

## Verification

- `VERITAS_DISABLE_WATCHERS=1 ./node_modules/.bin/vitest run server/src/__tests__/api-token-service.test.ts server/src/__tests__/middleware/auth.test.ts`
- `VERITAS_DISABLE_WATCHERS=1 ./node_modules/.bin/vitest run server/src/__tests__/routes/identity.test.ts`
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/multi-user-tab.test.tsx`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/server lint`
- `pnpm --filter @veritas-kanban/web lint`
- `pnpm build`
- Browser smoke: Multi-user settings tab rendered token controls, created a scoped token, showed the one-time token, listed active scopes, and reported no console errors.

## Notes

- Scoped API tokens cannot request `*`; they must use explicit permissions and cannot exceed the issuing actor permission boundary.
- Secrets are returned only once and only SHA-256 hashes are stored.
