### PR TITLE
Harden agent run timeline replay

### DIFF
--- a/web/src/__tests__/agent-run-timeline-mantine.test.tsx
+++ b/web/src/__tests__/agent-run-timeline-mantine.test.tsx
@@ -200,6 +200,7 @@ describe('agent run timeline Mantine surface', () => {
     expect(screen.getByText('command.completed')).toBeDefined();
     expect(screen.getByText('Run replay report')).toBeDefined();
     expect(screen.queryByText('super-secret-token')).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Agent logs' }).length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole('button', { name: 'Usage' }));
 
@@ -209,5 +210,35 @@ describe('agent run timeline Mantine surface', () => {
     await user.click(screen.getByRole('button', { name: 'Work Products' }));
 
     expect(mocks.onOpenTab).toHaveBeenCalledWith('work-products');
+  });
+
+  it('pages long timelines so replay rendering stays bounded', async () => {
+    const user = userEvent.setup();
+    const longTrace: AgentRunTrace = {
+      ...trace,
+      steps: Array.from({ length: 140 }, (_, index) => ({
+        type: 'execute',
+        sequence: index + 1,
+        startedAt: new Date(Date.UTC(2026, 5, 1, 10, index)).toISOString(),
+        metadata: {
+          eventType: `tool.progress.${index + 1}`,
+          summary: `Progress event ${index + 1}`,
+        },
+      })),
+    };
+    mocks.useAgentRunTraces.mockReturnValue({ data: [longTrace], isLoading: false });
+    mocks.useTaskTelemetryEvents.mockReturnValue({ data: [], isLoading: false });
+    mocks.useTaskWorkProducts.mockReturnValue({ data: [], isLoading: false });
+
+    renderWithProviders(<AgentRunTimelinePanel task={task} onOpenTab={mocks.onOpenTab} />);
+
+    expect(screen.getByText('Showing 80 of 146 filtered events.')).toBeDefined();
+    expect(screen.getByText('Progress event 1')).toBeDefined();
+    expect(screen.queryByText('Progress event 140')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Load 66 more' }));
+
+    expect(screen.getByText('Showing 146 of 146 filtered events.')).toBeDefined();
+    expect(screen.getByText('Progress event 140')).toBeDefined();
   });
 });

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -66,7 +66,7 @@ const EVENT_TYPES: AgentRunTimelineEventType[] = [
   'result',
 ];
 
-const MAX_RENDERED_EVENTS = 120;
+const TIMELINE_PAGE_SIZE = 80;
 
 const EVENT_LABELS: Record<AgentRunTimelineEventType, string> = {
   approval: 'Approval',
@@ -271,6 +271,15 @@ function telemetryEventType(event: AnyTelemetryEvent): AgentRunTimelineEventType
   return 'tool';
 }
 
+function logLinkForEvent(
+  type: AgentRunTimelineEventType
+): AgentRunTimelineEvent['link'] | undefined {
+  if (type === 'command' || type === 'error' || type === 'result' || type === 'tool') {
+    return { label: 'Agent logs', href: '#agent', target: 'agent' };
+  }
+  return undefined;
+}
+
 function metadataForTaskPrompt(task: Task, trace?: AgentRunTrace): Record<string, unknown> {
   return {
     taskId: task.id,
@@ -360,6 +369,7 @@ export function buildAgentRunTimelineEvents({
           traceSequence: step.sequence,
           ...step.metadata,
         },
+        link: logLinkForEvent(eventType),
       });
       nextSequence += 1;
     }
@@ -394,6 +404,7 @@ export function buildAgentRunTimelineEvents({
         totalTokens: run?.totalTokens,
         cost: run?.cost,
       },
+      link: logLinkForEvent(type),
     });
   }
 
@@ -412,6 +423,7 @@ export function buildAgentRunTimelineEvents({
         title: 'Task attempt started',
         detail: currentAttempt.agent,
         metadata: currentAttempt as unknown as Record<string, unknown>,
+        link: { label: 'Agent logs', href: '#agent', target: 'agent' },
       });
     }
     if (currentAttempt.ended) {
@@ -424,6 +436,7 @@ export function buildAgentRunTimelineEvents({
         title: currentAttempt.status === 'failed' ? 'Task attempt failed' : 'Task attempt finished',
         detail: currentAttempt.agent,
         metadata: currentAttempt as unknown as Record<string, unknown>,
+        link: { label: 'Agent logs', href: '#agent', target: 'agent' },
       });
     }
   }
