### PR TITLE
Migrate task detail work sections to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -344,6 +344,11 @@ Phase 3 progress:
   button, action icon, and paper primitives while preserving blocked-reason
   updates, verification-step mutations, dependency display, add/cancel, and
   remove behavior.
+- Task detail subtask, deliverable, and lessons-learned subsections now use
+  direct Mantine checkbox, switch, progress, text input, textarea, select,
+  badge, button, action icon, paper, theme icon, and modal primitives while
+  preserving subtask and criterion mutations, auto-complete toggling,
+  deliverable add/edit/delete flows, and lessons-note/tag updates.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/task-detail-work-sections-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-work-sections-mantine.test.tsx
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DeliverablesSection } from '@/components/task/DeliverablesSection';
+import { LessonsLearnedSection } from '@/components/task/LessonsLearnedSection';
+import { SubtasksSection } from '@/components/task/SubtasksSection';
+import { createMockTask, renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  addSubtask: vi.fn(),
+  updateSubtask: vi.fn(),
+  deleteSubtask: vi.fn(),
+  toggleCriteria: vi.fn(),
+  addDeliverable: vi.fn(),
+  updateDeliverable: vi.fn(),
+  deleteDeliverable: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTasks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useTasks')>('@/hooks/useTasks');
+  return {
+    ...actual,
+    useAddSubtask: () => ({ mutateAsync: mocks.addSubtask }),
+    useUpdateSubtask: () => ({ mutateAsync: mocks.updateSubtask }),
+    useDeleteSubtask: () => ({ mutateAsync: mocks.deleteSubtask }),
+    useToggleSubtaskCriteria: () => ({ mutateAsync: mocks.toggleCriteria }),
+  };
+});
+
+vi.mock('@/hooks/useDeliverables', () => ({
+  useAddDeliverable: () => ({ mutateAsync: mocks.addDeliverable, isPending: false }),
+  useUpdateDeliverable: () => ({ mutateAsync: mocks.updateDeliverable, isPending: false }),
+  useDeleteDeliverable: () => ({ mutateAsync: mocks.deleteDeliverable, isPending: false }),
+}));
+
+describe('task detail work sections Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    mocks.addSubtask.mockResolvedValue(undefined);
+    mocks.updateSubtask.mockResolvedValue(undefined);
+    mocks.deleteSubtask.mockResolvedValue(undefined);
+    mocks.toggleCriteria.mockResolvedValue(undefined);
+    mocks.addDeliverable.mockResolvedValue(undefined);
+    mocks.updateDeliverable.mockResolvedValue(undefined);
+    mocks.deleteDeliverable.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders subtasks through direct Mantine controls and keeps mutations wired', async () => {
+    const user = userEvent.setup();
+    const onAutoCompleteChange = vi.fn();
+    const task = createMockTask({
+      autoCompleteOnSubtasks: true,
+      subtasks: [
+        {
+          id: 'sub-1',
+          title: 'Write unit tests',
+          completed: false,
+          created: '2026-06-01T09:00:00Z',
+          acceptanceCriteria: ['Covers add path'],
+          criteriaChecked: [false],
+        },
+        {
+          id: 'sub-2',
+          title: 'Run smoke',
+          completed: true,
+          created: '2026-06-01T09:05:00Z',
+        },
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <SubtasksSection task={task} onAutoCompleteChange={onAutoCompleteChange} />
+    );
+
+    expect(container.querySelector('.mantine-Checkbox-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Switch-root')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="checkbox"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Mark subtask Write unit tests' }));
+    await user.click(screen.getByRole('button', { name: 'Expand criteria for Write unit tests' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Mark criterion Covers add path' }));
+    await user.type(screen.getByRole('textbox', { name: 'New subtask' }), 'Document rollout');
+    await user.click(screen.getByRole('button', { name: /add acceptance criteria/i }));
+    await user.type(screen.getByRole('textbox', { name: 'Criterion 1' }), 'Reviewer approved');
+    await user.click(screen.getByRole('button', { name: 'Add subtask' }));
+    await user.click(
+      screen.getByRole('switch', { name: 'Auto-complete task when all subtasks done' })
+    );
+
+    expect(mocks.updateSubtask).toHaveBeenCalledWith({
+      taskId: task.id,
+      subtaskId: 'sub-1',
+      updates: { completed: true },
+    });
+    expect(mocks.toggleCriteria).toHaveBeenCalledWith({
+      taskId: task.id,
+      subtaskId: 'sub-1',
+      criteriaIndex: 0,
+    });
+    expect(mocks.addSubtask).toHaveBeenCalledWith({
+      taskId: task.id,
+      title: 'Document rollout',
+      acceptanceCriteria: ['Reviewer approved'],
+    });
+    expect(onAutoCompleteChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders deliverable add and edit forms through direct Mantine primitives', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-deliverables',
+      deliverables: [
+        {
+          id: 'del-1',
+          title: 'Release notes',
+          type: 'document',
+          status: 'pending',
+          path: 'https://example.com/release-notes',
+          description: 'Draft notes',
+          created: '2026-06-01T09:00:00Z',
+        },
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(<DeliverablesSection task={task} />);
+
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Edit deliverable' }));
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Textarea-root')).toBeDefined();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Deliverable title' }), {
+      target: { value: 'Final release notes' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mocks.updateDeliverable).toHaveBeenCalledWith({
+      taskId: task.id,
+      deliverableId: 'del-1',
+      title: 'Final release notes',
+      type: 'document',
+      path: 'https://example.com/release-notes',
+      status: 'pending',
+      description: 'Draft notes',
+    });
+  });
+
+  it('uses direct Mantine add controls and delete modal for deliverables', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-deliverable-actions',
+      deliverables: [
+        {
+          id: 'del-2',
+          title: 'QA checklist',
+          type: 'report',
+          status: 'reviewed',
+          created: '2026-06-01T09:00:00Z',
+        },
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(<DeliverablesSection task={task} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'New deliverable title' }), {
+      target: { value: 'Build artifact' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'New deliverable path or URL' }), {
+      target: { value: '/tmp/build.zip' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Add Deliverable' }));
+
+    expect(mocks.addDeliverable).toHaveBeenCalledWith({
+      taskId: task.id,
+      title: 'Build artifact',
+      type: 'document',
+      path: '/tmp/build.zip',
+      description: undefined,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Delete deliverable' }));
+    const dialog = screen.getByRole('dialog', { name: 'Delete deliverable?' });
+    expect(container.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(mocks.deleteDeliverable).toHaveBeenCalledWith({
+      taskId: task.id,
+      deliverableId: 'del-2',
+    });
+  });
+
+  it('renders lessons learned through direct Mantine controls and keeps updates wired', () => {
+    vi.useFakeTimers();
+    const onUpdate = vi.fn();
+    const task = createMockTask({
+      status: 'done',
+      lessonsLearned: 'Initial note',
+      lessonTags: ['release'],
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <LessonsLearnedSection task={task} onUpdate={onUpdate} />
+    );
+
+    expect(container.querySelector('.mantine-Textarea-root')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        'What did you learn from this task? What would you do differently next time?'
+      ),
+      { target: { value: 'Document the deployment checklist' } }
+    );
+    vi.advanceTimersByTime(500);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'New lesson tag' }), {
+      target: { value: 'deployment' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add lesson tag' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove release tag' }));
+
+    expect(onUpdate).toHaveBeenCalledWith('lessonsLearned', 'Document the deployment checklist');
+    expect(onUpdate).toHaveBeenCalledWith('lessonTags', ['release', 'deployment']);
+    expect(onUpdate).toHaveBeenCalledWith('lessonTags', []);
+  });
+});

--- a/web/src/components/task/DeliverablesSection.tsx
+++ b/web/src/components/task/DeliverablesSection.tsx
@@ -1,26 +1,21 @@
 import { useState } from 'react';
 import { FileText, Pencil, Trash2, X, Check, Plus, ExternalLink } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Label } from '@/components/ui/label';
 import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Group,
+  Modal,
+  Paper,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+  SimpleGrid,
+  Stack,
+  Text,
+  TextInput,
+  Textarea,
+  ThemeIcon,
+} from '@mantine/core';
 import {
   useAddDeliverable,
   useUpdateDeliverable,
@@ -33,19 +28,34 @@ interface DeliverablesSectionProps {
 }
 
 const TYPE_COLORS: Record<DeliverableType, string> = {
-  document: 'bg-blue-500/10 text-blue-700 dark:text-blue-400',
-  code: 'bg-purple-500/10 text-purple-700 dark:text-purple-400',
-  report: 'bg-green-500/10 text-green-700 dark:text-green-400',
-  artifact: 'bg-orange-500/10 text-orange-700 dark:text-orange-400',
-  other: 'bg-gray-500/10 text-gray-700 dark:text-gray-400',
+  document: 'blue',
+  code: 'violet',
+  report: 'green',
+  artifact: 'orange',
+  other: 'gray',
 };
 
 const STATUS_COLORS: Record<DeliverableStatus, string> = {
-  pending: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400',
-  attached: 'bg-blue-500/10 text-blue-700 dark:text-blue-400',
-  reviewed: 'bg-purple-500/10 text-purple-700 dark:text-purple-400',
-  accepted: 'bg-green-500/10 text-green-700 dark:text-green-400',
+  pending: 'yellow',
+  attached: 'blue',
+  reviewed: 'violet',
+  accepted: 'green',
 };
+
+const DELIVERABLE_TYPES: { value: DeliverableType; label: string }[] = [
+  { value: 'document', label: 'Document' },
+  { value: 'code', label: 'Code' },
+  { value: 'report', label: 'Report' },
+  { value: 'artifact', label: 'Artifact' },
+  { value: 'other', label: 'Other' },
+];
+
+const DELIVERABLE_STATUSES: { value: DeliverableStatus; label: string }[] = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'attached', label: 'Attached' },
+  { value: 'reviewed', label: 'Reviewed' },
+  { value: 'accepted', label: 'Accepted' },
+];
 
 function DeliverableItem({ deliverable, taskId }: { deliverable: Deliverable; taskId: string }) {
   const [isEditing, setIsEditing] = useState(false);
@@ -91,178 +101,197 @@ function DeliverableItem({ deliverable, taskId }: { deliverable: Deliverable; ta
 
   return (
     <>
-      <div className="group flex gap-3 p-3 rounded-md bg-muted/30 border border-border/50">
-        <div className="h-8 w-8 flex-shrink-0 rounded-md bg-primary/10 flex items-center justify-center">
+      <Paper className="group flex gap-3 border border-border/50 bg-muted/30 p-3" radius="md">
+        <ThemeIcon variant="light" color="violet" size="lg" radius="md" className="flex-shrink-0">
           <FileText className="h-4 w-4" />
-        </div>
-        <div className="flex-1 min-w-0">
+        </ThemeIcon>
+        <Box className="min-w-0 flex-1">
           {isEditing ? (
-            <div className="space-y-3">
-              <div>
-                <Label className="text-xs">Title</Label>
-                <Input
+            <Stack gap="sm">
+              <Stack gap={4}>
+                <Text size="xs" fw={500}>
+                  Title
+                </Text>
+                <TextInput
                   value={editTitle}
-                  onChange={(e) => setEditTitle(e.target.value)}
+                  onChange={(e) => setEditTitle(e.currentTarget.value)}
                   placeholder="Deliverable title"
-                  className="text-sm h-8"
+                  size="xs"
                   autoFocus
+                  aria-label="Deliverable title"
                 />
-              </div>
-              <div className="grid grid-cols-2 gap-2">
-                <div>
-                  <Label className="text-xs">Type</Label>
-                  <Select value={editType} onValueChange={(v) => setEditType(v as DeliverableType)}>
-                    <SelectTrigger className="text-sm h-8">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="document">Document</SelectItem>
-                      <SelectItem value="code">Code</SelectItem>
-                      <SelectItem value="report">Report</SelectItem>
-                      <SelectItem value="artifact">Artifact</SelectItem>
-                      <SelectItem value="other">Other</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label className="text-xs">Status</Label>
+              </Stack>
+              <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+                <Stack gap={4}>
+                  <Text size="xs" fw={500}>
+                    Type
+                  </Text>
                   <Select
+                    aria-label="Deliverable type"
+                    allowDeselect={false}
+                    data={DELIVERABLE_TYPES}
+                    value={editType}
+                    onChange={(value) => {
+                      if (value) setEditType(value as DeliverableType);
+                    }}
+                    size="xs"
+                  />
+                </Stack>
+                <Stack gap={4}>
+                  <Text size="xs" fw={500}>
+                    Status
+                  </Text>
+                  <Select
+                    aria-label="Deliverable status"
+                    allowDeselect={false}
+                    data={DELIVERABLE_STATUSES}
                     value={editStatus}
-                    onValueChange={(v) => setEditStatus(v as DeliverableStatus)}
-                  >
-                    <SelectTrigger className="text-sm h-8">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="pending">Pending</SelectItem>
-                      <SelectItem value="attached">Attached</SelectItem>
-                      <SelectItem value="reviewed">Reviewed</SelectItem>
-                      <SelectItem value="accepted">Accepted</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <div>
-                <Label className="text-xs">Path / URL (optional)</Label>
-                <Input
+                    onChange={(value) => {
+                      if (value) setEditStatus(value as DeliverableStatus);
+                    }}
+                    size="xs"
+                  />
+                </Stack>
+              </SimpleGrid>
+              <Stack gap={4}>
+                <Text size="xs" fw={500}>
+                  Path / URL (optional)
+                </Text>
+                <TextInput
                   value={editPath}
-                  onChange={(e) => setEditPath(e.target.value)}
+                  onChange={(e) => setEditPath(e.currentTarget.value)}
                   placeholder="https://... or /path/to/file"
-                  className="text-sm h-8"
+                  size="xs"
+                  aria-label="Deliverable path or URL"
                 />
-              </div>
-              <div>
-                <Label className="text-xs">Description (optional)</Label>
+              </Stack>
+              <Stack gap={4}>
+                <Text size="xs" fw={500}>
+                  Description (optional)
+                </Text>
                 <Textarea
                   value={editDescription}
-                  onChange={(e) => setEditDescription(e.target.value)}
+                  onChange={(e) => setEditDescription(e.currentTarget.value)}
                   placeholder="Add details about this deliverable..."
-                  className="text-sm min-h-[60px] resize-none"
+                  rows={2}
+                  className="resize-none"
+                  aria-label="Deliverable description"
                 />
-              </div>
-              <div className="flex items-center gap-2">
+              </Stack>
+              <Group gap="xs">
                 <Button
-                  size="sm"
-                  className="h-7"
-                  onClick={handleSaveEdit}
+                  size="xs"
+                  onClick={() => {
+                    void handleSaveEdit();
+                  }}
                   disabled={!editTitle.trim() || updateDeliverable.isPending}
+                  leftSection={<Check className="h-3 w-3" />}
                 >
-                  <Check className="h-3 w-3 mr-1" />
                   Save
                 </Button>
-                <Button variant="ghost" size="sm" className="h-7" onClick={handleCancelEdit}>
-                  <X className="h-3 w-3 mr-1" />
+                <Button variant="subtle" size="xs" onClick={handleCancelEdit}>
+                  <X className="h-3 w-3" />
                   Cancel
                 </Button>
-              </div>
-            </div>
+              </Group>
+            </Stack>
           ) : (
-            <>
-              <div className="flex items-start gap-2 mb-1">
-                <span className="font-medium text-sm flex-1">{deliverable.title}</span>
-                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <Button
-                    variant="ghost"
+            <Stack gap={6}>
+              <Group align="flex-start" gap="xs" wrap="nowrap">
+                <Text size="sm" fw={500} className="min-w-0 flex-1">
+                  {deliverable.title}
+                </Text>
+                <Group gap={4} className="opacity-0 transition-opacity group-hover:opacity-100">
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
                     size="sm"
-                    className="h-6 w-6 p-0"
                     aria-label="Edit deliverable"
                     onClick={() => setIsEditing(true)}
                   >
                     <Pencil className="h-3 w-3 text-muted-foreground hover:text-foreground" />
-                  </Button>
-                  <Button
-                    variant="ghost"
+                  </ActionIcon>
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
                     size="sm"
-                    className="h-6 w-6 p-0"
                     aria-label="Delete deliverable"
                     onClick={() => setDeleteDialogOpen(true)}
                   >
-                    <Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-                  </Button>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 mb-2">
-                <span
-                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${TYPE_COLORS[deliverable.type]}`}
-                >
+                    <Trash2 className="h-3 w-3" />
+                  </ActionIcon>
+                </Group>
+              </Group>
+              <Group gap="xs">
+                <Badge color={TYPE_COLORS[deliverable.type]} variant="light" size="sm">
                   {deliverable.type}
-                </span>
-                <span
-                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[deliverable.status]}`}
-                >
+                </Badge>
+                <Badge color={STATUS_COLORS[deliverable.status]} variant="light" size="sm">
                   {deliverable.status}
-                </span>
+                </Badge>
                 {deliverable.agent && (
-                  <span className="text-xs text-muted-foreground">by {deliverable.agent}</span>
+                  <Text size="xs" c="dimmed">
+                    by {deliverable.agent}
+                  </Text>
                 )}
-              </div>
+              </Group>
               {deliverable.path && (
-                <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
+                <Group gap={4} className="min-w-0">
                   {isUrl ? (
-                    <a
+                    <Text
+                      component="a"
                       href={deliverable.path}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-primary hover:underline flex items-center gap-1"
+                      size="xs"
+                      className="flex min-w-0 items-center gap-1 text-primary hover:underline"
                     >
-                      {deliverable.path}
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
+                      <span className="truncate">{deliverable.path}</span>
+                      <ExternalLink className="h-3 w-3 flex-shrink-0" />
+                    </Text>
                   ) : (
-                    <span className="font-mono">{deliverable.path}</span>
+                    <Text size="xs" c="dimmed" ff="monospace" className="truncate">
+                      {deliverable.path}
+                    </Text>
                   )}
-                </div>
+                </Group>
               )}
               {deliverable.description && (
-                <p className="text-xs text-foreground/70 mt-1">{deliverable.description}</p>
+                <Text size="xs" className="text-foreground/70">
+                  {deliverable.description}
+                </Text>
               )}
-              <div className="text-xs text-muted-foreground mt-1">
+              <Text size="xs" c="dimmed">
                 Added {new Date(deliverable.created).toLocaleDateString()}
-              </div>
-            </>
+              </Text>
+            </Stack>
           )}
-        </div>
-      </div>
+        </Box>
+      </Paper>
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete deliverable?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Remove "{deliverable.title}" from this task's deliverables?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              className="bg-destructive hover:bg-destructive/90"
+      <Modal
+        opened={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        title="Delete deliverable?"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm">Remove "{deliverable.title}" from this task's deliverables?</Text>
+          <Group justify="flex-end" gap="sm">
+            <Button variant="default" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                void handleDelete();
+              }}
             >
               Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </>
   );
 }
@@ -303,98 +332,113 @@ export function DeliverablesSection({ task }: DeliverablesSectionProps) {
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
+    <Stack gap="sm">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
           <FileText className="h-4 w-4 text-muted-foreground" />
-          <Label className="text-sm font-medium">
+          <Text size="sm" fw={500}>
             Deliverables {deliverables.length > 0 && `(${deliverables.length})`}
-          </Label>
-        </div>
+          </Text>
+        </Group>
         {!showForm && (
           <Button
             variant="outline"
-            size="sm"
-            className="h-7 text-xs"
+            size="xs"
             onClick={() => setShowForm(true)}
+            leftSection={<Plus className="h-3 w-3" />}
           >
-            <Plus className="h-3 w-3 mr-1" />
             Add
           </Button>
         )}
-      </div>
+      </Group>
 
       {deliverables.length === 0 && !showForm && (
-        <p className="text-sm text-muted-foreground">No deliverables yet</p>
+        <Text size="sm" c="dimmed">
+          No deliverables yet
+        </Text>
       )}
 
       {showForm && (
-        <div className="space-y-3 p-3 rounded-md border border-border bg-muted/20">
-          <div>
-            <Label className="text-xs">Title *</Label>
-            <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g., API Documentation"
-              className="text-sm h-8"
-              autoFocus
-            />
-          </div>
-          <div>
-            <Label className="text-xs">Type *</Label>
-            <Select value={type} onValueChange={(v) => setType(v as DeliverableType)}>
-              <SelectTrigger className="text-sm h-8">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="document">Document</SelectItem>
-                <SelectItem value="code">Code</SelectItem>
-                <SelectItem value="report">Report</SelectItem>
-                <SelectItem value="artifact">Artifact</SelectItem>
-                <SelectItem value="other">Other</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <Label className="text-xs">Path / URL (optional)</Label>
-            <Input
-              value={path}
-              onChange={(e) => setPath(e.target.value)}
-              placeholder="https://... or /path/to/file"
-              className="text-sm h-8"
-            />
-          </div>
-          <div>
-            <Label className="text-xs">Description (optional)</Label>
-            <Textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Add details about this deliverable..."
-              className="text-sm min-h-[60px] resize-none"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              onClick={handleAddDeliverable}
-              disabled={!title.trim() || addDeliverable.isPending}
-            >
-              <Check className="h-3 w-3 mr-1" />
-              Add Deliverable
-            </Button>
-            <Button variant="ghost" size="sm" onClick={handleCancel}>
-              <X className="h-3 w-3 mr-1" />
-              Cancel
-            </Button>
-          </div>
-        </div>
+        <Paper className="border border-border bg-muted/20 p-3" radius="md">
+          <Stack gap="sm">
+            <Stack gap={4}>
+              <Text size="xs" fw={500}>
+                Title *
+              </Text>
+              <TextInput
+                value={title}
+                onChange={(e) => setTitle(e.currentTarget.value)}
+                placeholder="e.g., API Documentation"
+                size="xs"
+                autoFocus
+                aria-label="New deliverable title"
+              />
+            </Stack>
+            <Stack gap={4}>
+              <Text size="xs" fw={500}>
+                Type *
+              </Text>
+              <Select
+                aria-label="New deliverable type"
+                allowDeselect={false}
+                data={DELIVERABLE_TYPES}
+                value={type}
+                onChange={(value) => {
+                  if (value) setType(value as DeliverableType);
+                }}
+                size="xs"
+              />
+            </Stack>
+            <Stack gap={4}>
+              <Text size="xs" fw={500}>
+                Path / URL (optional)
+              </Text>
+              <TextInput
+                value={path}
+                onChange={(e) => setPath(e.currentTarget.value)}
+                placeholder="https://... or /path/to/file"
+                size="xs"
+                aria-label="New deliverable path or URL"
+              />
+            </Stack>
+            <Stack gap={4}>
+              <Text size="xs" fw={500}>
+                Description (optional)
+              </Text>
+              <Textarea
+                value={description}
+                onChange={(e) => setDescription(e.currentTarget.value)}
+                placeholder="Add details about this deliverable..."
+                rows={2}
+                className="resize-none"
+                aria-label="New deliverable description"
+              />
+            </Stack>
+            <Group gap="xs">
+              <Button
+                size="sm"
+                onClick={() => {
+                  void handleAddDeliverable();
+                }}
+                disabled={!title.trim() || addDeliverable.isPending}
+                leftSection={<Check className="h-3 w-3" />}
+              >
+                Add Deliverable
+              </Button>
+              <Button variant="subtle" size="sm" onClick={handleCancel}>
+                <X className="h-3 w-3" />
+                Cancel
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
       )}
 
-      <div className="space-y-2">
+      <Stack gap="xs">
         {deliverables.map((deliverable) => (
           <DeliverableItem key={deliverable.id} deliverable={deliverable} taskId={task.id} />
         ))}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/task/LessonsLearnedSection.tsx
+++ b/web/src/components/task/LessonsLearnedSection.tsx
@@ -1,9 +1,17 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { Textarea } from '@/components/ui/textarea';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
+import type { KeyboardEvent } from 'react';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  ThemeIcon,
+} from '@mantine/core';
 import { Lightbulb, X, Plus } from 'lucide-react';
 import type { Task } from '@veritas-kanban/shared';
 
@@ -63,7 +71,7 @@ export function LessonsLearnedSection({
     );
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter') {
       e.preventDefault();
       handleAddTag();
@@ -71,83 +79,105 @@ export function LessonsLearnedSection({
   };
 
   return (
-    <div className="space-y-4 rounded-lg border border-border bg-muted p-4">
-      <div className="flex items-center gap-2 text-violet-600 dark:text-violet-400">
-        <Lightbulb className="h-5 w-5" />
-        <h3 className="font-semibold">Lessons Learned</h3>
-      </div>
+    <Paper className="border border-border bg-muted p-4" radius="lg">
+      <Stack gap="md">
+        <Group gap="xs" className="text-violet-600 dark:text-violet-400">
+          <ThemeIcon variant="light" color="violet" size="sm" radius="xl">
+            <Lightbulb className="h-4 w-4" />
+          </ThemeIcon>
+          <Text fw={600}>Lessons Learned</Text>
+        </Group>
 
-      <p className="text-sm text-muted-foreground">
-        Capture institutional knowledge from this completed task. What worked well? What would you
-        do differently?
-      </p>
+        <Text size="sm" c="dimmed">
+          Capture institutional knowledge from this completed task. What worked well? What would you
+          do differently?
+        </Text>
 
-      <div className="space-y-2">
-        <Label htmlFor="lessonsLearned">Notes (Markdown supported)</Label>
-        {readOnly ? (
-          <div className="prose prose-sm dark:prose-invert max-w-none p-3 bg-card rounded border border-border">
-            {task.lessonsLearned || (
-              <span className="text-muted-foreground italic">No lessons captured</span>
-            )}
-          </div>
-        ) : (
-          <Textarea
-            id="lessonsLearned"
-            value={localNotes}
-            onChange={(e) => {
-              setLocalNotes(e.target.value);
-              debouncedUpdate(e.target.value);
-            }}
-            placeholder="What did you learn from this task? What would you do differently next time?"
-            className="min-h-[120px] bg-card border-border"
-          />
-        )}
-      </div>
-
-      <div className="space-y-2">
-        <Label>Tags</Label>
-        <div className="flex flex-wrap gap-2 mb-2">
-          {tags.map((tag) => (
-            <Badge key={tag} variant="secondary" className="gap-1">
-              {tag}
-              {!readOnly && (
-                <button
-                  type="button"
-                  onClick={() => handleRemoveTag(tag)}
-                  className="ml-1 hover:text-destructive"
-                  aria-label={`Remove ${tag} tag`}
-                >
-                  <X className="h-3 w-3" />
-                </button>
+        <Stack gap="xs">
+          <Text component="label" htmlFor="lessonsLearned" size="sm" fw={500}>
+            Notes (Markdown supported)
+          </Text>
+          {readOnly ? (
+            <Paper className="prose prose-sm dark:prose-invert max-w-none border border-border bg-card p-3">
+              {task.lessonsLearned || (
+                <Text component="span" size="sm" c="dimmed" fs="italic">
+                  No lessons captured
+                </Text>
               )}
-            </Badge>
-          ))}
-          {tags.length === 0 && (
-            <span className="text-sm text-muted-foreground italic">No tags added</span>
-          )}
-        </div>
-
-        {!readOnly && (
-          <div className="flex gap-2">
-            <Input
-              value={newTag}
-              onChange={(e) => setNewTag(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Add a tag..."
-              className="flex-1"
+            </Paper>
+          ) : (
+            <Textarea
+              id="lessonsLearned"
+              value={localNotes}
+              onChange={(e) => {
+                setLocalNotes(e.currentTarget.value);
+                debouncedUpdate(e.currentTarget.value);
+              }}
+              placeholder="What did you learn from this task? What would you do differently next time?"
+              rows={4}
+              className="bg-card"
             />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleAddTag}
-              disabled={!newTag.trim()}
-            >
-              <Plus className="h-4 w-4" />
-            </Button>
-          </div>
-        )}
-      </div>
-    </div>
+          )}
+        </Stack>
+
+        <Stack gap="xs">
+          <Text size="sm" fw={500}>
+            Tags
+          </Text>
+          <Group gap="xs">
+            {tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant="light"
+                color="violet"
+                rightSection={
+                  !readOnly ? (
+                    <ActionIcon
+                      aria-label={`Remove ${tag} tag`}
+                      color="gray"
+                      size="xs"
+                      variant="transparent"
+                      onClick={() => handleRemoveTag(tag)}
+                    >
+                      <X className="h-3 w-3" />
+                    </ActionIcon>
+                  ) : undefined
+                }
+              >
+                {tag}
+              </Badge>
+            ))}
+            {tags.length === 0 && (
+              <Text size="sm" c="dimmed" fs="italic">
+                No tags added
+              </Text>
+            )}
+          </Group>
+
+          {!readOnly && (
+            <Group gap="xs" align="flex-start" wrap="nowrap">
+              <TextInput
+                value={newTag}
+                onChange={(e) => setNewTag(e.currentTarget.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Add a tag..."
+                className="flex-1"
+                aria-label="New lesson tag"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleAddTag}
+                disabled={!newTag.trim()}
+                aria-label="Add lesson tag"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </Group>
+          )}
+        </Stack>
+      </Stack>
+    </Paper>
   );
 }

--- a/web/src/components/task/SubtasksSection.tsx
+++ b/web/src/components/task/SubtasksSection.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react';
 import { Plus, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Badge } from '@/components/ui/badge';
+import type { KeyboardEvent } from 'react';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Checkbox,
+  Group,
+  Progress,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import {
   useAddSubtask,
   useUpdateSubtask,
@@ -68,10 +75,10 @@ export function SubtasksSection({ task, onAutoCompleteChange }: SubtasksSectionP
     await deleteSubtask.mutateAsync({ taskId: task.id, subtaskId });
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleAddSubtask();
+      void handleAddSubtask();
     }
   };
 
@@ -90,13 +97,15 @@ export function SubtasksSection({ task, onAutoCompleteChange }: SubtasksSectionP
   };
 
   const toggleSubtaskExpanded = (subtaskId: string) => {
-    const newExpanded = new Set(expandedSubtasks);
-    if (newExpanded.has(subtaskId)) {
-      newExpanded.delete(subtaskId);
-    } else {
-      newExpanded.add(subtaskId);
-    }
-    setExpandedSubtasks(newExpanded);
+    setExpandedSubtasks((current) => {
+      const next = new Set(current);
+      if (next.has(subtaskId)) {
+        next.delete(subtaskId);
+      } else {
+        next.add(subtaskId);
+      }
+      return next;
+    });
   };
 
   const handleToggleCriteria = async (subtaskId: string, criteriaIndex: number) => {
@@ -111,181 +120,205 @@ export function SubtasksSection({ task, onAutoCompleteChange }: SubtasksSectionP
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <Label className="text-muted-foreground">Subtasks</Label>
+    <Stack gap="sm">
+      <Group justify="space-between" align="center">
+        <Text size="sm" c="dimmed" fw={500}>
+          Subtasks
+        </Text>
         {totalCount > 0 && (
-          <span className="text-xs text-muted-foreground">
+          <Text size="xs" c="dimmed">
             {completedCount}/{totalCount} complete
-          </span>
+          </Text>
         )}
-      </div>
+      </Group>
 
       {/* Progress bar */}
       {totalCount > 0 && (
-        <div className="h-1.5 bg-muted rounded-full overflow-hidden">
-          <div
-            className="h-full bg-primary transition-all duration-300"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
+        <Progress value={progress} size="xs" radius="xl" aria-label="Subtask progress" />
       )}
 
       {/* Subtask list */}
-      <div className="space-y-1">
+      <Stack gap={4}>
         {subtasks.map((subtask) => {
+          const criteria = subtask.acceptanceCriteria || [];
           const criteriaProgress = getCriteriaProgress(subtask);
           const isExpanded = expandedSubtasks.has(subtask.id);
-          const hasCriteria = subtask.acceptanceCriteria && subtask.acceptanceCriteria.length > 0;
+          const hasCriteria = criteria.length > 0;
 
           return (
-            <div key={subtask.id} className="space-y-1">
-              <div
+            <Stack key={subtask.id} gap={4}>
+              <Group
+                align="center"
+                gap="xs"
                 className={cn(
-                  'flex items-center gap-2 p-2 rounded-md group hover:bg-muted/50 transition-colors',
+                  'group rounded-md p-2 transition-colors hover:bg-muted/50',
                   subtask.completed && 'opacity-60'
                 )}
               >
                 <Checkbox
                   checked={subtask.completed}
-                  onCheckedChange={() => handleToggleSubtask(subtask)}
+                  onChange={() => {
+                    void handleToggleSubtask(subtask);
+                  }}
                   className="flex-shrink-0"
+                  aria-label={`Mark subtask ${subtask.title}`}
                 />
                 {hasCriteria && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    size="xs"
                     className="h-4 w-4 p-0"
                     onClick={() => toggleSubtaskExpanded(subtask.id)}
+                    aria-label={`${isExpanded ? 'Collapse' : 'Expand'} criteria for ${subtask.title}`}
                   >
                     {isExpanded ? (
                       <ChevronDown className="h-3 w-3" />
                     ) : (
                       <ChevronRight className="h-3 w-3" />
                     )}
-                  </Button>
+                  </ActionIcon>
                 )}
-                <span
+                <Text
+                  size="sm"
                   className={cn(
                     'flex-1 text-sm',
                     subtask.completed && 'line-through text-muted-foreground'
                   )}
                 >
                   {subtask.title}
-                </span>
+                </Text>
                 {criteriaProgress && (
-                  <Badge variant="outline" className="text-xs">
+                  <Badge variant="outline" color="gray" size="sm">
                     {criteriaProgress.checked}/{criteriaProgress.total}
                   </Badge>
                 )}
-                <Button
-                  variant="ghost"
-                  size="icon"
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
                   className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
-                  onClick={() => handleDeleteSubtask(subtask.id)}
+                  onClick={() => {
+                    void handleDeleteSubtask(subtask.id);
+                  }}
+                  aria-label={`Delete subtask: ${subtask.title}`}
                 >
                   <Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-                </Button>
-              </div>
+                </ActionIcon>
+              </Group>
 
               {/* Acceptance criteria checklist */}
               {hasCriteria && isExpanded && (
-                <div className="ml-10 space-y-1">
-                  {subtask.acceptanceCriteria!.map((criterion, idx) => (
-                    <div key={idx} className="flex items-start gap-2 p-1">
+                <Stack gap={4} className="ml-10">
+                  {criteria.map((criterion, idx) => (
+                    <Group key={idx} align="flex-start" gap="xs" className="p-1">
                       <Checkbox
                         checked={subtask.criteriaChecked?.[idx] || false}
-                        onCheckedChange={() => handleToggleCriteria(subtask.id, idx)}
+                        onChange={() => {
+                          void handleToggleCriteria(subtask.id, idx);
+                        }}
                         className="flex-shrink-0 mt-0.5"
+                        aria-label={`Mark criterion ${criterion}`}
                       />
-                      <span className="text-xs text-muted-foreground">{criterion}</span>
-                    </div>
+                      <Text size="xs" c="dimmed">
+                        {criterion}
+                      </Text>
+                    </Group>
                   ))}
-                </div>
+                </Stack>
               )}
-            </div>
+            </Stack>
           );
         })}
-      </div>
+      </Stack>
 
       {/* Add subtask input */}
-      <div className="space-y-2">
-        <div className="flex gap-2">
-          <Input
+      <Stack gap="xs">
+        <Group gap="xs" align="flex-start" wrap="nowrap">
+          <TextInput
+            aria-label="New subtask"
             value={newSubtaskTitle}
-            onChange={(e) => setNewSubtaskTitle(e.target.value)}
+            onChange={(e) => setNewSubtaskTitle(e.currentTarget.value)}
             onKeyDown={handleKeyDown}
             placeholder="Add a subtask..."
-            className="text-sm"
+            className="flex-1 text-sm"
             disabled={isAdding}
           />
           <Button
-            size="icon"
-            onClick={handleAddSubtask}
+            size="sm"
+            onClick={() => {
+              void handleAddSubtask();
+            }}
             disabled={!newSubtaskTitle.trim() || isAdding}
-            className="h-9 w-9 shrink-0"
+            className="shrink-0"
+            aria-label="Add subtask"
           >
             <Plus className="h-4 w-4" />
           </Button>
-        </div>
+        </Group>
 
         {/* Add Acceptance Criteria toggle */}
         <Button
-          variant="ghost"
+          variant="subtle"
           size="sm"
           onClick={() => setShowCriteriaInput(!showCriteriaInput)}
-          className="text-xs text-muted-foreground"
+          className="self-start text-xs text-muted-foreground"
         >
-          {showCriteriaInput ? '− Hide' : '+ Add'} Acceptance Criteria
+          {showCriteriaInput ? '- Hide' : '+ Add'} Acceptance Criteria
         </Button>
 
         {/* Acceptance Criteria inputs */}
         {showCriteriaInput && (
-          <div className="space-y-2 pl-4 border-l-2 border-muted">
+          <Stack gap="xs" className="border-l-2 border-muted pl-4">
             {criteriaInputs.map((criterion, idx) => (
-              <div key={idx} className="flex gap-2">
-                <Input
+              <Group key={idx} gap="xs" align="flex-start" wrap="nowrap">
+                <TextInput
                   value={criterion}
-                  onChange={(e) => handleCriteriaInputChange(idx, e.target.value)}
+                  onChange={(e) => handleCriteriaInputChange(idx, e.currentTarget.value)}
                   placeholder={`Criterion ${idx + 1}...`}
-                  className="text-xs"
+                  className="flex-1 text-xs"
+                  aria-label={`Criterion ${idx + 1}`}
                 />
-                <Button
-                  variant="ghost"
-                  size="icon"
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
                   className="h-8 w-8"
                   onClick={() => handleRemoveCriteriaInput(idx)}
                   disabled={criteriaInputs.length === 1}
+                  aria-label={`Remove criterion ${idx + 1}`}
                 >
                   <Trash2 className="h-3 w-3" />
-                </Button>
-              </div>
+                </ActionIcon>
+              </Group>
             ))}
             <Button
               variant="outline"
               size="sm"
               onClick={handleAddCriteriaInput}
-              className="text-xs"
+              className="self-start text-xs"
+              leftSection={<Plus className="h-3 w-3" />}
             >
-              <Plus className="h-3 w-3 mr-1" /> Add Criterion
+              Add Criterion
             </Button>
-          </div>
+          </Stack>
         )}
-      </div>
+      </Stack>
 
       {/* Auto-complete toggle */}
       {totalCount > 0 && (
-        <div className="flex items-center justify-between pt-2 border-t">
-          <Label htmlFor="auto-complete" className="text-xs text-muted-foreground cursor-pointer">
+        <Group justify="space-between" align="center" className="border-t pt-2">
+          <Text component="label" htmlFor="auto-complete" size="xs" c="dimmed">
             Auto-complete task when all subtasks done
-          </Label>
+          </Text>
           <Switch
             id="auto-complete"
             checked={task.autoCompleteOnSubtasks || false}
-            onCheckedChange={onAutoCompleteChange}
+            onChange={(event) => onAutoCompleteChange(event.currentTarget.checked)}
+            aria-label="Auto-complete task when all subtasks done"
           />
-        </div>
+        </Group>
       )}
-    </div>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates the task-detail subtask, deliverable, and lessons-learned subsections from compatibility wrappers to direct Mantine primitives.
- Preserves subtask add/toggle/delete, criterion expand/toggle/add/remove, auto-complete toggling, deliverable add/edit/delete confirmation, and lessons note/tag updates.
- Adds focused wrapper-regression coverage and updates the Mantine migration ledger.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-work-sections-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- env VERITAS_ADMIN_KEY=<local smoke key> VERITAS_AUTH_ENABLED=false VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/playwright test e2e/task-detail.spec.ts --project=chromium

## Notes
- Lint budget remains below the current cap at 679 warnings.
- Roadmap: advances #417 and #326.