### PR TITLE
Add task readiness start gate

### DIFF
--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -73,7 +73,7 @@ vi.mock('../services/circuit-registry.js', () => ({
   getBreaker: () => ({ execute: (fn: () => Promise<void>) => fn() }),
 }));
 
-import { ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
+import { AgentReadinessError, ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import type { Task } from '@veritas-kanban/shared';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
@@ -130,7 +130,8 @@ describe('ClawdbotAgentService Codex providers', () => {
     task = {
       id: 'task_codex_fixture',
       title: 'Codex fixture task',
-      description: 'Exercise mocked Codex JSONL.',
+      description:
+        'Exercise mocked Codex JSONL and produce a report artifact with verification evidence.',
       type: 'code',
       status: 'todo',
       priority: 'medium',
@@ -138,7 +139,24 @@ describe('ClawdbotAgentService Codex providers', () => {
       project: 'veritas',
       created: new Date().toISOString(),
       updated: new Date().toISOString(),
-      git: { worktreePath: tmpDir },
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'codex-fixture',
+        baseBranch: 'main',
+        worktreePath: tmpDir,
+      },
+      subtasks: [
+        {
+          id: 'sub_fixture',
+          title: 'Confirm fixture output',
+          completed: false,
+          created: new Date().toISOString(),
+          acceptanceCriteria: ['Codex fixture records the expected output artifact'],
+        },
+      ],
+      verificationSteps: [
+        { id: 'verify_fixture', description: 'Run mocked Codex provider test', checked: false },
+      ],
     } as Task;
 
     mockGetTask.mockResolvedValue(task);
@@ -247,5 +265,49 @@ describe('ClawdbotAgentService Codex providers', () => {
       expect.objectContaining({ attemptId: 'attempt_fixture', deliverableCount: 1 }),
       'codex'
     );
+  });
+
+  it('requires and records a readiness override for incomplete task starts', async () => {
+    task = {
+      ...task,
+      title: 'Fix',
+      description: 'Too short',
+      subtasks: [],
+      verificationSteps: [],
+    } as Task;
+    mockGetTask.mockResolvedValue(task);
+
+    const service = new ClawdbotAgentService();
+    (service as any).logsDir = tmpDir;
+
+    await expect(service.startAgent(task.id, 'codex')).rejects.toBeInstanceOf(AgentReadinessError);
+
+    mockSpawn.mockReturnValue(createFakeChild(path.join(fixtureDir, 'success.jsonl')));
+
+    const status = await service.startAgent(task.id, 'codex', {
+      overrideReason: 'Maintainer approved urgent fix',
+    });
+
+    expect(status.status).toBe('running');
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      'agent_event',
+      task.id,
+      task.title,
+      expect.objectContaining({
+        event: 'readiness_override',
+        overrideReason: 'Maintainer approved urgent fix',
+        missingChecks: expect.arrayContaining([
+          expect.objectContaining({ id: 'acceptance' }),
+          expect.objectContaining({ id: 'verification' }),
+        ]),
+      }),
+      'codex'
+    );
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(
+        task.id,
+        expect.objectContaining({ status: 'done' })
+      );
+    });
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,6 +1,10 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
-import { ClawdbotAgentService, clawdbotAgentService } from '../services/clawdbot-agent-service.js';
+import {
+  AgentReadinessError,
+  ClawdbotAgentService,
+  clawdbotAgentService,
+} from '../services/clawdbot-agent-service.js';
 import { getTelemetryService } from '../services/telemetry-service.js';
 import { getTaskService } from '../services/task-service.js';
 import type { AgentType, TokenTelemetryEvent } from '@veritas-kanban/shared';
@@ -14,6 +18,7 @@ const AgentTypeSchema = z.string().min(1).max(50);
 
 const startAgentSchema = z.object({
   agent: AgentTypeSchema.optional(),
+  overrideReason: z.string().trim().min(8).max(1000).optional(),
 });
 
 const completeAgentSchema = z.object({
@@ -36,15 +41,31 @@ router.post(
   '/:taskId/start',
   asyncHandler(async (req, res) => {
     let agent: AgentType | undefined;
+    let overrideReason: string | undefined;
     try {
-      ({ agent } = startAgentSchema.parse(req.body) as { agent?: AgentType });
+      ({ agent, overrideReason } = startAgentSchema.parse(req.body) as {
+        agent?: AgentType;
+        overrideReason?: string;
+      });
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new ValidationError('Validation failed', error.issues);
       }
       throw error;
     }
-    const status = await clawdbotAgentService.startAgent(req.params.taskId as string, agent);
+    let status;
+    try {
+      status = await clawdbotAgentService.startAgent(req.params.taskId as string, agent, {
+        overrideReason,
+      });
+    } catch (error) {
+      if (error instanceof AgentReadinessError) {
+        throw new ValidationError(error.message, {
+          readiness: error.readiness,
+        });
+      }
+      throw error;
+    }
     res.status(201).json(status);
   })
 );

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -11,6 +11,7 @@ const templateService = new TemplateService();
 const subtaskTemplateSchema = z.object({
   title: z.string(),
   order: z.number(),
+  acceptanceCriteria: z.array(z.string()).optional(),
 });
 
 const blueprintTaskSchema = z.object({

--- a/server/src/schemas/agent-schemas.ts
+++ b/server/src/schemas/agent-schemas.ts
@@ -7,6 +7,7 @@ const AgentTypeSchema = z.string().min(1).max(50);
  */
 export const StartAgentBodySchema = z.object({
   agent: AgentTypeSchema.optional(),
+  overrideReason: z.string().trim().min(8).max(1000).optional(),
 });
 
 export type StartAgentBody = z.infer<typeof StartAgentBodySchema>;

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -24,6 +24,7 @@ import { activityService } from './activity-service.js';
 import { getTraceService } from './trace-service.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
+import { evaluateTaskReadiness } from '@veritas-kanban/shared';
 import type {
   Task,
   AgentType,
@@ -36,6 +37,7 @@ import type {
   RunCompletedEvent,
   RunErrorEvent,
   TokenTelemetryEvent,
+  TaskReadinessSummary,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 const log = createLogger('clawdbot-agent-service');
@@ -91,6 +93,20 @@ export interface AgentOutput {
   timestamp: string;
 }
 
+export interface AgentStartOptions {
+  overrideReason?: string;
+}
+
+export class AgentReadinessError extends Error {
+  constructor(
+    public readiness: TaskReadinessSummary,
+    message = 'Task readiness override required'
+  ) {
+    super(message);
+    this.name = 'AgentReadinessError';
+  }
+}
+
 // Track pending agent requests
 interface PendingAgent {
   taskId: string;
@@ -130,7 +146,11 @@ export class ClawdbotAgentService {
   /**
    * Start an agent on a task by delegating to Clawdbot
    */
-  async startAgent(taskId: string, agentType?: AgentType): Promise<AgentStatus> {
+  async startAgent(
+    taskId: string,
+    agentType?: AgentType,
+    options: AgentStartOptions = {}
+  ): Promise<AgentStatus> {
     // Get task
     const task = await this.taskService.getTask(taskId);
     if (!task) {
@@ -169,6 +189,38 @@ export class ClawdbotAgentService {
 
     const agentConfig = this.resolveAgentConfig(config.agents, agent);
     const provider = this.resolveAgentProvider(agentConfig, agent);
+    const readiness = evaluateTaskReadiness(task, { isCodeTask: true, selectedAgent: agent });
+    const overrideReason = options.overrideReason?.trim();
+
+    if (!readiness.ready && !overrideReason) {
+      throw new AgentReadinessError(readiness);
+    }
+
+    if (!readiness.ready && overrideReason && overrideReason.length < 8) {
+      throw new AgentReadinessError(
+        readiness,
+        'Task readiness override reason must be at least 8 characters'
+      );
+    }
+
+    if (!readiness.ready && overrideReason) {
+      await activityService.logActivity(
+        'agent_event',
+        taskId,
+        task.title,
+        {
+          event: 'readiness_override',
+          overrideReason,
+          readinessPercent: readiness.percent,
+          missingChecks: readiness.missingRequired.map((check) => ({
+            id: check.id,
+            label: check.label,
+            detail: check.detail,
+          })),
+        },
+        agent
+      );
+    }
 
     // Create attempt
     const attemptId = `attempt_${nanoid(8)}`;

--- a/shared/src/types/template.types.ts
+++ b/shared/src/types/template.types.ts
@@ -4,14 +4,15 @@ import type { TaskType, TaskPriority, AgentType } from './task.types.js';
 
 /** Subtask template for pre-defined subtask lists */
 export interface SubtaskTemplate {
-  title: string;              // Supports variables: "Review {{project}} PR"
+  title: string; // Supports variables: "Review {{project}} PR"
   order: number;
+  acceptanceCriteria?: string[]; // Supports variables in each criterion
 }
 
 /** Blueprint task for multi-task template creation */
 export interface BlueprintTask {
-  refId: string;              // Local reference for dependency wiring
-  title: string;              // Supports variables
+  refId: string; // Local reference for dependency wiring
+  title: string; // Supports variables
   taskDefaults: {
     type?: TaskType;
     priority?: TaskPriority;
@@ -20,7 +21,7 @@ export interface BlueprintTask {
     agent?: AgentType;
   };
   subtaskTemplates?: SubtaskTemplate[];
-  blockedByRefs?: string[];   // References to other BlueprintTask.refIds
+  blockedByRefs?: string[]; // References to other BlueprintTask.refIds
 }
 
 /** Task template with enhanced features */
@@ -28,15 +29,15 @@ export interface TaskTemplate {
   id: string;
   name: string;
   description?: string;
-  category?: string;          // Template category: "sprint", "bug", "feature", etc.
-  version: number;            // Schema version for migration (0 = legacy, 1 = enhanced)
+  category?: string; // Template category: "sprint", "bug", "feature", etc.
+  version: number; // Schema version for migration (0 = legacy, 1 = enhanced)
 
   taskDefaults: {
     type?: TaskType;
     priority?: TaskPriority;
     project?: string;
     descriptionTemplate?: string;
-    agent?: AgentType;         // NEW in v1: preferred agent
+    agent?: AgentType; // NEW in v1: preferred agent
   };
 
   // NEW in v1: Pre-defined subtasks

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './constants.js';
 export * from './api-permissions.js';
 export * from './api-client.js';
 export * from './agent-helpers.js';
+export * from './task-readiness.js';

--- a/shared/src/utils/task-readiness.ts
+++ b/shared/src/utils/task-readiness.ts
@@ -1,0 +1,205 @@
+import type { AgentType, Task } from '../types/task.types.js';
+
+export type TaskReadinessCheckId =
+  | 'objective'
+  | 'acceptance'
+  | 'verification'
+  | 'context'
+  | 'artifact'
+  | 'blockers'
+  | 'risk'
+  | 'agent';
+
+export type TaskReadinessSeverity = 'required' | 'warning';
+
+export interface TaskReadinessCheck {
+  id: TaskReadinessCheckId;
+  label: string;
+  passed: boolean;
+  detail: string;
+  severity: TaskReadinessSeverity;
+}
+
+export interface TaskReadinessOptions {
+  isCodeTask?: boolean;
+  selectedAgent?: AgentType | 'auto';
+  disabledChecks?: TaskReadinessCheckId[];
+  requiredChecks?: TaskReadinessCheckId[];
+}
+
+export interface TaskReadinessSummary {
+  checks: TaskReadinessCheck[];
+  passed: number;
+  total: number;
+  percent: number;
+  ready: boolean;
+  missingRequired: TaskReadinessCheck[];
+  warnings: TaskReadinessCheck[];
+}
+
+function hasText(value: string | undefined, minLength = 12): boolean {
+  return Boolean(value && value.trim().length >= minLength);
+}
+
+function descriptionMatches(task: Task, pattern: RegExp): boolean {
+  return pattern.test(task.description.toLowerCase());
+}
+
+function getAcceptanceCriteriaCount(task: Task): number {
+  return (task.subtasks ?? []).reduce((count, subtask) => {
+    const criteriaCount =
+      subtask.acceptanceCriteria?.filter((criterion) => hasText(criterion, 6)).length ?? 0;
+    return count + criteriaCount;
+  }, 0);
+}
+
+function buildDefaultChecks(task: Task, options: TaskReadinessOptions): TaskReadinessCheck[] {
+  const isCodeTask = options.isCodeTask ?? task.type === 'code';
+  const blockers =
+    task.status === 'blocked' || Boolean(task.blockedReason) || Boolean(task.blockedBy?.length);
+  const dependencyCount =
+    (task.dependencies?.depends_on?.length ?? 0) + (task.blockedBy?.length ?? 0);
+  const verificationTotal = task.verificationSteps?.length ?? 0;
+  const acceptanceCriteriaCount = getAcceptanceCriteriaCount(task);
+  const hasAcceptanceSignal =
+    acceptanceCriteriaCount > 0 ||
+    descriptionMatches(task, /acceptance criteria|definition of done|done when|success criteria/);
+  const expectedArtifact =
+    (task.deliverables?.length ?? 0) > 0 ||
+    (task.attachments?.length ?? 0) > 0 ||
+    descriptionMatches(
+      task,
+      /deliverable|artifact|report|handoff|output|patch|code change|evidence|completion packet/
+    );
+  const selectedAgent =
+    options.selectedAgent && options.selectedAgent !== 'auto' ? options.selectedAgent : undefined;
+  const assignedAgent =
+    Boolean(selectedAgent) ||
+    Boolean(task.agent && task.agent !== 'auto') ||
+    Boolean(task.agents && task.agents.length > 0);
+
+  return [
+    {
+      id: 'objective',
+      label: 'Clear objective',
+      passed: hasText(task.title, 6) && hasText(task.description, 24),
+      detail: hasText(task.description, 24)
+        ? 'Title and description provide enough context.'
+        : 'Add a concrete description of the expected outcome.',
+      severity: 'required',
+    },
+    {
+      id: 'acceptance',
+      label: 'Acceptance criteria',
+      passed: hasAcceptanceSignal,
+      detail:
+        acceptanceCriteriaCount > 0
+          ? `${acceptanceCriteriaCount} acceptance ${
+              acceptanceCriteriaCount === 1 ? 'criterion' : 'criteria'
+            } defined.`
+          : 'Add explicit acceptance criteria or definition-of-done language.',
+      severity: 'required',
+    },
+    {
+      id: 'verification',
+      label: 'Verification plan',
+      passed: verificationTotal > 0,
+      detail:
+        verificationTotal > 0
+          ? `${verificationTotal} verification step${verificationTotal === 1 ? '' : 's'} defined.`
+          : 'Add at least one verification step before execution.',
+      severity: 'required',
+    },
+    {
+      id: 'context',
+      label: isCodeTask ? 'Repository context' : 'Project context',
+      passed: isCodeTask ? Boolean(task.git?.repo && task.git?.baseBranch) : Boolean(task.project),
+      detail: isCodeTask
+        ? task.git?.repo
+          ? `${task.git.repo} targeting ${task.git.baseBranch || 'default branch'}.`
+          : 'Select a repository and base branch for code execution.'
+        : task.project
+          ? `Project ${task.project} is set.`
+          : 'Assign a project or add context in the task description.',
+      severity: 'required',
+    },
+    {
+      id: 'artifact',
+      label: 'Expected artifact',
+      passed: expectedArtifact,
+      detail: expectedArtifact
+        ? 'Expected output is represented by deliverables, attachments, or description.'
+        : 'State the expected handoff artifact, report, code change, or evidence packet.',
+      severity: 'required',
+    },
+    {
+      id: 'blockers',
+      label: 'Dependencies and blockers',
+      passed: !blockers,
+      detail: blockers
+        ? task.blockedReason?.note || 'Task is blocked or has unresolved blockers.'
+        : dependencyCount > 0
+          ? `${dependencyCount} dependency link${dependencyCount === 1 ? '' : 's'} recorded.`
+          : 'No active blockers detected.',
+      severity: 'required',
+    },
+    {
+      id: 'risk',
+      label: 'Risk level',
+      passed: Boolean(task.priority),
+      detail: task.priority
+        ? `Priority is set to ${task.priority}.`
+        : 'Set a priority so execution risk is explicit.',
+      severity: 'required',
+    },
+    {
+      id: 'agent',
+      label: 'Agent or workflow path',
+      passed: assignedAgent || Boolean(task.runMode) || !isCodeTask,
+      detail:
+        assignedAgent || task.runMode
+          ? `Execution path: ${
+              selectedAgent ||
+              (task.agent && task.agent !== 'auto' ? task.agent : task.runMode || 'configured')
+            }.`
+          : 'Pick an agent, run mode, or workflow before starting.',
+      severity: 'required',
+    },
+  ];
+}
+
+export function getTaskReadinessChecks(
+  task: Task,
+  options: TaskReadinessOptions = {}
+): TaskReadinessCheck[] {
+  const disabledChecks = new Set(options.disabledChecks ?? []);
+  const requiredChecks = new Set(options.requiredChecks ?? []);
+
+  return buildDefaultChecks(task, options)
+    .filter((check) => !disabledChecks.has(check.id))
+    .map((check) => ({
+      ...check,
+      severity: requiredChecks.has(check.id) ? 'required' : check.severity,
+    }));
+}
+
+export function evaluateTaskReadiness(
+  task: Task,
+  options: TaskReadinessOptions = {}
+): TaskReadinessSummary {
+  const checks = getTaskReadinessChecks(task, options);
+  const passed = checks.filter((check) => check.passed).length;
+  const total = checks.length;
+  const missingRequired = checks.filter((check) => !check.passed && check.severity === 'required');
+  const warnings = checks.filter((check) => !check.passed && check.severity === 'warning');
+
+  return {
+    checks,
+    passed,
+    total,
+    percent: total > 0 ? Math.round((passed / total) * 100) : 100,
+    ready: missingRequired.length === 0,
+    missingRequired,
+    warnings,
+  };
+}

--- a/web/src/__tests__/TaskCard.test.tsx
+++ b/web/src/__tests__/TaskCard.test.tsx
@@ -304,4 +304,22 @@ describe('TaskCard', () => {
     renderCard(task);
     expect(screen.getByText('Snag')).toBeDefined();
   });
+
+  it('shows readiness metadata for code tasks', () => {
+    const task = createMockTask({
+      title: 'Fix',
+      description: 'Too short',
+      type: 'code',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'readiness',
+        baseBranch: 'main',
+      },
+    });
+
+    renderCard(task);
+
+    expect(screen.getByText('38% ready')).toBeDefined();
+    expect(screen.getByRole('article').getAttribute('aria-label')).toContain('Readiness: 38%');
+  });
 });

--- a/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
@@ -108,6 +108,7 @@ const template: TaskTemplate = {
     {
       title: 'Verify {{custom:bugId}}',
       order: 1,
+      acceptanceCriteria: ['{{custom:bugId}} includes regression evidence'],
     },
   ],
   created: '2026-06-01T09:00:00Z',
@@ -192,7 +193,24 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
     const user = userEvent.setup();
     const task = createMockTask({
       id: 'task-agent',
+      title: 'Run agent readiness path',
+      description:
+        'Start the configured agent and produce an evidence artifact after focused verification.',
+      type: 'code',
+      priority: 'medium',
       git: { repo: 'veritas', branch: 'feature/agent', baseBranch: 'main', worktreePath: '/tmp' },
+      subtasks: [
+        {
+          id: 'sub-ready',
+          title: 'Confirm agent output',
+          completed: false,
+          created: '2026-06-01T09:00:00Z',
+          acceptanceCriteria: ['Agent output includes verification evidence'],
+        },
+      ],
+      verificationSteps: [
+        { id: 'verify-ready', description: 'Run agent panel test', checked: false },
+      ],
     });
 
     const { baseElement, container } = renderWithProviders(<AgentPanel task={task} />);
@@ -211,6 +229,41 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
     expect(mocks.clearOutputs).toHaveBeenCalled();
     expect(mocks.startAgentMutate).toHaveBeenCalledWith(
       { taskId: 'task-agent', agent: 'codex' },
+      { onSuccess: expect.any(Function) }
+    );
+  });
+
+  it('requires an override reason before starting an incomplete agent task', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-agent-incomplete',
+      title: 'Fix',
+      description: 'Too short',
+      type: 'code',
+      git: { repo: 'veritas', branch: 'feature/agent', baseBranch: 'main', worktreePath: '/tmp' },
+    });
+
+    renderWithProviders(<AgentPanel task={task} />);
+
+    expect(screen.getByText('Task is not ready for agent execution')).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: 'Start' }));
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Start with readiness override?' })
+    ).toBeDefined();
+    expect(mocks.startAgentMutate).not.toHaveBeenCalled();
+
+    await user.type(screen.getByLabelText('Override reason'), 'Maintainer approved urgent fix');
+    await user.click(screen.getByRole('button', { name: 'Start Anyway' }));
+
+    expect(mocks.clearOutputs).toHaveBeenCalled();
+    expect(mocks.startAgentMutate).toHaveBeenCalledWith(
+      {
+        taskId: 'task-agent-incomplete',
+        agent: 'codex',
+        overrideReason: 'Maintainer approved urgent fix',
+      },
       { onSuccess: expect.any(Function) }
     );
   });
@@ -292,7 +345,12 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
           priority: 'high',
           project: 'veritas',
           subtasks: expect.arrayContaining([
-            expect.objectContaining({ title: 'Verify BUG-42', completed: false }),
+            expect.objectContaining({
+              title: 'Verify BUG-42',
+              completed: false,
+              acceptanceCriteria: ['BUG-42 includes regression evidence'],
+              criteriaChecked: [false],
+            }),
           ]),
         }),
       });

