### PR TITLE
Migrate board chrome controls to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -314,6 +314,10 @@ Phase 3 progress:
   button, action icon, and modal primitives while preserving installed-agent
   add/edit/remove/toggle behavior, Codex health refresh, routing defaults, and
   routing-rule create/edit controls.
+- Board filter and bulk-selection chrome now use direct Mantine text input,
+  select, badge, button, action icon, and modal primitives while preserving
+  search/filter URL behavior, selection groups, move, backlog, archive, and
+  delete confirmation flows.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/board-chrome-mantine.test.tsx
+++ b/web/src/__tests__/board-chrome-mantine.test.tsx
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { FilterBar, type FilterState } from '@/components/board/FilterBar';
+import { BulkActionsBar } from '@/components/board/BulkActionsBar';
+import {
+  createMockProject,
+  createMockTask,
+  createMockTaskType,
+  renderWithProviders,
+} from './test-utils';
+import type { AgentConfig, AgentType } from '@veritas-kanban/shared';
+
+const agents: AgentConfig[] = [
+  {
+    type: 'codex' as AgentType,
+    name: 'Codex',
+    command: 'codex',
+    args: ['exec'],
+    enabled: true,
+    provider: 'codex-cli',
+  },
+];
+
+const mocks = vi.hoisted(() => ({
+  bulkArchiveByIds: vi.fn(),
+  bulkDemote: vi.fn(),
+  bulkUpdate: vi.fn(),
+  clearSelection: vi.fn(),
+  deleteTask: vi.fn(),
+  selectAll: vi.fn(),
+  toast: vi.fn(),
+  toggleGroup: vi.fn(),
+  toggleSelecting: vi.fn(),
+  useBulkActions: vi.fn(),
+  useConfig: vi.fn(),
+  useProjects: vi.fn(),
+  useTaskTypes: vi.fn(),
+}));
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: mocks.useConfig,
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProjects: mocks.useProjects,
+}));
+
+vi.mock('@/hooks/useTaskTypes', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/useTaskTypes')>('@/hooks/useTaskTypes');
+  return {
+    ...actual,
+    useTaskTypes: mocks.useTaskTypes,
+  };
+});
+
+vi.mock('@/hooks/useBulkActions', () => ({
+  useBulkActions: mocks.useBulkActions,
+}));
+
+vi.mock('@/hooks/useTasks', () => ({
+  useBulkArchiveByIds: () => ({
+    mutateAsync: mocks.bulkArchiveByIds,
+  }),
+  useBulkUpdate: () => ({
+    mutateAsync: mocks.bulkUpdate,
+  }),
+  useDeleteTask: () => ({
+    mutateAsync: mocks.deleteTask,
+  }),
+}));
+
+vi.mock('@/hooks/useBacklog', () => ({
+  useBulkDemote: () => ({
+    mutateAsync: mocks.bulkDemote,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+function defaultFilters(overrides: Partial<FilterState> = {}): FilterState {
+  return {
+    search: '',
+    project: null,
+    type: null,
+    agent: null,
+    ...overrides,
+  };
+}
+
+describe('Board chrome Mantine migration', () => {
+  beforeEach(() => {
+    mocks.useProjects.mockReturnValue({
+      data: [createMockProject({ id: 'veritas', label: 'Veritas' })],
+      isLoading: false,
+    });
+    mocks.useTaskTypes.mockReturnValue({
+      data: [createMockTaskType({ id: 'feature', label: 'Feature', icon: 'Code' })],
+      isLoading: false,
+    });
+    mocks.useConfig.mockReturnValue({
+      data: { agents },
+      isLoading: false,
+    });
+    mocks.bulkArchiveByIds.mockResolvedValue({ archived: ['VK-1'], failed: [] });
+    mocks.bulkDemote.mockResolvedValue({ demoted: ['VK-1'], failed: [] });
+    mocks.bulkUpdate.mockResolvedValue({ updated: ['VK-1'], failed: [] });
+    mocks.deleteTask.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders board filters through direct Mantine primitives', () => {
+    const onFiltersChange = vi.fn();
+    const { container } = renderWithProviders(
+      <FilterBar
+        tasks={[]}
+        filters={defaultFilters({
+          search: 'docs',
+          project: 'veritas',
+          type: 'feature',
+          agent: 'codex',
+        })}
+        onFiltersChange={onFiltersChange}
+      />
+    );
+
+    expect(screen.getByRole('search', { name: 'Filter tasks' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Search tasks' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Filter by project' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Filter by type' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Filter by agent' })).toBeDefined();
+    expect(screen.getByText('4 active filters')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Select-root').length).toBe(3);
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(container.querySelector('[data-slot="input"]')).toBeNull();
+    expect(container.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(container.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search tasks' }), {
+      target: { value: 'release' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all filters' }));
+
+    expect(onFiltersChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: 'release',
+        project: 'veritas',
+        type: 'feature',
+        agent: 'codex',
+      })
+    );
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      search: '',
+      project: null,
+      type: null,
+      agent: null,
+    });
+  });
+
+  it('renders bulk selection actions through direct Mantine primitives', () => {
+    mocks.useBulkActions.mockReturnValue({
+      selectedIds: new Set(['VK-1']),
+      isSelecting: true,
+      toggleSelecting: mocks.toggleSelecting,
+      toggleSelect: vi.fn(),
+      selectAll: mocks.selectAll,
+      toggleGroup: mocks.toggleGroup,
+      clearSelection: mocks.clearSelection,
+      isSelected: (id: string) => id === 'VK-1',
+    });
+
+    const tasks = [
+      createMockTask({ id: 'VK-1', status: 'todo', title: 'Selected todo' }),
+      createMockTask({ id: 'VK-2', status: 'done', title: 'Completed task' }),
+    ];
+
+    const { baseElement, container } = renderWithProviders(<BulkActionsBar tasks={tasks} />);
+
+    expect(screen.getByRole('toolbar', { name: 'Bulk actions' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Exit selection mode' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Select all tasks' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Move selected tasks to status' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'To Backlog' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(5);
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all tasks' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Select all Todo tasks (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mocks.selectAll).toHaveBeenCalledWith(['VK-1', 'VK-2']);
+    expect(mocks.toggleGroup).toHaveBeenCalledWith(['VK-1']);
+    expect(screen.getByText('Delete 1 task?')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Modal-root')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByText('Delete 1 task?')).toBeNull();
+  });
+});

--- a/web/src/components/board/BulkActionsBar.tsx
+++ b/web/src/components/board/BulkActionsBar.tsx
@@ -1,18 +1,7 @@
 import { useState, useMemo } from 'react';
 import { X, Trash2, Archive, ArrowRight, Inbox } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
+import { ActionIcon, Button, Group, Modal, Select, Text } from '@mantine/core';
 import { useToast } from '@/hooks/useToast';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { useBulkActions } from '@/hooks/useBulkActions';
 import { useDeleteTask, useBulkUpdate, useBulkArchiveByIds } from '@/hooks/useTasks';
 import { useBulkDemote } from '@/hooks/useBacklog';
@@ -45,6 +34,8 @@ const STATUS_BUTTONS: { id: TaskStatus; label: string; color: string; activeColo
     activeColor: 'bg-green-500 text-white border-green-500',
   },
 ];
+
+const MOVE_STATUS_OPTIONS = STATUS_BUTTONS.map(({ id, label }) => ({ value: id, label }));
 
 interface BulkActionsBarProps {
   tasks: Task[];
@@ -177,7 +168,7 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
       }
 
       clearSelection();
-    } catch (error) {
+    } catch {
       toast({
         variant: 'destructive',
         title: 'Archive Failed',
@@ -216,7 +207,7 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
       }
 
       clearSelection();
-    } catch (error) {
+    } catch {
       toast({
         variant: 'destructive',
         title: 'Move Failed',
@@ -250,9 +241,14 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
         aria-label="Bulk actions"
       >
         <div className="flex items-center gap-3">
-          <Button variant="ghost" size="sm" onClick={toggleSelecting}>
-            <X className="h-4 w-4" />
-          </Button>
+          <ActionIcon
+            aria-label="Exit selection mode"
+            variant="subtle"
+            size="sm"
+            onClick={toggleSelecting}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </ActionIcon>
 
           <Button
             variant="outline"
@@ -274,7 +270,7 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
                 <Button
                   key={id}
                   variant="outline"
-                  size="sm"
+                  size="xs"
                   onClick={() => toggleGroup(taskIdsByStatus[id])}
                   className={cn(
                     'text-xs h-7 px-2 border transition-colors',
@@ -296,36 +292,25 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
           <div className="flex items-center gap-2">
             {/* Move to status — two-step: pick target → confirm */}
             <Select
-              value={moveTarget ?? ''}
-              onValueChange={(value) => setMoveTarget(value as TaskStatus)}
+              value={moveTarget}
+              onChange={(value) => setMoveTarget(value as TaskStatus | null)}
               disabled={isProcessing}
-            >
-              <SelectTrigger className="w-[140px]">
-                <div className="flex items-center gap-1">
-                  <ArrowRight className="h-4 w-4" />
-                  <span>
-                    {moveTarget
-                      ? (STATUS_BUTTONS.find((s) => s.id === moveTarget)?.label ?? 'Move to...')
-                      : 'Move to...'}
-                  </span>
-                </div>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="todo">To Do</SelectItem>
-                <SelectItem value="in-progress">In Progress</SelectItem>
-                <SelectItem value="blocked">Blocked</SelectItem>
-                <SelectItem value="done">Done</SelectItem>
-              </SelectContent>
-            </Select>
+              data={MOVE_STATUS_OPTIONS}
+              aria-label="Move selected tasks to status"
+              placeholder="Move to..."
+              className="w-[140px]"
+              leftSection={<ArrowRight className="h-4 w-4" aria-hidden="true" />}
+              clearable
+            />
 
             {moveTarget && (
               <Button
-                variant="default"
+                variant="filled"
                 size="sm"
                 onClick={handleMoveToStatus}
                 disabled={isProcessing}
+                leftSection={<ArrowRight className="h-4 w-4" aria-hidden="true" />}
               >
-                <ArrowRight className="h-4 w-4 mr-1" />
                 {isProcessing ? 'Moving...' : 'Move'}
               </Button>
             )}
@@ -336,8 +321,8 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
               size="sm"
               onClick={handleMoveToBacklog}
               disabled={isProcessing}
+              leftSection={<Inbox className="h-4 w-4" aria-hidden="true" />}
             >
-              <Inbox className="h-4 w-4 mr-1" />
               To Backlog
             </Button>
 
@@ -347,8 +332,8 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
               size="sm"
               onClick={handleArchiveSelected}
               disabled={isProcessing}
+              leftSection={<Archive className="h-4 w-4" aria-hidden="true" />}
             >
-              <Archive className="h-4 w-4 mr-1" />
               Archive
             </Button>
 
@@ -359,36 +344,36 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
               onClick={() => setShowDeleteConfirm(true)}
               disabled={isProcessing}
               className="text-destructive hover:text-destructive"
+              leftSection={<Trash2 className="h-4 w-4" aria-hidden="true" />}
             >
-              <Trash2 className="h-4 w-4 mr-1" />
               Delete
             </Button>
           </div>
         )}
       </div>
 
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              Delete {selectedCount} task{selectedCount !== 1 ? 's' : ''}?
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. The selected tasks will be permanently deleted.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isProcessing}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteSelected}
-              disabled={isProcessing}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isProcessing ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <Modal
+        opened={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title={`Delete ${selectedCount} task${selectedCount !== 1 ? 's' : ''}?`}
+        centered
+      >
+        <Text size="sm" c="dimmed">
+          This action cannot be undone. The selected tasks will be permanently deleted.
+        </Text>
+        <Group justify="flex-end" gap="sm" mt="lg">
+          <Button
+            variant="default"
+            onClick={() => setShowDeleteConfirm(false)}
+            disabled={isProcessing}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleDeleteSelected} disabled={isProcessing} color="red">
+            {isProcessing ? 'Deleting...' : 'Delete'}
+          </Button>
+        </Group>
+      </Modal>
     </>
   );
 }

--- a/web/src/components/board/FilterBar.tsx
+++ b/web/src/components/board/FilterBar.tsx
@@ -1,16 +1,7 @@
 import { Search, X, Filter } from 'lucide-react';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
+import { ActionIcon, Badge, Button, Select, TextInput } from '@mantine/core';
 import type { Task, TaskType } from '@veritas-kanban/shared';
-import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
+import { useTaskTypes } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useConfig } from '@/hooks/useConfig';
 
@@ -32,6 +23,20 @@ export function FilterBar({ filters, onFiltersChange }: FilterBarProps) {
   const { data: projects = [], isLoading: projectsLoading } = useProjects();
   const { data: config } = useConfig();
   const agents = config?.agents || [];
+  const projectOptions = [
+    { value: 'all', label: 'All Projects' },
+    ...projects.map((project) => ({ value: project.id, label: project.label })),
+  ];
+  const typeOptions = [
+    { value: 'all', label: 'All Types' },
+    ...taskTypes.map((type) => ({ value: type.id, label: type.label })),
+  ];
+  const agentOptions = [
+    { value: 'all', label: 'All Agents' },
+    { value: 'auto', label: 'Auto (routing)' },
+    { value: 'unassigned', label: 'Unassigned' },
+    ...agents.map((agent) => ({ value: agent.type, label: agent.name })),
+  ];
 
   // Count active filters
   const activeFilterCount = [filters.search, filters.project, filters.type, filters.agent].filter(
@@ -50,112 +55,86 @@ export function FilterBar({ filters, onFiltersChange }: FilterBarProps) {
     <div className="flex items-center gap-3" role="search" aria-label="Filter tasks">
       {/* Search */}
       <div className="relative flex-1 max-w-sm">
-        <Search
-          className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
-          aria-hidden="true"
-        />
-        <label htmlFor="task-search" className="sr-only">
-          Search tasks
-        </label>
-        <Input
+        <TextInput
           id="task-search"
+          aria-label="Search tasks"
           placeholder="Search tasks..."
           value={filters.search}
           onChange={(e) => updateSearch(e.target.value)}
-          className="pl-9 pr-9"
+          leftSection={<Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+          rightSectionPointerEvents="auto"
+          rightSection={
+            filters.search ? (
+              <ActionIcon
+                aria-label="Clear search"
+                variant="subtle"
+                size="sm"
+                onClick={() => updateSearch('')}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </ActionIcon>
+            ) : null
+          }
           aria-describedby={activeFilterCount > 0 ? 'active-filter-count' : undefined}
         />
-        {filters.search && (
-          <button
-            onClick={() => updateSearch('')}
-            aria-label="Clear search"
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          >
-            <X className="h-4 w-4" aria-hidden="true" />
-          </button>
-        )}
       </div>
 
       {/* Project filter */}
       <Select
         value={filters.project || 'all'}
-        onValueChange={(value) =>
-          onFiltersChange({ ...filters, project: value === 'all' ? null : value })
+        onChange={(value) =>
+          onFiltersChange({ ...filters, project: value && value !== 'all' ? value : null })
         }
         disabled={projectsLoading}
-      >
-        <SelectTrigger className="w-[160px]" aria-label="Filter by project">
-          <SelectValue placeholder="All Projects" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All Projects</SelectItem>
-          {projects.map((project) => (
-            <SelectItem key={project.id} value={project.id}>
-              {project.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        data={projectOptions}
+        aria-label="Filter by project"
+        className="w-[160px]"
+        allowDeselect={false}
+      />
 
       {/* Type filter */}
       <Select
         value={filters.type || 'all'}
-        onValueChange={(value) =>
-          onFiltersChange({ ...filters, type: value === 'all' ? null : (value as TaskType) })
+        onChange={(value) =>
+          onFiltersChange({
+            ...filters,
+            type: value && value !== 'all' ? (value as TaskType) : null,
+          })
         }
         disabled={typesLoading}
-      >
-        <SelectTrigger className="w-[160px]" aria-label="Filter by type">
-          <SelectValue placeholder="All Types" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All Types</SelectItem>
-          {taskTypes.map((type) => {
-            const IconComponent = getTypeIcon(type.icon);
-            return (
-              <SelectItem key={type.id} value={type.id}>
-                <div className="flex items-center gap-2">
-                  {IconComponent && <IconComponent className="h-4 w-4" />}
-                  {type.label}
-                </div>
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
+        data={typeOptions}
+        aria-label="Filter by type"
+        className="w-[160px]"
+        allowDeselect={false}
+      />
 
       {/* Agent filter */}
       <Select
         value={filters.agent || 'all'}
-        onValueChange={(value) =>
-          onFiltersChange({ ...filters, agent: value === 'all' ? null : value })
+        onChange={(value) =>
+          onFiltersChange({ ...filters, agent: value && value !== 'all' ? value : null })
         }
-      >
-        <SelectTrigger className="w-[160px]" aria-label="Filter by agent">
-          <SelectValue placeholder="All Agents" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All Agents</SelectItem>
-          <SelectItem value="auto">Auto (routing)</SelectItem>
-          <SelectItem value="unassigned">Unassigned</SelectItem>
-          {agents.map((a) => (
-            <SelectItem key={a.type} value={a.type}>
-              {a.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        data={agentOptions}
+        aria-label="Filter by agent"
+        className="w-[160px]"
+        allowDeselect={false}
+      />
 
       {/* Active filter indicator & clear */}
       {activeFilterCount > 0 && (
         <div className="flex items-center gap-2">
-          <Badge id="active-filter-count" variant="secondary" className="gap-1" aria-live="polite">
-            <Filter className="h-3 w-3" aria-hidden="true" />
+          <Badge
+            id="active-filter-count"
+            variant="light"
+            color="gray"
+            leftSection={<Filter className="h-3 w-3" aria-hidden="true" />}
+            aria-live="polite"
+          >
             {activeFilterCount} active {activeFilterCount === 1 ? 'filter' : 'filters'}
           </Badge>
           <Button
-            variant="ghost"
-            size="sm"
+            variant="subtle"
+            size="xs"
             onClick={clearAllFilters}
             aria-label="Clear all filters"
             className="text-muted-foreground hover:text-foreground"

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -19,7 +19,7 @@ import { BulkActionsBar } from './BulkActionsBar';
 import { BoardSidebar } from './BoardSidebar';
 import { useBulkActions } from '@/hooks/useBulkActions';
 import { CheckSquare } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { Button } from '@mantine/core';
 import { ArchiveSuggestionBanner } from './ArchiveSuggestionBanner';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import { useLiveAnnouncer } from '@/components/shared/LiveAnnouncer';
@@ -242,14 +242,14 @@ export function KanbanBoard() {
         <FilterBar tasks={tasks || []} filters={filters} onFiltersChange={setFilters} />
         {!isSelecting && (
           <Button
-            variant="ghost"
+            variant="subtle"
             size="sm"
             onClick={toggleSelecting}
             disabled={!canWriteTasks}
             title={canWriteTasks ? 'Select tasks' : 'Task write permission required'}
             className="text-muted-foreground shrink-0"
+            leftSection={<CheckSquare className="h-4 w-4" aria-hidden="true" />}
           >
-            <CheckSquare className="h-4 w-4 mr-1" />
             Select
           </Button>
         )}


### PR DESCRIPTION
## Summary

- Migrates board filter chrome to direct Mantine TextInput, Select, Badge, Button, and ActionIcon primitives.
- Migrates the bulk-selection toolbar and delete confirmation to direct Mantine ActionIcon, Button, Select, Modal, Text, and Group primitives.
- Adds focused regression coverage proving the board chrome renders through Mantine roots and no longer exposes legacy wrapper slots.
- Updates the Mantine migration plan progress for the board chrome slice.

## Verification

- `pnpm --filter @veritas-kanban/web test -- src/__tests__/board-chrome-mantine.test.tsx src/__tests__/KanbanBoard.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm lint:budget`
- `git diff --check`
- Rendered board smoke at `http://localhost:3000/` with a temp backend on `127.0.0.1:3001`: filter chrome used direct Mantine roots, selection mode opened the Mantine toolbar, old wrapper slots were absent, and browser console warnings/errors were empty.

## Roadmap

- Advances #417
- Updates #326
