### PR TITLE
Migrate task detail Git workflow controls to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -355,6 +355,12 @@ Phase 3 progress:
   icon primitives while preserving comment add/edit/delete, attachment upload,
   text preview, download and delete confirmation, observation add/delete, and
   manual time-entry add/delete behavior.
+- Task detail Git selection, worktree status/actions, pull-request creation,
+  workflow run modal, and run-mode/QA gate controls now use direct Mantine
+  select, text input, checkbox, switch, badge, button, alert, code, paper,
+  scroll area, modal, stack, group, and text primitives while preserving Git
+  updates, worktree create/rebase/merge/delete actions, PR draft creation,
+  workflow start behavior, run-mode changes, and QA gate toggles.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GitSection } from '@/components/task/GitSection';
+import { RunModeGateSection } from '@/components/task/RunModeGateSection';
+import { WorkflowSection } from '@/components/task/WorkflowSection';
+import { WorktreeStatus } from '@/components/task/git/WorktreeStatus';
+import { createMockTask, renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  useConfig: vi.fn(),
+  useRepoBranches: vi.fn(),
+  hasPermission: vi.fn(),
+  useWorktreeStatus: vi.fn(),
+  useGitHubStatus: vi.fn(),
+  useConflictStatus: vi.fn(),
+  createWorktreeMutate: vi.fn(),
+  deleteWorktreeMutate: vi.fn(),
+  rebaseWorktreeMutate: vi.fn(),
+  mergeWorktreeMutate: vi.fn(),
+  createPRMutateAsync: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: mocks.useConfig,
+  useRepoBranches: mocks.useRepoBranches,
+}));
+
+vi.mock('@/hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    hasPermission: mocks.hasPermission,
+  }),
+}));
+
+vi.mock('@/hooks/useWorktree', () => ({
+  useWorktreeStatus: mocks.useWorktreeStatus,
+  useCreateWorktree: () => ({
+    mutate: mocks.createWorktreeMutate,
+    isPending: false,
+    error: null,
+  }),
+  useDeleteWorktree: () => ({
+    mutate: mocks.deleteWorktreeMutate,
+    isPending: false,
+  }),
+  useRebaseWorktree: () => ({
+    mutate: mocks.rebaseWorktreeMutate,
+    isPending: false,
+  }),
+  useMergeWorktree: () => ({
+    mutate: mocks.mergeWorktreeMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useGitHub', () => ({
+  useGitHubStatus: mocks.useGitHubStatus,
+  useCreatePR: () => ({
+    mutateAsync: mocks.createPRMutateAsync,
+    isPending: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/hooks/useConflicts', () => ({
+  useConflictStatus: mocks.useConflictStatus,
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('@/components/task/ConflictResolver', () => ({
+  ConflictResolver: ({ open }: { open: boolean }) => (open ? <div>Conflict resolver</div> : null),
+}));
+
+function createJsonResponse(data: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue({ data }),
+    text: vi.fn().mockResolvedValue(ok ? '' : 'Request failed'),
+  };
+}
+
+describe('task detail Git and workflow Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    mocks.useConfig.mockReturnValue({
+      data: {
+        repos: [
+          {
+            name: 'veritas',
+            path: '/repo/veritas',
+            defaultBranch: 'main',
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    mocks.useRepoBranches.mockReturnValue({ data: ['main', 'develop'], isLoading: false });
+    mocks.hasPermission.mockReturnValue(true);
+    mocks.useWorktreeStatus.mockReturnValue({
+      data: {
+        path: '/tmp/veritas-worktree',
+        branch: 'feature/mantine-git',
+        baseBranch: 'main',
+        aheadBehind: { ahead: 2, behind: 1 },
+        hasChanges: false,
+        changedFiles: 0,
+      },
+      isLoading: false,
+      error: null,
+    });
+    mocks.useGitHubStatus.mockReturnValue({ data: { authenticated: true } });
+    mocks.useConflictStatus.mockReturnValue({
+      data: { hasConflicts: false, conflictingFiles: [], rebaseInProgress: false },
+    });
+    mocks.createPRMutateAsync.mockResolvedValue({ url: 'https://github.com/example/pr/1' });
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders Git selection through direct Mantine controls and keeps task Git updates wired', async () => {
+    const user = userEvent.setup();
+    const onGitChange = vi.fn();
+    const task = createMockTask({
+      id: 'task-git-selection',
+      title: 'Migrate Git controls',
+      git: {
+        repo: 'veritas',
+        baseBranch: 'main',
+        branch: 'feature/mantine-git',
+      },
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <GitSection task={task} onGitChange={onGitChange} />
+    );
+
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="label"]')).toBeNull();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Feature Branch' }), {
+      target: { value: 'feature/updated-git-controls' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(onGitChange).toHaveBeenCalledWith({
+      repo: 'veritas',
+      baseBranch: 'main',
+      branch: 'feature/updated-git-controls',
+    });
+    expect(onGitChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('renders worktree status and PR creation through direct Mantine buttons and modals', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-worktree',
+      git: {
+        repo: 'veritas',
+        baseBranch: 'main',
+        branch: 'feature/mantine-git',
+        worktreePath: '/tmp/veritas-worktree',
+      },
+    });
+
+    const { baseElement, container } = renderWithProviders(<WorktreeStatus task={task} />);
+
+    expect(screen.getByText('Worktree active')).toBeDefined();
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Code-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Create PR' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Create Pull Request' });
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
+
+    fireEvent.change(within(dialog).getByRole('textbox', { name: 'Title' }), {
+      target: { value: 'Migrate Git controls' },
+    });
+    fireEvent.change(within(dialog).getByRole('textbox', { name: 'Description' }), {
+      target: { value: 'Direct Mantine controls for Git workflow.' },
+    });
+    await user.click(within(dialog).getByRole('checkbox', { name: 'Create as draft PR' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Create PR' }));
+
+    expect(mocks.createPRMutateAsync).toHaveBeenCalledWith({
+      taskId: 'task-worktree',
+      title: 'Migrate Git controls',
+      body: 'Direct Mantine controls for Git workflow.',
+      draft: true,
+    });
+    expect(window.open).toHaveBeenCalledWith(
+      'https://github.com/example/pr/1',
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
+  it('renders workflow runs through direct Mantine modal controls and starts a run', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === 'POST') {
+        return createJsonResponse({
+          id: 'run-new',
+          workflowId: 'workflow-1',
+          status: 'running',
+          startedAt: '2026-06-01T09:15:00Z',
+        });
+      }
+      if (url.endsWith('/workflows')) {
+        return createJsonResponse([
+          {
+            id: 'workflow-1',
+            name: 'Release Workflow',
+            version: 3,
+            description: 'Run release checks',
+            agents: [{ id: 'agent-1', name: 'QA' }],
+            steps: [{ id: 'step-1', name: 'Smoke' }],
+          },
+        ]);
+      }
+      return createJsonResponse([
+        {
+          id: 'run-active',
+          workflowId: 'workflow-1',
+          status: 'blocked',
+          currentStep: 'Manual QA',
+          startedAt: '2026-06-01T09:00:00Z',
+        },
+      ]);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const task = createMockTask({ id: 'task-workflow' });
+    const { baseElement, container } = renderWithProviders(
+      <WorkflowSection task={task} open onOpenChange={vi.fn()} />
+    );
+
+    expect(await screen.findByText('Release Workflow')).toBeDefined();
+    expect(screen.getByText('run-active')).toBeDefined();
+    expect(container.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Start' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/workflows/workflow-1/runs'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ taskId: 'task-workflow' }),
+        })
+      );
+    });
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Workflow run started',
+      description: 'Run ID: run-new',
+    });
+  });
+
+  it('renders run mode and QA gate controls through direct Mantine primitives', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue(createJsonResponse({}));
+    vi.stubGlobal('fetch', fetchMock);
+    const task = createMockTask({
+      id: 'task-run-mode',
+      runMode: undefined,
+      qaGate: { required: false, passed: false },
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <RunModeGateSection task={task} onUpdate={onUpdate} />
+    );
+
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Switch-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="switch"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="label"]')).toBeNull();
+
+    await user.click(screen.getByRole('combobox', { name: 'Run Mode' }));
+    await user.click(await screen.findByText(/Eng Review/));
+    await user.click(screen.getByRole('switch', { name: 'Require QA before done' }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith('runMode', 'eng-review');
+    });
+    expect(onUpdate).toHaveBeenCalledWith('qaGate', {
+      required: true,
+      passed: false,
+      passedAt: undefined,
+      passedBy: undefined,
+    });
+  });
+});

