### PR TITLE
Migrate archive and backlog surfaces to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -11,33 +11,33 @@ component primitives are not the right abstraction.
 
 ## Current Inventory
 
-The current web app uses React, Vite, Tailwind, shadcn/Radix primitives, lucide
-icons, custom CSS tokens in `web/src/globals.css`, and product-specific feature
-components.
+The current web app uses React, Vite, Tailwind, Mantine-backed compatibility
+wrappers, lucide icons, custom CSS tokens in `web/src/globals.css`, and
+product-specific feature components.
 
 Current shared primitive usage:
 
-| Primitive                         | Current state                                                  | Observed use |
-| --------------------------------- | -------------------------------------------------------------- | ------------ |
-| `button`                          | Mantine Button/ActionIcon wrapper with Radix Slot escape hatch | 73 imports   |
-| `input`                           | Mantine Input compatibility wrapper                            | 41 imports   |
-| `select`                          | Mantine Select compatibility wrapper                           | 39 imports   |
-| `label`                           | Mantine Box label compatibility wrapper                        | 36 imports   |
-| `badge`                           | Mantine Badge wrapper with Radix Slot escape hatch             | 36 imports   |
-| `textarea`                        | Mantine Textarea compatibility wrapper                         | 20 imports   |
-| `skeleton`                        | Mantine Skeleton compatibility wrapper                         | 18 imports   |
-| `alert-dialog`                    | Mantine Modal compatibility wrapper                            | 18 imports   |
-| `scroll-area`                     | Mantine ScrollArea compatibility wrapper                       | 13 imports   |
-| `dialog`                          | Mantine Modal compatibility wrapper                            | 13 imports   |
-| `tabs`                            | Mantine Tabs compatibility wrapper                             | 9 imports    |
-| `checkbox`                        | Mantine Checkbox compatibility wrapper                         | 9 imports    |
-| `switch`                          | Mantine Switch compatibility wrapper                           | 8 imports    |
-| `sheet`                           | Mantine Drawer compatibility wrapper                           | 8 imports    |
-| `tooltip`                         | Mantine Tooltip compatibility wrapper                          | 4 imports    |
-| `popover`                         | Mantine Popover compatibility wrapper                          | 3 imports    |
-| `MarkdownEditor/MarkdownRenderer` | Custom markdown surfaces                                       | 2 imports    |
-| `toast`/`toaster`                 | Mantine Notifications bridge                                   | 1 import     |
-| `data-table`                      | Custom table wrapper                                           | 1 import     |
+| Primitive                         | Current state                                            | Observed use |
+| --------------------------------- | -------------------------------------------------------- | ------------ |
+| `button`                          | Mantine Button/ActionIcon wrapper with local Slot helper | 73 imports   |
+| `input`                           | Mantine Input compatibility wrapper                      | 41 imports   |
+| `select`                          | Mantine Select compatibility wrapper                     | 39 imports   |
+| `label`                           | Mantine Box label compatibility wrapper                  | 36 imports   |
+| `badge`                           | Mantine Badge wrapper with local Slot helper             | 36 imports   |
+| `textarea`                        | Mantine Textarea compatibility wrapper                   | 20 imports   |
+| `skeleton`                        | Mantine Skeleton compatibility wrapper                   | 18 imports   |
+| `alert-dialog`                    | Mantine Modal compatibility wrapper                      | 18 imports   |
+| `scroll-area`                     | Mantine ScrollArea compatibility wrapper                 | 13 imports   |
+| `dialog`                          | Mantine Modal compatibility wrapper                      | 13 imports   |
+| `tabs`                            | Mantine Tabs compatibility wrapper                       | 9 imports    |
+| `checkbox`                        | Mantine Checkbox compatibility wrapper                   | 9 imports    |
+| `switch`                          | Mantine Switch compatibility wrapper                     | 8 imports    |
+| `sheet`                           | Mantine Drawer compatibility wrapper                     | 8 imports    |
+| `tooltip`                         | Mantine Tooltip compatibility wrapper                    | 4 imports    |
+| `popover`                         | Mantine Popover compatibility wrapper                    | 3 imports    |
+| `MarkdownEditor/MarkdownRenderer` | Custom markdown surfaces                                 | 2 imports    |
+| `toast`/`toaster`                 | Mantine Notifications bridge                             | 1 import     |
+| `data-table`                      | Custom table wrapper                                     | 1 import     |
 
 Shared primitive migration progress:
 
