### PR TITLE
Migrate governance settings controls to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -302,6 +302,10 @@ Phase 3 progress:
   text input, textarea, select, button, badge, and action icon primitives while
   preserving managed-list metadata edits, template import/export/help, template
   create, and template delete behavior.
+- Tool Policies and Shared Resources settings now use direct Mantine alert,
+  modal, text input, textarea, checkbox, number input, badge, button, and action
+  icon primitives while preserving policy list/edit/create/delete affordances
+  and shared-resource allowed-type/max-resource controls.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/settings-governance-mantine.test.tsx
+++ b/web/src/__tests__/settings-governance-mantine.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { SharedResourcesTab } from '@/components/settings/tabs/SharedResourcesTab';
+import { ToolPoliciesTab } from '@/components/settings/tabs/ToolPoliciesTab';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  debouncedUpdate: vi.fn(),
+  toast: vi.fn(),
+  settings: {
+    sharedResources: {
+      enabled: true,
+      maxResources: 250,
+      allowedTypes: ['prompt', 'skill'],
+    },
+  },
+}));
+
+const policies = [
+  {
+    role: 'planner',
+    allowed: ['*'],
+    denied: [],
+    description: 'Plan work safely',
+  },
+  {
+    role: 'custom',
+    allowed: ['Read', 'Search', 'List', 'Inspect', 'Summarize', 'Report'],
+    denied: ['Write'],
+    description: 'Custom limited role',
+  },
+];
+
+vi.mock('@/lib/api/helpers', () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSettings: () => ({
+    settings: mocks.settings,
+  }),
+  useDebouncedFeatureUpdate: () => ({
+    debouncedUpdate: mocks.debouncedUpdate,
+    isPending: false,
+  }),
+}));
+
+describe('Settings governance Mantine controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.apiFetch.mockImplementation(async (url: string) => {
+      if (url === '/api/tool-policies') {
+        return policies;
+      }
+      return policies[0];
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders Shared Resources checkbox and number controls through direct Mantine primitives', () => {
+    const { container } = renderWithProviders(<SharedResourcesTab />);
+
+    expect(screen.getByRole('textbox', { name: 'Max Resources' })).toBeDefined();
+    expect(screen.getByRole('checkbox', { name: 'Prompt' })).toBeDefined();
+    expect(screen.getByRole('checkbox', { name: 'Skill' })).toBeDefined();
+    expect(container.querySelector('.mantine-NumberInput-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Checkbox-root').length).toBeGreaterThanOrEqual(5);
+    expect(container.querySelector('[data-slot="checkbox"]')).toBeNull();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Template' }));
+
+    expect(mocks.debouncedUpdate).toHaveBeenCalledWith({
+      sharedResources: expect.objectContaining({
+        allowedTypes: ['prompt', 'skill', 'template'],
+      }),
+    });
+  });
+
+  it('renders Tool Policies list and editor through direct Mantine primitives', async () => {
+    const { baseElement } = renderWithProviders(<ToolPoliciesTab />);
+
+    expect(await screen.findByText('planner')).toBeDefined();
+    expect(screen.getByText('all tools')).toBeDefined();
+    expect(screen.getByText('+1 more')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'New Policy' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Edit planner' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Delete custom' })).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Alert-root')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThanOrEqual(4);
+    expect(baseElement.querySelectorAll('.mantine-ActionIcon-root').length).toBeGreaterThanOrEqual(
+      3
+    );
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Policy' }));
+
+    expect(screen.getByRole('textbox', { name: 'Role Name' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Allowed Tools' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Denied Tools' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Description' })).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Modal-root')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-TextInput-root').length).toBeGreaterThanOrEqual(
+      3
+    );
+    expect(baseElement.querySelector('.mantine-Textarea-root')).toBeDefined();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Role Name' }), {
+      target: { value: 'analyst' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Allowed Tools' }), {
+      target: { value: 'Read, Search' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Denied Tools' }), {
+      target: { value: 'Write' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Description' }), {
+      target: { value: 'Read-only analyst role' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(mocks.apiFetch).toHaveBeenCalledWith(
+        '/api/tool-policies',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            role: 'analyst',
+            allowed: ['Read', 'Search'],
+            denied: ['Write'],
+            description: 'Read-only analyst role',
+          }),
+        })
+      );
+    });
+  });
+});