--- a/web/src/components/task/GitSection.tsx
+++ b/web/src/components/task/GitSection.tsx
@@ -1,5 +1,4 @@
-import { Label } from '@/components/ui/label';
-import { Button } from '@/components/ui/button';
+import { Button, Group, Paper, Stack, Text } from '@mantine/core';
 import { useConfig } from '@/hooks/useConfig';
 import { GitBranch, Loader2, AlertCircle } from 'lucide-react';
 import type { Task, TaskGit } from '@veritas-kanban/shared';
@@ -27,61 +26,69 @@ export function GitSection({ task, onGitChange }: GitSectionProps) {
 
   if (configLoading) {
     return (
-      <div className="space-y-2">
-        <Label className="text-muted-foreground flex items-center gap-2">
+      <Stack gap="xs">
+        <Group gap="xs">
           <GitBranch className="h-4 w-4" />
-          Git Integration
-        </Label>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Text size="sm" c="dimmed" fw={500}>
+            Git Integration
+          </Text>
+        </Group>
+        <Group gap="xs">
           <Loader2 className="h-4 w-4 animate-spin" />
-          Loading...
-        </div>
-      </div>
+          <Text size="sm" c="dimmed">
+            Loading...
+          </Text>
+        </Group>
+      </Stack>
     );
   }
 
   if (!config?.repos.length) {
     return (
-      <div className="space-y-2">
-        <Label className="text-muted-foreground flex items-center gap-2">
+      <Stack gap="xs">
+        <Group gap="xs">
           <GitBranch className="h-4 w-4" />
-          Git Integration
-        </Label>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground p-3 rounded-md border border-dashed">
-          <AlertCircle className="h-4 w-4" />
-          No repositories configured. Add one in Settings.
-        </div>
-      </div>
+          <Text size="sm" c="dimmed" fw={500}>
+            Git Integration
+          </Text>
+        </Group>
+        <Paper className="border-dashed p-3" radius="md" withBorder>
+          <Group gap="xs">
+            <AlertCircle className="h-4 w-4" />
+            <Text size="sm" c="dimmed">
+              No repositories configured. Add one in Settings.
+            </Text>
+          </Group>
+        </Paper>
+      </Stack>
     );
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <Label className="text-muted-foreground flex items-center gap-2">
+    <Stack gap="sm">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
           <GitBranch className="h-4 w-4" />
-          Git Integration
-        </Label>
+          <Text size="sm" c="dimmed" fw={500}>
+            Git Integration
+          </Text>
+        </Group>
         {selectedRepo && !isLocked && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 text-xs"
-            onClick={handleClearGit}
-            disabled={!canEditTaskGit}
-          >
+          <Button variant="subtle" size="xs" onClick={handleClearGit} disabled={!canEditTaskGit}>
             Clear
           </Button>
         )}
-      </div>
+      </Group>
 
       {!canEditTaskGit && (
-        <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
-          Task write permission is required to change Git settings.
-        </div>
+        <Paper className="border-dashed p-3" radius="md" withBorder>
+          <Text size="sm" c="dimmed">
+            Task write permission is required to change Git settings.
+          </Text>
+        </Paper>
       )}
       <GitSelectionForm task={task} onGitChange={onGitChange} disabled={!canEditTaskGit} />
       <WorktreeStatus task={task} />
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/task/RunModeGateSection.tsx
+++ b/web/src/components/task/RunModeGateSection.tsx
@@ -10,17 +10,7 @@
  */
 
 import { useState } from 'react';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Switch } from '@/components/ui/switch';
