### PR TITLE
Migrate command dialogs to Mantine modals

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -326,6 +326,10 @@ Phase 3 progress:
   Mantine password input, text input, checkbox, and button primitives while
   preserving password creation, remember-me login, recovery reset, key copy, and
   key-download behavior.
+- Command palette and keyboard-shortcut help overlays now use direct Mantine
+  modal, text input, scroll area, stack, text, and key badge primitives while
+  preserving keyboard launch, command filtering, shortcut display, and nested
+  search-dialog launch behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/command-dialogs-mantine.test.tsx
+++ b/web/src/__tests__/command-dialogs-mantine.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+
+import { ViewProvider } from '@/contexts/ViewContext';
+import { KeyboardProvider } from '@/hooks/useKeyboard';
+import { CommandPalette } from '@/components/layout/CommandPalette';
+import { KeyboardShortcutsDialog } from '@/components/layout/KeyboardShortcutsDialog';
+import { renderWithProviders } from './test-utils';
+
+function renderCommandSurface(ui: React.ReactElement) {
+  return renderWithProviders(
+    <KeyboardProvider>
+      <ViewProvider>{ui}</ViewProvider>
+    </KeyboardProvider>
+  );
+}
+
+describe('command and shortcut dialogs Mantine migration', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens the command palette through direct Mantine modal primitives', async () => {
+    const { baseElement } = renderCommandSurface(<CommandPalette />);
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+
+    expect(await screen.findByRole('dialog', { name: 'Command palette' })).toBeDefined();
+    expect(screen.getByLabelText('Search commands')).toBeDefined();
+    expect(screen.getByText('New Task')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="dialog-title"]')).toBeNull();
+  });
+
+  it('opens keyboard shortcuts through direct Mantine modal and key badges', async () => {
+    const { baseElement } = renderCommandSurface(<KeyboardShortcutsDialog />);
+
+    fireEvent.keyDown(window, { key: '?' });
+
+    expect(await screen.findByRole('dialog', { name: 'Keyboard Shortcuts' })).toBeDefined();
+    expect(screen.getByText('Select next task')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Kbd-root').length).toBeGreaterThan(0);
+    expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="dialog-title"]')).toBeNull();
+  });
+});

