### PR TITLE
Migrate shared select wrapper to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -17,39 +17,40 @@ components.
 
 Current shared primitive usage:
 
-| Primitive                         | Current state                                          | Observed use |
-| --------------------------------- | ------------------------------------------------------ | ------------ |
-| `button`                          | shadcn wrapper around Radix Slot and Tailwind variants | 73 imports   |
-| `input`                           | Tailwind input wrapper                                 | 41 imports   |
-| `select`                          | Radix Select wrapper                                   | 39 imports   |
-| `label`                           | Radix Label wrapper                                    | 36 imports   |
-| `badge`                           | Tailwind/CVA badge wrapper                             | 36 imports   |
-| `textarea`                        | Tailwind textarea wrapper                              | 20 imports   |
-| `skeleton`                        | Tailwind loading primitive                             | 18 imports   |
-| `alert-dialog`                    | Mantine Modal compatibility wrapper                    | 18 imports   |
-| `scroll-area`                     | Radix Scroll Area wrapper                              | 13 imports   |
-| `dialog`                          | Mantine Modal compatibility wrapper                    | 13 imports   |
-| `tabs`                            | Radix Tabs wrapper                                     | 9 imports    |
-| `checkbox`                        | Radix Checkbox wrapper                                 | 9 imports    |
-| `switch`                          | Radix Switch wrapper                                   | 8 imports    |
-| `sheet`                           | Mantine Drawer compatibility wrapper                   | 8 imports    |
-| `tooltip`                         | Mantine Tooltip compatibility wrapper                  | 4 imports    |
-| `popover`                         | Radix Popover wrapper                                  | 3 imports    |
-| `MarkdownEditor/MarkdownRenderer` | Custom markdown surfaces                               | 2 imports    |
-| `toast`/`toaster`                 | Radix Toast wrapper and app-level notification surface | 1 import     |
-| `data-table`                      | Custom table wrapper                                   | 1 import     |
+| Primitive                         | Current state                                                  | Observed use |
+| --------------------------------- | -------------------------------------------------------------- | ------------ |
+| `button`                          | Mantine Button/ActionIcon wrapper with Radix Slot escape hatch | 73 imports   |
+| `input`                           | Mantine Input compatibility wrapper                            | 41 imports   |
+| `select`                          | Mantine Select compatibility wrapper                           | 39 imports   |
+| `label`                           | Mantine Box label compatibility wrapper                        | 36 imports   |
+| `badge`                           | Mantine Badge wrapper with Radix Slot escape hatch             | 36 imports   |
+| `textarea`                        | Mantine Textarea compatibility wrapper                         | 20 imports   |
+| `skeleton`                        | Mantine Skeleton compatibility wrapper                         | 18 imports   |
+| `alert-dialog`                    | Mantine Modal compatibility wrapper                            | 18 imports   |
+| `scroll-area`                     | Mantine ScrollArea compatibility wrapper                       | 13 imports   |
+| `dialog`                          | Mantine Modal compatibility wrapper                            | 13 imports   |
+| `tabs`                            | Mantine Tabs compatibility wrapper                             | 9 imports    |
+| `checkbox`                        | Mantine Checkbox compatibility wrapper                         | 9 imports    |
+| `switch`                          | Mantine Switch compatibility wrapper                           | 8 imports    |
+| `sheet`                           | Mantine Drawer compatibility wrapper                           | 8 imports    |
+| `tooltip`                         | Mantine Tooltip compatibility wrapper                          | 4 imports    |
+| `popover`                         | Mantine Popover compatibility wrapper                          | 3 imports    |
+| `MarkdownEditor/MarkdownRenderer` | Custom markdown surfaces                                       | 2 imports    |
+| `toast`/`toaster`                 | Mantine Notifications bridge                                   | 1 import     |
+| `data-table`                      | Custom table wrapper                                           | 1 import     |
 
 Shared primitive migration progress:
 
 - Mantine-backed compatibility wrappers are now active for `button`, `badge`,
   `input`, `textarea`, `checkbox`, `switch`, `label`, `skeleton`,
   `scroll-area`, `number-input`, `dialog`, `sheet`, `alert-dialog`, `popover`,
