### PR TITLE
Migrate shared alert dialog wrapper to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -26,7 +26,7 @@ Current shared primitive usage:
 | `badge`                           | Tailwind/CVA badge wrapper                             | 36 imports   |
 | `textarea`                        | Tailwind textarea wrapper                              | 20 imports   |
 | `skeleton`                        | Tailwind loading primitive                             | 18 imports   |
-| `alert-dialog`                    | Radix Alert Dialog wrapper                             | 18 imports   |
+| `alert-dialog`                    | Mantine Modal compatibility wrapper                    | 18 imports   |
 | `scroll-area`                     | Radix Scroll Area wrapper                              | 13 imports   |
 | `dialog`                          | Mantine Modal compatibility wrapper                    | 13 imports   |
 | `tabs`                            | Radix Tabs wrapper                                     | 9 imports    |
@@ -43,10 +43,9 @@ Shared primitive migration progress:
 
 - Mantine-backed compatibility wrappers are now active for `button`, `badge`,
   `input`, `textarea`, `checkbox`, `switch`, `label`, `skeleton`,
-  `scroll-area`, `number-input`, `dialog`, `sheet`, `popover`, `tooltip`,
-  `tabs`, and the app-level `toaster` delivery path.
-- Temporary Radix holdouts remain for compound/focus-heavy APIs: `select` and
-  `alert-dialog`.
+  `scroll-area`, `number-input`, `dialog`, `sheet`, `alert-dialog`, `popover`,
+  `tooltip`, `tabs`, and the app-level `toaster` delivery path.
+- Temporary Radix holdouts remain for compound/focus-heavy APIs: `select`.
 - The holdouts stay intentionally until their feature surfaces can be migrated
   with visual and keyboard/focus checks in the same PR. New v5 surfaces should
   prefer Mantine primitives directly unless they need one of the compatibility
@@ -199,6 +198,8 @@ Foundation verification currently covers:
   description/close coverage and Modal focus/scroll/Escape behavior
 - Mantine-backed sheet compatibility wrapper with trigger/content/title/
   description/close coverage and Drawer position/focus/scroll/Escape behavior
+- Mantine-backed alert dialog compatibility wrapper with trigger/content/title/
+  description/action/cancel coverage and modal focus/scroll/Escape behavior
 
 ## Migration Order
 
@@ -234,9 +235,9 @@ Migration batches:
    number-like settings inputs now route through Mantine `NumberInput`; select
    remains for feature-surface migration PRs.
 3. Feedback: toast delivery now routes through Mantine notifications.
-4. Overlays: dialog/modal, sheet/drawer, popover, and tooltip now use
-   Mantine-backed compatibility wrappers. Alert dialog remains a Radix holdout
-   until its destructive confirmation surfaces have visual and focus QA.
+4. Overlays: dialog/modal, sheet/drawer, alert dialog, popover, and tooltip now
+   use Mantine-backed compatibility wrappers. Destructive confirmation surfaces
+   still need visual QA before the cleanup gate.
 5. Navigation modes: tabs now use a Mantine-backed compatibility wrapper.
    Segmented controls and command/search shell remain surface-level work.
 
