### PR TITLE
Migrate shared tooltip wrapper to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -33,7 +33,7 @@ Current shared primitive usage:
 | `checkbox`                        | Radix Checkbox wrapper                                 | 9 imports    |
 | `switch`                          | Radix Switch wrapper                                   | 8 imports    |
 | `sheet`                           | Radix Dialog based side panel wrapper                  | 8 imports    |
-| `tooltip`                         | Radix Tooltip wrapper                                  | 4 imports    |
+| `tooltip`                         | Mantine Tooltip compatibility wrapper                  | 4 imports    |
 | `popover`                         | Radix Popover wrapper                                  | 3 imports    |
 | `MarkdownEditor/MarkdownRenderer` | Custom markdown surfaces                               | 2 imports    |
 | `toast`/`toaster`                 | Radix Toast wrapper and app-level notification surface | 1 import     |
@@ -43,10 +43,10 @@ Shared primitive migration progress:
 
 - Mantine-backed compatibility wrappers are now active for `button`, `badge`,
   `input`, `textarea`, `checkbox`, `switch`, `label`, `skeleton`,
-  `scroll-area`, `number-input`, `popover`, `tabs`, and the app-level
+  `scroll-area`, `number-input`, `popover`, `tooltip`, `tabs`, and the app-level
   `toaster` delivery path.
 - Temporary Radix holdouts remain for compound/focus-heavy APIs: `select`,
-  `dialog`, `sheet`, `alert-dialog`, and `tooltip`.
+  `dialog`, `sheet`, and `alert-dialog`.
 - The holdouts stay intentionally until their feature surfaces can be migrated
   with visual and keyboard/focus checks in the same PR. New v5 surfaces should
   prefer Mantine primitives directly unless they need one of the compatibility
@@ -70,7 +70,7 @@ High-traffic feature surfaces:
 Package dependencies currently tied to the old primitive layer:
 
 - Radix packages: alert dialog, checkbox, dialog, dropdown menu, label, popover,
-  scroll area, select, slot, switch, tabs, toast, tooltip
+  scroll area, select, slot, switch, tabs, and toast
 - shadcn CLI/package
 - `class-variance-authority`
 - `tailwind-merge`
@@ -193,6 +193,8 @@ Foundation verification currently covers:
   checkbox/switch controls, labels, skeletons, scroll areas, and notifications
 - Mantine-backed shared primitives for number inputs, popovers, and tabs with
   legacy compatibility coverage
+- Mantine-backed tooltip compatibility wrapper with provider/trigger/content
+  coverage
 
 ## Migration Order
 
@@ -228,8 +230,8 @@ Migration batches:
    number-like settings inputs now route through Mantine `NumberInput`; select
    remains for feature-surface migration PRs.
 3. Feedback: toast delivery now routes through Mantine notifications.
-4. Overlays: popover now uses a Mantine-backed compatibility wrapper. Dialog,
-   alert dialog, sheet/drawer, and tooltip remain Radix holdouts until each
+4. Overlays: popover and tooltip now use Mantine-backed compatibility wrappers.
+   Dialog, alert dialog, and sheet/drawer remain Radix holdouts until each
    surface has visual and focus QA.
 5. Navigation modes: tabs now use a Mantine-backed compatibility wrapper.
    Segmented controls and command/search shell remain surface-level work.

--- a/web/src/__tests__/TaskCard.test.tsx
+++ b/web/src/__tests__/TaskCard.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { TaskCard } from '@/components/task/TaskCard';
 import { createMockTask } from './test-utils';
+import { MantineRoot } from '@/theme/MantineRoot';
 import type { Task } from '@veritas-kanban/shared';
 
 // ── Mocks ────────────────────────────────────────────────────
@@ -98,8 +99,31 @@ vi.mock('@/lib/sanitize', () => ({
 
 // ── Helpers ──────────────────────────────────────────────────
 
+function ensureMantineBrowserApis() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+}
+
 function renderCard(task: Task, props: Partial<React.ComponentProps<typeof TaskCard>> = {}) {
-  return render(<TaskCard task={task} {...props} />);
+  ensureMantineBrowserApis();
+  return render(
+    <MantineRoot env="test">
+      <TaskCard task={task} {...props} />
+    </MantineRoot>
+  );
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Toaster } from '@/components/ui/toaster';
 import { toast } from '@/hooks/useToast';
 
@@ -161,6 +162,25 @@ describe('Mantine-backed shared UI primitives', () => {
       expect(
         screen.getByText('Account actions').closest('[data-slot="popover-content"]')
       ).toBeDefined();
+    });
+  });
+
+  it('opens Mantine-backed tooltips through the legacy trigger/content API', async () => {
+    renderWithProviders(
+      <TooltipProvider delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button>Hover for help</Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Helpful detail</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Hover for help' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Helpful detail')).toBeDefined();
     });
   });
 });

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -1,53 +1,133 @@
 'use client';
 
 import * as React from 'react';
-import { Tooltip as TooltipPrimitive } from 'radix-ui';
+import { Tooltip as MantineTooltip, type TooltipProps as MantineTooltipProps } from '@mantine/core';
 
 import { cn } from '@/lib/utils';
 