-  `tooltip`, `tabs`, and the app-level `toaster` delivery path.
-- Temporary Radix holdouts remain for compound/focus-heavy APIs: `select`.
-- The holdouts stay intentionally until their feature surfaces can be migrated
-  with visual and keyboard/focus checks in the same PR. New v5 surfaces should
-  prefer Mantine primitives directly unless they need one of the compatibility
-  wrappers above.
+  `tooltip`, `tabs`, `select`, and the app-level `toaster` delivery path.
+- No shared `components/ui` primitive wrapper remains backed by a Radix
+  interaction primitive. Radix Slot can stay temporarily for `asChild`
+  composition while migrated feature surfaces still depend on that contract.
+- Feature surfaces still need visual and keyboard/focus checks before the final
+  cleanup gate. New v5 surfaces should prefer Mantine primitives directly unless
+  they need one of the compatibility wrappers above.
 
 High-traffic feature surfaces:
 
@@ -200,6 +201,8 @@ Foundation verification currently covers:
   description/close coverage and Drawer position/focus/scroll/Escape behavior
 - Mantine-backed alert dialog compatibility wrapper with trigger/content/title/
   description/action/cancel coverage and modal focus/scroll/Escape behavior
+- Mantine-backed select compatibility wrapper with trigger/value/content/item
+  coverage and legacy `onValueChange` behavior
 
 ## Migration Order
 
@@ -233,7 +236,7 @@ Migration batches:
    while preserving current imports.
 2. Form controls: checkbox and switch completed for the compatibility layer;
    number-like settings inputs now route through Mantine `NumberInput`; select
-   remains for feature-surface migration PRs.
+   now routes through Mantine `Select` while preserving the legacy value API.
 3. Feedback: toast delivery now routes through Mantine notifications.
 4. Overlays: dialog/modal, sheet/drawer, alert dialog, popover, and tooltip now
    use Mantine-backed compatibility wrappers. Destructive confirmation surfaces
