### PR TITLE
Add desktop native commands

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -61,6 +61,23 @@ restart. The app will regenerate the desktop bootstrap secrets for that
 profile/workspace. Existing database files, exports, backups, and debug bundles
 remain on disk in the workspace app home.
 
+## Native Commands
+
+The desktop shell owns a single command registry for menu items, keyboard
+shortcuts, deep links, notification actions, and renderer bridge dispatch. Menu
+commands are forwarded to the renderer through typed bridge events when the web
+app owns the business logic, and handled in main only for native operations such
+as restarting the local server, opening logs, checking update status, showing a
+local notification test, copying redacted diagnostics, and quitting.
+
+Supported `veritas://` deep-link resources include task, workflow, run,
+invite/pairing, settings, command center, search, and work product destinations.
+Notification previews support a private mode that replaces task/run details
+with generic copy while preserving the durable target for click-through.
+
+Window size, position, and maximized state are persisted per profile/workspace
+in `config/window-state.json`.
+
 ## Production Scaffold
 
 `pnpm desktop:build` compiles the Electron main, preload, and fallback renderer.

--- a/desktop/src/main/__tests__/commands.test.ts
+++ b/desktop/src/main/__tests__/commands.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Shell } from 'electron';
+
+import {
+  DESKTOP_COMMAND_REGISTRY,
+  DesktopCommandDispatcher,
+  createDesktopCommandRequest,
+} from '../commands.js';
+import type { DesktopRuntime } from '../runtime.js';
+import type { DesktopStatusSnapshot } from '../types.js';
+import { DESKTOP_COMMAND_NAMES } from '../../shared/desktop-bridge-contracts.js';
+
+function status(): DesktopStatusSnapshot {
+  return {
+    mode: 'local-dev',
+    profile: 'fresh',
+    workspace: 'local',
+    server: {
+      name: 'server',
+      state: 'ready',
+      pid: 1,
+      port: 3001,
+      lastError: null,
+      startedAt: '2026-05-31T00:00:00.000Z',
+      exitedAt: null,
+    },
+    web: undefined,
+    serverOrigin: 'http://127.0.0.1:3001',
+    rendererOrigin: 'http://127.0.0.1:3000',
+    appHome: '/tmp/veritas',
+    dataDir: '/tmp/veritas/data',
+    configDir: '/tmp/veritas/config',
+    logsDir: '/tmp/veritas/logs',
+    secretsBackedByKeychain: true,
+    warnings: [],
+    lastError: null,
+  };
+}
+
+function dispatcher() {
+  const runtime = {
+    snapshot: vi.fn(status),
+    restartLocalServer: vi.fn(async () => status()),
+  } as unknown as DesktopRuntime;
+  const shell = {
+    openPath: vi.fn(async () => ''),
+  } as unknown as Shell;
+  const sendRendererCommand = vi.fn();
+  const sendUpdateStatus = vi.fn();
+  const showTestNotification = vi.fn();
+  const copyRedactedDiagnostics = vi.fn();
+
+  return {
+    runtime,
+    shell,
+    sendRendererCommand,
+    sendUpdateStatus,
+    showTestNotification,
+    copyRedactedDiagnostics,
+    dispatcher: new DesktopCommandDispatcher({
+      runtime,
+      shell,
+      quit: vi.fn(),
+      sendRendererCommand,
+      sendUpdateStatus,
+      showTestNotification,
+      copyRedactedDiagnostics,
+    }),
+  };
+}
+
+describe('desktop command registry', () => {
+  it('defines every typed desktop command exactly once', () => {
+    expect(Object.keys(DESKTOP_COMMAND_REGISTRY).sort()).toEqual([...DESKTOP_COMMAND_NAMES].sort());
+    expect(DESKTOP_COMMAND_REGISTRY['new-task'].accelerator).toBe('CommandOrControl+N');
+    expect(DESKTOP_COMMAND_REGISTRY['open-command-center'].accelerator).toBe('CommandOrControl+K');
+  });
+
+  it('routes renderer commands through the menu command event path', async () => {
+    const harness = dispatcher();
+    const result = await harness.dispatcher.dispatch(
+      createDesktopCommandRequest('new-task', 'menu')
+    );
+
+    expect(result).toEqual({
+      command: 'new-task',
+      accepted: true,
+      handledBy: 'renderer',
+      message: undefined,
+    });
+    expect(harness.sendRendererCommand).toHaveBeenCalledWith({
+      command: 'new-task',
+      source: 'menu',
+      payload: undefined,
+    });
+  });
+
+  it('handles native desktop commands without exposing shell primitives to the renderer', async () => {
+    const harness = dispatcher();
+
+    await expect(
+      harness.dispatcher.dispatch(createDesktopCommandRequest('restart-local-server', 'menu'))
+    ).resolves.toMatchObject({
+      command: 'restart-local-server',
+      accepted: true,
+      handledBy: 'desktop',
+    });
+    await harness.dispatcher.dispatch(createDesktopCommandRequest('open-logs', 'menu'));
+    await harness.dispatcher.dispatch(createDesktopCommandRequest('check-for-updates', 'menu'));
+    await harness.dispatcher.dispatch(createDesktopCommandRequest('test-notification', 'menu'));
+    await harness.dispatcher.dispatch(
+      createDesktopCommandRequest('copy-redacted-diagnostics', 'menu')
+    );
+
+    expect(harness.runtime.restartLocalServer).toHaveBeenCalledTimes(1);
+    expect(harness.shell.openPath).toHaveBeenCalledWith('/tmp/veritas/logs');
+    expect(harness.sendUpdateStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'unsupported',
+      })
+    );
+    expect(harness.showTestNotification).toHaveBeenCalledTimes(1);
+    expect(harness.copyRedactedDiagnostics).toHaveBeenCalledWith(status());
+  });
+});