+const TooltipDelayContext = React.createContext(0);
+
+type TooltipPart = 'trigger' | 'content';
+type TooltipTriggerProps = {
+  asChild?: boolean;
+  children?: React.ReactNode;
+};
+type TooltipContentProps = React.ComponentProps<'span'> & {
+  side?: MantineTooltipProps['position'];
+  sideOffset?: number;
+};
+type TooltipPartComponent = React.FC<TooltipTriggerProps | TooltipContentProps> & {
+  __tooltipPart?: TooltipPart;
+};
+
+function isTooltipPart(
+  child: React.ReactNode,
+  part: TooltipPart
+): child is React.ReactElement<TooltipTriggerProps | TooltipContentProps> {
+  return React.isValidElement(child) && (child.type as TooltipPartComponent).__tooltipPart === part;
+}
+
 function TooltipProvider({
   delayDuration = 0,
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  children,
+}: {
+  delayDuration?: number;
+  children?: React.ReactNode;
+}) {
   return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delayDuration={delayDuration}
-      {...props}
-    />
+    <TooltipDelayContext.Provider value={delayDuration}>
+      <MantineTooltip.Group openDelay={delayDuration}>{children}</MantineTooltip.Group>
+    </TooltipDelayContext.Provider>
   );
 }
 
-function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+type TooltipProps = Omit<
+  MantineTooltipProps,
+  'children' | 'defaultOpened' | 'label' | 'opened' | 'openDelay'
+> & {
+  children?: React.ReactNode;
+  defaultOpen?: boolean;
+  delayDuration?: number;
+  open?: boolean;
+};
+
+function Tooltip({
+  children,
+  classNames,
+  defaultOpen,
+  delayDuration,
+  offset,
+  open,
+  position,
+  withArrow = true,
+  ...props
+}: TooltipProps) {
+  const providerDelay = React.useContext(TooltipDelayContext);
+  const childArray = React.Children.toArray(children);
+  const trigger = childArray.find((child) => isTooltipPart(child, 'trigger'));
+  const content = childArray.find((child) => isTooltipPart(child, 'content'));
+  const triggerChildren = trigger?.props.children;
+  const contentProps = content?.props as TooltipContentProps | undefined;
+  const classNameMap =
+    classNames && typeof classNames === 'object' && !Array.isArray(classNames) ? classNames : {};
+
+  if (!triggerChildren || !contentProps?.children) {
+    return <>{children}</>;
+  }
+
+  return (
+    <MantineTooltip
+      data-slot="tooltip"
+      defaultOpened={defaultOpen}
+      label={contentProps.children}
+      offset={contentProps.sideOffset ?? offset ?? 5}
+      opened={open}
+      openDelay={delayDuration ?? providerDelay}
+      position={contentProps.side ?? position ?? 'top'}
+      withArrow={withArrow}
+      classNames={{
+        ...classNameMap,
+        tooltip: cn(
+          'z-50 inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background',
+          classNameMap.tooltip,
+          contentProps.className
+        ),
+      }}
+      {...props}
+    >
+      {triggerChildren}
+    </MantineTooltip>
+  );
 }
 
-function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+function TooltipTrigger({ asChild: _asChild, children }: TooltipTriggerProps) {
+  return <>{children}</>;
 }
+
+TooltipTrigger.__tooltipPart = 'trigger';
 
 function TooltipContent({
   className,
+  side: _side,
   sideOffset = 0,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: TooltipContentProps) {
   return (
-    <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
-        data-slot="tooltip-content"
-        sideOffset={sideOffset}
-        className={cn(
-          'z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
-          className
-        )}
-        {...props}
-      >
-        {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
-      </TooltipPrimitive.Content>
-    </TooltipPrimitive.Portal>
+    <span
+      data-slot="tooltip-content"
+      data-side-offset={sideOffset}
+      className={cn(
+        'z-50 inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
   );
 }
+
+TooltipContent.__tooltipPart = 'content';
 
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION
## Summary

- Migrates the shared tooltip compatibility wrapper from Radix to Mantine.
- Preserves the existing `TooltipProvider` / `Tooltip` / `TooltipTrigger` / `TooltipContent` compound API to avoid broad feature churn.
- Adds primitive coverage for the Mantine tooltip bridge and updates `TaskCard` tests to render through the Mantine provider.
- Updates the Mantine migration plan to remove tooltip from the active Radix holdout list.

## Verification

- `pnpm --filter @veritas-kanban/web test -- src/__tests__/mantine-ui-primitives.test.tsx`
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/TaskCard.test.tsx`
- `pnpm --filter @veritas-kanban/web test`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web lint`
- `pnpm lint:budget`
- `pnpm build`

## Notes

- Refs #416.
- This does not close #416. `select`, `dialog`, `sheet`, `alert-dialog`, markdown editor wrappers, validation patterns, and overlay focus QA remain.
- Build output shows the Radix vendor chunk shrinking after tooltip leaves the Radix wrapper path.
