### PR TITLE
Migrate shared settings rows to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -280,6 +280,9 @@ Phase 3 progress:
   scroll area, and import/export/reset controls now use direct Mantine
   primitives while keeping lazy tab content and destructive confirmation behavior
   stable.
+- Shared settings row, toggle, and section header primitives now use direct
+  Mantine layout, text, switch, and button components while preserving existing
+  tab APIs.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/settings-shared-mantine.test.tsx
+++ b/web/src/__tests__/settings-shared-mantine.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { SectionHeader, SettingRow, ToggleRow } from '@/components/settings/shared';
+import { renderWithProviders } from './test-utils';
+
+describe('Settings shared Mantine rows', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders setting rows with direct Mantine layout and text primitives', () => {
+    const { container } = renderWithProviders(
+      <SettingRow label="Example setting" description="Helpful context">
+        <span>Control</span>
+      </SettingRow>
+    );
+
+    expect(screen.getByText('Example setting')).toBeDefined();
+    expect(screen.getByText('Helpful context')).toBeDefined();
+    expect(container.querySelector('.mantine-Group-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Text-root')).toBeDefined();
+  });
+
+  it('renders toggles through Mantine Switch and preserves checked changes', () => {
+    const onCheckedChange = vi.fn();
+    const { container } = renderWithProviders(
+      <ToggleRow label="Enable feature" checked={false} onCheckedChange={onCheckedChange} />
+    );
+
+    expect(container.querySelector('.mantine-Switch-root')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable feature' }));
+
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders section reset actions through Mantine Button', () => {
+    const { container } = renderWithProviders(<SectionHeader title="Board" onReset={vi.fn()} />);
+
+    expect(screen.getByText('Board')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+  });
+});

--- a/web/src/components/settings/shared/SectionHeader.tsx
+++ b/web/src/components/settings/shared/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@/components/ui/button';
+import { Button, Group, Text } from '@mantine/core';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,13 +14,20 @@ import { RotateCcw } from 'lucide-react';
 
 export function SectionHeader({ title, onReset }: { title: string; onReset?: () => void }) {
   return (
-    <div className="flex items-center justify-between pb-2 mb-2 border-b">
-      <h4 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">{title}</h4>
+    <Group justify="space-between" align="center" className="mb-2 border-b pb-2">
+      <Text size="sm" fw={600} c="dimmed" tt="uppercase">
+        {title}
+      </Text>
       {onReset && (
         <AlertDialog>
           <AlertDialogTrigger asChild>
-            <Button variant="ghost" size="sm" className="h-7 text-xs text-muted-foreground">
-              <RotateCcw className="h-3 w-3 mr-1" />
+            <Button
+              type="button"
+              variant="subtle"
+              size="xs"
+              color="gray"
+              leftSection={<RotateCcw className="h-3 w-3" />}
+            >
               Reset
             </Button>
           </AlertDialogTrigger>
@@ -38,6 +45,6 @@ export function SectionHeader({ title, onReset }: { title: string; onReset?: () 
           </AlertDialogContent>
         </AlertDialog>
       )}
-    </div>
+    </Group>
   );
 }

--- a/web/src/components/settings/shared/SettingRow.tsx
+++ b/web/src/components/settings/shared/SettingRow.tsx
@@ -1,19 +1,29 @@
 import { memo } from 'react';
+import type { ReactNode } from 'react';
+import { Group, Stack, Text } from '@mantine/core';
 
-export const SettingRow = memo(function SettingRow({ label, description, children }: {
+export const SettingRow = memo(function SettingRow({
+  label,
+  description,
+  children,
+}: {
   label: string;
   description?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between py-3 gap-4">
-      <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium">{label}</div>
+    <Group justify="space-between" align="center" gap="md" py="sm" wrap="nowrap">
+      <Stack gap={2} className="min-w-0 flex-1">
+        <Text size="sm" fw={500}>
+          {label}
+        </Text>
         {description && (
-          <div className="text-xs text-muted-foreground mt-0.5">{description}</div>
+          <Text size="xs" c="dimmed">
+            {description}
+          </Text>
         )}
-      </div>
+      </Stack>
       <div className="flex-shrink-0">{children}</div>
-    </div>
+    </Group>
   );
 });

--- a/web/src/components/settings/shared/ToggleRow.tsx
+++ b/web/src/components/settings/shared/ToggleRow.tsx
@@ -1,9 +1,13 @@
 import { memo } from 'react';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
+import { Switch } from '@mantine/core';
 import { SettingRow } from './SettingRow';
 
-export const ToggleRow = memo(function ToggleRow({ label, description, checked, onCheckedChange }: {
+export const ToggleRow = memo(function ToggleRow({
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
   label: string;
   description?: string;
   checked: boolean;
@@ -12,8 +16,12 @@ export const ToggleRow = memo(function ToggleRow({ label, description, checked, 
   const id = `toggle-${label.toLowerCase().replace(/\s+/g, '-')}`;
   return (
     <SettingRow label={label} description={description}>
-      <Label htmlFor={id} className="sr-only">{label}</Label>
-      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} aria-label={label} />
+      <Switch
+        id={id}
+        checked={checked}
+        onChange={(event) => onCheckedChange(event.currentTarget.checked)}
+        aria-label={label}
+      />
     </SettingRow>
   );
 });


### PR DESCRIPTION
## Summary
- Migrates shared settings row, toggle, and section header primitives to direct Mantine layout, text, switch, and button components.
- Preserves existing settings tab APIs and reset confirmation behavior.
- Adds focused shared-row coverage and updates the Mantine migration tracker.
- Advances #417.

## Verification
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test -- src/__tests__/settings-shared-mantine.test.tsx
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Browser smoke: Settings -> Board tab, confirmed direct Mantine shared row/switch/button/text roots, toggled a temporary setting off and back on, no console errors.