@@ -281,7 +284,7 @@ Target issue: `v5.0 QA: Mantine migration visual, accessibility, and cleanup gat
 | `components/ui/button.tsx`       | Mantine `Button`/`ActionIcon` wrapper or direct imports | High     |
 | `components/ui/input.tsx`        | Mantine `TextInput`                                     | High     |
 | `components/ui/textarea.tsx`     | Mantine `Textarea`                                      | High     |
-| `components/ui/select.tsx`       | Mantine `Select`/`MultiSelect`                          | High     |
+| `components/ui/select.tsx`       | Mantine `Select` compatibility wrapper                  | High     |
 | `components/ui/dialog.tsx`       | Mantine `Modal`                                         | High     |
 | `components/ui/sheet.tsx`        | Mantine `Drawer` compatibility wrapper                  | High     |
 | `components/ui/tabs.tsx`         | Mantine `Tabs`                                          | High     |

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { notifications } from '@mantine/notifications';
 import { renderWithProviders } from './test-utils';
@@ -31,6 +31,13 @@ import { NumberInput } from '@/components/ui/number-input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
   Sheet,
   SheetClose,
   SheetContent,
@@ -45,6 +52,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Toaster } from '@/components/ui/toaster';
 import { toast } from '@/hooks/useToast';
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
 
 function ToggleProbe() {
   const [checked, setChecked] = React.useState(false);
@@ -171,7 +180,34 @@ function AlertDialogProbe() {
   );
 }
 
+function SelectProbe() {
+  const [value, setValue] = React.useState('todo');
+
+  return (
+    <>
+      <Select value={value} onValueChange={setValue}>
+        <SelectTrigger aria-label="Status" className="w-44">
+          <SelectValue placeholder="Choose status" />
+        </SelectTrigger>
+        <SelectContent align="start">
+          <SelectItem value="todo">To Do</SelectItem>
+          <SelectItem value="done">Done</SelectItem>
+        </SelectContent>
+      </Select>
+      <span data-testid="select-state">{value}</span>
+    </>
+  );
+}
+
 describe('Mantine-backed shared UI primitives', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterAll(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
   afterEach(() => {
     notifications.clean();
     cleanup();
@@ -241,6 +277,17 @@ describe('Mantine-backed shared UI primitives', () => {
 
     expect(screen.getByTestId('selected-tab').textContent).toBe('activity');
     expect(screen.getByText('Activity content')).toBeDefined();
+  });
+
+  it('changes Mantine-backed selects through the legacy value API', async () => {
+    renderWithProviders(<SelectProbe />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Status' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'Done' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('select-state').textContent).toBe('done');
+    });
   });
 
   it('opens Mantine-backed popovers through the legacy trigger/content API', async () => {

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,171 +1,355 @@
+'use client';
+
+import {
+  Select as MantineSelect,
+  type ComboboxItem,
+  type ComboboxLikeRenderOptionInput,
+} from '@mantine/core';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import * as React from 'react';
-import { Select as SelectPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from 'lucide-react';
 
-function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />;
+type SelectAlign = 'start' | 'center' | 'end';
+
+type SelectItemRecord = {
+  className?: string;
+  disabled?: boolean;
+  label: string;
+  node: React.ReactNode;
+  value: string;
+};
+
+type SelectContextValue = {
+  align: SelectAlign;
+  defaultValue?: string;
+  disabled?: boolean;
+  items: SelectItemRecord[];
+  name?: string;
+  onValueChange?: (value: string) => void;
+  required?: boolean;
+  setAlign: (align: SelectAlign) => void;
+  setItems: (items: SelectItemRecord[]) => void;
+  value?: string;
+};
+
+type SelectProps<TValue extends string = string> = {
+  children?: React.ReactNode;
+  defaultValue?: TValue;
+  disabled?: boolean;
+  name?: string;
+  onValueChange?: (value: TValue) => void;
+  required?: boolean;
+  value?: TValue;
+};
+
+const SelectContext = React.createContext<SelectContextValue | null>(null);
+
+function useSelectContext(component: string) {
+  const context = React.useContext(SelectContext);
+  if (!context) {
+    throw new Error(`${component} must be used inside Select`);
+  }
+  return context;
 }
 
-function SelectGroup({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+function getTextContent(node: React.ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getTextContent).join(' ');
+  }
+
+  if (React.isValidElement(node)) {
+    const props = node.props as { children?: React.ReactNode };
+    return getTextContent(props.children);
+  }
+
+  return '';
+}
+
+function getSelectValuePlaceholder(node: React.ReactNode): string | undefined {
+  let placeholder: string | undefined;
+
+  React.Children.forEach(node, (child) => {
+    if (placeholder || !React.isValidElement(child)) {
+      return;
+    }
+
+    const props = child.props as { children?: React.ReactNode; placeholder?: React.ReactNode };
+    if (props.placeholder !== undefined) {
+      placeholder = getTextContent(props.placeholder).trim();
+      return;
+    }
+
+    placeholder = getSelectValuePlaceholder(props.children);
+  });
+
+  return placeholder;
+}
+
+function getSelectItems(node: React.ReactNode): SelectItemRecord[] {
+  const items: SelectItemRecord[] = [];
+
+  React.Children.forEach(node, (child) => {
+    if (!React.isValidElement(child)) {
+      return;
+    }
+
+    const props = child.props as {
+      children?: React.ReactNode;
+      className?: string;
+      disabled?: boolean;
+      textValue?: string;
+      value?: string;
+    };
+
+    if (typeof props.value === 'string') {
+      const label = props.textValue ?? getTextContent(props.children).replace(/\s+/g, ' ').trim();
+      items.push({
+        className: props.className,
+        disabled: props.disabled,
+        label: label || props.value,
+        node: props.children,
+        value: props.value,
+      });
+      return;
+    }
+
+    items.push(...getSelectItems(props.children));
+  });
+
+  return items;
+}
+
+function itemsEqual(current: SelectItemRecord[], next: SelectItemRecord[]) {
+  if (current.length !== next.length) {
+    return false;
+  }
+
+  return current.every((item, index) => {
+    const nextItem = next[index];
+    return (
+      item.value === nextItem.value &&
+      item.label === nextItem.label &&
+      item.disabled === nextItem.disabled &&
+      item.className === nextItem.className
+    );
+  });
+}
+
+function Select<TValue extends string = string>({
+  children,
+  defaultValue,
+  disabled,
+  name,
+  onValueChange,
+  required,
+  value,
+}: SelectProps<TValue>) {
+  const [items, setItemsState] = React.useState<SelectItemRecord[]>([]);
+  const [align, setAlign] = React.useState<SelectAlign>('center');
+
+  const setItems = React.useCallback((nextItems: SelectItemRecord[]) => {
+    setItemsState((currentItems) =>
+      itemsEqual(currentItems, nextItems) ? currentItems : nextItems
+    );
+  }, []);
+
+  const context = React.useMemo<SelectContextValue>(
+    () => ({
+      align,
+      defaultValue,
+      disabled,
+      items,
+      name,
+      onValueChange: onValueChange as ((value: string) => void) | undefined,
+      required,
+      setAlign,
+      setItems,
+      value,
+    }),
+    [align, defaultValue, disabled, items, name, onValueChange, required, setItems, value]
+  );
+
   return (
-    <SelectPrimitive.Group
-      data-slot="select-group"
-      className={cn('scroll-my-1 p-1', className)}
-      {...props}
+    <SelectContext.Provider value={context}>
+      <div data-slot="select" className="contents">
+        {children}
+      </div>
+    </SelectContext.Provider>
+  );
+}
+
+function SelectGroup({ children }: { children?: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+function SelectValue({ placeholder }: { placeholder?: React.ReactNode }) {
+  return (
+    <span
+      data-slot="select-value"
+      className="hidden"
+      data-placeholder={getTextContent(placeholder)}
     />
   );
 }
 
-function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+function getComboboxPosition(align: SelectAlign) {
+  if (align === 'start') {
+    return 'bottom-start' as const;
+  }
+
+  if (align === 'end') {
+    return 'bottom-end' as const;
+  }
+
+  return 'bottom' as const;
 }
 
 function SelectTrigger({
   className,
   size = 'default',
   children,
+  disabled,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+}: Omit<React.ComponentPropsWithoutRef<'input'>, 'defaultValue' | 'onChange' | 'size' | 'value'> & {
+  children?: React.ReactNode;
   size?: 'sm' | 'default';
 }) {
+  const context = useSelectContext('SelectTrigger');
+  const itemByValue = React.useMemo(
+    () => new Map(context.items.map((item) => [item.value, item])),
+    [context.items]
+  );
+  const data = React.useMemo(
+    () =>
+      context.items.map((item) => ({
+        disabled: item.disabled,
+        label: item.label,
+        value: item.value,
+      })),
+    [context.items]
+  );
+
   return (
-    <SelectPrimitive.Trigger
-      data-slot="select-trigger"
+    <MantineSelect
+      allowDeselect={false}
+      checkIconPosition="right"
+      className={className}
+      classNames={{
+        dropdown:
+          'z-50 min-w-36 overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10',
+        input: cn(
+          'flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus:border-ring focus:ring-3 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+          className
+        ),
+        option:
+          'rounded-md text-sm data-combobox-disabled:pointer-events-none data-combobox-disabled:opacity-50',
+      }}
+      comboboxProps={{
+        position: getComboboxPosition(context.align),
+        withinPortal: true,
+      }}
+      data={data}
       data-size={size}
-      className={cn(
-        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <SelectPrimitive.Icon asChild>
+      data-slot="select-trigger"
+      defaultValue={context.defaultValue}
+      disabled={context.disabled || disabled}
+      name={context.name}
+      onChange={(nextValue) => {
+        if (nextValue !== null) {
+          context.onValueChange?.(nextValue);
+        }
+      }}
+      placeholder={getSelectValuePlaceholder(children)}
+      renderOption={(input: ComboboxLikeRenderOptionInput<ComboboxItem>) => {
+        const item = itemByValue.get(input.option.value);
+        return (
+          <span className={cn('flex w-full items-center justify-between gap-2', item?.className)}>
+            <span className="flex items-center gap-2">{item?.node ?? input.option.label}</span>
+            {input.checked && <CheckIcon className="size-4" />}
+          </span>
+        );
+      }}
+      required={context.required}
+      rightSection={
         <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
-      </SelectPrimitive.Icon>
-    </SelectPrimitive.Trigger>
+      }
+      value={context.value}
+      withCheckIcon={false}
+      {...props}
+    />
   );
 }
 
 function SelectContent({
-  className,
-  children,
-  position = 'item-aligned',
   align = 'center',
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
-  return (
-    <SelectPrimitive.Portal>
-      <SelectPrimitive.Content
-        data-slot="select-content"
-        data-align-trigger={position === 'item-aligned'}
-        className={cn(
-          'relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
-          position === 'popper' &&
-            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-          className
-        )}
-        position={position}
-        align={align}
-        {...props}
-      >
-        <SelectScrollUpButton />
-        <SelectPrimitive.Viewport
-          data-position={position}
-          className={cn(
-            'data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)',
-            position === 'popper' && ''
-          )}
-        >
-          {children}
-        </SelectPrimitive.Viewport>
-        <SelectScrollDownButton />
-      </SelectPrimitive.Content>
-    </SelectPrimitive.Portal>
-  );
-}
-
-function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
-  return (
-    <SelectPrimitive.Label
-      data-slot="select-label"
-      className={cn('px-1.5 py-1 text-xs text-muted-foreground', className)}
-      {...props}
-    />
-  );
-}
-
-function SelectItem({
-  className,
   children,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
-  return (
-    <SelectPrimitive.Item
-      data-slot="select-item"
-      className={cn(
-        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-        className
-      )}
-      {...props}
-    >
-      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="pointer-events-none" />
-        </SelectPrimitive.ItemIndicator>
-      </span>
-      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-    </SelectPrimitive.Item>
-  );
+}: {
+  align?: SelectAlign;
+  children?: React.ReactNode;
+  className?: string;
+  position?: 'item-aligned' | 'popper';
+}) {
+  const { setAlign, setItems } = useSelectContext('SelectContent');
+  const items = React.useMemo(() => getSelectItems(children), [children]);
+
+  React.useEffect(() => {
+    setAlign(align);
+    setItems(items);
+  }, [align, items, setAlign, setItems]);
+
+  return null;
 }
 
-function SelectSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
-  return (
-    <SelectPrimitive.Separator
-      data-slot="select-separator"
-      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
-      {...props}
-    />
-  );
+function SelectLabel({ children }: { children?: React.ReactNode }) {
+  return <>{children}</>;
 }
 
-function SelectScrollUpButton({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+function SelectItem(_props: {
+  children?: React.ReactNode;
+  className?: string;
+  disabled?: boolean;
+  textValue?: string;
+  value: string;
+}) {
+  return null;
+}
+
+function SelectSeparator() {
+  return null;
+}
+
+function SelectScrollUpButton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <SelectPrimitive.ScrollUpButton
+    <div
       data-slot="select-scroll-up-button"
       className={cn(
-        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        "z-10 hidden cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
       <ChevronUpIcon />
-    </SelectPrimitive.ScrollUpButton>
+    </div>
   );
 }
 
-function SelectScrollDownButton({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+function SelectScrollDownButton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <SelectPrimitive.ScrollDownButton
+    <div
       data-slot="select-scroll-down-button"
       className={cn(
-        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        "z-10 hidden cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
       <ChevronDownIcon />
-    </SelectPrimitive.ScrollDownButton>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Migrate the shared Select compatibility wrapper from Radix to Mantine Select.
- Preserve the existing Select, Trigger, Value, Content, and Item exports plus disabled, default, value, name, required, and typed onValueChange behavior.
- Collect legacy SelectItem children into Mantine option data, including disabled, className, and custom node rendering.
- Update the Mantine migration notes to mark select as migrated and document the remaining Radix Slot escape hatch.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/mantine-ui-primitives.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test -- src/__tests__/SearchDialog.test.tsx src/__tests__/CreateTaskDuplicateDetection.test.tsx src/__tests__/SquadChatPanel.test.tsx
- pnpm --filter @veritas-kanban/web test
- pnpm --filter @veritas-kanban/web lint
- pnpm lint:budget
- pnpm build
- git diff --check

Refs #416