### PR TITLE
Finish Mantine feature surface cleanup

### DIFF
--- a/docs/UI-MANTINE-MIGRATION.md
+++ b/docs/UI-MANTINE-MIGRATION.md
@@ -48,6 +48,10 @@ Shared primitive migration progress:
 - No shared `components/ui` primitive wrapper remains backed by a Radix
   interaction primitive. A local Slot helper now preserves `asChild`
   composition while migrated feature surfaces still depend on that contract.
+- Active feature/runtime surfaces no longer import the `components/ui`
+  primitive compatibility wrappers. The remaining wrapper imports are confined
+  to the wrapper internals that support compatibility tests and the Phase 4
+  cleanup/removal gate.
 - The old direct Radix primitive package dependencies, `@radix-ui/react-slot`,
   and the shadcn package have been removed.
 - Feature surfaces still need visual and keyboard/focus checks before the final
@@ -405,6 +409,10 @@ Phase 3 progress:
   policy CRUD/evaluation, drift analysis/reset, scoring profile edits,
   decision assumption validation, and feedback submission/browse/analytics
   behavior.
+- Final feature-surface cleanup moved templates, board/archive suggestions,
+  archive sidebar, board status chrome, task-card tooltips, desktop onboarding,
+  markdown editing controls, and remaining settings confirmations off the
+  compatibility wrappers and onto direct Mantine controls.
 
 ### Phase 4: QA, Cleanup, and Dependency Removal
 

--- a/web/src/__tests__/final-surface-wrapper-cleanup.test.tsx
+++ b/web/src/__tests__/final-surface-wrapper-cleanup.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { TemplatesPage } from '@/components/templates/TemplatesPage';
+import { renderWithProviders } from './test-utils';
+import type { TaskTemplate } from '@/hooks/useTemplates';
+
+const mocks = vi.hoisted(() => ({
+  createTemplate: vi.fn(),
+  deleteTemplate: vi.fn(),
+  updateTemplate: vi.fn(),
+  toast: vi.fn(),
+}));
+
+const templates: TaskTemplate[] = [
+  {
+    id: 'template-bug',
+    name: 'Bug Fix',
+    description: 'Resolve a production defect',
+    category: 'bug',
+    version: 1,
+    taskDefaults: {
+      type: 'code',
+      priority: 'high',
+      project: 'veritas',
+      agent: 'veritas',
+      descriptionTemplate: 'Fix the reported issue and verify the regression path.',
+    },
+    subtaskTemplates: [{ title: 'Reproduce issue', order: 1 }],
+    created: '2026-06-01T09:00:00.000Z',
+    updated: '2026-06-01T09:00:00.000Z',
+  },
+  {
+    id: 'template-release',
+    name: 'Release Prep',
+    description: 'Ship release readiness work',
+    category: 'release',
+    version: 1,
+    taskDefaults: {
+      type: 'research',
+      priority: 'medium',
+      project: 'veritas',
+    },
+    created: '2026-06-01T09:00:00.000Z',
+    updated: '2026-06-01T09:00:00.000Z',
+  },
+];
+
+vi.mock('@/hooks/useTemplates', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/useTemplates')>('@/hooks/useTemplates');
+  return {
+    ...actual,
+    useTemplates: () => ({ data: templates, isLoading: false }),
+    useCreateTemplate: () => ({
+      mutateAsync: mocks.createTemplate,
+      isPending: false,
+    }),
+    useUpdateTemplate: () => ({
+      mutateAsync: mocks.updateTemplate,
+      isPending: false,
+    }),
+    useDeleteTemplate: () => ({
+      mutateAsync: mocks.deleteTemplate,
+      isPending: false,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useTaskTypes', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/useTaskTypes')>('@/hooks/useTaskTypes');
+  return {
+    ...actual,
+    useTaskTypesManager: () => ({
+      items: [
+        {
+          id: 'code',
+          label: 'Code',
+          icon: 'Code',
+          color: 'border-l-blue-500',
+          order: 0,
+          created: '2026-06-01T09:00:00.000Z',
+          updated: '2026-06-01T09:00:00.000Z',
+        },
+        {
+          id: 'research',
+          label: 'Research',
+          icon: 'Search',
+          color: 'border-l-violet-500',
+          order: 1,
+          created: '2026-06-01T09:00:00.000Z',
+          updated: '2026-06-01T09:00:00.000Z',
+        },
+      ],
+    }),
+  };
+});
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+describe('final Mantine feature surface cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createTemplate.mockResolvedValue({});
+    mocks.updateTemplate.mockResolvedValue({});
+    mocks.deleteTemplate.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps active feature surfaces off the compatibility wrappers', () => {
+    const componentSources = import.meta.glob('../components/**/*.tsx', {
+      query: '?raw',
+      import: 'default',
+      eager: true,
+    }) as Record<string, string>;
+    const allowedCompatibilityInternals = new Set([
+      'ui/alert-dialog.tsx',
+      'ui/dialog.tsx',
+      'ui/sheet.tsx',
+    ]);
+    const wrapperImportPattern =
+      /from ['"](?:@\/components\/ui|(?:\.\.?\/)+ui)\/(button|badge|card|dialog|sheet|alert-dialog|tooltip|tabs|select|input|textarea|checkbox|switch|skeleton|alert|scroll-area|progress|slider|label|popover|number-input)['"]/;
+
+    const offenders = Object.entries(componentSources)
+      .map(([path, source]) => {
+        const rel = path.replace('../components/', '');
+        if (allowedCompatibilityInternals.has(rel)) {
+          return null;
+        }
+        return wrapperImportPattern.test(source) ? rel : null;
+      })
+      .filter(Boolean);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('renders the standalone templates surface through direct Mantine controls', async () => {
+    const { baseElement, container } = renderWithProviders(<TemplatesPage onBack={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: 'Task Templates' })).toBeDefined();
+    expect(screen.getByPlaceholderText('Search templates...')).toBeDefined();
+    expect(screen.getByText('Bug Fix')).toBeDefined();
+    expect(screen.getByText('Release Prep')).toBeDefined();
+    expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Select-root')).toBeDefined();
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThanOrEqual(3);
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
+    expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Preview' })[0]);
+
+    expect((await screen.findAllByText('TASK PREVIEW')).length).toBeGreaterThanOrEqual(1);
+    expect(baseElement.querySelector('.mantine-Modal-root')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Bug Fix' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(mocks.deleteTemplate).toHaveBeenCalledWith('template-bug');
+    });
+  });
+});

