### PR TITLE
Migrate governance surfaces to Mantine

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -399,6 +399,12 @@ Phase 3 progress:
   status history, daily summaries, board/task chat export and clear
   confirmation, squad sender/filter controls, system-message toggling, and the
   floating chat launcher.
+- Governance, policy, scoring, drift, decision, and feedback surfaces now use
+  direct Mantine text input, textarea, select, tabs, scroll area, switch,
+  modal, badge, button, action icon, and skeleton primitives while preserving
+  policy CRUD/evaluation, drift analysis/reset, scoring profile edits,
+  decision assumption validation, and feedback submission/browse/analytics
+  behavior.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/governance-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/governance-surfaces-mantine.test.tsx
@@ -1,0 +1,443 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DecisionDetail } from '@/components/decisions/DecisionDetail';
+import { DecisionExplorer } from '@/components/decisions/DecisionExplorer';
+import { DriftMonitor } from '@/components/drift/DriftMonitor';
+import { FeedbackPanel } from '@/components/feedback/FeedbackPanel';
+import { PolicyManager } from '@/components/policies/PolicyManager';
+import { ScoringProfiles } from '@/components/scoring/ScoringProfiles';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  acknowledgeDriftAlert: vi.fn(),
+  analyzeDrift: vi.fn(),
+  createFeedback: vi.fn(),
+  createPolicy: vi.fn(),
+  createScoringProfile: vi.fn(),
+  deleteFeedback: vi.fn(),
+  deletePolicy: vi.fn(),
+  deleteScoringProfile: vi.fn(),
+  evaluatePolicies: vi.fn(),
+  resolveFeedback: vi.fn(),
+  resetDriftBaselines: vi.fn(),
+  runEvaluation: vi.fn(),
+  updateDecisionAssumption: vi.fn(),
+  updatePolicy: vi.fn(),
+  updateScoringProfile: vi.fn(),
+  useDecision: vi.fn(),
+  useDecisions: vi.fn(),
+  useDriftAlerts: vi.fn(),
+  useDriftBaselines: vi.fn(),
+  useFeedbackAnalytics: vi.fn(),
+  useFeedbackList: vi.fn(),
+  usePolicies: vi.fn(),
+  useScoringHistory: vi.fn(),
+  useScoringProfiles: vi.fn(),
+  useUnresolvedFeedback: vi.fn(),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/hooks/usePolicies', () => ({
+  usePolicies: mocks.usePolicies,
+  useCreatePolicy: () => ({ mutateAsync: mocks.createPolicy, isPending: false }),
+  useUpdatePolicy: () => ({ mutateAsync: mocks.updatePolicy, isPending: false }),
+  useDeletePolicy: () => ({ mutateAsync: mocks.deletePolicy, isPending: false }),
+  useEvaluatePolicies: () => ({
+    data: {
+      decision: 'warn',
+      matches: [
+        {
+          policyId: 'risk-prod',
+          policyName: 'Production risk gate',
+          policyType: 'risk-threshold',
+          responseAction: 'warn',
+          message: 'Risk exceeds warning threshold.',
+        },
+      ],
+      warnings: [],
+      blockedBy: [],
+      approvalRequiredBy: [],
+    },
+    mutateAsync: mocks.evaluatePolicies,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useDrift', () => ({
+  useAcknowledgeDriftAlert: () => ({
+    mutate: mocks.acknowledgeDriftAlert,
+    variables: undefined,
+    isPending: false,
+  }),
+  useAnalyzeDrift: () => ({ mutate: mocks.analyzeDrift, isPending: false }),
+  useDriftAlerts: mocks.useDriftAlerts,
+  useDriftBaselines: mocks.useDriftBaselines,
+  useResetDriftBaselines: () => ({ mutate: mocks.resetDriftBaselines, isPending: false }),
+}));
+
+vi.mock('@/hooks/useScoring', () => ({
+  useCreateScoringProfile: () => ({ mutateAsync: mocks.createScoringProfile, isPending: false }),
+  useDeleteScoringProfile: () => ({ mutateAsync: mocks.deleteScoringProfile, isPending: false }),
+  useRunEvaluation: () => ({
+    data: {
+      id: 'eval-1',
+      profileId: 'quality',
+      profileName: 'Quality',
+      output: 'Verified result',
+      scores: [
+        {
+          scorerId: 'keyword',
+          scorerName: 'Keyword check',
+          scorerType: 'KeywordContains',
+          weight: 1,
+          score: 0.9,
+          matched: true,
+          explanation: 'Matched verified.',
+        },
+      ],
+      compositeScore: 0.9,
+      created: '2026-06-01T12:00:00.000Z',
+    },
+    mutateAsync: mocks.runEvaluation,
+    isPending: false,
+  }),
+  useScoringHistory: mocks.useScoringHistory,
+  useScoringProfiles: mocks.useScoringProfiles,
+  useUpdateScoringProfile: () => ({ mutateAsync: mocks.updateScoringProfile, isPending: false }),
+}));
+
+vi.mock('@/hooks/useDecisions', () => ({
+  useDecision: mocks.useDecision,
+  useDecisions: mocks.useDecisions,
+  useUpdateDecisionAssumption: () => ({
+    mutateAsync: mocks.updateDecisionAssumption,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useFeedback', () => ({
+  useCreateFeedback: () => ({ mutateAsync: mocks.createFeedback, isPending: false }),
+  useDeleteFeedback: () => ({ mutateAsync: mocks.deleteFeedback, isPending: false }),
+  useFeedbackAnalytics: mocks.useFeedbackAnalytics,
+  useFeedbackList: mocks.useFeedbackList,
+  useResolveFeedback: () => ({ mutateAsync: mocks.resolveFeedback, isPending: false }),
+  useUnresolvedFeedback: mocks.useUnresolvedFeedback,
+}));
+
+function expectNoLegacySlots(root: ParentNode) {
+  expect(root.querySelector('[data-slot="input"]')).toBeNull();
+  expect(root.querySelector('[data-slot="select-trigger"]')).toBeNull();
+  expect(root.querySelector('[data-slot="tabs-list"]')).toBeNull();
+  expect(root.querySelector('[data-slot="dialog-content"]')).toBeNull();
+}
+
+describe('governance surfaces Mantine migration', () => {
+  const now = '2026-06-01T12:00:00.000Z';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createPolicy.mockResolvedValue({});
+    mocks.updatePolicy.mockResolvedValue({});
+    mocks.deletePolicy.mockResolvedValue({});
+    mocks.evaluatePolicies.mockResolvedValue({});
+    mocks.createScoringProfile.mockResolvedValue({ id: 'quality' });
+    mocks.updateScoringProfile.mockResolvedValue({ id: 'quality' });
+    mocks.deleteScoringProfile.mockResolvedValue({});
+    mocks.runEvaluation.mockResolvedValue({});
+    mocks.createFeedback.mockResolvedValue({});
+    mocks.deleteFeedback.mockResolvedValue({});
+    mocks.resolveFeedback.mockResolvedValue({});
+    mocks.updateDecisionAssumption.mockResolvedValue({});
+
+    mocks.usePolicies.mockReturnValue({
+      data: [
+        {
+          id: 'risk-prod',
+          name: 'Production risk gate',
+          type: 'risk-threshold',
+          enabled: true,
+          scope: { agents: ['codex'], projects: ['core'], actionTypes: ['git.push'] },
+          responseAction: 'warn',
+          config: { threshold: 70, comparator: 'gte' },
+          description: 'Warns on elevated production risk.',
+          preset: 'balanced',
+          createdAt: now,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useDriftAlerts.mockReturnValue({
+      data: [
+        {
+          id: 'drift-1',
+          agentId: 'codex',
+          metric: 'risk_score',
+          currentValue: 82,
+          baselineValue: 45,
+          zScore: 3.2,
+          severity: 'critical',
+          timestamp: now,
+          acknowledged: false,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useDriftBaselines.mockReturnValue({
+      data: [
+        {
+          agentId: 'codex',
+          metric: 'risk_score',
+          mean: 45,
+          stdDev: 8,
+          sampleCount: 20,
+          windowStart: '2026-05-01T00:00:00.000Z',
+          windowEnd: now,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useScoringProfiles.mockReturnValue({
+      data: [
+        {
+          id: 'quality',
+          name: 'Quality',
+          description: 'Checks verification language.',
+          compositeMethod: 'weightedAvg',
+          builtIn: false,
+          created: now,
+          updated: now,
+          scorers: [
+            {
+              id: 'keyword',
+              name: 'Keyword check',
+              type: 'KeywordContains',
+              keywords: ['verified'],
+              weight: 1,
+              target: 'output',
+            },
+          ],
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useScoringHistory.mockReturnValue({
+      data: [
+        {
+          id: 'eval-1',
+          profileId: 'quality',
+          profileName: 'Quality',
+          output: 'Verified result',
+          agent: 'codex',
+          taskId: 'task-1',
+          scores: [
+            {
+              scorerId: 'keyword',
+              scorerName: 'Keyword check',
+              scorerType: 'KeywordContains',
+              weight: 1,
+              score: 0.9,
+              matched: true,
+              explanation: 'Matched verified.',
+            },
+          ],
+          compositeScore: 0.9,
+          created: now,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useDecisions.mockReturnValue({
+      data: [
+        {
+          id: 'decision-1',
+          inputContext: 'Deploy request',
+          outputAction: 'Review production deploy',
+          assumptions: [{ text: 'Tests passed', status: 'pending' }],
+          confidenceLevel: 88,
+          riskScore: 76,
+          agentId: 'codex',
+          taskId: 'task-1',
+          timestamp: now,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useDecision.mockReturnValue({
+      data: {
+        decision: {
+          id: 'decision-1',
+          inputContext: 'Deploy request',
+          outputAction: 'Review production deploy',
+          assumptions: [{ text: 'Tests passed', status: 'pending' }],
+          confidenceLevel: 88,
+          riskScore: 76,
+          agentId: 'codex',
+          taskId: 'task-1',
+          timestamp: now,
+        },
+        chain: [
+          {
+            id: 'decision-1',
+            inputContext: 'Deploy request',
+            outputAction: 'Review production deploy',
+            assumptions: [{ text: 'Tests passed', status: 'pending' }],
+            confidenceLevel: 88,
+            riskScore: 76,
+            agentId: 'codex',
+            taskId: 'task-1',
+            timestamp: now,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    mocks.useFeedbackList.mockReturnValue({
+      data: [
+        {
+          id: 'feedback-1',
+          taskId: 'task-1',
+          agent: 'codex',
+          rating: 5,
+          comment: 'Helpful result.',
+          categories: ['quality'],
+          sentiment: 'positive',
+          resolved: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      isLoading: false,
+    });
+    mocks.useFeedbackAnalytics.mockReturnValue({
+      data: {
+        totalFeedback: 1,
+        averageRating: 5,
+        ratingDistribution: [{ star: 5, count: 1, percentage: 100 }],
+        satisfactionTrends: [{ date: '2026-06-01', averageRating: 5, count: 1 }],
+        agentScores: [
+          {
+            agent: 'codex',
+            averageRating: 5,
+            totalFeedback: 1,
+            sentimentBreakdown: { positive: 1, neutral: 0, negative: 0 },
+          },
+        ],
+        sentimentBreakdown: { positive: 1, neutral: 0, negative: 0 },
+        categoryBreakdown: { quality: 1, performance: 0, accuracy: 0, safety: 0, ux: 0 },
+        unresolvedCount: 1,
+      },
+      isLoading: false,
+    });
+    mocks.useUnresolvedFeedback.mockReturnValue({
+      data: [
+        {
+          id: 'feedback-1',
+          taskId: 'task-1',
+          rating: 5,
+          categories: ['quality'],
+          sentiment: 'positive',
+          resolved: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders policy management with Mantine forms, badges, switches, and modal chrome', async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderWithProviders(<PolicyManager onBack={vi.fn()} />);
+
+    expect(screen.getByText('Agent Policies')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Switch-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Badge-root')).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: /new policy/i }));
+
+    expect((await screen.findAllByText('Create Policy')).length).toBeGreaterThanOrEqual(1);
+    expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Select-root')).toBeDefined();
+    expectNoLegacySlots(baseElement);
+  });
+
+  it('renders drift and decision audit surfaces with direct Mantine primitives', () => {
+    const drift = renderWithProviders(<DriftMonitor onBack={vi.fn()} />);
+
+    expect(screen.getByText('Behavioral Drift Monitor')).toBeDefined();
+    expect(drift.baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(drift.baseElement.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(drift.baseElement.querySelector('.mantine-Button-root')).toBeDefined();
+    expectNoLegacySlots(drift.baseElement);
+    cleanup();
+
+    const decisions = renderWithProviders(<DecisionExplorer onBack={vi.fn()} />);
+
+    expect(screen.getByText('Decision Audit Trail')).toBeDefined();
+    expect(decisions.baseElement.querySelectorAll('.mantine-Select-root').length).toBeGreaterThan(
+      1
+    );
+    expect(decisions.baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expectNoLegacySlots(decisions.baseElement);
+    cleanup();
+
+    const detail = renderWithProviders(<DecisionDetail decisionId="decision-1" onBack={vi.fn()} />);
+
+    expect(screen.getByText('Assumptions')).toBeDefined();
+    expect(detail.baseElement.querySelector('.mantine-Textarea-root')).toBeDefined();
+    expect(detail.baseElement.querySelector('.mantine-Badge-root')).toBeDefined();
+    expectNoLegacySlots(detail.baseElement);
+  });
+
+  it('renders scoring profiles and score explorer with Mantine tabs, selects, and scroll areas', async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderWithProviders(<ScoringProfiles onBack={vi.fn()} />);
+
+    expect(screen.getByText('Agent Output Scoring')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Tabs-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Textarea-root')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
+
+    await user.click(screen.getByRole('tab', { name: /score explorer/i }));
+
+    expect(screen.getByText('Composite Score Trend')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(2);
+    expectNoLegacySlots(baseElement);
+  });
+
+  it('renders feedback submission, browse, and analytics panels with Mantine controls', async () => {
+    const user = userEvent.setup();
+    const { baseElement } = renderWithProviders(<FeedbackPanel />);
+
+    expect(screen.getByText('User Feedback')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Tabs-root')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-TextInput-root').length).toBeGreaterThanOrEqual(
+      2
+    );
+    expect(baseElement.querySelector('.mantine-Textarea-root')).toBeDefined();
+
+    await user.click(screen.getByRole('tab', { name: /browse/i }));
+
+    expect(screen.getByText('Helpful result.')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(3);
+    expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
+
+    await user.click(screen.getByRole('tab', { name: /analytics/i }));
+
+    expect(screen.getByText('Total Feedback')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Badge-root')).toBeDefined();
+    expectNoLegacySlots(baseElement);
+  });
+});

--- a/web/src/components/decisions/DecisionDetail.tsx
+++ b/web/src/components/decisions/DecisionDetail.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { ArrowLeft, CheckCircle2, AlertTriangle, GitBranch, MinusCircle } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { Badge, Button, Textarea } from '@mantine/core';
 import { useDecision, useUpdateDecisionAssumption } from '@/hooks/useDecisions';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/utils';
@@ -13,9 +11,9 @@ interface DecisionDetailProps {
 }
 
 const assumptionTone = {
-  pending: 'bg-muted text-muted-foreground',
-  validated: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200',
-  invalidated: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200',
+  pending: 'gray',
+  validated: 'green',
+  invalidated: 'red',
 } as const;
 
 export function DecisionDetail({ decisionId, onBack }: DecisionDetailProps) {
@@ -66,13 +64,17 @@ export function DecisionDetail({ decisionId, onBack }: DecisionDetailProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <Button variant="ghost" size="sm" onClick={onBack}>
+        <Button variant="subtle" size="sm" onClick={onBack}>
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back to Decisions
         </Button>
         <div className="flex items-center gap-2">
-          <Badge variant="secondary">{data.decision.agentId}</Badge>
-          <Badge variant="outline">{data.decision.taskId}</Badge>
+          <Badge variant="light" tt="none">
+            {data.decision.agentId}
+          </Badge>
+          <Badge variant="outline" tt="none">
+            {data.decision.taskId}
+          </Badge>
         </div>
       </div>
 
@@ -97,7 +99,7 @@ export function DecisionDetail({ decisionId, onBack }: DecisionDetailProps) {
                 >
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-medium">{item.outputAction}</span>
-                    {item.id === data.decision.id && <Badge>Selected</Badge>}
+                    {item.id === data.decision.id && <Badge tt="none">Selected</Badge>}
                   </div>
                   <p className="mt-2 text-sm text-muted-foreground">{item.inputContext}</p>
                   <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
@@ -121,7 +123,12 @@ export function DecisionDetail({ decisionId, onBack }: DecisionDetailProps) {
                 <div key={`${assumption.text}-${index}`} className="rounded-md border p-4">
                   <div className="flex items-start justify-between gap-3">
                     <p className="text-sm leading-6">{assumption.text}</p>
-                    <Badge className={cn('shrink-0', assumptionTone[assumption.status])}>
+                    <Badge
+                      color={assumptionTone[assumption.status]}
+                      variant="light"
+                      tt="none"
+                      className="shrink-0"
+                    >
                       {assumption.status}
                     </Badge>
                   </div>

--- a/web/src/components/decisions/DecisionExplorer.tsx
+++ b/web/src/components/decisions/DecisionExplorer.tsx
@@ -1,15 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, Search, ShieldAlert, BrainCircuit } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Badge, Button, Select, TextInput } from '@mantine/core';
 import { useDecisions } from '@/hooks/useDecisions';
 import type { DecisionListFilters, DecisionRecord } from '@veritas-kanban/shared';
 import { DecisionDetail } from './DecisionDetail';
@@ -20,11 +11,10 @@ interface DecisionExplorerProps {
 
 const BASE_PATH = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
 
-function riskTone(riskScore: number): string {
-  if (riskScore >= 75) return 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200';
-  if (riskScore >= 40)
-    return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-200';
-  return 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200';
+function riskColor(riskScore: number): string {
+  if (riskScore >= 75) return 'red';
+  if (riskScore >= 40) return 'yellow';
+  return 'green';
 }
 
 export function DecisionExplorer({ onBack }: DecisionExplorerProps) {
@@ -95,7 +85,7 @@ export function DecisionExplorer({ onBack }: DecisionExplorerProps) {
     <div className="space-y-6">
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={onBack}>
+          <Button variant="subtle" size="sm" onClick={onBack}>
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Board
           </Button>
@@ -106,57 +96,57 @@ export function DecisionExplorer({ onBack }: DecisionExplorerProps) {
             </p>
           </div>
         </div>
-        <Badge variant="secondary">{filteredDecisions.length} decisions</Badge>
+        <Badge variant="light" tt="none">
+          {filteredDecisions.length} decisions
+        </Badge>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-[1.2fr_220px_220px_220px]">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
+        <div>
+          <TextInput
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             placeholder="Search decision id, task, context..."
-            className="pl-9"
+            leftSection={<Search className="h-4 w-4 text-muted-foreground" />}
           />
         </div>
 
-        <Select value={agent} onValueChange={setAgent}>
-          <SelectTrigger>
-            <SelectValue placeholder="All agents" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All agents</SelectItem>
-            {agentOptions.map((option) => (
-              <SelectItem key={option} value={option}>
-                {option}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Select
+          value={agent}
+          onChange={(value) => setAgent(value ?? 'all')}
+          data={[
+            { value: 'all', label: 'All agents' },
+            ...agentOptions.map((option) => ({ value: option, label: option })),
+          ]}
+          placeholder="All agents"
+          allowDeselect={false}
+        />
 
-        <Select value={confidenceFilter} onValueChange={setConfidenceFilter}>
-          <SelectTrigger>
-            <SelectValue placeholder="Confidence" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All confidence</SelectItem>
-            <SelectItem value="high">80-100</SelectItem>
-            <SelectItem value="medium">50-79</SelectItem>
-            <SelectItem value="low">0-49</SelectItem>
-          </SelectContent>
-        </Select>
+        <Select
+          value={confidenceFilter}
+          onChange={(value) => setConfidenceFilter(value ?? 'all')}
+          data={[
+            { value: 'all', label: 'All confidence' },
+            { value: 'high', label: '80-100' },
+            { value: 'medium', label: '50-79' },
+            { value: 'low', label: '0-49' },
+          ]}
+          placeholder="Confidence"
+          allowDeselect={false}
+        />
 
-        <Select value={riskFilter} onValueChange={setRiskFilter}>
-          <SelectTrigger>
-            <SelectValue placeholder="Risk" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All risk</SelectItem>
-            <SelectItem value="low">0-39</SelectItem>
-            <SelectItem value="medium">40-69</SelectItem>
-            <SelectItem value="high">70-100</SelectItem>
-          </SelectContent>
-        </Select>
+        <Select
+          value={riskFilter}
+          onChange={(value) => setRiskFilter(value ?? 'all')}
+          data={[
+            { value: 'all', label: 'All risk' },
+            { value: 'low', label: '0-39' },
+            { value: 'medium', label: '40-69' },
+            { value: 'high', label: '70-100' },
+          ]}
+          placeholder="Risk"
+          allowDeselect={false}
+        />
       </div>
 
       <div className="overflow-hidden rounded-lg border bg-card">
@@ -213,8 +203,12 @@ function DecisionRow({ decision, onOpen }: { decision: DecisionRecord; onOpen: (
         <span>{decision.confidenceLevel}%</span>
       </div>
       <div>
-        <Badge className={riskTone(decision.riskScore)}>
-          <ShieldAlert className="mr-1 h-3 w-3" />
+        <Badge
+          color={riskColor(decision.riskScore)}
+          variant="light"
+          tt="none"
+          leftSection={<ShieldAlert className="h-3 w-3" />}
+        >
           {decision.riskScore}
         </Badge>
       </div>

--- a/web/src/components/drift/DriftMonitor.tsx
+++ b/web/src/components/drift/DriftMonitor.tsx
@@ -17,10 +17,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Skeleton } from '@/components/ui/skeleton';
+import { Badge, Button, Skeleton, TextInput } from '@mantine/core';
 import {
   useAcknowledgeDriftAlert,
   useAnalyzeDrift,
@@ -65,9 +62,9 @@ function formatMetricValue(metric: DriftMetric, value: number) {
 }
 
 function severityTone(severity: DriftSeverity) {
-  if (severity === 'critical') return 'destructive';
-  if (severity === 'warning') return 'secondary';
-  return 'outline';
+  if (severity === 'critical') return 'red';
+  if (severity === 'warning') return 'yellow';
+  return 'gray';
 }
 
 function zScoreColor(value: number) {
@@ -125,7 +122,9 @@ function AlertsTable({
           {alerts.map((alert) => (
             <tr key={alert.id} className="border-b last:border-b-0">
               <td className="px-4 py-3">
-                <Badge variant={severityTone(alert.severity)}>{alert.severity}</Badge>
+                <Badge color={severityTone(alert.severity)} variant="light" tt="none">
+                  {alert.severity}
+                </Badge>
               </td>
               <td className="px-4 py-3 font-medium">{alert.agentId}</td>
               <td className="px-4 py-3">{METRIC_LABELS[alert.metric]}</td>
@@ -255,7 +254,9 @@ function DriftChart({ alerts, baselines }: { alerts: DriftAlert[]; baselines: Dr
           <h3 className="font-semibold">Trend Visualization</h3>
           <p className="text-sm text-muted-foreground">{baselines.length} baselines loaded</p>
         </div>
-        <Badge variant="outline">Z-score bars</Badge>
+        <Badge variant="outline" tt="none">
+          Z-score bars
+        </Badge>
       </div>
       <div className="h-[320px]">
         <ResponsiveContainer width="100%" height="100%">
@@ -343,7 +344,7 @@ export function DriftMonitor({ onBack }: DriftMonitorProps) {
     <div className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <Button variant="ghost" size="sm" onClick={onBack}>
+          <Button variant="subtle" size="sm" onClick={onBack}>
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Board
           </Button>
@@ -356,7 +357,7 @@ export function DriftMonitor({ onBack }: DriftMonitorProps) {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <Input
+          <TextInput
             placeholder="Agent ID"
             value={agentId}
             onChange={(event) => setAgentId(event.target.value)}
@@ -447,7 +448,9 @@ export function DriftMonitor({ onBack }: DriftMonitorProps) {
       <section className="space-y-3">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold">Alerts</h2>
-          <Badge variant="outline">{sortedAlerts.length} total</Badge>
+          <Badge variant="outline" tt="none">
+            {sortedAlerts.length} total
+          </Badge>
         </div>
         <AlertsTable
           alerts={sortedAlerts}

--- a/web/src/components/feedback/FeedbackPanel.tsx
+++ b/web/src/components/feedback/FeedbackPanel.tsx
@@ -17,20 +17,17 @@ import type {
   Sentiment,
 } from '@veritas-kanban/shared';
 import { CheckCircle, MessageSquare, Star, Trash2 } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import {
+  ActionIcon,
+  Badge,
+  Button,
+  InputLabel,
+  ScrollArea,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Textarea } from '@/components/ui/textarea';
+  Tabs,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
 import { useToast } from '@/hooks/useToast';
 import {
   useCreateFeedback,
@@ -55,6 +52,28 @@ const CATEGORY_LABELS: Record<FeedbackCategory, string> = {
   safety: 'Safety',
   ux: 'UX',
 };
+
+const sentimentSelectData = [
+  { value: 'all', label: 'All sentiments' },
+  ...SENTIMENTS.map((sentiment) => ({
+    value: sentiment,
+    label: sentiment.charAt(0).toUpperCase() + sentiment.slice(1),
+  })),
+];
+
+const categorySelectData = [
+  { value: 'all', label: 'All categories' },
+  ...CATEGORIES.map((category) => ({
+    value: category,
+    label: CATEGORY_LABELS[category],
+  })),
+];
+
+const statusSelectData = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'false', label: 'Unresolved' },
+  { value: 'true', label: 'Resolved' },
+];
 
 // ─── Star Rating Input ────────────────────────────────────────────────────────
 
@@ -98,16 +117,14 @@ function StarRating({
 
 function SentimentBadge({ sentiment }: { sentiment: Sentiment }) {
   const colors: Record<Sentiment, string> = {
-    positive: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    neutral: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-    negative: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+    positive: 'green',
+    neutral: 'gray',
+    negative: 'red',
   };
   return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors[sentiment]}`}
-    >
+    <Badge color={colors[sentiment]} variant="light" tt="none">
       {sentiment}
-    </span>
+    </Badge>
   );
 }
 
@@ -162,18 +179,19 @@ function SubmitTab() {
     <form onSubmit={handleSubmit} className="flex flex-col gap-5 p-4">
       <div className="grid grid-cols-2 gap-4">
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="taskId">Task ID *</Label>
-          <Input
+          <TextInput
             id="taskId"
+            label="Task ID"
+            required
             placeholder="task_xxx"
             value={taskId}
             onChange={(e) => setTaskId(e.target.value)}
           />
         </div>
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="agent">Agent (optional)</Label>
-          <Input
+          <TextInput
             id="agent"
+            label="Agent (optional)"
             placeholder="e.g. VERITAS"
             value={agent}
             onChange={(e) => setAgent(e.target.value)}
@@ -182,12 +200,12 @@ function SubmitTab() {
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label>Rating *</Label>
+        <InputLabel required>Rating</InputLabel>
         <StarRating value={rating} onChange={setRating} />
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label>Categories</Label>
+        <InputLabel>Categories</InputLabel>
         <div className="flex flex-wrap gap-2">
           {CATEGORIES.map((cat) => (
             <button
@@ -208,9 +226,9 @@ function SubmitTab() {
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="comment">Comment</Label>
         <Textarea
           id="comment"
+          label="Comment"
           placeholder="What went well or didn't? Sentiment is detected automatically."
           rows={4}
           value={comment}
@@ -258,74 +276,51 @@ function BrowseTab() {
     <div className="flex flex-col gap-4 p-4">
       {/* Filters */}
       <div className="flex flex-wrap gap-3">
-        <Input
+        <TextInput
           placeholder="Filter by agent"
           className="w-40"
           value={filters.agent ?? ''}
-          onChange={(e) =>
-            setFilters((f) => ({ ...f, agent: e.target.value || undefined }))
-          }
+          onChange={(e) => setFilters((f) => ({ ...f, agent: e.target.value || undefined }))}
         />
         <Select
           value={filters.sentiment ?? 'all'}
-          onValueChange={(val) =>
+          onChange={(val) =>
             setFilters((f) => ({
               ...f,
-              sentiment: val === 'all' ? undefined : (val as Sentiment),
+              sentiment: !val || val === 'all' ? undefined : (val as Sentiment),
             }))
           }
-        >
-          <SelectTrigger className="w-36">
-            <SelectValue placeholder="Sentiment" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All sentiments</SelectItem>
-            {SENTIMENTS.map((s) => (
-              <SelectItem key={s} value={s}>
-                {s.charAt(0).toUpperCase() + s.slice(1)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          data={sentimentSelectData}
+          placeholder="Sentiment"
+          className="w-36"
+          allowDeselect={false}
+        />
         <Select
           value={filters.category ?? 'all'}
-          onValueChange={(val) =>
+          onChange={(val) =>
             setFilters((f) => ({
               ...f,
-              category: val === 'all' ? undefined : (val as FeedbackCategory),
+              category: !val || val === 'all' ? undefined : (val as FeedbackCategory),
             }))
           }
-        >
-          <SelectTrigger className="w-36">
-            <SelectValue placeholder="Category" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All categories</SelectItem>
-            {CATEGORIES.map((c) => (
-              <SelectItem key={c} value={c}>
-                {CATEGORY_LABELS[c]}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          data={categorySelectData}
+          placeholder="Category"
+          className="w-36"
+          allowDeselect={false}
+        />
         <Select
           value={filters.resolved !== undefined ? String(filters.resolved) : 'all'}
-          onValueChange={(val) =>
+          onChange={(val) =>
             setFilters((f) => ({
               ...f,
-              resolved: val === 'all' ? undefined : val === 'true',
+              resolved: !val || val === 'all' ? undefined : val === 'true',
             }))
           }
-        >
-          <SelectTrigger className="w-36">
-            <SelectValue placeholder="Status" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All statuses</SelectItem>
-            <SelectItem value="false">Unresolved</SelectItem>
-            <SelectItem value="true">Resolved</SelectItem>
-          </SelectContent>
-        </Select>
+          data={statusSelectData}
+          placeholder="Status"
+          className="w-36"
+          allowDeselect={false}
+        />
       </div>
 
       {isLoading ? (
@@ -367,7 +362,7 @@ function FeedbackCard({
             <StarRating value={item.rating} readOnly />
             <SentimentBadge sentiment={item.sentiment} />
             {item.resolved && (
-              <Badge variant="outline" className="text-green-600">
+              <Badge variant="outline" color="green" tt="none">
                 Resolved
               </Badge>
             )}
@@ -379,13 +374,13 @@ function FeedbackCard({
                 {' '}
                 · Agent: <span className="font-medium">{item.agent}</span>
               </>
-            )}
-            {' '}· {new Date(item.createdAt).toLocaleDateString()}
+            )}{' '}
+            · {new Date(item.createdAt).toLocaleDateString()}
           </p>
           {item.categories.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-1">
               {item.categories.map((cat) => (
-                <Badge key={cat} variant="secondary" className="text-xs">
+                <Badge key={cat} variant="light" tt="none" className="text-xs">
                   {CATEGORY_LABELS[cat]}
                 </Badge>
               ))}
@@ -397,25 +392,25 @@ function FeedbackCard({
         </div>
         <div className="flex gap-1 shrink-0">
           {!item.resolved && (
-            <Button
-              variant="ghost"
-              size="icon"
+            <ActionIcon
+              variant="subtle"
               className="h-7 w-7 text-green-600 hover:text-green-700"
               title="Mark resolved"
+              aria-label="Mark resolved"
               onClick={() => onResolve(item.id)}
             >
               <CheckCircle className="h-4 w-4" />
-            </Button>
+            </ActionIcon>
           )}
-          <Button
-            variant="ghost"
-            size="icon"
+          <ActionIcon
+            variant="subtle"
             className="h-7 w-7 text-destructive hover:text-destructive"
             title="Delete"
+            aria-label="Delete feedback"
             onClick={() => onDelete(item.id)}
           >
             <Trash2 className="h-4 w-4" />
-          </Button>
+          </ActionIcon>
         </div>
       </div>
     </div>
@@ -484,9 +479,7 @@ function AnalyticsTab() {
                       style={{ width: `${pct}%` }}
                     />
                   </div>
-                  <span className="w-10 text-right text-muted-foreground">
-                    {pct.toFixed(0)}%
-                  </span>
+                  <span className="w-10 text-right text-muted-foreground">{pct.toFixed(0)}%</span>
                 </div>
               );
             })}
@@ -500,11 +493,7 @@ function AnalyticsTab() {
             <ResponsiveContainer width="100%" height={200}>
               <LineChart data={analytics.satisfactionTrends}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-                <XAxis
-                  dataKey="date"
-                  tick={{ fontSize: 11 }}
-                  className="fill-muted-foreground"
-                />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} className="fill-muted-foreground" />
                 <YAxis domain={[0, 5]} tick={{ fontSize: 11 }} className="fill-muted-foreground" />
                 <Tooltip
                   formatter={(val) => [`${Number(val).toFixed(2)}`, 'Avg Rating']}
@@ -598,26 +587,26 @@ export function FeedbackPanel() {
         <MessageSquare className="h-4 w-4 text-muted-foreground" />
         <h2 className="text-sm font-semibold">User Feedback</h2>
         {unresolved.length > 0 && (
-          <Badge variant="destructive" className="ml-auto text-xs">
+          <Badge color="red" variant="light" tt="none" className="ml-auto text-xs">
             {unresolved.length} unresolved
           </Badge>
         )}
       </div>
       <Tabs defaultValue="submit">
-        <TabsList className="mx-4 mt-3 mb-0">
-          <TabsTrigger value="submit">Submit</TabsTrigger>
-          <TabsTrigger value="browse">Browse</TabsTrigger>
-          <TabsTrigger value="analytics">Analytics</TabsTrigger>
-        </TabsList>
-        <TabsContent value="submit">
+        <Tabs.List className="mx-4 mt-3 mb-0">
+          <Tabs.Tab value="submit">Submit</Tabs.Tab>
+          <Tabs.Tab value="browse">Browse</Tabs.Tab>
+          <Tabs.Tab value="analytics">Analytics</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="submit">
           <SubmitTab />
-        </TabsContent>
-        <TabsContent value="browse">
+        </Tabs.Panel>
+        <Tabs.Panel value="browse">
           <BrowseTab />
-        </TabsContent>
-        <TabsContent value="analytics">
+        </Tabs.Panel>
+        <Tabs.Panel value="analytics">
           <AnalyticsTab />
-        </TabsContent>
+        </Tabs.Panel>
       </Tabs>
     </div>
   );

--- a/web/src/components/policies/PolicyManager.tsx
+++ b/web/src/components/policies/PolicyManager.tsx
@@ -6,6 +6,17 @@ import type {
   PolicyResponseAction,
 } from '@veritas-kanban/shared';
 import { ArrowLeft, Edit, FlaskConical, Plus, ShieldAlert, Trash2 } from 'lucide-react';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Select,
+  Switch,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
 import { useToast } from '@/hooks/useToast';
 import {
   useCreatePolicy,
@@ -14,27 +25,6 @@ import {
   usePolicies,
   useUpdatePolicy,
 } from '@/hooks/usePolicies';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { DataTable, type DataTableColumn } from '@/components/ui/data-table';
 
 interface PolicyManagerProps {
@@ -107,6 +97,44 @@ const DEFAULT_PREVIEW: PreviewState = {
   preview: true,
 };
 
+const policyTypeSelectData = [
+  { value: 'risk-threshold', label: 'Risk Threshold' },
+  { value: 'require-approval', label: 'Require Approval' },
+  { value: 'block-action-type', label: 'Block Action Type' },
+  { value: 'rate-limit', label: 'Rate Limit' },
+  { value: 'webhook-check', label: 'Webhook Check' },
+];
+
+const responseActionSelectData = [
+  { value: 'warn', label: 'Warn' },
+  { value: 'require-approval', label: 'Require Approval' },
+  { value: 'block', label: 'Block' },
+];
+
+const comparatorSelectData = [
+  { value: 'gte', label: 'Greater than or equal' },
+  { value: 'gt', label: 'Greater than' },
+  { value: 'lte', label: 'Less than or equal' },
+  { value: 'lt', label: 'Less than' },
+];
+
+const rateLimitScopeSelectData = [
+  { value: 'agent', label: 'Agent' },
+  { value: 'project', label: 'Project' },
+  { value: 'action-type', label: 'Action Type' },
+  { value: 'global', label: 'Global' },
+];
+
+const webhookMethodSelectData = [
+  { value: 'GET', label: 'GET' },
+  { value: 'POST', label: 'POST' },
+];
+
+const webhookTriggerSelectData = [
+  { value: 'failure', label: 'Failure' },
+  { value: 'success', label: 'Success' },
+];
+
 function splitCsv(value: string): string[] {
   return value
     .split(',')
@@ -141,12 +169,10 @@ function policyTypeLabel(type: PolicyType): string {
   }
 }
 
-function responseVariant(
-  action: PolicyResponseAction
-): 'default' | 'destructive' | 'secondary' | 'outline' {
-  if (action === 'block') return 'destructive';
-  if (action === 'require-approval') return 'secondary';
-  return 'outline';
+function responseColor(action: PolicyResponseAction | 'allow') {
+  if (action === 'block') return 'red';
+  if (action === 'require-approval') return 'yellow';
+  return 'gray';
 }
 
 function policyToForm(policy: AgentPolicy): PolicyFormState {
@@ -388,7 +414,7 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
           <div className="flex items-center gap-2">
             <div className="font-medium">{policy.name}</div>
             {policy.preset && (
-              <Badge variant="outline" className="capitalize">
+              <Badge variant="outline" tt="none" className="capitalize">
                 {policy.preset}
               </Badge>
             )}
@@ -403,7 +429,11 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
     {
       key: 'type',
       header: 'Type',
-      cell: (policy) => <Badge variant="secondary">{policyTypeLabel(policy.type)}</Badge>,
+      cell: (policy) => (
+        <Badge variant="light" tt="none">
+          {policyTypeLabel(policy.type)}
+        </Badge>
+      ),
     },
     {
       key: 'scope',
@@ -416,7 +446,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
       key: 'response',
       header: 'Response',
       cell: (policy) => (
-        <Badge variant={responseVariant(policy.responseAction)}>{policy.responseAction}</Badge>
+        <Badge color={responseColor(policy.responseAction)} variant="light" tt="none">
+          {policy.responseAction}
+        </Badge>
       ),
     },
     {
@@ -425,8 +457,8 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
       cell: (policy) => (
         <Switch
           checked={policy.enabled}
-          onCheckedChange={(enabled) => {
-            void handleToggle(policy, enabled);
+          onChange={(event) => {
+            void handleToggle(policy, event.currentTarget.checked);
           }}
           aria-label={`Toggle ${policy.name}`}
         />
@@ -446,9 +478,13 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
             <FlaskConical className="mr-1 h-3.5 w-3.5" />
             Test
           </Button>
-          <Button variant="ghost" size="icon" onClick={() => void handleDelete(policy)}>
+          <ActionIcon
+            variant="subtle"
+            onClick={() => void handleDelete(policy)}
+            aria-label={`Delete ${policy.name}`}
+          >
             <Trash2 className="h-4 w-4" />
-          </Button>
+          </ActionIcon>
         </div>
       ),
     },
@@ -459,9 +495,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
       <div className="border-b bg-card px-6 py-4">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" onClick={onBack} aria-label="Back to board">
+            <ActionIcon variant="subtle" onClick={onBack} aria-label="Back to board">
               <ArrowLeft className="h-4 w-4" />
-            </Button>
+            </ActionIcon>
             <div>
               <h1 className="flex items-center gap-2 text-2xl font-bold">
                 <ShieldAlert className="h-6 w-6" />
@@ -503,13 +539,15 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
         </div>
 
         <div className="flex items-center gap-3">
-          <Input
+          <TextInput
             placeholder="Search policies by name, id, type, or scope..."
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             className="max-w-md"
           />
-          <Badge variant="outline">{filteredPolicies.length} policies</Badge>
+          <Badge variant="outline" tt="none">
+            {filteredPolicies.length} policies
+          </Badge>
         </div>
 
         {isLoading ? (
@@ -526,29 +564,37 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
         )}
       </div>
 
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>{editingPolicyId ? 'Edit Policy' : 'Create Policy'}</DialogTitle>
-            <DialogDescription>
+      <Modal
+        opened={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        size="xl"
+        centered
+        title={
+          <div>
+            <div className="text-lg font-semibold">
+              {editingPolicyId ? 'Edit Policy' : 'Create Policy'}
+            </div>
+            <div className="text-sm text-muted-foreground">
               Define when the policy applies, what it checks, and how the agent should respond.
-            </DialogDescription>
-          </DialogHeader>
-
+            </div>
+          </div>
+        }
+      >
+        <div className="max-h-[75vh] overflow-y-auto pr-2">
           <div className="grid gap-4 py-2 md:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="policy-id">Policy ID</Label>
-              <Input
+              <TextInput
                 id="policy-id"
+                label="Policy ID"
                 value={form.id}
                 onChange={(event) => setForm((current) => ({ ...current, id: event.target.value }))}
                 disabled={Boolean(editingPolicyId)}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="policy-name">Name</Label>
-              <Input
+              <TextInput
                 id="policy-name"
+                label="Name"
                 value={form.name}
                 onChange={(event) =>
                   setForm((current) => ({ ...current, name: event.target.value }))
@@ -556,48 +602,37 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label>Type</Label>
               <Select
+                label="Type"
                 value={form.type}
-                onValueChange={(value: PolicyType) =>
-                  setForm((current) => ({ ...current, type: value }))
-                }
+                onChange={(value) => {
+                  if (!value) return;
+                  setForm((current) => ({ ...current, type: value as PolicyType }));
+                }}
+                data={policyTypeSelectData}
                 disabled={Boolean(editingPolicyId)}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="risk-threshold">Risk Threshold</SelectItem>
-                  <SelectItem value="require-approval">Require Approval</SelectItem>
-                  <SelectItem value="block-action-type">Block Action Type</SelectItem>
-                  <SelectItem value="rate-limit">Rate Limit</SelectItem>
-                  <SelectItem value="webhook-check">Webhook Check</SelectItem>
-                </SelectContent>
-              </Select>
+                allowDeselect={false}
+              />
             </div>
             <div className="space-y-2">
-              <Label>Response Action</Label>
               <Select
+                label="Response Action"
                 value={form.responseAction}
-                onValueChange={(value: PolicyResponseAction) =>
-                  setForm((current) => ({ ...current, responseAction: value }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="warn">Warn</SelectItem>
-                  <SelectItem value="require-approval">Require Approval</SelectItem>
-                  <SelectItem value="block">Block</SelectItem>
-                </SelectContent>
-              </Select>
+                onChange={(value) => {
+                  if (!value) return;
+                  setForm((current) => ({
+                    ...current,
+                    responseAction: value as PolicyResponseAction,
+                  }));
+                }}
+                data={responseActionSelectData}
+                allowDeselect={false}
+              />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="policy-description">Description</Label>
               <Textarea
                 id="policy-description"
+                label="Description"
                 value={form.description}
                 onChange={(event) =>
                   setForm((current) => ({ ...current, description: event.target.value }))
@@ -606,9 +641,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="scope-agents">Scope: Agents</Label>
-              <Input
+              <TextInput
                 id="scope-agents"
+                label="Scope: Agents"
                 placeholder="codex, reviewer"
                 value={form.scopeAgents}
                 onChange={(event) =>
@@ -617,9 +652,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="scope-projects">Scope: Projects</Label>
-              <Input
+              <TextInput
                 id="scope-projects"
+                label="Scope: Projects"
                 placeholder="core, docs"
                 value={form.scopeProjects}
                 onChange={(event) =>
@@ -628,9 +663,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
               />
             </div>
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="scope-actions">Scope: Action Types</Label>
-              <Input
+              <TextInput
                 id="scope-actions"
+                label="Scope: Action Types"
                 placeholder="git.push, deploy.release"
                 value={form.scopeActionTypes}
                 onChange={(event) =>
@@ -643,9 +678,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
           {form.type === 'risk-threshold' && (
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="risk-threshold">Threshold</Label>
-                <Input
+                <TextInput
                   id="risk-threshold"
+                  label="Threshold"
                   type="number"
                   value={form.riskThreshold}
                   onChange={(event) =>
@@ -654,23 +689,19 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 />
               </div>
               <div className="space-y-2">
-                <Label>Comparator</Label>
                 <Select
+                  label="Comparator"
                   value={form.riskComparator}
-                  onValueChange={(value: 'gte' | 'gt' | 'lte' | 'lt') =>
-                    setForm((current) => ({ ...current, riskComparator: value }))
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="gte">Greater than or equal</SelectItem>
-                    <SelectItem value="gt">Greater than</SelectItem>
-                    <SelectItem value="lte">Less than or equal</SelectItem>
-                    <SelectItem value="lt">Less than</SelectItem>
-                  </SelectContent>
-                </Select>
+                  onChange={(value) => {
+                    if (!value) return;
+                    setForm((current) => ({
+                      ...current,
+                      riskComparator: value as 'gte' | 'gt' | 'lte' | 'lt',
+                    }));
+                  }}
+                  data={comparatorSelectData}
+                  allowDeselect={false}
+                />
               </div>
             </div>
           )}
@@ -678,9 +709,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
           {form.type === 'require-approval' && (
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="approval-reason">Reason</Label>
                 <Textarea
                   id="approval-reason"
+                  label="Reason"
                   value={form.approvalReason}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, approvalReason: event.target.value }))
@@ -689,9 +720,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="approval-approvers">Approvers</Label>
-                <Input
+                <TextInput
                   id="approval-approvers"
+                  label="Approvers"
                   placeholder="lead, security"
                   value={form.approvalApprovers}
                   onChange={(event) =>
@@ -704,9 +735,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
 
           {form.type === 'block-action-type' && (
             <div className="space-y-2">
-              <Label htmlFor="blocked-actions">Blocked Action Types</Label>
-              <Input
+              <TextInput
                 id="blocked-actions"
+                label="Blocked Action Types"
                 placeholder="git.force-push, prod.delete"
                 value={form.blockedActionTypes}
                 onChange={(event) =>
@@ -719,9 +750,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
           {form.type === 'rate-limit' && (
             <div className="grid gap-4 md:grid-cols-3">
               <div className="space-y-2">
-                <Label htmlFor="rate-attempts">Max Attempts</Label>
-                <Input
+                <TextInput
                   id="rate-attempts"
+                  label="Max Attempts"
                   type="number"
                   value={form.rateLimitAttempts}
                   onChange={(event) =>
@@ -730,9 +761,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="rate-window">Window (ms)</Label>
-                <Input
+                <TextInput
                   id="rate-window"
+                  label="Window (ms)"
                   type="number"
                   value={form.rateLimitWindowMs}
                   onChange={(event) =>
@@ -741,23 +772,19 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 />
               </div>
               <div className="space-y-2">
-                <Label>Rate Limit Key</Label>
                 <Select
+                  label="Rate Limit Key"
                   value={form.rateLimitScopeKey}
-                  onValueChange={(value: 'agent' | 'project' | 'action-type' | 'global') =>
-                    setForm((current) => ({ ...current, rateLimitScopeKey: value }))
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="agent">Agent</SelectItem>
-                    <SelectItem value="project">Project</SelectItem>
-                    <SelectItem value="action-type">Action Type</SelectItem>
-                    <SelectItem value="global">Global</SelectItem>
-                  </SelectContent>
-                </Select>
+                  onChange={(value) => {
+                    if (!value) return;
+                    setForm((current) => ({
+                      ...current,
+                      rateLimitScopeKey: value as 'agent' | 'project' | 'action-type' | 'global',
+                    }));
+                  }}
+                  data={rateLimitScopeSelectData}
+                  allowDeselect={false}
+                />
               </div>
             </div>
           )}
@@ -765,9 +792,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
           {form.type === 'webhook-check' && (
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2 md:col-span-2">
-                <Label htmlFor="webhook-url">Webhook URL</Label>
-                <Input
+                <TextInput
                   id="webhook-url"
+                  label="Webhook URL"
                   value={form.webhookUrl}
                   onChange={(event) =>
                     setForm((current) => ({ ...current, webhookUrl: event.target.value }))
@@ -775,43 +802,36 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 />
               </div>
               <div className="space-y-2">
-                <Label>Method</Label>
                 <Select
+                  label="Method"
                   value={form.webhookMethod}
-                  onValueChange={(value: 'GET' | 'POST') =>
-                    setForm((current) => ({ ...current, webhookMethod: value }))
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="GET">GET</SelectItem>
-                    <SelectItem value="POST">POST</SelectItem>
-                  </SelectContent>
-                </Select>
+                  onChange={(value) => {
+                    if (!value) return;
+                    setForm((current) => ({ ...current, webhookMethod: value as 'GET' | 'POST' }));
+                  }}
+                  data={webhookMethodSelectData}
+                  allowDeselect={false}
+                />
               </div>
               <div className="space-y-2">
-                <Label>Trigger On</Label>
                 <Select
+                  label="Trigger On"
                   value={form.webhookTriggerOn}
-                  onValueChange={(value: 'success' | 'failure') =>
-                    setForm((current) => ({ ...current, webhookTriggerOn: value }))
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="failure">Failure</SelectItem>
-                    <SelectItem value="success">Success</SelectItem>
-                  </SelectContent>
-                </Select>
+                  onChange={(value) => {
+                    if (!value) return;
+                    setForm((current) => ({
+                      ...current,
+                      webhookTriggerOn: value as 'success' | 'failure',
+                    }));
+                  }}
+                  data={webhookTriggerSelectData}
+                  allowDeselect={false}
+                />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="webhook-timeout">Timeout (ms)</Label>
-                <Input
+                <TextInput
                   id="webhook-timeout"
+                  label="Timeout (ms)"
                   type="number"
                   value={form.webhookTimeoutMs}
                   onChange={(event) =>
@@ -820,9 +840,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="webhook-status">Expected Status</Label>
-                <Input
+                <TextInput
                   id="webhook-status"
+                  label="Expected Status"
                   type="number"
                   value={form.webhookExpectedStatus}
                   onChange={(event) =>
@@ -834,9 +854,9 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 />
               </div>
               <div className="space-y-2 md:col-span-2">
-                <Label htmlFor="webhook-body-contains">Expected Body Contains</Label>
-                <Input
+                <TextInput
                   id="webhook-body-contains"
+                  label="Expected Body Contains"
                   value={form.webhookExpectedBodyContains}
                   onChange={(event) =>
                     setForm((current) => ({
@@ -855,8 +875,11 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
                 </div>
                 <Switch
                   checked={form.webhookSendContext}
-                  onCheckedChange={(checked) =>
-                    setForm((current) => ({ ...current, webhookSendContext: checked }))
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      webhookSendContext: event.currentTarget.checked,
+                    }))
                   }
                 />
               </div>
@@ -872,13 +895,13 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
             </div>
             <Switch
               checked={form.enabled}
-              onCheckedChange={(checked) =>
-                setForm((current) => ({ ...current, enabled: checked }))
+              onChange={(event) =>
+                setForm((current) => ({ ...current, enabled: event.currentTarget.checked }))
               }
             />
           </div>
 
-          <DialogFooter>
+          <Group justify="flex-end" mt="md">
             <Button variant="outline" onClick={() => setDialogOpen(false)}>
               Cancel
             </Button>
@@ -888,114 +911,120 @@ export function PolicyManager({ onBack }: PolicyManagerProps) {
             >
               {editingPolicyId ? 'Save Changes' : 'Create Policy'}
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </Group>
+        </div>
+      </Modal>
 
-      <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Test Policy Evaluation</DialogTitle>
-            <DialogDescription>
+      <Modal
+        opened={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        size="lg"
+        centered
+        title={
+          <div>
+            <div className="text-lg font-semibold">Test Policy Evaluation</div>
+            <div className="text-sm text-muted-foreground">
               Preview how the guard engine would evaluate an action before an agent executes it.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="grid gap-4 py-2 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="preview-agent">Agent</Label>
-              <Input
-                id="preview-agent"
-                value={previewInput.agent || ''}
-                onChange={(event) =>
-                  setPreviewInput((current) => ({ ...current, agent: event.target.value }))
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="preview-project">Project</Label>
-              <Input
-                id="preview-project"
-                value={previewInput.project || ''}
-                onChange={(event) =>
-                  setPreviewInput((current) => ({ ...current, project: event.target.value }))
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="preview-action">Action Type</Label>
-              <Input
-                id="preview-action"
-                value={previewInput.actionType}
-                onChange={(event) =>
-                  setPreviewInput((current) => ({ ...current, actionType: event.target.value }))
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="preview-risk">Risk Score</Label>
-              <Input
-                id="preview-risk"
-                type="number"
-                value={previewInput.riskScore ?? ''}
-                onChange={(event) =>
-                  setPreviewInput((current) => ({
-                    ...current,
-                    riskScore: event.target.value ? Number(event.target.value) : undefined,
-                  }))
-                }
-              />
             </div>
           </div>
+        }
+      >
+        <div className="grid gap-4 py-2 md:grid-cols-2">
+          <div className="space-y-2">
+            <TextInput
+              id="preview-agent"
+              label="Agent"
+              value={previewInput.agent || ''}
+              onChange={(event) =>
+                setPreviewInput((current) => ({ ...current, agent: event.target.value }))
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <TextInput
+              id="preview-project"
+              label="Project"
+              value={previewInput.project || ''}
+              onChange={(event) =>
+                setPreviewInput((current) => ({ ...current, project: event.target.value }))
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <TextInput
+              id="preview-action"
+              label="Action Type"
+              value={previewInput.actionType}
+              onChange={(event) =>
+                setPreviewInput((current) => ({ ...current, actionType: event.target.value }))
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <TextInput
+              id="preview-risk"
+              label="Risk Score"
+              type="number"
+              value={previewInput.riskScore ?? ''}
+              onChange={(event) =>
+                setPreviewInput((current) => ({
+                  ...current,
+                  riskScore: event.target.value ? Number(event.target.value) : undefined,
+                }))
+              }
+            />
+          </div>
+        </div>
 
-          {previewPolicy && (
-            <div className="rounded-lg border bg-muted/20 p-3 text-sm">
-              Testing against <span className="font-medium">{previewPolicy.name}</span>. Evaluation
-              runs against all enabled policies so you can see collisions and escalations.
+        {previewPolicy && (
+          <div className="rounded-lg border bg-muted/20 p-3 text-sm">
+            Testing against <span className="font-medium">{previewPolicy.name}</span>. Evaluation
+            runs against all enabled policies so you can see collisions and escalations.
+          </div>
+        )}
+
+        {evaluatePolicies.data && (
+          <div className="space-y-3 rounded-lg border bg-card p-4">
+            <div className="flex items-center gap-2">
+              <Badge
+                color={responseColor(evaluatePolicies.data.decision)}
+                variant="light"
+                tt="none"
+              >
+                {evaluatePolicies.data.decision}
+              </Badge>
+              <span className="text-sm text-muted-foreground">
+                {evaluatePolicies.data.matches.length} matching policies
+              </span>
             </div>
-          )}
-
-          {evaluatePolicies.data && (
-            <div className="space-y-3 rounded-lg border bg-card p-4">
-              <div className="flex items-center gap-2">
-                <Badge
-                  variant={evaluatePolicies.data.decision === 'block' ? 'destructive' : 'secondary'}
-                >
-                  {evaluatePolicies.data.decision}
-                </Badge>
-                <span className="text-sm text-muted-foreground">
-                  {evaluatePolicies.data.matches.length} matching policies
-                </span>
-              </div>
-              <div className="space-y-2">
-                {evaluatePolicies.data.matches.map((match) => (
-                  <div key={match.policyId} className="rounded-md border px-3 py-2">
-                    <div className="flex items-center gap-2">
-                      <div className="font-medium">{match.policyName}</div>
-                      <Badge variant={responseVariant(match.responseAction)}>
-                        {match.responseAction}
-                      </Badge>
-                    </div>
-                    <div className="mt-1 text-sm text-muted-foreground">{match.message}</div>
+            <div className="space-y-2">
+              {evaluatePolicies.data.matches.map((match) => (
+                <div key={match.policyId} className="rounded-md border px-3 py-2">
+                  <div className="flex items-center gap-2">
+                    <div className="font-medium">{match.policyName}</div>
+                    <Badge color={responseColor(match.responseAction)} variant="light" tt="none">
+                      {match.responseAction}
+                    </Badge>
                   </div>
-                ))}
-              </div>
+                  <div className="mt-1 text-sm text-muted-foreground">{match.message}</div>
+                </div>
+              ))}
             </div>
-          )}
+          </div>
+        )}
 
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setPreviewOpen(false)}>
-              Close
-            </Button>
-            <Button
-              onClick={() => void evaluatePolicies.mutateAsync({ ...previewInput, preview: true })}
-              disabled={evaluatePolicies.isPending}
-            >
-              {evaluatePolicies.isPending ? 'Evaluating...' : 'Run Preview'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        <Group justify="flex-end" mt="md">
+          <Button variant="outline" onClick={() => setPreviewOpen(false)}>
+            Close
+          </Button>
+          <Button
+            onClick={() => void evaluatePolicies.mutateAsync({ ...previewInput, preview: true })}
+            disabled={evaluatePolicies.isPending}
+          >
+            {evaluatePolicies.isPending ? 'Evaluating...' : 'Run Preview'}
+          </Button>
+        </Group>
+      </Modal>
     </div>
   );
 }

--- a/web/src/components/scoring/ScoreExplorer.tsx
+++ b/web/src/components/scoring/ScoreExplorer.tsx
@@ -10,16 +10,7 @@ import {
   YAxis,
 } from 'recharts';
 import type { EvaluationResult, ScoringProfile } from '@veritas-kanban/shared';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge, ScrollArea, Select, TextInput } from '@mantine/core';
 import { useScoringHistory } from '@/hooks/useScoring';
 
 interface ScoreExplorerProps {
@@ -90,38 +81,29 @@ export function ScoreExplorer({ profiles }: ScoreExplorerProps) {
   return (
     <div className="space-y-4">
       <div className="grid gap-3 lg:grid-cols-[220px_220px_1fr]">
-        <Select value={profileId} onValueChange={setProfileId}>
-          <SelectTrigger>
-            <SelectValue placeholder="Filter by profile" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All profiles</SelectItem>
-            {profiles.map((profile) => (
-              <SelectItem key={profile.id} value={profile.id}>
-                {profile.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Select
+          value={profileId}
+          onChange={(value) => setProfileId(value ?? 'all')}
+          data={[
+            { value: 'all', label: 'All profiles' },
+            ...profiles.map((profile) => ({ value: profile.id, label: profile.name })),
+          ]}
+          placeholder="Filter by profile"
+          allowDeselect={false}
+        />
 
         <Select
           value={agent || 'all'}
-          onValueChange={(value) => setAgent(value === 'all' ? '' : value)}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Filter by agent" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All agents</SelectItem>
-            {availableAgents.map((agentName) => (
-              <SelectItem key={agentName} value={agentName}>
-                {agentName}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={(value) => setAgent(value === 'all' || !value ? '' : value)}
+          data={[
+            { value: 'all', label: 'All agents' },
+            ...availableAgents.map((agentName) => ({ value: agentName, label: agentName })),
+          ]}
+          placeholder="Filter by agent"
+          allowDeselect={false}
+        />
 
-        <Input
+        <TextInput
           placeholder="Filter by task ID"
           value={taskId}
           onChange={(event) => setTaskId(event.target.value)}
@@ -229,10 +211,16 @@ export function ScoreExplorer({ profiles }: ScoreExplorerProps) {
                 <div key={result.id} className="space-y-3 p-4">
                   <div className="flex flex-wrap items-center gap-2">
                     <div className="font-medium">{result.profileName}</div>
-                    <Badge variant="secondary">{Math.round(result.compositeScore * 100)}%</Badge>
-                    {result.agent && <Badge variant="outline">{result.agent}</Badge>}
+                    <Badge variant="light" tt="none">
+                      {Math.round(result.compositeScore * 100)}%
+                    </Badge>
+                    {result.agent && (
+                      <Badge variant="outline" tt="none">
+                        {result.agent}
+                      </Badge>
+                    )}
                     {result.taskId && (
-                      <Badge variant="outline" className="font-mono">
+                      <Badge variant="outline" tt="none" className="font-mono">
                         {result.taskId}
                       </Badge>
                     )}

--- a/web/src/components/scoring/ScoringProfiles.tsx
+++ b/web/src/components/scoring/ScoringProfiles.tsx
@@ -7,19 +7,16 @@ import type {
   ScoringProfile,
 } from '@veritas-kanban/shared';
 import { ArrowLeft, Copy, Plus, Save, Trash2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
+  ActionIcon,
+  Badge,
+  Button,
+  ScrollArea,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
+  Tabs,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
 import { useToast } from '@/hooks/useToast';
 import {
   useCreateScoringProfile,
@@ -76,6 +73,20 @@ const scorerTypeOptions: ScorerType[] = [
   'RegexMatch',
   'NumericRange',
   'CustomExpression',
+];
+
+const scorerTypeSelectData = scorerTypeOptions.map((type) => ({ value: type, label: type }));
+
+const compositeMethodSelectData = [
+  { value: 'weightedAvg', label: 'Weighted average' },
+  { value: 'minimum', label: 'Minimum' },
+  { value: 'geometricMean', label: 'Geometric mean' },
+];
+
+const targetSelectData = [
+  { value: 'output', label: 'Output' },
+  { value: 'action', label: 'Action' },
+  { value: 'combined', label: 'Combined' },
 ];
 
 export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
@@ -228,9 +239,9 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
       <div className="border-b bg-card px-6 py-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" onClick={onBack} aria-label="Back to board">
+            <ActionIcon variant="subtle" onClick={onBack} aria-label="Back to board">
               <ArrowLeft className="h-4 w-4" />
-            </Button>
+            </ActionIcon>
             <div>
               <h1 className="text-2xl font-bold">Agent Output Scoring</h1>
               <p className="text-sm text-muted-foreground">
@@ -255,13 +266,17 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
       </div>
 
       <div className="flex-1 overflow-hidden px-6 pb-6">
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="flex h-full flex-col gap-4">
-          <TabsList className="w-fit">
-            <TabsTrigger value="profiles">Profiles</TabsTrigger>
-            <TabsTrigger value="explorer">Score Explorer</TabsTrigger>
-          </TabsList>
+        <Tabs
+          value={activeTab}
+          onChange={(value) => setActiveTab(value ?? 'profiles')}
+          className="flex h-full flex-col gap-4"
+        >
+          <Tabs.List className="w-fit">
+            <Tabs.Tab value="profiles">Profiles</Tabs.Tab>
+            <Tabs.Tab value="explorer">Score Explorer</Tabs.Tab>
+          </Tabs.List>
 
-          <TabsContent value="profiles" className="m-0 flex min-h-0 flex-1 gap-4">
+          <Tabs.Panel value="profiles" className="m-0 flex min-h-0 flex-1 gap-4">
             <div className="flex w-[340px] min-w-[320px] flex-col rounded-lg border bg-card">
               <div className="border-b px-4 py-3">
                 <div className="font-semibold">Scoring Profiles</div>
@@ -285,8 +300,14 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                         <div className="flex items-center justify-between gap-2">
                           <div className="font-medium">{profile.name}</div>
                           <div className="flex gap-2">
-                            {profile.builtIn && <Badge variant="secondary">Built-in</Badge>}
-                            <Badge variant="outline">{profile.compositeMethod}</Badge>
+                            {profile.builtIn && (
+                              <Badge variant="light" tt="none">
+                                Built-in
+                              </Badge>
+                            )}
+                            <Badge variant="outline" tt="none">
+                              {profile.compositeMethod}
+                            </Badge>
                           </div>
                         </div>
                         {profile.description && (
@@ -341,7 +362,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                   <div className="grid gap-4 lg:grid-cols-2">
                     <div className="space-y-2">
                       <label className="text-sm font-medium">Name</label>
-                      <Input
+                      <TextInput
                         value={draft.name}
                         onChange={(event) =>
                           setDraft((current) => ({ ...current, name: event.target.value }))
@@ -353,23 +374,18 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                       <label className="text-sm font-medium">Composite Method</label>
                       <Select
                         value={draft.compositeMethod}
-                        onValueChange={(value) =>
+                        onChange={(value) =>
                           setDraft((current) => ({
                             ...current,
-                            compositeMethod: value as ProfileDraft['compositeMethod'],
+                            compositeMethod:
+                              (value as ProfileDraft['compositeMethod'] | null) ??
+                              current.compositeMethod,
                           }))
                         }
+                        data={compositeMethodSelectData}
                         disabled={selectedProfile?.builtIn}
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="weightedAvg">Weighted average</SelectItem>
-                          <SelectItem value="minimum">Minimum</SelectItem>
-                          <SelectItem value="geometricMean">Geometric mean</SelectItem>
-                        </SelectContent>
-                      </Select>
+                        allowDeselect={false}
+                      />
                     </div>
                   </div>
 
@@ -413,7 +429,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                           >
                             <div className="flex items-center justify-between gap-3">
                               <div className="grid flex-1 gap-3 lg:grid-cols-[1fr_180px_120px]">
-                                <Input
+                                <TextInput
                                   value={scorer.name}
                                   onChange={(event) =>
                                     updateScorer(index, (current) => ({
@@ -425,28 +441,20 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                 />
                                 <Select
                                   value={scorer.type}
-                                  onValueChange={(value) =>
+                                  onChange={(value) => {
+                                    if (!value) return;
                                     updateScorer(index, () => ({
                                       ...createScorer(value as ScorerType),
                                       id: scorer.id,
                                       name: scorer.name,
                                       weight: scorer.weight,
-                                    }))
-                                  }
+                                    }));
+                                  }}
+                                  data={scorerTypeSelectData}
                                   disabled={selectedProfile?.builtIn}
-                                >
-                                  <SelectTrigger>
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {scorerTypeOptions.map((type) => (
-                                      <SelectItem key={type} value={type}>
-                                        {type}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                                <Input
+                                  allowDeselect={false}
+                                />
+                                <TextInput
                                   type="number"
                                   min="0"
                                   step="0.1"
@@ -460,9 +468,8 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                   disabled={selectedProfile?.builtIn}
                                 />
                               </div>
-                              <Button
-                                variant="ghost"
-                                size="icon"
+                              <ActionIcon
+                                variant="subtle"
                                 onClick={() =>
                                   setDraft((current) => ({
                                     ...current,
@@ -472,9 +479,10 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                   }))
                                 }
                                 disabled={selectedProfile?.builtIn || draft.scorers.length === 1}
+                                aria-label="Remove scorer"
                               >
                                 <Trash2 className="h-4 w-4" />
-                              </Button>
+                              </ActionIcon>
                             </div>
 
                             <div className="grid gap-3 lg:grid-cols-2">
@@ -484,23 +492,16 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                 </label>
                                 <Select
                                   value={scorer.target || 'output'}
-                                  onValueChange={(value) =>
+                                  onChange={(value) =>
                                     updateScorer(index, (current) => ({
                                       ...current,
-                                      target: value as Scorer['target'],
+                                      target: (value as Scorer['target'] | null) ?? current.target,
                                     }))
                                   }
+                                  data={targetSelectData}
                                   disabled={selectedProfile?.builtIn}
-                                >
-                                  <SelectTrigger>
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    <SelectItem value="output">Output</SelectItem>
-                                    <SelectItem value="action">Action</SelectItem>
-                                    <SelectItem value="combined">Combined</SelectItem>
-                                  </SelectContent>
-                                </Select>
+                                  allowDeselect={false}
+                                />
                               </div>
 
                               {'keywords' in scorer && (
@@ -508,7 +509,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                   <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                                     Keywords
                                   </label>
-                                  <Input
+                                  <TextInput
                                     value={scorer.keywords.join(', ')}
                                     onChange={(event) =>
                                       updateScorer(index, (current) => ({
@@ -530,7 +531,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                     <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                                       Regex Pattern
                                     </label>
-                                    <Input
+                                    <TextInput
                                       value={scorer.pattern}
                                       onChange={(event) =>
                                         updateScorer(index, (current) => ({
@@ -545,7 +546,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                     <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                                       Flags
                                     </label>
-                                    <Input
+                                    <TextInput
                                       value={scorer.flags || ''}
                                       onChange={(event) =>
                                         updateScorer(index, (current) => ({
@@ -565,7 +566,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                     <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                                       Value Path
                                     </label>
-                                    <Input
+                                    <TextInput
                                       value={scorer.valuePath}
                                       onChange={(event) =>
                                         updateScorer(index, (current) => ({
@@ -577,7 +578,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                     />
                                   </div>
                                   <div className="grid gap-3 sm:grid-cols-2">
-                                    <Input
+                                    <TextInput
                                       type="number"
                                       placeholder="Min"
                                       value={scorer.min ?? ''}
@@ -592,7 +593,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                                       }
                                       disabled={selectedProfile?.builtIn}
                                     />
-                                    <Input
+                                    <TextInput
                                       type="number"
                                       placeholder="Max"
                                       value={scorer.max ?? ''}
@@ -648,23 +649,18 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                   <div className="space-y-3">
                     <Select
                       value={evaluationForm.profileId}
-                      onValueChange={(value) =>
-                        setEvaluationForm((current) => ({ ...current, profileId: value }))
+                      onChange={(value) =>
+                        setEvaluationForm((current) => ({
+                          ...current,
+                          profileId: value ?? current.profileId,
+                        }))
                       }
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select profile" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {profiles.map((profile) => (
-                          <SelectItem key={profile.id} value={profile.id}>
-                            {profile.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      data={profiles.map((profile) => ({ value: profile.id, label: profile.name }))}
+                      placeholder="Select profile"
+                      allowDeselect={false}
+                    />
 
-                    <Input
+                    <TextInput
                       placeholder="Agent (optional)"
                       value={evaluationForm.agent || ''}
                       onChange={(event) =>
@@ -672,7 +668,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                       }
                     />
 
-                    <Input
+                    <TextInput
                       placeholder="Task ID (optional)"
                       value={evaluationForm.taskId || ''}
                       onChange={(event) =>
@@ -707,7 +703,9 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                     <div className="space-y-3 rounded-lg border bg-muted/20 p-4">
                       <div className="flex items-center justify-between gap-3">
                         <div className="font-medium">Latest Evaluation</div>
-                        <Badge>{Math.round(runEvaluation.data.compositeScore * 100)}%</Badge>
+                        <Badge tt="none">
+                          {Math.round(runEvaluation.data.compositeScore * 100)}%
+                        </Badge>
                       </div>
                       {runEvaluation.data.scores.map((score) => (
                         <div key={score.scorerId} className="space-y-1">
@@ -731,11 +729,11 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                 </div>
               </div>
             </div>
-          </TabsContent>
+          </Tabs.Panel>
 
-          <TabsContent value="explorer" className="m-0 min-h-0 flex-1 overflow-auto">
+          <Tabs.Panel value="explorer" className="m-0 min-h-0 flex-1 overflow-auto">
             <ScoreExplorer profiles={profiles} />
-          </TabsContent>
+          </Tabs.Panel>
         </Tabs>
       </div>
     </div>


### PR DESCRIPTION
Summary
- Migrates governance-adjacent surfaces to direct Mantine primitives: policies, drift, scoring, decisions, and feedback.
- Adds focused Mantine migration coverage for those surfaces and updates the v5 Mantine migration plan.

Verification
- pnpm --filter @veritas-kanban/web test -- src/__tests__/governance-surfaces-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Focused wrapper-import scan for policies/drift/scoring/decisions/feedback
- Rendered smoke at http://127.0.0.1:3000/ with no framework overlay or console warnings/errors; password visibility toggle changed password input type from password to text.

Refs #417, #326