### PR TITLE
Migrate dashboard widgets to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -387,6 +387,12 @@ Phase 3 progress:
   custom ranges, export scope/format/date controls, drawer close behavior,
   task selection, failure summaries, token summaries, duration summaries, and
   per-agent breakdowns.
+- Dashboard widget and chart shells now use direct Mantine paper, skeleton,
+  tooltip, action icon, progress, stack, group, simple grid, text, and theme icon
+  primitives for active dashboard cards, status timeline, agent comparison,
+  trends, wall-time, activity clock, and the budget widget while preserving
+  existing metric queries, chart rendering, sorting, help affordances, and
+  toggle behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/dashboard-widgets-mantine.test.tsx
+++ b/web/src/__tests__/dashboard-widgets-mantine.test.tsx
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Stack } from '@mantine/core';
+
+import { ActivityClock } from '@/components/dashboard/ActivityClock';
+import { AgentComparison } from '@/components/dashboard/AgentComparison';
+import { BudgetCard } from '@/components/dashboard/BudgetCard';
+import { StatusTimeline } from '@/components/dashboard/StatusTimeline';
+import { TrendsCharts } from '@/components/dashboard/TrendsCharts';
+import { WallTimeToggle } from '@/components/dashboard/WallTimeToggle';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  useDailySummary: vi.fn(),
+  useTrends: vi.fn(),
+  useBudgetMetrics: vi.fn(),
+}));
+
+vi.mock('@/lib/api/helpers', () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+vi.mock('@/hooks/useStatusHistory', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useStatusHistory')>(
+    '@/hooks/useStatusHistory'
+  );
+  return {
+    ...actual,
+    useDailySummary: mocks.useDailySummary,
+  };
+});
+
+vi.mock('@/hooks/useTrends', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useTrends')>('@/hooks/useTrends');
+  return {
+    ...actual,
+    useTrends: mocks.useTrends,
+  };
+});
+
+vi.mock('@/hooks/useBudgetMetrics', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useBudgetMetrics')>(
+    '@/hooks/useBudgetMetrics'
+  );
+  return {
+    ...actual,
+    useBudgetMetrics: mocks.useBudgetMetrics,
+  };
+});
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSettings: () => ({
+    settings: {
+      budget: {
+        enabled: true,
+        monthlyTokenLimit: 100000,
+        monthlyCostLimit: 100,
+        warningThreshold: 80,
+      },
+    },
+  }),
+}));
+
+const trendDaily = [
+  {
+    date: '2026-06-01',
+    runs: 4,
+    successes: 3,
+    failures: 1,
+    errors: 1,
+    successRate: 75,
+    totalTokens: 24000,
+    inputTokens: 15000,
+    outputTokens: 9000,
+    avgDurationMs: 90000,
+    tasksCreated: 2,
+    statusChanges: 6,
+    tasksArchived: 1,
+  },
+  {
+    date: '2026-06-02',
+    runs: 2,
+    successes: 2,
+    failures: 0,
+    errors: 0,
+    successRate: 100,
+    totalTokens: 16000,
+    inputTokens: 10000,
+    outputTokens: 6000,
+    avgDurationMs: 60000,
+    tasksCreated: 1,
+    statusChanges: 4,
+    tasksArchived: 0,
+  },
+];
+
+describe('dashboard widget Mantine migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useDailySummary.mockReturnValue({
+      data: {
+        date: '2026-06-01',
+        activeMs: 7200000,
+        idleMs: 1800000,
+        errorMs: 0,
+        transitions: 8,
+      },
+      isLoading: false,
+    });
+    mocks.useTrends.mockReturnValue({
+      data: { period: '7d', daily: trendDaily },
+      isLoading: false,
+      error: null,
+    });
+    mocks.useBudgetMetrics.mockReturnValue({
+      data: {
+        periodStart: '2026-06-01',
+        periodEnd: '2026-06-30',
+        daysInMonth: 30,
+        daysElapsed: 1,
+        daysRemaining: 29,
+        totalTokens: 24000,
+        inputTokens: 15000,
+        outputTokens: 9000,
+        estimatedCost: 12,
+        tokensPerDay: 24000,
+        costPerDay: 12,
+        projectedMonthlyTokens: 720000,
+        projectedMonthlyCost: 360,
+        tokenBudget: 1000000,
+        costBudget: 500,
+        tokenBudgetUsed: 24,
+        costBudgetUsed: 2.4,
+        projectedTokenOverage: 72,
+        projectedCostOverage: 72,
+        status: 'ok',
+      },
+      isLoading: false,
+      error: null,
+    });
+    mocks.apiFetch.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/metrics/agents/comparison')) {
+        return {
+          period: '7d',
+          minRuns: 1,
+          agents: [
+            {
+              agent: 'codex',
+              runs: 4,
+              successes: 4,
+              failures: 0,
+              successRate: 100,
+              avgDurationMs: 60000,
+              avgTokensPerRun: 4000,
+              totalTokens: 16000,
+              avgCostPerRun: 0.5,
+              totalCost: 2,
+            },
+          ],
+          recommendations: [
+            {
+              category: 'reliability',
+              agent: 'codex',
+              value: '100%',
+              reason: 'Best success rate',
+            },
+          ],
+          totalAgents: 1,
+          qualifyingAgents: 1,
+        };
+      }
+      if (url.startsWith('/api/status-history')) {
+        return [
+          {
+            timestamp: '2026-06-01T10:00:00Z',
+            previousStatus: 'idle',
+            newStatus: 'working',
+          },
+          {
+            timestamp: '2026-06-01T11:00:00Z',
+            previousStatus: 'working',
+            newStatus: 'idle',
+          },
+        ];
+      }
+      if (url.startsWith('/api/metrics/task-cost')) {
+        return {
+          tasks: [
+            {
+              taskId: 'task-1',
+              totalDurationMs: 120000,
+              runs: 2,
+            },
+          ],
+        };
+      }
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders dashboard widgets through direct Mantine primitives', async () => {
+    const user = userEvent.setup();
+    const { baseElement, container } = renderWithProviders(
+      <Stack>
+        <StatusTimeline />
+        <AgentComparison />
+        <TrendsCharts />
+        <ActivityClock period="7d" />
+        <WallTimeToggle period="7d" />
+        <BudgetCard />
+      </Stack>
+    );
+
+    expect(screen.getByText('Daily Activity (2026-06-01)')).toBeDefined();
+    expect(await screen.findByText('Agent Comparison')).toBeDefined();
+    expect(await screen.findByText('Most Reliable')).toBeDefined();
+    expect(screen.getByText('Historical Trends')).toBeDefined();
+    expect(await screen.findByText('Activity Clock')).toBeDefined();
+    expect(await screen.findByText('Total Agent Time')).toBeDefined();
+    expect(screen.getByText('Monthly Budget')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(8);
+    expect(container.querySelectorAll('.mantine-ActionIcon-root').length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="skeleton"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="tooltip-content"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Total' }));
+
+    expect(screen.getByText('Avg Run Duration')).toBeDefined();
+  });
+
+  it('uses Mantine skeletons for dashboard widget loading states', () => {
+    mocks.useDailySummary.mockReturnValueOnce({ data: undefined, isLoading: true });
+    mocks.useTrends.mockReturnValueOnce({ data: undefined, isLoading: true, error: null });
+    mocks.useBudgetMetrics.mockReturnValueOnce({ data: undefined, isLoading: true, error: null });
+
+    const { baseElement, container } = renderWithProviders(
+      <Stack>
+        <StatusTimeline />
+        <TrendsCharts />
+        <BudgetCard />
+      </Stack>
+    );
+
+    expect(container.querySelectorAll('.mantine-Skeleton-root').length).toBeGreaterThanOrEqual(10);
+    expect(baseElement.querySelector('[data-slot="skeleton"]')).toBeNull();
+  });
+});

