### PR TITLE
Migrate dashboard drilldowns to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -380,6 +380,13 @@ Phase 3 progress:
   simple grid, alert, code, text, title, and theme icon primitives while
   preserving workflow search, run start, dashboard filters, run selection, live
   status rendering, health progress, resume action, and step output expansion.
+- Dashboard telemetry filter, export, drawer, task, failure, token, and duration
+  drilldown surfaces now use direct Mantine select, text input, modal, drawer,
+  badge, skeleton, paper, progress, stack, group, simple grid, text, title,
+  theme icon, and scroll area primitives while preserving period selection,
+  custom ranges, export scope/format/date controls, drawer close behavior,
+  task selection, failure summaries, token summaries, duration summaries, and
+  per-agent breakdowns.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/dashboard-drilldowns-mantine.test.tsx
+++ b/web/src/__tests__/dashboard-drilldowns-mantine.test.tsx
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Stack } from '@mantine/core';
+
+import { DashboardFilterBar } from '@/components/dashboard/DashboardFilterBar';
+import { DrillDownPanel } from '@/components/dashboard/DrillDownPanel';
+import { DurationDrillDown } from '@/components/dashboard/DurationDrillDown';
+import { ErrorsDrillDown } from '@/components/dashboard/ErrorsDrillDown';
+import { ExportDialog } from '@/components/dashboard/ExportDialog';
+import { TasksDrillDown } from '@/components/dashboard/TasksDrillDown';
+import { TokensDrillDown } from '@/components/dashboard/TokensDrillDown';
+import { createMockProject, createMockTask, renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  useTasks: vi.fn(),
+  useProjects: vi.fn(),
+  useFailedRuns: vi.fn(),
+  useTokenMetrics: vi.fn(),
+  useDurationMetrics: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTasks', () => ({
+  useTasks: mocks.useTasks,
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProjects: mocks.useProjects,
+}));
+
+vi.mock('@/hooks/useMetrics', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useMetrics')>('@/hooks/useMetrics');
+  return {
+    ...actual,
+    useFailedRuns: mocks.useFailedRuns,
+    useTokenMetrics: mocks.useTokenMetrics,
+    useDurationMetrics: mocks.useDurationMetrics,
+  };
+});
+
+const projects = [
+  createMockProject({ id: 'proj-1', label: 'Platform' }),
+  createMockProject({ id: 'proj-2', label: 'Desktop' }),
+];
+
+describe('dashboard Mantine drilldown surfaces', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useTasks.mockReturnValue({
+      data: [
+        createMockTask({
+          id: 'task-1',
+          title: 'Migrate dashboard drilldowns',
+          status: 'in-progress',
+          project: 'proj-1',
+          updated: '2026-06-01T10:00:00Z',
+        }),
+        createMockTask({
+          id: 'task-2',
+          title: 'Fix export flow',
+          status: 'blocked',
+          project: 'proj-2',
+          updated: '2026-06-01T09:00:00Z',
+        }),
+      ],
+      isLoading: false,
+    });
+    mocks.useProjects.mockReturnValue({ data: projects });
+    mocks.useFailedRuns.mockReturnValue({
+      data: [
+        {
+          timestamp: '2026-06-01T10:00:00Z',
+          taskId: 'task-2',
+          project: 'proj-2',
+          agent: 'codex',
+          errorMessage: 'Smoke test failed',
+          durationMs: 125000,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useTokenMetrics.mockReturnValue({
+      data: {
+        period: '7d',
+        totalTokens: 24000,
+        inputTokens: 15000,
+        outputTokens: 8000,
+        cacheTokens: 1000,
+        runs: 4,
+        perSuccessfulRun: { avg: 6000, p50: 5400, p95: 9000 },
+        byAgent: [
+          {
+            agent: 'codex',
+            totalTokens: 24000,
+            inputTokens: 15000,
+            outputTokens: 8000,
+            cacheTokens: 1000,
+            runs: 4,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    mocks.useDurationMetrics.mockReturnValue({
+      data: {
+        period: '7d',
+        runs: 4,
+        avgMs: 125000,
+        p50Ms: 120000,
+        p95Ms: 180000,
+        byAgent: [
+          {
+            agent: 'codex',
+            runs: 4,
+            avgMs: 125000,
+            p50Ms: 120000,
+            p95Ms: 180000,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders dashboard filters through direct Mantine controls and preserves callbacks', async () => {
+    const user = userEvent.setup();
+    const onPeriodChange = vi.fn();
+    const onProjectChange = vi.fn();
+    const onExportClick = vi.fn();
+
+    const { baseElement, container } = renderWithProviders(
+      <DashboardFilterBar
+        period="7d"
+        onPeriodChange={onPeriodChange}
+        project="proj-1"
+        onProjectChange={onProjectChange}
+        projects={projects}
+        onExportClick={onExportClick}
+      />
+    );
+
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(10);
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-TextInput-root')).toHaveLength(2);
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Today' }));
+    expect(onPeriodChange).toHaveBeenCalledWith('today');
+
+    fireEvent.change(screen.getByLabelText('Custom date from'), {
+      target: { value: '2026-06-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Custom date to'), {
+      target: { value: '2026-06-03' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onPeriodChange).toHaveBeenLastCalledWith(
+      'custom',
+      expect.any(String),
+      expect.any(String)
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    expect(onExportClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders export and drilldown overlays through Mantine modal and drawer primitives', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onClose = vi.fn();
+
+    const { baseElement } = renderWithProviders(
+      <>
+        <ExportDialog open onOpenChange={onOpenChange} project="proj-1" projects={projects} />
+        <DrillDownPanel type="tokens" title="Token details" onClose={onClose}>
+          <p>Panel body</p>
+        </DrillDownPanel>
+      </>
+    );
+
+    expect(screen.getByRole('dialog', { name: /export metrics/i })).toBeDefined();
+    expect(screen.getByText('Token details')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Drawer-content')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(3);
+    expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="sheet-content"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    await user.click(screen.getByRole('button', { name: 'Close drilldown' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders dashboard drilldown content through direct Mantine primitives and preserves selection', async () => {
+    const user = userEvent.setup();
+    const onTaskClick = vi.fn();
+
+    const { baseElement, container } = renderWithProviders(
+      <Stack>
+        <TasksDrillDown onTaskClick={onTaskClick} />
+        <ErrorsDrillDown period="7d" onTaskClick={onTaskClick} />
+        <TokensDrillDown period="7d" />
+        <DurationDrillDown period="7d" />
+      </Stack>
+    );
+
+    expect(screen.getByText('Migrate dashboard drilldowns')).toBeDefined();
+    expect(screen.getByText('Smoke test failed')).toBeDefined();
+    expect(screen.getByText('Token Usage Summary (last 7 days)')).toBeDefined();
+    expect(screen.getByText('Run Duration Summary (last 7 days)')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThanOrEqual(8);
+    expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(4);
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="skeleton"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /migrate dashboard drilldowns/i }));
+    expect(onTaskClick).toHaveBeenCalledWith('task-1');
+
+    await user.click(screen.getByRole('button', { name: /task-2/i }));
+    expect(onTaskClick).toHaveBeenCalledWith('task-2');
+  });
+
+  it('uses Mantine skeletons for drilldown loading states', () => {
+    mocks.useTasks.mockReturnValueOnce({ data: undefined, isLoading: true });
+
+    const { baseElement, container } = renderWithProviders(<TasksDrillDown />);
+
+    expect(container.querySelectorAll('.mantine-Skeleton-root')).toHaveLength(5);
+    expect(baseElement.querySelector('[data-slot="skeleton"]')).toBeNull();
+  });
+});

--- a/web/src/components/dashboard/DashboardFilterBar.tsx
+++ b/web/src/components/dashboard/DashboardFilterBar.tsx
@@ -1,14 +1,6 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Button, Group, Select, Text, TextInput } from '@mantine/core';
 import { Download } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import type { MetricsPeriod } from '@/hooks/useMetrics';
 import type { ProjectConfig } from '@veritas-kanban/shared';
 
@@ -62,88 +54,82 @@ export function DashboardFilterBar({
   const isCustomActive = period === 'custom';
 
   return (
-    <div className="flex items-center gap-3 border-b pb-4 w-full">
+    <Group className="w-full border-b pb-4" gap="sm" justify="space-between" wrap="nowrap">
       {/* Left: Preset Pills */}
-      <div className="flex items-center gap-1.5 shrink-0">
+      <Group gap={6} className="shrink-0" wrap="nowrap">
         {PERIOD_PRESETS.map((preset) => (
           <Button
             key={preset.value}
-            variant={isPresetActive(preset.value) ? 'default' : 'ghost'}
-            size="sm"
-            className={cn(
-              'h-8 px-3 text-xs font-medium transition-all',
-              isPresetActive(preset.value) && 'shadow-sm'
-            )}
+            variant={isPresetActive(preset.value) ? 'filled' : 'subtle'}
+            size="xs"
             onClick={() => handlePresetClick(preset.value)}
           >
             {preset.label}
           </Button>
         ))}
-      </div>
+      </Group>
 
       {/* Right: Project + Custom Range + Export */}
-      <div className="flex items-center gap-3 ml-auto shrink-0">
+      <Group gap="sm" justify="flex-end" className="ml-auto shrink-0" wrap="nowrap">
         {/* Project Selector */}
         <Select
+          aria-label="Dashboard project filter"
+          size="xs"
+          w={160}
           value={project || 'all'}
-          onValueChange={(v) => onProjectChange(v === 'all' ? undefined : v)}
-        >
-          <SelectTrigger className="w-[160px] h-8 text-xs">
-            <SelectValue placeholder="All Projects" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Projects</SelectItem>
-            {projects.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={(value) => onProjectChange(value === 'all' ? undefined : (value ?? undefined))}
+          data={[
+            { value: 'all', label: 'All Projects' },
+            ...projects.map((p) => ({ value: p.id, label: p.label })),
+          ]}
+        />
 
         {/* Custom Date Range */}
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground whitespace-nowrap">Custom:</span>
-          <input
+        <Group gap={6} wrap="nowrap">
+          <Text size="xs" c="dimmed" className="whitespace-nowrap">
+            Custom:
+          </Text>
+          <TextInput
+            aria-label="Custom date from"
             type="date"
+            size="xs"
+            w={130}
             value={customFrom}
             onChange={(e) => setCustomFrom(e.target.value)}
-            className={cn(
-              'h-8 px-2 text-xs rounded-md border border-input bg-background',
-              'focus:outline-none focus:ring-2 focus:ring-ring',
-              'disabled:cursor-not-allowed disabled:opacity-50'
-            )}
             max={customTo || undefined}
           />
-          <span className="text-xs text-muted-foreground">→</span>
-          <input
+          <Text size="xs" c="dimmed">
+            to
+          </Text>
+          <TextInput
+            aria-label="Custom date to"
             type="date"
+            size="xs"
+            w={130}
             value={customTo}
             onChange={(e) => setCustomTo(e.target.value)}
-            className={cn(
-              'h-8 px-2 text-xs rounded-md border border-input bg-background',
-              'focus:outline-none focus:ring-2 focus:ring-ring',
-              'disabled:cursor-not-allowed disabled:opacity-50'
-            )}
             min={customFrom || undefined}
           />
           <Button
-            size="sm"
-            variant={isCustomActive ? 'default' : 'outline'}
-            className="h-8 px-3 text-xs"
+            size="xs"
+            variant={isCustomActive ? 'filled' : 'outline'}
             onClick={handleCustomApply}
             disabled={!customFrom || !customTo}
           >
             Apply
           </Button>
-        </div>
+        </Group>
 
         {/* Export Button */}
-        <Button variant="outline" size="sm" className="h-8 px-3 text-xs" onClick={onExportClick}>
-          <Download className="h-3 w-3 mr-1.5" />
+        <Button
+          variant="outline"
+          size="xs"
+          leftSection={<Download className="h-3 w-3" />}
+          onClick={onExportClick}
+        >
           Export
         </Button>
-      </div>
-    </div>
+      </Group>
+    </Group>
   );
 }

--- a/web/src/components/dashboard/DrillDownPanel.tsx
+++ b/web/src/components/dashboard/DrillDownPanel.tsx
@@ -1,6 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { Button } from '@/components/ui/button';
+import { ActionIcon, Drawer, Group, ScrollArea, Stack, Title } from '@mantine/core';
 
 export type DrillDownType = 'tasks' | 'errors' | 'tokens' | 'duration' | null;
 
@@ -13,19 +12,28 @@ interface DrillDownPanelProps {
 
 export function DrillDownPanel({ type, title, onClose, children }: DrillDownPanelProps) {
   return (
-    <Sheet open={type !== null} onOpenChange={() => onClose()}>
-      <SheetContent className="w-[600px] sm:max-w-[600px] overflow-hidden flex flex-col">
-        <SheetHeader className="flex-shrink-0">
-          <div className="flex items-center gap-2">
-            <Button variant="ghost" size="icon" onClick={onClose} className="h-8 w-8">
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-            <SheetTitle className="flex-1">{title}</SheetTitle>
-          </div>
-        </SheetHeader>
+    <Drawer
+      opened={type !== null}
+      onClose={onClose}
+      position="right"
+      size={600}
+      withCloseButton={false}
+      classNames={{ body: 'h-full overflow-hidden' }}
+    >
+      <Stack h="100%" gap={0}>
+        <Group gap="sm" className="flex-shrink-0">
+          <ActionIcon aria-label="Close drilldown" variant="subtle" onClick={onClose}>
+            <ArrowLeft className="h-4 w-4" />
+          </ActionIcon>
+          <Title order={2} className="text-lg">
+            {title}
+          </Title>
+        </Group>
 
-        <div className="flex-1 overflow-y-auto mt-4">{children}</div>
-      </SheetContent>
-    </Sheet>
+        <ScrollArea className="mt-4 flex-1" type="auto">
+          {children}
+        </ScrollArea>
+      </Stack>
+    </Drawer>
   );
 }

--- a/web/src/components/dashboard/DurationDrillDown.tsx
+++ b/web/src/components/dashboard/DurationDrillDown.tsx
@@ -1,6 +1,5 @@
+import { Badge, Group, Paper, SimpleGrid, Skeleton, Stack, Text } from '@mantine/core';
 import { useDurationMetrics, formatDuration, type MetricsPeriod } from '@/hooks/useMetrics';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Badge } from '@/components/ui/badge';
 import { Clock, Bot, TrendingUp, TrendingDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -35,32 +34,32 @@ export function DurationDrillDown({ period, project, from, to }: DurationDrillDo
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        <Skeleton className="h-24 w-full" />
+      <Stack gap="md">
+        <Skeleton h={96} radius="md" />
         {[...Array(3)].map((_, i) => (
-          <Skeleton key={i} className="h-16 w-full" />
+          <Skeleton key={i} h={64} radius="md" />
         ))}
-      </div>
+      </Stack>
     );
   }
 
   if (!metrics) {
     return (
-      <div className="text-center py-8">
+      <Stack align="center" gap="xs" py="xl">
         <Clock className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-        <p className="text-muted-foreground">No duration data available</p>
-      </div>
+        <Text c="dimmed">No duration data available</Text>
+      </Stack>
     );
   }
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Summary Card */}
-      <div className="rounded-lg border bg-card p-4">
-        <h4 className="text-sm font-medium text-muted-foreground mb-3">
+      <Paper withBorder p="md" radius="md">
+        <Text size="sm" fw={500} c="dimmed" mb="sm">
           Run Duration Summary ({getPeriodLabel(period)})
-        </h4>
-        <div className="grid grid-cols-4 gap-4">
+        </Text>
+        <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="md">
           <div>
             <div className="text-2xl font-bold text-primary">{metrics.runs}</div>
             <div className="text-xs text-muted-foreground">Total Runs</div>
@@ -79,20 +78,24 @@ export function DurationDrillDown({ period, project, from, to }: DurationDrillDo
             </div>
             <div className="text-xs text-muted-foreground">95th Percentile</div>
           </div>
-        </div>
-      </div>
+        </SimpleGrid>
+      </Paper>
 
       {/* Per-Agent Breakdown */}
-      <div>
-        <h4 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
+      <Stack gap="sm">
+        <Group gap="xs">
           <Bot className="h-4 w-4" />
-          Breakdown by Agent
-        </h4>
+          <Text size="sm" fw={500} c="dimmed">
+            Breakdown by Agent
+          </Text>
+        </Group>
 
         {metrics.byAgent.length === 0 ? (
-          <div className="text-center py-4 text-muted-foreground">No agent data available</div>
+          <Text ta="center" c="dimmed" py="md">
+            No agent data available
+          </Text>
         ) : (
-          <div className="space-y-2">
+          <Stack gap="xs">
             {metrics.byAgent.map((agent, index) => {
               // Find fastest and slowest
               const isFastest =
@@ -113,10 +116,10 @@ export function DurationDrillDown({ period, project, from, to }: DurationDrillDo
                 />
               );
             })}
-          </div>
+          </Stack>
         )}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }
 
@@ -139,36 +142,46 @@ function AgentDurationRow({ agent, overallAvg, isFastest, isSlowest }: AgentDura
   const isAboveAvg = diff > 0;
 
   return (
-    <div
+    <Paper
+      withBorder
+      p="sm"
+      radius="md"
       className={cn(
-        'rounded-lg border p-3',
         isFastest && 'border-green-500/30 bg-green-500/5',
         isSlowest && 'border-yellow-500/30 bg-yellow-500/5'
       )}
     >
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
+      <Group align="center" justify="space-between" gap="sm" mb="xs" wrap="nowrap">
+        <Group gap="xs" wrap="wrap">
           <Bot className="h-4 w-4 text-muted-foreground" />
           <span className="font-medium">{agent.agent}</span>
           {isFastest && (
-            <Badge variant="secondary" className="text-xs flex items-center gap-1 text-green-500">
-              <TrendingDown className="h-3 w-3" />
+            <Badge
+              variant="light"
+              color="green"
+              size="xs"
+              leftSection={<TrendingDown className="h-3 w-3" />}
+            >
               Fastest
             </Badge>
           )}
           {isSlowest && (
-            <Badge variant="secondary" className="text-xs flex items-center gap-1 text-yellow-500">
-              <TrendingUp className="h-3 w-3" />
+            <Badge
+              variant="light"
+              color="yellow"
+              size="xs"
+              leftSection={<TrendingUp className="h-3 w-3" />}
+            >
               Slowest
             </Badge>
           )}
-        </div>
-        <Badge variant="outline" className="text-xs">
+        </Group>
+        <Badge variant="outline" color="gray" size="xs">
           {agent.runs} runs
         </Badge>
-      </div>
+      </Group>
 
-      <div className="grid grid-cols-4 gap-4 text-sm">
+      <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="md" className="text-sm">
         <div>
           <span className="text-muted-foreground text-xs block">Average</span>
           <span className="font-medium">{formatDuration(agent.avgMs)}</span>
@@ -188,7 +201,7 @@ function AgentDurationRow({ agent, overallAvg, isFastest, isSlowest }: AgentDura
             {diffPercent.toFixed(1)}%
           </span>
         </div>
-      </div>
-    </div>
+      </SimpleGrid>
+    </Paper>
   );
 }

--- a/web/src/components/dashboard/ErrorsDrillDown.tsx
+++ b/web/src/components/dashboard/ErrorsDrillDown.tsx
@@ -1,7 +1,6 @@
+import { Badge, Group, Paper, Skeleton, Stack, Text, ThemeIcon } from '@mantine/core';
 import { useFailedRuns, formatDuration, type MetricsPeriod } from '@/hooks/useMetrics';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
-import { AlertTriangle, Clock, Bot, ExternalLink } from 'lucide-react';
+import { AlertTriangle, Clock, Bot, ExternalLink, CheckCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ErrorsDrillDownProps {
@@ -36,43 +35,45 @@ export function ErrorsDrillDown({ period, project, onTaskClick, from, to }: Erro
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <Stack gap="md">
         {[...Array(5)].map((_, i) => (
-          <Skeleton key={i} className="h-20 w-full" />
+          <Skeleton key={i} h={80} radius="md" />
         ))}
-      </div>
+      </Stack>
     );
   }
 
   if (!failedRuns || failedRuns.length === 0) {
     return (
-      <div className="text-center py-8">
-        <div className="h-12 w-12 mx-auto mb-4 rounded-full bg-green-500/10 flex items-center justify-center">
-          <span className="text-green-500 text-xl">✓</span>
-        </div>
-        <p className="text-foreground font-medium">All runs successful</p>
-        <p className="text-sm text-muted-foreground mt-1">No failures in the selected period</p>
-      </div>
+      <Stack align="center" gap="xs" py="xl">
+        <ThemeIcon color="green" variant="light" size={48} radius="xl">
+          <CheckCircle className="h-6 w-6" />
+        </ThemeIcon>
+        <Text fw={600}>All runs successful</Text>
+        <Text size="sm" c="dimmed">
+          No failures in the selected period
+        </Text>
+      </Stack>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Summary */}
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <Group gap="xs" className="text-sm text-muted-foreground">
         <AlertTriangle className="h-4 w-4 text-red-500" />
         <span>
           {failedRuns.length} failed run(s) in the {getPeriodLabel(period)}
         </span>
-      </div>
+      </Group>
 
       {/* Failed Runs List */}
-      <div className="space-y-2">
+      <Stack gap="xs">
         {failedRuns.map((run, index) => (
           <FailedRunRow key={`${run.timestamp}-${index}`} run={run} onTaskClick={onTaskClick} />
         ))}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }
 
@@ -90,58 +91,63 @@ interface FailedRunRowProps {
 
 function FailedRunRow({ run, onTaskClick }: FailedRunRowProps) {
   const date = new Date(run.timestamp);
-  const canNavigate = run.taskId && onTaskClick;
+  const taskId = run.taskId;
+  const canNavigate = Boolean(taskId && onTaskClick);
 
   const content = (
-    <div
+    <Paper
+      withBorder
+      p="sm"
+      radius="md"
       className={cn(
-        'rounded-lg border border-red-500/20 bg-red-500/5 p-3',
+        'border-red-500/20 bg-red-500/5',
         canNavigate && 'hover:bg-red-500/10 transition-colors cursor-pointer'
       )}
     >
-      <div className="flex items-start justify-between gap-2">
+      <Group align="flex-start" justify="space-between" gap="sm" wrap="nowrap">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
+          <Group gap="xs" wrap="nowrap">
             <AlertTriangle className="h-4 w-4 text-red-500 flex-shrink-0" />
             <span className="font-medium truncate">{run.taskId || 'Unknown task'}</span>
             {canNavigate && <ExternalLink className="h-3 w-3 text-muted-foreground" />}
-          </div>
+          </Group>
 
           {run.errorMessage && (
             <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{run.errorMessage}</p>
           )}
 
-          <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
-            <span className="flex items-center gap-1">
+          <Group gap="sm" mt="xs" className="text-xs text-muted-foreground" wrap="wrap">
+            <Group gap={4}>
               <Bot className="h-3 w-3" />
               {run.agent}
-            </span>
+            </Group>
             {run.project && (
-              <Badge variant="outline" className="text-xs">
+              <Badge variant="outline" color="gray" size="xs">
                 {run.project}
               </Badge>
             )}
             {run.durationMs && (
-              <span className="flex items-center gap-1">
+              <Group gap={4}>
                 <Clock className="h-3 w-3" />
                 {formatDuration(run.durationMs)}
-              </span>
+              </Group>
             )}
-          </div>
+          </Group>
         </div>
 
         <div className="text-xs text-muted-foreground text-right flex-shrink-0">
           <div>{date.toLocaleDateString()}</div>
           <div>{date.toLocaleTimeString()}</div>
         </div>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 
-  if (canNavigate) {
+  if (taskId && onTaskClick) {
     return (
       <button
-        onClick={() => onTaskClick(run.taskId!)}
+        type="button"
+        onClick={() => onTaskClick(taskId)}
         className="w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset rounded-lg"
       >
         {content}

--- a/web/src/components/dashboard/ExportDialog.tsx
+++ b/web/src/components/dashboard/ExportDialog.tsx
@@ -1,24 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { Button, Group, Loader, Modal, Select, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Download } from 'lucide-react';
 import { API_BASE } from '@/lib/config';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Download, Loader2 } from 'lucide-react';
 
 export type ExportScope = 'full' | 'project' | 'task';
 export type ExportFormat = 'csv' | 'json';
@@ -56,38 +39,45 @@ export function ExportDialog({
   const [toDate, setToDate] = useState('');
   const [isExporting, setIsExporting] = useState(false);
 
+  useEffect(() => {
+    if (!open) return;
+
+    setFormat('csv');
+    setScope(initialTaskId ? 'task' : initialProject ? 'project' : 'full');
+    setTaskId(initialTaskId || '');
+    setProject(initialProject || '');
+    setFromDate('');
+    setToDate('');
+  }, [open, initialTaskId, initialProject]);
+
   const handleExport = async () => {
     setIsExporting(true);
-    
+
     try {
-      // Build query params
       const params = new URLSearchParams();
       params.set('format', format);
-      
+
       if (scope === 'task' && taskId) {
         params.set('taskId', taskId);
       } else if (scope === 'project' && project) {
         params.set('project', project);
       }
-      
+
       if (fromDate) {
         params.set('from', new Date(fromDate).toISOString());
       }
       if (toDate) {
-        // Set to end of day
         const toDateTime = new Date(toDate);
         toDateTime.setHours(23, 59, 59, 999);
         params.set('to', toDateTime.toISOString());
       }
-      
-      // Fetch the export
+
       const response = await fetch(`${API_BASE}/telemetry/export?${params}`);
-      
+
       if (!response.ok) {
         throw new Error('Export failed');
       }
-      
-      // Get filename from Content-Disposition header or generate one
+
       const disposition = response.headers.get('Content-Disposition');
       let filename = `telemetry-export.${format}`;
       if (disposition) {
@@ -96,8 +86,7 @@ export function ExportDialog({
           filename = match[1];
         }
       }
-      
-      // Create blob and download
+
       const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
@@ -107,171 +96,114 @@ export function ExportDialog({
       link.click();
       document.body.removeChild(link);
       window.URL.revokeObjectURL(url);
-      
+
       onOpenChange(false);
     } catch (error) {
       console.error('Export error:', error);
-      // Could add toast notification here
     } finally {
       setIsExporting(false);
     }
   };
 
-  // Reset form when dialog opens
-  const handleOpenChange = (open: boolean) => {
-    if (open) {
-      setFormat('csv');
-      setScope(initialTaskId ? 'task' : initialProject ? 'project' : 'full');
-      setTaskId(initialTaskId || '');
-      setProject(initialProject || '');
-      setFromDate('');
-      setToDate('');
-    }
-    onOpenChange(open);
-  };
+  const handleClose = () => onOpenChange(false);
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Download className="h-5 w-5" />
+    <Modal
+      opened={open}
+      onClose={handleClose}
+      size="md"
+      centered
+      title={
+        <Group gap="sm">
+          <Download className="h-5 w-5" />
+          <Title order={2} className="text-lg">
             Export Metrics
-          </DialogTitle>
-          <DialogDescription>
-            Export telemetry data as CSV or JSON for reporting and analysis.
-          </DialogDescription>
-        </DialogHeader>
+          </Title>
+        </Group>
+      }
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          Export telemetry data as CSV or JSON for reporting and analysis.
+        </Text>
 
-        <div className="grid gap-4 py-4">
-          {/* Format Selection */}
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="format" className="text-right">
-              Format
-            </Label>
-            <Select value={format} onValueChange={(v) => setFormat(v as ExportFormat)}>
-              <SelectTrigger className="col-span-3">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="csv">CSV (Spreadsheets)</SelectItem>
-                <SelectItem value="json">JSON (Programmatic)</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+        <Select
+          label="Format"
+          value={format}
+          onChange={(value) => setFormat((value ?? 'csv') as ExportFormat)}
+          data={[
+            { value: 'csv', label: 'CSV (Spreadsheets)' },
+            { value: 'json', label: 'JSON (Programmatic)' },
+          ]}
+        />
 
-          {/* Scope Selection */}
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="scope" className="text-right">
-              Scope
-            </Label>
-            <Select value={scope} onValueChange={(v) => setScope(v as ExportScope)}>
-              <SelectTrigger className="col-span-3">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="full">All Data</SelectItem>
-                <SelectItem value="project">By Project</SelectItem>
-                <SelectItem value="task">By Task</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+        <Select
+          label="Scope"
+          value={scope}
+          onChange={(value) => setScope((value ?? 'full') as ExportScope)}
+          data={[
+            { value: 'full', label: 'All Data' },
+            { value: 'project', label: 'By Project' },
+            { value: 'task', label: 'By Task' },
+          ]}
+        />
 
-          {/* Project Selection (conditional) */}
-          {scope === 'project' && (
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="project" className="text-right">
-                Project
-              </Label>
-              {projects.length > 0 ? (
-                <Select value={project} onValueChange={setProject}>
-                  <SelectTrigger className="col-span-3">
-                    <SelectValue placeholder="Select project..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {projects.map((p) => (
-                      <SelectItem key={p.id} value={p.id}>{p.label}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <Input
-                  id="project"
-                  value={project}
-                  onChange={(e) => setProject(e.target.value)}
-                  placeholder="Project name"
-                  className="col-span-3"
-                />
-              )}
-            </div>
-          )}
-
-          {/* Task ID (conditional) */}
-          {scope === 'task' && (
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="taskId" className="text-right">
-                Task ID
-              </Label>
-              <Input
-                id="taskId"
-                value={taskId}
-                onChange={(e) => setTaskId(e.target.value)}
-                placeholder="task_..."
-                className="col-span-3"
-              />
-            </div>
-          )}
-
-          {/* Date Range */}
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="from" className="text-right">
-              From
-            </Label>
-            <Input
-              id="from"
-              type="date"
-              value={fromDate}
-              onChange={(e) => setFromDate(e.target.value)}
-              className="col-span-3"
+        {scope === 'project' &&
+          (projects.length > 0 ? (
+            <Select
+              label="Project"
+              value={project}
+              onChange={(value) => setProject(value ?? '')}
+              placeholder="Select project..."
+              data={projects.map((p) => ({ value: p.id, label: p.label }))}
             />
-          </div>
-
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="to" className="text-right">
-              To
-            </Label>
-            <Input
-              id="to"
-              type="date"
-              value={toDate}
-              onChange={(e) => setToDate(e.target.value)}
-              className="col-span-3"
+          ) : (
+            <TextInput
+              label="Project"
+              value={project}
+              onChange={(e) => setProject(e.target.value)}
+              placeholder="Project name"
             />
-          </div>
-        </div>
+          ))}
 
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+        {scope === 'task' && (
+          <TextInput
+            label="Task ID"
+            value={taskId}
+            onChange={(e) => setTaskId(e.target.value)}
+            placeholder="task_..."
+          />
+        )}
+
+        <TextInput
+          label="From"
+          type="date"
+          value={fromDate}
+          onChange={(e) => setFromDate(e.target.value)}
+        />
+
+        <TextInput
+          label="To"
+          type="date"
+          value={toDate}
+          onChange={(e) => setToDate(e.target.value)}
+        />
+
+        <Group justify="flex-end" mt="sm">
+          <Button variant="outline" onClick={handleClose}>
             Cancel
           </Button>
-          <Button 
-            onClick={handleExport} 
-            disabled={isExporting || (scope === 'task' && !taskId) || (scope === 'project' && !project)}
+          <Button
+            onClick={handleExport}
+            disabled={
+              isExporting || (scope === 'task' && !taskId) || (scope === 'project' && !project)
+            }
+            leftSection={isExporting ? <Loader size={14} /> : <Download className="h-4 w-4" />}
           >
-            {isExporting ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Exporting...
-              </>
-            ) : (
-              <>
-                <Download className="mr-2 h-4 w-4" />
-                Export
-              </>
-            )}
+            {isExporting ? 'Exporting...' : 'Export'}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </Group>
+      </Stack>
+    </Modal>
   );
 }

--- a/web/src/components/dashboard/TasksDrillDown.tsx
+++ b/web/src/components/dashboard/TasksDrillDown.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
+import { Badge, Group, Paper, Skeleton, Stack, Text } from '@mantine/core';
 import { useTasks } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
 import { CheckCircle, Play, Ban, ListTodo } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { TaskStatus, Task } from '@veritas-kanban/shared';
@@ -18,32 +17,38 @@ const statusConfig: Record<
   {
     icon: React.ReactNode;
     color: string;
+    iconClassName: string;
     label: string;
   }
 > = {
   todo: {
     icon: <ListTodo className="h-4 w-4" />,
-    color: 'text-muted-foreground',
+    color: 'gray',
+    iconClassName: 'text-muted-foreground',
     label: 'To Do',
   },
   'in-progress': {
     icon: <Play className="h-4 w-4" />,
-    color: 'text-blue-500',
+    color: 'blue',
+    iconClassName: 'text-blue-500',
     label: 'In Progress',
   },
   blocked: {
     icon: <Ban className="h-4 w-4" />,
-    color: 'text-red-500',
+    color: 'red',
+    iconClassName: 'text-red-500',
     label: 'Blocked',
   },
   done: {
     icon: <CheckCircle className="h-4 w-4" />,
-    color: 'text-green-500',
+    color: 'green',
+    iconClassName: 'text-green-500',
     label: 'Done',
   },
   cancelled: {
     icon: <Ban className="h-4 w-4" />,
-    color: 'text-gray-400',
+    color: 'gray',
+    iconClassName: 'text-gray-400',
     label: 'Cancelled',
   },
 };
@@ -92,37 +97,34 @@ export function TasksDrillDown({
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <Stack gap="md">
         {[...Array(5)].map((_, i) => (
-          <Skeleton key={i} className="h-16 w-full" />
+          <Skeleton key={i} h={64} radius="md" />
         ))}
-      </div>
+      </Stack>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Summary Stats */}
-      <div className="flex gap-2 flex-wrap">
+      <Group gap="xs" wrap="wrap">
         {Object.entries(statusCounts).map(([status, count]) => {
           const config = statusConfig[status as TaskStatus];
           return (
-            <Badge
-              key={status}
-              variant="secondary"
-              className={cn('flex items-center gap-1', config.color)}
-            >
-              {config.icon}
+            <Badge key={status} variant="light" color={config.color} leftSection={config.icon}>
               {config.label}: {count}
             </Badge>
           );
         })}
-      </div>
+      </Group>
 
       {/* Task List */}
-      <div className="space-y-2">
+      <Stack gap="xs">
         {filteredTasks.length === 0 ? (
-          <div className="text-center text-muted-foreground py-8">No tasks found</div>
+          <Text ta="center" c="dimmed" py="xl">
+            No tasks found
+          </Text>
         ) : (
           filteredTasks.map((task) => (
             <TaskRow
@@ -133,8 +135,8 @@ export function TasksDrillDown({
             />
           ))
         )}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }
 
@@ -153,31 +155,36 @@ function TaskRow({
     : null;
 
   return (
-    <button
+    <Paper
+      component="button"
+      type="button"
+      withBorder
+      radius="md"
+      p="sm"
       onClick={onClick}
       className={cn(
-        'w-full text-left rounded-lg border p-3',
+        'w-full text-left',
         'hover:bg-muted/50 transition-colors',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
       )}
     >
-      <div className="flex items-start gap-3">
-        <div className={cn('mt-0.5', config.color)}>{config.icon}</div>
+      <Group align="flex-start" gap="sm" wrap="nowrap">
+        <div className={cn('mt-0.5', config.iconClassName)}>{config.icon}</div>
         <div className="flex-1 min-w-0">
           <div className="font-medium truncate">{task.title}</div>
-          <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+          <Group gap="xs" mt={4} className="text-xs text-muted-foreground" wrap="wrap">
             {projectLabel && (
-              <Badge variant="outline" className="text-xs">
+              <Badge variant="outline" color="gray" size="xs">
                 {projectLabel}
               </Badge>
             )}
             <span>{new Date(task.updated).toLocaleDateString()}</span>
-          </div>
+          </Group>
         </div>
-        <Badge variant="secondary" className={cn('text-xs', config.color)}>
+        <Badge variant="light" color={config.color} size="xs">
           {config.label}
         </Badge>
-      </div>
-    </button>
+      </Group>
+    </Paper>
   );
 }

--- a/web/src/components/dashboard/TokensDrillDown.tsx
+++ b/web/src/components/dashboard/TokensDrillDown.tsx
@@ -1,6 +1,5 @@
+import { Badge, Group, Paper, Progress, SimpleGrid, Skeleton, Stack, Text } from '@mantine/core';
 import { useTokenMetrics, formatTokens, type MetricsPeriod } from '@/hooks/useMetrics';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Badge } from '@/components/ui/badge';
 import { Coins, Bot, TrendingUp } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -35,32 +34,32 @@ export function TokensDrillDown({ period, project, from, to }: TokensDrillDownPr
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        <Skeleton className="h-24 w-full" />
+      <Stack gap="md">
+        <Skeleton h={96} radius="md" />
         {[...Array(3)].map((_, i) => (
-          <Skeleton key={i} className="h-16 w-full" />
+          <Skeleton key={i} h={64} radius="md" />
         ))}
-      </div>
+      </Stack>
     );
   }
 
   if (!metrics) {
     return (
-      <div className="text-center py-8">
+      <Stack align="center" gap="xs" py="xl">
         <Coins className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-        <p className="text-muted-foreground">No token data available</p>
-      </div>
+        <Text c="dimmed">No token data available</Text>
+      </Stack>
     );
   }
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Summary Card */}
-      <div className="rounded-lg border bg-card p-4">
-        <h4 className="text-sm font-medium text-muted-foreground mb-3">
+      <Paper withBorder p="md" radius="md">
+        <Text size="sm" fw={500} c="dimmed" mb="sm">
           Token Usage Summary ({getPeriodLabel(period)})
-        </h4>
-        <div className={cn('grid gap-4', metrics.cacheTokens > 0 ? 'grid-cols-4' : 'grid-cols-3')}>
+        </Text>
+        <SimpleGrid cols={{ base: 2, sm: metrics.cacheTokens > 0 ? 4 : 3 }} spacing="md">
           <div>
             <div className="text-2xl font-bold text-primary">
               {formatTokens(metrics.totalTokens)}
@@ -87,13 +86,13 @@ export function TokensDrillDown({ period, project, from, to }: TokensDrillDownPr
               <div className="text-xs text-muted-foreground">Cache Hits</div>
             </div>
           )}
-        </div>
+        </SimpleGrid>
 
-        <div className="mt-4 pt-3 border-t">
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">Per Run Statistics:</span>
-          </div>
-          <div className="flex gap-4 mt-1">
+        <div className="mt-4 border-t pt-3">
+          <Text size="sm" c="dimmed">
+            Per Run Statistics:
+          </Text>
+          <Group gap="md" mt={4}>
             <div>
               <span className="text-muted-foreground text-xs">Avg: </span>
               <span className="font-medium">{formatTokens(metrics.perSuccessfulRun.avg)}</span>
@@ -106,21 +105,25 @@ export function TokensDrillDown({ period, project, from, to }: TokensDrillDownPr
               <span className="text-muted-foreground text-xs">p95: </span>
               <span className="font-medium">{formatTokens(metrics.perSuccessfulRun.p95)}</span>
             </div>
-          </div>
+          </Group>
         </div>
-      </div>
+      </Paper>
 
       {/* Per-Agent Breakdown */}
-      <div>
-        <h4 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
+      <Stack gap="sm">
+        <Group gap="xs">
           <Bot className="h-4 w-4" />
-          Breakdown by Agent
-        </h4>
+          <Text size="sm" fw={500} c="dimmed">
+            Breakdown by Agent
+          </Text>
+        </Group>
 
         {metrics.byAgent.length === 0 ? (
-          <div className="text-center py-4 text-muted-foreground">No agent data available</div>
+          <Text ta="center" c="dimmed" py="md">
+            No agent data available
+          </Text>
         ) : (
-          <div className="space-y-2">
+          <Stack gap="xs">
             {metrics.byAgent.map((agent, index) => {
               const percentage =
                 metrics.totalTokens > 0 ? (agent.totalTokens / metrics.totalTokens) * 100 : 0;
@@ -134,10 +137,10 @@ export function TokensDrillDown({ period, project, from, to }: TokensDrillDownPr
                 />
               );
             })}
-          </div>
+          </Stack>
         )}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }
 
@@ -156,30 +159,31 @@ interface AgentTokenRowProps {
 
 function AgentTokenRow({ agent, percentage, isTop }: AgentTokenRowProps) {
   return (
-    <div className={cn('rounded-lg border p-3', isTop && 'border-primary/30 bg-primary/5')}>
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
+    <Paper withBorder p="sm" radius="md" className={cn(isTop && 'border-primary/30 bg-primary/5')}>
+      <Group align="center" justify="space-between" gap="sm" mb="xs" wrap="nowrap">
+        <Group gap="xs" wrap="wrap">
           <Bot className="h-4 w-4 text-muted-foreground" />
           <span className="font-medium">{agent.agent}</span>
           {isTop && (
-            <Badge variant="secondary" className="text-xs flex items-center gap-1">
-              <TrendingUp className="h-3 w-3" />
+            <Badge
+              variant="light"
+              color="blue"
+              size="xs"
+              leftSection={<TrendingUp className="h-3 w-3" />}
+            >
               Top Consumer
             </Badge>
           )}
-        </div>
-        <Badge variant="outline" className="text-xs">
+        </Group>
+        <Badge variant="outline" color="gray" size="xs">
           {agent.runs} runs
         </Badge>
-      </div>
+      </Group>
 
-      {/* Progress Bar */}
-      <div className="h-2 bg-muted rounded-full overflow-hidden mb-2">
-        <div className="h-full bg-primary transition-all" style={{ width: `${percentage}%` }} />
-      </div>
+      <Progress value={percentage} size="sm" mb="xs" />
 
-      <div className="flex justify-between text-sm">
-        <div className="flex gap-4 flex-wrap">
+      <Group justify="space-between" align="flex-start" gap="sm" className="text-sm">
+        <Group gap="md" wrap="wrap">
           <span>
             <span className="text-muted-foreground">Total: </span>
             <span className="font-medium">{formatTokens(agent.totalTokens)}</span>
@@ -198,9 +202,9 @@ function AgentTokenRow({ agent, percentage, isTop }: AgentTokenRowProps) {
               <span className="text-amber-500">{formatTokens(agent.cacheTokens)}</span>
             </span>
           )}
-        </div>
+        </Group>
         <span className="text-muted-foreground">{percentage.toFixed(1)}%</span>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary

- Migrates dashboard filter, export, drawer, task, error, token, and duration drilldown surfaces to direct Mantine primitives.
- Preserves period selection, custom date range application, export scope and date controls, drilldown close behavior, task row selection, failure summaries, token summaries, duration summaries, and per-agent breakdowns.
- Adds focused regression coverage proving the migrated dashboard path no longer renders the old compatibility wrapper markers.

## Verification

- `pnpm --filter @veritas-kanban/web test -- src/__tests__/dashboard-drilldowns-mantine.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm lint:budget`
- `git diff --check`
- Rendered smoke on `http://127.0.0.1:3000/` with the local API on `127.0.0.1:3001`: app booted to setup, no framework overlay, no browser warnings or errors.

## Notes

- This advances #417 and the v5 roadmap epic #326.
- Remaining dashboard widget/chart wrappers are intentionally left for a follow-up slice.