--- a/web/src/components/settings/tabs/SharedResourcesTab.tsx
+++ b/web/src/components/settings/tabs/SharedResourcesTab.tsx
@@ -1,7 +1,7 @@
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
-import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import { Checkbox, NumberInput } from '@mantine/core';
+import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings } from '@veritas-kanban/shared';
 import { ToggleRow, SectionHeader, SaveIndicator, SettingRow } from '../shared';
-import { Checkbox } from '@/components/ui/checkbox';
 
 const TYPE_OPTIONS: Array<{
   key: 'prompt' | 'guideline' | 'skill' | 'config' | 'template';
@@ -20,7 +20,7 @@ export function SharedResourcesTab() {
 
   const sharedResources = settings?.sharedResources ?? DEFAULT_FEATURE_SETTINGS.sharedResources;
 
-  const updateSharedResources = (patch: Record<string, any>) => {
+  const updateSharedResources = (patch: Partial<FeatureSettings['sharedResources']>) => {
     debouncedUpdate({ sharedResources: { ...sharedResources, ...patch } });
   };
 
@@ -62,19 +62,21 @@ export function SharedResourcesTab() {
             label="Max Resources"
             description="Global limit for shared resources (1-1000)"
           >
-            <div className="flex items-center gap-3 min-w-[200px]">
-              <input
-                type="range"
-                min={1}
-                max={1000}
-                value={sharedResources.maxResources}
-                onChange={(e) => updateSharedResources({ maxResources: Number(e.target.value) })}
-                className="w-40"
-              />
-              <span className="text-xs text-muted-foreground w-10 text-right">
-                {sharedResources.maxResources}
-              </span>
-            </div>
+            <NumberInput
+              min={1}
+              max={1000}
+              value={sharedResources.maxResources}
+              onChange={(value) => {
+                const nextValue = typeof value === 'number' ? value : Number(value);
+                if (Number.isFinite(nextValue)) {
+                  updateSharedResources({ maxResources: nextValue });
+                }
+              }}
+              size="xs"
+              radius="md"
+              w={160}
+              aria-label="Max Resources"
+            />
           </SettingRow>
         )}
       </div>
@@ -86,13 +88,13 @@ export function SharedResourcesTab() {
           </h4>
           <div className="space-y-2">
             {TYPE_OPTIONS.map((option) => (
-              <label key={option.key} className="flex items-center gap-3 text-sm">
-                <Checkbox
-                  checked={allowedTypes.includes(option.key)}
-                  onCheckedChange={() => toggleAllowedType(option.key)}
-                />
-                <span>{option.label}</span>
-              </label>
+              <Checkbox
+                key={option.key}
+                checked={allowedTypes.includes(option.key)}
+                onChange={() => toggleAllowedType(option.key)}
+                label={option.label}
+                radius="sm"
+              />
             ))}
           </div>
         </div>

--- a/web/src/components/settings/tabs/ToolPoliciesTab.tsx
+++ b/web/src/components/settings/tabs/ToolPoliciesTab.tsx
@@ -6,22 +6,21 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Stack,
+  Text,
+  TextInput,
+  Textarea,
+} from '@mantine/core';
 import { apiFetch } from '@/lib/api/helpers';
 import { useToast } from '@/hooks/useToast';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Badge } from '@/components/ui/badge';
-import { Plus, Edit, Trash2, Shield, Info } from 'lucide-react';
+import { Edit, Info, Plus, Shield, Trash2 } from 'lucide-react';
 
 interface ToolPolicy {
   role: string;
@@ -171,21 +170,29 @@ export function ToolPoliciesTab() {
         </p>
       </div>
 
-      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-        <div className="flex gap-2">
-          <Info className="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
-          <div className="text-sm text-blue-900 dark:text-blue-100">
-            <strong>Default roles:</strong> planner, developer, reviewer, tester, deployer.
-            <br />
-            Default policies can be edited but not deleted. Custom roles can be created for
-            specialized workflows.
-          </div>
-        </div>
-      </div>
+      <Alert
+        color="blue"
+        variant="light"
+        radius="md"
+        icon={<Info className="h-5 w-5" />}
+        className="border border-blue-200 dark:border-blue-800"
+      >
+        <Text size="sm">
+          <strong>Default roles:</strong> planner, developer, reviewer, tester, deployer.
+          <br />
+          Default policies can be edited but not deleted. Custom roles can be created for
+          specialized workflows.
+        </Text>
+      </Alert>
 
       <div className="flex justify-end">
-        <Button onClick={() => openEditDialog(null)} size="sm">
-          <Plus className="h-4 w-4 mr-2" />
+        <Button
+          type="button"
+          onClick={() => openEditDialog(null)}
+          size="sm"
+          radius="md"
+          leftSection={<Plus className="h-4 w-4" />}
+        >
           New Policy
         </Button>
       </div>
@@ -206,7 +213,7 @@ export function ToolPoliciesTab() {
                   <div className="flex items-center gap-2">
                     <h4 className="font-semibold">{policy.role}</h4>
                     {DEFAULT_ROLES.has(policy.role) && (
-                      <Badge variant="secondary" className="text-xs">
+                      <Badge variant="light" color="gray" size="xs">
                         default
                       </Badge>
                     )}
@@ -222,16 +229,18 @@ export function ToolPoliciesTab() {
                       {policy.allowed.length === 0 ? (
                         <span className="text-muted-foreground">none</span>
                       ) : policy.allowed.includes('*') ? (
-                        <Badge variant="outline">all tools</Badge>
+                        <Badge variant="outline" color="gray">
+                          all tools
+                        </Badge>
                       ) : (
                         <div className="flex flex-wrap gap-1">
                           {policy.allowed.slice(0, 5).map((tool) => (
-                            <Badge key={tool} variant="outline" className="text-xs">
+                            <Badge key={tool} variant="outline" color="gray" size="xs">
                               {tool}
                             </Badge>
                           ))}
                           {policy.allowed.length > 5 && (
-                            <Badge variant="outline" className="text-xs">
+                            <Badge variant="outline" color="gray" size="xs">
                               +{policy.allowed.length - 5} more
                             </Badge>
                           )}
@@ -246,12 +255,12 @@ export function ToolPoliciesTab() {
                         </span>
                         <div className="flex flex-wrap gap-1">
                           {policy.denied.slice(0, 5).map((tool) => (
-                            <Badge key={tool} variant="destructive" className="text-xs">
+                            <Badge key={tool} variant="light" color="red" size="xs">
                               {tool}
                             </Badge>
                           ))}
                           {policy.denied.length > 5 && (
-                            <Badge variant="destructive" className="text-xs">
+                            <Badge variant="light" color="red" size="xs">
                               +{policy.denied.length - 5} more
                             </Badge>
                           )}
@@ -262,23 +271,29 @@ export function ToolPoliciesTab() {
                 </div>
 
                 <div className="flex items-center gap-2 flex-shrink-0">
-                  <Button
-                    variant="ghost"
+                  <ActionIcon
+                    type="button"
+                    variant="subtle"
+                    color="gray"
                     size="sm"
+                    radius="md"
+                    aria-label={`Edit ${policy.role}`}
                     onClick={() => openEditDialog(policy)}
-                    className="h-8 w-8 p-0"
                   >
                     <Edit className="h-4 w-4" />
-                  </Button>
+                  </ActionIcon>
                   {!DEFAULT_ROLES.has(policy.role) && (
-                    <Button
-                      variant="ghost"
+                    <ActionIcon
+                      type="button"
+                      variant="subtle"
+                      color="red"
                       size="sm"
+                      radius="md"
+                      aria-label={`Delete ${policy.role}`}
                       onClick={() => handleDeletePolicy(policy.role)}
-                      className="h-8 w-8 p-0 text-destructive hover:text-destructive"
                     >
                       <Trash2 className="h-4 w-4" />
-                    </Button>
+                    </ActionIcon>
                   )}
                 </div>
               </div>
@@ -287,77 +302,76 @@ export function ToolPoliciesTab() {
         )}
       </div>
 
-      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>{isNew ? 'Create Tool Policy' : `Edit Policy: ${formRole}`}</DialogTitle>
-            <DialogDescription>
-              Define tool access restrictions for an agent role. Denied tools take precedence over
-              allowed tools.
-            </DialogDescription>
-          </DialogHeader>
+      <Modal
+        opened={editDialogOpen}
+        onClose={() => setEditDialogOpen(false)}
+        title={isNew ? 'Create Tool Policy' : `Edit Policy: ${formRole}`}
+        size="lg"
+        radius="md"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Define tool access restrictions for an agent role. Denied tools take precedence over
+            allowed tools.
+          </Text>
 
-          <div className="space-y-4">
-            <div>
-              <Label htmlFor="role">Role Name</Label>
-              <Input
-                id="role"
-                value={formRole}
-                onChange={(e) => setFormRole(e.target.value)}
-                placeholder="e.g., analyst, deployer, custom-role"
-                disabled={!isNew}
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Role name (lowercase, no spaces). Cannot be changed after creation.
-              </p>
-            </div>
+          <TextInput
+            label="Role Name"
+            description="Role name (lowercase, no spaces). Cannot be changed after creation."
+            value={formRole}
+            onChange={(e) => setFormRole(e.target.value)}
+            placeholder="e.g., analyst, deployer, custom-role"
+            disabled={!isNew}
+            size="sm"
+            radius="md"
+          />
 
-            <div>
-              <Label htmlFor="allowed">Allowed Tools</Label>
-              <Input
-                id="allowed"
-                value={formAllowed}
-                onChange={(e) => setFormAllowed(e.target.value)}
-                placeholder="e.g., Read, web_search, browser or * for all"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Comma-separated list of tool names. Use * to allow all tools.
-              </p>
-            </div>
+          <TextInput
+            label="Allowed Tools"
+            description="Comma-separated list of tool names. Use * to allow all tools."
+            value={formAllowed}
+            onChange={(e) => setFormAllowed(e.target.value)}
+            placeholder="e.g., Read, web_search, browser or * for all"
+            size="sm"
+            radius="md"
+          />
 
-            <div>
-              <Label htmlFor="denied">Denied Tools</Label>
-              <Input
-                id="denied"
-                value={formDenied}
-                onChange={(e) => setFormDenied(e.target.value)}
-                placeholder="e.g., Write, Edit, exec, message"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Comma-separated list of tool names. Denied tools take precedence.
-              </p>
-            </div>
+          <TextInput
+            label="Denied Tools"
+            description="Comma-separated list of tool names. Denied tools take precedence."
+            value={formDenied}
+            onChange={(e) => setFormDenied(e.target.value)}
+            placeholder="e.g., Write, Edit, exec, message"
+            size="sm"
+            radius="md"
+          />
 
-            <div>
-              <Label htmlFor="description">Description</Label>
-              <Textarea
-                id="description"
-                value={formDescription}
-                onChange={(e) => setFormDescription(e.target.value)}
-                placeholder="Describe when to use this role and what it can do..."
-                rows={3}
-              />
-            </div>
-          </div>
+          <Textarea
+            label="Description"
+            value={formDescription}
+            onChange={(e) => setFormDescription(e.target.value)}
+            placeholder="Describe when to use this role and what it can do..."
+            rows={3}
+            size="sm"
+            radius="md"
+          />
 
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEditDialogOpen(false)}>
+          <Group justify="flex-end" gap="sm">
+            <Button
+              type="button"
+              variant="outline"
+              radius="md"
+              onClick={() => setEditDialogOpen(false)}
+            >
               Cancel
             </Button>
-            <Button onClick={handleSavePolicy}>{isNew ? 'Create' : 'Save Changes'}</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            <Button type="button" radius="md" onClick={handleSavePolicy}>
+              {isNew ? 'Create' : 'Save Changes'}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates the Tool Policies settings list and editor from the legacy UI wrappers to direct Mantine Alert, Modal, TextInput, Textarea, Badge, Button, and ActionIcon primitives.
- Migrates Shared Resources allowed type controls and max resource input to direct Mantine Checkbox and NumberInput primitives.
- Adds focused regression coverage for both settings tabs and updates the Mantine migration tracker.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/settings-governance-mantine.test.tsx src/__tests__/settings-dialog-mantine.test.tsx src/__tests__/settings-shared-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Browser smoke at http://localhost:3000/ covering Settings > Tool Policies and Settings > Shared Resources with no console warnings or errors.

## Notes
- Advances #417 under the v5 epic #326.
- No data migration required.