### PR TITLE
Add agent timeline links and entry points

### DIFF
--- a/server/src/services/metrics/run-metrics.ts
+++ b/server/src/services/metrics/run-metrics.ts
@@ -233,6 +233,7 @@ export async function computeFailedRuns(
               timestamp: event.timestamp,
               taskId: event.taskId,
               project: event.project,
+              attemptId: event.attemptId,
               agent: event.agent || 'veritas',
               success: false,
               errorMessage: event.error,

--- a/server/src/services/metrics/types.ts
+++ b/server/src/services/metrics/types.ts
@@ -151,6 +151,7 @@ export interface FailedRunDetails {
   timestamp: string;
   taskId?: string;
   project?: string;
+  attemptId?: string;
   agent: string;
   success: boolean;
   errorMessage?: string;

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -178,7 +178,7 @@ export interface AgentRunTimelineEvent {
   link?: {
     label: string;
     href: string;
-    target?: 'agent' | 'changes' | 'review' | 'work-products' | 'workflow' | 'external';
+    target?: 'agent' | 'changes' | 'details' | 'review' | 'work-products' | 'workflow' | 'external';
   };
 }
 

--- a/web/src/__tests__/agent-run-timeline-mantine.test.tsx
+++ b/web/src/__tests__/agent-run-timeline-mantine.test.tsx
@@ -18,8 +18,13 @@ import type {
 
 const mocks = vi.hoisted(() => ({
   onOpenTab: vi.fn(),
+  onOpenWorkflow: vi.fn(),
   useAgentRunTraces: vi.fn(),
+  useActiveRuns: vi.fn(),
+  usePendingAgentApprovals: vi.fn(),
+  useRecentRuns: vi.fn(),
   useTaskTelemetryEvents: vi.fn(),
+  useTaskNotifications: vi.fn(),
   useTaskWorkProducts: vi.fn(),
 }));
 
@@ -28,8 +33,21 @@ vi.mock('@/hooks/useAgentRunTimeline', () => ({
   useTaskTelemetryEvents: mocks.useTaskTelemetryEvents,
 }));
 
+vi.mock('@/hooks/useAgent', () => ({
+  usePendingAgentApprovals: mocks.usePendingAgentApprovals,
+}));
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useTaskNotifications: mocks.useTaskNotifications,
+}));
+
 vi.mock('@/hooks/useWorkProducts', () => ({
   useTaskWorkProducts: mocks.useTaskWorkProducts,
+}));
+
+vi.mock('@/hooks/useWorkflowStats', () => ({
+  useActiveRuns: mocks.useActiveRuns,
+  useRecentRuns: mocks.useRecentRuns,
 }));
 
 const task: Task = createMockTask({
@@ -60,6 +78,33 @@ const task: Task = createMockTask({
     decidedAt: '2026-06-01T10:07:00.000Z',
     summary: 'Ready to merge',
   },
+  reviewComments: [
+    {
+      id: 'comment-1',
+      file: 'web/src/App.tsx',
+      line: 42,
+      content: 'Check the timeline entry point',
+      created: '2026-06-01T10:08:00.000Z',
+    },
+  ],
+  qaGate: {
+    required: true,
+    passed: false,
+  },
+  deliverables: [
+    {
+      id: 'deliverable-1',
+      title: 'Replay evidence log',
+      type: 'document',
+      path: 'reports/replay.md',
+      status: 'attached',
+      agent: 'veritas',
+      sourceRunId: 'attempt-1',
+      version: 1,
+      created: '2026-06-01T10:06:20.000Z',
+      description: 'Timeline replay evidence',
+    },
+  ],
   verificationSteps: [{ id: 'verify-1', description: 'Run tests', checked: true }],
 });
 
@@ -150,11 +195,59 @@ const product: WorkProductPreview = {
   updatedAt: '2026-06-01T10:06:30.000Z',
 };
 
+const approval = {
+  id: 'approval-1',
+  agentId: 'veritas',
+  action: 'write_file',
+  taskId: 'task-timeline',
+  details: 'Needs permission to update replay docs',
+  status: 'pending' as const,
+  createdAt: '2026-06-01T10:02:00.000Z',
+};
+
+const notification = {
+  id: 'notification-1',
+  taskId: 'task-timeline',
+  targetAgent: 'veritas',
+  fromAgent: 'system',
+  content: 'Run replay needs review',
+  type: 'review_needed',
+  title: 'Timeline notification',
+  delivered: false,
+  createdAt: '2026-06-01T10:06:45.000Z',
+  source: { attemptId: 'attempt-1' },
+};
+
+const workflowRun = {
+  id: 'workflow-run-1',
+  workflowId: 'wf-release',
+  workflowVersion: 1,
+  taskId: 'task-timeline',
+  status: 'blocked' as const,
+  currentStep: 'approval',
+  context: { attemptId: 'attempt-1', taskId: 'task-timeline' },
+  startedAt: '2026-06-01T10:03:00.000Z',
+  lastCheckpoint: '2026-06-01T10:03:30.000Z',
+  steps: [
+    {
+      stepId: 'approval',
+      status: 'failed',
+      agent: 'veritas',
+      retries: 1,
+      error: 'Approval required',
+    },
+  ],
+};
+
 describe('agent run timeline Mantine surface', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.useAgentRunTraces.mockReturnValue({ data: [trace], isLoading: false });
+    mocks.useActiveRuns.mockReturnValue({ data: [workflowRun], isLoading: false });
+    mocks.usePendingAgentApprovals.mockReturnValue({ data: [approval], isLoading: false });
+    mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useTaskTelemetryEvents.mockReturnValue({ data: telemetryEvents, isLoading: false });
+    mocks.useTaskNotifications.mockReturnValue({ data: [notification], isLoading: false });
     mocks.useTaskWorkProducts.mockReturnValue({ data: [product], isLoading: false });
   });
 
