### PR TITLE
Migrate task detail validation controls to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -339,6 +339,11 @@ Phase 3 progress:
   delete confirmation now use direct Mantine drawer, tabs, text input, textarea,
   select, badge, button, paper, loader, and modal primitives while preserving
   task update, progress, archive, restore, and delete behavior.
+- Task detail blocked reason, done criteria, and dependency subsections now use
+  direct Mantine select, textarea, checkbox, progress, text input, badge,
+  button, action icon, and paper primitives while preserving blocked-reason
+  updates, verification-step mutations, dependency display, add/cancel, and
+  remove behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/task-detail-validation-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-validation-mantine.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BlockedReasonSection } from '@/components/task/BlockedReasonSection';
+import { DependenciesSection } from '@/components/task/DependenciesSection';
+import { VerificationSection } from '@/components/task/VerificationSection';
+import { createMockTask, renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  addVerificationStep: vi.fn(),
+  updateVerificationStep: vi.fn(),
+  deleteVerificationStep: vi.fn(),
+  useTasks: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTasks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useTasks')>('@/hooks/useTasks');
+  return {
+    ...actual,
+    useTasks: mocks.useTasks,
+    useAddVerificationStep: () => ({ mutateAsync: mocks.addVerificationStep }),
+    useUpdateVerificationStep: () => ({ mutateAsync: mocks.updateVerificationStep }),
+    useDeleteVerificationStep: () => ({ mutateAsync: mocks.deleteVerificationStep }),
+  };
+});
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+describe('task detail validation Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    mocks.addVerificationStep.mockResolvedValue(undefined);
+    mocks.updateVerificationStep.mockResolvedValue(undefined);
+    mocks.deleteVerificationStep.mockResolvedValue(undefined);
+    mocks.useTasks.mockReturnValue({ data: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders blocked reason controls through direct Mantine select and textarea', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    const task = createMockTask({
+      status: 'blocked',
+      blockedReason: {
+        category: 'waiting-on-feedback',
+        note: 'Waiting for product confirmation',
+      },
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <BlockedReasonSection task={task} onUpdate={onUpdate} />
+    );
+
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Textarea-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+
+    await user.click(screen.getByRole('combobox', { name: 'Blocked category' }));
+    await user.click(await screen.findByText('Technical Snag'));
+    fireEvent.change(
+      screen.getByPlaceholderText("Add details about what's blocking this task..."),
+      {
+        target: { value: 'Blocked by API logs' },
+      }
+    );
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      category: 'technical-snag',
+      note: 'Waiting for product confirmation',
+    });
+    expect(onUpdate).toHaveBeenCalledWith({
+      category: 'waiting-on-feedback',
+      note: 'Blocked by API logs',
+    });
+  });
+
+  it('renders verification steps through direct Mantine controls and keeps mutations wired', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      verificationSteps: [
+        {
+          id: 'step-1',
+          description: 'Write tests',
+          checked: false,
+        },
+        {
+          id: 'step-2',
+          description: 'Run smoke',
+          checked: true,
+          checkedAt: '2026-06-01T09:00:00Z',
+        },
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(<VerificationSection task={task} />);
+
+    expect(container.querySelector('.mantine-Checkbox-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="checkbox"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Mark verification step Write tests' }));
+    await user.type(screen.getByRole('textbox', { name: 'New verification step' }), 'Manual QA');
+    await user.click(screen.getByRole('button', { name: 'Add verification step' }));
+    await user.click(screen.getByRole('button', { name: 'Delete verification step: Run smoke' }));
+
+    expect(mocks.updateVerificationStep).toHaveBeenCalledWith({
+      taskId: task.id,
+      stepId: 'step-1',
+      updates: { checked: true },
+    });
+    expect(mocks.addVerificationStep).toHaveBeenCalledWith({
+      taskId: task.id,
+      description: 'Manual QA',
+    });
+    expect(mocks.deleteVerificationStep).toHaveBeenCalledWith({
+      taskId: task.id,
+      stepId: 'step-2',
+    });
+  });
+
+  it('renders dependency summaries and add selectors through direct Mantine primitives', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-main',
+      dependencies: {
+        depends_on: ['task-dep'],
+        blocks: ['task-blocked'],
+      },
+    });
+    mocks.useTasks.mockReturnValue({
+      data: [
+        task,
+        createMockTask({ id: 'task-dep', title: 'Foundation task', status: 'todo' }),
+        createMockTask({ id: 'task-blocked', title: 'Blocked downstream task', status: 'todo' }),
+        createMockTask({ id: 'task-available', title: 'Available task', status: 'todo' }),
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <DependenciesSection task={task} onBlockedByChange={vi.fn()} />
+    );
+
+    expect(screen.getByText('Foundation task')).toBeDefined();
+    expect(screen.getByText('Blocked downstream task')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(2);
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Add Dependency' }));
+
+    expect(screen.getByRole('combobox', { name: 'Select dependency task' })).toBeDefined();
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+  });
+});

