### PR TITLE
Add desktop onboarding preflight

### DIFF
--- a/desktop/src/main/__tests__/bridge-contracts.test.ts
+++ b/desktop/src/main/__tests__/bridge-contracts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { IpcMain, Shell } from 'electron';
 
 import {
@@ -91,6 +91,10 @@ function handlers(): DesktopBridgeHandlerMap {
 }
 
 describe('desktop bridge contracts', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('keeps contract registries and name lists in sync', () => {
     expect(Object.keys(DESKTOP_BRIDGE_METHODS).sort()).toEqual(
       [...DESKTOP_BRIDGE_METHOD_NAMES].sort()
@@ -200,11 +204,13 @@ describe('desktop bridge contracts', () => {
       validateConnectionConfigRequest({
         mode: 'remote',
         serverUrl: ' https://example.com/veritas ',
+        serverToken: 'vk_pat_secret',
         workspaceId: 'workspace-1',
       })
     ).toEqual({
       mode: 'remote',
       serverUrl: 'https://example.com/veritas',
+      serverToken: 'vk_pat_secret',
       workspaceId: 'workspace-1',
     });
     expect(() =>
@@ -213,6 +219,37 @@ describe('desktop bridge contracts', () => {
     expect(() =>
       validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'https://user@example.com' })
     ).toThrow('credentials are not allowed');
+    expect(() =>
+      validateConnectionConfigRequest({
+        mode: 'remote',
+        serverUrl: 'https://example.com',
+        serverToken: 'bad\ntoken',
+      })
+    ).toThrow('cannot contain newlines');
+  });
+
+  it('validates remote connection reachability in the desktop process', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ authenticated: false }))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handlers().validateConnectionConfig({
+      mode: 'remote',
+      serverUrl: 'https://remote.example/veritas',
+      serverToken: 'vk_pat_secret',
+    });
+
+    expect(result).toMatchObject({
+      mode: 'remote',
+      valid: true,
+      normalizedServerUrl: 'https://remote.example/veritas',
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://remote.example/api/auth/status');
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: { Authorization: 'Bearer vk_pat_secret' },
+    });
   });
 
   it('validates command names, file paths, notification actions, and work product exports', () => {
@@ -359,6 +396,8 @@ describe('desktop bridge contracts', () => {
       'local-server-health',
       'renderer-health',
       'communication-health',
+      'desktop-secrets',
+      'local-database',
       'cli-auth',
       'mcp-auth',
     ]);

--- a/desktop/src/main/__tests__/commands.test.ts
+++ b/desktop/src/main/__tests__/commands.test.ts
@@ -92,6 +92,7 @@ describe('desktop command registry', () => {
     expect(Object.keys(DESKTOP_COMMAND_REGISTRY).sort()).toEqual([...DESKTOP_COMMAND_NAMES].sort());
     expect(DESKTOP_COMMAND_REGISTRY['new-task'].accelerator).toBe('CommandOrControl+N');
     expect(DESKTOP_COMMAND_REGISTRY['open-command-center'].accelerator).toBe('CommandOrControl+K');
+    expect(DESKTOP_COMMAND_REGISTRY['open-onboarding'].label).toBe('Setup & Diagnostics');
   });
 
   it('routes renderer commands through the menu command event path', async () => {

--- a/desktop/src/main/__tests__/menu.test.ts
+++ b/desktop/src/main/__tests__/menu.test.ts
@@ -49,6 +49,7 @@ describe('desktop native menu', () => {
     );
 
     expect(labels).toContain('New Task');
+    expect(labels).toContain('Setup & Diagnostics');
     expect(labels).toContain('Command Center');
     expect(labels).toContain('Search');
     expect(labels).toContain('Settings');

--- a/desktop/src/main/bridge.ts
+++ b/desktop/src/main/bridge.ts
@@ -23,6 +23,8 @@ import {
   type DesktopBridgeMethod,
   type DesktopBridgeRequest,
   type DesktopBridgeResponse,
+  type DesktopConnectionConfigRequest,
+  type DesktopConnectionValidationResult,
 } from '../shared/desktop-bridge-contracts.js';
 
 type MaybePromise<T> = T | Promise<T>;
@@ -32,6 +34,63 @@ export type DesktopBridgeHandlerMap = {
     request: DesktopBridgeRequest<Method>
   ) => MaybePromise<DesktopBridgeResponse<Method>>;
 };
+
+async function validateRemoteConnection(
+  config: DesktopConnectionConfigRequest
+): Promise<DesktopConnectionValidationResult> {
+  if (!config.serverUrl) {
+    return {
+      mode: 'remote',
+      valid: false,
+      normalizedServerUrl: null,
+      warnings: [],
+      errors: ['Remote server URL is required.'],
+    };
+  }
+
+  const statusUrl = new URL('/api/auth/status', config.serverUrl);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5_000);
+
+  try {
+    const response = await fetch(statusUrl, {
+      method: 'GET',
+      headers: config.serverToken ? { Authorization: `Bearer ${config.serverToken}` } : undefined,
+      signal: controller.signal,
+    });
+    const warnings: string[] = [];
+    if (response.status === 401 || response.status === 403) {
+      warnings.push('Remote server is reachable but rejected the supplied credentials.');
+    }
+    if (response.ok) {
+      return {
+        mode: 'remote',
+        valid: true,
+        normalizedServerUrl: config.serverUrl,
+        warnings,
+        errors: [],
+      };
+    }
+
+    return {
+      mode: 'remote',
+      valid: false,
+      normalizedServerUrl: config.serverUrl,
+      warnings,
+      errors: [`Remote server returned HTTP ${response.status}.`],
+    };
+  } catch (error) {
+    return {
+      mode: 'remote',
+      valid: false,
+      normalizedServerUrl: config.serverUrl,
+      warnings: [],
+      errors: [redactDesktopBridgeError(error)],
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 export function createDesktopBridgeHandlers(
   runtime: DesktopRuntime,
@@ -52,14 +111,18 @@ export function createDesktopBridgeHandlers(
     getAppInfo: appInfo,
     getConnectionStatus: () => runtime.snapshot(),
     getSetupDiagnostics: () => createDesktopSetupDiagnostics(runtime.snapshot()),
-    validateConnectionConfig: (request) => {
+    validateConnectionConfig: async (request) => {
       const config = validateConnectionConfigRequest(request);
+      if (config.mode === 'remote') {
+        return validateRemoteConnection(config);
+      }
+      const status = runtime.snapshot();
       return {
         mode: config.mode,
-        valid: true,
+        valid: status.server.state === 'ready',
         normalizedServerUrl: config.serverUrl ?? null,
-        warnings: [],
-        errors: [],
+        warnings: status.server.state === 'ready' ? [] : ['Local server is not ready.'],
+        errors: status.server.lastError ? [status.server.lastError] : [],
       };
     },
     restartLocalServer: (request) => {

--- a/desktop/src/main/commands.ts
+++ b/desktop/src/main/commands.ts
@@ -52,6 +52,8 @@ function commandLabel(name: DesktopCommandName): string {
   switch (name) {
     case 'new-task':
       return 'New Task';
+    case 'open-onboarding':
+      return 'Setup & Diagnostics';
     case 'open-search':
       return 'Search';
     case 'open-settings':

--- a/desktop/src/main/menu.ts
+++ b/desktop/src/main/menu.ts
@@ -38,6 +38,7 @@ export function createDesktopMenuTemplate(
     {
       label: 'Veritas Kanban',
       submenu: [
+        command('open-onboarding'),
         command('open-settings'),
         command('communication-health'),
         { type: 'separator' },

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -51,6 +51,7 @@ export type DesktopConnectionModeRequest = 'local' | 'remote';
 export interface DesktopConnectionConfigRequest {
   mode: DesktopConnectionModeRequest;
   serverUrl?: string;
+  serverToken?: string;
   workspaceId?: string;
 }
 
@@ -83,6 +84,7 @@ export interface DesktopSetupDiagnostics {
 
 export const DESKTOP_COMMAND_NAMES = [
   'new-task',
+  'open-onboarding',
   'open-search',
   'open-settings',
   'open-command-center',
@@ -639,6 +641,17 @@ function diagnosticCheck(
   };
 }
 
+function optionalSecret(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const text = requireString(value, label, 4096);
+  if (/[\r\n]/.test(text)) {
+    throw new Error(`${label} cannot contain newlines`);
+  }
+  return text;
+}
+
 export function validateRestartLocalServerRequest(
   payload: unknown
 ): DesktopRestartLocalServerRequest {
@@ -707,6 +720,7 @@ export function validateConnectionConfigRequest(payload: unknown): DesktopConnec
   return {
     mode: 'remote',
     serverUrl: parsed.toString(),
+    serverToken: optionalSecret(request.serverToken, 'Remote server token'),
     workspaceId,
   };
 }
@@ -862,6 +876,22 @@ export function createDesktopSetupDiagnostics(
         status.serverOrigin && status.rendererOrigin
           ? 'Loopback origins are configured.'
           : 'Loopback origins are not fully configured.',
+        checkedAt
+      ),
+      diagnosticCheck(
+        'desktop-secrets',
+        status.secretsBackedByKeychain ? 'ok' : 'warning',
+        status.secretsBackedByKeychain
+          ? 'Desktop runtime secrets are backed by Keychain.'
+          : 'Desktop runtime secrets are not backed by Keychain.',
+        checkedAt
+      ),
+      diagnosticCheck(
+        'local-database',
+        status.server.state === 'ready' ? 'ok' : 'unknown',
+        status.server.state === 'ready'
+          ? 'SQLite storage is managed by the local server.'
+          : 'Local database readiness depends on server startup.',
         checkedAt
       ),
       diagnosticCheck(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { KanbanBoard } from './components/board/KanbanBoard';
 import { Header } from './components/layout/Header';
 import { Toaster } from './components/ui/toaster';
@@ -12,6 +12,7 @@ import { ViewProvider, useView } from './contexts/ViewContext';
 import { AuthProvider } from './hooks/useAuth';
 import { IdentityProvider } from './hooks/useIdentity';
 import { AuthGuard } from './components/auth';
+import { DesktopOnboardingDialog } from './components/auth/DesktopOnboarding';
 import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import { SkipToContent } from './components/shared/SkipToContent';
 import { LiveAnnouncerProvider } from './components/shared/LiveAnnouncer';
@@ -168,6 +169,31 @@ function MainContent() {
 function AppContent() {
   // Connect to WebSocket for real-time task updates
   const { isConnected, connectionState, reconnectAttempt } = useTaskSync();
+  const [showDesktopOnboarding, setShowDesktopOnboarding] = useState(false);
+
+  useEffect(() => {
+    const desktop = (
+      window as Window & {
+        veritasDesktop?: {
+          onMenuCommand(listener: (payload: { command: string }) => void): () => void;
+        };
+      }
+    ).veritasDesktop;
+
+    if (!desktop?.onMenuCommand) {
+      return undefined;
+    }
+
+    return desktop.onMenuCommand((payload) => {
+      if (
+        payload.command === 'open-onboarding' ||
+        payload.command === 'show-diagnostics' ||
+        payload.command === 'communication-health'
+      ) {
+        setShowDesktopOnboarding(true);
+      }
+    });
+  }, []);
 
   return (
     <WebSocketStatusProvider
@@ -193,6 +219,10 @@ function AppContent() {
                     <Toaster />
                     <CommandPalette />
                     <FloatingChat />
+                    <DesktopOnboardingDialog
+                      open={showDesktopOnboarding}
+                      onOpenChange={setShowDesktopOnboarding}
+                    />
                   </div>
                 </IdentityProvider>
               </ViewProvider>

--- a/web/src/__tests__/desktop-onboarding.test.tsx
+++ b/web/src/__tests__/desktop-onboarding.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+
+import { renderWithProviders } from './test-utils';
+import {
+  DESKTOP_ONBOARDING_STORAGE_KEY,
+  DesktopOnboardingPanel,
+} from '@/components/auth/DesktopOnboarding';
+import { SetupScreen } from '@/components/auth/SetupScreen';
+import { AuthProvider } from '@/hooks/useAuth';
+
+function diagnostics() {
+  return {
+    generatedAt: '2026-05-31T00:00:00.000Z',
+    checks: [
+      {
+        name: 'local-server-health',
+        state: 'ok' as const,
+        detail: 'ready',
+        checkedAt: '2026-05-31T00:00:00.000Z',
+      },
+    ],
+    supportSnapshot: null,
+  };
+}
+
+describe('desktop onboarding', () => {
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+    delete (window as Window & { veritasDesktop?: unknown }).veritasDesktop;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the board-only first-run path before password setup', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ needsSetup: true })))
+    );
+
+    renderWithProviders(
+      <AuthProvider>
+        <SetupScreen />
+      </AuthProvider>
+    );
+
+    expect(await screen.findByText('Choose setup path')).toBeDefined();
+    fireEvent.click(screen.getByTestId('setup-mode-board'));
+    fireEvent.click(screen.getByRole('button', { name: 'Continue to Password' }));
+
+    expect(screen.getByText('Secure Your Board')).toBeDefined();
+    expect(window.localStorage.getItem(DESKTOP_ONBOARDING_STORAGE_KEY)).toBe('true');
+  });
+
+  it('validates a remote URL through the desktop bridge', async () => {
+    const validateConnectionConfig = vi.fn(async () => ({
+      mode: 'remote' as const,
+      valid: true,
+      normalizedServerUrl: 'https://remote.example/',
+      warnings: [],
+      errors: [],
+    }));
+    Object.defineProperty(window, 'veritasDesktop', {
+      configurable: true,
+      value: {
+        getSetupDiagnostics: vi.fn(async () => diagnostics()),
+        validateConnectionConfig,
+      },
+    });
+
+    renderWithProviders(<DesktopOnboardingPanel onContinue={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('setup-mode-remote'));
+    fireEvent.change(screen.getByLabelText('Server URL'), {
+      target: { value: 'https://remote.example' },
+    });
+    fireEvent.change(screen.getByLabelText('Token'), {
+      target: { value: 'vk_pat_secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Validate Remote' }));
+
+    expect(await screen.findByText('Remote target is reachable.')).toBeDefined();
+    expect(validateConnectionConfig).toHaveBeenCalledWith({
+      mode: 'remote',
+      serverUrl: 'https://remote.example',
+      serverToken: 'vk_pat_secret',
+    });
+  });
+
+  it('labels browser-only remote checks as URL validation', async () => {
+    renderWithProviders(<DesktopOnboardingPanel onContinue={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('setup-mode-remote'));
+    fireEvent.change(screen.getByLabelText('Server URL'), {
+      target: { value: 'http://127.0.0.1:3001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Validate Remote' }));
+
+    expect(await screen.findByText('URL syntax is valid.')).toBeDefined();
+    expect(screen.getByText('Live reachability checks require the desktop app.')).toBeDefined();
+  });
+});

--- a/web/src/components/auth/DesktopOnboarding.tsx
+++ b/web/src/components/auth/DesktopOnboarding.tsx
@@ -1,0 +1,617 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertCircle,
+  Bot,
+  CheckCircle2,
+  Clipboard,
+  DatabaseBackup,
+  KanbanSquare,
+  Loader2,
+  RotateCw,
+  Server,
+  ShieldCheck,
+  Upload,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+
+export const DESKTOP_ONBOARDING_STORAGE_KEY = 'veritas-desktop-onboarding-complete';
+
+type HealthState = 'ok' | 'warning' | 'failed' | 'unknown' | 'unsupported';
+type SetupMode = 'board' | 'agent' | 'remote' | 'restore';
+
+interface DesktopDiagnosticCheck {
+  name: string;
+  state: HealthState;
+  detail: string;
+  checkedAt: string;
+}
+
+interface DesktopSetupDiagnostics {
+  generatedAt: string;
+  checks: DesktopDiagnosticCheck[];
+  supportSnapshot: unknown;
+}
+
+interface DesktopConnectionValidationResult {
+  mode: 'local' | 'remote';
+  valid: boolean;
+  normalizedServerUrl: string | null;
+  warnings: string[];
+  errors: string[];
+}
+
+interface DesktopSelectedFile {
+  path: string;
+  name: string;
+  size: number;
+  lastModified: string | null;
+}
+
+interface DesktopFilePickerResult {
+  cancelled: boolean;
+  files: DesktopSelectedFile[];
+}
+
+interface DesktopBridgeApi {
+  getSetupDiagnostics(): Promise<DesktopSetupDiagnostics>;
+  validateConnectionConfig(request: {
+    mode: 'local' | 'remote';
+    serverUrl?: string;
+    serverToken?: string;
+  }): Promise<DesktopConnectionValidationResult>;
+  pickUploadFiles?(request: {
+    purpose: 'backup-restore';
+    allowMultiple?: boolean;
+    allowedExtensions?: string[];
+  }): Promise<DesktopFilePickerResult>;
+}
+
+interface DesktopOnboardingPanelProps {
+  onContinue?: () => void;
+  compact?: boolean;
+}
+
+const setupModes: Array<{
+  id: SetupMode;
+  title: string;
+  badge: string;
+  description: string;
+  icon: typeof KanbanSquare;
+}> = [
+  {
+    id: 'board',
+    title: 'Board Only',
+    badge: 'Recommended',
+    description: 'Start with a protected local board. Agent, MCP, and delivery setup can wait.',
+    icon: KanbanSquare,
+  },
+  {
+    id: 'agent',
+    title: 'Agent Ready',
+    badge: 'Optional',
+    description: 'Review local server, Keychain, CLI, and MCP readiness before agent work.',
+    icon: Bot,
+  },
+  {
+    id: 'remote',
+    title: 'Remote Server',
+    badge: 'Preflight',
+    description: 'Validate a trusted Veritas host before remote pairing and device sessions land.',
+    icon: Server,
+  },
+  {
+    id: 'restore',
+    title: 'Restore or Migrate',
+    badge: 'Recovery',
+    description: 'Check desktop paths and select a backup bundle before continuing setup.',
+    icon: DatabaseBackup,
+  },
+];
+
+function getDesktopBridge(): DesktopBridgeApi | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return ((window as Window & { veritasDesktop?: DesktopBridgeApi }).veritasDesktop ??
+    null) as DesktopBridgeApi | null;
+}
+
+function readOnboardingComplete(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(DESKTOP_ONBOARDING_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function markDesktopOnboardingComplete(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(DESKTOP_ONBOARDING_STORAGE_KEY, 'true');
+  } catch {
+    // Local storage can be unavailable in restricted browser contexts.
+  }
+}
+
+export function shouldShowDesktopOnboarding(): boolean {
+  return !readOnboardingComplete();
+}
+
+function stateLabel(state: HealthState): string {
+  switch (state) {
+    case 'ok':
+      return 'Ready';
+    case 'warning':
+      return 'Needs Review';
+    case 'failed':
+      return 'Failed';
+    case 'unsupported':
+      return 'Unsupported';
+    default:
+      return 'Unknown';
+  }
+}
+
+function stateClass(state: HealthState): string {
+  switch (state) {
+    case 'ok':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+    case 'warning':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-300';
+    case 'failed':
+      return 'border-red-500/30 bg-red-500/10 text-red-300';
+    default:
+      return 'border-border bg-muted/40 text-muted-foreground';
+  }
+}
+
+function formatCheckName(name: string): string {
+  return name
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function fallbackDiagnostics(): DesktopSetupDiagnostics {
+  const checkedAt = new Date().toISOString();
+  return {
+    generatedAt: checkedAt,
+    checks: [
+      {
+        name: 'desktop-bridge',
+        state: 'unsupported',
+        detail: 'Desktop bridge is not available in this browser session.',
+        checkedAt,
+      },
+    ],
+    supportSnapshot: null,
+  };
+}
+
+async function validateRemoteWithoutDesktop(
+  serverUrl: string
+): Promise<DesktopConnectionValidationResult> {
+  try {
+    const parsed = new URL(serverUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Remote server URL protocol is not allowed.');
+    }
+    if (parsed.username || parsed.password) {
+      throw new Error('Remote server URL credentials are not allowed.');
+    }
+    return {
+      mode: 'remote',
+      valid: true,
+      normalizedServerUrl: parsed.toString(),
+      warnings: ['Live reachability checks require the desktop app.'],
+      errors: [],
+    };
+  } catch (error) {
+    return {
+      mode: 'remote',
+      valid: false,
+      normalizedServerUrl: null,
+      warnings: [],
+      errors: [error instanceof Error ? error.message : 'Remote server URL is invalid.'],
+    };
+  }
+}
+
+function remoteValidationTitle(result: DesktopConnectionValidationResult): string {
+  if (!result.valid) {
+    return 'Remote validation failed.';
+  }
+
+  if (result.warnings.includes('Live reachability checks require the desktop app.')) {
+    return 'URL syntax is valid.';
+  }
+
+  return 'Remote target is reachable.';
+}
+
+export function DesktopOnboardingPanel({
+  onContinue,
+  compact = false,
+}: DesktopOnboardingPanelProps) {
+  const [selectedMode, setSelectedMode] = useState<SetupMode>('board');
+  const [diagnostics, setDiagnostics] = useState<DesktopSetupDiagnostics | null>(null);
+  const [diagnosticsLoading, setDiagnosticsLoading] = useState(false);
+  const [copiedDiagnostics, setCopiedDiagnostics] = useState(false);
+  const [remoteUrl, setRemoteUrl] = useState('');
+  const [remoteToken, setRemoteToken] = useState('');
+  const [remoteResult, setRemoteResult] = useState<DesktopConnectionValidationResult | null>(null);
+  const [remoteLoading, setRemoteLoading] = useState(false);
+  const [restoreFiles, setRestoreFiles] = useState<DesktopSelectedFile[]>([]);
+  const desktopBridge = useMemo(() => getDesktopBridge(), []);
+
+  const loadDiagnostics = useCallback(async () => {
+    setDiagnosticsLoading(true);
+    try {
+      setDiagnostics(
+        desktopBridge ? await desktopBridge.getSetupDiagnostics() : fallbackDiagnostics()
+      );
+    } finally {
+      setDiagnosticsLoading(false);
+    }
+  }, [desktopBridge]);
+
+  useEffect(() => {
+    void loadDiagnostics();
+  }, [loadDiagnostics]);
+
+  const validateRemote = async () => {
+    setRemoteLoading(true);
+    setRemoteResult(null);
+    try {
+      const result = desktopBridge
+        ? await desktopBridge.validateConnectionConfig({
+            mode: 'remote',
+            serverUrl: remoteUrl,
+            serverToken: remoteToken || undefined,
+          })
+        : await validateRemoteWithoutDesktop(remoteUrl);
+      setRemoteResult(result);
+    } finally {
+      setRemoteLoading(false);
+    }
+  };
+
+  const pickRestoreFile = async () => {
+    if (!desktopBridge?.pickUploadFiles) {
+      setRestoreFiles([]);
+      return;
+    }
+    const result = await desktopBridge.pickUploadFiles({
+      purpose: 'backup-restore',
+      allowMultiple: false,
+      allowedExtensions: ['.json', '.zip', '.db'],
+    });
+    setRestoreFiles(result.cancelled ? [] : result.files);
+  };
+
+  const copyDiagnostics = async () => {
+    if (!diagnostics) return;
+    await navigator.clipboard.writeText(JSON.stringify(diagnostics, null, 2));
+    setCopiedDiagnostics(true);
+    setTimeout(() => setCopiedDiagnostics(false), 2000);
+  };
+
+  const canContinue = selectedMode !== 'remote' || remoteResult?.valid;
+
+  return (
+    <div
+      className={cn(
+        'grid w-full gap-6 text-foreground lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]',
+        compact ? 'max-w-5xl' : 'max-w-6xl'
+      )}
+    >
+      <section className="space-y-5">
+        <div className="space-y-3">
+          <Badge variant="outline" className="border-cyan-500/30 text-cyan-300">
+            v5 Desktop Setup
+          </Badge>
+          <div className="space-y-2">
+            <h1 className={cn('font-bold tracking-normal', compact ? 'text-2xl' : 'text-3xl')}>
+              Choose setup path
+            </h1>
+            <p className="max-w-xl text-sm leading-6 text-muted-foreground">
+              Start with the board, then layer in agents, remote access, and recovery paths when
+              they are needed.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-2">
+          {['Select path', 'Check readiness', 'Secure board'].map((step, index) => (
+            <div key={step} className="flex items-center gap-3 rounded-lg border bg-card/60 p-3">
+              <span className="flex size-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+                {index + 1}
+              </span>
+              <span className="text-sm font-medium">{step}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="rounded-lg border bg-card/60 p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold">Readiness</h2>
+              <p className="text-xs text-muted-foreground">Redacted desktop diagnostics</p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={loadDiagnostics}
+              disabled={diagnosticsLoading}
+            >
+              {diagnosticsLoading ? (
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RotateCw className="mr-1 h-3.5 w-3.5" />
+              )}
+              Refresh
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {(diagnostics?.checks ?? []).slice(0, 6).map((check) => (
+              <div
+                key={check.name}
+                className="flex items-start justify-between gap-3 rounded-md border bg-background/50 p-2"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-medium">{formatCheckName(check.name)}</div>
+                  <div className="truncate text-xs text-muted-foreground">{check.detail}</div>
+                </div>
+                <span
+                  className={cn(
+                    'shrink-0 rounded-full border px-2 py-0.5 text-[0.68rem] font-semibold',
+                    stateClass(check.state)
+                  )}
+                >
+                  {stateLabel(check.state)}
+                </span>
+              </div>
+            ))}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3 w-full"
+            onClick={copyDiagnostics}
+            disabled={!diagnostics}
+          >
+            <Clipboard className="mr-1.5 h-3.5 w-3.5" />
+            {copiedDiagnostics ? 'Copied' : 'Copy Diagnostics'}
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {setupModes.map((mode) => {
+            const Icon = mode.icon;
+            const selected = selectedMode === mode.id;
+            return (
+              <button
+                key={mode.id}
+                type="button"
+                data-testid={`setup-mode-${mode.id}`}
+                onClick={() => setSelectedMode(mode.id)}
+                className={cn(
+                  'min-h-36 rounded-lg border bg-card p-4 text-left transition-colors hover:border-primary/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none',
+                  selected && 'border-primary bg-primary/5'
+                )}
+              >
+                <div className="mb-4 flex items-center justify-between gap-3">
+                  <span className="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <Badge variant={mode.id === 'board' ? 'default' : 'outline'}>{mode.badge}</Badge>
+                </div>
+                <div className="space-y-1">
+                  <h2 className="text-base font-semibold">{mode.title}</h2>
+                  <p className="text-sm leading-5 text-muted-foreground">{mode.description}</p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="rounded-lg border bg-card p-4">
+          {selectedMode === 'board' && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <ShieldCheck className="h-4 w-4 text-emerald-400" />
+                Local board setup
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Veritas will create a local SQLite-backed workspace, store desktop secrets through
+                the native secret store when available, and keep optional integrations disabled.
+              </p>
+            </div>
+          )}
+
+          {selectedMode === 'agent' && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Bot className="h-4 w-4 text-cyan-300" />
+                Agent readiness
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Agent setup remains optional. Use diagnostics after password setup to verify API,
+                CLI, MCP, and runner access before starting agent work.
+              </p>
+            </div>
+          )}
+
+          {selectedMode === 'remote' && (
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <Server className="h-4 w-4 text-violet-300" />
+                  Remote validation
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Validate reachability now. Pairing, device sessions, and tunnels are completed by
+                  the remote-security workstream.
+                </p>
+              </div>
+              <div className="grid gap-3">
+                <div className="grid gap-2">
+                  <Label htmlFor="remote-url">Server URL</Label>
+                  <Input
+                    id="remote-url"
+                    value={remoteUrl}
+                    onChange={(event) => {
+                      setRemoteUrl(event.target.value);
+                      setRemoteResult(null);
+                    }}
+                    placeholder="https://veritas.example.com"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="remote-token">Token</Label>
+                  <Input
+                    id="remote-token"
+                    type="password"
+                    value={remoteToken}
+                    onChange={(event) => setRemoteToken(event.target.value)}
+                    placeholder="Optional scoped token"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={validateRemote}
+                  disabled={!remoteUrl || remoteLoading}
+                >
+                  {remoteLoading ? (
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Server className="mr-1.5 h-4 w-4" />
+                  )}
+                  Validate Remote
+                </Button>
+                {remoteResult && (
+                  <div
+                    className={cn(
+                      'rounded-lg border p-3 text-sm',
+                      remoteResult.valid
+                        ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100'
+                        : 'border-red-500/30 bg-red-500/10 text-red-100'
+                    )}
+                  >
+                    <div className="mb-1 flex items-center gap-2 font-medium">
+                      {remoteResult.valid ? (
+                        <CheckCircle2 className="h-4 w-4" />
+                      ) : (
+                        <AlertCircle className="h-4 w-4" />
+                      )}
+                      {remoteValidationTitle(remoteResult)}
+                    </div>
+                    {[...remoteResult.warnings, ...remoteResult.errors].map((message) => (
+                      <div key={message} className="text-xs opacity-90">
+                        {message}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {selectedMode === 'restore' && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Upload className="h-4 w-4 text-amber-300" />
+                Restore preflight
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Desktop startup already copies legacy profile data forward without deleting it.
+                Select a backup bundle now, then complete restore from Data settings after setup.
+              </p>
+              <Button type="button" variant="outline" onClick={pickRestoreFile}>
+                <Upload className="mr-1.5 h-4 w-4" />
+                Select Backup Bundle
+              </Button>
+              {restoreFiles.length > 0 && (
+                <div className="rounded-md border bg-background/50 p-2 text-sm">
+                  {restoreFiles.map((file) => (
+                    <div key={file.path} className="truncate">
+                      {file.name}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {onContinue && (
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              className="sm:min-w-44"
+              disabled={!canContinue}
+              onClick={() => {
+                markDesktopOnboardingComplete();
+                onContinue();
+              }}
+            >
+              Continue to Password
+            </Button>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export function DesktopOnboardingScreen({ onContinue }: { onContinue: () => void }) {
+  return (
+    <div className="min-h-screen bg-background px-4 py-8">
+      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+        <DesktopOnboardingPanel onContinue={onContinue} />
+      </div>
+    </div>
+  );
+}
+
+export function DesktopOnboardingDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Setup & Diagnostics</DialogTitle>
+          <DialogDescription>
+            Recheck desktop readiness, copy redacted diagnostics, and validate remote targets.
+          </DialogDescription>
+        </DialogHeader>
+        <DesktopOnboardingPanel compact />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/auth/SetupScreen.tsx
+++ b/web/src/components/auth/SetupScreen.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Eye, EyeOff, Copy, Download, Check, Shield, Key } from 'lucide-react';
+import { DesktopOnboardingScreen, shouldShowDesktopOnboarding } from './DesktopOnboarding';
 
 // Password strength calculation
 function getPasswordStrength(password: string): { score: number; label: string; color: string } {
@@ -14,7 +15,7 @@ function getPasswordStrength(password: string): { score: number; label: string; 
   if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score++;
   if (/\d/.test(password)) score++;
   if (/[^a-zA-Z0-9]/.test(password)) score++;
-  
+
   if (score <= 1) return { score, label: 'Weak', color: 'bg-red-500' };
   if (score <= 2) return { score, label: 'Fair', color: 'bg-orange-500' };
   if (score <= 3) return { score, label: 'Good', color: 'bg-yellow-500' };
@@ -24,12 +25,13 @@ function getPasswordStrength(password: string): { score: number; label: string; 
 
 export function SetupScreen() {
   const { setup } = useAuth();
+  const [showOnboarding, setShowOnboarding] = useState(() => shouldShowDesktopOnboarding());
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   // Recovery key state
   const [recoveryKey, setRecoveryKey] = useState<string | null>(null);
   const [copiedKey, setCopiedKey] = useState(false);
@@ -39,21 +41,25 @@ export function SetupScreen() {
   const passwordsMatch = password === confirmPassword;
   const isValid = password.length >= 8 && passwordsMatch;
 
+  if (showOnboarding) {
+    return <DesktopOnboardingScreen onContinue={() => setShowOnboarding(false)} />;
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isValid || isSubmitting) return;
-    
+
     setIsSubmitting(true);
     setError(null);
-    
+
     const result = await setup(password);
-    
+
     if (result.success && result.recoveryKey) {
       setRecoveryKey(result.recoveryKey);
     } else {
       setError(result.error || 'Setup failed');
     }
-    
+
     setIsSubmitting(false);
   };
 
@@ -67,7 +73,9 @@ export function SetupScreen() {
   const downloadRecoveryKey = () => {
     if (!recoveryKey) return;
     const blob = new Blob(
-      [`Veritas Kanban Recovery Key\n\nYour recovery key: ${recoveryKey}\n\nKeep this file safe! You will need it if you forget your password.\n\nGenerated: ${new Date().toISOString()}`],
+      [
+        `Veritas Kanban Recovery Key\n\nYour recovery key: ${recoveryKey}\n\nKeep this file safe! You will need it if you forget your password.\n\nGenerated: ${new Date().toISOString()}`,
+      ],
       { type: 'text/plain' }
     );
     const url = URL.createObjectURL(blob);
@@ -96,9 +104,7 @@ export function SetupScreen() {
           </div>
 
           <div className="bg-muted/50 border border-border rounded-lg p-4 space-y-3">
-            <div className="font-mono text-xl text-center tracking-wider py-2">
-              {recoveryKey}
-            </div>
+            <div className="font-mono text-xl text-center tracking-wider py-2">{recoveryKey}</div>
             <div className="flex gap-2">
               <Button variant="outline" className="flex-1" onClick={copyRecoveryKey}>
                 {copiedKey ? <Check className="w-4 h-4 mr-2" /> : <Copy className="w-4 h-4 mr-2" />}


### PR DESCRIPTION
## Summary
- Add first-run desktop onboarding before password setup with Board Only, Agent Ready, Remote Server, and Restore or Migrate paths.
- Add redacted setup diagnostics and a Setup & Diagnostics desktop menu command.
- Validate remote server URL and token reachability through the desktop bridge.
- Add coverage for onboarding flow, remote validation, desktop diagnostics, and menu wiring.

## Verification
- pnpm --filter @veritas-kanban/desktop typecheck
- pnpm --filter @veritas-kanban/desktop test
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test -- src/__tests__/desktop-onboarding.test.tsx
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Browser smoke on http://127.0.0.1:3000: onboarding rendered, remote fallback showed URL syntax only, Continue reached password setup, no console warnings or errors
- pnpm desktop:package:mac:unsigned
- Packaged app smoke with package-smoke-343 profile: app-owned server listened on 127.0.0.1:3001, /api/health returned OK, packaged server launched from Contents/Resources/server/dist/index.js

Closes #343