### PR TITLE
Add desktop bridge contracts

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -28,9 +28,17 @@ can be tested without reusing the default development home.
   work.
 - The renderer uses the existing Veritas web app and has no Node, filesystem,
   process, or secret access.
-- The preload bridge exposes only typed desktop operations:
-  `getAppInfo`, `getConnectionStatus`, `restartLocalServer`, `openExternal`,
-  and `onServerStatus`.
+- The preload bridge exposes only typed desktop operations. The current v5
+  contract covers app/setup diagnostics, local server lifecycle, connection
+  validation, update status, native command dispatch, upload/import picking,
+  diagnostics bundles, notification actions, work product export, external URL
+  opening, and desktop event subscriptions.
+- Bridge methods, event channels, validation, and redaction live in the shared
+  desktop bridge contract module so main and preload cannot drift silently.
+- Dangerous bridge methods require typed request objects and contract validators
+  before native execution. Unsupported native features return explicit
+  placeholder results until their dedicated v5 issues implement the backing
+  behavior.
 - Local development mode disables app auth only for the supervised loopback
   runtime. The packaged app path keeps auth enabled and is expected to move to
   keychain-backed bootstrap credentials in the dedicated keychain issue.

--- a/desktop/src/main/__tests__/bridge-contracts.test.ts
+++ b/desktop/src/main/__tests__/bridge-contracts.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IpcMain, Shell } from 'electron';
+
+import {
+  createDesktopBridgeHandlers,
+  registerDesktopBridge,
+  type DesktopBridgeHandlerMap,
+} from '../bridge.js';
+import type { DesktopRuntime } from '../runtime.js';
+import type { DesktopStatusSnapshot } from '../types.js';
+import {
+  assertDesktopBridgeMethodAvailable,
+  createDesktopBridgeEventCleanup,
+  createDesktopSetupDiagnostics,
+  createDesktopSupportSnapshot,
+  DESKTOP_BRIDGE_CAPABILITIES,
+  DESKTOP_BRIDGE_EVENT_NAMES,
+  DESKTOP_BRIDGE_EVENTS,
+  DESKTOP_BRIDGE_METHOD_NAMES,
+  DESKTOP_BRIDGE_METHOD_VALIDATORS,
+  DESKTOP_BRIDGE_METHODS,
+  DESKTOP_COMMAND_NAMES,
+  DESKTOP_FILE_PICKER_PURPOSES,
+  DESKTOP_PRELOAD_API_METHODS,
+  DESKTOP_PRELOAD_EVENT_METHODS,
+  DESKTOP_REDACTED_VALUE,
+  DESKTOP_RESTART_CONFIRMATION,
+  redactDesktopBridgeError,
+  redactDesktopBridgeValue,
+  validateConnectionConfigRequest,
+  validateDesktopCommandDispatchRequest,
+  validateDiagnosticsBundleRequest,
+  validateFilePickerRequest,
+  validateNotificationActionRequest,
+  validateOpenExternalRequest,
+  validateRestartLocalServerRequest,
+  validateWorkProductExportRequest,
+} from '../../shared/desktop-bridge-contracts.js';
+
+function snapshot(): DesktopStatusSnapshot {
+  return {
+    mode: 'local-dev',
+    server: {
+      name: 'server',
+      state: 'ready',
+      pid: 123,
+      port: 3001,
+      lastError: null,
+      startedAt: '2026-05-31T00:00:00.000Z',
+      exitedAt: null,
+    },
+    web: {
+      name: 'web',
+      state: 'ready',
+      pid: 124,
+      port: 3000,
+      lastError: null,
+      startedAt: '2026-05-31T00:00:00.000Z',
+      exitedAt: null,
+    },
+    serverOrigin: 'http://127.0.0.1:3001',
+    rendererOrigin: 'http://127.0.0.1:3000',
+    appHome: '/Users/bradgroux/Projects/veritas-kanban/.veritas-desktop-dev/fresh',
+    lastError: null,
+  };
+}
+
+function runtime(): DesktopRuntime {
+  const currentSnapshot = snapshot();
+  return {
+    snapshot: vi.fn(() => currentSnapshot),
+    restartLocalServer: vi.fn(async () => currentSnapshot),
+  } as unknown as DesktopRuntime;
+}
+
+function shell(): Shell {
+  return {
+    openExternal: vi.fn(async () => undefined),
+  } as unknown as Shell;
+}
+
+function handlers(): DesktopBridgeHandlerMap {
+  return createDesktopBridgeHandlers(runtime(), shell(), false);
+}
+
+describe('desktop bridge contracts', () => {
+  it('keeps contract registries and name lists in sync', () => {
+    expect(Object.keys(DESKTOP_BRIDGE_METHODS).sort()).toEqual(
+      [...DESKTOP_BRIDGE_METHOD_NAMES].sort()
+    );
+    expect(Object.keys(DESKTOP_BRIDGE_EVENTS).sort()).toEqual(
+      [...DESKTOP_BRIDGE_EVENT_NAMES].sort()
+    );
+    expect(Object.keys(handlers()).sort()).toEqual([...DESKTOP_BRIDGE_METHOD_NAMES].sort());
+  });
+
+  it('registers exactly one native handler for each declared bridge method', () => {
+    const registered = new Map<string, unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: unknown) => {
+        registered.set(channel, handler);
+      }),
+    } as unknown as IpcMain;
+
+    registerDesktopBridge(ipcMain, runtime(), shell(), false);
+
+    expect([...registered.keys()].sort()).toEqual(
+      DESKTOP_BRIDGE_METHOD_NAMES.map((method) => DESKTOP_BRIDGE_METHODS[method].channel).sort()
+    );
+    expect(registered.size).toBe(DESKTOP_BRIDGE_METHOD_NAMES.length);
+  });
+
+  it('keeps the preload API method list aligned to invoke and event contracts', () => {
+    expect(DESKTOP_PRELOAD_API_METHODS).toEqual([
+      ...DESKTOP_BRIDGE_METHOD_NAMES,
+      ...Object.values(DESKTOP_PRELOAD_EVENT_METHODS),
+    ]);
+
+    for (const method of DESKTOP_BRIDGE_METHOD_NAMES) {
+      expect(DESKTOP_BRIDGE_CAPABILITIES).toContain(DESKTOP_BRIDGE_METHODS[method].capability);
+    }
+
+    for (const event of DESKTOP_BRIDGE_EVENT_NAMES) {
+      expect(DESKTOP_BRIDGE_CAPABILITIES).toContain(DESKTOP_BRIDGE_EVENTS[event].capability);
+      expect(DESKTOP_PRELOAD_API_METHODS).toContain(DESKTOP_PRELOAD_EVENT_METHODS[event]);
+    }
+  });
+
+  it('requires validators for every dangerous bridge method', () => {
+    for (const method of DESKTOP_BRIDGE_METHOD_NAMES) {
+      if (DESKTOP_BRIDGE_METHODS[method].dangerous) {
+        expect(DESKTOP_BRIDGE_METHODS[method].validator).toBeDefined();
+        expect(DESKTOP_BRIDGE_METHOD_VALIDATORS[method]).toEqual(expect.any(Function));
+      }
+    }
+  });
+
+  it('blocks desktop-only bridge methods from unsupported client modes', () => {
+    expect(() => assertDesktopBridgeMethodAvailable('openExternal', 'desktop')).not.toThrow();
+    expect(() => assertDesktopBridgeMethodAvailable('openExternal', 'browser')).toThrow(
+      'desktop client'
+    );
+    expect(() => assertDesktopBridgeMethodAvailable('restartLocalServer', 'mobile')).toThrow(
+      'desktop client'
+    );
+  });
+
+  it('validates dangerous openExternal requests before shell execution', async () => {
+    const fakeShell = shell();
+    const bridgeHandlers: DesktopBridgeHandlerMap = createDesktopBridgeHandlers(
+      runtime(),
+      fakeShell,
+      false
+    );
+
+    await expect(
+      bridgeHandlers.openExternal({ url: 'file:///Users/bradgroux/.ssh/id_ed25519' })
+    ).rejects.toThrow('protocol is not allowed');
+    await expect(bridgeHandlers.openExternal('https://example.com' as never)).rejects.toThrow(
+      'typed request object'
+    );
+    await expect(
+      bridgeHandlers.openExternal({ url: 'https://user:pass@example.com' })
+    ).rejects.toThrow('credentials are not allowed');
+
+    await bridgeHandlers.openExternal({ url: 'https://example.com/docs' });
+
+    expect(fakeShell.openExternal).toHaveBeenCalledTimes(1);
+    expect(fakeShell.openExternal).toHaveBeenCalledWith('https://example.com/docs');
+  });
+
+  it('validates restart confirmation before restarting the local server', async () => {
+    const fakeRuntime = runtime();
+    const bridgeHandlers = createDesktopBridgeHandlers(fakeRuntime, shell(), false);
+
+    expect(() => bridgeHandlers.restartLocalServer({ confirmation: 'restart' } as never)).toThrow(
+      'explicit restart confirmation'
+    );
+
+    await bridgeHandlers.restartLocalServer({ confirmation: DESKTOP_RESTART_CONFIRMATION });
+
+    expect(fakeRuntime.restartLocalServer).toHaveBeenCalledTimes(1);
+    expect(
+      validateRestartLocalServerRequest({ confirmation: DESKTOP_RESTART_CONFIRMATION })
+    ).toEqual({
+      confirmation: DESKTOP_RESTART_CONFIRMATION,
+    });
+  });
+
+  it('validates connection config without accepting credentials or unsupported protocols', () => {
+    expect(validateConnectionConfigRequest({ mode: 'local' })).toEqual({ mode: 'local' });
+    expect(
+      validateConnectionConfigRequest({
+        mode: 'remote',
+        serverUrl: ' https://example.com/veritas ',
+        workspaceId: 'workspace-1',
+      })
+    ).toEqual({
+      mode: 'remote',
+      serverUrl: 'https://example.com/veritas',
+      workspaceId: 'workspace-1',
+    });
+    expect(() =>
+      validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'ftp://example.com' })
+    ).toThrow('protocol is not allowed');
+    expect(() =>
+      validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'https://user@example.com' })
+    ).toThrow('credentials are not allowed');
+  });
+
+  it('validates command names, file paths, notification actions, and work product exports', () => {
+    expect(
+      validateDesktopCommandDispatchRequest({
+        command: DESKTOP_COMMAND_NAMES[0],
+        source: 'menu',
+        payload: { route: 'settings' },
+      })
+    ).toEqual({
+      command: DESKTOP_COMMAND_NAMES[0],
+      source: 'menu',
+      payload: { route: 'settings' },
+    });
+    expect(() => validateDesktopCommandDispatchRequest({ command: 'rm -rf' })).toThrow(
+      'command is not allowed'
+    );
+
+    expect(
+      validateFilePickerRequest({
+        purpose: DESKTOP_FILE_PICKER_PURPOSES[0],
+        allowMultiple: true,
+        allowedExtensions: ['.MD', '.json'],
+        initialPath: '/Users/bradgroux/Desktop',
+      })
+    ).toEqual({
+      purpose: DESKTOP_FILE_PICKER_PURPOSES[0],
+      allowMultiple: true,
+      allowedExtensions: ['.md', '.json'],
+      initialPath: '/Users/bradgroux/Desktop',
+    });
+    expect(() =>
+      validateFilePickerRequest({
+        purpose: DESKTOP_FILE_PICKER_PURPOSES[0],
+        initialPath: 'https://example.com/file.md',
+      })
+    ).toThrow('local filesystem path');
+
+    expect(validateDiagnosticsBundleRequest({ includeLogs: true, reason: 'support' })).toEqual({
+      includeLogs: true,
+      includeRuntimeState: undefined,
+      reason: 'support',
+    });
+
+    expect(
+      validateNotificationActionRequest({
+        notificationId: 'notice-1',
+        action: 'complete-task',
+        taskId: 'task-1',
+      })
+    ).toEqual({
+      notificationId: 'notice-1',
+      action: 'complete-task',
+      taskId: 'task-1',
+    });
+    expect(() =>
+      validateNotificationActionRequest({ notificationId: 'notice-1', action: 'exec' })
+    ).toThrow('action is not allowed');
+
+    expect(
+      validateWorkProductExportRequest({
+        taskId: 'task-1',
+        workProductId: 'artifact-1',
+        targetPath: '/Users/bradgroux/Desktop/export.md',
+        openWhenDone: true,
+      })
+    ).toEqual({
+      taskId: 'task-1',
+      workProductId: 'artifact-1',
+      targetPath: '/Users/bradgroux/Desktop/export.md',
+      openWhenDone: true,
+    });
+    expect(() =>
+      validateWorkProductExportRequest({
+        taskId: 'task-1',
+        workProductId: 'artifact-1',
+        targetPath: 'relative/export.md',
+      })
+    ).toThrow('absolute local path');
+  });
+
+  it('normalizes allowed external URLs', () => {
+    expect(validateOpenExternalRequest({ url: ' https://example.com/a ' })).toEqual({
+      url: 'https://example.com/a',
+    });
+    expect(validateOpenExternalRequest({ url: 'mailto:help@example.com' })).toEqual({
+      url: 'mailto:help@example.com',
+    });
+  });
+
+  it('event cleanup unsubscribes once even when cleanup is called repeatedly', () => {
+    const detach = vi.fn();
+    const handler = vi.fn();
+    const cleanup = createDesktopBridgeEventCleanup('desktop:server-status', handler, detach);
+
+    cleanup();
+    cleanup();
+
+    expect(detach).toHaveBeenCalledTimes(1);
+    expect(detach).toHaveBeenCalledWith('desktop:server-status', handler);
+  });
+
+  it('redacts bridge diagnostics and error payloads', () => {
+    const redacted = redactDesktopBridgeValue({
+      token: 'secret-token',
+      message:
+        'Authorization: Bearer abc123 VERITAS_ADMIN_KEY=admin-key path=/Users/bradgroux/.ssh',
+      nested: {
+        webhookSecret: 'hook-secret',
+        safe: 'plain value',
+      },
+    });
+
+    expect(redacted).toEqual({
+      token: DESKTOP_REDACTED_VALUE,
+      message: `Authorization: Bearer ${DESKTOP_REDACTED_VALUE} VERITAS_ADMIN_KEY=${DESKTOP_REDACTED_VALUE} path=/Users/${DESKTOP_REDACTED_VALUE}/.ssh`,
+      nested: {
+        webhookSecret: DESKTOP_REDACTED_VALUE,
+        safe: 'plain value',
+      },
+    });
+
+    expect(
+      redactDesktopBridgeError(
+        new Error('Failed with token=abc123 from /Users/bradgroux/Projects/veritas-kanban')
+      )
+    ).toBe(
+      `Failed with token=${DESKTOP_REDACTED_VALUE} from /Users/${DESKTOP_REDACTED_VALUE}/Projects/veritas-kanban`
+    );
+  });
+
+  it('returns redacted setup diagnostics and support snapshots', () => {
+    const support = createDesktopSupportSnapshot(snapshot(), new Date('2026-05-31T12:00:00.000Z'));
+    const diagnostics = createDesktopSetupDiagnostics(
+      snapshot(),
+      new Date('2026-05-31T12:00:00.000Z')
+    );
+
+    expect(support.generatedAt).toBe('2026-05-31T12:00:00.000Z');
+    expect(support.status.appHome).toBe(
+      `/Users/${DESKTOP_REDACTED_VALUE}/Projects/veritas-kanban/.veritas-desktop-dev/fresh`
+    );
+    expect(diagnostics.checks.map((check) => check.name)).toEqual([
+      'local-server-health',
+      'renderer-health',
+      'communication-health',
+      'cli-auth',
+      'mcp-auth',
+    ]);
+    expect(diagnostics.supportSnapshot.status.appHome).toContain(DESKTOP_REDACTED_VALUE);
+  });
+});

