### PR TITLE
Migrate task detail agent, template, and metrics controls to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -367,6 +367,13 @@ Phase 3 progress:
   loader, and theme icon primitives while preserving review decision summaries,
   merge confirmation, inline comment add/remove, preview output/external/stop
   controls, manual conflict resolution, and abort behavior.
+- Task detail agent controls, apply-template flow, task metrics panel, create-task
+  dialog shell, blueprint preview, and template variable helpers now use direct
+  Mantine modal, tabs, select, switch, text input, badge, button, action icon,
+  skeleton, paper, alert, code, stack, group, text, and theme icon primitives
+  while preserving agent start/stop/message flows, template merge previews,
+  force-overwrite/custom-variable application, metrics expansion/export, and
+  blueprint/custom-variable rendering.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
@@ -1,0 +1,387 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AgentPanel } from '@/components/task/AgentPanel';
+import { ApplyTemplateDialog } from '@/components/task/ApplyTemplateDialog';
+import { TaskMetricsPanel } from '@/components/task/TaskMetricsPanel';
+import { BlueprintPreview } from '@/components/task/create/BlueprintPreview';
+import { TemplateVariableInputs } from '@/components/task/create/TemplateVariableInputs';
+import { api } from '@/lib/api';
+import { createMockTask, renderWithProviders } from './test-utils';
+import type { TaskTemplate } from '@/hooks/useTemplates';
+
+const mocks = vi.hoisted(() => ({
+  useConfig: vi.fn(),
+  useAgentStatus: vi.fn(),
+  useAgentStream: vi.fn(),
+  useAgentAttempts: vi.fn(),
+  useAgentLog: vi.fn(),
+  useResolveAgent: vi.fn(),
+  startAgentMutate: vi.fn(),
+  stopAgentMutate: vi.fn(),
+  sendMessageMutate: vi.fn(),
+  clearOutputs: vi.fn(),
+  refetchAttempts: vi.fn(),
+  useTemplates: vi.fn(),
+  updateTaskMutateAsync: vi.fn(),
+  useTaskMetrics: vi.fn(),
+  applyTemplateActivity: vi.fn(),
+}));
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: mocks.useConfig,
+}));
+
+vi.mock('@/hooks/useAgent', () => ({
+  useAgentStatus: mocks.useAgentStatus,
+  useAgentStream: mocks.useAgentStream,
+  useAgentAttempts: mocks.useAgentAttempts,
+  useAgentLog: mocks.useAgentLog,
+  useStartAgent: () => ({
+    mutate: mocks.startAgentMutate,
+    isPending: false,
+  }),
+  useStopAgent: () => ({
+    mutate: mocks.stopAgentMutate,
+  }),
+  useSendMessage: () => ({
+    mutate: mocks.sendMessageMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useRouting', () => ({
+  useResolveAgent: mocks.useResolveAgent,
+}));
+
+vi.mock('@/hooks/useTemplates', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/useTemplates')>('@/hooks/useTemplates');
+  return {
+    ...actual,
+    useTemplates: mocks.useTemplates,
+  };
+});
+
+vi.mock('@/hooks/useTasks', () => ({
+  useUpdateTask: () => ({
+    mutateAsync: mocks.updateTaskMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useTaskMetrics', () => ({
+  useTaskMetrics: mocks.useTaskMetrics,
+}));
+
+vi.mock('@/components/dashboard/ExportDialog', () => ({
+  ExportDialog: ({ open }: { open: boolean }) =>
+    open ? (
+      <div role="dialog" aria-label="Export task metrics">
+        Export task metrics
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    tasks: {
+      applyTemplate: mocks.applyTemplateActivity,
+    },
+  },
+}));
+
+const template: TaskTemplate = {
+  id: 'template-bug',
+  name: 'Bug Fix',
+  description: 'Resolve defect',
+  category: 'bug',
+  version: 1,
+  taskDefaults: {
+    type: 'bug',
+    priority: 'high',
+    project: 'veritas',
+    descriptionTemplate: 'Fix {{custom:bugId}} for {{project}}',
+  },
+  subtaskTemplates: [
+    {
+      title: 'Verify {{custom:bugId}}',
+      order: 1,
+    },
+  ],
+  created: '2026-06-01T09:00:00Z',
+  updated: '2026-06-01T09:00:00Z',
+};
+
+describe('task detail agent, template, and metrics Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    mocks.useConfig.mockReturnValue({
+      data: {
+        defaultAgent: 'codex',
+        agents: [
+          { type: 'codex', name: 'Codex', enabled: true },
+          { type: 'claude', name: 'Claude', enabled: true },
+        ],
+      },
+    });
+    mocks.useAgentStatus.mockReturnValue({ data: { running: false } });
+    mocks.useAgentStream.mockReturnValue({
+      outputs: [],
+      isConnected: true,
+      isRunning: false,
+      clearOutputs: mocks.clearOutputs,
+    });
+    mocks.useAgentAttempts.mockReturnValue({
+      data: ['attempt-1'],
+      refetch: mocks.refetchAttempts,
+    });
+    mocks.useAgentLog.mockReturnValue({ data: null, isLoading: false });
+    mocks.useResolveAgent.mockReturnValue({
+      data: { agent: 'codex', model: 'sonnet', reason: 'Best configured agent' },
+    });
+    mocks.useTemplates.mockReturnValue({ data: [template] });
+    mocks.updateTaskMutateAsync.mockResolvedValue({});
+    mocks.applyTemplateActivity.mockResolvedValue({});
+    mocks.useTaskMetrics.mockReturnValue({
+      data: {
+        totalRuns: 2,
+        successfulRuns: 1,
+        failedRuns: 1,
+        successRate: 0.5,
+        totalDurationMs: 120000,
+        avgDurationMs: 60000,
+        totalInputTokens: 1200,
+        totalOutputTokens: 800,
+        totalCacheTokens: 300,
+        totalCost: 0.18,
+        lastRun: {
+          agent: 'codex',
+          model: 'sonnet',
+          success: true,
+          durationMs: 60000,
+        },
+        attempts: [
+          {
+            attemptId: 'attempt-1',
+            agent: 'codex',
+            model: 'sonnet',
+            startTime: '2026-06-01T09:00:00Z',
+            durationMs: 60000,
+            totalTokens: 2000,
+            inputTokens: 1200,
+            outputTokens: 800,
+            cacheTokens: 300,
+            cost: 0.18,
+            success: true,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders agent controls through direct Mantine controls and keeps start wired', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-agent',
+      git: { repo: 'veritas', branch: 'feature/agent', baseBranch: 'main', worktreePath: '/tmp' },
+    });
+
+    const { baseElement, container } = renderWithProviders(<AgentPanel task={task} />);
+
+    expect(container.querySelectorAll('.mantine-Select-root')).toHaveLength(2);
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Start' }));
+
+    expect(mocks.clearOutputs).toHaveBeenCalled();
+    expect(mocks.startAgentMutate).toHaveBeenCalledWith(
+      { taskId: 'task-agent', agent: 'codex' },
+      { onSuccess: expect.any(Function) }
+    );
+  });
+
+  it('keeps running-agent message send and stop confirmation wired through Mantine modal', async () => {
+    const user = userEvent.setup();
+    mocks.useAgentStatus.mockReturnValue({ data: { running: true } });
+    mocks.useAgentStream.mockReturnValue({
+      outputs: [{ type: 'stdout', content: 'working' }],
+      isConnected: true,
+      isRunning: true,
+      clearOutputs: mocks.clearOutputs,
+    });
+    const task = createMockTask({
+      id: 'task-agent-running',
+      git: { repo: 'veritas', branch: 'feature/agent', baseBranch: 'main', worktreePath: '/tmp' },
+    });
+
+    const { baseElement, container } = renderWithProviders(<AgentPanel task={task} />);
+
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    fireEvent.change(screen.getByPlaceholderText('Send a message to the agent...'), {
+      target: { value: 'continue with tests' },
+    });
+    const messageForm = screen
+      .getByPlaceholderText('Send a message to the agent...')
+      .closest('form');
+    expect(messageForm).not.toBeNull();
+    fireEvent.submit(messageForm as HTMLFormElement);
+
+    await user.click(screen.getByRole('button', { name: 'Stop' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Stop the agent?' });
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'Stop Agent' }));
+
+    expect(mocks.sendMessageMutate).toHaveBeenCalledWith({
+      taskId: 'task-agent-running',
+      message: 'continue with tests',
+    });
+    expect(mocks.stopAgentMutate).toHaveBeenCalledWith('task-agent-running');
+    expect(dialog).toBeDefined();
+  });
+
+  it('applies a template through direct Mantine modal, tabs, select, switch, and inputs', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onApplied = vi.fn();
+    const task = createMockTask({
+      id: 'task-template',
+      description: '',
+      project: 'veritas',
+      priority: undefined,
+      subtasks: [],
+    });
+
+    const { baseElement, container } = renderWithProviders(
+      <ApplyTemplateDialog task={task} open onOpenChange={onOpenChange} onApplied={onApplied} />
+    );
+
+    expect(container.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(container.querySelector('.mantine-Tabs-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="tabs-list"]')).toBeNull();
+
+    await user.click(screen.getByRole('combobox', { name: 'Template' }));
+    await user.click(await screen.findByRole('option', { name: /Bug Fix - Resolve defect/ }));
+    fireEvent.change(screen.getByLabelText('bugId'), { target: { value: 'BUG-42' } });
+    await user.click(screen.getByRole('switch', { name: 'Force overwrite' }));
+    await user.click(screen.getByRole('button', { name: 'Apply Template' }));
+
+    await waitFor(() => {
+      expect(mocks.updateTaskMutateAsync).toHaveBeenCalledWith({
+        id: 'task-template',
+        input: expect.objectContaining({
+          description: 'Fix BUG-42 for veritas',
+          priority: 'high',
+          project: 'veritas',
+          subtasks: expect.arrayContaining([
+            expect.objectContaining({ title: 'Verify BUG-42', completed: false }),
+          ]),
+        }),
+      });
+    });
+    expect(api.tasks.applyTemplate).toHaveBeenCalledWith(
+      'task-template',
+      'template-bug',
+      'Bug Fix',
+      expect.arrayContaining(['description', 'priority', 'project', 'subtasks'])
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onApplied).toHaveBeenCalled();
+  });
+
+  it('renders task metrics and export controls through direct Mantine primitives', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-metrics',
+      comments: [
+        {
+          id: 'comment-1',
+          author: 'User',
+          text: 'Looks good',
+          timestamp: '2026-06-01T09:00:00Z',
+        },
+      ],
+      subtasks: [{ id: 'subtask-1', title: 'Write tests', completed: true, created: '' }],
+      attachments: [
+        {
+          id: 'attachment-1',
+          filename: 'notes.txt',
+          originalName: 'notes.txt',
+          mimeType: 'text/plain',
+          size: 12,
+          uploaded: '2026-06-01T09:00:00Z',
+        },
+      ],
+      timeTracking: { totalSeconds: 1800, entries: [], isRunning: false },
+    });
+
+    const { baseElement, container } = renderWithProviders(<TaskMetricsPanel task={task} />);
+
+    expect(screen.getByText('Task Overview')).toBeDefined();
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Button-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="skeleton"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /codex sonnet/i }));
+    expect(screen.getByText('Input:')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    expect(await screen.findByRole('dialog', { name: 'Export task metrics' })).toBeDefined();
+  });
+
+  it('renders create-template helper surfaces through direct Mantine inputs and papers', () => {
+    const onChange = vi.fn();
+    const { baseElement, container, rerender } = renderWithProviders(
+      <TemplateVariableInputs variables={['ticket']} values={{ ticket: '' }} onChange={onChange} />
+    );
+
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="label"]')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('ticket'), { target: { value: 'VK-5' } });
+    expect(onChange).toHaveBeenCalledWith('ticket', 'VK-5');
+
+    rerender(
+      <BlueprintPreview
+        template={{
+          ...template,
+          blueprint: [
+            {
+              refId: 'task-a',
+              title: 'Build foundation',
+              taskDefaults: { type: 'feature' },
+              subtaskTemplates: [{ title: 'Review', order: 1 }],
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByText('Blueprint: Multiple Tasks')).toBeDefined();
+    expect(
+      screen.getByText((_, node) => node?.textContent === '1. Build foundation')
+    ).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="label"]')).toBeNull();
+  });
+});

