### PR TITLE
Add desktop data and keychain storage

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -13,8 +13,8 @@ pnpm desktop:dev:fresh
 
 `desktop:dev` launches a loopback-only local server and a Vite web renderer
 without requiring a separate terminal. The desktop runtime chooses available
-ports, writes logs under `.veritas-desktop-dev/<profile>/logs`, and uses SQLite
-data under `.veritas-desktop-dev/<profile>/data`.
+ports and isolates data by profile and workspace:
+`.veritas-desktop-dev/profiles/<profile>/workspaces/<workspace>/`.
 
 `desktop:dev:fresh` uses the `fresh` profile so onboarding and startup behavior
 can be tested without reusing the default development home.
@@ -39,9 +39,27 @@ can be tested without reusing the default development home.
   before native execution. Unsupported native features return explicit
   placeholder results until their dedicated v5 issues implement the backing
   behavior.
+- Fresh packaged installs store desktop data below the OS app data directory
+  returned by Electron `app.getPath('userData')`, then under
+  `profiles/<profile>/workspaces/<workspace>/`.
+- Desktop runtime secrets are created through Electron `safeStorage`, which uses
+  the OS credential backend on macOS. The encrypted metadata file lives at
+  `<appHome>/config/desktop-secrets.json`; plaintext admin/JWT secrets are only
+  passed to the supervised local server process environment.
+- Legacy desktop data is copied forward into the profile/workspace app home when
+  a new isolated app home is first initialized. The legacy source is left in
+  place for manual rollback.
 - Local development mode disables app auth only for the supervised loopback
-  runtime. The packaged app path keeps auth enabled and is expected to move to
-  keychain-backed bootstrap credentials in the dedicated keychain issue.
+  runtime. Packaged mode keeps auth enabled and uses the keychain-backed
+  bootstrap secrets for admin and JWT signing.
+
+## Recovery Notes
+
+If Keychain or encrypted desktop secret state breaks, quit the app, move
+`desktop-secrets.json` out of the affected workspace `config` directory, and
+restart. The app will regenerate the desktop bootstrap secrets for that
+profile/workspace. Existing database files, exports, backups, and debug bundles
+remain on disk in the workspace app home.
 
 ## Production Scaffold
 

