### PR TITLE
Add task work products panel

### DIFF
--- a/web/src/__tests__/task-detail-work-products-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-work-products-mantine.test.tsx
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { WorkProductsSection } from '@/components/task/WorkProductsSection';
+import { api } from '@/lib/api';
+import { renderWithProviders } from './test-utils';
+import type { WorkProductPreview, WorkProductVersion } from '@veritas-kanban/shared';
+
+const mocks = vi.hoisted(() => ({
+  clipboardWrite: vi.fn(),
+  execCommand: vi.fn(),
+  exportWorkProduct: vi.fn(),
+  listForTask: vi.fn(),
+  listVersions: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    workProducts: {
+      export: mocks.exportWorkProduct,
+      listForTask: mocks.listForTask,
+      listVersions: mocks.listVersions,
+    },
+  },
+}));
+
+const listForTaskMock = vi.mocked(api.workProducts.listForTask);
+const exportWorkProductMock = vi.mocked(api.workProducts.export);
+const listVersionsMock = vi.mocked(api.workProducts.listVersions);
+
+const product: WorkProductPreview = {
+  id: 'wp_launch_readiness',
+  workspaceId: 'local',
+  kind: 'report',
+  title: 'Launch readiness report',
+  status: 'active',
+  version: 2,
+  taskId: 'task-work-products',
+  sourceRunId: 'run-123',
+  agent: 'codex',
+  model: 'gpt-5',
+  sourceLinks: [{ label: 'Source run', href: '/runs/run-123', type: 'run' }],
+  redacted: true,
+  snippet: 'Redacted launch summary with checklist evidence.',
+  createdAt: '2026-06-01T10:00:00.000Z',
+  updatedAt: '2026-06-01T11:00:00.000Z',
+};
+
+const versions: WorkProductVersion[] = [
+  {
+    id: 'wpv-2',
+    productId: product.id,
+    workspaceId: 'local',
+    version: 2,
+    changeType: 'refine',
+    changeSummary: 'Added QA evidence',
+    render: { schemaVersion: 1, kind: 'markdown', markdown: '# Redacted' },
+    title: product.title,
+    kind: 'report',
+    agent: 'codex',
+    model: 'gpt-5',
+    createdAt: '2026-06-01T11:00:00.000Z',
+  },
+  {
+    id: 'wpv-1',
+    productId: product.id,
+    workspaceId: 'local',
+    version: 1,
+    changeType: 'create',
+    render: { schemaVersion: 1, kind: 'markdown', markdown: '# Initial' },
+    title: product.title,
+    kind: 'report',
+    createdAt: '2026-06-01T10:00:00.000Z',
+  },
+];
+
+describe('task detail work products surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listForTaskMock.mockResolvedValue([product]);
+    listVersionsMock.mockResolvedValue(versions);
+    exportWorkProductMock.mockResolvedValue('# Redacted launch report');
+    mocks.clipboardWrite.mockResolvedValue(undefined);
+    mocks.execCommand.mockReturnValue(true);
+
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocks.clipboardWrite,
+      },
+    });
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:work-product'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: mocks.execCommand,
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders task work products with Mantine cards, provenance, and redaction labels', async () => {
+    const { baseElement, container } = renderWithProviders(
+      <WorkProductsSection taskId="task-work-products" />
+    );
+
+    expect(await screen.findByText('Launch readiness report')).toBeDefined();
+    expect(screen.getByText('Redacted launch summary with checklist evidence.')).toBeDefined();
+    expect(screen.getByText('Redacted preview')).toBeDefined();
+    expect(screen.getByText('Run run-123')).toBeDefined();
+    expect(screen.getByRole('link', { name: /source run/i }).getAttribute('href')).toBe(
+      '/runs/run-123'
+    );
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
+    expect(container.querySelector('.mantine-ActionIcon-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+    expect(listForTaskMock).toHaveBeenCalledWith('task-work-products', {
+      includeArchived: true,
+      limit: 20,
+    });
+  });
+
+  it('requests redacted markdown when copying', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<WorkProductsSection taskId="task-work-products" />);
+
+    await user.click(await screen.findByRole('button', { name: /copy redacted/i }));
+
+    await waitFor(() =>
+      expect(exportWorkProductMock).toHaveBeenCalledWith(product.id, {
+        format: 'markdown',
+        redacted: true,
+      })
+    );
+  });
+
+  it('exports redacted markdown by default', async () => {
+    const user = userEvent.setup();
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const removeSpy = vi.spyOn(document.body, 'removeChild');
+
+    renderWithProviders(<WorkProductsSection taskId="task-work-products" />);
+
+    await user.click(await screen.findByRole('button', { name: /export redacted/i }));
+
+    await waitFor(() =>
+      expect(exportWorkProductMock).toHaveBeenCalledWith(product.id, {
+        format: 'markdown',
+        redacted: true,
+      })
+    );
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:work-product');
+    expect(appendSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+  });
+
+  it('opens version history without rendering raw version payloads', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<WorkProductsSection taskId="task-work-products" />);
+
+    await user.click(await screen.findByRole('button', { name: /open version history/i }));
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Version history: Launch readiness report',
+    });
+    expect(listVersionsMock).toHaveBeenCalledWith(product.id);
+    expect(within(dialog).getByText('Refine v2')).toBeDefined();
+    expect(within(dialog).getByText('Create v1')).toBeDefined();
+    expect(within(dialog).getByText('Added QA evidence')).toBeDefined();
+    expect(within(dialog).queryByText('# Redacted')).toBeNull();
+    expect(within(dialog).queryByText('# Initial')).toBeNull();
+  });
+});

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -27,6 +27,7 @@ import { ChatPanel } from '@/components/chat/ChatPanel';
 import { ApplyTemplateDialog } from './ApplyTemplateDialog';
 import { TaskMetricsPanel } from './TaskMetricsPanel';
 import { WorkflowSection } from './WorkflowSection';
