### PR TITLE
Migrate layout chrome to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -269,8 +269,8 @@ Recommended order:
 
 Phase 3 progress:
 
-- Auth/setup screens and the app shell/header/command palette have an initial
-  direct Mantine surface slice.
+- Auth/setup screens and the app shell/header/command palette have direct
+  Mantine surface slices.
 - Archive and backlog list/filter pages now use direct Mantine layout and form
   controls while preserving custom task card/list behavior.
 - Create-task dialog form controls now use direct Mantine text, textarea,
@@ -330,6 +330,10 @@ Phase 3 progress:
   modal, text input, scroll area, stack, text, and key badge primitives while
   preserving keyboard launch, command filtering, shortcut display, and nested
   search-dialog launch behavior.
+- Header action chrome, workspace switching, session menu, and WebSocket status
+  now use direct Mantine button, action icon, select, badge, popover, and key
+  badge primitives while preserving navigation, theme switching, workspace
+  switching, settings shortcuts, session actions, and status popover behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ViewProvider } from '@/contexts/ViewContext';
+import { KeyboardProvider } from '@/hooks/useKeyboard';
+import { Header } from '@/components/layout/Header';
+import { UserMenu } from '@/components/layout/UserMenu';
+import { WorkspaceSwitcher } from '@/components/layout/WorkspaceSwitcher';
+import { WebSocketIndicator } from '@/components/shared/WebSocketIndicator';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => {
+  const workspaces = [
+    {
+      workspace: {
+        id: 'workspace-a',
+        slug: 'veritas',
+        name: 'Veritas',
+        description: null,
+        mode: 'local',
+        createdBy: 'user-1',
+        archivedAt: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      membership: {
+        workspaceId: 'workspace-a',
+        userId: 'user-1',
+        role: 'owner' as const,
+        status: 'active',
+        invitedBy: null,
+        joinedAt: '2026-01-01T00:00:00Z',
+        disabledAt: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    },
+    {
+      workspace: {
+        id: 'workspace-b',
+        slug: 'ops',
+        name: 'Operations',
+        description: null,
+        mode: 'local',
+        createdBy: 'user-1',
+        archivedAt: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      membership: {
+        workspaceId: 'workspace-b',
+        userId: 'user-1',
+        role: 'admin' as const,
+        status: 'active',
+        invitedBy: null,
+        joinedAt: '2026-01-01T00:00:00Z',
+        disabledAt: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    },
+  ];
+
+  return {
+    identity: {
+      authContext: {
+        authMethod: 'password',
+        keyName: 'Local key',
+        permissions: ['*'],
+        role: 'owner',
+        tokenName: 'Desktop session',
+      },
+      profile: {
+        user: {
+          id: 'user-1',
+          displayName: 'Brad Groux',
+          email: 'brad@example.com',
+          handle: 'brad',
+          authSubject: null,
+          avatarUrl: null,
+          disabledAt: null,
+          lastSeenAt: null,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+        workspaces,
+      },
+      workspaces,
+      activeWorkspace: workspaces[0].workspace,
+      activeMembership: workspaces[0].membership,
+      activeWorkspaceId: 'workspace-a',
+      isLoading: false,
+      error: null,
+      canManageMembers: true,
+      hasPermission: vi.fn(() => true),
+      switchWorkspace: vi.fn(),
+    },
+    logout: vi.fn(),
+    setTheme: vi.fn(),
+  };
+});
+
+vi.mock('@/hooks/useIdentity', () => ({
+  useIdentity: () => mocks.identity,
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    status: {
+      authenticated: true,
+      sessionExpiry: '2030-01-01T00:00:00Z',
+    },
+    logout: mocks.logout,
+  }),
+}));
+
+vi.mock('@/hooks/useBacklog', () => ({
+  useBacklogCount: () => ({ data: 7 }),
+}));
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'dark',
+    setTheme: mocks.setTheme,
+  }),
+}));
+
+function renderHeaderChrome() {
+  return renderWithProviders(
+    <KeyboardProvider>
+      <ViewProvider>
+        <Header />
+      </ViewProvider>
+    </KeyboardProvider>
+  );
+}
+
+describe('layout chrome Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/');
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the header actions, workspace switcher, and user menu through direct Mantine controls', () => {
+    const { container } = renderHeaderChrome();
+
+    expect(screen.getByRole('banner')).toBeDefined();
+    expect(screen.getByRole('toolbar', { name: 'Board actions' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'New Task' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Workspace' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Command palette' })).toBeDefined();
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-ActionIcon-root').length).toBeGreaterThanOrEqual(6);
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+    expect(container.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(container.querySelector('[data-slot="select-trigger"]')).toBeNull();
+  });
+
+  it('keeps workspace switching wired while rendering a direct Mantine Select', async () => {
+    const user = userEvent.setup();
+    const { baseElement, container } = renderWithProviders(<WorkspaceSwitcher />);
+
+    expect(screen.getByRole('combobox', { name: 'Workspace' })).toBeDefined();
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(container.querySelector('[data-slot="badge"]')).toBeNull();
+
+    await user.click(screen.getByRole('combobox', { name: 'Workspace' }));
+    await user.click(await screen.findByText('Operations'));
+
+    await waitFor(() => expect(mocks.identity.switchWorkspace).toHaveBeenCalledWith('workspace-b'));
+    expect(baseElement.querySelector('.mantine-Combobox-dropdown')).toBeDefined();
+  });
+
+  it('renders the session popover with direct Mantine popover, badge, and key controls', async () => {
+    const user = userEvent.setup();
+    const onOpenSecuritySettings = vi.fn();
+    const onOpenIdentitySettings = vi.fn();
+    const { baseElement } = renderWithProviders(
+      <UserMenu
+        onOpenSecuritySettings={onOpenSecuritySettings}
+        onOpenIdentitySettings={onOpenIdentitySettings}
+      />
+    );
+
+    await user.click(screen.getByTitle('Session menu'));
+
+    expect(screen.getByText('Members & Permissions')).toBeDefined();
+    expect(screen.getByText('Security Settings')).toBeDefined();
+    expect(screen.getByText('Log Out')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Popover-dropdown')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThanOrEqual(2);
+    expect(baseElement.querySelector('.mantine-Kbd-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="popover-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+
+    await user.click(screen.getByText('Members & Permissions'));
+
+    expect(onOpenIdentitySettings).toHaveBeenCalledOnce();
+  });
+
+  it('renders WebSocket status with a direct Mantine popover', async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderWithProviders(<WebSocketIndicator />);
+
+    await user.click(screen.getByRole('button', { name: 'WebSocket connected' }));
+
+    expect(screen.getByText('Real-time sync active')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Popover-dropdown')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="popover-content"]')).toBeNull();
+  });
+});

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,4 +1,14 @@
-import { Box, Container, Divider, Group, Kbd, Text } from '@mantine/core';
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Container,
+  Divider,
+  Group,
+  Kbd,
+  Text,
+} from '@mantine/core';
 import {
   Plus,
   Settings,
@@ -18,7 +28,6 @@ import {
   ShieldAlert,
   type LucideIcon,
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 // ActivitySidebar removed — merged into ActivityFeed (GH-66)
 // ArchiveSidebar removed — replaced with full-page ArchivePage
 import { UserMenu } from './UserMenu';
@@ -30,7 +39,6 @@ import { useView } from '@/contexts/ViewContext';
 import { useBacklogCount } from '@/hooks/useBacklog';
 import { useTheme } from '@/hooks/useTheme';
 import { useIdentity } from '@/hooks/useIdentity';
-import { Badge } from '@/components/ui/badge';
 import { NAVIGATION_VIEWS, type ViewIcon } from '@/lib/views';
 
 const CreateTaskDialog = lazy(() =>
@@ -187,13 +195,13 @@ export function Header() {
 
           <Group gap="xs" wrap="nowrap" role="toolbar" aria-label="Board actions">
             <Button
-              variant="default"
-              size="sm"
+              variant="filled"
+              size="xs"
+              leftSection={<Plus className="h-4 w-4" aria-hidden="true" />}
               onClick={openCreateDialog}
               disabled={!canCreateTask}
               title={canCreateTask ? 'New Task' : 'Task write permission required'}
             >
-              <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
               New Task
             </Button>
             {NAVIGATION_VIEWS.map((item) => {
@@ -201,58 +209,67 @@ export function Header() {
               const isBacklog = item.view === 'backlog';
 
               return (
-                <Button
+                <ActionIcon
                   key={item.view}
-                  variant={view === item.view ? 'secondary' : 'ghost'}
-                  size="icon"
+                  variant={view === item.view ? 'light' : 'subtle'}
+                  color={view === item.view ? 'veritas' : 'gray'}
+                  size={32}
                   onClick={() => setView(view === item.view ? 'board' : item.view)}
                   aria-label={item.label}
+                  aria-pressed={view === item.view}
                   title={item.title ?? item.label}
                   className={isBacklog ? 'relative' : undefined}
                 >
                   <Icon className="h-4 w-4" aria-hidden="true" />
                   {isBacklog && backlogCount > 0 && (
                     <Badge
-                      variant="secondary"
-                      className="absolute -top-1 -right-1 h-5 w-5 rounded-full p-0 flex items-center justify-center text-[10px]"
+                      variant="light"
+                      color="gray"
+                      size="xs"
+                      px={0}
+                      className="absolute -top-1 -right-1 flex h-5 min-w-5 items-center justify-center rounded-full text-[10px]"
                     >
                       {backlogCount > 99 ? '99+' : backlogCount}
                     </Badge>
                   )}
-                </Button>
+                </ActionIcon>
               );
             })}
-            <Button
-              variant="ghost"
-              size="icon"
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size={32}
               onClick={openSearchDialog}
               aria-label="Search"
               title="Search"
             >
               <Search className="h-4 w-4" aria-hidden="true" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
+            </ActionIcon>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size={32}
               onClick={openSquadChatPanel}
               aria-label="Squad Chat"
               title="Squad Chat — Agent communication"
             >
               <Users className="h-4 w-4" aria-hidden="true" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
+            </ActionIcon>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size={32}
               onClick={openSettingsDialog}
               disabled={!canOpenSettings}
               aria-label="Settings"
               title={canOpenSettings ? 'Settings' : 'Settings permission required'}
             >
               <Settings className="h-4 w-4" aria-hidden="true" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
+            </ActionIcon>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size={32}
               onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
               aria-label="Toggle theme"
               title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
@@ -262,14 +279,16 @@ export function Header() {
               ) : (
                 <Sun className="h-4 w-4" aria-hidden="true" />
               )}
-            </Button>
+            </ActionIcon>
             <UserMenu
               onOpenSecuritySettings={openSecuritySettings}
               onOpenIdentitySettings={openIdentitySettings}
             />
             <Button
-              variant="ghost"
-              size="sm"
+              variant="subtle"
+              color="gray"
+              size="xs"
+              leftSection={<Search className="h-4 w-4" aria-hidden="true" />}
               onClick={() =>
                 window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))
               }
@@ -277,7 +296,6 @@ export function Header() {
               title="Command palette (⌘K)"
               className="gap-1.5 text-muted-foreground"
             >
-              <Search className="h-4 w-4" aria-hidden="true" />
               <Kbd className="hidden h-5 items-center gap-0.5 rounded border bg-muted px-1.5 font-mono text-[10px] sm:inline-flex">
                 ⌘K
               </Kbd>

--- a/web/src/components/layout/UserMenu.tsx
+++ b/web/src/components/layout/UserMenu.tsx
@@ -1,8 +1,16 @@
 import { useCallback, useEffect, useState } from 'react';
+import {
+  Badge,
+  Box,
+  Button,
+  Group,
+  Kbd,
+  Popover,
+  Stack,
+  Text,
+  UnstyledButton,
+} from '@mantine/core';
 import { Building2, Clock, ChevronDown, KeyRound, Lock, LogOut, Shield, User } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useAuth } from '@/hooks/useAuth';
 import { useIdentity } from '@/hooks/useIdentity';
 
@@ -82,54 +90,78 @@ export function UserMenu({ onOpenSecuritySettings, onOpenIdentitySettings }: Use
   const role = activeMembership?.role ?? authContext?.role ?? 'admin';
 
   return (
-    <Popover open={open} onOpenChange={setOpen} position="bottom-end">
-      <PopoverTrigger asChild>
-        <Button variant="ghost" size="sm" className="gap-2" title="Session menu">
-          <Lock className="h-4 w-4 text-emerald-500" />
-          <span className="text-xs text-muted-foreground hidden sm:inline">{displayName}</span>
-          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+    <Popover
+      opened={open}
+      onChange={setOpen}
+      position="bottom-end"
+      offset={4}
+      radius="md"
+      shadow="md"
+      withinPortal
+    >
+      <Popover.Target>
+        <Button
+          variant="subtle"
+          color="gray"
+          size="xs"
+          leftSection={<Lock className="h-4 w-4 text-emerald-500" aria-hidden="true" />}
+          rightSection={
+            <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
+          }
+          title="Session menu"
+          onClick={() => setOpen((current) => !current)}
+        >
+          <Text span size="xs" c="dimmed" className="hidden sm:inline">
+            {displayName}
+          </Text>
         </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-72 p-0">
-        <div className="p-3 border-b border-border">
-          <div className="flex items-start gap-2">
-            <div className="mt-0.5 rounded-full bg-primary/10 p-1.5 text-primary">
+      </Popover.Target>
+      <Popover.Dropdown className="w-72 bg-popover p-0 text-popover-foreground">
+        <Box className="border-b border-border p-3">
+          <Group align="flex-start" gap="xs" wrap="nowrap">
+            <Box className="mt-0.5 rounded-full bg-primary/10 p-1.5 text-primary">
               <User className="h-4 w-4" aria-hidden="true" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="truncate text-sm font-medium">{displayName}</div>
-              <div className="mt-1 flex flex-wrap items-center gap-1.5">
-                <Badge variant="secondary" className="capitalize">
+            </Box>
+            <Box className="min-w-0 flex-1">
+              <Text size="sm" fw={500} truncate>
+                {displayName}
+              </Text>
+              <Group mt={4} gap={6} wrap="wrap">
+                <Badge variant="light" color="gray" size="xs" className="capitalize">
                   {role}
                 </Badge>
                 {authContext?.authMethod && (
-                  <Badge variant="outline" className="capitalize">
+                  <Badge variant="outline" color="gray" size="xs" className="capitalize">
                     {authContext.authMethod}
                   </Badge>
                 )}
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 mt-3 text-xs text-muted-foreground">
+              </Group>
+            </Box>
+          </Group>
+          <Group gap="xs" mt="sm" wrap="nowrap" className="text-xs text-muted-foreground">
             <Clock className="h-3 w-3" />
             {formatExpiry(status.sessionExpiry)}
-          </div>
+          </Group>
           {activeWorkspace && (
-            <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+            <Group gap="xs" mt={4} wrap="nowrap" className="text-xs text-muted-foreground">
               <Building2 className="h-3 w-3" />
-              <span className="truncate">{activeWorkspace.name}</span>
-            </div>
+              <Text span size="xs" c="dimmed" truncate>
+                {activeWorkspace.name}
+              </Text>
+            </Group>
           )}
           {authContext?.tokenName && (
-            <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+            <Group gap="xs" mt={4} wrap="nowrap" className="text-xs text-muted-foreground">
               <KeyRound className="h-3 w-3" />
-              <span className="truncate">{authContext.tokenName}</span>
-            </div>
+              <Text span size="xs" c="dimmed" truncate>
+                {authContext.tokenName}
+              </Text>
+            </Group>
           )}
-        </div>
+        </Box>
 
-        <div className="p-1">
-          <button
+        <Stack gap={2} p={4}>
+          <UnstyledButton
             onClick={handleIdentityClick}
             className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-accent transition-colors"
           >
@@ -138,27 +170,27 @@ export function UserMenu({ onOpenSecuritySettings, onOpenIdentitySettings }: Use
             {!canManageMembers && (
               <span className="ml-auto text-xs text-muted-foreground">View</span>
             )}
-          </button>
+          </UnstyledButton>
 
-          <button
+          <UnstyledButton
             onClick={handleSecurityClick}
             className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-accent transition-colors"
           >
             <Shield className="h-4 w-4" />
             Security Settings
-          </button>
+          </UnstyledButton>
 
-          <button
+          <UnstyledButton
             onClick={handleLogout}
             disabled={isLoggingOut}
             className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-destructive/10 text-destructive transition-colors"
           >
             <LogOut className="h-4 w-4" />
             {isLoggingOut ? 'Logging out...' : 'Log Out'}
-            <span className="ml-auto text-xs text-muted-foreground">⌘⇧L</span>
-          </button>
-        </div>
-      </PopoverContent>
+            <Kbd className="ml-auto text-[10px] text-muted-foreground">⌘⇧L</Kbd>
+          </UnstyledButton>
+        </Stack>
+      </Popover.Dropdown>
     </Popover>
   );
 }

--- a/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -1,13 +1,6 @@
 import { useState } from 'react';
+import { Badge, Group, Select, Text } from '@mantine/core';
 import { Building2, Loader2 } from 'lucide-react';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
 import { useIdentity } from '@/hooks/useIdentity';
 
 export function WorkspaceSwitcher() {
@@ -34,31 +27,50 @@ export function WorkspaceSwitcher() {
     }
   };
 
+  const workspaceOptions = workspaces.map(({ workspace }) => ({
+    value: workspace.id,
+    label: workspace.name,
+  }));
+  const roleByWorkspaceId = new Map(
+    workspaces.map(({ workspace, membership }) => [workspace.id, membership.role])
+  );
+
   return (
     <div className="hidden md:flex items-center gap-2">
-      <Select value={activeWorkspaceId ?? undefined} onValueChange={handleSwitch}>
-        <SelectTrigger
-          className="h-8 w-[190px] bg-background/60"
-          aria-label="Workspace"
-          disabled={isSwitching}
-        >
-          <Building2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-          <SelectValue placeholder={activeWorkspace?.name ?? 'Workspace'} />
-          {isSwitching && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
-        </SelectTrigger>
-        <SelectContent align="start">
-          {workspaces.map(({ workspace, membership }) => (
-            <SelectItem key={workspace.id} value={workspace.id}>
-              <span className="flex min-w-0 items-center gap-2">
-                <span className="truncate">{workspace.name}</span>
-                <span className="text-xs text-muted-foreground">{membership.role}</span>
-              </span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <Select
+        aria-label="Workspace"
+        value={activeWorkspaceId ?? null}
+        onChange={(workspaceId) => {
+          if (workspaceId) void handleSwitch(workspaceId);
+        }}
+        data={workspaceOptions}
+        placeholder={activeWorkspace?.name ?? 'Workspace'}
+        disabled={isSwitching}
+        allowDeselect={false}
+        checkIconPosition="right"
+        className="w-[190px]"
+        classNames={{
+          input: 'h-8 bg-background/60 text-xs',
+          dropdown: 'bg-popover text-popover-foreground',
+          option: 'text-xs',
+        }}
+        leftSection={<Building2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+        rightSection={
+          isSwitching ? <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" /> : undefined
+        }
+        renderOption={({ option }) => (
+          <Group gap="xs" justify="space-between" wrap="nowrap" className="w-full">
+            <Text span size="xs" truncate>
+              {option.label}
+            </Text>
+            <Text span size="xs" c="dimmed" className="capitalize">
+              {roleByWorkspaceId.get(option.value)}
+            </Text>
+          </Group>
+        )}
+      />
       {activeMembership && (
-        <Badge variant="secondary" className="hidden lg:inline-flex capitalize">
+        <Badge variant="light" color="gray" size="xs" className="hidden lg:inline-flex capitalize">
           {activeMembership.role}
         </Badge>
       )}

--- a/web/src/components/shared/WebSocketIndicator.tsx
+++ b/web/src/components/shared/WebSocketIndicator.tsx
@@ -1,6 +1,6 @@
+import { Box, Group, Popover, Text, UnstyledButton } from '@mantine/core';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { Wifi, WifiOff, RefreshCw } from 'lucide-react';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 /**
  * Tiny indicator showing WebSocket connection status.
@@ -55,24 +55,28 @@ export function WebSocketIndicator() {
 
   return (
     <Popover position="bottom-end">
-      <PopoverTrigger asChild>
-        <button
+      <Popover.Target>
+        <UnstyledButton
           className="flex items-center gap-1 text-xs text-muted-foreground cursor-pointer select-none rounded px-1.5 py-1 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label={label}
         >
-          <span className={`inline-block h-2 w-2 rounded-full ${dotClass}`} />
-          <Icon className={`h-3 w-3 ${iconClass}`} />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent className="w-64 p-3">
-        <div className="space-y-1.5">
-          <div className="flex items-center gap-2">
+          <Box component="span" className={`inline-block h-2 w-2 rounded-full ${dotClass}`} />
+          <Icon className={`h-3 w-3 ${iconClass}`} aria-hidden="true" />
+        </UnstyledButton>
+      </Popover.Target>
+      <Popover.Dropdown className="w-64 bg-popover p-3 text-popover-foreground">
+        <Box className="space-y-1.5">
+          <Group gap="xs" wrap="nowrap">
             <Icon className={`h-4 w-4 ${iconColor} shrink-0`} />
-            <span className="text-sm font-medium">{heading}</span>
-          </div>
-          <p className="text-xs text-muted-foreground leading-relaxed">{body}</p>
-        </div>
-      </PopoverContent>
+            <Text size="sm" fw={500}>
+              {heading}
+            </Text>
+          </Group>
+          <Text size="xs" c="dimmed" lh="sm">
+            {body}
+          </Text>
+        </Box>
+      </Popover.Dropdown>
     </Popover>
   );
 }


### PR DESCRIPTION
## Summary

- Migrates the header action chrome, workspace switcher, session menu, and WebSocket status popover to direct Mantine primitives.
- Keeps navigation, workspace switching, session actions, theme switching, and status popover behavior wired.
- Adds focused layout chrome coverage and updates the v5 Mantine migration progress note.

## Verification

- `pnpm --filter @veritas-kanban/web test -- src/__tests__/layout-chrome-mantine.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm lint:budget` (685 warnings, under 714 budget)
- `git diff --check`
- Rendered smoke at `http://127.0.0.1:3000/` with a temp local API profile:
  - header/banner rendered
  - board toolbar rendered
  - session menu opened
  - header had 0 legacy `data-slot="button"`, `data-slot="badge"`, `data-slot="select-trigger"`, and `data-slot="popover-content"` elements
  - console capture after login/user-menu interaction was clean

## Notes

- The broader page still has one legacy button slot outside the header. This PR intentionally scopes cleanup to layout chrome.
