### PR TITLE
Migrate activity and chat overlays to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -393,6 +393,12 @@ Phase 3 progress:
   trends, wall-time, activity clock, and the budget widget while preserving
   existing metric queries, chart rendering, sorting, help affordances, and
   toggle behavior.
+- Activity and chat overlays now use direct Mantine drawer, modal, tabs, select,
+  text input, scroll area, button, action icon, skeleton, badge, paper, stack,
+  group, text, and theme icon primitives while preserving activity filtering,
+  status history, daily summaries, board/task chat export and clear
+  confirmation, squad sender/filter controls, system-message toggling, and the
+  floating chat launcher.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/activity-chat-mantine.test.tsx
+++ b/web/src/__tests__/activity-chat-mantine.test.tsx
@@ -1,0 +1,273 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ActivityFeed } from '@/components/activity/ActivityFeed';
+import { ChatPanel } from '@/components/chat/ChatPanel';
+import { FloatingChat } from '@/components/chat/FloatingChat';
+import { SquadChatPanel } from '@/components/chat/SquadChatPanel';
+import { ActivitySidebar } from '@/components/layout/ActivitySidebar';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  clearActivities: vi.fn(),
+  deleteChatSession: vi.fn(),
+  refetchActivities: vi.fn(),
+  sendChatMessage: vi.fn(),
+  sendSquadMessage: vi.fn(),
+  useActivities: vi.fn(),
+  useActivityFeed: vi.fn(),
+  useChatSession: vi.fn(),
+  useChatSessions: vi.fn(),
+  useChatStream: vi.fn(),
+  useConfig: vi.fn(),
+  useDailySummary: vi.fn(),
+  useDeleteChatSession: vi.fn(),
+  useFeatureSetting: vi.fn(),
+  useSendChatMessage: vi.fn(),
+  useSendSquadMessage: vi.fn(),
+  useSquadMessages: vi.fn(),
+  useSquadStream: vi.fn(),
+  useStatusHistory: vi.fn(),
+  useTask: vi.fn(),
+}));
+
+vi.mock('@/hooks/useActivity', () => ({
+  useActivities: mocks.useActivities,
+  useActivityFeed: mocks.useActivityFeed,
+  useClearActivities: () => ({ mutate: mocks.clearActivities, isPending: false }),
+}));
+
+vi.mock('@/hooks/useChat', () => ({
+  useChatSession: mocks.useChatSession,
+  useChatSessions: mocks.useChatSessions,
+  useChatStream: mocks.useChatStream,
+  useDeleteChatSession: mocks.useDeleteChatSession,
+  useSendChatMessage: mocks.useSendChatMessage,
+  useSendSquadMessage: mocks.useSendSquadMessage,
+  useSquadMessages: mocks.useSquadMessages,
+  useSquadStream: mocks.useSquadStream,
+}));
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: mocks.useConfig,
+}));
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSetting: mocks.useFeatureSetting,
+}));
+
+vi.mock('@/hooks/useStatusHistory', () => ({
+  formatDurationMs: (ms: number) => `${Math.round(ms / 60000)}m`,
+  getStatusColor: (status: string) => {
+    if (status === 'working') return 'bg-green-500';
+    if (status === 'idle') return 'bg-gray-500';
+    return 'bg-blue-500';
+  },
+  useDailySummary: mocks.useDailySummary,
+  useStatusHistory: mocks.useStatusHistory,
+}));
+
+vi.mock('@/hooks/useTasks', () => ({
+  useTask: mocks.useTask,
+}));
+
+describe('activity and chat Mantine migration', () => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+  const originalHasPointerCapture = Element.prototype.hasPointerCapture;
+  const originalSetPointerCapture = Element.prototype.setPointerCapture;
+  const originalReleasePointerCapture = Element.prototype.releasePointerCapture;
+
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.hasPointerCapture = vi.fn(() => false);
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
+
+  afterAll(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    Element.prototype.hasPointerCapture = originalHasPointerCapture;
+    Element.prototype.setPointerCapture = originalSetPointerCapture;
+    Element.prototype.releasePointerCapture = originalReleasePointerCapture;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const now = new Date().toISOString();
+
+    mocks.useActivities.mockReturnValue({
+      data: [
+        {
+          id: 'activity-1',
+          type: 'task_created',
+          taskId: 'task-1',
+          taskTitle: 'Draft launch checklist',
+          timestamp: now,
+          details: {},
+        },
+        {
+          id: 'activity-2',
+          type: 'status_changed',
+          taskId: 'task-1',
+          taskTitle: 'Draft launch checklist',
+          timestamp: now,
+          details: { status: 'done' },
+        },
+      ],
+      isLoading: false,
+      isRefetching: false,
+      refetch: mocks.refetchActivities,
+    });
+    mocks.useActivityFeed.mockReturnValue({
+      data: {
+        pages: [
+          [
+            {
+              id: 'activity-3',
+              type: 'status_changed',
+              taskId: 'task-2',
+              taskTitle: 'Review release notes',
+              timestamp: now,
+              details: { from: 'todo', status: 'in-progress' },
+            },
+          ],
+        ],
+      },
+      isLoading: false,
+    });
+    mocks.useDailySummary.mockReturnValue({
+      data: {
+        activeMs: 7_200_000,
+        idleMs: 1_800_000,
+        errorMs: 0,
+      },
+      isLoading: false,
+    });
+    mocks.useStatusHistory.mockReturnValue({
+      data: [
+        {
+          id: 'status-1',
+          timestamp: now,
+          previousStatus: 'idle',
+          newStatus: 'working',
+          durationMs: 1_800_000,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useChatSessions.mockReturnValue({ data: [{ id: 'board-chat', taskId: undefined }] });
+    mocks.useChatSession.mockImplementation((sessionId?: string) => ({
+      data: sessionId
+        ? {
+            id: sessionId,
+            messages: [
+              {
+                id: 'chat-1',
+                role: 'assistant',
+                content: 'Ready to help with the board.',
+                timestamp: now,
+              },
+            ],
+          }
+        : undefined,
+    }));
+    mocks.useChatStream.mockReturnValue({ streamingMessage: null });
+    mocks.useDeleteChatSession.mockReturnValue({
+      mutate: mocks.deleteChatSession,
+      isPending: false,
+    });
+    mocks.useSendChatMessage.mockReturnValue({
+      mutate: mocks.sendChatMessage,
+      isPending: false,
+    });
+    mocks.useSquadMessages.mockReturnValue({
+      data: [
+        {
+          id: 'squad-1',
+          agent: 'Human',
+          message: 'Code review ready.',
+          timestamp: now,
+          system: false,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useSendSquadMessage.mockReturnValue({
+      mutate: mocks.sendSquadMessage,
+      isPending: false,
+    });
+    mocks.useSquadStream.mockReturnValue({ newMessage: null });
+    mocks.useFeatureSetting.mockReturnValue('Coby');
+    mocks.useConfig.mockReturnValue({
+      data: {
+        agents: [
+          { name: 'OpenAI Codex', enabled: true },
+          { name: 'Claude Code Opus 4.7 Reviewer', enabled: true },
+          { name: 'Amp', enabled: false },
+        ],
+      },
+    });
+    mocks.useTask.mockReturnValue({ data: { id: 'task-1', title: 'Draft launch checklist' } });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders activity surfaces with direct Mantine primitives', () => {
+    const { baseElement } = renderWithProviders(
+      <>
+        <ActivitySidebar open={true} onOpenChange={vi.fn()} />
+        <ActivityFeed onBack={vi.fn()} onTaskClick={vi.fn()} />
+      </>
+    );
+
+    expect(screen.getByText('Activity Log')).toBeDefined();
+    expect(screen.getByText("Today's Summary")).toBeDefined();
+    expect(screen.getByText('Task Activity')).toBeDefined();
+    expect(screen.getByText('Status History')).toBeDefined();
+    expect(screen.getByText('Activity')).toBeDefined();
+    expect(screen.getByText('Review release notes')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Drawer-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Tabs-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="sheet-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="tabs-list"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+  });
+
+  it('renders chat overlays with direct Mantine primitives', async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderWithProviders(
+      <>
+        <ChatPanel open={true} onOpenChange={vi.fn()} />
+        <SquadChatPanel open={true} onOpenChange={vi.fn()} />
+        <FloatingChat />
+      </>
+    );
+
+    expect(await screen.findByText('Board Chat')).toBeDefined();
+    expect(screen.getByText('Ready to help with the board.')).toBeDefined();
+    expect(screen.getByText('Squad Chat')).toBeDefined();
+    expect(screen.getByText('Code review ready.')).toBeDefined();
+    expect(screen.getByLabelText('Open chat')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Drawer-root').length).toBeGreaterThanOrEqual(2);
+    expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+
+    await user.click(await screen.findByLabelText('Clear chat'));
+
+    expect(await screen.findByText('Clear chat history?')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Modal-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="sheet-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+  });
+});

--- a/web/src/components/activity/ActivityFeed.tsx
+++ b/web/src/components/activity/ActivityFeed.tsx
@@ -7,7 +7,7 @@ import {
   Zap,
   Coffee,
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { ActionIcon, Badge, Group, Paper, SimpleGrid, Stack, Text, ThemeIcon } from '@mantine/core';
 import {
   useDailySummary,
   useStatusHistory,
@@ -59,35 +59,49 @@ function DailySummaryPanel() {
   const activePercent = total > 0 ? Math.round((summary.activeMs / total) * 100) : 0;
 
   return (
-    <div className="space-y-6">
+    <Stack gap="lg">
       {/* Summary Cards */}
-      <div className="grid grid-cols-3 gap-4">
-        <div className="p-4 rounded-lg border bg-card">
-          <div className="flex items-center gap-2 mb-2">
-            <Zap className="h-5 w-5 text-green-500" />
-            <span className="text-sm text-muted-foreground">Active Time</span>
-          </div>
-          <div className="text-2xl font-bold text-green-500">
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+        <Paper withBorder p="md" radius="md">
+          <Group gap="xs" mb="xs">
+            <ThemeIcon variant="transparent" color="green">
+              <Zap className="h-5 w-5" />
+            </ThemeIcon>
+            <Text size="sm" c="dimmed">
+              Active Time
+            </Text>
+          </Group>
+          <Text size="xl" fw={700} c="green">
             {formatDurationMs(summary.activeMs)}
-          </div>
-        </div>
-        <div className="p-4 rounded-lg border bg-card">
-          <div className="flex items-center gap-2 mb-2">
-            <Coffee className="h-5 w-5 text-muted-foreground" />
-            <span className="text-sm text-muted-foreground">Idle Time</span>
-          </div>
-          <div className="text-2xl font-bold text-muted-foreground">
+          </Text>
+        </Paper>
+        <Paper withBorder p="md" radius="md">
+          <Group gap="xs" mb="xs">
+            <ThemeIcon variant="transparent" color="gray">
+              <Coffee className="h-5 w-5" />
+            </ThemeIcon>
+            <Text size="sm" c="dimmed">
+              Idle Time
+            </Text>
+          </Group>
+          <Text size="xl" fw={700} c="dimmed">
             {formatDurationMs(summary.idleMs)}
-          </div>
-        </div>
-        <div className="p-4 rounded-lg border bg-card">
-          <div className="flex items-center gap-2 mb-2">
-            <ActivityIcon className="h-5 w-5 text-primary" />
-            <span className="text-sm text-muted-foreground">Utilization</span>
-          </div>
-          <div className="text-2xl font-bold">{activePercent}%</div>
-        </div>
-      </div>
+          </Text>
+        </Paper>
+        <Paper withBorder p="md" radius="md">
+          <Group gap="xs" mb="xs">
+            <ThemeIcon variant="transparent" color="violet">
+              <ActivityIcon className="h-5 w-5" />
+            </ThemeIcon>
+            <Text size="sm" c="dimmed">
+              Utilization
+            </Text>
+          </Group>
+          <Text size="xl" fw={700}>
+            {activePercent}%
+          </Text>
+        </Paper>
+      </SimpleGrid>
 
       {/* Progress bar */}
       {total > 0 && (
@@ -108,7 +122,7 @@ function DailySummaryPanel() {
           )}
         </div>
       )}
-    </div>
+    </Stack>
   );
 }
 
@@ -119,14 +133,14 @@ function StatusBadge({ status, isTaskStatus }: { status: string; isTaskStatus?: 
   // Format task status for display
   const displayStatus = isTaskStatus ? (status === 'in-progress' ? 'in-progress' : status) : status;
   return (
-    <span
-      className={cn(
-        'inline-flex items-center justify-center w-[5.5rem] px-2 py-0.5 rounded text-xs font-medium text-white',
-        colorClass
-      )}
+    <Badge
+      size="sm"
+      radius="sm"
+      tt="none"
+      className={cn('w-[5.5rem] justify-center text-white', colorClass)}
     >
       {displayStatus}
-    </span>
+    </Badge>
   );
 }
 
@@ -340,9 +354,14 @@ export function ActivityFeed({ onBack, onTaskClick }: ActivityFeedProps) {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
-        <Button variant="ghost" size="icon" onClick={onBack} title="Back to board">
+        <ActionIcon
+          variant="subtle"
+          onClick={onBack}
+          title="Back to board"
+          aria-label="Back to board"
+        >
           <ArrowLeft className="h-5 w-5" />
-        </Button>
+        </ActionIcon>
         <div className="flex items-center gap-2">
           <ActivityIcon className="h-6 w-6 text-primary" />
           <h2 className="text-2xl font-bold">Activity</h2>

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -1,19 +1,15 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
+  ActionIcon,
+  Button,
+  Drawer,
+  Group,
+  Modal,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import {
   MessageSquare,
   Send,
@@ -45,6 +41,7 @@ export function ChatPanel({ open, onOpenChange, taskId }: ChatPanelProps) {
   const [message, setMessage] = useState('');
   const [mode, setMode] = useState<'ask' | 'build'>('ask');
   const [currentSessionId, setCurrentSessionId] = useState<string | undefined>();
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
   const { data: task } = useTask(taskId || '');
   const { data: sessions = [] } = useChatSessions();
   const { data: session } = useChatSession(currentSessionId);
@@ -119,96 +116,79 @@ export function ChatPanel({ open, onOpenChange, taskId }: ChatPanelProps) {
   }, [filteredSessions, currentSessionId, taskId]);
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        className="w-[500px] sm:max-w-[500px] overflow-hidden flex flex-col p-0"
-        side="right"
-      >
-        {/* Header action buttons — positioned next to Sheet's built-in X */}
-        {currentSessionId && session?.messages && session.messages.length > 0 && (
-          <button
-            onClick={() => {
-              if (!session?.messages?.length) return;
-              const title = taskId && task ? task.title : 'Board Chat';
-              const date = new Date().toLocaleString();
-              const lines = [`# Chat Export — ${title}`, `*Exported: ${date}*`, ''];
-              for (const msg of session.messages) {
-                const role =
-                  msg.role === 'user'
-                    ? '👤 User'
-                    : msg.role === 'assistant'
-                      ? '🤖 Assistant'
-                      : '⚙️ System';
-                const time = new Date(msg.timestamp).toLocaleString();
-                lines.push('---', '', `### ${role}`, `*${time}*`, '', msg.content, '');
-              }
-              const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement('a');
-              a.href = url;
-              a.download = `chat-${taskId || 'board'}-${new Date().toISOString().slice(0, 10)}.md`;
-              a.click();
-              URL.revokeObjectURL(url);
-            }}
-            className="absolute right-20 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 hover:text-primary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-          >
-            <Download className="h-4 w-4" />
-            <span className="sr-only">Export chat</span>
-          </button>
-        )}
-        {currentSessionId && session?.messages && session.messages.length > 0 && (
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <button className="absolute right-12 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 hover:text-destructive focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
-                <Trash2 className="h-4 w-4" />
-                <span className="sr-only">Clear chat</span>
-              </button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Clear chat history?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will permanently delete all messages in this chat. This action cannot be
-                  undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
+    <>
+      <Drawer
+        opened={open}
+        onClose={() => onOpenChange(false)}
+        position="right"
+        size={500}
+        padding={0}
+        title={
+          <Group justify="space-between" wrap="nowrap" className="w-full pr-8">
+            <Stack gap={4}>
+              <Group gap="xs" wrap="nowrap">
+                <Bot className="h-5 w-5" />
+                <Text fw={600}>{taskId ? 'Task Chat' : 'Board Chat'}</Text>
+              </Group>
+              {taskId && task && (
+                <Group gap="xs" className="border-t border-border/50 pt-2">
+                  <MessageSquare className="h-3 w-3" />
+                  <Text size="xs" c="dimmed">
+                    Task: {task.title}
+                  </Text>
+                </Group>
+              )}
+            </Stack>
+            {currentSessionId && session?.messages && session.messages.length > 0 && (
+              <Group gap={4} wrap="nowrap">
+                <ActionIcon
+                  variant="subtle"
+                  aria-label="Export chat"
                   onClick={() => {
-                    if (currentSessionId) {
-                      deleteChatSession(currentSessionId, {
-                        onSuccess: () => {
-                          setCurrentSessionId(undefined);
-                          if (taskId) {
-                            setTimeout(() => setCurrentSessionId(`task_${taskId}`), 100);
-                          }
-                        },
-                      });
+                    if (!session?.messages?.length) return;
+                    const title = taskId && task ? task.title : 'Board Chat';
+                    const date = new Date().toLocaleString();
+                    const lines = [`# Chat Export — ${title}`, `*Exported: ${date}*`, ''];
+                    for (const msg of session.messages) {
+                      const role =
+                        msg.role === 'user'
+                          ? '👤 User'
+                          : msg.role === 'assistant'
+                            ? '🤖 Assistant'
+                            : '⚙️ System';
+                      const time = new Date(msg.timestamp).toLocaleString();
+                      lines.push('---', '', `### ${role}`, `*${time}*`, '', msg.content, '');
                     }
+                    const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `chat-${taskId || 'board'}-${new Date()
+                      .toISOString()
+                      .slice(0, 10)}.md`;
+                    a.click();
+                    URL.revokeObjectURL(url);
                   }}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 >
-                  Clear History
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        )}
-
-        <SheetHeader className="border-b border-border px-4 py-3 pr-10 flex-shrink-0">
-          <SheetTitle className="flex items-center gap-2">
-            <Bot className="h-5 w-5" />
-            {taskId ? 'Task Chat' : 'Board Chat'}
-          </SheetTitle>
-          {taskId && task && (
-            <div className="text-xs text-muted-foreground flex items-center gap-2 pt-2 border-t border-border/50 mt-2">
-              <MessageSquare className="h-3 w-3" />
-              Task: {task.title}
-            </div>
-          )}
-        </SheetHeader>
-
+                  <Download className="h-4 w-4" />
+                </ActionIcon>
+                <ActionIcon
+                  variant="subtle"
+                  color="red"
+                  aria-label="Clear chat"
+                  onClick={() => setClearConfirmOpen(true)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </ActionIcon>
+              </Group>
+            )}
+          </Group>
+        }
+        styles={{
+          content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+          body: { display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 },
+        }}
+      >
         {/* Messages */}
         <ScrollArea className="flex-1 px-4" onScrollCapture={handleScroll} ref={scrollAreaRef}>
           <div className="py-4 space-y-4">
@@ -241,7 +221,7 @@ export function ChatPanel({ open, onOpenChange, taskId }: ChatPanelProps) {
         {/* Input Area */}
         <div className="border-t border-border p-4 flex-shrink-0 space-y-3">
           <div className="flex items-center gap-2">
-            <Input
+            <TextInput
               ref={inputRef}
               value={message}
               onChange={(e) => setMessage(e.target.value)}
@@ -251,31 +231,33 @@ export function ChatPanel({ open, onOpenChange, taskId }: ChatPanelProps) {
               className="flex-1"
               autoFocus
             />
-            <Button onClick={handleSend} disabled={!message.trim() || isPending} size="icon">
+            <ActionIcon
+              onClick={handleSend}
+              disabled={!message.trim() || isPending}
+              aria-label="Send chat message"
+            >
               {isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <Send className="h-4 w-4" />
               )}
-            </Button>
+            </ActionIcon>
           </div>
 
           {/* Mode Toggle */}
           <div className="flex items-center gap-2 text-xs">
             <span className="text-muted-foreground">Mode:</span>
             <Button
-              variant={mode === 'ask' ? 'default' : 'outline'}
-              size="sm"
+              variant={mode === 'ask' ? 'filled' : 'outline'}
+              size="xs"
               onClick={() => setMode('ask')}
-              className="h-7 text-xs"
             >
               Ask
             </Button>
             <Button
-              variant={mode === 'build' ? 'default' : 'outline'}
-              size="sm"
+              variant={mode === 'build' ? 'filled' : 'outline'}
+              size="xs"
               onClick={() => setMode('build')}
-              className="h-7 text-xs"
             >
               Build
             </Button>
@@ -284,8 +266,43 @@ export function ChatPanel({ open, onOpenChange, taskId }: ChatPanelProps) {
             </span>
           </div>
         </div>
-      </SheetContent>
-    </Sheet>
+      </Drawer>
+      <Modal
+        opened={clearConfirmOpen}
+        onClose={() => setClearConfirmOpen(false)}
+        centered
+        title="Clear chat history?"
+      >
+        <Stack>
+          <Text size="sm" c="dimmed">
+            This will permanently delete all messages in this chat. This action cannot be undone.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="outline" onClick={() => setClearConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                if (currentSessionId) {
+                  deleteChatSession(currentSessionId, {
+                    onSuccess: () => {
+                      setClearConfirmOpen(false);
+                      setCurrentSessionId(undefined);
+                      if (taskId) {
+                        setTimeout(() => setCurrentSessionId(`task_${taskId}`), 100);
+                      }
+                    },
+                  });
+                }
+              }}
+            >
+              Clear History
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </>
   );
 }
 

--- a/web/src/components/chat/FloatingChat.tsx
+++ b/web/src/components/chat/FloatingChat.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
+import { ActionIcon } from '@mantine/core';
 import { MessageSquare } from 'lucide-react';
 import { chatEventTarget } from '@/hooks/useTaskSync';
 import { cn } from '@/lib/utils';
@@ -49,9 +49,11 @@ export function FloatingChat() {
   return (
     <>
       {/* Floating button */}
-      <Button
+      <ActionIcon
         onClick={handleOpen}
-        size="icon"
+        size={56}
+        radius="xl"
+        variant="filled"
         className={cn(
           'fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full shadow-lg',
           'bg-primary hover:bg-primary/90 text-primary-foreground',
@@ -67,7 +69,7 @@ export function FloatingChat() {
             <span className="relative inline-flex rounded-full h-4 w-4 bg-emerald-500" />
           </span>
         )}
-      </Button>
+      </ActionIcon>
 
       {/* Chat panel — board-level (no taskId) */}
       {panelMounted && (

--- a/web/src/components/chat/SquadChatPanel.tsx
+++ b/web/src/components/chat/SquadChatPanel.tsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import {
+  ActionIcon,
+  Button,
+  Drawer,
+  Group,
+  ScrollArea,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+  Text,
+  TextInput,
+} from '@mantine/core';
 import { Send, Loader2, Users, Filter, Settings2 } from 'lucide-react';
 import { useSquadMessages, useSendSquadMessage, useSquadStream } from '@/hooks/useChat';
 import { useConfig } from '@/hooks/useConfig';
@@ -99,7 +98,9 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
       messagesEndRef.current.scrollIntoView({ behavior });
     }
     // Fallback: find the Mantine-backed ScrollArea viewport and scroll it directly.
-    const viewport = scrollAreaRef.current?.querySelector('[data-slot="scroll-area-viewport"]');
+    const viewport = scrollAreaRef.current?.querySelector(
+      '[data-slot="scroll-area-viewport"], .mantine-ScrollArea-viewport'
+    );
     if (viewport) {
       viewport.scrollTop = viewport.scrollHeight;
     }
@@ -169,45 +170,52 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
   const uniqueAgents = Array.from(new Set(messages.map((m) => m.agent))).sort();
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        className="w-[500px] sm:max-w-[500px] overflow-hidden flex flex-col p-0"
-        side="right"
-      >
-        <SheetHeader className="border-b border-border px-4 py-3 pr-10 flex-shrink-0">
-          <SheetTitle className="flex items-center gap-2">
+    <Drawer
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      position="right"
+      size={500}
+      padding={0}
+      title={
+        <div>
+          <Group gap="xs" wrap="nowrap">
             <Users className="h-5 w-5" />
-            Squad Chat
-          </SheetTitle>
-          <div className="text-xs text-muted-foreground pt-2">
+            <Text fw={600}>Squad Chat</Text>
+          </Group>
+          <Text size="xs" c="dimmed" pt={4}>
             Agent-to-agent communication channel
-          </div>
-        </SheetHeader>
-
+          </Text>
+        </div>
+      }
+      styles={{
+        content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+        body: { display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 },
+      }}
+    >
+      <div className="flex min-h-0 flex-1 flex-col">
         {/* Filter Bar */}
         <div className="border-b border-border px-4 py-2 flex items-center gap-2 flex-shrink-0">
           <Filter className="h-4 w-4 text-muted-foreground" />
-          <Select value={agentFilter} onValueChange={setAgentFilter}>
-            <SelectTrigger className="h-8 text-xs w-[150px]">
-              <SelectValue placeholder="Filter by agent" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Agents</SelectItem>
-              {uniqueAgents.map((agent) => (
-                <SelectItem key={agent} value={agent}>
-                  {agent}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Select
+            value={agentFilter}
+            onChange={(value) => setAgentFilter(value ?? 'all')}
+            allowDeselect={false}
+            size="xs"
+            w={150}
+            data={[
+              { value: 'all', label: 'All Agents' },
+              ...uniqueAgents.map((agent) => ({ value: agent, label: agent })),
+            ]}
+            aria-label="Filter by agent"
+          />
           <Button
-            variant={includeSystem ? 'default' : 'outline'}
-            size="sm"
+            variant={includeSystem ? 'filled' : 'outline'}
+            size="xs"
             onClick={() => setIncludeSystem(!includeSystem)}
-            className="ml-auto h-8 text-xs gap-1.5"
+            className="ml-auto gap-1.5"
             title={includeSystem ? 'Hide system messages' : 'Show system messages'}
+            leftSection={<Settings2 className="h-3.5 w-3.5" />}
           >
-            <Settings2 className="h-3.5 w-3.5" />
             {includeSystem ? 'Hide' : 'Show'} System
           </Button>
         </div>
@@ -254,21 +262,18 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
         <div className="border-t border-border p-4 flex-shrink-0 space-y-2">
           <div className="flex items-center gap-2 mb-2">
             <span className="text-xs text-muted-foreground">Sending as:</span>
-            <Select value={selectedAgent} onValueChange={setSelectedAgent}>
-              <SelectTrigger className="h-8 text-xs w-[140px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {availableAgents.map((agent) => (
-                  <SelectItem key={agent} value={agent}>
-                    {agent}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Select
+              value={selectedAgent}
+              onChange={(value) => setSelectedAgent(value ?? humanDisplayName ?? 'Human')}
+              allowDeselect={false}
+              size="xs"
+              w={140}
+              data={availableAgents.map((agent) => ({ value: agent, label: agent }))}
+              aria-label="Sending as"
+            />
           </div>
           <div className="flex items-center gap-2">
-            <Input
+            <TextInput
               ref={inputRef}
               value={message}
               onChange={(e) => setMessage(e.target.value)}
@@ -278,17 +283,21 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
               className="flex-1"
               autoFocus
             />
-            <Button onClick={handleSend} disabled={!message.trim() || isPending} size="icon">
+            <ActionIcon
+              onClick={handleSend}
+              disabled={!message.trim() || isPending}
+              aria-label="Send squad message"
+            >
               {isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <Send className="h-4 w-4" />
               )}
-            </Button>
+            </ActionIcon>
           </div>
         </div>
-      </SheetContent>
-    </Sheet>
+      </div>
+    </Drawer>
   );
 }
 

--- a/web/src/components/layout/ActivitySidebar.tsx
+++ b/web/src/components/layout/ActivitySidebar.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react';
 import { Activity, Trash2, RefreshCw, Coffee, ArrowRight, Zap } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import {
+  ActionIcon,
+  Badge,
+  Box,
+  Drawer,
+  Group,
+  ScrollArea,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+  Skeleton,
+  Tabs,
+  Text,
+} from '@mantine/core';
 import {
   useActivities,
   useClearActivities,
@@ -109,14 +110,9 @@ function StatusBadge({ status }: { status: string }) {
   const colorClass = getStatusColor(status);
 
   return (
-    <span
-      className={cn(
-        'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-white',
-        colorClass
-      )}
-    >
+    <Badge size="sm" radius="sm" tt="none" className={cn('text-white', colorClass)}>
       {status}
-    </span>
+    </Badge>
   );
 }
 
@@ -126,13 +122,13 @@ function DailySummaryCard() {
 
   if (isLoading || !summary) {
     return (
-      <div className="px-4 py-3 border-b bg-muted/30">
-        <div className="animate-pulse flex items-center gap-4">
-          <div className="h-10 w-20 bg-muted rounded"></div>
-          <div className="h-10 w-20 bg-muted rounded"></div>
-          <div className="h-10 w-20 bg-muted rounded"></div>
-        </div>
-      </div>
+      <Box px="md" py="sm" className="border-b bg-muted/30">
+        <Group gap="md">
+          <Skeleton h={40} w={80} radius="sm" />
+          <Skeleton h={40} w={80} radius="sm" />
+          <Skeleton h={40} w={80} radius="sm" />
+        </Group>
+      </Box>
     );
   }
 
@@ -140,10 +136,12 @@ function DailySummaryCard() {
   const activePercent = total > 0 ? Math.round((summary.activeMs / total) * 100) : 0;
 
   return (
-    <div className="px-4 py-3 border-b bg-muted/30">
-      <div className="text-xs font-medium text-muted-foreground mb-2">Today's Summary</div>
-      <div className="flex items-center gap-3">
-        <div className="flex items-center gap-1.5">
+    <Box px="md" py="sm" className="border-b bg-muted/30">
+      <Text size="xs" fw={500} c="dimmed" mb="xs">
+        Today's Summary
+      </Text>
+      <Group gap="sm">
+        <Group gap={6}>
           <Zap className="h-4 w-4 text-green-500" />
           <div>
             <div className="text-sm font-bold text-green-500">
@@ -151,8 +149,8 @@ function DailySummaryCard() {
             </div>
             <div className="text-xs text-muted-foreground">Active</div>
           </div>
-        </div>
-        <div className="flex items-center gap-1.5">
+        </Group>
+        <Group gap={6}>
           <Coffee className="h-4 w-4 text-muted-foreground" />
           <div>
             <div className="text-sm font-bold text-muted-foreground">
@@ -160,14 +158,14 @@ function DailySummaryCard() {
             </div>
             <div className="text-xs text-muted-foreground">Idle</div>
           </div>
-        </div>
-        <div className="flex items-center gap-1.5 ml-auto">
+        </Group>
+        <Group gap={6} ml="auto">
           <div className="text-right">
             <div className="text-sm font-bold">{activePercent}%</div>
             <div className="text-xs text-muted-foreground">Utilization</div>
           </div>
-        </div>
-      </div>
+        </Group>
+      </Group>
       {/* Mini progress bar */}
       {total > 0 && (
         <div className="mt-2 h-1.5 rounded-full overflow-hidden flex bg-muted">
@@ -187,7 +185,7 @@ function DailySummaryCard() {
           )}
         </div>
       )}
-    </div>
+    </Box>
   );
 }
 
@@ -253,92 +251,100 @@ export function ActivitySidebar({ open, onOpenChange }: ActivitySidebarProps) {
   const activityTypes = activities ? [...new Set(activities.map((a) => a.type))] : [];
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[400px] sm:w-[450px] p-0">
-        <SheetHeader className="px-4 py-3 border-b">
-          <div className="flex items-center justify-between pr-8">
-            <SheetTitle className="flex items-center gap-2">
-              <Activity className="h-5 w-5" />
-              Activity Log
-            </SheetTitle>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => refetch()}
-                disabled={isRefetching}
-                className="h-8 w-8"
-              >
-                <RefreshCw className={cn('h-4 w-4', isRefetching && 'animate-spin')} />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => clearActivities.mutate()}
-                disabled={clearActivities.isPending || !activities?.length}
-                className="h-8 w-8 text-muted-foreground hover:text-destructive"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
+    <Drawer
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      position="right"
+      size={450}
+      padding={0}
+      title={
+        <Group justify="space-between" wrap="nowrap" className="w-full pr-8">
+          <Group gap="xs" wrap="nowrap">
+            <Activity className="h-5 w-5" />
+            <Text fw={600}>Activity Log</Text>
+          </Group>
+          <Group gap={4} wrap="nowrap">
+            <ActionIcon
+              variant="subtle"
+              onClick={() => refetch()}
+              disabled={isRefetching}
+              aria-label="Refresh activity log"
+            >
+              <RefreshCw className={cn('h-4 w-4', isRefetching && 'animate-spin')} />
+            </ActionIcon>
+            <ActionIcon
+              variant="subtle"
+              color="red"
+              onClick={() => clearActivities.mutate()}
+              disabled={clearActivities.isPending || !activities?.length}
+              aria-label="Clear activity log"
+            >
+              <Trash2 className="h-4 w-4" />
+            </ActionIcon>
+          </Group>
+        </Group>
+      }
+      styles={{
+        content: { display: 'flex', flexDirection: 'column' },
+        body: { display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 },
+      }}
+    >
+      {/* Daily Summary always visible at top */}
+      <DailySummaryCard />
+
+      <Tabs
+        value={tab}
+        onChange={(value) => setTab(value ?? 'tasks')}
+        className="flex flex-col h-[calc(100vh-200px)]"
+      >
+        <Tabs.List grow mx="md" mt="sm">
+          <Tabs.Tab value="tasks">Task Activity</Tabs.Tab>
+          <Tabs.Tab value="status">Status History</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tasks" className="flex-1 mt-0">
+          {activityTypes.length > 1 && (
+            <div className="px-4 py-2">
+              <Select
+                value={filter}
+                onChange={(value) => setFilter(value ?? 'all')}
+                allowDeselect={false}
+                placeholder="Filter activities"
+                data={[
+                  { value: 'all', label: 'All Activities' },
+                  ...activityTypes.map((type) => ({
+                    value: type,
+                    label: `${activityIcons[type]} ${activityLabels[type]}`,
+                  })),
+                ]}
+              />
             </div>
-          </div>
-        </SheetHeader>
+          )}
+          <ScrollArea className="h-full">
+            <div className="px-2 py-2">
+              {isLoading ? (
+                <div className="text-center text-muted-foreground py-8">Loading activities...</div>
+              ) : filteredActivities.length === 0 ? (
+                <div className="text-center text-muted-foreground py-8">No activities yet</div>
+              ) : (
+                <div className="divide-y divide-border">
+                  {filteredActivities.map((activity) => (
+                    <ActivityRow key={activity.id} activity={activity} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+        </Tabs.Panel>
 
-        {/* Daily Summary always visible at top */}
-        <DailySummaryCard />
-
-        <Tabs value={tab} onValueChange={setTab} className="flex flex-col h-[calc(100vh-200px)]">
-          <TabsList className="mx-4 mt-2 grid w-[calc(100%-32px)] grid-cols-2">
-            <TabsTrigger value="tasks">Task Activity</TabsTrigger>
-            <TabsTrigger value="status">Status History</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="tasks" className="flex-1 mt-0">
-            {activityTypes.length > 1 && (
-              <div className="px-4 py-2">
-                <Select value={filter} onValueChange={setFilter}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Filter activities" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Activities</SelectItem>
-                    {activityTypes.map((type) => (
-                      <SelectItem key={type} value={type}>
-                        {activityIcons[type]} {activityLabels[type]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-            <ScrollArea className="h-full">
-              <div className="px-2 py-2">
-                {isLoading ? (
-                  <div className="text-center text-muted-foreground py-8">
-                    Loading activities...
-                  </div>
-                ) : filteredActivities.length === 0 ? (
-                  <div className="text-center text-muted-foreground py-8">No activities yet</div>
-                ) : (
-                  <div className="divide-y divide-border">
-                    {filteredActivities.map((activity) => (
-                      <ActivityRow key={activity.id} activity={activity} />
-                    ))}
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value="status" className="flex-1 mt-0">
-            <ScrollArea className="h-full">
-              <div className="px-2 py-2">
-                <StatusHistoryList />
-              </div>
-            </ScrollArea>
-          </TabsContent>
-        </Tabs>
-      </SheetContent>
-    </Sheet>
+        <Tabs.Panel value="status" className="flex-1 mt-0">
+          <ScrollArea className="h-full">
+            <div className="px-2 py-2">
+              <StatusHistoryList />
+            </div>
+          </ScrollArea>
+        </Tabs.Panel>
+      </Tabs>
+    </Drawer>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates activity and chat overlay surfaces to direct Mantine Drawer, Modal, Tabs, Select, TextInput, ScrollArea, Button, ActionIcon, Skeleton, Badge, Paper, Stack, Group, Text, and ThemeIcon primitives.
- Removes active activity/chat compatibility wrapper imports while preserving activity filtering, status history, daily summaries, board/task chat export, clear confirmation, squad sender/filter controls, system-message toggling, and the floating chat launcher.
- Adds focused regression coverage for the activity/chat Mantine surfaces and updates the migration tracker.

## Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/activity-chat-mantine.test.tsx src/__tests__/SquadChatPanel.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Focused wrapper scan for activity/chat files
- In-app Browser smoke at http://127.0.0.1:3000/: setup screen rendered, no console warnings/errors, no framework overlay, password visibility toggle changed the first password field from password to text.

## Notes
- Advances #417 and #326.
- Remaining #417 slices: policy/governance/scoring/drift, templates, specialized runtime surfaces, then the final #418 QA cleanup gate.