### PR TITLE
Add agent run timeline replay view

### DIFF
--- a/server/src/__tests__/trace-service.test.ts
+++ b/server/src/__tests__/trace-service.test.ts
@@ -59,7 +59,14 @@ describe('TraceService', () => {
     });
 
     it('should create a new trace when enabled', () => {
-      const trace = service.startTrace('attempt-1', 'task-1', 'veritas', 'my-project');
+      const trace = service.startTrace('attempt-1', 'task-1', 'veritas', 'my-project', {
+        clientSource: 'agent-service',
+        mode: 'eng-review',
+        capabilitySet: ['start', 'status', 'logs', 'complete'],
+        workspaceId: 'local',
+        runKey: 'attempt-1',
+        policyProfile: 'codex-cli:workspace-write',
+      });
       expect(trace).not.toBeNull();
       expect(trace!.traceId).toBe('attempt-1');
       expect(trace!.taskId).toBe('task-1');
@@ -68,6 +75,11 @@ describe('TraceService', () => {
       expect(trace!.status).toBe('running');
       expect(trace!.steps).toHaveLength(0);
       expect(trace!.startedAt).toBeDefined();
+      expect(trace!.metadata).toMatchObject({
+        clientSource: 'agent-service',
+        runKey: 'attempt-1',
+        policyProfile: 'codex-cli:workspace-write',
+      });
     });
   });
 