--- a/web/src/components/dashboard/ActivityClock.tsx
+++ b/web/src/components/dashboard/ActivityClock.tsx
@@ -9,14 +9,9 @@
 
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { apiFetch } from '@/lib/api/helpers';
 import { Clock, Info } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 import type { MetricsPeriod } from '@/hooks/useMetrics';
 
 interface ActivityClockProps {
@@ -104,48 +99,59 @@ export function ActivityClock({ period }: ActivityClockProps) {
         stroke="rgba(0,0,0,0.15)"
         strokeWidth="0.5"
       >
-        <title>{data.label}: {data.count} transitions</title>
+        <title>
+          {data.label}: {data.count} transitions
+        </title>
       </path>
     );
   });
 
   return (
-    <div className="rounded-lg border bg-card p-4">
-      <h3 className="text-sm font-medium mb-3 flex items-center gap-2">
+    <Paper withBorder p="md" radius="md">
+      <Group gap="xs" mb="sm">
         <Clock className="w-4 h-4 text-muted-foreground" />
-        Activity Clock
-        <TooltipProvider delayDuration={0}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button type="button" className="inline-flex"><Info className="w-3 h-3 text-muted-foreground" /></button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="max-w-[250px]">
-              <p className="text-xs">
-                24-hour ring showing when agent state transitions happen.
-                Brighter/thicker segments = more activity at that hour.
-                Midnight at top, noon at bottom. Based on status history.
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </h3>
+        <Text size="sm" fw={500}>
+          Activity Clock
+        </Text>
+        <Tooltip
+          multiline
+          w={260}
+          label="24-hour ring showing when agent state transitions happen. Brighter/thicker segments mean more activity at that hour. Midnight is at top, noon at bottom. Based on status history."
+        >
+          <ActionIcon aria-label="Activity clock help" size="xs" variant="subtle">
+            <Info className="w-3 h-3 text-muted-foreground" />
+          </ActionIcon>
+        </Tooltip>
+      </Group>
 
-      <div className="flex items-center justify-center">
+      <Stack align="center" gap="xs">
         <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
           {segments}
-          <text x={center} y={center - 8} textAnchor="middle" className="fill-foreground text-lg font-bold">
+          <text
+            x={center}
+            y={center - 8}
+            textAnchor="middle"
+            className="fill-foreground text-lg font-bold"
+          >
             {totalActivity}
           </text>
-          <text x={center} y={center + 8} textAnchor="middle" className="fill-muted-foreground text-[10px]">
+          <text
+            x={center}
+            y={center + 8}
+            textAnchor="middle"
+            className="fill-muted-foreground text-[10px]"
+          >
             transitions
           </text>
         </svg>
-      </div>
+      </Stack>
 
-      <div className="flex justify-between text-[10px] text-muted-foreground mt-2 px-2">
-        <span>Peak: {peakHour.label} ({peakHour.count})</span>
+      <Group justify="space-between" mt="xs" px="xs" className="text-[10px] text-muted-foreground">
+        <span>
+          Peak: {peakHour.label} ({peakHour.count})
+        </span>
         <span>24h distribution</span>
-      </div>
-    </div>
+      </Group>
+    </Paper>
   );
 }