--- a/desktop/src/main/__tests__/deep-links.test.ts
+++ b/desktop/src/main/__tests__/deep-links.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractDeepLinkFromArgv, parseDesktopDeepLink } from '../deep-links.js';
+
+describe('desktop deep links', () => {
+  it('maps task links into command-center navigation payloads', () => {
+    expect(parseDesktopDeepLink('veritas://task/task-123?tab=work')).toEqual({
+      url: 'veritas://task/task-123?tab=work',
+      resource: 'task',
+      resourceId: 'task-123',
+      command: {
+        command: 'open-command-center',
+        source: 'deep-link',
+        payload: {
+          deepLink: {
+            url: 'veritas://task/task-123?tab=work',
+            resource: 'task',
+            resourceId: 'task-123',
+            params: {
+              tab: 'work',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('supports settings, pairing, run, workflow, and command-center destinations', () => {
+    expect(parseDesktopDeepLink('veritas://settings').command.command).toBe('open-settings');
+    expect(parseDesktopDeepLink('veritas://pairing/device-1').command.command).toBe(
+      'open-settings'
+    );
+    expect(parseDesktopDeepLink('veritas://run/run-1').command.command).toBe('open-command-center');
+    expect(parseDesktopDeepLink('veritas://workflow/workflow-1').command.command).toBe(
+      'open-command-center'
+    );
+    expect(parseDesktopDeepLink('veritas://command-center').command.command).toBe(
+      'open-command-center'
+    );
+  });
+
+  it('rejects unsupported protocols and resources', () => {
+    expect(() => parseDesktopDeepLink('https://example.com/task/1')).toThrow('protocol');
+    expect(() => parseDesktopDeepLink('veritas://shell/rm')).toThrow('not supported');
+  });
+
+  it('extracts veritas links from process argv', () => {
+    expect(extractDeepLinkFromArgv(['Electron', '.', 'veritas://task/task-1'])).toBe(
+      'veritas://task/task-1'
+    );
+    expect(extractDeepLinkFromArgv(['Electron', '.'])).toBeNull();
+  });
+});

--- a/desktop/src/main/__tests__/menu.test.ts
+++ b/desktop/src/main/__tests__/menu.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createDesktopMenuTemplate } from '../menu.js';
+import type { DesktopStatusSnapshot } from '../types.js';
+
+function status(state: DesktopStatusSnapshot['server']['state'] = 'ready'): DesktopStatusSnapshot {
+  return {
+    mode: 'local-dev',
+    profile: 'fresh',
+    workspace: 'local',
+    server: {
+      name: 'server',
+      state,
+      pid: 1,
+      port: 3001,
+      lastError: null,
+      startedAt: '2026-05-31T00:00:00.000Z',
+      exitedAt: null,
+    },
+    web: undefined,
+    serverOrigin: 'http://127.0.0.1:3001',
+    rendererOrigin: 'http://127.0.0.1:3000',
+    appHome: '/tmp/veritas',
+    dataDir: '/tmp/veritas/data',
+    configDir: '/tmp/veritas/config',
+    logsDir: '/tmp/veritas/logs',
+    secretsBackedByKeychain: true,
+    warnings: [],
+    lastError: null,
+  };
+}
+
+describe('desktop native menu', () => {
+  it('exposes common actions with keyboard shortcuts', () => {
+    const dispatch = vi.fn();
+    const template = createDesktopMenuTemplate({ status: status(), dispatch });
+    const labels = template.flatMap((item) =>
+      Array.isArray(item.submenu) ? item.submenu.map((child) => child.label) : []
+    );
+
+    expect(labels).toContain('New Task');
+    expect(labels).toContain('Command Center');
+    expect(labels).toContain('Search');
+    expect(labels).toContain('Settings');
+    expect(labels).toContain('Restart Local Server');
+
+    const fileMenu = template.find((item) => item.label === 'File');
+    const newTask = Array.isArray(fileMenu?.submenu)
+      ? fileMenu.submenu.find((item) => item.label === 'New Task')
+      : null;
+    newTask?.click?.(undefined as never, undefined as never, undefined as never);
+
+    expect(newTask?.accelerator).toBe('CommandOrControl+N');
+    expect(dispatch).toHaveBeenCalledWith('new-task');
+  });
+
+  it('keeps external delivery test status-aware', () => {
+    const desktopMenu = createDesktopMenuTemplate({
+      status: status('failed'),
+      dispatch: vi.fn(),
+    }).find((item) => item.label === 'Desktop');
+    const externalTest = Array.isArray(desktopMenu?.submenu)
+      ? desktopMenu.submenu.find((item) => item.label === 'Test External Delivery')
+      : null;
+
+    expect(externalTest?.enabled).toBe(false);
+  });
+});

--- a/desktop/src/main/__tests__/notifications.test.ts
+++ b/desktop/src/main/__tests__/notifications.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createNotificationPreview,
+  DesktopNotificationCenter,
+  type DesktopNotificationAdapter,
+} from '../notifications.js';
+
+describe('desktop notifications', () => {
+  it('creates privacy-safe previews when private mode is enabled', () => {
+    const preview = createNotificationPreview({
+      id: 'notice-1',
+      kind: 'mention',
+      title: 'Brad mentioned you on Secret Task',
+      body: 'Sensitive task body',
+      target: { type: 'task', id: 'task-1' },
+      privacyMode: 'private',
+    });
+
+    expect(preview.title).toBe('New mention');
+    expect(preview.body).toBe('Open Veritas Kanban to view details.');
+    expect(preview.target).toEqual({ type: 'task', id: 'task-1' });
+  });
+
+  it('dedupes notifications and emits open actions for durable targets', () => {
+    const show = vi.fn((_, onClick: () => void) => onClick());
+    const dispatchAction = vi.fn();
+    const center = new DesktopNotificationCenter(
+      { show } as DesktopNotificationAdapter,
+      dispatchAction
+    );
+    const request = {
+      id: 'notice-1',
+      kind: 'agent-complete' as const,
+      title: 'Agent finished',
+      body: 'Done',
+      target: { type: 'task' as const, id: 'task-1' },
+      dedupeKey: 'task-1:done',
+    };
+
+    expect(center.show(request)).not.toBeNull();
+    expect(center.show(request)).toBeNull();
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith({
+      notificationId: 'notice-1',
+      action: 'open',
+      taskId: 'task-1',
+    });
+  });
+
+  it('supports mark-read style notification actions', () => {
+    const dispatchAction = vi.fn();
+    const center = new DesktopNotificationCenter(
+      { show: vi.fn() } as DesktopNotificationAdapter,
+      dispatchAction
+    );
+
+    center.markRead('notice-1');
+
+    expect(dispatchAction).toHaveBeenCalledWith({
+      notificationId: 'notice-1',
+      action: 'dismiss',
+    });
+  });
+});

--- a/desktop/src/main/__tests__/window-state.test.ts
+++ b/desktop/src/main/__tests__/window-state.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { createDesktopPaths } from '../paths.js';
+import {
+  applyDesktopWindowState,
+  readDesktopWindowState,
+  writeDesktopWindowState,
+  writeDesktopWindowStateSync,
+} from '../window-state.js';
+
+async function paths() {
+  const root = await mkdtemp(path.join(tmpdir(), 'veritas-window-state-'));
+  return createDesktopPaths({
+    userDataPath: path.join(root, 'userData'),
+    repoRoot: root,
+    isPackaged: true,
+  });
+}
+
+describe('desktop window state', () => {
+  it('persists and restores sanitized window state', async () => {
+    const desktopPaths = await paths();
+
+    await writeDesktopWindowState(desktopPaths, {
+      width: 1400.2,
+      height: 920.7,
+      x: 40.4,
+      y: 50.5,
+      maximized: true,
+    });
+
+    await expect(readDesktopWindowState(desktopPaths)).resolves.toEqual({
+      width: 1400,
+      height: 921,
+      x: 40,
+      y: 51,
+      maximized: true,
+    });
+  });
+
+  it('falls back to stable dimensions for invalid saved state', () => {
+    expect(applyDesktopWindowState({ width: 10, height: Number.NaN })).toEqual({
+      width: 720,
+      height: 900,
+      x: undefined,
+      y: undefined,
+    });
+  });
+
+  it('supports synchronous close-path persistence', async () => {
+    const desktopPaths = await paths();
+
+    writeDesktopWindowStateSync(desktopPaths, {
+      width: 1200,
+      height: 800,
+      x: 10,
+      y: 20,
+    });
+
+    await expect(readDesktopWindowState(desktopPaths)).resolves.toMatchObject({
+      width: 1200,
+      height: 800,
+      x: 10,
+      y: 20,
+    });
+  });
+});

--- a/desktop/src/main/bridge.ts
+++ b/desktop/src/main/bridge.ts
@@ -1,6 +1,7 @@
 import type { IpcMain, Shell } from 'electron';
 
 import { DESKTOP_APP_ID, DESKTOP_APP_NAME } from './app-metadata.js';
+import type { DesktopCommandDispatcher } from './commands.js';
 import type { DesktopAppInfo } from './types.js';
 import type { DesktopRuntime } from './runtime.js';
 import {
@@ -34,7 +35,8 @@ export type DesktopBridgeHandlerMap = {
 export function createDesktopBridgeHandlers(
   runtime: DesktopRuntime,
   shell: Shell,
-  packaged: boolean
+  packaged: boolean,
+  commandDispatcher?: DesktopCommandDispatcher
 ): DesktopBridgeHandlerMap {
   const appInfo = (): DesktopAppInfo => ({
     name: DESKTOP_APP_NAME,
@@ -72,12 +74,14 @@ export function createDesktopBridgeHandlers(
     }),
     dispatchCommand: (request) => {
       const command = validateDesktopCommandDispatchRequest(request);
-      return {
-        command: command.command,
-        accepted: false,
-        handledBy: 'unsupported',
-        message: 'Native command handling is reserved for the desktop menus issue.',
-      };
+      return commandDispatcher
+        ? commandDispatcher.dispatch(command)
+        : {
+            command: command.command,
+            accepted: false,
+            handledBy: 'unsupported',
+            message: 'Native command handling is reserved for the desktop menus issue.',
+          };
     },
     pickUploadFiles: (request) => {
       validateFilePickerRequest(request);
@@ -123,9 +127,10 @@ export function registerDesktopBridge(
   ipcMain: IpcMain,
   runtime: DesktopRuntime,
   shell: Shell,
-  packaged: boolean
+  packaged: boolean,
+  commandDispatcher?: DesktopCommandDispatcher
 ): void {
-  const handlers = createDesktopBridgeHandlers(runtime, shell, packaged);
+  const handlers = createDesktopBridgeHandlers(runtime, shell, packaged, commandDispatcher);
 
   for (const method of DESKTOP_BRIDGE_METHOD_NAMES) {
     const definition = DESKTOP_BRIDGE_METHODS[method];

--- a/desktop/src/main/commands.ts
+++ b/desktop/src/main/commands.ts
@@ -1,0 +1,220 @@
+import type { Shell } from 'electron';
+
+import type { DesktopRuntime } from './runtime.js';
+import type { DesktopStatusSnapshot } from './types.js';
+import {
+  DESKTOP_COMMAND_NAMES,
+  type DesktopCommandDispatchRequest,
+  type DesktopCommandDispatchResult,
+  type DesktopCommandName,
+  type DesktopCommandSource,
+  type DesktopUpdateStatus,
+  validateDesktopCommandDispatchRequest,
+} from '../shared/desktop-bridge-contracts.js';
+
+export type DesktopCommandNativeAction =
+  | 'renderer'
+  | 'restart-server'
+  | 'open-logs'
+  | 'show-diagnostics'
+  | 'create-debug-bundle'
+  | 'check-updates'
+  | 'test-notification'
+  | 'test-external-delivery'
+  | 'copy-diagnostics'
+  | 'quit';
+
+export interface DesktopCommandDefinition {
+  name: DesktopCommandName;
+  label: string;
+  accelerator?: string;
+  nativeAction: DesktopCommandNativeAction;
+  privacySensitive: boolean;
+}
+
+export const DESKTOP_COMMAND_REGISTRY: Record<DesktopCommandName, DesktopCommandDefinition> =
+  Object.fromEntries(
+    DESKTOP_COMMAND_NAMES.map((name) => [
+      name,
+      {
+        name,
+        label: commandLabel(name),
+        accelerator: commandAccelerator(name),
+        nativeAction: commandNativeAction(name),
+        privacySensitive: commandPrivacySensitive(name),
+      },
+    ])
+  ) as Record<DesktopCommandName, DesktopCommandDefinition>;
+
+function commandLabel(name: DesktopCommandName): string {
+  switch (name) {
+    case 'new-task':
+      return 'New Task';
+    case 'open-search':
+      return 'Search';
+    case 'open-settings':
+      return 'Settings';
+    case 'open-command-center':
+      return 'Command Center';
+    case 'import-data':
+      return 'Import';
+    case 'export-data':
+      return 'Export';
+    case 'create-backup':
+      return 'Create Backup';
+    case 'open-logs':
+      return 'Open Logs';
+    case 'restart-local-server':
+      return 'Restart Local Server';
+    case 'communication-health':
+      return 'Communication Health';
+    case 'show-diagnostics':
+      return 'Diagnostics';
+    case 'create-debug-bundle':
+      return 'Create Debug Bundle';
+    case 'check-for-updates':
+      return 'Check for Updates';
+    case 'test-notification':
+      return 'Test Local Notification';
+    case 'test-squad-webhook':
+      return 'Test External Delivery';
+    case 'copy-redacted-diagnostics':
+      return 'Copy Redacted Diagnostics';
+    case 'export-work-product':
+      return 'Export Work Product';
+    case 'quit':
+      return 'Quit Veritas Kanban';
+  }
+}
+
+function commandAccelerator(name: DesktopCommandName): string | undefined {
+  switch (name) {
+    case 'new-task':
+      return 'CommandOrControl+N';
+    case 'open-search':
+      return 'CommandOrControl+F';
+    case 'open-settings':
+      return 'CommandOrControl+,';
+    case 'open-command-center':
+      return 'CommandOrControl+K';
+    case 'restart-local-server':
+      return 'CommandOrControl+R';
+    default:
+      return undefined;
+  }
+}
+
+function commandNativeAction(name: DesktopCommandName): DesktopCommandNativeAction {
+  switch (name) {
+    case 'restart-local-server':
+      return 'restart-server';
+    case 'open-logs':
+      return 'open-logs';
+    case 'show-diagnostics':
+      return 'show-diagnostics';
+    case 'create-debug-bundle':
+      return 'create-debug-bundle';
+    case 'check-for-updates':
+      return 'check-updates';
+    case 'test-notification':
+      return 'test-notification';
+    case 'test-squad-webhook':
+      return 'test-external-delivery';
+    case 'copy-redacted-diagnostics':
+      return 'copy-diagnostics';
+    case 'quit':
+      return 'quit';
+    default:
+      return 'renderer';
+  }
+}
+
+function commandPrivacySensitive(name: DesktopCommandName): boolean {
+  return name === 'export-work-product' || name === 'copy-redacted-diagnostics';
+}
+
+export interface DesktopCommandDispatcherOptions {
+  runtime: DesktopRuntime;
+  shell: Shell;
+  quit(): void;
+  sendRendererCommand(command: DesktopCommandDispatchRequest): void;
+  sendUpdateStatus(status: DesktopUpdateStatus): void;
+  showTestNotification(): void;
+  copyRedactedDiagnostics(status: DesktopStatusSnapshot): void;
+}
+
+export class DesktopCommandDispatcher {
+  constructor(private readonly options: DesktopCommandDispatcherOptions) {}
+
+  async dispatch(payload: unknown): Promise<DesktopCommandDispatchResult> {
+    const request = validateDesktopCommandDispatchRequest(payload);
+    const definition = DESKTOP_COMMAND_REGISTRY[request.command];
+
+    switch (definition.nativeAction) {
+      case 'renderer':
+        this.options.sendRendererCommand(request);
+        return accepted(request, 'renderer');
+      case 'restart-server':
+        await this.options.runtime.restartLocalServer();
+        this.options.sendRendererCommand(request);
+        return accepted(request, 'desktop');
+      case 'open-logs':
+        await this.options.shell.openPath(this.options.runtime.snapshot().logsDir);
+        return accepted(request, 'desktop');
+      case 'show-diagnostics':
+      case 'create-debug-bundle':
+        this.options.sendRendererCommand(request);
+        return accepted(request, 'renderer');
+      case 'check-updates':
+        this.options.sendUpdateStatus({
+          state: 'unsupported',
+          currentVersion: process.env.npm_package_version || '0.0.0',
+          channel: 'dev',
+          checkedAt: new Date().toISOString(),
+          detail: 'Updater implementation is tracked in the desktop release pipeline issue.',
+        });
+        return accepted(request, 'desktop');
+      case 'test-notification':
+        this.options.showTestNotification();
+        return accepted(request, 'desktop');
+      case 'test-external-delivery':
+        this.options.sendRendererCommand(request);
+        return accepted(
+          request,
+          'renderer',
+          'External delivery test requires configured delivery.'
+        );
+      case 'copy-diagnostics':
+        this.options.copyRedactedDiagnostics(this.options.runtime.snapshot());
+        return accepted(request, 'desktop');
+      case 'quit':
+        this.options.quit();
+        return accepted(request, 'desktop');
+    }
+  }
+}
+
+function accepted(
+  request: DesktopCommandDispatchRequest,
+  handledBy: DesktopCommandDispatchResult['handledBy'],
+  message?: string
+): DesktopCommandDispatchResult {
+  return {
+    command: request.command,
+    accepted: true,
+    handledBy,
+    message,
+  };
+}
+
+export function createDesktopCommandRequest(
+  command: DesktopCommandName,
+  source: DesktopCommandSource,
+  payload?: Record<string, unknown>
+): DesktopCommandDispatchRequest {
+  return {
+    command,
+    source,
+    payload,
+  };
+}

--- a/desktop/src/main/deep-links.ts
+++ b/desktop/src/main/deep-links.ts
@@ -1,0 +1,68 @@
+import {
+  DESKTOP_COMMAND_NAMES,
+  type DesktopCommandDispatchRequest,
+  type DesktopCommandName,
+} from '../shared/desktop-bridge-contracts.js';
+
+const RESOURCE_COMMANDS: Record<string, DesktopCommandName> = {
+  task: 'open-command-center',
+  workflow: 'open-command-center',
+  invite: 'open-settings',
+  pairing: 'open-settings',
+  run: 'open-command-center',
+  settings: 'open-settings',
+  'command-center': 'open-command-center',
+  search: 'open-search',
+  'work-product': 'export-work-product',
+};
+
+export interface DesktopDeepLinkResult {
+  url: string;
+  resource: string;
+  resourceId: string | null;
+  command: DesktopCommandDispatchRequest;
+}
+
+export function parseDesktopDeepLink(rawUrl: string): DesktopDeepLinkResult {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error('Deep link URL is invalid');
+  }
+
+  if (url.protocol !== 'veritas:') {
+    throw new Error(`Deep link protocol is not supported: ${url.protocol}`);
+  }
+
+  const resource = url.hostname || url.pathname.split('/').filter(Boolean)[0] || 'command-center';
+  const segments = url.pathname.split('/').filter(Boolean);
+  const resourceId = segments[0] && segments[0] !== resource ? segments[0] : (segments[1] ?? null);
+  const command = RESOURCE_COMMANDS[resource];
+
+  if (!command || !DESKTOP_COMMAND_NAMES.includes(command)) {
+    throw new Error(`Deep link resource is not supported: ${resource}`);
+  }
+
+  return {
+    url: url.toString(),
+    resource,
+    resourceId,
+    command: {
+      command,
+      source: 'deep-link',
+      payload: {
+        deepLink: {
+          url: url.toString(),
+          resource,
+          resourceId,
+          params: Object.fromEntries(url.searchParams.entries()),
+        },
+      },
+    },
+  };
+}
+
+export function extractDeepLinkFromArgv(argv: string[]): string | null {
+  return argv.find((arg) => arg.startsWith('veritas://')) ?? null;
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,20 +1,37 @@
-import { app, BrowserWindow, ipcMain, safeStorage, shell } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, Notification, safeStorage, shell } from 'electron';
 import path from 'node:path';
 import { mkdirSync } from 'node:fs';
 
 import { DESKTOP_APP_ID, DESKTOP_APP_NAME, DESKTOP_MIN_WINDOW } from './app-metadata.js';
 import { registerDesktopBridge } from './bridge.js';
+import { DesktopCommandDispatcher } from './commands.js';
+import { extractDeepLinkFromArgv, parseDesktopDeepLink } from './deep-links.js';
+import { configureDesktopMenu, dispatchDesktopMenuCommand } from './menu.js';
+import { DesktopNotificationCenter, ElectronNotificationAdapter } from './notifications.js';
 import { createDesktopPaths, resolveRepoRoot } from './paths.js';
 import { findAvailablePort } from './ports.js';
 import { DesktopRuntime } from './runtime.js';
 import { DesktopSecretStore } from './secrets.js';
 import { statusPageUrl } from './status-page.js';
-import { DESKTOP_BRIDGE_EVENTS } from '../shared/desktop-bridge-contracts.js';
+import {
+  DESKTOP_BRIDGE_EVENTS,
+  redactDesktopBridgeValue,
+} from '../shared/desktop-bridge-contracts.js';
+import {
+  applyDesktopWindowState,
+  captureDesktopWindowState,
+  readDesktopWindowState,
+  writeDesktopWindowStateSync,
+  type DesktopWindowState,
+} from './window-state.js';
 
 let mainWindow: BrowserWindow | null = null;
 let runtime: DesktopRuntime | null = null;
+let commandDispatcher: DesktopCommandDispatcher | null = null;
+let windowStatePaths: ReturnType<typeof createDesktopPaths> | null = null;
 let quitting = false;
 let shutdownStarted = false;
+const pendingDeepLinks: string[] = [];
 
 function isPackagedRuntime(): boolean {
   return app.isPackaged || process.env.VERITAS_DESKTOP_PRODUCTION === 'true';
@@ -36,15 +53,19 @@ if (!launchPackaged) {
   app.setPath('userData', devUserDataPath);
 }
 
-function createMainWindow(): BrowserWindow {
+if (!app.requestSingleInstanceLock()) {
+  app.quit();
+}
+
+function createMainWindow(savedState: DesktopWindowState): BrowserWindow {
   const preloadPath = path.join(__dirname, '../preload/index.mjs');
+  const windowBounds = applyDesktopWindowState(savedState);
 
   const window = new BrowserWindow({
     title: DESKTOP_APP_NAME,
     minWidth: DESKTOP_MIN_WINDOW.width,
     minHeight: DESKTOP_MIN_WINDOW.height,
-    width: 1360,
-    height: 900,
+    ...windowBounds,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     backgroundColor: '#111318',
     show: false,
@@ -57,6 +78,14 @@ function createMainWindow(): BrowserWindow {
   });
 
   window.once('ready-to-show', () => window.show());
+  if (savedState.maximized) {
+    window.maximize();
+  }
+  window.on('close', () => {
+    if (windowStatePaths) {
+      writeDesktopWindowStateSync(windowStatePaths, captureDesktopWindowState(window));
+    }
+  });
   window.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
     return { action: 'deny' };
@@ -79,6 +108,31 @@ function createMainWindow(): BrowserWindow {
   return window;
 }
 
+function handleDeepLink(url: string): void {
+  if (!commandDispatcher) {
+    pendingDeepLinks.push(url);
+    return;
+  }
+
+  try {
+    const deepLink = parseDesktopDeepLink(url);
+    void commandDispatcher.dispatch(deepLink.command);
+  } catch (error) {
+    mainWindow?.webContents.send(DESKTOP_BRIDGE_EVENTS.communicationCheck.channel, {
+      target: 'external',
+      state: 'failed',
+      detail: error instanceof Error ? error.message : String(error),
+      checkedAt: new Date().toISOString(),
+    });
+  }
+}
+
+function flushPendingDeepLinks(): void {
+  for (const deepLink of pendingDeepLinks.splice(0)) {
+    handleDeepLink(deepLink);
+  }
+}
+
 async function boot(): Promise<void> {
   app.setName(DESKTOP_APP_NAME);
   app.setAppUserModelId(DESKTOP_APP_ID);
@@ -94,13 +148,14 @@ async function boot(): Promise<void> {
     profile,
     workspace,
   });
+  windowStatePaths = paths;
 
   const serverPort = await findAvailablePort(
     Number(process.env.VERITAS_DESKTOP_SERVER_PORT || 3001)
   );
   const webPort = await findAvailablePort(Number(process.env.VERITAS_DESKTOP_WEB_PORT || 3000));
 
-  mainWindow = createMainWindow();
+  mainWindow = createMainWindow(await readDesktopWindowState(paths));
   await mainWindow.loadURL(statusPageUrl('Starting Veritas Kanban', 'Preparing the local app.'));
 
   const secretStore = new DesktopSecretStore({ safeStorage, paths });
@@ -137,13 +192,62 @@ async function boot(): Promise<void> {
     secretsBackedByKeychain: secretState.available,
   });
 
-  registerDesktopBridge(ipcMain, runtime, shell, packaged);
+  const notifications = new DesktopNotificationCenter(
+    new ElectronNotificationAdapter(Notification),
+    (request) => {
+      mainWindow?.webContents.send(DESKTOP_BRIDGE_EVENTS.notificationAction.channel, request);
+    }
+  );
+
+  commandDispatcher = new DesktopCommandDispatcher({
+    runtime,
+    shell,
+    quit: () => app.quit(),
+    sendRendererCommand: (command) => {
+      mainWindow?.webContents.send(DESKTOP_BRIDGE_EVENTS.menuCommand.channel, command);
+    },
+    sendUpdateStatus: (status) => {
+      mainWindow?.webContents.send(DESKTOP_BRIDGE_EVENTS.updateStatus.channel, status);
+    },
+    showTestNotification: () => {
+      notifications.show({
+        id: `setup-test-${Date.now()}`,
+        kind: 'setup-test',
+        title: 'Veritas Kanban notification test',
+        body: 'Local desktop notifications are working.',
+        target: { type: 'settings' },
+        privacyMode: 'private',
+      });
+    },
+    copyRedactedDiagnostics: (status) => {
+      clipboard.writeText(JSON.stringify(redactDesktopBridgeValue(status), null, 2));
+    },
+  });
+
+  registerDesktopBridge(ipcMain, runtime, shell, packaged, commandDispatcher);
+  configureDesktopMenu({
+    status: runtime.snapshot(),
+    dispatch: (command) => {
+      if (commandDispatcher) {
+        dispatchDesktopMenuCommand(commandDispatcher, command);
+      }
+    },
+  });
   runtime.on('status', (status) => {
     mainWindow?.webContents.send(DESKTOP_BRIDGE_EVENTS.serverStatus.channel, status);
+    configureDesktopMenu({
+      status,
+      dispatch: (command) => {
+        if (commandDispatcher) {
+          dispatchDesktopMenuCommand(commandDispatcher, command);
+        }
+      },
+    });
   });
 
   try {
     await runtime.start();
+    flushPendingDeepLinks();
     await mainWindow.loadURL(runtime.getRendererOrigin());
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -154,7 +258,30 @@ async function boot(): Promise<void> {
 }
 
 app.on('ready', () => {
+  app.setAsDefaultProtocolClient('veritas');
+  const initialDeepLink = extractDeepLinkFromArgv(process.argv);
+  if (initialDeepLink) {
+    pendingDeepLinks.push(initialDeepLink);
+  }
   void boot();
+});
+
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  handleDeepLink(url);
+});
+
+app.on('second-instance', (_event, argv) => {
+  const deepLink = extractDeepLinkFromArgv(argv);
+  if (deepLink) {
+    handleDeepLink(deepLink);
+  }
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+    mainWindow.focus();
+  }
 });
 
 app.on('before-quit', (event) => {

--- a/desktop/src/main/menu.ts
+++ b/desktop/src/main/menu.ts
@@ -1,0 +1,92 @@
+import { Menu, type MenuItemConstructorOptions } from 'electron';
+
+import {
+  createDesktopCommandRequest,
+  DESKTOP_COMMAND_REGISTRY,
+  type DesktopCommandDispatcher,
+} from './commands.js';
+import type { DesktopStatusSnapshot } from './types.js';
+import type { DesktopCommandName } from '../shared/desktop-bridge-contracts.js';
+
+export interface ConfigureDesktopMenuOptions {
+  dispatch(command: DesktopCommandName): void;
+  status: DesktopStatusSnapshot;
+}
+
+export function configureDesktopMenu(options: ConfigureDesktopMenuOptions): void {
+  Menu.setApplicationMenu(Menu.buildFromTemplate(createDesktopMenuTemplate(options)));
+}
+
+export function createDesktopMenuTemplate(
+  options: ConfigureDesktopMenuOptions
+): MenuItemConstructorOptions[] {
+  const command = (name: DesktopCommandName): MenuItemConstructorOptions => {
+    const definition = DESKTOP_COMMAND_REGISTRY[name];
+    return {
+      label: definition.label,
+      accelerator: definition.accelerator,
+      enabled: isCommandEnabled(name, options.status),
+      click: () => options.dispatch(name),
+    };
+  };
+
+  return [
+    {
+      label: 'Veritas Kanban',
+      submenu: [
+        command('open-settings'),
+        command('communication-health'),
+        { type: 'separator' },
+        command('check-for-updates'),
+        { type: 'separator' },
+        command('quit'),
+      ],
+    },
+    {
+      label: 'File',
+      submenu: [
+        command('new-task'),
+        command('import-data'),
+        command('export-data'),
+        command('create-backup'),
+      ],
+    },
+    {
+      label: 'Navigate',
+      submenu: [command('open-command-center'), command('open-search'), command('open-settings')],
+    },
+    {
+      label: 'Desktop',
+      submenu: [
+        command('restart-local-server'),
+        command('open-logs'),
+        command('show-diagnostics'),
+        command('create-debug-bundle'),
+        { type: 'separator' },
+        command('test-notification'),
+        command('test-squad-webhook'),
+        command('copy-redacted-diagnostics'),
+      ],
+    },
+  ];
+}
+
+export function dispatchDesktopMenuCommand(
+  dispatcher: DesktopCommandDispatcher,
+  command: DesktopCommandName
+): void {
+  void dispatcher.dispatch(createDesktopCommandRequest(command, 'menu'));
+}
+
+function isCommandEnabled(command: DesktopCommandName, status: DesktopStatusSnapshot): boolean {
+  if (command === 'restart-local-server') {
+    return status.mode === 'local-dev' || status.mode === 'local-production';
+  }
+  if (command === 'open-logs') {
+    return Boolean(status.logsDir);
+  }
+  if (command === 'test-squad-webhook') {
+    return status.server.state === 'ready';
+  }
+  return true;
+}

--- a/desktop/src/main/notifications.ts
+++ b/desktop/src/main/notifications.ts
@@ -1,0 +1,129 @@
+import type { Notification as ElectronNotificationConstructor } from 'electron';
+
+import type {
+  DesktopNotificationAction,
+  DesktopNotificationActionRequest,
+} from '../shared/desktop-bridge-contracts.js';
+
+export type DesktopNotificationKind =
+  | 'mention'
+  | 'approval'
+  | 'blocked-workflow'
+  | 'agent-complete'
+  | 'failed-run'
+  | 'update-available'
+  | 'setup-test';
+
+export interface DesktopNotificationRequest {
+  id: string;
+  kind: DesktopNotificationKind;
+  title: string;
+  body: string;
+  target?: {
+    type:
+      | 'task'
+      | 'run'
+      | 'workflow-gate'
+      | 'approval'
+      | 'settings'
+      | 'maintenance'
+      | 'work-product';
+    id?: string;
+  };
+  dedupeKey?: string;
+  privacyMode?: 'full' | 'private';
+}
+
+export interface DesktopNotificationPreview {
+  id: string;
+  title: string;
+  body: string;
+  dedupeKey: string;
+  target?: DesktopNotificationRequest['target'];
+}
+
+export interface DesktopNotificationAdapter {
+  show(preview: DesktopNotificationPreview, onClick: () => void): void;
+}
+
+export class ElectronNotificationAdapter implements DesktopNotificationAdapter {
+  constructor(private readonly NotificationCtor: typeof ElectronNotificationConstructor) {}
+
+  show(preview: DesktopNotificationPreview, onClick: () => void): void {
+    if (!this.NotificationCtor.isSupported()) {
+      return;
+    }
+
+    const notification = new this.NotificationCtor({
+      title: preview.title,
+      body: preview.body,
+    });
+    notification.once('click', onClick);
+    notification.show();
+  }
+}
+
+export class DesktopNotificationCenter {
+  private readonly displayed = new Set<string>();
+
+  constructor(
+    private readonly adapter: DesktopNotificationAdapter,
+    private readonly dispatchAction: (request: DesktopNotificationActionRequest) => void
+  ) {}
+
+  show(request: DesktopNotificationRequest): DesktopNotificationPreview | null {
+    const preview = createNotificationPreview(request);
+    if (this.displayed.has(preview.dedupeKey)) {
+      return null;
+    }
+
+    this.displayed.add(preview.dedupeKey);
+    this.adapter.show(preview, () => {
+      this.dispatchAction({
+        notificationId: preview.id,
+        action: 'open',
+        taskId: preview.target?.type === 'task' ? preview.target.id : undefined,
+      });
+    });
+    return preview;
+  }
+
+  markRead(notificationId: string, action: DesktopNotificationAction = 'dismiss'): void {
+    this.dispatchAction({
+      notificationId,
+      action,
+    });
+  }
+}
+
+export function createNotificationPreview(
+  request: DesktopNotificationRequest
+): DesktopNotificationPreview {
+  const privateMode = request.privacyMode === 'private';
+  return {
+    id: request.id,
+    title: privateMode ? privacyTitle(request.kind) : request.title,
+    body: privateMode ? 'Open Veritas Kanban to view details.' : request.body,
+    dedupeKey: request.dedupeKey ?? `${request.kind}:${request.id}`,
+    target: request.target,
+  };
+}
+
+function privacyTitle(kind: DesktopNotificationKind): string {
+  switch (kind) {
+    case 'mention':
+      return 'New mention';
+    case 'approval':
+      return 'Approval requested';
+    case 'blocked-workflow':
+      return 'Workflow blocked';
+    case 'agent-complete':
+      return 'Agent run completed';
+    case 'failed-run':
+      return 'Run failed';
+    case 'update-available':
+      return 'Update available';
+    case 'setup-test':
+      return 'Veritas Kanban notification test';
+  }
+}

--- a/desktop/src/main/window-state.ts
+++ b/desktop/src/main/window-state.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import type { BrowserWindow, Rectangle } from 'electron';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { DesktopPaths } from './types.js';
+
+export interface DesktopWindowState {
+  width: number;
+  height: number;
+  x?: number;
+  y?: number;
+  maximized?: boolean;
+}
+
+export const DEFAULT_DESKTOP_WINDOW_STATE: DesktopWindowState = {
+  width: 1360,
+  height: 900,
+};
+
+function statePath(paths: DesktopPaths): string {
+  return path.join(paths.configDir, 'window-state.json');
+}
+
+export async function readDesktopWindowState(paths: DesktopPaths): Promise<DesktopWindowState> {
+  try {
+    const parsed = JSON.parse(await readFile(statePath(paths), 'utf-8')) as DesktopWindowState;
+    return sanitizeWindowState(parsed);
+  } catch {
+    return DEFAULT_DESKTOP_WINDOW_STATE;
+  }
+}
+
+export async function writeDesktopWindowState(
+  paths: DesktopPaths,
+  state: DesktopWindowState
+): Promise<void> {
+  await mkdir(paths.configDir, { recursive: true });
+  await writeFile(statePath(paths), serializeWindowState(state), 'utf-8');
+}
+
+export function writeDesktopWindowStateSync(paths: DesktopPaths, state: DesktopWindowState): void {
+  mkdirSync(paths.configDir, { recursive: true });
+  writeFileSync(statePath(paths), serializeWindowState(state), 'utf-8');
+}
+
+export function captureDesktopWindowState(window: BrowserWindow): DesktopWindowState {
+  const bounds = window.getBounds();
+  return {
+    ...boundsToWindowState(bounds),
+    maximized: window.isMaximized(),
+  };
+}
+
+export function applyDesktopWindowState(
+  state: DesktopWindowState,
+  fallback = DEFAULT_DESKTOP_WINDOW_STATE
+): Required<Pick<DesktopWindowState, 'width' | 'height'>> & Pick<DesktopWindowState, 'x' | 'y'> {
+  const sanitized = sanitizeWindowState(state);
+  return {
+    width: sanitized.width || fallback.width,
+    height: sanitized.height || fallback.height,
+    x: sanitized.x,
+    y: sanitized.y,
+  };
+}
+
+function boundsToWindowState(bounds: Rectangle): DesktopWindowState {
+  return {
+    width: bounds.width,
+    height: bounds.height,
+    x: bounds.x,
+    y: bounds.y,
+  };
+}
+
+function sanitizeWindowState(state: DesktopWindowState): DesktopWindowState {
+  return {
+    width: clampDimension(state.width, DEFAULT_DESKTOP_WINDOW_STATE.width),
+    height: clampDimension(state.height, DEFAULT_DESKTOP_WINDOW_STATE.height),
+    x: sanitizePosition(state.x),
+    y: sanitizePosition(state.y),
+    maximized: Boolean(state.maximized),
+  };
+}
+
+function serializeWindowState(state: DesktopWindowState): string {
+  return JSON.stringify(sanitizeWindowState(state), null, 2);
+}
+
+function clampDimension(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(Math.max(Math.round(value), 720), 4096)
+    : fallback;
+}
+
+function sanitizePosition(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : undefined;
+}

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -82,12 +82,24 @@ export interface DesktopSetupDiagnostics {
 }
 
 export const DESKTOP_COMMAND_NAMES = [
+  'new-task',
+  'open-search',
   'open-settings',
   'open-command-center',
+  'import-data',
+  'export-data',
+  'create-backup',
+  'open-logs',
   'restart-local-server',
+  'communication-health',
   'show-diagnostics',
+  'create-debug-bundle',
   'check-for-updates',
+  'test-notification',
+  'test-squad-webhook',
+  'copy-redacted-diagnostics',
   'export-work-product',
+  'quit',
 ] as const;
 
 export type DesktopCommandName = (typeof DESKTOP_COMMAND_NAMES)[number];


### PR DESCRIPTION
Closes #341.

## Summary

- Add a typed native desktop command registry that backs menu items, shortcuts, bridge dispatch, deep links, notifications, diagnostics, and desktop shell actions from one source.
- Wire status-aware native menus for common board actions, desktop diagnostics, local server restart, update checks, notification tests, external delivery tests, and quit.
- Add `veritas://` deep-link parsing for task, workflow, run, invite/pairing, settings, command center, search, and work product destinations.
- Add privacy-safe desktop notification preview helpers, durable targets, dedupe handling, and notification click dispatch back through typed bridge events.
- Persist window size, position, and maximized state per profile/workspace, including synchronous close-path persistence.
- Document the native command, deep-link, notification, and window-state behavior in the desktop README.

## Verification

- `pnpm --filter @veritas-kanban/desktop test`
- `pnpm --filter @veritas-kanban/desktop typecheck`
- `pnpm --filter @veritas-kanban/desktop build`
- `pnpm typecheck`
- `pnpm lint:budget` (701 warnings, 0 errors, budget 714)
- `pnpm build`
- `git diff --check`
- Desktop smoke: `pnpm --filter @veritas-kanban/desktop dev:fresh`
- Smoke health check: `curl -fsS http://127.0.0.1:3001/api/health`
- Confirmed no remaining listeners on 3000 or 3001 after stopping the smoke app.

## Notes

- Update installation/signing/notarization remains in the desktop release pipeline issue. This PR exposes update status through the typed command/event path and reports unsupported status until that pipeline lands.
- Renderer destination handling receives typed menu/deep-link events and can wire exact in-app navigation as the command center and settings surfaces continue to mature.
