### PR TITLE
Migrate shared popover tabs and number inputs to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -43,9 +43,10 @@ Shared primitive migration progress:
 
 - Mantine-backed compatibility wrappers are now active for `button`, `badge`,
   `input`, `textarea`, `checkbox`, `switch`, `label`, `skeleton`,
-  `scroll-area`, and the app-level `toaster` delivery path.
+  `scroll-area`, `number-input`, `popover`, `tabs`, and the app-level
+  `toaster` delivery path.
 - Temporary Radix holdouts remain for compound/focus-heavy APIs: `select`,
-  `dialog`, `sheet`, `alert-dialog`, `popover`, `tooltip`, and `tabs`.
+  `dialog`, `sheet`, `alert-dialog`, and `tooltip`.
 - The holdouts stay intentionally until their feature surfaces can be migrated
   with visual and keyboard/focus checks in the same PR. New v5 surfaces should
   prefer Mantine primitives directly unless they need one of the compatibility
@@ -190,6 +191,8 @@ Foundation verification currently covers:
 - reduced-motion, focus ring, auto contrast, and breakpoint defaults
 - Mantine-backed shared primitives for buttons, badges, text fields,
   checkbox/switch controls, labels, skeletons, scroll areas, and notifications
+- Mantine-backed shared primitives for number inputs, popovers, and tabs with
+  legacy compatibility coverage
 
 ## Migration Order
 
@@ -222,12 +225,14 @@ Migration batches:
    for the compatibility layer; feature surfaces can now use these wrappers
    while preserving current imports.
 2. Form controls: checkbox and switch completed for the compatibility layer;
-   select and number-like inputs remain for feature-surface migration PRs.
+   number-like settings inputs now route through Mantine `NumberInput`; select
+   remains for feature-surface migration PRs.
 3. Feedback: toast delivery now routes through Mantine notifications.
-4. Overlays: dialog, alert dialog, sheet/drawer, popover, tooltip. Still Radix
-   holdouts until each surface has visual and focus QA.
-5. Navigation modes: tabs, segmented controls, command/search shell. Tabs remain
-   a Radix holdout; new mode controls should use Mantine directly.
+4. Overlays: popover now uses a Mantine-backed compatibility wrapper. Dialog,
+   alert dialog, sheet/drawer, and tooltip remain Radix holdouts until each
+   surface has visual and focus QA.
+5. Navigation modes: tabs now use a Mantine-backed compatibility wrapper.
+   Segmented controls and command/search shell remain surface-level work.
 
 Use compatibility wrappers only when they reduce churn. Each wrapper must have a
 removal target and should not hide incompatible behavior.

--- a/web/src/__tests__/AgentStatusIndicator.test.tsx
+++ b/web/src/__tests__/AgentStatusIndicator.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AgentStatusIndicator } from '@/components/shared/AgentStatusIndicator';
+import { MantineRoot } from '@/theme/MantineRoot';
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -30,14 +31,35 @@ vi.mock('@/lib/api', () => ({
 
 // ── Helpers ──────────────────────────────────────────────────
 
+function ensureMantineBrowserApis() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+}
+
 function renderIndicator(props: { onOpenActivityLog?: () => void } = {}) {
+  ensureMantineBrowserApis();
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
-    <QueryClientProvider client={queryClient}>
-      <AgentStatusIndicator {...props} />
-    </QueryClientProvider>
+    <MantineRoot env="test">
+      <QueryClientProvider client={queryClient}>
+        <AgentStatusIndicator {...props} />
+      </QueryClientProvider>
+    </MantineRoot>
   );
 }
 

--- a/web/src/__tests__/WebSocketIndicator.test.tsx
+++ b/web/src/__tests__/WebSocketIndicator.test.tsx
@@ -5,19 +5,41 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { WebSocketStatusProvider } from '@/contexts/WebSocketContext';
 import { WebSocketIndicator } from '@/components/shared/WebSocketIndicator';
+import { MantineRoot } from '@/theme/MantineRoot';
 import type { ConnectionState } from '@/hooks/useWebSocket';
 
 // ── Helpers ──────────────────────────────────────────────────
 
+function ensureMantineBrowserApis() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+}
+
 function renderIndicator(connectionState: ConnectionState, reconnectAttempt = 0) {
+  ensureMantineBrowserApis();
   return render(
-    <WebSocketStatusProvider
-      isConnected={connectionState === 'connected'}
-      connectionState={connectionState}
-      reconnectAttempt={reconnectAttempt}
-    >
-      <WebSocketIndicator />
-    </WebSocketStatusProvider>
+    <MantineRoot env="test">
+      <WebSocketStatusProvider
+        isConnected={connectionState === 'connected'}
+        connectionState={connectionState}
+        reconnectAttempt={reconnectAttempt}
+      >
+        <WebSocketIndicator />
+      </WebSocketStatusProvider>
+    </MantineRoot>
   );
 }
 

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -8,9 +8,12 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { NumberInput } from '@/components/ui/number-input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { Toaster } from '@/components/ui/toaster';
 import { toast } from '@/hooks/useToast';
