### PR TITLE
Migrate managed list settings controls to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -295,6 +295,9 @@ Phase 3 progress:
 - Delegation settings now uses direct Mantine select, switch, badge, and button
   primitives while preserving delegation enable, revoke, scope, duration, and
   critical-priority exclusion behavior.
+- Shared managed-list settings controls now use direct Mantine text input,
+  button, and action icon primitives while preserving create, inline edit,
+  keyboard save/cancel, drag handles, and explicit move/delete actions.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/settings-managed-list-mantine.test.tsx
+++ b/web/src/__tests__/settings-managed-list-mantine.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { ManagedListManager } from '@/components/settings/ManagedListManager';
+import { renderWithProviders } from './test-utils';
+import type { ManagedListItem } from '@veritas-kanban/shared';
+import { AVAILABLE_COLORS } from '@/hooks/useTaskTypes';
+
+const baseItems: ManagedListItem[] = [
+  {
+    id: 'feature',
+    label: 'Feature',
+    order: 0,
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'bug',
+    label: 'Bug',
+    order: 1,
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-01T00:00:00.000Z',
+  },
+];
+
+describe('Managed list Mantine migration', () => {
+  const handlers = {
+    onCreate: vi.fn(),
+    onUpdate: vi.fn(),
+    onDelete: vi.fn(),
+    onReorder: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers.onCreate.mockResolvedValue({});
+    handlers.onUpdate.mockResolvedValue({});
+    handlers.onDelete.mockResolvedValue({});
+    handlers.onReorder.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderManagedList() {
+    return renderWithProviders(
+      <ManagedListManager
+        title="Task Types"
+        items={baseItems}
+        isLoading={false}
+        newItemDefaults={{ isHidden: false }}
+        {...handlers}
+      />
+    );
+  }
+
+  it('renders add and reorder controls through direct Mantine primitives', async () => {
+    const { container } = renderManagedList();
+
+    expect(screen.getByRole('heading', { name: 'Task Types' })).toBeDefined();
+    expect(screen.getByPlaceholderText('New item name...')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-ActionIcon-root').length).toBeGreaterThanOrEqual(6);
+
+    fireEvent.change(screen.getByPlaceholderText('New item name...'), {
+      target: { value: 'Spike' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => {
+      expect(handlers.onCreate).toHaveBeenCalledWith({
+        label: 'Spike',
+        isHidden: false,
+      });
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Move down' })[0]);
+
+    expect(handlers.onReorder).toHaveBeenCalledWith(['bug', 'feature']);
+  });
+
+  it('edits item labels through Mantine text input', async () => {
+    const { container } = renderManagedList();
+
+    fireEvent.click(screen.getByText('Feature'));
+
+    const editInput = screen.getByRole('textbox', { name: 'Edit Feature' });
+    expect(container.querySelectorAll('.mantine-TextInput-root').length).toBeGreaterThanOrEqual(2);
+
+    fireEvent.change(editInput, { target: { value: 'Feature Work' } });
+    fireEvent.blur(editInput);
+
+    await waitFor(() => {
+      expect(handlers.onUpdate).toHaveBeenCalledWith('feature', {
+        label: 'Feature Work',
+      });
+    });
+  });
+
+  it('keeps the task-type default color available in the Manage tab picker', () => {
+    expect(AVAILABLE_COLORS).toContainEqual({
+      value: 'border-l-gray-500',
+      label: 'Gray',
+    });
+  });
+});

--- a/web/src/components/settings/ManagedListManager.tsx
+++ b/web/src/components/settings/ManagedListManager.tsx
@@ -1,27 +1,23 @@
 import { useState } from 'react';
 import type { ManagedListItem } from '@veritas-kanban/shared';
-import { Button } from '../ui/button';
-import { Input } from '../ui/input';
+import { Button, TextInput } from '@mantine/core';
 import { DndContext, closestCenter } from '@dnd-kit/core';
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useSortableList } from '@/hooks/useSortableList';
 import { SortableListItem } from './SortableListItem';
+
+type ManagedListCreateInput<T extends ManagedListItem> = Partial<T> & Pick<T, 'label'>;
+type ManagedListPatch<T extends ManagedListItem> = Partial<T> | Pick<ManagedListItem, 'label'>;
 
 export interface ManagedListManagerProps<T extends ManagedListItem> {
   title: string;
   items: T[];
   isLoading: boolean;
-  onCreate: (input: any) => Promise<any>;
-  onUpdate: (id: string, patch: any) => Promise<any>;
-  onDelete: (id: string) => Promise<any>;
-  onReorder: (ids: string[]) => Promise<any>;
-  renderExtraFields?: (
-    item: T,
-    onChange: (patch: Partial<T>) => void
-  ) => React.ReactNode;
+  onCreate: (input: ManagedListCreateInput<T>) => Promise<unknown>;
+  onUpdate: (id: string, patch: ManagedListPatch<T>) => Promise<unknown>;
+  onDelete: (id: string) => Promise<unknown>;
+  onReorder: (ids: string[]) => Promise<unknown>;
+  renderExtraFields?: (item: T, onChange: (patch: Partial<T>) => void) => React.ReactNode;
   newItemDefaults?: Partial<T>;
   canDeleteCheck?: (id: string) => Promise<{
     allowed: boolean;
@@ -45,21 +41,21 @@ export function ManagedListManager<T extends ManagedListItem>({
   const [newItemLabel, setNewItemLabel] = useState('');
   const [isCreating, setIsCreating] = useState(false);
 
-  const { localItems, sensors, handleDragEnd, handleMoveUp, handleMoveDown } =
-    useSortableList({
-      items,
-      onReorder,
-    });
+  const { localItems, sensors, handleDragEnd, handleMoveUp, handleMoveDown } = useSortableList({
+    items,
+    onReorder,
+  });
 
   const handleCreate = async () => {
     if (!newItemLabel.trim()) return;
 
     setIsCreating(true);
     try {
-      await onCreate({
-        label: newItemLabel.trim(),
+      const input = {
         ...newItemDefaults,
-      });
+        label: newItemLabel.trim(),
+      } as ManagedListCreateInput<T>;
+      await onCreate(input);
       setNewItemLabel('');
     } finally {
       setIsCreating(false);
@@ -67,22 +63,14 @@ export function ManagedListManager<T extends ManagedListItem>({
   };
 
   if (isLoading) {
-    return (
-      <div className="text-sm text-muted-foreground">
-        Loading {title.toLowerCase()}...
-      </div>
-    );
+    return <div className="text-sm text-muted-foreground">Loading {title.toLowerCase()}...</div>;
   }
 
   return (
     <div className="space-y-2">
       {title && <h3 className="text-sm font-semibold">{title}</h3>}
 
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext
           items={localItems.map((item) => item.id)}
           strategy={verticalListSortingStrategy}
@@ -105,7 +93,7 @@ export function ManagedListManager<T extends ManagedListItem>({
       </DndContext>
 
       <div className="flex gap-2">
-        <Input
+        <TextInput
           placeholder="New item name..."
           value={newItemLabel}
           onChange={(e) => setNewItemLabel(e.target.value)}
@@ -113,10 +101,13 @@ export function ManagedListManager<T extends ManagedListItem>({
             if (e.key === 'Enter') handleCreate();
           }}
           disabled={isCreating}
-          className="h-8 text-sm"
+          size="xs"
+          radius="md"
+          className="flex-1"
         />
         <Button
-          size="sm"
+          size="xs"
+          radius="md"
           onClick={handleCreate}
           disabled={!newItemLabel.trim() || isCreating}
         >

--- a/web/src/components/settings/SortableListItem.tsx
+++ b/web/src/components/settings/SortableListItem.tsx
@@ -1,7 +1,6 @@
 import { useState, memo } from 'react';
 import type { ManagedListItem } from '@veritas-kanban/shared';
-import { Button } from '../ui/button';
-import { Input } from '../ui/input';
+import { ActionIcon, TextInput } from '@mantine/core';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -16,18 +15,17 @@ import { Trash2, GripVertical, ChevronUp, ChevronDown } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
+type ManagedListPatch<T extends ManagedListItem> = Partial<T> | Pick<ManagedListItem, 'label'>;
+
 export interface SortableListItemProps<T extends ManagedListItem> {
   item: T;
   index: number;
   totalItems: number;
-  onUpdate: (id: string, patch: any) => Promise<any>;
-  onDelete: (id: string) => Promise<any>;
+  onUpdate: (id: string, patch: ManagedListPatch<T>) => Promise<unknown>;
+  onDelete: (id: string) => Promise<unknown>;
   onMoveUp: (index: number) => void;
   onMoveDown: (index: number) => void;
-  renderExtraFields?: (
-    item: T,
-    onChange: (patch: Partial<T>) => void
-  ) => React.ReactNode;
+  renderExtraFields?: (item: T, onChange: (patch: Partial<T>) => void) => React.ReactNode;
   canDeleteCheck?: (id: string) => Promise<{
     allowed: boolean;
     referenceCount: number;
@@ -35,9 +33,7 @@ export interface SortableListItemProps<T extends ManagedListItem> {
   }>;
 }
 
-export const SortableListItem = memo(function SortableListItem<
-  T extends ManagedListItem
->({
+export const SortableListItem = memo(function SortableListItem<T extends ManagedListItem>({
   item,
   index,
   totalItems,
@@ -57,8 +53,7 @@ export const SortableListItem = memo(function SortableListItem<
     isDefault: boolean;
   } | null>(null);
 
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: item.id });
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: item.id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -100,43 +95,52 @@ export const SortableListItem = memo(function SortableListItem<
         style={style}
         className="flex items-center gap-1.5 px-2 py-1.5 bg-card border rounded-md mb-1"
       >
-        <button
-          className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 flex-shrink-0"
+        <ActionIcon
+          type="button"
+          variant="subtle"
+          color="gray"
+          size="sm"
+          radius="md"
+          className="cursor-grab active:cursor-grabbing flex-shrink-0"
           aria-label="Drag to reorder"
           {...attributes}
           {...listeners}
         >
           <GripVertical className="h-3.5 w-3.5" />
-        </button>
+        </ActionIcon>
 
         <div className="flex gap-0.5 flex-shrink-0">
-          <Button
-            variant="ghost"
+          <ActionIcon
+            type="button"
+            variant="subtle"
+            color="gray"
             size="sm"
-            className="h-6 w-6 p-0"
+            radius="md"
             onClick={() => onMoveUp(index)}
             disabled={index === 0}
             title="Move up"
             aria-label="Move up"
           >
             <ChevronUp className="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
+          </ActionIcon>
+          <ActionIcon
+            type="button"
+            variant="subtle"
+            color="gray"
             size="sm"
-            className="h-6 w-6 p-0"
+            radius="md"
             onClick={() => onMoveDown(index)}
             disabled={index === totalItems - 1}
             title="Move down"
             aria-label="Move down"
           >
             <ChevronDown className="h-3.5 w-3.5" />
-          </Button>
+          </ActionIcon>
         </div>
 
         <div className="flex-1 min-w-0">
           {isEditing ? (
-            <Input
+            <TextInput
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               onBlur={handleLabelSave}
@@ -148,7 +152,9 @@ export const SortableListItem = memo(function SortableListItem<
                 }
               }}
               autoFocus
-              className="h-7 text-sm"
+              size="xs"
+              radius="md"
+              aria-label={`Edit ${item.label}`}
             />
           ) : (
             <div
@@ -157,9 +163,7 @@ export const SortableListItem = memo(function SortableListItem<
             >
               {item.label}
               {item.isHidden && (
-                <span className="ml-2 text-xs text-muted-foreground">
-                  (hidden)
-                </span>
+                <span className="ml-2 text-xs text-muted-foreground">(hidden)</span>
               )}
             </div>
           )}
@@ -167,16 +171,19 @@ export const SortableListItem = memo(function SortableListItem<
           {renderExtraFields && renderExtraFields(item, handleExtraFieldChange)}
         </div>
 
-        <Button
-          variant="ghost"
+        <ActionIcon
+          type="button"
+          variant="subtle"
+          color="red"
           size="sm"
-          className="h-7 w-7 p-0 flex-shrink-0"
+          radius="md"
+          className="flex-shrink-0"
           onClick={handleDeleteClick}
           title={`Delete ${item.label}`}
           aria-label={`Delete ${item.label}`}
         >
           <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-        </Button>
+        </ActionIcon>
       </div>
 
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
@@ -188,14 +195,13 @@ export const SortableListItem = memo(function SortableListItem<
             <AlertDialogDescription>
               {deleteInfo && deleteInfo.referenceCount > 0 && !deleteInfo.allowed ? (
                 <span>
-                  &quot;{item.label}&quot; is used by {deleteInfo.referenceCount}{' '}
-                  task(s). Remove or reassign those tasks first before deleting
-                  this item.
+                  &quot;{item.label}&quot; is used by {deleteInfo.referenceCount} task(s). Remove or
+                  reassign those tasks first before deleting this item.
                 </span>
               ) : (
                 <span>
-                  Are you sure you want to delete &quot;{item.label}&quot;? This
-                  action cannot be undone.
+                  Are you sure you want to delete &quot;{item.label}&quot;? This action cannot be
+                  undone.
                 </span>
               )}
             </AlertDialogDescription>
@@ -215,6 +221,4 @@ export const SortableListItem = memo(function SortableListItem<
       </AlertDialog>
     </>
   );
-}) as <T extends ManagedListItem>(
-  props: SortableListItemProps<T>
-) => React.JSX.Element;
+}) as <T extends ManagedListItem>(props: SortableListItemProps<T>) => React.JSX.Element;

--- a/web/src/hooks/useTaskTypes.ts
+++ b/web/src/hooks/useTaskTypes.ts
@@ -96,6 +96,7 @@ export function getTypeIconName(types: TaskTypeConfig[], typeId: string): string
  * Available border colors for task types
  */
 export const AVAILABLE_COLORS = [
+  { value: 'border-l-gray-500', label: 'Gray' },
   { value: 'border-l-violet-500', label: 'Violet' },
   { value: 'border-l-cyan-500', label: 'Cyan' },
   { value: 'border-l-orange-500', label: 'Orange' },


### PR DESCRIPTION
## Summary
- Migrates shared settings managed-list add, inline edit, reorder, drag, and delete controls to direct Mantine TextInput, Button, and ActionIcon primitives.
- Tightens managed-list prop typing for create, update, delete, and reorder handlers.
- Adds the Gray task-type color option so the Manage tab default color renders as a valid picker value.
- Updates the Mantine migration progress notes for the settings/admin surface.

Part of #417 and #326.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/settings-managed-list-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget, 690 warnings, 0 errors
- git diff --check
- Browser smoke: http://localhost:3000 -> Settings -> Manage; verified managed-list Mantine roots, added a Smoke Type item, confirmed Gray default color, and saw no console errors.