### PR TITLE
Migrate task detail core to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -334,6 +334,11 @@ Phase 3 progress:
   now use direct Mantine button, action icon, select, badge, popover, and key
   badge primitives while preserving navigation, theme switching, workspace
   switching, settings shortcuts, session actions, and status popover behavior.
+- Task detail shell, core tabs, task title editing, metadata selectors,
+  description fallback editing, progress notes, checkpoint status, archive, and
+  delete confirmation now use direct Mantine drawer, tabs, text input, textarea,
+  select, badge, button, paper, loader, and modal primitives while preserving
+  task update, progress, archive, restore, and delete behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/e2e/task-detail.spec.ts
+++ b/e2e/task-detail.spec.ts
@@ -29,13 +29,16 @@ test.describe('Task Detail Panel', () => {
     await page.goto('/');
 
     // Click the task card
-    const taskCard = page.locator('text=E2E Detail Test Task');
+    const taskCard = page.locator('text=E2E Detail Test Task').first();
     await expect(taskCard).toBeVisible({ timeout: 10_000 });
     await taskCard.click();
 
-    // The detail panel (Sheet) should open
+    // The detail panel drawer should open
     const detailPanel = page.locator('[role="dialog"]');
     await expect(detailPanel).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.mantine-Drawer-content')).toBeVisible();
+    await expect(detailPanel.locator('.mantine-Tabs-root').first()).toBeVisible();
+    await expect(page.locator('[data-slot="sheet-content"]')).toHaveCount(0);
 
     // Verify the task title is shown in the panel — it's an input field
     const titleInput = detailPanel.locator('input').first();
@@ -54,7 +57,7 @@ test.describe('Task Detail Panel', () => {
     await page.goto('/');
 
     // Click the task to open the detail panel
-    const taskCard = page.locator('text=E2E Info Panel Task');
+    const taskCard = page.locator('text=E2E Info Panel Task').first();
     await expect(taskCard).toBeVisible({ timeout: 10_000 });
     await taskCard.click();
 
@@ -62,7 +65,8 @@ test.describe('Task Detail Panel', () => {
     await expect(detailPanel).toBeVisible({ timeout: 5_000 });
 
     // The details tab should be active by default and show task info
-    await expect(detailPanel.locator('text=Details')).toBeVisible();
+    await expect(detailPanel.getByRole('tab', { name: 'Details' })).toBeVisible();
+    await expect(detailPanel.locator('.mantine-Select-root').first()).toBeVisible();
 
     // The task title should be editable (it's an input in non-readOnly mode)
     const titleInput = detailPanel.locator('input').first();
@@ -79,7 +83,7 @@ test.describe('Task Detail Panel', () => {
     await page.goto('/');
 
     // Open the detail panel
-    const taskCard = page.locator('text=E2E Close Panel Task');
+    const taskCard = page.locator('text=E2E Close Panel Task').first();
     await expect(taskCard).toBeVisible({ timeout: 10_000 });
     await taskCard.click();
 

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TaskDetailPanel } from '@/components/task/TaskDetailPanel';
+import { renderWithProviders, createMockTask } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  archiveTask: vi.fn(),
+  deleteTask: vi.fn(),
+  updateField: vi.fn(),
+  updateProgress: vi.fn(),
+  onOpenChange: vi.fn(),
+}));
+
+vi.mock('@/hooks/useDebouncedSave', () => ({
+  useDebouncedSave: (task: unknown) => ({
+    localTask: task,
+    updateField: mocks.updateField,
+    isDirty: false,
+  }),
+}));
+
+vi.mock('@/hooks/useTaskTypes', () => ({
+  useTaskTypes: () => ({
+    data: [
+      { id: 'feature', label: 'Feature', icon: 'Code' },
+      { id: 'code', label: 'Code', icon: 'Code' },
+    ],
+  }),
+  getTypeIcon: () => undefined,
+}));
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSettings: () => ({
+    settings: {
+      tasks: {
+        enableAttachments: true,
+        enableComments: false,
+        enableDependencies: false,
+        enableTimeTracking: false,
+      },
+      agents: {
+        enablePreview: true,
+      },
+      markdown: {
+        enableMarkdown: false,
+      },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProjects: () => ({
+    data: [{ id: 'proj-1', label: 'Veritas' }],
+  }),
+}));
+
+vi.mock('@/hooks/useSprints', () => ({
+  useSprints: () => ({
+    data: [{ id: 'sprint-1', label: 'Sprint 1' }],
+  }),
+}));
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({
+    data: {
+      agents: [{ type: 'codex', name: 'Codex', enabled: true }],
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useTasks', () => ({
+  useAddObservation: () => ({ mutateAsync: vi.fn() }),
+  useDeleteObservation: () => ({ mutateAsync: vi.fn() }),
+  useDeleteTask: () => ({ mutateAsync: mocks.deleteTask }),
+  useArchiveTask: () => ({ mutateAsync: mocks.archiveTask }),
+}));
+
+vi.mock('@/hooks/useTaskProgress', () => ({
+  useTaskProgress: () => ({
+    data: '## Learnings\n- Mantine task detail renders',
+    isLoading: false,
+  }),
+  useUpdateProgress: () => ({ mutateAsync: mocks.updateProgress, isPending: false }),
+}));
+
+vi.mock('@/components/task/GitSection', () => ({
+  GitSection: () => <div>Git section</div>,
+}));
+
+vi.mock('@/components/task/AgentPanel', () => ({
+  AgentPanel: () => <div>Agent panel</div>,
+}));
+
+vi.mock('@/components/task/DiffViewer', () => ({
+  DiffViewer: () => <div>Diff viewer</div>,
+}));
+
+vi.mock('@/components/task/ReviewPanel', () => ({
+  ReviewPanel: () => <div>Review panel</div>,
+}));
+
+vi.mock('@/components/task/PreviewPanel', () => ({
+  PreviewPanel: () => null,
+}));
+
+vi.mock('@/components/task/AttachmentsSection', () => ({
+  AttachmentsSection: () => <div>Attachments section</div>,
+}));
+
+vi.mock('@/components/task/ObservationsSection', () => ({
+  ObservationsSection: () => <div>Observations section</div>,
+}));
+
+vi.mock('@/components/chat/ChatPanel', () => ({
+  ChatPanel: () => null,
+}));
+
+vi.mock('@/components/task/ApplyTemplateDialog', () => ({
+  ApplyTemplateDialog: () => null,
+}));
+
+vi.mock('@/components/task/TaskMetricsPanel', () => ({
+  TaskMetricsPanel: () => <div>Metrics panel</div>,
+}));
+
+vi.mock('@/components/task/WorkflowSection', () => ({
+  WorkflowSection: () => null,
+}));
+
+vi.mock('@/components/task/SubtasksSection', () => ({
+  SubtasksSection: () => <div>Subtasks section</div>,
+}));
+
+vi.mock('@/components/task/VerificationSection', () => ({
+  VerificationSection: () => <div>Verification section</div>,
+}));
+
+vi.mock('@/components/task/DeliverablesSection', () => ({
+  DeliverablesSection: () => <div>Deliverables section</div>,
+}));
+
+function renderTaskDetail() {
+  const task = createMockTask({
+    id: 'task-1',
+    title: 'Ship Mantine task detail',
+    description: 'Task detail migration',
+    priority: 'high',
+    project: 'proj-1',
+    sprint: 'sprint-1',
+    agent: 'codex',
+  });
+
+  return renderWithProviders(
+    <TaskDetailPanel task={task} open onOpenChange={mocks.onOpenChange} />
+  );
+}
+
+describe('task detail Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    mocks.archiveTask.mockResolvedValue(undefined);
+    mocks.deleteTask.mockResolvedValue(undefined);
+    mocks.updateProgress.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the task detail shell and metadata controls through direct Mantine primitives', () => {
+    const { baseElement, container } = renderTaskDetail();
+
+    expect((screen.getByLabelText('Task title') as HTMLInputElement).value).toBe(
+      'Ship Mantine task detail'
+    );
+    expect(screen.getByRole('tab', { name: 'Details' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Chat' })).toBeDefined();
+    expect(container.querySelector('.mantine-Drawer-content')).toBeDefined();
+    expect(container.querySelector('.mantine-Tabs-root')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(5);
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(5);
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="sheet-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="tabs-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+  });
+
+  it('keeps title editing and progress tab behavior wired after the migration', async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderTaskDetail();
+
+    fireEvent.change(screen.getByLabelText('Task title'), { target: { value: 'Renamed task' } });
+    await user.click(screen.getByRole('tab', { name: 'Progress' }));
+
+    expect(mocks.updateField).toHaveBeenCalledWith('title', 'Renamed task');
+    expect(screen.getByText('Progress Notes')).toBeDefined();
+    expect(screen.getByText('Mantine task detail renders')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+  });
+
+  it('uses a direct Mantine modal for destructive delete confirmation', async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderTaskDetail();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete this task?' });
+    expect(dialog).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mocks.deleteTask).toHaveBeenCalledWith('task-1'));
+    expect(mocks.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Drawer,
+  Group,
+  SimpleGrid,
+  Stack,
+  Tabs,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import { useDebouncedSave } from '@/hooks/useDebouncedSave';
@@ -35,6 +42,7 @@ import {
   NotebookPen,
   Workflow,
   Eye,
+  X,
   type LucideIcon,
 } from 'lucide-react';
 import type { Task, ReviewComment, ReviewState } from '@veritas-kanban/shared';
@@ -258,128 +266,172 @@ export function TaskDetailPanel({
   };
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        className="w-[700px] sm:max-w-[700px] overflow-hidden flex flex-col p-0"
-        aria-label={`Task details: ${localTask.title}`}
+    <>
+      <Drawer.Root
+        closeOnEscape
+        lockScroll
+        onClose={() => onOpenChange(false)}
+        opened={open}
+        position="right"
+        returnFocus
+        size="auto"
+        trapFocus
       >
-        <SheetHeader className="space-y-1 flex-shrink-0 border-b px-6 py-4 pr-12">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            {TypeIconComponent && <TypeIconComponent className="h-4 w-4" />}
-            <span className="text-xs uppercase tracking-wide">{typeLabel} Task</span>
-            {readOnly && (
-              <Badge variant="secondary" className="flex items-center gap-1 ml-auto">
-                <Archive className="h-3 w-3" />
-                Archived
-              </Badge>
-            )}
-            {!readOnly && isDirty && (
-              <span className="text-xs text-amber-500 ml-auto">Saving...</span>
-            )}
-          </div>
-          <SheetTitle className="pr-8">
-            {readOnly ? (
-              <span className="text-xl font-semibold">{localTask.title}</span>
-            ) : (
-              <Input
-                value={localTask.title}
-                onChange={(e) => updateField('title', e.target.value)}
-                className="text-xl font-semibold border-0 px-0 focus-visible:ring-0 bg-transparent"
-                placeholder="Task title..."
-                aria-label="Task title"
-              />
-            )}
-          </SheetTitle>
-        </SheetHeader>
-
-        {/* Action buttons above tabs */}
-        <div className="grid grid-cols-3 gap-2 px-6 pt-4 flex-shrink-0">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setTaskChatOpen(true)}
-            className="flex items-center justify-center gap-1 w-full"
-          >
-            <MessageSquare className="h-3 w-3" />
-            Chat
-          </Button>
-          {!readOnly ? (
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setApplyTemplateOpen(true)}
-                className="flex items-center justify-center gap-1 w-full"
-              >
-                <FileCode className="h-3 w-3" />
-                Template
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setWorkflowOpen(true)}
-                className="flex items-center justify-center gap-1 w-full"
-              >
-                <Workflow className="h-3 w-3" />
-                Workflow
-              </Button>
-            </>
-          ) : (
-            <>
-              <div />
-              <div />
-            </>
-          )}
-          {!readOnly && isCodeTask && localTask.git?.repo && agentSettings.enablePreview && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setPreviewOpen(true)}
-              className="flex items-center justify-center gap-1 w-full col-span-2"
-            >
-              <Monitor className="h-3 w-3" />
-              Preview
-            </Button>
-          )}
-        </div>
-
-        <Tabs
-          value={activeTab}
-          onValueChange={setActiveTab}
-          className="flex-1 flex flex-col overflow-hidden px-6 pt-3 pb-6"
+        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
+        <Drawer.Content
+          aria-label={`Task details: ${localTask.title}`}
+          className="flex h-full w-[700px] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:max-w-[700px]"
         >
-          <TabsList className="w-full flex-shrink-0 justify-start overflow-x-auto">
-            {visibleTabs.map((tab) => {
-              const Icon = tab.Icon;
-              return (
-                <TabsTrigger
-                  key={tab.id}
-                  value={tab.id}
-                  disabled={tab.disabled}
-                  className="flex-none px-3"
+          <Drawer.Body className="contents">
+            <Stack gap={0} className="h-full overflow-hidden">
+              <header className="flex-shrink-0 border-b px-6 py-4 pr-12">
+                <Group
+                  gap="xs"
+                  justify="space-between"
+                  wrap="nowrap"
+                  className="text-muted-foreground"
                 >
-                  {Icon && <Icon className="h-3 w-3" />}
-                  {tab.label}
-                </TabsTrigger>
-              );
-            })}
-          </TabsList>
+                  <Group gap="xs" wrap="nowrap">
+                    {TypeIconComponent && <TypeIconComponent className="h-4 w-4" />}
+                    <Text size="xs" tt="uppercase" className="tracking-wide">
+                      {typeLabel} Task
+                    </Text>
+                  </Group>
+                  <Group gap="xs" wrap="nowrap">
+                    {readOnly && (
+                      <Badge
+                        color="gray"
+                        variant="light"
+                        leftSection={<Archive className="h-3 w-3" />}
+                      >
+                        Archived
+                      </Badge>
+                    )}
+                    {!readOnly && isDirty && (
+                      <Text size="xs" c="yellow.5">
+                        Saving...
+                      </Text>
+                    )}
+                    <ActionIcon
+                      aria-label="Close task details"
+                      variant="subtle"
+                      color="gray"
+                      onClick={() => onOpenChange(false)}
+                    >
+                      <X className="h-4 w-4" />
+                    </ActionIcon>
+                  </Group>
+                </Group>
+                <Drawer.Title className="mt-1 pr-8 text-xl font-semibold text-foreground">
+                  {readOnly ? (
+                    <Text component="span" size="xl" fw={600}>
+                      {localTask.title}
+                    </Text>
+                  ) : (
+                    <TextInput
+                      value={localTask.title}
+                      onChange={(e) => updateField('title', e.currentTarget.value)}
+                      variant="unstyled"
+                      placeholder="Task title..."
+                      aria-label="Task title"
+                      classNames={{
+                        input: 'text-xl font-semibold text-foreground',
+                      }}
+                    />
+                  )}
+                </Drawer.Title>
+              </header>
 
-          <div className="flex-1 overflow-y-auto mt-4 pr-1">
-            {visibleTabs.map((tab) => (
-              <TabsContent key={tab.id} value={tab.id} className="mt-0">
-                {tab.fallbackTitle ? (
-                  <FeatureErrorBoundary fallbackTitle={tab.fallbackTitle}>
-                    {renderTabContent(tab.id)}
-                  </FeatureErrorBoundary>
+              {/* Action buttons above tabs */}
+              <SimpleGrid cols={3} spacing="xs" className="flex-shrink-0 px-6 pt-4">
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => setTaskChatOpen(true)}
+                  leftSection={<MessageSquare className="h-3 w-3" />}
+                >
+                  Chat
+                </Button>
+                {!readOnly ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() => setApplyTemplateOpen(true)}
+                      leftSection={<FileCode className="h-3 w-3" />}
+                    >
+                      Template
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() => setWorkflowOpen(true)}
+                      leftSection={<Workflow className="h-3 w-3" />}
+                    >
+                      Workflow
+                    </Button>
+                  </>
                 ) : (
-                  renderTabContent(tab.id)
+                  <>
+                    <div />
+                    <div />
+                  </>
                 )}
-              </TabsContent>
-            ))}
-          </div>
-        </Tabs>
-      </SheetContent>
+                {!readOnly && isCodeTask && localTask.git?.repo && agentSettings.enablePreview && (
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    onClick={() => setPreviewOpen(true)}
+                    className="col-span-2"
+                    leftSection={<Monitor className="h-3 w-3" />}
+                  >
+                    Preview
+                  </Button>
+                )}
+              </SimpleGrid>
+
+              <Tabs
+                value={activeTab}
+                onChange={(value) => {
+                  if (value) setActiveTab(value);
+                }}
+                className="flex flex-1 flex-col overflow-hidden px-6 pt-3 pb-6"
+              >
+                <Tabs.List className="w-full flex-shrink-0 justify-start overflow-x-auto">
+                  {visibleTabs.map((tab) => {
+                    const Icon = tab.Icon;
+                    return (
+                      <Tabs.Tab
+                        key={tab.id}
+                        value={tab.id}
+                        disabled={tab.disabled}
+                        className="flex-none px-3"
+                        leftSection={Icon ? <Icon className="h-3 w-3" /> : undefined}
+                      >
+                        {tab.label}
+                      </Tabs.Tab>
+                    );
+                  })}
+                </Tabs.List>
+
+                <div className="mt-4 flex-1 overflow-y-auto pr-1">
+                  {visibleTabs.map((tab) => (
+                    <Tabs.Panel key={tab.id} value={tab.id} className="mt-0">
+                      {tab.fallbackTitle ? (
+                        <FeatureErrorBoundary fallbackTitle={tab.fallbackTitle}>
+                          {renderTabContent(tab.id)}
+                        </FeatureErrorBoundary>
+                      ) : (
+                        renderTabContent(tab.id)
+                      )}
+                    </Tabs.Panel>
+                  ))}
+                </div>
+              </Tabs>
+            </Stack>
+          </Drawer.Body>
+        </Drawer.Content>
+      </Drawer.Root>
 
       {/* Preview Panel */}
       {localTask && (
@@ -404,6 +456,6 @@ export function TaskDetailPanel({
       {localTask && (
         <WorkflowSection task={localTask} open={workflowOpen} onOpenChange={setWorkflowOpen} />
       )}
-    </Sheet>
+    </>
   );
 }

--- a/web/src/components/task/detail/ProgressTab.tsx
+++ b/web/src/components/task/detail/ProgressTab.tsx
@@ -1,6 +1,15 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import {
+  Button,
+  Center,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Text,
+  Textarea,
+  ThemeIcon,
+} from '@mantine/core';
 import { MarkdownText } from '@/components/shared/MarkdownText';
 import { useTaskProgress, useUpdateProgress } from '@/hooks/useTaskProgress';
 import { Pencil, Save, X, FileText } from 'lucide-react';
@@ -37,36 +46,42 @@ export function ProgressTab({ task }: ProgressTabProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-32 text-muted-foreground">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-      </div>
+      <Center h={128} className="text-muted-foreground">
+        <Loader size="sm" />
+      </Center>
     );
   }
 
   const isEmpty = !progress || progress.trim() === '';
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
           <FileText className="h-4 w-4 text-muted-foreground" />
-          <h3 className="text-sm font-medium">Progress Notes</h3>
-        </div>
+          <Text size="sm" fw={500}>
+            Progress Notes
+          </Text>
+        </Group>
         {!isEditing && (
-          <Button variant="outline" size="sm" onClick={handleEdit}>
-            <Pencil className="h-3 w-3 mr-1" />
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={handleEdit}
+            leftSection={<Pencil className="h-3 w-3" />}
+          >
             Edit
           </Button>
         )}
-      </div>
+      </Group>
 
       {/* Edit Mode */}
       {isEditing && (
-        <div className="space-y-3">
+        <Stack gap="sm">
           <Textarea
             value={editContent}
-            onChange={(e) => setEditContent(e.target.value)}
+            onChange={(e) => setEditContent(e.currentTarget.value)}
             placeholder="# Progress Notes
 
 ## Learnings
@@ -80,46 +95,58 @@ export function ProgressTab({ task }: ProgressTabProps) {
             className="font-mono text-sm min-h-[400px]"
             autoFocus
           />
-          <div className="flex gap-2">
-            <Button size="sm" onClick={handleSave} disabled={updateProgress.isPending}>
-              <Save className="h-3 w-3 mr-1" />
+          <Group gap="xs">
+            <Button
+              size="xs"
+              onClick={handleSave}
+              disabled={updateProgress.isPending}
+              leftSection={<Save className="h-3 w-3" />}
+            >
               {updateProgress.isPending ? 'Saving...' : 'Save'}
             </Button>
-            <Button variant="outline" size="sm" onClick={handleCancel}>
-              <X className="h-3 w-3 mr-1" />
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={handleCancel}
+              leftSection={<X className="h-3 w-3" />}
+            >
               Cancel
             </Button>
-          </div>
-        </div>
+          </Group>
+        </Stack>
       )}
 
       {/* View Mode */}
       {!isEditing && (
-        <div className="rounded-lg border bg-card p-4 min-h-[200px]">
+        <Paper className="min-h-[200px] border bg-card p-4" radius="lg">
           {isEmpty ? (
-            <div className="text-center text-muted-foreground py-8">
-              <FileText className="h-12 w-12 mx-auto mb-3 opacity-50" />
-              <p className="text-sm mb-1">No progress notes yet</p>
-              <p className="text-xs">
+            <Stack align="center" gap={4} className="py-8 text-center text-muted-foreground">
+              <ThemeIcon color="gray" variant="subtle" size={48}>
+                <FileText className="h-8 w-8 opacity-50" />
+              </ThemeIcon>
+              <Text size="sm">No progress notes yet</Text>
+              <Text size="xs">
                 Click Edit to add learnings, issues, and next steps for future sessions
-              </p>
-            </div>
+              </Text>
+            </Stack>
           ) : (
             <MarkdownText>{progress}</MarkdownText>
           )}
-        </div>
+        </Paper>
       )}
 
       {/* Help Text */}
-      <div className="text-xs text-muted-foreground border-t pt-3">
-        <p className="font-medium mb-1">💡 Progress Notes Best Practices:</p>
+      <Stack gap={4} className="border-t pt-3 text-xs text-muted-foreground">
+        <Text size="xs" fw={500}>
+          Progress Notes Best Practices:
+        </Text>
         <ul className="list-disc list-inside space-y-1 ml-2">
           <li>Document key learnings and insights discovered during work</li>
           <li>Track issues encountered and their solutions</li>
           <li>List next steps for future sessions to pick up where you left off</li>
           <li>Use markdown sections (##) to organize by category</li>
         </ul>
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/task/detail/TaskDetailsTab.tsx
+++ b/web/src/components/task/detail/TaskDetailsTab.tsx
@@ -1,20 +1,8 @@
+import { useState } from 'react';
+import { Badge, Box, Button, Group, Modal, Paper, Stack, Text, Textarea } from '@mantine/core';
 import { API_BASE } from '@/lib/config';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { MarkdownEditor } from '@/components/ui/MarkdownEditor';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
-import { Button } from '@/components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
 import { TaskMetadataSection } from './TaskMetadataSection';
 import { SubtasksSection } from '../SubtasksSection';
 import { VerificationSection } from '../VerificationSection';
@@ -50,6 +38,7 @@ export function TaskDetailsTab({
   const taskSettings = featureSettings.tasks;
   const markdownSettings = featureSettings.markdown;
   const markdownEnabled = markdownSettings?.enableMarkdown ?? true;
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   const handleDelete = async () => {
     await deleteTask.mutateAsync(task.id);
@@ -72,12 +61,14 @@ export function TaskDetailsTab({
   };
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Description */}
-      <div className="space-y-2">
-        <Label className="text-muted-foreground">Description</Label>
+      <Stack gap={6}>
+        <Text size="sm" c="dimmed" fw={500}>
+          Description
+        </Text>
         {readOnly ? (
-          <div className="text-sm text-foreground/80 bg-muted/30 rounded-md p-3 min-h-[60px]">
+          <Paper className="min-h-[60px] bg-muted/30 p-3 text-sm text-foreground/80" radius="md">
             {task.description ? (
               markdownEnabled ? (
                 <MarkdownRenderer content={task.description} />
@@ -87,7 +78,7 @@ export function TaskDetailsTab({
             ) : (
               <span className="text-muted-foreground italic">No description</span>
             )}
-          </div>
+          </Paper>
         ) : markdownEnabled ? (
           <MarkdownEditor
             value={task.description}
@@ -98,13 +89,13 @@ export function TaskDetailsTab({
         ) : (
           <Textarea
             value={task.description}
-            onChange={(e) => onUpdate('description', e.target.value)}
+            onChange={(e) => onUpdate('description', e.currentTarget.value)}
             placeholder="Add a description..."
             rows={4}
             className="resize-none"
           />
         )}
-      </div>
+      </Stack>
 
       {/* Plan section removed (GH-66 cleanup — planning was agent-internal, not board-level) */}
 
@@ -113,7 +104,7 @@ export function TaskDetailsTab({
 
       {/* Blocked Reason (shown when status is blocked) */}
       {task.status === 'blocked' && (
-        <div className="border-t pt-4">
+        <Box className="border-t pt-4">
           <BlockedReasonSection
             task={task}
             onUpdate={(blockedReason: BlockedReason | undefined) =>
@@ -121,19 +112,21 @@ export function TaskDetailsTab({
             }
             readOnly={readOnly}
           />
-        </div>
+        </Box>
       )}
 
       {/* Checkpoint Status (shown when checkpoint exists) */}
       {task.checkpoint && (
-        <div className="border-t pt-4">
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <Label className="text-muted-foreground">Checkpoint</Label>
+        <Box className="border-t pt-4">
+          <Stack gap="sm">
+            <Group justify="space-between" align="center">
+              <Text size="sm" c="dimmed" fw={500}>
+                Checkpoint
+              </Text>
               {!readOnly && (
                 <Button
-                  variant="ghost"
-                  size="sm"
+                  variant="subtle"
+                  size="xs"
                   aria-label="Clear checkpoint and discard saved progress"
                   onClick={async () => {
                     try {
@@ -147,137 +140,139 @@ export function TaskDetailsTab({
                   Clear Checkpoint
                 </Button>
               )}
-            </div>
-            <div
+            </Group>
+            <Paper
               role="status"
               aria-live="polite"
               className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-md p-3 space-y-2"
             >
-              <div className="flex items-center gap-2">
-                <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-amber-100 dark:bg-amber-900/30 text-amber-900 dark:text-amber-100 text-xs font-medium">
-                  💾 CHECKPOINT SAVED
-                </span>
-                <span className="text-xs text-muted-foreground">Step {task.checkpoint.step}</span>
-              </div>
-              <div className="text-xs text-muted-foreground">
+              <Group gap="xs">
+                <Badge color="yellow" variant="light">
+                  Checkpoint saved
+                </Badge>
+                <Text size="xs" c="dimmed">
+                  Step {task.checkpoint.step}
+                </Text>
+              </Group>
+              <Text size="xs" c="dimmed">
                 Saved: {formatDate(task.checkpoint.timestamp)}
-              </div>
+              </Text>
               {task.checkpoint.resumeCount && task.checkpoint.resumeCount > 0 && (
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Group gap={6} className="text-muted-foreground">
                   <RotateCcw className="h-3 w-3" />
-                  <span>Resumed {task.checkpoint.resumeCount} time(s)</span>
-                </div>
+                  <Text size="xs">Resumed {task.checkpoint.resumeCount} time(s)</Text>
+                </Group>
               )}
-            </div>
-          </div>
-        </div>
+            </Paper>
+          </Stack>
+        </Box>
       )}
 
       {/* Subtasks */}
-      <div className="border-t pt-4">
+      <Box className="border-t pt-4">
         <SubtasksSection
           task={task}
           onAutoCompleteChange={(value) => onUpdate('autoCompleteOnSubtasks', value || undefined)}
         />
-      </div>
+      </Box>
 
       {/* Verification / Done Criteria */}
-      <div className="border-t pt-4">
+      <Box className="border-t pt-4">
         <VerificationSection task={task} />
-      </div>
+      </Box>
 
       {/* Dependencies */}
       {taskSettings.enableDependencies && (
-        <div className="border-t pt-4">
+        <Box className="border-t pt-4">
           <DependenciesSection
             task={task}
             onBlockedByChange={(blockedBy) => onUpdate('blockedBy', blockedBy)}
           />
-        </div>
+        </Box>
       )}
 
       {/* Time Tracking */}
       {taskSettings.enableTimeTracking && (
-        <div className="border-t pt-4">
+        <Box className="border-t pt-4">
           <TimeTrackingSection task={task} />
-        </div>
+        </Box>
       )}
 
       {/* Deliverables */}
-      <div className="border-t pt-4">
+      <Box className="border-t pt-4">
         <DeliverablesSection task={task} />
-      </div>
+      </Box>
 
       {/* Comments */}
       {taskSettings.enableComments && (
-        <div className="border-t pt-4">
+        <Box className="border-t pt-4">
           <CommentsSection task={task} />
-        </div>
+        </Box>
       )}
 
       {/* Lessons Learned (only shown for completed tasks) */}
       {task.status === 'done' && (
-        <div className="border-t pt-4">
+        <Box className="border-t pt-4">
           <LessonsLearnedSection task={task} onUpdate={onUpdate} readOnly={readOnly} />
-        </div>
+        </Box>
       )}
 
       {/* Metadata Footer */}
-      <div className="border-t pt-4 space-y-2 text-sm text-muted-foreground">
-        <div className="flex items-center gap-2">
+      <Stack gap={6} className="border-t pt-4 text-muted-foreground">
+        <Group gap="xs">
           <Calendar className="h-4 w-4" />
-          <span>Created: {formatDate(task.created)}</span>
-        </div>
-        <div className="flex items-center gap-2">
+          <Text size="sm">Created: {formatDate(task.created)}</Text>
+        </Group>
+        <Group gap="xs">
           <Clock className="h-4 w-4" />
-          <span>Updated: {formatDate(task.updated)}</span>
-        </div>
-        <div className="text-xs font-mono opacity-50">ID: {task.id}</div>
-      </div>
+          <Text size="sm">Updated: {formatDate(task.updated)}</Text>
+        </Group>
+        <Text size="xs" ff="monospace" opacity={0.5}>
+          ID: {task.id}
+        </Text>
+      </Stack>
 
       {/* Delete/Restore Button */}
-      <div className="border-t pt-4">
+      <Box className="border-t pt-4">
         {readOnly && onRestore ? (
           <Button variant="default" className="w-full" onClick={() => onRestore(task.id)}>
-            <RotateCcw className="h-4 w-4 mr-2" />
+            <RotateCcw className="mr-2 h-4 w-4" />
             Restore to Board
           </Button>
         ) : (
           !readOnly && (
-            <div className="flex gap-2">
+            <Group gap="xs" grow>
               <Button variant="outline" className="flex-1" onClick={handleArchive}>
-                <Archive className="h-4 w-4 mr-2" />
+                <Archive className="mr-2 h-4 w-4" />
                 Archive
               </Button>
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button variant="destructive" className="flex-1">
-                    <Trash2 className="h-4 w-4 mr-2" />
-                    Delete
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Delete this task?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will permanently delete "{task.title}".
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={handleDelete}
-                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                    >
-                      Delete
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </div>
+              <Button color="red" className="flex-1" onClick={() => setDeleteConfirmOpen(true)}>
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </Button>
+            </Group>
           )
         )}
-      </div>
-    </div>
+      </Box>
+
+      <Modal
+        opened={deleteConfirmOpen}
+        onClose={() => setDeleteConfirmOpen(false)}
+        title="Delete this task?"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm">This will permanently delete "{task.title}".</Text>
+          <Group justify="flex-end" gap="sm">
+            <Button variant="default" onClick={() => setDeleteConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button color="red" onClick={handleDelete}>
+              Delete
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Stack>
   );
 }

--- a/web/src/components/task/detail/TaskMetadataSection.tsx
+++ b/web/src/components/task/detail/TaskMetadataSection.tsx
@@ -1,19 +1,11 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Box, Button, Group, Select, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
 import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
 import { useConfig } from '@/hooks/useConfig';
 import type { Task, TaskStatus, TaskPriority, AgentType } from '@veritas-kanban/shared';
+import type { ReactNode } from 'react';
 
 interface TaskMetadataSectionProps {
   task: Task;
@@ -36,6 +28,14 @@ const priorityLabels: Record<TaskPriority, string> = {
   critical: 'Critical',
 };
 
+function ReadOnlyValue({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <Box className={`rounded-md bg-muted/30 px-3 py-2 text-sm font-medium ${className}`}>
+      {children}
+    </Box>
+  );
+}
+
 export function TaskMetadataSection({
   task,
   onUpdate,
@@ -54,126 +54,118 @@ export function TaskMetadataSection({
   const typeLabel = currentType ? currentType.label : task.type;
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Status, Type, Priority */}
-      <div className="grid grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label className="text-muted-foreground">Status</Label>
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+        <Stack gap={6}>
+          <Text size="sm" c="dimmed" fw={500}>
+            Status
+          </Text>
           {readOnly ? (
-            <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md">
-              {statusLabels[task.status]}
-            </div>
-          ) : (
-            <Select value={task.status} onValueChange={(v) => onUpdate('status', v as TaskStatus)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(statusLabels).map(([value, label]) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-        </div>
-
-        <div className="space-y-2">
-          <Label className="text-muted-foreground">Type</Label>
-          {readOnly ? (
-            <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md">{typeLabel}</div>
-          ) : (
-            <Select value={task.type} onValueChange={(v) => onUpdate('type', v)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {taskTypes.map((type) => {
-                  const IconComponent = getTypeIcon(type.icon);
-                  return (
-                    <SelectItem key={type.id} value={type.id}>
-                      <div className="flex items-center gap-2">
-                        {IconComponent && <IconComponent className="h-4 w-4" />}
-                        {type.label}
-                      </div>
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
-          )}
-        </div>
-
-        <div className="space-y-2">
-          <Label className="text-muted-foreground">Priority</Label>
-          {readOnly ? (
-            <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md capitalize">
-              {task.priority}
-            </div>
+            <ReadOnlyValue>{statusLabels[task.status]}</ReadOnlyValue>
           ) : (
             <Select
-              value={task.priority}
-              onValueChange={(v) => onUpdate('priority', v as TaskPriority)}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(priorityLabels).map(([value, label]) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              aria-label="Status"
+              allowDeselect={false}
+              data={Object.entries(statusLabels).map(([value, label]) => ({ value, label }))}
+              value={task.status}
+              onChange={(value) => {
+                if (value) onUpdate('status', value as TaskStatus);
+              }}
+            />
           )}
-        </div>
-      </div>
+        </Stack>
+
+        <Stack gap={6}>
+          <Text size="sm" c="dimmed" fw={500}>
+            Type
+          </Text>
+          {readOnly ? (
+            <ReadOnlyValue>{typeLabel}</ReadOnlyValue>
+          ) : (
+            <Select
+              aria-label="Type"
+              allowDeselect={false}
+              data={taskTypes.map((type) => ({ value: type.id, label: type.label }))}
+              renderOption={({ option }) => {
+                const type = taskTypes.find((item) => item.id === option.value);
+                if (!type) return option.label;
+                const IconComponent = getTypeIcon(type.icon);
+                return (
+                  <Group gap="xs">
+                    {IconComponent && <IconComponent className="h-4 w-4" />}
+                    <Text size="sm">{type.label}</Text>
+                  </Group>
+                );
+              }}
+              value={task.type}
+              onChange={(value) => {
+                if (value) onUpdate('type', value);
+              }}
+            />
+          )}
+        </Stack>
+
+        <Stack gap={6}>
+          <Text size="sm" c="dimmed" fw={500}>
+            Priority
+          </Text>
+          {readOnly ? (
+            <ReadOnlyValue className="capitalize">{task.priority}</ReadOnlyValue>
+          ) : (
+            <Select
+              aria-label="Priority"
+              allowDeselect={false}
+              data={Object.entries(priorityLabels).map(([value, label]) => ({ value, label }))}
+              value={task.priority}
+              onChange={(value) => {
+                if (value) onUpdate('priority', value as TaskPriority);
+              }}
+            />
+          )}
+        </Stack>
+      </SimpleGrid>
 
       {/* Project */}
-      <div className="space-y-2">
-        <Label className="text-muted-foreground">Project</Label>
+      <Stack gap={6}>
+        <Text size="sm" c="dimmed" fw={500}>
+          Project
+        </Text>
         {readOnly ? (
-          <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md">
+          <ReadOnlyValue>
             {projects.find((p) => p.id === task.project)?.label || task.project || 'No project'}
-          </div>
+          </ReadOnlyValue>
         ) : !showNewProject ? (
           <Select
+            aria-label="Project"
+            allowDeselect={false}
+            data={[
+              { value: '__none__', label: 'No project' },
+              ...projects.map((proj) => ({ value: proj.id, label: proj.label })),
+              { value: '__new__', label: '+ New Project' },
+            ]}
+            placeholder="Select project..."
             value={task.project || '__none__'}
-            onValueChange={(value) => {
+            onChange={(value) => {
               if (value === '__new__') {
                 setShowNewProject(true);
                 setNewProjectName('');
               } else if (value === '__none__') {
                 onUpdate('project', undefined);
-              } else {
+              } else if (value) {
                 onUpdate('project', value);
               }
             }}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select project..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__none__">No project</SelectItem>
-              {projects.map((proj) => (
-                <SelectItem key={proj.id} value={proj.id}>
-                  {proj.label}
-                </SelectItem>
-              ))}
-              <SelectItem value="__new__" className="text-primary">
-                + New Project
-              </SelectItem>
-            </SelectContent>
-          </Select>
+          />
         ) : (
-          <div className="flex gap-2">
-            <Input
+          <Group gap="xs" align="flex-start" wrap="nowrap">
+            <TextInput
+              aria-label="New project name"
               value={newProjectName}
-              onChange={(e) => setNewProjectName(e.target.value)}
+              onChange={(e) => setNewProjectName(e.currentTarget.value)}
               placeholder="Enter project name..."
               autoFocus
+              className="flex-1"
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && newProjectName.trim()) {
                   e.preventDefault();
@@ -188,7 +180,7 @@ export function TaskMetadataSection({
             />
             <Button
               type="button"
-              size="sm"
+              size="xs"
               onClick={() => {
                 if (newProjectName.trim()) {
                   onUpdate('project', newProjectName.trim());
@@ -200,7 +192,7 @@ export function TaskMetadataSection({
             </Button>
             <Button
               type="button"
-              size="sm"
+              size="xs"
               variant="outline"
               onClick={() => {
                 setShowNewProject(false);
@@ -209,70 +201,63 @@ export function TaskMetadataSection({
             >
               Cancel
             </Button>
-          </div>
+          </Group>
         )}
-      </div>
+      </Stack>
 
       {/* Sprint & Agent */}
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label className="text-muted-foreground">Sprint</Label>
+      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+        <Stack gap={6}>
+          <Text size="sm" c="dimmed" fw={500}>
+            Sprint
+          </Text>
           {readOnly ? (
-            <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md">
+            <ReadOnlyValue>
               {sprints.find((s) => s.id === task.sprint)?.label || task.sprint || 'No sprint'}
-            </div>
+            </ReadOnlyValue>
           ) : (
             <Select
+              aria-label="Sprint"
+              allowDeselect={false}
+              data={[
+                { value: '__none__', label: 'No Sprint' },
+                ...sprints.map((s) => ({ value: s.id, label: s.label })),
+              ]}
+              placeholder="No sprint"
               value={task.sprint || '__none__'}
-              onValueChange={(value) =>
-                onUpdate('sprint', value === '__none__' ? undefined : value)
+              onChange={(value) =>
+                onUpdate('sprint', value === '__none__' ? undefined : value || undefined)
               }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="No sprint" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__none__">No Sprint</SelectItem>
-                {sprints.map((s) => (
-                  <SelectItem key={s.id} value={s.id}>
-                    {s.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            />
           )}
-        </div>
+        </Stack>
 
-        <div className="space-y-2">
-          <Label className="text-muted-foreground">Agent</Label>
+        <Stack gap={6}>
+          <Text size="sm" c="dimmed" fw={500}>
+            Agent
+          </Text>
           {readOnly ? (
-            <div className="text-sm font-medium px-3 py-2 bg-muted/30 rounded-md">
+            <ReadOnlyValue>
               {task.agent === 'auto' || !task.agent
                 ? 'Auto (routing)'
                 : enabledAgents.find((a) => a.type === task.agent)?.name || task.agent}
-            </div>
+            </ReadOnlyValue>
           ) : (
             <Select
+              aria-label="Agent"
+              allowDeselect={false}
+              data={[
+                { value: 'auto', label: 'Auto (routing)' },
+                ...enabledAgents.map((a) => ({ value: a.type, label: a.name })),
+              ]}
               value={task.agent || 'auto'}
-              onValueChange={(value) =>
-                onUpdate('agent', value === 'auto' ? undefined : (value as AgentType))
+              onChange={(value) =>
+                onUpdate('agent', value === 'auto' ? undefined : ((value || 'auto') as AgentType))
               }
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="auto">Auto (routing)</SelectItem>
-                {enabledAgents.map((a) => (
-                  <SelectItem key={a.type} value={a.type}>
-                    {a.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            />
           )}
-        </div>
-      </div>
-    </div>
+        </Stack>
+      </SimpleGrid>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- migrate the task detail drawer, action chrome, tabs, title input, metadata selectors, progress notes, checkpoint status, and delete confirmation to direct Mantine primitives
- keep nested product-specific task sections intact while preserving update, archive, restore, delete, and progress-note behavior
- extend task-detail unit and e2e coverage plus update the Mantine migration tracker

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm --filter @veritas-kanban/server build
- pnpm lint:budget
- git diff --check
- node_modules/.bin/playwright test e2e/task-detail.spec.ts --project=chromium

## Notes
- Nested task subsections still include some compatibility wrappers and remain in the next #417 slices.