--- a/desktop/src/main/bridge.ts
+++ b/desktop/src/main/bridge.ts
@@ -3,8 +3,121 @@ import type { IpcMain, Shell } from 'electron';
 import { DESKTOP_APP_ID, DESKTOP_APP_NAME } from './app-metadata.js';
 import type { DesktopAppInfo } from './types.js';
 import type { DesktopRuntime } from './runtime.js';
+import {
+  createDesktopSetupDiagnostics,
+  createDesktopSupportSnapshot,
+  DESKTOP_BRIDGE_METHOD_NAMES,
+  DESKTOP_BRIDGE_METHODS,
+  DESKTOP_BRIDGE_METHOD_VALIDATORS,
+  redactDesktopBridgeError,
+  validateConnectionConfigRequest,
+  validateDesktopCommandDispatchRequest,
+  validateDiagnosticsBundleRequest,
+  validateFilePickerRequest,
+  validateNotificationActionRequest,
+  validateOpenExternalRequest,
+  validateRestartLocalServerRequest,
+  validateWorkProductExportRequest,
+  type DesktopBridgeMethod,
+  type DesktopBridgeRequest,
+  type DesktopBridgeResponse,
+} from '../shared/desktop-bridge-contracts.js';
 
-const SAFE_EXTERNAL_PROTOCOLS = new Set(['https:', 'http:', 'mailto:']);
+type MaybePromise<T> = T | Promise<T>;
+
+export type DesktopBridgeHandlerMap = {
+  [Method in DesktopBridgeMethod]: (
+    request: DesktopBridgeRequest<Method>
+  ) => MaybePromise<DesktopBridgeResponse<Method>>;
+};
+
+export function createDesktopBridgeHandlers(
+  runtime: DesktopRuntime,
+  shell: Shell,
+  packaged: boolean
+): DesktopBridgeHandlerMap {
+  const appInfo = (): DesktopAppInfo => ({
+    name: DESKTOP_APP_NAME,
+    appId: DESKTOP_APP_ID,
+    version: process.env.npm_package_version || '0.0.0',
+    platform: process.platform,
+    packaged,
+  });
+
+  return {
+    getAppInfo: appInfo,
+    getConnectionStatus: () => runtime.snapshot(),
+    getSetupDiagnostics: () => createDesktopSetupDiagnostics(runtime.snapshot()),
+    validateConnectionConfig: (request) => {
+      const config = validateConnectionConfigRequest(request);
+      return {
+        mode: config.mode,
+        valid: true,
+        normalizedServerUrl: config.serverUrl ?? null,
+        warnings: [],
+        errors: [],
+      };
+    },
+    restartLocalServer: (request) => {
+      validateRestartLocalServerRequest(request);
+      return runtime.restartLocalServer();
+    },
+    getSupportSnapshot: () => createDesktopSupportSnapshot(runtime.snapshot()),
+    getUpdateStatus: () => ({
+      state: 'unsupported',
+      currentVersion: appInfo().version,
+      channel: packaged ? 'stable' : 'dev',
+      checkedAt: new Date().toISOString(),
+      detail: 'Updater implementation is tracked in the desktop release pipeline issue.',
+    }),
+    dispatchCommand: (request) => {
+      const command = validateDesktopCommandDispatchRequest(request);
+      return {
+        command: command.command,
+        accepted: false,
+        handledBy: 'unsupported',
+        message: 'Native command handling is reserved for the desktop menus issue.',
+      };
+    },
+    pickUploadFiles: (request) => {
+      validateFilePickerRequest(request);
+      return {
+        cancelled: true,
+        files: [],
+      };
+    },
+    createDiagnosticsBundle: (request) => {
+      validateDiagnosticsBundleRequest(request);
+      return {
+        bundlePath: null,
+        redacted: true,
+        warnings: ['Diagnostics bundle creation is reserved for the diagnostics workflow.'],
+      };
+    },
+    performNotificationAction: (request) => {
+      const action = validateNotificationActionRequest(request);
+      return {
+        notificationId: action.notificationId,
+        action: action.action,
+        accepted: false,
+        message: 'Native notification handling is reserved for the notifications issue.',
+      };
+    },
+    exportWorkProduct: (request) => {
+      validateWorkProductExportRequest(request);
+      return {
+        exportedPath: null,
+        opened: false,
+        warnings: ['Native work product export is reserved for the work products issue.'],
+      };
+    },
+    openExternal: async (request) => {
+      const { url } = validateOpenExternalRequest(request);
+      await shell.openExternal(url);
+      return undefined;
+    },
+  };
+}
 
 export function registerDesktopBridge(
   ipcMain: IpcMain,
@@ -12,29 +125,21 @@ export function registerDesktopBridge(
   shell: Shell,
   packaged: boolean
 ): void {
-  ipcMain.handle(
-    'desktop:get-app-info',
-    (): DesktopAppInfo => ({
-      name: DESKTOP_APP_NAME,
-      appId: DESKTOP_APP_ID,
-      version: process.env.npm_package_version || '0.0.0',
-      platform: process.platform,
-      packaged,
-    })
-  );
+  const handlers = createDesktopBridgeHandlers(runtime, shell, packaged);
 
-  ipcMain.handle('desktop:get-connection-status', () => runtime.snapshot());
-  ipcMain.handle('desktop:restart-local-server', () => runtime.restartLocalServer());
-  ipcMain.handle('desktop:open-external', async (_event, url: unknown) => {
-    if (typeof url !== 'string') {
-      throw new Error('URL must be a string');
-    }
+  for (const method of DESKTOP_BRIDGE_METHOD_NAMES) {
+    const definition = DESKTOP_BRIDGE_METHODS[method];
+    const handler = handlers[method] as (request: unknown) => MaybePromise<unknown>;
+    const validator = DESKTOP_BRIDGE_METHOD_VALIDATORS[method] as
+      | ((payload: unknown) => unknown)
+      | undefined;
 
-    const parsed = new URL(url);
-    if (!SAFE_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
-      throw new Error(`External URL protocol is not allowed: ${parsed.protocol}`);
-    }
-
-    await shell.openExternal(parsed.toString());
-  });
+    ipcMain.handle(definition.channel, async (_event, request: unknown) => {
+      try {
+        return await handler(validator ? validator(request) : request);
+      } catch (error) {
+        throw new Error(redactDesktopBridgeError(error));
+      }
+    });
+  }
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import { createDesktopPaths, resolveRepoRoot } from './paths.js';
 import { findAvailablePort } from './ports.js';
 import { DesktopRuntime } from './runtime.js';
 import { statusPageUrl } from './status-page.js';
+import { DESKTOP_BRIDGE_EVENTS } from '../shared/desktop-bridge-contracts.js';
 
 let mainWindow: BrowserWindow | null = null;
 let runtime: DesktopRuntime | null = null;
@@ -109,7 +110,7 @@ async function boot(): Promise<void> {
 
   registerDesktopBridge(ipcMain, runtime, shell, packaged);
   runtime.on('status', (status) => {
-    mainWindow?.webContents.send('desktop:server-status', status);
+    mainWindow?.webContents.send(DESKTOP_BRIDGE_EVENTS.serverStatus.channel, status);
   });
 
   try {

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,29 +1,147 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 import type { DesktopAppInfo, DesktopStatusSnapshot } from '../main/types.js';
+import {
+  createDesktopBridgeEventCleanup,
+  DESKTOP_RESTART_CONFIRMATION,
+  DESKTOP_BRIDGE_EVENTS,
+  DESKTOP_BRIDGE_METHODS,
+  type DesktopBridgeEvent,
+  type DesktopBridgeEventPayload,
+  type DesktopCommandDispatchRequest,
+  type DesktopCommandDispatchResult,
+  type DesktopConnectionConfigRequest,
+  type DesktopConnectionValidationResult,
+  type DesktopDiagnosticsBundleRequest,
+  type DesktopDiagnosticsBundleResult,
+  type DesktopFilePickerRequest,
+  type DesktopFilePickerResult,
+  type DesktopNotificationActionRequest,
+  type DesktopNotificationActionResult,
+  type DesktopSetupDiagnostics,
+  type DesktopSupportSnapshot,
+  type DesktopUpdateStatus,
+  type DesktopWorkProductExportRequest,
+  type DesktopWorkProductExportResult,
+} from '../shared/desktop-bridge-contracts.js';
 
 export interface VeritasDesktopApi {
   getAppInfo(): Promise<DesktopAppInfo>;
   getConnectionStatus(): Promise<DesktopStatusSnapshot>;
+  getSetupDiagnostics(): Promise<DesktopSetupDiagnostics>;
+  validateConnectionConfig(
+    request: DesktopConnectionConfigRequest
+  ): Promise<DesktopConnectionValidationResult>;
   restartLocalServer(): Promise<DesktopStatusSnapshot>;
+  getSupportSnapshot(): Promise<DesktopSupportSnapshot>;
+  getUpdateStatus(): Promise<DesktopUpdateStatus>;
+  dispatchCommand(request: DesktopCommandDispatchRequest): Promise<DesktopCommandDispatchResult>;
+  pickUploadFiles(request: DesktopFilePickerRequest): Promise<DesktopFilePickerResult>;
+  createDiagnosticsBundle(
+    request: DesktopDiagnosticsBundleRequest
+  ): Promise<DesktopDiagnosticsBundleResult>;
+  performNotificationAction(
+    request: DesktopNotificationActionRequest
+  ): Promise<DesktopNotificationActionResult>;
+  exportWorkProduct(
+    request: DesktopWorkProductExportRequest
+  ): Promise<DesktopWorkProductExportResult>;
   openExternal(url: string): Promise<void>;
+  onSetupProgress(listener: BridgeEventListener<'setupProgress'>): () => void;
+  onCommunicationCheck(listener: BridgeEventListener<'communicationCheck'>): () => void;
   onServerStatus(listener: (status: DesktopStatusSnapshot) => void): () => void;
+  onRunProgress(listener: BridgeEventListener<'runProgress'>): () => void;
+  onUpdateStatus(listener: BridgeEventListener<'updateStatus'>): () => void;
+  onNotificationAction(listener: BridgeEventListener<'notificationAction'>): () => void;
+  onMenuCommand(listener: BridgeEventListener<'menuCommand'>): () => void;
+  onUploadProgress(listener: BridgeEventListener<'uploadProgress'>): () => void;
+  onWorkProductExportProgress(
+    listener: BridgeEventListener<'workProductExportProgress'>
+  ): () => void;
+  onExternalDeliveryVerification(
+    listener: BridgeEventListener<'externalDeliveryVerification'>
+  ): () => void;
+}
+
+type BridgeEventListener<Event extends DesktopBridgeEvent> = (
+  payload: DesktopBridgeEventPayload<Event>
+) => void;
+
+function invokeDesktop<ReturnValue>(channel: string, request?: unknown): Promise<ReturnValue> {
+  return ipcRenderer.invoke(channel, request) as Promise<ReturnValue>;
+}
+
+function onDesktopEvent<Event extends DesktopBridgeEvent>(
+  event: Event,
+  listener: BridgeEventListener<Event>
+): () => void {
+  const channel = DESKTOP_BRIDGE_EVENTS[event].channel;
+  const handler = (
+    _event: Electron.IpcRendererEvent,
+    payload: DesktopBridgeEventPayload<Event>
+  ): void => {
+    listener(payload);
+  };
+  ipcRenderer.on(channel, handler);
+  return createDesktopBridgeEventCleanup(channel, handler, (eventChannel, eventHandler) => {
+    ipcRenderer.off(eventChannel, eventHandler);
+  });
 }
 
 const api: VeritasDesktopApi = {
-  getAppInfo: () => ipcRenderer.invoke('desktop:get-app-info') as Promise<DesktopAppInfo>,
+  getAppInfo: () => invokeDesktop<DesktopAppInfo>(DESKTOP_BRIDGE_METHODS.getAppInfo.channel),
   getConnectionStatus: () =>
-    ipcRenderer.invoke('desktop:get-connection-status') as Promise<DesktopStatusSnapshot>,
+    invokeDesktop<DesktopStatusSnapshot>(DESKTOP_BRIDGE_METHODS.getConnectionStatus.channel),
+  getSetupDiagnostics: () =>
+    invokeDesktop<DesktopSetupDiagnostics>(DESKTOP_BRIDGE_METHODS.getSetupDiagnostics.channel),
+  validateConnectionConfig: (request) =>
+    invokeDesktop<DesktopConnectionValidationResult>(
+      DESKTOP_BRIDGE_METHODS.validateConnectionConfig.channel,
+      request
+    ),
   restartLocalServer: () =>
-    ipcRenderer.invoke('desktop:restart-local-server') as Promise<DesktopStatusSnapshot>,
-  openExternal: (url: string) => ipcRenderer.invoke('desktop:open-external', url) as Promise<void>,
-  onServerStatus: (listener) => {
-    const handler = (_event: Electron.IpcRendererEvent, status: DesktopStatusSnapshot): void => {
-      listener(status);
-    };
-    ipcRenderer.on('desktop:server-status', handler);
-    return () => ipcRenderer.off('desktop:server-status', handler);
-  },
+    invokeDesktop<DesktopStatusSnapshot>(DESKTOP_BRIDGE_METHODS.restartLocalServer.channel, {
+      confirmation: DESKTOP_RESTART_CONFIRMATION,
+    }),
+  getSupportSnapshot: () =>
+    invokeDesktop<DesktopSupportSnapshot>(DESKTOP_BRIDGE_METHODS.getSupportSnapshot.channel),
+  getUpdateStatus: () =>
+    invokeDesktop<DesktopUpdateStatus>(DESKTOP_BRIDGE_METHODS.getUpdateStatus.channel),
+  dispatchCommand: (request) =>
+    invokeDesktop<DesktopCommandDispatchResult>(
+      DESKTOP_BRIDGE_METHODS.dispatchCommand.channel,
+      request
+    ),
+  pickUploadFiles: (request) =>
+    invokeDesktop<DesktopFilePickerResult>(DESKTOP_BRIDGE_METHODS.pickUploadFiles.channel, request),
+  createDiagnosticsBundle: (request) =>
+    invokeDesktop<DesktopDiagnosticsBundleResult>(
+      DESKTOP_BRIDGE_METHODS.createDiagnosticsBundle.channel,
+      request
+    ),
+  performNotificationAction: (request) =>
+    invokeDesktop<DesktopNotificationActionResult>(
+      DESKTOP_BRIDGE_METHODS.performNotificationAction.channel,
+      request
+    ),
+  exportWorkProduct: (request) =>
+    invokeDesktop<DesktopWorkProductExportResult>(
+      DESKTOP_BRIDGE_METHODS.exportWorkProduct.channel,
+      request
+    ),
+  openExternal: (url: string) =>
+    invokeDesktop<void>(DESKTOP_BRIDGE_METHODS.openExternal.channel, { url }),
+  onSetupProgress: (listener) => onDesktopEvent('setupProgress', listener),
+  onCommunicationCheck: (listener) => onDesktopEvent('communicationCheck', listener),
+  onServerStatus: (listener) => onDesktopEvent('serverStatus', listener),
+  onRunProgress: (listener) => onDesktopEvent('runProgress', listener),
+  onUpdateStatus: (listener) => onDesktopEvent('updateStatus', listener),
+  onNotificationAction: (listener) => onDesktopEvent('notificationAction', listener),
+  onMenuCommand: (listener) => onDesktopEvent('menuCommand', listener),
+  onUploadProgress: (listener) => onDesktopEvent('uploadProgress', listener),
+  onWorkProductExportProgress: (listener) => onDesktopEvent('workProductExportProgress', listener),
+  onExternalDeliveryVerification: (listener) =>
+    onDesktopEvent('externalDeliveryVerification', listener),
 };
 
 contextBridge.exposeInMainWorld('veritasDesktop', api);

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -1,0 +1,867 @@
+import type { DesktopAppInfo, DesktopStatusSnapshot } from '../main/types.js';
+
+export const DESKTOP_REDACTED_VALUE = '[redacted]';
+export const DESKTOP_RESTART_CONFIRMATION = 'restart-local-server';
+
+export const DESKTOP_BRIDGE_CAPABILITIES = [
+  'setup',
+  'serverLifecycle',
+  'connection',
+  'secrets',
+  'logs',
+  'backupImport',
+  'diagnostics',
+  'updates',
+  'notifications',
+  'deepLinks',
+  'shell',
+] as const;
+
+export type DesktopBridgeCapability = (typeof DESKTOP_BRIDGE_CAPABILITIES)[number];
+export type DesktopBridgeClientMode = 'desktop' | 'browser' | 'remote' | 'mobile';
+export type DesktopBridgeHealthState = 'ok' | 'warning' | 'failed' | 'unknown' | 'unsupported';
+export type DesktopBridgeValidatorName =
+  | 'restartLocalServer'
+  | 'openExternal'
+  | 'validateConnectionConfig'
+  | 'dispatchCommand'
+  | 'pickUploadFiles'
+  | 'createDiagnosticsBundle'
+  | 'performNotificationAction'
+  | 'exportWorkProduct';
+
+interface DesktopBridgeMethodDefinition {
+  capability: DesktopBridgeCapability;
+  channel: string;
+  desktopOnly: boolean;
+  dangerous: boolean;
+  validator?: DesktopBridgeValidatorName;
+}
+
+export interface DesktopRestartLocalServerRequest {
+  confirmation: typeof DESKTOP_RESTART_CONFIRMATION;
+}
+
+export interface OpenExternalRequest {
+  url: string;
+}
+
+export type DesktopConnectionModeRequest = 'local' | 'remote';
+
+export interface DesktopConnectionConfigRequest {
+  mode: DesktopConnectionModeRequest;
+  serverUrl?: string;
+  workspaceId?: string;
+}
+
+export interface DesktopConnectionValidationResult {
+  mode: DesktopConnectionModeRequest;
+  valid: boolean;
+  normalizedServerUrl: string | null;
+  warnings: string[];
+  errors: string[];
+}
+
+export interface DesktopSupportSnapshot {
+  generatedAt: string;
+  status: DesktopStatusSnapshot;
+  warnings: string[];
+}
+
+export interface DesktopSetupDiagnosticCheck {
+  name: string;
+  state: DesktopBridgeHealthState;
+  detail: string;
+  checkedAt: string;
+}
+
+export interface DesktopSetupDiagnostics {
+  generatedAt: string;
+  checks: DesktopSetupDiagnosticCheck[];
+  supportSnapshot: DesktopSupportSnapshot;
+}
+
+export const DESKTOP_COMMAND_NAMES = [
+  'open-settings',
+  'open-command-center',
+  'restart-local-server',
+  'show-diagnostics',
+  'check-for-updates',
+  'export-work-product',
+] as const;
+
+export type DesktopCommandName = (typeof DESKTOP_COMMAND_NAMES)[number];
+export type DesktopCommandSource = 'renderer' | 'menu' | 'shortcut' | 'deep-link';
+
+export interface DesktopCommandDispatchRequest {
+  command: DesktopCommandName;
+  source?: DesktopCommandSource;
+  payload?: Record<string, unknown>;
+}
+
+export interface DesktopCommandDispatchResult {
+  command: DesktopCommandName;
+  accepted: boolean;
+  handledBy: 'desktop' | 'renderer' | 'unsupported';
+  message?: string;
+}
+
+export const DESKTOP_FILE_PICKER_PURPOSES = [
+  'attachment-upload',
+  'markdown-import',
+  'work-product-import',
+  'backup-restore',
+] as const;
+
+export type DesktopFilePickerPurpose = (typeof DESKTOP_FILE_PICKER_PURPOSES)[number];
+
+export interface DesktopFilePickerRequest {
+  purpose: DesktopFilePickerPurpose;
+  allowMultiple?: boolean;
+  allowedExtensions?: string[];
+  initialPath?: string;
+}
+
+export interface DesktopSelectedFile {
+  path: string;
+  name: string;
+  sizeBytes?: number;
+  mimeType?: string;
+}
+
+export interface DesktopFilePickerResult {
+  cancelled: boolean;
+  files: DesktopSelectedFile[];
+}
+
+export interface DesktopDiagnosticsBundleRequest {
+  includeLogs?: boolean;
+  includeRuntimeState?: boolean;
+  reason?: string;
+}
+
+export interface DesktopDiagnosticsBundleResult {
+  bundlePath: string | null;
+  redacted: boolean;
+  warnings: string[];
+}
+
+export interface DesktopUpdateStatus {
+  state: 'unsupported' | 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'failed';
+  currentVersion: string;
+  channel: 'dev' | 'beta' | 'stable';
+  checkedAt: string;
+  detail?: string;
+}
+
+export const DESKTOP_NOTIFICATION_ACTIONS = ['open', 'dismiss', 'snooze', 'complete-task'] as const;
+
+export type DesktopNotificationAction = (typeof DESKTOP_NOTIFICATION_ACTIONS)[number];
+
+export interface DesktopNotificationActionRequest {
+  notificationId: string;
+  action: DesktopNotificationAction;
+  taskId?: string;
+}
+
+export interface DesktopNotificationActionResult {
+  notificationId: string;
+  action: DesktopNotificationAction;
+  accepted: boolean;
+  message?: string;
+}
+
+export interface DesktopWorkProductExportRequest {
+  taskId: string;
+  workProductId: string;
+  targetPath?: string;
+  openWhenDone?: boolean;
+}
+
+export interface DesktopWorkProductExportResult {
+  exportedPath: string | null;
+  opened: boolean;
+  warnings: string[];
+}
+
+export const DESKTOP_BRIDGE_METHODS = {
+  getAppInfo: {
+    capability: 'setup',
+    channel: 'desktop:get-app-info',
+    desktopOnly: true,
+    dangerous: false,
+  },
+  getConnectionStatus: {
+    capability: 'connection',
+    channel: 'desktop:get-connection-status',
+    desktopOnly: true,
+    dangerous: false,
+  },
+  getSetupDiagnostics: {
+    capability: 'setup',
+    channel: 'desktop:get-setup-diagnostics',
+    desktopOnly: true,
+    dangerous: false,
+  },
+  validateConnectionConfig: {
+    capability: 'connection',
+    channel: 'desktop:validate-connection-config',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'validateConnectionConfig',
+  },
+  restartLocalServer: {
+    capability: 'serverLifecycle',
+    channel: 'desktop:restart-local-server',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'restartLocalServer',
+  },
+  getSupportSnapshot: {
+    capability: 'diagnostics',
+    channel: 'desktop:get-support-snapshot',
+    desktopOnly: true,
+    dangerous: false,
+  },
+  getUpdateStatus: {
+    capability: 'updates',
+    channel: 'desktop:get-update-status',
+    desktopOnly: true,
+    dangerous: false,
+  },
+  dispatchCommand: {
+    capability: 'shell',
+    channel: 'desktop:dispatch-command',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'dispatchCommand',
+  },
+  pickUploadFiles: {
+    capability: 'backupImport',
+    channel: 'desktop:pick-upload-files',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'pickUploadFiles',
+  },
+  createDiagnosticsBundle: {
+    capability: 'diagnostics',
+    channel: 'desktop:create-diagnostics-bundle',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'createDiagnosticsBundle',
+  },
+  performNotificationAction: {
+    capability: 'notifications',
+    channel: 'desktop:perform-notification-action',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'performNotificationAction',
+  },
+  exportWorkProduct: {
+    capability: 'backupImport',
+    channel: 'desktop:export-work-product',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'exportWorkProduct',
+  },
+  openExternal: {
+    capability: 'shell',
+    channel: 'desktop:open-external',
+    desktopOnly: true,
+    dangerous: true,
+    validator: 'openExternal',
+  },
+} as const satisfies Record<string, DesktopBridgeMethodDefinition>;
+
+export const DESKTOP_BRIDGE_METHOD_NAMES = [
+  'getAppInfo',
+  'getConnectionStatus',
+  'getSetupDiagnostics',
+  'validateConnectionConfig',
+  'restartLocalServer',
+  'getSupportSnapshot',
+  'getUpdateStatus',
+  'dispatchCommand',
+  'pickUploadFiles',
+  'createDiagnosticsBundle',
+  'performNotificationAction',
+  'exportWorkProduct',
+  'openExternal',
+] as const;
+
+export type DesktopBridgeMethod = (typeof DESKTOP_BRIDGE_METHOD_NAMES)[number];
+
+export const DESKTOP_BRIDGE_EVENTS = {
+  setupProgress: {
+    capability: 'setup',
+    channel: 'desktop:setup-progress',
+    desktopOnly: true,
+  },
+  communicationCheck: {
+    capability: 'connection',
+    channel: 'desktop:communication-check',
+    desktopOnly: true,
+  },
+  serverStatus: {
+    capability: 'serverLifecycle',
+    channel: 'desktop:server-status',
+    desktopOnly: true,
+  },
+  runProgress: {
+    capability: 'logs',
+    channel: 'desktop:run-progress',
+    desktopOnly: true,
+  },
+  updateStatus: {
+    capability: 'updates',
+    channel: 'desktop:update-status',
+    desktopOnly: true,
+  },
+  notificationAction: {
+    capability: 'notifications',
+    channel: 'desktop:notification-action',
+    desktopOnly: true,
+  },
+  menuCommand: {
+    capability: 'shell',
+    channel: 'desktop:menu-command',
+    desktopOnly: true,
+  },
+  uploadProgress: {
+    capability: 'backupImport',
+    channel: 'desktop:upload-progress',
+    desktopOnly: true,
+  },
+  workProductExportProgress: {
+    capability: 'backupImport',
+    channel: 'desktop:work-product-export-progress',
+    desktopOnly: true,
+  },
+  externalDeliveryVerification: {
+    capability: 'connection',
+    channel: 'desktop:external-delivery-verification',
+    desktopOnly: true,
+  },
+} as const satisfies Record<
+  string,
+  { capability: DesktopBridgeCapability; channel: string; desktopOnly: boolean }
+>;
+
+export const DESKTOP_BRIDGE_EVENT_NAMES = [
+  'setupProgress',
+  'communicationCheck',
+  'serverStatus',
+  'runProgress',
+  'updateStatus',
+  'notificationAction',
+  'menuCommand',
+  'uploadProgress',
+  'workProductExportProgress',
+  'externalDeliveryVerification',
+] as const;
+
+export type DesktopBridgeEvent = (typeof DESKTOP_BRIDGE_EVENT_NAMES)[number];
+
+export const DESKTOP_PRELOAD_EVENT_METHODS = {
+  setupProgress: 'onSetupProgress',
+  communicationCheck: 'onCommunicationCheck',
+  serverStatus: 'onServerStatus',
+  runProgress: 'onRunProgress',
+  updateStatus: 'onUpdateStatus',
+  notificationAction: 'onNotificationAction',
+  menuCommand: 'onMenuCommand',
+  uploadProgress: 'onUploadProgress',
+  workProductExportProgress: 'onWorkProductExportProgress',
+  externalDeliveryVerification: 'onExternalDeliveryVerification',
+} as const satisfies Record<DesktopBridgeEvent, string>;
+
+export const DESKTOP_PRELOAD_API_METHODS = [
+  ...DESKTOP_BRIDGE_METHOD_NAMES,
+  ...Object.values(DESKTOP_PRELOAD_EVENT_METHODS),
+] as const;
+
+export interface DesktopBridgeRequestMap {
+  getAppInfo: undefined;
+  getConnectionStatus: undefined;
+  getSetupDiagnostics: undefined;
+  validateConnectionConfig: DesktopConnectionConfigRequest;
+  restartLocalServer: DesktopRestartLocalServerRequest;
+  getSupportSnapshot: undefined;
+  getUpdateStatus: undefined;
+  dispatchCommand: DesktopCommandDispatchRequest;
+  pickUploadFiles: DesktopFilePickerRequest;
+  createDiagnosticsBundle: DesktopDiagnosticsBundleRequest;
+  performNotificationAction: DesktopNotificationActionRequest;
+  exportWorkProduct: DesktopWorkProductExportRequest;
+  openExternal: OpenExternalRequest;
+}
+
+export interface DesktopBridgeResponseMap {
+  getAppInfo: DesktopAppInfo;
+  getConnectionStatus: DesktopStatusSnapshot;
+  getSetupDiagnostics: DesktopSetupDiagnostics;
+  validateConnectionConfig: DesktopConnectionValidationResult;
+  restartLocalServer: DesktopStatusSnapshot;
+  getSupportSnapshot: DesktopSupportSnapshot;
+  getUpdateStatus: DesktopUpdateStatus;
+  dispatchCommand: DesktopCommandDispatchResult;
+  pickUploadFiles: DesktopFilePickerResult;
+  createDiagnosticsBundle: DesktopDiagnosticsBundleResult;
+  performNotificationAction: DesktopNotificationActionResult;
+  exportWorkProduct: DesktopWorkProductExportResult;
+  openExternal: undefined;
+}
+
+export interface DesktopBridgeEventPayloadMap {
+  setupProgress: {
+    step: string;
+    state: DesktopBridgeHealthState;
+    message?: string;
+    updatedAt: string;
+  };
+  communicationCheck: {
+    target: 'server' | 'renderer' | 'cli' | 'mcp' | 'external';
+    state: DesktopBridgeHealthState;
+    detail?: string;
+    checkedAt: string;
+  };
+  serverStatus: DesktopStatusSnapshot;
+  runProgress: {
+    runId: string;
+    state: 'queued' | 'running' | 'completed' | 'failed';
+    detail?: string;
+    updatedAt: string;
+  };
+  updateStatus: DesktopUpdateStatus;
+  notificationAction: DesktopNotificationActionRequest;
+  menuCommand: DesktopCommandDispatchRequest;
+  uploadProgress: {
+    uploadId: string;
+    state: 'queued' | 'running' | 'completed' | 'failed';
+    uploadedBytes: number;
+    totalBytes?: number;
+    updatedAt: string;
+  };
+  workProductExportProgress: {
+    exportId: string;
+    state: 'queued' | 'running' | 'completed' | 'failed';
+    detail?: string;
+    updatedAt: string;
+  };
+  externalDeliveryVerification: {
+    deliveryId: string;
+    target: string;
+    state: DesktopBridgeHealthState;
+    checkedAt: string;
+  };
+}
+
+export type DesktopBridgeRequest<Method extends DesktopBridgeMethod> =
+  DesktopBridgeRequestMap[Method];
+
+export type DesktopBridgeResponse<Method extends DesktopBridgeMethod> =
+  DesktopBridgeResponseMap[Method];
+
+export type DesktopBridgeEventPayload<Event extends DesktopBridgeEvent> =
+  DesktopBridgeEventPayloadMap[Event];
+
+type DesktopBridgeValidatorMap = Partial<{
+  [Method in DesktopBridgeMethod]: (payload: unknown) => DesktopBridgeRequest<Method>;
+}>;
+
+export const DESKTOP_BRIDGE_METHOD_VALIDATORS: DesktopBridgeValidatorMap = {
+  restartLocalServer: validateRestartLocalServerRequest,
+  openExternal: validateOpenExternalRequest,
+  validateConnectionConfig: validateConnectionConfigRequest,
+  dispatchCommand: validateDesktopCommandDispatchRequest,
+  pickUploadFiles: validateFilePickerRequest,
+  createDiagnosticsBundle: validateDiagnosticsBundleRequest,
+  performNotificationAction: validateNotificationActionRequest,
+  exportWorkProduct: validateWorkProductExportRequest,
+};
+
+export function assertDesktopBridgeMethodAvailable(
+  method: DesktopBridgeMethod,
+  clientMode: DesktopBridgeClientMode
+): void {
+  if (DESKTOP_BRIDGE_METHODS[method].desktopOnly && clientMode !== 'desktop') {
+    throw new Error(`Bridge method ${method} is available only in the desktop client`);
+  }
+}
+
+export function createDesktopBridgeEventCleanup<Handler>(
+  channel: string,
+  handler: Handler,
+  detach: (channel: string, handler: Handler) => void
+): () => void {
+  let active = true;
+  return () => {
+    if (!active) {
+      return;
+    }
+    active = false;
+    detach(channel, handler);
+  };
+}
+
+const SAFE_EXTERNAL_PROTOCOLS = new Set(['https:', 'http:', 'mailto:']);
+const SAFE_CONNECTION_PROTOCOLS = new Set(['https:', 'http:']);
+const SAFE_COMMAND_SOURCES = new Set<DesktopCommandSource>([
+  'renderer',
+  'menu',
+  'shortcut',
+  'deep-link',
+]);
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+const SENSITIVE_KEY_PATTERN =
+  /(authorization|cookie|password|secret|token|api[_-]?key|admin[_-]?key|webhook)/i;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b([a-z0-9_.-]*(?:token|secret|password|api[_-]?key|admin[_-]?key|webhook)[a-z0-9_.-]*)=([^\s&]+)/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const USER_PATH_PATTERN = /\/Users\/[^/\s]+/g;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${label} requires a typed request object`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, label: string, maxLength = 4096): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a string`);
+  }
+
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maxLength) {
+    throw new Error(`${label} is empty or too long`);
+  }
+  return normalized;
+}
+
+function optionalBoolean(value: unknown, label: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'boolean') {
+    throw new Error(`${label} must be a boolean`);
+  }
+  return value;
+}
+
+function optionalSafeId(value: unknown, label: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return validateSafeId(value, label);
+}
+
+function validateSafeId(value: unknown, label: string): string {
+  const id = requireString(value, label, 128);
+  if (!SAFE_ID_PATTERN.test(id)) {
+    throw new Error(`${label} contains unsupported characters`);
+  }
+  return id;
+}
+
+function validateOptionalPayload(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new Error('Command payload must be an object');
+  }
+  return value;
+}
+
+function validateLocalFilesystemPath(value: unknown, label: string): string {
+  const targetPath = requireString(value, label);
+  if (targetPath.includes('\0') || /[\r\n]/.test(targetPath)) {
+    throw new Error(`${label} contains unsupported characters`);
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(targetPath)) {
+    throw new Error(`${label} must be a local filesystem path, not a URL`);
+  }
+  if (!targetPath.startsWith('/') && !targetPath.startsWith('~/')) {
+    throw new Error(`${label} must be an absolute local path`);
+  }
+  return targetPath;
+}
+
+function normalizeExtension(value: unknown): string {
+  const extension = requireString(value, 'Allowed extension', 32);
+  if (!/^\.[A-Za-z0-9][A-Za-z0-9.+-]{0,31}$/.test(extension)) {
+    throw new Error('Allowed extension is invalid');
+  }
+  return extension.toLowerCase();
+}
+
+function statusStateToHealth(state: string): DesktopBridgeHealthState {
+  if (state === 'ready') {
+    return 'ok';
+  }
+  if (state === 'failed') {
+    return 'failed';
+  }
+  return 'warning';
+}
+
+function diagnosticCheck(
+  name: string,
+  state: DesktopBridgeHealthState,
+  detail: string,
+  checkedAt: string
+): DesktopSetupDiagnosticCheck {
+  return {
+    name,
+    state,
+    detail: redactSensitiveString(detail),
+    checkedAt,
+  };
+}
+
+export function validateRestartLocalServerRequest(
+  payload: unknown
+): DesktopRestartLocalServerRequest {
+  const request = requireRecord(payload, 'restartLocalServer');
+  if (request.confirmation !== DESKTOP_RESTART_CONFIRMATION) {
+    throw new Error('restartLocalServer requires explicit restart confirmation');
+  }
+  return { confirmation: DESKTOP_RESTART_CONFIRMATION };
+}
+
+export function validateOpenExternalRequest(payload: unknown): OpenExternalRequest {
+  const request = requireRecord(payload, 'openExternal');
+  const url = requireString(request.url, 'External URL');
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('External URL is invalid');
+  }
+
+  if (!SAFE_EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`External URL protocol is not allowed: ${parsed.protocol}`);
+  }
+
+  if (
+    (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+    (parsed.username || parsed.password)
+  ) {
+    throw new Error('External URL credentials are not allowed');
+  }
+
+  return { url: parsed.toString() };
+}
+
+export function validateConnectionConfigRequest(payload: unknown): DesktopConnectionConfigRequest {
+  const request = requireRecord(payload, 'validateConnectionConfig');
+  if (request.mode !== 'local' && request.mode !== 'remote') {
+    throw new Error('Connection mode must be local or remote');
+  }
+
+  const workspaceId = optionalSafeId(request.workspaceId, 'Workspace ID');
+  if (request.mode === 'local') {
+    return {
+      mode: 'local',
+      workspaceId,
+    };
+  }
+
+  const serverUrl = requireString(request.serverUrl, 'Remote server URL');
+  let parsed: URL;
+  try {
+    parsed = new URL(serverUrl);
+  } catch {
+    throw new Error('Remote server URL is invalid');
+  }
+
+  if (!SAFE_CONNECTION_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`Remote server URL protocol is not allowed: ${parsed.protocol}`);
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new Error('Remote server URL credentials are not allowed');
+  }
+
+  return {
+    mode: 'remote',
+    serverUrl: parsed.toString(),
+    workspaceId,
+  };
+}
+
+export function validateDesktopCommandDispatchRequest(
+  payload: unknown
+): DesktopCommandDispatchRequest {
+  const request = requireRecord(payload, 'dispatchCommand');
+  if (!DESKTOP_COMMAND_NAMES.includes(request.command as DesktopCommandName)) {
+    throw new Error('Desktop command is not allowed');
+  }
+  const source = request.source ?? 'renderer';
+  if (!SAFE_COMMAND_SOURCES.has(source as DesktopCommandSource)) {
+    throw new Error('Desktop command source is not allowed');
+  }
+  return {
+    command: request.command as DesktopCommandName,
+    source: source as DesktopCommandSource,
+    payload: validateOptionalPayload(request.payload),
+  };
+}
+
+export function validateFilePickerRequest(payload: unknown): DesktopFilePickerRequest {
+  const request = requireRecord(payload, 'pickUploadFiles');
+  if (!DESKTOP_FILE_PICKER_PURPOSES.includes(request.purpose as DesktopFilePickerPurpose)) {
+    throw new Error('File picker purpose is not allowed');
+  }
+  const allowedExtensions = Array.isArray(request.allowedExtensions)
+    ? request.allowedExtensions.map((extension) => normalizeExtension(extension))
+    : undefined;
+  if (allowedExtensions && allowedExtensions.length > 20) {
+    throw new Error('Too many allowed file extensions');
+  }
+
+  return {
+    purpose: request.purpose as DesktopFilePickerPurpose,
+    allowMultiple: optionalBoolean(request.allowMultiple, 'allowMultiple'),
+    allowedExtensions,
+    initialPath:
+      request.initialPath === undefined
+        ? undefined
+        : validateLocalFilesystemPath(request.initialPath, 'Initial path'),
+  };
+}
+
+export function validateDiagnosticsBundleRequest(
+  payload: unknown
+): DesktopDiagnosticsBundleRequest {
+  const request = requireRecord(payload, 'createDiagnosticsBundle');
+  return {
+    includeLogs: optionalBoolean(request.includeLogs, 'includeLogs'),
+    includeRuntimeState: optionalBoolean(request.includeRuntimeState, 'includeRuntimeState'),
+    reason:
+      request.reason === undefined
+        ? undefined
+        : requireString(request.reason, 'Bundle reason', 256),
+  };
+}
+
+export function validateNotificationActionRequest(
+  payload: unknown
+): DesktopNotificationActionRequest {
+  const request = requireRecord(payload, 'performNotificationAction');
+  if (!DESKTOP_NOTIFICATION_ACTIONS.includes(request.action as DesktopNotificationAction)) {
+    throw new Error('Notification action is not allowed');
+  }
+  return {
+    notificationId: validateSafeId(request.notificationId, 'Notification ID'),
+    action: request.action as DesktopNotificationAction,
+    taskId: optionalSafeId(request.taskId, 'Task ID'),
+  };
+}
+
+export function validateWorkProductExportRequest(
+  payload: unknown
+): DesktopWorkProductExportRequest {
+  const request = requireRecord(payload, 'exportWorkProduct');
+  return {
+    taskId: validateSafeId(request.taskId, 'Task ID'),
+    workProductId: validateSafeId(request.workProductId, 'Work product ID'),
+    targetPath:
+      request.targetPath === undefined
+        ? undefined
+        : validateLocalFilesystemPath(request.targetPath, 'Export target path'),
+    openWhenDone: optionalBoolean(request.openWhenDone, 'openWhenDone'),
+  };
+}
+
+export function redactSensitiveString(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, `Bearer ${DESKTOP_REDACTED_VALUE}`)
+    .replace(SECRET_ASSIGNMENT_PATTERN, `$1=${DESKTOP_REDACTED_VALUE}`)
+    .replace(USER_PATH_PATTERN, `/Users/${DESKTOP_REDACTED_VALUE}`);
+}
+
+export function redactDesktopBridgeValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return redactSensitiveString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactDesktopBridgeValue(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      SENSITIVE_KEY_PATTERN.test(key) ? DESKTOP_REDACTED_VALUE : redactDesktopBridgeValue(entry),
+    ])
+  );
+}
+
+export function redactDesktopBridgeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return redactSensitiveString(message);
+}
+
+export function createDesktopSupportSnapshot(
+  status: DesktopStatusSnapshot,
+  generatedAt = new Date()
+): DesktopSupportSnapshot {
+  return {
+    generatedAt: generatedAt.toISOString(),
+    status: redactDesktopBridgeValue(status) as DesktopStatusSnapshot,
+    warnings: [],
+  };
+}
+
+export function createDesktopSetupDiagnostics(
+  status: DesktopStatusSnapshot,
+  generatedAt = new Date()
+): DesktopSetupDiagnostics {
+  const checkedAt = generatedAt.toISOString();
+  const webState = status.web?.state ?? (status.mode === 'local-production' ? 'ready' : 'unknown');
+
+  return {
+    generatedAt: checkedAt,
+    checks: [
+      diagnosticCheck(
+        'local-server-health',
+        statusStateToHealth(status.server.state),
+        status.server.lastError ?? status.server.state,
+        checkedAt
+      ),
+      diagnosticCheck('renderer-health', statusStateToHealth(webState), webState, checkedAt),
+      diagnosticCheck(
+        'communication-health',
+        status.serverOrigin && status.rendererOrigin ? 'ok' : 'warning',
+        status.serverOrigin && status.rendererOrigin
+          ? 'Loopback origins are configured.'
+          : 'Loopback origins are not fully configured.',
+        checkedAt
+      ),
+      diagnosticCheck(
+        'cli-auth',
+        'unknown',
+        'CLI auth checks are reserved for the desktop setup workflow.',
+        checkedAt
+      ),
+      diagnosticCheck(
+        'mcp-auth',
+        'unknown',
+        'MCP auth checks are reserved for the desktop setup workflow.',
+        checkedAt
+      ),
+    ],
+    supportSnapshot: createDesktopSupportSnapshot(status, generatedAt),
+  };
+}


