### PR TITLE
Migrate security settings to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -289,6 +289,9 @@ Phase 3 progress:
 - General settings now uses direct Mantine switch, text input, select, button,
   badge, and icon action primitives for theme, profile, repository, and default
   agent controls.
+- Security settings and the settings error fallback now use direct Mantine
+  password input and button primitives while preserving password-change,
+  visibility, reset, and retry behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/settings-security-mantine.test.tsx
+++ b/web/src/__tests__/settings-security-mantine.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { SecurityTab } from '@/components/settings/tabs/SecurityTab';
+import { SettingsErrorBoundary } from '@/components/settings/shared/SettingsErrorBoundary';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  changePassword: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    changePassword: mocks.changePassword,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: mocks.toast,
+  }),
+}));
+
+describe('Security settings Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.changePassword.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders password controls through direct Mantine primitives and changes passwords', async () => {
+    const { container } = renderWithProviders(<SecurityTab />);
+
+    expect(screen.getByLabelText('Current Password')).toBeDefined();
+    expect(screen.getByLabelText('New Password')).toBeDefined();
+    expect(screen.getByLabelText('Confirm New Password')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-PasswordInput-root')).toHaveLength(3);
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(2);
+
+    fireEvent.change(screen.getByLabelText('Current Password'), {
+      target: { value: 'current-pass' },
+    });
+    fireEvent.change(screen.getByLabelText('New Password'), {
+      target: { value: 'New-Password-123!' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm New Password'), {
+      target: { value: 'New-Password-123!' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Change Password' }));
+
+    await waitFor(() => {
+      expect(mocks.changePassword).toHaveBeenCalledWith('current-pass', 'New-Password-123!');
+    });
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Password changed' })
+    );
+  });
+
+  it('renders the settings error fallback through Mantine buttons', () => {
+    let shouldThrow = true;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    function FlakySettingsSection() {
+      if (shouldThrow) throw new Error('settings exploded');
+      return <div>Recovered settings</div>;
+    }
+
+    const { container } = renderWithProviders(
+      <SettingsErrorBoundary tabName="Security">
+        <FlakySettingsSection />
+      </SettingsErrorBoundary>
+    );
+
+    expect(screen.getByText('This section failed to load')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Button-root')).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show error details' }));
+
+    expect(screen.getAllByText(/settings exploded/).length).toBeGreaterThanOrEqual(1);
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+
+    expect(screen.getByText('Recovered settings')).toBeDefined();
+    consoleError.mockRestore();
+  });
+});