+import { Badge, Button, Group, Paper, Select, Stack, Switch, Text } from '@mantine/core';
 import { CheckCircle2, XCircle, ShieldCheck, Loader2 } from 'lucide-react';
 import { API_BASE } from '@/lib/config';
 import { useToast } from '@/hooks/useToast';
@@ -45,6 +35,15 @@ const RUN_MODE_DESCRIPTIONS: Record<RunMode, string> = {
   'paranoid-review': 'Extra-thorough review — security-sensitive or critical infra',
   qa: 'QA pass required before marking done',
 };
+
+const RUN_MODE_OPTIONS = [
+  { value: 'none', label: 'None' },
+  ...(Object.keys(RUN_MODE_LABELS) as RunMode[]).map((mode) => ({
+    value: mode,
+    label: RUN_MODE_LABELS[mode],
+    description: RUN_MODE_DESCRIPTIONS[mode],
+  })),
+];
 
 export function RunModeGateSection({ task, onUpdate, readOnly = false }: RunModeGateSectionProps) {
   const { toast } = useToast();
@@ -135,138 +134,166 @@ export function RunModeGateSection({ task, onUpdate, readOnly = false }: RunMode
   };
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Run Mode */}
-      <div className="space-y-2">
-        <Label className="text-muted-foreground flex items-center gap-1">
+      <Stack gap="xs">
+        <Group gap={6}>
           <ShieldCheck className="h-3.5 w-3.5" />