### PR DESCRIPTION
## Summary

Closes #370.

Adds the typed desktop native bridge contract layer for the v5 Mac app. The bridge now has a shared method and event registry, typed request/response contracts, capability labels, desktop-only checks, validators for dangerous/native-facing actions, event cleanup helpers, and redaction helpers for diagnostics and support snapshots.

## What Changed

- Added `desktop/src/shared/desktop-bridge-contracts.ts` as the single contract surface for desktop bridge methods, event channels, validators, capability groups, redaction, setup diagnostics, support snapshots, and client-mode guards.
- Reworked Electron main bridge registration to register every declared method from the contract registry and reject invalid/dangerous payloads before native execution.
- Expanded preload API methods and event subscriptions so setup, communication checks, server health, run progress, updates, notifications, menu commands, uploads, work product exports, diagnostics, and external delivery checks have typed renderer contracts.
- Added bridge contract tests for method/handler drift, preload API drift, dangerous method validation, desktop-only capability checks, event cleanup, URL/path/command/config validation, and redaction.
- Updated desktop README bridge boundary notes.

## Verification

- `pnpm --filter @veritas-kanban/desktop test`
- `pnpm --filter @veritas-kanban/desktop typecheck`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `git diff --check`

## Notes

Several native-backed features intentionally return explicit unsupported or placeholder results until their dedicated v5 issues implement the backing behavior. This PR lands the typed and testable bridge boundary those features will use.