--- a/web/src/__tests__/task-work-view-mantine.test.tsx
+++ b/web/src/__tests__/task-work-view-mantine.test.tsx
@@ -117,6 +117,15 @@ describe('task work view Mantine surface', () => {
         { id: 'verify-1', description: 'Run tests', checked: true },
         { id: 'verify-2', description: 'Smoke desktop app', checked: false },
       ],
+      subtasks: [
+        {
+          id: 'sub-1',
+          title: 'Confirm release readiness',
+          completed: false,
+          created: '2026-06-01T11:15:00.000Z',
+          acceptanceCriteria: ['Release report includes verification evidence'],
+        },
+      ],
       deliverables: [
         {
           id: 'del-1',
@@ -169,11 +178,22 @@ describe('task work view Mantine surface', () => {
         branch: 'timeline',
         baseBranch: 'main',
       },
+      subtasks: [
+        {
+          id: 'sub-1',
+          title: 'Confirm timeline output',
+          completed: false,
+          created: '2026-06-01T11:00:00.000Z',
+          acceptanceCriteria: ['Timeline artifact shows ordered run events'],
+        },
+      ],
       verificationSteps: [{ id: 'verify-1', description: 'Run timeline test', checked: false }],
     });
 
     const readiness = getTaskReadinessChecks(task, true);
 
+    expect(readiness.map((check) => check.label)).toContain('Acceptance criteria');
+    expect(readiness.map((check) => check.label)).toContain('Risk level');
     expect(readiness.every((check) => check.passed)).toBe(true);
     expect(shouldDefaultTaskDetailToWork(task)).toBe(true);
     expect(shouldDefaultTaskDetailToWork(createMockTask({ type: 'feature' }))).toBe(false);

--- a/web/src/components/task/AgentPanel.tsx
+++ b/web/src/components/task/AgentPanel.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import {
   ActionIcon,
+  Alert,
   Badge,
   Button,
   Code,
@@ -11,6 +12,7 @@ import {
   Stack,
   Text,
   TextInput,
+  Textarea,
   Tooltip,
 } from '@mantine/core';
 import { useConfig } from '@/hooks/useConfig';
@@ -40,6 +42,7 @@ import {
   XCircle,
   Clock,
 } from 'lucide-react';
+import { evaluateTaskReadiness } from '@veritas-kanban/shared';
 import type { Task, AgentType, AttemptStatus } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
 import { sanitizeText } from '@/lib/sanitize';
@@ -74,6 +77,8 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
   const [autoScroll, setAutoScroll] = useState(true);
   const [viewingAttemptId, setViewingAttemptId] = useState<string | null>(null);
   const [stopDialogOpen, setStopDialogOpen] = useState(false);
+  const [readinessOverrideOpen, setReadinessOverrideOpen] = useState(false);
+  const [readinessOverrideReason, setReadinessOverrideReason] = useState('');
 
   const models = ['sonnet', 'opus', 'haiku'];
 
@@ -93,6 +98,19 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
     label: `${agent.name}${agent.type === defaultAgent ? ' (default)' : ''}`,
   }));
   const modelOptions = models.map((model) => ({ value: model, label: model }));