@@ -165,8 +258,11 @@ describe('agent run timeline Mantine surface', () => {
   it('builds chronological timeline events with trace, telemetry, and work product context', () => {
     const events = buildAgentRunTimelineEvents({
       task,
+      approvals: [approval],
+      notifications: [notification],
       traces: [trace],
       telemetryEvents,
+      workflowRuns: [workflowRun],
       workProducts: [product],
       selectedAttemptId: 'attempt-1',
     });
@@ -176,6 +272,10 @@ describe('agent run timeline Mantine surface', () => {
     expect(events.some((event) => event.type === 'command')).toBe(true);
     expect(events.some((event) => event.type === 'usage')).toBe(true);
     expect(events.some((event) => event.title.includes('Work product saved'))).toBe(true);
+    expect(events.some((event) => event.title.includes('Permission pending'))).toBe(true);
+    expect(events.some((event) => event.title.includes('Workflow blocked'))).toBe(true);
+    expect(events.some((event) => event.title.includes('Deliverable attached'))).toBe(true);
+    expect(events.some((event) => event.title.includes('Timeline notification'))).toBe(true);
     expect(getTimelineEventType('execute', { eventType: 'tool.progress' })).toBe('tool');
     expect(getTimelineEventType('error', { summary: 'failed' })).toBe('error');
   });
@@ -191,16 +291,61 @@ describe('agent run timeline Mantine surface', () => {
     expect(redacted).not.toContain('sk-supersecret123456');
   });
 
+  it('falls back to internal links when derived external targets are not http urls', () => {
+    const events = buildAgentRunTimelineEvents({
+      task,
+      notifications: [
+        {
+          ...notification,
+          id: 'notification-unsafe',
+          targetUrl: 'javascript:alert(1)',
+        },
+      ],
+      traces: [],
+      telemetryEvents: [],
+      workProducts: [
+        {
+          ...product,
+          id: 'wp-unsafe',
+          sourceLinks: [{ label: 'Unsafe source', href: 'javascript:alert(1)', type: 'url' }],
+        },
+      ],
+      selectedAttemptId: 'attempt-1',
+    });
+
+    expect(events.find((event) => event.id === 'work-product-wp-unsafe')?.link).toMatchObject({
+      target: 'work-products',
+    });
+    expect(
+      events.find((event) => event.id === 'notification-notification-unsafe')?.link
+    ).toMatchObject({
+      target: 'agent',
+    });
+  });
+
   it('renders run replay controls, filters by event type, and links back to task surfaces', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<AgentRunTimelinePanel task={task} onOpenTab={mocks.onOpenTab} />);
+    renderWithProviders(
+      <AgentRunTimelinePanel
+        task={task}
+        onOpenTab={mocks.onOpenTab}
+        onOpenWorkflow={mocks.onOpenWorkflow}
+      />
+    );
 
     expect(screen.getByText('Run Timeline')).toBeDefined();
     expect(screen.getByText('Stored replay')).toBeDefined();
     expect(screen.getByText('command.completed')).toBeDefined();
     expect(screen.getByText('Run replay report')).toBeDefined();
+    expect(screen.getByText('Timeline notification')).toBeDefined();
+    expect(screen.getByText('Workflow blocked: wf-release')).toBeDefined();
+    expect(screen.getByText('Deliverable attached: Replay evidence log')).toBeDefined();
     expect(screen.queryByText('super-secret-token')).toBeNull();
     expect(screen.getAllByRole('button', { name: 'Agent logs' }).length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('button', { name: 'Workflow run' }));
+
+    expect(mocks.onOpenWorkflow).toHaveBeenCalledWith('workflow-run-1');
 
     await user.click(screen.getByRole('button', { name: 'Usage' }));
 
@@ -227,18 +372,22 @@ describe('agent run timeline Mantine surface', () => {
       })),
     };
     mocks.useAgentRunTraces.mockReturnValue({ data: [longTrace], isLoading: false });
+    mocks.useActiveRuns.mockReturnValue({ data: [], isLoading: false });
+    mocks.usePendingAgentApprovals.mockReturnValue({ data: [], isLoading: false });
+    mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useTaskTelemetryEvents.mockReturnValue({ data: [], isLoading: false });
+    mocks.useTaskNotifications.mockReturnValue({ data: [], isLoading: false });
     mocks.useTaskWorkProducts.mockReturnValue({ data: [], isLoading: false });
 
     renderWithProviders(<AgentRunTimelinePanel task={task} onOpenTab={mocks.onOpenTab} />);
 
-    expect(screen.getByText('Showing 80 of 146 filtered events.')).toBeDefined();
+    expect(screen.getByText('Showing 80 of 149 filtered events.')).toBeDefined();
     expect(screen.getByText('Progress event 1')).toBeDefined();
     expect(screen.queryByText('Progress event 140')).toBeNull();
 
-    await user.click(screen.getByRole('button', { name: 'Load 66 more' }));
+    await user.click(screen.getByRole('button', { name: 'Load 69 more' }));
 
-    expect(screen.getByText('Showing 146 of 146 filtered events.')).toBeDefined();
+    expect(screen.getByText('Showing 149 of 149 filtered events.')).toBeDefined();
     expect(screen.getByText('Progress event 140')).toBeDefined();
   });
 });