--- a/web/src/components/layout/CommandPalette.tsx
+++ b/web/src/components/layout/CommandPalette.tsx
@@ -1,6 +1,15 @@
 import { lazy, Suspense, useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { Box, Group, Kbd, ScrollArea, Stack, Text, TextInput, UnstyledButton } from '@mantine/core';
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import {
+  Box,
+  Group,
+  Kbd,
+  Modal,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from '@mantine/core';
 import { useKeyboard } from '@/hooks/useKeyboard';
 import { useView } from '@/contexts/ViewContext';
 import {
@@ -275,15 +284,19 @@ export function CommandPalette() {
 
   return (
     <>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent
-          className="max-w-[520px] p-0 gap-0 overflow-hidden"
-          onKeyDown={handleKeyDown}
-        >
-          <DialogTitle className="sr-only">Command palette</DialogTitle>
-          <DialogDescription className="sr-only">
+      <Modal
+        opened={open}
+        onClose={() => setOpen(false)}
+        size={520}
+        padding={0}
+        title={<span className="sr-only">Command palette</span>}
+        withCloseButton={false}
+        classNames={{ content: 'overflow-hidden', header: 'sr-only', body: 'p-0' }}
+      >
+        <Box onKeyDown={handleKeyDown}>
+          <Text component="p" className="sr-only">
             Search and run board actions, navigation commands, and shortcuts.
-          </DialogDescription>
+          </Text>
 
           <Group gap="sm" px="md" className="border-b" wrap="nowrap">
             <TextInput
@@ -365,8 +378,8 @@ export function CommandPalette() {
               ))
             )}
           </ScrollArea>
-        </DialogContent>
-      </Dialog>
+        </Box>
+      </Modal>
       {searchMounted && (
         <Suspense fallback={null}>
           <SearchDialog

--- a/web/src/components/layout/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/layout/KeyboardShortcutsDialog.tsx
@@ -1,4 +1,5 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Group, Kbd, Modal, Stack, Text } from '@mantine/core';
+import { Keyboard } from 'lucide-react';
 import { useKeyboard } from '@/hooks/useKeyboard';
 
 interface Shortcut {
@@ -36,9 +37,9 @@ const shortcuts: { category: string; items: Shortcut[] }[] = [
 
 function KeyBadge({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="inline-flex items-center justify-center min-w-[24px] h-6 px-2 text-xs font-medium bg-muted border border-border rounded shadow-sm">
+    <Kbd className="inline-flex min-w-[24px] items-center justify-center px-2 text-xs font-medium">
       {children}
-    </kbd>
+    </Kbd>
   );
 }
 
@@ -46,45 +47,49 @@ export function KeyboardShortcutsDialog() {
   const { isHelpOpen, closeHelpDialog } = useKeyboard();
 
   return (
-    <Dialog open={isHelpOpen} onOpenChange={(open) => !open && closeHelpDialog()}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">⌨️ Keyboard Shortcuts</DialogTitle>
-        </DialogHeader>
-
-        <div className="space-y-6 py-2">
-          {shortcuts.map((section) => (
-            <section key={section.category} aria-label={`${section.category} shortcuts`}>
-              <h3 className="text-sm font-semibold text-muted-foreground mb-3">
-                {section.category}
-              </h3>
-              <dl className="space-y-2">
-                {section.items.map((shortcut, i) => (
-                  <div key={i} className="flex items-center justify-between">
-                    <dt className="text-sm">{shortcut.description}</dt>
-                    <dd className="flex items-center gap-1">
-                      {shortcut.keys.map((key, j) => (
-                        <span key={j} className="flex items-center gap-1">
-                          {j > 0 && (
-                            <span className="text-muted-foreground text-xs" aria-hidden="true">
-                              or
-                            </span>
-                          )}
-                          <KeyBadge>{key}</KeyBadge>
-                        </span>
-                      ))}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </section>
-          ))}
-        </div>
+    <Modal
+      opened={isHelpOpen}
+      onClose={closeHelpDialog}
+      size="md"
+      title={
+        <Group gap="xs">
+          <Keyboard className="h-4 w-4" aria-hidden="true" />
+          <span>Keyboard Shortcuts</span>
+        </Group>
+      }
+    >
+      <Stack gap="lg" py="xs">
+        {shortcuts.map((section) => (
+          <section key={section.category} aria-label={`${section.category} shortcuts`}>
+            <Text component="h3" size="sm" fw={600} c="dimmed" mb="sm">
+              {section.category}
+            </Text>
+            <dl className="space-y-2">
+              {section.items.map((shortcut, i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <dt className="text-sm">{shortcut.description}</dt>
+                  <dd className="flex items-center gap-1">
+                    {shortcut.keys.map((key, j) => (
+                      <span key={j} className="flex items-center gap-1">
+                        {j > 0 && (
+                          <span className="text-muted-foreground text-xs" aria-hidden="true">
+                            or
+                          </span>
+                        )}
+                        <KeyBadge>{key}</KeyBadge>
+                      </span>
+                    ))}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ))}
 
         <div className="text-xs text-muted-foreground text-center pt-2 border-t">
           Press <KeyBadge>?</KeyBadge> anytime to toggle this help
         </div>
-      </DialogContent>
-    </Dialog>
+      </Stack>
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates the command palette from the legacy dialog wrapper to a direct Mantine Modal while preserving keyboard launch, command filtering, shortcut rows, and nested search-dialog launch behavior.
- Migrates keyboard shortcut help to a direct Mantine Modal with Mantine Kbd badges and a lucide keyboard icon.
- Adds focused regression coverage for direct Mantine roots and old dialog slot removal, and updates the Mantine migration plan.

## Verification
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/command-dialogs-mantine.test.tsx src/__tests__/useKeyboard.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm lint:budget`
- `git diff --check`
- Rendered command palette smoke at `http://localhost:3000/` with a temp backend: direct Mantine modal, text input, and scroll area present, old dialog slots absent, browser console warnings/errors empty. Keyboard shortcut help is covered by component tests because the browser key injector did not deliver the `?` shortcut.

## Roadmap
- Advances #417
- Advances #364
- Updates #326