### PR TITLE
Migrate auth screens to Mantine controls

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -322,6 +322,10 @@ Phase 3 progress:
   checkbox, badge, button, and scroll-area primitives while preserving task/doc
   search, collection filters, backend selection, fallback status, and task-open
   callbacks.
+- Setup, login, recovery, and recovery-key confirmation controls now use direct
+  Mantine password input, text input, checkbox, and button primitives while
+  preserving password creation, remember-me login, recovery reset, key copy, and
+  key-download behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/auth-screens-mantine.test.tsx
+++ b/web/src/__tests__/auth-screens-mantine.test.tsx
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { LoginScreen } from '@/components/auth/LoginScreen';
+import { DESKTOP_ONBOARDING_STORAGE_KEY } from '@/components/auth/DesktopOnboarding';
+import { SetupScreen } from '@/components/auth/SetupScreen';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  setup: vi.fn(),
+  login: vi.fn(),
+  recover: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    setup: mocks.setup,
+    login: mocks.login,
+    recover: mocks.recover,
+  }),
+}));
+
+function ensureLocalStorage() {
+  if (window.localStorage) return;
+
+  const storage = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      get length() {
+        return storage.size;
+      },
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => Array.from(storage.keys())[index] ?? null,
+      removeItem: (key: string) => storage.delete(key),
+      setItem: (key: string, value: string) => storage.set(key, value),
+    },
+  });
+}
+
+describe('auth screens Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ensureLocalStorage();
+    window.localStorage.setItem(DESKTOP_ONBOARDING_STORAGE_KEY, 'true');
+    mocks.setup.mockResolvedValue({ success: true, recoveryKey: 'AAAA-BBBB-CCCC-DDDD' });
+    mocks.login.mockResolvedValue({ success: true });
+    mocks.recover.mockResolvedValue({ success: true, recoveryKey: 'EEEE-FFFF-GGGG-HHHH' });
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('renders setup password and recovery controls through direct Mantine primitives', async () => {
+    const { container } = renderWithProviders(<SetupScreen />);
+
+    expect(screen.getByText('Secure Your Board')).toBeDefined();
+    expect(screen.getByLabelText('Password')).toBeDefined();
+    expect(screen.getByLabelText('Confirm Password')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-PasswordInput-root')).toHaveLength(2);
+    expect(container.querySelectorAll('.mantine-Button-root')).toHaveLength(1);
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+    expect(container.querySelector('[data-slot="checkbox"]')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'StrongPass1!' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'StrongPass1!' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Password' }));
+
+    await waitFor(() => expect(mocks.setup).toHaveBeenCalledWith('StrongPass1!'));
+    expect(await screen.findByText('Save Your Recovery Key')).toBeDefined();
+    expect(screen.getByText('AAAA-BBBB-CCCC-DDDD')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Checkbox-root')).toHaveLength(1);
+    expect(container.querySelectorAll('.mantine-Button-root')).toHaveLength(3);
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+    expect(container.querySelector('[data-slot="checkbox"]')).toBeNull();
+  });
+
+  it('renders login controls through direct Mantine primitives and submits remember-me state', async () => {
+    const { container } = renderWithProviders(<LoginScreen />);
+
+    expect(screen.getByText('Welcome Back')).toBeDefined();
+    expect(screen.getByLabelText('Password')).toBeDefined();
+    expect(screen.getByLabelText('Remember me for 30 days')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-PasswordInput-root')).toHaveLength(1);
+    expect(container.querySelectorAll('.mantine-Checkbox-root')).toHaveLength(1);
+    expect(container.querySelectorAll('.mantine-Button-root')).toHaveLength(2);
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+    expect(container.querySelector('[data-slot="checkbox"]')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'StrongPass1!' },
+    });
+    fireEvent.click(screen.getByLabelText('Remember me for 30 days'));
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+
+    await waitFor(() => expect(mocks.login).toHaveBeenCalledWith('StrongPass1!', true));
+  });
+
+  it('renders recovery controls through direct Mantine primitives and submits uppercase key', async () => {
+    const { container } = renderWithProviders(<LoginScreen />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Forgot password?' }));
+
+    expect(screen.getByRole('heading', { name: 'Reset Password' })).toBeDefined();
+    expect(screen.getByLabelText('Recovery Key')).toBeDefined();
+    expect(screen.getByLabelText('New Password')).toBeDefined();
+    expect(screen.getByLabelText('Confirm New Password')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-TextInput-root')).toHaveLength(1);
+    expect(container.querySelectorAll('.mantine-PasswordInput-root')).toHaveLength(2);
+    expect(container.querySelectorAll('.mantine-Button-root')).toHaveLength(2);
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+    expect(container.querySelector('[data-slot="input"]')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Recovery Key'), {
+      target: { value: 'abcd-efgh-1234-5678' },
+    });
+    fireEvent.change(screen.getByLabelText('New Password'), {
+      target: { value: 'NewStrongPass1!' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm New Password'), {
+      target: { value: 'NewStrongPass1!' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Reset Password' }));
+
+    await waitFor(() =>
+      expect(mocks.recover).toHaveBeenCalledWith('ABCD-EFGH-1234-5678', 'NewStrongPass1!')
+    );
+  });
+});

--- a/web/src/components/auth/LoginScreen.tsx
+++ b/web/src/components/auth/LoginScreen.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react';
-import { PasswordInput, TextInput } from '@mantine/core';
+import { Button, Checkbox, PasswordInput, TextInput } from '@mantine/core';
 import { useAuth } from '@/hooks/useAuth';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Lock, Key, Check, Copy, Download } from 'lucide-react';
 
 export function LoginScreen() {
@@ -104,26 +101,35 @@ export function LoginScreen() {
               {newRecoveryKey}
             </div>
             <div className="flex gap-2">
-              <Button variant="outline" className="flex-1" onClick={copyRecoveryKey}>
-                {copiedKey ? <Check className="w-4 h-4 mr-2" /> : <Copy className="w-4 h-4 mr-2" />}
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={copyRecoveryKey}
+                leftSection={
+                  copiedKey ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />
+                }
+              >
                 {copiedKey ? 'Copied!' : 'Copy'}
               </Button>
-              <Button variant="outline" className="flex-1" onClick={downloadRecoveryKey}>
-                <Download className="w-4 h-4 mr-2" />
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={downloadRecoveryKey}
+                leftSection={<Download className="w-4 h-4" />}
+              >
                 Download
               </Button>
             </div>
           </div>
 
-          <div className="flex items-start space-x-3 p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+          <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
             <Checkbox
               id="saved-confirm"
               checked={savedConfirmed}
-              onCheckedChange={(checked) => setSavedConfirmed(!!checked)}
+              onChange={(event) => setSavedConfirmed(event.currentTarget.checked)}
+              label="I have saved my recovery key in a safe place"
+              classNames={{ label: 'text-sm cursor-pointer' }}
             />
-            <Label htmlFor="saved-confirm" className="text-sm cursor-pointer">
-              I have saved my recovery key in a safe place
-            </Label>
           </div>
 
           <Button
@@ -156,9 +162,9 @@ export function LoginScreen() {
 
           <form onSubmit={handleRecover} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="recovery-key">Recovery Key</Label>
               <TextInput
                 id="recovery-key"
+                label="Recovery Key"
                 value={recoveryKey}
                 onChange={(e) => setRecoveryKey(e.target.value.toUpperCase())}
                 placeholder="XXXX-XXXX-XXXX-XXXX"
@@ -168,9 +174,9 @@ export function LoginScreen() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="new-password">New Password</Label>
               <PasswordInput
                 id="new-password"
+                label="New Password"
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
                 placeholder="Enter new password (8+ characters)"
@@ -180,9 +186,9 @@ export function LoginScreen() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="confirm-new-password">Confirm New Password</Label>
               <PasswordInput
                 id="confirm-new-password"
+                label="Confirm New Password"
                 value={confirmNewPassword}
                 onChange={(e) => setConfirmNewPassword(e.target.value)}
                 placeholder="Confirm new password"
@@ -204,8 +210,10 @@ export function LoginScreen() {
               {isSubmitting ? 'Resetting...' : 'Reset Password'}
             </Button>
 
-            <button
+            <Button
               type="button"
+              variant="subtle"
+              color="gray"
               onClick={() => {
                 setShowRecovery(false);
                 setError(null);
@@ -213,7 +221,7 @@ export function LoginScreen() {
               className="w-full text-sm text-muted-foreground hover:text-foreground"
             >
               Back to login
-            </button>
+            </Button>
           </form>
         </div>
       </div>
@@ -234,9 +242,9 @@ export function LoginScreen() {
 
         <form onSubmit={handleLogin} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="password">Password</Label>
             <PasswordInput
               id="password"
+              label="Password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Enter your password"
@@ -246,15 +254,14 @@ export function LoginScreen() {
             />
           </div>
 
-          <div className="flex items-center space-x-2">
+          <div>
             <Checkbox
               id="remember-me"
               checked={rememberMe}
-              onCheckedChange={(checked) => setRememberMe(!!checked)}
+              onChange={(event) => setRememberMe(event.currentTarget.checked)}
+              label="Remember me for 30 days"
+              classNames={{ label: 'text-sm cursor-pointer' }}
             />
-            <Label htmlFor="remember-me" className="text-sm cursor-pointer">
-              Remember me for 30 days
-            </Label>
           </div>
 
           {error && (
@@ -267,8 +274,10 @@ export function LoginScreen() {
             {isSubmitting ? 'Logging in...' : 'Login'}
           </Button>
 
-          <button
+          <Button
             type="button"
+            variant="subtle"
+            color="gray"
             onClick={() => {
               setShowRecovery(true);
               setError(null);
@@ -276,7 +285,7 @@ export function LoginScreen() {
             className="w-full text-sm text-muted-foreground hover:text-foreground"
           >
             Forgot password?
-          </button>
+          </Button>
         </form>
       </div>
     </div>

--- a/web/src/components/auth/SetupScreen.tsx
+++ b/web/src/components/auth/SetupScreen.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react';
-import { PasswordInput } from '@mantine/core';
+import { Button, Checkbox, PasswordInput } from '@mantine/core';
 import { useAuth } from '@/hooks/useAuth';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Copy, Download, Check, Shield, Key } from 'lucide-react';
 import { DesktopOnboardingScreen, shouldShowDesktopOnboarding } from './DesktopOnboarding';
 
@@ -106,26 +103,35 @@ export function SetupScreen() {
           <div className="bg-muted/50 border border-border rounded-lg p-4 space-y-3">
             <div className="font-mono text-xl text-center tracking-wider py-2">{recoveryKey}</div>
             <div className="flex gap-2">
-              <Button variant="outline" className="flex-1" onClick={copyRecoveryKey}>
-                {copiedKey ? <Check className="w-4 h-4 mr-2" /> : <Copy className="w-4 h-4 mr-2" />}
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={copyRecoveryKey}
+                leftSection={
+                  copiedKey ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />
+                }
+              >
                 {copiedKey ? 'Copied!' : 'Copy'}
               </Button>
-              <Button variant="outline" className="flex-1" onClick={downloadRecoveryKey}>
-                <Download className="w-4 h-4 mr-2" />
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={downloadRecoveryKey}
+                leftSection={<Download className="w-4 h-4" />}
+              >
                 Download
               </Button>
             </div>
           </div>
 
-          <div className="flex items-start space-x-3 p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+          <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
             <Checkbox
               id="saved-confirm"
               checked={savedConfirmed}
-              onCheckedChange={(checked) => setSavedConfirmed(!!checked)}
+              onChange={(event) => setSavedConfirmed(event.currentTarget.checked)}
+              label="I have saved my recovery key in a safe place"
+              classNames={{ label: 'text-sm cursor-pointer' }}
             />
-            <Label htmlFor="saved-confirm" className="text-sm cursor-pointer">
-              I have saved my recovery key in a safe place
-            </Label>
           </div>
 
           <Button
@@ -155,9 +161,9 @@ export function SetupScreen() {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="password">Password</Label>
             <PasswordInput
               id="password"
+              label="Password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Enter password (8+ characters)"
@@ -185,9 +191,9 @@ export function SetupScreen() {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="confirm-password">Confirm Password</Label>
             <PasswordInput
               id="confirm-password"
+              label="Confirm Password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               placeholder="Confirm password"


### PR DESCRIPTION
## Summary
- Migrates setup, login, recovery, and recovery-key confirmation controls to direct Mantine Button, Checkbox, TextInput, and PasswordInput primitives.
- Moves auth labels onto Mantine input labels while preserving password setup, remember-me login, recovery reset, key copy, and key-download behavior.
- Adds focused auth-screen regression coverage and updates the Mantine migration plan.

## Verification
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/auth-screens-mantine.test.tsx src/__tests__/desktop-onboarding.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm lint:budget`
- `git diff --check`
- Rendered auth smoke at `http://localhost:3000/` with temp setup and login backend states: direct Mantine roots present, old wrapper slots absent, browser console warnings/errors empty.

## Roadmap
- Advances #417
- Updates #326