--- a/web/src/__tests__/needs-attention-queue-mantine.test.tsx
+++ b/web/src/__tests__/needs-attention-queue-mantine.test.tsx
@@ -113,6 +113,7 @@ const failedRuns = [
     timestamp: '2026-06-01T08:00:00Z',
     taskId: 'task-blocked',
     project: 'platform',
+    attemptId: 'attempt-failed-1',
     agent: 'claude-code',
     success: false,
     errorMessage: 'Unit test failed',
@@ -187,6 +188,7 @@ const notifications = [
     title: 'Review notification',
     taskTitle: 'Review generated PR',
     project: 'platform',
+    source: { attemptId: 'attempt-review-1' },
     delivered: false,
     createdAt: '2026-06-01T11:00:00Z',
   },
@@ -284,6 +286,12 @@ describe('needs attention queue', () => {
     expect(items.find((item) => item.source === 'blocked-task')?.reason).toContain(
       'Smoke test is failing'
     );
+    expect(items.find((item) => item.source === 'failed-run')?.timelineAttemptId).toBe(
+      'attempt-failed-1'
+    );
+    expect(items.find((item) => item.source === 'notification')?.destinationLabel).toBe(
+      'timeline:attempt-review-1'
+    );
   });
 
   it('renders queue items through Mantine controls and opens task targets', async () => {
@@ -305,7 +313,7 @@ describe('needs attention queue', () => {
 
     await user.click(screen.getAllByRole('button', { name: /Open task: Blocked queue task/i })[0]);
 
-    expect(onOpenTask).toHaveBeenCalledWith('task-blocked');
+    expect(onOpenTask).toHaveBeenCalledWith('task-blocked', undefined);
   });
 
   it('filters by source and marks notification items read when dismissed', async () => {

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -25,6 +25,7 @@ import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import { useLiveAnnouncer } from '@/components/shared/LiveAnnouncer';
 import { useView } from '@/contexts/ViewContext';
 import { useIdentity } from '@/hooks/useIdentity';
+import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
 
 // Lazy-load Dashboard to split recharts + d3 (~800KB) out of main bundle
 const Dashboard = lazy(() =>
@@ -55,6 +56,8 @@ export function KanbanBoard() {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailPanelMounted, setDetailPanelMounted] = useState(false);
+  const [detailNavigationTarget, setDetailNavigationTarget] =
+    useState<TaskDetailNavigationTarget | null>(null);
 
   // Initialize filters from URL
   const [filters, setFilters] = useState<FilterState>(() => {
@@ -66,7 +69,7 @@ export function KanbanBoard() {
 
   const { selectedTaskId, setTasks, setOnOpenTask, setOnMoveTask } = useKeyboard();
   const { isSelecting, toggleSelecting } = useBulkActions();
-  const { pendingTaskId, clearPendingTask } = useView();
+  const { pendingTaskId, pendingTaskTarget, clearPendingTask } = useView();
 
   // Handle navigation from other views (e.g., Activity page clicking on a task)
   useEffect(() => {
@@ -77,6 +80,7 @@ export function KanbanBoard() {
       const localTask = tasks?.find((t) => t.id === pendingTaskId);
       if (localTask) {
         setDetailPanelMounted(true);
+        setDetailNavigationTarget(pendingTaskTarget);
         setSelectedTask(localTask);
         setDetailOpen(true);
         clearPendingTask();
@@ -89,6 +93,7 @@ export function KanbanBoard() {
         const fetchedTask = await api.tasks.get(pendingTaskId);
         if (fetchedTask) {
           setDetailPanelMounted(true);
+          setDetailNavigationTarget(pendingTaskTarget);
           setSelectedTask(fetchedTask);
           setDetailOpen(true);
         }
@@ -99,7 +104,7 @@ export function KanbanBoard() {
     };
 
     openPendingTask();
-  }, [pendingTaskId, tasks, clearPendingTask]);
+  }, [pendingTaskId, pendingTaskTarget, tasks, clearPendingTask]);
 
   // Sync filters to URL
   useEffect(() => {
@@ -124,22 +129,50 @@ export function KanbanBoard() {
   }, [filteredTasks, setTasks]);
 
   // Handler for opening a task
-  const handleTaskClick = useCallback((task: Task) => {
+  const handleTaskClick = useCallback((task: Task, target?: TaskDetailNavigationTarget) => {
     setDetailPanelMounted(true);
+    setDetailNavigationTarget(target ?? null);
     setSelectedTask(task);
     setDetailOpen(true);
   }, []);
 
+  const handleTaskIdClick = useCallback(
+    async (taskId: string, target?: TaskDetailNavigationTarget) => {
+      const localTask = tasks?.find((t) => t.id === taskId);
+      if (localTask) {
+        handleTaskClick(localTask, target);
+        return;
+      }
+
+      try {
+        const { api } = await import('@/lib/api');
+        const fetchedTask = await api.tasks.get(taskId);
+        if (fetchedTask) {
+          handleTaskClick(fetchedTask, target);
+        }
+      } catch {
+        // Task no longer exists — ignore silently
+      }
+    },
+    [handleTaskClick, tasks]
+  );
+
   // Listen for open-task events from dashboard drill-downs
   useEffect(() => {
     const handler = async (e: Event) => {
-      const taskId = (e as CustomEvent).detail?.taskId;
+      const detail = (e as CustomEvent).detail;
+      const taskId = detail?.taskId;
       if (!taskId) return;
+      const target: TaskDetailNavigationTarget = {
+        tab: detail?.tab,
+        timelineAttemptId: detail?.timelineAttemptId,
+      };
 
       // Try local task list first
       const localTask = tasks?.find((t) => t.id === taskId);
       if (localTask) {
         setDetailPanelMounted(true);
+        setDetailNavigationTarget(target);
         setSelectedTask(localTask);
         setDetailOpen(true);
         return;
@@ -151,6 +184,7 @@ export function KanbanBoard() {
         const fetchedTask = await api.tasks.get(taskId);
         if (fetchedTask) {
           setDetailPanelMounted(true);
+          setDetailNavigationTarget(target);
           setSelectedTask(fetchedTask);
           setDetailOpen(true);
         }
@@ -319,13 +353,7 @@ export function KanbanBoard() {
 
           <BoardSidebar
             onTaskClick={(taskId) => {
-              const task = filteredTasks.find((t) => t.id === taskId);
-              if (task) {
-                handleTaskClick(task);
-              } else {
-                // Task may be archived or not on board — fire open-task event for API fallback
-                window.dispatchEvent(new CustomEvent('open-task', { detail: { taskId } }));
-              }
+              void handleTaskIdClick(taskId);
             }}
           />
         </div>
@@ -342,7 +370,11 @@ export function KanbanBoard() {
             }
           >
             <div className="mt-6 border-t pt-4">
-              <Dashboard />
+              <Dashboard
+                onTaskClick={(taskId, target) => {
+                  void handleTaskIdClick(taskId, target);
+                }}
+              />
             </div>
           </Suspense>
         )}
@@ -355,6 +387,7 @@ export function KanbanBoard() {
             open={detailOpen}
             onOpenChange={handleDetailClose}
             readOnly={!canWriteTasks}
+            navigationTarget={detailNavigationTarget}
           />
         </Suspense>
       )}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -33,6 +33,7 @@ import { SessionMetrics } from './SessionMetrics';
 import { EnforcementIndicator } from './EnforcementIndicator';
 import { NeedsAttentionQueue } from './NeedsAttentionQueue';
 import { useView } from '@/contexts/ViewContext';
+import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
 
 // Trend indicator component
 // direction: 'up' always means improvement, 'down' means decline (from backend)
@@ -117,14 +118,18 @@ function StatRow({ label, value, subLabel, highlight }: StatRowProps) {
   );
 }
 
-export function Dashboard() {
+interface DashboardProps {
+  onTaskClick?: (taskId: string, target?: TaskDetailNavigationTarget) => void;
+}
+
+export function Dashboard({ onTaskClick }: DashboardProps = {}) {
   const [period, setPeriod] = useState<MetricsPeriod>('7d');
   const [customFrom, setCustomFrom] = useState<string | undefined>();
   const [customTo, setCustomTo] = useState<string | undefined>();
   const [project, setProject] = useState<string | undefined>(undefined);
   const [drillDown, setDrillDown] = useState<DrillDownType>(null);
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
-  const { setView } = useView();
+  const { navigateToTask, setView } = useView();
 
   const { settings } = useFeatureSettings();
   const widgets: DashboardWidgetSettings = settings.board.dashboardWidgets ?? {
@@ -179,11 +184,14 @@ export function Dashboard() {
     }
   };
 
-  const handleTaskClick = (taskId: string) => {
+  const handleTaskClick = (taskId: string, options?: TaskDetailNavigationTarget) => {
     // Close drill-down and navigate to task (you may want to integrate with your task panel)
     setDrillDown(null);
-    // This could dispatch an event or call a callback to open the task detail panel
-    window.dispatchEvent(new CustomEvent('open-task', { detail: { taskId } }));
+    if (onTaskClick) {
+      onTaskClick(taskId, options);
+      return;
+    }
+    navigateToTask(taskId, options);
   };
 
   return (

--- a/web/src/components/dashboard/NeedsAttentionQueue.tsx
+++ b/web/src/components/dashboard/NeedsAttentionQueue.tsx
@@ -71,6 +71,7 @@ export interface NeedsAttentionItem {
   taskId?: string;
   taskTitle?: string;
   taskType?: string;
+  timelineAttemptId?: string;
   project?: string;
   destination: NeedsAttentionDestination;
   destinationLabel: string;
@@ -99,7 +100,7 @@ interface NeedsAttentionQueueProps {
   to?: string;
   onOpenDrift?: () => void;
   onOpenErrors?: () => void;
-  onOpenTask?: (taskId: string) => void;
+  onOpenTask?: (taskId: string, options?: { tab?: 'timeline'; timelineAttemptId?: string }) => void;
   onOpenWorkflows?: () => void;
 }
 
@@ -194,6 +195,14 @@ function getBlockedReason(task: Task): string {
 
 function maybeString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function notificationRunId(notification: AgentNotification): string | undefined {
+  return (
+    maybeString(notification.source?.attemptId) ??
+    maybeString(notification.source?.runId) ??
+    maybeString(notification.source?.sourceRunId)
+  );
 }
 
 function itemProject(task: Task | undefined, sourceProject?: string): string | undefined {
@@ -342,7 +351,7 @@ export function buildNeedsAttentionItems(
       dedupeKey: `failed-run:${run.taskId ?? run.agent}:${run.timestamp}`,
       title: task?.title ?? (run.taskId ? `Task ${run.taskId}` : `Failed ${run.agent} run`),
       reason: run.errorMessage ?? 'Agent run failed without an error message',
-      nextAction: task ? 'Open task' : 'Open failed runs',
+      nextAction: task && run.attemptId ? 'Open timeline' : task ? 'Open task' : 'Open failed runs',
       severity: 'high',
       source: 'failed-run',
       sourceLabel: SOURCE_LABELS['failed-run'],
@@ -352,9 +361,15 @@ export function buildNeedsAttentionItems(
       taskId: run.taskId,
       taskTitle: task?.title,
       taskType: task?.type,
+      timelineAttemptId: run.attemptId,
       project,
       destination: task ? 'task' : 'failed-runs',
-      destinationLabel: task ? `task:${task.id}` : 'dashboard:failed-runs',
+      destinationLabel:
+        task && run.attemptId
+          ? `timeline:${run.attemptId}`
+          : task
+            ? `task:${task.id}`
+            : 'dashboard:failed-runs',
     });
   }
 
@@ -479,6 +494,7 @@ export function buildNeedsAttentionItems(
     const task = notification.taskId ? taskById.get(notification.taskId) : undefined;
     const project = itemProject(task, notification.project);
     if (!projectMatches(input.project, project)) continue;
+    const runId = notificationRunId(notification);
 
     addItem(items, {
       id: `notification:${notification.id}`,
@@ -488,7 +504,12 @@ export function buildNeedsAttentionItems(
         notification.taskTitle ??
         `Notification for ${notification.targetAgent}`,
       reason: notification.content,
-      nextAction: notification.taskId ? 'Open task' : 'Open target',
+      nextAction:
+        notification.taskId && runId
+          ? 'Open timeline'
+          : notification.taskId
+            ? 'Open task'
+            : 'Open target',
       severity:
         notification.type.includes('failure') || notification.type.includes('review')
           ? 'high'
@@ -501,11 +522,16 @@ export function buildNeedsAttentionItems(
       taskId: notification.taskId,
       taskTitle: task?.title ?? notification.taskTitle,
       taskType: task?.type,
+      timelineAttemptId: runId,
       project,
       destination: notification.taskId ? 'task' : notification.targetUrl ? 'url' : 'failed-runs',
       destinationLabel:
         notification.targetUrl ??
-        (notification.taskId ? `task:${notification.taskId}` : 'notification'),
+        (notification.taskId && runId
+          ? `timeline:${runId}`
+          : notification.taskId
+            ? `task:${notification.taskId}`
+            : 'notification'),
       targetUrl: notification.targetUrl,
       notificationId: notification.id,
     });
@@ -718,7 +744,12 @@ export function NeedsAttentionQueue({
 
   const openItem = (item: NeedsAttentionItem) => {
     if (item.taskId) {
-      onOpenTask?.(item.taskId);
+      onOpenTask?.(
+        item.taskId,
+        item.timelineAttemptId
+          ? { tab: 'timeline', timelineAttemptId: item.timelineAttemptId }
+          : undefined
+      );
       return;
     }
     if (item.destination === 'drift') {

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -38,20 +38,25 @@ import type {
   AgentRunTrace,
   AgentRunTraceStep,
   AnyTelemetryEvent,
+  Deliverable,
   Task,
   TelemetryEventType,
   WorkProductPreview,
 } from '@veritas-kanban/shared';
+import { usePendingAgentApprovals, type AgentApprovalRequest } from '@/hooks/useAgent';
 import { useAgentRunTraces, useTaskTelemetryEvents } from '@/hooks/useAgentRunTimeline';
+import { useTaskNotifications, type AgentNotification } from '@/hooks/useNotifications';
 import { useTaskWorkProducts } from '@/hooks/useWorkProducts';
+import { useActiveRuns, useRecentRuns, type WorkflowRun } from '@/hooks/useWorkflowStats';
 import { sanitizeText } from '@/lib/sanitize';
 
-type TimelineTabTarget = 'agent' | 'changes' | 'review' | 'work-products';
+type TimelineTabTarget = 'agent' | 'changes' | 'details' | 'review' | 'work-products';
 
 interface AgentRunTimelinePanelProps {
   task: Task;
   initialAttemptId?: string | null;
   onOpenTab?: (target: TimelineTabTarget) => void;
+  onOpenWorkflow?: (runId?: string) => void;
 }
 
 const EVENT_TYPES: AgentRunTimelineEventType[] = [
@@ -169,6 +174,56 @@ function safeString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const sanitized = sanitizeText(value.trim());
   return sanitized.length > 0 ? sanitized : undefined;
+}
+
+function safeExternalHref(value: unknown): string | undefined {
+  const href = safeString(value);
+  if (!href) return undefined;
+  try {
+    const parsed = new URL(href);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? href : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sourceRunIdFromRecord(source?: Record<string, unknown>): string | undefined {
+  return (
+    safeString(source?.attemptId) ?? safeString(source?.runId) ?? safeString(source?.sourceRunId)
+  );
+}
+
+function sourceRunMatches(selectedAttemptId: string | undefined, sourceRunId?: string): boolean {
+  return !selectedAttemptId || !sourceRunId || sourceRunId === selectedAttemptId;
+}
+
+function workflowTaskId(run: WorkflowRun): string | undefined {
+  return run.taskId ?? safeString(run.context?.taskId);
+}
+
+function workflowStartedAt(run: WorkflowRun): string {
+  return run.lastCheckpoint ?? run.completedAt ?? run.startedAt;
+}
+
+function workProductLink(product: WorkProductPreview): AgentRunTimelineEvent['link'] {
+  const sourceLink = product.sourceLinks?.find((link) => link.type === 'pr' || link.type === 'url');
+  const href = safeExternalHref(sourceLink?.href);
+  if (sourceLink && href) {
+    return {
+      label: sourceLink.label || 'Open source',
+      href,
+      target: 'external',
+    };
+  }
+  return { label: 'Work products', href: '#work-products', target: 'work-products' };
+}
+
+function deliverableLink(deliverable: Deliverable): AgentRunTimelineEvent['link'] {
+  const href = safeExternalHref(deliverable.path);
+  if (href) {
+    return { label: 'Open deliverable', href, target: 'external' };
+  }
+  return { label: 'Task details', href: '#details', target: 'details' };
 }
 
 export function redactTimelineText(value: string): string {
@@ -318,16 +373,22 @@ function sortTimelineEvents(events: AgentRunTimelineEvent[]): AgentRunTimelineEv
 
 interface BuildTimelineOptions {
   task: Task;
+  approvals?: AgentApprovalRequest[];
+  notifications?: AgentNotification[];
   traces: AgentRunTrace[];
   telemetryEvents: AnyTelemetryEvent[];
+  workflowRuns?: WorkflowRun[];
   workProducts: WorkProductPreview[];
   selectedAttemptId?: string | null;
 }
 
 export function buildAgentRunTimelineEvents({
   task,
+  approvals = [],
+  notifications = [],
   traces,
   telemetryEvents,
+  workflowRuns = [],
   workProducts,
   selectedAttemptId,
 }: BuildTimelineOptions): AgentRunTimelineEvent[] {
@@ -476,6 +537,96 @@ export function buildAgentRunTimelineEvents({
     });
   }
 
+  for (const comment of task.reviewComments ?? []) {
+    events.push({
+      id: `review-comment-${comment.id}`,
+      sequence: nextSequence++,
+      type: 'file',
+      source: 'derived',
+      timestamp: comment.created,
+      title: `Review comment: ${comment.file}:${comment.line}`,
+      detail: comment.content,
+      metadata: comment as unknown as Record<string, unknown>,
+      link: { label: 'Changes', href: '#changes', target: 'changes' },
+    });
+  }
+
+  if (task.qaGate) {
+    events.push({
+      id: `qa-gate-${task.id}`,
+      sequence: nextSequence++,
+      type: task.qaGate.passed ? 'approval' : 'policy',
+      source: 'derived',
+      timestamp: task.qaGate.passedAt || task.updated,
+      title: task.qaGate.passed ? 'QA gate approved' : 'QA gate pending',
+      detail: task.qaGate.required
+        ? 'Task requires QA approval before completion'
+        : 'QA gate is not required',
+      metadata: task.qaGate as unknown as Record<string, unknown>,
+      link: { label: 'Task details', href: '#details', target: 'details' },
+    });
+  }
+
+  for (const approval of approvals) {
+    if (approval.taskId !== task.id) continue;
+    events.push({
+      id: `approval-request-${approval.id}`,
+      sequence: nextSequence++,
+      type: approval.status === 'rejected' ? 'error' : 'approval',
+      source: 'derived',
+      timestamp: approval.reviewedAt || approval.createdAt,
+      title: `Permission ${approval.status}: ${approval.action}`,
+      detail: approval.details,
+      metadata: approval as unknown as Record<string, unknown>,
+      link: { label: 'Agent', href: '#agent', target: 'agent' },
+    });
+  }
+
+  for (const run of workflowRuns) {
+    if (workflowTaskId(run) !== task.id) continue;
+    const workflowSourceRunId =
+      safeString(run.context?.attemptId) ?? safeString(run.context?.runId);
+    if (!sourceRunMatches(attemptId, workflowSourceRunId)) continue;
+    events.push({
+      id: `workflow-run-${run.id}`,
+      sequence: nextSequence++,
+      type:
+        run.status === 'blocked'
+          ? 'approval'
+          : run.status === 'failed'
+            ? 'error'
+            : run.status === 'completed'
+              ? 'result'
+              : 'tool',
+      source: 'derived',
+      timestamp: workflowStartedAt(run),
+      title: `Workflow ${run.status}: ${run.workflowId}`,
+      detail: run.currentStep
+        ? `Current step: ${run.currentStep}`
+        : run.error || `${run.steps.length} step${run.steps.length === 1 ? '' : 's'}`,
+      durationMs:
+        run.completedAt && run.startedAt
+          ? new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime()
+          : undefined,
+      metadata: {
+        runId: run.id,
+        workflowId: run.workflowId,
+        workflowVersion: run.workflowVersion,
+        status: run.status,
+        currentStep: run.currentStep,
+        context: run.context,
+        steps: run.steps.map((step) => ({
+          stepId: step.stepId,
+          status: step.status,
+          agent: step.agent,
+          error: step.error,
+          retries: step.retries,
+        })),
+      },
+      link: { label: 'Workflow run', href: `#workflow:${run.id}`, target: 'workflow' },
+    });
+  }
+
   for (const product of workProducts) {
     if (attemptId && product.sourceRunId && product.sourceRunId !== attemptId) continue;
     events.push({
@@ -494,8 +645,58 @@ export function buildAgentRunTimelineEvents({
         agent: product.agent,
         model: product.model,
         redacted: product.redacted,
+        sourceLinks: product.sourceLinks,
       },
-      link: { label: 'Work products', href: '#work-products', target: 'work-products' },
+      link: workProductLink(product),
+    });
+  }
+
+  for (const deliverable of task.deliverables ?? []) {
+    if (!sourceRunMatches(attemptId, deliverable.sourceRunId)) continue;
+    events.push({
+      id: `deliverable-${deliverable.id}`,
+      sequence: nextSequence++,
+      type: 'file',
+      source: 'derived',
+      timestamp: deliverable.updated || deliverable.created,
+      title: `Deliverable attached: ${deliverable.title}`,
+      detail: deliverable.description || deliverable.path,
+      metadata: deliverable as unknown as Record<string, unknown>,
+      link: deliverableLink(deliverable),
+    });
+  }
+
+  for (const notification of notifications) {
+    if (notification.taskId !== task.id) continue;
+    const notificationRunId = sourceRunIdFromRecord(notification.source);
+    if (!sourceRunMatches(attemptId, notificationRunId)) continue;
+    const targetHref = safeExternalHref(notification.targetUrl);
+    events.push({
+      id: `notification-${notification.id}`,
+      sequence: nextSequence++,
+      type:
+        notification.type.includes('failure') || notification.type.includes('error')
+          ? 'error'
+          : notification.type.includes('approval') || notification.type.includes('review')
+            ? 'approval'
+            : 'tool',
+      source: 'derived',
+      timestamp: notification.deliveredAt || notification.createdAt,
+      title: notification.title || `Notification: ${notification.type}`,
+      detail: notification.content,
+      metadata: {
+        id: notification.id,
+        targetAgent: notification.targetAgent,
+        fromAgent: notification.fromAgent,
+        type: notification.type,
+        delivered: notification.delivered,
+        deliveredAt: notification.deliveredAt,
+        dedupeKey: notification.dedupeKey,
+        source: notification.source,
+      },
+      link: targetHref
+        ? { label: 'Notification target', href: targetHref, target: 'external' }
+        : { label: 'Agent', href: '#agent', target: 'agent' },
     });
   }
 
@@ -522,7 +723,9 @@ function getRunOptions(
   task: Task,
   traces: AgentRunTrace[],
   telemetryEvents: AnyTelemetryEvent[],
-  workProducts: WorkProductPreview[]
+  workProducts: WorkProductPreview[],
+  notifications: AgentNotification[],
+  workflowRuns: WorkflowRun[]
 ): Array<{ value: string; label: string }> {
   const attempts = new Map<string, string>();
   const addAttempt = (id: string | undefined, label: string) => {
@@ -543,6 +746,18 @@ function getRunOptions(
   for (const product of workProducts) {
     addAttempt(product.sourceRunId, `${product.sourceRunId} (work product)`);
   }
+  for (const deliverable of task.deliverables ?? []) {
+    addAttempt(deliverable.sourceRunId, `${deliverable.sourceRunId} (deliverable)`);
+  }
+  for (const notification of notifications) {
+    const sourceRunId = sourceRunIdFromRecord(notification.source);
+    addAttempt(sourceRunId, `${sourceRunId} (notification)`);
+  }
+  for (const run of workflowRuns) {
+    addAttempt(run.id, `${run.id} (workflow run)`);
+    const sourceRunId = safeString(run.context?.attemptId) ?? safeString(run.context?.runId);
+    addAttempt(sourceRunId, `${sourceRunId} (workflow)`);
+  }
 
   return Array.from(attempts.entries()).map(([value, label]) => ({ value, label }));
 }
@@ -554,15 +769,19 @@ function typeFilterLabel(type: AgentRunTimelineEventType): string {
 function EventRow({
   event,
   onOpenTab,
+  onOpenWorkflow,
 }: {
   event: AgentRunTimelineEvent;
   onOpenTab?: (target: TimelineTabTarget) => void;
+  onOpenWorkflow?: (runId?: string) => void;
 }) {
   const Icon = EVENT_ICONS[event.type];
   const metadata = stringifyMetadata(event.metadata);
   const linkTarget = event.link?.target;
   const canOpenInternal =
     linkTarget && linkTarget !== 'external' && linkTarget !== 'workflow' && onOpenTab;
+  const canOpenWorkflow = linkTarget === 'workflow' && onOpenWorkflow;
+  const canOpenExternal = linkTarget === 'external' && event.link?.href;
 
   return (
     <Paper withBorder p="sm" radius="md">
@@ -604,15 +823,38 @@ function EventRow({
             {metadata}
           </Code>
         )}
-        {canOpenInternal && event.link && linkTarget && (
+        {(canOpenInternal || canOpenWorkflow || canOpenExternal) && event.link && (
           <Group gap="xs">
-            <Button
-              size="compact-xs"
-              variant="subtle"
-              onClick={() => onOpenTab?.(linkTarget as TimelineTabTarget)}
-            >
-              {event.link.label}
-            </Button>
+            {canOpenInternal && linkTarget && (
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                onClick={() => onOpenTab?.(linkTarget as TimelineTabTarget)}
+              >
+                {event.link.label}
+              </Button>
+            )}
+            {canOpenWorkflow && (
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                onClick={() => onOpenWorkflow?.(safeString(event.metadata?.runId))}
+              >
+                {event.link.label}
+              </Button>
+            )}
+            {canOpenExternal && (
+              <Button
+                component="a"
+                href={event.link.href}
+                rel="noopener noreferrer"
+                size="compact-xs"
+                target="_blank"
+                variant="subtle"
+              >
+                {event.link.label}
+              </Button>
+            )}
           </Group>
         )}
       </Stack>
@@ -624,6 +866,7 @@ export function AgentRunTimelinePanel({
   task,
   initialAttemptId,
   onOpenTab,
+  onOpenWorkflow,
 }: AgentRunTimelinePanelProps) {
   const hasLiveAttempt = task.attempt?.status === 'running';
   const { data: traces = [], isLoading: tracesLoading } = useAgentRunTraces(task.id, {
@@ -634,6 +877,12 @@ export function AgentRunTimelinePanel({
     { live: hasLiveAttempt }
   );
   const { data: workProducts = [], isLoading: workProductsLoading } = useTaskWorkProducts(task.id);
+  const { data: notifications = [], isLoading: notificationsLoading } = useTaskNotifications(
+    task.id
+  );
+  const { data: approvals = [], isLoading: approvalsLoading } = usePendingAgentApprovals();
+  const { data: activeRuns = [], isLoading: activeRunsLoading } = useActiveRuns();
+  const { data: recentRuns = [], isLoading: recentRunsLoading } = useRecentRuns();
   const [selectedAttemptId, setSelectedAttemptId] = useState<string | null>(
     initialAttemptId ?? task.attempt?.id ?? null
   );
@@ -647,8 +896,12 @@ export function AgentRunTimelinePanel({
   }, [initialAttemptId]);
 
   const runOptions = useMemo(
-    () => getRunOptions(task, traces, telemetryEvents, workProducts),
-    [task, traces, telemetryEvents, workProducts]
+    () =>
+      getRunOptions(task, traces, telemetryEvents, workProducts, notifications, [
+        ...activeRuns,
+        ...recentRuns,
+      ]),
+    [activeRuns, notifications, recentRuns, task, traces, telemetryEvents, workProducts]
   );
 
   useEffect(() => {
@@ -670,12 +923,25 @@ export function AgentRunTimelinePanel({
     () =>
       buildAgentRunTimelineEvents({
         task,
+        approvals,
+        notifications,
         traces,
         telemetryEvents,
+        workflowRuns: [...activeRuns, ...recentRuns],
         workProducts,
         selectedAttemptId,
       }),
-    [task, traces, telemetryEvents, workProducts, selectedAttemptId]
+    [
+      activeRuns,
+      approvals,
+      notifications,
+      recentRuns,
+      task,
+      traces,
+      telemetryEvents,
+      workProducts,
+      selectedAttemptId,
+    ]
   );
 
   const filteredEvents = useMemo(
@@ -684,7 +950,14 @@ export function AgentRunTimelinePanel({
   );
   const visibleEvents = filteredEvents.slice(0, visibleCount);
   const canLoadMore = filteredEvents.length > visibleEvents.length;
-  const isLoading = tracesLoading || telemetryLoading || workProductsLoading;
+  const isLoading =
+    tracesLoading ||
+    telemetryLoading ||
+    workProductsLoading ||
+    notificationsLoading ||
+    approvalsLoading ||
+    activeRunsLoading ||
+    recentRunsLoading;
   const source = sourceForTrace(selectedTrace);
   const linkedWorkProducts = workProducts.filter(
     (product) => !selectedAttemptId || product.sourceRunId === selectedAttemptId
@@ -889,7 +1162,12 @@ export function AgentRunTimelinePanel({
         <Stack gap="xs" pr="xs">
           {visibleEvents.length > 0 ? (
             visibleEvents.map((event) => (
-              <EventRow key={event.id} event={event} onOpenTab={onOpenTab} />
+              <EventRow
+                key={event.id}
+                event={event}
+                onOpenTab={onOpenTab}
+                onOpenWorkflow={onOpenWorkflow}
+              />
             ))
           ) : (
             <Paper withBorder p="md" radius="md">

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -60,9 +60,10 @@ interface TaskDetailPanelProps {
   onOpenChange: (open: boolean) => void;
   readOnly?: boolean;
   onRestore?: (taskId: string) => void;
+  navigationTarget?: TaskDetailNavigationTarget | null;
 }
 
-type TaskDetailTabId =
+export type TaskDetailTabId =
   | 'work'
   | 'details'
   | 'progress'
@@ -75,6 +76,11 @@ type TaskDetailTabId =
   | 'changes'
   | 'review'
   | 'metrics';
+
+export interface TaskDetailNavigationTarget {
+  tab?: TaskDetailTabId;
+  timelineAttemptId?: string | null;
+}
 
 interface TaskDetailTabDefinition {
   id: TaskDetailTabId;
@@ -169,6 +175,7 @@ export function TaskDetailPanel({
   onOpenChange,
   readOnly = false,
   onRestore,
+  navigationTarget,
 }: TaskDetailPanelProps) {
   const { data: taskTypes = [] } = useTaskTypes();
   const { settings: featureSettings } = useFeatureSettings();
@@ -222,12 +229,27 @@ export function TaskDetailPanel({
   useEffect(() => {
     if (!activeTaskId) {
       lastDefaultedTaskIdRef.current = undefined;
+      setTimelineAttemptId(null);
       return;
     }
     if (lastDefaultedTaskIdRef.current === activeTaskId) return;
     lastDefaultedTaskIdRef.current = activeTaskId;
+    setTimelineAttemptId(null);
     setActiveTab(defaultTab);
   }, [activeTaskId, defaultTab]);
+
+  useEffect(() => {
+    if (!activeTaskId || !navigationTarget) return;
+    if (navigationTarget.timelineAttemptId !== undefined) {
+      setTimelineAttemptId(navigationTarget.timelineAttemptId ?? null);
+    }
+    if (
+      navigationTarget.tab &&
+      visibleTabs.some((tab) => tab.id === navigationTarget.tab && !tab.disabled)
+    ) {
+      setActiveTab(navigationTarget.tab);
+    }
+  }, [activeTaskId, navigationTarget, visibleTabs]);
 
   if (!localTask) return null;
 
@@ -302,6 +324,7 @@ export function TaskDetailPanel({
             task={localTask}
             initialAttemptId={timelineAttemptId}
             onOpenTab={setActiveTab}
+            onOpenWorkflow={() => setWorkflowOpen(true)}
           />
         );
       case 'changes':

--- a/web/src/components/workflows/WorkflowRunView.tsx
+++ b/web/src/components/workflows/WorkflowRunView.tsx
@@ -33,10 +33,12 @@ import {
   PlayCircle,
   Clock,
   Pause,
+  History,
 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/utils';
 import { useWebSocket, type WebSocketMessage } from '@/hooks/useWebSocket';
+import { useView } from '@/contexts/ViewContext';
 
 interface WorkflowRunViewProps {
   runId: string;
@@ -62,10 +64,12 @@ interface WorkflowRun {
   id: string;
   workflowId: string;
   workflowVersion: number;
+  taskId?: string;
   status: WorkflowRunStatus;
   currentStep?: string;
   startedAt: string;
   completedAt?: string;
+  context?: Record<string, unknown>;
   error?: string;
   steps: StepRun[];
 }
@@ -90,6 +94,20 @@ function isWorkflowStatusMessage(msg: WebSocketMessage): msg is WorkflowStatusMe
   return msg.type === 'workflow:status' && typeof msg.data === 'object' && msg.data !== null;
 }
 
+function safeContextString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function workflowTaskId(run: WorkflowRun): string | undefined {
+  return run.taskId ?? safeContextString(run.context?.taskId);
+}
+
+function workflowTimelineAttemptId(run: WorkflowRun): string {
+  return (
+    safeContextString(run.context?.attemptId) ?? safeContextString(run.context?.runId) ?? run.id
+  );
+}
+
 export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
   const [run, setRun] = useState<WorkflowRun | null>(null);
   const [workflow, setWorkflow] = useState<WorkflowDefinition | null>(null);
@@ -97,6 +115,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
   const [isWorkflowLoading, setIsWorkflowLoading] = useState(true);
   const [expandedStepId, setExpandedStepId] = useState<string | null>(null);
   const { toast } = useToast();
+  const { navigateToTask } = useView();
 
   // Fetch run details
   const fetchRun = useCallback(async () => {
@@ -213,6 +232,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
   }
 
   const workflowName = workflow?.name ?? `Workflow ${run.workflowId}`;
+  const taskTimelineId = workflowTaskId(run);
   const stepDefinitions =
     workflow?.steps ??
     run.steps?.map((step) => ({ id: step.stepId, name: step.stepId, agent: step.agent }));
@@ -296,6 +316,21 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
               onClick={handleResume}
             >
               Resume
+            </Button>
+          )}
+          {taskTimelineId && (
+            <Button
+              size="sm"
+              variant="light"
+              leftSection={<History className="h-4 w-4" />}
+              onClick={() => {
+                navigateToTask(taskTimelineId, {
+                  tab: 'timeline',
+                  timelineAttemptId: workflowTimelineAttemptId(run),
+                });
+              }}
+            >
+              Task Timeline
             </Button>
           )}
         </Group>

--- a/web/src/contexts/ViewContext.tsx
+++ b/web/src/contexts/ViewContext.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from 'react';
 import { VIEW_PATHS, type AppView } from '@/lib/views';
+import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
 
 const basePath = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
 
@@ -29,9 +30,11 @@ interface ViewContextValue {
   view: AppView;
   setView: (view: AppView) => void;
   /** Navigate to a specific task by opening the board and setting selectedTaskId. */
-  navigateToTask: (taskId: string) => void;
+  navigateToTask: (taskId: string, target?: TaskDetailNavigationTarget) => void;
   /** The task ID requested by view navigation (consumed once by the board). */
   pendingTaskId: string | null;
+  /** Optional tab/run target for the pending task navigation. */
+  pendingTaskTarget: TaskDetailNavigationTarget | null;
   clearPendingTask: () => void;
 }
 
@@ -40,12 +43,16 @@ const ViewContext = createContext<ViewContextValue>({
   setView: () => {},
   navigateToTask: () => {},
   pendingTaskId: null,
+  pendingTaskTarget: null,
   clearPendingTask: () => {},
 });
 
 export function ViewProvider({ children }: { children: ReactNode }) {
   const [view, setViewState] = useState<AppView>(() => getViewFromLocation());
   const [pendingTaskId, setPendingTaskId] = useState<string | null>(null);
+  const [pendingTaskTarget, setPendingTaskTarget] = useState<TaskDetailNavigationTarget | null>(
+    null
+  );
 
   const setView = useCallback((nextView: AppView) => {
     setViewState(nextView);
@@ -61,8 +68,9 @@ export function ViewProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const navigateToTask = useCallback(
-    (taskId: string) => {
+    (taskId: string, target?: TaskDetailNavigationTarget) => {
       setPendingTaskId(taskId);
+      setPendingTaskTarget(target ?? null);
       setView('board');
     },
     [setView]
@@ -70,11 +78,19 @@ export function ViewProvider({ children }: { children: ReactNode }) {
 
   const clearPendingTask = useCallback(() => {
     setPendingTaskId(null);
+    setPendingTaskTarget(null);
   }, []);
 
   const value = useMemo(
-    () => ({ view, setView, navigateToTask, pendingTaskId, clearPendingTask }),
-    [view, setView, navigateToTask, pendingTaskId, clearPendingTask]
+    () => ({
+      view,
+      setView,
+      navigateToTask,
+      pendingTaskId,
+      pendingTaskTarget,
+      clearPendingTask,
+    }),
+    [view, setView, navigateToTask, pendingTaskId, pendingTaskTarget, clearPendingTask]
   );
 
   useEffect(() => {

--- a/web/src/hooks/useMetrics.ts
+++ b/web/src/hooks/useMetrics.ts
@@ -186,6 +186,7 @@ export interface FailedRunDetails {
   timestamp: string;
   taskId?: string;
   project?: string;
+  attemptId?: string;
   agent: string;
   success: boolean;
   errorMessage?: string;

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -30,6 +30,20 @@ export function useUndeliveredNotifications(limit = 50) {
   });
 }
 
+export function useTaskNotifications(taskId: string | undefined, limit = 100) {
+  return useQuery({
+    queryKey: ['notifications', 'task', taskId, limit],
+    queryFn: async () => {
+      const notifications = await apiFetch<AgentNotification[]>(
+        `${API_BASE}/notifications?limit=${encodeURIComponent(String(limit))}`
+      );
+      return notifications.filter((notification) => notification.taskId === taskId);
+    },
+    enabled: !!taskId,
+    staleTime: 30_000,
+  });
+}
+
 export function useMarkNotificationDelivered() {
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Summary
- Enrich the agent run timeline with derived links for approvals, workflow runs, notifications, review comments, QA gates, deliverables, and work-product source links.
- Add task navigation targets so dashboard and workflow surfaces can open a task directly to the Timeline tab with a selected attempt.
- Carry failed-run attempt IDs through metrics so failed-run and notification queue items can jump to replay evidence instead of only opening the task.

## Verification
- `pnpm --filter @veritas-kanban/web test -- agent-run-timeline-mantine.test.tsx needs-attention-queue-mantine.test.tsx workflow-surfaces-mantine.test.tsx task-detail-mantine.test.tsx`
- `pnpm lint:budget`
- `pnpm build`
- Rendered smoke with a disposable local API/Vite setup: Needs Attention `Open timeline` opened the task drawer on Timeline with the failed attempt selected and notification/deliverable rows visible.

## Follow-ups
- #360 still needs the remaining live backend event capture and ordering consistency work before it should be closed.

Refs #360