+  const resolvedAgent =
+    selectedAgent ||
+    (task.agent && task.agent !== 'auto' ? task.agent : undefined) ||
+    routingResult?.agent ||
+    defaultAgent;
+  const readinessSummary = useMemo(
+    () =>
+      evaluateTaskReadiness(task, {
+        isCodeTask: task.type === 'code',
+        selectedAgent: resolvedAgent,
+      }),
+    [task, resolvedAgent]
+  );
 
   // Auto-scroll to bottom
   useEffect(() => {
@@ -109,24 +127,38 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
     setAutoScroll(isAtBottom);
   };
 
-  const handleStart = () => {
+  const startAgentRun = (overrideReason?: string) => {
     clearOutputs();
     setViewingAttemptId(null); // Switch back to live view
     startAgent.mutate(
       {
         taskId: task.id,
-        agent:
-          selectedAgent ||
-          (task.agent && task.agent !== 'auto' ? task.agent : undefined) ||
-          routingResult?.agent ||
-          defaultAgent,
+        agent: resolvedAgent,
+        ...(overrideReason ? { overrideReason } : {}),
       },
       {
         onSuccess: () => {
           refetchAttempts();
+          setReadinessOverrideOpen(false);
+          setReadinessOverrideReason('');
         },
       }
     );
+  };
+
+  const handleStart = () => {
+    if (!readinessSummary.ready) {
+      setReadinessOverrideOpen(true);
+      return;
+    }
+
+    startAgentRun();
+  };
+
+  const handleReadinessOverride = () => {
+    const reason = readinessOverrideReason.trim();
+    if (reason.length < 8) return;
+    startAgentRun(reason);
   };
 
   const handleStop = () => {
@@ -196,6 +228,23 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
         </Group>
 
         <Paper className="overflow-hidden bg-muted/30" radius="md" withBorder>
+          {!isAgentRunning && !readinessSummary.ready && (
+            <Alert
+              color="yellow"
+              icon={<AlertCircle className="h-4 w-4" />}
+              title="Task is not ready for agent execution"
+              className="m-2"
+            >
+              <Stack gap={4}>
+                {readinessSummary.missingRequired.map((check) => (
+                  <Text key={check.id} size="xs">
+                    {check.label}: {check.detail}
+                  </Text>
+                ))}
+              </Stack>
+            </Alert>
+          )}
+
           {/* Controls */}
           <Group gap="xs" className="border-b bg-card p-2">
             {!isAgentRunning ? (
@@ -215,12 +264,7 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
                   </Text>
                 )}
                 <Select
-                  value={
-                    selectedAgent ||
-                    (task.agent && task.agent !== 'auto' ? task.agent : undefined) ||
-                    routingResult?.agent ||
-                    defaultAgent
-                  }
+                  value={resolvedAgent}
                   onChange={(value) => setSelectedAgent(value as AgentType)}
                   data={agentOptions}
                   placeholder="Select agent..."
@@ -473,6 +517,50 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
               </Button>
               <Button color="red" onClick={handleStop}>
                 Stop Agent
+              </Button>
+            </Group>
+          </Stack>
+        </Modal>
+
+        <Modal
+          opened={readinessOverrideOpen}
+          onClose={() => setReadinessOverrideOpen(false)}
+          title="Start with readiness override?"
+          centered
+        >
+          <Stack gap="md">
+            <Stack gap={6}>
+              {readinessSummary.missingRequired.map((check) => (
+                <Group key={check.id} gap="xs" align="flex-start" wrap="nowrap">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
+                  <div>
+                    <Text size="sm" fw={500}>
+                      {check.label}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {check.detail}
+                    </Text>
+                  </div>
+                </Group>
+              ))}
+            </Stack>
+            <Textarea
+              label="Override reason"
+              value={readinessOverrideReason}
+              onChange={(event) => setReadinessOverrideReason(event.currentTarget.value)}
+              rows={3}
+              placeholder="Why is this task safe to start before it is ready?"
+            />
+            <Group justify="flex-end" gap="xs">
+              <Button variant="default" onClick={() => setReadinessOverrideOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                color="yellow"
+                onClick={handleReadinessOverride}
+                disabled={readinessOverrideReason.trim().length < 8 || startAgent.isPending}
+              >
+                Start Anyway
               </Button>
             </Group>
           </Stack>

--- a/web/src/components/task/ApplyTemplateDialog.tsx
+++ b/web/src/components/task/ApplyTemplateDialog.tsx
@@ -200,6 +200,7 @@ export function ApplyTemplateDialog({
     const allTemplateText = [
       selected.taskDefaults.descriptionTemplate || '',
       ...(selected.subtaskTemplates?.map((st) => st.title) || []),
+      ...(selected.subtaskTemplates?.flatMap((st) => st.acceptanceCriteria || []) || []),
     ].join(' ');
 
     const customVarNames = extractCustomVariables(allTemplateText);
@@ -260,6 +261,12 @@ export function ApplyTemplateDialog({
           title: interpolateVariables(st.title, context),
           completed: false,
           created: now,
+          ...(st.acceptanceCriteria?.length && {
+            acceptanceCriteria: st.acceptanceCriteria.map((criterion) =>
+              interpolateVariables(criterion, context)
+            ),
+            criteriaChecked: new Array(st.acceptanceCriteria.length).fill(false),
+          }),
         }));
 
       // Append to existing subtasks

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -3,6 +3,7 @@ import { Tooltip } from '@mantine/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
+import { evaluateTaskReadiness } from '@veritas-kanban/shared';
 import type { Task, TaskPriority, BlockedCategory } from '@veritas-kanban/shared';
 import {
   Check,
@@ -94,6 +95,10 @@ function areTaskCardPropsEqual(prev: TaskCardProps, next: TaskCardProps): boolea
     if (pt.type !== nt.type) return false;
     if (pt.project !== nt.project) return false;
     if (pt.sprint !== nt.sprint) return false;
+    if (pt.agent !== nt.agent) return false;
+    if (pt.runMode !== nt.runMode) return false;
+    if (pt.git?.repo !== nt.git?.repo) return false;
+    if (pt.git?.baseBranch !== nt.git?.baseBranch) return false;
     if (pt.timeTracking?.totalSeconds !== nt.timeTracking?.totalSeconds) return false;
     if (pt.timeTracking?.isRunning !== nt.timeTracking?.isRunning) return false;
     if (pt.attempt?.status !== nt.attempt?.status) return false;
@@ -106,6 +111,12 @@ function areTaskCardPropsEqual(prev: TaskCardProps, next: TaskCardProps): boolea
     if (pSubs.length !== nSubs.length) return false;
     for (let i = 0; i < pSubs.length; i++) {
       if (pSubs[i].completed !== nSubs[i].completed) return false;
+      const pCriteria = pSubs[i].acceptanceCriteria || [];
+      const nCriteria = nSubs[i].acceptanceCriteria || [];
+      if (pCriteria.length !== nCriteria.length) return false;
+      for (let criteriaIndex = 0; criteriaIndex < pCriteria.length; criteriaIndex++) {
+        if (pCriteria[criteriaIndex] !== nCriteria[criteriaIndex]) return false;
+      }
     }
     // Verification steps — compare count and checked state
     const pVSteps = pt.verificationSteps || [];
@@ -122,6 +133,13 @@ function areTaskCardPropsEqual(prev: TaskCardProps, next: TaskCardProps): boolea
       return false;
     if ((pt.dependencies?.blocks?.length || 0) !== (nt.dependencies?.blocks?.length || 0))
       return false;
+    if ((pt.blockedBy?.length || 0) !== (nt.blockedBy?.length || 0)) return false;
+    const pAgents = pt.agents || [];
+    const nAgents = nt.agents || [];
+    if (pAgents.length !== nAgents.length) return false;
+    for (let i = 0; i < pAgents.length; i++) {
+      if (pAgents[i] !== nAgents[i]) return false;
+    }
     // Checkpoint — compare existence and step
     if (!!pt.checkpoint !== !!nt.checkpoint) return false;
     if (pt.checkpoint?.step !== nt.checkpoint?.step) return false;
@@ -270,6 +288,17 @@ export const TaskCard = memo(function TaskCard({
     };
   }, [task.verificationSteps]);
 
+  const readinessSummary = useMemo(
+    () => (task.type === 'code' ? evaluateTaskReadiness(task, { isCodeTask: true }) : null),
+    [task]
+  );
+  const readinessColor = readinessSummary?.ready
+    ? 'bg-green-500/20 text-green-500'
+    : readinessSummary && readinessSummary.percent >= 60
+      ? 'bg-amber-500/20 text-amber-500'
+      : 'bg-red-500/20 text-red-500';
+  const readinessAria = readinessSummary ? `, Readiness: ${readinessSummary.percent}%` : '';
+
   // Suppress the outer card tooltip entirely during any drag operation
   const suppressCardTooltip = isDragActive || isDragging || isCurrentlyDragging;
 
@@ -298,7 +327,7 @@ export const TaskCard = memo(function TaskCard({
         onKeyDown={handleKeyDown}
         role="article"
         tabIndex={0}
-        aria-label={`Task: ${task.title}, Priority: ${task.priority}${isBlocked ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}`}
+        aria-label={`Task: ${task.title}, Priority: ${task.priority}${readinessAria}${isBlocked ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}`}
         className={cn(
           'group bg-card border border-border rounded-md cursor-grab active:cursor-grabbing',
           isCompact ? 'p-2' : 'p-3',
@@ -492,6 +521,35 @@ export const TaskCard = memo(function TaskCard({
             >
               {task.priority}
             </span>
+          )}
+          {readinessSummary && (
+            <Tooltip
+              label={
+                <div>
+                  <p className="font-medium">Readiness Gate</p>
+                  <p className="text-sm">{readinessSummary.percent}% ready for agent start</p>
+                  {!readinessSummary.ready && (
+                    <p className="text-sm text-muted-foreground mt-1">
+                      Missing:{' '}
+                      {readinessSummary.missingRequired
+                        .slice(0, 3)
+                        .map((check) => check.label)
+                        .join(', ')}
+                    </p>
+                  )}
+                </div>
+              }
+            >
+              <span
+                className={cn(
+                  'text-xs px-1.5 py-0.5 rounded flex items-center gap-1',
+                  readinessColor
+                )}
+              >
+                <ShieldCheck className="h-3 w-3" />
+                {readinessSummary.percent}% ready
+              </span>
+            </Tooltip>
           )}
           {/* Attachment indicator */}
           {task.attachments && task.attachments.length > 0 && (

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -31,8 +31,16 @@ import {
   Workflow,
   XCircle,
 } from 'lucide-react';
-import type { Task, TaskAttempt, TaskStatus } from '@veritas-kanban/shared';
+import {
+  evaluateTaskReadiness,
+  getTaskReadinessChecks as getSharedTaskReadinessChecks,
+} from '@veritas-kanban/shared';
+import type { Task, TaskAttempt, TaskReadinessCheck, TaskStatus } from '@veritas-kanban/shared';
 import { useTaskWorkProducts } from '@/hooks/useWorkProducts';
+
+export function getTaskReadinessChecks(task: Task, isCodeTask: boolean): TaskReadinessCheck[] {
+  return getSharedTaskReadinessChecks(task, { isCodeTask });
+}
 
 export type TaskWorkViewTarget =
   | 'details'
@@ -54,13 +62,6 @@ interface TaskWorkViewProps {
   onOpenTab: (target: TaskWorkViewTarget) => void;
   onOpenChat: () => void;
   onOpenWorkflow: () => void;
-}
-
-interface ReadinessCheck {
-  id: string;
-  label: string;
-  passed: boolean;
-  detail: string;
 }
 
 const STATUS_COLORS: Record<TaskStatus, string> = {
@@ -112,88 +113,9 @@ function getAttemptColor(status?: TaskAttempt['status']): string {
   }
 }
 
-function hasText(value: string | undefined, minLength = 12): boolean {
-  return Boolean(value && value.trim().length >= minLength);
-}
-
-export function getTaskReadinessChecks(task: Task, isCodeTask: boolean): ReadinessCheck[] {
-  const blockers =
-    task.status === 'blocked' || Boolean(task.blockedReason) || Boolean(task.blockedBy?.length);
-  const dependencyCount =
-    (task.dependencies?.depends_on?.length ?? 0) + (task.blockedBy?.length ?? 0);
-  const verificationTotal = task.verificationSteps?.length ?? 0;
-  const expectedArtifact =
-    (task.deliverables?.length ?? 0) > 0 ||
-    (task.attachments?.length ?? 0) > 0 ||
-    task.description.toLowerCase().includes('deliverable') ||
-    task.description.toLowerCase().includes('artifact') ||
-    task.description.toLowerCase().includes('report');
-  const assignedAgent =
-    Boolean(task.agent && task.agent !== 'auto') || Boolean(task.agents && task.agents.length > 0);
-
-  return [
-    {
-      id: 'objective',
-      label: 'Clear objective',
-      passed: hasText(task.title, 6) && hasText(task.description, 24),
-      detail: hasText(task.description, 24)
-        ? 'Title and description provide enough context.'
-        : 'Add a concrete description of the expected outcome.',
-    },
-    {
-      id: 'verification',
-      label: 'Verification plan',
-      passed: verificationTotal > 0,
-      detail:
-        verificationTotal > 0
-          ? `${verificationTotal} verification step${verificationTotal === 1 ? '' : 's'} defined.`
-          : 'Add at least one verification step before execution.',
-    },
-    {
-      id: 'context',
-      label: isCodeTask ? 'Repository context' : 'Project context',
-      passed: isCodeTask ? Boolean(task.git?.repo && task.git?.baseBranch) : Boolean(task.project),
-      detail: isCodeTask
-        ? task.git?.repo
-          ? `${task.git.repo} targeting ${task.git.baseBranch || 'default branch'}.`
-          : 'Select a repository and base branch for code execution.'
-        : task.project
-          ? `Project ${task.project} is set.`
-          : 'Assign a project or add context in the task description.',
-    },
-    {
-      id: 'artifact',
-      label: 'Expected artifact',
-      passed: expectedArtifact,
-      detail: expectedArtifact
-        ? 'Expected output is represented by deliverables, attachments, or description.'
-        : 'State the expected handoff artifact, report, code change, or evidence packet.',
-    },
-    {
-      id: 'blockers',
-      label: 'Dependencies and blockers',
-      passed: !blockers,
-      detail: blockers
-        ? task.blockedReason?.note || 'Task is blocked or has unresolved blockers.'
-        : dependencyCount > 0
-          ? `${dependencyCount} dependency link${dependencyCount === 1 ? '' : 's'} recorded.`
-          : 'No active blockers detected.',
-    },
-    {
-      id: 'agent',
-      label: 'Agent or workflow path',
-      passed: assignedAgent || Boolean(task.runMode) || !isCodeTask,
-      detail:
-        assignedAgent || task.runMode
-          ? `Execution path: ${task.agent && task.agent !== 'auto' ? task.agent : task.runMode || 'configured'}.`
-          : 'Pick an agent, run mode, or workflow before starting.',
-    },
-  ];
-}
-
 function getNextAction(
   task: Task,
-  readinessChecks: ReadinessCheck[]
+  readinessChecks: TaskReadinessCheck[]
 ): {
   label: string;
   detail: string;
@@ -300,12 +222,13 @@ export function TaskWorkView({
   onOpenWorkflow,
 }: TaskWorkViewProps) {
   const { data: workProducts = [], isLoading: workProductsLoading } = useTaskWorkProducts(task.id);
-  const readinessChecks = useMemo(
-    () => getTaskReadinessChecks(task, isCodeTask),
+  const readinessSummary = useMemo(
+    () => evaluateTaskReadiness(task, { isCodeTask }),
     [task, isCodeTask]
   );
-  const passedReadiness = readinessChecks.filter((check) => check.passed).length;
-  const readinessPercent = Math.round((passedReadiness / readinessChecks.length) * 100);
+  const readinessChecks = readinessSummary.checks;
+  const passedReadiness = readinessSummary.passed;
+  const readinessPercent = readinessSummary.percent;
   const nextAction = getNextAction(task, readinessChecks);
   const verification = getVerificationSummary(task);
   const latestWorkProducts = workProducts.slice(0, 3);

--- a/web/src/hooks/useAgent.ts
+++ b/web/src/hooks/useAgent.ts
@@ -5,6 +5,12 @@ import { apiFetch, API_BASE } from '@/lib/api/helpers';
 import { useWebSocket, type WebSocketMessage } from './useWebSocket';
 import type { AgentType } from '@veritas-kanban/shared';
 
+export interface StartAgentInput {
+  taskId: string;
+  agent?: AgentType;
+  overrideReason?: string;
+}
+
 export interface AgentApprovalRequest {
   id: string;
   agentId: string;
@@ -30,8 +36,8 @@ export function useStartAgent() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ taskId, agent }: { taskId: string; agent?: AgentType }) =>
-      api.agent.start(taskId, agent),
+    mutationFn: ({ taskId, agent, overrideReason }: StartAgentInput) =>
+      api.agent.start(taskId, { agent, overrideReason }),
     onSuccess: (_, { taskId }) => {
       queryClient.invalidateQueries({ queryKey: ['agent', 'status', taskId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });

--- a/web/src/hooks/useTemplateForm.ts
+++ b/web/src/hooks/useTemplateForm.ts
@@ -28,6 +28,7 @@ export function useTemplateForm() {
           bt.title,
           bt.taskDefaults.descriptionTemplate || '',
           ...(bt.subtaskTemplates?.map((st) => st.title) || []),
+          ...(bt.subtaskTemplates?.flatMap((st) => st.acceptanceCriteria || []) || []),
         ])
         .join(' ');
 
@@ -53,6 +54,7 @@ export function useTemplateForm() {
     const allTemplateText = [
       template.taskDefaults.descriptionTemplate || '',
       ...(template.subtaskTemplates?.map((st) => st.title) || []),
+      ...(template.subtaskTemplates?.flatMap((st) => st.acceptanceCriteria || []) || []),
     ].join(' ');
 
     const customVarNames = extractCustomVariables(allTemplateText);
@@ -75,6 +77,10 @@ export function useTemplateForm() {
           title: st.title,
           completed: false,
           created: now,
+          ...(st.acceptanceCriteria?.length && {
+            acceptanceCriteria: st.acceptanceCriteria,
+            criteriaChecked: new Array(st.acceptanceCriteria.length).fill(false),
+          }),
         }));
       setSubtasks(templateSubtasks);
     } else {
@@ -131,6 +137,9 @@ export function useTemplateForm() {
       const interpolatedSubtasks = subtasks.map((st) => ({
         ...st,
         title: interpolateVariables(st.title, context),
+        acceptanceCriteria: st.acceptanceCriteria?.map((criterion) =>
+          interpolateVariables(criterion, context)
+        ),
       }));
 
       await createTask.mutateAsync({
@@ -175,6 +184,12 @@ export function useTemplateForm() {
           title: interpolateVariables(st.title, context),
           completed: false,
           created: now,
+          ...(st.acceptanceCriteria?.length && {
+            acceptanceCriteria: st.acceptanceCriteria.map((criterion) =>
+              interpolateVariables(criterion, context)
+            ),
+            criteriaChecked: new Array(st.acceptanceCriteria.length).fill(false),
+          }),
         };
       });
 

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -4,6 +4,11 @@
 import type { AgentType, AgentRoutingConfig, RoutingResult } from '@veritas-kanban/shared';
 import { API_BASE, handleResponse } from './helpers';
 
+export interface StartAgentRequest {
+  agent?: AgentType;
+  overrideReason?: string;
+}
+
 export const worktreeApi = {
   create: async (taskId: string): Promise<WorktreeInfo> => {
     const response = await fetch(`${API_BASE}/tasks/${taskId}/worktree`, {
@@ -55,12 +60,17 @@ export const agentApi = {
     return handleResponse<GlobalAgentStatus>(response);
   },
 
-  start: async (taskId: string, agent?: AgentType): Promise<AgentStatus> => {
+  start: async (
+    taskId: string,
+    agentOrRequest?: AgentType | StartAgentRequest
+  ): Promise<AgentStatus> => {
+    const body =
+      typeof agentOrRequest === 'string' ? { agent: agentOrRequest } : (agentOrRequest ?? {});
     const response = await fetch(`${API_BASE}/agents/${taskId}/start`, {
       credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ agent }),
+      body: JSON.stringify(body),
     });
     return handleResponse<AgentStatus>(response);
   },

--- a/web/src/lib/template-schema.ts
+++ b/web/src/lib/template-schema.ts
@@ -12,119 +12,150 @@ const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
  * Check if a string contains dangerous keys
  */
 function hasDangerousKeys(str: string): boolean {
-  return DANGEROUS_KEYS.some(key => str.includes(key));
+  return DANGEROUS_KEYS.some((key) => str.includes(key));
 }
 
 /**
  * Subtask template schema
  */
-const SubtaskTemplateSchema = z.object({
-  title: z.string()
-    .min(1, 'Subtask title cannot be empty')
-    .refine(val => !hasDangerousKeys(val), {
-      message: 'Subtask title contains forbidden keys',
-    }),
-  order: z.number().int().min(0).optional(),
-}).strict();
+const SubtaskTemplateSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, 'Subtask title cannot be empty')
+      .refine((val) => !hasDangerousKeys(val), {
+        message: 'Subtask title contains forbidden keys',
+      }),
+    order: z.number().int().min(0).optional(),
+    acceptanceCriteria: z
+      .array(
+        z
+          .string()
+          .min(1, 'Acceptance criterion cannot be empty')
+          .refine((val) => !hasDangerousKeys(val), {
+            message: 'Acceptance criterion contains forbidden keys',
+          })
+      )
+      .max(20, 'Maximum 20 acceptance criteria allowed')
+      .optional(),
+  })
+  .strict();
 
 /**
  * Blueprint task schema
  */
-const BlueprintTaskSchema = z.object({
-  refId: z.string()
-    .min(1, 'Blueprint task refId cannot be empty')
-    .refine(val => !hasDangerousKeys(val), {
-      message: 'Blueprint refId contains forbidden keys',
-    }),
-  title: z.string()
-    .min(1, 'Blueprint task title cannot be empty')
-    .refine(val => !hasDangerousKeys(val), {
-      message: 'Blueprint task title contains forbidden keys',
-    }),
-  taskDefaults: z.object({
-    type: z.string().optional(),
-    priority: z.string().optional(),
-    project: z.string().optional(),
-    descriptionTemplate: z.string().optional(),
-    agent: z.string().optional(),
-  }).strict().optional(),
-  subtaskTemplates: z.array(SubtaskTemplateSchema).optional(),
-  blockedByRefs: z.array(z.string()).optional(),
-}).strict();
+const BlueprintTaskSchema = z
+  .object({
+    refId: z
+      .string()
+      .min(1, 'Blueprint task refId cannot be empty')
+      .refine((val) => !hasDangerousKeys(val), {
+        message: 'Blueprint refId contains forbidden keys',
+      }),
+    title: z
+      .string()
+      .min(1, 'Blueprint task title cannot be empty')
+      .refine((val) => !hasDangerousKeys(val), {
+        message: 'Blueprint task title contains forbidden keys',
+      }),
+    taskDefaults: z
+      .object({
+        type: z.string().optional(),
+        priority: z.string().optional(),
+        project: z.string().optional(),
+        descriptionTemplate: z.string().optional(),
+        agent: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    subtaskTemplates: z.array(SubtaskTemplateSchema).optional(),
+    blockedByRefs: z.array(z.string()).optional(),
+  })
+  .strict();
 
 /**
  * Task template schema with strict validation
  */
-export const TaskTemplateSchema = z.object({
-  id: z.string().optional(), // Optional for imports
-  name: z.string()
-    .min(1, 'Template name is required')
-    .max(100, 'Template name must be 100 characters or less')
-    .refine(val => !hasDangerousKeys(val), {
-      message: 'Template name contains forbidden keys',
-    }),
-  description: z.string()
-    .max(500, 'Template description must be 500 characters or less')
-    .optional()
-    .refine(val => !val || !hasDangerousKeys(val), {
-      message: 'Template description contains forbidden keys',
-    }),
-  category: z.string()
-    .optional()
-    .refine(val => !val || !hasDangerousKeys(val), {
-      message: 'Template category contains forbidden keys',
-    }),
-  version: z.number().int().min(0).optional(),
-  
-  taskDefaults: z.object({
-    type: z.string().optional(),
-    priority: z.string().optional(),
-    project: z.string().optional(),
-    descriptionTemplate: z.string().optional(),
-    agent: z.string().optional(),
-  }).strict(),
-  
-  subtaskTemplates: z.array(SubtaskTemplateSchema)
-    .max(50, 'Maximum 50 subtask templates allowed')
-    .optional(),
-  
-  blueprint: z.array(BlueprintTaskSchema)
-    .max(20, 'Maximum 20 blueprint tasks allowed')
-    .optional(),
-  
-  created: z.string().optional(),
-  updated: z.string().optional(),
-}).strict()
-  .refine((data) => {
-    // Validate blueprint dependency references
-    if (!data.blueprint || data.blueprint.length === 0) {
-      return true;
-    }
-    
-    const refIds = new Set(data.blueprint.map(task => task.refId));
-    
-    for (const task of data.blueprint) {
-      if (task.blockedByRefs) {
-        for (const ref of task.blockedByRefs) {
-          if (!refIds.has(ref)) {
-            return false;
+export const TaskTemplateSchema = z
+  .object({
+    id: z.string().optional(), // Optional for imports
+    name: z
+      .string()
+      .min(1, 'Template name is required')
+      .max(100, 'Template name must be 100 characters or less')
+      .refine((val) => !hasDangerousKeys(val), {
+        message: 'Template name contains forbidden keys',
+      }),
+    description: z
+      .string()
+      .max(500, 'Template description must be 500 characters or less')
+      .optional()
+      .refine((val) => !val || !hasDangerousKeys(val), {
+        message: 'Template description contains forbidden keys',
+      }),
+    category: z
+      .string()
+      .optional()
+      .refine((val) => !val || !hasDangerousKeys(val), {
+        message: 'Template category contains forbidden keys',
+      }),
+    version: z.number().int().min(0).optional(),
+
+    taskDefaults: z
+      .object({
+        type: z.string().optional(),
+        priority: z.string().optional(),
+        project: z.string().optional(),
+        descriptionTemplate: z.string().optional(),
+        agent: z.string().optional(),
+      })
+      .strict(),
+
+    subtaskTemplates: z
+      .array(SubtaskTemplateSchema)
+      .max(50, 'Maximum 50 subtask templates allowed')
+      .optional(),
+
+    blueprint: z
+      .array(BlueprintTaskSchema)
+      .max(20, 'Maximum 20 blueprint tasks allowed')
+      .optional(),
+
+    created: z.string().optional(),
+    updated: z.string().optional(),
+  })
+  .strict()
+  .refine(
+    (data) => {
+      // Validate blueprint dependency references
+      if (!data.blueprint || data.blueprint.length === 0) {
+        return true;
+      }
+
+      const refIds = new Set(data.blueprint.map((task) => task.refId));
+
+      for (const task of data.blueprint) {
+        if (task.blockedByRefs) {
+          for (const ref of task.blockedByRefs) {
+            if (!refIds.has(ref)) {
+              return false;
+            }
           }
         }
       }
+
+      return true;
+    },
+    {
+      message:
+        'Blueprint dependency references must point to valid refIds within the same blueprint',
     }
-    
-    return true;
-  }, {
-    message: 'Blueprint dependency references must point to valid refIds within the same blueprint',
-  });
+  );
 
 /**
  * Schema for importing templates (single or array)
  */
-export const TemplateImportSchema = z.union([
-  TaskTemplateSchema,
-  z.array(TaskTemplateSchema),
-]);
+export const TemplateImportSchema = z.union([TaskTemplateSchema, z.array(TaskTemplateSchema)]);
 
 /**
  * Type exports


### PR DESCRIPTION
## Summary
- Move readiness checks into a shared evaluator for objective, acceptance criteria, verification, context, artifact, blockers, risk, and execution path.
- Show readiness in the Work view, task cards, and the agent panel before start.
- Enforce the same gate server-side, require override reasons for incomplete starts, record overrides as task activity, and carry template acceptance criteria into created subtasks.

## Verification
- Shared package build
- Focused web readiness and agent-panel tests
- Focused server provider test
- Web typecheck
- Server typecheck
- Web lint, warnings only
- Server lint, warnings only

Closes #362