### PR TITLE
Migrate task detail review and preview controls to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -361,6 +361,12 @@ Phase 3 progress:
   scroll area, modal, stack, group, and text primitives while preserving Git
   updates, worktree create/rebase/merge/delete actions, PR draft creation,
   workflow start behavior, run-mode changes, and QA gate toggles.
+- Task detail review decisions, inline review comments, preview drawer, and
+  conflict-resolution drawer now use direct Mantine drawer, modal, tabs,
+  textarea, button, action icon, code, paper, scroll area, stack, group, text,
+  loader, and theme icon primitives while preserving review decision summaries,
+  merge confirmation, inline comment add/remove, preview output/external/stop
+  controls, manual conflict resolution, and abort behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConflictResolver } from '@/components/task/ConflictResolver';
+import { PreviewPanel } from '@/components/task/PreviewPanel';
+import { ReviewPanel } from '@/components/task/ReviewPanel';
+import { CommentDisplay, CommentInput } from '@/components/task/diff/ReviewComment';
+import { createMockTask, renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  mergeWorktreeMutate: vi.fn(),
+  usePreviewStatus: vi.fn(),
+  usePreviewOutput: vi.fn(),
+  startPreviewMutate: vi.fn(),
+  stopPreviewMutate: vi.fn(),
+  useConflictStatus: vi.fn(),
+  useFileConflict: vi.fn(),
+  resolveConflictMutateAsync: vi.fn(),
+  abortConflictMutateAsync: vi.fn(),
+  continueConflictMutateAsync: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWorktree', () => ({
+  useMergeWorktree: () => ({
+    mutate: mocks.mergeWorktreeMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/usePreview', () => ({
+  usePreviewStatus: mocks.usePreviewStatus,
+  usePreviewOutput: mocks.usePreviewOutput,
+  useStartPreview: () => ({
+    mutate: mocks.startPreviewMutate,
+    isPending: false,
+    error: null,
+  }),
+  useStopPreview: () => ({
+    mutate: mocks.stopPreviewMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useConflicts', () => ({
+  useConflictStatus: mocks.useConflictStatus,
+  useFileConflict: mocks.useFileConflict,
+  useResolveConflict: () => ({
+    mutateAsync: mocks.resolveConflictMutateAsync,
+    isPending: false,
+  }),
+  useAbortConflict: () => ({
+    mutateAsync: mocks.abortConflictMutateAsync,
+    isPending: false,
+  }),
+  useContinueConflict: () => ({
+    mutateAsync: mocks.continueConflictMutateAsync,
+    isPending: false,
+  }),
+}));
+
+describe('task detail review and preview Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal('open', vi.fn());
+    mocks.mergeWorktreeMutate.mockImplementation((_taskId, options) => {
+      options?.onSuccess?.();
+    });
+    mocks.resolveConflictMutateAsync.mockResolvedValue({ success: true });
+    mocks.abortConflictMutateAsync.mockResolvedValue({ success: true });
+    mocks.continueConflictMutateAsync.mockResolvedValue({ success: true });
+    mocks.usePreviewStatus.mockReturnValue({
+      data: { status: 'stopped' },
+      isLoading: false,
+    });
+    mocks.usePreviewOutput.mockReturnValue({ data: { output: [] } });
+    mocks.useConflictStatus.mockReturnValue({
+      data: {
+        hasConflicts: true,
+        conflictingFiles: ['src/App.tsx', 'src/routes.ts'],
+        rebaseInProgress: true,
+        mergeInProgress: false,
+      },
+      isLoading: false,
+    });
+    mocks.useFileConflict.mockReturnValue({
+      data: {
+        filePath: 'src/App.tsx',
+        content: 'resolved content',
+        oursContent: 'ours content',
+        theirsContent: 'theirs content',
+        markers: [],
+      },
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders review decisions and merge confirmation through direct Mantine controls', async () => {
+    const user = userEvent.setup();
+    const onReview = vi.fn();
+    const onMergeComplete = vi.fn();
+    const task = createMockTask({
+      id: 'task-review',
+      git: {
+        repo: 'veritas',
+        branch: 'feature/review',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-review',
+      },
+      reviewComments: [
+        {
+          id: 'review-comment-1',
+          file: 'src/App.tsx',
+          line: 12,
+          content: 'Check this branch',
+          created: '2026-06-01T09:00:00Z',
+        },
+      ],
+    });
+
+    const { baseElement, container, rerender } = renderWithProviders(
+      <ReviewPanel task={task} onReview={onReview} onMergeComplete={onMergeComplete} />
+    );
+
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Request Changes' }));
+    expect(container.querySelector('.mantine-Textarea-root')).toBeDefined();
+    fireEvent.change(screen.getByPlaceholderText('Describe the changes needed...'), {
+      target: { value: 'Add regression coverage' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Submit Changes Requested' }));
+
+    expect(onReview).toHaveBeenCalledWith({
+      decision: 'changes-requested',
+      decidedAt: expect.any(String),
+      summary: 'Add regression coverage',
+    });
+
+    rerender(
+      <ReviewPanel
+        task={{
+          ...task,
+          review: {
+            decision: 'approved',
+            decidedAt: '2026-06-01T10:00:00Z',
+            summary: 'Ready to merge',
+          },
+        }}
+        onReview={onReview}
+        onMergeComplete={onMergeComplete}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Merge & Close Task' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Merge changes to main?' });
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    await user.click(within(dialog).getByRole('button', { name: 'Merge & Close' }));
+
+    expect(mocks.mergeWorktreeMutate).toHaveBeenCalledWith('task-review', {
+      onSuccess: expect.any(Function),
+    });
+    expect(onMergeComplete).toHaveBeenCalled();
+  });
+
+  it('renders inline review comments through direct Mantine textarea, button, and action icon', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const onRemove = vi.fn();
+
+    const { baseElement, container, rerender } = renderWithProviders(
+      <CommentInput onSubmit={onSubmit} onCancel={onCancel} />
+    );
+
+    expect(container.querySelector('.mantine-Textarea-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText('Add review comment...'), {
+      target: { value: 'Tighten this branch' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Add Comment' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('Tighten this branch');
+    expect(onCancel).toHaveBeenCalled();
+
+    rerender(
+      <CommentDisplay
+        comment={{
+          id: 'review-comment-2',
+          file: 'src/App.tsx',
+          line: 42,
+          content: 'Existing comment',
+          created: '2026-06-01T09:00:00Z',
+        }}
+        onRemove={onRemove}
+      />
+    );
+
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Remove review comment' }));
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('renders preview drawer controls through direct Mantine primitives', async () => {
+    const user = userEvent.setup();
+    mocks.usePreviewStatus.mockReturnValue({
+      data: {
+        status: 'running',
+        url: 'http://127.0.0.1:5173',
+        output: ['ready'],
+      },
+      isLoading: false,
+    });
+    mocks.usePreviewOutput.mockReturnValue({
+      data: { output: ['vite ready', 'compiled successfully'] },
+    });
+    const task = createMockTask({
+      id: 'task-preview',
+      git: { repo: 'veritas', branch: 'feature/preview', baseBranch: 'main' },
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <PreviewPanel task={task} open onOpenChange={vi.fn()} />
+    );
+
+    expect(screen.getByText('Preview')).toBeDefined();
+    expect(container.querySelector('.mantine-Drawer-content')).toBeDefined();
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Code-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="sheet-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle preview output' }));
+    expect(screen.getByText('compiled successfully')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Open preview externally' }));
+    await user.click(screen.getByRole('button', { name: 'Stop preview' }));
+
+    expect(window.open).toHaveBeenCalledWith(
+      'http://127.0.0.1:5173',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(mocks.stopPreviewMutate).toHaveBeenCalledWith('task-preview');
+  });
+
+  it('renders conflict resolution drawer and abort modal through direct Mantine controls', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const task = createMockTask({
+      id: 'task-conflict',
+      git: {
+        repo: 'veritas',
+        branch: 'feature/conflict',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-conflict',
+      },
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <ConflictResolver task={task} open onOpenChange={onOpenChange} />
+    );
+
+    expect(await screen.findByText('Merge Conflicts')).toBeDefined();
+    expect(screen.getByText('App.tsx')).toBeDefined();
+    expect(container.querySelector('.mantine-Drawer-content')).toBeDefined();
+    expect(container.querySelector('.mantine-Tabs-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="sheet-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="tabs-list"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    await user.click(screen.getByRole('tab', { name: 'Manual Edit' }));
+    fireEvent.change(screen.getByPlaceholderText('Edit the file content to resolve conflicts...'), {
+      target: { value: 'manually resolved' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Save Resolution' }));
+
+    expect(mocks.resolveConflictMutateAsync).toHaveBeenCalledWith({
+      taskId: 'task-conflict',
+      filePath: 'src/App.tsx',
+      resolution: 'manual',
+      manualContent: 'manually resolved',
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Abort' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Abort Rebase?' });
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    await user.click(within(dialog).getByRole('button', { name: 'Abort' }));
+
+    expect(mocks.abortConflictMutateAsync).toHaveBeenCalledWith('task-conflict');
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/web/src/components/task/ConflictResolver.tsx
+++ b/web/src/components/task/ConflictResolver.tsx
@@ -1,25 +1,18 @@
 import { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+  Button,
+  Code,
+  Drawer,
+  Group,
+  Loader,
+  Modal,
+  Paper,
+  ScrollArea,
+  Stack,
+  Tabs,
+  Text,
+  Textarea,
+} from '@mantine/core';
 import {
   useConflictStatus,
   useFileConflict,
@@ -126,59 +119,75 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent side="right" className="w-[90vw] sm:max-w-[1200px] p-0 flex flex-col">
-          <SheetHeader className="px-6 py-4 border-b">
-            <div className="flex items-center justify-between pr-8">
-              <div>
-                <SheetTitle className="flex items-center gap-2">
-                  <AlertTriangle className="h-5 w-5 text-amber-500" />
-                  Merge Conflicts
-                </SheetTitle>
-                <SheetDescription>
-                  {status?.rebaseInProgress ? 'Rebase' : 'Merge'} has conflicts that need to be
-                  resolved
-                </SheetDescription>
-              </div>
+      <Drawer
+        opened={open}
+        onClose={() => onOpenChange(false)}
+        position="right"
+        size="90vw"
+        padding={0}
+        title={
+          <Group gap="xs">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            <Text fw={600}>Merge Conflicts</Text>
+          </Group>
+        }
+      >
+        <Stack gap={0} className="h-[calc(100vh-64px)]">
+          <Group justify="space-between" align="center" className="border-b px-6 py-4">
+            <Text size="sm" c="dimmed">
+              {status?.rebaseInProgress ? 'Rebase' : 'Merge'} has conflicts that need to be resolved
+            </Text>
 
-              <div className="flex items-center gap-2">
-                {status?.conflictingFiles.length === 0 && (
-                  <Button onClick={handleContinue} disabled={continueConflict.isPending}>
-                    {continueConflict.isPending ? (
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            <Group gap="xs">
+              {status?.conflictingFiles.length === 0 && (
+                <Button
+                  onClick={handleContinue}
+                  disabled={continueConflict.isPending}
+                  leftSection={
+                    continueConflict.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
                     ) : (
-                      <GitMerge className="h-4 w-4 mr-2" />
-                    )}
-                    Continue {status?.rebaseInProgress ? 'Rebase' : 'Merge'}
-                  </Button>
-                )}
-                <Button variant="outline" onClick={() => setShowAbortDialog(true)}>
-                  <X className="h-4 w-4 mr-2" />
-                  Abort
+                      <GitMerge className="h-4 w-4" />
+                    )
+                  }
+                >
+                  Continue {status?.rebaseInProgress ? 'Rebase' : 'Merge'}
                 </Button>
-              </div>
-            </div>
-          </SheetHeader>
+              )}
+              <Button
+                variant="outline"
+                color="red"
+                onClick={() => setShowAbortDialog(true)}
+                leftSection={<X className="h-4 w-4" />}
+              >
+                Abort
+              </Button>
+            </Group>
+          </Group>
 
           <div className="flex flex-1 overflow-hidden">
             {/* File list sidebar */}
             <div className="w-64 border-r flex flex-col">
               <div className="p-3 border-b bg-muted/50">
-                <h3 className="text-sm font-medium">
+                <Text size="sm" fw={500}>
                   Conflicting Files ({status?.conflictingFiles.length || 0})
-                </h3>
+                </Text>
               </div>
               <ScrollArea className="flex-1">
                 {statusLoading ? (
-                  <div className="p-4 text-center text-muted-foreground">
-                    <Loader2 className="h-4 w-4 animate-spin mx-auto mb-2" />
-                    Loading...
-                  </div>
+                  <Stack align="center" gap="xs" className="p-4" c="dimmed">
+                    <Loader color="gray" size="sm" />
+                    <Text size="sm" c="dimmed">
+                      Loading...
+                    </Text>
+                  </Stack>
                 ) : status?.conflictingFiles.length === 0 ? (
-                  <div className="p-4 text-center text-muted-foreground">
+                  <Stack align="center" gap="xs" className="p-4">
                     <Check className="h-8 w-8 mx-auto mb-2 text-green-500" />
-                    All conflicts resolved!
-                  </div>
+                    <Text size="sm" c="dimmed">
+                      All conflicts resolved!
+                    </Text>
+                  </Stack>
                 ) : (
                   <div className="p-2">
                     {status?.conflictingFiles.map((file) => (
@@ -211,169 +220,193 @@ export function ConflictResolver({ task, open, onOpenChange }: ConflictResolverP
                   <div className="px-4 py-2 border-b bg-muted/30 flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Button
-                        variant="ghost"
-                        size="sm"
+                        variant="subtle"
+                        size="xs"
                         onClick={() => navigateFile('prev')}
                         disabled={!status?.conflictingFiles.length}
                       >
                         <ChevronLeft className="h-4 w-4" />
                       </Button>
-                      <span className="text-sm">
+                      <Text size="sm">
                         {currentIndex + 1} of {status?.conflictingFiles.length}
-                      </span>
+                      </Text>
                       <Button
-                        variant="ghost"
-                        size="sm"
+                        variant="subtle"
+                        size="xs"
                         onClick={() => navigateFile('next')}
                         disabled={!status?.conflictingFiles.length}
                       >
                         <ChevronRight className="h-4 w-4" />
                       </Button>
                     </div>
-                    <code className="text-sm bg-muted px-2 py-1 rounded">{selectedFile}</code>
+                    <Code>{selectedFile}</Code>
                   </div>
 
                   {/* Conflict viewer tabs */}
                   <Tabs defaultValue="sidebyside" className="flex-1 flex flex-col overflow-hidden">
-                    <TabsList className="mx-4 mt-2 w-fit">
-                      <TabsTrigger value="sidebyside">Side by Side</TabsTrigger>
-                      <TabsTrigger value="manual">Manual Edit</TabsTrigger>
-                    </TabsList>
+                    <Tabs.List className="mx-4 mt-2 w-fit">
+                      <Tabs.Tab value="sidebyside">Side by Side</Tabs.Tab>
+                      <Tabs.Tab value="manual">Manual Edit</Tabs.Tab>
+                    </Tabs.List>
 
                     {/* Side by side view */}
-                    <TabsContent value="sidebyside" className="flex-1 overflow-hidden m-0 p-4">
+                    <Tabs.Panel value="sidebyside" className="m-0 flex-1 overflow-hidden p-4">
                       <div className="grid grid-cols-2 gap-4 h-full">
                         {/* Ours */}
-                        <div className="flex flex-col border rounded-lg overflow-hidden">
-                          <div className="px-3 py-2 bg-blue-500/10 border-b flex items-center justify-between">
-                            <span className="text-sm font-medium flex items-center gap-2">
+                        <Paper className="flex flex-col overflow-hidden" radius="md" withBorder>
+                          <Group
+                            justify="space-between"
+                            className="border-b bg-blue-500/10 px-3 py-2"
+                          >
+                            <Group gap="xs">
                               <ArrowLeft className="h-4 w-4" />
-                              Ours (Current)
-                            </span>
+                              <Text size="sm" fw={500}>
+                                Ours (Current)
+                              </Text>
+                            </Group>
                             <Button
-                              size="sm"
+                              size="xs"
                               variant="outline"
                               onClick={() => handleResolve('ours')}
                               disabled={resolveConflict.isPending}
+                              leftSection={
+                                resolveConflict.isPending ? (
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                ) : (
+                                  <Check className="h-3 w-3" />
+                                )
+                              }
                             >
-                              {resolveConflict.isPending ? (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                              ) : (
-                                <>
-                                  <Check className="h-3 w-3 mr-1" />
-                                  Accept Ours
-                                </>
-                              )}
+                              Accept Ours
                             </Button>
-                          </div>
+                          </Group>
                           <ScrollArea className="flex-1">
                             <pre className="p-3 text-xs font-mono whitespace-pre-wrap">
                               {fileConflict.oursContent || '(empty)'}
                             </pre>
                           </ScrollArea>
-                        </div>
+                        </Paper>
 
                         {/* Theirs */}
-                        <div className="flex flex-col border rounded-lg overflow-hidden">
-                          <div className="px-3 py-2 bg-green-500/10 border-b flex items-center justify-between">
-                            <span className="text-sm font-medium flex items-center gap-2">
+                        <Paper className="flex flex-col overflow-hidden" radius="md" withBorder>
+                          <Group
+                            justify="space-between"
+                            className="border-b bg-green-500/10 px-3 py-2"
+                          >
+                            <Group gap="xs">
                               <ArrowRight className="h-4 w-4" />
-                              Theirs (Incoming)
-                            </span>
+                              <Text size="sm" fw={500}>
+                                Theirs (Incoming)
+                              </Text>
+                            </Group>
                             <Button
-                              size="sm"
+                              size="xs"
                               variant="outline"
                               onClick={() => handleResolve('theirs')}
                               disabled={resolveConflict.isPending}
+                              leftSection={
+                                resolveConflict.isPending ? (
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                ) : (
+                                  <Check className="h-3 w-3" />
+                                )
+                              }
                             >
-                              {resolveConflict.isPending ? (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                              ) : (
-                                <>
-                                  <Check className="h-3 w-3 mr-1" />
-                                  Accept Theirs
-                                </>
-                              )}
+                              Accept Theirs
                             </Button>
-                          </div>
+                          </Group>
                           <ScrollArea className="flex-1">
                             <pre className="p-3 text-xs font-mono whitespace-pre-wrap">
                               {fileConflict.theirsContent || '(empty)'}
                             </pre>
                           </ScrollArea>
-                        </div>
+                        </Paper>
                       </div>
-                    </TabsContent>
+                    </Tabs.Panel>
 
                     {/* Manual edit view */}
-                    <TabsContent
+                    <Tabs.Panel
                       value="manual"
                       className="flex-1 overflow-hidden m-0 p-4 flex flex-col"
                     >
-                      <div className="flex-1 flex flex-col border rounded-lg overflow-hidden">
-                        <div className="px-3 py-2 bg-muted/50 border-b flex items-center justify-between">
-                          <span className="text-sm font-medium">Manual Resolution</span>
+                      <Paper
+                        className="flex flex-1 flex-col overflow-hidden"
+                        radius="md"
+                        withBorder
+                      >
+                        <Group justify="space-between" className="border-b bg-muted/50 px-3 py-2">
+                          <Text size="sm" fw={500}>
+                            Manual Resolution
+                          </Text>
                           <Button
-                            size="sm"
+                            size="xs"
                             onClick={() => handleResolve('manual')}
                             disabled={resolveConflict.isPending}
+                            leftSection={
+                              resolveConflict.isPending ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Check className="h-4 w-4" />
+                              )
+                            }
                           >
-                            {resolveConflict.isPending ? (
-                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                            ) : (
-                              <Check className="h-4 w-4 mr-2" />
-                            )}
                             Save Resolution
                           </Button>
-                        </div>
+                        </Group>
                         <Textarea
                           value={manualContent}
-                          onChange={(e) => setManualContent(e.target.value)}
+                          onChange={(e) => setManualContent(e.currentTarget.value)}
                           className="flex-1 font-mono text-xs resize-none border-0 rounded-none focus-visible:ring-0"
                           placeholder="Edit the file content to resolve conflicts..."
                         />
-                      </div>
-                    </TabsContent>
+                      </Paper>
+                    </Tabs.Panel>
                   </Tabs>
                 </>
               ) : fileLoading ? (
-                <div className="flex-1 flex items-center justify-center">
-                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                </div>
+                <Stack align="center" justify="center" className="flex-1">
+                  <Loader color="gray" size="md" />
+                </Stack>
               ) : (
-                <div className="flex-1 flex items-center justify-center text-muted-foreground">
+                <Text className="flex flex-1 items-center justify-center" c="dimmed">
                   Select a file to resolve conflicts
-                </div>
+                </Text>
               )}
             </div>
           </div>
-        </SheetContent>
-      </Sheet>
+        </Stack>
+      </Drawer>
 
       {/* Abort confirmation dialog */}
-      <AlertDialog open={showAbortDialog} onOpenChange={setShowAbortDialog}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              Abort {status?.rebaseInProgress ? 'Rebase' : 'Merge'}?
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              This will discard all conflict resolutions and return to the state before the
-              {status?.rebaseInProgress ? ' rebase' : ' merge'} started.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleAbort}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      <Modal
+        opened={showAbortDialog}
+        onClose={() => setShowAbortDialog(false)}
+        title={`Abort ${status?.rebaseInProgress ? 'Rebase' : 'Merge'}?`}
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will discard all conflict resolutions and return to the state before the
+            {status?.rebaseInProgress ? ' rebase' : ' merge'} started.
+          </Text>
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setShowAbortDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                void handleAbort();
+              }}
+              leftSection={
+                abortConflict.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+              }
             >
-              {abortConflict.isPending ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
               Abort
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </>
   );
 }

--- a/web/src/components/task/PreviewPanel.tsx
+++ b/web/src/components/task/PreviewPanel.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
-import { ScrollArea } from '@/components/ui/scroll-area';
+  ActionIcon,
+  Button,
+  Code,
+  Drawer,
+  Group,
+  Loader,
+  Paper,
+  ScrollArea,
+  Stack,
+  Text,
+} from '@mantine/core';
 import {
   usePreviewStatus,
   usePreviewOutput,
@@ -25,7 +28,6 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import type { Task } from '@veritas-kanban/shared';
-import { cn } from '@/lib/utils';
 
 interface PreviewPanelProps {
   task: Task;
@@ -67,132 +69,141 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
   };
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[800px] sm:max-w-[800px] p-0 flex flex-col">
-        <SheetHeader className="px-6 py-4 border-b">
-          <div className="flex items-center justify-between pr-8">
-            <div>
-              <SheetTitle className="flex items-center gap-2">
-                <Monitor className="h-5 w-5" />
-                Preview
-              </SheetTitle>
-              <SheetDescription>
-                {task.git?.repo ? `Dev server for ${task.git.repo}` : 'No repository configured'}
-              </SheetDescription>
-            </div>
+    <Drawer
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      position="right"
+      size="min(800px, 92vw)"
+      padding={0}
+      title={
+        <Group gap="xs">
+          <Monitor className="h-5 w-5" />
+          <Text fw={600}>Preview</Text>
+        </Group>
+      }
+    >
+      <Stack gap={0} className="h-[calc(100vh-64px)]">
+        <Group justify="space-between" align="center" className="border-b px-6 py-4">
+          <Text size="sm" c="dimmed">
+            {task.git?.repo ? `Dev server for ${task.git.repo}` : 'No repository configured'}
+          </Text>
 
-            {/* Controls */}
-            <div className="flex items-center gap-2">
-              {isRunning && (
-                <>
-                  <Button variant="outline" size="sm" onClick={handleRefresh}>
-                    <RefreshCw className="h-4 w-4" />
-                  </Button>
-                  <Button variant="outline" size="sm" onClick={handleOpenExternal}>
-                    <ExternalLink className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowOutput(!showOutput)}
-                    className={cn(showOutput && 'bg-muted')}
-                  >
-                    <Terminal className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={handleStop}
-                    disabled={stopPreview.isPending}
-                  >
-                    {stopPreview.isPending ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Square className="h-4 w-4" />
-                    )}
-                  </Button>
-                </>
-              )}
-
-              {!isRunning && !isStarting && (
-                <Button onClick={handleStart} disabled={startPreview.isPending || !task.git?.repo}>
-                  {startPreview.isPending ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Starting...
-                    </>
+          {/* Controls */}
+          <Group gap="xs">
+            {isRunning && (
+              <>
+                <ActionIcon
+                  variant="outline"
+                  size="lg"
+                  aria-label="Refresh preview"
+                  onClick={handleRefresh}
+                >
+                  <RefreshCw className="h-4 w-4" />
+                </ActionIcon>
+                <ActionIcon
+                  variant="outline"
+                  size="lg"
+                  aria-label="Open preview externally"
+                  onClick={handleOpenExternal}
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </ActionIcon>
+                <ActionIcon
+                  variant={showOutput ? 'filled' : 'outline'}
+                  size="lg"
+                  aria-label="Toggle preview output"
+                  onClick={() => setShowOutput(!showOutput)}
+                >
+                  <Terminal className="h-4 w-4" />
+                </ActionIcon>
+                <ActionIcon
+                  color="red"
+                  variant="filled"
+                  size="lg"
+                  aria-label="Stop preview"
+                  onClick={handleStop}
+                  disabled={stopPreview.isPending}
+                >
+                  {stopPreview.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
                   ) : (
-                    <>
-                      <Play className="h-4 w-4 mr-2" />
-                      Start Preview
-                    </>
+                    <Square className="h-4 w-4" />
                   )}
-                </Button>
-              )}
-            </div>
-          </div>
-        </SheetHeader>
+                </ActionIcon>
+              </>
+            )}
+
+            {!isRunning && !isStarting && (
+              <Button
+                onClick={handleStart}
+                disabled={startPreview.isPending || !task.git?.repo}
+                leftSection={
+                  startPreview.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Play className="h-4 w-4" />
+                  )
+                }
+              >
+                {startPreview.isPending ? 'Starting...' : 'Start Preview'}
+              </Button>
+            )}
+          </Group>
+        </Group>
 
         {/* Content Area */}
-        <div className="flex-1 flex flex-col overflow-hidden">
+        <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
           {/* Loading state */}
           {(isLoading || isStarting) && (
-            <div className="flex-1 flex items-center justify-center">
-              <div className="text-center">
-                <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4 text-muted-foreground" />
-                <p className="text-muted-foreground">
-                  {isStarting ? 'Starting dev server...' : 'Loading...'}
-                </p>
-                {isStarting && status && 'output' in status && status.output.length > 0 && (
-                  <p className="text-xs text-muted-foreground mt-2 font-mono">
-                    {status.output[status.output.length - 1]?.slice(0, 80)}
-                  </p>
-                )}
-              </div>
-            </div>
+            <Stack align="center" justify="center" gap="sm" className="flex-1">
+              <Loader color="gray" size="md" />
+              <Text c="dimmed">{isStarting ? 'Starting dev server...' : 'Loading...'}</Text>
+              {isStarting && status && 'output' in status && status.output.length > 0 && (
+                <Text size="xs" c="dimmed" className="font-mono">
+                  {status.output[status.output.length - 1]?.slice(0, 80)}
+                </Text>
+              )}
+            </Stack>
           )}
 
           {/* Error state */}
           {hasError && !isStarting && (
-            <div className="flex-1 flex items-center justify-center p-6">
-              <div className="text-center max-w-md">
-                <AlertCircle className="h-12 w-12 mx-auto mb-4 text-red-500" />
-                <h3 className="font-semibold mb-2">Preview Error</h3>
-                <p className="text-sm text-muted-foreground mb-4">
-                  {status && 'error' in status ? status.error : 'An error occurred'}
-                </p>
-                <Button onClick={handleStart}>
-                  <RefreshCw className="h-4 w-4 mr-2" />
-                  Try Again
-                </Button>
-              </div>
-            </div>
+            <Stack align="center" justify="center" gap="sm" className="flex-1 p-6" ta="center">
+              <AlertCircle className="h-12 w-12 mx-auto mb-4 text-red-500" />
+              <Text fw={600}>Preview Error</Text>
+              <Text size="sm" c="dimmed" className="max-w-md">
+                {status && 'error' in status ? status.error : 'An error occurred'}
+              </Text>
+              <Button onClick={handleStart} leftSection={<RefreshCw className="h-4 w-4" />}>
+                Try Again
+              </Button>
+            </Stack>
           )}
 
           {/* Stopped state */}
           {!isRunning && !isStarting && !hasError && !isLoading && (
-            <div className="flex-1 flex items-center justify-center p-6">
-              <div className="text-center max-w-md">
-                <Monitor className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-                <h3 className="font-semibold mb-2">Preview Not Running</h3>
-                <p className="text-sm text-muted-foreground mb-4">
-                  {task.git?.repo
-                    ? 'Start the dev server to see a live preview of your changes.'
-                    : 'Configure a repository for this task to use preview.'}
-                </p>
-                {startPreview.error && (
-                  <p className="text-sm text-red-500 mb-4">{startPreview.error.message}</p>
-                )}
-              </div>
-            </div>
+            <Stack align="center" justify="center" gap="sm" className="flex-1 p-6" ta="center">
+              <Monitor className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+              <Text fw={600}>Preview Not Running</Text>
+              <Text size="sm" c="dimmed" className="max-w-md">
+                {task.git?.repo
+                  ? 'Start the dev server to see a live preview of your changes.'
+                  : 'Configure a repository for this task to use preview.'}
+              </Text>
+              {startPreview.error && (
+                <Text size="sm" c="red">
+                  {startPreview.error.message}
+                </Text>
+              )}
+            </Stack>
           )}
 
           {/* Running - show iframe */}
           {isRunning && previewUrl && (
-            <div className="flex-1 flex flex-col overflow-hidden">
+            <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
               {/* Output panel (collapsible) */}
               {showOutput && (
-                <div className="h-48 border-b bg-black text-green-400 font-mono text-xs">
+                <Paper className="h-48 rounded-none border-b bg-black font-mono text-xs text-green-400">
                   <ScrollArea className="h-full">
                     <div className="p-4">
                       {outputData?.output.map((line, i) => (
@@ -202,14 +213,16 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
                       ))}
                     </div>
                   </ScrollArea>
-                </div>
+                </Paper>
               )}
 
               {/* URL bar */}
-              <div className="px-4 py-2 border-b bg-muted/50 flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">URL:</span>
-                <code className="text-xs bg-muted px-2 py-1 rounded flex-1">{previewUrl}</code>
-              </div>
+              <Group gap="xs" className="border-b bg-muted/50 px-4 py-2" wrap="nowrap">
+                <Text size="xs" c="dimmed">
+                  URL:
+                </Text>
+                <Code className="min-w-0 flex-1 truncate">{previewUrl}</Code>
+              </Group>
 
               {/* iframe */}
               <div className="flex-1 bg-white">
@@ -221,10 +234,10 @@ export function PreviewPanel({ task, open, onOpenChange }: PreviewPanelProps) {
                   sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
                 />
               </div>
-            </div>
+            </Stack>
           )}
-        </div>
-      </SheetContent>
-    </Sheet>
+        </Stack>
+      </Stack>
+    </Drawer>
   );
 }

--- a/web/src/components/task/ReviewPanel.tsx
+++ b/web/src/components/task/ReviewPanel.tsx
@@ -1,28 +1,8 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import {
-  CheckCircle,
-  XCircle,
-  RefreshCcw,
-  MessageSquare,
-  GitMerge,
-  Loader2,
-} from 'lucide-react';
+import { Button, Code, Group, Modal, Paper, Stack, Text, Textarea, ThemeIcon } from '@mantine/core';
+import { CheckCircle, XCircle, RefreshCcw, MessageSquare, GitMerge, Loader2 } from 'lucide-react';
 import { useMergeWorktree } from '@/hooks/useWorktree';
 import type { Task, ReviewDecision, ReviewState } from '@veritas-kanban/shared';
-import { cn } from '@/lib/utils';
 
 interface ReviewPanelProps {
   task: Task;
@@ -30,21 +10,24 @@ interface ReviewPanelProps {
   onMergeComplete?: () => void;
 }
 
-const decisionStyles: Record<ReviewDecision, { icon: React.ReactNode; label: string; className: string }> = {
-  'approved': {
+const decisionStyles: Record<
+  ReviewDecision,
+  { icon: React.ReactNode; label: string; color: string }
+> = {
+  approved: {
     icon: <CheckCircle className="h-4 w-4" />,
     label: 'Approved',
-    className: 'bg-green-500/10 text-green-600 border-green-500/30',
+    color: 'green',
   },
   'changes-requested': {
     icon: <RefreshCcw className="h-4 w-4" />,
     label: 'Changes Requested',
-    className: 'bg-amber-500/10 text-amber-600 border-amber-500/30',
+    color: 'yellow',
   },
-  'rejected': {
+  rejected: {
     icon: <XCircle className="h-4 w-4" />,
     label: 'Rejected',
-    className: 'bg-red-500/10 text-red-600 border-red-500/30',
+    color: 'red',
   },
 };
 
@@ -52,6 +35,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
   const [showSummary, setShowSummary] = useState(false);
   const [summary, setSummary] = useState('');
   const [pendingDecision, setPendingDecision] = useState<ReviewDecision | null>(null);
+  const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
 
   const mergeWorktree = useMergeWorktree();
   const hasWorktree = !!task.git?.worktreePath;
@@ -81,165 +65,170 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
 
   if (!hasWorktree) {
     return (
-      <div className="text-center text-muted-foreground py-8">
+      <Text ta="center" c="dimmed" className="py-8">
         Start a worktree to enable code review
-      </div>
+      </Text>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Current review status */}
       {currentReview?.decision && (
-        <div
-          className={cn(
-            'flex items-center gap-2 p-3 rounded-md border',
-            decisionStyles[currentReview.decision].className
-          )}
-        >
-          {decisionStyles[currentReview.decision].icon}
-          <div className="flex-1">
-            <div className="font-medium">
-              {decisionStyles[currentReview.decision].label}
-            </div>
-            {currentReview.decidedAt && (
-              <div className="text-xs opacity-75">
-                {new Date(currentReview.decidedAt).toLocaleString()}
-              </div>
-            )}
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => onReview({})}
-          >
-            Clear
-          </Button>
-        </div>
+        <Paper className="p-3" radius="md" withBorder>
+          <Group gap="sm" wrap="nowrap">
+            <ThemeIcon color={decisionStyles[currentReview.decision].color} variant="light">
+              {decisionStyles[currentReview.decision].icon}
+            </ThemeIcon>
+            <Stack gap={2} className="min-w-0 flex-1">
+              <Text size="sm" fw={500}>
+                {decisionStyles[currentReview.decision].label}
+              </Text>
+              {currentReview.decidedAt && (
+                <Text size="xs" c="dimmed">
+                  {new Date(currentReview.decidedAt).toLocaleString()}
+                </Text>
+              )}
+            </Stack>
+            <Button variant="subtle" size="xs" onClick={() => onReview({})}>
+              Clear
+            </Button>
+          </Group>
+        </Paper>
       )}
 
       {currentReview?.summary && (
-        <div className="p-3 rounded-md border bg-muted/50">
-          <p className="text-sm whitespace-pre-wrap">{currentReview.summary}</p>
-        </div>
+        <Paper className="bg-muted/50 p-3" radius="md" withBorder>
+          <Text size="sm" className="whitespace-pre-wrap">
+            {currentReview.summary}
+          </Text>
+        </Paper>
       )}
 
       {/* Merge button when approved */}
       {isApproved && hasWorktree && (
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button className="w-full bg-green-600 hover:bg-green-700" disabled={mergeWorktree.isPending}>
-              {mergeWorktree.isPending ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Merging...
-                </>
-              ) : (
-                <>
-                  <GitMerge className="h-4 w-4 mr-2" />
-                  Merge & Close Task
-                </>
-              )}
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Merge changes to {task.git?.baseBranch || 'main'}?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This will merge the branch <code className="px-1 bg-muted rounded">{task.git?.branch}</code> into{' '}
-                <code className="px-1 bg-muted rounded">{task.git?.baseBranch || 'main'}</code>,
-                delete the worktree, and mark this task as done.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={() => {
-                  mergeWorktree.mutate(task.id, {
-                    onSuccess: () => {
-                      onMergeComplete?.();
-                    },
-                  });
-                }}
-                className="bg-green-600 hover:bg-green-700"
-              >
-                Merge & Close
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <Button
+          fullWidth
+          color="green"
+          onClick={() => setMergeDialogOpen(true)}
+          disabled={mergeWorktree.isPending}
+          leftSection={
+            mergeWorktree.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <GitMerge className="h-4 w-4" />
+            )
+          }
+        >
+          {mergeWorktree.isPending ? 'Merging...' : 'Merge & Close Task'}
+        </Button>
       )}
 
       {/* Comment summary */}
       {comments.length > 0 && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Group gap="xs">
           <MessageSquare className="h-4 w-4" />
-          {comments.length} review comment{comments.length === 1 ? '' : 's'}
-        </div>
+          <Text size="sm" c="dimmed">
+            {comments.length} review comment{comments.length === 1 ? '' : 's'}
+          </Text>
+        </Group>
       )}
 
       {/* Summary input for changes-requested/rejected */}
       {showSummary && pendingDecision && (
-        <div className="space-y-2 p-3 rounded-md border bg-muted/50">
-          <Textarea
-            value={summary}
-            onChange={(e) => setSummary(e.target.value)}
-            placeholder={
-              pendingDecision === 'rejected'
-                ? 'Explain why this is rejected...'
-                : 'Describe the changes needed...'
-            }
-            rows={3}
-          />
-          <div className="flex gap-2">
-            <Button
-              onClick={() => submitReview(pendingDecision, summary || undefined)}
-              variant={pendingDecision === 'rejected' ? 'destructive' : 'default'}
-            >
-              Submit {decisionStyles[pendingDecision].label}
-            </Button>
-            <Button
-              variant="ghost"
-              onClick={() => {
-                setShowSummary(false);
-                setSummary('');
-                setPendingDecision(null);
-              }}
-            >
-              Cancel
-            </Button>
-          </div>
-        </div>
+        <Paper className="bg-muted/50 p-3" radius="md" withBorder>
+          <Stack gap="xs">
+            <Textarea
+              value={summary}
+              onChange={(e) => setSummary(e.currentTarget.value)}
+              placeholder={
+                pendingDecision === 'rejected'
+                  ? 'Explain why this is rejected...'
+                  : 'Describe the changes needed...'
+              }
+              minRows={3}
+            />
+            <Group gap="xs">
+              <Button
+                onClick={() => submitReview(pendingDecision, summary || undefined)}
+                color={pendingDecision === 'rejected' ? 'red' : undefined}
+              >
+                Submit {decisionStyles[pendingDecision].label}
+              </Button>
+              <Button
+                variant="subtle"
+                onClick={() => {
+                  setShowSummary(false);
+                  setSummary('');
+                  setPendingDecision(null);
+                }}
+              >
+                Cancel
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
       )}
 
       {/* Action buttons */}
       {!currentReview?.decision && !showSummary && (
-        <div className="flex gap-2">
+        <Group gap="xs" grow>
           <Button
             onClick={() => handleDecision('approved')}
-            className="flex-1 bg-green-600 hover:bg-green-700"
+            color="green"
+            leftSection={<CheckCircle className="h-4 w-4" />}
           >
-            <CheckCircle className="h-4 w-4 mr-2" />
             Approve
           </Button>
           <Button
             onClick={() => handleDecision('changes-requested')}
             variant="outline"
-            className="flex-1"
+            leftSection={<RefreshCcw className="h-4 w-4" />}
           >
-            <RefreshCcw className="h-4 w-4 mr-2" />
             Request Changes
           </Button>
           <Button
             onClick={() => handleDecision('rejected')}
-            variant="destructive"
-            className="flex-1"
+            color="red"
+            leftSection={<XCircle className="h-4 w-4" />}
           >
-            <XCircle className="h-4 w-4 mr-2" />
             Reject
           </Button>
-        </div>
+        </Group>
       )}
-    </div>
+
+      <Modal
+        opened={mergeDialogOpen}
+        onClose={() => setMergeDialogOpen(false)}
+        title={`Merge changes to ${task.git?.baseBranch || 'main'}?`}
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will merge the branch <Code>{task.git?.branch}</Code> into{' '}
+            <Code>{task.git?.baseBranch || 'main'}</Code>, delete the worktree, and mark this task
+            as done.
+          </Text>
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setMergeDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="green"
+              onClick={() => {
+                mergeWorktree.mutate(task.id, {
+                  onSuccess: () => {
+                    onMergeComplete?.();
+                  },
+                });
+                setMergeDialogOpen(false);
+              }}
+            >
+              Merge & Close
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Stack>
   );
 }

--- a/web/src/components/task/diff/ReviewComment.tsx
+++ b/web/src/components/task/diff/ReviewComment.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { ActionIcon, Button, Group, Paper, Text, Textarea } from '@mantine/core';
 import { X } from 'lucide-react';
 import type { ReviewComment } from '@veritas-kanban/shared';
 import { sanitizeText } from '@/lib/sanitize';
@@ -21,24 +20,24 @@ export function CommentInput({ onSubmit, onCancel }: CommentInputProps) {
   };
 
   return (
-    <div className="p-2 bg-amber-500/10 border-l-2 border-amber-500 space-y-2">
+    <Paper className="space-y-2 border-l-2 border-amber-500 bg-amber-500/10 p-2" radius={0}>
       <Textarea
         value={content}
-        onChange={(e) => setContent(e.target.value)}
+        onChange={(e) => setContent(e.currentTarget.value)}
         placeholder="Add review comment..."
-        rows={2}
+        minRows={2}
         className="text-xs"
         autoFocus
       />
-      <div className="flex gap-2">
+      <Group gap="xs">
         <Button size="sm" onClick={handleSubmit} disabled={!content.trim()}>
           Add Comment
         </Button>
-        <Button size="sm" variant="ghost" onClick={onCancel}>
+        <Button size="sm" variant="subtle" onClick={onCancel}>
           Cancel
         </Button>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 }
 
@@ -49,19 +48,25 @@ interface CommentDisplayProps {
 
 export function CommentDisplay({ comment, onRemove }: CommentDisplayProps) {
   return (
-    <div className="p-2 bg-amber-500/10 border-l-2 border-amber-500 group">
-      <div className="flex items-start justify-between">
-        <p className="text-xs whitespace-pre-wrap">{sanitizeText(comment.content)}</p>
-        <button
+    <Paper className="group border-l-2 border-amber-500 bg-amber-500/10 p-2" radius={0}>
+      <Group align="flex-start" justify="space-between" wrap="nowrap">
+        <Text size="xs" className="whitespace-pre-wrap">
+          {sanitizeText(comment.content)}
+        </Text>
+        <ActionIcon
+          aria-label="Remove review comment"
+          variant="subtle"
+          color="red"
+          size="xs"
           onClick={onRemove}
-          className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
+          className="opacity-0 transition-opacity group-hover:opacity-100"
         >
           <X className="h-3 w-3" />
-        </button>
-      </div>
-      <p className="text-[10px] text-muted-foreground mt-1">
+        </ActionIcon>
+      </Group>
+      <Text size="10px" c="dimmed" className="mt-1">
         {new Date(comment.created).toLocaleString()}
-      </p>
-    </div>
+      </Text>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- Move task detail review decisions, inline review comments, preview drawer, and conflict resolver to direct Mantine primitives.
- Preserve review decision summaries, merge confirmation, inline comment add/remove, preview output/external/stop controls, manual conflict resolution, and abort behavior.
- Add focused wrapper-regression coverage and update the Mantine migration plan.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-review-preview-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- env VERITAS_ADMIN_KEY=local-smoke-admin-key-0000000000000000000000 VERITAS_AUTH_ENABLED=false VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/playwright test e2e/task-detail.spec.ts --project=chromium
- Browser smoke on http://localhost:3000/: setup screen rendered with API, no framework overlay, no connection error, no console warn/error; task-detail rendering covered by Playwright e2e because the local Browser profile is on setup.

## Notes
- Remaining task detail Mantine work after this PR: agent controls and create/apply-template/task-metric leftovers as needed.