### PR TITLE
Migrate task detail support sections to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -349,6 +349,12 @@ Phase 3 progress:
   badge, button, action icon, paper, theme icon, and modal primitives while
   preserving subtask and criterion mutations, auto-complete toggling,
   deliverable add/edit/delete flows, and lessons-note/tag updates.
+- Task detail comments, attachments, observations, and time tracking now use
+  direct Mantine text input, textarea, select, slider, badge, button, action
+  icon, alert, paper, scroll area, modal, stack, group, text, avatar, and theme
+  icon primitives while preserving comment add/edit/delete, attachment upload,
+  text preview, download and delete confirmation, observation add/delete, and
+  manual time-entry add/delete behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/task-detail-support-sections-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-support-sections-mantine.test.tsx
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AttachmentsSection } from '@/components/task/AttachmentsSection';
+import { CommentsSection } from '@/components/task/CommentsSection';
+import { ObservationsSection } from '@/components/task/ObservationsSection';
+import { TimeTrackingSection } from '@/components/task/TimeTrackingSection';
+import { createMockTask, renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  addComment: vi.fn(),
+  editComment: vi.fn(),
+  deleteComment: vi.fn(),
+  uploadAttachment: vi.fn(),
+  deleteAttachment: vi.fn(),
+  timeStart: vi.fn(),
+  timeStop: vi.fn(),
+  timeAddEntry: vi.fn(),
+  timeDeleteEntry: vi.fn(),
+  getTask: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTasks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useTasks')>('@/hooks/useTasks');
+  return {
+    ...actual,
+    useAddComment: () => ({ mutateAsync: mocks.addComment, isPending: false }),
+    useEditComment: () => ({ mutateAsync: mocks.editComment, isPending: false }),
+    useDeleteComment: () => ({ mutateAsync: mocks.deleteComment, isPending: false }),
+  };
+});
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSettings: () => ({
+    settings: {
+      markdown: {
+        enableMarkdown: false,
+      },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useAttachments', () => ({
+  useUploadAttachment: () => ({ mutateAsync: mocks.uploadAttachment, isPending: false }),
+  useDeleteAttachment: () => ({ mutateAsync: mocks.deleteAttachment, isPending: false }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    tasks: {
+      get: mocks.getTask,
+    },
+    time: {
+      start: mocks.timeStart,
+      stop: mocks.timeStop,
+      addEntry: mocks.timeAddEntry,
+      deleteEntry: mocks.timeDeleteEntry,
+    },
+  },
+}));
+
+describe('task detail support sections Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    mocks.addComment.mockResolvedValue(undefined);
+    mocks.editComment.mockResolvedValue(undefined);
+    mocks.deleteComment.mockResolvedValue(undefined);
+    mocks.uploadAttachment.mockResolvedValue(undefined);
+    mocks.deleteAttachment.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders comments through direct Mantine controls and keeps mutations wired', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-comments',
+      comments: [
+        {
+          id: 'comment-1',
+          author: 'Veritas',
+          text: 'Initial review note',
+          timestamp: '2026-06-01T09:00:00Z',
+        },
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(<CommentsSection task={task} />);
+
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Edit comment' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit comment text' }), {
+      target: { value: 'Edited review note' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Comment author' }), {
+      target: { value: 'Reviewer' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Comment text' }), {
+      target: { value: 'New follow-up' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Add Comment' }));
+
+    await user.click(screen.getByRole('button', { name: 'Delete comment' }));
+    const dialog = screen.getByRole('dialog', { name: 'Delete comment?' });
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(mocks.editComment).toHaveBeenCalledWith({
+      taskId: task.id,
+      commentId: 'comment-1',
+      text: 'Edited review note',
+    });
+    expect(mocks.addComment).toHaveBeenCalledWith({
+      taskId: task.id,
+      author: 'Reviewer',
+      text: 'New follow-up',
+    });
+    expect(mocks.deleteComment).toHaveBeenCalledWith({
+      taskId: task.id,
+      commentId: 'comment-1',
+    });
+  });
+
+  it('renders attachments through direct Mantine controls and preserves upload, preview, and delete', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ text: 'Extracted design notes' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = createMockTask({
+      id: 'task-attachments',
+      attachments: [
+        {
+          id: 'attachment-1',
+          filename: 'design.md',
+          originalName: 'Design Notes.md',
+          mimeType: 'text/markdown',
+          size: 2048,
+          uploaded: '2026-06-01T09:00:00Z',
+        },
+        {
+          id: 'attachment-2',
+          filename: 'screenshot.png',
+          originalName: 'Screenshot.png',
+          mimeType: 'image/png',
+          size: 4096,
+          uploaded: '2026-06-01T09:05:00Z',
+        },
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(<AttachmentsSection task={task} />);
+
+    expect(container.querySelector('.mantine-Alert-root')).toBeDefined();
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="label"]')).toBeNull();
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['notes'], 'notes.md', { type: 'text/markdown' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await user.click(screen.getByRole('button', { name: 'Expand text preview' }));
+    expect(await screen.findByText('Extracted design notes')).toBeDefined();
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete attachment' })[0]);
+    const dialog = screen.getByRole('dialog', { name: 'Delete attachment?' });
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(mocks.uploadAttachment).toHaveBeenCalledWith({
+      taskId: task.id,
+      formData: expect.any(FormData),
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/tasks/task-attachments/attachments/attachment-1/text')
+    );
+    expect(mocks.deleteAttachment).toHaveBeenCalledWith({
+      taskId: task.id,
+      attachmentId: 'attachment-1',
+    });
+  });
+
+  it('renders observations through direct Mantine select, slider, textarea, badges, and modal', async () => {
+    const user = userEvent.setup();
+    const onAddObservation = vi.fn().mockResolvedValue(undefined);
+    const onDeleteObservation = vi.fn().mockResolvedValue(undefined);
+    const task = createMockTask({
+      id: 'task-observations',
+      observations: [
+        {
+          id: 'obs-1',
+          type: 'insight',
+          content: 'Documented rollout risk',
+          score: 7,
+          timestamp: '2026-06-01T09:00:00Z',
+          agent: 'planner',
+        },
+      ],
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <ObservationsSection
+        task={task}
+        onAddObservation={onAddObservation}
+        onDeleteObservation={onDeleteObservation}
+      />
+    );
+
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Add Observation' }));
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Slider-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Textarea-root')).toBeDefined();
+
+    fireEvent.change(
+      screen.getByPlaceholderText('Record a decision, blocker, insight, or context...'),
+      {
+        target: { value: 'Keep mobile QA in scope' },
+      }
+    );
+    await user.click(screen.getByRole('button', { name: 'Add Observation' }));
+
+    await user.click(screen.getByRole('button', { name: 'Delete observation' }));
+    const dialog = screen.getByRole('dialog', { name: 'Delete Observation' });
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(onAddObservation).toHaveBeenCalledWith({
+      type: 'context',
+      content: 'Keep mobile QA in scope',
+      score: 5,
+    });
+    expect(onDeleteObservation).toHaveBeenCalledWith('obs-1');
+  });
+
+  it('renders time tracking through direct Mantine controls and keeps manual entry mutations wired', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-time',
+      timeTracking: {
+        totalSeconds: 1800,
+        isRunning: false,
+        entries: [
+          {
+            id: 'entry-1',
+            startTime: '2026-06-01T09:00:00Z',
+            endTime: '2026-06-01T09:30:00Z',
+            duration: 1800,
+            description: 'Initial QA pass',
+            manual: true,
+          },
+        ],
+      },
+    });
+
+    mocks.timeAddEntry.mockResolvedValue({
+      ...task,
+      timeTracking: {
+        totalSeconds: 4500,
+        isRunning: false,
+        entries: [
+          ...(task.timeTracking?.entries ?? []),
+          {
+            id: 'entry-2',
+            startTime: '2026-06-01T10:00:00Z',
+            endTime: '2026-06-01T10:45:00Z',
+            duration: 2700,
+            description: 'Manual QA',
+            manual: true,
+          },
+        ],
+      },
+    });
+    mocks.timeDeleteEntry.mockResolvedValue({
+      ...task,
+      timeTracking: {
+        totalSeconds: 0,
+        isRunning: false,
+        entries: [],
+      },
+    });
+
+    const { baseElement, container } = renderWithProviders(<TimeTrackingSection task={task} />);
+
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(container.querySelector('.mantine-ScrollArea-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Add Time' }));
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Duration' }), {
+      target: { value: '45m' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Description (optional)' }), {
+      target: { value: 'Manual QA' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Add Entry' }));
+
+    await waitFor(() => {
+      expect(mocks.timeAddEntry).toHaveBeenCalledWith(task.id, 2700, 'Manual QA');
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete time entry' })[0]);
+
+    expect(mocks.timeDeleteEntry).toHaveBeenCalledWith(task.id, 'entry-2');
+  });
+});

--- a/web/src/components/task/AttachmentsSection.tsx
+++ b/web/src/components/task/AttachmentsSection.tsx
@@ -14,8 +14,18 @@ import {
   ChevronUp,
   AlertTriangle,
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
+import {
+  ActionIcon,
+  Alert,
+  Box,
+  Button,
+  Group,
+  Modal,
+  Paper,
+  Stack,
+  Text,
+  ThemeIcon,
+} from '@mantine/core';
 import { useUploadAttachment, useDeleteAttachment } from '@/hooks/useAttachments';
 import { cn } from '@/lib/utils';
 import type { Task, Attachment } from '@veritas-kanban/shared';
@@ -53,15 +63,15 @@ function AttachmentItem({ taskId, attachment }: { taskId: string; attachment: At
   const [expanded, setExpanded] = useState(false);
   const [extractedText, setExtractedText] = useState<string | null>(null);
   const [loadingText, setLoadingText] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const deleteAttachment = useDeleteAttachment();
 
   const isImage = attachment.mimeType.startsWith('image/');
   const isDocument = !isImage;
 
   const handleDelete = async () => {
-    if (confirm(`Delete attachment "${attachment.originalName}"?`)) {
-      await deleteAttachment.mutateAsync({ taskId, attachmentId: attachment.id });
-    }
+    await deleteAttachment.mutateAsync({ taskId, attachmentId: attachment.id });
+    setDeleteDialogOpen(false);
   };
 
   const handleToggleExpand = async () => {
@@ -86,71 +96,108 @@ function AttachmentItem({ taskId, attachment }: { taskId: string; attachment: At
   const downloadUrl = `${API_BASE}/tasks/${taskId}/attachments/${attachment.id}/download`;
 
   return (
-    <div className="border rounded-md p-3 space-y-2">
-      <div className="flex items-start gap-2">
-        <div className="text-muted-foreground mt-0.5">{getFileIcon(attachment.mimeType)}</div>
-        <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium truncate">{attachment.originalName}</div>
-          <div className="text-xs text-muted-foreground">
-            {formatFileSize(attachment.size)} • {new Date(attachment.uploaded).toLocaleDateString()}
-          </div>
-        </div>
-        <div className="flex items-center gap-1">
-          {isDocument && (
-            <Button
+    <>
+      <Paper className="space-y-2 p-3" radius="md" withBorder>
+        <Group align="flex-start" gap="xs" wrap="nowrap">
+          <Box className="mt-0.5 text-muted-foreground">{getFileIcon(attachment.mimeType)}</Box>
+          <Box className="min-w-0 flex-1">
+            <Text size="sm" fw={500} className="truncate">
+              {attachment.originalName}
+            </Text>
+            <Text size="xs" c="dimmed">
+              {formatFileSize(attachment.size)} •{' '}
+              {new Date(attachment.uploaded).toLocaleDateString()}
+            </Text>
+          </Box>
+          <Group gap={4}>
+            {isDocument && (
+              <ActionIcon
+                size="sm"
+                variant="subtle"
+                color="gray"
+                onClick={() => {
+                  void handleToggleExpand();
+                }}
+                disabled={loadingText}
+                aria-label={expanded ? 'Collapse text preview' : 'Expand text preview'}
+              >
+                {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+              </ActionIcon>
+            )}
+            <ActionIcon
               size="sm"
-              variant="ghost"
-              onClick={handleToggleExpand}
-              disabled={loadingText}
-              className="h-7 w-7 p-0"
-              aria-label={expanded ? 'Collapse text preview' : 'Expand text preview'}
+              variant="subtle"
+              color="gray"
+              component="a"
+              href={downloadUrl}
+              download={attachment.originalName}
+              aria-label="Download attachment"
             >
-              {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-            </Button>
-          )}
-          <Button
-            size="sm"
-            variant="ghost"
-            asChild
-            className="h-7 w-7 p-0"
-            aria-label="Download attachment"
-          >
-            <a href={downloadUrl} download={attachment.originalName}>
               <Download className="h-3 w-3" />
-            </a>
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={handleDelete}
-            disabled={deleteAttachment.isPending}
-            className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-            aria-label="Delete attachment"
+            </ActionIcon>
+            <ActionIcon
+              size="sm"
+              variant="subtle"
+              color="red"
+              onClick={() => setDeleteDialogOpen(true)}
+              disabled={deleteAttachment.isPending}
+              aria-label="Delete attachment"
+            >
+              <Trash2 className="h-3 w-3" />
+            </ActionIcon>
+          </Group>
+        </Group>
+
+        {/* Image thumbnail */}
+        {isImage && (
+          <Box className="mt-2">
+            <img
+              src={downloadUrl}
+              alt={attachment.originalName}
+              className="max-w-full h-auto rounded border"
+              style={{ maxHeight: '300px' }}
+            />
+          </Box>
+        )}
+
+        {/* Expanded text preview */}
+        {expanded && isDocument && (
+          <Paper
+            className="mt-2 max-h-[300px] overflow-y-auto whitespace-pre-wrap bg-muted/30 p-2 text-xs"
+            ff="monospace"
+            radius="sm"
           >
-            <Trash2 className="h-3 w-3" />
-          </Button>
-        </div>
-      </div>
-
-      {/* Image thumbnail */}
-      {isImage && (
-        <div className="mt-2">
-          <img
-            src={downloadUrl}
-            alt={attachment.originalName}
-            className="max-w-full h-auto rounded border"
-            style={{ maxHeight: '300px' }}
-          />
-        </div>
-      )}
-
-      {/* Expanded text preview */}
-      {expanded && isDocument && (
-        <div className="mt-2 p-2 bg-muted/30 rounded text-xs font-mono whitespace-pre-wrap max-h-[300px] overflow-y-auto">
-          {loadingText ? 'Loading...' : extractedText}
-        </div>
-      )}
-    </div>
+            {loadingText ? 'Loading...' : extractedText}
+          </Paper>
+        )}
+      </Paper>
+      <Modal
+        opened={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        title="Delete attachment?"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will permanently delete "{attachment.originalName}". This action cannot be undone.
+          </Text>
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                void handleDelete();
+              }}
+              loading={deleteAttachment.isPending}
+            >
+              Delete
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </>
   );
 }
 
@@ -199,38 +246,47 @@ export function AttachmentsSection({ task }: AttachmentsSectionProps) {
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2">
+    <Stack gap="md">
+      <Group gap="xs">
         <Paperclip className="h-4 w-4 text-muted-foreground" />
-        <Label className="text-muted-foreground">Attachments</Label>
+        <Text size="sm" c="dimmed" fw={500}>
+          Attachments
+        </Text>
         {attachments.length > 0 && (
-          <span className="text-xs text-muted-foreground">({attachments.length})</span>
+          <Text size="xs" c="dimmed">
+            ({attachments.length})
+          </Text>
         )}
-      </div>
+      </Group>
 
       {/* Token cost warning */}
       {showWarning && (
-        <div className="flex items-start gap-3 p-3 rounded-md border border-amber-500 bg-amber-50 dark:bg-amber-950/20">
-          <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-500 mt-0.5 flex-shrink-0" />
-          <p className="text-sm text-amber-900 dark:text-amber-200">
-            ⚠️ Each attachment adds to agent token costs. Only include files essential for task
-            context.
-          </p>
-        </div>
+        <Alert color="yellow" variant="light" icon={<AlertTriangle className="h-4 w-4" />}>
+          Each attachment adds to agent token costs. Only include files essential for task context.
+        </Alert>
       )}
 
       {/* Upload zone */}
-      <div
+      <Paper
+        role="button"
+        tabIndex={0}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         onClick={handleClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
         className={cn(
           'border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors',
           isDragging && 'border-primary bg-primary/5',
           !isDragging && 'border-muted-foreground/25 hover:border-muted-foreground/50',
           uploadAttachment.isPending && 'opacity-50 pointer-events-none'
         )}
+        radius="lg"
       >
         <input
           ref={fileInputRef}
@@ -239,25 +295,31 @@ export function AttachmentsSection({ task }: AttachmentsSectionProps) {
           onChange={(e) => handleFileSelect(e.target.files)}
           className="hidden"
         />
-        <Upload className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
-        <p className="text-sm text-muted-foreground mb-1">
+        <ThemeIcon variant="transparent" color="gray" size="xl" className="mx-auto mb-2">
+          <Upload className="h-8 w-8 text-muted-foreground" />
+        </ThemeIcon>
+        <Text size="sm" c="dimmed" className="mb-1">
           {uploadAttachment.isPending ? 'Uploading...' : 'Drop files here or click to browse'}
-        </p>
-        <p className="text-xs text-muted-foreground">Max 10MB per file, 20 files total</p>
-      </div>
+        </Text>
+        <Text size="xs" c="dimmed">
+          Max 10MB per file, 20 files total
+        </Text>
+      </Paper>
 
       {/* Attachments list */}
       {attachments.length === 0 ? (
-        <div className="text-sm text-muted-foreground italic py-4 text-center border rounded-md">
-          No attachments yet
-        </div>
+        <Paper className="py-4 text-center" radius="md" withBorder>
+          <Text size="sm" c="dimmed" fs="italic">
+            No attachments yet
+          </Text>
+        </Paper>
       ) : (
-        <div className="space-y-2">
+        <Stack gap="xs">
           {attachments.map((attachment) => (
             <AttachmentItem key={attachment.id} taskId={task.id} attachment={attachment} />
           ))}
-        </div>
+        </Stack>
       )}
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/task/CommentsSection.tsx
+++ b/web/src/components/task/CommentsSection.tsx
@@ -1,21 +1,20 @@
 import { useState } from 'react';
 import { MessageSquare, Pencil, Trash2, X, Check } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
+import {
+  ActionIcon,
+  Avatar,
+  Box,
+  Button,
+  Group,
+  Modal,
+  Paper,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
 import { MarkdownEditor } from '@/components/ui/MarkdownEditor';
 import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
-import { Label } from '@/components/ui/label';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { useAddComment, useEditComment, useDeleteComment } from '@/hooks/useTasks';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import type { Task, Comment } from '@veritas-kanban/shared';
@@ -87,22 +86,24 @@ function CommentItem({
 
   return (
     <>
-      <div className="group flex gap-3 p-3 rounded-md bg-muted/30">
-        <div className="h-8 w-8 flex-shrink-0 rounded-full bg-primary/10 flex items-center justify-center text-xs font-medium">
+      <Paper className="group flex gap-3 bg-muted/30 p-3" radius="md">
+        <Avatar color="violet" radius="xl" size="sm" className="flex-shrink-0">
           {getInitials(comment.author)}
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-baseline gap-2 mb-1">
-            <span className="font-medium text-sm">{comment.author}</span>
-            <span className="text-xs text-muted-foreground">
+        </Avatar>
+        <Box className="min-w-0 flex-1">
+          <Group align="baseline" gap="xs" className="mb-1">
+            <Text size="sm" fw={500}>
+              {comment.author}
+            </Text>
+            <Text size="xs" c="dimmed">
               {formatRelativeTime(comment.timestamp)}
-            </span>
+            </Text>
             {/* Edit/Delete buttons - visible on hover */}
-            <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-              <Button
-                variant="ghost"
+            <Group gap={4} className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
+              <ActionIcon
+                variant="subtle"
+                color="gray"
                 size="sm"
-                className="h-6 w-6 p-0"
                 aria-label="Edit comment"
                 onClick={() => {
                   setEditText(comment.text);
@@ -110,20 +111,20 @@ function CommentItem({
                 }}
               >
                 <Pencil className="h-3 w-3 text-muted-foreground hover:text-foreground" />
-              </Button>
-              <Button
-                variant="ghost"
+              </ActionIcon>
+              <ActionIcon
+                variant="subtle"
+                color="red"
                 size="sm"
-                className="h-6 w-6 p-0"
                 aria-label="Delete comment"
                 onClick={() => setDeleteDialogOpen(true)}
               >
-                <Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-              </Button>
-            </div>
-          </div>
+                <Trash2 className="h-3 w-3" />
+              </ActionIcon>
+            </Group>
+          </Group>
           {isEditing ? (
-            <div className="space-y-2">
+            <Stack gap="xs">
               {markdownEnabled ? (
                 <MarkdownEditor
                   value={editText}
@@ -140,9 +141,10 @@ function CommentItem({
               ) : (
                 <Textarea
                   value={editText}
-                  onChange={(e) => setEditText(e.target.value)}
+                  onChange={(e) => setEditText(e.currentTarget.value)}
                   className="text-sm min-h-[60px] resize-none"
                   autoFocus
+                  aria-label="Edit comment text"
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                       e.preventDefault();
@@ -152,54 +154,65 @@ function CommentItem({
                   }}
                 />
               )}
-              <div className="flex items-center gap-2">
+              <Group gap="xs">
                 <Button
-                  size="sm"
-                  className="h-7"
-                  onClick={handleSaveEdit}
+                  size="xs"
+                  onClick={() => {
+                    void handleSaveEdit();
+                  }}
                   disabled={!editText.trim() || editComment.isPending}
+                  leftSection={<Check className="h-3 w-3" />}
                 >
-                  <Check className="h-3 w-3 mr-1" />
                   Save
                 </Button>
-                <Button variant="ghost" size="sm" className="h-7" onClick={handleCancelEdit}>
-                  <X className="h-3 w-3 mr-1" />
+                <Button
+                  variant="subtle"
+                  size="xs"
+                  onClick={handleCancelEdit}
+                  leftSection={<X className="h-3 w-3" />}
+                >
                   Cancel
                 </Button>
-              </div>
-            </div>
+              </Group>
+            </Stack>
           ) : (
-            <div className="text-sm text-foreground break-words">
+            <Box className="break-words text-sm text-foreground">
               {markdownEnabled ? (
                 <MarkdownRenderer content={comment.text} className="break-words" />
               ) : (
                 <p className="whitespace-pre-wrap">{comment.text}</p>
               )}
-            </div>
+            </Box>
           )}
-        </div>
-      </div>
+        </Box>
+      </Paper>
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete comment?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete this comment by {comment.author}. This action cannot be
-              undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      <Modal
+        opened={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        title="Delete comment?"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will permanently delete this comment by {comment.author}. This action cannot be
+            undone.
+          </Text>
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                void handleDelete();
+              }}
             >
               Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </>
   );
 }
@@ -239,22 +252,28 @@ export function CommentsSection({ task }: CommentsSectionProps) {
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2">
+    <Stack gap="md">
+      <Group gap="xs">
         <MessageSquare className="h-4 w-4 text-muted-foreground" />
-        <Label className="text-muted-foreground">Comments</Label>
+        <Text size="sm" c="dimmed" fw={500}>
+          Comments
+        </Text>
         {comments.length > 0 && (
-          <span className="text-xs text-muted-foreground">({comments.length})</span>
+          <Text size="xs" c="dimmed">
+            ({comments.length})
+          </Text>
         )}
-      </div>
+      </Group>
 
       {/* Comments list */}
       {comments.length === 0 ? (
-        <div className="text-sm text-muted-foreground italic py-4 text-center border rounded-md">
-          No comments yet
-        </div>
+        <Paper className="py-4 text-center" radius="md" withBorder>
+          <Text size="sm" c="dimmed" fs="italic">
+            No comments yet
+          </Text>
+        </Paper>
       ) : (
-        <div className="space-y-3">
+        <Stack gap="sm">
           {comments.map((comment) => (
             <CommentItem
               key={comment.id}
@@ -263,21 +282,22 @@ export function CommentsSection({ task }: CommentsSectionProps) {
               markdownEnabled={markdownEnabled}
             />
           ))}
-        </div>
+        </Stack>
       )}
 
       {/* Add comment form */}
-      <div className="space-y-2 pt-2 border-t">
-        <div className="flex gap-2">
-          <Input
+      <Stack gap="xs" className="border-t pt-2">
+        <Group gap="xs">
+          <TextInput
             value={author}
-            onChange={(e) => setAuthor(e.target.value)}
+            onChange={(e) => setAuthor(e.currentTarget.value)}
             placeholder="Your name"
             className="text-sm max-w-[150px]"
             disabled={isAdding}
+            aria-label="Comment author"
           />
-        </div>
-        <div className="flex gap-2">
+        </Group>
+        <Box>
           {markdownEnabled ? (
             <MarkdownEditor
               value={text}
@@ -291,24 +311,27 @@ export function CommentsSection({ task }: CommentsSectionProps) {
           ) : (
             <Textarea
               value={text}
-              onChange={(e) => setText(e.target.value)}
+              onChange={(e) => setText(e.currentTarget.value)}
               onKeyDown={handleKeyDown}
               placeholder="Add a comment... (Cmd/Ctrl+Enter to submit)"
               className="text-sm min-h-[80px] resize-none"
               disabled={isAdding}
+              aria-label="Comment text"
             />
           )}
-        </div>
-        <div className="flex justify-end">
+        </Box>
+        <Group justify="flex-end">
           <Button
             size="sm"
-            onClick={handleAddComment}
+            onClick={() => {
+              void handleAddComment();
+            }}
             disabled={!text.trim() || !author.trim() || isAdding}
           >
             Add Comment
           </Button>
-        </div>
-      </div>
-    </div>
+        </Group>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/task/ObservationsSection.tsx
+++ b/web/src/components/task/ObservationsSection.tsx
@@ -1,25 +1,19 @@
 import { useState } from 'react';
 import { Eye, Trash2, Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
-import { Label } from '@/components/ui/label';
 import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Paper,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+  SimpleGrid,
+  Slider,
+  Stack,
+  Text,
+  Textarea,
+} from '@mantine/core';
 import type { Task, Observation, ObservationType } from '@veritas-kanban/shared';
 
 interface ObservationsSectionProps {
@@ -50,11 +44,18 @@ function formatRelativeTime(timestamp: string): string {
 }
 
 const TYPE_COLORS: Record<ObservationType, string> = {
-  decision: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
-  blocker: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-  insight: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-  context: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+  decision: 'violet',
+  blocker: 'red',
+  insight: 'blue',
+  context: 'gray',
 };
+
+const OBSERVATION_TYPES: { value: ObservationType; label: string }[] = [
+  { value: 'context', label: 'Context' },
+  { value: 'decision', label: 'Decision' },
+  { value: 'insight', label: 'Insight' },
+  { value: 'blocker', label: 'Blocker' },
+];
 
 function ObservationItem({
   observation,
@@ -72,59 +73,73 @@ function ObservationItem({
 
   return (
     <>
-      <div className="group flex gap-3 p-3 rounded-md border bg-card hover:bg-muted/30 transition-colors">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-2">
-            <span
-              className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${TYPE_COLORS[observation.type]}`}
-            >
+      <Paper
+        className="group bg-card p-3 transition-colors hover:bg-muted/30"
+        radius="md"
+        withBorder
+      >
+        <Stack gap="xs">
+          <Group gap="xs" align="center">
+            <Badge color={TYPE_COLORS[observation.type]} variant="light" size="sm">
               {observation.type}
-            </span>
-            <span className="text-xs font-medium text-muted-foreground">
+            </Badge>
+            <Text size="xs" fw={500} c="dimmed">
               Score: {observation.score}/10
-            </span>
-            <span className="text-xs text-muted-foreground">
+            </Text>
+            <Text size="xs" c="dimmed">
               {formatRelativeTime(observation.timestamp)}
-            </span>
+            </Text>
             {observation.agent && (
-              <span className="text-xs text-muted-foreground">by {observation.agent}</span>
+              <Text size="xs" c="dimmed">
+                by {observation.agent}
+              </Text>
             )}
             {/* Delete button - visible on hover */}
-            <div className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-6 w-6 p-0"
-                aria-label="Delete observation"
-                onClick={() => setDeleteDialogOpen(true)}
-              >
-                <Trash2
-                  className="h-3 w-3 text-muted-foreground hover:text-destructive"
-                  aria-hidden="true"
-                />
-              </Button>
-            </div>
-          </div>
-          <p className="text-sm text-foreground whitespace-pre-wrap">{observation.content}</p>
-        </div>
-      </div>
+            <ActionIcon
+              variant="subtle"
+              color="red"
+              size="sm"
+              className="ml-auto opacity-0 transition-opacity group-hover:opacity-100"
+              aria-label="Delete observation"
+              onClick={() => setDeleteDialogOpen(true)}
+            >
+              <Trash2
+                className="h-3 w-3 text-muted-foreground hover:text-destructive"
+                aria-hidden="true"
+              />
+            </ActionIcon>
+          </Group>
+          <Text size="sm" className="whitespace-pre-wrap text-foreground">
+            {observation.content}
+          </Text>
+        </Stack>
+      </Paper>
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Observation</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete this observation? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} className="bg-destructive">
+      <Modal
+        opened={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        title="Delete Observation"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Are you sure you want to delete this observation? This action cannot be undone.
+          </Text>
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                void handleDelete();
+              }}
+            >
               Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </>
   );
 }
@@ -162,94 +177,109 @@ export function ObservationsSection({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
+    <Stack gap="md">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
           <Eye className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
-          <h3 className="text-lg font-semibold">Observations</h3>
-          <span className="text-sm text-muted-foreground">({observations.length})</span>
-        </div>
+          <Text size="lg" fw={600}>
+            Observations
+          </Text>
+          <Text size="sm" c="dimmed">
+            ({observations.length})
+          </Text>
+        </Group>
         {!isAdding && (
-          <Button variant="outline" size="sm" onClick={() => setIsAdding(true)}>
-            <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsAdding(true)}
+            leftSection={<Plus className="h-4 w-4" aria-hidden="true" />}
+          >
             Add Observation
           </Button>
         )}
-      </div>
+      </Group>
 
       {isAdding && (
-        <div className="border rounded-lg p-4 bg-card space-y-3">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="obs-type">Type</Label>
-              <Select value={newObsType} onValueChange={(v) => setNewObsType(v as ObservationType)}>
-                <SelectTrigger id="obs-type">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="context">Context</SelectItem>
-                  <SelectItem value="decision">Decision</SelectItem>
-                  <SelectItem value="insight">Insight</SelectItem>
-                  <SelectItem value="blocker">Blocker</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="obs-score">Importance: {newObsScore}/10</Label>
-              <input
-                type="range"
-                id="obs-score"
-                min="1"
-                max="10"
-                value={newObsScore}
-                onChange={(e) => setNewObsScore(parseInt(e.target.value))}
-                className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-primary"
-                aria-label={`Importance score: ${newObsScore} out of 10`}
-                aria-valuenow={newObsScore}
-                aria-valuemin={1}
-                aria-valuemax={10}
-                aria-valuetext={`${newObsScore} out of 10`}
+        <Paper className="bg-card p-4" radius="lg" withBorder>
+          <Stack gap="sm">
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+              <Stack gap="xs">
+                <Text component="label" htmlFor="obs-type" size="sm" fw={500}>
+                  Type
+                </Text>
+                <Select
+                  id="obs-type"
+                  aria-label="Observation type"
+                  allowDeselect={false}
+                  data={OBSERVATION_TYPES}
+                  value={newObsType}
+                  onChange={(value) => {
+                    if (value) setNewObsType(value as ObservationType);
+                  }}
+                />
+              </Stack>
+              <Stack gap="xs">
+                <Text component="label" htmlFor="obs-score" size="sm" fw={500}>
+                  Importance: {newObsScore}/10
+                </Text>
+                <Slider
+                  id="obs-score"
+                  min={1}
+                  max={10}
+                  value={newObsScore}
+                  onChange={setNewObsScore}
+                  aria-label={`Importance score: ${newObsScore} out of 10`}
+                />
+              </Stack>
+            </SimpleGrid>
+            <Stack gap="xs">
+              <Text component="label" htmlFor="obs-content" size="sm" fw={500}>
+                Content
+              </Text>
+              <Textarea
+                id="obs-content"
+                value={newObsContent}
+                onChange={(e) => setNewObsContent(e.currentTarget.value)}
+                placeholder="Record a decision, blocker, insight, or context..."
+                className="min-h-[100px] resize-none"
+                autoFocus
               />
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="obs-content">Content</Label>
-            <Textarea
-              id="obs-content"
-              value={newObsContent}
-              onChange={(e) => setNewObsContent(e.target.value)}
-              placeholder="Record a decision, blocker, insight, or context..."
-              className="min-h-[100px] resize-none"
-              autoFocus
-            />
-          </div>
-          <div className="flex gap-2 justify-end">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setIsAdding(false);
-                setNewObsContent('');
-                setNewObsScore(5);
-                setNewObsType('context');
-              }}
-              disabled={isSubmitting}
-            >
-              Cancel
-            </Button>
-            <Button size="sm" onClick={handleAdd} disabled={!newObsContent.trim() || isSubmitting}>
-              {isSubmitting ? 'Adding...' : 'Add Observation'}
-            </Button>
-          </div>
-        </div>
+            </Stack>
+            <Group gap="xs" justify="flex-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setIsAdding(false);
+                  setNewObsContent('');
+                  setNewObsScore(5);
+                  setNewObsType('context');
+                }}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => {
+                  void handleAdd();
+                }}
+                disabled={!newObsContent.trim() || isSubmitting}
+              >
+                {isSubmitting ? 'Adding...' : 'Add Observation'}
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
       )}
 
-      <div className="space-y-2">
+      <Stack gap="xs">
         {observations.length === 0 && !isAdding && (
-          <p className="text-sm text-muted-foreground text-center py-8">
+          <Text size="sm" c="dimmed" ta="center" className="py-8">
             No observations yet. Add context, decisions, insights, or blockers as you work on this
             task.
-          </p>
+          </Text>
         )}
         {observations
           .slice()
@@ -257,7 +287,7 @@ export function ObservationsSection({
           .map((obs) => (
             <ObservationItem key={obs.id} observation={obs} onDelete={onDeleteObservation} />
           ))}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/task/TimeTrackingSection.tsx
+++ b/web/src/components/task/TimeTrackingSection.tsx
@@ -1,18 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
+  ActionIcon,
+  Box,
+  Button,
+  Group,
+  Modal,
+  Paper,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import { formatDuration, parseDuration } from '@/hooks/useTimeTracking';
 import { api } from '@/lib/api';
 import { Play, Square, Plus, Trash2, Clock, Loader2, Timer } from 'lucide-react';
@@ -38,9 +37,13 @@ function RunningTimer({ startTime }: { startTime: string }) {
   }, [startTime]);
 
   return (
-    <span className="font-mono tabular-nums text-green-600 dark:text-green-400">
+    <Text
+      component="span"
+      ff="monospace"
+      className="tabular-nums text-green-600 dark:text-green-400"
+    >
       {formatDuration(elapsed)}
-    </span>
+    </Text>
   );
 }
 
@@ -162,22 +165,33 @@ export function TimeTrackingSection({ task }: TimeTrackingSectionProps) {
   // ── Render ──
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <Label className="text-muted-foreground flex items-center gap-2">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
           <Clock className="h-4 w-4" />
-          Time Tracking
-        </Label>
-        <span className="text-sm font-medium">Total: {formatDuration(totalSeconds)}</span>
-      </div>
+          <Text size="sm" c="dimmed" fw={500}>
+            Time Tracking
+          </Text>
+        </Group>
+        <Text size="sm" fw={500}>
+          Total: {formatDuration(totalSeconds)}
+        </Text>
+      </Group>
 
-      <div className="p-4 rounded-lg border bg-muted/30 space-y-4">
+      <Paper className="space-y-4 bg-muted/30 p-4" radius="lg" withBorder>
         {/* Timer Controls */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        <Group justify="space-between" align="center">
+          <Group gap="sm">
             {isRunning ? (
-              <Button variant="destructive" size="sm" onClick={handleStartStop} disabled={busy}>
+              <Button
+                color="red"
+                size="sm"
+                onClick={() => {
+                  void handleStartStop();
+                }}
+                disabled={busy}
+              >
                 {busy ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
@@ -188,7 +202,14 @@ export function TimeTrackingSection({ task }: TimeTrackingSectionProps) {
                 )}
               </Button>
             ) : (
-              <Button variant="default" size="sm" onClick={handleStartStop} disabled={busy}>
+              <Button
+                variant="filled"
+                size="sm"
+                onClick={() => {
+                  void handleStartStop();
+                }}
+                disabled={busy}
+              >
                 {busy ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
@@ -201,90 +222,102 @@ export function TimeTrackingSection({ task }: TimeTrackingSectionProps) {
             )}
 
             {isRunning && activeEntry && (
-              <div className="flex items-center gap-2">
+              <Group gap="xs">
                 <Timer className="h-4 w-4 text-green-500 animate-pulse" />
                 <RunningTimer startTime={activeEntry.startTime} />
-              </div>
+              </Group>
             )}
-          </div>
+          </Group>
 
           {/* Add Manual Entry */}
-          <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-            <DialogTrigger asChild>
-              <Button variant="outline" size="sm">
-                <Plus className="h-4 w-4 mr-1" />
-                Add Time
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAddDialogOpen(true)}
+            leftSection={<Plus className="h-4 w-4" />}
+          >
+            Add Time
+          </Button>
+        </Group>
+
+        <Modal
+          opened={addDialogOpen}
+          onClose={() => setAddDialogOpen(false)}
+          title="Add Time Entry"
+          centered
+        >
+          <Stack gap="md">
+            <Text size="sm" c="dimmed">
+              Manually add time spent on this task.
+            </Text>
+            <Stack gap="xs">
+              <Text component="label" htmlFor="duration" size="sm" fw={500}>
+                Duration
+              </Text>
+              <TextInput
+                id="duration"
+                value={durationInput}
+                onChange={(e) => setDurationInput(e.currentTarget.value)}
+                placeholder="e.g., 1h 30m or 45m or 30"
+              />
+              <Text size="xs" c="dimmed">
+                Enter as &quot;1h 30m&quot;, &quot;45m&quot;, or just minutes (e.g., &quot;30&quot;)
+              </Text>
+            </Stack>
+            <Stack gap="xs">
+              <Text component="label" htmlFor="description" size="sm" fw={500}>
+                Description (optional)
+              </Text>
+              <TextInput
+                id="description"
+                value={descriptionInput}
+                onChange={(e) => setDescriptionInput(e.currentTarget.value)}
+                placeholder="What did you work on?"
+              />
+            </Stack>
+            <Group justify="flex-end" gap="xs">
+              <Button variant="outline" onClick={() => setAddDialogOpen(false)}>
+                Cancel
               </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Add Time Entry</DialogTitle>
-                <DialogDescription>Manually add time spent on this task.</DialogDescription>
-              </DialogHeader>
-              <div className="grid gap-4 py-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="duration">Duration</Label>
-                  <Input
-                    id="duration"
-                    value={durationInput}
-                    onChange={(e) => setDurationInput(e.target.value)}
-                    placeholder="e.g., 1h 30m or 45m or 30"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Enter as &quot;1h 30m&quot;, &quot;45m&quot;, or just minutes (e.g.,
-                    &quot;30&quot;)
-                  </p>
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="description">Description (optional)</Label>
-                  <Input
-                    id="description"
-                    value={descriptionInput}
-                    onChange={(e) => setDescriptionInput(e.target.value)}
-                    placeholder="What did you work on?"
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setAddDialogOpen(false)}>
-                  Cancel
-                </Button>
-                <Button onClick={handleAddEntry} disabled={!parseDuration(durationInput) || busy}>
-                  {busy ? (
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  ) : (
-                    <Plus className="h-4 w-4 mr-2" />
-                  )}
-                  Add Entry
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        </div>
+              <Button
+                onClick={() => {
+                  void handleAddEntry();
+                }}
+                disabled={!parseDuration(durationInput) || busy}
+                leftSection={
+                  busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />
+                }
+              >
+                Add Entry
+              </Button>
+            </Group>
+          </Stack>
+        </Modal>
 
         {/* Time Entries List */}
         {entries.length > 0 && (
-          <div className="border-t pt-3">
-            <Label className="text-xs text-muted-foreground mb-2 block">
+          <Box className="border-t pt-3">
+            <Text size="xs" c="dimmed" className="mb-2 block">
               Time Entries ({entries.length})
-            </Label>
-            <ScrollArea className="max-h-48">
-              <div className="space-y-2">
+            </Text>
+            <ScrollArea.Autosize mah={192}>
+              <Stack gap="xs">
                 {entries
                   .slice()
                   .reverse()
                   .map((entry) => {
                     const isActive = entry.id === timeTracking?.activeEntryId;
                     return (
-                      <div
+                      <Paper
                         key={entry.id}
                         className={cn(
-                          'flex items-center justify-between p-2 rounded text-sm',
+                          'flex items-center justify-between p-2 text-sm',
                           isActive ? 'bg-green-500/10 border border-green-500/20' : 'bg-muted/50'
                         )}
+                        radius="sm"
                       >
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2">
+                        <Box className="min-w-0 flex-1">
+                          <Group gap="xs">
                             {isActive ? (
                               <Timer className="h-3 w-3 text-green-500 animate-pulse flex-shrink-0" />
                             ) : (
@@ -298,34 +331,39 @@ export function TimeTrackingSection({ task }: TimeTrackingSectionProps) {
                               )}
                             </span>
                             {entry.manual && (
-                              <span className="text-xs text-muted-foreground">(manual)</span>
+                              <Text component="span" size="xs" c="dimmed">
+                                (manual)
+                              </Text>
                             )}
-                          </div>
-                          <div className="text-xs text-muted-foreground pl-5 truncate">
+                          </Group>
+                          <Text size="xs" c="dimmed" className="truncate pl-5">
                             {entry.description
                               ? sanitizeText(entry.description)
                               : formatEntryTime(entry)}
-                          </div>
-                        </div>
+                          </Text>
+                        </Box>
                         {!isActive && (
-                          <Button
-                            variant="ghost"
+                          <ActionIcon
+                            variant="subtle"
+                            color="red"
                             size="sm"
-                            className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
-                            onClick={() => handleDeleteEntry(entry.id)}
+                            onClick={() => {
+                              void handleDeleteEntry(entry.id);
+                            }}
                             disabled={busy}
+                            aria-label="Delete time entry"
                           >
                             <Trash2 className="h-3 w-3" />
-                          </Button>
+                          </ActionIcon>
                         )}
-                      </div>
+                      </Paper>
                     );
                   })}
-              </div>
-            </ScrollArea>
-          </div>
+              </Stack>
+            </ScrollArea.Autosize>
+          </Box>
         )}
-      </div>
-    </div>
+      </Paper>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates task detail comments, attachments, observations, and time tracking support sections to direct Mantine controls, layout, alerts, scroll areas, and modals.
- Preserves comment add/edit/delete, attachment upload/text-preview/download/delete, observation add/delete, and manual time-entry add/delete behavior.
- Updates the Mantine migration ledger for the completed support-section slice.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-support-sections-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- env VERITAS_ADMIN_KEY=<local smoke key> VERITAS_AUTH_ENABLED=false VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/playwright test e2e/task-detail.spec.ts --project=chromium
- Browser smoke: localhost app loaded without framework overlay or console errors; local profile was on setup screen, with task-detail rendering covered by the e2e gate

## Risk
- Markdown editor/renderer remain retained custom surfaces; this PR only removes wrapper imports from the containing comments section.