@@ -46,10 +46,10 @@ Shared primitive migration progress:
   `scroll-area`, `number-input`, `dialog`, `sheet`, `alert-dialog`, `popover`,
   `tooltip`, `tabs`, `select`, and the app-level `toaster` delivery path.
 - No shared `components/ui` primitive wrapper remains backed by a Radix
-  interaction primitive. Radix Slot can stay temporarily for `asChild`
+  interaction primitive. A local Slot helper now preserves `asChild`
   composition while migrated feature surfaces still depend on that contract.
-- The old direct Radix primitive package dependencies have been removed; only
-  `@radix-ui/react-slot` remains for `button`/`badge` `asChild` composition.
+- The old direct Radix primitive package dependencies, `@radix-ui/react-slot`,
+  and the shadcn package have been removed.
 - Feature surfaces still need visual and keyboard/focus checks before the final
   cleanup gate. New v5 surfaces should prefer Mantine primitives directly unless
   they need one of the compatibility wrappers above.
@@ -69,10 +69,8 @@ High-traffic feature surfaces:
 | Chat/activity        | chat sheets, floating chat, activity feed                                            | Mantine overlays     |
 | Archive/backlog      | archive and backlog list/filter pages                                                | Mantine tables/forms |
 
-Package dependencies still tied to the old primitive layer:
+Legacy helper dependencies still tied to compatibility wrappers:
 
-- `@radix-ui/react-slot` for `button`/`badge` `asChild` composition
-- shadcn CLI/package
 - `class-variance-authority`
 - `tailwind-merge`
 - Tailwind animation helpers used by shadcn-style primitives
@@ -268,6 +266,13 @@ Recommended order:
 8. Dashboard shell and drilldowns
 9. Chat/activity overlays
 10. Board filter/bulk action chrome while preserving custom board internals
