### PR TITLE
Migrate workflow surfaces to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -374,6 +374,12 @@ Phase 3 progress:
   while preserving agent start/stop/message flows, template merge previews,
   force-overwrite/custom-variable application, metrics expansion/export, and
   blueprint/custom-variable rendering.
+- Workflow browse, dashboard, run list, active/recent run cards, summary cards,
+  health metrics, and run detail/timeline surfaces now use direct Mantine
+  select, text input, badge, button, skeleton, paper, progress, stack, group,
+  simple grid, alert, code, text, title, and theme icon primitives while
+  preserving workflow search, run start, dashboard filters, run selection, live
+  status rendering, health progress, resume action, and step output expansion.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/workflow-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/workflow-surfaces-mantine.test.tsx
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { WorkflowsPage } from '@/components/workflows/WorkflowsPage';
+import { WorkflowDashboard } from '@/components/workflows/WorkflowDashboard';
+import { WorkflowRunView } from '@/components/workflows/WorkflowRunView';
+import { ActiveRunsList } from '@/components/workflows/dashboard/ActiveRunsList';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  hasPermission: vi.fn(),
+  useWorkflowStats: vi.fn(),
+  useActiveRuns: vi.fn(),
+  useRecentRuns: vi.fn(),
+  useWebSocket: vi.fn(),
+}));
+
+vi.mock('@/hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    hasPermission: mocks.hasPermission,
+  }),
+}));
+
+vi.mock('@/hooks/useWorkflowStats', () => ({
+  useWorkflowStats: mocks.useWorkflowStats,
+  useActiveRuns: mocks.useActiveRuns,
+  useRecentRuns: mocks.useRecentRuns,
+}));
+
+vi.mock('@/hooks/useWebSocket', () => ({
+  useWebSocket: mocks.useWebSocket,
+}));
+
+const workflowRun = {
+  id: 'run-1',
+  workflowId: 'wf-release',
+  workflowVersion: 3,
+  status: 'running' as const,
+  currentStep: 'build',
+  startedAt: '2026-06-01T10:00:00Z',
+  steps: [
+    {
+      stepId: 'build',
+      status: 'completed',
+      agent: 'codex',
+      startedAt: '2026-06-01T10:00:00Z',
+      completedAt: '2026-06-01T10:02:00Z',
+      duration: 120,
+      retries: 1,
+      output: 'artifact ready',
+    },
+    {
+      stepId: 'smoke',
+      status: 'running',
+      agent: 'codex',
+      startedAt: '2026-06-01T10:03:00Z',
+      retries: 0,
+    },
+  ],
+};
+
+const workflowStats = {
+  period: '7d',
+  totalWorkflows: 4,
+  activeRuns: 1,
+  completedRuns: 8,
+  failedRuns: 1,
+  avgDuration: 120000,
+  successRate: 0.89,
+  perWorkflow: [
+    {
+      workflowId: 'wf-release',
+      workflowName: 'Release workflow',
+      runs: 9,
+      completed: 8,
+      failed: 1,
+      successRate: 0.89,
+      avgDuration: 120000,
+    },
+  ],
+};
+
+function jsonResponse(data: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => ({ data }),
+  } as Response;
+}
+
+describe('workflow surfaces Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasPermission.mockReturnValue(true);
+    mocks.useWebSocket.mockReturnValue(undefined);
+    mocks.useWorkflowStats.mockReturnValue({ data: workflowStats, isLoading: false, error: null });
+    mocks.useActiveRuns.mockReturnValue({
+      data: [workflowRun],
+      isLoading: false,
+      error: null,
+    });
+    mocks.useRecentRuns.mockReturnValue({
+      data: [{ ...workflowRun, status: 'completed' }],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders workflow browse controls through direct Mantine primitives and preserves start run', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/workflows') && !init?.method) {
+        return jsonResponse([
+          {
+            id: 'wf-release',
+            name: 'Release workflow',
+            version: 3,
+            description: 'Build and smoke the release',
+            agents: [{ id: 'codex', name: 'Codex', role: 'builder' }],
+            steps: [{ id: 'build', name: 'Build' }],
+            activeRunCount: 1,
+          },
+        ]);
+      }
+      if (url.endsWith('/workflows/wf-release/runs') && init?.method === 'POST') {
+        return jsonResponse({ id: 'run-1' });
+      }
+      return jsonResponse(null, false);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { baseElement, container } = renderWithProviders(<WorkflowsPage onBack={vi.fn()} />);
+
+    expect(await screen.findByText('Release workflow')).toBeDefined();
+    expect(screen.getByPlaceholderText('Search workflows...')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Start Run' }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/workflows/wf-release/runs',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(await screen.findByText('Workflow Runs')).toBeDefined();
+  });
+
+  it('renders workflow dashboard lists and filters through direct Mantine primitives', () => {
+    const { baseElement, container } = renderWithProviders(<WorkflowDashboard onBack={vi.fn()} />);
+
+    expect(screen.getByText('Workflow Dashboard')).toBeDefined();
+    expect(screen.getAllByText('Active Runs').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Recent Runs')).toBeDefined();
+    expect(screen.getByText('Workflow Health')).toBeDefined();
+    expect(screen.getByText('Release workflow')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Select-root')).toHaveLength(2);
+    expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(5);
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="skeleton"]')).toBeNull();
+  });
+
+  it('keeps active run card selection wired after the Mantine card migration', async () => {
+    const user = userEvent.setup();
+    const onSelectRun = vi.fn();
+    const { baseElement, container } = renderWithProviders(
+      <ActiveRunsList runs={[workflowRun]} onSelectRun={onSelectRun} />
+    );
+
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /run-1/i }));
+
+    expect(onSelectRun).toHaveBeenCalledWith('run-1');
+  });
+
+  it('renders workflow run detail through direct Mantine primitives and preserves step expansion', async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/workflows/runs/run-1')) {
+        return jsonResponse(workflowRun);
+      }
+      if (url.endsWith('/workflows/wf-release')) {
+        return jsonResponse({
+          id: 'wf-release',
+          name: 'Release workflow',
+          version: 3,
+          steps: [
+            { id: 'build', name: 'Build artifact', agent: 'codex' },
+            { id: 'smoke', name: 'Smoke test', agent: 'codex' },
+          ],
+        });
+      }
+      return jsonResponse(null, false);
+    }) as typeof fetch;
+
+    const { baseElement, container } = renderWithProviders(
+      <WorkflowRunView runId="run-1" onBack={vi.fn()} />
+    );
+
+    expect(await screen.findByText('Release workflow')).toBeDefined();
+    expect(screen.getByText('Overall Progress')).toBeDefined();
+    expect(screen.queryByText('artifact ready')).toBeNull();
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(3);
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="skeleton"]')).toBeNull();
+
+    await user.click(screen.getByText('Build artifact'));
+
+    await waitFor(() => expect(screen.getByText('artifact ready')).toBeDefined());
+  });
+});