--- a/web/src/components/dashboard/AgentComparison.tsx
+++ b/web/src/components/dashboard/AgentComparison.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import {
+  ActionIcon,
+  Group,
+  Paper,
+  SimpleGrid,
+  Skeleton,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
 import { apiFetch } from '@/lib/api/helpers';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import {
@@ -13,8 +23,6 @@ import {
   ArrowDown,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 interface AgentComparisonData {
   agent: string;
   runs: number;
@@ -165,71 +173,84 @@ export function AgentComparison({ project }: AgentComparisonProps) {
   };
 
   return (
-    <div className="rounded-lg border bg-card">
+    <Paper withBorder radius="md">
       {/* Header */}
-      <div className="flex items-center justify-between p-4">
-        <div className="flex items-center gap-2">
-          <h3 className="text-sm font-medium">Agent Comparison</h3>
+      <Group justify="space-between" p="md">
+        <Group gap="xs">
+          <Text size="sm" fw={500}>
+            Agent Comparison
+          </Text>
           {data && (
-            <span className="text-xs text-muted-foreground">
+            <Text size="xs" c="dimmed">
               ({data.qualifyingAgents} of {data.totalAgents} agents with 3+ runs)
-            </span>
+            </Text>
           )}
-        </div>
-      </div>
+        </Group>
+      </Group>
 
       {/* Content */}
-      <div className="p-4 pt-0 space-y-4">
+      <Stack gap="md" p="md" pt={0}>
         {isLoading && (
-          <div className="space-y-3">
-            <Skeleton className="h-16 w-full" />
-            <Skeleton className="h-32 w-full" />
-          </div>
+          <Stack gap="sm">
+            <Skeleton h={64} radius="md" />
+            <Skeleton h={128} radius="md" />
+          </Stack>
         )}
 
         {error && (
-          <div className="text-sm text-destructive text-center py-4">
+          <Text size="sm" c="red" ta="center" py="md">
             Failed to load agent comparison data
-          </div>
+          </Text>
         )}
 
         {data && data.qualifyingAgents === 0 && (
-          <div className="text-center py-8 text-muted-foreground">
-            <p className="text-sm">No agents have enough runs for comparison</p>
-            <p className="text-xs mt-1">Minimum 3 runs required per agent</p>
-          </div>
+          <Stack gap={4} ta="center" py="xl">
+            <Text size="sm" c="dimmed">
+              No agents have enough runs for comparison
+            </Text>
+            <Text size="xs" c="dimmed">
+              Minimum 3 runs required per agent
+            </Text>
+          </Stack>
         )}
 
         {data && data.qualifyingAgents > 0 && (
           <>
             {/* Recommendations */}
             {data.recommendations.length > 0 && (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                <TooltipProvider>
-                  {data.recommendations.map((rec) => (
-                    <Tooltip key={rec.category}>
-                      <TooltipTrigger asChild>
-                        <div className="rounded-lg border bg-muted/30 p-3 cursor-help">
-                          <div className="flex items-center gap-2 mb-1">
-                            {categoryIcons[rec.category]}
-                            <span className="text-xs font-medium text-muted-foreground">
-                              {categoryLabels[rec.category]}
-                            </span>
-                          </div>
-                          <div className="font-semibold text-sm">{rec.agent}</div>
-                          <div className="text-xs text-muted-foreground">{rec.value}</div>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" className="max-w-[200px]">
-                        <p className="text-xs">{rec.reason}</p>
-                        <p className="text-xs text-muted-foreground mt-1">
+              <SimpleGrid cols={{ base: 2, md: 4 }} spacing="sm">
+                {data.recommendations.map((rec) => (
+                  <Tooltip
+                    key={rec.category}
+                    multiline
+                    w={220}
+                    position="bottom"
+                    label={
+                      <Stack gap={4}>
+                        <Text size="xs">{rec.reason}</Text>
+                        <Text size="xs" c="dimmed">
                           {categoryTooltips[rec.category]}
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  ))}
-                </TooltipProvider>
-              </div>
+                        </Text>
+                      </Stack>
+                    }
+                  >
+                    <Paper withBorder radius="md" p="sm" className="cursor-help bg-muted/30">
+                      <Group gap="xs" mb={4} wrap="nowrap">
+                        {categoryIcons[rec.category]}
+                        <Text size="xs" fw={500} c="dimmed">
+                          {categoryLabels[rec.category]}
+                        </Text>
+                      </Group>
+                      <Text size="sm" fw={600}>
+                        {rec.agent}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {rec.value}
+                      </Text>
+                    </Paper>
+                  </Tooltip>
+                ))}
+              </SimpleGrid>
             )}
 
             {/* Comparison Table */}
@@ -244,65 +265,41 @@ export function AgentComparison({ project }: AgentComparisonProps) {
                     <th className="pb-2 px-2 font-medium text-right">
                       <div className="flex items-center justify-end gap-1">
                         <SortHeader field="successRate" label="Success" />
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Info className="h-3 w-3 text-muted-foreground" />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p className="text-xs">
-                                Percentage of runs that completed successfully
-                              </p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <Tooltip label="Percentage of runs that completed successfully">
+                          <ActionIcon variant="subtle" size="xs" aria-label="Success rate help">
+                            <Info className="h-3 w-3 text-muted-foreground" />
+                          </ActionIcon>
+                        </Tooltip>
                       </div>
                     </th>
                     <th className="pb-2 px-2 font-medium text-right">
                       <div className="flex items-center justify-end gap-1">
                         <SortHeader field="avgDurationMs" label="Avg Time" />
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Info className="h-3 w-3 text-muted-foreground" />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p className="text-xs">Average run duration (lower is better)</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <Tooltip label="Average run duration (lower is better)">
+                          <ActionIcon variant="subtle" size="xs" aria-label="Average time help">
+                            <Info className="h-3 w-3 text-muted-foreground" />
+                          </ActionIcon>
+                        </Tooltip>
                       </div>
                     </th>
                     <th className="pb-2 px-2 font-medium text-right">
                       <div className="flex items-center justify-end gap-1">
                         <SortHeader field="avgTokensPerRun" label="Avg Tokens" />
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Info className="h-3 w-3 text-muted-foreground" />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p className="text-xs">
-                                Average tokens per run (lower is more efficient)
-                              </p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <Tooltip label="Average tokens per run (lower is more efficient)">
+                          <ActionIcon variant="subtle" size="xs" aria-label="Average tokens help">
+                            <Info className="h-3 w-3 text-muted-foreground" />
+                          </ActionIcon>
+                        </Tooltip>
                       </div>
                     </th>
                     <th className="pb-2 pl-2 font-medium text-right">
                       <div className="flex items-center justify-end gap-1">
                         <SortHeader field="avgCostPerRun" label="Avg Cost" />
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Info className="h-3 w-3 text-muted-foreground" />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p className="text-xs">Estimated cost per run (lower is cheaper)</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <Tooltip label="Estimated cost per run (lower is cheaper)">
+                          <ActionIcon variant="subtle" size="xs" aria-label="Average cost help">
+                            <Info className="h-3 w-3 text-muted-foreground" />
+                          </ActionIcon>
+                        </Tooltip>
                       </div>
                     </th>
                   </tr>
@@ -365,7 +362,7 @@ export function AgentComparison({ project }: AgentComparisonProps) {
             </div>
           </>
         )}
-      </div>
-    </div>
+      </Stack>
+    </Paper>
   );
 }

--- a/web/src/components/dashboard/BudgetCard.tsx
+++ b/web/src/components/dashboard/BudgetCard.tsx
@@ -1,15 +1,17 @@
+import {
+  Group,
+  Paper,
+  Progress,
+  SimpleGrid,
+  Skeleton,
+  Stack,
+  Text,
+  ThemeIcon,
+} from '@mantine/core';
 import { useBudgetMetrics, formatBudgetTokens, formatCurrency } from '@/hooks/useBudgetMetrics';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
-import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
-import { 
-  Wallet, 
-  TrendingUp, 
-  AlertTriangle, 
-  CheckCircle,
-  XCircle,
-  Coins,
-} from 'lucide-react';
+import { Wallet, TrendingUp, AlertTriangle, CheckCircle, XCircle, Coins } from 'lucide-react';
 
 interface BudgetCardProps {
   project?: string;
@@ -25,55 +27,55 @@ interface ProgressBarProps {
 
 function ProgressBar({ value, projected, warningThreshold, label, subLabel }: ProgressBarProps) {
   const getColor = (pct: number) => {
-    if (pct >= 100) return 'bg-red-500';
-    if (pct >= warningThreshold) return 'bg-yellow-500';
-    if (pct >= 60) return 'bg-yellow-400';
-    return 'bg-green-500';
+    if (pct >= 100) return 'red';
+    if (pct >= warningThreshold) return 'yellow';
+    if (pct >= 60) return 'yellow';
+    return 'green';
   };
 
   const cappedValue = Math.min(value, 100);
   const cappedProjected = projected !== undefined ? Math.min(projected, 100) : undefined;
 
   return (
-    <div className="space-y-1">
-      <div className="flex justify-between text-sm">
-        <span className="text-muted-foreground">{label}</span>
-        <span className={cn(
-          'font-medium',
-          value >= 100 && 'text-red-500',
-          value >= warningThreshold && value < 100 && 'text-yellow-500',
-        )}>
+    <Stack gap={4}>
+      <Group justify="space-between" className="text-sm">
+        <Text component="span" size="sm" c="dimmed">
+          {label}
+        </Text>
+        <span
+          className={cn(
+            'font-medium',
+            value >= 100 && 'text-red-500',
+            value >= warningThreshold && value < 100 && 'text-yellow-500'
+          )}
+        >
           {value.toFixed(1)}%
           {subLabel && <span className="text-xs text-muted-foreground ml-1">({subLabel})</span>}
         </span>
-      </div>
-      <div className="h-2 bg-muted rounded-full overflow-hidden relative">
+      </Group>
+      <div className="relative">
         {/* Projected line (dashed marker) */}
         {cappedProjected !== undefined && cappedProjected > cappedValue && (
-          <div 
-            className="absolute top-0 h-full w-0.5 bg-foreground/30 z-10"
+          <div
+            className="absolute top-0 z-10 h-full w-0.5 bg-foreground/30"
             style={{ left: `${cappedProjected}%` }}
           />
         )}
         {/* Warning threshold marker */}
-        <div 
-          className="absolute top-0 h-full w-px bg-yellow-500/50"
+        <div
+          className="absolute top-0 z-10 h-full w-px bg-yellow-500/50"
           style={{ left: `${warningThreshold}%` }}
         />
-        {/* Actual progress */}
-        <div 
-          className={cn('h-full transition-all duration-500', getColor(value))}
-          style={{ width: `${cappedValue}%` }}
-        />
+        <Progress value={cappedValue} color={getColor(value)} size="sm" />
       </div>
-    </div>
+    </Stack>
   );
 }
 
 export function BudgetCard({ project }: BudgetCardProps) {
   const { settings } = useFeatureSettings();
   const { data: metrics, isLoading, error } = useBudgetMetrics(project);
-  
+
   // Don't render if budget tracking is disabled
   if (!settings.budget.enabled) {
     return null;
@@ -84,30 +86,32 @@ export function BudgetCard({ project }: BudgetCardProps) {
 
   if (error) {
     return (
-      <div className="rounded-lg border bg-card p-4">
-        <div className="flex items-center gap-2 text-destructive">
+      <Paper withBorder p="md" radius="md">
+        <Group gap="xs" c="red">
           <XCircle className="h-4 w-4" />
-          <span className="text-sm">Failed to load budget metrics</span>
-        </div>
-      </div>
+          <Text size="sm">Failed to load budget metrics</Text>
+        </Group>
+      </Paper>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="rounded-lg border bg-card p-4 space-y-4">
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-5 w-5" />
-          <Skeleton className="h-5 w-24" />
-        </div>
-        <Skeleton className="h-2 w-full" />
-        <Skeleton className="h-2 w-full" />
-        <div className="grid grid-cols-3 gap-4">
-          <Skeleton className="h-12" />
-          <Skeleton className="h-12" />
-          <Skeleton className="h-12" />
-        </div>
-      </div>
+      <Paper withBorder p="md" radius="md">
+        <Stack gap="md">
+          <Group gap="xs">
+            <Skeleton h={20} w={20} radius="sm" />
+            <Skeleton h={20} w={96} radius="sm" />
+          </Group>
+          <Skeleton h={8} radius="xl" />
+          <Skeleton h={8} radius="xl" />
+          <SimpleGrid cols={3} spacing="md">
+            <Skeleton h={48} radius="md" />
+            <Skeleton h={48} radius="md" />
+            <Skeleton h={48} radius="md" />
+          </SimpleGrid>
+        </Stack>
+      </Paper>
     );
   }
 
@@ -115,161 +119,188 @@ export function BudgetCard({ project }: BudgetCardProps) {
     return null;
   }
 
-  const StatusIcon = metrics.status === 'danger' 
-    ? AlertTriangle 
-    : metrics.status === 'warning' 
-      ? AlertTriangle 
-      : CheckCircle;
+  const StatusIcon =
+    metrics.status === 'danger'
+      ? AlertTriangle
+      : metrics.status === 'warning'
+        ? AlertTriangle
+        : CheckCircle;
 
-  const statusColor = metrics.status === 'danger'
-    ? 'text-red-500'
-    : metrics.status === 'warning'
-      ? 'text-yellow-500'
-      : 'text-green-500';
+  const statusColor =
+    metrics.status === 'danger'
+      ? 'text-red-500'
+      : metrics.status === 'warning'
+        ? 'text-yellow-500'
+        : 'text-green-500';
 
-  const statusBg = metrics.status === 'danger'
-    ? 'bg-red-500/10 border-red-500/20'
-    : metrics.status === 'warning'
-      ? 'bg-yellow-500/10 border-yellow-500/20'
-      : 'bg-green-500/10 border-green-500/20';
+  const statusBg =
+    metrics.status === 'danger'
+      ? 'bg-red-500/10 border-red-500/20'
+      : metrics.status === 'warning'
+        ? 'bg-yellow-500/10 border-yellow-500/20'
+        : 'bg-green-500/10 border-green-500/20';
 
   return (
-    <div className={cn('rounded-lg border p-4 space-y-4', statusBg)}>
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Wallet className={cn('h-5 w-5', statusColor)} />
-          <h3 className="font-medium">Monthly Budget</h3>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <StatusIcon className={cn('h-4 w-4', statusColor)} />
-          <span className={cn('text-sm font-medium capitalize', statusColor)}>
-            {metrics.status === 'ok' ? 'On Track' : metrics.status}
-          </span>
-        </div>
-      </div>
+    <Paper withBorder p="md" radius="md" className={cn(statusBg)}>
+      <Stack gap="md">
+        {/* Header */}
+        <Group justify="space-between">
+          <Group gap="xs">
+            <Wallet className={cn('h-5 w-5', statusColor)} />
+            <Text fw={500}>Monthly Budget</Text>
+          </Group>
+          <Group gap={6}>
+            <StatusIcon className={cn('h-4 w-4', statusColor)} />
+            <span className={cn('text-sm font-medium capitalize', statusColor)}>
+              {metrics.status === 'ok' ? 'On Track' : metrics.status}
+            </span>
+          </Group>
+        </Group>
 
-      {/* Period info */}
-      <div className="text-xs text-muted-foreground">
-        {(() => {
-          // Parse as local date to avoid timezone issues (YYYY-MM-DD format)
-          const [year, month] = metrics.periodStart.split('-').map(Number);
-          const date = new Date(year, month - 1, 1);
-          return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-        })()}
-        {' • '}
-        Day {metrics.daysElapsed} of {metrics.daysInMonth}
-        {' • '}
-        {metrics.daysRemaining} days remaining
-      </div>
+        {/* Period info */}
+        <Text size="xs" c="dimmed">
+          {(() => {
+            // Parse as local date to avoid timezone issues (YYYY-MM-DD format)
+            const [year, month] = metrics.periodStart.split('-').map(Number);
+            const date = new Date(year, month - 1, 1);
+            return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+          })()}
+          {' • '}
+          Day {metrics.daysElapsed} of {metrics.daysInMonth}
+          {' • '}
+          {metrics.daysRemaining} days remaining
+        </Text>
 
-      {!hasBudget ? (
-        <div className="py-4 text-center text-sm text-muted-foreground">
-          <p>No budget limits set.</p>
-          <p className="text-xs mt-1">Configure token or cost limits in Settings → Data.</p>
-        </div>
-      ) : (
-        <>
-          {/* Progress Bars */}
-          <div className="space-y-3">
-            {metrics.tokenBudget > 0 && (
-              <ProgressBar
-                value={metrics.tokenBudgetUsed}
-                projected={metrics.projectedTokenOverage}
-                warningThreshold={settings.budget.warningThreshold}
-                label="Token Usage"
-                subLabel={`${formatBudgetTokens(metrics.totalTokens)} / ${formatBudgetTokens(metrics.tokenBudget)}`}
-              />
-            )}
-            {metrics.costBudget > 0 && (
-              <ProgressBar
-                value={metrics.costBudgetUsed}
-                projected={metrics.projectedCostOverage}
-                warningThreshold={settings.budget.warningThreshold}
-                label="Cost"
-                subLabel={`${formatCurrency(metrics.estimatedCost)} / ${formatCurrency(metrics.costBudget)}`}
-              />
-            )}
-          </div>
-
-          {/* Stats Grid */}
-          <div className="grid grid-cols-3 gap-3 pt-2 border-t">
-            <div className="text-center">
-              <div className="flex items-center justify-center gap-1 text-muted-foreground">
-                <Coins className="h-3.5 w-3.5" />
-                <span className="text-xs">Daily Burn</span>
-              </div>
-              <div className="font-semibold text-sm mt-0.5">
-                {formatBudgetTokens(metrics.tokensPerDay)}/day
-              </div>
-              {metrics.costPerDay > 0 && (
-                <div className="text-xs text-muted-foreground">
-                  {formatCurrency(metrics.costPerDay)}/day
-                </div>
+        {!hasBudget ? (
+          <Stack gap={4} py="md" ta="center">
+            <Text size="sm" c="dimmed">
+              No budget limits set.
+            </Text>
+            <Text size="xs" c="dimmed">
+              Configure token or cost limits in Settings → Data.
+            </Text>
+          </Stack>
+        ) : (
+          <>
+            {/* Progress Bars */}
+            <Stack gap="sm">
+              {metrics.tokenBudget > 0 && (
+                <ProgressBar
+                  value={metrics.tokenBudgetUsed}
+                  projected={metrics.projectedTokenOverage}
+                  warningThreshold={settings.budget.warningThreshold}
+                  label="Token Usage"
+                  subLabel={`${formatBudgetTokens(metrics.totalTokens)} / ${formatBudgetTokens(metrics.tokenBudget)}`}
+                />
               )}
-            </div>
-            
-            <div className="text-center">
-              <div className="flex items-center justify-center gap-1 text-muted-foreground">
-                <TrendingUp className="h-3.5 w-3.5" />
-                <span className="text-xs">Projected</span>
-              </div>
-              <div className={cn(
-                'font-semibold text-sm mt-0.5',
-                metrics.projectedTokenOverage > 100 && 'text-red-500',
-                metrics.projectedTokenOverage > settings.budget.warningThreshold && metrics.projectedTokenOverage <= 100 && 'text-yellow-500',
-              )}>
-                {formatBudgetTokens(metrics.projectedMonthlyTokens)}
-              </div>
-              {metrics.projectedMonthlyCost > 0 && (
-                <div className={cn(
-                  'text-xs',
-                  metrics.projectedCostOverage > 100 ? 'text-red-500' : 'text-muted-foreground',
-                )}>
-                  {formatCurrency(metrics.projectedMonthlyCost)}
-                </div>
-              )}
-            </div>
-            
-            <div className="text-center">
-              <div className="flex items-center justify-center gap-1 text-muted-foreground">
-                <Wallet className="h-3.5 w-3.5" />
-                <span className="text-xs">Budget</span>
-              </div>
-              <div className="font-semibold text-sm mt-0.5">
-                {metrics.tokenBudget > 0 
-                  ? formatBudgetTokens(metrics.tokenBudget) 
-                  : '—'}
-              </div>
               {metrics.costBudget > 0 && (
-                <div className="text-xs text-muted-foreground">
-                  {formatCurrency(metrics.costBudget)}
-                </div>
+                <ProgressBar
+                  value={metrics.costBudgetUsed}
+                  projected={metrics.projectedCostOverage}
+                  warningThreshold={settings.budget.warningThreshold}
+                  label="Cost"
+                  subLabel={`${formatCurrency(metrics.estimatedCost)} / ${formatCurrency(metrics.costBudget)}`}
+                />
               )}
-            </div>
-          </div>
+            </Stack>
 
-          {/* Projected overage warning */}
-          {(metrics.projectedTokenOverage > 100 || metrics.projectedCostOverage > 100) && (
-            <div className="flex items-start gap-2 p-2 rounded bg-red-500/10 text-red-500 text-xs">
-              <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />
-              <div>
-                <span className="font-medium">Projected to exceed budget</span>
-                {metrics.projectedTokenOverage > 100 && metrics.tokenBudget > 0 && (
-                  <div>
-                    Tokens: {formatBudgetTokens(metrics.projectedMonthlyTokens - metrics.tokenBudget)} over budget
-                  </div>
-                )}
-                {metrics.projectedCostOverage > 100 && metrics.costBudget > 0 && (
-                  <div>
-                    Cost: {formatCurrency(metrics.projectedMonthlyCost - metrics.costBudget)} over budget
+            {/* Stats Grid */}
+            <SimpleGrid cols={3} spacing="sm" className="border-t pt-2">
+              <div className="text-center">
+                <Group justify="center" gap={4} c="dimmed">
+                  <ThemeIcon variant="transparent" color="gray" size="xs">
+                    <Coins className="h-3.5 w-3.5" />
+                  </ThemeIcon>
+                  <Text size="xs">Daily Burn</Text>
+                </Group>
+                <div className="font-semibold text-sm mt-0.5">
+                  {formatBudgetTokens(metrics.tokensPerDay)}/day
+                </div>
+                {metrics.costPerDay > 0 && (
+                  <div className="text-xs text-muted-foreground">
+                    {formatCurrency(metrics.costPerDay)}/day
                   </div>
                 )}
               </div>
-            </div>
-          )}
-        </>
-      )}
-    </div>
+
+              <div className="text-center">
+                <Group justify="center" gap={4} c="dimmed">
+                  <ThemeIcon variant="transparent" color="gray" size="xs">
+                    <TrendingUp className="h-3.5 w-3.5" />
+                  </ThemeIcon>
+                  <Text size="xs">Projected</Text>
+                </Group>
+                <div
+                  className={cn(
+                    'font-semibold text-sm mt-0.5',
+                    metrics.projectedTokenOverage > 100 && 'text-red-500',
+                    metrics.projectedTokenOverage > settings.budget.warningThreshold &&
+                      metrics.projectedTokenOverage <= 100 &&
+                      'text-yellow-500'
+                  )}
+                >
+                  {formatBudgetTokens(metrics.projectedMonthlyTokens)}
+                </div>
+                {metrics.projectedMonthlyCost > 0 && (
+                  <div
+                    className={cn(
+                      'text-xs',
+                      metrics.projectedCostOverage > 100 ? 'text-red-500' : 'text-muted-foreground'
+                    )}
+                  >
+                    {formatCurrency(metrics.projectedMonthlyCost)}
+                  </div>
+                )}
+              </div>
+
+              <div className="text-center">
+                <Group justify="center" gap={4} c="dimmed">
+                  <ThemeIcon variant="transparent" color="gray" size="xs">
+                    <Wallet className="h-3.5 w-3.5" />
+                  </ThemeIcon>
+                  <Text size="xs">Budget</Text>
+                </Group>
+                <div className="font-semibold text-sm mt-0.5">
+                  {metrics.tokenBudget > 0 ? formatBudgetTokens(metrics.tokenBudget) : '—'}
+                </div>
+                {metrics.costBudget > 0 && (
+                  <div className="text-xs text-muted-foreground">
+                    {formatCurrency(metrics.costBudget)}
+                  </div>
+                )}
+              </div>
+            </SimpleGrid>
+
+            {/* Projected overage warning */}
+            {(metrics.projectedTokenOverage > 100 || metrics.projectedCostOverage > 100) && (
+              <Group
+                align="flex-start"
+                gap="xs"
+                p="xs"
+                className="rounded bg-red-500/10 text-xs text-red-500"
+              >
+                <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+                <div>
+                  <span className="font-medium">Projected to exceed budget</span>
+                  {metrics.projectedTokenOverage > 100 && metrics.tokenBudget > 0 && (
+                    <div>
+                      Tokens:{' '}
+                      {formatBudgetTokens(metrics.projectedMonthlyTokens - metrics.tokenBudget)}{' '}
+                      over budget
+                    </div>
+                  )}
+                  {metrics.projectedCostOverage > 100 && metrics.costBudget > 0 && (
+                    <div>
+                      Cost: {formatCurrency(metrics.projectedMonthlyCost - metrics.costBudget)} over
+                      budget
+                    </div>
+                  )}
+                </div>
+              </Group>
+            )}
+          </>
+        )}
+      </Stack>
+    </Paper>
   );
 }

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Skeleton } from '@mantine/core';
 import {
   useMetrics,
   useTaskCost,
@@ -10,7 +11,6 @@ import {
 } from '@/hooks/useMetrics';
 import { useTasks } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
-import { Skeleton } from '@/components/ui/skeleton';
 import { TrendingUp, TrendingDown, Minus, RefreshCw } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
 import { DashboardFilterBar } from './DashboardFilterBar';

--- a/web/src/components/dashboard/DashboardPage.tsx
+++ b/web/src/components/dashboard/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Skeleton } from '@mantine/core';
 import { RefreshCw } from 'lucide-react';
 import {
   useMetrics,
@@ -11,7 +12,6 @@ import {
 } from '@/hooks/useMetrics';
 import { useTasks } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
-import { Skeleton } from '@/components/ui/skeleton';
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
 import { DashboardFilterBar } from './DashboardFilterBar';
@@ -165,11 +165,16 @@ export function DashboardPage() {
 
   const getDrillDownTitle = () => {
     switch (drillDown) {
-      case 'tasks': return 'Task Details';
-      case 'errors': return 'Failed Runs';
-      case 'tokens': return 'Token Usage Breakdown';
-      case 'duration': return 'Run Duration Breakdown';
-      default: return '';
+      case 'tasks':
+        return 'Task Details';
+      case 'errors':
+        return 'Failed Runs';
+      case 'tokens':
+        return 'Token Usage Breakdown';
+      case 'duration':
+        return 'Run Duration Breakdown';
+      default:
+        return '';
     }
   };
 
@@ -190,7 +195,10 @@ export function DashboardPage() {
       title={
         <div className="flex items-center justify-between">
           <span>Token Usage</span>
-          <TrendIndicator direction={metrics.trends.tokensTrend} change={metrics.trends.tokensChange} />
+          <TrendIndicator
+            direction={metrics.trends.tokensTrend}
+            change={metrics.trends.tokensChange}
+          />
         </div>
       }
       onClick={() => setDrillDown('tokens')}
@@ -219,7 +227,10 @@ export function DashboardPage() {
       title={
         <div className="flex items-center justify-between">
           <span>Run Duration</span>
-          <TrendIndicator direction={metrics.trends.durationTrend} change={metrics.trends.durationChange} />
+          <TrendIndicator
+            direction={metrics.trends.durationTrend}
+            change={metrics.trends.durationChange}
+          />
         </div>
       }
       onClick={() => setDrillDown('duration')}
@@ -229,8 +240,14 @@ export function DashboardPage() {
       <StatRow label="Average" value={formatDuration(metrics.duration.avgMs)} />
       <div className="pt-2 border-t mt-2">
         <div className="flex justify-between text-sm">
-          <div><span className="text-muted-foreground">p50: </span><span className="font-medium">{formatDuration(metrics.duration.p50Ms)}</span></div>
-          <div><span className="text-muted-foreground">p95: </span><span className="font-medium">{formatDuration(metrics.duration.p95Ms)}</span></div>
+          <div>
+            <span className="text-muted-foreground">p50: </span>
+            <span className="font-medium">{formatDuration(metrics.duration.p50Ms)}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">p95: </span>
+            <span className="font-medium">{formatDuration(metrics.duration.p95Ms)}</span>
+          </div>
         </div>
       </div>
     </StatCard>
@@ -262,7 +279,9 @@ export function DashboardPage() {
             </span>
             <div className="flex items-center gap-1 shrink-0">
               <span className="font-mono font-medium">${t.estimatedCost.toFixed(2)}</span>
-              <span className="text-muted-foreground/0 group-hover:text-primary transition-colors text-xs">→</span>
+              <span className="text-muted-foreground/0 group-hover:text-primary transition-colors text-xs">
+                →
+              </span>
             </div>
           </button>
         ))}
@@ -276,11 +295,16 @@ export function DashboardPage() {
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-muted-foreground text-sm">Overall</span>
-        <span className={cn(
-          'font-bold text-lg',
-          utilization.utilizationPercent > 50 ? 'text-green-500' :
-          utilization.utilizationPercent > 20 ? 'text-yellow-500' : 'text-muted-foreground'
-        )}>
+        <span
+          className={cn(
+            'font-bold text-lg',
+            utilization.utilizationPercent > 50
+              ? 'text-green-500'
+              : utilization.utilizationPercent > 20
+                ? 'text-yellow-500'
+                : 'text-muted-foreground'
+          )}
+        >
           {utilization.utilizationPercent.toFixed(1)}%
         </span>
       </div>
@@ -289,14 +313,21 @@ export function DashboardPage() {
         <span className="font-semibold">{formatDuration(utilization.totalActiveMs)}</span>
       </div>
       <div className="border-t pt-2 space-y-1.5 overflow-y-auto">
-        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">Daily</div>
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">
+          Daily
+        </div>
         {utilization.daily.map((d) => (
           <div key={d.date} className="flex items-center gap-2 text-sm">
             <span className="text-muted-foreground w-20 shrink-0 text-xs">{d.date.slice(5)}</span>
             <div className="flex-1 h-4 bg-muted rounded-sm overflow-hidden">
-              <div className="h-full bg-green-500 rounded-sm transition-all" style={{ width: `${Math.min(100, d.utilizationPercent)}%` }} />
+              <div
+                className="h-full bg-green-500 rounded-sm transition-all"
+                style={{ width: `${Math.min(100, d.utilizationPercent)}%` }}
+              />
             </div>
-            <span className="font-mono text-xs w-12 text-right shrink-0">{d.utilizationPercent.toFixed(1)}%</span>
+            <span className="font-mono text-xs w-12 text-right shrink-0">
+              {d.utilizationPercent.toFixed(1)}%
+            </span>
           </div>
         ))}
       </div>
@@ -346,20 +377,12 @@ export function DashboardPage() {
     {
       id: 'cost-per-task',
       visible: widgets.showCostPerTask,
-      content: (
-        <WidgetWrapper title="Cost per Task">
-          {costPerTaskContent}
-        </WidgetWrapper>
-      ),
+      content: <WidgetWrapper title="Cost per Task">{costPerTaskContent}</WidgetWrapper>,
     },
     {
       id: 'agent-utilization',
       visible: widgets.showAgentUtilization,
-      content: (
-        <WidgetWrapper title="Agent Utilization">
-          {agentUtilizationContent}
-        </WidgetWrapper>
-      ),
+      content: <WidgetWrapper title="Agent Utilization">{agentUtilizationContent}</WidgetWrapper>,
     },
     {
       id: 'wall-time',

--- a/web/src/components/dashboard/StatusTimeline.tsx
+++ b/web/src/components/dashboard/StatusTimeline.tsx
@@ -4,7 +4,7 @@ import {
   calculateActivePercent,
   type DailySummary,
 } from '@/hooks/useStatusHistory';
-import { Skeleton } from '@/components/ui/skeleton';
+import { Box, Group, Paper, SimpleGrid, Skeleton, Stack, Text, ThemeIcon } from '@mantine/core';
 import { Clock, Activity, Coffee } from 'lucide-react';
 
 interface StatusTimelineProps {
@@ -16,9 +16,9 @@ function TimelineBar({ summary }: { summary: DailySummary }) {
 
   if (total === 0) {
     return (
-      <div className="h-8 bg-muted rounded-md flex items-center justify-center text-sm text-muted-foreground">
+      <Box className="flex h-8 items-center justify-center rounded-md bg-muted text-sm text-muted-foreground">
         No activity recorded
-      </div>
+      </Box>
     );
   }
 
@@ -28,7 +28,7 @@ function TimelineBar({ summary }: { summary: DailySummary }) {
   const errorPercent = (summary.errorMs / total) * 100;
 
   return (
-    <div className="h-8 rounded-md overflow-hidden flex">
+    <Group className="h-8 overflow-hidden rounded-md" gap={0} wrap="nowrap">
       {activePercent > 0 && (
         <div
           className="bg-green-500 flex items-center justify-center text-xs text-white font-medium transition-all"
@@ -56,7 +56,7 @@ function TimelineBar({ summary }: { summary: DailySummary }) {
           {errorPercent >= 15 && formatDurationMs(summary.errorMs)}
         </div>
       )}
-    </div>
+    </Group>
   );
 }
 
@@ -65,83 +65,101 @@ export function StatusTimeline({ date }: StatusTimelineProps) {
 
   if (summaryLoading) {
     return (
-      <div className="space-y-4">
-        <Skeleton className="h-8 w-full" />
-        <div className="grid grid-cols-3 gap-4">
-          <Skeleton className="h-20" />
-          <Skeleton className="h-20" />
-          <Skeleton className="h-20" />
-        </div>
-      </div>
+      <Stack gap="md">
+        <Skeleton h={32} radius="md" />
+        <SimpleGrid cols={3} spacing="md">
+          <Skeleton h={80} radius="md" />
+          <Skeleton h={80} radius="md" />
+          <Skeleton h={80} radius="md" />
+        </SimpleGrid>
+      </Stack>
     );
   }
 
   if (!summary) {
-    return <div className="text-center text-muted-foreground py-4">No status data available</div>;
+    return (
+      <Text ta="center" c="dimmed" py="md">
+        No status data available
+      </Text>
+    );
   }
 
   const activePercent = calculateActivePercent(summary);
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Daily Activity — full width */}
-      <div className="space-y-4">
+      <Stack gap="md">
         {/* Timeline Bar */}
         <div>
-          <div className="flex items-center justify-between mb-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
+          <Group justify="space-between" mb="xs">
+            <Text size="sm" fw={500} c="dimmed">
               Daily Activity ({summary.date})
-            </h4>
-            <span className="text-sm font-medium">{activePercent}% active</span>
-          </div>
+            </Text>
+            <Text size="sm" fw={500}>
+              {activePercent}% active
+            </Text>
+          </Group>
           <TimelineBar summary={summary} />
         </div>
 
         {/* Summary Stats */}
-        <div className="grid grid-cols-3 gap-4">
-          <div className="rounded-lg border bg-green-500/10 border-green-500/20 p-3 text-center">
-            <Activity className="h-4 w-4 mx-auto mb-1 text-green-500" />
+        <SimpleGrid cols={3} spacing="md">
+          <Paper
+            withBorder
+            p="sm"
+            radius="md"
+            ta="center"
+            className="border-green-500/20 bg-green-500/10"
+          >
+            <ThemeIcon color="green" variant="transparent" mx="auto" mb={4} size="sm">
+              <Activity className="h-4 w-4" />
+            </ThemeIcon>
             <div className="text-lg font-bold text-green-500">
               {formatDurationMs(summary.activeMs)}
             </div>
             <div className="text-xs text-muted-foreground">Active</div>
-          </div>
+          </Paper>
 
-          <div className="rounded-lg border bg-muted/50 p-3 text-center">
-            <Coffee className="h-4 w-4 mx-auto mb-1 text-muted-foreground" />
+          <Paper withBorder p="sm" radius="md" ta="center" className="bg-muted/50">
+            <ThemeIcon color="gray" variant="transparent" mx="auto" mb={4} size="sm">
+              <Coffee className="h-4 w-4" />
+            </ThemeIcon>
             <div className="text-lg font-bold text-muted-foreground">
               {formatDurationMs(summary.idleMs)}
             </div>
             <div className="text-xs text-muted-foreground">Idle</div>
-          </div>
+          </Paper>
 
-          <div className="rounded-lg border bg-card p-3 text-center">
-            <Clock className="h-4 w-4 mx-auto mb-1 text-muted-foreground" />
+          <Paper withBorder p="sm" radius="md" ta="center">
+            <ThemeIcon color="gray" variant="transparent" mx="auto" mb={4} size="sm">
+              <Clock className="h-4 w-4" />
+            </ThemeIcon>
             <div className="text-lg font-bold">{summary.transitions}</div>
             <div className="text-xs text-muted-foreground">Transitions</div>
-          </div>
-        </div>
-      </div>
+          </Paper>
+        </SimpleGrid>
+      </Stack>
 
       {/* Legend */}
-      <div className="flex items-center gap-4 text-xs text-muted-foreground justify-center pt-2 border-t">
-        <div className="flex items-center gap-1">
+      <Group gap="md" justify="center" className="border-t pt-2 text-xs text-muted-foreground">
+        <Group gap={4}>
           <div className="w-3 h-3 rounded bg-green-500" />
           <span>Working/Thinking</span>
-        </div>
-        <div className="flex items-center gap-1">
+        </Group>
+        <Group gap={4}>
           <div className="w-3 h-3 rounded bg-blue-500" />
           <span>Sub-agent</span>
-        </div>
-        <div className="flex items-center gap-1">
+        </Group>
+        <Group gap={4}>
           <div className="w-3 h-3 rounded bg-gray-400" />
           <span>Idle</span>
-        </div>
-        <div className="flex items-center gap-1">
+        </Group>
+        <Group gap={4}>
           <div className="w-3 h-3 rounded bg-red-500" />
           <span>Error</span>
-        </div>
-      </div>
-    </div>
+        </Group>
+      </Group>
+    </Stack>
   );
 }

--- a/web/src/components/dashboard/TrendsCharts.tsx
+++ b/web/src/components/dashboard/TrendsCharts.tsx
@@ -10,9 +10,9 @@ import {
   ResponsiveContainer,
   Legend,
 } from 'recharts';
+import { Group, Paper, SimpleGrid, Skeleton, Stack, Text } from '@mantine/core';
 import { useTrends, type TrendsPeriod, formatShortDate } from '@/hooks/useTrends';
 import { formatDuration } from '@/hooks/useMetrics';
-import { Skeleton } from '@/components/ui/skeleton';
 interface TrendsChartsProps {
   project?: string;
 }
@@ -43,18 +43,22 @@ function CustomTooltip({
   if (!active || !payload?.length) return null;
 
   return (
-    <div className="rounded-lg border bg-popover p-3 shadow-md">
-      <p className="font-medium mb-2">{label}</p>
+    <Paper withBorder p="sm" radius="md" shadow="md">
+      <Text fw={500} mb="xs">
+        {label}
+      </Text>
       {payload.map((entry, index) => (
-        <div key={index} className="flex items-center gap-2 text-sm">
+        <Group key={index} gap="xs" className="text-sm">
           <div className="w-3 h-3 rounded-full" style={{ backgroundColor: entry.color }} />
-          <span className="text-muted-foreground">{entry.name}:</span>
-          <span className="font-medium">
+          <Text component="span" size="sm" c="dimmed">
+            {entry.name}:
+          </Text>
+          <Text component="span" size="sm" fw={500}>
             {formatter ? formatter(entry.value, entry.name) : entry.value}
-          </span>
-        </div>
+          </Text>
+        </Group>
       ))}
-    </div>
+    </Paper>
   );
 }
 
@@ -239,13 +243,15 @@ function ChartCard({
   extra?: React.ReactNode;
 }) {
   return (
-    <div className="rounded-lg border bg-card p-4">
-      <div className="flex items-center justify-between mb-3">
-        <h4 className="text-sm font-medium text-muted-foreground">{title}</h4>
+    <Paper withBorder p="md" radius="md">
+      <Group justify="space-between" mb="sm">
+        <Text size="sm" fw={500} c="dimmed">
+          {title}
+        </Text>
         {extra}
-      </div>
+      </Group>
       {children}
-    </div>
+    </Paper>
   );
 }
 
@@ -254,48 +260,57 @@ export function TrendsCharts({ project }: TrendsChartsProps) {
   const { data, isLoading, error } = useTrends(period, project);
 
   if (error) {
-    return <div className="p-4 text-center text-destructive">Failed to load trends data</div>;
+    return (
+      <Text p="md" ta="center" c="red">
+        Failed to load trends data
+      </Text>
+    );
   }
 
   // Check if we have any data with runs
-  const hasData = data?.daily.some((d) => d.runs > 0);
+  const daily = data?.daily ?? [];
+  const hasData = daily.some((d) => d.runs > 0);
 
   return (
-    <div className="space-y-4">
+    <Stack gap="md">
       {/* Header */}
-      <h3 className="text-sm font-medium text-muted-foreground">Historical Trends</h3>
+      <Text size="sm" fw={500} c="dimmed">
+        Historical Trends
+      </Text>
 
       {/* Charts grid - 2x2 on larger screens, stacked on mobile */}
       {isLoading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
           {[...Array(4)].map((_, i) => (
-            <Skeleton key={i} className="h-[250px] rounded-lg" />
+            <Skeleton key={i} h={250} radius="md" />
           ))}
-        </div>
+        </SimpleGrid>
       ) : !hasData ? (
-        <div className="rounded-lg border bg-card p-8 text-center text-muted-foreground">
-          <p>No telemetry data available for the selected period.</p>
-          <p className="text-sm mt-2">Run some tasks to see historical trends.</p>
-        </div>
+        <Paper withBorder p="xl" radius="md" ta="center">
+          <Text c="dimmed">No telemetry data available for the selected period.</Text>
+          <Text size="sm" c="dimmed" mt="xs">
+            Run some tasks to see historical trends.
+          </Text>
+        </Paper>
       ) : (
-        <div className="space-y-4">
+        <Stack gap="md">
           {/* Task Activity full width */}
           <ChartCard title="Task Activity per Day">
-            <TaskActivityChart data={data!.daily} />
+            <TaskActivityChart data={daily} />
           </ChartCard>
 
           {/* Other charts in 2-col grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
             <ChartCard title="Token Usage">
-              <TokensChart data={data!.daily} />
+              <TokensChart data={daily} />
             </ChartCard>
 
             <ChartCard title="Average Run Duration">
-              <DurationChart data={data!.daily} />
+              <DurationChart data={daily} />
             </ChartCard>
-          </div>
-        </div>
+          </SimpleGrid>
+        </Stack>
       )}
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/dashboard/WallTimeToggle.tsx
+++ b/web/src/components/dashboard/WallTimeToggle.tsx
@@ -8,15 +8,10 @@
 
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { ActionIcon, Button, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { apiFetch } from '@/lib/api/helpers';
 import { formatDuration, type MetricsPeriod } from '@/hooks/useMetrics';
 import { Clock, Timer, ToggleLeft, ToggleRight, Info } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 
 interface WallTimeToggleProps {
   period: MetricsPeriod;
@@ -48,73 +43,100 @@ export function WallTimeToggle({ period }: WallTimeToggleProps) {
   // Active time = average per run
   const activeTime = totalRuns > 0 ? wallTime / totalRuns : 0;
   // Efficiency = ratio of tasks actually worked vs calendar time in period
-  const periodHours = period === '24h' ? 24 : period === '3d' ? 72 : period === '7d' ? 168 : period === '30d' ? 720 : 168;
-  const efficiency = periodHours > 0 ? ((wallTime / 3600000) / periodHours) * 100 : 0;
+  const periodHours =
+    period === '24h'
+      ? 24
+      : period === '3d'
+        ? 72
+        : period === '7d'
+          ? 168
+          : period === '30d'
+            ? 720
+            : 168;
+  const efficiency = periodHours > 0 ? (wallTime / 3600000 / periodHours) * 100 : 0;
 
   const displayTime = showActive ? activeTime : wallTime;
   const label = showActive ? 'Avg Run Duration' : 'Total Agent Time';
   const Icon = showActive ? Timer : Clock;
 
   return (
-    <div className="rounded-lg border bg-card p-4">
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-medium flex items-center gap-2">
-          <Icon className="w-4 h-4 text-muted-foreground" />
-          {label}
-          <TooltipProvider delayDuration={0}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button type="button" className="inline-flex"><Info className="w-3 h-3 text-muted-foreground" /></button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="max-w-[250px]">
-                <p className="text-xs">
+    <Paper withBorder p="md" radius="md">
+      <Group justify="space-between" mb="sm" wrap="nowrap">
+        <Group gap="xs" wrap="nowrap">
+          <Icon className="h-4 w-4 text-muted-foreground" />
+          <Text size="sm" fw={500}>
+            {label}
+          </Text>
+          <Tooltip
+            multiline
+            w={260}
+            label={
+              <Stack gap={6}>
+                <Text size="xs">
                   <strong>Total Agent Time:</strong> Sum of all run durations in the period.
-                  <br /><br />
+                </Text>
+                <Text size="xs">
                   <strong>Avg Run Duration:</strong> Average time per agent run.
-                  <br /><br />
+                </Text>
+                <Text size="xs">
                   <strong>Utilization:</strong> Percentage of calendar time with agent activity.
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </h3>
-        <button
-          className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                </Text>
+              </Stack>
+            }
+          >
+            <ActionIcon aria-label="Wall time help" size="xs" variant="subtle">
+              <Info className="w-3 h-3 text-muted-foreground" />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+        <Button
+          variant="subtle"
+          size="compact-xs"
+          className="text-muted-foreground"
           onClick={() => setShowActive(!showActive)}
+          leftSection={
+            showActive ? (
+              <ToggleRight className="h-4 w-4 text-purple-500" />
+            ) : (
+              <ToggleLeft className="h-4 w-4" />
+            )
+          }
         >
-          {showActive ? (
-            <ToggleRight className="w-4 h-4 text-purple-500" />
-          ) : (
-            <ToggleLeft className="w-4 h-4" />
-          )}
           {showActive ? 'Per Run' : 'Total'}
-        </button>
-      </div>
+        </Button>
+      </Group>
 
-      <div className="text-2xl font-bold mb-1">
+      <Text size="xl" fw={700} mb={4}>
         {formatDuration(displayTime)}
-      </div>
+      </Text>
 
-      <div className="text-xs text-muted-foreground space-y-1">
-        <div className="flex justify-between">
+      <Stack gap={4} className="text-xs text-muted-foreground">
+        <Group justify="space-between">
           <span>Total time</span>
-          <span className={!showActive ? 'font-medium text-foreground' : ''}>{formatDuration(wallTime)}</span>
-        </div>
-        <div className="flex justify-between">
+          <span className={!showActive ? 'font-medium text-foreground' : ''}>
+            {formatDuration(wallTime)}
+          </span>
+        </Group>
+        <Group justify="space-between">
           <span>Avg per run</span>
-          <span className={showActive ? 'font-medium text-foreground' : ''}>{formatDuration(activeTime)}</span>
-        </div>
-        <div className="flex justify-between">
+          <span className={showActive ? 'font-medium text-foreground' : ''}>
+            {formatDuration(activeTime)}
+          </span>
+        </Group>
+        <Group justify="space-between">
           <span>Total runs</span>
           <span>{totalRuns}</span>
-        </div>
-        <div className="flex justify-between pt-1 border-t">
+        </Group>
+        <Group justify="space-between" className="border-t pt-1">
           <span>Utilization</span>
-          <span className="font-medium" style={{ color: efficiency > 10 ? '#22c55e' : efficiency > 3 ? '#f59e0b' : '#6b7280' }}>
+          <span
+            className="font-medium"
+            style={{ color: efficiency > 10 ? '#22c55e' : efficiency > 3 ? '#f59e0b' : '#6b7280' }}
+          >
             {efficiency.toFixed(1)}%
           </span>
-        </div>
-      </div>
-    </div>
+        </Group>
+      </Stack>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates the remaining active dashboard widget and chart shells to direct Mantine primitives, including Paper, Skeleton, Tooltip, ActionIcon, Progress, Stack, Group, SimpleGrid, Text, and ThemeIcon.
- Removes active dashboard skeleton/tooltip wrapper imports while preserving status timeline summaries, agent comparison recommendations/sorting/help affordances, historical charts, wall-time toggles, activity clock rendering, and budget loading/progress states.
- Adds focused regression coverage for the migrated dashboard widget surfaces and updates the Mantine migration tracker.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/dashboard-widgets-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- In-app Browser smoke at http://127.0.0.1:3000/: setup screen rendered, no console warnings/errors, no framework overlay, password visibility toggle changed the first password field from password to text.

## Notes
- Advances #417 and #326.
- Remaining #417 slices: activity/chat overlays, policy/governance/scoring/drift, templates, specialized runtime surfaces, then the final #418 QA cleanup gate.