### PR TITLE
Add work product search command registry

### DIFF
--- a/web/src/__tests__/SearchDialog.test.tsx
+++ b/web/src/__tests__/SearchDialog.test.tsx
@@ -47,19 +47,32 @@ describe('SearchDialog', () => {
           snippet: 'Search active tasks, archive, and docs.',
           score: 4,
         },
+        {
+          id: 'wp-search-brief',
+          title: 'Search implementation brief',
+          path: '/work-products/wp-search-brief',
+          collection: 'work-products',
+          snippet: 'Durable work product with evidence and follow-up notes.',
+          score: 3,
+        },
       ],
     });
 
     const { baseElement } = renderWithProviders(<SearchDialog open onOpenChange={vi.fn()} />);
 
-    expect(screen.getByRole('dialog', { name: 'Search Tasks and Docs' })).toBeDefined();
-    expect(screen.getByRole('textbox', { name: 'Search tasks and docs' })).toBeDefined();
+    expect(
+      screen.getByRole('dialog', { name: 'Search Tasks, Docs, and Work Products' })
+    ).toBeDefined();
+    expect(
+      screen.getByRole('textbox', { name: 'Search tasks, docs, and work products' })
+    ).toBeDefined();
     expect(screen.getByRole('combobox', { name: 'Search backend' })).toBeDefined();
     expect(screen.getByRole('checkbox', { name: 'Active' })).toBeDefined();
+    expect(screen.getByRole('checkbox', { name: 'Work Products' })).toBeDefined();
     expect(baseElement.querySelector('.mantine-Modal-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Select-root')).toBeDefined();
-    expect(baseElement.querySelectorAll('.mantine-Checkbox-root').length).toBe(3);
+    expect(baseElement.querySelectorAll('.mantine-Checkbox-root').length).toBe(4);
     expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
@@ -72,10 +85,12 @@ describe('SearchDialog', () => {
     expect(queryMock).toHaveBeenCalledWith({
       query: 'qmd',
       backend: 'auto',
-      collections: ['tasks-active', 'tasks-archive', 'docs'],
+      collections: ['tasks-active', 'tasks-archive', 'docs', 'work-products'],
       limit: 12,
     });
     expect(await screen.findByText('Build search UI')).toBeDefined();
+    expect(await screen.findByText('Search implementation brief')).toBeDefined();
+    expect(screen.getByText('/work-products/wp-search-brief')).toBeDefined();
     expect(screen.getByText('Fallback')).toBeDefined();
     expect(screen.getByText('qmd unavailable')).toBeDefined();
   });