@@ -53,6 +56,22 @@ function ToastProbe() {
   );
 }
 
+function TabsProbe() {
+  const [selectedTab, setSelectedTab] = React.useState('summary');
+
+  return (
+    <Tabs value={selectedTab} onValueChange={setSelectedTab}>
+      <TabsList>
+        <TabsTrigger value="summary">Summary</TabsTrigger>
+        <TabsTrigger value="activity">Activity</TabsTrigger>
+      </TabsList>
+      <TabsContent value="summary">Summary content</TabsContent>
+      <TabsContent value="activity">Activity content</TabsContent>
+      <span data-testid="selected-tab">{selectedTab}</span>
+    </Tabs>
+  );
+}
+
 describe('Mantine-backed shared UI primitives', () => {
   afterEach(() => {
     notifications.clean();
@@ -69,6 +88,7 @@ describe('Mantine-backed shared UI primitives', () => {
         <Badge variant="secondary">Ready</Badge>
         <Label htmlFor="name">Name</Label>
         <Input id="name" aria-label="Name" placeholder="Task name" />
+        <NumberInput aria-label="Estimate" value={3} />
         <Textarea aria-label="Notes" placeholder="Task notes" />
         <Skeleton data-testid="loading-row" className="h-8 w-full" />
         <ScrollArea data-testid="scroll-area" className="h-24">
@@ -83,6 +103,7 @@ describe('Mantine-backed shared UI primitives', () => {
     );
     expect(screen.getByText('Ready').closest('[data-slot="badge"]')).toBeDefined();
     expect(screen.getByLabelText('Name').getAttribute('data-slot')).toBe('input');
+    expect(screen.getByLabelText('Estimate').closest('[data-slot="number-input"]')).toBeDefined();
     expect(screen.getByLabelText('Notes')).toBeDefined();
     expect(screen.getByTestId('loading-row').getAttribute('data-slot')).toBe('skeleton');
     expect(screen.getByTestId('scroll-area').getAttribute('data-slot')).toBe('scroll-area');
@@ -111,6 +132,35 @@ describe('Mantine-backed shared UI primitives', () => {
     await waitFor(() => {
       expect(screen.getByText('Saved')).toBeDefined();
       expect(screen.getByText('Mantine notification bridge is active.')).toBeDefined();
+    });
+  });
+
+  it('preserves tabs value changes through the legacy onValueChange contract', () => {
+    renderWithProviders(<TabsProbe />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Activity' }));
+
+    expect(screen.getByTestId('selected-tab').textContent).toBe('activity');
+    expect(screen.getByText('Activity content')).toBeDefined();
+  });
+
+  it('opens Mantine-backed popovers through the legacy trigger/content API', async () => {
+    renderWithProviders(
+      <Popover position="bottom-end">
+        <PopoverTrigger asChild>
+          <Button>Open account menu</Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64">Account actions</PopoverContent>
+      </Popover>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open account menu' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Account actions')).toBeDefined();
+      expect(
+        screen.getByText('Account actions').closest('[data-slot="popover-content"]')
+      ).toBeDefined();
     });
   });
 });

--- a/web/src/components/layout/UserMenu.tsx
+++ b/web/src/components/layout/UserMenu.tsx
@@ -82,7 +82,7 @@ export function UserMenu({ onOpenSecuritySettings, onOpenIdentitySettings }: Use
   const role = activeMembership?.role ?? authContext?.role ?? 'admin';
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setOpen} position="bottom-end">
       <PopoverTrigger asChild>
         <Button variant="ghost" size="sm" className="gap-2" title="Session menu">
           <Lock className="h-4 w-4 text-emerald-500" />
@@ -90,7 +90,7 @@ export function UserMenu({ onOpenSecuritySettings, onOpenIdentitySettings }: Use
           <ChevronDown className="h-3 w-3 text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="end">
+      <PopoverContent className="w-72 p-0">
         <div className="p-3 border-b border-border">
           <div className="flex items-start gap-2">
             <div className="mt-0.5 rounded-full bg-primary/10 p-1.5 text-primary">

--- a/web/src/components/settings/shared/NumberRow.tsx
+++ b/web/src/components/settings/shared/NumberRow.tsx
@@ -1,8 +1,19 @@
 import { memo, useState, useEffect } from 'react';
-import { Input } from '@/components/ui/input';
+import { NumberInput } from '@/components/ui/number-input';
 import { SettingRow } from './SettingRow';
 
-export const NumberRow = memo(function NumberRow({ label, description, value, onChange, min, max, step, unit, hideSpinners, maxLength }: {
+export const NumberRow = memo(function NumberRow({
+  label,
+  description,
+  value,
+  onChange,
+  min,
+  max,
+  step,
+  unit,
+  hideSpinners,
+  maxLength,
+}: {
   label: string;
   description?: string;
   value: number;
@@ -16,11 +27,15 @@ export const NumberRow = memo(function NumberRow({ label, description, value, on
 }) {
   // Use text input with local state - only save on blur
   const [localValue, setLocalValue] = useState(value.toString());
-  
+
   // Sync local value when external value changes (e.g., reset)
   useEffect(() => {
     setLocalValue(value.toString());
   }, [value]);
+
+  const clamp = (nextValue: number, fallbackMin: number) => {
+    return Math.max(min ?? fallbackMin, Math.min(max ?? Infinity, nextValue));
+  };
 
   if (hideSpinners) {
     const handleBlur = () => {
@@ -32,7 +47,7 @@ export const NumberRow = memo(function NumberRow({ label, description, value, on
       }
       const v = parseInt(raw, 10);
       if (!isNaN(v)) {
-        const clamped = Math.max(min ?? 0, Math.min(max ?? Infinity, v));
+        const clamped = clamp(v, 0);
         setLocalValue(clamped.toString());
         onChange(clamped);
       }
@@ -41,15 +56,18 @@ export const NumberRow = memo(function NumberRow({ label, description, value, on
     return (
       <SettingRow label={label} description={description}>
         <div className="flex items-center gap-2">
-          <Input
+          <NumberInput
+            aria-label={label}
             type="text"
             inputMode="numeric"
-            pattern="[0-9]*"
+            allowDecimal={false}
+            allowNegative={false}
+            clampBehavior="blur"
+            hideControls
             value={localValue}
-            onChange={(e) => {
-              // Only allow digits, update local state without saving
-              const raw = e.target.value.replace(/[^0-9]/g, '');
-              setLocalValue(raw);
+            onChange={(nextValue) => {
+              const raw = String(nextValue).replace(/[^0-9]/g, '');
+              setLocalValue(maxLength ? raw.slice(0, maxLength) : raw);
             }}
             onBlur={handleBlur}
             onKeyDown={(e) => {
@@ -58,8 +76,12 @@ export const NumberRow = memo(function NumberRow({ label, description, value, on
                 (e.target as HTMLInputElement).blur();
               }
             }}
+            min={min}
+            max={max}
+            step={step}
             maxLength={maxLength ?? 10}
-            className="w-28 h-8 text-right"
+            className="w-28"
+            styles={{ input: { textAlign: 'right' } }}
           />
           {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
         </div>
@@ -70,20 +92,20 @@ export const NumberRow = memo(function NumberRow({ label, description, value, on
   return (
     <SettingRow label={label} description={description}>
       <div className="flex items-center gap-2">
-        <Input
-          type="number"
+        <NumberInput
+          aria-label={label}
           value={value}
-          onChange={(e) => {
-            const v = parseFloat(e.target.value);
+          onChange={(nextValue) => {
+            const v = typeof nextValue === 'number' ? nextValue : parseFloat(nextValue);
             if (!isNaN(v)) {
-              const clamped = Math.max(min ?? -Infinity, Math.min(max ?? Infinity, v));
-              onChange(clamped);
+              onChange(clamp(v, -Infinity));
             }
           }}
           min={min}
           max={max}
           step={step}
-          className="w-24 h-8 text-right"
+          className="w-24"
+          styles={{ input: { textAlign: 'right' } }}
         />
         {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
       </div>

--- a/web/src/components/shared/AgentStatusIndicator.tsx
+++ b/web/src/components/shared/AgentStatusIndicator.tsx
@@ -314,7 +314,7 @@ export function AgentStatusIndicator({
   const Icon = config.icon;
 
   return (
-    <Popover>
+    <Popover position="bottom-start">
       <PopoverTrigger asChild>
         <button
           className={`flex items-center gap-2 min-w-[32px] sm:min-w-[140px] md:min-w-[200px] cursor-pointer hover:bg-muted/50 rounded-md px-2 py-1 transition-colors ${className}`}
@@ -349,7 +349,7 @@ export function AgentStatusIndicator({
         </button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-80" align="start">
+      <PopoverContent className="w-80">
         <div className="space-y-4">
           {/* Current Status Header */}
           <div className="flex items-center gap-3">

--- a/web/src/components/shared/WebSocketIndicator.tsx
+++ b/web/src/components/shared/WebSocketIndicator.tsx
@@ -54,7 +54,7 @@ export function WebSocketIndicator() {
       : 'Could not establish a WebSocket connection after multiple attempts. The board is polling the server every 10 seconds for updates. Refresh the page to try again.';
 
   return (
-    <Popover>
+    <Popover position="bottom-end">
       <PopoverTrigger asChild>
         <button
           className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none rounded px-1.5 py-1 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
@@ -64,7 +64,7 @@ export function WebSocketIndicator() {
           <Icon className={`h-3 w-3 ${iconClass}`} />
         </button>
       </PopoverTrigger>
-      <PopoverContent side="bottom" align="end" className="w-64 p-3">
+      <PopoverContent className="w-64 p-3">
         <div className="space-y-1.5">
           <div className="flex items-center gap-2">
             <Icon className={`h-4 w-4 ${iconColor} shrink-0`} />

--- a/web/src/components/ui/number-input.tsx
+++ b/web/src/components/ui/number-input.tsx
@@ -1,0 +1,20 @@
+import {
+  NumberInput as MantineNumberInput,
+  type NumberInputProps as MantineNumberInputProps,
+} from '@mantine/core';
+
+import { cn } from '@/lib/utils';
+
+function NumberInput({ className, size = 'xs', radius = 'md', ...props }: MantineNumberInputProps) {
+  return (
+    <MantineNumberInput
+      data-slot="number-input"
+      size={size}
+      radius={radius}
+      className={cn('w-full', className)}
+      {...props}
+    />
+  );
+}
+
+export { NumberInput };

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -1,40 +1,75 @@
 import * as React from 'react';
-import { Popover as PopoverPrimitive } from 'radix-ui';
+import { Popover as MantinePopover, type PopoverProps as MantinePopoverProps } from '@mantine/core';
 
 import { cn } from '@/lib/utils';
 
-function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
-}
+type PopoverProps = Omit<MantinePopoverProps, 'opened' | 'defaultOpened' | 'onChange'> & {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
 
-function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
-}
-
-function PopoverContent({
-  className,
-  align = 'center',
-  sideOffset = 4,
+function Popover({
+  open,
+  defaultOpen,
+  onOpenChange,
+  offset = 4,
+  radius = 'md',
+  shadow = 'md',
+  withinPortal = true,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: PopoverProps) {
   return (
-    <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          'z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
-          className
-        )}
-        {...props}
-      />
-    </PopoverPrimitive.Portal>
+    <MantinePopover
+      opened={open}
+      defaultOpened={defaultOpen}
+      onChange={onOpenChange}
+      offset={offset}
+      radius={radius}
+      shadow={shadow}
+      withinPortal={withinPortal}
+      {...props}
+    />
   );
 }
 
-function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+function PopoverTrigger({
+  asChild: _asChild,
+  children,
+}: {
+  asChild?: boolean;
+  children: React.ReactNode;
+}) {
+  return <MantinePopover.Target>{children}</MantinePopover.Target>;
+}
+
+type PopoverContentProps = React.ComponentProps<typeof MantinePopover.Dropdown> & {
+  align?: 'start' | 'center' | 'end';
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  sideOffset?: number;
+};
+
+function PopoverContent({
+  className,
+  align: _align,
+  side: _side,
+  sideOffset: _sideOffset,
+  ...props
+}: PopoverContentProps) {
+  return (
+    <MantinePopover.Dropdown
+      data-slot="popover-content"
+      className={cn(
+        'z-50 flex w-72 flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function PopoverAnchor({ children }: { children: React.ReactNode }) {
+  return <MantinePopover.Target>{children}</MantinePopover.Target>;
 }
 
 function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -1,18 +1,34 @@
 import * as React from 'react';
+import { Tabs as MantineTabs, type TabsProps as MantineTabsProps } from '@mantine/core';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { Tabs as TabsPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
+
+type TabsProps = Omit<MantineTabsProps, 'onChange'> & {
+  onChange?: (value: string | null) => void;
+  onValueChange?: (value: string) => void;
+};
 
 function Tabs({
   className,
   orientation = 'horizontal',
+  onChange,
+  onValueChange,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+}: TabsProps) {
+  const handleChange = (nextValue: string | null) => {
+    onChange?.(nextValue);
+    if (nextValue !== null) {
+      onValueChange?.(nextValue);
+    }
+  };
+
   return (
-    <TabsPrimitive.Root
+    <MantineTabs
       data-slot="tabs"
       data-orientation={orientation}
+      orientation={orientation}
+      onChange={handleChange}
       className={cn('group/tabs flex gap-2 data-horizontal:flex-col', className)}
       {...props}
     />
@@ -38,9 +54,9 @@ function TabsList({
   className,
   variant = 'default',
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+}: React.ComponentProps<typeof MantineTabs.List> & VariantProps<typeof tabsListVariants>) {
   return (
-    <TabsPrimitive.List
+    <MantineTabs.List
       data-slot="tabs-list"
       data-variant={variant}
       className={cn(tabsListVariants({ variant }), className)}
@@ -49,9 +65,9 @@ function TabsList({
   );
 }
 
-function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof MantineTabs.Tab>) {
   return (
-    <TabsPrimitive.Trigger
+    <MantineTabs.Tab
       data-slot="tabs-trigger"
       className={cn(
         "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -65,9 +81,9 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
   );
 }
 
-function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: React.ComponentProps<typeof MantineTabs.Panel>) {
   return (
-    <TabsPrimitive.Content
+    <MantineTabs.Panel
       data-slot="tabs-content"
       className={cn('flex-1 text-sm outline-none', className)}
       {...props}


### PR DESCRIPTION
## Summary

- Migrates the shared `Popover` and `Tabs` compatibility wrappers from Radix to Mantine.
- Adds a Mantine-backed `NumberInput` primitive and uses it in settings `NumberRow`.
- Updates affected indicator tests, primitive coverage, and the Mantine migration plan.

## Verification

- `pnpm --filter @veritas-kanban/web test -- src/__tests__/mantine-ui-primitives.test.tsx`
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/AgentStatusIndicator.test.tsx src/__tests__/WebSocketIndicator.test.tsx src/__tests__/mantine-ui-primitives.test.tsx`
- `pnpm --filter @veritas-kanban/web test`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web lint`
- `pnpm lint:budget`
- `pnpm build`
- HTTP smoke: `curl -i http://127.0.0.1:3000/`
- HTTP smoke: `curl -i http://127.0.0.1:3000/src/main.tsx`

## Notes

- Refs #416.
- This does not close #416. `select`, `dialog`, `sheet`, `alert-dialog`, and `tooltip` still need dedicated migration/QA slices.
- Headless browser smoke was blocked by the local macOS sandbox before page launch; unit, build, and Vite HTTP smoke passed.
