### PR TITLE
Migrate manage settings tab to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -298,6 +298,10 @@ Phase 3 progress:
 - Shared managed-list settings controls now use direct Mantine text input,
   button, and action icon primitives while preserving create, inline edit,
   keyboard save/cancel, drag handles, and explicit move/delete actions.
+- Manage settings extra fields and template controls now use direct Mantine
+  text input, textarea, select, button, badge, and action icon primitives while
+  preserving managed-list metadata edits, template import/export/help, template
+  create, and template delete behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/server/src/__tests__/template-service.test.ts
+++ b/server/src/__tests__/template-service.test.ts
@@ -157,6 +157,22 @@ describe('TemplateService', () => {
       const files = await fs.readdir(templatesDir);
       expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(1);
     });
+
+    it('should preserve empty task defaults when reading created templates', async () => {
+      const created = await service.createTemplate({
+        name: 'Empty Defaults',
+        taskDefaults: {},
+      });
+
+      expect(created.taskDefaults).toEqual({});
+
+      const listed = await service.getTemplates();
+      expect(listed).toHaveLength(1);
+      expect(listed[0]?.taskDefaults).toEqual({});
+
+      const loaded = await service.getTemplate(created.id);
+      expect(loaded?.taskDefaults).toEqual({});
+    });
   });
 
   describe('updateTemplate', () => {

--- a/server/src/services/template-service.ts
+++ b/server/src/services/template-service.ts
@@ -66,6 +66,13 @@ export class TemplateService {
     return obj;
   }
 
+  private cleanTemplateForYaml(template: TaskTemplate): Record<string, unknown> {
+    return {
+      ...(this.cleanForYaml(template) ?? {}),
+      taskDefaults: this.cleanForYaml(template.taskDefaults) ?? {},
+    };
+  }
+
   private slugify(name: string): string {
     return name
       .toLowerCase()
@@ -87,7 +94,10 @@ export class TemplateService {
   private migrateTemplate(data: any): TaskTemplate {
     // If version is already 1, no migration needed
     if (data.version === 1) {
-      return data as TaskTemplate;
+      return {
+        ...data,
+        taskDefaults: data.taskDefaults ?? {},
+      } as TaskTemplate;
     }
 
     // Migrate v0 to v1
@@ -186,7 +196,7 @@ export class TemplateService {
     };
 
     // Recursively filter out undefined values for YAML serialization
-    const cleanTemplate = this.cleanForYaml(template);
+    const cleanTemplate = this.cleanTemplateForYaml(template);
 
     const content = matter.stringify('', cleanTemplate);
     await writeFile(this.templatePath(id), content, 'utf-8');
@@ -218,7 +228,7 @@ export class TemplateService {
     };
 
     // Recursively filter out undefined values for YAML serialization
-    const cleanTemplate = this.cleanForYaml(updated);
+    const cleanTemplate = this.cleanTemplateForYaml(updated);
 
     const content = matter.stringify('', cleanTemplate);
     await writeFile(this.templatePath(id), content, 'utf-8');

--- a/web/src/__tests__/settings-manage-mantine.test.tsx
+++ b/web/src/__tests__/settings-manage-mantine.test.tsx
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { ManageTab } from '@/components/settings/tabs/ManageTab';
+import { renderWithProviders } from './test-utils';
+import type { ManagedListItem, TaskTemplate } from '@veritas-kanban/shared';
+
+const mocks = vi.hoisted(() => ({
+  canDelete: vi.fn(),
+  createItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+  reorderItems: vi.fn(),
+  createTemplate: vi.fn(),
+  deleteTemplate: vi.fn(),
+  toast: vi.fn(),
+}));
+
+const baseItemFields = {
+  order: 0,
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-01T00:00:00.000Z',
+} satisfies Omit<ManagedListItem, 'id' | 'label'>;
+
+const taskTemplates: TaskTemplate[] = [
+  {
+    id: 'template-bug',
+    name: 'Bug Fix',
+    category: 'bug',
+    version: 1,
+    taskDefaults: {
+      type: 'bug',
+      priority: 'high',
+      project: 'rubicon',
+      agent: 'veritas',
+    },
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'template-empty-defaults',
+    name: 'Empty Defaults',
+    version: 1,
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-01T00:00:00.000Z',
+  } as TaskTemplate,
+];
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({ data: {}, isLoading: false }),
+}));
+
+vi.mock('@/hooks/useTemplates', () => ({
+  useTemplates: () => ({ data: taskTemplates, isLoading: false }),
+  useCreateTemplate: () => ({
+    mutateAsync: mocks.createTemplate,
+    isPending: false,
+  }),
+  useDeleteTemplate: () => ({
+    mutate: mocks.deleteTemplate,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('@/hooks/useTaskTypes', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/useTaskTypes')>('@/hooks/useTaskTypes');
+  return {
+    ...actual,
+    useTaskTypesManager: () => ({
+      items: [
+        {
+          ...baseItemFields,
+          id: 'bug',
+          label: 'Bug',
+          icon: 'Code',
+          color: 'border-l-gray-500',
+        },
+      ],
+      isLoading: false,
+      create: mocks.createItem,
+      update: mocks.updateItem,
+      remove: mocks.deleteItem,
+      reorder: mocks.reorderItems,
+      canDelete: mocks.canDelete,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useProjects', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useProjects')>('@/hooks/useProjects');
+  return {
+    ...actual,
+    useProjectsManager: () => ({
+      items: [
+        {
+          ...baseItemFields,
+          id: 'rubicon',
+          label: 'Rubicon',
+          description: 'Core project',
+          color: 'bg-blue-500/20',
+        },
+      ],
+      isLoading: false,
+      create: mocks.createItem,
+      update: mocks.updateItem,
+      remove: mocks.deleteItem,
+      reorder: mocks.reorderItems,
+      canDelete: mocks.canDelete,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useSprints', () => ({
+  useSprintsManager: () => ({
+    items: [
+      {
+        ...baseItemFields,
+        id: 'sprint-1',
+        label: 'Sprint 1',
+        description: 'Planning',
+      },
+    ],
+    isLoading: false,
+    create: mocks.createItem,
+    update: mocks.updateItem,
+    remove: mocks.deleteItem,
+    reorder: mocks.reorderItems,
+    canDelete: mocks.canDelete,
+  }),
+}));
+
+describe('Manage settings Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.canDelete.mockResolvedValue({
+      allowed: true,
+      referenceCount: 0,
+      isDefault: false,
+    });
+    mocks.createItem.mockResolvedValue({});
+    mocks.updateItem.mockResolvedValue({});
+    mocks.deleteItem.mockResolvedValue({});
+    mocks.reorderItems.mockResolvedValue({});
+    mocks.createTemplate.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders managed-list extra fields and template actions through direct Mantine primitives', () => {
+    const { container } = renderWithProviders(<ManageTab />);
+
+    expect(screen.getByRole('combobox', { name: 'Bug icon' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Bug color' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Rubicon description' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Sprint 1 description' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Toggle template guide' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Delete Bug Fix' })).toBeDefined();
+    expect(screen.getByText('Empty Defaults')).toBeDefined();
+    expect(screen.getByText('No defaults')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelectorAll('.mantine-TextInput-root').length).toBeGreaterThanOrEqual(5);
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(4);
+    expect(container.querySelectorAll('.mantine-ActionIcon-root').length).toBeGreaterThanOrEqual(5);
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+    expect(container.querySelector('[data-slot="input"]')).toBeNull();
+    expect(container.querySelector('[data-slot="select-trigger"]')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle template guide' }));
+
+    expect(screen.getByText('Template Guide')).toBeDefined();
+  });
+
+  it('creates templates through the Mantine form controls', async () => {
+    const { container } = renderWithProviders(<ManageTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add template' }));
+
+    expect(screen.getByRole('textbox', { name: 'Name *' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Description' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Category' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Default Type' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Default Priority' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Default Project' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Preferred Agent' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Description Template' })).toBeDefined();
+    expect(container.querySelector('.mantine-Textarea-root')).toBeDefined();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name *' }), {
+      target: { value: 'Ops Review' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Template' }));
+
+    await waitFor(() => {
+      expect(mocks.createTemplate).toHaveBeenCalledWith({
+        name: 'Ops Review',
+        description: undefined,
+        category: undefined,
+        taskDefaults: {
+          type: undefined,
+          priority: undefined,
+          project: undefined,
+          agent: undefined,
+          descriptionTemplate: undefined,
+        },
+      });
+    });
+  });
+});

--- a/web/src/components/settings/tabs/ManageTab.tsx
+++ b/web/src/components/settings/tabs/ManageTab.tsx
@@ -1,33 +1,24 @@
-import { useState, useRef } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { useRef, useState } from 'react';
+import { ActionIcon, Button, Select, Text, TextInput } from '@mantine/core';
 import { useConfig } from '@/hooks/useConfig';
 import { useTemplates, useCreateTemplate } from '@/hooks/useTemplates';
 import {
-  useTaskTypesManager,
-  getTypeIcon,
-  getAvailableIcons,
   AVAILABLE_COLORS,
+  getAvailableIcons,
+  getTypeIcon,
+  useTaskTypesManager,
 } from '@/hooks/useTaskTypes';
-import { useProjectsManager, AVAILABLE_PROJECT_COLORS } from '@/hooks/useProjects';
+import { AVAILABLE_PROJECT_COLORS, useProjectsManager } from '@/hooks/useProjects';
 import { useSprintsManager } from '@/hooks/useSprints';
 import { useToast } from '@/hooks/useToast';
-import { Plus, Download, Upload, HelpCircle, Info } from 'lucide-react';
+import { Download, HelpCircle, Info, Plus, Upload } from 'lucide-react';
 import type {
-  TaskTypeConfig,
-  SprintConfig,
-  ProjectConfig,
   CreateTemplateInput,
+  ProjectConfig,
+  SprintConfig,
+  TaskTypeConfig,
 } from '@veritas-kanban/shared';
-import { exportAllTemplates, parseTemplateFile, checkDuplicateName } from '@/lib/template-io';
+import { checkDuplicateName, exportAllTemplates, parseTemplateFile } from '@/lib/template-io';
 import { ManagedListManager } from '../ManagedListManager';
 import { AddTemplateForm, TemplateItem } from './TemplateComponents';
 
@@ -100,9 +91,23 @@ export function ManageTab() {
     }
   };
 
+  const iconOptions = getAvailableIcons().map((iconName) => ({
+    value: iconName,
+    label: iconName,
+  }));
+
+  const taskTypeColorOptions = AVAILABLE_COLORS.map((color) => ({
+    value: color.value,
+    label: color.label,
+  }));
+
+  const projectColorOptions = AVAILABLE_PROJECT_COLORS.map((color) => ({
+    value: color.value,
+    label: color.label,
+  }));
+
   return (
     <div className="space-y-6">
-      {/* Task Types */}
       <div className="space-y-2">
         <h3 className="text-sm font-medium">Task Types</h3>
         <div className="border rounded-md p-3">
@@ -118,46 +123,51 @@ export function ManageTab() {
             renderExtraFields={(item, onChange) => (
               <div className="flex items-center gap-4 mt-2">
                 <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground whitespace-nowrap">Icon</Label>
-                  <Select value={item.icon} onValueChange={(icon) => onChange({ icon })}>
-                    <SelectTrigger className="h-7 w-[120px]">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {getAvailableIcons().map((iconName) => {
-                        const IconComponent = getTypeIcon(iconName);
-                        return (
-                          <SelectItem key={iconName} value={iconName}>
-                            <div className="flex items-center gap-2">
-                              {IconComponent && <IconComponent className="h-4 w-4" />}
-                              {iconName}
-                            </div>
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <Text size="xs" c="dimmed" className="whitespace-nowrap">
+                    Icon
+                  </Text>
+                  <Select
+                    value={item.icon}
+                    onChange={(icon) => {
+                      if (icon) onChange({ icon });
+                    }}
+                    data={iconOptions}
+                    size="xs"
+                    radius="md"
+                    w={120}
+                    aria-label={`${item.label} icon`}
+                    renderOption={({ option }) => {
+                      const IconComponent = getTypeIcon(option.value);
+                      return (
+                        <div className="flex items-center gap-2">
+                          {IconComponent && <IconComponent className="h-4 w-4" />}
+                          {option.label}
+                        </div>
+                      );
+                    }}
+                  />
                 </div>
                 <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground whitespace-nowrap">Color</Label>
+                  <Text size="xs" c="dimmed" className="whitespace-nowrap">
+                    Color
+                  </Text>
                   <Select
                     value={item.color || 'border-l-gray-500'}
-                    onValueChange={(color) => onChange({ color })}
-                  >
-                    <SelectTrigger className="h-7 w-[120px]">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {AVAILABLE_COLORS.map((color) => (
-                        <SelectItem key={color.value} value={color.value}>
-                          <div className="flex items-center gap-2">
-                            <div className={`w-4 h-4 rounded border-l-4 ${color.value}`}></div>
-                            {color.label}
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    onChange={(color) => {
+                      if (color) onChange({ color });
+                    }}
+                    data={taskTypeColorOptions}
+                    size="xs"
+                    radius="md"
+                    w={120}
+                    aria-label={`${item.label} color`}
+                    renderOption={({ option }) => (
+                      <div className="flex items-center gap-2">
+                        <div className={`w-4 h-4 rounded border-l-4 ${option.value}`} />
+                        {option.label}
+                      </div>
+                    )}
+                  />
                 </div>
               </div>
             )}
@@ -166,7 +176,6 @@ export function ManageTab() {
         </div>
       </div>
 
-      {/* Projects */}
       <div className="space-y-2">
         <h3 className="text-sm font-medium">Projects</h3>
         <div className="border rounded-md p-3">
@@ -182,34 +191,40 @@ export function ManageTab() {
             renderExtraFields={(item, onChange) => (
               <div className="flex items-center gap-4 mt-2">
                 <div className="flex items-center gap-2 flex-1">
-                  <Label className="text-xs text-muted-foreground whitespace-nowrap">Desc</Label>
-                  <Input
+                  <Text size="xs" c="dimmed" className="whitespace-nowrap">
+                    Desc
+                  </Text>
+                  <TextInput
                     value={item.description || ''}
                     onChange={(e) => onChange({ description: e.target.value })}
                     placeholder="Optional..."
-                    className="h-7 flex-1"
+                    size="xs"
+                    radius="md"
+                    className="flex-1"
+                    aria-label={`${item.label} description`}
                   />
                 </div>
                 <div className="flex items-center gap-2">
-                  <Label className="text-xs text-muted-foreground whitespace-nowrap">Color</Label>
+                  <Text size="xs" c="dimmed" className="whitespace-nowrap">
+                    Color
+                  </Text>
                   <Select
                     value={item.color || 'bg-muted'}
-                    onValueChange={(color) => onChange({ color })}
-                  >
-                    <SelectTrigger className="h-7 w-[120px]">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {AVAILABLE_PROJECT_COLORS.map((color) => (
-                        <SelectItem key={color.value} value={color.value}>
-                          <div className="flex items-center gap-2">
-                            <div className={`w-4 h-4 rounded ${color.value}`}></div>
-                            {color.label}
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    onChange={(color) => {
+                      if (color) onChange({ color });
+                    }}
+                    data={projectColorOptions}
+                    size="xs"
+                    radius="md"
+                    w={120}
+                    aria-label={`${item.label} color`}
+                    renderOption={({ option }) => (
+                      <div className="flex items-center gap-2">
+                        <div className={`w-4 h-4 rounded ${option.value}`} />
+                        {option.label}
+                      </div>
+                    )}
+                  />
                 </div>
               </div>
             )}
@@ -218,7 +233,6 @@ export function ManageTab() {
         </div>
       </div>
 
-      {/* Sprints */}
       <div className="space-y-2">
         <h3 className="text-sm font-medium">Sprints</h3>
         <div className="border rounded-md p-3">
@@ -233,12 +247,17 @@ export function ManageTab() {
             canDeleteCheck={sprintsManager.canDelete}
             renderExtraFields={(item, onChange) => (
               <div className="flex items-center gap-2 mt-2">
-                <Label className="text-xs text-muted-foreground whitespace-nowrap">Desc</Label>
-                <Input
+                <Text size="xs" c="dimmed" className="whitespace-nowrap">
+                  Desc
+                </Text>
+                <TextInput
                   value={item.description || ''}
                   onChange={(e) => onChange({ description: e.target.value })}
                   placeholder="Optional..."
-                  className="h-7 flex-1"
+                  size="xs"
+                  radius="md"
+                  className="flex-1"
+                  aria-label={`${item.label} description`}
                 />
               </div>
             )}
@@ -247,32 +266,56 @@ export function ManageTab() {
         </div>
       </div>
 
-      {/* Templates */}
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <h3 className="text-sm font-medium">Task Templates</h3>
-            <Button
-              variant="ghost"
+            <ActionIcon
+              type="button"
+              variant="subtle"
+              color="gray"
               size="sm"
-              className="h-6 w-6 p-0"
+              radius="md"
+              aria-label="Toggle template guide"
               onClick={() => setShowTemplateHelp(!showTemplateHelp)}
             >
-              <HelpCircle className="h-4 w-4 text-muted-foreground" />
-            </Button>
+              <HelpCircle className="h-4 w-4" />
+            </ActionIcon>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleImportClick}>
-              <Upload className="h-4 w-4 mr-1" /> Import
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              radius="md"
+              leftSection={<Upload className="h-4 w-4" />}
+              onClick={handleImportClick}
+            >
+              Import
             </Button>
             {templates && templates.length > 0 && (
-              <Button variant="outline" size="sm" onClick={handleExportTemplates}>
-                <Download className="h-4 w-4 mr-1" /> Export
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                radius="md"
+                leftSection={<Download className="h-4 w-4" />}
+                onClick={handleExportTemplates}
+              >
+                Export
               </Button>
             )}
             {!showAddTemplateForm && (
-              <Button variant="outline" size="sm" onClick={() => setShowAddTemplateForm(true)}>
-                <Plus className="h-4 w-4 mr-1" /> Add
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                radius="md"
+                leftSection={<Plus className="h-4 w-4" />}
+                aria-label="Add template"
+                onClick={() => setShowAddTemplateForm(true)}
+              >
+                Add
               </Button>
             )}
           </div>
@@ -290,8 +333,7 @@ export function ManageTab() {
                     lists
                   </div>
                   <div>
-                    <strong className="text-foreground">Categories:</strong> Bug 🐛, Feature ✨,
-                    Sprint 🔄
+                    <strong className="text-foreground">Categories:</strong> Bug, Feature, Sprint
                   </div>
                   <div>
                     <strong className="text-foreground">Variables:</strong> {'{{date}}'},{' '}

--- a/web/src/components/settings/tabs/TemplateComponents.tsx
+++ b/web/src/components/settings/tabs/TemplateComponents.tsx
@@ -1,15 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { ActionIcon, Badge, Button, Select, Text, Textarea, TextInput } from '@mantine/core';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,15 +11,25 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import {
-  useCreateTemplate,
-  useDeleteTemplate,
-  type TaskTemplate,
-} from '@/hooks/useTemplates';
-import { useTaskTypesManager, getTypeIcon } from '@/hooks/useTaskTypes';
-import { Trash2, FileText } from 'lucide-react';
-import type { TaskPriority, AgentType } from '@veritas-kanban/shared';
+import { type TaskTemplate, useCreateTemplate, useDeleteTemplate } from '@/hooks/useTemplates';
+import { getTypeIcon, useTaskTypesManager } from '@/hooks/useTaskTypes';
+import { FileText, Trash2 } from 'lucide-react';
+import type { AgentType, TaskPriority } from '@veritas-kanban/shared';
 import { TEMPLATE_CATEGORIES, getCategoryIcon, getCategoryLabel } from '@/lib/template-categories';
+
+const priorityOptions: Array<{ value: TaskPriority; label: string }> = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+const agentOptions: Array<{ value: AgentType; label: string }> = [
+  { value: 'claude-code', label: 'Claude Code' },
+  { value: 'amp', label: 'Amp' },
+  { value: 'copilot', label: 'Copilot' },
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'veritas', label: 'Veritas' },
+];
 
 export function AddTemplateForm({ onClose }: { onClose: () => void }) {
   const [name, setName] = useState('');
@@ -42,6 +42,17 @@ export function AddTemplateForm({ onClose }: { onClose: () => void }) {
   const [descriptionTemplate, setDescriptionTemplate] = useState('');
   const createTemplate = useCreateTemplate();
   const { items: taskTypes } = useTaskTypesManager();
+
+  const categoryOptions = Object.entries(TEMPLATE_CATEGORIES).map(([key, { label, icon }]) => ({
+    value: key,
+    label: `${icon} ${label}`,
+  }));
+
+  const taskTypeOptions = taskTypes.map((taskType) => ({
+    value: taskType.id,
+    label: taskType.label,
+    icon: taskType.icon,
+  }));
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -63,88 +74,106 @@ export function AddTemplateForm({ onClose }: { onClose: () => void }) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 border rounded-lg p-4 bg-muted/30">
-      <div className="flex items-center gap-2 text-sm font-medium"><FileText className="h-4 w-4" /> Add Template</div>
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <FileText className="h-4 w-4" /> Add Template
+      </div>
       <div className="grid gap-3">
         <div className="grid grid-cols-2 gap-3">
-          <div className="grid gap-2">
-            <Label>Name *</Label>
-            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g., Bug Fix" />
-          </div>
-          <div className="grid gap-2">
-            <Label>Description</Label>
-            <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="e.g., Template for bug fixes" />
-          </div>
+          <TextInput
+            label="Name *"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Bug Fix"
+            size="sm"
+            radius="md"
+          />
+          <TextInput
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="e.g., Template for bug fixes"
+            size="sm"
+            radius="md"
+          />
         </div>
-        <div className="grid gap-2">
-          <Label>Category</Label>
-          <Select value={category} onValueChange={setCategory}>
-            <SelectTrigger><SelectValue placeholder="Select category..." /></SelectTrigger>
-            <SelectContent>
-              {Object.entries(TEMPLATE_CATEGORIES).map(([key, { label, icon }]) => (
-                <SelectItem key={key} value={key}>{icon} {label}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <Select
+          label="Category"
+          value={category || null}
+          onChange={(value) => setCategory(value ?? '')}
+          data={categoryOptions}
+          placeholder="Select category..."
+          size="sm"
+          radius="md"
+        />
+        <div className="grid grid-cols-2 gap-3">
+          <Select
+            label="Default Type"
+            value={type || null}
+            onChange={(value) => setType(value ?? '')}
+            data={taskTypeOptions}
+            placeholder="Any"
+            size="sm"
+            radius="md"
+            renderOption={({ option }) => {
+              const iconName = taskTypeOptions.find((entry) => entry.value === option.value)?.icon;
+              const IconComponent = iconName ? getTypeIcon(iconName) : null;
+              return (
+                <div className="flex items-center gap-2">
+                  {IconComponent && <IconComponent className="h-4 w-4" />}
+                  {option.label}
+                </div>
+              );
+            }}
+          />
+          <Select
+            label="Default Priority"
+            value={priority || null}
+            onChange={(value) => setPriority((value as TaskPriority | null) ?? '')}
+            data={priorityOptions}
+            placeholder="Any"
+            size="sm"
+            radius="md"
+          />
         </div>
         <div className="grid grid-cols-2 gap-3">
-          <div className="grid gap-2">
-            <Label>Default Type</Label>
-            <Select value={type} onValueChange={setType}>
-              <SelectTrigger><SelectValue placeholder="Any" /></SelectTrigger>
-              <SelectContent>
-                {taskTypes.map((taskType) => {
-                  const IconComponent = getTypeIcon(taskType.icon);
-                  return (
-                    <SelectItem key={taskType.id} value={taskType.id}>
-                      <div className="flex items-center gap-2">
-                        {IconComponent && <IconComponent className="h-4 w-4" />}
-                        {taskType.label}
-                      </div>
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="grid gap-2">
-            <Label>Default Priority</Label>
-            <Select value={priority} onValueChange={(v) => setPriority(v as TaskPriority)}>
-              <SelectTrigger><SelectValue placeholder="Any" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="low">Low</SelectItem>
-                <SelectItem value="medium">Medium</SelectItem>
-                <SelectItem value="high">High</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          <TextInput
+            label="Default Project"
+            value={project}
+            onChange={(e) => setProject(e.target.value)}
+            placeholder="e.g., rubicon"
+            size="sm"
+            radius="md"
+          />
+          <Select
+            label="Preferred Agent"
+            value={agent || null}
+            onChange={(value) => setAgent((value as AgentType | null) ?? '')}
+            data={agentOptions}
+            placeholder="Any"
+            size="sm"
+            radius="md"
+          />
         </div>
-        <div className="grid grid-cols-2 gap-3">
-          <div className="grid gap-2">
-            <Label>Default Project</Label>
-            <Input value={project} onChange={(e) => setProject(e.target.value)} placeholder="e.g., rubicon" />
-          </div>
-          <div className="grid gap-2">
-            <Label>Preferred Agent</Label>
-            <Select value={agent} onValueChange={(v) => setAgent(v as AgentType)}>
-              <SelectTrigger><SelectValue placeholder="Any" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="claude-code">Claude Code</SelectItem>
-                <SelectItem value="amp">Amp</SelectItem>
-                <SelectItem value="copilot">Copilot</SelectItem>
-                <SelectItem value="gemini">Gemini</SelectItem>
-                <SelectItem value="veritas">Veritas</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-        <div className="grid gap-2">
-          <Label>Description Template</Label>
-          <Textarea value={descriptionTemplate} onChange={(e) => setDescriptionTemplate(e.target.value)} placeholder="Pre-filled description text..." rows={2} />
-        </div>
+        <Textarea
+          label="Description Template"
+          value={descriptionTemplate}
+          onChange={(e) => setDescriptionTemplate(e.target.value)}
+          placeholder="Pre-filled description text..."
+          rows={2}
+          size="sm"
+          radius="md"
+        />
       </div>
       <div className="flex justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onClose}>Cancel</Button>
-        <Button type="submit" disabled={!name.trim() || createTemplate.isPending}>
+        <Button type="button" variant="outline" size="sm" radius="md" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          size="sm"
+          radius="md"
+          disabled={!name.trim() || createTemplate.isPending}
+        >
           {createTemplate.isPending ? 'Creating...' : 'Create Template'}
         </Button>
       </div>
@@ -154,29 +183,48 @@ export function AddTemplateForm({ onClose }: { onClose: () => void }) {
 
 export function TemplateItem({ template }: { template: TaskTemplate }) {
   const deleteTemplate = useDeleteTemplate();
+  const taskDefaults = template.taskDefaults ?? {};
+  const metadata = [
+    taskDefaults.type,
+    taskDefaults.priority,
+    taskDefaults.project,
+    taskDefaults.agent,
+  ]
+    .filter(Boolean)
+    .join(' • ');
+
   return (
     <div className="flex items-center justify-between py-2 px-3 rounded-md border bg-card">
       <div className="flex items-center gap-3">
         <FileText className="h-4 w-4 text-muted-foreground" />
         <div className="flex-1">
           <div className="flex items-center gap-2">
-            <span className="font-medium">{template.name}</span>
+            <Text size="sm" fw={500}>
+              {template.name}
+            </Text>
             {template.category && (
-              <span className="text-xs px-1.5 py-0.5 rounded bg-muted">
+              <Badge variant="light" color="gray" size="xs">
                 {getCategoryIcon(template.category)} {getCategoryLabel(template.category)}
-              </span>
+              </Badge>
             )}
           </div>
-          <div className="text-xs text-muted-foreground">
-            {[template.taskDefaults.type, template.taskDefaults.priority, template.taskDefaults.project, template.taskDefaults.agent].filter(Boolean).join(' • ') || 'No defaults'}
-          </div>
+          <Text size="xs" c="dimmed">
+            {metadata || 'No defaults'}
+          </Text>
         </div>
       </div>
       <AlertDialog>
         <AlertDialogTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
-          </Button>
+          <ActionIcon
+            type="button"
+            variant="subtle"
+            color="red"
+            size="sm"
+            radius="md"
+            aria-label={`Delete ${template.name}`}
+          >
+            <Trash2 className="h-4 w-4" />
+          </ActionIcon>
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -185,7 +233,12 @@ export function TemplateItem({ template }: { template: TaskTemplate }) {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={() => deleteTemplate.mutate(template.id)} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">Delete</AlertDialogAction>
+            <AlertDialogAction
+              onClick={() => deleteTemplate.mutate(template.id)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
## Summary

- Migrates the Manage settings metadata fields and template controls to direct Mantine primitives.
- Preserves managed-list icon, color, description, import, export, help, create, and delete behavior.
- Keeps empty task template defaults from being dropped by file-backed storage and guards existing malformed template records from crashing the Manage tab.

Advances #417 and #326.

## Verification

- `pnpm --filter @veritas-kanban/web test -- src/__tests__/settings-manage-mantine.test.tsx src/__tests__/settings-managed-list-mantine.test.tsx`
- `pnpm --filter @veritas-kanban/server test -- src/__tests__/template-service.test.ts`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm lint:budget`
- `git diff --check`
- Browser smoke: Settings -> Manage -> Add template -> create template with empty defaults, verified Mantine controls, no section error boundary, no console errors, and cleaned smoke records afterward.