--- a/web/src/components/task/AgentPanel.tsx
+++ b/web/src/components/task/AgentPanel.tsx
@@ -1,26 +1,16 @@
 import { useState, useRef, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
 import {
+  Badge,
+  Button,
+  Code,
+  Group,
+  Modal,
+  Paper,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import { useConfig } from '@/hooks/useConfig';
 import {
   useAgentStatus,
@@ -80,6 +70,7 @@ export function AgentPanel({ task }: AgentPanelProps) {
   const [message, setMessage] = useState('');
   const [autoScroll, setAutoScroll] = useState(true);
   const [viewingAttemptId, setViewingAttemptId] = useState<string | null>(null);
+  const [stopDialogOpen, setStopDialogOpen] = useState(false);
 
   const models = ['sonnet', 'opus', 'haiku'];
 
@@ -94,6 +85,11 @@ export function AgentPanel({ task }: AgentPanelProps) {
   // Get enabled agents
   const enabledAgents = config?.agents.filter((a) => a.enabled) || [];
   const defaultAgent = config?.defaultAgent;
+  const agentOptions = enabledAgents.map((agent) => ({
+    value: agent.type,
+    label: `${agent.name}${agent.type === defaultAgent ? ' (default)' : ''}`,
+  }));
+  const modelOptions = models.map((model) => ({ value: model, label: model }));
 
   // Auto-scroll to bottom
   useEffect(() => {
@@ -132,6 +128,7 @@ export function AgentPanel({ task }: AgentPanelProps) {
 
   const handleStop = () => {
     stopAgent.mutate(task.id);
+    setStopDialogOpen(false);
   };
 
   const handleSendMessage = (e: React.FormEvent) => {
@@ -151,57 +148,68 @@ export function AgentPanel({ task }: AgentPanelProps) {
 
   if (!task.git?.worktreePath) {
     return (
-      <div className="space-y-2">
-        <Label className="text-muted-foreground flex items-center gap-2">
-          <Bot className="h-4 w-4" />
-          AI Agent
-        </Label>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground p-3 rounded-md border border-dashed">
-          <AlertCircle className="h-4 w-4" />
-          Create a worktree first to use an AI agent.
-        </div>
-      </div>
+      <Stack gap="xs">
+        <Group gap="xs">
+          <Bot className="h-4 w-4 text-muted-foreground" />
+          <Text size="sm" c="dimmed">
+            AI Agent
+          </Text>
+        </Group>
+        <Paper className="p-3" radius="md" withBorder>
+          <Group gap="xs" wrap="nowrap">
+            <AlertCircle className="h-4 w-4 text-muted-foreground" />
+            <Text size="sm" c="dimmed">
+              Create a worktree first to use an AI agent.
+            </Text>
+          </Group>
+        </Paper>
+      </Stack>
     );
   }
 
   return (
     <FeatureErrorBoundary fallbackTitle="Agent panel failed to load">
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <Label className="text-muted-foreground flex items-center gap-2">
-            <Bot className="h-4 w-4" />
-            AI Agent
-          </Label>
-          <div className="flex items-center gap-2">
+      <Stack gap="sm">
+        <Group justify="space-between">
+          <Group gap="xs">
+            <Bot className="h-4 w-4 text-muted-foreground" />
+            <Text size="sm" c="dimmed">
+              AI Agent
+            </Text>
+          </Group>
+          <Group gap="xs">
             {isConnected ? (
               <Wifi className="h-3 w-3 text-green-500" />
             ) : (
               <WifiOff className="h-3 w-3 text-muted-foreground" />
             )}
             {isAgentRunning && (
-              <span className="flex items-center gap-1 text-xs text-green-500">
+              <Text component="span" size="xs" c="green" className="flex items-center gap-1">
                 <span className="h-2 w-2 rounded-full bg-green-500 animate-pulse" />
                 Running
-              </span>
+              </Text>
             )}
-          </div>
-        </div>
+          </Group>
+        </Group>
 
-        <div className="rounded-md border bg-muted/30 overflow-hidden">
+        <Paper className="overflow-hidden bg-muted/30" radius="md" withBorder>
           {/* Controls */}
-          <div className="flex items-center gap-2 p-2 border-b bg-card">
+          <Group gap="xs" className="border-b bg-card p-2">
             {!isAgentRunning ? (
               <>
                 {routingResult && !selectedAgent && (
-                  <span
-                    className="text-xs text-muted-foreground truncate max-w-[200px]"
+                  <Text
+                    size="xs"
+                    c="dimmed"
+                    truncate
+                    className="max-w-[200px]"
                     title={routingResult.reason}
                   >
                     Rec:{' '}
                     {enabledAgents.find((a) => a.type === routingResult.agent)?.name ||
                       routingResult.agent}
                     {routingResult.model ? ` (${routingResult.model})` : ''}
-                  </span>
+                  </Text>
                 )}
                 <Select
                   value={
@@ -210,81 +218,50 @@ export function AgentPanel({ task }: AgentPanelProps) {
                     routingResult?.agent ||
                     defaultAgent
                   }
-                  onValueChange={(v) => setSelectedAgent(v as AgentType)}
-                >
-                  <SelectTrigger className="w-[180px] h-8">
-                    <SelectValue placeholder="Select agent..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {enabledAgents.map((agent) => (
-                      <SelectItem key={agent.type} value={agent.type}>
-                        <div className="flex items-center gap-2">
-                          <Bot className="h-3 w-3" />
-                          {agent.name}
-                          {agent.type === defaultAgent && (
-                            <span className="text-xs text-muted-foreground">(default)</span>
-                          )}
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(value) => setSelectedAgent(value as AgentType)}
+                  data={agentOptions}
+                  placeholder="Select agent..."
+                  aria-label="Agent"
+                  className="w-[180px]"
+                  size="xs"
+                  checkIconPosition="right"
+                />
                 <Select
                   value={selectedModel || routingResult?.model || 'sonnet'}
-                  onValueChange={setSelectedModel}
-                >
-                  <SelectTrigger className="w-[100px] h-8">
-                    <SelectValue placeholder="Model..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {models.map((model) => (
-                      <SelectItem key={model} value={model}>
-                        {model}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(value) => setSelectedModel(value ?? undefined)}
+                  data={modelOptions}
+                  placeholder="Model..."
+                  aria-label="Model"
+                  className="w-[100px]"
+                  size="xs"
+                  checkIconPosition="right"
+                />
                 <Button
                   size="sm"
                   onClick={handleStart}
                   disabled={!canStart || startAgent.isPending}
+                  leftSection={
+                    startAgent.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Play className="h-4 w-4" />
+                    )
+                  }
                 >
-                  {startAgent.isPending ? (
-                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                  ) : (
-                    <Play className="h-4 w-4 mr-1" />
-                  )}
                   Start
                 </Button>
               </>
             ) : (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button size="sm" variant="destructive">
-                    <Square className="h-4 w-4 mr-1" />
-                    Stop
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Stop the agent?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will terminate the running agent. The attempt will be marked as failed.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={handleStop}
-                      className="bg-destructive text-destructive-foreground"
-                    >
-                      Stop Agent
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+              <Button
+                size="sm"
+                color="red"
+                leftSection={<Square className="h-4 w-4" />}
+                onClick={() => setStopDialogOpen(true)}
+              >
+                Stop
+              </Button>
             )}
-          </div>
+          </Group>
 
           {/* Output */}
           <div
@@ -319,9 +296,9 @@ export function AgentPanel({ task }: AgentPanelProps) {
           {/* Input */}
           {isAgentRunning && (
             <form onSubmit={handleSendMessage} className="flex gap-2 p-2 border-t bg-card">
-              <Input
+              <TextInput
                 value={message}
-                onChange={(e) => setMessage(e.target.value)}
+                onChange={(e) => setMessage(e.currentTarget.value)}
                 placeholder="Send a message to the agent..."
                 className="flex-1 h-8 text-sm"
               />
@@ -330,25 +307,32 @@ export function AgentPanel({ task }: AgentPanelProps) {
               </Button>
             </form>
           )}
-        </div>
+        </Paper>
 
         {/* New Attempt button for completed/failed tasks */}
         {task.attempt &&
           ['complete', 'failed'].includes(task.attempt.status) &&
           !isAgentRunning && (
-            <Button variant="outline" size="sm" className="w-full" onClick={handleStart}>
-              <RotateCcw className="h-4 w-4 mr-2" />
+            <Button
+              variant="outline"
+              size="sm"
+              fullWidth
+              leftSection={<RotateCcw className="h-4 w-4" />}
+              onClick={handleStart}
+            >
               New Attempt
             </Button>
           )}
 
         {/* Attempt History */}
         {attempts && attempts.length > 0 && (
-          <div className="space-y-2">
-            <Label className="text-muted-foreground flex items-center gap-2">
+          <Stack gap="xs">
+            <Group gap="xs">
               <History className="h-4 w-4" />
-              Attempt History ({attempts.length})
-            </Label>
+              <Text size="sm" c="dimmed">
+                Attempt History ({attempts.length})
+              </Text>
+            </Group>
             <div className="space-y-1 max-h-32 overflow-y-auto">
               {attempts.map((attemptId) => {
                 const isCurrentAttempt = task.attempt?.id === attemptId;
@@ -376,12 +360,12 @@ export function AgentPanel({ task }: AgentPanelProps) {
                       attemptStatusIcons.complete}
                     <span className="font-mono flex-1 truncate">{attemptId}</span>
                     {isCurrentAttempt && (
-                      <Badge variant="secondary" className="text-xs">
+                      <Badge variant="light" size="xs">
                         Current
                       </Badge>
                     )}
                     {isViewing && !isCurrentAttempt && (
-                      <Badge variant="outline" className="text-xs">
+                      <Badge variant="outline" size="xs">
                         Viewing
                       </Badge>
                     )}
@@ -389,18 +373,20 @@ export function AgentPanel({ task }: AgentPanelProps) {
                 );
               })}
             </div>
-          </div>
+          </Stack>
         )}
 
         {/* Historical attempt log viewer */}
         {viewingAttemptId && viewingAttemptId !== task.attempt?.id && (
-          <div className="rounded-md border bg-muted/30 overflow-hidden">
-            <div className="flex items-center justify-between p-2 border-b bg-card">
-              <span className="text-xs text-muted-foreground">Viewing: {viewingAttemptId}</span>
-              <Button variant="ghost" size="sm" onClick={() => setViewingAttemptId(null)}>
+          <Paper className="overflow-hidden bg-muted/30" radius="md" withBorder>
+            <Group justify="space-between" className="border-b bg-card p-2">
+              <Text size="xs" c="dimmed">
+                Viewing: <Code>{viewingAttemptId}</Code>
+              </Text>
+              <Button variant="subtle" size="xs" onClick={() => setViewingAttemptId(null)}>
                 Close
               </Button>
-            </div>
+            </Group>
             <div className="h-[200px] overflow-y-auto p-3 font-mono text-xs bg-zinc-950 text-zinc-200">
               {isLoadingLog ? (
                 <div className="flex items-center justify-center h-full">
@@ -413,26 +399,57 @@ export function AgentPanel({ task }: AgentPanelProps) {
                 <div className="text-muted-foreground">No log available</div>
               )}
             </div>
-          </div>
+          </Paper>
         )}
 
         {/* Current attempt info */}
         {task.attempt && !viewingAttemptId && (
-          <div className="text-xs text-muted-foreground space-y-1 p-2 rounded-md bg-muted/30">
-            <div className="flex items-center gap-2">
-              {attemptStatusIcons[task.attempt.status]}
-              <span className="font-medium">Current: {task.attempt.id}</span>
-            </div>
-            <div>Agent: {task.attempt.agent}</div>
-            {task.attempt.started && (
-              <div>Started: {new Date(task.attempt.started).toLocaleString()}</div>
-            )}
-            {task.attempt.ended && (
-              <div>Ended: {new Date(task.attempt.ended).toLocaleString()}</div>
-            )}
-          </div>
+          <Paper className="bg-muted/30 p-2" radius="md">
+            <Stack gap={4}>
+              <Group gap="xs">
+                {attemptStatusIcons[task.attempt.status]}
+                <Text size="xs" c="dimmed" fw={500}>
+                  Current: {task.attempt.id}
+                </Text>
+              </Group>
+              <Text size="xs" c="dimmed">
+                Agent: {task.attempt.agent}
+              </Text>
+              {task.attempt.started && (
+                <Text size="xs" c="dimmed">
+                  Started: {new Date(task.attempt.started).toLocaleString()}
+                </Text>
+              )}
+              {task.attempt.ended && (
+                <Text size="xs" c="dimmed">
+                  Ended: {new Date(task.attempt.ended).toLocaleString()}
+                </Text>
+              )}
+            </Stack>
+          </Paper>
         )}
-      </div>
+
+        <Modal
+          opened={stopDialogOpen}
+          onClose={() => setStopDialogOpen(false)}
+          title="Stop the agent?"
+          centered
+        >
+          <Stack gap="md">
+            <Text size="sm" c="dimmed">
+              This will terminate the running agent. The attempt will be marked as failed.
+            </Text>
+            <Group justify="flex-end" gap="xs">
+              <Button variant="default" onClick={() => setStopDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button color="red" onClick={handleStop}>
+                Stop Agent
+              </Button>
+            </Group>
+          </Stack>
+        </Modal>
+      </Stack>
     </FeatureErrorBoundary>
   );
 }

--- a/web/src/components/task/ApplyTemplateDialog.tsx
+++ b/web/src/components/task/ApplyTemplateDialog.tsx
@@ -1,23 +1,19 @@
 import { useState, useMemo } from 'react';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
+  Alert,
+  Button,
+  Code,
+  Group,
+  Modal,
+  Paper,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Switch } from '@/components/ui/switch';
+  Stack,
+  Switch,
+  Tabs,
+  Text,
+  TextInput,
+  ThemeIcon,
+} from '@mantine/core';
 import { useTemplates } from '@/hooks/useTemplates';
 import { useUpdateTask } from '@/hooks/useTasks';
 import type { Task, Subtask } from '@veritas-kanban/shared';
@@ -82,6 +78,21 @@ export function ApplyTemplateDialog({
     if (categoryFilter === 'all') return templates;
     return templates.filter((t) => (t.category || 'custom') === categoryFilter);
   }, [templates, categoryFilter]);
+
+  const templateOptions = useMemo(
+    () => [
+      { value: 'none', label: 'No template selected' },
+      ...filteredTemplates
+        .filter((t) => !t.blueprint)
+        .map((template) => ({
+          value: template.id,
+          label: `${template.category ? `${getCategoryIcon(template.category)} ` : ''}${
+            template.name
+          }${template.description ? ` - ${template.description}` : ''}`,
+        })),
+    ],
+    [filteredTemplates]
+  );
 
   // Get the selected template
   const template = useMemo(() => {
@@ -285,230 +296,213 @@ export function ApplyTemplateDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px]">
-        <DialogHeader>
-          <div className="flex items-center justify-between">
-            <DialogTitle className="flex items-center gap-2">
-              <FileCode className="h-5 w-5" />
-              Apply Template to Task
-            </DialogTitle>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowHelp(!showHelp)}
-              className="h-8 gap-1 text-muted-foreground"
-            >
-              <HelpCircle className="h-4 w-4" />
-              {showHelp ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-            </Button>
-          </div>
-          {showHelp && (
-            <div className="mt-2 p-3 rounded-md bg-muted/50 border border-muted-foreground/20 text-sm space-y-3">
-              <div className="flex items-start gap-2">
-                <AlertCircle className="h-4 w-4 text-blue-500 mt-0.5 flex-shrink-0" />
-                <div className="space-y-2">
-                  <p className="font-medium text-sm">Apply Template Guide</p>
+    <Modal
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      title={
+        <Group gap="xs">
+          <FileCode className="h-5 w-5" />
+          <Text fw={600}>Apply Template to Task</Text>
+        </Group>
+      }
+      size="lg"
+    >
+      <Stack gap="md">
+        <Group justify="flex-end">
+          <Button
+            variant="subtle"
+            size="xs"
+            color="gray"
+            onClick={() => setShowHelp(!showHelp)}
+            leftSection={<HelpCircle className="h-4 w-4" />}
+            rightSection={
+              showHelp ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />
+            }
+          >
+            Help
+          </Button>
+        </Group>
 
-                  <div className="text-xs text-muted-foreground space-y-1.5">
-                    <div>
-                      <strong className="text-foreground">Safe by Default:</strong>
-                      <p className="mt-0.5">
-                        Templates only fill in empty fields — your existing task data is never
-                        overwritten unless you choose to.
-                      </p>
-                    </div>
+        {showHelp && (
+          <Alert
+            color="blue"
+            variant="light"
+            icon={<AlertCircle className="h-4 w-4" />}
+            title="Apply Template Guide"
+          >
+            <Stack gap="xs">
+              <Text size="xs" c="dimmed">
+                <strong>Safe by Default:</strong> Templates only fill in empty fields. Existing task
+                data is not overwritten unless you choose to.
+              </Text>
+              <Text size="xs" c="dimmed">
+                <strong>Force Overwrite:</strong> Toggle this on to replace existing values with
+                template values. The preview shows exactly what will be modified.
+              </Text>
+              <Text size="xs" c="dimmed">
+                <strong>Subtasks:</strong> Template subtasks are added to your existing subtasks.
+              </Text>
+              <Text size="xs" c="dimmed">
+                <strong>Variables:</strong> Templates with <Code>{'{{date}}'}</Code> or{' '}
+                <Code>{'{{custom:name}}'}</Code> prompt for values before applying.
+              </Text>
+              <Text size="xs" c="dimmed">
+                <strong>Changes Preview:</strong> A before/after diff appears below showing exactly
+                what will change.
+              </Text>
+            </Stack>
+          </Alert>
+        )}
 
-                    <div>
-                      <strong className="text-foreground">Force Overwrite:</strong>
-                      <p className="mt-0.5">
-                        Toggle this on to replace existing values with template values. The changes
-                        preview shows exactly what will be modified before you apply.
-                      </p>
-                    </div>
-
-                    <div>
-                      <strong className="text-foreground">Subtasks:</strong>
-                      <p className="mt-0.5">
-                        Template subtasks are <em>added</em> to your existing subtasks, never
-                        replaced. You'll see a count of how many will be appended.
-                      </p>
-                    </div>
-
-                    <div>
-                      <strong className="text-foreground">Variables:</strong>
-                      <p className="mt-0.5">
-                        Templates with{' '}
-                        <code className="px-1 py-0.5 rounded bg-muted">{'{{date}}'}</code> or{' '}
-                        <code className="px-1 py-0.5 rounded bg-muted">{'{{custom:name}}'}</code>{' '}
-                        will prompt you for values before applying.
-                      </p>
-                    </div>
-
-                    <div>
-                      <strong className="text-foreground">Changes Preview:</strong>
-                      <p className="mt-0.5">
-                        A before/after diff appears below showing exactly what will change. Green
-                        lines are additions, red lines are removals.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-        </DialogHeader>
-
-        <div className="grid gap-4 py-4">
-          {/* Template selector */}
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
-              <Label className="text-sm">Select Template</Label>
-            </div>
-            <Tabs value={categoryFilter} onValueChange={setCategoryFilter}>
-              <TabsList className="grid w-full grid-cols-4">
-                <TabsTrigger value="all" className="text-xs">
-                  All
-                </TabsTrigger>
-                <TabsTrigger value="bug" className="text-xs">
-                  🐛
-                </TabsTrigger>
-                <TabsTrigger value="feature" className="text-xs">
-                  ✨
-                </TabsTrigger>
-                <TabsTrigger value="sprint" className="text-xs">
-                  🔄
-                </TabsTrigger>
-              </TabsList>
+        <Stack gap="md">
+          <Stack gap="sm">
+            <Text size="sm" fw={500}>
+              Select Template
+            </Text>
+            <Tabs value={categoryFilter} onChange={(value) => setCategoryFilter(value ?? 'all')}>
+              <Tabs.List grow>
+                <Tabs.Tab value="all">All</Tabs.Tab>
+                <Tabs.Tab value="bug" aria-label="Bug templates">
+                  Bug
+                </Tabs.Tab>
+                <Tabs.Tab value="feature" aria-label="Feature templates">
+                  Feature
+                </Tabs.Tab>
+                <Tabs.Tab value="sprint" aria-label="Sprint templates">
+                  Sprint
+                </Tabs.Tab>
+              </Tabs.List>
             </Tabs>
             <Select
               value={selectedTemplate || 'none'}
-              onValueChange={(value) => {
-                if (value === 'none') {
+              onChange={(value) => {
+                if (!value || value === 'none') {
                   setSelectedTemplate(null);
                 } else {
                   handleTemplateSelect(value);
                 }
               }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Choose a template..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">No template selected</SelectItem>
-                {filteredTemplates
-                  .filter((t) => !t.blueprint) // Exclude blueprint templates
-                  .map((template) => (
-                    <SelectItem key={template.id} value={template.id}>
-                      {template.category && `${getCategoryIcon(template.category)} `}
-                      {template.name}
-                      {template.description && (
-                        <span className="text-muted-foreground ml-2">— {template.description}</span>
-                      )}
-                    </SelectItem>
-                  ))}
-              </SelectContent>
-            </Select>
-          </div>
+              data={templateOptions}
+              label="Template"
+              placeholder="Choose a template..."
+              checkIconPosition="right"
+            />
+          </Stack>
 
-          {/* Custom variable inputs */}
           {requiredCustomVars.length > 0 && (
-            <div className="grid gap-3 border rounded-md p-3 bg-muted/30">
-              <div className="flex items-center gap-2">
-                <AlertCircle className="h-4 w-4 text-blue-500" />
-                <Label className="text-sm font-medium">Template Variables</Label>
-              </div>
-              {requiredCustomVars.map((varName) => (
-                <div key={varName} className="grid gap-1.5">
-                  <Label htmlFor={`var-${varName}`} className="text-xs">
-                    {varName}
-                  </Label>
-                  <Input
+            <Paper className="bg-muted/30 p-3" radius="md" withBorder>
+              <Stack gap="sm">
+                <Group gap="xs">
+                  <ThemeIcon size="sm" color="blue" variant="light">
+                    <AlertCircle className="h-4 w-4" />
+                  </ThemeIcon>
+                  <Text size="sm" fw={500}>
+                    Template Variables
+                  </Text>
+                </Group>
+                {requiredCustomVars.map((varName) => (
+                  <TextInput
+                    key={varName}
                     id={`var-${varName}`}
+                    label={varName}
                     value={customVars[varName] || ''}
                     onChange={(e) =>
-                      setCustomVars((prev) => ({ ...prev, [varName]: e.target.value }))
+                      setCustomVars((prev) => ({ ...prev, [varName]: e.currentTarget.value }))
                     }
                     placeholder={`Enter ${varName}...`}
-                    className="h-8"
+                    size="xs"
                   />
-                </div>
-              ))}
-            </div>
+                ))}
+              </Stack>
+            </Paper>
           )}
 
-          {/* Force overwrite toggle */}
           {template && (
-            <div className="flex items-center justify-between border rounded-md p-3 bg-muted/30">
-              <div className="space-y-0.5">
-                <Label className="text-sm font-medium">Force Overwrite</Label>
-                <p className="text-xs text-muted-foreground">
-                  Replace existing values with template values
-                </p>
-              </div>
-              <Switch checked={forceOverwrite} onCheckedChange={setForceOverwrite} />
-            </div>
+            <Paper className="bg-muted/30 p-3" radius="md" withBorder>
+              <Group justify="space-between" gap="sm" wrap="nowrap">
+                <Stack gap={2}>
+                  <Text size="sm" fw={500}>
+                    Force Overwrite
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    Replace existing values with template values
+                  </Text>
+                </Stack>
+                <Switch
+                  checked={forceOverwrite}
+                  onChange={(event) => setForceOverwrite(event.currentTarget.checked)}
+                  aria-label="Force overwrite"
+                />
+              </Group>
+            </Paper>
           )}
 
-          {/* Merge preview */}
           {mergePreview && mergePreview.fields.length > 0 && (
-            <div className="border rounded-md p-3 bg-muted/30 space-y-3">
-              <div className="flex items-center gap-2">
-                <AlertCircle className="h-4 w-4 text-blue-500" />
-                <Label className="text-sm font-medium">Changes Preview</Label>
-              </div>
+            <Paper className="bg-muted/30 p-3" radius="md" withBorder>
+              <Stack gap="sm">
+                <Group gap="xs">
+                  <ThemeIcon size="sm" color="blue" variant="light">
+                    <AlertCircle className="h-4 w-4" />
+                  </ThemeIcon>
+                  <Text size="sm" fw={500}>
+                    Changes Preview
+                  </Text>
+                </Group>
 
-              {mergePreview.fields.map((field) => (
-                <div key={field.field} className="text-sm border-l-2 border-primary/50 pl-3 py-1">
-                  <div className="font-medium text-xs text-muted-foreground uppercase">
-                    {field.label}
+                {mergePreview.fields.map((field) => (
+                  <div key={field.field} className="border-l-2 border-primary/50 py-1 pl-3">
+                    <Text size="xs" c="dimmed" fw={600} tt="uppercase">
+                      {field.label}
+                    </Text>
+                    <Group align="flex-start" gap="xs" mt={4} wrap="nowrap">
+                      <Minus className="mt-0.5 h-3 w-3 flex-shrink-0 text-red-500" />
+                      <Text size="sm" c="red" td="line-through" className="flex-1">
+                        {field.before || '(empty)'}
+                      </Text>
+                    </Group>
+                    <Group align="flex-start" gap="xs" wrap="nowrap">
+                      <Plus className="mt-0.5 h-3 w-3 flex-shrink-0 text-green-500" />
+                      <Text size="sm" c="green" className="flex-1">
+                        {field.after}
+                      </Text>
+                    </Group>
                   </div>
-                  <div className="flex items-start gap-2 mt-1">
-                    <Minus className="h-3 w-3 text-red-500 mt-0.5 flex-shrink-0" />
-                    <span className="text-red-500/80 line-through flex-1">
-                      {field.before || '(empty)'}
-                    </span>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <Plus className="h-3 w-3 text-green-500 mt-0.5 flex-shrink-0" />
-                    <span className="text-green-500/80 flex-1">{field.after}</span>
-                  </div>
-                </div>
-              ))}
+                ))}
 
-              {mergePreview.subtasksAdded > 0 && (
-                <div className="text-sm border-l-2 border-primary/50 pl-3 py-1">
-                  <div className="font-medium text-xs text-muted-foreground uppercase">
-                    Subtasks
+                {mergePreview.subtasksAdded > 0 && (
+                  <div className="border-l-2 border-primary/50 py-1 pl-3">
+                    <Text size="xs" c="dimmed" fw={600} tt="uppercase">
+                      Subtasks
+                    </Text>
+                    <Group gap="xs" mt={4}>
+                      <Plus className="h-3 w-3 text-blue-500" />
+                      <Text size="sm">
+                        Will add {mergePreview.subtasksAdded} subtasks to existing{' '}
+                        {mergePreview.existingSubtasks}
+                      </Text>
+                    </Group>
                   </div>
-                  <div className="flex items-center gap-2 mt-1">
-                    <Plus className="h-3 w-3 text-blue-500" />
-                    <span className="text-sm">
-                      Will add {mergePreview.subtasksAdded} subtasks to existing{' '}
-                      {mergePreview.existingSubtasks}
-                    </span>
-                  </div>
-                </div>
-              )}
-            </div>
+                )}
+              </Stack>
+            </Paper>
           )}
 
           {!template && (
-            <div className="text-center text-sm text-muted-foreground py-8">
+            <Text ta="center" size="sm" c="dimmed" className="py-8">
               Select a template to see what will change
-            </div>
+            </Text>
           )}
-        </div>
+        </Stack>
 
-        <DialogFooter>
+        <Group justify="flex-end" gap="xs">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button type="button" onClick={handleApply} disabled={!template || updateTask.isPending}>
             {updateTask.isPending ? 'Applying...' : 'Apply Template'}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </Group>
+      </Stack>
+    </Modal>
   );
 }

--- a/web/src/components/task/CreateTaskDialog.tsx
+++ b/web/src/components/task/CreateTaskDialog.tsx
@@ -1,16 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import {
   ActionIcon,
   Alert,
+  Badge,
+  Button,
   Code,
   Group,
+  Modal,
   Paper,
   ScrollArea,
   Select,
@@ -22,7 +18,6 @@ import {
   TextInput,
   ThemeIcon,
 } from '@mantine/core';
-import { Button } from '@/components/ui/button';
 import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
@@ -48,7 +43,6 @@ import {
 import { getCategoryIcon } from '@/lib/template-categories';
 import { api, type SearchResult } from '@/lib/api';
 import { extractTaskId } from '@/lib/search-utils';
-import { Badge } from '@/components/ui/badge';
 import { useView } from '@/contexts/ViewContext';
 
 interface CreateTaskDialogProps {
@@ -265,368 +259,361 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
-        <form onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>Create New Task</DialogTitle>
-          </DialogHeader>
-
-          {/* Template selector */}
-          {templates && templates.length > 0 && (
-            <Stack gap="sm" className="border-b pb-2">
-              <Group justify="space-between" gap="sm">
-                <Group gap="xs">
-                  <ThemeIcon size="sm" variant="light" color="violet">
-                    <FileText className="h-3.5 w-3.5" />
-                  </ThemeIcon>
-                  <Text size="sm" fw={500}>
-                    Template
-                  </Text>
-                </Group>
-                <ActionIcon
-                  type="button"
-                  variant="subtle"
-                  size="sm"
-                  onClick={toggleHelp}
-                  aria-label={showHelp ? 'Hide template help' : 'Show template help'}
-                >
-                  <HelpCircle className="h-4 w-4 text-muted-foreground" />
-                </ActionIcon>
+    <Modal opened={open} onClose={() => onOpenChange(false)} title="Create New Task" size="md">
+      <form onSubmit={handleSubmit}>
+        {/* Template selector */}
+        {templates && templates.length > 0 && (
+          <Stack gap="sm" className="border-b pb-2">
+            <Group justify="space-between" gap="sm">
+              <Group gap="xs">
+                <ThemeIcon size="sm" variant="light" color="violet">
+                  <FileText className="h-3.5 w-3.5" />
+                </ThemeIcon>
+                <Text size="sm" fw={500}>
+                  Template
+                </Text>
               </Group>
+              <ActionIcon
+                type="button"
+                variant="subtle"
+                size="sm"
+                onClick={toggleHelp}
+                aria-label={showHelp ? 'Hide template help' : 'Show template help'}
+              >
+                <HelpCircle className="h-4 w-4 text-muted-foreground" />
+              </ActionIcon>
+            </Group>
 
-              {/* Help Section */}
-              {showHelp && (
-                <Alert
-                  variant="light"
-                  color="blue"
-                  icon={<Info className="h-4 w-4" />}
-                  title="Using Templates"
-                >
-                  <Stack gap={4}>
-                    <Text component="div" size="xs" c="dimmed">
-                      <ul className="space-y-1">
-                        <li>
-                          <strong>Simple templates</strong> pre-fill task fields and can include
-                          subtasks
-                        </li>
-                        <li>
-                          <strong>Variables</strong> like <Code>{'{{date}}'}</Code> or{' '}
-                          <Code>{'{{author}}'}</Code> are replaced when creating the task
-                        </li>
-                        <li>
-                          <strong>Custom variables</strong> such as <Code>{'{{bugId}}'}</Code>{' '}
-                          prompt you for values
-                        </li>
-                        <li>
-                          <strong>Blueprint templates</strong> create multiple linked tasks with
-                          dependencies
-                        </li>
-                      </ul>
-                    </Text>
-                  </Stack>
-                </Alert>
-              )}
-
-              <Tabs value={categoryFilter} onChange={(value) => setCategoryFilter(value ?? 'all')}>
-                <Tabs.List grow>
-                  <Tabs.Tab value="all">All</Tabs.Tab>
-                  <Tabs.Tab value="bug" aria-label="Bug templates">
-                    <Bug className="h-4 w-4" />
-                  </Tabs.Tab>
-                  <Tabs.Tab value="feature" aria-label="Feature templates">
-                    <Sparkles className="h-4 w-4" />
-                  </Tabs.Tab>
-                  <Tabs.Tab value="sprint" aria-label="Sprint templates">
-                    <RefreshCw className="h-4 w-4" />
-                  </Tabs.Tab>
-                </Tabs.List>
-              </Tabs>
-
-              <Select
-                value={selectedTemplate || 'none'}
-                onChange={(value) => handleTemplateSelect(value ?? 'none')}
-                data={templateOptions}
-                placeholder="Select template..."
-                checkIconPosition="right"
-              />
-            </Stack>
-          )}
-
-          {/* Blueprint preview or regular form */}
-          <Stack gap="md" py="md">
-            {isBlueprint ? (
-              currentTemplate ? (
-                <>
-                  <BlueprintPreview template={currentTemplate} />
-                  <TemplateVariableInputs
-                    variables={requiredCustomVars}
-                    values={customVars}
-                    onChange={(name, value) =>
-                      setCustomVars((prev) => ({ ...prev, [name]: value }))
-                    }
-                  />
-                </>
-              ) : null
-            ) : (
-              <>
-                <TextInput
-                  id="title"
-                  label="Title"
-                  value={title}
-                  onChange={(event) => setTitle(event.currentTarget.value)}
-                  placeholder="Enter task title..."
-                  autoFocus
-                />
-
-                <Textarea
-                  id="description"
-                  label="Description"
-                  value={description}
-                  onChange={(event) => setDescription(event.currentTarget.value)}
-                  placeholder="Describe the task..."
-                  rows={3}
-                />
-
-                {(isCheckingDuplicates || duplicateResults.length > 0 || duplicateError) && (
-                  <Alert
-                    color="yellow"
-                    variant="light"
-                    icon={<AlertTriangle className="h-4 w-4" aria-hidden="true" />}
-                    title={
-                      <Group justify="space-between" gap="sm">
-                        <Text size="sm" fw={600}>
-                          Possible duplicates
-                        </Text>
-                        {isCheckingDuplicates && (
-                          <Loader2
-                            className="h-4 w-4 animate-spin text-muted-foreground"
-                            aria-label="Checking duplicates"
-                          />
-                        )}
-                      </Group>
-                    }
-                  >
-                    <Stack gap="sm" mt={duplicateResults.length > 0 ? 'xs' : 0}>
-                      {isCheckingDuplicates && (
-                        <Text size="sm" c="dimmed">
-                          Checking existing tasks...
-                        </Text>
-                      )}
-                      {duplicateResults.length > 0 ? (
-                        duplicateResults.map((result) => {
-                          const taskId = extractTaskId(result.path);
-                          return (
-                            <Paper
-                              key={`${result.collection}:${result.id}`}
-                              component="button"
-                              type="button"
-                              withBorder
-                              radius="md"
-                              p="sm"
-                              className="flex w-full items-start gap-2 bg-background text-left transition-colors hover:bg-muted/50"
-                              onClick={() => {
-                                if (!taskId) return;
-                                navigateToTask(taskId);
-                                onOpenChange(false);
-                              }}
-                            >
-                              <span className="min-w-0 flex-1">
-                                <span className="flex flex-wrap items-center gap-2">
-                                  <span className="text-sm font-medium">{result.title}</span>
-                                  <Badge variant="secondary">{result.collection}</Badge>
-                                </span>
-                                <span className="mt-1 block break-all text-xs text-muted-foreground">
-                                  {result.path}
-                                </span>
-                                {result.snippet && (
-                                  <span className="mt-1 block text-xs leading-5 text-muted-foreground">
-                                    {result.snippet}
-                                  </span>
-                                )}
-                              </span>
-                              {taskId && (
-                                <ExternalLink
-                                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                                  aria-hidden="true"
-                                />
-                              )}
-                            </Paper>
-                          );
-                        })
-                      ) : !isCheckingDuplicates ? (
-                        <Text size="sm" c="dimmed">
-                          No likely task duplicates found.
-                        </Text>
-                      ) : null}
-                      {duplicateError && (
-                        <Text size="xs" c="dimmed">
-                          {duplicateError}
-                        </Text>
-                      )}
-                    </Stack>
-                  </Alert>
-                )}
-
-                <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-                  <Select
-                    label="Type"
-                    value={type}
-                    onChange={(value) => setType(value ?? 'code')}
-                    data={taskTypeOptions}
-                    renderOption={({ option }) => {
-                      const taskType = taskTypes.find((item) => item.id === option.value);
-                      const IconComponent = taskType ? getTypeIcon(taskType.icon) : null;
-                      return (
-                        <Group gap="xs">
-                          {IconComponent && <IconComponent className="h-4 w-4" />}
-                          <span>{option.label}</span>
-                        </Group>
-                      );
-                    }}
-                    checkIconPosition="right"
-                  />
-
-                  <Select
-                    label="Priority"
-                    value={priority}
-                    onChange={(value) => setPriority((value ?? 'medium') as TaskPriority)}
-                    data={priorityOptions}
-                    checkIconPosition="right"
-                  />
-                </SimpleGrid>
-
-                <Stack gap="xs">
-                  {!showNewProject ? (
-                    <Select
-                      label="Project (optional)"
-                      value={project || '__none__'}
-                      onChange={(value) => {
-                        if (value === '__new__') {
-                          onShowNewProject();
-                        } else {
-                          setProject(value === '__none__' ? '' : (value ?? ''));
-                        }
-                      }}
-                      data={projectOptions}
-                      placeholder="Select project..."
-                      checkIconPosition="right"
-                    />
-                  ) : (
-                    <Group gap="sm" align="end" wrap="nowrap">
-                      <TextInput
-                        label="New project"
-                        value={newProjectName}
-                        onChange={(event) => setNewProjectName(event.currentTarget.value)}
-                        placeholder="Enter project name..."
-                        autoFocus
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' && newProjectName.trim()) {
-                            e.preventDefault();
-                            setProject(newProjectName.trim());
-                          }
-                          if (e.key === 'Escape') {
-                            hideNewProject();
-                          }
-                        }}
-                        className="flex-1"
-                      />
-                      <Button
-                        type="button"
-                        size="sm"
-                        onClick={() => {
-                          if (newProjectName.trim()) {
-                            setProject(newProjectName.trim());
-                          }
-                        }}
-                      >
-                        Add
-                      </Button>
-                      <Button type="button" size="sm" variant="outline" onClick={hideNewProject}>
-                        Cancel
-                      </Button>
-                    </Group>
-                  )}
+            {/* Help Section */}
+            {showHelp && (
+              <Alert
+                variant="light"
+                color="blue"
+                icon={<Info className="h-4 w-4" />}
+                title="Using Templates"
+              >
+                <Stack gap={4}>
+                  <Text component="div" size="xs" c="dimmed">
+                    <ul className="space-y-1">
+                      <li>
+                        <strong>Simple templates</strong> pre-fill task fields and can include
+                        subtasks
+                      </li>
+                      <li>
+                        <strong>Variables</strong> like <Code>{'{{date}}'}</Code> or{' '}
+                        <Code>{'{{author}}'}</Code> are replaced when creating the task
+                      </li>
+                      <li>
+                        <strong>Custom variables</strong> such as <Code>{'{{bugId}}'}</Code> prompt
+                        you for values
+                      </li>
+                      <li>
+                        <strong>Blueprint templates</strong> create multiple linked tasks with
+                        dependencies
+                      </li>
+                    </ul>
+                  </Text>
                 </Stack>
+              </Alert>
+            )}
 
-                <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-                  <Select
-                    label="Sprint (optional)"
-                    value={sprint || '__none__'}
-                    onChange={(value) => setSprint(value === '__none__' ? '' : (value ?? ''))}
-                    data={sprintOptions}
-                    placeholder="No sprint"
-                    checkIconPosition="right"
-                  />
+            <Tabs value={categoryFilter} onChange={(value) => setCategoryFilter(value ?? 'all')}>
+              <Tabs.List grow>
+                <Tabs.Tab value="all">All</Tabs.Tab>
+                <Tabs.Tab value="bug" aria-label="Bug templates">
+                  <Bug className="h-4 w-4" />
+                </Tabs.Tab>
+                <Tabs.Tab value="feature" aria-label="Feature templates">
+                  <Sparkles className="h-4 w-4" />
+                </Tabs.Tab>
+                <Tabs.Tab value="sprint" aria-label="Sprint templates">
+                  <RefreshCw className="h-4 w-4" />
+                </Tabs.Tab>
+              </Tabs.List>
+            </Tabs>
 
-                  <Select
-                    label="Agent"
-                    value={agent || 'auto'}
-                    onChange={(value) => setAgent(value ?? 'auto')}
-                    data={agentOptions}
-                    checkIconPosition="right"
-                  />
-                </SimpleGrid>
+            <Select
+              value={selectedTemplate || 'none'}
+              onChange={(value) => handleTemplateSelect(value ?? 'none')}
+              data={templateOptions}
+              placeholder="Select template..."
+              checkIconPosition="right"
+            />
+          </Stack>
+        )}
 
+        {/* Blueprint preview or regular form */}
+        <Stack gap="md" py="md">
+          {isBlueprint ? (
+            currentTemplate ? (
+              <>
+                <BlueprintPreview template={currentTemplate} />
                 <TemplateVariableInputs
                   variables={requiredCustomVars}
                   values={customVars}
                   onChange={(name, value) => setCustomVars((prev) => ({ ...prev, [name]: value }))}
                 />
-
-                {subtasks.length > 0 && (
-                  <Stack gap="xs">
-                    <Text size="sm" fw={500}>
-                      Subtasks ({subtasks.length})
-                    </Text>
-                    <Paper withBorder radius="md" p="xs">
-                      <ScrollArea.Autosize mah={160} type="auto">
-                        <Stack gap={4}>
-                          {subtasks.map((subtask) => (
-                            <Group
-                              key={subtask.id}
-                              justify="space-between"
-                              gap="sm"
-                              wrap="nowrap"
-                              className="rounded px-2 py-1 transition-colors hover:bg-muted/50"
-                            >
-                              <Group gap="xs" className="min-w-0 flex-1" wrap="nowrap">
-                                <Check className="h-3 w-3 shrink-0 text-muted-foreground" />
-                                <Text size="sm" truncate>
-                                  {subtask.title}
-                                </Text>
-                              </Group>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                className="h-6 w-6 p-0"
-                                onClick={() => removeSubtask(subtask.id)}
-                                aria-label={`Remove subtask: ${subtask.title}`}
-                              >
-                                <X className="h-3 w-3" />
-                              </Button>
-                            </Group>
-                          ))}
-                        </Stack>
-                      </ScrollArea.Autosize>
-                    </Paper>
-                  </Stack>
-                )}
               </>
-            )}
-          </Stack>
+            ) : null
+          ) : (
+            <>
+              <TextInput
+                id="title"
+                label="Title"
+                value={title}
+                onChange={(event) => setTitle(event.currentTarget.value)}
+                placeholder="Enter task title..."
+                autoFocus
+              />
 
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={!canSubmit(isBlueprint) || isCreating}>
-              {isCreating ? 'Creating...' : isBlueprint ? 'Create Tasks' : 'Create Task'}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+              <Textarea
+                id="description"
+                label="Description"
+                value={description}
+                onChange={(event) => setDescription(event.currentTarget.value)}
+                placeholder="Describe the task..."
+                rows={3}
+              />
+
+              {(isCheckingDuplicates || duplicateResults.length > 0 || duplicateError) && (
+                <Alert
+                  color="yellow"
+                  variant="light"
+                  icon={<AlertTriangle className="h-4 w-4" aria-hidden="true" />}
+                  title={
+                    <Group justify="space-between" gap="sm">
+                      <Text size="sm" fw={600}>
+                        Possible duplicates
+                      </Text>
+                      {isCheckingDuplicates && (
+                        <Loader2
+                          className="h-4 w-4 animate-spin text-muted-foreground"
+                          aria-label="Checking duplicates"
+                        />
+                      )}
+                    </Group>
+                  }
+                >
+                  <Stack gap="sm" mt={duplicateResults.length > 0 ? 'xs' : 0}>
+                    {isCheckingDuplicates && (
+                      <Text size="sm" c="dimmed">
+                        Checking existing tasks...
+                      </Text>
+                    )}
+                    {duplicateResults.length > 0 ? (
+                      duplicateResults.map((result) => {
+                        const taskId = extractTaskId(result.path);
+                        return (
+                          <Paper
+                            key={`${result.collection}:${result.id}`}
+                            component="button"
+                            type="button"
+                            withBorder
+                            radius="md"
+                            p="sm"
+                            className="flex w-full items-start gap-2 bg-background text-left transition-colors hover:bg-muted/50"
+                            onClick={() => {
+                              if (!taskId) return;
+                              navigateToTask(taskId);
+                              onOpenChange(false);
+                            }}
+                          >
+                            <span className="min-w-0 flex-1">
+                              <span className="flex flex-wrap items-center gap-2">
+                                <span className="text-sm font-medium">{result.title}</span>
+                                <Badge variant="light" color="gray">
+                                  {result.collection}
+                                </Badge>
+                              </span>
+                              <span className="mt-1 block break-all text-xs text-muted-foreground">
+                                {result.path}
+                              </span>
+                              {result.snippet && (
+                                <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                                  {result.snippet}
+                                </span>
+                              )}
+                            </span>
+                            {taskId && (
+                              <ExternalLink
+                                className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                                aria-hidden="true"
+                              />
+                            )}
+                          </Paper>
+                        );
+                      })
+                    ) : !isCheckingDuplicates ? (
+                      <Text size="sm" c="dimmed">
+                        No likely task duplicates found.
+                      </Text>
+                    ) : null}
+                    {duplicateError && (
+                      <Text size="xs" c="dimmed">
+                        {duplicateError}
+                      </Text>
+                    )}
+                  </Stack>
+                </Alert>
+              )}
+
+              <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                <Select
+                  label="Type"
+                  value={type}
+                  onChange={(value) => setType(value ?? 'code')}
+                  data={taskTypeOptions}
+                  renderOption={({ option }) => {
+                    const taskType = taskTypes.find((item) => item.id === option.value);
+                    const IconComponent = taskType ? getTypeIcon(taskType.icon) : null;
+                    return (
+                      <Group gap="xs">
+                        {IconComponent && <IconComponent className="h-4 w-4" />}
+                        <span>{option.label}</span>
+                      </Group>
+                    );
+                  }}
+                  checkIconPosition="right"
+                />
+
+                <Select
+                  label="Priority"
+                  value={priority}
+                  onChange={(value) => setPriority((value ?? 'medium') as TaskPriority)}
+                  data={priorityOptions}
+                  checkIconPosition="right"
+                />
+              </SimpleGrid>
+
+              <Stack gap="xs">
+                {!showNewProject ? (
+                  <Select
+                    label="Project (optional)"
+                    value={project || '__none__'}
+                    onChange={(value) => {
+                      if (value === '__new__') {
+                        onShowNewProject();
+                      } else {
+                        setProject(value === '__none__' ? '' : (value ?? ''));
+                      }
+                    }}
+                    data={projectOptions}
+                    placeholder="Select project..."
+                    checkIconPosition="right"
+                  />
+                ) : (
+                  <Group gap="sm" align="end" wrap="nowrap">
+                    <TextInput
+                      label="New project"
+                      value={newProjectName}
+                      onChange={(event) => setNewProjectName(event.currentTarget.value)}
+                      placeholder="Enter project name..."
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && newProjectName.trim()) {
+                          e.preventDefault();
+                          setProject(newProjectName.trim());
+                        }
+                        if (e.key === 'Escape') {
+                          hideNewProject();
+                        }
+                      }}
+                      className="flex-1"
+                    />
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => {
+                        if (newProjectName.trim()) {
+                          setProject(newProjectName.trim());
+                        }
+                      }}
+                    >
+                      Add
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" onClick={hideNewProject}>
+                      Cancel
+                    </Button>
+                  </Group>
+                )}
+              </Stack>
+
+              <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                <Select
+                  label="Sprint (optional)"
+                  value={sprint || '__none__'}
+                  onChange={(value) => setSprint(value === '__none__' ? '' : (value ?? ''))}
+                  data={sprintOptions}
+                  placeholder="No sprint"
+                  checkIconPosition="right"
+                />
+
+                <Select
+                  label="Agent"
+                  value={agent || 'auto'}
+                  onChange={(value) => setAgent(value ?? 'auto')}
+                  data={agentOptions}
+                  checkIconPosition="right"
+                />
+              </SimpleGrid>
+
+              <TemplateVariableInputs
+                variables={requiredCustomVars}
+                values={customVars}
+                onChange={(name, value) => setCustomVars((prev) => ({ ...prev, [name]: value }))}
+              />
+
+              {subtasks.length > 0 && (
+                <Stack gap="xs">
+                  <Text size="sm" fw={500}>
+                    Subtasks ({subtasks.length})
+                  </Text>
+                  <Paper withBorder radius="md" p="xs">
+                    <ScrollArea.Autosize mah={160} type="auto">
+                      <Stack gap={4}>
+                        {subtasks.map((subtask) => (
+                          <Group
+                            key={subtask.id}
+                            justify="space-between"
+                            gap="sm"
+                            wrap="nowrap"
+                            className="rounded px-2 py-1 transition-colors hover:bg-muted/50"
+                          >
+                            <Group gap="xs" className="min-w-0 flex-1" wrap="nowrap">
+                              <Check className="h-3 w-3 shrink-0 text-muted-foreground" />
+                              <Text size="sm" truncate>
+                                {subtask.title}
+                              </Text>
+                            </Group>
+                            <ActionIcon
+                              type="button"
+                              variant="subtle"
+                              size="sm"
+                              onClick={() => removeSubtask(subtask.id)}
+                              aria-label={`Remove subtask: ${subtask.title}`}
+                            >
+                              <X className="h-3 w-3" />
+                            </ActionIcon>
+                          </Group>
+                        ))}
+                      </Stack>
+                    </ScrollArea.Autosize>
+                  </Paper>
+                </Stack>
+              )}
+            </>
+          )}
+        </Stack>
+
+        <Group justify="flex-end" gap="xs">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!canSubmit(isBlueprint) || isCreating}>
+            {isCreating ? 'Creating...' : isBlueprint ? 'Create Tasks' : 'Create Task'}
+          </Button>
+        </Group>
+      </form>
+    </Modal>
   );
 }

--- a/web/src/components/task/TaskMetricsPanel.tsx
+++ b/web/src/components/task/TaskMetricsPanel.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 import { useTaskMetrics, type AttemptMetrics } from '@/hooks/useTaskMetrics';
 import { formatDuration, formatTokens } from '@/hooks/useMetrics';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
+import { Badge, Button, Group, Paper, Skeleton, Text } from '@mantine/core';
 import {
   Play,
   CheckCircle,
@@ -103,18 +101,30 @@ function MetricCard({
   };
 
   return (
-    <div className={`rounded-lg border p-3 ${variantClasses[variant]}`}>
-      <div className="flex items-center gap-2 mb-1">
+    <Paper className={`p-3 ${variantClasses[variant]}`} radius="md" withBorder>
+      <Group gap="xs" mb={4}>
         <Icon className={`h-4 w-4 ${iconClasses[variant]}`} />
-        <span className="text-xs text-muted-foreground">{label}</span>
-      </div>
-      <div className="text-lg font-semibold">{value}</div>
-      {subValue && <div className="text-xs text-muted-foreground">{subValue}</div>}
-    </div>
+        <Text size="xs" c="dimmed">
+          {label}
+        </Text>
+      </Group>
+      <Text size="lg" fw={600}>
+        {value}
+      </Text>
+      {subValue && (
+        <Text size="xs" c="dimmed">
+          {subValue}
+        </Text>
+      )}
+    </Paper>
   );
 }
 
-function AttemptRow({ attempt, isExpanded, onToggle }: {
+function AttemptRow({
+  attempt,
+  isExpanded,
+  onToggle,
+}: {
   attempt: AttemptMetrics;
   isExpanded: boolean;
   onToggle: () => void;
@@ -135,7 +145,7 @@ function AttemptRow({ attempt, isExpanded, onToggle }: {
   };
 
   return (
-    <div className="border rounded-lg overflow-hidden">
+    <Paper className="overflow-hidden" radius="md" withBorder>
       <button
         onClick={onToggle}
         className="w-full flex items-center gap-3 p-3 hover:bg-muted/50 transition-colors text-left"
@@ -145,13 +155,11 @@ function AttemptRow({ attempt, isExpanded, onToggle }: {
         ) : (
           <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
         )}
-        
+
         {attempt.success === true && (
           <CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
         )}
-        {attempt.success === false && (
-          <XCircle className="h-4 w-4 text-red-500 flex-shrink-0" />
-        )}
+        {attempt.success === false && <XCircle className="h-4 w-4 text-red-500 flex-shrink-0" />}
         {attempt.success === undefined && (
           <Play className="h-4 w-4 text-muted-foreground flex-shrink-0" />
         )}
@@ -160,26 +168,18 @@ function AttemptRow({ attempt, isExpanded, onToggle }: {
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium truncate">{attempt.agent}</span>
             {attempt.model && (
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="light" size="xs">
                 {attempt.model}
               </Badge>
             )}
           </div>
-          <div className="text-xs text-muted-foreground">
-            {formatDate(attempt.startTime)}
-          </div>
+          <div className="text-xs text-muted-foreground">{formatDate(attempt.startTime)}</div>
         </div>
 
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
-          {attempt.durationMs !== undefined && (
-            <span>{formatDuration(attempt.durationMs)}</span>
-          )}
-          {attempt.totalTokens > 0 && (
-            <span>{formatTokens(attempt.totalTokens)} tokens</span>
-          )}
-          {attempt.cost > 0 && (
-            <span>{formatCost(attempt.cost)}</span>
-          )}
+          {attempt.durationMs !== undefined && <span>{formatDuration(attempt.durationMs)}</span>}
+          {attempt.totalTokens > 0 && <span>{formatTokens(attempt.totalTokens)} tokens</span>}
+          {attempt.cost > 0 && <span>{formatCost(attempt.cost)}</span>}
         </div>
       </button>
 
@@ -210,7 +210,9 @@ function AttemptRow({ attempt, isExpanded, onToggle }: {
             <div className="text-sm">
               <span className="text-muted-foreground">Duration:</span>{' '}
               <span className="font-mono">{formatDuration(attempt.durationMs)}</span>
-              <span className="text-muted-foreground ml-2">({attempt.durationMs.toLocaleString()}ms)</span>
+              <span className="text-muted-foreground ml-2">
+                ({attempt.durationMs.toLocaleString()}ms)
+              </span>
             </div>
           )}
 
@@ -231,7 +233,7 @@ function AttemptRow({ attempt, isExpanded, onToggle }: {
           )}
         </div>
       )}
-    </div>
+    </Paper>
   );
 }
 
@@ -241,7 +243,7 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
 
   const toggleAttempt = (attemptId: string) => {
-    setExpandedAttempts(prev => {
+    setExpandedAttempts((prev) => {
       const next = new Set(prev);
       if (next.has(attemptId)) {
         next.delete(attemptId);
@@ -260,10 +262,9 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
 
   // Compute subtask metrics
   const subtaskTotal = task.subtasks?.length ?? 0;
-  const subtaskCompleted = task.subtasks?.filter(s => s.completed).length ?? 0;
+  const subtaskCompleted = task.subtasks?.filter((s) => s.completed).length ?? 0;
   const subtaskVariant: 'default' | 'success' | 'warning' =
-    subtaskTotal === 0 ? 'default' :
-    subtaskCompleted === subtaskTotal ? 'success' : 'warning';
+    subtaskTotal === 0 ? 'default' : subtaskCompleted === subtaskTotal ? 'success' : 'warning';
 
   const hasAgentData = metrics && metrics.totalRuns > 0;
 
@@ -279,18 +280,26 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
           <MetricCard
             icon={Clock}
             label="Time Tracked"
-            value={task.timeTracking && task.timeTracking.totalSeconds > 0
-              ? formatTrackedTime(task.timeTracking.totalSeconds)
-              : '—'}
-            subValue={task.timeTracking
-              ? `${task.timeTracking.entries.length} ${task.timeTracking.entries.length === 1 ? 'entry' : 'entries'}${task.timeTracking.isRunning ? ' (running)' : ''}`
-              : 'No time tracked'}
+            value={
+              task.timeTracking && task.timeTracking.totalSeconds > 0
+                ? formatTrackedTime(task.timeTracking.totalSeconds)
+                : '—'
+            }
+            subValue={
+              task.timeTracking
+                ? `${task.timeTracking.entries.length} ${task.timeTracking.entries.length === 1 ? 'entry' : 'entries'}${task.timeTracking.isRunning ? ' (running)' : ''}`
+                : 'No time tracked'
+            }
           />
           <MetricCard
             icon={Calendar}
             label="Task Age"
             value={formatAge(task.created)}
-            subValue={new Date(task.created).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+            subValue={new Date(task.created).toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })}
           />
           {task.status === 'done' ? (
             <MetricCard
@@ -308,25 +317,19 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
               subValue={`Since ${new Date(task.updated).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`}
             />
           )}
-          <MetricCard
-            icon={MessageSquare}
-            label="Comments"
-            value={task.comments?.length ?? 0}
-          />
+          <MetricCard icon={MessageSquare} label="Comments" value={task.comments?.length ?? 0} />
           <MetricCard
             icon={ListChecks}
             label="Subtasks"
             value={subtaskTotal > 0 ? `${subtaskCompleted}/${subtaskTotal}` : '—'}
-            subValue={subtaskTotal > 0
-              ? `${Math.round((subtaskCompleted / subtaskTotal) * 100)}% complete`
-              : 'None'}
+            subValue={
+              subtaskTotal > 0
+                ? `${Math.round((subtaskCompleted / subtaskTotal) * 100)}% complete`
+                : 'None'
+            }
             variant={subtaskVariant}
           />
-          <MetricCard
-            icon={Paperclip}
-            label="Attachments"
-            value={task.attachments?.length ?? 0}
-          />
+          <MetricCard icon={Paperclip} label="Attachments" value={task.attachments?.length ?? 0} />
         </div>
       </div>
 
@@ -360,11 +363,7 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
               <Bot className="h-4 w-4" />
               Agent Run History
             </h3>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setExportDialogOpen(true)}
-            >
+            <Button variant="outline" size="sm" onClick={() => setExportDialogOpen(true)}>
               <Download className="h-4 w-4 mr-2" />
               Export
             </Button>
@@ -390,8 +389,11 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
               label="Success Rate"
               value={`${(metrics.successRate * 100).toFixed(0)}%`}
               variant={
-                metrics.successRate >= 0.8 ? 'success' :
-                metrics.successRate >= 0.5 ? 'warning' : 'error'
+                metrics.successRate >= 0.8
+                  ? 'success'
+                  : metrics.successRate >= 0.5
+                    ? 'warning'
+                    : 'error'
               }
             />
             <MetricCard
@@ -414,7 +416,11 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
               icon={Coins}
               label="Estimated Cost"
               value={formatCost(metrics.totalCost)}
-              subValue={metrics.totalCacheTokens > 0 ? `${formatTokens(metrics.totalCacheTokens)} cached` : undefined}
+              subValue={
+                metrics.totalCacheTokens > 0
+                  ? `${formatTokens(metrics.totalCacheTokens)} cached`
+                  : undefined
+              }
             />
           </div>
 
@@ -427,21 +433,19 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
               </h3>
               <div className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
                 {metrics.lastRun.success === true && (
-                  <Badge variant="default" className="bg-green-500/20 text-green-500 border-green-500/30">
+                  <Badge color="green" variant="light">
                     <CheckCircle className="h-3 w-3 mr-1" />
                     Success
                   </Badge>
                 )}
                 {metrics.lastRun.success === false && (
-                  <Badge variant="destructive">
+                  <Badge color="red" variant="light">
                     <XCircle className="h-3 w-3 mr-1" />
                     Failed
                   </Badge>
                 )}
                 <span className="text-sm">{metrics.lastRun.agent}</span>
-                {metrics.lastRun.model && (
-                  <Badge variant="secondary">{metrics.lastRun.model}</Badge>
-                )}
+                {metrics.lastRun.model && <Badge variant="light">{metrics.lastRun.model}</Badge>}
                 {metrics.lastRun.durationMs && (
                   <span className="text-sm text-muted-foreground">
                     {formatDuration(metrics.lastRun.durationMs)}
@@ -461,22 +465,24 @@ export function TaskMetricsPanel({ task }: TaskMetricsPanelProps) {
                 </h3>
                 {metrics.attempts.length > 1 && (
                   <Button
-                    variant="ghost"
+                    variant="subtle"
                     size="sm"
                     onClick={() => {
                       if (expandedAttempts.size === metrics.attempts.length) {
                         setExpandedAttempts(new Set());
                       } else {
-                        setExpandedAttempts(new Set(metrics.attempts.map(a => a.attemptId)));
+                        setExpandedAttempts(new Set(metrics.attempts.map((a) => a.attemptId)));
                       }
                     }}
                   >
-                    {expandedAttempts.size === metrics.attempts.length ? 'Collapse All' : 'Expand All'}
+                    {expandedAttempts.size === metrics.attempts.length
+                      ? 'Collapse All'
+                      : 'Expand All'}
                   </Button>
                 )}
               </div>
               <div className="space-y-2">
-                {metrics.attempts.map(attempt => (
+                {metrics.attempts.map((attempt) => (
                   <AttemptRow
                     key={attempt.attemptId}
                     attempt={attempt}

--- a/web/src/components/task/create/BlueprintPreview.tsx
+++ b/web/src/components/task/create/BlueprintPreview.tsx
@@ -1,4 +1,4 @@
-import { Label } from '@/components/ui/label';
+import { Group, Paper, Stack, Text, ThemeIcon } from '@mantine/core';
 import { AlertCircle } from 'lucide-react';
 import type { TaskTemplate } from '@/hooks/useTemplates';
 
@@ -12,33 +12,37 @@ export function BlueprintPreview({ template }: BlueprintPreviewProps) {
   }
 
   return (
-    <div className="border rounded-md p-3 bg-muted/30">
-      <div className="flex items-center gap-2 mb-2">
-        <AlertCircle className="h-4 w-4 text-blue-500" />
-        <Label className="text-sm font-medium">Blueprint: Multiple Tasks</Label>
-      </div>
-      <p className="text-xs text-muted-foreground mb-3">
+    <Paper className="bg-muted/30 p-3" radius="md" withBorder>
+      <Group gap="xs" mb="xs">
+        <ThemeIcon size="sm" color="blue" variant="light">
+          <AlertCircle className="h-4 w-4" />
+        </ThemeIcon>
+        <Text size="sm" fw={500}>
+          Blueprint: Multiple Tasks
+        </Text>
+      </Group>
+      <Text size="xs" c="dimmed" mb="sm">
         This template will create {template.blueprint.length} linked tasks.
-      </p>
-      <div className="space-y-2">
+      </Text>
+      <Stack gap="xs">
         {template.blueprint.map((bt, idx) => (
           <div key={bt.refId} className="text-sm border-l-2 border-primary/50 pl-3 py-1">
-            <div className="font-medium">
+            <Text size="sm" fw={500}>
               {idx + 1}. {bt.title}
-            </div>
+            </Text>
             {bt.blockedByRefs && bt.blockedByRefs.length > 0 && (
-              <div className="text-xs text-muted-foreground">
+              <Text size="xs" c="dimmed">
                 Blocked by: {bt.blockedByRefs.join(', ')}
-              </div>
+              </Text>
             )}
             {bt.subtaskTemplates && bt.subtaskTemplates.length > 0 && (
-              <div className="text-xs text-muted-foreground">
+              <Text size="xs" c="dimmed">
                 {bt.subtaskTemplates.length} subtasks
-              </div>
+              </Text>
             )}
           </div>
         ))}
-      </div>
-    </div>
+      </Stack>
+    </Paper>
   );
 }

--- a/web/src/components/task/create/TemplateVariableInputs.tsx
+++ b/web/src/components/task/create/TemplateVariableInputs.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { Group, Paper, Stack, Text, TextInput, ThemeIcon } from '@mantine/core';
 import { AlertCircle } from 'lucide-react';
 
 interface TemplateVariableInputsProps {
@@ -8,31 +7,38 @@ interface TemplateVariableInputsProps {
   onChange: (name: string, value: string) => void;
 }
 
-export function TemplateVariableInputs({ variables, values, onChange }: TemplateVariableInputsProps) {
+export function TemplateVariableInputs({
+  variables,
+  values,
+  onChange,
+}: TemplateVariableInputsProps) {
   if (variables.length === 0) {
     return null;
   }
 
   return (
-    <div className="grid gap-3 border rounded-md p-3 bg-muted/30">
-      <div className="flex items-center gap-2">
-        <AlertCircle className="h-4 w-4 text-blue-500" />
-        <Label className="text-sm font-medium">Template Variables</Label>
-      </div>
-      {variables.map((varName) => (
-        <div key={varName} className="grid gap-1.5">
-          <Label htmlFor={`var-${varName}`} className="text-xs">
-            {varName}
-          </Label>
-          <Input
+    <Paper className="bg-muted/30 p-3" radius="md" withBorder>
+      <Stack gap="sm">
+        <Group gap="xs">
+          <ThemeIcon size="sm" color="blue" variant="light">
+            <AlertCircle className="h-4 w-4" />
+          </ThemeIcon>
+          <Text size="sm" fw={500}>
+            Template Variables
+          </Text>
+        </Group>
+        {variables.map((varName) => (
+          <TextInput
+            key={varName}
             id={`var-${varName}`}
+            label={varName}
             value={values[varName] || ''}
-            onChange={(e) => onChange(varName, e.target.value)}
+            onChange={(e) => onChange(varName, e.currentTarget.value)}
             placeholder={`Enter ${varName}...`}
-            className="h-8"
+            size="xs"
           />
-        </div>
-      ))}
-    </div>
+        ))}
+      </Stack>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- Move task detail agent controls, apply-template flow, task metrics panel, create-task dialog shell, blueprint preview, and template variable helpers to direct Mantine primitives.
- Preserve agent start/stop/message flows, template merge previews, force-overwrite/custom-variable application, metrics expansion/export, duplicate detection, and blueprint/custom-variable rendering.
- Add focused wrapper-regression coverage and update the Mantine migration plan.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx src/__tests__/CreateTaskDuplicateDetection.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- env VERITAS_ADMIN_KEY=local-smoke-admin-key-0000000000000000000000 VERITAS_AUTH_ENABLED=false VERITAS_DISABLE_WATCHERS=1 node_modules/.bin/playwright test e2e/task-detail.spec.ts --project=chromium
- Browser smoke on http://localhost:3000/: setup screen rendered with API, no framework overlay, no connection error, no console warn/error; task-detail rendering covered by Playwright e2e because the local Browser profile is on setup.

## Notes
- Remaining #417 work after this PR is now outside the task-detail leftovers: dashboard, workflow, activity, chat, policy, governance, and any specialized runtime surfaces still enabled.