### PR TITLE
Migrate shared dialog wrapper to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -28,7 +28,7 @@ Current shared primitive usage:
 | `skeleton`                        | Tailwind loading primitive                             | 18 imports   |
 | `alert-dialog`                    | Radix Alert Dialog wrapper                             | 18 imports   |
 | `scroll-area`                     | Radix Scroll Area wrapper                              | 13 imports   |
-| `dialog`                          | Radix Dialog wrapper                                   | 13 imports   |
+| `dialog`                          | Mantine Modal compatibility wrapper                    | 13 imports   |
 | `tabs`                            | Radix Tabs wrapper                                     | 9 imports    |
 | `checkbox`                        | Radix Checkbox wrapper                                 | 9 imports    |
 | `switch`                          | Radix Switch wrapper                                   | 8 imports    |
@@ -43,10 +43,10 @@ Shared primitive migration progress:
 
 - Mantine-backed compatibility wrappers are now active for `button`, `badge`,
   `input`, `textarea`, `checkbox`, `switch`, `label`, `skeleton`,
-  `scroll-area`, `number-input`, `popover`, `tooltip`, `tabs`, and the app-level
-  `toaster` delivery path.
+  `scroll-area`, `number-input`, `dialog`, `popover`, `tooltip`, `tabs`, and
+  the app-level `toaster` delivery path.
 - Temporary Radix holdouts remain for compound/focus-heavy APIs: `select`,
-  `dialog`, `sheet`, and `alert-dialog`.
+  `sheet`, and `alert-dialog`.
 - The holdouts stay intentionally until their feature surfaces can be migrated
   with visual and keyboard/focus checks in the same PR. New v5 surfaces should
   prefer Mantine primitives directly unless they need one of the compatibility
@@ -195,6 +195,8 @@ Foundation verification currently covers:
   legacy compatibility coverage
 - Mantine-backed tooltip compatibility wrapper with provider/trigger/content
   coverage
+- Mantine-backed dialog compatibility wrapper with trigger/content/title/
+  description/close coverage and Modal focus/scroll/Escape behavior
 
 ## Migration Order
 
@@ -230,9 +232,9 @@ Migration batches:
    number-like settings inputs now route through Mantine `NumberInput`; select
    remains for feature-surface migration PRs.
 3. Feedback: toast delivery now routes through Mantine notifications.
-4. Overlays: popover and tooltip now use Mantine-backed compatibility wrappers.
-   Dialog, alert dialog, and sheet/drawer remain Radix holdouts until each
-   surface has visual and focus QA.
+4. Overlays: dialog/modal, popover, and tooltip now use Mantine-backed
+   compatibility wrappers. Alert dialog and sheet/drawer remain Radix holdouts
+   until each surface has visual and focus QA.
 5. Navigation modes: tabs now use a Mantine-backed compatibility wrapper.
    Segmented controls and command/search shell remain surface-level work.
 

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -6,6 +6,14 @@ import { renderWithProviders } from './test-utils';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { NumberInput } from '@/components/ui/number-input';
@@ -70,6 +78,28 @@ function TabsProbe() {
       <TabsContent value="activity">Activity content</TabsContent>
       <span data-testid="selected-tab">{selectedTab}</span>
     </Tabs>
+  );
+}
+
+function DialogProbe() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button>Open dialog</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogTitle>Dialog title</DialogTitle>
+          <DialogDescription>Dialog description</DialogDescription>
+          <DialogClose asChild>
+            <Button>Done</Button>
+          </DialogClose>
+        </DialogContent>
+      </Dialog>
+      <span data-testid="dialog-state">{String(open)}</span>
+    </>
   );
 }
 
@@ -181,6 +211,32 @@ describe('Mantine-backed shared UI primitives', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Helpful detail')).toBeDefined();
+    });
+  });
+
+  it('opens and closes Mantine-backed dialogs through the legacy API', async () => {
+    renderWithProviders(<DialogProbe />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      const title = screen.getByText('Dialog title');
+      const description = screen.getByText('Dialog description');
+      const describedBy = dialog.getAttribute('aria-describedby');
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe(title.getAttribute('id'));
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy ?? '')?.textContent).toContain(
+        description.textContent
+      );
+      expect(screen.getByTestId('dialog-state').textContent).toBe('true');
+    });
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog-state').textContent).toBe('false');
     });
   });
 });

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -1,37 +1,145 @@
 'use client';
 
 import * as React from 'react';
-import { Dialog as DialogPrimitive } from 'radix-ui';
-
-import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
+import { Modal } from '@mantine/core';
 import { XIcon } from 'lucide-react';
 
-function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type DialogContextValue = {
+  modalId: string;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+const DialogContext = React.createContext<DialogContextValue | null>(null);
+
+function useDialogContext(component: string) {
+  const context = React.useContext(DialogContext);
+  if (!context) {
+    throw new Error(`${component} must be used inside Dialog`);
+  }
+  return context;
 }
 
-function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+function Dialog({
+  children,
+  defaultOpen = false,
+  onOpenChange,
+  open,
+}: {
+  children?: React.ReactNode;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+}) {
+  const modalId = React.useId();
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const isControlled = open !== undefined;
+  const resolvedOpen = isControlled ? open : uncontrolledOpen;
+
+  const setOpen = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(nextOpen);
+      }
+      onOpenChange?.(nextOpen);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const context = React.useMemo<DialogContextValue>(
+    () => ({
+      modalId,
+      open: resolvedOpen,
+      setOpen,
+    }),
+    [modalId, resolvedOpen, setOpen]
+  );
+
+  return <DialogContext.Provider value={context}>{children}</DialogContext.Provider>;
 }
 