--- a/web/src/components/task/BlockedReasonSection.tsx
+++ b/web/src/components/task/BlockedReasonSection.tsx
@@ -1,15 +1,8 @@
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Group, Paper, Select, Stack, Text, Textarea } from '@mantine/core';
 import { Ban, MessageSquare, Wrench, Link2, HelpCircle } from 'lucide-react';
 import type { Task, BlockedCategory, BlockedReason } from '@veritas-kanban/shared';
 import { sanitizeText } from '@/lib/sanitize';
+import type { ReactNode } from 'react';
 
 interface BlockedReasonSectionProps {
   task: Task;
@@ -17,34 +10,43 @@ interface BlockedReasonSectionProps {
   readOnly?: boolean;
 }
 
-const BLOCKED_CATEGORIES: { value: BlockedCategory; label: string; icon: React.ReactNode; description: string }[] = [
-  { 
-    value: 'waiting-on-feedback', 
-    label: 'Waiting on Feedback', 
+const BLOCKED_CATEGORIES: {
+  value: BlockedCategory;
+  label: string;
+  icon: ReactNode;
+  description: string;
+}[] = [
+  {
+    value: 'waiting-on-feedback',
+    label: 'Waiting on Feedback',
     icon: <MessageSquare className="h-4 w-4" />,
     description: 'Blocked waiting for input from someone',
   },
-  { 
-    value: 'technical-snag', 
-    label: 'Technical Snag', 
+  {
+    value: 'technical-snag',
+    label: 'Technical Snag',
     icon: <Wrench className="h-4 w-4" />,
     description: 'Blocked by a technical issue or bug',
   },
-  { 
-    value: 'prerequisite', 
-    label: 'Prerequisite', 
+  {
+    value: 'prerequisite',
+    label: 'Prerequisite',
     icon: <Link2 className="h-4 w-4" />,
     description: 'Blocked by another task that must complete first',
   },
-  { 
-    value: 'other', 
-    label: 'Other', 
+  {
+    value: 'other',
+    label: 'Other',
     icon: <HelpCircle className="h-4 w-4" />,
     description: 'Blocked for another reason',
   },
 ];
 
-export function BlockedReasonSection({ task, onUpdate, readOnly = false }: BlockedReasonSectionProps) {
+export function BlockedReasonSection({
+  task,
+  onUpdate,
+  readOnly = false,
+}: BlockedReasonSectionProps) {
   // Only show when status is blocked
   if (task.status !== 'blocked') {
     return null;
@@ -76,69 +78,79 @@ export function BlockedReasonSection({ task, onUpdate, readOnly = false }: Block
   };
 
   const getCategoryInfo = (category: BlockedCategory) => {
-    return BLOCKED_CATEGORIES.find(c => c.value === category);
+    return BLOCKED_CATEGORIES.find((c) => c.value === category);
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2">
+    <Stack gap="sm">
+      <Group gap="xs">
         <Ban className="h-4 w-4 text-red-500" />
-        <Label className="text-muted-foreground font-medium">Blocked Reason</Label>
-      </div>
+        <Text size="sm" c="dimmed" fw={500}>
+          Blocked Reason
+        </Text>
+      </Group>
 
       {readOnly ? (
-        <div className="bg-red-500/10 border border-red-500/20 rounded-md p-3 space-y-2">
+        <Paper className="space-y-2 border border-red-500/20 bg-red-500/10 p-3" radius="md">
           {currentCategory ? (
             <>
-              <div className="flex items-center gap-2 text-red-400">
+              <Group gap="xs" className="text-red-400">
                 {getCategoryInfo(currentCategory)?.icon}
-                <span className="font-medium">{getCategoryInfo(currentCategory)?.label}</span>
-              </div>
+                <Text size="sm" fw={500}>
+                  {getCategoryInfo(currentCategory)?.label}
+                </Text>
+              </Group>
               {currentNote && (
-                <p className="text-sm text-muted-foreground">{sanitizeText(currentNote)}</p>
+                <Text size="sm" c="dimmed">
+                  {sanitizeText(currentNote)}
+                </Text>
               )}
             </>
           ) : (
-            <p className="text-sm text-muted-foreground">No reason specified</p>
+            <Text size="sm" c="dimmed">
+              No reason specified
+            </Text>
           )}
-        </div>
+        </Paper>
       ) : (
         <>
           <Select
-            value={currentCategory || ''}
-            onValueChange={(value) => handleCategoryChange(value as BlockedCategory)}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Why is this task blocked?" />
-            </SelectTrigger>
-            <SelectContent>
-              {BLOCKED_CATEGORIES.map((cat) => (
-                <SelectItem key={cat.value} value={cat.value}>
-                  <div className="flex items-center gap-2">
-                    {cat.icon}
-                    <span>{cat.label}</span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            aria-label="Blocked category"
+            allowDeselect={false}
+            data={BLOCKED_CATEGORIES.map((cat) => ({ value: cat.value, label: cat.label }))}
+            placeholder="Why is this task blocked?"
+            value={currentCategory ?? null}
+            onChange={(value) => {
+              if (value) handleCategoryChange(value as BlockedCategory);
+            }}
+            renderOption={({ option }) => {
+              const category = BLOCKED_CATEGORIES.find((cat) => cat.value === option.value);
+              if (!category) return option.label;
+              return (
+                <Group gap="xs">
+                  {category.icon}
+                  <Text size="sm">{category.label}</Text>
+                </Group>
+              );
+            }}
+          />
 
           <Textarea
             value={currentNote}
-            onChange={(e) => handleNoteChange(e.target.value)}
+            onChange={(e) => handleNoteChange(e.currentTarget.value)}
             placeholder="Add details about what's blocking this task..."
             rows={2}
             className="resize-none text-sm"
           />
 
           {currentCategory && (
-            <p className="text-xs text-muted-foreground">
+            <Text size="xs" c="dimmed">
               {getCategoryInfo(currentCategory)?.description}
-            </p>
+            </Text>
           )}
         </>
       )}
-    </div>
+    </Stack>
   );
 }
 

--- a/web/src/components/task/DependenciesSection.tsx
+++ b/web/src/components/task/DependenciesSection.tsx
@@ -1,16 +1,7 @@
 import { useState, useMemo, useRef } from 'react';
 import { API_BASE } from '@/lib/config';
 import { Plus, X, Ban, CheckCircle2, Link as LinkIcon } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
+import { ActionIcon, Badge, Button, Group, Paper, Select, Stack, Text } from '@mantine/core';
 import { useTasks, isTaskBlocked } from '@/hooks/useTasks';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/useToast';
@@ -36,8 +27,11 @@ export function DependenciesSection({
   const addDependsOnButtonRef = useRef<HTMLButtonElement>(null);
   const addBlocksButtonRef = useRef<HTMLButtonElement>(null);
 
-  const dependsOn = task.dependencies?.depends_on || [];
-  const blocks = task.dependencies?.blocks || [];
+  const dependsOn = useMemo(
+    () => task.dependencies?.depends_on || [],
+    [task.dependencies?.depends_on]
+  );
+  const blocks = useMemo(() => task.dependencies?.blocks || [], [task.dependencies?.blocks]);
 
   // Get available tasks (not self, not already in relationship)
   const availableTasksForDependsOn = useMemo(() => {
@@ -84,7 +78,7 @@ export function DependenciesSection({
       }
 
       // Invalidate queries to refresh data
-      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      void queryClient.invalidateQueries({ queryKey: ['tasks'] });
 
       toast({
         title: 'Dependency added',
@@ -121,13 +115,13 @@ export function DependenciesSection({
       }
 
       // Invalidate queries to refresh data
-      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      void queryClient.invalidateQueries({ queryKey: ['tasks'] });
 
       toast({
         title: 'Dependency removed',
         description: 'Successfully removed dependency',
       });
-    } catch (error) {
+    } catch {
       toast({
         title: 'Error',
         description: 'Failed to remove dependency',
@@ -137,31 +131,35 @@ export function DependenciesSection({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <Label className="text-muted-foreground flex items-center gap-2">
+    <Stack gap="md">
+      <Group justify="space-between" align="center">
+        <Group gap="xs" className="text-muted-foreground">
           <LinkIcon className="h-4 w-4" aria-hidden="true" />
-          Dependencies
-        </Label>
+          <Text size="sm" fw={500}>
+            Dependencies
+          </Text>
+        </Group>
         {isCurrentlyBlocked && (
-          <Badge variant="destructive" className="text-xs">
-            <Ban className="h-3 w-3 mr-1" aria-hidden="true" />
+          <Badge color="red" variant="filled" size="sm" leftSection={<Ban className="h-3 w-3" />}>
             Blocked
           </Badge>
         )}
-      </div>
+      </Group>
 
       {/* Depends On Section */}
-      <div className="space-y-2">
-        <div className="text-sm font-medium text-foreground/70">Depends On</div>
+      <Stack gap="xs">
+        <Text size="sm" fw={500} className="text-foreground/70">
+          Depends On
+        </Text>
 
         {dependsOnTasks.length > 0 && (
-          <div className="space-y-1">
+          <Stack gap={4}>
             {dependsOnTasks.map((dep) => (
-              <div
+              <Paper
                 key={dep.id}
+                radius="md"
                 className={cn(
-                  'flex items-center gap-2 p-2 rounded-md bg-muted/50 group',
+                  'group flex items-center gap-2 bg-muted/50 p-2',
                   dep.status === 'done' && 'opacity-60'
                 )}
               >
@@ -181,146 +179,139 @@ export function DependenciesSection({
                 >
                   {dep.title}
                 </span>
-                <Badge variant="secondary" className="text-xs">
+                <Badge color="gray" variant="light" size="sm">
                   {dep.status}
                 </Badge>
-                <Button
-                  variant="ghost"
-                  size="icon"
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
                   className="h-6 w-6 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
-                  onClick={() => handleRemoveDependency(dep.id)}
+                  onClick={() => {
+                    void handleRemoveDependency(dep.id);
+                  }}
                   aria-label={`Remove dependency: ${dep.title}`}
                 >
                   <X className="h-3 w-3" aria-hidden="true" />
-                </Button>
-              </div>
+                </ActionIcon>
+              </Paper>
             ))}
-          </div>
+          </Stack>
         )}
 
         {/* Add depends_on */}
         {isAddingDependsOn ? (
-          <div className="flex gap-2">
-            <Select onValueChange={(id) => handleAddDependency(id, 'depends_on')}>
-              <SelectTrigger className="flex-1">
-                <SelectValue placeholder="Select a task this depends on..." />
-              </SelectTrigger>
-              <SelectContent>
-                {availableTasksForDependsOn.length === 0 ? (
-                  <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                    No available tasks
-                  </div>
-                ) : (
-                  availableTasksForDependsOn.map((t) => (
-                    <SelectItem key={t.id} value={t.id}>
-                      <span className="truncate">{t.title}</span>
-                    </SelectItem>
-                  ))
-                )}
-              </SelectContent>
-            </Select>
+          <Group gap="xs" align="flex-start" wrap="nowrap">
+            <Select
+              aria-label="Select dependency task"
+              className="flex-1"
+              placeholder="Select a task this depends on..."
+              data={availableTasksForDependsOn.map((t) => ({ value: t.id, label: t.title }))}
+              nothingFoundMessage="No available tasks"
+              onChange={(id) => {
+                if (id) void handleAddDependency(id, 'depends_on');
+              }}
+            />
             <Button
-              variant="ghost"
-              size="sm"
+              variant="subtle"
+              size="xs"
               onClick={() => setIsAddingDependsOn(false)}
               aria-label="Cancel adding dependency"
             >
               Cancel
             </Button>
-          </div>
+          </Group>
         ) : (
           <Button
             ref={addDependsOnButtonRef}
             variant="outline"
-            size="sm"
+            size="xs"
             className="w-full"
             onClick={() => setIsAddingDependsOn(true)}
+            leftSection={<Plus className="h-4 w-4" aria-hidden="true" />}
           >
-            <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
             Add Dependency
           </Button>
         )}
-      </div>
+      </Stack>
 
       {/* Blocks Section */}
-      <div className="space-y-2 border-t pt-3">
-        <div className="text-sm font-medium text-foreground/70">Blocks</div>
+      <Stack gap="xs" className="border-t pt-3">
+        <Text size="sm" fw={500} className="text-foreground/70">
+          Blocks
+        </Text>
 
         {blocksTasks.length > 0 && (
-          <div className="space-y-1">
+          <Stack gap={4}>
             {blocksTasks.map((blocked) => (
-              <div
+              <Paper
                 key={blocked.id}
-                className="flex items-center gap-2 p-2 rounded-md bg-muted/50 group"
+                radius="md"
+                className="group flex items-center gap-2 bg-muted/50 p-2"
               >
                 <Ban className="h-4 w-4 text-amber-500 flex-shrink-0" aria-hidden="true" />
                 <span className="flex-1 text-sm truncate">{blocked.title}</span>
-                <Badge variant="secondary" className="text-xs">
+                <Badge color="gray" variant="light" size="sm">
                   {blocked.status}
                 </Badge>
-                <Button
-                  variant="ghost"
-                  size="icon"
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
                   className="h-6 w-6 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
-                  onClick={() => handleRemoveDependency(blocked.id)}
+                  onClick={() => {
+                    void handleRemoveDependency(blocked.id);
+                  }}
                   aria-label={`Remove blocker: ${blocked.title}`}
                 >
                   <X className="h-3 w-3" aria-hidden="true" />
-                </Button>
-              </div>
+                </ActionIcon>
+              </Paper>
             ))}
-          </div>
+          </Stack>
         )}
 
         {/* Add blocks */}
         {isAddingBlocks ? (
-          <div className="flex gap-2">
-            <Select onValueChange={(id) => handleAddDependency(id, 'blocks')}>
-              <SelectTrigger className="flex-1">
-                <SelectValue placeholder="Select a task this blocks..." />
-              </SelectTrigger>
-              <SelectContent>
-                {availableTasksForBlocks.length === 0 ? (
-                  <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                    No available tasks
-                  </div>
-                ) : (
-                  availableTasksForBlocks.map((t) => (
-                    <SelectItem key={t.id} value={t.id}>
-                      <span className="truncate">{t.title}</span>
-                    </SelectItem>
-                  ))
-                )}
-              </SelectContent>
-            </Select>
+          <Group gap="xs" align="flex-start" wrap="nowrap">
+            <Select
+              aria-label="Select blocked task"
+              className="flex-1"
+              placeholder="Select a task this blocks..."
+              data={availableTasksForBlocks.map((t) => ({ value: t.id, label: t.title }))}
+              nothingFoundMessage="No available tasks"
+              onChange={(id) => {
+                if (id) void handleAddDependency(id, 'blocks');
+              }}
+            />
             <Button
-              variant="ghost"
-              size="sm"
+              variant="subtle"
+              size="xs"
               onClick={() => setIsAddingBlocks(false)}
               aria-label="Cancel adding blocker"
             >
               Cancel
             </Button>
-          </div>
+          </Group>
         ) : (
           <Button
             ref={addBlocksButtonRef}
             variant="outline"
-            size="sm"
+            size="xs"
             className="w-full"
             onClick={() => setIsAddingBlocks(true)}
+            leftSection={<Plus className="h-4 w-4" aria-hidden="true" />}
           >
-            <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
             Add Blocker
           </Button>
         )}
-      </div>
+      </Stack>
 
       {dependsOnTasks.length === 0 && blocksTasks.length === 0 && (
-        <p className="text-xs text-muted-foreground text-center pt-2">
+        <Text size="xs" c="dimmed" ta="center" pt="xs">
           No dependencies. This task is independent.
-        </p>
+        </Text>
       )}
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/task/VerificationSection.tsx
+++ b/web/src/components/task/VerificationSection.tsx
@@ -1,9 +1,16 @@
 import { useState } from 'react';
 import { Plus, Trash2, ShieldCheck, Check } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Checkbox,
+  Group,
+  Progress,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import {
   useAddVerificationStep,
   useUpdateVerificationStep,
@@ -56,7 +63,7 @@ export function VerificationSection({ task }: VerificationSectionProps) {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleAddStep();
+      void handleAddStep();
     }
   };
 
@@ -70,95 +77,109 @@ export function VerificationSection({ task }: VerificationSectionProps) {
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-1.5">
+    <Stack gap="sm">
+      <Group justify="space-between" align="center">
+        <Group gap={6}>
           <ShieldCheck className="h-4 w-4 text-muted-foreground" />
-          <Label className="text-muted-foreground">Done Criteria</Label>
-        </div>
+          <Text size="sm" c="dimmed" fw={500}>
+            Done Criteria
+          </Text>
+        </Group>
         {totalCount > 0 && (
-          <span className="text-xs text-muted-foreground">
+          <Text size="xs" c="dimmed">
             {checkedCount}/{totalCount} verified
-          </span>
+          </Text>
         )}
-      </div>
+      </Group>
 
       {/* Progress bar */}
       {totalCount > 0 && (
-        <div className="h-1.5 bg-muted rounded-full overflow-hidden">
-          <div
-            className={cn(
-              'h-full transition-all duration-300',
-              checkedCount === totalCount ? 'bg-green-500' : 'bg-primary'
-            )}
-            style={{ width: `${progress}%` }}
-          />
-        </div>
+        <Progress
+          value={progress}
+          size="xs"
+          radius="xl"
+          color={checkedCount === totalCount ? 'green' : 'violet'}
+          aria-label="Done criteria progress"
+        />
       )}
 
       {/* Verification step list */}
-      <div className="space-y-1">
+      <Stack gap={4}>
         {steps.map((step) => (
-          <div
+          <Group
             key={step.id}
+            align="flex-start"
+            gap="xs"
             className={cn(
-              'flex items-start gap-2 p-2 rounded-md group hover:bg-muted/50 transition-colors',
+              'group rounded-md p-2 transition-colors hover:bg-muted/50',
               step.checked && 'opacity-70'
             )}
           >
             <Checkbox
               checked={step.checked}
-              onCheckedChange={() => handleToggleStep(step)}
-              className={cn(
-                'flex-shrink-0 mt-0.5',
-                step.checked &&
-                  'data-[state=checked]:bg-green-600 data-[state=checked]:border-green-600'
-              )}
+              onChange={() => {
+                void handleToggleStep(step);
+              }}
+              color="green"
+              className="mt-0.5 flex-shrink-0"
+              aria-label={`Mark verification step ${step.description}`}
             />
-            <div className="flex-1 min-w-0">
-              <span className={cn('text-sm', step.checked && 'line-through text-muted-foreground')}>
+            <Box className="min-w-0 flex-1">
+              <Text
+                component="span"
+                size="sm"
+                className={cn(step.checked && 'text-muted-foreground line-through')}
+              >
                 {step.description}
-              </span>
+              </Text>
               {step.checked && step.checkedAt && (
-                <div className="flex items-center gap-1 mt-0.5">
+                <Group gap={4} mt={2}>
                   <Check className="h-3 w-3 text-green-500" />
-                  <span className="text-xs text-green-500/80">
+                  <Text size="xs" c="green.5">
                     {formatTimestamp(step.checkedAt)}
-                  </span>
-                </div>
+                  </Text>
+                </Group>
               )}
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
+            </Box>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="sm"
               className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
-              onClick={() => handleDeleteStep(step.id)}
+              onClick={() => {
+                void handleDeleteStep(step.id);
+              }}
+              aria-label={`Delete verification step: ${step.description}`}
             >
               <Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-            </Button>
-          </div>
+            </ActionIcon>
+          </Group>
         ))}
-      </div>
+      </Stack>
 
       {/* Add verification step input */}
-      <div className="flex gap-2">
-        <Input
+      <Group gap="xs" align="flex-start" wrap="nowrap">
+        <TextInput
+          aria-label="New verification step"
           value={newDescription}
-          onChange={(e) => setNewDescription(e.target.value)}
+          onChange={(e) => setNewDescription(e.currentTarget.value)}
           onKeyDown={handleKeyDown}
           placeholder="Add verification step..."
-          className="text-sm"
+          className="flex-1 text-sm"
           disabled={isAdding}
         />
         <Button
-          size="icon"
-          onClick={handleAddStep}
+          size="sm"
+          onClick={() => {
+            void handleAddStep();
+          }}
           disabled={!newDescription.trim() || isAdding}
-          className="h-9 w-9 shrink-0"
+          className="shrink-0"
+          aria-label="Add verification step"
         >
           <Plus className="h-4 w-4" />
         </Button>
-      </div>
-    </div>
+      </Group>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates the task-detail blocked reason, done criteria, and dependency subsections from compatibility wrappers to direct Mantine primitives.
- Preserves blocked-reason updates, verification-step add/toggle/delete mutations, dependency display, add/cancel, removal, focus return, and empty states.
- Adds focused wrapper-regression coverage and updates the Mantine migration ledger.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-validation-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- env VERITAS_ADMIN_KEY=<local smoke key> VERITAS_AUTH_ENABLED=false VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/playwright test e2e/task-detail.spec.ts --project=chromium

## Notes
- Rendered e2e needs VERITAS_ADMIN_KEY in the server environment; without it the API dev server fails environment validation before Playwright can connect.
- Roadmap: advances #417 and #326.