+
+Phase 3 progress:
+
+- Auth/setup screens and the app shell/header/command palette have an initial
+  direct Mantine surface slice.
+- Archive and backlog list/filter pages now use direct Mantine layout and form
+  controls while preserving custom task card/list behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/archive-backlog-mantine.test.tsx
+++ b/web/src/__tests__/archive-backlog-mantine.test.tsx
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { ArchivePage } from '@/components/archive/ArchivePage';
+import { BacklogPage } from '@/components/backlog/BacklogPage';
+import {
+  createMockProject,
+  createMockSprint,
+  createMockTask,
+  createMockTaskType,
+  renderWithProviders,
+} from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  bulkPromoteMutateAsync: vi.fn(),
+  deleteBacklogMutateAsync: vi.fn(),
+  refetchArchivedTasks: vi.fn(),
+  restoreTaskMutateAsync: vi.fn(),
+  promoteTaskMutateAsync: vi.fn(),
+  toast: vi.fn(),
+  useArchivedTasks: vi.fn(),
+  useBacklogTasks: vi.fn(),
+  useProjects: vi.fn(),
+  useSprints: vi.fn(),
+  useTaskTypes: vi.fn(),
+}));
+
+vi.mock('@/hooks/useBacklog', () => ({
+  useBacklogTasks: mocks.useBacklogTasks,
+  usePromoteTask: () => ({
+    mutateAsync: mocks.promoteTaskMutateAsync,
+    isPending: false,
+  }),
+  useBulkPromote: () => ({
+    mutateAsync: mocks.bulkPromoteMutateAsync,
+    isPending: false,
+  }),
+  useDeleteBacklogTask: () => ({
+    mutateAsync: mocks.deleteBacklogMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProjects: mocks.useProjects,
+}));
+
+vi.mock('@/hooks/useSprints', () => ({
+  useSprints: mocks.useSprints,
+}));
+
+vi.mock('@/hooks/useTaskTypes', () => ({
+  useTaskTypes: mocks.useTaskTypes,
+}));
+
+vi.mock('@/hooks/useTasks', () => ({
+  useArchivedTasks: mocks.useArchivedTasks,
+  useRestoreTask: () => ({
+    mutateAsync: mocks.restoreTaskMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  toast: mocks.toast,
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+describe('Archive and backlog Mantine surfaces', () => {
+  beforeEach(() => {
+    const projects = [createMockProject({ id: 'veritas', label: 'Veritas' })];
+    const taskTypes = [
+      createMockTaskType({ id: 'code', label: 'Code', icon: 'Code' }),
+      createMockTaskType({ id: 'research', label: 'Research', icon: 'Search' }),
+    ];
+    const sprints = [createMockSprint({ id: 'v5', label: 'v5 Release' })];
+
+    mocks.useProjects.mockReturnValue({ data: projects });
+    mocks.useTaskTypes.mockReturnValue({ data: taskTypes });
+    mocks.useSprints.mockReturnValue({ data: sprints });
+    mocks.bulkPromoteMutateAsync.mockResolvedValue({ promoted: [], failed: [] });
+    mocks.deleteBacklogMutateAsync.mockResolvedValue(undefined);
+    mocks.promoteTaskMutateAsync.mockResolvedValue(undefined);
+    mocks.refetchArchivedTasks.mockResolvedValue(undefined);
+    mocks.restoreTaskMutateAsync.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders backlog filters and cards through direct Mantine components', () => {
+    mocks.useBacklogTasks.mockReturnValue({
+      data: [
+        createMockTask({
+          id: 'VK-101',
+          title: 'Backlog API importer',
+          description: 'Queue import work before sprint planning',
+          priority: 'high',
+          project: 'veritas',
+          sprint: 'v5',
+          status: 'todo',
+          type: 'code',
+        }),
+        createMockTask({
+          id: 'VK-102',
+          title: 'Backlog cleanup workflow',
+          description: 'Clean old intake notes',
+          priority: 'medium',
+          project: 'veritas',
+          status: 'todo',
+          type: 'research',
+        }),
+      ],
+      isLoading: false,
+    });
+
+    const { container } = renderWithProviders(<BacklogPage onBack={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: 'Backlog' })).toBeDefined();
+    expect(screen.getByLabelText('Search backlog tasks')).toBeDefined();
+    expect(screen.getByText('Backlog API importer')).toBeDefined();
+    expect(screen.getByText('Backlog cleanup workflow')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelectorAll('.mantine-Checkbox-root').length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(2);
+
+    fireEvent.change(screen.getByLabelText('Search backlog tasks'), {
+      target: { value: 'API' },
+    });
+
+    expect(screen.getByText('Backlog API importer')).toBeDefined();
+    expect(screen.queryByText('Backlog cleanup workflow')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Select all'));
+
+    expect(screen.getByText('1 selected')).toBeDefined();
+  });
+
+  it('renders archive filters, icons, and refresh behavior through direct Mantine components', () => {
+    mocks.useArchivedTasks.mockReturnValue({
+      data: [
+        createMockTask({
+          id: 'VK-201',
+          title: 'Archived release audit',
+          description: 'Evidence retained for the release archive',
+          project: 'veritas',
+          sprint: 'v5',
+          status: 'done',
+          type: 'code',
+        }),
+        createMockTask({
+          id: 'VK-202',
+          title: 'Archived research packet',
+          description: 'Research notes retained for later reference',
+          project: 'veritas',
+          status: 'done',
+          type: 'research',
+        }),
+      ],
+      isLoading: false,
+      isRefetching: false,
+      refetch: mocks.refetchArchivedTasks,
+    });
+
+    const { container } = renderWithProviders(<ArchivePage onBack={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: 'Archive' })).toBeDefined();
+    expect(screen.getByLabelText('Search archived tasks')).toBeDefined();
+    expect(screen.getByText('Archived release audit')).toBeDefined();
+    expect(screen.getByText('Archived research packet')).toBeDefined();
+    expect(screen.getAllByText('v5 Release').length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelectorAll('.mantine-Checkbox-root').length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelectorAll('.mantine-ThemeIcon-root').length).toBeGreaterThanOrEqual(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh archived tasks' }));
+    expect(mocks.refetchArchivedTasks).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText('Search archived tasks'), {
+      target: { value: 'release' },
+    });
+
+    expect(screen.getByText('Archived release audit')).toBeDefined();
+    expect(screen.queryByText('Archived research packet')).toBeNull();
+  });
+});

--- a/web/src/components/archive/ArchivePage.tsx
+++ b/web/src/components/archive/ArchivePage.tsx
@@ -6,31 +6,45 @@
  */
 
 import { useState, useMemo } from 'react';
-import { ArrowLeft, RotateCcw, Search, Calendar, FolderOpen, RefreshCw } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
+  ActionIcon,
+  Checkbox,
+  Group,
+  Paper,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+  SimpleGrid,
+  Stack,
+  Text,
+  TextInput,
+  ThemeIcon,
+} from '@mantine/core';
+import {
+  ArrowLeft,
+  Bot,
+  Calendar,
+  ClipboardList,
+  Code2,
+  FileText,
+  FolderOpen,
+  Microscope,
+  RefreshCw,
+  RotateCcw,
+  Search,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { useArchivedTasks, useRestoreTask } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
 import { useTaskTypes } from '@/hooks/useTaskTypes';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/utils';
-import type { TaskType } from '@veritas-kanban/shared';
 
-const typeIcons: Record<TaskType, string> = {
-  code: '💻',
-  research: '🔬',
-  content: '📝',
-  automation: '🤖',
+const typeIcons = {
+  code: Code2,
+  research: Microscope,
+  content: FileText,
+  automation: Bot,
 };
 
 function formatDate(dateString: string): string {
@@ -67,6 +81,30 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
     const sprintIds = new Set(archivedTasks.map((t) => t.sprint).filter(Boolean) as string[]);
     return sprints.filter((s) => sprintIds.has(s.id));
   }, [archivedTasks, sprints]);
+
+  const projectOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All Projects' },
+      ...projects.map((project) => ({ value: project.id, label: project.label })),
+    ],
+    [projects]
+  );
+
+  const taskTypeOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All Types' },
+      ...taskTypes.map((type) => ({ value: type.id, label: type.label })),
+    ],
+    [taskTypes]
+  );
+
+  const sprintOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All Sprints' },
+      ...archiveSprints.map((sprint) => ({ value: sprint.id, label: sprint.label })),
+    ],
+    [archiveSprints]
+  );
 
   // Filter tasks
   const filteredTasks = useMemo(() => {
@@ -147,132 +185,121 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
   };
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
+    <Stack gap="lg">
+      <Group justify="space-between" align="center" gap="md" wrap="wrap">
+        <Group gap="md" wrap="wrap">
           <Button variant="ghost" size="sm" onClick={onBack}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Back to Board
           </Button>
-          <h1 className="text-2xl font-bold">Archive</h1>
+          <Text component="h1" size="xl" fw={700} lh={1.1} m={0}>
+            Archive
+          </Text>
           <Badge variant="secondary">{filteredTasks.length} tasks</Badge>
           {archivedTasks.length !== filteredTasks.length && (
-            <span className="text-sm text-muted-foreground">of {archivedTasks.length} total</span>
+            <Text size="sm" c="dimmed">
+              of {archivedTasks.length} total
+            </Text>
           )}
-        </div>
+        </Group>
 
-        <div className="flex items-center gap-2">
-          {/* Bulk Actions */}
+        <Group gap="sm">
           {selectedIds.size > 0 && (
             <>
-              <span className="text-sm text-muted-foreground">{selectedIds.size} selected</span>
+              <Text size="sm" c="dimmed">
+                {selectedIds.size} selected
+              </Text>
               <Button size="sm" onClick={handleBulkRestore}>
                 <RotateCcw className="h-4 w-4 mr-2" />
                 Restore to Board
               </Button>
             </>
           )}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
+          <ActionIcon
+            variant="subtle"
+            size="lg"
             onClick={() => refetch()}
             disabled={isRefetching}
-            title="Refresh"
+            aria-label="Refresh archived tasks"
           >
             <RefreshCw className={cn('h-4 w-4', isRefetching && 'animate-spin')} />
-          </Button>
-        </div>
-      </div>
+          </ActionIcon>
+        </Group>
+      </Group>
 
-      {/* Filters */}
-      <div className="flex gap-4 items-center">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search archived tasks..."
+      <Paper withBorder radius="md" p="md">
+        <Group gap="md" align="end" wrap="wrap">
+          <TextInput
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-10"
+            onChange={(event) => setSearch(event.currentTarget.value)}
+            placeholder="Search archived tasks..."
+            aria-label="Search archived tasks"
+            leftSection={<Search className="h-4 w-4" aria-hidden="true" />}
+            className="min-w-[240px] flex-1"
           />
-        </div>
 
-        <Select value={projectFilter} onValueChange={setProjectFilter}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="All Projects" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Projects</SelectItem>
-            {projects.map((project) => (
-              <SelectItem key={project.id} value={project.id}>
-                {project.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select value={typeFilter} onValueChange={setTypeFilter}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="All Types" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Types</SelectItem>
-            {taskTypes.map((type) => (
-              <SelectItem key={type.id} value={type.id}>
-                {type.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        {archiveSprints.length > 0 && (
-          <Select value={sprintFilter} onValueChange={setSprintFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="All Sprints" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Sprints</SelectItem>
-              {archiveSprints.map((sprint) => (
-                <SelectItem key={sprint.id} value={sprint.id}>
-                  {sprint.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      </div>
-
-      {/* Select All */}
-      {filteredTasks.length > 0 && (
-        <div className="flex items-center gap-2">
-          <Checkbox
-            checked={selectedIds.size === filteredTasks.length && filteredTasks.length > 0}
-            onCheckedChange={handleSelectAll}
-            id="select-all-archive"
+          <Select
+            value={projectFilter}
+            onChange={(value) => setProjectFilter(value ?? 'all')}
+            data={projectOptions}
+            aria-label="Filter archive by project"
+            checkIconPosition="right"
+            className="w-[180px]"
           />
-          <label htmlFor="select-all-archive" className="text-sm cursor-pointer">
-            Select all
-          </label>
-        </div>
-      )}
+
+          <Select
+            value={typeFilter}
+            onChange={(value) => setTypeFilter(value ?? 'all')}
+            data={taskTypeOptions}
+            aria-label="Filter archive by type"
+            checkIconPosition="right"
+            className="w-[180px]"
+          />
+
+          {archiveSprints.length > 0 && (
+            <Select
+              value={sprintFilter}
+              onChange={(value) => setSprintFilter(value ?? 'all')}
+              data={sprintOptions}
+              aria-label="Filter archive by sprint"
+              checkIconPosition="right"
+              className="w-[180px]"
+            />
+          )}
+
+          {filteredTasks.length > 0 && (
+            <Checkbox
+              checked={selectedIds.size === filteredTasks.length && filteredTasks.length > 0}
+              onChange={handleSelectAll}
+              id="select-all-archive"
+              label="Select all"
+              className="shrink-0"
+            />
+          )}
+        </Group>
+      </Paper>
 
       {/* Task List */}
       {isLoading ? (
-        <div className="text-center py-12 text-muted-foreground">Loading archived tasks...</div>
+        <Text ta="center" py="xl" c="dimmed">
+          Loading archived tasks...
+        </Text>
       ) : filteredTasks.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">
+        <Text ta="center" py="xl" c="dimmed">
           {search || projectFilter !== 'all' || typeFilter !== 'all'
             ? 'No tasks match your filters'
             : 'No archived tasks'}
-        </div>
+        </Text>
       ) : (
-        <div className="space-y-3">
+        <Stack gap="sm">
           {filteredTasks.map((task) => (
-            <div
+            <Paper
               key={task.id}
+              withBorder
+              radius="md"
+              p="md"
               className={cn(
-                'p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors cursor-pointer',
+                'bg-card hover:bg-accent/50 transition-colors cursor-pointer',
                 selectedIds.has(task.id) && 'ring-2 ring-primary',
                 expandedTaskId === task.id && 'ring-2 ring-accent'
               )}
@@ -280,12 +307,13 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
               <div className="flex items-start gap-3">
                 <Checkbox
                   checked={selectedIds.has(task.id)}
-                  onCheckedChange={() => handleToggleSelect(task.id)}
+                  onChange={() => handleToggleSelect(task.id)}
                   onClick={(e) => e.stopPropagation()}
                   className="mt-1"
                 />
 
-                <div
+                <Stack
+                  gap="sm"
                   className="flex-1 min-w-0"
                   onClick={() => setExpandedTaskId(expandedTaskId === task.id ? null : task.id)}
                   role="button"
@@ -297,16 +325,24 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                     }
                   }}
                 >
-                  <div className="flex items-start justify-between gap-4">
+                  <Group align="flex-start" justify="space-between" gap="md" wrap="nowrap">
                     <div className="flex-1 min-w-0">
-                      <h3 className="font-medium truncate">
-                        <span className="mr-2">{typeIcons[task.type] || '📋'}</span>
-                        {task.title}
-                      </h3>
+                      <Group gap="xs" wrap="nowrap">
+                        <ThemeIcon size="sm" variant="light" color="violet">
+                          {(() => {
+                            const TypeIcon =
+                              typeIcons[task.type as keyof typeof typeIcons] ?? ClipboardList;
+                            return <TypeIcon className="h-3.5 w-3.5" aria-hidden="true" />;
+                          })()}
+                        </ThemeIcon>
+                        <Text fw={600} truncate>
+                          {task.title}
+                        </Text>
+                      </Group>
                       {expandedTaskId !== task.id && task.description && (
-                        <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+                        <Text size="sm" c="dimmed" lineClamp={2} mt={4}>
                           {task.description}
-                        </p>
+                        </Text>
                       )}
                     </div>
 
@@ -329,9 +365,9 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                         Restore
                       </Button>
                     </div>
-                  </div>
+                  </Group>
 
-                  <div className="flex items-center gap-2 mt-3 flex-wrap">
+                  <Group gap="xs" wrap="wrap">
                     <Badge variant="outline" className="text-xs">
                       {task.id}
                     </Badge>
@@ -349,11 +385,11 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                         {sprints.find((s) => s.id === task.sprint)?.label || task.sprint}
                       </Badge>
                     )}
-                    <span className="text-xs text-muted-foreground flex items-center gap-1 ml-auto">
+                    <Text size="xs" c="dimmed" className="ml-auto flex items-center gap-1">
                       <Calendar className="h-3 w-3" />
                       {formatDate(task.updated)}
-                    </span>
-                  </div>
+                    </Text>
+                  </Group>
 
                   {/* Expanded detail view */}
                   {expandedTaskId === task.id && (
@@ -361,32 +397,41 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                       {task.description && (
                         <div>
                           <h4 className="text-sm font-medium mb-1">Description</h4>
-                          <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                          <Text size="sm" c="dimmed" className="whitespace-pre-wrap">
                             {task.description}
-                          </p>
+                          </Text>
                         </div>
                       )}
-                      <div className="grid grid-cols-2 gap-4 text-sm">
-                        <div>
-                          <span className="text-muted-foreground">Created:</span>{' '}
+                      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                        <Text size="sm">
+                          <Text component="span" c="dimmed" inherit>
+                            Created:
+                          </Text>{' '}
                           {new Date(task.created).toLocaleDateString()}
-                        </div>
-                        <div>
-                          <span className="text-muted-foreground">Archived:</span>{' '}
+                        </Text>
+                        <Text size="sm">
+                          <Text component="span" c="dimmed" inherit>
+                            Archived:
+                          </Text>{' '}
                           {new Date(task.updated).toLocaleDateString()}
-                        </div>
+                        </Text>
                         {task.agent && (
-                          <div>
-                            <span className="text-muted-foreground">Agent:</span> {task.agent}
-                          </div>
+                          <Text size="sm">
+                            <Text component="span" c="dimmed" inherit>
+                              Agent:
+                            </Text>{' '}
+                            {task.agent}
+                          </Text>
                         )}
                         {task.status && (
-                          <div>
-                            <span className="text-muted-foreground">Final status:</span>{' '}
+                          <Text size="sm">
+                            <Text component="span" c="dimmed" inherit>
+                              Final status:
+                            </Text>{' '}
                             {task.status}
-                          </div>
+                          </Text>
                         )}
-                      </div>
+                      </SimpleGrid>
                       {task.comments && task.comments.length > 0 && (
                         <div>
                           <h4 className="text-sm font-medium mb-1">
@@ -404,12 +449,12 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                       )}
                     </div>
                   )}
-                </div>
+                </Stack>
               </div>
-            </div>
+            </Paper>
           ))}
-        </div>
+        </Stack>
       )}
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/backlog/BacklogPage.tsx
+++ b/web/src/components/backlog/BacklogPage.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useMemo } from 'react';
+import { Checkbox, Group, Paper, Select, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
 import {
   useBacklogTasks,
   usePromoteTask,
@@ -17,16 +18,7 @@ import {
 import { useProjects } from '@/hooks/useProjects';
 import { useTaskTypes } from '@/hooks/useTaskTypes';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Checkbox } from '@/components/ui/checkbox';
 import { ArrowLeft, ArrowUp, Search, Trash2 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import type { Task } from '@veritas-kanban/shared';
@@ -51,6 +43,22 @@ export function BacklogPage({ onBack }: BacklogPageProps) {
   const promoteTask = usePromoteTask();
   const bulkPromote = useBulkPromote();
   const deleteTask = useDeleteBacklogTask();
+
+  const projectOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All Projects' },
+      ...projects.map((project) => ({ value: project.id, label: project.label })),
+    ],
+    [projects]
+  );
+
+  const taskTypeOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All Types' },
+      ...taskTypes.map((type) => ({ value: type.id, label: type.label })),
+    ],
+    [taskTypes]
+  );
 
   // Filter tasks
   const filteredTasks = useMemo(() => {
@@ -139,101 +147,93 @@ export function BacklogPage({ onBack }: BacklogPageProps) {
   };
 
   const priorityColors = {
-    low: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-    medium: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-    high: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+    low: 'blue',
+    medium: 'yellow',
+    high: 'red',
+    critical: 'pink',
   };
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
+    <Stack gap="lg">
+      <Group justify="space-between" align="center" gap="md" wrap="wrap">
+        <Group gap="md" wrap="wrap">
           <Button variant="ghost" size="sm" onClick={onBack}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Back to Board
           </Button>
-          <h1 className="text-2xl font-bold">Backlog</h1>
+          <Text component="h1" size="xl" fw={700} lh={1.1} m={0}>
+            Backlog
+          </Text>
           <Badge variant="secondary">{filteredTasks.length} tasks</Badge>
-        </div>
+        </Group>
 
-        {/* Bulk Actions */}
         {selectedIds.size > 0 && (
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">{selectedIds.size} selected</span>
+          <Group gap="sm">
+            <Text size="sm" c="dimmed">
+              {selectedIds.size} selected
+            </Text>
             <Button size="sm" onClick={handleBulkPromote} disabled={bulkPromote.isPending}>
               <ArrowUp className="h-4 w-4 mr-2" />
               Promote to Board
             </Button>
-          </div>
+          </Group>
         )}
-      </div>
+      </Group>
 
-      {/* Filters */}
-      <div className="flex gap-4 items-center">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search tasks..."
+      <Paper withBorder radius="md" p="md">
+        <Group gap="md" align="end" wrap="wrap">
+          <TextInput
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-10"
+            onChange={(event) => setSearch(event.currentTarget.value)}
+            placeholder="Search tasks..."
+            aria-label="Search backlog tasks"
+            leftSection={<Search className="h-4 w-4" aria-hidden="true" />}
+            className="min-w-[240px] flex-1"
           />
-        </div>
 
-        <Select value={projectFilter} onValueChange={setProjectFilter}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="All Projects" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Projects</SelectItem>
-            {projects.map((project) => (
-              <SelectItem key={project.id} value={project.id}>
-                {project.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          <Select
+            value={projectFilter}
+            onChange={(value) => setProjectFilter(value ?? 'all')}
+            data={projectOptions}
+            aria-label="Filter backlog by project"
+            checkIconPosition="right"
+            className="w-[180px]"
+          />
 
-        <Select value={typeFilter} onValueChange={setTypeFilter}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="All Types" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Types</SelectItem>
-            {taskTypes.map((type) => (
-              <SelectItem key={type.id} value={type.id}>
-                {type.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          <Select
+            value={typeFilter}
+            onChange={(value) => setTypeFilter(value ?? 'all')}
+            data={taskTypeOptions}
+            aria-label="Filter backlog by type"
+            checkIconPosition="right"
+            className="w-[180px]"
+          />
 
-        {filteredTasks.length > 0 && (
-          <div className="flex items-center gap-2 shrink-0">
+          {filteredTasks.length > 0 && (
             <Checkbox
               checked={selectedIds.size === filteredTasks.length}
-              onCheckedChange={handleSelectAll}
+              onChange={handleSelectAll}
               id="select-all"
+              label="Select all"
+              className="shrink-0"
             />
-            <label htmlFor="select-all" className="text-sm cursor-pointer whitespace-nowrap">
-              Select all
-            </label>
-          </div>
-        )}
-      </div>
+          )}
+        </Group>
+      </Paper>
 
       {/* Task List */}
       {isLoading ? (
-        <div className="text-center py-12 text-muted-foreground">Loading backlog tasks...</div>
+        <Text ta="center" py="xl" c="dimmed">
+          Loading backlog tasks...
+        </Text>
       ) : filteredTasks.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">
+        <Text ta="center" py="xl" c="dimmed">
           {search || projectFilter !== 'all' || typeFilter !== 'all'
             ? 'No tasks match your filters'
             : 'No tasks in backlog'}
-        </div>
+        </Text>
       ) : (
-        <div className="space-y-3">
+        <Stack gap="sm">
           {filteredTasks.map((task) => (
             <BacklogTaskCard
               key={task.id}
@@ -247,9 +247,9 @@ export function BacklogPage({ onBack }: BacklogPageProps) {
               priorityColors={priorityColors}
             />
           ))}
-        </div>
+        </Stack>
       )}
-    </div>
+    </Stack>
   );
 }
 
@@ -275,9 +275,12 @@ function BacklogTaskCard({
   priorityColors,
 }: BacklogTaskCardProps) {
   return (
-    <div
+    <Paper
+      withBorder
+      radius="md"
+      p="md"
       className={cn(
-        'p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors cursor-pointer',
+        'bg-card hover:bg-accent/50 transition-colors cursor-pointer',
         isSelected && 'ring-2 ring-primary',
         isExpanded && 'ring-2 ring-accent'
       )}
@@ -285,12 +288,13 @@ function BacklogTaskCard({
       <div className="flex items-start gap-3">
         <Checkbox
           checked={isSelected}
-          onCheckedChange={onToggleSelect}
+          onChange={onToggleSelect}
           onClick={(e) => e.stopPropagation()}
           className="mt-1"
         />
 
-        <div
+        <Stack
+          gap="sm"
           className="flex-1 min-w-0"
           onClick={onClick}
           role="button"
@@ -302,13 +306,15 @@ function BacklogTaskCard({
             }
           }}
         >
-          <div className="flex items-start justify-between gap-4">
+          <Group align="flex-start" justify="space-between" gap="md" wrap="nowrap">
             <div className="flex-1 min-w-0">
-              <h3 className="font-medium truncate">{task.title}</h3>
+              <Text fw={600} truncate>
+                {task.title}
+              </Text>
               {!isExpanded && task.description && (
-                <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+                <Text size="sm" c="dimmed" lineClamp={2} mt={4}>
                   {task.description}
-                </p>
+                </Text>
               )}
             </div>
 
@@ -335,13 +341,15 @@ function BacklogTaskCard({
                 <Trash2 className="h-3 w-3" />
               </Button>
             </div>
-          </div>
+          </Group>
 
-          <div className="flex items-center gap-2 mt-3 flex-wrap">
+          <Group gap="xs" wrap="wrap">
             <Badge variant="outline" className="text-xs">
               {task.id}
             </Badge>
-            <Badge className={cn('text-xs', priorityColors[task.priority])}>{task.priority}</Badge>
+            <Badge color={priorityColors[task.priority] ?? 'gray'} className="text-xs">
+              {task.priority}
+            </Badge>
             <Badge variant="secondary" className="text-xs">
               {task.type}
             </Badge>
@@ -360,7 +368,7 @@ function BacklogTaskCard({
                 {task.subtasks.filter((st) => st.completed).length}/{task.subtasks.length} subtasks
               </Badge>
             )}
-          </div>
+          </Group>
 
           {/* Expanded detail view */}
           {isExpanded && (
@@ -368,26 +376,33 @@ function BacklogTaskCard({
               {task.description && (
                 <div>
                   <h4 className="text-sm font-medium mb-1">Description</h4>
-                  <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                  <Text size="sm" c="dimmed" className="whitespace-pre-wrap">
                     {task.description}
-                  </p>
+                  </Text>
                 </div>
               )}
-              <div className="grid grid-cols-2 gap-4 text-sm">
-                <div>
-                  <span className="text-muted-foreground">Created:</span>{' '}
+              <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                <Text size="sm">
+                  <Text component="span" c="dimmed" inherit>
+                    Created:
+                  </Text>{' '}
                   {new Date(task.created).toLocaleDateString()}
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Updated:</span>{' '}
+                </Text>
+                <Text size="sm">
+                  <Text component="span" c="dimmed" inherit>
+                    Updated:
+                  </Text>{' '}
                   {new Date(task.updated).toLocaleDateString()}
-                </div>
+                </Text>
                 {task.agent && (
-                  <div>
-                    <span className="text-muted-foreground">Agent:</span> {task.agent}
-                  </div>
+                  <Text size="sm">
+                    <Text component="span" c="dimmed" inherit>
+                      Agent:
+                    </Text>{' '}
+                    {task.agent}
+                  </Text>
                 )}
-              </div>
+              </SimpleGrid>
               {task.comments && task.comments.length > 0 && (
                 <div>
                   <h4 className="text-sm font-medium mb-1">Comments ({task.comments.length})</h4>
@@ -400,8 +415,8 @@ function BacklogTaskCard({
               )}
             </div>
           )}
-        </div>
+        </Stack>
       </div>
-    </div>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- migrate the archive and backlog full-page list/filter surfaces to direct Mantine layout, form, card, icon, and action primitives
- keep the existing task-card behaviors for search, filtering, selection, promote, restore, and refresh flows
- update the Mantine migration inventory and progress notes

## Verification
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test -- src/__tests__/archive-backlog-mantine.test.tsx
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check

Advances #417