--- a/web/src/components/archive/ArchivePage.tsx
+++ b/web/src/components/archive/ArchivePage.tsx
@@ -8,6 +8,8 @@
 import { useState, useMemo } from 'react';
 import {
   ActionIcon,
+  Badge,
+  Button,
   Checkbox,
   Group,
   Paper,
@@ -31,8 +33,6 @@ import {
   RotateCcw,
   Search,
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { useArchivedTasks, useRestoreTask } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
@@ -188,14 +188,16 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
     <Stack gap="lg">
       <Group justify="space-between" align="center" gap="md" wrap="wrap">
         <Group gap="md" wrap="wrap">
-          <Button variant="ghost" size="sm" onClick={onBack}>
+          <Button variant="subtle" size="sm" onClick={onBack}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Back to Board
           </Button>
           <Text component="h1" size="xl" fw={700} lh={1.1} m={0}>
             Archive
           </Text>
-          <Badge variant="secondary">{filteredTasks.length} tasks</Badge>
+          <Badge variant="light" color="gray" tt="none">
+            {filteredTasks.length} tasks
+          </Badge>
           {archivedTasks.length !== filteredTasks.length && (
             <Text size="sm" c="dimmed">
               of {archivedTasks.length} total
@@ -368,20 +370,20 @@ export function ArchivePage({ onBack }: ArchivePageProps) {
                   </Group>
 
                   <Group gap="xs" wrap="wrap">
-                    <Badge variant="outline" className="text-xs">
+                    <Badge variant="outline" color="gray" size="xs" tt="none">
                       {task.id}
                     </Badge>
-                    <Badge variant="secondary" className="text-xs">
+                    <Badge variant="light" color="gray" size="xs" tt="none">
                       {task.type}
                     </Badge>
                     {task.project && (
-                      <Badge variant="secondary" className="text-xs">
+                      <Badge variant="light" color="gray" size="xs" tt="none">
                         <FolderOpen className="h-3 w-3 mr-1" />
                         {projects.find((p) => p.id === task.project)?.label || task.project}
                       </Badge>
                     )}
                     {task.sprint && (
-                      <Badge variant="secondary" className="text-xs">
+                      <Badge variant="light" color="gray" size="xs" tt="none">
                         {sprints.find((s) => s.id === task.sprint)?.label || task.sprint}
                       </Badge>
                     )}

--- a/web/src/components/auth/DesktopOnboarding.tsx
+++ b/web/src/components/auth/DesktopOnboarding.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Badge, Button, Modal, PasswordInput, TextInput } from '@mantine/core';
 import {
   AlertCircle,
   Bot,
@@ -13,17 +14,6 @@ import {
   Upload,
 } from 'lucide-react';
 
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 
 export const DESKTOP_ONBOARDING_STORAGE_KEY = 'veritas-desktop-onboarding-complete';
@@ -324,7 +314,7 @@ export function DesktopOnboardingPanel({
     >
       <section className="space-y-5">
         <div className="space-y-3">
-          <Badge variant="outline" className="border-cyan-500/30 text-cyan-300">
+          <Badge variant="outline" color="cyan" tt="none">
             v5 Desktop Setup
           </Badge>
           <div className="space-y-2">
@@ -356,7 +346,8 @@ export function DesktopOnboardingPanel({
               <p className="text-xs text-muted-foreground">Redacted desktop diagnostics</p>
             </div>
             <Button
-              variant="ghost"
+              variant="subtle"
+              color="gray"
               size="sm"
               onClick={loadDiagnostics}
               disabled={diagnosticsLoading}
@@ -423,7 +414,13 @@ export function DesktopOnboardingPanel({
                   <span className="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground">
                     <Icon className="h-4 w-4" />
                   </span>
-                  <Badge variant={mode.id === 'board' ? 'default' : 'outline'}>{mode.badge}</Badge>
+                  <Badge
+                    variant={mode.id === 'board' ? 'filled' : 'outline'}
+                    color={mode.id === 'board' ? 'violet' : 'gray'}
+                    tt="none"
+                  >
+                    {mode.badge}
+                  </Badge>
                 </div>
                 <div className="space-y-1">
                   <h2 className="text-base font-semibold">{mode.title}</h2>
@@ -474,28 +471,23 @@ export function DesktopOnboardingPanel({
                 </p>
               </div>
               <div className="grid gap-3">
-                <div className="grid gap-2">
-                  <Label htmlFor="remote-url">Server URL</Label>
-                  <Input
-                    id="remote-url"
-                    value={remoteUrl}
-                    onChange={(event) => {
-                      setRemoteUrl(event.target.value);
-                      setRemoteResult(null);
-                    }}
-                    placeholder="https://veritas.example.com"
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="remote-token">Token</Label>
-                  <Input
-                    id="remote-token"
-                    type="password"
-                    value={remoteToken}
-                    onChange={(event) => setRemoteToken(event.target.value)}
-                    placeholder="Optional scoped token"
-                  />
-                </div>
+                <TextInput
+                  id="remote-url"
+                  label="Server URL"
+                  value={remoteUrl}
+                  onChange={(event) => {
+                    setRemoteUrl(event.target.value);
+                    setRemoteResult(null);
+                  }}
+                  placeholder="https://veritas.example.com"
+                />
+                <PasswordInput
+                  id="remote-token"
+                  label="Token"
+                  value={remoteToken}
+                  onChange={(event) => setRemoteToken(event.target.value)}
+                  placeholder="Optional scoped token"
+                />
                 <Button
                   type="button"
                   variant="outline"
@@ -602,16 +594,17 @@ export function DesktopOnboardingDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-5xl">
-        <DialogHeader>
-          <DialogTitle>Setup & Diagnostics</DialogTitle>
-          <DialogDescription>
-            Recheck desktop readiness, copy redacted diagnostics, and validate remote targets.
-          </DialogDescription>
-        </DialogHeader>
-        <DesktopOnboardingPanel compact />
-      </DialogContent>
-    </Dialog>
+    <Modal
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      title="Setup & Diagnostics"
+      size="xl"
+      centered
+    >
+      <p className="mb-4 text-sm text-muted-foreground">
+        Recheck desktop readiness, copy redacted diagnostics, and validate remote targets.
+      </p>
+      <DesktopOnboardingPanel compact />
+    </Modal>
   );
 }

--- a/web/src/components/backlog/BacklogPage.tsx
+++ b/web/src/components/backlog/BacklogPage.tsx
@@ -8,7 +8,18 @@
  */
 
 import { useState, useMemo } from 'react';
-import { Checkbox, Group, Paper, Select, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Group,
+  Paper,
+  Select,
+  SimpleGrid,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import {
   useBacklogTasks,
   usePromoteTask,
@@ -17,8 +28,6 @@ import {
 } from '@/hooks/useBacklog';
 import { useProjects } from '@/hooks/useProjects';
 import { useTaskTypes } from '@/hooks/useTaskTypes';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, ArrowUp, Search, Trash2 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import type { Task } from '@veritas-kanban/shared';
@@ -157,14 +166,16 @@ export function BacklogPage({ onBack }: BacklogPageProps) {
     <Stack gap="lg">
       <Group justify="space-between" align="center" gap="md" wrap="wrap">
         <Group gap="md" wrap="wrap">
-          <Button variant="ghost" size="sm" onClick={onBack}>
+          <Button variant="subtle" size="sm" onClick={onBack}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Back to Board
           </Button>
           <Text component="h1" size="xl" fw={700} lh={1.1} m={0}>
             Backlog
           </Text>
-          <Badge variant="secondary">{filteredTasks.length} tasks</Badge>
+          <Badge variant="light" color="gray" tt="none">
+            {filteredTasks.length} tasks
+          </Badge>
         </Group>
 
         {selectedIds.size > 0 && (
@@ -332,7 +343,8 @@ function BacklogTaskCard({
               </Button>
               <Button
                 size="sm"
-                variant="ghost"
+                variant="subtle"
+                color="gray"
                 onClick={(e) => {
                   e.stopPropagation();
                   onDelete();
@@ -344,27 +356,27 @@ function BacklogTaskCard({
           </Group>
 
           <Group gap="xs" wrap="wrap">
-            <Badge variant="outline" className="text-xs">
+            <Badge variant="outline" color="gray" size="xs" tt="none">
               {task.id}
             </Badge>
-            <Badge color={priorityColors[task.priority] ?? 'gray'} className="text-xs">
+            <Badge color={priorityColors[task.priority] ?? 'gray'} size="xs" tt="none">
               {task.priority}
             </Badge>
-            <Badge variant="secondary" className="text-xs">
+            <Badge variant="light" color="gray" size="xs" tt="none">
               {task.type}
             </Badge>
             {task.project && (
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="light" color="gray" size="xs" tt="none">
                 {task.project}
               </Badge>
             )}
             {task.sprint && (
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="light" color="gray" size="xs" tt="none">
                 Sprint: {task.sprint}
               </Badge>
             )}
             {task.subtasks && task.subtasks.length > 0 && (
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="light" color="gray" size="xs" tt="none">
                 {task.subtasks.filter((st) => st.completed).length}/{task.subtasks.length} subtasks
               </Badge>
             )}

--- a/web/src/components/board/ArchiveSuggestionBanner.tsx
+++ b/web/src/components/board/ArchiveSuggestionBanner.tsx
@@ -1,15 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ActionIcon, Button, Group, Modal, Stack, Text } from '@mantine/core';
 import { useArchiveSuggestions, useArchiveSprint } from '@/hooks/useTasks';
 import { Archive, X, Loader2, CheckCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -83,33 +73,39 @@ export function ArchiveSuggestionBanner() {
                   </>
                 )}
               </Button>
-              <Button
-                variant="ghost"
+              <ActionIcon
+                type="button"
+                variant="subtle"
+                color="gray"
                 size="sm"
                 onClick={() => handleDismiss(suggestion.sprint)}
-                className="hover:bg-green-500/10"
+                aria-label={`Dismiss archive suggestion for ${suggestion.sprint}`}
               >
                 <X className="h-4 w-4" />
-              </Button>
+              </ActionIcon>
             </div>
           </div>
         ))}
       </div>
 
       {/* Confirmation Dialog */}
-      <AlertDialog open={!!confirmSprint} onOpenChange={() => setConfirmSprint(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Archive sprint "{confirmSprint}"?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will archive all{' '}
-              {suggestions.find((s) => s.sprint === confirmSprint)?.taskCount || 0} tasks in this
-              sprint. You can restore them from the archive later.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
+      <Modal
+        opened={!!confirmSprint}
+        onClose={() => setConfirmSprint(null)}
+        title={`Archive sprint "${confirmSprint}"?`}
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will archive all{' '}
+            {suggestions.find((s) => s.sprint === confirmSprint)?.taskCount || 0} tasks in this
+            sprint. You can restore them from the archive later.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="subtle" color="gray" onClick={() => setConfirmSprint(null)}>
+              Cancel
+            </Button>
+            <Button
               onClick={() => confirmSprint && handleArchive(confirmSprint)}
               disabled={archiveSprint.isPending}
             >
@@ -124,10 +120,10 @@ export function ArchiveSuggestionBanner() {
                   Archive Sprint
                 </>
               )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </>
   );
 }

--- a/web/src/components/board/BoardLoadingSkeleton.tsx
+++ b/web/src/components/board/BoardLoadingSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from '@mantine/core';
 import type { TaskStatus } from '@veritas-kanban/shared';
 
 interface Column {

--- a/web/src/components/board/BoardSidebar.tsx
+++ b/web/src/components/board/BoardSidebar.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Button } from '@mantine/core';
 import { useRealtimeAgentStatus } from '@/hooks/useAgentStatus';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { api, Activity } from '@/lib/api';
@@ -30,7 +31,6 @@ import {
   GitBranch,
   ShieldAlert,
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { BudgetCard } from '@/components/dashboard/BudgetCard';
 import { MultiAgentPanel } from './MultiAgentPanel';
 

--- a/web/src/components/board/SprintArchiveSuggestion.tsx
+++ b/web/src/components/board/SprintArchiveSuggestion.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Archive, X, Loader2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { ActionIcon, Button } from '@mantine/core';
 import { useBulkArchive } from '@/hooks/useTasks';
 import type { Task } from '@veritas-kanban/shared';
 
@@ -21,10 +21,10 @@ export function SprintArchiveSuggestion({ tasks }: SprintArchiveSuggestionProps)
   // Find sprints where all tasks are done
   const completedSprints = useMemo(() => {
     const sprintTaskCounts = new Map<string, { total: number; done: number }>();
-    
-    tasks.forEach(task => {
+
+    tasks.forEach((task) => {
       if (!task.sprint) return;
-      
+
       const counts = sprintTaskCounts.get(task.sprint) || { total: 0, done: 0 };
       counts.total++;
       if (task.status === 'done') counts.done++;
@@ -45,30 +45,28 @@ export function SprintArchiveSuggestion({ tasks }: SprintArchiveSuggestionProps)
     setArchivingSprint(sprint);
     try {
       await bulkArchive.mutateAsync(sprint);
-      setDismissedSprints(prev => new Set(prev).add(sprint));
+      setDismissedSprints((prev) => new Set(prev).add(sprint));
     } finally {
       setArchivingSprint(null);
     }
   };
 
   const handleDismiss = (sprint: string) => {
-    setDismissedSprints(prev => new Set(prev).add(sprint));
+    setDismissedSprints((prev) => new Set(prev).add(sprint));
   };
 
   if (completedSprints.length === 0) return null;
 
   return (
     <div className="space-y-2 mb-4">
-      {completedSprints.map(sprint => (
+      {completedSprints.map((sprint) => (
         <div
           key={sprint.name}
           className="flex items-center gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20"
         >
           <Archive className="h-5 w-5 text-green-500 flex-shrink-0" />
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium">
-              All tasks in sprint "{sprint.name}" are complete!
-            </p>
+            <p className="text-sm font-medium">All tasks in sprint "{sprint.name}" are complete!</p>
             <p className="text-xs text-muted-foreground">
               {sprint.taskCount} task{sprint.taskCount > 1 ? 's' : ''} ready to archive
             </p>
@@ -76,7 +74,7 @@ export function SprintArchiveSuggestion({ tasks }: SprintArchiveSuggestionProps)
           <div className="flex items-center gap-2">
             <Button
               size="sm"
-              variant="secondary"
+              variant="light"
               onClick={() => handleArchive(sprint.name)}
               disabled={archivingSprint === sprint.name}
             >
@@ -87,14 +85,16 @@ export function SprintArchiveSuggestion({ tasks }: SprintArchiveSuggestionProps)
               )}
               Archive Sprint
             </Button>
-            <Button
+            <ActionIcon
+              type="button"
               size="sm"
-              variant="ghost"
+              variant="subtle"
+              color="gray"
               onClick={() => handleDismiss(sprint.name)}
-              className="h-8 w-8 p-0"
+              aria-label={`Dismiss archive suggestion for ${sprint.name}`}
             >
               <X className="h-4 w-4" />
-            </Button>
+            </ActionIcon>
           </div>
         </div>
       ))}

--- a/web/src/components/layout/ArchiveSidebar.tsx
+++ b/web/src/components/layout/ArchiveSidebar.tsx
@@ -1,5 +1,15 @@
 import { useState, useMemo, useEffect } from 'react';
 import {
+  ActionIcon,
+  Badge,
+  Button,
+  Drawer,
+  Group,
+  ScrollArea,
+  Select,
+  TextInput,
+} from '@mantine/core';
+import {
   Archive,
   RefreshCw,
   Search,
@@ -8,18 +18,6 @@ import {
   RotateCcw,
   ChevronDown,
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Badge } from '@/components/ui/badge';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { useArchivedTasks, useRestoreTask } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
@@ -114,16 +112,18 @@ function ArchivedTaskItem({
         </div>
         {sprintLabel && (
           <div className="flex flex-wrap gap-1 mt-1">
-            <Badge variant="secondary" className="text-xs px-1 py-0">
+            <Badge variant="light" color="gray" size="xs" tt="none">
               {sprintLabel}
             </Badge>
           </div>
         )}
       </div>
       {onRestore && (
-        <Button
-          variant="ghost"
-          size="icon"
+        <ActionIcon
+          type="button"
+          variant="subtle"
+          color="gray"
+          size="sm"
           className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
           onClick={(e) => {
             e.stopPropagation();
@@ -131,9 +131,10 @@ function ArchivedTaskItem({
           }}
           disabled={isRestoring}
           title="Restore to board"
+          aria-label={`Restore ${task.title} to board`}
         >
           <RotateCcw className={cn('h-4 w-4', isRestoring && 'animate-spin')} />
-        </Button>
+        </ActionIcon>
       )}
     </div>
   );
@@ -236,138 +237,143 @@ export function ArchiveSidebar({ open, onOpenChange }: ArchiveSidebarProps) {
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent side="right" className="w-[400px] sm:w-[450px] p-0">
-          <SheetHeader className="px-4 py-3 border-b">
-            <div className="flex items-center justify-between pr-8">
-              <SheetTitle className="flex items-center gap-2">
-                <Archive className="h-5 w-5" />
-                Archive
-                {archivedTasks && archivedTasks.length > 0 && (
-                  <Badge variant="secondary" className="ml-1">
-                    {archivedTasks.length}
-                  </Badge>
-                )}
-              </SheetTitle>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => refetch()}
-                disabled={isRefetching}
-                className="h-8 w-8"
-              >
-                <RefreshCw className={cn('h-4 w-4', isRefetching && 'animate-spin')} />
-              </Button>
-            </div>
+      <Drawer
+        opened={open}
+        onClose={() => onOpenChange(false)}
+        position="right"
+        size={450}
+        padding={0}
+        withCloseButton={false}
+      >
+        <div className="px-4 py-3 border-b">
+          <div className="flex items-center justify-between pr-8">
+            <h2 className="flex items-center gap-2 text-base font-semibold">
+              <Archive className="h-5 w-5" />
+              Archive
+              {archivedTasks && archivedTasks.length > 0 && (
+                <Badge variant="light" color="gray" size="sm" tt="none">
+                  {archivedTasks.length}
+                </Badge>
+              )}
+            </h2>
+            <ActionIcon
+              type="button"
+              variant="subtle"
+              color="gray"
+              size="sm"
+              onClick={() => refetch()}
+              disabled={isRefetching}
+              className="h-8 w-8"
+              aria-label="Refresh archive"
+            >
+              <RefreshCw className={cn('h-4 w-4', isRefetching && 'animate-spin')} />
+            </ActionIcon>
+          </div>
 
-            {/* Search */}
-            <div className="relative mt-2">
-              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="Search archived tasks..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="pl-8"
+          {/* Search */}
+          <div className="mt-2">
+            <TextInput
+              placeholder="Search archived tasks..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              leftSection={<Search className="h-4 w-4" aria-hidden="true" />}
+              aria-label="Search archived tasks"
+            />
+          </div>
+
+          {/* Filters */}
+          <Group gap="xs" mt="sm" grow>
+            <Select
+              value={typeFilter}
+              onChange={(value) => setTypeFilter(value ?? 'all')}
+              data={[
+                { value: 'all', label: 'All Types' },
+                ...Object.entries(typeLabels).map(([type, label]) => ({
+                  value: type,
+                  label: `${typeIcons[type as TaskType]} ${label}`,
+                })),
+              ]}
+              aria-label="Filter archived tasks by type"
+              allowDeselect={false}
+            />
+
+            {projects.length > 0 && (
+              <Select
+                value={projectFilter}
+                onChange={(value) => setProjectFilter(value ?? 'all')}
+                data={[
+                  { value: 'all', label: 'All Projects' },
+                  ...projects.map((project) => ({ value: project.id, label: project.label })),
+                ]}
+                aria-label="Filter archived tasks by project"
+                allowDeselect={false}
               />
-            </div>
-
-            {/* Filters */}
-            <div className="flex gap-2 mt-2">
-              <Select value={typeFilter} onValueChange={setTypeFilter}>
-                <SelectTrigger className="flex-1">
-                  <SelectValue placeholder="Type" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Types</SelectItem>
-                  {Object.entries(typeLabels).map(([type, label]) => (
-                    <SelectItem key={type} value={type}>
-                      {typeIcons[type as TaskType]} {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              {projects.length > 0 && (
-                <Select value={projectFilter} onValueChange={setProjectFilter}>
-                  <SelectTrigger className="flex-1">
-                    <SelectValue placeholder="Project" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Projects</SelectItem>
-                    {projects.map((project) => (
-                      <SelectItem key={project.id} value={project.id}>
-                        {project.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            </div>
-
-            {/* Results count */}
-            {filteredTasks.length > 0 && filteredTasks.length !== archivedTasks?.length && (
-              <div className="text-xs text-muted-foreground mt-1">
-                Showing {Math.min(visibleCount, filteredTasks.length)} of {filteredTasks.length}{' '}
-                filtered tasks
-              </div>
             )}
-          </SheetHeader>
+          </Group>
 
-          <ScrollArea className="h-[calc(100vh-240px)]">
-            <div className="px-2 py-2">
-              {isLoading ? (
-                <div className="text-center text-muted-foreground py-8">
-                  Loading archived tasks...
-                </div>
-              ) : filteredTasks.length === 0 ? (
-                <div className="text-center text-muted-foreground py-8">
-                  {archivedTasks?.length === 0
-                    ? 'No archived tasks yet'
-                    : 'No tasks match your filters'}
-                </div>
-              ) : (
-                <>
-                  <div className="divide-y divide-border">
-                    {visibleTasks.map((task) => (
-                      <ArchivedTaskItem
-                        key={task.id}
-                        task={task}
-                        onClick={() => handleTaskClick(task)}
-                        onRestore={() => handleRestore(task)}
-                        isRestoring={restoringId === task.id}
-                        projects={projectsList}
-                        sprints={sprintsList}
-                      />
-                    ))}
-                  </div>
-
-                  {/* Load More */}
-                  {hasMore && (
-                    <div className="py-4 text-center">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setVisibleCount((prev) => prev + PAGE_SIZE)}
-                        className="flex items-center gap-1 mx-auto"
-                      >
-                        <ChevronDown className="h-4 w-4" />
-                        Load More ({remaining} remaining)
-                      </Button>
-                    </div>
-                  )}
-
-                  {/* Page info */}
-                  {!hasMore && filteredTasks.length > PAGE_SIZE && (
-                    <div className="py-3 text-center text-xs text-muted-foreground">
-                      All {filteredTasks.length} tasks loaded
-                    </div>
-                  )}
-                </>
-              )}
+          {/* Results count */}
+          {filteredTasks.length > 0 && filteredTasks.length !== archivedTasks?.length && (
+            <div className="text-xs text-muted-foreground mt-1">
+              Showing {Math.min(visibleCount, filteredTasks.length)} of {filteredTasks.length}{' '}
+              filtered tasks
             </div>
-          </ScrollArea>
-        </SheetContent>
-      </Sheet>
+          )}
+        </div>
+
+        <ScrollArea className="h-[calc(100vh-240px)]">
+          <div className="px-2 py-2">
+            {isLoading ? (
+              <div className="text-center text-muted-foreground py-8">
+                Loading archived tasks...
+              </div>
+            ) : filteredTasks.length === 0 ? (
+              <div className="text-center text-muted-foreground py-8">
+                {archivedTasks?.length === 0
+                  ? 'No archived tasks yet'
+                  : 'No tasks match your filters'}
+              </div>
+            ) : (
+              <>
+                <div className="divide-y divide-border">
+                  {visibleTasks.map((task) => (
+                    <ArchivedTaskItem
+                      key={task.id}
+                      task={task}
+                      onClick={() => handleTaskClick(task)}
+                      onRestore={() => handleRestore(task)}
+                      isRestoring={restoringId === task.id}
+                      projects={projectsList}
+                      sprints={sprintsList}
+                    />
+                  ))}
+                </div>
+
+                {/* Load More */}
+                {hasMore && (
+                  <div className="py-4 text-center">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setVisibleCount((prev) => prev + PAGE_SIZE)}
+                      className="flex items-center gap-1 mx-auto"
+                    >
+                      <ChevronDown className="h-4 w-4" />
+                      Load More ({remaining} remaining)
+                    </Button>
+                  </div>
+                )}
+
+                {/* Page info */}
+                {!hasMore && filteredTasks.length > PAGE_SIZE && (
+                  <div className="py-3 text-center text-xs text-muted-foreground">
+                    All {filteredTasks.length} tasks loaded
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </ScrollArea>
+      </Drawer>
 
       {/* Read-only task detail panel for archived tasks */}
       <TaskDetailPanel

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,23 +1,5 @@
 import { useState, useRef, useCallback, lazy, Suspense, useEffect, useMemo } from 'react';
-import { Button, ScrollArea, Select, Skeleton, Stack } from '@mantine/core';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { Button, Group, Modal, ScrollArea, Select, Skeleton, Stack, Text } from '@mantine/core';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { useIdentity } from '@/hooks/useIdentity';
 import { useToast } from '@/hooks/useToast';
@@ -193,6 +175,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
   const { toast } = useToast();
   const contentAreaRef = useRef<HTMLDivElement>(null);
   const firstTabButtonRef = useRef<HTMLButtonElement>(null);
+  const [resetAllOpen, setResetAllOpen] = useState(false);
 
   // Focus first tab when dialog opens
   useEffect(() => {
@@ -298,6 +281,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
 
   const handleResetAll = () => {
     debouncedUpdate({ ...DEFAULT_FEATURE_SETTINGS });
+    setResetAllOpen(false);
   };
 
   const handleKeyDown = useCallback(
@@ -395,171 +379,173 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[800px] h-[85vh] p-0 overflow-hidden">
-        <DialogDescription className="sr-only">
-          Manage board, task, data, security, and workspace settings.
-        </DialogDescription>
-        <ErrorBoundary level="section">
-          <div className="flex h-full min-h-0">
-            {/* Sidebar Tabs — hidden on narrow screens, shown as dropdown instead */}
-            <div className="hidden sm:flex flex-col w-48 border-r bg-muted/30 py-4">
-              <div className="px-4 pb-3">
-                <h2 className="text-sm font-semibold">Settings</h2>
-              </div>
-              <nav
-                className="flex-1 space-y-0.5 px-2"
-                role="tablist"
-                aria-orientation="vertical"
-                onKeyDown={handleKeyDown}
-              >
-                <Stack gap={4}>
-                  {TABS.map((tab, index) => {
-                    const Icon = tab.icon;
-                    const allowed = canUseTab(tab);
-                    const active = activeTab === tab.id;
-                    return (
-                      <Button
-                        key={tab.id}
-                        id={`tab-${tab.id}`}
-                        ref={index === 0 ? firstTabButtonRef : undefined}
-                        type="button"
-                        role="tab"
-                        aria-selected={active}
-                        aria-controls="settings-tab-content"
-                        tabIndex={active ? 0 : -1}
-                        onClick={() => setActiveTab(tab.id)}
-                        disabled={!allowed}
-                        title={
-                          allowed ? tab.label : `${tab.requiredPermission} permission required`
-                        }
-                        variant={active ? 'light' : 'subtle'}
-                        color={active ? 'violet' : 'gray'}
-                        size="xs"
-                        radius="md"
-                        fullWidth
-                        justify="flex-start"
-                        leftSection={<Icon className="h-4 w-4 flex-shrink-0" />}
-                      >
-                        {tab.label}
-                      </Button>
-                    );
-                  })}
-                </Stack>
-              </nav>
-
-              {/* Import/Export/Reset */}
-              <Stack gap={4} className="mt-auto border-t px-2 pt-3">
-                <input
-                  ref={settingsFileInputRef}
-                  type="file"
-                  accept="application/json,.json"
-                  onChange={handleImportSettings}
-                  className="hidden"
-                  aria-label="Import settings file"
-                />
-                <Button
-                  type="button"
-                  onClick={handleExportSettings}
-                  aria-label="Export settings as JSON file"
-                  variant="subtle"
-                  color="gray"
-                  size="xs"
-                  fullWidth
-                  justify="flex-start"
-                  leftSection={
-                    <Download className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
-                  }
-                >
-                  Export Settings
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => settingsFileInputRef.current?.click()}
-                  disabled={!canWriteSettings}
-                  aria-label="Import settings from JSON file"
-                  variant="subtle"
-                  color="gray"
-                  size="xs"
-                  fullWidth
-                  justify="flex-start"
-                  leftSection={<Upload className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />}
-                >
-                  Import Settings
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
+    <Modal
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      title={<span className="sr-only">Settings</span>}
+      size={800}
+      padding={0}
+      centered
+      styles={{
+        content: { height: '85vh', overflow: 'hidden' },
+        body: { height: '100%', padding: 0 },
+      }}
+    >
+      <ErrorBoundary level="section">
+        <div className="flex h-full min-h-0">
+          {/* Sidebar Tabs — hidden on narrow screens, shown as dropdown instead */}
+          <div className="hidden sm:flex flex-col w-48 border-r bg-muted/30 py-4">
+            <div className="px-4 pb-3">
+              <h2 className="text-sm font-semibold">Settings</h2>
+            </div>
+            <nav
+              className="flex-1 space-y-0.5 px-2"
+              role="tablist"
+              aria-orientation="vertical"
+              onKeyDown={handleKeyDown}
+            >
+              <Stack gap={4}>
+                {TABS.map((tab, index) => {
+                  const Icon = tab.icon;
+                  const allowed = canUseTab(tab);
+                  const active = activeTab === tab.id;
+                  return (
                     <Button
+                      key={tab.id}
+                      id={`tab-${tab.id}`}
+                      ref={index === 0 ? firstTabButtonRef : undefined}
                       type="button"
-                      disabled={!canWriteSettings}
-                      variant="subtle"
-                      color="red"
+                      role="tab"
+                      aria-selected={active}
+                      aria-controls="settings-tab-content"
+                      tabIndex={active ? 0 : -1}
+                      onClick={() => setActiveTab(tab.id)}
+                      disabled={!allowed}
+                      title={allowed ? tab.label : `${tab.requiredPermission} permission required`}
+                      variant={active ? 'light' : 'subtle'}
+                      color={active ? 'violet' : 'gray'}
                       size="xs"
+                      radius="md"
                       fullWidth
                       justify="flex-start"
-                      leftSection={<RotateCcw className="h-3.5 w-3.5 flex-shrink-0" />}
+                      leftSection={<Icon className="h-4 w-4 flex-shrink-0" />}
                     >
-                      Reset All
+                      {tab.label}
                     </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Reset all settings?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        This will reset ALL feature settings across every section back to their
-                        default values. This cannot be undone.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={handleResetAll}
-                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                      >
-                        Reset Everything
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                  );
+                })}
               </Stack>
-            </div>
+            </nav>
 
-            {/* Mobile Tab Selector */}
-            <div className="sm:hidden absolute top-3 right-12">
-              <Select
-                value={activeTab}
-                onChange={(value) => {
-                  if (value) setActiveTab(value as TabId);
-                }}
-                data={mobileTabOptions}
-                aria-label="Select settings section"
-                size="xs"
-                checkIconPosition="right"
-                className="w-40"
+            {/* Import/Export/Reset */}
+            <Stack gap={4} className="mt-auto border-t px-2 pt-3">
+              <input
+                ref={settingsFileInputRef}
+                type="file"
+                accept="application/json,.json"
+                onChange={handleImportSettings}
+                className="hidden"
+                aria-label="Import settings file"
               />
-            </div>
-
-            {/* Content */}
-            <div className="flex-1 flex flex-col min-w-0 min-h-0">
-              <DialogHeader className="px-6 py-4 border-b sm:hidden">
-                <DialogTitle>Settings</DialogTitle>
-              </DialogHeader>
-              <ScrollArea className="flex-1 min-h-0">
-                <div
-                  id="settings-tab-content"
-                  ref={contentAreaRef}
-                  className="px-6 py-4"
-                  role="tabpanel"
-                  tabIndex={-1}
-                  aria-labelledby={`tab-${activeTab}`}
-                >
-                  {renderTab()}
-                </div>
-              </ScrollArea>
-            </div>
+              <Button
+                type="button"
+                onClick={handleExportSettings}
+                aria-label="Export settings as JSON file"
+                variant="subtle"
+                color="gray"
+                size="xs"
+                fullWidth
+                justify="flex-start"
+                leftSection={<Download className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />}
+              >
+                Export Settings
+              </Button>
+              <Button
+                type="button"
+                onClick={() => settingsFileInputRef.current?.click()}
+                disabled={!canWriteSettings}
+                aria-label="Import settings from JSON file"
+                variant="subtle"
+                color="gray"
+                size="xs"
+                fullWidth
+                justify="flex-start"
+                leftSection={<Upload className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />}
+              >
+                Import Settings
+              </Button>
+              <Button
+                type="button"
+                disabled={!canWriteSettings}
+                variant="subtle"
+                color="red"
+                size="xs"
+                fullWidth
+                justify="flex-start"
+                leftSection={<RotateCcw className="h-3.5 w-3.5 flex-shrink-0" />}
+                onClick={() => setResetAllOpen(true)}
+              >
+                Reset All
+              </Button>
+            </Stack>
           </div>
-        </ErrorBoundary>
-      </DialogContent>
-    </Dialog>
+
+          {/* Mobile Tab Selector */}
+          <div className="sm:hidden absolute top-3 right-12">
+            <Select
+              value={activeTab}
+              onChange={(value) => {
+                if (value) setActiveTab(value as TabId);
+              }}
+              data={mobileTabOptions}
+              aria-label="Select settings section"
+              size="xs"
+              checkIconPosition="right"
+              className="w-40"
+            />
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 flex flex-col min-w-0 min-h-0">
+            <div className="px-6 py-4 border-b sm:hidden">
+              <h2 className="text-lg font-semibold">Settings</h2>
+            </div>
+            <ScrollArea className="flex-1 min-h-0">
+              <div
+                id="settings-tab-content"
+                ref={contentAreaRef}
+                className="px-6 py-4"
+                role="tabpanel"
+                tabIndex={-1}
+                aria-labelledby={`tab-${activeTab}`}
+              >
+                {renderTab()}
+              </div>
+            </ScrollArea>
+          </div>
+        </div>
+      </ErrorBoundary>
+      <Modal
+        opened={resetAllOpen}
+        onClose={() => setResetAllOpen(false)}
+        title="Reset all settings?"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will reset ALL feature settings across every section back to their default values.
+            This cannot be undone.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="subtle" color="gray" onClick={() => setResetAllOpen(false)}>
+              Cancel
+            </Button>
+            <Button color="red" onClick={handleResetAll}>
+              Reset Everything
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Modal>
   );
 }

--- a/web/src/components/settings/SortableListItem.tsx
+++ b/web/src/components/settings/SortableListItem.tsx
@@ -1,16 +1,6 @@
 import { useState, memo } from 'react';
 import type { ManagedListItem } from '@veritas-kanban/shared';
-import { ActionIcon, TextInput } from '@mantine/core';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '../ui/alert-dialog';
+import { ActionIcon, Button, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
 import { Trash2, GripVertical, ChevronUp, ChevronDown } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -186,39 +176,38 @@ export const SortableListItem = memo(function SortableListItem<T extends Managed
         </ActionIcon>
       </div>
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {deleteInfo && !deleteInfo.allowed ? 'Cannot Delete' : 'Delete Item?'}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteInfo && deleteInfo.referenceCount > 0 && !deleteInfo.allowed ? (
-                <span>
-                  &quot;{item.label}&quot; is used by {deleteInfo.referenceCount} task(s). Remove or
-                  reassign those tasks first before deleting this item.
-                </span>
-              ) : (
-                <span>
-                  Are you sure you want to delete &quot;{item.label}&quot;? This action cannot be
-                  undone.
-                </span>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            {(!deleteInfo || deleteInfo.allowed) && (
-              <AlertDialogAction
-                onClick={handleDeleteConfirm}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              >
-                Delete
-              </AlertDialogAction>
+      <Modal
+        opened={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        title={deleteInfo && !deleteInfo.allowed ? 'Cannot Delete' : 'Delete Item?'}
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            {deleteInfo && deleteInfo.referenceCount > 0 && !deleteInfo.allowed ? (
+              <>
+                &quot;{item.label}&quot; is used by {deleteInfo.referenceCount} task(s). Remove or
+                reassign those tasks first before deleting this item.
+              </>
+            ) : (
+              <>
+                Are you sure you want to delete &quot;{item.label}&quot;? This action cannot be
+                undone.
+              </>
             )}
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="subtle" color="gray" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            {(!deleteInfo || deleteInfo.allowed) && (
+              <Button color="red" onClick={handleDeleteConfirm}>
+                Delete
+              </Button>
+            )}
+          </Group>
+        </Stack>
+      </Modal>
     </>
   );
 }) as <T extends ManagedListItem>(props: SortableListItemProps<T>) => React.JSX.Element;

--- a/web/src/components/settings/shared/NumberRow.tsx
+++ b/web/src/components/settings/shared/NumberRow.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect } from 'react';
-import { NumberInput } from '@/components/ui/number-input';
+import { NumberInput } from '@mantine/core';
 import { SettingRow } from './SettingRow';
 
 export const NumberRow = memo(function NumberRow({

--- a/web/src/components/settings/shared/SectionHeader.tsx
+++ b/web/src/components/settings/shared/SectionHeader.tsx
@@ -1,49 +1,51 @@
-import { Button, Group, Text } from '@mantine/core';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { useState } from 'react';
+import { Button, Group, Modal, Stack, Text } from '@mantine/core';
 import { RotateCcw } from 'lucide-react';
 
 export function SectionHeader({ title, onReset }: { title: string; onReset?: () => void }) {
+  const [resetOpen, setResetOpen] = useState(false);
+
+  const handleReset = () => {
+    onReset?.();
+    setResetOpen(false);
+  };
+
   return (
     <Group justify="space-between" align="center" className="mb-2 border-b pb-2">
       <Text size="sm" fw={600} c="dimmed" tt="uppercase">
         {title}
       </Text>
       {onReset && (
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button
-              type="button"
-              variant="subtle"
-              size="xs"
-              color="gray"
-              leftSection={<RotateCcw className="h-3 w-3" />}
-            >
-              Reset
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Reset to defaults?</AlertDialogTitle>
-              <AlertDialogDescription>
+        <>
+          <Button
+            type="button"
+            variant="subtle"
+            size="xs"
+            color="gray"
+            leftSection={<RotateCcw className="h-3 w-3" />}
+            onClick={() => setResetOpen(true)}
+          >
+            Reset
+          </Button>
+          <Modal
+            opened={resetOpen}
+            onClose={() => setResetOpen(false)}
+            title="Reset to defaults?"
+            centered
+          >
+            <Stack gap="md">
+              <Text size="sm" c="dimmed">
                 This will reset all {title.toLowerCase()} settings to their default values.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={onReset}>Reset</AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+              </Text>
+              <Group justify="flex-end">
+                <Button variant="subtle" color="gray" onClick={() => setResetOpen(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={handleReset}>Reset</Button>
+              </Group>
+            </Stack>
+          </Modal>
+        </>
       )}
     </Group>
   );

--- a/web/src/components/settings/tabs/GeneralTab.tsx
+++ b/web/src/components/settings/tabs/GeneralTab.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
-import { ActionIcon, Badge, Button, Group, Select, Switch, TextInput } from '@mantine/core';
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import {
   useConfig,
   useAddRepo,
@@ -300,6 +300,13 @@ function AddRepoForm({ onClose }: { onClose: () => void }) {
 
 function RepoItem({ repo }: { repo: RepoConfig }) {
   const removeRepo = useRemoveRepo();
+  const [removeOpen, setRemoveOpen] = useState(false);
+
+  const handleRemove = () => {
+    removeRepo.mutate(repo.name);
+    setRemoveOpen(false);
+  };
+
   return (
     <div className="flex items-center justify-between py-2 px-3 rounded-md border bg-card">
       <div className="flex items-center gap-3">
@@ -313,36 +320,36 @@ function RepoItem({ repo }: { repo: RepoConfig }) {
         <Badge variant="light" color="gray" size="sm">
           {repo.defaultBranch}
         </Badge>
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <ActionIcon
-              type="button"
-              variant="subtle"
-              color="gray"
-              size="sm"
-              aria-label={`Remove ${repo.name}`}
-            >
-              <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
-            </ActionIcon>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Remove repository?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This will remove "{repo.name}" from your configuration.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={() => removeRepo.mutate(repo.name)}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              >
+        <ActionIcon
+          type="button"
+          variant="subtle"
+          color="gray"
+          size="sm"
+          aria-label={`Remove ${repo.name}`}
+          onClick={() => setRemoveOpen(true)}
+        >
+          <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+        </ActionIcon>
+        <Modal
+          opened={removeOpen}
+          onClose={() => setRemoveOpen(false)}
+          title="Remove repository?"
+          centered
+        >
+          <Stack gap="md">
+            <Text size="sm" c="dimmed">
+              This will remove "{repo.name}" from your configuration.
+            </Text>
+            <Group justify="flex-end">
+              <Button variant="subtle" color="gray" onClick={() => setRemoveOpen(false)}>
+                Cancel
+              </Button>
+              <Button color="red" onClick={handleRemove}>
                 Remove
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+              </Button>
+            </Group>
+          </Stack>
+        </Modal>
       </div>
     </div>
   );

--- a/web/src/components/settings/tabs/SecurityTab.tsx
+++ b/web/src/components/settings/tabs/SecurityTab.tsx
@@ -1,17 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { Button, PasswordInput } from '@mantine/core';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { Button, Group, Modal, PasswordInput, Stack, Text } from '@mantine/core';
 import { Eye, EyeOff, Check, AlertTriangle, Key } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 
@@ -42,6 +31,7 @@ export function SecurityTab() {
   const [showPasswords, setShowPasswords] = useState(false);
   const [isChanging, setIsChanging] = useState(false);
   const [changeSuccess, setChangeSuccess] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
 
   const strength = getPasswordStrength(newPassword);
   const passwordsMatch = newPassword === confirmPassword;
@@ -182,24 +172,26 @@ export function SecurityTab() {
             </p>
           </div>
 
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button color="red" size="sm">
-                Reset All Security
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Reset all security settings?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This action cannot be undone. Your password and recovery key will be deleted.
-                  You'll need to set up a new password on the next page load.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          <Button color="red" size="sm" onClick={() => setResetOpen(true)}>
+            Reset All Security
+          </Button>
+          <Modal
+            opened={resetOpen}
+            onClose={() => setResetOpen(false)}
+            title="Reset all security settings?"
+            centered
+          >
+            <Stack gap="md">
+              <Text size="sm" c="dimmed">
+                This action cannot be undone. Your password and recovery key will be deleted. You'll
+                need to set up a new password on the next page load.
+              </Text>
+              <Group justify="flex-end">
+                <Button variant="subtle" color="gray" onClick={() => setResetOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  color="red"
                   onClick={async () => {
                     // Call the reset endpoint
                     try {
@@ -221,14 +213,16 @@ export function SecurityTab() {
                         description: 'Please use the CLI command instead.',
                         duration: 5000,
                       });
+                    } finally {
+                      setResetOpen(false);
                     }
                   }}
                 >
                   Reset Everything
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+                </Button>
+              </Group>
+            </Stack>
+          </Modal>
         </div>
       </section>
     </div>

--- a/web/src/components/settings/tabs/TemplateComponents.tsx
+++ b/web/src/components/settings/tabs/TemplateComponents.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
-import { ActionIcon, Badge, Button, Select, Text, Textarea, TextInput } from '@mantine/core';
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
 import { type TaskTemplate, useCreateTemplate, useDeleteTemplate } from '@/hooks/useTemplates';
 import { getTypeIcon, useTaskTypesManager } from '@/hooks/useTaskTypes';
 import { FileText, Trash2 } from 'lucide-react';
@@ -183,6 +183,7 @@ export function AddTemplateForm({ onClose }: { onClose: () => void }) {
 
 export function TemplateItem({ template }: { template: TaskTemplate }) {
   const deleteTemplate = useDeleteTemplate();
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const taskDefaults = template.taskDefaults ?? {};
   const metadata = [
     taskDefaults.type,
@@ -213,35 +214,43 @@ export function TemplateItem({ template }: { template: TaskTemplate }) {
           </Text>
         </div>
       </div>
-      <AlertDialog>
-        <AlertDialogTrigger asChild>
-          <ActionIcon
-            type="button"
-            variant="subtle"
-            color="red"
-            size="sm"
-            radius="md"
-            aria-label={`Delete ${template.name}`}
-          >
-            <Trash2 className="h-4 w-4" />
-          </ActionIcon>
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete template?</AlertDialogTitle>
-            <AlertDialogDescription>This will delete "{template.name}".</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => deleteTemplate.mutate(template.id)}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      <ActionIcon
+        type="button"
+        variant="subtle"
+        color="red"
+        size="sm"
+        radius="md"
+        aria-label={`Delete ${template.name}`}
+        onClick={() => setDeleteOpen(true)}
+      >
+        <Trash2 className="h-4 w-4" />
+      </ActionIcon>
+      <Modal
+        opened={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        title="Delete template?"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            This will delete "{template.name}".
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="subtle" color="gray" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                deleteTemplate.mutate(template.id);
+                setDeleteOpen(false);
+              }}
             >
               Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </div>
   );
 }

--- a/web/src/components/shared/AgentStatusIndicator.tsx
+++ b/web/src/components/shared/AgentStatusIndicator.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Popover } from '@mantine/core';
 import { useRealtimeAgentStatus } from '@/hooks/useAgentStatus';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { api, Activity } from '@/lib/api';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Clock,
   Users,
@@ -314,8 +314,8 @@ export function AgentStatusIndicator({
   const Icon = config.icon;
 
   return (
-    <Popover position="bottom-start">
-      <PopoverTrigger asChild>
+    <Popover position="bottom-start" width={320} shadow="md" withinPortal>
+      <Popover.Target>
         <button
           className={`flex items-center gap-2 min-w-[32px] sm:min-w-[140px] md:min-w-[200px] cursor-pointer hover:bg-muted/50 rounded-md px-2 py-1 transition-colors ${className}`}
           role="status"
@@ -347,9 +347,9 @@ export function AgentStatusIndicator({
             </span>
           )}
         </button>
-      </PopoverTrigger>
+      </Popover.Target>
 
-      <PopoverContent className="w-80">
+      <Popover.Dropdown>
         <div className="space-y-4">
           {/* Current Status Header */}
           <div className="flex items-center gap-3">
@@ -497,7 +497,7 @@ export function AgentStatusIndicator({
             </p>
           )}
         </div>
-      </PopoverContent>
+      </Popover.Dropdown>
     </Popover>
   );
 }

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -1,8 +1,8 @@
 import { memo, useMemo } from 'react';
+import { Tooltip } from '@mantine/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { Task, TaskPriority, BlockedCategory } from '@veritas-kanban/shared';
 import {
   Check,
@@ -274,374 +274,382 @@ export const TaskCard = memo(function TaskCard({
   const suppressCardTooltip = isDragActive || isDragging || isCurrentlyDragging;
 
   return (
-    <TooltipProvider>
-      <Tooltip delayDuration={500} open={suppressCardTooltip ? false : undefined}>
-        <TooltipTrigger asChild>
-          <div
-            ref={setNodeRef}
-            style={style}
-            {...listeners}
-            {...attributes}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
-            role="article"
-            tabIndex={0}
-            aria-label={`Task: ${task.title}, Priority: ${task.priority}${isBlocked ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}`}
-            className={cn(
-              'group bg-card border border-border rounded-md cursor-grab active:cursor-grabbing',
-              isCompact ? 'p-2' : 'p-3',
-              'hover:border-muted-foreground/50 hover:bg-card/80 transition-all',
-              'border-l-2',
-              typeColor,
-              isDragging && 'opacity-50 shadow-lg rotate-2 scale-105',
-              isCurrentlyDragging && 'opacity-50',
-              isSelected && 'ring-2 ring-primary border-primary',
-              isAgentRunning &&
-                'ring-2 ring-blue-500/50 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.3)]'
-            )}
-          >
-            <span className="sr-only">Status: {task.status}</span>
-            <div className="flex items-start gap-2">
-              {isSelecting && (
-                <button
-                  onClick={handleCheckboxClick}
-                  aria-label={isChecked ? 'Deselect task' : 'Select task'}
-                  className={cn(
-                    'h-4 w-4 rounded border-2 flex items-center justify-center flex-shrink-0 mt-0.5 transition-colors',
-                    isChecked
-                      ? 'bg-primary border-primary text-primary-foreground'
-                      : 'border-muted-foreground/50 hover:border-primary'
-                  )}
-                >
-                  {isChecked && <Check className="h-3 w-3" />}
-                </button>
-              )}
-              <span className="text-muted-foreground mt-0.5 flex-shrink-0" aria-hidden="true">
-                {TypeIconComponent && <TypeIconComponent className="h-3.5 w-3.5" />}
-              </span>
-              <div className="flex-1 min-w-0">
-                <h3 className="text-sm font-medium leading-tight truncate">{task.title}</h3>
-                {!isCompact && task.description && (
-                  <div className="mt-1">
-                    <p className="text-xs text-muted-foreground line-clamp-2">
-                      {plainDescriptionPreview}
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2 mt-2 flex-wrap">
-              {/* Agent running indicator */}
-              {isAgentRunning && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1 animate-pulse">
-                      <span className="sr-only">
-                        Agent {agentNames[task.attempt?.agent || ''] || task.attempt?.agent} is
-                        actively running on this task
-                      </span>
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                      {agentNames[task.attempt?.agent || ''] || 'Agent'} running
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="font-medium">Agent Active</p>
-                    <p className="text-sm">
-                      {agentNames[task.attempt?.agent || ''] || task.attempt?.agent} is working on
-                      this task
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {isBlocked && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1">
-                      <Ban className="h-3 w-3" />
-                      Blocked
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="font-medium">Blocked by:</p>
-                    <ul className="text-sm">
-                      {blockerTitles?.map((title, i) => (
-                        <li key={i}>• {title}</li>
-                      ))}
-                    </ul>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {/* Dependencies indicator */}
-              {(() => {
-                const dependsOnCount = task.dependencies?.depends_on?.length || 0;
-                const blocksCount = task.dependencies?.blocks?.length || 0;
-                const totalDeps = dependsOnCount + blocksCount;
-
-                if (totalDeps === 0) return null;
-
-                return (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 flex items-center gap-1">
-                        <Link2 className="h-3 w-3" aria-hidden="true" />
-                        {totalDeps}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <div className="space-y-1">
-                        <p className="font-medium">Dependencies</p>
-                        {dependsOnCount > 0 && (
-                          <p className="text-sm">
-                            Depends on: {dependsOnCount} task{dependsOnCount !== 1 ? 's' : ''}
-                          </p>
-                        )}
-                        {blocksCount > 0 && (
-                          <p className="text-sm">
-                            Blocks: {blocksCount} task{blocksCount !== 1 ? 's' : ''}
-                          </p>
-                        )}
-                      </div>
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              })()}
-              {/* Checkpoint indicator */}
-              {task.checkpoint && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 flex items-center gap-1">
-                      <Save className="h-3 w-3" aria-hidden="true" />
-                      <span className="sr-only">Checkpoint saved at </span>
-                      Step {task.checkpoint.step}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div className="space-y-1">
-                      <p className="font-medium">Checkpoint Saved</p>
-                      <p className="text-sm">Step {task.checkpoint.step}</p>
-                      {task.checkpoint.resumeCount && task.checkpoint.resumeCount > 0 && (
-                        <p className="text-sm flex items-center gap-1">
-                          <RotateCcw className="h-3 w-3" aria-hidden="true" />
-                          Resumed {task.checkpoint.resumeCount} time(s)
-                        </p>
-                      )}
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {/* Blocked reason badge (only shown in Blocked column) */}
-              {task.status === 'blocked' &&
-                task.blockedReason &&
-                (() => {
-                  const info = blockedCategoryInfo[task.blockedReason.category];
-                  const BlockedIcon = info.icon;
-                  return (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400 flex items-center gap-1">
-                          <BlockedIcon className="h-3 w-3" />
-                          {info.shortLabel}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p className="font-medium">{info.label}</p>
-                        {task.blockedReason.note && (
-                          <p className="text-sm text-muted-foreground mt-1">
-                            {sanitizeText(task.blockedReason.note)}
-                          </p>
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                  );
-                })()}
-              {/* Left side: project, type label, priority — controlled by board settings */}
-              {boardSettings.showProjectBadges && task.project && (
-                <span className={cn('text-xs px-1.5 py-0.5 rounded', projectColor)}>
-                  {projectLabel}
-                </span>
-              )}
-              {boardSettings.showSprintBadges && task.sprint && (
-                <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 flex items-center gap-1">
-                  <Zap className="h-3 w-3" />
-                  {getSprintLabel(sprints, task.sprint)}
-                </span>
-              )}
-              <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                {typeLabel}
-              </span>
-              {boardSettings.showPriorityIndicators && (
-                <span
-                  className={cn(
-                    'text-xs px-1.5 py-0.5 rounded capitalize',
-                    priorityColors[task.priority]
-                  )}
-                >
-                  {task.priority}
-                </span>
-              )}
-              {/* Attachment indicator */}
-              {task.attachments && task.attachments.length > 0 && (
-                <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex items-center gap-1">
-                  <Paperclip className="h-3 w-3" />
-                  {task.attachments.length}
-                </span>
-              )}
-              {/* Deliverable indicator */}
-              {task.deliverables && task.deliverables.length > 0 && (
-                <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex items-center gap-1">
-                  <FileText className="h-3 w-3" />
-                  {task.deliverables.length}
-                </span>
-              )}
-              {/* Plan indicator removed — planning was agent-internal */}
-              {/* Right side: subtask count + time tracking */}
-              {subtaskTotal > 0 && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      className={cn(
-                        'text-xs px-1.5 py-0.5 rounded flex items-center gap-1 ml-auto',
-                        allSubtasksDone
-                          ? 'bg-green-500/20 text-green-500'
-                          : 'bg-muted text-muted-foreground'
-                      )}
-                    >
-                      <ListChecks className="h-3 w-3" />
-                      {subtaskCompleted}/{subtaskTotal}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="font-medium">Subtasks</p>
-                    <p className="text-sm">
-                      {subtaskCompleted} of {subtaskTotal} completed
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {/* Verification progress indicator */}
-              {verificationTotal > 0 && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      className={cn(
-                        'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
-                        !subtaskTotal && 'ml-auto',
-                        allVerificationDone
-                          ? 'bg-green-500/20 text-green-500'
-                          : 'bg-muted text-muted-foreground'
-                      )}
-                    >
-                      <ShieldCheck className="h-3 w-3" />
-                      {verificationChecked}/{verificationTotal}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="font-medium">Done Criteria</p>
-                    <p className="text-sm">
-                      {verificationChecked} of {verificationTotal} verified
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {/* Time tracking indicator */}
-              {(task.timeTracking?.totalSeconds || task.timeTracking?.isRunning) && (
-                <span
-                  className={cn(
-                    'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
-                    !subtaskTotal && !verificationTotal && !cardMetrics && 'ml-auto',
-                    task.timeTracking?.isRunning
-                      ? 'bg-green-500/20 text-green-500'
-                      : 'bg-muted text-muted-foreground'
-                  )}
-                >
-                  {task.timeTracking?.isRunning ? (
-                    <Timer className="h-3 w-3 animate-pulse" />
-                  ) : (
-                    <Clock className="h-3 w-3" />
-                  )}
-                  {formatDuration(task.timeTracking?.totalSeconds || 0)}
-                </span>
-              )}
-              {/* Agent run metrics (for done tasks only) */}
-              {cardMetrics && cardMetrics.totalRuns > 0 && (
-                <>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        className={cn(
-                          'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
-                          !subtaskTotal && !task.timeTracking?.totalSeconds && 'ml-auto',
-                          'bg-muted text-muted-foreground'
-                        )}
-                      >
-                        <Play className="h-3 w-3" />
-                        {cardMetrics.totalRuns}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="font-medium">
-                        {cardMetrics.totalRuns} run{cardMetrics.totalRuns !== 1 ? 's' : ''}
-                      </p>
-                      <p className="text-sm text-muted-foreground">
-                        {cardMetrics.successfulRuns} successful, {cardMetrics.failedRuns} failed
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                  {cardMetrics.lastRunSuccess !== undefined && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          className={cn(
-                            'text-xs px-1 py-0.5 rounded flex items-center',
-                            cardMetrics.lastRunSuccess
-                              ? 'bg-green-500/20 text-green-500'
-                              : 'bg-red-500/20 text-red-500'
-                          )}
-                        >
-                          {cardMetrics.lastRunSuccess ? (
-                            <CheckCircle className="h-3 w-3" />
-                          ) : (
-                            <XCircle className="h-3 w-3" />
-                          )}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p className="font-medium">
-                          Last run: {cardMetrics.lastRunSuccess ? 'Success' : 'Failed'}
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                  {cardMetrics.totalDurationMs > 0 && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="text-xs px-1.5 py-0.5 rounded flex items-center gap-1 bg-muted text-muted-foreground">
-                          <Clock className="h-3 w-3" />
-                          {formatCompactDuration(cardMetrics.totalDurationMs)}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p className="font-medium">Total agent time</p>
-                        <p className="text-sm text-muted-foreground">
-                          {formatCompactDuration(cardMetrics.totalDurationMs)} across{' '}
-                          {cardMetrics.totalRuns} run{cardMetrics.totalRuns !== 1 ? 's' : ''}
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </>
-              )}
-            </div>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-xs">
+    <Tooltip
+      openDelay={500}
+      disabled={suppressCardTooltip}
+      position="top"
+      multiline
+      w={320}
+      label={
+        <div>
           <p className="font-medium">{task.title}</p>
           {task.description && (
             <p className="text-muted-foreground text-sm mt-1">{plainDescriptionPreview}</p>
           )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+        </div>
+      }
+    >
+      <div
+        ref={setNodeRef}
+        style={style}
+        {...listeners}
+        {...attributes}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        role="article"
+        tabIndex={0}
+        aria-label={`Task: ${task.title}, Priority: ${task.priority}${isBlocked ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}`}
+        className={cn(
+          'group bg-card border border-border rounded-md cursor-grab active:cursor-grabbing',
+          isCompact ? 'p-2' : 'p-3',
+          'hover:border-muted-foreground/50 hover:bg-card/80 transition-all',
+          'border-l-2',
+          typeColor,
+          isDragging && 'opacity-50 shadow-lg rotate-2 scale-105',
+          isCurrentlyDragging && 'opacity-50',
+          isSelected && 'ring-2 ring-primary border-primary',
+          isAgentRunning &&
+            'ring-2 ring-blue-500/50 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.3)]'
+        )}
+      >
+        <span className="sr-only">Status: {task.status}</span>
+        <div className="flex items-start gap-2">
+          {isSelecting && (
+            <button
+              onClick={handleCheckboxClick}
+              aria-label={isChecked ? 'Deselect task' : 'Select task'}
+              className={cn(
+                'h-4 w-4 rounded border-2 flex items-center justify-center flex-shrink-0 mt-0.5 transition-colors',
+                isChecked
+                  ? 'bg-primary border-primary text-primary-foreground'
+                  : 'border-muted-foreground/50 hover:border-primary'
+              )}
+            >
+              {isChecked && <Check className="h-3 w-3" />}
+            </button>
+          )}
+          <span className="text-muted-foreground mt-0.5 flex-shrink-0" aria-hidden="true">
+            {TypeIconComponent && <TypeIconComponent className="h-3.5 w-3.5" />}
+          </span>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-medium leading-tight truncate">{task.title}</h3>
+            {!isCompact && task.description && (
+              <div className="mt-1">
+                <p className="text-xs text-muted-foreground line-clamp-2">
+                  {plainDescriptionPreview}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 mt-2 flex-wrap">
+          {/* Agent running indicator */}
+          {isAgentRunning && (
+            <Tooltip
+              label={
+                <div>
+                  <p className="font-medium">Agent Active</p>
+                  <p className="text-sm">
+                    {agentNames[task.attempt?.agent || ''] || task.attempt?.agent} is working on
+                    this task
+                  </p>
+                </div>
+              }
+            >
+              <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1 animate-pulse">
+                <span className="sr-only">
+                  Agent {agentNames[task.attempt?.agent || ''] || task.attempt?.agent} is actively
+                  running on this task
+                </span>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                {agentNames[task.attempt?.agent || ''] || 'Agent'} running
+              </span>
+            </Tooltip>
+          )}
+          {isBlocked && (
+            <Tooltip
+              label={
+                <div>
+                  <p className="font-medium">Blocked by:</p>
+                  <ul className="text-sm">
+                    {blockerTitles?.map((title, i) => (
+                      <li key={i}>• {title}</li>
+                    ))}
+                  </ul>
+                </div>
+              }
+            >
+              <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1">
+                <Ban className="h-3 w-3" />
+                Blocked
+              </span>
+            </Tooltip>
+          )}
+          {/* Dependencies indicator */}
+          {(() => {
+            const dependsOnCount = task.dependencies?.depends_on?.length || 0;
+            const blocksCount = task.dependencies?.blocks?.length || 0;
+            const totalDeps = dependsOnCount + blocksCount;
+
+            if (totalDeps === 0) return null;
+
+            return (
+              <Tooltip
+                label={
+                  <div className="space-y-1">
+                    <p className="font-medium">Dependencies</p>
+                    {dependsOnCount > 0 && (
+                      <p className="text-sm">
+                        Depends on: {dependsOnCount} task{dependsOnCount !== 1 ? 's' : ''}
+                      </p>
+                    )}
+                    {blocksCount > 0 && (
+                      <p className="text-sm">
+                        Blocks: {blocksCount} task{blocksCount !== 1 ? 's' : ''}
+                      </p>
+                    )}
+                  </div>
+                }
+              >
+                <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 flex items-center gap-1">
+                  <Link2 className="h-3 w-3" aria-hidden="true" />
+                  {totalDeps}
+                </span>
+              </Tooltip>
+            );
+          })()}
+          {/* Checkpoint indicator */}
+          {task.checkpoint && (
+            <Tooltip
+              label={
+                <div className="space-y-1">
+                  <p className="font-medium">Checkpoint Saved</p>
+                  <p className="text-sm">Step {task.checkpoint.step}</p>
+                  {task.checkpoint.resumeCount && task.checkpoint.resumeCount > 0 && (
+                    <p className="text-sm flex items-center gap-1">
+                      <RotateCcw className="h-3 w-3" aria-hidden="true" />
+                      Resumed {task.checkpoint.resumeCount} time(s)
+                    </p>
+                  )}
+                </div>
+              }
+            >
+              <span className="text-xs px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 flex items-center gap-1">
+                <Save className="h-3 w-3" aria-hidden="true" />
+                <span className="sr-only">Checkpoint saved at </span>
+                Step {task.checkpoint.step}
+              </span>
+            </Tooltip>
+          )}
+          {/* Blocked reason badge (only shown in Blocked column) */}
+          {task.status === 'blocked' &&
+            task.blockedReason &&
+            (() => {
+              const info = blockedCategoryInfo[task.blockedReason.category];
+              const BlockedIcon = info.icon;
+              return (
+                <Tooltip
+                  label={
+                    <div>
+                      <p className="font-medium">{info.label}</p>
+                      {task.blockedReason.note && (
+                        <p className="text-sm text-muted-foreground mt-1">
+                          {sanitizeText(task.blockedReason.note)}
+                        </p>
+                      )}
+                    </div>
+                  }
+                >
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400 flex items-center gap-1">
+                    <BlockedIcon className="h-3 w-3" />
+                    {info.shortLabel}
+                  </span>
+                </Tooltip>
+              );
+            })()}
+          {/* Left side: project, type label, priority — controlled by board settings */}
+          {boardSettings.showProjectBadges && task.project && (
+            <span className={cn('text-xs px-1.5 py-0.5 rounded', projectColor)}>
+              {projectLabel}
+            </span>
+          )}
+          {boardSettings.showSprintBadges && task.sprint && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 flex items-center gap-1">
+              <Zap className="h-3 w-3" />
+              {getSprintLabel(sprints, task.sprint)}
+            </span>
+          )}
+          <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+            {typeLabel}
+          </span>
+          {boardSettings.showPriorityIndicators && (
+            <span
+              className={cn(
+                'text-xs px-1.5 py-0.5 rounded capitalize',
+                priorityColors[task.priority]
+              )}
+            >
+              {task.priority}
+            </span>
+          )}
+          {/* Attachment indicator */}
+          {task.attachments && task.attachments.length > 0 && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex items-center gap-1">
+              <Paperclip className="h-3 w-3" />
+              {task.attachments.length}
+            </span>
+          )}
+          {/* Deliverable indicator */}
+          {task.deliverables && task.deliverables.length > 0 && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex items-center gap-1">
+              <FileText className="h-3 w-3" />
+              {task.deliverables.length}
+            </span>
+          )}
+          {/* Plan indicator removed — planning was agent-internal */}
+          {/* Right side: subtask count + time tracking */}
+          {subtaskTotal > 0 && (
+            <Tooltip
+              label={
+                <div>
+                  <p className="font-medium">Subtasks</p>
+                  <p className="text-sm">
+                    {subtaskCompleted} of {subtaskTotal} completed
+                  </p>
+                </div>
+              }
+            >
+              <span
+                className={cn(
+                  'text-xs px-1.5 py-0.5 rounded flex items-center gap-1 ml-auto',
+                  allSubtasksDone
+                    ? 'bg-green-500/20 text-green-500'
+                    : 'bg-muted text-muted-foreground'
+                )}
+              >
+                <ListChecks className="h-3 w-3" />
+                {subtaskCompleted}/{subtaskTotal}
+              </span>
+            </Tooltip>
+          )}
+          {/* Verification progress indicator */}
+          {verificationTotal > 0 && (
+            <Tooltip
+              label={
+                <div>
+                  <p className="font-medium">Done Criteria</p>
+                  <p className="text-sm">
+                    {verificationChecked} of {verificationTotal} verified
+                  </p>
+                </div>
+              }
+            >
+              <span
+                className={cn(
+                  'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
+                  !subtaskTotal && 'ml-auto',
+                  allVerificationDone
+                    ? 'bg-green-500/20 text-green-500'
+                    : 'bg-muted text-muted-foreground'
+                )}
+              >
+                <ShieldCheck className="h-3 w-3" />
+                {verificationChecked}/{verificationTotal}
+              </span>
+            </Tooltip>
+          )}
+          {/* Time tracking indicator */}
+          {(task.timeTracking?.totalSeconds || task.timeTracking?.isRunning) && (
+            <span
+              className={cn(
+                'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
+                !subtaskTotal && !verificationTotal && !cardMetrics && 'ml-auto',
+                task.timeTracking?.isRunning
+                  ? 'bg-green-500/20 text-green-500'
+                  : 'bg-muted text-muted-foreground'
+              )}
+            >
+              {task.timeTracking?.isRunning ? (
+                <Timer className="h-3 w-3 animate-pulse" />
+              ) : (
+                <Clock className="h-3 w-3" />
+              )}
+              {formatDuration(task.timeTracking?.totalSeconds || 0)}
+            </span>
+          )}
+          {/* Agent run metrics (for done tasks only) */}
+          {cardMetrics && cardMetrics.totalRuns > 0 && (
+            <>
+              <Tooltip
+                label={
+                  <div>
+                    <p className="font-medium">
+                      {cardMetrics.totalRuns} run{cardMetrics.totalRuns !== 1 ? 's' : ''}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {cardMetrics.successfulRuns} successful, {cardMetrics.failedRuns} failed
+                    </p>
+                  </div>
+                }
+              >
+                <span
+                  className={cn(
+                    'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
+                    !subtaskTotal && !task.timeTracking?.totalSeconds && 'ml-auto',
+                    'bg-muted text-muted-foreground'
+                  )}
+                >
+                  <Play className="h-3 w-3" />
+                  {cardMetrics.totalRuns}
+                </span>
+              </Tooltip>
+              {cardMetrics.lastRunSuccess !== undefined && (
+                <Tooltip
+                  label={
+                    <p className="font-medium">
+                      Last run: {cardMetrics.lastRunSuccess ? 'Success' : 'Failed'}
+                    </p>
+                  }
+                >
+                  <span
+                    className={cn(
+                      'text-xs px-1 py-0.5 rounded flex items-center',
+                      cardMetrics.lastRunSuccess
+                        ? 'bg-green-500/20 text-green-500'
+                        : 'bg-red-500/20 text-red-500'
+                    )}
+                  >
+                    {cardMetrics.lastRunSuccess ? (
+                      <CheckCircle className="h-3 w-3" />
+                    ) : (
+                      <XCircle className="h-3 w-3" />
+                    )}
+                  </span>
+                </Tooltip>
+              )}
+              {cardMetrics.totalDurationMs > 0 && (
+                <Tooltip
+                  label={
+                    <div>
+                      <p className="font-medium">Total agent time</p>
+                      <p className="text-sm text-muted-foreground">
+                        {formatCompactDuration(cardMetrics.totalDurationMs)} across{' '}
+                        {cardMetrics.totalRuns} run{cardMetrics.totalRuns !== 1 ? 's' : ''}
+                      </p>
+                    </div>
+                  }
+                >
+                  <span className="text-xs px-1.5 py-0.5 rounded flex items-center gap-1 bg-muted text-muted-foreground">
+                    <Clock className="h-3 w-3" />
+                    {formatCompactDuration(cardMetrics.totalDurationMs)}
+                  </span>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </Tooltip>
   );
 }, areTaskCardPropsEqual);

--- a/web/src/components/templates/TemplateEditorDialog.tsx
+++ b/web/src/components/templates/TemplateEditorDialog.tsx
@@ -1,23 +1,15 @@
 import { useEffect, useState } from 'react';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import {
+  Button,
+  Group,
+  Modal,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+  Stack,
+  Tabs,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
 import { useCreateTemplate, useUpdateTemplate, type TaskTemplate } from '@/hooks/useTemplates';
 import { useTaskTypesManager, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useToast } from '@/hooks/useToast';
@@ -46,6 +38,26 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
   const createTemplate = useCreateTemplate();
   const updateTemplate = useUpdateTemplate();
   const isLoading = createTemplate.isPending || updateTemplate.isPending;
+  const categoryOptions = Object.entries(TEMPLATE_CATEGORIES).map(([key, { label }]) => ({
+    value: key,
+    label: `${getCategoryIcon(key)} ${label}`,
+  }));
+  const taskTypeOptions = taskTypes.map((taskType) => ({
+    value: taskType.id,
+    label: taskType.label,
+    icon: taskType.icon,
+  }));
+  const priorityOptions = [
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'urgent', label: 'Urgent' },
+  ];
+  const agentOptions = [
+    { value: 'claude-opus-4', label: 'Claude Opus 4' },
+    { value: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
+    { value: 'gpt-4', label: 'GPT-4' },
+  ];
 
   // Populate form when editing
   useEffect(() => {
@@ -126,153 +138,129 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{template ? 'Edit Template' : 'Create New Template'}</DialogTitle>
-        </DialogHeader>
-
-        <form onSubmit={handleSubmit} className="space-y-6">
+    <Modal
+      opened={open}
+      onClose={() => onOpenChange(false)}
+      title={template ? 'Edit Template' : 'Create New Template'}
+      size="lg"
+      centered
+    >
+      <form onSubmit={handleSubmit}>
+        <Stack gap="lg">
           <Tabs defaultValue="basic" className="w-full">
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="basic">Basic Info</TabsTrigger>
-              <TabsTrigger value="defaults">Task Defaults</TabsTrigger>
-            </TabsList>
+            <Tabs.List grow>
+              <Tabs.Tab value="basic">Basic Info</Tabs.Tab>
+              <Tabs.Tab value="defaults">Task Defaults</Tabs.Tab>
+            </Tabs.List>
 
             {/* Basic Info Tab */}
-            <TabsContent value="basic" className="space-y-4 mt-4">
+            <Tabs.Panel value="basic" className="space-y-4 mt-4">
               <div className="grid gap-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="name">
-                    Template Name <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="name"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder="e.g., Bug Fix, Feature Implementation"
-                    required
-                  />
-                </div>
+                <TextInput
+                  id="name"
+                  label={
+                    <>
+                      Template Name <span className="text-destructive">*</span>
+                    </>
+                  }
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g., Bug Fix, Feature Implementation"
+                  required
+                />
 
-                <div className="grid gap-2">
-                  <Label htmlFor="description">Description</Label>
-                  <Textarea
-                    id="description"
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder="What is this template used for?"
-                    rows={3}
-                  />
-                </div>
+                <Textarea
+                  id="description"
+                  label="Description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="What is this template used for?"
+                  rows={3}
+                />
 
-                <div className="grid gap-2">
-                  <Label htmlFor="category">Category</Label>
-                  <Select value={category} onValueChange={setCategory}>
-                    <SelectTrigger id="category">
-                      <SelectValue placeholder="Select a category..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.entries(TEMPLATE_CATEGORIES).map(([key, { label }]) => (
-                        <SelectItem key={key} value={key}>
-                          {getCategoryIcon(key)} {label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+                <Select
+                  id="category"
+                  label="Category"
+                  value={category || null}
+                  onChange={(value) => setCategory(value ?? '')}
+                  data={categoryOptions}
+                  placeholder="Select a category..."
+                />
               </div>
-            </TabsContent>
+            </Tabs.Panel>
 
             {/* Task Defaults Tab */}
-            <TabsContent value="defaults" className="space-y-4 mt-4">
+            <Tabs.Panel value="defaults" className="space-y-4 mt-4">
               <div className="grid gap-4">
                 <div className="grid grid-cols-2 gap-4">
-                  <div className="grid gap-2">
-                    <Label htmlFor="type">Default Type</Label>
-                    <Select value={type} onValueChange={setType}>
-                      <SelectTrigger id="type">
-                        <SelectValue placeholder="Any" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {taskTypes.map((taskType) => {
-                          const IconComponent = getTypeIcon(taskType.icon);
-                          return (
-                            <SelectItem key={taskType.id} value={taskType.id}>
-                              <div className="flex items-center gap-2">
-                                {IconComponent && <IconComponent className="h-4 w-4" />}
-                                {taskType.label}
-                              </div>
-                            </SelectItem>
-                          );
-                        })}
-                      </SelectContent>
-                    </Select>
-                  </div>
+                  <Select
+                    id="type"
+                    label="Default Type"
+                    value={type || null}
+                    onChange={(value) => setType(value ?? '')}
+                    data={taskTypeOptions}
+                    placeholder="Any"
+                    renderOption={({ option }) => {
+                      const iconName = taskTypeOptions.find(
+                        (entry) => entry.value === option.value
+                      )?.icon;
+                      const IconComponent = iconName ? getTypeIcon(iconName) : null;
+                      return (
+                        <Group gap="xs">
+                          {IconComponent && <IconComponent className="h-4 w-4" />}
+                          <span>{option.label}</span>
+                        </Group>
+                      );
+                    }}
+                  />
 
-                  <div className="grid gap-2">
-                    <Label htmlFor="priority">Default Priority</Label>
-                    <Select
-                      value={priority}
-                      onValueChange={(v) => setPriority(v as TaskPriority | '')}
-                    >
-                      <SelectTrigger id="priority">
-                        <SelectValue placeholder="None" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="low">Low</SelectItem>
-                        <SelectItem value="medium">Medium</SelectItem>
-                        <SelectItem value="high">High</SelectItem>
-                        <SelectItem value="urgent">Urgent</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
+                  <Select
+                    id="priority"
+                    label="Default Priority"
+                    value={priority || null}
+                    onChange={(value) => setPriority((value as TaskPriority | null) ?? '')}
+                    data={priorityOptions}
+                    placeholder="None"
+                  />
                 </div>
 
                 <div className="grid grid-cols-2 gap-4">
-                  <div className="grid gap-2">
-                    <Label htmlFor="project">Default Project</Label>
-                    <Input
-                      id="project"
-                      value={project}
-                      onChange={(e) => setProject(e.target.value)}
-                      placeholder="e.g., VK-001"
-                    />
-                  </div>
+                  <TextInput
+                    id="project"
+                    label="Default Project"
+                    value={project}
+                    onChange={(e) => setProject(e.target.value)}
+                    placeholder="e.g., VK-001"
+                  />
 
-                  <div className="grid gap-2">
-                    <Label htmlFor="agent">Default Agent</Label>
-                    <Select value={agent} onValueChange={(v) => setAgent(v as AgentType | '')}>
-                      <SelectTrigger id="agent">
-                        <SelectValue placeholder="None" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="claude-opus-4">Claude Opus 4</SelectItem>
-                        <SelectItem value="claude-sonnet-4">Claude Sonnet 4</SelectItem>
-                        <SelectItem value="gpt-4">GPT-4</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
+                  <Select
+                    id="agent"
+                    label="Default Agent"
+                    value={agent || null}
+                    onChange={(value) => setAgent((value as AgentType | null) ?? '')}
+                    data={agentOptions}
+                    placeholder="None"
+                  />
                 </div>
 
                 <div className="grid gap-2">
-                  <Label htmlFor="descriptionTemplate">Description Template</Label>
                   <Textarea
                     id="descriptionTemplate"
+                    label="Description Template"
                     value={descriptionTemplate}
                     onChange={(e) => setDescriptionTemplate(e.target.value)}
                     placeholder="Template for task description (can include variables like {{date}}, {{project}})"
                     rows={4}
                   />
-                  <p className="text-xs text-muted-foreground">
+                  <Text size="xs" c="dimmed">
                     Tip: Use variables like {'{{date}}'} to auto-populate values
-                  </p>
+                  </Text>
                 </div>
               </div>
-            </TabsContent>
+            </Tabs.Panel>
           </Tabs>
 
-          <DialogFooter>
+          <Group justify="flex-end">
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
@@ -280,9 +268,9 @@ export function TemplateEditorDialog({ template, open, onOpenChange }: TemplateE
               {isLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               {template ? 'Update Template' : 'Create Template'}
             </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
   );
 }

--- a/web/src/components/templates/TemplatePreviewPanel.tsx
+++ b/web/src/components/templates/TemplatePreviewPanel.tsx
@@ -1,5 +1,4 @@
-import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge, ScrollArea } from '@mantine/core';
 import type { TaskTemplate } from '@/hooks/useTemplates';
 import { getCategoryIcon, getCategoryLabel } from '@/lib/template-categories';
 import { Calendar, Flag, FileText, ClipboardList, Link2 } from 'lucide-react';
@@ -15,15 +14,15 @@ export function TemplatePreviewPanel({ template }: TemplatePreviewPanelProps) {
   const getPriorityColor = (priority?: string) => {
     switch (priority) {
       case 'urgent':
-        return 'bg-red-500/20 text-red-700 dark:text-red-400 border-red-500/50';
+        return 'red';
       case 'high':
-        return 'bg-orange-500/20 text-orange-700 dark:text-orange-400 border-orange-500/50';
+        return 'orange';
       case 'medium':
-        return 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-400 border-yellow-500/50';
+        return 'yellow';
       case 'low':
-        return 'bg-green-500/20 text-green-700 dark:text-green-400 border-green-500/50';
+        return 'green';
       default:
-        return 'bg-gray-500/20 text-gray-700 dark:text-gray-400 border-gray-500/50';
+        return 'gray';
     }
   };
 
@@ -42,7 +41,7 @@ export function TemplatePreviewPanel({ template }: TemplatePreviewPanelProps) {
         {template.category && (
           <div className="space-y-2">
             <label className="text-xs font-semibold text-muted-foreground">CATEGORY</label>
-            <Badge variant="outline" className="text-sm">
+            <Badge variant="outline" color="gray" tt="none">
               {getCategoryIcon(template.category)}
               {getCategoryLabel(template.category)}
             </Badge>
@@ -70,7 +69,9 @@ export function TemplatePreviewPanel({ template }: TemplatePreviewPanelProps) {
               <div className="flex items-center gap-2">
                 <Flag className="h-4 w-4 text-muted-foreground" />
                 <Badge
-                  className={`capitalize border ${getPriorityColor(template.taskDefaults.priority)}`}
+                  color={getPriorityColor(template.taskDefaults.priority)}
+                  variant="light"
+                  tt="capitalize"
                 >
                   {template.taskDefaults.priority}
                 </Badge>

--- a/web/src/components/templates/TemplatesPage.tsx
+++ b/web/src/components/templates/TemplatesPage.tsx
@@ -10,28 +10,19 @@
  */
 
 import { useState, useMemo } from 'react';
-import { useTemplates, useDeleteTemplate } from '@/hooks/useTemplates';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  ScrollArea,
   Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { useTemplates, useDeleteTemplate } from '@/hooks/useTemplates';
 import { ArrowLeft, Plus, Trash2, Eye, Edit2, FileText } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import type { TaskTemplate } from '@/hooks/useTemplates';
@@ -56,6 +47,13 @@ export function TemplatesPage({ onBack }: TemplatesPageProps) {
   const { toast } = useToast();
   const { data: templates = [], isLoading } = useTemplates();
   const deleteTemplate = useDeleteTemplate();
+  const categoryOptions = [
+    { value: 'all', label: 'All Categories' },
+    ...Object.entries(TEMPLATE_CATEGORIES).map(([key, { label }]) => ({
+      value: key,
+      label,
+    })),
+  ];
 
   // Filter templates
   const filteredTemplates = useMemo(() => {
@@ -95,7 +93,7 @@ export function TemplatesPage({ onBack }: TemplatesPageProps) {
         setSelectedTemplate(null);
       }
       setTemplateToDelete(null);
-    } catch (err) {
+    } catch {
       toast({
         title: 'Error',
         description: 'Failed to delete template',
@@ -115,9 +113,15 @@ export function TemplatesPage({ onBack }: TemplatesPageProps) {
       <div className="border-b bg-card px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" onClick={onBack} aria-label="Back to board">
+            <ActionIcon
+              type="button"
+              variant="subtle"
+              color="gray"
+              onClick={onBack}
+              aria-label="Back to board"
+            >
               <ArrowLeft className="h-4 w-4" />
-            </Button>
+            </ActionIcon>
             <div>
               <h1 className="text-2xl font-bold">Task Templates</h1>
               <p className="text-sm text-muted-foreground">
@@ -138,25 +142,20 @@ export function TemplatesPage({ onBack }: TemplatesPageProps) {
         <div className="flex-1 flex flex-col gap-4 min-w-0">
           {/* Filters */}
           <div className="flex gap-3">
-            <Input
+            <TextInput
               placeholder="Search templates..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="flex-1"
             />
-            <Select value={categoryFilter} onValueChange={setCategoryFilter}>
-              <SelectTrigger className="w-40">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Categories</SelectItem>
-                {Object.entries(TEMPLATE_CATEGORIES).map(([key, { label }]) => (
-                  <SelectItem key={key} value={key}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Select
+              value={categoryFilter}
+              onChange={(value) => setCategoryFilter(value ?? 'all')}
+              data={categoryOptions}
+              allowDeselect={false}
+              className="w-40"
+              aria-label="Filter templates by category"
+            />
           </div>
 
           {/* Templates Grid */}
@@ -202,18 +201,18 @@ export function TemplatesPage({ onBack }: TemplatesPageProps) {
                         {/* Category and Type Badge */}
                         <div className="flex flex-wrap gap-2">
                           {template.category && (
-                            <Badge variant="outline" className="text-xs">
+                            <Badge variant="outline" color="gray" size="xs" tt="none">
                               {getCategoryIcon(template.category)}
                               {getCategoryLabel(template.category)}
                             </Badge>
                           )}
                           {template.taskDefaults?.type && (
-                            <Badge variant="secondary" className="text-xs">
+                            <Badge variant="light" color="gray" size="xs" tt="none">
                               {template.taskDefaults.type}
                             </Badge>
                           )}
                           {template.taskDefaults?.priority && (
-                            <Badge variant="secondary" className="text-xs">
+                            <Badge variant="light" color="gray" size="xs" tt="none">
                               {template.taskDefaults.priority}
                             </Badge>
                           )}
@@ -261,17 +260,19 @@ export function TemplatesPage({ onBack }: TemplatesPageProps) {
                             <Edit2 className="h-3.5 w-3.5 mr-1" />
                             Edit
                           </Button>
-                          <Button
+                          <ActionIcon
+                            type="button"
                             variant="outline"
                             size="sm"
-                            className="text-destructive hover:text-destructive"
+                            color="red"
                             onClick={(e) => {
                               e.stopPropagation();
                               setTemplateToDelete(template);
                             }}
+                            aria-label={`Delete ${template.name}`}
                           >
                             <Trash2 className="h-3.5 w-3.5" />
-                          </Button>
+                          </ActionIcon>
                         </div>
                       </div>
                     </div>
@@ -298,53 +299,47 @@ export function TemplatesPage({ onBack }: TemplatesPageProps) {
       />
 
       {/* Delete Confirmation */}
-      <AlertDialog
-        open={!!templateToDelete}
-        onOpenChange={(open) => !open && setTemplateToDelete(null)}
+      <Modal
+        opened={!!templateToDelete}
+        onClose={() => setTemplateToDelete(null)}
+        title="Delete Template?"
+        centered
       >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Template?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete "{templateToDelete?.name}"? This action cannot be
-              undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Are you sure you want to delete "{templateToDelete?.name}"? This action cannot be
+            undone.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="subtle" color="gray" onClick={() => setTemplateToDelete(null)}>
+              Cancel
+            </Button>
+            <Button color="red" onClick={handleDeleteConfirm}>
               Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
 
       {/* Preview Dialog */}
-      {showPreview && selectedTemplate && (
-        <div
-          className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm"
-          onClick={() => setShowPreview(false)}
-        >
-          <div
-            className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-2xl max-h-[80vh]"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="rounded-lg shadow-lg overflow-hidden border bg-card">
-              <div className="p-6 overflow-y-auto max-h-[80vh]">
-                <TemplatePreviewPanel template={selectedTemplate} />
-                <div className="mt-6 flex justify-end">
-                  <Button variant="outline" onClick={() => setShowPreview(false)}>
-                    Close
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <Modal
+        opened={showPreview && !!selectedTemplate}
+        onClose={() => setShowPreview(false)}
+        title="Template Preview"
+        size="lg"
+        centered
+      >
+        {selectedTemplate && (
+          <Stack gap="md">
+            <TemplatePreviewPanel template={selectedTemplate} />
+            <Group justify="flex-end">
+              <Button variant="outline" onClick={() => setShowPreview(false)}>
+                Close
+              </Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/web/src/components/ui/MarkdownEditor.tsx
+++ b/web/src/components/ui/MarkdownEditor.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { ActionIcon, Tabs, Textarea } from '@mantine/core';
 import { Bold, Italic, Code, Link2, List, Heading2, Code2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { MarkdownRenderer } from './MarkdownRenderer';
 
@@ -183,14 +181,15 @@ export function MarkdownEditor({
   const previewContent = useMemo(() => value?.trim(), [value]);
 
   return (
-    <Tabs value={mode} onValueChange={setMode} className="space-y-2">
+    <Tabs value={mode} onChange={(value) => value && setMode(value)} className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
         <div className="flex flex-wrap items-center gap-1">
           {TOOLBAR_BUTTONS.map(({ id, label, icon: Icon }) => (
-            <Button
+            <ActionIcon
               key={id}
-              variant="ghost"
-              size="icon"
+              variant="subtle"
+              color="gray"
+              size="sm"
               className="h-7 w-7 text-muted-foreground hover:text-foreground"
               aria-label={label}
               onClick={() => handleToolbarAction(id)}
@@ -198,20 +197,20 @@ export function MarkdownEditor({
               disabled={disabled}
             >
               <Icon className="h-3.5 w-3.5" />
-            </Button>
+            </ActionIcon>
           ))}
         </div>
-        <TabsList className="ml-auto">
-          <TabsTrigger value="edit" className="text-xs">
+        <Tabs.List className="ml-auto">
+          <Tabs.Tab value="edit" className="text-xs">
             Edit
-          </TabsTrigger>
-          <TabsTrigger value="preview" className="text-xs">
+          </Tabs.Tab>
+          <Tabs.Tab value="preview" className="text-xs">
             Preview
-          </TabsTrigger>
-        </TabsList>
+          </Tabs.Tab>
+        </Tabs.List>
       </div>
 
-      <TabsContent value="edit" className="mt-0">
+      <Tabs.Panel value="edit" className="mt-0">
         <Textarea
           ref={textareaRef}
           value={value}
@@ -222,9 +221,9 @@ export function MarkdownEditor({
           style={{ minHeight, maxHeight }}
           disabled={disabled}
         />
-      </TabsContent>
+      </Tabs.Panel>
 
-      <TabsContent value="preview" className="mt-0">
+      <Tabs.Panel value="preview" className="mt-0">
         <div
           className={cn(
             'rounded-md border border-border bg-muted/30 p-3 text-sm text-foreground/80',
@@ -234,7 +233,7 @@ export function MarkdownEditor({
         >
           {previewContent ? <MarkdownRenderer content={value} /> : <span>Nothing to preview</span>}
         </div>
-      </TabsContent>
+      </Tabs.Panel>
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary
- Moves the remaining enabled feature surfaces off compatibility UI wrappers and onto direct Mantine primitives.
- Covers templates, archive/sidebar suggestions, desktop onboarding, task-card tooltips, markdown editing controls, and remaining settings confirmations.
- Adds a regression test that fails if active feature components reintroduce the old wrapper imports.

## Verification
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test -- src/__tests__/final-surface-wrapper-cleanup.test.tsx src/__tests__/archive-backlog-mantine.test.tsx src/__tests__/settings-manage-mantine.test.tsx src/__tests__/settings-general-mantine.test.tsx src/__tests__/settings-security-mantine.test.tsx src/__tests__/desktop-onboarding.test.tsx src/__tests__/TaskCard.test.tsx
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- wrapper import rg scan
- Browser smoke at http://127.0.0.1:3000/: setup screen rendered, inputs visible, no console errors/warnings

## Notes
- Leaves the remaining compatibility wrapper internals in place for alert-dialog/dialog/sheet until dead-code removal and the #418 QA gate.