--- a/desktop/src/main/__tests__/bridge-contracts.test.ts
+++ b/desktop/src/main/__tests__/bridge-contracts.test.ts
@@ -40,6 +40,8 @@ import {
 function snapshot(): DesktopStatusSnapshot {
   return {
     mode: 'local-dev',
+    profile: 'fresh',
+    workspace: 'local',
     server: {
       name: 'server',
       state: 'ready',
@@ -61,6 +63,11 @@ function snapshot(): DesktopStatusSnapshot {
     serverOrigin: 'http://127.0.0.1:3001',
     rendererOrigin: 'http://127.0.0.1:3000',
     appHome: '/Users/bradgroux/Projects/veritas-kanban/.veritas-desktop-dev/fresh',
+    dataDir: '/Users/bradgroux/Projects/veritas-kanban/.veritas-desktop-dev/fresh/data',
+    configDir: '/Users/bradgroux/Projects/veritas-kanban/.veritas-desktop-dev/fresh/config',
+    logsDir: '/Users/bradgroux/Projects/veritas-kanban/.veritas-desktop-dev/fresh/logs',
+    secretsBackedByKeychain: true,
+    warnings: [],
     lastError: null,
   };
 }

--- a/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/desktop/src/main/__tests__/lifecycle.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   buildServerEnvironment,
   buildWebEnvironment,
-  createDesktopAdminKey,
   createManagedProcessConfigs,
 } from '../lifecycle.js';
 import type { DesktopLifecycleOptions } from '../lifecycle.js';
@@ -12,7 +11,12 @@ function options(): DesktopLifecycleOptions {
   return {
     repoRoot: '/repo/veritas-kanban',
     paths: {
+      profile: 'fresh-profile',
+      workspace: 'local',
       appHome: '/tmp/veritas-desktop',
+      profileDir: '/tmp/veritas-desktop-profile',
+      workspaceDir: '/tmp/veritas-desktop',
+      legacyAppHome: null,
       configDir: '/tmp/veritas-desktop/config',
       dataDir: '/tmp/veritas-desktop/data',
       logsDir: '/tmp/veritas-desktop/logs',
@@ -20,23 +24,28 @@ function options(): DesktopLifecycleOptions {
       exportsDir: '/tmp/veritas-desktop/exports',
       backupsDir: '/tmp/veritas-desktop/backups',
       debugBundlesDir: '/tmp/veritas-desktop/debug-bundles',
+      secretsFile: '/tmp/veritas-desktop/config/desktop-secrets.json',
+      migrationManifest: '/tmp/veritas-desktop/config/desktop-path-migration.json',
     },
     serverPort: 39123,
     webPort: 39124,
     isPackaged: false,
+    secrets: {
+      adminKey: 'desktop-keychain-admin-key',
+      jwtSecret: 'desktop-keychain-jwt-secret',
+      warnings: [],
+    },
   };
 }
 
 describe('desktop lifecycle config', () => {
-  it('creates a dev-only admin key shape without fixed secrets', () => {
-    expect(createDesktopAdminKey('fresh profile')).toMatch(/^desktop-dev-admin-key-fresh-profile-/);
-  });
-
   it('builds loopback server environment for local desktop dev mode', () => {
-    const env = buildServerEnvironment(options(), 'desktop-dev-admin-key-test-000000000000');
+    const env = buildServerEnvironment(options());
 
     expect(env.HOST).toBe('127.0.0.1');
     expect(env.PORT).toBe('39123');
+    expect(env.VERITAS_ADMIN_KEY).toBe('desktop-keychain-admin-key');
+    expect(env.VERITAS_JWT_SECRET).toBe('desktop-keychain-jwt-secret');
     expect(env.VERITAS_STORAGE).toBe('sqlite');
     expect(env.VERITAS_DATA_DIR).toBe('/tmp/veritas-desktop/data');
     expect(env.VERITAS_AUTH_ENABLED).toBe('false');
@@ -51,10 +60,7 @@ describe('desktop lifecycle config', () => {
   });
 
   it('creates server and web process configs in dev mode', () => {
-    const configs = createManagedProcessConfigs(
-      options(),
-      'desktop-dev-admin-key-test-000000000000'
-    );
+    const configs = createManagedProcessConfigs(options());
 
     expect(configs.map((config) => config.name)).toEqual(['server', 'web']);
     expect(configs[0]?.readyUrl).toBe('http://127.0.0.1:39123/api/health');

--- a/desktop/src/main/__tests__/paths.test.ts
+++ b/desktop/src/main/__tests__/paths.test.ts
@@ -1,33 +1,80 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 
-import { createDesktopPaths, resolveRepoRoot } from '../paths.js';
+import { createDesktopPaths, ensureDesktopPathLayout, resolveRepoRoot } from '../paths.js';
 
 describe('desktop paths', () => {
-  it('uses a profile-isolated dev home in the repo', () => {
+  it('uses profile and workspace isolated dev homes in the repo', () => {
     const paths = createDesktopPaths({
       userDataPath: '/Users/example/Library/Application Support/Veritas Kanban',
       repoRoot: '/repo/veritas-kanban',
       isPackaged: false,
       profile: 'fresh profile',
+      workspace: 'demo workspace',
     });
 
     expect(paths.appHome).toBe(
+      path.join(
+        '/repo/veritas-kanban',
+        '.veritas-desktop-dev',
+        'profiles',
+        'fresh-profile',
+        'workspaces',
+        'demo-workspace'
+      )
+    );
+    expect(paths.profile).toBe('fresh-profile');
+    expect(paths.workspace).toBe('demo-workspace');
+    expect(paths.legacyAppHome).toBe(
       path.join('/repo/veritas-kanban', '.veritas-desktop-dev', 'fresh-profile')
     );
     expect(paths.dataDir).toBe(path.join(paths.appHome, 'data'));
     expect(paths.logsDir).toBe(path.join(paths.appHome, 'logs'));
     expect(paths.runtimeDir).toBe(path.join(paths.appHome, 'runtime'));
+    expect(paths.secretsFile).toBe(path.join(paths.configDir, 'desktop-secrets.json'));
   });
 
-  it('uses app userData in packaged mode', () => {
+  it('uses app userData with profile and workspace isolation in packaged mode', () => {
     const paths = createDesktopPaths({
       userDataPath: '/Users/example/Library/Application Support/Veritas Kanban',
       repoRoot: '/repo/veritas-kanban',
       isPackaged: true,
+      profile: 'default',
+      workspace: 'local',
     });
 
-    expect(paths.appHome).toBe('/Users/example/Library/Application Support/Veritas Kanban');
+    expect(paths.appHome).toBe(
+      path.join(
+        '/Users/example/Library/Application Support/Veritas Kanban',
+        'profiles',
+        'default',
+        'workspaces',
+        'local'
+      )
+    );
+    expect(paths.legacyAppHome).toBe('/Users/example/Library/Application Support/Veritas Kanban');
+  });
+
+  it('copies legacy desktop data into the workspace app home without deleting the source', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'veritas-desktop-paths-'));
+    const legacyData = path.join(root, '.veritas-desktop-dev', 'fresh', 'data');
+    const paths = createDesktopPaths({
+      userDataPath: path.join(root, 'userData'),
+      repoRoot: root,
+      isPackaged: false,
+      profile: 'fresh',
+    });
+    await mkdir(legacyData, { recursive: true });
+    await writeFile(path.join(legacyData, 'veritas.db'), 'db');
+
+    const result = await ensureDesktopPathLayout(paths);
+
+    expect(result.migrated).toBe(true);
+    expect(result.copiedEntries).toEqual(['data']);
+    await expect(readFile(path.join(paths.dataDir, 'veritas.db'), 'utf-8')).resolves.toBe('db');
+    await expect(readFile(path.join(legacyData, 'veritas.db'), 'utf-8')).resolves.toBe('db');
   });
 
   it('resolves repo root from package cwd', () => {

--- a/desktop/src/main/__tests__/secrets.test.ts
+++ b/desktop/src/main/__tests__/secrets.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { createDesktopPaths } from '../paths.js';
+import { DesktopSecretStore, type DesktopSafeStorage } from '../secrets.js';
+
+function mockSafeStorage(available = true): DesktopSafeStorage {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (value) => Buffer.from(`encrypted:${value}`, 'utf-8'),
+    decryptString: (encrypted) => encrypted.toString('utf-8').replace(/^encrypted:/, ''),
+  };
+}
+
+async function testPaths() {
+  const root = await mkdtemp(path.join(tmpdir(), 'veritas-desktop-secrets-'));
+  return createDesktopPaths({
+    userDataPath: path.join(root, 'user-data'),
+    repoRoot: root,
+    isPackaged: true,
+    profile: 'fresh',
+    workspace: 'local',
+  });
+}
+
+describe('desktop secret store', () => {
+  it('stores runtime secrets as encrypted keychain-backed blobs scoped by profile and workspace', async () => {
+    const paths = await testPaths();
+    const store = new DesktopSecretStore({
+      safeStorage: mockSafeStorage(),
+      paths,
+    });
+
+    const first = await store.loadRuntimeSecrets();
+    const second = await store.loadRuntimeSecrets();
+    const raw = await readFile(paths.secretsFile, 'utf-8');
+
+    expect(second).toEqual(first);
+    expect(first.adminKey).toMatch(/^vk_admin_/);
+    expect(first.jwtSecret).toMatch(/^vk_jwt_/);
+    expect(raw).toContain('"profile": "fresh"');
+    expect(raw).toContain('"workspace": "local"');
+    expect(raw).not.toContain(first.adminKey);
+    expect(raw).not.toContain(first.jwtSecret);
+    expect(raw).toContain(Buffer.from(`encrypted:${first.adminKey}`).toString('base64'));
+  });
+
+  it('surfaces keychain availability recovery actions without writing plaintext fallbacks', async () => {
+    const paths = await testPaths();
+    const store = new DesktopSecretStore({
+      safeStorage: mockSafeStorage(false),
+      paths,
+    });
+
+    const state = store.inspect();
+
+    expect(state.available).toBe(false);
+    expect(state.error).toContain('safeStorage encryption is unavailable');
+    expect(state.recoveryActions.join(' ')).toContain('Keychain');
+    await expect(store.loadRuntimeSecrets()).rejects.toThrow('Keychain');
+  });
+
+  it('rejects corrupt secret state with reset instructions', async () => {
+    const paths = await testPaths();
+    const store = new DesktopSecretStore({
+      safeStorage: mockSafeStorage(),
+      paths,
+    });
+    await store.loadRuntimeSecrets();
+    await writeFile(paths.secretsFile, '{bad json', 'utf-8');
+
+    await expect(store.loadRuntimeSecrets()).rejects.toThrow('Desktop secret state is unreadable');
+  });
+});

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, safeStorage, shell } from 'electron';
 import path from 'node:path';
 import { mkdirSync } from 'node:fs';
 
@@ -7,6 +7,7 @@ import { registerDesktopBridge } from './bridge.js';
 import { createDesktopPaths, resolveRepoRoot } from './paths.js';
 import { findAvailablePort } from './ports.js';
 import { DesktopRuntime } from './runtime.js';
+import { DesktopSecretStore } from './secrets.js';
 import { statusPageUrl } from './status-page.js';
 import { DESKTOP_BRIDGE_EVENTS } from '../shared/desktop-bridge-contracts.js';
 
@@ -22,6 +23,7 @@ function isPackagedRuntime(): boolean {
 const launchPackaged = isPackagedRuntime();
 const launchRepoRoot = resolveRepoRoot(app.getAppPath());
 const launchProfile = process.env.VERITAS_DESKTOP_PROFILE || 'default';
+const launchWorkspace = process.env.VERITAS_DESKTOP_WORKSPACE || 'local';
 
 if (!launchPackaged) {
   const devUserDataPath = path.join(
@@ -84,11 +86,13 @@ async function boot(): Promise<void> {
   const packaged = launchPackaged;
   const repoRoot = launchRepoRoot;
   const profile = launchProfile;
+  const workspace = launchWorkspace;
   const paths = createDesktopPaths({
     userDataPath: app.getPath('userData'),
     repoRoot,
     isPackaged: packaged,
     profile,
+    workspace,
   });
 
   const serverPort = await findAvailablePort(
@@ -99,6 +103,28 @@ async function boot(): Promise<void> {
   mainWindow = createMainWindow();
   await mainWindow.loadURL(statusPageUrl('Starting Veritas Kanban', 'Preparing the local app.'));
 
+  const secretStore = new DesktopSecretStore({ safeStorage, paths });
+  const secretState = secretStore.inspect();
+  if (!secretState.available) {
+    await mainWindow.loadURL(
+      statusPageUrl(
+        'Veritas Kanban needs Keychain access',
+        `${secretState.error} ${secretState.recoveryActions.join(' ')}`,
+        undefined
+      )
+    );
+    return;
+  }
+
+  let secrets;
+  try {
+    secrets = await secretStore.loadRuntimeSecrets();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await mainWindow.loadURL(statusPageUrl('Veritas Kanban secret recovery needed', message));
+    return;
+  }
+
   runtime = new DesktopRuntime({
     repoRoot,
     paths,
@@ -106,6 +132,9 @@ async function boot(): Promise<void> {
     webPort,
     isPackaged: packaged,
     profile,
+    workspace,
+    secrets,
+    secretsBackedByKeychain: secretState.available,
   });
 
   registerDesktopBridge(ipcMain, runtime, shell, packaged);

--- a/desktop/src/main/lifecycle.ts
+++ b/desktop/src/main/lifecycle.ts
@@ -1,9 +1,6 @@
 import path from 'node:path';
-import { randomUUID } from 'node:crypto';
 
-import type { DesktopPaths, ManagedProcessConfig } from './types.js';
-
-const ADMIN_KEY_PREFIX = 'desktop-dev-admin-key';
+import type { DesktopPaths, DesktopRuntimeSecrets, ManagedProcessConfig } from './types.js';
 
 export interface DesktopLifecycleOptions {
   repoRoot: string;
@@ -11,21 +8,14 @@ export interface DesktopLifecycleOptions {
   serverPort: number;
   webPort: number;
   isPackaged: boolean;
+  secrets: DesktopRuntimeSecrets;
 }
 
 function pnpmCommand(): string {
   return process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 }
 
-export function createDesktopAdminKey(profile = 'default'): string {
-  const safeProfile = profile.replace(/[^a-zA-Z0-9._-]/g, '-');
-  return `${ADMIN_KEY_PREFIX}-${safeProfile}-${randomUUID()}`;
-}
-
-export function buildServerEnvironment(
-  options: DesktopLifecycleOptions,
-  adminKey: string
-): NodeJS.ProcessEnv {
+export function buildServerEnvironment(options: DesktopLifecycleOptions): NodeJS.ProcessEnv {
   const serverOrigin = `http://127.0.0.1:${options.serverPort}`;
   const webOrigin = `http://127.0.0.1:${options.webPort}`;
 
@@ -34,7 +24,8 @@ export function buildServerEnvironment(
     NODE_ENV: options.isPackaged ? 'production' : 'development',
     HOST: '127.0.0.1',
     PORT: String(options.serverPort),
-    VERITAS_ADMIN_KEY: adminKey,
+    VERITAS_ADMIN_KEY: options.secrets.adminKey,
+    VERITAS_JWT_SECRET: options.secrets.jwtSecret,
     VERITAS_AUTH_ENABLED: options.isPackaged ? 'true' : 'false',
     VERITAS_AUTH_LOCALHOST_BYPASS: 'false',
     VERITAS_STORAGE: 'sqlite',
@@ -56,8 +47,7 @@ export function buildWebEnvironment(options: DesktopLifecycleOptions): NodeJS.Pr
 }
 
 export function createManagedProcessConfigs(
-  options: DesktopLifecycleOptions,
-  adminKey: string
+  options: DesktopLifecycleOptions
 ): ManagedProcessConfig[] {
   const serverConfig: ManagedProcessConfig = options.isPackaged
     ? {
@@ -68,7 +58,7 @@ export function createManagedProcessConfigs(
             path.join(options.repoRoot, 'server/dist/index.js'),
         ],
         cwd: options.repoRoot,
-        env: buildServerEnvironment(options, adminKey),
+        env: buildServerEnvironment(options),
         logFile: path.join(options.paths.logsDir, 'server.log'),
         readyUrl: `http://127.0.0.1:${options.serverPort}/api/health`,
       }
@@ -77,7 +67,7 @@ export function createManagedProcessConfigs(
         command: pnpmCommand(),
         args: ['--filter', '@veritas-kanban/server', 'dev'],
         cwd: options.repoRoot,
-        env: buildServerEnvironment(options, adminKey),
+        env: buildServerEnvironment(options),
         logFile: path.join(options.paths.logsDir, 'server.log'),
         readyUrl: `http://127.0.0.1:${options.serverPort}/api/health`,
       };

--- a/desktop/src/main/paths.ts
+++ b/desktop/src/main/paths.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { cp, mkdir, stat, writeFile } from 'node:fs/promises';
 
 import type { DesktopPaths } from './types.js';
 
@@ -7,27 +8,126 @@ export interface CreateDesktopPathsOptions {
   repoRoot: string;
   isPackaged: boolean;
   profile?: string;
+  workspace?: string;
 }
 
 function profileSegment(profile: string | undefined): string {
   return (profile || 'default').replace(/[^a-zA-Z0-9._-]/g, '-');
 }
 
+function workspaceSegment(workspace: string | undefined): string {
+  return (workspace || 'local').replace(/[^a-zA-Z0-9._-]/g, '-');
+}
+
 export function createDesktopPaths(options: CreateDesktopPathsOptions): DesktopPaths {
-  const appHome = options.isPackaged
+  const profile = profileSegment(options.profile);
+  const workspace = workspaceSegment(options.workspace);
+  const legacyAppHome = options.isPackaged
     ? options.userDataPath
-    : path.join(options.repoRoot, '.veritas-desktop-dev', profileSegment(options.profile));
+    : path.join(options.repoRoot, '.veritas-desktop-dev', profile);
+  const profileDir = options.isPackaged
+    ? path.join(options.userDataPath, 'profiles', profile)
+    : path.join(options.repoRoot, '.veritas-desktop-dev', 'profiles', profile);
+  const workspaceDir = path.join(profileDir, 'workspaces', workspace);
+  const appHome = workspaceDir;
+  const configDir = path.join(appHome, 'config');
 
   return {
+    profile,
+    workspace,
     appHome,
-    configDir: path.join(appHome, 'config'),
+    profileDir,
+    workspaceDir,
+    legacyAppHome: legacyAppHome === appHome ? null : legacyAppHome,
+    configDir,
     dataDir: path.join(appHome, 'data'),
     logsDir: path.join(appHome, 'logs'),
     runtimeDir: path.join(appHome, 'runtime'),
     exportsDir: path.join(appHome, 'exports'),
     backupsDir: path.join(appHome, 'backups'),
     debugBundlesDir: path.join(appHome, 'debug-bundles'),
+    secretsFile: path.join(configDir, 'desktop-secrets.json'),
+    migrationManifest: path.join(configDir, 'desktop-path-migration.json'),
   };
+}
+
+const MIGRATED_ENTRIES = ['config', 'data', 'logs', 'exports', 'backups', 'debug-bundles'] as const;
+
+export interface DesktopPathMigrationResult {
+  migrated: boolean;
+  from: string | null;
+  to: string;
+  copiedEntries: string[];
+  skippedReason?: string;
+}
+
+async function exists(targetPath: string): Promise<boolean> {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureDesktopPathLayout(
+  paths: DesktopPaths
+): Promise<DesktopPathMigrationResult> {
+  await Promise.all([
+    mkdir(paths.profileDir, { recursive: true }),
+    mkdir(paths.workspaceDir, { recursive: true }),
+    mkdir(paths.configDir, { recursive: true }),
+    mkdir(paths.dataDir, { recursive: true }),
+    mkdir(paths.logsDir, { recursive: true }),
+    mkdir(paths.runtimeDir, { recursive: true }),
+    mkdir(paths.exportsDir, { recursive: true }),
+    mkdir(paths.backupsDir, { recursive: true }),
+    mkdir(paths.debugBundlesDir, { recursive: true }),
+  ]);
+
+  if (!paths.legacyAppHome) {
+    return {
+      migrated: false,
+      from: null,
+      to: paths.appHome,
+      copiedEntries: [],
+      skippedReason: 'no legacy app home',
+    };
+  }
+
+  if (!(await exists(paths.legacyAppHome))) {
+    return {
+      migrated: false,
+      from: paths.legacyAppHome,
+      to: paths.appHome,
+      copiedEntries: [],
+      skippedReason: 'legacy app home does not exist',
+    };
+  }
+
+  const copiedEntries: string[] = [];
+  for (const entry of MIGRATED_ENTRIES) {
+    const source = path.join(paths.legacyAppHome, entry);
+    const target = path.join(paths.appHome, entry);
+    if (await exists(source)) {
+      await cp(source, target, {
+        recursive: true,
+        force: false,
+      });
+      copiedEntries.push(entry);
+    }
+  }
+
+  const result: DesktopPathMigrationResult = {
+    migrated: copiedEntries.length > 0,
+    from: paths.legacyAppHome,
+    to: paths.appHome,
+    copiedEntries,
+    skippedReason: copiedEntries.length > 0 ? undefined : 'workspace app home already initialized',
+  };
+
+  await writeFile(paths.migrationManifest, JSON.stringify(result, null, 2), 'utf-8');
+  return result;
 }
 
 export function resolveRepoRoot(appPath: string, cwd = process.cwd()): string {

--- a/desktop/src/main/runtime.ts
+++ b/desktop/src/main/runtime.ts
@@ -2,9 +2,10 @@ import { EventEmitter } from 'node:events';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import path from 'node:path';
 
-import { createDesktopAdminKey, createManagedProcessConfigs } from './lifecycle.js';
+import { createManagedProcessConfigs } from './lifecycle.js';
+import { ensureDesktopPathLayout, type DesktopPathMigrationResult } from './paths.js';
 import { ProcessSupervisor } from './process-supervisor.js';
-import type { DesktopPaths, DesktopStatusSnapshot } from './types.js';
+import type { DesktopPaths, DesktopRuntimeSecrets, DesktopStatusSnapshot } from './types.js';
 
 export interface DesktopRuntimeOptions {
   repoRoot: string;
@@ -13,6 +14,9 @@ export interface DesktopRuntimeOptions {
   webPort: number;
   isPackaged: boolean;
   profile: string;
+  workspace: string;
+  secrets: DesktopRuntimeSecrets;
+  secretsBackedByKeychain: boolean;
 }
 
 export class DesktopRuntime extends EventEmitter {
@@ -21,11 +25,13 @@ export class DesktopRuntime extends EventEmitter {
   private lastError: string | null = null;
   private readonly serverOrigin: string;
   private readonly rendererOrigin: string;
+  private pathMigration: DesktopPathMigrationResult | null = null;
+  private readonly warnings: string[] = [];
 
   constructor(private readonly options: DesktopRuntimeOptions) {
     super();
-    const adminKey = createDesktopAdminKey(options.profile);
-    const [serverConfig, webConfig] = createManagedProcessConfigs(options, adminKey);
+    this.warnings.push(...options.secrets.warnings);
+    const [serverConfig, webConfig] = createManagedProcessConfigs(options);
     this.server = new ProcessSupervisor(serverConfig);
     this.web = webConfig ? new ProcessSupervisor(webConfig) : null;
     this.serverOrigin = `http://127.0.0.1:${options.serverPort}`;
@@ -49,11 +55,18 @@ export class DesktopRuntime extends EventEmitter {
   snapshot(): DesktopStatusSnapshot {
     return {
       mode: this.options.isPackaged ? 'local-production' : 'local-dev',
+      profile: this.options.profile,
+      workspace: this.options.workspace,
       server: this.server.snapshot(),
       web: this.web?.snapshot(),
       serverOrigin: this.serverOrigin,
       rendererOrigin: this.rendererOrigin,
       appHome: this.options.paths.appHome,
+      dataDir: this.options.paths.dataDir,
+      configDir: this.options.paths.configDir,
+      logsDir: this.options.paths.logsDir,
+      secretsBackedByKeychain: this.options.secretsBackedByKeychain,
+      warnings: this.runtimeWarnings(),
       lastError: this.lastError,
     };
   }
@@ -88,9 +101,7 @@ export class DesktopRuntime extends EventEmitter {
   }
 
   private async ensureDirectories(): Promise<void> {
-    await Promise.all(
-      Object.values(this.options.paths).map((targetPath) => mkdir(targetPath, { recursive: true }))
-    );
+    this.pathMigration = await ensureDesktopPathLayout(this.options.paths);
   }
 
   private async writeRuntimeState(): Promise<void> {
@@ -100,8 +111,13 @@ export class DesktopRuntime extends EventEmitter {
       JSON.stringify(
         {
           mode: this.options.isPackaged ? 'local-production' : 'local-dev',
+          profile: this.options.profile,
+          workspace: this.options.workspace,
           serverOrigin: this.serverOrigin,
           rendererOrigin: this.rendererOrigin,
+          appHome: this.options.paths.appHome,
+          dataDir: this.options.paths.dataDir,
+          configDir: this.options.paths.configDir,
           updatedAt: new Date().toISOString(),
         },
         null,
@@ -134,5 +150,15 @@ export class DesktopRuntime extends EventEmitter {
 
   private emitStatus(): void {
     this.emit('status', this.snapshot());
+  }
+
+  private runtimeWarnings(): string[] {
+    const warnings = [...this.warnings];
+    if (this.pathMigration?.migrated && this.pathMigration.from) {
+      warnings.push(
+        `Desktop data was copied from ${this.pathMigration.from} to ${this.pathMigration.to}.`
+      );
+    }
+    return warnings;
   }
 }

--- a/desktop/src/main/secrets.ts
+++ b/desktop/src/main/secrets.ts
@@ -1,0 +1,168 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { DesktopPaths, DesktopRuntimeSecrets } from './types.js';
+
+export interface DesktopSafeStorage {
+  isEncryptionAvailable(): boolean;
+  encryptString(value: string): Buffer;
+  decryptString(encrypted: Buffer): string;
+}
+
+export interface DesktopSecretRecord {
+  ciphertext: string;
+  updatedAt: string;
+}
+
+export interface DesktopSecretFile {
+  version: 1;
+  keychainProvider: 'electron-safeStorage';
+  scope: {
+    profile: string;
+    workspace: string;
+  };
+  secrets: Record<string, DesktopSecretRecord>;
+}
+
+export interface DesktopSecretState {
+  available: boolean;
+  filePath: string;
+  recoveryActions: string[];
+  error: string | null;
+}
+
+export interface DesktopSecretStoreOptions {
+  safeStorage: DesktopSafeStorage;
+  paths: DesktopPaths;
+}
+
+function createSecretValue(prefix: string): string {
+  return `${prefix}_${randomBytes(48).toString('base64url')}`;
+}
+
+function emptySecretFile(paths: DesktopPaths): DesktopSecretFile {
+  return {
+    version: 1,
+    keychainProvider: 'electron-safeStorage',
+    scope: {
+      profile: paths.profile,
+      workspace: paths.workspace,
+    },
+    secrets: {},
+  };
+}
+
+function recoveryActions(paths: DesktopPaths): string[] {
+  return [
+    'Confirm macOS Keychain is unlocked and available.',
+    `Quit Veritas Kanban and move ${path.basename(paths.secretsFile)} out of ${paths.configDir}.`,
+    'Restart the app so desktop secrets can be regenerated for this profile and workspace.',
+  ];
+}
+
+export class DesktopSecretStore {
+  constructor(private readonly options: DesktopSecretStoreOptions) {}
+
+  inspect(): DesktopSecretState {
+    if (!this.options.safeStorage.isEncryptionAvailable()) {
+      return {
+        available: false,
+        filePath: this.options.paths.secretsFile,
+        recoveryActions: recoveryActions(this.options.paths),
+        error: 'Electron safeStorage encryption is unavailable.',
+      };
+    }
+
+    return {
+      available: true,
+      filePath: this.options.paths.secretsFile,
+      recoveryActions: recoveryActions(this.options.paths),
+      error: null,
+    };
+  }
+
+  async loadRuntimeSecrets(): Promise<DesktopRuntimeSecrets> {
+    const state = this.inspect();
+    if (!state.available) {
+      throw new Error(`${state.error} ${state.recoveryActions.join(' ')}`);
+    }
+
+    const adminKey = await this.getOrCreateSecret('admin-key', () => createSecretValue('vk_admin'));
+    const jwtSecret = await this.getOrCreateSecret('jwt-secret', () => createSecretValue('vk_jwt'));
+
+    return {
+      adminKey,
+      jwtSecret,
+      warnings: [],
+    };
+  }
+
+  async getOrCreateSecret(name: string, createValue: () => string): Promise<string> {
+    const file = await this.readSecretFile();
+    const existing = file.secrets[name];
+    if (existing) {
+      return this.decrypt(existing.ciphertext);
+    }
+
+    const value = createValue();
+    file.secrets[name] = {
+      ciphertext: this.encrypt(value),
+      updatedAt: new Date().toISOString(),
+    };
+    await this.writeSecretFile(file);
+    return value;
+  }
+
+  async clearSecrets(): Promise<void> {
+    await this.writeSecretFile(emptySecretFile(this.options.paths));
+  }
+
+  private async readSecretFile(): Promise<DesktopSecretFile> {
+    try {
+      const raw = await readFile(this.options.paths.secretsFile, 'utf-8');
+      const parsed = JSON.parse(raw) as DesktopSecretFile;
+      if (
+        parsed.version !== 1 ||
+        parsed.scope?.profile !== this.options.paths.profile ||
+        parsed.scope?.workspace !== this.options.paths.workspace ||
+        typeof parsed.secrets !== 'object' ||
+        parsed.secrets === null
+      ) {
+        throw new Error('Desktop secret file scope or schema is invalid.');
+      }
+      return parsed;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return emptySecretFile(this.options.paths);
+      }
+      throw new Error(
+        `Desktop secret state is unreadable. ${recoveryActions(this.options.paths).join(' ')}`,
+        { cause: error }
+      );
+    }
+  }
+
+  private async writeSecretFile(file: DesktopSecretFile): Promise<void> {
+    await mkdir(path.dirname(this.options.paths.secretsFile), { recursive: true });
+    await writeFile(this.options.paths.secretsFile, JSON.stringify(file, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+  }
+
+  private encrypt(value: string): string {
+    return this.options.safeStorage.encryptString(value).toString('base64');
+  }
+
+  private decrypt(ciphertext: string): string {
+    try {
+      return this.options.safeStorage.decryptString(Buffer.from(ciphertext, 'base64'));
+    } catch (error) {
+      throw new Error(
+        `Desktop secret could not be decrypted. ${recoveryActions(this.options.paths).join(' ')}`,
+        { cause: error }
+      );
+    }
+  }
+}

--- a/desktop/src/main/types.ts
+++ b/desktop/src/main/types.ts
@@ -5,7 +5,12 @@ export type DesktopProcessState = 'idle' | 'starting' | 'ready' | 'stopping' | '
 export type DesktopConnectionMode = 'local-dev' | 'local-production';
 
 export interface DesktopPaths {
+  profile: string;
+  workspace: string;
   appHome: string;
+  profileDir: string;
+  workspaceDir: string;
+  legacyAppHome: string | null;
   configDir: string;
   dataDir: string;
   logsDir: string;
@@ -13,6 +18,14 @@ export interface DesktopPaths {
   exportsDir: string;
   backupsDir: string;
   debugBundlesDir: string;
+  secretsFile: string;
+  migrationManifest: string;
+}
+
+export interface DesktopRuntimeSecrets {
+  adminKey: string;
+  jwtSecret: string;
+  warnings: string[];
 }
 
 export interface ManagedProcessConfig {
@@ -38,11 +51,18 @@ export interface ManagedProcessSnapshot {
 
 export interface DesktopStatusSnapshot {
   mode: DesktopConnectionMode;
+  profile: string;
+  workspace: string;
   server: ManagedProcessSnapshot;
   web?: ManagedProcessSnapshot;
   serverOrigin: string | null;
   rendererOrigin: string | null;
   appHome: string;
+  dataDir: string;
+  configDir: string;
+  logsDir: string;
+  secretsBackedByKeychain: boolean;
+  warnings: string[];
   lastError: string | null;
 }
 


### PR DESCRIPTION
## Summary

Closes #340.

Adds the desktop data and secret-management layer for the v5 Mac app. Desktop data now resolves into profile/workspace-specific app homes, legacy desktop data is copied forward without deleting the source, and runtime bootstrap secrets are backed by Electron `safeStorage` instead of plaintext files.

## What Changed

- Added profile/workspace-aware desktop paths under `profiles/<profile>/workspaces/<workspace>/` for config, SQLite data, logs, runtime state, exports, backups, and debug bundles.
- Added non-destructive legacy desktop data migration from the previous app-home layout into the isolated workspace app home, with a migration manifest.
- Added `DesktopSecretStore` backed by Electron `safeStorage` for admin/JWT runtime secrets, plus recovery guidance for unavailable or corrupt Keychain-backed state.
- Passed keychain-backed admin/JWT secrets into the supervised server via environment variables so the server keeps its existing auth/storage contract.
- Extended desktop status snapshots and runtime state with profile, workspace, app/data/config/log paths, keychain-backed state, and warnings.
- Documented the on-disk layout, encrypted secret metadata, migration behavior, and reset procedure.

## Verification

- `pnpm --filter @veritas-kanban/desktop test`
- `pnpm --filter @veritas-kanban/desktop typecheck`
- `pnpm --filter @veritas-kanban/desktop build`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `git diff --check`
- Desktop smoke: `pnpm --filter @veritas-kanban/desktop dev:fresh`
- Desktop smoke: confirmed isolated app home at `.veritas-desktop-dev/profiles/fresh/workspaces/local`
- Desktop smoke: confirmed SQLite DB, runtime state, logs, encrypted `desktop-secrets.json`, and migration manifest under the isolated app home
- Desktop smoke: confirmed no plaintext `vk_admin_` or `vk_jwt_` secret values under the workspace app home
- Desktop smoke: loopback health returned OK from the supervised server

## Notes

The encrypted metadata file stores ciphertext only. The OS credential backend remains responsible for protecting the encryption key material. The legacy source directory is intentionally left in place for manual rollback.