@@ -284,7 +285,7 @@ Target issue: `v5.0 QA: Mantine migration visual, accessibility, and cleanup gat
 | `components/ui/dialog.tsx`       | Mantine `Modal`                                         | High     |
 | `components/ui/sheet.tsx`        | Mantine `Drawer` compatibility wrapper                  | High     |
 | `components/ui/tabs.tsx`         | Mantine `Tabs`                                          | High     |
-| `components/ui/alert-dialog.tsx` | Mantine `Modal` with danger action pattern              | High     |
+| `components/ui/alert-dialog.tsx` | Mantine `Modal` compatibility wrapper                   | High     |
 | `components/ui/checkbox.tsx`     | Mantine `Checkbox`                                      | Medium   |
 | `components/ui/switch.tsx`       | Mantine `Switch`                                        | Medium   |
 | `components/ui/popover.tsx`      | Mantine `Popover`/`Menu`                                | Medium   |

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -3,6 +3,17 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { notifications } from '@mantine/notifications';
 import { renderWithProviders } from './test-utils';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -129,6 +140,33 @@ function SheetProbe() {
         </SheetContent>
       </Sheet>
       <span data-testid="sheet-state">{String(open)}</span>
+    </>
+  );
+}
+
+function AlertDialogProbe() {
+  const [confirmed, setConfirmed] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogTrigger asChild>
+          <Button>Open alert</Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Alert title</AlertDialogTitle>
+            <AlertDialogDescription>Alert description</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => setConfirmed(true)}>Confirm</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <span data-testid="alert-state">{String(open)}</span>
+      <span data-testid="alert-confirmed">{String(confirmed)}</span>
     </>
   );
 }
@@ -294,6 +332,47 @@ describe('Mantine-backed shared UI primitives', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('sheet-state').textContent).toBe('false');
+    });
+  });
+
+  it('opens and closes Mantine-backed alert dialogs through the legacy API', async () => {
+    renderWithProviders(<AlertDialogProbe />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open alert' }));
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      const title = screen.getByText('Alert title');
+      const description = screen.getByText('Alert description');
+      const describedBy = dialog.getAttribute('aria-describedby');
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe(title.getAttribute('id'));
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy ?? '')?.textContent).toContain(
+        description.textContent
+      );
+      expect(screen.getByTestId('alert-state').textContent).toBe('true');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-state').textContent).toBe('false');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open alert' }));
+    fireEvent.keyDown(await screen.findByRole('dialog'), { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-state').textContent).toBe('false');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open alert' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-state').textContent).toBe('false');
+      expect(screen.getByTestId('alert-confirmed').textContent).toBe('true');
     });
   });
 });

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,32 +1,124 @@
+'use client';
+
+import { Modal } from '@mantine/core';
 import * as React from 'react';
-import { AlertDialog as AlertDialogPrimitive } from 'radix-ui';
 
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
-function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+type AlertDialogContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  modalId: string;
+};
+
+const AlertDialogContext = React.createContext<AlertDialogContextValue | null>(null);
+
+function useAlertDialogContext(component: string) {
+  const context = React.useContext(AlertDialogContext);
+  if (!context) {
+    throw new Error(`${component} must be used inside AlertDialog`);
+  }
+  return context;
 }
 
-function AlertDialogTrigger({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+function AlertDialog({
+  children,
+  defaultOpen = false,
+  onOpenChange,
+  open,
+}: {
+  children?: React.ReactNode;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+}) {
+  const modalId = React.useId();
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const isControlled = open !== undefined;
+  const resolvedOpen = isControlled ? open : uncontrolledOpen;
+
+  const setOpen = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(nextOpen);
+      }
+      onOpenChange?.(nextOpen);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const context = React.useMemo<AlertDialogContextValue>(
+    () => ({
+      modalId,
+      open: resolvedOpen,
+      setOpen,
+    }),
+    [modalId, resolvedOpen, setOpen]
+  );
+
+  return <AlertDialogContext.Provider value={context}>{children}</AlertDialogContext.Provider>;
 }
 
-function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
-  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+type AlertDialogButtonProps = React.ComponentProps<'button'> & {
+  asChild?: boolean;
+};
+
+function cloneButtonChild(
+  children: React.ReactNode,
+  props: Omit<AlertDialogButtonProps, 'asChild' | 'children'>,
+  onClick: (event: React.MouseEvent<HTMLElement>) => void,
+  dataSlot: string
+) {
+  if (React.isValidElement(children)) {
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childOnClick = child.props.onClick as
+      | ((event: React.MouseEvent<HTMLElement>) => void)
+      | undefined;
+
+    return React.cloneElement(child, {
+      ...props,
+      'data-slot': dataSlot,
+      onClick: (event: React.MouseEvent<HTMLElement>) => {
+        childOnClick?.(event);
+        onClick(event);
+      },
+    });
+  }
+
+  return null;
 }
 
-function AlertDialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+function AlertDialogTrigger({ asChild, children, onClick, ...props }: AlertDialogButtonProps) {
+  const { setOpen } = useAlertDialogContext('AlertDialogTrigger');
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    onClick?.(event as React.MouseEvent<HTMLButtonElement>);
+    if (!event.defaultPrevented) {
+      setOpen(true);
+    }
+  };
+
+  if (asChild) {
+    return cloneButtonChild(children, props, handleClick, 'alert-dialog-trigger');
+  }
+
   return (
-    <AlertDialogPrimitive.Overlay
+    <button data-slot="alert-dialog-trigger" type="button" onClick={handleClick} {...props}>
+      {children}
+    </button>
+  );
+}
+
+function AlertDialogPortal({ children }: { children?: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+function AlertDialogOverlay({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
       data-slot="alert-dialog-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        'fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs',
         className
       )}
       {...props}
@@ -35,25 +127,43 @@ function AlertDialogOverlay({
 }
 
 function AlertDialogContent({
+  children,
   className,
   size = 'default',
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+}: React.ComponentPropsWithoutRef<'div'> & {
+  children?: React.ReactNode;
   size?: 'default' | 'sm';
 }) {
+  const { modalId, open, setOpen } = useAlertDialogContext('AlertDialogContent');
+
   return (
-    <AlertDialogPortal>
-      <AlertDialogOverlay />
-      <AlertDialogPrimitive.Content
-        data-slot="alert-dialog-content"
+    <Modal.Root
+      centered
+      closeOnClickOutside={false}
+      closeOnEscape
+      id={modalId}
+      lockScroll
+      onClose={() => setOpen(false)}
+      opened={open}
+      padding={0}
+      returnFocus
+      size="auto"
+      trapFocus
+    >
+      <Modal.Overlay className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
+      <Modal.Content
         data-size={size}
+        data-slot="alert-dialog-content"
         className={cn(
-          'group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'group/alert-dialog-content grid w-full gap-4 rounded-xl bg-background p-4 ring-1 ring-foreground/10 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm',
           className
         )}
         {...props}
-      />
-    </AlertDialogPortal>
+      >
+        <Modal.Body className="contents">{children}</Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
   );
 }
 
@@ -96,12 +206,9 @@ function AlertDialogMedia({ className, ...props }: React.ComponentProps<'div'>) 
   );
 }
 
-function AlertDialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+function AlertDialogTitle({ className, id: _legacyId, ...props }: React.ComponentProps<'h2'>) {
   return (
-    <AlertDialogPrimitive.Title
+    <Modal.Title
       data-slot="alert-dialog-title"
       className={cn(
         'text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2',
@@ -112,13 +219,11 @@ function AlertDialogTitle({
   );
 }
 
-function AlertDialogDescription({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+function AlertDialogDescription({ className, id, ...props }: React.ComponentProps<'p'>) {
   return (
-    <AlertDialogPrimitive.Description
+    <p
       data-slot="alert-dialog-description"
+      id={id}
       className={cn(
         'text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
         className
@@ -130,37 +235,55 @@ function AlertDialogDescription({
 
 function AlertDialogAction({
   className,
+  onClick,
   variant = 'default',
   size = 'default',
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
-  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+}: React.ComponentProps<'button'> & Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  const { setOpen } = useAlertDialogContext('AlertDialogAction');
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (!event.defaultPrevented) {
+      setOpen(false);
+    }
+  };
+
   return (
-    <Button variant={variant} size={size} asChild>
-      <AlertDialogPrimitive.Action
-        data-slot="alert-dialog-action"
-        className={cn(className)}
-        {...props}
-      />
-    </Button>
+    <Button
+      data-slot="alert-dialog-action"
+      variant={variant}
+      size={size}
+      className={cn(className)}
+      onClick={handleClick}
+      {...props}
+    />
   );
 }
 
 function AlertDialogCancel({
   className,
+  onClick,
   variant = 'outline',
   size = 'default',
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
-  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+}: React.ComponentProps<'button'> & Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  const { setOpen } = useAlertDialogContext('AlertDialogCancel');
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (!event.defaultPrevented) {
+      setOpen(false);
+    }
+  };
+
   return (
-    <Button variant={variant} size={size} asChild>
-      <AlertDialogPrimitive.Cancel
-        data-slot="alert-dialog-cancel"
-        className={cn(className)}
-        {...props}
-      />
-    </Button>
+    <Button
+      data-slot="alert-dialog-cancel"
+      variant={variant}
+      size={size}
+      className={cn(className)}
+      onClick={handleClick}
+      {...props}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- Migrate the shared AlertDialog compatibility wrapper from Radix Alert Dialog to Mantine Modal.
- Preserve the existing AlertDialog, Trigger, Content, Title, Description, Action, Cancel, Header, Footer, Media, Portal, and Overlay exports.
- Keep action and cancel click behavior closing the dialog after handlers run unless default is prevented.
- Disable outside-click dismissal for destructive confirmation semantics while preserving Escape close behavior.
- Add primitive coverage for trigger, title labelling, described content, cancel, Escape, and action confirmation.
- Update the Mantine migration plan so alert-dialog is no longer listed as a Radix holdout.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/mantine-ui-primitives.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test
- pnpm --filter @veritas-kanban/web lint
- pnpm lint:budget
- pnpm build
- git diff --check

## Notes
- Refs #416.
- Keeps #416 open for select, markdown editor wrappers, validation patterns, and overlay visual QA.