--- a/web/src/components/workflows/WorkflowDashboard.tsx
+++ b/web/src/components/workflows/WorkflowDashboard.tsx
@@ -9,18 +9,19 @@
  */
 
 import { useState, useCallback, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import {
+  Badge,
+  Button,
+  Group,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+  Skeleton,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
 import { ArrowLeft, Activity, Clock, Zap, AlertCircle } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
-import { Skeleton } from '@/components/ui/skeleton';
 import { WorkflowRunView } from './WorkflowRunView';
 import { useWebSocket, type WebSocketMessage } from '@/hooks/useWebSocket';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
@@ -130,34 +131,41 @@ export function WorkflowDashboard({ onBack }: WorkflowDashboardProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={onBack}>
-            <ArrowLeft className="h-4 w-4 mr-2" />
+      <Group justify="space-between" align="center">
+        <Group gap="md" align="center">
+          <Button
+            variant="subtle"
+            size="sm"
+            leftSection={<ArrowLeft className="h-4 w-4" />}
+            onClick={onBack}
+          >
             Back to Workflows
           </Button>
-          <h1 className="text-2xl font-bold">Workflow Dashboard</h1>
-        </div>
+          <Title order={1} className="text-2xl">
+            Workflow Dashboard
+          </Title>
+        </Group>
 
-        <Select value={period} onValueChange={(value) => setPeriod(value as WorkflowPeriod)}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="Select period" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="24h">Last 24 hours</SelectItem>
-            <SelectItem value="7d">Last 7 days</SelectItem>
-            <SelectItem value="30d">Last 30 days</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+        <Select
+          aria-label="Workflow dashboard period"
+          className="w-[180px]"
+          value={period}
+          onChange={(value) => setPeriod((value ?? '7d') as WorkflowPeriod)}
+          data={[
+            { value: '24h', label: 'Last 24 hours' },
+            { value: '7d', label: 'Last 7 days' },
+            { value: '30d', label: 'Last 30 days' },
+          ]}
+        />
+      </Group>
 
       {/* Summary Cards */}
       {isStatsLoading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[...Array(6)].map((_, i) => (
-            <Skeleton key={i} className="h-32" />
+            <Skeleton key={i} h={128} />
           ))}
         </div>
       ) : stats ? (
@@ -165,61 +173,75 @@ export function WorkflowDashboard({ onBack }: WorkflowDashboardProps) {
       ) : null}
 
       {/* Active Runs */}
-      <div className="space-y-4">
-        <div className="flex items-center gap-2">
-          <Activity className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-lg font-semibold">Active Runs</h2>
-          <Badge variant="secondary">{activeRuns.length}</Badge>
+      <Stack gap="md">
+        <Group gap="xs">
+          <ThemeIcon variant="transparent" color="gray" size="sm">
+            <Activity className="h-5 w-5" />
+          </ThemeIcon>
+          <Title order={2} className="text-lg">
+            Active Runs
+          </Title>
+          <Badge variant="light">{activeRuns.length}</Badge>
           {!isConnected && (
-            <Badge variant="outline" className="text-yellow-600">
-              <AlertCircle className="h-3 w-3 mr-1" />
+            <Badge
+              color="yellow"
+              variant="outline"
+              leftSection={<AlertCircle className="h-3 w-3" />}
+            >
               WebSocket disconnected
             </Badge>
           )}
-        </div>
+        </Group>
 
         {isActiveRunsLoading ? (
-          <div className="space-y-3">
+          <Stack gap="sm">
             {[...Array(3)].map((_, i) => (
-              <Skeleton key={i} className="h-24" />
+              <Skeleton key={i} h={96} />
             ))}
-          </div>
+          </Stack>
         ) : activeRuns.length === 0 ? (
-          <div className="text-center py-12 text-muted-foreground">No active runs</div>
+          <Text ta="center" c="dimmed" py="xl">
+            No active runs
+          </Text>
         ) : (
           <ActiveRunsList runs={activeRuns} onSelectRun={setSelectedRunId} />
         )}
-      </div>
+      </Stack>
 
       {/* Recent Runs */}
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Clock className="h-5 w-5 text-muted-foreground" />
-            <h2 className="text-lg font-semibold">Recent Runs</h2>
-            <Badge variant="secondary">{recentRuns.length}</Badge>
-          </div>
+      <Stack gap="md">
+        <Group justify="space-between" align="center">
+          <Group gap="xs">
+            <ThemeIcon variant="transparent" color="gray" size="sm">
+              <Clock className="h-5 w-5" />
+            </ThemeIcon>
+            <Title order={2} className="text-lg">
+              Recent Runs
+            </Title>
+            <Badge variant="light">{recentRuns.length}</Badge>
+          </Group>
 
-          <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="All Statuses" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Statuses</SelectItem>
-              <SelectItem value="completed">Completed</SelectItem>
-              <SelectItem value="failed">Failed</SelectItem>
-              <SelectItem value="blocked">Blocked</SelectItem>
-              <SelectItem value="pending">Pending</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+          <Select
+            aria-label="Recent workflow run status filter"
+            className="w-[180px]"
+            value={statusFilter}
+            onChange={(value) => setStatusFilter(value ?? 'all')}
+            data={[
+              { value: 'all', label: 'All Statuses' },
+              { value: 'completed', label: 'Completed' },
+              { value: 'failed', label: 'Failed' },
+              { value: 'blocked', label: 'Blocked' },
+              { value: 'pending', label: 'Pending' },
+            ]}
+          />
+        </Group>
 
         {isRecentRunsLoading ? (
-          <div className="space-y-3">
+          <Stack gap="sm">
             {[...Array(5)].map((_, i) => (
-              <Skeleton key={i} className="h-20" />
+              <Skeleton key={i} h={80} />
             ))}
-          </div>
+          </Stack>
         ) : (
           <RecentRunsList
             runs={recentRuns}
@@ -227,19 +249,23 @@ export function WorkflowDashboard({ onBack }: WorkflowDashboardProps) {
             onSelectRun={setSelectedRunId}
           />
         )}
-      </div>
+      </Stack>
 
       {/* Workflow Health */}
       {stats && stats.perWorkflow.length > 0 && (
-        <div className="space-y-4">
-          <div className="flex items-center gap-2">
-            <Zap className="h-5 w-5 text-muted-foreground" />
-            <h2 className="text-lg font-semibold">Workflow Health</h2>
-          </div>
+        <Stack gap="md">
+          <Group gap="xs">
+            <ThemeIcon variant="transparent" color="gray" size="sm">
+              <Zap className="h-5 w-5" />
+            </ThemeIcon>
+            <Title order={2} className="text-lg">
+              Workflow Health
+            </Title>
+          </Group>
 
           <WorkflowHealthMetrics workflowStats={stats.perWorkflow} />
-        </div>
+        </Stack>
       )}
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/workflows/WorkflowRunList.tsx
+++ b/web/src/components/workflows/WorkflowRunList.tsx
@@ -10,18 +10,20 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import { API_BASE } from '@/lib/config';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import {
+  Badge,
+  Button,
+  Group,
+  Paper,
+  Progress,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+  Skeleton,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
 import { ArrowLeft, Clock, CheckCircle2, XCircle, AlertCircle, PlayCircle } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
-import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { WorkflowRunView } from './WorkflowRunView';
 
@@ -84,52 +86,59 @@ export function WorkflowRunList({ workflowId, onBack }: WorkflowRunListProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={onBack}>
-            <ArrowLeft className="h-4 w-4 mr-2" />
+      <Group justify="space-between" align="center">
+        <Group gap="md" align="center">
+          <Button
+            variant="subtle"
+            size="sm"
+            leftSection={<ArrowLeft className="h-4 w-4" />}
+            onClick={onBack}
+          >
             Back to Workflows
           </Button>
-          <h1 className="text-2xl font-bold">Workflow Runs</h1>
-          <Badge variant="secondary">{filteredRuns.length} runs</Badge>
-        </div>
+          <Title order={1} className="text-2xl">
+            Workflow Runs
+          </Title>
+          <Badge variant="light">{filteredRuns.length} runs</Badge>
+        </Group>
 
-        <Select value={statusFilter} onValueChange={setStatusFilter}>
-          <SelectTrigger className="w-[180px]">
-            <SelectValue placeholder="All Statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Statuses</SelectItem>
-            <SelectItem value="running">Running</SelectItem>
-            <SelectItem value="completed">Completed</SelectItem>
-            <SelectItem value="failed">Failed</SelectItem>
-            <SelectItem value="blocked">Blocked</SelectItem>
-            <SelectItem value="pending">Pending</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+        <Select
+          aria-label="Workflow run status filter"
+          className="w-[180px]"
+          value={statusFilter}
+          onChange={(value) => setStatusFilter(value ?? 'all')}
+          data={[
+            { value: 'all', label: 'All Statuses' },
+            { value: 'running', label: 'Running' },
+            { value: 'completed', label: 'Completed' },
+            { value: 'failed', label: 'Failed' },
+            { value: 'blocked', label: 'Blocked' },
+            { value: 'pending', label: 'Pending' },
+          ]}
+        />
+      </Group>
 
       {/* Run List */}
       {isLoading ? (
-        <div className="space-y-3">
+        <Stack gap="sm">
           {[...Array(5)].map((_, i) => (
-            <Skeleton key={i} className="h-24 w-full" />
+            <Skeleton key={i} h={96} />
           ))}
-        </div>
+        </Stack>
       ) : filteredRuns.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">
+        <Text ta="center" c="dimmed" py="xl">
           {statusFilter !== 'all' ? 'No runs match your filter' : 'No runs yet'}
-        </div>
+        </Text>
       ) : (
-        <div className="space-y-3">
+        <Stack gap="sm">
           {filteredRuns.map((run) => (
             <RunCard key={run.id} run={run} onClick={() => setSelectedRunId(run.id)} />
           ))}
-        </div>
+        </Stack>
       )}
-    </div>
+    </Stack>
   );
 }
 
@@ -145,31 +154,37 @@ function RunCard({ run, onClick }: RunCardProps) {
 
   const completedSteps = run.steps?.filter((s) => s.status === 'completed').length;
   const totalSteps = run.steps?.length ?? 0;
+  const progress = totalSteps > 0 ? (completedSteps / totalSteps) * 100 : 0;
 
   const statusConfig = {
     pending: {
       icon: Clock,
       color: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200',
+      progressColor: 'gray',
       label: 'Pending',
     },
     running: {
       icon: PlayCircle,
       color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+      progressColor: 'blue',
       label: 'Running',
     },
     completed: {
       icon: CheckCircle2,
       color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      progressColor: 'green',
       label: 'Completed',
     },
     failed: {
       icon: XCircle,
       color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+      progressColor: 'red',
       label: 'Failed',
     },
     blocked: {
       icon: AlertCircle,
       color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+      progressColor: 'yellow',
       label: 'Blocked',
     },
   };
@@ -178,8 +193,10 @@ function RunCard({ run, onClick }: RunCardProps) {
   const Icon = config.icon;
 
   return (
-    <div
-      className="p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors cursor-pointer"
+    <Paper
+      className="p-4 transition-colors cursor-pointer hover:bg-accent/50"
+      radius="md"
+      withBorder
       onClick={onClick}
       role="button"
       tabIndex={0}
@@ -190,9 +207,9 @@ function RunCard({ run, onClick }: RunCardProps) {
         }
       }}
     >
-      <div className="flex items-start justify-between gap-4">
+      <Group align="flex-start" justify="space-between" gap="md">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-3 mb-2">
+          <Group gap="sm" mb="xs">
             <Badge variant="outline" className="text-xs font-mono">
               {run.id}
             </Badge>
@@ -200,40 +217,36 @@ function RunCard({ run, onClick }: RunCardProps) {
               <Icon className="h-3 w-3 mr-1" />
               {config.label}
             </Badge>
-          </div>
+          </Group>
 
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <div>Started: {new Date(run.startedAt).toLocaleString()}</div>
-            <div>
+          <Group gap="md" className="text-sm text-muted-foreground">
+            <Text span inherit>
+              Started: {new Date(run.startedAt).toLocaleString()}
+            </Text>
+            <Text span inherit>
               Duration: {Math.floor(duration / 60)}m {duration % 60}s
-            </div>
-            {run.currentStep && <div>Current: {run.currentStep}</div>}
-          </div>
+            </Text>
+            {run.currentStep && (
+              <Text span inherit>
+                Current: {run.currentStep}
+              </Text>
+            )}
+          </Group>
 
-          <div className="mt-2 flex items-center gap-2">
-            <div className="text-sm text-muted-foreground">
+          <Group gap="xs" mt="xs">
+            <Text size="sm" c="dimmed">
               Progress: {completedSteps}/{totalSteps} steps
-            </div>
-            <div className="flex-1 max-w-xs h-2 bg-secondary rounded-full overflow-hidden">
-              <div
-                className={cn(
-                  'h-full transition-all',
-                  run.status === 'completed'
-                    ? 'bg-green-500'
-                    : run.status === 'failed'
-                      ? 'bg-red-500'
-                      : run.status === 'blocked'
-                        ? 'bg-yellow-500'
-                        : 'bg-blue-500'
-                )}
-                style={{ width: `${(completedSteps / totalSteps) * 100}%` }}
-              />
-            </div>
-          </div>
+            </Text>
+            <Progress className="flex-1 max-w-xs" value={progress} color={config.progressColor} />
+          </Group>
 
-          {run.error && <div className="mt-2 text-sm text-destructive">Error: {run.error}</div>}
+          {run.error && (
+            <Text mt="xs" size="sm" c="red">
+              Error: {run.error}
+            </Text>
+          )}
         </div>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 }

--- a/web/src/components/workflows/WorkflowRunView.tsx
+++ b/web/src/components/workflows/WorkflowRunView.tsx
@@ -11,8 +11,20 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { API_BASE } from '@/lib/config';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import {
+  Alert,
+  Badge,
+  Button,
+  Code,
+  Group,
+  Paper,
+  Progress,
+  Skeleton,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
 import {
   ArrowLeft,
   CheckCircle2,
@@ -23,7 +35,6 @@ import {
   Pause,
 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
-import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { useWebSocket, type WebSocketMessage } from '@/hooks/useWebSocket';
 
@@ -109,9 +120,11 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
     fetchRun();
   }, [fetchRun]);
 
+  const workflowId = run?.workflowId;
+
   // Fetch workflow definition when run loads
   useEffect(() => {
-    if (!run) return;
+    if (!workflowId) return;
 
     setWorkflow(null);
     setIsWorkflowLoading(true);
@@ -119,7 +132,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
     let isCancelled = false;
     const fetchWorkflow = async () => {
       try {
-        const workflowResponse = await fetch(`${API_BASE}/workflows/${run.workflowId}`);
+        const workflowResponse = await fetch(`${API_BASE}/workflows/${workflowId}`);
         if (!workflowResponse.ok) throw new Error('Failed to fetch workflow definition');
         const json = await workflowResponse.json();
         if (!isCancelled) {
@@ -142,7 +155,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
     return () => {
       isCancelled = true;
     };
-  }, [run?.workflowId]);
+  }, [workflowId]);
 
   // WebSocket subscription for live updates
   const handleWebSocketMessage = useCallback(
@@ -184,15 +197,19 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
 
   if (isLoading || (run && isWorkflowLoading)) {
     return (
-      <div className="space-y-6">
-        <Skeleton className="h-12 w-full" />
-        <Skeleton className="h-64 w-full" />
-      </div>
+      <Stack gap="lg">
+        <Skeleton h={48} />
+        <Skeleton h={256} />
+      </Stack>
     );
   }
 
   if (!run) {
-    return <div className="text-center py-12 text-muted-foreground">Workflow run not found</div>;
+    return (
+      <Text ta="center" c="dimmed" py="xl">
+        Workflow run not found
+      </Text>
+    );
   }
 
   const workflowName = workflow?.name ?? `Workflow ${run.workflowId}`;
@@ -202,6 +219,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
 
   const completedSteps = run.steps?.filter((s) => s.status === 'completed').length;
   const totalSteps = run.steps?.length ?? 0;
+  const progress = totalSteps > 0 ? (completedSteps / totalSteps) * 100 : 0;
 
   const duration = run.completedAt
     ? Math.floor((new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime()) / 1000)
@@ -211,26 +229,31 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
     pending: {
       icon: Clock,
       color: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200',
+      progressColor: 'gray',
       label: 'Pending',
     },
     running: {
       icon: PlayCircle,
       color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+      progressColor: 'blue',
       label: 'Running',
     },
     completed: {
       icon: CheckCircle2,
       color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      progressColor: 'green',
       label: 'Completed',
     },
     failed: {
       icon: XCircle,
       color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+      progressColor: 'red',
       label: 'Failed',
     },
     blocked: {
       icon: AlertCircle,
       color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+      progressColor: 'yellow',
       label: 'Blocked',
     },
   };
@@ -239,79 +262,85 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
   const Icon = config.icon;
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={onBack}>
-            <ArrowLeft className="h-4 w-4 mr-2" />
+      <Group justify="space-between" align="center">
+        <Group gap="md" align="center">
+          <Button
+            variant="subtle"
+            size="sm"
+            leftSection={<ArrowLeft className="h-4 w-4" />}
+            onClick={onBack}
+          >
             Back to Runs
           </Button>
           <div>
-            <h1 className="text-2xl font-bold">{workflowName}</h1>
-            <p className="text-sm text-muted-foreground">Run: {run.id}</p>
+            <Title order={1} className="text-2xl">
+              {workflowName}
+            </Title>
+            <Text size="sm" c="dimmed">
+              Run: {run.id}
+            </Text>
           </div>
-        </div>
+        </Group>
 
-        <div className="flex items-center gap-3">
+        <Group gap="sm">
           <Badge className={cn('text-sm', config.color)}>
             <Icon className="h-4 w-4 mr-1" />
             {config.label}
           </Badge>
           {run.status === 'blocked' && (
-            <Button size="sm" onClick={handleResume}>
-              <PlayCircle className="h-4 w-4 mr-1" />
+            <Button
+              size="sm"
+              leftSection={<PlayCircle className="h-4 w-4" />}
+              onClick={handleResume}
+            >
               Resume
             </Button>
           )}
-        </div>
-      </div>
+        </Group>
+      </Group>
 
       {/* Progress Overview */}
-      <div className="p-6 rounded-lg border bg-card space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold">Overall Progress</h2>
-            <p className="text-sm text-muted-foreground">
-              Step {completedSteps} of {totalSteps}
-            </p>
-          </div>
-          <div className="text-right space-y-1">
-            <div className="text-sm text-muted-foreground">
-              Duration: {Math.floor(duration / 60)}m {duration % 60}s
+      <Paper className="p-6" radius="md" withBorder>
+        <Stack gap="md">
+          <Group justify="space-between" align="flex-start">
+            <div className="space-y-1">
+              <Title order={2} className="text-lg">
+                Overall Progress
+              </Title>
+              <Text size="sm" c="dimmed">
+                Step {completedSteps} of {totalSteps}
+              </Text>
             </div>
-            <div className="text-sm text-muted-foreground">
-              Started: {new Date(run.startedAt).toLocaleString()}
-            </div>
-          </div>
-        </div>
+            <Stack gap={4} align="flex-end">
+              <Text size="sm" c="dimmed">
+                Duration: {Math.floor(duration / 60)}m {duration % 60}s
+              </Text>
+              <Text size="sm" c="dimmed">
+                Started: {new Date(run.startedAt).toLocaleString()}
+              </Text>
+            </Stack>
+          </Group>
 
-        <div className="h-3 bg-secondary rounded-full overflow-hidden">
-          <div
-            className={cn(
-              'h-full transition-all',
-              run.status === 'completed'
-                ? 'bg-green-500'
-                : run.status === 'failed'
-                  ? 'bg-red-500'
-                  : run.status === 'blocked'
-                    ? 'bg-yellow-500'
-                    : 'bg-blue-500'
-            )}
-            style={{ width: `${(completedSteps / totalSteps) * 100}%` }}
-          />
-        </div>
+          <Progress value={progress} color={config.progressColor} size="md" radius="xl" />
 
-        {run.error && (
-          <div className="p-3 rounded bg-destructive/10 text-destructive text-sm">
-            <strong>Error:</strong> {run.error}
-          </div>
-        )}
-      </div>
+          {run.error && (
+            <Alert color="red" variant="light">
+              <Text span fw={600}>
+                Error:
+              </Text>{' '}
+              {run.error}
+            </Alert>
+          )}
+        </Stack>
+      </Paper>
 
       {/* Step Timeline */}
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">Steps</h2>
+      <Stack gap="sm">
+        <Title order={2} className="text-lg">
+          Steps
+        </Title>
         {stepDefinitions.map((stepDef, index) => {
           const stepRun = run.steps?.find((s) => s.stepId === stepDef.id);
           if (!stepRun) return null;
@@ -329,8 +358,8 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
             />
           );
         })}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }
 
@@ -375,12 +404,14 @@ function StepCard({ stepDef, stepRun, index, isExpanded, onToggleExpand }: StepC
   const Icon = config.icon;
 
   return (
-    <div
+    <Paper
       className={cn(
-        'p-4 rounded-lg border-2 bg-card transition-colors cursor-pointer',
+        'p-4 border-2 transition-colors cursor-pointer',
         config.borderColor,
         isExpanded && 'ring-2 ring-accent'
       )}
+      radius="md"
+      withBorder
       onClick={onToggleExpand}
       role="button"
       tabIndex={0}
@@ -391,14 +422,16 @@ function StepCard({ stepDef, stepRun, index, isExpanded, onToggleExpand }: StepC
         }
       }}
     >
-      <div className="flex items-start gap-4">
-        <div className="flex items-center justify-center w-8 h-8 rounded-full bg-secondary text-sm font-medium">
+      <Group align="flex-start" gap="md">
+        <ThemeIcon className="shrink-0" radius="xl" variant="light" color="gray">
           {index + 1}
-        </div>
+        </ThemeIcon>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-3 mb-2">
-            <h3 className="font-medium">{stepDef.name}</h3>
+          <Group gap="sm" mb="xs">
+            <Title order={3} className="text-base">
+              {stepDef.name}
+            </Title>
             <Badge className={cn('text-xs', config.color)}>
               <Icon className="h-3 w-3 mr-1" />
               {stepRun.status}
@@ -409,34 +442,51 @@ function StepCard({ stepDef, stepRun, index, isExpanded, onToggleExpand }: StepC
               </Badge>
             )}
             {stepRun.retries > 0 && (
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="light" className="text-xs">
                 Retry {stepRun.retries}
               </Badge>
             )}
-          </div>
+          </Group>
 
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <Group gap="md" className="text-sm text-muted-foreground">
             {stepRun.startedAt && (
-              <div>Started: {new Date(stepRun.startedAt).toLocaleTimeString()}</div>
+              <Text span inherit>
+                Started: {new Date(stepRun.startedAt).toLocaleTimeString()}
+              </Text>
             )}
-            {stepRun.duration !== undefined && <div>Duration: {stepRun.duration}s</div>}
-          </div>
+            {stepRun.completedAt && (
+              <Text span inherit>
+                Completed: {new Date(stepRun.completedAt).toLocaleTimeString()}
+              </Text>
+            )}
+            {stepRun.duration !== undefined && (
+              <Text span inherit>
+                Duration: {stepRun.duration}s
+              </Text>
+            )}
+          </Group>
 
           {stepRun.error && (
-            <div className="mt-2 p-2 rounded bg-destructive/10 text-destructive text-sm">
-              <strong>Error:</strong> {stepRun.error}
-            </div>
+            <Alert mt="xs" color="red" variant="light">
+              <Text span fw={600}>
+                Error:
+              </Text>{' '}
+              {stepRun.error}
+            </Alert>
           )}
 
           {isExpanded && stepRun.output && (
-            <div className="mt-3 p-3 rounded bg-secondary text-sm font-mono whitespace-pre-wrap">
-              <strong>Output:</strong>
-              <br />
-              {stepRun.output}
-            </div>
+            <Paper mt="sm" p="sm" radius="sm" className="bg-secondary">
+              <Text size="sm" fw={600}>
+                Output:
+              </Text>
+              <Code block className="mt-2 whitespace-pre-wrap">
+                {stepRun.output}
+              </Code>
+            </Paper>
           )}
         </div>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 }

--- a/web/src/components/workflows/WorkflowsPage.tsx
+++ b/web/src/components/workflows/WorkflowsPage.tsx
@@ -10,12 +10,19 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import { API_BASE } from '@/lib/config';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
+import {
+  Badge,
+  Button,
+  Group,
+  Paper,
+  Skeleton,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
 import { ArrowLeft, Search, Play, Users, ListOrdered, BarChart3 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
-import { Skeleton } from '@/components/ui/skeleton';
 import { WorkflowRunList } from './WorkflowRunList';
 import { WorkflowDashboard } from './WorkflowDashboard';
 import { useIdentity } from '@/hooks/useIdentity';
@@ -115,48 +122,54 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={onBack}>
-            <ArrowLeft className="h-4 w-4 mr-2" />
+      <Group justify="space-between" align="center">
+        <Group gap="md" align="center">
+          <Button
+            variant="subtle"
+            size="sm"
+            leftSection={<ArrowLeft className="h-4 w-4" />}
+            onClick={onBack}
+          >
             Back to Board
           </Button>
-          <h1 className="text-2xl font-bold">Workflows</h1>
-          <Badge variant="secondary">{filteredWorkflows.length} workflows</Badge>
-        </div>
+          <Title order={1} className="text-2xl">
+            Workflows
+          </Title>
+          <Badge variant="light">{filteredWorkflows.length} workflows</Badge>
+        </Group>
 
-        <Button onClick={() => setShowDashboard(true)}>
-          <BarChart3 className="h-4 w-4 mr-2" />
+        <Button
+          leftSection={<BarChart3 className="h-4 w-4" />}
+          onClick={() => setShowDashboard(true)}
+        >
           Dashboard
         </Button>
-      </div>
+      </Group>
 
       {/* Search */}
-      <div className="relative flex-1 max-w-md">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search workflows..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-10"
-        />
-      </div>
+      <TextInput
+        className="max-w-md"
+        leftSection={<Search className="h-4 w-4" />}
+        placeholder="Search workflows..."
+        value={search}
+        onChange={(event) => setSearch(event.currentTarget.value)}
+      />
 
       {/* Workflow List */}
       {isLoading ? (
-        <div className="space-y-3">
+        <Stack gap="sm">
           {[...Array(3)].map((_, i) => (
-            <Skeleton key={i} className="h-32 w-full" />
+            <Skeleton key={i} h={128} />
           ))}
-        </div>
+        </Stack>
       ) : filteredWorkflows.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">
+        <Text ta="center" c="dimmed" py="xl">
           {search ? 'No workflows match your search' : 'No workflows available'}
-        </div>
+        </Text>
       ) : (
-        <div className="space-y-4">
+        <Stack gap="md">
           {filteredWorkflows.map((workflow) => (
             <WorkflowCard
               key={workflow.id}
@@ -166,9 +179,9 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
               canStartRun={canExecuteWorkflows}
             />
           ))}
-        </div>
+        </Stack>
       )}
-    </div>
+    </Stack>
   );
 }
 