-function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+type DialogButtonProps = React.ComponentProps<'button'> & {
+  asChild?: boolean;
+};
+
+function cloneButtonChild(
+  children: React.ReactNode,
+  props: Omit<DialogButtonProps, 'asChild' | 'children'>,
+  onClick: (event: React.MouseEvent<HTMLElement>) => void,
+  dataSlot: string
+) {
+  if (React.isValidElement(children)) {
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childOnClick = child.props.onClick as
+      | ((event: React.MouseEvent<HTMLElement>) => void)
+      | undefined;
+
+    return React.cloneElement(child, {
+      ...props,
+      'data-slot': dataSlot,
+      onClick: (event: React.MouseEvent<HTMLElement>) => {
+        childOnClick?.(event);
+        onClick(event);
+      },
+    });
+  }
+
+  return null;
 }
 
-function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
-}
+function DialogTrigger({ asChild, children, onClick, ...props }: DialogButtonProps) {
+  const { setOpen } = useDialogContext('DialogTrigger');
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    onClick?.(event as React.MouseEvent<HTMLButtonElement>);
+    if (!event.defaultPrevented) {
+      setOpen(true);
+    }
+  };
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  if (asChild) {
+    return cloneButtonChild(children, props, handleClick, 'dialog-trigger');
+  }
+
   return (
-    <DialogPrimitive.Overlay
+    <button data-slot="dialog-trigger" type="button" onClick={handleClick} {...props}>
+      {children}
+    </button>
+  );
+}
+
+function DialogPortal({ children }: { children?: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+function DialogClose({ asChild, children, onClick, ...props }: DialogButtonProps) {
+  const { setOpen } = useDialogContext('DialogClose');
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    onClick?.(event as React.MouseEvent<HTMLButtonElement>);
+    if (!event.defaultPrevented) {
+      setOpen(false);
+    }
+  };
+
+  if (asChild) {
+    return cloneButtonChild(children, props, handleClick, 'dialog-close');
+  }
+
+  return (
+    <button data-slot="dialog-close" type="button" onClick={handleClick} {...props}>
+      {children}
+    </button>
+  );
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        'fixed inset-0 isolate z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs',
         className
       )}
       {...props}
@@ -44,31 +152,47 @@ function DialogContent({
   children,
   showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+}: React.ComponentPropsWithoutRef<'div'> & {
+  children?: React.ReactNode;
   showCloseButton?: boolean;
 }) {
+  const { modalId, open, setOpen } = useDialogContext('DialogContent');
+
   return (
-    <DialogPortal>
-      <DialogOverlay />
-      <DialogPrimitive.Content
+    <Modal.Root
+      centered
+      closeOnEscape
+      lockScroll
+      opened={open}
+      onClose={() => setOpen(false)}
+      id={modalId}
+      padding={0}
+      returnFocus
+      size="auto"
+      trapFocus
+    >
+      <Modal.Overlay className="fixed inset-0 isolate z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
+      <Modal.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 outline-none sm:max-w-sm',
           className
         )}
         {...props}
       >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close data-slot="dialog-close" asChild>
-            <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm">
-              <XIcon />
-              <span className="sr-only">Close</span>
-            </Button>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
-    </DialogPortal>
+        <Modal.Body className="contents">
+          {children}
+          {showCloseButton && (
+            <DialogClose asChild>
+              <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm">
+                <XIcon />
+                <span className="sr-only">Close</span>
+              </Button>
+            </DialogClose>
+          )}
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
   );
 }
 
@@ -97,17 +221,17 @@ function DialogFooter({
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close asChild>
+        <DialogClose asChild>
           <Button variant="outline">Close</Button>
-        </DialogPrimitive.Close>
+        </DialogClose>
       )}
     </div>
   );
 }
 
-function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, id: _legacyId, ...props }: React.ComponentProps<'h2'>) {
   return (
-    <DialogPrimitive.Title
+    <Modal.Title
       data-slot="dialog-title"
       className={cn('text-base leading-none font-medium', className)}
       {...props}
@@ -115,13 +239,11 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   );
 }
 
-function DialogDescription({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+function DialogDescription({ className, id, ...props }: React.ComponentProps<'p'>) {
   return (
-    <DialogPrimitive.Description
+    <p
       data-slot="dialog-description"
+      id={id}
       className={cn(
         'text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
         className


### PR DESCRIPTION
## Summary
- Migrate the shared Dialog compatibility wrapper from Radix to Mantine Modal.
- Preserve the existing Dialog, Trigger, Content, Title, Description, Close, Header, Footer, Portal, and Overlay exports used by current feature surfaces.
- Add primitive coverage for open, close, Escape, title labelling, and described content wiring.
- Update the Mantine migration notes so dialog/modal is no longer listed as a Radix holdout.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/mantine-ui-primitives.test.tsx
- pnpm --filter @veritas-kanban/web test -- src/__tests__/SearchDialog.test.tsx src/__tests__/CreateTaskDuplicateDetection.test.tsx
- pnpm --filter @veritas-kanban/web test
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web lint
- pnpm lint:budget
- pnpm build
- git diff --check

## Notes
- Refs #416.
- Keeps #416 open for select, sheet, alert-dialog, markdown editor wrappers, validation patterns, and overlay focus QA.