-          Run Mode
-        </Label>
+          <Text size="sm" c="dimmed" fw={500}>
+            Run Mode
+          </Text>
+        </Group>
         {readOnly ? (
-          <div>
+          <Group gap="xs">
             {runMode ? (
               <Badge variant="outline" className="text-xs">
                 {RUN_MODE_LABELS[runMode]}
               </Badge>
             ) : (
-              <span className="text-xs text-muted-foreground">None</span>
+              <Text size="xs" c="dimmed">
+                None
+              </Text>
             )}
-          </div>
+          </Group>
         ) : (
-          <Select value={runMode ?? 'none'} onValueChange={handleRunModeChange} disabled={isSaving}>
-            <SelectTrigger className="h-8 text-sm">
-              <SelectValue placeholder="Select run mode…" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="none">
-                <span className="text-muted-foreground">None</span>
-              </SelectItem>
-              {(Object.keys(RUN_MODE_LABELS) as RunMode[]).map((mode) => (
-                <SelectItem key={mode} value={mode}>
-                  <span className="font-medium">{RUN_MODE_LABELS[mode]}</span>
-                  <span className="ml-2 text-xs text-muted-foreground hidden sm:inline">
-                    — {RUN_MODE_DESCRIPTIONS[mode]}
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Select
+            aria-label="Run Mode"
+            allowDeselect={false}
+            data={RUN_MODE_OPTIONS}
+            value={runMode ?? 'none'}
+            onChange={(value) => {
+              if (value) void handleRunModeChange(value);
+            }}
+            disabled={isSaving}
+            placeholder="Select run mode..."
+            renderOption={({ option }) => {
+              const runOption = RUN_MODE_OPTIONS.find((item) => item.value === option.value);
+              return (
+                <Stack gap={2}>
+                  <Text size="sm" fw={option.value === 'none' ? 400 : 500}>
+                    {option.label}
+                  </Text>
+                  {runOption && 'description' in runOption && (
+                    <Text size="xs" c="dimmed">
+                      {runOption.description}
+                    </Text>
+                  )}
+                </Stack>
+              );
+            }}
+          />
         )}
         {runMode && (
-          <p className="text-xs text-muted-foreground">{RUN_MODE_DESCRIPTIONS[runMode]}</p>
+          <Text size="xs" c="dimmed">
+            {RUN_MODE_DESCRIPTIONS[runMode]}
+          </Text>
         )}
-      </div>
+      </Stack>
 
       {/* QA Gate */}
-      <div className="space-y-2">
-        <Label className="text-muted-foreground">QA Gate</Label>
+      <Stack gap="xs">
+        <Text size="sm" c="dimmed" fw={500}>
+          QA Gate
+        </Text>
 
         {readOnly ? (
-          <div className="flex items-center gap-2">
+          <Group gap="xs">
             {qaGate?.required ? (
               qaGate.passed ? (
-                <Badge className="bg-green-100 text-green-800 border-green-300 text-xs flex items-center gap-1">
-                  <CheckCircle2 className="h-3 w-3" />
+                <Badge
+                  color="green"
+                  variant="light"
+                  leftSection={<CheckCircle2 className="h-3 w-3" />}
+                >
                   QA Passed
                 </Badge>
               ) : (
-                <Badge variant="destructive" className="text-xs flex items-center gap-1">
-                  <XCircle className="h-3 w-3" />
+                <Badge color="red" variant="light" leftSection={<XCircle className="h-3 w-3" />}>
                   QA Required — Not Passed
                 </Badge>
               )
             ) : (
-              <span className="text-xs text-muted-foreground">No QA gate</span>
+              <Text size="xs" c="dimmed">
+                No QA gate
+              </Text>
             )}
-          </div>
+          </Group>
         ) : (
-          <div className="space-y-3">
+          <Stack gap="sm">
             {/* Required toggle */}
-            <div className="flex items-center justify-between">
-              <span className="text-sm">Require QA before done</span>
+            <Group justify="space-between" align="center">
+              <Text size="sm">Require QA before done</Text>
               <Switch
+                aria-label="Require QA before done"
                 checked={qaGate?.required ?? false}
-                onCheckedChange={handleQaRequiredToggle}
+                onChange={(event) => {
+                  void handleQaRequiredToggle(event.currentTarget.checked);
+                }}
                 disabled={isSaving}
               />
-            </div>
+            </Group>
 
             {/* Pass/fail button — only visible when required */}
             {qaGate?.required && (
-              <div className="flex items-center gap-3 p-3 rounded-md border bg-muted/30">
+              <Paper className="bg-muted/30 p-3" radius="md" withBorder>
                 {qaGate.passed ? (
-                  <>
-                    <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-green-700">QA Passed</p>
+                  <Group align="center" gap="sm" wrap="nowrap">
+                    <CheckCircle2 className="h-4 w-4 flex-shrink-0 text-green-600" />
+                    <Stack gap={2} className="min-w-0 flex-1">
+                      <Text size="sm" fw={500} c="green.7">
+                        QA Passed
+                      </Text>
                       {qaGate.passedAt && (
-                        <p className="text-xs text-muted-foreground">
+                        <Text size="xs" c="dimmed">
                           {new Date(qaGate.passedAt).toLocaleString()}
                           {qaGate.passedBy ? ` · ${qaGate.passedBy}` : ''}
-                        </p>
+                        </Text>
                       )}
-                    </div>
+                    </Stack>
                     <Button
                       size="sm"
                       variant="outline"
                       onClick={handleQaPassToggle}
                       disabled={isSaving}
-                      className="text-xs h-7"
+                      className="text-xs"
                     >
                       {isSaving ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Revoke'}
                     </Button>
-                  </>
+                  </Group>
                 ) : (
-                  <>
-                    <XCircle className="h-4 w-4 text-destructive flex-shrink-0" />
-                    <div className="flex-1">
-                      <p className="text-sm font-medium text-destructive">QA Not Passed</p>
-                      <p className="text-xs text-muted-foreground">
+                  <Group align="center" gap="sm" wrap="nowrap">
+                    <XCircle className="h-4 w-4 flex-shrink-0 text-destructive" />
+                    <Stack gap={2} className="flex-1">
+                      <Text size="sm" fw={500} c="red">
+                        QA Not Passed
+                      </Text>
+                      <Text size="xs" c="dimmed">
                         Task cannot be moved to Done until QA is approved
-                      </p>
-                    </div>
+                      </Text>
+                    </Stack>
                     <Button
                       size="sm"
                       onClick={handleQaPassToggle}
                       disabled={isSaving}
-                      className="text-xs h-7 bg-green-600 hover:bg-green-700"
+                      color="green"
+                      className="text-xs"
+                      leftSection={
+                        isSaving ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <CheckCircle2 className="h-3 w-3" />
+                        )
+                      }
                     >
-                      {isSaving ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <>
-                          <CheckCircle2 className="h-3 w-3 mr-1" />
-                          Pass QA
-                        </>
-                      )}
+                      {isSaving ? 'Saving...' : 'Pass QA'}
                     </Button>
-                  </>
+                  </Group>
                 )}
-              </div>
+              </Paper>
             )}
-          </div>
+          </Stack>
         )}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/task/WorkflowSection.tsx
+++ b/web/src/components/task/WorkflowSection.tsx
@@ -9,15 +9,7 @@
 
 import { useState, useEffect } from 'react';
 import { API_BASE } from '@/lib/config';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Badge, Button, Group, Loader, Modal, Paper, ScrollArea, Stack, Text } from '@mantine/core';
 import { Play, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import type { Task } from '@veritas-kanban/shared';
@@ -43,6 +35,21 @@ interface WorkflowRun {
   status: 'pending' | 'running' | 'blocked' | 'completed' | 'failed';
   currentStep?: string;
   startedAt: string;
+}
+
+function getRunStatusColor(status: WorkflowRun['status']) {
+  switch (status) {
+    case 'running':
+      return 'blue';
+    case 'blocked':
+      return 'yellow';
+    case 'completed':
+      return 'green';
+    case 'failed':
+      return 'red';
+    default:
+      return 'gray';
+  }
 }
 
 export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionProps) {
@@ -114,98 +121,117 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Run Workflow</DialogTitle>
-          <DialogDescription>Select a workflow to run against this task</DialogDescription>
-        </DialogHeader>
+    <Modal
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      title="Run Workflow"
+      centered
+      size="xl"
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          Select a workflow to run against this task
+        </Text>
 
         {isLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-          </div>
+          <Group justify="center" className="py-12">
+            <Loader color="gray" size="sm" />
+          </Group>
         ) : (
-          <div className="space-y-6">
-            {/* Active Runs */}
-            {activeRuns.length > 0 && (
-              <div className="space-y-3">
-                <h3 className="text-sm font-medium">Active Runs</h3>
-                {activeRuns.map((run) => (
-                  <div
-                    key={run.id}
-                    className="p-3 rounded-lg border bg-card flex items-center justify-between"
-                  >
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="text-xs font-mono">
-                          {run.id}
-                        </Badge>
-                        <Badge
-                          variant="secondary"
-                          className={run.status === 'running' ? 'bg-blue-100 text-blue-800' : ''}
-                        >
-                          {run.status}
-                        </Badge>
-                      </div>
-                      {run.currentStep && (
-                        <p className="text-sm text-muted-foreground mt-1">
-                          Current: {run.currentStep}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Available Workflows */}
-            <div className="space-y-3">
-              <h3 className="text-sm font-medium">Available Workflows</h3>
-              {workflows.length === 0 ? (
-                <p className="text-sm text-muted-foreground text-center py-6">
-                  No workflows available
-                </p>
-              ) : (
-                workflows.map((workflow) => (
-                  <div
-                    key={workflow.id}
-                    className="p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
-                  >
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2 mb-1">
-                          <h4 className="font-medium">{workflow.name}</h4>
-                          <Badge variant="outline" className="text-xs">
-                            v{workflow.version}
-                          </Badge>
-                        </div>
-                        <p className="text-sm text-muted-foreground mb-2">{workflow.description}</p>
-                        <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                          <span>{workflow.agents.length} agents</span>
-                          <span>{workflow.steps.length} steps</span>
-                        </div>
-                      </div>
-                      <Button
-                        size="sm"
-                        onClick={() => handleStartWorkflow(workflow.id)}
-                        disabled={isStarting === workflow.id}
-                      >
-                        {isStarting === workflow.id ? (
-                          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                        ) : (
-                          <Play className="h-3 w-3 mr-1" />
-                        )}
-                        Start
-                      </Button>
-                    </div>
-                  </div>
-                ))
+          <ScrollArea.Autosize mah="65vh" type="auto">
+            <Stack gap="lg">
+              {/* Active Runs */}
+              {activeRuns.length > 0 && (
+                <Stack gap="xs">
+                  <Text size="sm" fw={500}>
+                    Active Runs
+                  </Text>
+                  {activeRuns.map((run) => (
+                    <Paper key={run.id} className="bg-card p-3" radius="md" withBorder>
+                      <Group justify="space-between" align="center">
+                        <Stack gap={4} className="min-w-0 flex-1">
+                          <Group gap="xs">
+                            <Badge variant="outline" className="font-mono">
+                              {run.id}
+                            </Badge>
+                            <Badge variant="light" color={getRunStatusColor(run.status)}>
+                              {run.status}
+                            </Badge>
+                          </Group>
+                          {run.currentStep && (
+                            <Text size="sm" c="dimmed">
+                              Current: {run.currentStep}
+                            </Text>
+                          )}
+                        </Stack>
+                      </Group>
+                    </Paper>
+                  ))}
+                </Stack>
               )}
-            </div>
-          </div>
+
+              {/* Available Workflows */}
+              <Stack gap="xs">
+                <Text size="sm" fw={500}>
+                  Available Workflows
+                </Text>
+                {workflows.length === 0 ? (
+                  <Text size="sm" c="dimmed" ta="center" className="py-6">
+                    No workflows available
+                  </Text>
+                ) : (
+                  workflows.map((workflow) => (
+                    <Paper
+                      key={workflow.id}
+                      className="bg-card p-4 transition-colors hover:bg-accent/50"
+                      radius="md"
+                      withBorder
+                    >
+                      <Group align="flex-start" justify="space-between" gap="md" wrap="nowrap">
+                        <Stack gap={4} className="min-w-0 flex-1">
+                          <Group gap="xs">
+                            <Text size="sm" fw={500}>
+                              {workflow.name}
+                            </Text>
+                            <Badge variant="outline" size="sm">
+                              v{workflow.version}
+                            </Badge>
+                          </Group>
+                          <Text size="sm" c="dimmed">
+                            {workflow.description}
+                          </Text>
+                          <Group gap="md">
+                            <Text size="xs" c="dimmed">
+                              {workflow.agents.length} agents
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                              {workflow.steps.length} steps
+                            </Text>
+                          </Group>
+                        </Stack>
+                        <Button
+                          size="sm"
+                          onClick={() => handleStartWorkflow(workflow.id)}
+                          disabled={isStarting === workflow.id}
+                          leftSection={
+                            isStarting === workflow.id ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <Play className="h-3 w-3" />
+                            )
+                          }
+                        >
+                          Start
+                        </Button>
+                      </Group>
+                    </Paper>
+                  ))
+                )}
+              </Stack>
+            </Stack>
+          </ScrollArea.Autosize>
         )}
-      </DialogContent>
-    </Dialog>
+      </Stack>
+    </Modal>
   );
 }

--- a/web/src/components/task/git/GitSelectionForm.tsx
+++ b/web/src/components/task/git/GitSelectionForm.tsx
@@ -1,13 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Group, Paper, Select, Stack, Text, TextInput } from '@mantine/core';
 import { useConfig, useRepoBranches } from '@/hooks/useConfig';
 import { Loader2, FolderGit2 } from 'lucide-react';
 import type { Task, TaskGit } from '@veritas-kanban/shared';
@@ -103,69 +95,85 @@ export function GitSelectionForm({ task, onGitChange, disabled = false }: GitSel
   const isLocked = !!task.git?.worktreePath || disabled;
 
   return (
-    <div className="grid gap-3 p-3 rounded-md border bg-muted/30">
-      {/* Repository Selection */}
-      <div className="grid gap-1.5">
-        <Label className="text-xs">Repository</Label>
-        <Select value={selectedRepo} onValueChange={handleRepoChange} disabled={isLocked}>
-          <SelectTrigger className={cn(isLocked && 'opacity-60')}>
-            <SelectValue placeholder="Select repository..." />
-          </SelectTrigger>
-          <SelectContent>
-            {config?.repos.map((repo) => (
-              <SelectItem key={repo.name} value={repo.name}>
-                <div className="flex items-center gap-2">
-                  <FolderGit2 className="h-3 w-3" />
-                  {repo.name}
-                </div>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      {selectedRepo && (
-        <>
-          {/* Base Branch */}
-          <div className="grid gap-1.5">
-            <Label className="text-xs">Base Branch</Label>
-            {branchesLoading ? (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground h-9 px-3">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Loading branches...
-              </div>
-            ) : (
-              <Select value={baseBranch} onValueChange={handleBaseBranchChange} disabled={isLocked}>
-                <SelectTrigger className={cn(isLocked && 'opacity-60')}>
-                  <SelectValue placeholder="Select base branch..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {branches?.map((branch) => (
-                    <SelectItem key={branch} value={branch}>
-                      {branch}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+    <Paper className="bg-muted/30 p-3" radius="md" withBorder>
+      <Stack gap="sm">
+        {/* Repository Selection */}
+        <Stack gap={6}>
+          <Text size="xs" fw={500}>
+            Repository
+          </Text>
+          <Select
+            aria-label="Repository"
+            allowDeselect={false}
+            data={config?.repos.map((repo) => ({ value: repo.name, label: repo.name })) ?? []}
+            value={selectedRepo || null}
+            onChange={(value) => {
+              if (value) handleRepoChange(value);
+            }}
+            disabled={isLocked}
+            className={cn(isLocked && 'opacity-60')}
+            placeholder="Select repository..."
+            renderOption={({ option }) => (
+              <Group gap="xs">
+                <FolderGit2 className="h-3 w-3" />
+                <Text size="sm">{option.label}</Text>
+              </Group>
             )}
-          </div>
+          />
+        </Stack>
 
-          {/* Feature Branch */}
-          <div className="grid gap-1.5">
-            <Label className="text-xs">Feature Branch</Label>
-            <Input
-              value={featureBranch}
-              onChange={(e) => handleFeatureBranchChange(e.target.value)}
-              placeholder="feature/my-feature"
-              disabled={isLocked}
-              className={cn(isLocked && 'opacity-60')}
-            />
-            {autoGenerateBranch && featureBranch && !isLocked && (
-              <p className="text-xs text-muted-foreground">Auto-generated from task title</p>
-            )}
-          </div>
-        </>
-      )}
-    </div>
+        {selectedRepo && (
+          <>
+            {/* Base Branch */}
+            <Stack gap={6}>
+              <Text size="xs" fw={500}>
+                Base Branch
+              </Text>
+              {branchesLoading ? (
+                <Group gap="xs" className="h-9 px-3">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  <Text size="sm" c="dimmed">
+                    Loading branches...
+                  </Text>
+                </Group>
+              ) : (
+                <Select
+                  aria-label="Base Branch"
+                  allowDeselect={false}
+                  data={branches?.map((branch) => ({ value: branch, label: branch })) ?? []}
+                  value={baseBranch || null}
+                  onChange={(value) => {
+                    if (value) handleBaseBranchChange(value);
+                  }}
+                  disabled={isLocked}
+                  className={cn(isLocked && 'opacity-60')}
+                  placeholder="Select base branch..."
+                />
+              )}
+            </Stack>
+
+            {/* Feature Branch */}
+            <Stack gap={6}>
+              <Text size="xs" fw={500}>
+                Feature Branch
+              </Text>
+              <TextInput
+                aria-label="Feature Branch"
+                value={featureBranch}
+                onChange={(e) => handleFeatureBranchChange(e.currentTarget.value)}
+                placeholder="feature/my-feature"
+                disabled={isLocked}
+                className={cn(isLocked && 'opacity-60')}
+              />
+              {autoGenerateBranch && featureBranch && !isLocked && (
+                <Text size="xs" c="dimmed">
+                  Auto-generated from task title
+                </Text>
+              )}
+            </Stack>
+          </>
+        )}
+      </Stack>
+    </Paper>
   );
 }

--- a/web/src/components/task/git/PRDialog.tsx
+++ b/web/src/components/task/git/PRDialog.tsx
@@ -1,17 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Button, Checkbox, Group, Modal, Stack, Text, Textarea, TextInput } from '@mantine/core';
 import { useCreatePR } from '@/hooks/useGitHub';
 import { Loader2, GitPullRequest } from 'lucide-react';
 import type { Task } from '@veritas-kanban/shared';
@@ -46,67 +34,64 @@ export function PRDialog({ task, open, onOpenChange }: PRDialogProps) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
-        <DialogHeader>
-          <DialogTitle>Create Pull Request</DialogTitle>
-          <DialogDescription>
-            Create a PR from {task.git?.branch} to {task.git?.baseBranch}
-          </DialogDescription>
-        </DialogHeader>
-        <div className="grid gap-4 py-4">
-          <div className="grid gap-2">
-            <Label htmlFor="pr-title">Title</Label>
-            <Input
-              id="pr-title"
-              value={prTitle}
-              onChange={(e) => setPrTitle(e.target.value)}
-              placeholder="PR title"
-            />
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="pr-body">Description</Label>
-            <Textarea
-              id="pr-body"
-              value={prBody}
-              onChange={(e) => setPrBody(e.target.value)}
-              placeholder="Describe your changes..."
-              rows={5}
-            />
-          </div>
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="pr-draft"
-              checked={prDraft}
-              onCheckedChange={(checked) => setPrDraft(checked === true)}
-            />
-            <Label htmlFor="pr-draft" className="text-sm font-normal">
-              Create as draft PR
-            </Label>
-          </div>
-          {createPR.error && (
-            <p className="text-sm text-red-500">{(createPR.error as Error).message}</p>
-          )}
-        </div>
-        <DialogFooter>
+    <Modal
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      title="Create Pull Request"
+      centered
+      size="lg"
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          Create a PR from {task.git?.branch} to {task.git?.baseBranch}
+        </Text>
+        <TextInput
+          id="pr-title"
+          label="Title"
+          value={prTitle}
+          onChange={(e) => setPrTitle(e.currentTarget.value)}
+          placeholder="PR title"
+        />
+        <Textarea
+          id="pr-body"
+          label="Description"
+          value={prBody}
+          onChange={(e) => setPrBody(e.currentTarget.value)}
+          placeholder="Describe your changes..."
+          minRows={5}
+        />
+        <Checkbox
+          id="pr-draft"
+          label="Create as draft PR"
+          checked={prDraft}
+          onChange={(event) => setPrDraft(event.currentTarget.checked)}
+        />
+        {createPR.error && (
+          <Text size="sm" c="red">
+            {(createPR.error as Error).message}
+          </Text>
+        )}
+        <Group justify="flex-end" gap="xs">
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleCreatePR} disabled={createPR.isPending || !prTitle}>
-            {createPR.isPending ? (
-              <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Creating...
-              </>
-            ) : (
-              <>
-                <GitPullRequest className="h-4 w-4 mr-2" />
-                Create PR
-              </>
-            )}
+          <Button
+            onClick={() => {
+              void handleCreatePR();
+            }}
+            disabled={createPR.isPending || !prTitle}
+            leftSection={
+              createPR.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <GitPullRequest className="h-4 w-4" />
+              )
+            }
+          >
+            {createPR.isPending ? 'Creating...' : 'Create PR'}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </Group>
+      </Stack>
+    </Modal>
   );
 }

--- a/web/src/components/task/git/WorktreeStatus.tsx
+++ b/web/src/components/task/git/WorktreeStatus.tsx
@@ -1,16 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { Alert, Badge, Button, Code, Group, Modal, Stack, Text } from '@mantine/core';
 import {
   useWorktreeStatus,
   useCreateWorktree,
@@ -37,7 +26,6 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 import type { Task } from '@veritas-kanban/shared';
-import { cn } from '@/lib/utils';
 
 interface WorktreeStatusProps {
   task: Task;
@@ -58,6 +46,8 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
   // Conflict resolver state
   const [conflictResolverOpen, setConflictResolverOpen] = useState(false);
   const [prDialogOpen, setPrDialogOpen] = useState(false);
+  const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const handleOpenInVSCode = () => {
     if (task.git?.worktreePath) {
@@ -78,89 +68,91 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
   // No worktree yet - show create button
   if (!hasWorktree) {
     return (
-      <div className="mt-3 pt-3 border-t">
+      <Stack gap="xs" className="mt-3 border-t pt-3">
         <Button
           variant="outline"
-          className="w-full"
+          fullWidth
           onClick={() => createWorktree.mutate(task.id)}
           disabled={createWorktree.isPending}
+          leftSection={
+            createWorktree.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Play className="h-4 w-4" />
+            )
+          }
         >
-          {createWorktree.isPending ? (
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-          ) : (
-            <Play className="h-4 w-4 mr-2" />
-          )}
           Create Worktree
         </Button>
         {createWorktree.error && (
-          <p className="text-xs text-red-500 mt-2">{(createWorktree.error as Error).message}</p>
+          <Text size="xs" c="red">
+            {(createWorktree.error as Error).message}
+          </Text>
         )}
-      </div>
+      </Stack>
     );
   }
 
   // Loading worktree status
   if (isLoading) {
     return (
-      <div className="mt-3 pt-3 border-t">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
+      <Group gap="xs" className="mt-3 border-t pt-3">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <Text size="sm" c="dimmed">
           Loading worktree status...
-        </div>
-      </div>
+        </Text>
+      </Group>
     );
   }
 
   // Error loading status
   if (error) {
     return (
-      <div className="mt-3 pt-3 border-t">
-        <div className="flex items-center gap-2 text-sm text-red-500">
-          <AlertCircle className="h-4 w-4" />
+      <Group gap="xs" className="mt-3 border-t pt-3">
+        <AlertCircle className="h-4 w-4" />
+        <Text size="sm" c="red">
           {(error as Error).message}
-        </div>
-      </div>
+        </Text>
+      </Group>
     );
   }
 
   // Show worktree status
   return (
-    <div className="mt-3 pt-3 border-t space-y-3">
+    <Stack gap="sm" className="mt-3 border-t pt-3">
       {/* Conflict warning banner */}
       {conflictStatus?.hasConflicts && (
-        <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
-          <div className="flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5 text-amber-500 flex-shrink-0" />
-            <div>
-              <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
-                {conflictStatus.conflictingFiles.length} conflict
-                {conflictStatus.conflictingFiles.length !== 1 ? 's' : ''} detected
-              </p>
-              <p className="text-xs text-amber-600 dark:text-amber-500">
-                {conflictStatus.rebaseInProgress ? 'Rebase' : 'Merge'} requires manual resolution
-              </p>
-            </div>
-          </div>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setConflictResolverOpen(true)}
-            className="border-amber-500/30 hover:bg-amber-500/10"
-          >
-            <AlertTriangle className="h-4 w-4 mr-1" />
-            Resolve Conflicts
-          </Button>
-        </div>
+        <Alert
+          color="yellow"
+          icon={<AlertTriangle className="h-5 w-5" />}
+          title={`${conflictStatus.conflictingFiles.length} conflict${
+            conflictStatus.conflictingFiles.length !== 1 ? 's' : ''
+          } detected`}
+        >
+          <Group justify="space-between" align="center" gap="sm">
+            <Text size="xs" c="yellow.7">
+              {conflictStatus.rebaseInProgress ? 'Rebase' : 'Merge'} requires manual resolution
+            </Text>
+            <Button
+              size="xs"
+              variant="outline"
+              color="yellow"
+              onClick={() => setConflictResolverOpen(true)}
+              leftSection={<AlertTriangle className="h-4 w-4" />}
+            >
+              Resolve Conflicts
+            </Button>
+          </Group>
+        </Alert>
       )}
 
       {/* Status indicators */}
-      <div className="flex items-center justify-between text-sm">
-        <div className="flex items-center gap-2">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
           <span
-            className={cn(
-              'h-2 w-2 rounded-full',
+            className={`h-2 w-2 rounded-full ${
               conflictStatus?.hasConflicts ? 'bg-amber-500' : 'bg-green-500'
-            )}
+            }`}
           >
             <span className="sr-only">
               {conflictStatus?.hasConflicts
@@ -168,55 +160,68 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
                 : 'Status: active and healthy'}
             </span>
           </span>
-          <span className="text-muted-foreground">
+          <Text size="sm" c="dimmed">
             {conflictStatus?.hasConflicts ? 'Conflicts detected' : 'Worktree active'}
-          </span>
-        </div>
-        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          </Text>
+        </Group>
+        <Group gap="sm">
           {status && (
             <>
               {status.aheadBehind.ahead > 0 && (
-                <span className="flex items-center gap-1">
-                  <ArrowUp className="h-3 w-3" />
+                <Badge variant="light" color="blue" leftSection={<ArrowUp className="h-3 w-3" />}>
                   {status.aheadBehind.ahead} ahead
-                </span>
+                </Badge>
               )}
               {status.aheadBehind.behind > 0 && (
-                <span className="flex items-center gap-1 text-amber-500">
-                  <ArrowDown className="h-3 w-3" />
+                <Badge
+                  variant="light"
+                  color="yellow"
+                  leftSection={<ArrowDown className="h-3 w-3" />}
+                >
                   {status.aheadBehind.behind} behind
-                </span>
+                </Badge>
               )}
               {status.hasChanges && (
-                <span className="flex items-center gap-1">
-                  <FileCode className="h-3 w-3" />
+                <Badge variant="light" color="gray" leftSection={<FileCode className="h-3 w-3" />}>
                   {status.changedFiles} changed
-                </span>
+                </Badge>
               )}
             </>
           )}
-        </div>
-      </div>
+        </Group>
+      </Group>
 
       {/* Action buttons */}
-      <div className="flex flex-wrap gap-2">
-        <Button variant="outline" size="sm" onClick={handleOpenInVSCode}>
-          <ExternalLink className="h-3 w-3 mr-1" />
+      <Group gap="xs">
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={handleOpenInVSCode}
+          leftSection={<ExternalLink className="h-3 w-3" />}
+        >
           Open in VS Code
         </Button>
 
         {/* PR Button - show View PR if exists, Create PR if not */}
         {hasPR ? (
-          <Button variant="outline" size="sm" onClick={handleOpenPR}>
-            <GitPullRequest className="h-3 w-3 mr-1" />
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={handleOpenPR}
+            leftSection={<GitPullRequest className="h-3 w-3" />}
+          >
             View PR #{task.git?.prNumber}
           </Button>
         ) : (
           status &&
           status.aheadBehind.ahead > 0 &&
           ghStatus?.authenticated && (
-            <Button variant="outline" size="sm" onClick={() => setPrDialogOpen(true)}>
-              <GitPullRequest className="h-3 w-3 mr-1" />
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => setPrDialogOpen(true)}
+              leftSection={<GitPullRequest className="h-3 w-3" />}
+            >
               Create PR
             </Button>
           )
@@ -225,86 +230,47 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
         {status && status.aheadBehind.behind > 0 && (
           <Button
             variant="outline"
-            size="sm"
+            size="xs"
             onClick={() => rebaseWorktree.mutate(task.id)}
             disabled={rebaseWorktree.isPending}
+            leftSection={
+              rebaseWorktree.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3 w-3" />
+              )
+            }
           >
-            {rebaseWorktree.isPending ? (
-              <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-            ) : (
-              <RefreshCw className="h-3 w-3 mr-1" />
-            )}
             Rebase
           </Button>
         )}
 
         {status && status.aheadBehind.ahead > 0 && !status.hasChanges && (
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="default" size="sm">
-                <GitMerge className="h-3 w-3 mr-1" />
-                Merge
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Merge to {task.git?.baseBranch}?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will merge {task.git?.branch} into {task.git?.baseBranch}, push to remote,
-                  delete the worktree, and mark the task as Done.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() => mergeWorktree.mutate(task.id)}
-                  disabled={mergeWorktree.isPending}
-                >
-                  {mergeWorktree.isPending ? 'Merging...' : 'Merge & Complete'}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <Button
+            color="green"
+            size="xs"
+            onClick={() => setMergeDialogOpen(true)}
+            leftSection={<GitMerge className="h-3 w-3" />}
+          >
+            Merge
+          </Button>
         )}
 
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button variant="ghost" size="sm" className="text-muted-foreground">
-              <Trash2 className="h-3 w-3 mr-1" />
-              Delete Worktree
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Delete worktree?</AlertDialogTitle>
-              <AlertDialogDescription>
-                {status?.hasChanges
-                  ? 'Warning: This worktree has uncommitted changes that will be lost.'
-                  : 'This will remove the worktree but keep the branch.'}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={() =>
-                  deleteWorktree.mutate({
-                    taskId: task.id,
-                    force: status?.hasChanges,
-                  })
-                }
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              >
-                Delete
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </div>
+        <Button
+          variant="subtle"
+          color="gray"
+          size="xs"
+          onClick={() => setDeleteDialogOpen(true)}
+          leftSection={<Trash2 className="h-3 w-3" />}
+        >
+          Delete Worktree
+        </Button>
+      </Group>
 
       {/* Worktree path */}
-      <div className="text-xs text-muted-foreground font-mono truncate">
+      <Code className="truncate" color="dark">
         {task.git.worktreePath}
-      </div>
+      </Code>
 
       {/* Conflict Resolver */}
       <ConflictResolver
@@ -315,6 +281,67 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
 
       {/* PR Dialog */}
       <PRDialog task={task} open={prDialogOpen} onOpenChange={setPrDialogOpen} />
-    </div>
+
+      <Modal
+        opened={mergeDialogOpen}
+        onClose={() => setMergeDialogOpen(false)}
+        title={`Merge to ${task.git?.baseBranch}?`}
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will merge {task.git?.branch} into {task.git?.baseBranch}, push to remote, delete
+            the worktree, and mark the task as Done.
+          </Text>
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setMergeDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="green"
+              onClick={() => {
+                mergeWorktree.mutate(task.id);
+                setMergeDialogOpen(false);
+              }}
+              disabled={mergeWorktree.isPending}
+            >
+              {mergeWorktree.isPending ? 'Merging...' : 'Merge & Complete'}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      <Modal
+        opened={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        title="Delete worktree?"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            {status?.hasChanges
+              ? 'Warning: This worktree has uncommitted changes that will be lost.'
+              : 'This will remove the worktree but keep the branch.'}
+          </Text>
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                deleteWorktree.mutate({
+                  taskId: task.id,
+                  force: status?.hasChanges,
+                });
+                setDeleteDialogOpen(false);
+              }}
+            >
+              Delete
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Move task detail Git selection, worktree status/actions, PR creation, workflow-run modal, and run-mode/QA gate controls to direct Mantine primitives.
- Add focused wrapper-regression coverage for Git/worktree/PR/workflow/run-mode interactions.
- Update the Mantine migration plan with this task-detail slice.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-git-workflow-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- env VERITAS_ADMIN_KEY=local-smoke-admin-key-0000000000000000000000 VERITAS_AUTH_ENABLED=false VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/playwright test e2e/task-detail.spec.ts --project=chromium
- Browser smoke on http://localhost:3000/: page loaded without overlay/console errors; setup visibility toggle changed the password field from password to text. Task-detail rendering was covered by Playwright e2e because this local Browser profile was on the setup screen.

## Notes
- Remaining task-detail Mantine work after this PR: agent, review/diff, preview, and related specialized runtime surfaces.