@@ -89,6 +101,7 @@ describe('TraceService', () => {
 
       expect(step).not.toBeNull();
       expect(step!.type).toBe('execute');
+      expect(step!.sequence).toBe(1);
       expect(step!.startedAt).toBeDefined();
       expect(step!.metadata).toEqual({ tool: 'vitest' });
 

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -28,6 +28,7 @@ import type {
   Task,
   AgentType,
   AgentConfig,
+  AgentRunTraceMetadata,
   TaskAttempt,
   AttemptStatus,
   Deliverable,
@@ -483,7 +484,14 @@ export class ClawdbotAgentService {
       id: 'openclaw',
       label: 'OpenClaw',
       capabilities: { ...commonCapabilities, stop: false, resume: false },
-      start: async ({ prompt, task, attemptId }) => {
+      start: async ({ prompt, task, attemptId, agentConfig }) => {
+        void this.recordAgentStarted(
+          task,
+          attemptId,
+          agentConfig?.type || 'openclaw',
+          'openclaw',
+          agentConfig
+        );
         const agentBreaker = getBreaker('agent');
         await agentBreaker.execute(() => this.sendToClawdbot(prompt, task.id, attemptId));
       },
@@ -525,7 +533,13 @@ export class ClawdbotAgentService {
       logPath,
       `\n## Codex CLI\n\n**Command:** \`${[command, ...args.map((a) => (a === prompt ? '<prompt>' : a))].join(' ')}\`\n**PID:** ${child.pid ?? 'unknown'}\n\n`
     );
-    void this.recordAgentStarted(task, attemptId, agentConfig?.type || 'codex', 'codex-cli');
+    void this.recordAgentStarted(
+      task,
+      attemptId,
+      agentConfig?.type || 'codex',
+      'codex-cli',
+      agentConfig
+    );
 
     let stdoutBuffer = '';
     let stderrBuffer = '';
@@ -662,7 +676,13 @@ export class ClawdbotAgentService {
       logPath,
       `\n## Codex SDK\n\n**Worktree:** \`${worktreePath}\`\n**Model:** ${agentConfig?.model || 'default'}\n\n`
     );
-    await this.recordAgentStarted(task, attemptId, agentConfig?.type || 'codex-sdk', 'codex-sdk');
+    await this.recordAgentStarted(
+      task,
+      attemptId,
+      agentConfig?.type || 'codex-sdk',
+      'codex-sdk',
+      agentConfig
+    );
 
     const streamed = await thread.runStreamed(prompt, { signal: abortController.signal });
     let finalSummary = '';
@@ -764,9 +784,16 @@ export class ClawdbotAgentService {
     task: Task,
     attemptId: string,
     agent: string,
-    provider: AgentProvider
+    provider: AgentProvider,
+    agentConfig?: AgentConfig
   ): Promise<void> {
-    getTraceService().startTrace(attemptId, task.id, agent as AgentType, task.project);
+    getTraceService().startTrace(
+      attemptId,
+      task.id,
+      agent as AgentType,
+      task.project,
+      this.buildTraceMetadata(task, attemptId, provider, agentConfig)
+    );
     getTraceService().startStep(attemptId, 'init', { provider });
     getTraceService().endStep(attemptId, 'init');
     await activityService.logActivity(
@@ -776,6 +803,41 @@ export class ClawdbotAgentService {
       { attemptId, provider },
       agent
     );
+  }
+
+  private buildTraceMetadata(
+    task: Task,
+    attemptId: string,
+    provider: AgentProvider,
+    agentConfig?: AgentConfig
+  ): AgentRunTraceMetadata {
+    return {
+      clientSource: 'agent-service',
+      mode: task.runMode ?? 'agent',
+      capabilitySet: this.traceCapabilitiesForProvider(provider),
+      workspaceId: 'local',
+      runKey: attemptId,
+      policyProfile:
+        provider === 'codex-sdk'
+          ? 'codex-sdk:workspace-write:approval-never'
+          : provider === 'codex-cli'
+            ? 'codex-cli:workspace-write'
+            : 'openclaw:delegated',
+      provider,
+      model: agentConfig?.model,
+      taskType: task.type,
+      repo: task.git?.repo,
+      branch: task.git?.branch,
+      baseBranch: task.git?.baseBranch,
+      worktreePath: task.git?.worktreePath,
+    };
+  }
+
+  private traceCapabilitiesForProvider(provider: AgentProvider): string[] {
+    const base = ['start', 'status', 'logs', 'complete'];
+    if (provider === 'openclaw') return base;
+    if (provider === 'codex-cli') return [...base, 'stop'];
+    return [...base, 'stop', 'resume'];
   }
 
   private async recordCodexEvent(

--- a/server/src/services/trace-service.ts
+++ b/server/src/services/trace-service.ts
@@ -1,33 +1,21 @@
 import fs from 'fs/promises';
 import path from 'path';
-import type { AgentType } from '@veritas-kanban/shared';
+import type {
+  AgentRunTrace,
+  AgentRunTraceMetadata,
+  AgentRunTraceStep,
+  AgentRunTraceStepType,
+  AgentType,
+} from '@veritas-kanban/shared';
 import { getTelemetryService } from './telemetry-service.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
+import { getTracesDir } from '../utils/paths.js';
 
-const PROJECT_ROOT = path.resolve(process.cwd(), '..');
-const TRACES_DIR = path.join(PROJECT_ROOT, '.veritas-kanban', 'traces');
+const TRACES_DIR = getTracesDir();
 
-export type TraceStepType = 'init' | 'execute' | 'complete' | 'error';
-
-export interface TraceStep {
-  type: TraceStepType;
-  startedAt: string;
-  endedAt?: string;
-  durationMs?: number;
-  metadata?: Record<string, unknown>;
-}
-
-export interface Trace {
-  traceId: string; // Same as attemptId
-  taskId: string;
-  agent: AgentType;
-  project?: string;
-  startedAt: string;
-  endedAt?: string;
-  totalDurationMs?: number;
-  steps: TraceStep[];
-  status: 'running' | 'completed' | 'failed' | 'error';
-}
+export type TraceStepType = AgentRunTraceStepType;
+export type TraceStep = AgentRunTraceStep;
+export type Trace = AgentRunTrace;
 
 // In-memory store for active traces
 const activeTraces = new Map<string, Trace>();
@@ -73,7 +61,13 @@ export class TraceService {
   /**
    * Start a new trace for an agent run
    */
-  startTrace(attemptId: string, taskId: string, agent: AgentType, project?: string): Trace | null {
+  startTrace(
+    attemptId: string,
+    taskId: string,
+    agent: AgentType,
+    project?: string,
+    metadata?: AgentRunTraceMetadata
+  ): Trace | null {
     if (!this.enabled) return null;
 
     const trace: Trace = {
@@ -84,6 +78,7 @@ export class TraceService {
       startedAt: new Date().toISOString(),
       steps: [],
       status: 'running',
+      metadata,
     };
 
     activeTraces.set(attemptId, trace);
@@ -105,6 +100,7 @@ export class TraceService {
 
     const step: TraceStep = {
       type: stepType,
+      sequence: trace.steps.length + 1,
       startedAt: new Date().toISOString(),
       metadata,
     };
@@ -217,7 +213,9 @@ export class TraceService {
         if (!file.endsWith('.json')) continue;
 
         try {
-          const content = await fs.readFile(path.join(this.tracesDir, file), 'utf-8');
+          const filepath = path.join(this.tracesDir, file);
+          ensureWithinBase(this.tracesDir, filepath);
+          const content = await fs.readFile(filepath, 'utf-8');
           const trace = JSON.parse(content) as Trace;
           if (trace.taskId === taskId && !activeTraces.has(trace.traceId)) {
             traces.push(trace);

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -103,14 +103,90 @@ export type AnyTelemetryEvent =
 export interface TelemetryConfig {
   enabled: boolean;
   retention: number; // Days to retain events
-  traces?: boolean;  // Optional trace collection (future)
+  traces?: boolean; // Optional trace collection (future)
+}
+
+/** Low-level trace step types captured during an agent attempt. */
+export type AgentRunTraceStepType = 'init' | 'execute' | 'complete' | 'error';
+
+/** Additional run context persisted with each trace for replay/audit surfaces. */
+export interface AgentRunTraceMetadata {
+  clientSource?: string;
+  mode?: string | null;
+  capabilitySet?: string[];
+  workspaceId?: string;
+  sessionKey?: string;
+  runKey?: string;
+  policyProfile?: string;
+  provider?: string;
+  model?: string;
+  taskType?: string;
+  repo?: string;
+  branch?: string;
+  baseBranch?: string;
+  worktreePath?: string;
+}
+
+/** A single sequenced step inside an agent run trace. */
+export interface AgentRunTraceStep {
+  type: AgentRunTraceStepType;
+  sequence?: number;
+  startedAt: string;
+  endedAt?: string;
+  durationMs?: number;
+  metadata?: Record<string, unknown>;
+}
+
+/** Stored or active trace for one agent attempt. */
+export interface AgentRunTrace {
+  traceId: string; // Same as attemptId
+  taskId: string;
+  agent: AgentType;
+  project?: string;
+  startedAt: string;
+  endedAt?: string;
+  totalDurationMs?: number;
+  steps: AgentRunTraceStep[];
+  status: 'running' | 'completed' | 'failed' | 'error';
+  metadata?: AgentRunTraceMetadata;
+}
+
+/** Timeline event categories exposed to the task run replay UI. */
+export type AgentRunTimelineEventType =
+  | 'prompt'
+  | 'command'
+  | 'file'
+  | 'policy'
+  | 'approval'
+  | 'error'
+  | 'usage'
+  | 'tool'
+  | 'result';
+
+export type AgentRunTimelineEventSource = 'live' | 'stored' | 'derived';
+
+export interface AgentRunTimelineEvent {
+  id: string;
+  sequence: number;
+  type: AgentRunTimelineEventType;
+  source: AgentRunTimelineEventSource;
+  timestamp: string;
+  title: string;
+  detail?: string;
+  durationMs?: number;
+  metadata?: Record<string, unknown>;
+  link?: {
+    label: string;
+    href: string;
+    target?: 'agent' | 'changes' | 'review' | 'work-products' | 'workflow' | 'external';
+  };
 }
 
 /** Query options for fetching events */
 export interface TelemetryQueryOptions {
   type?: TelemetryEventType | TelemetryEventType[];
-  since?: string;  // ISO timestamp
-  until?: string;  // ISO timestamp
+  since?: string; // ISO timestamp
+  until?: string; // ISO timestamp
   taskId?: string;
   project?: string;
   limit?: number;

--- a/web/src/__tests__/agent-run-timeline-mantine.test.tsx
+++ b/web/src/__tests__/agent-run-timeline-mantine.test.tsx
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  AgentRunTimelinePanel,
+  buildAgentRunTimelineEvents,
+  getTimelineEventType,
+  redactTimelineText,
+} from '@/components/task/AgentRunTimelinePanel';
+import { createMockTask, renderWithProviders } from './test-utils';
+import type {
+  AgentRunTrace,
+  AnyTelemetryEvent,
+  Task,
+  WorkProductPreview,
+} from '@veritas-kanban/shared';
+
+const mocks = vi.hoisted(() => ({
+  onOpenTab: vi.fn(),
+  useAgentRunTraces: vi.fn(),
+  useTaskTelemetryEvents: vi.fn(),
+  useTaskWorkProducts: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAgentRunTimeline', () => ({
+  useAgentRunTraces: mocks.useAgentRunTraces,
+  useTaskTelemetryEvents: mocks.useTaskTelemetryEvents,
+}));
+
+vi.mock('@/hooks/useWorkProducts', () => ({
+  useTaskWorkProducts: mocks.useTaskWorkProducts,
+}));
+
+const task: Task = createMockTask({
+  id: 'task-timeline',
+  title: 'Implement run timeline',
+  description: 'Render stored agent run events with replay metadata and safe redaction.',
+  type: 'code',
+  status: 'in-progress',
+  priority: 'high',
+  agent: 'veritas',
+  git: {
+    repo: 'BradGroux/veritas-kanban',
+    branch: 'v5-agent-run-timeline-replay',
+    baseBranch: 'main',
+    worktreePath: '/tmp/veritas-worktree',
+  },
+  attempt: {
+    id: 'attempt-1',
+    agent: 'veritas',
+    status: 'complete',
+    model: 'gpt-5',
+    provider: 'openai',
+    started: '2026-06-01T10:00:00.000Z',
+    ended: '2026-06-01T10:05:00.000Z',
+  },
+  review: {
+    decision: 'approved',
+    decidedAt: '2026-06-01T10:07:00.000Z',
+    summary: 'Ready to merge',
+  },
+  verificationSteps: [{ id: 'verify-1', description: 'Run tests', checked: true }],
+});
+
+const trace: AgentRunTrace = {
+  traceId: 'attempt-1',
+  taskId: 'task-timeline',
+  agent: 'veritas',
+  project: 'veritas',
+  startedAt: '2026-06-01T10:00:00.000Z',
+  endedAt: '2026-06-01T10:05:00.000Z',
+  totalDurationMs: 300000,
+  status: 'completed',
+  metadata: {
+    clientSource: 'agent-service',
+    mode: 'eng-review',
+    capabilitySet: ['start', 'status', 'logs', 'complete'],
+    workspaceId: 'local',
+    runKey: 'attempt-1',
+    policyProfile: 'codex-cli:workspace-write',
+    provider: 'codex-cli',
+    model: 'gpt-5',
+    repo: 'BradGroux/veritas-kanban',
+    branch: 'v5-agent-run-timeline-replay',
+  },
+  steps: [
+    {
+      type: 'init',
+      sequence: 1,
+      startedAt: '2026-06-01T10:00:01.000Z',
+      endedAt: '2026-06-01T10:00:02.000Z',
+      durationMs: 1000,
+      metadata: { provider: 'codex-cli' },
+    },
+    {
+      type: 'execute',
+      sequence: 2,
+      startedAt: '2026-06-01T10:01:00.000Z',
+      endedAt: '2026-06-01T10:01:05.000Z',
+      durationMs: 5000,
+      metadata: {
+        eventType: 'command.completed',
+        summary: 'pnpm test TOKEN=super-secret-token',
+      },
+    },
+  ],
+};
+
+const telemetryEvents: AnyTelemetryEvent[] = [
+  {
+    id: 'evt-start',
+    type: 'run.started',
+    timestamp: '2026-06-01T10:00:00.000Z',
+    taskId: 'task-timeline',
+    agent: 'veritas',
+    model: 'gpt-5',
+    attemptId: 'attempt-1',
+  },
+  {
+    id: 'evt-tokens',
+    type: 'run.tokens',
+    timestamp: '2026-06-01T10:04:00.000Z',
+    taskId: 'task-timeline',
+    agent: 'veritas',
+    model: 'gpt-5',
+    inputTokens: 1200,
+    outputTokens: 800,
+    totalTokens: 2000,
+    cost: 0.14,
+    attemptId: 'attempt-1',
+  },
+];
+
+const product: WorkProductPreview = {
+  id: 'wp-timeline',
+  workspaceId: 'local',
+  kind: 'report',
+  title: 'Run replay report',
+  status: 'active',
+  version: 2,
+  taskId: 'task-timeline',
+  sourceRunId: 'attempt-1',
+  agent: 'veritas',
+  model: 'gpt-5',
+  sourceLinks: [{ label: 'Source run', href: '/runs/attempt-1', type: 'run' }],
+  redacted: true,
+  snippet: 'Replay summary',
+  createdAt: '2026-06-01T10:06:00.000Z',
+  updatedAt: '2026-06-01T10:06:30.000Z',
+};
+
+describe('agent run timeline Mantine surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAgentRunTraces.mockReturnValue({ data: [trace], isLoading: false });
+    mocks.useTaskTelemetryEvents.mockReturnValue({ data: telemetryEvents, isLoading: false });
+    mocks.useTaskWorkProducts.mockReturnValue({ data: [product], isLoading: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('builds chronological timeline events with trace, telemetry, and work product context', () => {
+    const events = buildAgentRunTimelineEvents({
+      task,
+      traces: [trace],
+      telemetryEvents,
+      workProducts: [product],
+      selectedAttemptId: 'attempt-1',
+    });
+
+    expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index + 1));
+    expect(events.some((event) => event.type === 'prompt')).toBe(true);
+    expect(events.some((event) => event.type === 'command')).toBe(true);
+    expect(events.some((event) => event.type === 'usage')).toBe(true);
+    expect(events.some((event) => event.title.includes('Work product saved'))).toBe(true);
+    expect(getTimelineEventType('execute', { eventType: 'tool.progress' })).toBe('tool');
+    expect(getTimelineEventType('error', { summary: 'failed' })).toBe('error');
+  });
+
+  it('redacts sensitive values before rendering timeline metadata', () => {
+    const redacted = redactTimelineText(
+      'Authorization: Bearer abc123supersecret OPENAI_API_KEY=sk-supersecret123456'
+    );
+
+    expect(redacted).toContain('[REDACTED]');
+    expect(redacted).toContain('OPENAI_API_KEY=[REDACTED]');
+    expect(redacted).not.toContain('abc123supersecret');
+    expect(redacted).not.toContain('sk-supersecret123456');
+  });
+
+  it('renders run replay controls, filters by event type, and links back to task surfaces', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AgentRunTimelinePanel task={task} onOpenTab={mocks.onOpenTab} />);
+
+    expect(screen.getByText('Run Timeline')).toBeDefined();
+    expect(screen.getByText('Stored replay')).toBeDefined();
+    expect(screen.getByText('command.completed')).toBeDefined();
+    expect(screen.getByText('Run replay report')).toBeDefined();
+    expect(screen.queryByText('super-secret-token')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Usage' }));
+
+    expect(screen.getByText('Token usage recorded')).toBeDefined();
+    expect(screen.queryByText('command.completed')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Work Products' }));
+
+    expect(mocks.onOpenTab).toHaveBeenCalledWith('work-products');
+  });
+});

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -98,6 +98,10 @@ vi.mock('@/components/task/AgentPanel', () => ({
   AgentPanel: () => <div>Agent panel</div>,
 }));
 
+vi.mock('@/components/task/AgentRunTimelinePanel', () => ({
+  AgentRunTimelinePanel: () => <div>Run timeline panel</div>,
+}));
+
 vi.mock('@/components/task/DiffViewer', () => ({
   DiffViewer: () => <div>Diff viewer</div>,
 }));
@@ -246,6 +250,7 @@ describe('task detail Mantine migration', () => {
     renderWithProviders(<TaskDetailPanel task={task} open onOpenChange={mocks.onOpenChange} />);
 
     expect(screen.getByRole('tab', { name: 'Work' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Timeline' })).toBeDefined();
     expect(screen.getByText('Work View')).toBeDefined();
   });
 });

--- a/web/src/components/task/AgentPanel.tsx
+++ b/web/src/components/task/AgentPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import {
+  ActionIcon,
   Badge,
   Button,
   Code,
@@ -10,6 +11,7 @@ import {
   Stack,
   Text,
   TextInput,
+  Tooltip,
 } from '@mantine/core';
 import { useConfig } from '@/hooks/useConfig';
 import {
@@ -45,6 +47,7 @@ import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 
 interface AgentPanelProps {
   task: Task;
+  onOpenTimeline?: (attemptId?: string) => void;
 }
 
 const attemptStatusIcons: Record<AttemptStatus, React.ReactNode> = {
@@ -54,7 +57,7 @@ const attemptStatusIcons: Record<AttemptStatus, React.ReactNode> = {
   failed: <XCircle className="h-3 w-3 text-red-500" />,
 };
 
-export function AgentPanel({ task }: AgentPanelProps) {
+export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
   const { data: config } = useConfig();
   const { data: agentStatus } = useAgentStatus(task.id);
   const { outputs, isConnected, isRunning, clearOutputs } = useAgentStream(task.id);
@@ -369,6 +372,21 @@ export function AgentPanel({ task }: AgentPanelProps) {
                         Viewing
                       </Badge>
                     )}
+                    {onOpenTimeline && (
+                      <Tooltip label="Open run timeline">
+                        <ActionIcon
+                          aria-label={`Open timeline for ${attemptId}`}
+                          size="sm"
+                          variant="subtle"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onOpenTimeline(attemptId);
+                          }}
+                        >
+                          <History className="h-3 w-3" />
+                        </ActionIcon>
+                      </Tooltip>
+                    )}
                   </div>
                 );
               })}
@@ -424,6 +442,16 @@ export function AgentPanel({ task }: AgentPanelProps) {
                 <Text size="xs" c="dimmed">
                   Ended: {new Date(task.attempt.ended).toLocaleString()}
                 </Text>
+              )}
+              {onOpenTimeline && (
+                <Button
+                  size="compact-xs"
+                  variant="subtle"
+                  leftSection={<History className="h-3 w-3" />}
+                  onClick={() => onOpenTimeline(task.attempt?.id)}
+                >
+                  Timeline
+                </Button>
               )}
             </Stack>
           </Paper>

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -1,0 +1,889 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Code,
+  Group,
+  Loader,
+  Paper,
+  ScrollArea,
+  Select,
+  SimpleGrid,
+  Stack,
+  Text,
+  ThemeIcon,
+} from '@mantine/core';
+import {
+  AlertTriangle,
+  Bot,
+  CheckCircle2,
+  ClipboardCheck,
+  Code2,
+  FileDiff,
+  FileText,
+  GitBranch,
+  History,
+  KeyRound,
+  ListFilter,
+  Play,
+  ShieldCheck,
+  Terminal,
+  Timer,
+  Wrench,
+} from 'lucide-react';
+import type {
+  AgentRunTimelineEvent,
+  AgentRunTimelineEventSource,
+  AgentRunTimelineEventType,
+  AgentRunTrace,
+  AgentRunTraceStep,
+  AnyTelemetryEvent,
+  Task,
+  TelemetryEventType,
+  WorkProductPreview,
+} from '@veritas-kanban/shared';
+import { useAgentRunTraces, useTaskTelemetryEvents } from '@/hooks/useAgentRunTimeline';
+import { useTaskWorkProducts } from '@/hooks/useWorkProducts';
+import { sanitizeText } from '@/lib/sanitize';
+
+type TimelineTabTarget = 'agent' | 'changes' | 'review' | 'work-products';
+
+interface AgentRunTimelinePanelProps {
+  task: Task;
+  initialAttemptId?: string | null;
+  onOpenTab?: (target: TimelineTabTarget) => void;
+}
+
+const EVENT_TYPES: AgentRunTimelineEventType[] = [
+  'prompt',
+  'command',
+  'file',
+  'policy',
+  'approval',
+  'error',
+  'usage',
+  'tool',
+  'result',
+];
+
+const MAX_RENDERED_EVENTS = 120;
+
+const EVENT_LABELS: Record<AgentRunTimelineEventType, string> = {
+  approval: 'Approval',
+  command: 'Command',
+  error: 'Error',
+  file: 'File',
+  policy: 'Policy',
+  prompt: 'Prompt',
+  result: 'Result',
+  tool: 'Tool',
+  usage: 'Usage',
+};
+
+const EVENT_COLORS: Record<AgentRunTimelineEventType, string> = {
+  approval: 'green',
+  command: 'blue',
+  error: 'red',
+  file: 'grape',
+  policy: 'yellow',
+  prompt: 'cyan',
+  result: 'green',
+  tool: 'indigo',
+  usage: 'orange',
+};
+
+const SOURCE_COLORS: Record<AgentRunTimelineEventSource, string> = {
+  derived: 'gray',
+  live: 'blue',
+  stored: 'green',
+};
+
+const EVENT_ICONS: Record<AgentRunTimelineEventType, React.ElementType> = {
+  approval: CheckCircle2,
+  command: Terminal,
+  error: AlertTriangle,
+  file: FileText,
+  policy: ShieldCheck,
+  prompt: Bot,
+  result: ClipboardCheck,
+  tool: Wrench,
+  usage: Timer,
+};
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
+  [/\bsk-[A-Za-z0-9_-]{12,}/g, 'sk-[REDACTED]'],
+  [/\bghp_[A-Za-z0-9_]{12,}/g, 'ghp_[REDACTED]'],
+  [/\bgithub_pat_[A-Za-z0-9_]{12,}/g, 'github_pat_[REDACTED]'],
+  [
+    /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*)\s*=\s*([^\s"'`]+)/gi,
+    '$1=[REDACTED]',
+  ],
+  [/\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*([^\s"'`,}]+)/gi, '$1=[REDACTED]'],
+];
+
+function isRunEvent(event: AnyTelemetryEvent): event is AnyTelemetryEvent & {
+  attemptId?: string;
+  agent?: string;
+  model?: string;
+  durationMs?: number;
+  success?: boolean;
+  error?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheTokens?: number;
+  totalTokens?: number;
+  cost?: number;
+} {
+  return event.type.startsWith('run.');
+}
+
+function formatDate(value?: string): string {
+  if (!value) return 'Not recorded';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Not recorded';
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function formatDurationMs(value?: number): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'Not recorded';
+  if (value < 1000) return `${Math.max(0, Math.round(value))}ms`;
+  const seconds = Math.round(value / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours === 0) return `${minutes}m ${remainingSeconds}s`;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function getEventAttemptId(event: AnyTelemetryEvent): string | undefined {
+  return isRunEvent(event) ? event.attemptId : undefined;
+}
+
+function safeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const sanitized = sanitizeText(value.trim());
+  return sanitized.length > 0 ? sanitized : undefined;
+}
+
+export function redactTimelineText(value: string): string {
+  let redacted = sanitizeText(value);
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, replacement);
+  }
+  return redacted;
+}
+
+function redactValue(value: unknown): unknown {
+  if (typeof value === 'string') return redactTimelineText(value);
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, entry]) => {
+      const sensitiveKey = /(token|secret|password|authorization|api[_-]?key)/i.test(key);
+      return [key, sensitiveKey ? '[REDACTED]' : redactValue(entry)];
+    })
+  );
+}
+
+function stringifyMetadata(metadata?: Record<string, unknown>): string {
+  if (!metadata || Object.keys(metadata).length === 0) return '';
+  const serialized = JSON.stringify(redactValue(metadata), null, 2);
+  if (serialized.length <= 4000) return serialized;
+  return `${serialized.slice(0, 4000)}\n...`;
+}
+
+function sourceForTrace(trace?: AgentRunTrace): AgentRunTimelineEventSource {
+  if (!trace) return 'derived';
+  return trace.status === 'running' ? 'live' : 'stored';
+}
+
+function eventText(metadata: Record<string, unknown> | undefined): string {
+  return [
+    safeString(metadata?.eventType),
+    safeString(metadata?.summary),
+    safeString(metadata?.tool),
+    safeString(metadata?.command),
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function getTimelineEventType(
+  stepType: AgentRunTraceStep['type'],
+  metadata?: Record<string, unknown>
+): AgentRunTimelineEventType {
+  const text = `${stepType} ${eventText(metadata)}`.toLowerCase();
+
+  if (stepType === 'error' || /error|failed|failure|abort|exception/.test(text)) return 'error';
+  if (stepType === 'complete') return 'result';
+  if (/approval|approve|denied|deny|permission request/.test(text)) return 'approval';
+  if (/policy|permission|sandbox|security|guard/.test(text)) return 'policy';
+  if (/file|diff|patch|write|edit|created|modified|deleted/.test(text)) return 'file';
+  if (/\b(command|shell|terminal|stdout|stderr)\b|exec[.:_-]/.test(text)) return 'command';
+  if (/token|usage|cost|input_tokens|output_tokens/.test(text)) return 'usage';
+  if (/tool|function|mcp/.test(text)) return 'tool';
+  if (/completed|final|result|finish/.test(text)) return 'result';
+  return stepType === 'init' ? 'prompt' : 'tool';
+}
+
+function titleForStep(type: AgentRunTimelineEventType, step: AgentRunTraceStep): string {
+  const eventType = safeString(step.metadata?.eventType);
+  const summary = safeString(step.metadata?.summary);
+  if (eventType) return eventType;
+  if (summary) return summary.length > 80 ? `${summary.slice(0, 77)}...` : summary;
+
+  switch (type) {
+    case 'prompt':
+      return 'Run initialized';
+    case 'result':
+      return 'Run completed';
+    case 'error':
+      return 'Run error recorded';
+    default:
+      return `${EVENT_LABELS[type]} event`;
+  }
+}
+
+function telemetryTitle(event: AnyTelemetryEvent): string {
+  if (event.type === 'run.started') return 'Run started';
+  if (event.type === 'run.completed') {
+    return isRunEvent(event) && event.success === false ? 'Run failed' : 'Run completed';
+  }
+  if (event.type === 'run.error') return 'Run error recorded';
+  if (event.type === 'run.tokens') return 'Token usage recorded';
+  return event.type;
+}
+
+function telemetryEventType(event: AnyTelemetryEvent): AgentRunTimelineEventType {
+  if (event.type === 'run.started') return 'prompt';
+  if (event.type === 'run.completed') {
+    return isRunEvent(event) && event.success === false ? 'error' : 'result';
+  }
+  if (event.type === 'run.error') return 'error';
+  if (event.type === 'run.tokens') return 'usage';
+  return 'tool';
+}
+
+function metadataForTaskPrompt(task: Task, trace?: AgentRunTrace): Record<string, unknown> {
+  return {
+    taskId: task.id,
+    title: task.title,
+    description: task.description,
+    project: task.project,
+    sprint: task.sprint,
+    type: task.type,
+    priority: task.priority,
+    runMode: task.runMode,
+    assignedAgent: task.agent,
+    selectedAgent: trace?.agent || task.attempt?.agent,
+    model: trace?.metadata?.model || task.attempt?.model,
+    provider: trace?.metadata?.provider || task.attempt?.provider,
+    repo: task.git?.repo,
+    branch: task.git?.branch,
+    baseBranch: task.git?.baseBranch,
+    worktreePath: task.git?.worktreePath,
+    policyProfile: trace?.metadata?.policyProfile,
+    capabilitySet: trace?.metadata?.capabilitySet,
+    workspaceId: trace?.metadata?.workspaceId,
+    sessionKey: trace?.metadata?.sessionKey,
+    runKey: trace?.metadata?.runKey || task.attempt?.id,
+  };
+}
+
+function sortTimelineEvents(events: AgentRunTimelineEvent[]): AgentRunTimelineEvent[] {
+  return events
+    .sort((a, b) => {
+      const byTime = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+      if (Number.isFinite(byTime) && byTime !== 0) return byTime;
+      return a.sequence - b.sequence;
+    })
+    .map((event, index) => ({ ...event, sequence: index + 1 }));
+}
+
+interface BuildTimelineOptions {
+  task: Task;
+  traces: AgentRunTrace[];
+  telemetryEvents: AnyTelemetryEvent[];
+  workProducts: WorkProductPreview[];
+  selectedAttemptId?: string | null;
+}
+
+export function buildAgentRunTimelineEvents({
+  task,
+  traces,
+  telemetryEvents,
+  workProducts,
+  selectedAttemptId,
+}: BuildTimelineOptions): AgentRunTimelineEvent[] {
+  const selectedTrace =
+    traces.find((trace) => trace.traceId === selectedAttemptId) ||
+    traces[0] ||
+    (selectedAttemptId ? undefined : null);
+  const attemptId = selectedAttemptId || selectedTrace?.traceId || task.attempt?.id;
+  const source = sourceForTrace(selectedTrace || undefined);
+  const events: AgentRunTimelineEvent[] = [];
+  let nextSequence = 1;
+  const startedAt = selectedTrace?.startedAt || task.attempt?.started || task.created;
+
+  events.push({
+    id: `prompt-${attemptId || task.id}`,
+    sequence: nextSequence++,
+    type: 'prompt',
+    source: selectedTrace ? source : 'derived',
+    timestamp: startedAt,
+    title: 'Prompt and task input prepared',
+    detail: task.title,
+    metadata: metadataForTaskPrompt(task, selectedTrace || undefined),
+  });
+
+  if (selectedTrace) {
+    for (const step of selectedTrace.steps) {
+      const eventType = getTimelineEventType(step.type, step.metadata);
+      events.push({
+        id: `trace-${selectedTrace.traceId}-${step.sequence ?? nextSequence}`,
+        sequence: step.sequence ?? nextSequence,
+        type: eventType,
+        source,
+        timestamp: step.startedAt,
+        title: titleForStep(eventType, step),
+        detail: safeString(step.metadata?.summary),
+        durationMs: step.durationMs,
+        metadata: {
+          traceStepType: step.type,
+          traceSequence: step.sequence,
+          ...step.metadata,
+        },
+      });
+      nextSequence += 1;
+    }
+  }
+
+  const relevantTelemetry = telemetryEvents.filter((event) => {
+    if (!attemptId) return event.taskId === task.id;
+    return event.taskId === task.id && getEventAttemptId(event) === attemptId;
+  });
+
+  for (const event of relevantTelemetry) {
+    const run = isRunEvent(event) ? event : undefined;
+    const type = telemetryEventType(event);
+    events.push({
+      id: `telemetry-${event.id}`,
+      sequence: nextSequence++,
+      type,
+      source: selectedTrace ? source : 'derived',
+      timestamp: event.timestamp,
+      title: telemetryTitle(event),
+      detail: run?.error,
+      durationMs: run?.durationMs,
+      metadata: {
+        telemetryType: event.type as TelemetryEventType,
+        agent: run?.agent,
+        model: run?.model,
+        attemptId: run?.attemptId,
+        success: run?.success,
+        inputTokens: run?.inputTokens,
+        outputTokens: run?.outputTokens,
+        cacheTokens: run?.cacheTokens,
+        totalTokens: run?.totalTokens,
+        cost: run?.cost,
+      },
+    });
+  }
+
+  const currentAttempt = task.attempt;
+  if (currentAttempt && (!attemptId || currentAttempt.id === attemptId)) {
+    if (
+      currentAttempt.started &&
+      !events.some((event) => event.id === `attempt-start-${currentAttempt.id}`)
+    ) {
+      events.push({
+        id: `attempt-start-${currentAttempt.id}`,
+        sequence: nextSequence++,
+        type: 'prompt',
+        source: 'derived',
+        timestamp: currentAttempt.started,
+        title: 'Task attempt started',
+        detail: currentAttempt.agent,
+        metadata: currentAttempt as unknown as Record<string, unknown>,
+      });
+    }
+    if (currentAttempt.ended) {
+      events.push({
+        id: `attempt-end-${currentAttempt.id}`,
+        sequence: nextSequence++,
+        type: currentAttempt.status === 'failed' ? 'error' : 'result',
+        source: 'derived',
+        timestamp: currentAttempt.ended,
+        title: currentAttempt.status === 'failed' ? 'Task attempt failed' : 'Task attempt finished',
+        detail: currentAttempt.agent,
+        metadata: currentAttempt as unknown as Record<string, unknown>,
+      });
+    }
+  }
+
+  if (task.git?.worktreePath) {
+    events.push({
+      id: `worktree-${task.id}`,
+      sequence: nextSequence++,
+      type: 'file',
+      source: 'derived',
+      timestamp: startedAt,
+      title: 'Worktree attached',
+      detail: task.git.branch || task.git.baseBranch,
+      metadata: {
+        repo: task.git.repo,
+        branch: task.git.branch,
+        baseBranch: task.git.baseBranch,
+        worktreePath: task.git.worktreePath,
+        prUrl: task.git.prUrl,
+        prNumber: task.git.prNumber,
+      },
+      link: { label: 'Changes', href: '#changes', target: 'changes' },
+    });
+  }
+
+  if (task.review?.decision) {
+    events.push({
+      id: `review-${task.id}`,
+      sequence: nextSequence++,
+      type: task.review.decision === 'approved' ? 'approval' : 'error',
+      source: 'derived',
+      timestamp: task.review.decidedAt || task.updated,
+      title: `Review ${task.review.decision}`,
+      detail: task.review.summary,
+      metadata: task.review as unknown as Record<string, unknown>,
+      link: { label: 'Review', href: '#review', target: 'review' },
+    });
+  }
+
+  for (const product of workProducts) {
+    if (attemptId && product.sourceRunId && product.sourceRunId !== attemptId) continue;
+    events.push({
+      id: `work-product-${product.id}`,
+      sequence: nextSequence++,
+      type: 'file',
+      source: 'derived',
+      timestamp: product.createdAt,
+      title: `Work product saved: ${product.title}`,
+      detail: product.snippet,
+      metadata: {
+        kind: product.kind,
+        version: product.version,
+        status: product.status,
+        sourceRunId: product.sourceRunId,
+        agent: product.agent,
+        model: product.model,
+        redacted: product.redacted,
+      },
+      link: { label: 'Work products', href: '#work-products', target: 'work-products' },
+    });
+  }
+
+  if ((task.verificationSteps?.length ?? 0) > 0) {
+    const checked = task.verificationSteps?.filter((step) => step.checked).length ?? 0;
+    events.push({
+      id: `verification-${task.id}`,
+      sequence: nextSequence++,
+      type: checked === task.verificationSteps?.length ? 'approval' : 'result',
+      source: 'derived',
+      timestamp: task.updated,
+      title: 'Verification checklist updated',
+      detail: `${checked}/${task.verificationSteps?.length ?? 0} checks complete`,
+      metadata: {
+        checks: task.verificationSteps,
+      },
+    });
+  }
+
+  return sortTimelineEvents(events);
+}
+
+function getRunOptions(
+  task: Task,
+  traces: AgentRunTrace[],
+  telemetryEvents: AnyTelemetryEvent[],
+  workProducts: WorkProductPreview[]
+): Array<{ value: string; label: string }> {
+  const attempts = new Map<string, string>();
+  const addAttempt = (id: string | undefined, label: string) => {
+    if (!id || attempts.has(id)) return;
+    attempts.set(id, label);
+  };
+
+  for (const trace of traces) {
+    addAttempt(trace.traceId, `${trace.traceId} (${trace.status})`);
+  }
+  addAttempt(task.attempt?.id, `${task.attempt?.id} (${task.attempt?.status ?? 'current'})`);
+  for (const attempt of task.attempts ?? []) {
+    addAttempt(attempt.id, `${attempt.id} (${attempt.status})`);
+  }
+  for (const event of telemetryEvents) {
+    addAttempt(getEventAttemptId(event), `${getEventAttemptId(event)} (telemetry)`);
+  }
+  for (const product of workProducts) {
+    addAttempt(product.sourceRunId, `${product.sourceRunId} (work product)`);
+  }
+
+  return Array.from(attempts.entries()).map(([value, label]) => ({ value, label }));
+}
+
+function typeFilterLabel(type: AgentRunTimelineEventType): string {
+  return EVENT_LABELS[type];
+}
+
+function EventRow({
+  event,
+  onOpenTab,
+}: {
+  event: AgentRunTimelineEvent;
+  onOpenTab?: (target: TimelineTabTarget) => void;
+}) {
+  const Icon = EVENT_ICONS[event.type];
+  const metadata = stringifyMetadata(event.metadata);
+  const linkTarget = event.link?.target;
+  const canOpenInternal =
+    linkTarget && linkTarget !== 'external' && linkTarget !== 'workflow' && onOpenTab;
+
+  return (
+    <Paper withBorder p="sm" radius="md">
+      <Stack gap="xs">
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Group gap="sm" align="flex-start" wrap="nowrap" className="min-w-0">
+            <ThemeIcon size="sm" radius="xl" color={EVENT_COLORS[event.type]} variant="light">
+              <Icon className="h-4 w-4" />
+            </ThemeIcon>
+            <div className="min-w-0">
+              <Group gap="xs" wrap="wrap">
+                <Text size="sm" fw={600}>
+                  {redactTimelineText(event.title)}
+                </Text>
+                <Badge size="xs" color={EVENT_COLORS[event.type]} variant="light">
+                  {EVENT_LABELS[event.type]}
+                </Badge>
+                <Badge size="xs" color={SOURCE_COLORS[event.source]} variant="outline">
+                  {event.source}
+                </Badge>
+              </Group>
+              <Text size="xs" c="dimmed">
+                {formatDate(event.timestamp)}
+                {event.durationMs !== undefined ? ` | ${formatDurationMs(event.durationMs)}` : ''}
+              </Text>
+            </div>
+          </Group>
+          <Text size="xs" c="dimmed" className="shrink-0 tabular-nums">
+            #{event.sequence}
+          </Text>
+        </Group>
+        {event.detail && (
+          <Text size="sm" c="dimmed">
+            {redactTimelineText(event.detail)}
+          </Text>
+        )}
+        {metadata && (
+          <Code block className="max-h-40 overflow-auto whitespace-pre-wrap break-words text-xs">
+            {metadata}
+          </Code>
+        )}
+        {canOpenInternal && event.link && linkTarget && (
+          <Group gap="xs">
+            <Button
+              size="compact-xs"
+              variant="subtle"
+              onClick={() => onOpenTab?.(linkTarget as TimelineTabTarget)}
+            >
+              {event.link.label}
+            </Button>
+          </Group>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+export function AgentRunTimelinePanel({
+  task,
+  initialAttemptId,
+  onOpenTab,
+}: AgentRunTimelinePanelProps) {
+  const { data: traces = [], isLoading: tracesLoading } = useAgentRunTraces(task.id);
+  const { data: telemetryEvents = [], isLoading: telemetryLoading } = useTaskTelemetryEvents(
+    task.id
+  );
+  const { data: workProducts = [], isLoading: workProductsLoading } = useTaskWorkProducts(task.id);
+  const [selectedAttemptId, setSelectedAttemptId] = useState<string | null>(
+    initialAttemptId ?? task.attempt?.id ?? null
+  );
+  const [filter, setFilter] = useState<AgentRunTimelineEventType | 'all'>('all');
+
+  useEffect(() => {
+    if (initialAttemptId) {
+      setSelectedAttemptId(initialAttemptId);
+    }
+  }, [initialAttemptId]);
+
+  const runOptions = useMemo(
+    () => getRunOptions(task, traces, telemetryEvents, workProducts),
+    [task, traces, telemetryEvents, workProducts]
+  );
+
+  useEffect(() => {
+    if (runOptions.length === 0) {
+      if (selectedAttemptId) setSelectedAttemptId(null);
+      return;
+    }
+    if (!selectedAttemptId || !runOptions.some((option) => option.value === selectedAttemptId)) {
+      setSelectedAttemptId(runOptions[0].value);
+    }
+  }, [runOptions, selectedAttemptId]);
+
+  const selectedTrace = useMemo(
+    () => traces.find((trace) => trace.traceId === selectedAttemptId),
+    [selectedAttemptId, traces]
+  );
+
+  const events = useMemo(
+    () =>
+      buildAgentRunTimelineEvents({
+        task,
+        traces,
+        telemetryEvents,
+        workProducts,
+        selectedAttemptId,
+      }),
+    [task, traces, telemetryEvents, workProducts, selectedAttemptId]
+  );
+
+  const filteredEvents = useMemo(
+    () => (filter === 'all' ? events : events.filter((event) => event.type === filter)),
+    [events, filter]
+  );
+  const visibleEvents = filteredEvents.slice(0, MAX_RENDERED_EVENTS);
+  const isLoading = tracesLoading || telemetryLoading || workProductsLoading;
+  const source = sourceForTrace(selectedTrace);
+  const linkedWorkProducts = workProducts.filter(
+    (product) => !selectedAttemptId || product.sourceRunId === selectedAttemptId
+  );
+
+  return (
+    <Stack gap="md">
+      <Paper withBorder p="md" radius="md">
+        <Stack gap="sm">
+          <Group justify="space-between" align="flex-start" gap="md" wrap="nowrap">
+            <div className="min-w-0">
+              <Group gap="xs" wrap="wrap">
+                <ThemeIcon size="sm" radius="xl" variant="light">
+                  <History className="h-4 w-4" />
+                </ThemeIcon>
+                <Text fw={700}>Run Timeline</Text>
+                <Badge color={SOURCE_COLORS[source]} variant="light">
+                  {source === 'live' ? 'Live' : source === 'stored' ? 'Stored replay' : 'Derived'}
+                </Badge>
+                {selectedTrace && (
+                  <Badge
+                    color={selectedTrace.status === 'failed' ? 'red' : 'gray'}
+                    variant="outline"
+                  >
+                    {selectedTrace.status}
+                  </Badge>
+                )}
+              </Group>
+              <Text size="sm" c="dimmed" mt={6}>
+                {selectedAttemptId || 'No attempt selected'} | {events.length} events
+              </Text>
+            </div>
+            {isLoading && (
+              <Group gap="xs" className="shrink-0">
+                <Loader size="xs" />
+                <Text size="xs" c="dimmed">
+                  Loading
+                </Text>
+              </Group>
+            )}
+          </Group>
+
+          <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+            <Select
+              label="Run"
+              aria-label="Run"
+              value={selectedAttemptId}
+              onChange={setSelectedAttemptId}
+              data={runOptions}
+              placeholder="Derived task timeline"
+              size="xs"
+              checkIconPosition="right"
+              disabled={runOptions.length === 0}
+            />
+            <Group gap="xs" align="flex-end">
+              <Button
+                size="compact-xs"
+                variant="light"
+                leftSection={<Bot className="h-3 w-3" />}
+                onClick={() => onOpenTab?.('agent')}
+              >
+                Agent
+              </Button>
+              {task.git?.worktreePath && (
+                <Button
+                  size="compact-xs"
+                  variant="subtle"
+                  leftSection={<FileDiff className="h-3 w-3" />}
+                  onClick={() => onOpenTab?.('changes')}
+                >
+                  Changes
+                </Button>
+              )}
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                leftSection={<ClipboardCheck className="h-3 w-3" />}
+                onClick={() => onOpenTab?.('review')}
+              >
+                Review
+              </Button>
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                leftSection={<FileText className="h-3 w-3" />}
+                onClick={() => onOpenTab?.('work-products')}
+              >
+                Work Products
+              </Button>
+            </Group>
+          </SimpleGrid>
+        </Stack>
+      </Paper>
+
+      <Paper withBorder p="md" radius="md">
+        <Stack gap="sm">
+          <Group gap="xs">
+            <ListFilter className="h-4 w-4 text-muted-foreground" />
+            <Text fw={600} size="sm">
+              Event Filters
+            </Text>
+          </Group>
+          <Group gap="xs">
+            <Button
+              size="compact-xs"
+              variant={filter === 'all' ? 'filled' : 'light'}
+              onClick={() => setFilter('all')}
+            >
+              All
+            </Button>
+            {EVENT_TYPES.map((type) => (
+              <Button
+                key={type}
+                size="compact-xs"
+                color={EVENT_COLORS[type]}
+                variant={filter === type ? 'filled' : 'light'}
+                onClick={() => setFilter(type)}
+              >
+                {typeFilterLabel(type)}
+              </Button>
+            ))}
+          </Group>
+        </Stack>
+      </Paper>
+
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+        <Paper withBorder p="sm" radius="md">
+          <Group gap="xs" wrap="nowrap">
+            <Code2 className="h-4 w-4 text-muted-foreground" />
+            <div className="min-w-0">
+              <Text size="xs" c="dimmed">
+                Agent / model
+              </Text>
+              <Text size="sm" fw={600} truncate>
+                {selectedTrace?.agent || task.attempt?.agent || task.agent || 'Unassigned'}
+                {selectedTrace?.metadata?.model || task.attempt?.model
+                  ? ` / ${selectedTrace?.metadata?.model || task.attempt?.model}`
+                  : ''}
+              </Text>
+            </div>
+          </Group>
+        </Paper>
+        <Paper withBorder p="sm" radius="md">
+          <Group gap="xs" wrap="nowrap">
+            <GitBranch className="h-4 w-4 text-muted-foreground" />
+            <div className="min-w-0">
+              <Text size="xs" c="dimmed">
+                Branch / worktree
+              </Text>
+              <Text size="sm" fw={600} truncate>
+                {task.git?.branch || task.git?.baseBranch || 'Not configured'}
+              </Text>
+            </div>
+          </Group>
+        </Paper>
+        <Paper withBorder p="sm" radius="md">
+          <Group gap="xs" wrap="nowrap">
+            <KeyRound className="h-4 w-4 text-muted-foreground" />
+            <div className="min-w-0">
+              <Text size="xs" c="dimmed">
+                Policy / capabilities
+              </Text>
+              <Text size="sm" fw={600} truncate>
+                {selectedTrace?.metadata?.policyProfile || task.runMode || 'Default'}
+              </Text>
+            </div>
+          </Group>
+        </Paper>
+      </SimpleGrid>
+
+      {linkedWorkProducts.length > 0 && (
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="xs">
+            <Group gap="xs">
+              <FileText className="h-4 w-4 text-muted-foreground" />
+              <Text fw={600} size="sm">
+                Linked Work Products
+              </Text>
+              <Badge variant="light">{linkedWorkProducts.length}</Badge>
+            </Group>
+            {linkedWorkProducts.slice(0, 4).map((product) => (
+              <Group key={product.id} gap="xs" wrap="nowrap">
+                <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
+                <Text size="sm" truncate className="min-w-0">
+                  {product.title}
+                </Text>
+                <Badge size="xs" variant="outline">
+                  v{product.version}
+                </Badge>
+              </Group>
+            ))}
+          </Stack>
+        </Paper>
+      )}
+
+      <ScrollArea.Autosize mah={520} type="auto">
+        <Stack gap="xs" pr="xs">
+          {visibleEvents.length > 0 ? (
+            visibleEvents.map((event) => (
+              <EventRow key={event.id} event={event} onOpenTab={onOpenTab} />
+            ))
+          ) : (
+            <Paper withBorder p="md" radius="md">
+              <Group gap="xs">
+                <Play className="h-4 w-4 text-muted-foreground" />
+                <Text size="sm" c="dimmed">
+                  No timeline events match this run and filter.
+                </Text>
+              </Group>
+            </Paper>
+          )}
+          {filteredEvents.length > visibleEvents.length && (
+            <Text size="xs" c="dimmed" ta="center" py="xs">
+              Showing {visibleEvents.length} of {filteredEvents.length} filtered events.
+            </Text>
+          )}
+        </Stack>
+      </ScrollArea.Autosize>
+    </Stack>
+  );
+}

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -28,6 +28,7 @@ import { ApplyTemplateDialog } from './ApplyTemplateDialog';
 import { TaskMetricsPanel } from './TaskMetricsPanel';
 import { WorkflowSection } from './WorkflowSection';
 import { WorkProductsSection } from './WorkProductsSection';
+import { AgentRunTimelinePanel } from './AgentRunTimelinePanel';
 import { shouldDefaultTaskDetailToWork, TaskWorkView } from './TaskWorkView';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import {
@@ -46,6 +47,7 @@ import {
   Workflow,
   Eye,
   Files,
+  History,
   X,
   type LucideIcon,
 } from 'lucide-react';
@@ -69,6 +71,7 @@ type TaskDetailTabId =
   | 'attachments'
   | 'git'
   | 'agent'
+  | 'timeline'
   | 'changes'
   | 'review'
   | 'metrics';
@@ -131,6 +134,13 @@ const TASK_DETAIL_TABS: readonly TaskDetailTabDefinition[] = [
     codeOnly: true,
   },
   {
+    id: 'timeline',
+    label: 'Timeline',
+    Icon: History,
+    fallbackTitle: 'Run timeline failed to load',
+    codeOnly: true,
+  },
+  {
     id: 'changes',
     label: 'Changes',
     Icon: FileDiff,
@@ -170,6 +180,7 @@ export function TaskDetailPanel({
   const [applyTemplateOpen, setApplyTemplateOpen] = useState(false);
   const [taskChatOpen, setTaskChatOpen] = useState(false);
   const [workflowOpen, setWorkflowOpen] = useState(false);
+  const [timelineAttemptId, setTimelineAttemptId] = useState<string | null>(null);
   const lastDefaultedTaskIdRef = useRef<string | undefined>(undefined);
   const addObservation = useAddObservation();
   const deleteObservation = useDeleteObservation();
@@ -276,7 +287,23 @@ export function TaskDetailPanel({
           />
         );
       case 'agent':
-        return <AgentPanel task={localTask} />;
+        return (
+          <AgentPanel
+            task={localTask}
+            onOpenTimeline={(attemptId) => {
+              setTimelineAttemptId(attemptId ?? null);
+              setActiveTab('timeline');
+            }}
+          />
+        );
+      case 'timeline':
+        return (
+          <AgentRunTimelinePanel
+            task={localTask}
+            initialAttemptId={timelineAttemptId}
+            onOpenTab={setActiveTab}
+          />
+        );
       case 'changes':
         if (!hasWorktree) return null;
         return (

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -42,6 +42,7 @@ export type TaskWorkViewTarget =
   | 'attachments'
   | 'git'
   | 'agent'
+  | 'timeline'
   | 'changes'
   | 'review'
   | 'metrics';
@@ -392,6 +393,16 @@ export function TaskWorkView({
               >
                 Open Agent
               </Button>
+              {isCodeTask && (
+                <Button
+                  size="compact-xs"
+                  variant="subtle"
+                  leftSection={<History className="h-3 w-3" />}
+                  onClick={() => onOpenTab('timeline')}
+                >
+                  Timeline
+                </Button>
+              )}
               <Button
                 size="compact-xs"
                 variant="subtle"

--- a/web/src/hooks/useAgentRunTimeline.ts
+++ b/web/src/hooks/useAgentRunTimeline.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { apiFetch } from '@/lib/api/helpers';
+import type { AnyTelemetryEvent } from '@veritas-kanban/shared';
+
+export function useAgentRunTraces(taskId: string | undefined) {
+  return useQuery({
+    queryKey: ['traces', 'task', taskId],
+    queryFn: () => (taskId ? api.traces.listForTask(taskId) : Promise.resolve([])),
+    enabled: Boolean(taskId),
+  });
+}
+
+export function useTaskTelemetryEvents(taskId: string | undefined) {
+  return useQuery({
+    queryKey: ['telemetry', 'task', taskId],
+    queryFn: () =>
+      taskId
+        ? apiFetch<AnyTelemetryEvent[]>(`/api/telemetry/events/task/${encodeURIComponent(taskId)}`)
+        : Promise.resolve([]),
+    enabled: Boolean(taskId),
+    staleTime: 30000,
+  });
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -17,6 +17,7 @@ import { scoringApi } from './scoring';
 import { searchApi } from './search';
 import { identityApi } from './identity';
 import { workProductsApi } from './work-products';
+import { tracesApi } from './traces';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -44,6 +45,7 @@ export const api = {
   search: searchApi,
   identity: identityApi,
   workProducts: workProductsApi,
+  traces: tracesApi,
 };
 
 export type {
@@ -55,6 +57,7 @@ export type {
 } from './search';
 
 export type { WorkProductExportFormat, WorkProductExportOptions } from './work-products';
+export type { TraceStatus } from './traces';
 
 // Re-export managed list helper
 export { managedList } from './managed-list';

--- a/web/src/lib/api/traces.ts
+++ b/web/src/lib/api/traces.ts
@@ -1,0 +1,29 @@
+import type { AgentRunTrace } from '@veritas-kanban/shared';
+import { API_BASE, handleResponse } from './helpers';
+
+export interface TraceStatus {
+  enabled: boolean;
+}
+
+export const tracesApi = {
+  status: async (): Promise<TraceStatus> => {
+    const response = await fetch(`${API_BASE}/traces/status`, {
+      credentials: 'include',
+    });
+    return handleResponse<TraceStatus>(response);
+  },
+
+  get: async (attemptId: string): Promise<AgentRunTrace> => {
+    const response = await fetch(`${API_BASE}/traces/${encodeURIComponent(attemptId)}`, {
+      credentials: 'include',
+    });
+    return handleResponse<AgentRunTrace>(response);
+  },
+
+  listForTask: async (taskId: string): Promise<AgentRunTrace[]> => {
+    const response = await fetch(`${API_BASE}/traces/task/${encodeURIComponent(taskId)}`, {
+      credentials: 'include',
+    });
+    return handleResponse<AgentRunTrace[]>(response);
+  },
+};


### PR DESCRIPTION
Summary:
- Adds a Timeline tab for code tasks with replay events from task context, trace steps, telemetry, work products, review, verification, and worktree metadata.
- Persists richer trace metadata and sequence numbers for agent attempts.
- Adds timeline links from the Agent panel and Work view plus API/hooks/tests for trace retrieval and redaction.

Verification:
- Focused server trace/provider tests passed.
- Focused web task detail/work view/timeline tests passed.
- Full typecheck, lint budget, build, and unit suite passed locally before commit.
- Rendered smoke against an isolated local server opened a disposable code task, selected Timeline, and verified the Prompt filter changed the visible event state.

Risk:
- This adds the replay surface and derived/stored trace handling. True live streaming event replay and deeper dashboard/notification entry points remain follow-on work for the roadmap issue.

Refs #360
Refs #359
Refs #403