+import { WorkProductsSection } from './WorkProductsSection';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import {
   GitBranch,
@@ -42,6 +43,7 @@ import {
   NotebookPen,
   Workflow,
   Eye,
+  Files,
   X,
   type LucideIcon,
 } from 'lucide-react';
@@ -59,6 +61,7 @@ interface TaskDetailPanelProps {
 type TaskDetailTabId =
   | 'details'
   | 'progress'
+  | 'work-products'
   | 'observations'
   | 'attachments'
   | 'git'
@@ -84,6 +87,12 @@ const TASK_DETAIL_TABS: readonly TaskDetailTabDefinition[] = [
     label: 'Progress',
     Icon: NotebookPen,
     fallbackTitle: 'Progress section failed to load',
+  },
+  {
+    id: 'work-products',
+    label: 'Work Products',
+    Icon: Files,
+    fallbackTitle: 'Work products section failed to load',
   },
   {
     id: 'observations',
@@ -207,6 +216,8 @@ export function TaskDetailPanel({
         );
       case 'progress':
         return <ProgressTab task={localTask} />;
+      case 'work-products':
+        return <WorkProductsSection taskId={localTask.id} />;
       case 'observations':
         return (
           <ObservationsSection

--- a/web/src/components/task/WorkProductsSection.tsx
+++ b/web/src/components/task/WorkProductsSection.tsx
@@ -1,0 +1,352 @@
+import { useMemo, useState } from 'react';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Modal,
+  Paper,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  ThemeIcon,
+  Tooltip,
+} from '@mantine/core';
+import { api } from '@/lib/api';
+import { useTaskWorkProducts, useWorkProductVersions } from '@/hooks/useWorkProducts';
+import { toast } from '@/hooks/useToast';
+import {
+  AlertCircle,
+  Clipboard,
+  Download,
+  ExternalLink,
+  FileText,
+  History,
+  Sparkles,
+} from 'lucide-react';
+import type {
+  WorkProductKind,
+  WorkProductPreview,
+  WorkProductVersion,
+} from '@veritas-kanban/shared';
+
+interface WorkProductsSectionProps {
+  taskId: string;
+}
+
+const KIND_LABELS: Record<WorkProductKind, string> = {
+  checklist: 'Checklist',
+  dashboard: 'Dashboard',
+  markdown: 'Markdown',
+  report: 'Report',
+  summary: 'Summary',
+  table: 'Table',
+  text: 'Text',
+};
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function safeDownloadName(product: WorkProductPreview, extension: string): string {
+  const slug = product.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+  return `${slug || product.id}-v${product.version}.${extension}`;
+}
+
+function versionLabel(version: WorkProductVersion): string {
+  const changeType = version.changeType.charAt(0).toUpperCase() + version.changeType.slice(1);
+  return `${changeType} v${version.version}`;
+}
+
+async function writeClipboardText(content: string): Promise<void> {
+  const clipboard = window.navigator.clipboard;
+  if (clipboard?.writeText) {
+    await clipboard.writeText(content);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = content;
+  textarea.setAttribute('readonly', 'true');
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+
+  if (!copied) {
+    throw new Error('Clipboard is unavailable');
+  }
+}
+
+export function WorkProductsSection({ taskId }: WorkProductsSectionProps) {
+  const { data: products = [], isLoading, error } = useTaskWorkProducts(taskId);
+  const [historyProduct, setHistoryProduct] = useState<WorkProductPreview | null>(null);
+  const { data: versions = [], isLoading: versionsLoading } = useWorkProductVersions(
+    historyProduct?.id ?? null
+  );
+  const sortedProducts = useMemo(
+    () => [...products].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    [products]
+  );
+
+  const copyRedacted = async (product: WorkProductPreview) => {
+    try {
+      const content = await api.workProducts.export(product.id, {
+        format: 'markdown',
+        redacted: true,
+      });
+      await writeClipboardText(content);
+      toast({
+        title: 'Work product copied',
+        description: `${product.title} was copied with redaction enabled.`,
+      });
+    } catch (err) {
+      toast({
+        title: 'Copy failed',
+        description: err instanceof Error ? err.message : 'Could not copy work product.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const exportRedacted = async (product: WorkProductPreview) => {
+    try {
+      const content = await api.workProducts.export(product.id, {
+        format: 'markdown',
+        redacted: true,
+      });
+      const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = safeDownloadName(product, 'md');
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast({
+        title: 'Work product exported',
+        description: `${product.title} was exported with redaction enabled.`,
+      });
+    } catch (err) {
+      toast({
+        title: 'Export failed',
+        description: err instanceof Error ? err.message : 'Could not export work product.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Paper withBorder p="md" radius="md">
+        <Group gap="sm">
+          <Loader size="sm" />
+          <Text size="sm" c="dimmed">
+            Loading work products...
+          </Text>
+        </Group>
+      </Paper>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert
+        color="red"
+        icon={<AlertCircle className="h-4 w-4" />}
+        title="Work products failed to load"
+      >
+        {error instanceof Error ? error.message : 'Could not load task work products.'}
+      </Alert>
+    );
+  }
+
+  return (
+    <>
+      <Stack gap="md">
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <div>
+            <Group gap="xs">
+              <ThemeIcon size="sm" radius="xl" variant="light">
+                <Sparkles className="h-4 w-4" />
+              </ThemeIcon>
+              <Text fw={600}>Work Products</Text>
+              <Badge variant="light" color="gray">
+                {sortedProducts.length}
+              </Badge>
+            </Group>
+            <Text size="sm" c="dimmed" mt={4}>
+              Durable outputs linked to this task, with redacted copy/export defaults.
+            </Text>
+          </div>
+        </Group>
+
+        {sortedProducts.length === 0 ? (
+          <Paper withBorder p="lg" radius="md" className="text-center">
+            <ThemeIcon size="lg" radius="xl" variant="light" className="mx-auto">
+              <FileText className="h-5 w-5" />
+            </ThemeIcon>
+            <Text fw={600} mt="sm">
+              No work products yet
+            </Text>
+            <Text size="sm" c="dimmed" mt={4}>
+              Generated reports, checklists, handoff notes, and evidence summaries will appear here.
+            </Text>
+          </Paper>
+        ) : (
+          <Stack gap="sm">
+            {sortedProducts.map((product) => (
+              <Paper key={product.id} withBorder p="md" radius="md">
+                <Stack gap="sm">
+                  <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
+                    <div className="min-w-0">
+                      <Group gap="xs" wrap="wrap">
+                        <Text fw={600} className="break-words">
+                          {product.title}
+                        </Text>
+                        <Badge variant="light">{KIND_LABELS[product.kind]}</Badge>
+                        <Badge
+                          variant="outline"
+                          color={product.status === 'active' ? 'green' : 'gray'}
+                        >
+                          {product.status}
+                        </Badge>
+                        {product.redacted && (
+                          <Badge variant="outline" color="yellow">
+                            Redacted preview
+                          </Badge>
+                        )}
+                      </Group>
+                      <Text size="xs" c="dimmed" mt={4}>
+                        Updated {formatDate(product.updatedAt)} | v{product.version}
+                        {product.agent ? ` | ${product.agent}` : ''}
+                        {product.model ? ` | ${product.model}` : ''}
+                      </Text>
+                    </div>
+                    <Group gap={4} wrap="nowrap">
+                      <Tooltip label="Copy redacted markdown">
+                        <ActionIcon
+                          aria-label={`Copy redacted ${product.title}`}
+                          variant="subtle"
+                          onClick={() => copyRedacted(product)}
+                        >
+                          <Clipboard className="h-4 w-4" />
+                        </ActionIcon>
+                      </Tooltip>
+                      <Tooltip label="Export redacted markdown">
+                        <ActionIcon
+                          aria-label={`Export redacted ${product.title}`}
+                          variant="subtle"
+                          onClick={() => exportRedacted(product)}
+                        >
+                          <Download className="h-4 w-4" />
+                        </ActionIcon>
+                      </Tooltip>
+                      <Tooltip label="Version history">
+                        <ActionIcon
+                          aria-label={`Open version history for ${product.title}`}
+                          variant="subtle"
+                          onClick={() => setHistoryProduct(product)}
+                        >
+                          <History className="h-4 w-4" />
+                        </ActionIcon>
+                      </Tooltip>
+                    </Group>
+                  </Group>
+
+                  <Text size="sm" c="dimmed" className="whitespace-pre-wrap">
+                    {product.snippet || 'No preview text available.'}
+                  </Text>
+
+                  {(product.sourceRunId || (product.sourceLinks?.length ?? 0) > 0) && (
+                    <Group gap="xs" wrap="wrap">
+                      {product.sourceRunId && (
+                        <Badge variant="light" color="blue">
+                          Run {product.sourceRunId}
+                        </Badge>
+                      )}
+                      {product.sourceLinks?.map((link) => (
+                        <Button
+                          key={`${product.id}:${link.href}:${link.label}`}
+                          component="a"
+                          href={link.href}
+                          target={link.href.startsWith('http') ? '_blank' : undefined}
+                          rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+                          variant="subtle"
+                          size="compact-xs"
+                          rightSection={<ExternalLink className="h-3 w-3" />}
+                        >
+                          {link.label}
+                        </Button>
+                      ))}
+                    </Group>
+                  )}
+                </Stack>
+              </Paper>
+            ))}
+          </Stack>
+        )}
+      </Stack>
+
+      <Modal
+        opened={Boolean(historyProduct)}
+        onClose={() => setHistoryProduct(null)}
+        title={historyProduct ? `Version history: ${historyProduct.title}` : 'Version history'}
+        size="lg"
+      >
+        {versionsLoading ? (
+          <Group gap="sm">
+            <Loader size="sm" />
+            <Text size="sm" c="dimmed">
+              Loading version history...
+            </Text>
+          </Group>
+        ) : versions.length === 0 ? (
+          <Text size="sm" c="dimmed">
+            No version history is available for this work product.
+          </Text>
+        ) : (
+          <ScrollArea h={320}>
+            <Table striped highlightOnHover withTableBorder>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Version</Table.Th>
+                  <Table.Th>Changed</Table.Th>
+                  <Table.Th>Summary</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {versions.map((version) => (
+                  <Table.Tr key={version.id}>
+                    <Table.Td>
+                      <Badge variant="light">{versionLabel(version)}</Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm">{formatDate(version.createdAt)}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm">{version.changeSummary || version.title}</Text>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </ScrollArea>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/web/src/hooks/useWorkProducts.ts
+++ b/web/src/hooks/useWorkProducts.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export function useTaskWorkProducts(taskId: string | undefined) {
+  return useQuery({
+    queryKey: ['tasks', taskId, 'work-products'],
+    queryFn: () =>
+      taskId
+        ? api.workProducts.listForTask(taskId, { includeArchived: true, limit: 20 })
+        : Promise.resolve([]),
+    enabled: Boolean(taskId),
+  });
+}
+
+export function useWorkProductVersions(productId: string | null) {
+  return useQuery({
+    queryKey: ['work-products', productId, 'versions'],
+    queryFn: () => (productId ? api.workProducts.listVersions(productId) : Promise.resolve([])),
+    enabled: Boolean(productId),
+  });
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -16,6 +16,7 @@ import { decisionsApi } from './decisions';
 import { scoringApi } from './scoring';
 import { searchApi } from './search';
 import { identityApi } from './identity';
+import { workProductsApi } from './work-products';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -42,6 +43,7 @@ export const api = {
   scoring: scoringApi,
   search: searchApi,
   identity: identityApi,
+  workProducts: workProductsApi,
 };
 
 export type {
@@ -51,6 +53,8 @@ export type {
   SearchResponse,
   SearchResult,
 } from './search';
+
+export type { WorkProductExportFormat, WorkProductExportOptions } from './work-products';
 
 // Re-export managed list helper
 export { managedList } from './managed-list';

--- a/web/src/lib/api/work-products.ts
+++ b/web/src/lib/api/work-products.ts
@@ -1,0 +1,86 @@
+import type { WorkProductPreview, WorkProductVersion } from '@veritas-kanban/shared';
+import { API_BASE, handleResponse } from './helpers';
+
+export type WorkProductExportFormat = 'markdown' | 'json';
+
+export interface WorkProductExportOptions {
+  format?: WorkProductExportFormat;
+  redacted?: boolean;
+}
+
+function buildQuery(params: Record<string, string | number | boolean | undefined>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      query.set(key, String(value));
+    }
+  }
+  const serialized = query.toString();
+  return serialized ? `?${serialized}` : '';
+}
+
+function getErrorMessage(body: unknown, status: number): string {
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>;
+    if (typeof record.message === 'string') {
+      return record.message;
+    }
+    if (typeof record.error === 'string') {
+      return record.error;
+    }
+    if (record.error && typeof record.error === 'object') {
+      const error = record.error as Record<string, unknown>;
+      if (typeof error.message === 'string') {
+        return error.message;
+      }
+    }
+  }
+  return `HTTP ${status}`;
+}
+
+export const workProductsApi = {
+  listForTask: async (
+    taskId: string,
+    options: { includeArchived?: boolean; limit?: number } = {}
+  ): Promise<WorkProductPreview[]> => {
+    const query = buildQuery({
+      view: 'preview',
+      includeArchived: options.includeArchived,
+      limit: options.limit,
+    });
+    const response = await fetch(
+      `${API_BASE}/tasks/${encodeURIComponent(taskId)}/work-products${query}`,
+      {
+        credentials: 'include',
+      }
+    );
+    return handleResponse<WorkProductPreview[]>(response);
+  },
+
+  listVersions: async (id: string): Promise<WorkProductVersion[]> => {
+    const response = await fetch(`${API_BASE}/work-products/${encodeURIComponent(id)}/versions`, {
+      credentials: 'include',
+    });
+    return handleResponse<WorkProductVersion[]>(response);
+  },
+
+  export: async (id: string, options: WorkProductExportOptions = {}): Promise<string> => {
+    const query = buildQuery({
+      format: options.format ?? 'markdown',
+      redacted: options.redacted ?? true,
+    });
+    const response = await fetch(
+      `${API_BASE}/work-products/${encodeURIComponent(id)}/export${query}`,
+      {
+        credentials: 'include',
+      }
+    );
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      throw new Error(getErrorMessage(body, response.status));
+    }
+
+    return response.text();
+  },
+};


### PR DESCRIPTION
## Summary

- add a task-detail Work Products tab backed by the task-scoped work product API
- add redacted markdown copy/export actions, source-run/provenance links, and version-history metadata
- add web API helpers and React Query hooks for task work products and versions
- cover the Mantine task-detail surface with focused component tests

Advances #326, #359, and #403.

## Verification

- pnpm --filter @veritas-kanban/web test -- task-detail-work-products-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm lint:budget
- git diff --check
- git diff --cached --check

## Notes

- This does not close the broader unified Work view, run timeline rendering, completion packet reachability, or maintenance cleanup requirements.
- The existing untracked server/storage/ directory was left untouched.