@@ -181,45 +194,47 @@ interface WorkflowCardProps {
 
 function WorkflowCard({ workflow, onStartRun, onViewRuns, canStartRun }: WorkflowCardProps) {
   return (
-    <div className="p-6 rounded-lg border bg-card hover:bg-accent/50 transition-colors">
-      <div className="flex items-start justify-between gap-4">
+    <Paper className="p-6 transition-colors hover:bg-accent/50" radius="md" withBorder>
+      <Group align="flex-start" justify="space-between" gap="md">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-3 mb-2">
-            <h3 className="font-semibold text-lg">{workflow.name}</h3>
+          <Group gap="sm" mb="xs">
+            <Title order={3} className="text-lg">
+              {workflow.name}
+            </Title>
             <Badge variant="outline" className="text-xs">
               v{workflow.version}
             </Badge>
             {workflow.activeRunCount !== undefined && workflow.activeRunCount > 0 && (
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="light" className="text-xs">
                 {workflow.activeRunCount} active run{workflow.activeRunCount !== 1 ? 's' : ''}
               </Badge>
             )}
-          </div>
+          </Group>
 
-          <p className="text-sm text-muted-foreground mb-4 whitespace-pre-wrap">
+          <Text size="sm" c="dimmed" mb="md" className="whitespace-pre-wrap">
             {workflow.description}
-          </p>
+          </Text>
 
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <div className="flex items-center gap-1">
+          <Group gap="md" className="text-sm text-muted-foreground">
+            <Group gap={4}>
               <Users className="h-4 w-4" />
               <span>{workflow.agents?.length ?? 0} agents</span>
-            </div>
-            <div className="flex items-center gap-1">
+            </Group>
+            <Group gap={4}>
               <ListOrdered className="h-4 w-4" />
               <span>{workflow.steps?.length ?? 0} steps</span>
-            </div>
-          </div>
+            </Group>
+          </Group>
         </div>
 
-        <div className="flex flex-col gap-2 shrink-0">
+        <Stack gap="xs" className="shrink-0">
           <Button
             size="sm"
             onClick={onStartRun}
             disabled={!canStartRun}
             title={canStartRun ? 'Start run' : 'Workflow execute permission required'}
+            leftSection={<Play className="h-3 w-3" />}
           >
-            <Play className="h-3 w-3 mr-1" />
             Start Run
           </Button>
           {workflow.activeRunCount !== undefined && workflow.activeRunCount > 0 && (
@@ -227,8 +242,8 @@ function WorkflowCard({ workflow, onStartRun, onViewRuns, canStartRun }: Workflo
               View Runs
             </Button>
           )}
-        </div>
-      </div>
-    </div>
+        </Stack>
+      </Group>
+    </Paper>
   );
 }

--- a/web/src/components/workflows/dashboard/ActiveRunsList.tsx
+++ b/web/src/components/workflows/dashboard/ActiveRunsList.tsx
@@ -3,7 +3,7 @@
  */
 
 import { memo } from 'react';
-import { Badge } from '@/components/ui/badge';
+import { Badge, Group, Paper, Progress, Stack, Text } from '@mantine/core';
 import { PlayCircle } from 'lucide-react';
 import type { WorkflowRun } from '@/hooks/useWorkflowStats';
 
@@ -17,11 +17,11 @@ export const ActiveRunsList = memo(function ActiveRunsList({
   onSelectRun,
 }: ActiveRunsListProps) {
   return (
-    <div className="space-y-3">
+    <Stack gap="sm">
       {runs.map((run) => (
         <ActiveRunCard key={run.id} run={run} onClick={() => onSelectRun(run.id)} />
       ))}
-    </div>
+    </Stack>
   );
 });
 
@@ -34,10 +34,13 @@ const ActiveRunCard = memo(function ActiveRunCard({ run, onClick }: ActiveRunCar
   const duration = Math.floor((Date.now() - new Date(run.startedAt).getTime()) / 1000);
   const completedSteps = run.steps?.filter((s) => s.status === 'completed').length;
   const totalSteps = run.steps?.length ?? 0;
+  const progress = totalSteps > 0 ? (completedSteps / totalSteps) * 100 : 0;
 
   return (
-    <div
-      className="p-4 rounded-lg border-2 border-blue-500 bg-card hover:bg-accent/50 transition-colors cursor-pointer"
+    <Paper
+      className="p-4 border-2 border-blue-500 transition-colors cursor-pointer hover:bg-accent/50"
+      radius="md"
+      withBorder
       onClick={onClick}
       role="button"
       tabIndex={0}
@@ -48,9 +51,9 @@ const ActiveRunCard = memo(function ActiveRunCard({ run, onClick }: ActiveRunCar
         }
       }}
     >
-      <div className="flex items-start justify-between gap-4">
+      <Group align="flex-start" justify="space-between" gap="md">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-3 mb-2">
+          <Group gap="sm" mb="xs">
             <Badge variant="outline" className="text-xs font-mono">
               {run.id}
             </Badge>
@@ -58,29 +61,30 @@ const ActiveRunCard = memo(function ActiveRunCard({ run, onClick }: ActiveRunCar
               <PlayCircle className="h-3 w-3 mr-1" />
               Running
             </Badge>
-          </div>
+          </Group>
 
-          <div className="flex items-center gap-4 text-sm text-muted-foreground mb-2">
-            <div>Started: {new Date(run.startedAt).toLocaleString()}</div>
-            <div>
+          <Group gap="md" mb="xs" className="text-sm text-muted-foreground">
+            <Text span inherit>
+              Started: {new Date(run.startedAt).toLocaleString()}
+            </Text>
+            <Text span inherit>
               Duration: {Math.floor(duration / 60)}m {duration % 60}s
-            </div>
-            {run.currentStep && <div className="font-medium">Current: {run.currentStep}</div>}
-          </div>
+            </Text>
+            {run.currentStep && (
+              <Text span inherit fw={500}>
+                Current: {run.currentStep}
+              </Text>
+            )}
+          </Group>
 
-          <div className="flex items-center gap-2">
-            <div className="text-sm text-muted-foreground">
+          <Group gap="xs">
+            <Text size="sm" c="dimmed">
               Progress: {completedSteps}/{totalSteps} steps
-            </div>
-            <div className="flex-1 max-w-xs h-2 bg-secondary rounded-full overflow-hidden">
-              <div
-                className="h-full bg-blue-500 transition-all"
-                style={{ width: `${(completedSteps / totalSteps) * 100}%` }}
-              />
-            </div>
-          </div>
+            </Text>
+            <Progress className="flex-1 max-w-xs" value={progress} color="blue" />
+          </Group>
         </div>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 });

--- a/web/src/components/workflows/dashboard/RecentRunsList.tsx
+++ b/web/src/components/workflows/dashboard/RecentRunsList.tsx
@@ -3,7 +3,7 @@
  */
 
 import { memo, useMemo } from 'react';
-import { Badge } from '@/components/ui/badge';
+import { Badge, Group, Paper, Stack, Text } from '@mantine/core';
 import { Clock, PlayCircle, CheckCircle2, XCircle, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { WorkflowRun } from '@/hooks/useWorkflowStats';
@@ -32,18 +32,18 @@ export const RecentRunsList = memo(function RecentRunsList({
 
   if (filteredRuns.length === 0) {
     return (
-      <div className="text-center py-12 text-muted-foreground">
+      <Text ta="center" c="dimmed" py="xl">
         {statusFilter !== 'all' ? 'No runs match your filter' : 'No recent runs'}
-      </div>
+      </Text>
     );
   }
 
   return (
-    <div className="space-y-3">
+    <Stack gap="sm">
       {filteredRuns.map((run) => (
         <RecentRunCard key={run.id} run={run} onClick={() => onSelectRun(run.id)} />
       ))}
-    </div>
+    </Stack>
   );
 });
 
@@ -92,8 +92,10 @@ const RecentRunCard = memo(function RecentRunCard({ run, onClick }: RecentRunCar
   const Icon = config.icon;
 
   return (
-    <div
-      className="p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors cursor-pointer"
+    <Paper
+      className="p-4 transition-colors cursor-pointer hover:bg-accent/50"
+      radius="md"
+      withBorder
       onClick={onClick}
       role="button"
       tabIndex={0}
@@ -104,9 +106,9 @@ const RecentRunCard = memo(function RecentRunCard({ run, onClick }: RecentRunCar
         }
       }}
     >
-      <div className="flex items-start justify-between gap-4">
+      <Group align="flex-start" justify="space-between" gap="md">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-3 mb-2">
+          <Group gap="sm" mb="xs">
             <Badge variant="outline" className="text-xs font-mono">
               {run.id}
             </Badge>
@@ -114,21 +116,27 @@ const RecentRunCard = memo(function RecentRunCard({ run, onClick }: RecentRunCar
               <Icon className="h-3 w-3 mr-1" />
               {config.label}
             </Badge>
-          </div>
+          </Group>
 
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
-            <div>Started: {new Date(run.startedAt).toLocaleString()}</div>
-            <div>
+          <Group gap="md" className="text-sm text-muted-foreground">
+            <Text span inherit>
+              Started: {new Date(run.startedAt).toLocaleString()}
+            </Text>
+            <Text span inherit>
               Duration: {Math.floor(duration / 60)}m {duration % 60}s
-            </div>
-            <div>
+            </Text>
+            <Text span inherit>
               Steps: {completedSteps}/{totalSteps}
-            </div>
-          </div>
+            </Text>
+          </Group>
 
-          {run.error && <div className="mt-2 text-sm text-destructive">Error: {run.error}</div>}
+          {run.error && (
+            <Text mt="xs" size="sm" c="red">
+              Error: {run.error}
+            </Text>
+          )}
         </div>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 });

--- a/web/src/components/workflows/dashboard/WorkflowHealthMetrics.tsx
+++ b/web/src/components/workflows/dashboard/WorkflowHealthMetrics.tsx
@@ -3,7 +3,7 @@
  */
 
 import { memo } from 'react';
-import { cn } from '@/lib/utils';
+import { Group, Paper, Progress, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { formatDuration } from '@/hooks/useMetrics';
 
 interface WorkflowHealthMetricsProps {
@@ -22,11 +22,11 @@ export const WorkflowHealthMetrics = memo(function WorkflowHealthMetrics({
   workflowStats,
 }: WorkflowHealthMetricsProps) {
   return (
-    <div className="space-y-3">
+    <Stack gap="sm">
       {workflowStats.map((stats) => (
         <WorkflowHealthCard key={stats.workflowId} stats={stats} />
       ))}
-    </div>
+    </Stack>
   );
 });
 
@@ -47,50 +47,49 @@ const WorkflowHealthCard = memo(function WorkflowHealthCard({ stats }: WorkflowH
   const healthColor =
     stats.successRate >= 0.8 ? 'green' : stats.successRate >= 0.5 ? 'yellow' : 'red';
 
-  const colorClasses = {
-    green: 'bg-green-500',
-    yellow: 'bg-yellow-500',
-    red: 'bg-red-500',
-  };
-
   return (
-    <div className="p-4 rounded-lg border bg-card">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1 min-w-0">
-          <h3 className="font-semibold mb-2">{stats.workflowName}</h3>
+    <Paper className="p-4" radius="md" withBorder>
+      <Group align="flex-start" justify="space-between" gap="md">
+        <Stack gap="sm" className="flex-1 min-w-0">
+          <Title order={3} className="text-base">
+            {stats.workflowName}
+          </Title>
 
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+          <SimpleGrid cols={{ base: 2, md: 4 }} spacing="md" className="text-sm">
             <div>
-              <p className="text-muted-foreground">Runs</p>
-              <p className="font-medium">{stats.runs}</p>
+              <Text c="dimmed">Runs</Text>
+              <Text fw={500}>{stats.runs}</Text>
             </div>
             <div>
-              <p className="text-muted-foreground">Success Rate</p>
-              <p className="font-medium">{successRatePercent}%</p>
+              <Text c="dimmed">Success Rate</Text>
+              <Text fw={500}>{successRatePercent}%</Text>
             </div>
             <div>
-              <p className="text-muted-foreground">Completed</p>
-              <p className="font-medium text-green-600">{stats.completed}</p>
+              <Text c="dimmed">Completed</Text>
+              <Text fw={500} c="green">
+                {stats.completed}
+              </Text>
             </div>
             <div>
-              <p className="text-muted-foreground">Failed</p>
-              <p className="font-medium text-red-600">{stats.failed}</p>
+              <Text c="dimmed">Failed</Text>
+              <Text fw={500} c="red">
+                {stats.failed}
+              </Text>
             </div>
-          </div>
+          </SimpleGrid>
 
-          <div className="mt-3 flex items-center gap-2">
-            <div className="text-sm text-muted-foreground">
+          <Group gap="xs">
+            <Text size="sm" c="dimmed">
               Avg Duration: {formatDuration(stats.avgDuration)}
-            </div>
-            <div className="flex-1 max-w-xs h-2 bg-secondary rounded-full overflow-hidden">
-              <div
-                className={cn('h-full transition-all', colorClasses[healthColor])}
-                style={{ width: `${stats.successRate * 100}%` }}
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+            </Text>
+            <Progress
+              className="flex-1 max-w-xs"
+              value={stats.successRate * 100}
+              color={healthColor}
+            />
+          </Group>
+        </Stack>
+      </Group>
+    </Paper>
   );
 });

--- a/web/src/components/workflows/dashboard/WorkflowSummaryCards.tsx
+++ b/web/src/components/workflows/dashboard/WorkflowSummaryCards.tsx
@@ -3,8 +3,9 @@
  */
 
 import { memo } from 'react';
+import type { ElementType } from 'react';
+import { Group, Paper, SimpleGrid, Text, ThemeIcon } from '@mantine/core';
 import { BarChart3, Activity, CheckCircle2, XCircle, TrendingUp, Clock } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import type { WorkflowStats, WorkflowPeriod } from '@/hooks/useWorkflowStats';
 import { formatDuration } from '@/hooks/useMetrics';
 
@@ -18,7 +19,7 @@ export const WorkflowSummaryCards = memo(function WorkflowSummaryCards({
   period,
 }: WorkflowSummaryCardsProps) {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <SimpleGrid cols={{ base: 1, md: 2, lg: 3 }} spacing="md">
       <SummaryCard
         title="Total Workflows"
         value={stats.totalWorkflows}
@@ -52,7 +53,7 @@ export const WorkflowSummaryCards = memo(function WorkflowSummaryCards({
         icon={Clock}
         color="blue"
       />
-    </div>
+    </SimpleGrid>
   );
 });
 
@@ -60,31 +61,31 @@ interface SummaryCardProps {
   title: string;
   value: string | number;
   subtitle?: string;
-  icon: React.ElementType;
+  icon: ElementType;
   color: 'blue' | 'green' | 'red' | 'yellow';
 }
 
 function SummaryCard({ title, value, subtitle, icon: Icon, color }: SummaryCardProps) {
-  const colorClasses = {
-    blue: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-    green: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-    red: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-    yellow: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-  };
-
   return (
-    <div className="p-6 rounded-lg border bg-card">
-      <div className="flex items-start justify-between">
+    <Paper className="p-6" radius="md" withBorder>
+      <Group align="flex-start" justify="space-between">
         <div>
-          <p className="text-sm text-muted-foreground mb-1">{title}</p>
-          <p className="text-3xl font-bold">
-            {value} {subtitle && <span className="text-sm text-muted-foreground">{subtitle}</span>}
-          </p>
+          <Text size="sm" c="dimmed" mb={4}>
+            {title}
+          </Text>
+          <Text size="xl" fw={700} className="text-3xl">
+            {value}{' '}
+            {subtitle && (
+              <Text span size="sm" c="dimmed">
+                {subtitle}
+              </Text>
+            )}
+          </Text>
         </div>
-        <div className={cn('p-3 rounded-lg', colorClasses[color])}>
+        <ThemeIcon variant="light" color={color} size="xl" radius="md">
           <Icon className="h-6 w-6" />
-        </div>
-      </div>
-    </div>
+        </ThemeIcon>
+      </Group>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- Migrate workflow browse, dashboard, run list, active/recent run cards, health metrics, and run detail/timeline surfaces to direct Mantine primitives.
- Preserve workflow search, run start, dashboard filters, run selection, live status display, health progress, resume action, and step output expansion.
- Update the Mantine migration ledger and add focused wrapper-regression coverage for the workflow surfaces.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/workflow-surfaces-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Browser smoke at http://127.0.0.1:3000/ with setup screen rendered, setup controls responding, no framework overlay, and no console warnings/errors

## Notes
- Remaining #417 surfaces after this are dashboard telemetry/drilldowns, activity/chat overlays, policy/governance/scoring/drift, templates, and specialized runtime surfaces still using compatibility wrappers.