@@ -612,15 +625,20 @@ export function AgentRunTimelinePanel({
   initialAttemptId,
   onOpenTab,
 }: AgentRunTimelinePanelProps) {
-  const { data: traces = [], isLoading: tracesLoading } = useAgentRunTraces(task.id);
+  const hasLiveAttempt = task.attempt?.status === 'running';
+  const { data: traces = [], isLoading: tracesLoading } = useAgentRunTraces(task.id, {
+    live: hasLiveAttempt,
+  });
   const { data: telemetryEvents = [], isLoading: telemetryLoading } = useTaskTelemetryEvents(
-    task.id
+    task.id,
+    { live: hasLiveAttempt }
   );
   const { data: workProducts = [], isLoading: workProductsLoading } = useTaskWorkProducts(task.id);
   const [selectedAttemptId, setSelectedAttemptId] = useState<string | null>(
     initialAttemptId ?? task.attempt?.id ?? null
   );
   const [filter, setFilter] = useState<AgentRunTimelineEventType | 'all'>('all');
+  const [visibleCount, setVisibleCount] = useState(TIMELINE_PAGE_SIZE);
 
   useEffect(() => {
     if (initialAttemptId) {
@@ -664,12 +682,17 @@ export function AgentRunTimelinePanel({
     () => (filter === 'all' ? events : events.filter((event) => event.type === filter)),
     [events, filter]
   );
-  const visibleEvents = filteredEvents.slice(0, MAX_RENDERED_EVENTS);
+  const visibleEvents = filteredEvents.slice(0, visibleCount);
+  const canLoadMore = filteredEvents.length > visibleEvents.length;
   const isLoading = tracesLoading || telemetryLoading || workProductsLoading;
   const source = sourceForTrace(selectedTrace);
   const linkedWorkProducts = workProducts.filter(
     (product) => !selectedAttemptId || product.sourceRunId === selectedAttemptId
   );
+
+  useEffect(() => {
+    setVisibleCount(TIMELINE_PAGE_SIZE);
+  }, [filter, selectedAttemptId, events.length]);
 
   return (
     <Stack gap="md">
@@ -696,6 +719,7 @@ export function AgentRunTimelinePanel({
               </Group>
               <Text size="sm" c="dimmed" mt={6}>
                 {selectedAttemptId || 'No attempt selected'} | {events.length} events
+                {hasLiveAttempt ? ' | live polling' : ''}
               </Text>
             </div>
             {isLoading && (
@@ -877,10 +901,29 @@ export function AgentRunTimelinePanel({
               </Group>
             </Paper>
           )}
-          {filteredEvents.length > visibleEvents.length && (
-            <Text size="xs" c="dimmed" ta="center" py="xs">
-              Showing {visibleEvents.length} of {filteredEvents.length} filtered events.
-            </Text>
+          {filteredEvents.length > TIMELINE_PAGE_SIZE && (
+            <Paper withBorder p="sm" radius="md">
+              <Group justify="space-between" gap="sm">
+                <Text size="xs" c="dimmed">
+                  Showing {visibleEvents.length} of {filteredEvents.length} filtered events.
+                </Text>
+                {canLoadMore && (
+                  <Button
+                    size="compact-xs"
+                    variant="subtle"
+                    onClick={() =>
+                      setVisibleCount((count) =>
+                        Math.min(count + TIMELINE_PAGE_SIZE, filteredEvents.length)
+                      )
+                    }
+                  >
+                    Load{' '}
+                    {Math.min(TIMELINE_PAGE_SIZE, filteredEvents.length - visibleEvents.length)}{' '}
+                    more
+                  </Button>
+                )}
+              </Group>
+            </Paper>
           )}
         </Stack>
       </ScrollArea.Autosize>

--- a/web/src/hooks/useAgentRunTimeline.ts
+++ b/web/src/hooks/useAgentRunTimeline.ts
@@ -3,15 +3,29 @@ import { api } from '@/lib/api';
 import { apiFetch } from '@/lib/api/helpers';
 import type { AnyTelemetryEvent } from '@veritas-kanban/shared';
 
-export function useAgentRunTraces(taskId: string | undefined) {
+interface AgentRunTimelineQueryOptions {
+  live?: boolean;
+}
+
+const LIVE_RUN_REFETCH_MS = 2000;
+
+export function useAgentRunTraces(
+  taskId: string | undefined,
+  options: AgentRunTimelineQueryOptions = {}
+) {
   return useQuery({
     queryKey: ['traces', 'task', taskId],
     queryFn: () => (taskId ? api.traces.listForTask(taskId) : Promise.resolve([])),
     enabled: Boolean(taskId),
+    refetchInterval: options.live ? LIVE_RUN_REFETCH_MS : false,
+    staleTime: options.live ? 0 : 30000,
   });
 }
 
-export function useTaskTelemetryEvents(taskId: string | undefined) {
+export function useTaskTelemetryEvents(
+  taskId: string | undefined,
+  options: AgentRunTimelineQueryOptions = {}
+) {
   return useQuery({
     queryKey: ['telemetry', 'task', taskId],
     queryFn: () =>
@@ -19,6 +33,7 @@ export function useTaskTelemetryEvents(taskId: string | undefined) {
         ? apiFetch<AnyTelemetryEvent[]>(`/api/telemetry/events/task/${encodeURIComponent(taskId)}`)
         : Promise.resolve([]),
     enabled: Boolean(taskId),
-    staleTime: 30000,
+    refetchInterval: options.live ? LIVE_RUN_REFETCH_MS : false,
+    staleTime: options.live ? 0 : 30000,
   });
 }


### PR DESCRIPTION
## Summary
- Poll timeline traces and telemetry while a task attempt is actively running.
- Page long timeline replays with a bounded initial render and load-more control.
- Link command, tool, result, and error timeline rows back to the Agent logs surface.

## Verification
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web test -- agent-run-timeline-mantine.test.tsx
- pnpm --filter @veritas-kanban/web test -- agent-run-timeline-mantine.test.tsx task-work-view-mantine.test.tsx task-detail-mantine.test.tsx task-detail-agent-template-metrics-mantine.test.tsx
- pnpm lint:budget
- Rendered smoke on local API/web: created a task, opened Detail > Timeline, verified Agent logs routing

Refs #360