--- a/web/src/__tests__/command-registry.test.ts
+++ b/web/src/__tests__/command-registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCommandRegistry } from '@/lib/command-registry';
+import { VIEW_DEFINITIONS } from '@/lib/views';
+
+describe('command registry', () => {
+  it('exposes shared command descriptors without duplicate ids', () => {
+    const commands = createCommandRegistry({ theme: 'dark' });
+    const ids = commands.map((command) => command.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain('new-task');
+    expect(ids).toContain('open-search');
+    expect(ids).toContain('move-todo');
+  });
+
+  it('registers navigation commands from the shared view definitions', () => {
+    const commands = createCommandRegistry({ theme: 'dark' });
+
+    for (const view of VIEW_DEFINITIONS) {
+      const command = commands.find((item) => item.id === `go-${view.view}`);
+
+      expect(command?.label).toBe(view.commandLabel);
+      expect(command?.action).toEqual({ type: 'navigate-view', view: view.view });
+      expect(command?.keywords).toBe(view.keywords);
+    }
+  });
+
+  it('tracks theme-sensitive command labels and the expanded search surface', () => {
+    const darkCommands = createCommandRegistry({ theme: 'dark' });
+    const lightCommands = createCommandRegistry({ theme: 'light' });
+
+    expect(darkCommands.find((command) => command.id === 'toggle-theme')?.label).toBe(
+      'Switch to Light Mode'
+    );
+    expect(lightCommands.find((command) => command.id === 'toggle-theme')?.label).toBe(
+      'Switch to Dark Mode'
+    );
+    expect(darkCommands.find((command) => command.id === 'open-search')?.label).toBe(
+      'Search Tasks, Docs, and Work Products'
+    );
+  });
+
+  it('marks board-context commands unavailable until a task is selected', () => {
+    const commands = createCommandRegistry({ theme: 'dark' });
+    const boardCommand = commands.find((command) => command.id === 'move-done');
+
+    expect(boardCommand?.disabledReason).toBe('Select a task on the board to use this shortcut.');
+  });
+});

--- a/web/src/components/layout/CommandPalette.tsx
+++ b/web/src/components/layout/CommandPalette.tsx
@@ -1,4 +1,13 @@
-import { lazy, Suspense, useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import {
+  lazy,
+  Suspense,
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+  type ReactNode,
+} from 'react';
 import {
   Box,
   Group,
@@ -34,7 +43,12 @@ import {
 } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { cn } from '@/lib/utils';
-import { VIEW_DEFINITIONS, type ViewIcon } from '@/lib/views';
+import {
+  createCommandRegistry,
+  type CommandDescriptor,
+  type CommandIcon,
+} from '@/lib/command-registry';
+import type { ViewIcon } from '@/lib/views';
 
 const SearchDialog = lazy(() =>
   import('@/components/search').then((mod) => ({
@@ -55,19 +69,23 @@ const VIEW_ICONS: Record<ViewIcon, LucideIcon> = {
   Workflow,
 };
 
-function renderViewIcon(icon: ViewIcon) {
-  const Icon = VIEW_ICONS[icon];
+const COMMAND_ICONS: Record<CommandIcon, LucideIcon> = {
+  ...VIEW_ICONS,
+  ArrowRight,
+  Keyboard,
+  Moon,
+  Plus,
+  Sparkles,
+  Sun,
+};
+
+function renderCommandIcon(icon: CommandIcon) {
+  const Icon = COMMAND_ICONS[icon];
   return <Icon className="h-4 w-4" />;
 }
 
-interface CommandItem {
-  id: string;
-  label: string;
-  shortcut?: string;
-  icon: React.ReactNode;
-  category: string;
-  action: () => void;
-  keywords?: readonly string[];
+interface CommandItem extends CommandDescriptor {
+  iconNode: ReactNode;
 }
 
 export function CommandPalette() {
@@ -88,111 +106,35 @@ export function CommandPalette() {
     setSearchOpen(true);
   }, []);
 
+  const executeCommand = useCallback(
+    (cmd: CommandDescriptor) => {
+      switch (cmd.action.type) {
+        case 'open-create-task':
+          openCreateDialog();
+          return;
+        case 'toggle-theme':
+          setTheme(theme === 'dark' ? 'light' : 'dark');
+          return;
+        case 'open-search':
+          openSearchDialog();
+          return;
+        case 'navigate-view':
+          setView(cmd.action.view);
+          return;
+        case 'board-shortcut':
+          return;
+      }
+    },
+    [openCreateDialog, openSearchDialog, setTheme, setView, theme]
+  );
+
   const commands: CommandItem[] = useMemo(
-    () => [
-      // Actions
-      {
-        id: 'new-task',
-        label: 'New Task',
-        shortcut: 'C',
-        icon: <Plus className="h-4 w-4" />,
-        category: 'Actions',
-        action: () => openCreateDialog(),
-        keywords: ['create', 'add', 'task'],
-      },
-      {
-        id: 'toggle-theme',
-        label: theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode',
-        icon: theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />,
-        category: 'Actions',
-        action: () => setTheme(theme === 'dark' ? 'light' : 'dark'),
-        keywords: ['theme', 'dark', 'light', 'mode', 'appearance'],
-      },
-      {
-        id: 'open-search',
-        label: 'Search Tasks and Docs',
-        icon: <Sparkles className="h-4 w-4" />,
-        category: 'Actions',
-        action: openSearchDialog,
-        keywords: ['qmd', 'semantic', 'retrieval', 'docs', 'archive'],
-      },
-
-      ...VIEW_DEFINITIONS.map((definition) => ({
-        id: `go-${definition.view}`,
-        label: definition.commandLabel,
-        shortcut: definition.view === 'board' ? 'B' : undefined,
-        icon: renderViewIcon(definition.icon),
-        category: 'Navigation',
-        action: () => setView(definition.view),
-        keywords: definition.keywords,
+    () =>
+      createCommandRegistry({ theme }).map((command) => ({
+        ...command,
+        iconNode: renderCommandIcon(command.icon),
       })),
-
-      // Board shortcuts
-      {
-        id: 'move-todo',
-        label: 'Move Task → To Do',
-        shortcut: '1',
-        icon: <ArrowRight className="h-4 w-4" />,
-        category: 'Board',
-        action: () => {},
-        keywords: ['status', 'move'],
-      },
-      {
-        id: 'move-inprogress',
-        label: 'Move Task → In Progress',
-        shortcut: '2',
-        icon: <ArrowRight className="h-4 w-4" />,
-        category: 'Board',
-        action: () => {},
-        keywords: ['status', 'move'],
-      },
-      {
-        id: 'move-blocked',
-        label: 'Move Task → Blocked',
-        shortcut: '3',
-        icon: <ArrowRight className="h-4 w-4" />,
-        category: 'Board',
-        action: () => {},
-        keywords: ['status', 'move'],
-      },
-      {
-        id: 'move-done',
-        label: 'Move Task → Done',
-        shortcut: '4',
-        icon: <ArrowRight className="h-4 w-4" />,
-        category: 'Board',
-        action: () => {},
-        keywords: ['status', 'move', 'complete'],
-      },
-      {
-        id: 'nav-up',
-        label: 'Select Previous Task',
-        shortcut: 'K / ↑',
-        icon: <Keyboard className="h-4 w-4" />,
-        category: 'Board',
-        action: () => {},
-        keywords: ['navigate', 'up'],
-      },
-      {
-        id: 'nav-down',
-        label: 'Select Next Task',
-        shortcut: 'J / ↓',
-        icon: <Keyboard className="h-4 w-4" />,
-        category: 'Board',
-        action: () => {},
-        keywords: ['navigate', 'down'],
-      },
-      {
-        id: 'open-task',
-        label: 'Open Selected Task',
-        shortcut: 'Enter',
-        icon: <Keyboard className="h-4 w-4" />,
-        category: 'Board',
-        action: () => {},
-        keywords: ['view', 'detail'],
-      },
-    ],
-    [openCreateDialog, openSearchDialog, setView, theme, setTheme]
+    [theme]
   );
 
   // Filter commands by query
@@ -203,7 +145,8 @@ export function CommandPalette() {
       (cmd) =>
         cmd.label.toLowerCase().includes(q) ||
         cmd.category.toLowerCase().includes(q) ||
-        cmd.keywords?.some((k) => k.includes(q))
+        cmd.keywords?.some((keyword) => keyword.toLowerCase().includes(q)) ||
+        cmd.aliases?.some((alias) => alias.toLowerCase().includes(q))
     );
   }, [commands, query]);
 
@@ -252,11 +195,15 @@ export function CommandPalette() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  const runCommand = useCallback((cmd: CommandItem) => {
-    setOpen(false);
-    // Small delay so dialog closes before action fires
-    setTimeout(() => cmd.action(), 50);
-  }, []);
+  const runCommand = useCallback(
+    (cmd: CommandItem) => {
+      if (cmd.disabledReason) return;
+      setOpen(false);
+      // Small delay so dialog closes before action fires
+      setTimeout(() => executeCommand(cmd), 50);
+    },
+    [executeCommand]
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
@@ -347,11 +294,15 @@ export function CommandPalette() {
                         <UnstyledButton
                           key={cmd.id}
                           data-index={idx}
+                          disabled={Boolean(cmd.disabledReason)}
+                          title={cmd.disabledReason}
                           className={cn(
                             'flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm transition-colors',
-                            idx === selectedIndex
-                              ? 'bg-primary/10 text-primary'
-                              : 'text-foreground hover:bg-muted/50'
+                            cmd.disabledReason
+                              ? 'cursor-not-allowed opacity-60'
+                              : idx === selectedIndex
+                                ? 'bg-primary/10 text-primary'
+                                : 'text-foreground hover:bg-muted/50'
                           )}
                           onClick={() => runCommand(cmd)}
                           onMouseEnter={() => setSelectedIndex(idx)}
@@ -362,7 +313,7 @@ export function CommandPalette() {
                               idx === selectedIndex ? 'text-primary' : 'text-muted-foreground'
                             )}
                           >
-                            {cmd.icon}
+                            {cmd.iconNode}
                           </span>
                           <span className="flex-1 text-left">{cmd.label}</span>
                           {cmd.shortcut && (

--- a/web/src/components/search/SearchDialog.tsx
+++ b/web/src/components/search/SearchDialog.tsx
@@ -20,6 +20,7 @@ const COLLECTIONS: { id: SearchCollection; label: string }[] = [
   { id: 'tasks-active', label: 'Active' },
   { id: 'tasks-archive', label: 'Archive' },
   { id: 'docs', label: 'Docs' },
+  { id: 'work-products', label: 'Work Products' },
 ];
 
 const BACKENDS: { id: SearchBackend; label: string }[] = [
@@ -37,6 +38,7 @@ interface SearchDialogProps {
 function collectionIcon(collection: string) {
   if (collection === 'docs') return FileText;
   if (collection === 'tasks-archive') return Archive;
+  if (collection === 'work-products') return Sparkles;
   return Search;
 }
 
@@ -98,7 +100,7 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
         <Group gap="xs">
           <span className="flex items-center gap-2 text-base font-semibold">
             <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
-            Search Tasks and Docs
+            Search Tasks, Docs, and Work Products
           </span>
         </Group>
       }
@@ -106,7 +108,7 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
     >
       <div className="border-b px-5 pb-4">
         <Text size="sm" c="dimmed">
-          Find active work, archived decisions, and project documentation.
+          Find active work, archived decisions, durable work products, and project documentation.
         </Text>
       </div>
 
@@ -122,8 +124,8 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
             <TextInput
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search task titles, descriptions, notes, docs..."
-              aria-label="Search tasks and docs"
+              placeholder="Search task titles, notes, docs, work products..."
+              aria-label="Search tasks, docs, and work products"
               leftSection={<Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
               autoFocus
             />
@@ -183,7 +185,7 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
         <ScrollArea h={460} className="rounded-md border">
           {!response && !error ? (
             <div className="px-4 py-10 text-center text-sm text-muted-foreground">
-              Search across task markdown and docs.
+              Search across task markdown, docs, and work products.
             </div>
           ) : response && response.results.length === 0 ? (
             <div className="px-4 py-10 text-center text-sm text-muted-foreground">

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -1,7 +1,7 @@
 import { API_BASE, handleResponse } from './helpers';
 
 export type SearchBackend = 'auto' | 'qmd' | 'keyword';
-export type SearchCollection = 'tasks-active' | 'tasks-archive' | 'docs';
+export type SearchCollection = 'tasks-active' | 'tasks-archive' | 'docs' | 'work-products';
 
 export interface SearchRequest {
   query: string;

--- a/web/src/lib/command-registry.ts
+++ b/web/src/lib/command-registry.ts
@@ -1,0 +1,176 @@
+import { VIEW_DEFINITIONS, type AppView, type ViewIcon } from './views';
+
+export type ThemeMode = 'dark' | 'light';
+
+export type CommandCategory = 'Actions' | 'Navigation' | 'Board';
+
+export type CommandIcon =
+  | ViewIcon
+  | 'ArrowRight'
+  | 'Keyboard'
+  | 'Moon'
+  | 'Plus'
+  | 'Sparkles'
+  | 'Sun';
+
+export type BoardShortcutCommand =
+  | 'move-todo'
+  | 'move-inprogress'
+  | 'move-blocked'
+  | 'move-done'
+  | 'nav-up'
+  | 'nav-down'
+  | 'open-task';
+
+export type CommandAction =
+  | { type: 'open-create-task' }
+  | { type: 'toggle-theme' }
+  | { type: 'open-search' }
+  | { type: 'navigate-view'; view: AppView }
+  | { type: 'board-shortcut'; shortcut: BoardShortcutCommand };
+
+export interface CommandDescriptor {
+  id: string;
+  label: string;
+  category: CommandCategory;
+  action: CommandAction;
+  icon: CommandIcon;
+  shortcut?: string;
+  keywords?: readonly string[];
+  aliases?: readonly string[];
+  disabledReason?: string;
+}
+
+const SELECTED_TASK_REQUIRED = 'Select a task on the board to use this shortcut.';
+
+const BOARD_SHORTCUTS: readonly CommandDescriptor[] = [
+  {
+    id: 'move-todo',
+    label: 'Move Task to To Do',
+    shortcut: '1',
+    icon: 'ArrowRight',
+    category: 'Board',
+    action: { type: 'board-shortcut', shortcut: 'move-todo' },
+    keywords: ['status', 'move', 'todo'],
+    disabledReason: SELECTED_TASK_REQUIRED,
+  },
+  {
+    id: 'move-inprogress',
+    label: 'Move Task to In Progress',
+    shortcut: '2',
+    icon: 'ArrowRight',
+    category: 'Board',
+    action: { type: 'board-shortcut', shortcut: 'move-inprogress' },
+    keywords: ['status', 'move', 'progress'],
+    disabledReason: SELECTED_TASK_REQUIRED,
+  },
+  {
+    id: 'move-blocked',
+    label: 'Move Task to Blocked',
+    shortcut: '3',
+    icon: 'ArrowRight',
+    category: 'Board',
+    action: { type: 'board-shortcut', shortcut: 'move-blocked' },
+    keywords: ['status', 'move', 'blocked'],
+    disabledReason: SELECTED_TASK_REQUIRED,
+  },
+  {
+    id: 'move-done',
+    label: 'Move Task to Done',
+    shortcut: '4',
+    icon: 'ArrowRight',
+    category: 'Board',
+    action: { type: 'board-shortcut', shortcut: 'move-done' },
+    keywords: ['status', 'move', 'complete', 'done'],
+    disabledReason: SELECTED_TASK_REQUIRED,
+  },
+  {
+    id: 'nav-up',
+    label: 'Select Previous Task',
+    shortcut: 'K / Up',
+    icon: 'Keyboard',
+    category: 'Board',
+    action: { type: 'board-shortcut', shortcut: 'nav-up' },
+    keywords: ['navigate', 'up', 'previous'],
+    disabledReason: SELECTED_TASK_REQUIRED,
+  },
+  {
+    id: 'nav-down',
+    label: 'Select Next Task',
+    shortcut: 'J / Down',
+    icon: 'Keyboard',
+    category: 'Board',
+    action: { type: 'board-shortcut', shortcut: 'nav-down' },
+    keywords: ['navigate', 'down', 'next'],
+    disabledReason: SELECTED_TASK_REQUIRED,
+  },
+  {
+    id: 'open-task',
+    label: 'Open Selected Task',
+    shortcut: 'Enter',
+    icon: 'Keyboard',
+    category: 'Board',
+    action: { type: 'board-shortcut', shortcut: 'open-task' },
+    keywords: ['view', 'detail', 'open'],
+    disabledReason: SELECTED_TASK_REQUIRED,
+  },
+];
+
+export interface CommandRegistryOptions {
+  theme: ThemeMode;
+  includeBoardShortcuts?: boolean;
+}
+
+export function createCommandRegistry({
+  theme,
+  includeBoardShortcuts = true,
+}: CommandRegistryOptions): readonly CommandDescriptor[] {
+  const commands: CommandDescriptor[] = [
+    {
+      id: 'new-task',
+      label: 'New Task',
+      shortcut: 'C',
+      icon: 'Plus',
+      category: 'Actions',
+      action: { type: 'open-create-task' },
+      keywords: ['create', 'add', 'task'],
+      aliases: ['task new', 'create task'],
+    },
+    {
+      id: 'toggle-theme',
+      label: theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode',
+      icon: theme === 'dark' ? 'Sun' : 'Moon',
+      category: 'Actions',
+      action: { type: 'toggle-theme' },
+      keywords: ['theme', 'dark', 'light', 'mode', 'appearance'],
+      aliases: ['appearance'],
+    },
+    {
+      id: 'open-search',
+      label: 'Search Tasks, Docs, and Work Products',
+      icon: 'Sparkles',
+      category: 'Actions',
+      action: { type: 'open-search' },
+      keywords: ['qmd', 'semantic', 'retrieval', 'docs', 'archive', 'work products'],
+      aliases: ['find', 'universal search', 'command search'],
+    },
+    ...VIEW_DEFINITIONS.map(
+      (definition): CommandDescriptor => ({
+        id: `go-${definition.view}`,
+        label: definition.commandLabel,
+        shortcut: definition.view === 'board' ? 'B' : undefined,
+        icon: definition.icon,
+        category: 'Navigation',
+        action: { type: 'navigate-view', view: definition.view },
+        keywords: definition.keywords,
+        aliases: [definition.label.toLowerCase()],
+      })
+    ),
+  ];
+
+  if (includeBoardShortcuts) {
+    commands.push(...BOARD_SHORTCUTS);
+  }
+
+  return commands;
+}


### PR DESCRIPTION
## Summary
- Expose work products as a first-class web search collection so the existing server index is reachable from the search dialog.
- Move command palette metadata into a shared command registry for command center, native menu, shortcut, and alias reuse.
- Mark board-context commands unavailable until a task selection context exists instead of leaving silent no-op actions.

## Validation
- pnpm --filter @veritas-kanban/web test -- SearchDialog.test.tsx command-dialogs-mantine.test.tsx command-registry.test.ts
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- Browser load smoke on localhost with temp API: no connection error, no framework overlay, no console errors. Full command/search interaction remained covered by component tests because this browser runtime could not type into the local auth form.

Refs #364.