--- a/web/src/components/settings/shared/SettingsErrorBoundary.tsx
+++ b/web/src/components/settings/shared/SettingsErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import React, { Component, ReactNode } from 'react';
 import { AlertCircle, ChevronDown, ChevronUp, RotateCcw } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { Button } from '@mantine/core';
 
 interface SettingsErrorBoundaryProps {
   tabName: string;
@@ -58,23 +58,28 @@ export class SettingsErrorBoundary extends Component<
                   This section failed to load
                 </h3>
                 <p className="text-sm text-muted-foreground">
-                  The {this.props.tabName} tab encountered an unexpected error and couldn't render properly.
+                  The {this.props.tabName} tab encountered an unexpected error and couldn't render
+                  properly.
                 </p>
-                
+
                 {this.state.error && (
                   <div className="pt-2">
-                    <button
+                    <Button
                       onClick={this.toggleErrorDetails}
-                      className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      variant="subtle"
+                      color="gray"
+                      size="compact-xs"
+                      leftSection={
+                        this.state.errorExpanded ? (
+                          <ChevronUp className="h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3" />
+                        )
+                      }
                     >
-                      {this.state.errorExpanded ? (
-                        <ChevronUp className="h-3 w-3" />
-                      ) : (
-                        <ChevronDown className="h-3 w-3" />
-                      )}
                       {this.state.errorExpanded ? 'Hide' : 'Show'} error details
-                    </button>
-                    
+                    </Button>
+
                     {this.state.errorExpanded && (
                       <div className="mt-2 p-3 rounded bg-background/50 border border-border">
                         <code className="text-xs text-red-400 break-all whitespace-pre-wrap">
@@ -97,9 +102,8 @@ export class SettingsErrorBoundary extends Component<
                 onClick={this.handleReset}
                 variant="outline"
                 size="sm"
-                className="gap-2"
+                leftSection={<RotateCcw className="h-3.5 w-3.5" />}
               >
-                <RotateCcw className="h-3.5 w-3.5" />
                 Try Again
               </Button>
             </div>

--- a/web/src/components/settings/tabs/SecurityTab.tsx
+++ b/web/src/components/settings/tabs/SecurityTab.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { Button, PasswordInput } from '@mantine/core';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -92,34 +90,32 @@ export function SecurityTab() {
 
         <div className="space-y-4 max-w-md">
           <div className="space-y-2">
-            <Label htmlFor="current-password">Current Password</Label>
-            <div className="relative">
-              <Input
-                id="current-password"
-                type={showPasswords ? 'text' : 'password'}
-                value={currentPassword}
-                onChange={(e) => setCurrentPassword(e.target.value)}
-                placeholder="Enter current password"
-                className="pr-10"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPasswords(!showPasswords)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              >
-                {showPasswords ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-              </button>
-            </div>
+            <PasswordInput
+              id="current-password"
+              label="Current Password"
+              visible={showPasswords}
+              onVisibilityChange={setShowPasswords}
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              placeholder="Enter current password"
+              visibilityToggleIcon={({ reveal }) =>
+                reveal ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />
+              }
+            />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="new-password">New Password</Label>
-            <Input
+            <PasswordInput
               id="new-password"
-              type={showPasswords ? 'text' : 'password'}
+              label="New Password"
+              visible={showPasswords}
+              onVisibilityChange={setShowPasswords}
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
               placeholder="Enter new password (8+ characters)"
+              visibilityToggleIcon={({ reveal }) =>
+                reveal ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />
+              }
             />
             {newPassword && (
               <div className="space-y-1">
@@ -141,13 +137,17 @@ export function SecurityTab() {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="confirm-new-password">Confirm New Password</Label>
-            <Input
+            <PasswordInput
               id="confirm-new-password"
-              type={showPasswords ? 'text' : 'password'}
+              label="Confirm New Password"
+              visible={showPasswords}
+              onVisibilityChange={setShowPasswords}
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               placeholder="Confirm new password"
+              visibilityToggleIcon={({ reveal }) =>
+                reveal ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />
+              }
             />
             {confirmPassword && !passwordsMatch && (
               <p className="text-xs text-destructive">Passwords do not match</p>
@@ -157,18 +157,10 @@ export function SecurityTab() {
           <Button
             onClick={handleChangePassword}
             disabled={!canChange || isChanging}
-            className="w-full"
+            fullWidth
+            leftSection={changeSuccess ? <Check className="w-4 h-4" /> : undefined}
           >
-            {isChanging ? (
-              'Changing...'
-            ) : changeSuccess ? (
-              <>
-                <Check className="w-4 h-4 mr-2" />
-                Password Changed
-              </>
-            ) : (
-              'Change Password'
-            )}
+            {isChanging ? 'Changing...' : changeSuccess ? 'Password Changed' : 'Change Password'}
           </Button>
         </div>
       </section>
@@ -192,7 +184,7 @@ export function SecurityTab() {
 
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              <Button variant="destructive" size="sm">
+              <Button color="red" size="sm">
                 Reset All Security
               </Button>
             </AlertDialogTrigger>


### PR DESCRIPTION
## Summary
- Migrates Security settings password fields and buttons to direct Mantine PasswordInput and Button primitives.
- Migrates the settings tab error fallback retry/detail controls to direct Mantine Button primitives.
- Preserves password-change, visibility-toggle, reset confirmation, and error retry behavior.
- Adds focused Security settings Mantine coverage and updates the migration tracker.
- Advances #417.

## Verification
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test -- src/__tests__/settings-security-mantine.test.tsx
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Browser smoke: Settings -> Security, confirmed three Mantine PasswordInput roots, Mantine buttons, no old input roots, no console errors, and password visibility toggled from password to text.