### PR TITLE
Add task Work view readiness surface

### DIFF
--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -70,6 +70,11 @@ vi.mock('@/hooks/useConfig', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useWorkProducts', () => ({
+  useTaskWorkProducts: () => ({ data: [], isLoading: false }),
+  useWorkProductVersions: () => ({ data: [], isLoading: false }),
+}));
+
 vi.mock('@/hooks/useTasks', () => ({
   useAddObservation: () => ({ mutateAsync: vi.fn() }),
   useDeleteObservation: () => ({ mutateAsync: vi.fn() }),
@@ -176,6 +181,7 @@ describe('task detail Mantine migration', () => {
     expect((screen.getByLabelText('Task title') as HTMLInputElement).value).toBe(
       'Ship Mantine task detail'
     );
+    expect(screen.getByRole('tab', { name: 'Work' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Details' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Chat' })).toBeDefined();
     expect(container.querySelector('.mantine-Drawer-content')).toBeDefined();
@@ -220,5 +226,26 @@ describe('task detail Mantine migration', () => {
 
     await waitFor(() => expect(mocks.deleteTask).toHaveBeenCalledWith('task-1'));
     expect(mocks.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('defaults code tasks with execution context to the Work tab', () => {
+    const task = createMockTask({
+      id: 'task-code-work',
+      title: 'Ship task work view',
+      description: 'Add a unified task work view with enough execution context.',
+      type: 'code',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'v5-task-work-view-readiness',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-worktree',
+      },
+      verificationSteps: [{ id: 'verify-1', description: 'Run focused test', checked: false }],
+    });
+
+    renderWithProviders(<TaskDetailPanel task={task} open onOpenChange={mocks.onOpenChange} />);
+
+    expect(screen.getByRole('tab', { name: 'Work' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('Work View')).toBeDefined();
   });
 });

--- a/web/src/__tests__/task-work-view-mantine.test.tsx
+++ b/web/src/__tests__/task-work-view-mantine.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  getTaskReadinessChecks,
+  shouldDefaultTaskDetailToWork,
+  TaskWorkView,
+} from '@/components/task/TaskWorkView';
+import { createMockTask, renderWithProviders } from './test-utils';
+import type { WorkProductPreview } from '@veritas-kanban/shared';
+
+const mocks = vi.hoisted(() => ({
+  onOpenChat: vi.fn(),
+  onOpenTab: vi.fn(),
+  onOpenWorkflow: vi.fn(),
+  useTaskWorkProducts: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWorkProducts', () => ({
+  useTaskWorkProducts: mocks.useTaskWorkProducts,
+}));
+
+const product: WorkProductPreview = {
+  id: 'wp-release',
+  workspaceId: 'local',
+  kind: 'report',
+  title: 'Release readiness report',
+  status: 'active',
+  version: 3,
+  taskId: 'task-work',
+  sourceRunId: 'run-456',
+  agent: 'veritas',
+  model: 'gpt-5',
+  sourceLinks: [{ label: 'Source run', href: '/runs/run-456', type: 'run' }],
+  redacted: true,
+  snippet: 'Release summary',
+  createdAt: '2026-06-01T10:00:00.000Z',
+  updatedAt: '2026-06-01T12:00:00.000Z',
+};
+
+function renderWorkView(task = createMockTask()) {
+  return renderWithProviders(
+    <TaskWorkView
+      task={task}
+      isCodeTask={task.type === 'code'}
+      onOpenChat={mocks.onOpenChat}
+      onOpenTab={mocks.onOpenTab}
+      onOpenWorkflow={mocks.onOpenWorkflow}
+    />
+  );
+}
+
+describe('task work view Mantine surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useTaskWorkProducts.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('surfaces blockers and missing readiness items in one task work view', () => {
+    const task = createMockTask({
+      id: 'task-blocked',
+      title: 'Fix',
+      description: 'Too short',
+      type: 'code',
+      status: 'blocked',
+      blockedReason: {
+        category: 'waiting-on-feedback',
+        note: 'Waiting on security review',
+      },
+    });
+
+    const { baseElement, container } = renderWorkView(task);
+
+    expect(screen.getByText('Work View')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Resolve blocker' })).toBeDefined();
+    expect(screen.getAllByText('Waiting on security review').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Readiness Gate')).toBeDefined();
+    expect(screen.getByText('Clear objective')).toBeDefined();
+    expect(screen.getByText('Add a concrete description of the expected outcome.')).toBeDefined();
+    expect(container.querySelector('.mantine-Paper-root')).toBeDefined();
+    expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
+    expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
+  });
+
+  it('links live execution, code review, handoff, and work products from the Work view', async () => {
+    const user = userEvent.setup();
+    mocks.useTaskWorkProducts.mockReturnValue({ data: [product], isLoading: false });
+    const task = createMockTask({
+      id: 'task-work',
+      title: 'Ship release candidate',
+      description:
+        'Ship the release candidate with an explicit report artifact and verification evidence.',
+      type: 'code',
+      status: 'in-progress',
+      priority: 'high',
+      agent: 'veritas',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'v5-release-candidate',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-worktree',
+      },
+      attempt: {
+        id: 'attempt-1',
+        agent: 'veritas',
+        status: 'running',
+        model: 'gpt-5',
+        provider: 'openai',
+        started: '2026-06-01T11:00:00.000Z',
+      },
+      verificationSteps: [
+        { id: 'verify-1', description: 'Run tests', checked: true },
+        { id: 'verify-2', description: 'Smoke desktop app', checked: false },
+      ],
+      deliverables: [
+        {
+          id: 'del-1',
+          title: 'Release report',
+          type: 'report',
+          status: 'pending',
+          created: '2026-06-01T11:30:00.000Z',
+        },
+      ],
+      review: {
+        decision: 'approved',
+        decidedAt: '2026-06-01T11:45:00.000Z',
+      },
+      qaGate: {
+        required: true,
+        passed: false,
+      },
+    });
+
+    renderWorkView(task);
+
+    expect(screen.getByText('Monitor active run')).toBeDefined();
+    expect(screen.getByText('Attempt attempt-1')).toBeDefined();
+    expect(screen.getByText('Release readiness report')).toBeDefined();
+    expect(screen.getByText('v3 | report | run run-456')).toBeDefined();
+    expect(
+      screen
+        .getByRole('link', { name: 'Open origin for Release readiness report' })
+        .getAttribute('href')
+    ).toBe('/runs/run-456');
+
+    await user.click(screen.getByRole('button', { name: 'Open Agent' }));
+    await user.click(screen.getByRole('button', { name: 'Work Products' }));
+    await user.click(screen.getByRole('button', { name: 'Workflow' }));
+
+    expect(mocks.onOpenTab).toHaveBeenCalledWith('agent');
+    expect(mocks.onOpenTab).toHaveBeenCalledWith('work-products');
+    expect(mocks.onOpenWorkflow).toHaveBeenCalled();
+  });
+
+  it('keeps readiness and default-tab decisions deterministic', () => {
+    const task = createMockTask({
+      title: 'Implement run timeline',
+      description:
+        'Implement a timeline artifact with report output, clear verification, and enough task context.',
+      type: 'code',
+      agent: 'veritas',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'timeline',
+        baseBranch: 'main',
+      },
+      verificationSteps: [{ id: 'verify-1', description: 'Run timeline test', checked: false }],
+    });
+
+    const readiness = getTaskReadinessChecks(task, true);
+
+    expect(readiness.every((check) => check.passed)).toBe(true);
+    expect(shouldDefaultTaskDetailToWork(task)).toBe(true);
+    expect(shouldDefaultTaskDetailToWork(createMockTask({ type: 'feature' }))).toBe(false);
+  });
+});

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActionIcon,
   Badge,
@@ -28,8 +28,10 @@ import { ApplyTemplateDialog } from './ApplyTemplateDialog';
 import { TaskMetricsPanel } from './TaskMetricsPanel';
 import { WorkflowSection } from './WorkflowSection';
 import { WorkProductsSection } from './WorkProductsSection';
+import { shouldDefaultTaskDetailToWork, TaskWorkView } from './TaskWorkView';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import {
+  BriefcaseBusiness,
   GitBranch,
   Bot,
   FileDiff,
@@ -59,6 +61,7 @@ interface TaskDetailPanelProps {
 }
 
 type TaskDetailTabId =
+  | 'work'
   | 'details'
   | 'progress'
   | 'work-products'
@@ -81,6 +84,12 @@ interface TaskDetailTabDefinition {
 }
 
 const TASK_DETAIL_TABS: readonly TaskDetailTabDefinition[] = [
+  {
+    id: 'work',
+    label: 'Work',
+    Icon: BriefcaseBusiness,
+    fallbackTitle: 'Work view failed to load',
+  },
   { id: 'details', label: 'Details' },
   {
     id: 'progress',
@@ -156,11 +165,12 @@ export function TaskDetailPanel({
   const taskSettings = featureSettings.tasks;
   const agentSettings = featureSettings.agents;
   const { localTask, updateField, isDirty } = useDebouncedSave(task);
-  const [activeTab, setActiveTab] = useState('details');
+  const [activeTab, setActiveTab] = useState<TaskDetailTabId>('details');
   const [previewOpen, setPreviewOpen] = useState(false);
   const [applyTemplateOpen, setApplyTemplateOpen] = useState(false);
   const [taskChatOpen, setTaskChatOpen] = useState(false);
   const [workflowOpen, setWorkflowOpen] = useState(false);
+  const lastDefaultedTaskIdRef = useRef<string | undefined>(undefined);
   const addObservation = useAddObservation();
   const deleteObservation = useDeleteObservation();
 
@@ -176,6 +186,8 @@ export function TaskDetailPanel({
 
   const isCodeTask = localTask?.type === 'code';
   const hasWorktree = !!localTask?.git?.worktreePath;
+  const activeTaskId = localTask?.id;
+  const defaultTab = localTask && shouldDefaultTaskDetailToWork(localTask) ? 'work' : 'details';
   const visibleTabs = useMemo(
     () =>
       TASK_DETAIL_TABS.filter((tab) => {
@@ -192,9 +204,19 @@ export function TaskDetailPanel({
   useEffect(() => {
     const activeTabAvailable = visibleTabs.some((tab) => tab.id === activeTab && !tab.disabled);
     if (!activeTabAvailable) {
-      setActiveTab('details');
+      setActiveTab(defaultTab);
     }
-  }, [activeTab, visibleTabs]);
+  }, [activeTab, defaultTab, visibleTabs]);
+
+  useEffect(() => {
+    if (!activeTaskId) {
+      lastDefaultedTaskIdRef.current = undefined;
+      return;
+    }
+    if (lastDefaultedTaskIdRef.current === activeTaskId) return;
+    lastDefaultedTaskIdRef.current = activeTaskId;
+    setActiveTab(defaultTab);
+  }, [activeTaskId, defaultTab]);
 
   if (!localTask) return null;
 
@@ -204,6 +226,17 @@ export function TaskDetailPanel({
   const typeLabel = currentType ? currentType.label : localTask.type;
   const renderTabContent = (tabId: TaskDetailTabId) => {
     switch (tabId) {
+      case 'work':
+        return (
+          <TaskWorkView
+            task={localTask}
+            isCodeTask={isCodeTask}
+            readOnly={readOnly}
+            onOpenTab={setActiveTab}
+            onOpenChat={() => setTaskChatOpen(true)}
+            onOpenWorkflow={() => setWorkflowOpen(true)}
+          />
+        );
       case 'details':
         return (
           <TaskDetailsTab
@@ -404,7 +437,7 @@ export function TaskDetailPanel({
               <Tabs
                 value={activeTab}
                 onChange={(value) => {
-                  if (value) setActiveTab(value);
+                  if (value) setActiveTab(value as TaskDetailTabId);
                 }}
                 className="flex flex-1 flex-col overflow-hidden px-6 pt-3 pb-6"
               >

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -1,0 +1,616 @@
+import { useMemo } from 'react';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  Progress,
+  SimpleGrid,
+  Stack,
+  Text,
+  ThemeIcon,
+  Tooltip,
+} from '@mantine/core';
+import {
+  AlertTriangle,
+  Bot,
+  CheckCircle2,
+  ClipboardCheck,
+  ExternalLink,
+  FileText,
+  GitBranch,
+  History,
+  MessageSquare,
+  PackageCheck,
+  Play,
+  Route,
+  ShieldCheck,
+  Workflow,
+  XCircle,
+} from 'lucide-react';
+import type { Task, TaskAttempt, TaskStatus } from '@veritas-kanban/shared';
+import { useTaskWorkProducts } from '@/hooks/useWorkProducts';
+
+export type TaskWorkViewTarget =
+  | 'details'
+  | 'progress'
+  | 'work-products'
+  | 'observations'
+  | 'attachments'
+  | 'git'
+  | 'agent'
+  | 'changes'
+  | 'review'
+  | 'metrics';
+
+interface TaskWorkViewProps {
+  task: Task;
+  isCodeTask: boolean;
+  readOnly?: boolean;
+  onOpenTab: (target: TaskWorkViewTarget) => void;
+  onOpenChat: () => void;
+  onOpenWorkflow: () => void;
+}
+
+interface ReadinessCheck {
+  id: string;
+  label: string;
+  passed: boolean;
+  detail: string;
+}
+
+const STATUS_COLORS: Record<TaskStatus, string> = {
+  blocked: 'red',
+  cancelled: 'gray',
+  done: 'green',
+  'in-progress': 'blue',
+  todo: 'gray',
+};
+
+function formatDate(value?: string): string {
+  if (!value) return 'Not recorded';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Not recorded';
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function formatAttemptStatus(status?: TaskAttempt['status']): string {
+  switch (status) {
+    case 'complete':
+      return 'Complete';
+    case 'failed':
+      return 'Failed';
+    case 'pending':
+      return 'Pending';
+    case 'running':
+      return 'Running';
+    default:
+      return 'No attempt';
+  }
+}
+
+function getAttemptColor(status?: TaskAttempt['status']): string {
+  switch (status) {
+    case 'complete':
+      return 'green';
+    case 'failed':
+      return 'red';
+    case 'pending':
+      return 'yellow';
+    case 'running':
+      return 'blue';
+    default:
+      return 'gray';
+  }
+}
+
+function hasText(value: string | undefined, minLength = 12): boolean {
+  return Boolean(value && value.trim().length >= minLength);
+}
+
+export function getTaskReadinessChecks(task: Task, isCodeTask: boolean): ReadinessCheck[] {
+  const blockers =
+    task.status === 'blocked' || Boolean(task.blockedReason) || Boolean(task.blockedBy?.length);
+  const dependencyCount =
+    (task.dependencies?.depends_on?.length ?? 0) + (task.blockedBy?.length ?? 0);
+  const verificationTotal = task.verificationSteps?.length ?? 0;
+  const expectedArtifact =
+    (task.deliverables?.length ?? 0) > 0 ||
+    (task.attachments?.length ?? 0) > 0 ||
+    task.description.toLowerCase().includes('deliverable') ||
+    task.description.toLowerCase().includes('artifact') ||
+    task.description.toLowerCase().includes('report');
+  const assignedAgent =
+    Boolean(task.agent && task.agent !== 'auto') || Boolean(task.agents && task.agents.length > 0);
+
+  return [
+    {
+      id: 'objective',
+      label: 'Clear objective',
+      passed: hasText(task.title, 6) && hasText(task.description, 24),
+      detail: hasText(task.description, 24)
+        ? 'Title and description provide enough context.'
+        : 'Add a concrete description of the expected outcome.',
+    },
+    {
+      id: 'verification',
+      label: 'Verification plan',
+      passed: verificationTotal > 0,
+      detail:
+        verificationTotal > 0
+          ? `${verificationTotal} verification step${verificationTotal === 1 ? '' : 's'} defined.`
+          : 'Add at least one verification step before execution.',
+    },
+    {
+      id: 'context',
+      label: isCodeTask ? 'Repository context' : 'Project context',
+      passed: isCodeTask ? Boolean(task.git?.repo && task.git?.baseBranch) : Boolean(task.project),
+      detail: isCodeTask
+        ? task.git?.repo
+          ? `${task.git.repo} targeting ${task.git.baseBranch || 'default branch'}.`
+          : 'Select a repository and base branch for code execution.'
+        : task.project
+          ? `Project ${task.project} is set.`
+          : 'Assign a project or add context in the task description.',
+    },
+    {
+      id: 'artifact',
+      label: 'Expected artifact',
+      passed: expectedArtifact,
+      detail: expectedArtifact
+        ? 'Expected output is represented by deliverables, attachments, or description.'
+        : 'State the expected handoff artifact, report, code change, or evidence packet.',
+    },
+    {
+      id: 'blockers',
+      label: 'Dependencies and blockers',
+      passed: !blockers,
+      detail: blockers
+        ? task.blockedReason?.note || 'Task is blocked or has unresolved blockers.'
+        : dependencyCount > 0
+          ? `${dependencyCount} dependency link${dependencyCount === 1 ? '' : 's'} recorded.`
+          : 'No active blockers detected.',
+    },
+    {
+      id: 'agent',
+      label: 'Agent or workflow path',
+      passed: assignedAgent || Boolean(task.runMode) || !isCodeTask,
+      detail:
+        assignedAgent || task.runMode
+          ? `Execution path: ${task.agent && task.agent !== 'auto' ? task.agent : task.runMode || 'configured'}.`
+          : 'Pick an agent, run mode, or workflow before starting.',
+    },
+  ];
+}
+
+function getNextAction(
+  task: Task,
+  readinessChecks: ReadinessCheck[]
+): {
+  label: string;
+  detail: string;
+  target: TaskWorkViewTarget | 'workflow' | 'chat';
+} {
+  if (task.status === 'blocked') {
+    return {
+      label: 'Resolve blocker',
+      detail: task.blockedReason?.note || 'Review the blocker details before starting execution.',
+      target: 'details',
+    };
+  }
+
+  const missingReadiness = readinessChecks.find((check) => !check.passed);
+  if (missingReadiness) {
+    return {
+      label: 'Fix readiness',
+      detail: missingReadiness.detail,
+      target: 'details',
+    };
+  }
+
+  if (task.attempt?.status === 'running' || task.attempt?.status === 'pending') {
+    return {
+      label: 'Monitor active run',
+      detail: 'An agent attempt is active. Watch the live session before changing task state.',
+      target: 'agent',
+    };
+  }
+
+  if (task.type === 'code' && !task.git?.worktreePath) {
+    return {
+      label: 'Prepare worktree',
+      detail: 'Create a worktree before starting the agent.',
+      target: 'git',
+    };
+  }
+
+  const uncheckedVerification = task.verificationSteps?.some((step) => !step.checked);
+  if (uncheckedVerification) {
+    return {
+      label: 'Complete verification',
+      detail: 'There are unchecked verification steps.',
+      target: 'details',
+    };
+  }
+
+  if (task.review?.decision === 'changes-requested' || task.review?.decision === 'rejected') {
+    return {
+      label: 'Address review decision',
+      detail: task.review.summary || 'Review requires follow-up before handoff.',
+      target: 'review',
+    };
+  }
+
+  if (task.status === 'done') {
+    return {
+      label: 'Review handoff',
+      detail: 'Task is marked done. Confirm work products and completion evidence.',
+      target: 'work-products',
+    };
+  }
+
+  return {
+    label: 'Start or continue execution',
+    detail: 'Task is ready enough to start the agent or workflow.',
+    target: 'agent',
+  };
+}
+
+function getVerificationSummary(task: Task): { complete: number; total: number } {
+  const steps = task.verificationSteps ?? [];
+  return {
+    complete: steps.filter((step) => step.checked).length,
+    total: steps.length,
+  };
+}
+
+function getReviewLabel(task: Task): string {
+  if (task.review?.decision) return task.review.decision;
+  if ((task.reviewComments?.length ?? 0) > 0) return 'comments pending';
+  return 'not started';
+}
+
+export function shouldDefaultTaskDetailToWork(task: Task): boolean {
+  if (task.type !== 'code') return false;
+  return Boolean(
+    task.git ||
+    task.attempt ||
+    task.review ||
+    task.reviewComments?.length ||
+    task.verificationSteps?.length ||
+    task.deliverables?.length ||
+    task.status === 'blocked'
+  );
+}
+
+export function TaskWorkView({
+  task,
+  isCodeTask,
+  readOnly = false,
+  onOpenTab,
+  onOpenChat,
+  onOpenWorkflow,
+}: TaskWorkViewProps) {
+  const { data: workProducts = [], isLoading: workProductsLoading } = useTaskWorkProducts(task.id);
+  const readinessChecks = useMemo(
+    () => getTaskReadinessChecks(task, isCodeTask),
+    [task, isCodeTask]
+  );
+  const passedReadiness = readinessChecks.filter((check) => check.passed).length;
+  const readinessPercent = Math.round((passedReadiness / readinessChecks.length) * 100);
+  const nextAction = getNextAction(task, readinessChecks);
+  const verification = getVerificationSummary(task);
+  const latestWorkProducts = workProducts.slice(0, 3);
+
+  const openNextAction = () => {
+    if (nextAction.target === 'workflow') {
+      onOpenWorkflow();
+      return;
+    }
+    if (nextAction.target === 'chat') {
+      onOpenChat();
+      return;
+    }
+    onOpenTab(nextAction.target);
+  };
+
+  return (
+    <Stack gap="md">
+      <Paper withBorder p="md" radius="md">
+        <Group justify="space-between" align="flex-start" gap="md" wrap="nowrap">
+          <div className="min-w-0">
+            <Group gap="xs" wrap="wrap">
+              <ThemeIcon size="sm" radius="xl" variant="light">
+                <Route className="h-4 w-4" />
+              </ThemeIcon>
+              <Text fw={700}>Work View</Text>
+              <Badge color={STATUS_COLORS[task.status]} variant="light">
+                {task.status}
+              </Badge>
+              <Badge color={readinessPercent === 100 ? 'green' : 'yellow'} variant="outline">
+                {readinessPercent}% ready
+              </Badge>
+            </Group>
+            <Text size="sm" c="dimmed" mt={6}>
+              {nextAction.detail}
+            </Text>
+          </div>
+          {!readOnly && (
+            <Button size="xs" onClick={openNextAction}>
+              {nextAction.label}
+            </Button>
+          )}
+        </Group>
+      </Paper>
+
+      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="xs">
+            <Group justify="space-between" wrap="nowrap">
+              <Group gap="xs">
+                <Bot className="h-4 w-4 text-muted-foreground" />
+                <Text fw={600} size="sm">
+                  Live Session
+                </Text>
+              </Group>
+              <Badge color={getAttemptColor(task.attempt?.status)} variant="light">
+                {formatAttemptStatus(task.attempt?.status)}
+              </Badge>
+            </Group>
+            {task.attempt ? (
+              <Stack gap={4}>
+                <Text size="xs" c="dimmed">
+                  Attempt {task.attempt.id}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  {task.attempt.agent}
+                  {task.attempt.model ? ` | ${task.attempt.model}` : ''}
+                  {task.attempt.provider ? ` | ${task.attempt.provider}` : ''}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  Started {formatDate(task.attempt.started)}
+                </Text>
+              </Stack>
+            ) : (
+              <Text size="sm" c="dimmed">
+                No agent attempt has been started for this task.
+              </Text>
+            )}
+            <Group gap="xs" mt="xs">
+              <Button
+                size="compact-xs"
+                variant="light"
+                leftSection={<Play className="h-3 w-3" />}
+                onClick={() => onOpenTab('agent')}
+              >
+                Open Agent
+              </Button>
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                leftSection={<MessageSquare className="h-3 w-3" />}
+                onClick={onOpenChat}
+              >
+                Chat
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
+
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="xs">
+            <Group justify="space-between" wrap="nowrap">
+              <Group gap="xs">
+                <GitBranch className="h-4 w-4 text-muted-foreground" />
+                <Text fw={600} size="sm">
+                  Code and Review
+                </Text>
+              </Group>
+              <Badge
+                color={task.git?.worktreePath ? 'green' : task.git?.repo ? 'yellow' : 'gray'}
+                variant="light"
+              >
+                {task.git?.worktreePath
+                  ? 'worktree ready'
+                  : task.git?.repo
+                    ? 'repo set'
+                    : 'not set'}
+              </Badge>
+            </Group>
+            <Text size="xs" c="dimmed">
+              Repo: {task.git?.repo || 'Not configured'}
+            </Text>
+            <Text size="xs" c="dimmed">
+              Branch: {task.git?.branch || task.git?.baseBranch || 'Not configured'}
+            </Text>
+            <Text size="xs" c="dimmed">
+              Review: {getReviewLabel(task)}
+            </Text>
+            <Group gap="xs" mt="xs">
+              {isCodeTask && (
+                <Button
+                  size="compact-xs"
+                  variant="light"
+                  leftSection={<GitBranch className="h-3 w-3" />}
+                  onClick={() => onOpenTab('git')}
+                >
+                  Git
+                </Button>
+              )}
+              {isCodeTask && (
+                <Button
+                  size="compact-xs"
+                  variant="subtle"
+                  leftSection={<ClipboardCheck className="h-3 w-3" />}
+                  onClick={() => onOpenTab('review')}
+                >
+                  Review
+                </Button>
+              )}
+            </Group>
+          </Stack>
+        </Paper>
+      </SimpleGrid>
+
+      <Paper withBorder p="md" radius="md">
+        <Stack gap="sm">
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <Group gap="xs">
+              <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+              <Text fw={600}>Readiness Gate</Text>
+            </Group>
+            <Text size="xs" c="dimmed">
+              {passedReadiness}/{readinessChecks.length} checks
+            </Text>
+          </Group>
+          <Progress
+            value={readinessPercent}
+            color={readinessPercent === 100 ? 'green' : 'yellow'}
+          />
+          <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+            {readinessChecks.map((check) => (
+              <Group key={check.id} gap="xs" align="flex-start" wrap="nowrap">
+                {check.passed ? (
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+                ) : (
+                  <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
+                )}
+                <div className="min-w-0">
+                  <Text size="sm" fw={500}>
+                    {check.label}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {check.detail}
+                  </Text>
+                </div>
+              </Group>
+            ))}
+          </SimpleGrid>
+        </Stack>
+      </Paper>
+
+      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="xs">
+            <Group justify="space-between" wrap="nowrap">
+              <Group gap="xs">
+                <PackageCheck className="h-4 w-4 text-muted-foreground" />
+                <Text fw={600} size="sm">
+                  Handoff
+                </Text>
+              </Group>
+              <Badge variant="light" color={verification.total ? 'blue' : 'gray'}>
+                {verification.complete}/{verification.total} verified
+              </Badge>
+            </Group>
+            <Text size="xs" c="dimmed">
+              Deliverables: {task.deliverables?.length ?? 0}
+            </Text>
+            <Text size="xs" c="dimmed">
+              Attachments: {task.attachments?.length ?? 0}
+            </Text>
+            {task.qaGate?.required && (
+              <Alert
+                color={task.qaGate.passed ? 'green' : 'yellow'}
+                icon={<AlertTriangle className="h-4 w-4" />}
+              >
+                QA gate {task.qaGate.passed ? 'passed' : 'is required before completion'}.
+              </Alert>
+            )}
+            <Group gap="xs" mt="xs">
+              <Button
+                size="compact-xs"
+                variant="light"
+                leftSection={<PackageCheck className="h-3 w-3" />}
+                onClick={() => onOpenTab('work-products')}
+              >
+                Work Products
+              </Button>
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                leftSection={<Workflow className="h-3 w-3" />}
+                onClick={onOpenWorkflow}
+              >
+                Workflow
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
+
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="xs">
+            <Group justify="space-between" wrap="nowrap">
+              <Group gap="xs">
+                <FileText className="h-4 w-4 text-muted-foreground" />
+                <Text fw={600} size="sm">
+                  Work Products
+                </Text>
+              </Group>
+              <Badge variant="light" color="gray">
+                {workProducts.length}
+              </Badge>
+            </Group>
+            {workProductsLoading ? (
+              <Group gap="xs">
+                <Loader size="xs" />
+                <Text size="xs" c="dimmed">
+                  Loading saved outputs...
+                </Text>
+              </Group>
+            ) : latestWorkProducts.length > 0 ? (
+              <Stack gap={6}>
+                {latestWorkProducts.map((product) => (
+                  <Group key={product.id} gap="xs" wrap="nowrap" align="flex-start">
+                    <History className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <Text size="sm" truncate>
+                        {product.title}
+                      </Text>
+                      <Text size="xs" c="dimmed" truncate>
+                        v{product.version} | {product.kind}
+                        {product.sourceRunId ? ` | run ${product.sourceRunId}` : ''}
+                      </Text>
+                    </div>
+                    {product.sourceLinks?.[0] && (
+                      <Tooltip label={`Open ${product.sourceLinks[0].label}`}>
+                        <ActionIcon
+                          component="a"
+                          href={product.sourceLinks[0].href}
+                          target={
+                            product.sourceLinks[0].href.startsWith('http') ? '_blank' : undefined
+                          }
+                          rel={
+                            product.sourceLinks[0].href.startsWith('http')
+                              ? 'noopener noreferrer'
+                              : undefined
+                          }
+                          size="sm"
+                          variant="subtle"
+                          aria-label={`Open origin for ${product.title}`}
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                        </ActionIcon>
+                      </Tooltip>
+                    )}
+                  </Group>
+                ))}
+              </Stack>
+            ) : (
+              <Text size="sm" c="dimmed">
+                Reports, checklists, completion packets, and evidence summaries will appear here.
+              </Text>
+            )}
+          </Stack>
+        </Paper>
+      </SimpleGrid>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a first-class Work tab to task detail with consolidated next action, live session, code/review, readiness, handoff, and work-product summaries.
- Default code tasks with execution context to the Work tab while preserving manual tab changes within the same task.
- Add focused Mantine coverage for readiness checks, Work tab defaulting, work-product links, and Work view navigation actions.

Advances #359 and #362.

## Verification
- pnpm --filter @veritas-kanban/web test -- task-work-view-mantine.test.tsx task-detail-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm --filter @veritas-kanban/server build
- pnpm lint:budget
- git diff --check

## Notes
- Manual Browser smoke reached the local board shell with no console errors, but the temp auth/session path blocked a full drawer click. The new Work view is covered by focused rendered component tests.