### PR TITLE
Complete agent run timeline replay

### DIFF
--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -221,6 +221,26 @@ describe('ClawdbotAgentService Codex providers', () => {
         'codex'
       );
     });
+    expect(mockStartStep).toHaveBeenCalledWith(
+      expect.any(String),
+      'complete',
+      expect.objectContaining({
+        eventType: 'turn.completed',
+        totalTokens: 20,
+        model: 'gpt-5.5',
+        finalResult: 'Codex completed the task.',
+      })
+    );
+    expect(mockStartStep).toHaveBeenCalledWith(
+      expect.any(String),
+      'complete',
+      expect.objectContaining({
+        eventType: 'run.completed',
+        success: true,
+        provider: 'codex-cli',
+        model: 'gpt-5.5',
+      })
+    );
   });
 
   it('maps Codex file events to task deliverables linked to the attempt', async () => {
@@ -258,6 +278,15 @@ describe('ClawdbotAgentService Codex providers', () => {
         })
       );
     });
+    expect(mockStartStep).toHaveBeenCalledWith(
+      'attempt_fixture',
+      'execute',
+      expect.objectContaining({
+        eventType: 'item.completed',
+        tool: 'file_change',
+        files: ['server/src/services/codex-provider.ts'],
+      })
+    );
     expect(mockLogActivity).toHaveBeenCalledWith(
       'deliverable_added',
       task.id,

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -47,6 +47,18 @@ const LOGS_DIR = path.join(PROJECT_ROOT, '.veritas-kanban', 'logs');
 const CLAWDBOT_GATEWAY = process.env.CLAWDBOT_GATEWAY || 'http://127.0.0.1:18789';
 export type AgentProvider = 'openclaw' | 'codex-cli' | 'codex-sdk';
 
+const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
+  [/\bsk-[A-Za-z0-9_-]{12,}/g, 'sk-[REDACTED]'],
+  [/\bghp_[A-Za-z0-9_]{12,}/g, 'ghp_[REDACTED]'],
+  [/\bgithub_pat_[A-Za-z0-9_]{12,}/g, 'github_pat_[REDACTED]'],
+  [
+    /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*)\s*=\s*([^\s"'`]+)/gi,
+    '$1=[REDACTED]',
+  ],
+  [/\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*([^\s"'`,}]+)/gi, '$1=[REDACTED]'],
+];
+
 export interface AgentProviderStartContext {
   task: Task;
   agentConfig?: AgentConfig;
@@ -397,6 +409,19 @@ export class ClawdbotAgentService {
     emitter.emit('complete', { status, summary });
 
     const task = await this.taskService.getTask(taskId);
+    const completionStepType = result.success ? 'complete' : 'error';
+    getTraceService().startStep(attemptId, completionStepType, {
+      eventType: result.success ? 'run.completed' : 'run.failed',
+      summary: this.redactTraceText(summary),
+      success: result.success,
+      status,
+      error: result.error ? this.redactTraceText(result.error) : undefined,
+      durationMs,
+      agent: pending.agent,
+      provider: pending.provider,
+      model: pending.model,
+    });
+    getTraceService().endStep(attemptId, completionStepType);
     await getTelemetryService().emit<RunCompletedEvent>({
       type: 'run.completed',
       taskId,
@@ -846,7 +871,14 @@ export class ClawdbotAgentService {
       task.project,
       this.buildTraceMetadata(task, attemptId, provider, agentConfig)
     );
-    getTraceService().startStep(attemptId, 'init', { provider });
+    getTraceService().startStep(attemptId, 'init', {
+      provider,
+      eventType: 'run.started',
+      summary: 'Agent run initialized',
+      agent,
+      model: agentConfig?.model,
+      worktreePath: task.git?.worktreePath,
+    });
     getTraceService().endStep(attemptId, 'init');
     await activityService.logActivity(
       'agent_started',
@@ -902,12 +934,28 @@ export class ClawdbotAgentService {
   ): Promise<void> {
     const agent =
       agentConfig?.type || (agentConfig?.provider === 'codex-sdk' ? 'codex-sdk' : 'codex');
-    getTraceService().startStep(attemptId, this.codexTraceStepType(type), {
+    const files = this.extractCodexFiles(event);
+    const usage = this.extractCodexUsage(event);
+    const command = this.extractCodexCommand(event);
+    const tool = this.extractCodexTool(event, type);
+    const error = this.extractCodexError(event, type);
+    const sanitizedSummary = summary ? this.redactTraceText(summary) : undefined;
+    const stepType = this.codexTraceStepType(type);
+    getTraceService().startStep(attemptId, stepType, {
       provider: agentConfig?.provider || 'codex-cli',
       eventType: type,
-      summary,
+      summary: sanitizedSummary,
+      command: command ? this.redactTraceText(command) : undefined,
+      tool,
+      files,
+      error: error ? this.redactTraceText(error) : undefined,
+      inputTokens: usage?.inputTokens,
+      outputTokens: usage?.outputTokens,
+      totalTokens: usage?.totalTokens,
+      model: usage?.model || agentConfig?.model,
+      finalResult: stepType === 'complete' ? sanitizedSummary : undefined,
     });
-    getTraceService().endStep(attemptId, this.codexTraceStepType(type));
+    getTraceService().endStep(attemptId, stepType);
 
     if (this.shouldLogCodexActivity(type)) {
       await activityService.logActivity(
@@ -918,13 +966,12 @@ export class ClawdbotAgentService {
           attemptId,
           provider: agentConfig?.provider || 'codex-cli',
           eventType: type,
-          summary,
+          summary: sanitizedSummary,
         },
         agent
       );
     }
 
-    const files = this.extractCodexFiles(event);
     if (files.length > 0) {
       await this.attachCodexDeliverables(task, attemptId, agent, files);
     }
@@ -932,7 +979,7 @@ export class ClawdbotAgentService {
 
   private codexTraceStepType(type: string): 'execute' | 'complete' | 'error' {
     if (type.includes('failed') || type === 'error') return 'error';
-    if (type.includes('completed')) return 'complete';
+    if (type === 'turn.completed' || type === 'response.completed') return 'complete';
     return 'execute';
   }
 
@@ -980,6 +1027,113 @@ export class ClawdbotAgentService {
 
     visit(event);
     return [...files].slice(0, 25);
+  }
+
+  private extractCodexCommand(event: unknown): string | undefined {
+    const command = this.findCodexString(event, [
+      'command',
+      'cmd',
+      'shell_command',
+      'shellCommand',
+    ]);
+    const args = this.findCodexStringArray(event, ['args', 'argv']);
+    if (command && args.length > 0) return `${command} ${args.join(' ')}`;
+    return command ?? (args.length > 0 ? args.join(' ') : undefined);
+  }
+
+  private extractCodexTool(event: unknown, fallbackType: string): string | undefined {
+    const tool = this.findCodexString(event, [
+      'tool',
+      'tool_name',
+      'toolName',
+      'function_name',
+      'functionName',
+    ]);
+    if (tool) return tool;
+
+    if (event && typeof event === 'object') {
+      const item = (event as Record<string, unknown>).item;
+      if (item && typeof item === 'object') {
+        const itemType = (item as Record<string, unknown>).type;
+        if (typeof itemType === 'string' && itemType.trim()) return itemType.trim();
+      }
+    }
+
+    return fallbackType;
+  }
+
+  private extractCodexError(event: unknown, type: string): string | undefined {
+    if (!type.includes('failed') && type !== 'error') return undefined;
+    const error = this.findCodexString(event, ['error', 'message']);
+    return error;
+  }
+
+  private findCodexString(event: unknown, keys: string[]): string | undefined {
+    const wanted = new Set(keys);
+    const seen = new Set<unknown>();
+
+    const visit = (value: unknown, key?: string): string | undefined => {
+      if (!value) return undefined;
+      if (typeof value === 'string') {
+        if (key && wanted.has(key) && value.trim()) return value.trim();
+        return undefined;
+      }
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          const result = visit(item, key);
+          if (result) return result;
+        }
+        return undefined;
+      }
+      if (typeof value !== 'object' || seen.has(value)) return undefined;
+      seen.add(value);
+      for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+        const result = visit(childValue, childKey);
+        if (result) return result;
+      }
+      return undefined;
+    };
+
+    return visit(event);
+  }
+
+  private findCodexStringArray(event: unknown, keys: string[]): string[] {
+    const wanted = new Set(keys);
+    const seen = new Set<unknown>();
+
+    const visit = (value: unknown, key?: string): string[] => {
+      if (!value) return [];
+      if (Array.isArray(value)) {
+        if (key && wanted.has(key)) {
+          return value
+            .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+            .map((item) => item.trim())
+            .slice(0, 20);
+        }
+        for (const item of value) {
+          const result = visit(item, key);
+          if (result.length > 0) return result;
+        }
+        return [];
+      }
+      if (typeof value !== 'object' || seen.has(value)) return [];
+      seen.add(value);
+      for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+        const result = visit(childValue, childKey);
+        if (result.length > 0) return result;
+      }
+      return [];
+    };
+
+    return visit(event);
+  }
+
+  private redactTraceText(value: string): string {
+    let redacted = value;
+    for (const [pattern, replacement] of TRACE_SECRET_PATTERNS) {
+      redacted = redacted.replace(pattern, replacement);
+    }
+    return redacted.length > 2000 ? `${redacted.slice(0, 2000)}...` : redacted;
   }
 
   private looksLikeFilePath(value: string): boolean {

--- a/web/src/__tests__/agent-run-timeline-mantine.test.tsx
+++ b/web/src/__tests__/agent-run-timeline-mantine.test.tsx
@@ -149,6 +149,30 @@ const trace: AgentRunTrace = {
         summary: 'pnpm test TOKEN=super-secret-token',
       },
     },
+    {
+      type: 'execute',
+      sequence: 3,
+      startedAt: '2026-06-01T10:02:00.000Z',
+      endedAt: '2026-06-01T10:02:02.000Z',
+      durationMs: 2000,
+      metadata: {
+        eventType: 'item.completed',
+        tool: 'file_change',
+        files: ['web/src/components/task/AgentRunTimelinePanel.tsx'],
+      },
+    },
+    {
+      type: 'complete',
+      sequence: 4,
+      startedAt: '2026-06-01T10:05:00.000Z',
+      endedAt: '2026-06-01T10:05:00.000Z',
+      durationMs: 0,
+      metadata: {
+        eventType: 'turn.completed',
+        summary: 'Timeline replay captured with final result evidence.',
+        finalResult: 'Timeline replay captured with final result evidence.',
+      },
+    },
   ],
 };
 
@@ -173,6 +197,16 @@ const telemetryEvents: AnyTelemetryEvent[] = [
     outputTokens: 800,
     totalTokens: 2000,
     cost: 0.14,
+    attemptId: 'attempt-1',
+  },
+  {
+    id: 'evt-completed',
+    type: 'run.completed',
+    timestamp: '2026-06-01T10:05:00.000Z',
+    taskId: 'task-timeline',
+    agent: 'veritas',
+    durationMs: 300000,
+    success: true,
     attemptId: 'attempt-1',
   },
 ];
@@ -215,6 +249,7 @@ const notification = {
   title: 'Timeline notification',
   delivered: false,
   createdAt: '2026-06-01T10:06:45.000Z',
+  targetUrl: 'veritas://task/task-timeline?tab=timeline&attempt=attempt-1',
   source: { attemptId: 'attempt-1' },
 };
 
@@ -270,6 +305,7 @@ describe('agent run timeline Mantine surface', () => {
     expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index + 1));
     expect(events.some((event) => event.type === 'prompt')).toBe(true);
     expect(events.some((event) => event.type === 'command')).toBe(true);
+    expect(events.some((event) => event.type === 'file')).toBe(true);
     expect(events.some((event) => event.type === 'usage')).toBe(true);
     expect(events.some((event) => event.title.includes('Work product saved'))).toBe(true);
     expect(events.some((event) => event.title.includes('Permission pending'))).toBe(true);
@@ -321,6 +357,27 @@ describe('agent run timeline Mantine surface', () => {
     ).toMatchObject({
       target: 'agent',
     });
+
+    const deepLinkEvents = buildAgentRunTimelineEvents({
+      task,
+      notifications: [
+        {
+          ...notification,
+          id: 'notification-deeplink',
+        },
+      ],
+      traces: [],
+      telemetryEvents: [],
+      workProducts: [],
+      selectedAttemptId: 'attempt-1',
+    });
+
+    expect(
+      deepLinkEvents.find((event) => event.id === 'notification-notification-deeplink')?.link
+    ).toMatchObject({
+      href: 'veritas://task/task-timeline?tab=timeline&attempt=attempt-1',
+      target: 'external',
+    });
   });
 
   it('renders run replay controls, filters by event type, and links back to task surfaces', async () => {
@@ -336,6 +393,11 @@ describe('agent run timeline Mantine surface', () => {
     expect(screen.getByText('Run Timeline')).toBeDefined();
     expect(screen.getByText('Stored replay')).toBeDefined();
     expect(screen.getByText('command.completed')).toBeDefined();
+    expect(
+      screen.getAllByText('Timeline replay captured with final result evidence.').length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText('2,000 tokens / $0.14')).toBeDefined();
+    expect(screen.getByText('5m 0s')).toBeDefined();
     expect(screen.getByText('Run replay report')).toBeDefined();
     expect(screen.getByText('Timeline notification')).toBeDefined();
     expect(screen.getByText('Workflow blocked: wf-release')).toBeDefined();

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -166,6 +166,50 @@ function formatDurationMs(value?: number): string {
   return `${hours}h ${remainingMinutes}m`;
 }
 
+function formatTokenCount(value?: number): string {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 'Not recorded';
+  return `${Math.round(value).toLocaleString()} tokens`;
+}
+
+function formatCost(value?: number): string {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 'No cost recorded';
+  return `$${value.toFixed(2)}`;
+}
+
+function formatRunStatus(value?: string): string {
+  switch (value) {
+    case 'complete':
+    case 'completed':
+      return 'Completed';
+    case 'failed':
+    case 'error':
+      return 'Failed';
+    case 'running':
+      return 'Running';
+    case 'pending':
+      return 'Pending';
+    default:
+      return 'Unknown';
+  }
+}
+
+function runStatusColor(value?: string): string {
+  switch (value) {
+    case 'complete':
+    case 'completed':
+      return 'green';
+    case 'failed':
+    case 'error':
+      return 'red';
+    case 'running':
+      return 'blue';
+    case 'pending':
+      return 'yellow';
+    default:
+      return 'gray';
+  }
+}
+
 function getEventAttemptId(event: AnyTelemetryEvent): string | undefined {
   return isRunEvent(event) ? event.attemptId : undefined;
 }
@@ -176,12 +220,13 @@ function safeString(value: unknown): string | undefined {
   return sanitized.length > 0 ? sanitized : undefined;
 }
 
-function safeExternalHref(value: unknown): string | undefined {
+function safeTimelineHref(value: unknown): string | undefined {
   const href = safeString(value);
   if (!href) return undefined;
+  if (href.startsWith('/') && !href.startsWith('//')) return href;
   try {
     const parsed = new URL(href);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? href : undefined;
+    return ['http:', 'https:', 'veritas:'].includes(parsed.protocol) ? href : undefined;
   } catch {
     return undefined;
   }
@@ -207,7 +252,7 @@ function workflowStartedAt(run: WorkflowRun): string {
 
 function workProductLink(product: WorkProductPreview): AgentRunTimelineEvent['link'] {
   const sourceLink = product.sourceLinks?.find((link) => link.type === 'pr' || link.type === 'url');
-  const href = safeExternalHref(sourceLink?.href);
+  const href = safeTimelineHref(sourceLink?.href);
   if (sourceLink && href) {
     return {
       label: sourceLink.label || 'Open source',
@@ -219,7 +264,7 @@ function workProductLink(product: WorkProductPreview): AgentRunTimelineEvent['li
 }
 
 function deliverableLink(deliverable: Deliverable): AgentRunTimelineEvent['link'] {
-  const href = safeExternalHref(deliverable.path);
+  const href = safeTimelineHref(deliverable.path);
   if (href) {
     return { label: 'Open deliverable', href, target: 'external' };
   }
@@ -291,8 +336,14 @@ export function getTimelineEventType(
 function titleForStep(type: AgentRunTimelineEventType, step: AgentRunTraceStep): string {
   const eventType = safeString(step.metadata?.eventType);
   const summary = safeString(step.metadata?.summary);
+  const command = safeString(step.metadata?.command);
+  const tool = safeString(step.metadata?.tool);
+  const error = safeString(step.metadata?.error);
   if (eventType) return eventType;
   if (summary) return summary.length > 80 ? `${summary.slice(0, 77)}...` : summary;
+  if (command) return command.length > 80 ? `${command.slice(0, 77)}...` : command;
+  if (error) return error.length > 80 ? `${error.slice(0, 77)}...` : error;
+  if (tool) return tool;
 
   switch (type) {
     case 'prompt':
@@ -304,6 +355,22 @@ function titleForStep(type: AgentRunTimelineEventType, step: AgentRunTraceStep):
     default:
       return `${EVENT_LABELS[type]} event`;
   }
+}
+
+function detailForStep(step: AgentRunTraceStep): string | undefined {
+  const summary = safeString(step.metadata?.summary);
+  if (summary) return summary;
+  const error = safeString(step.metadata?.error);
+  if (error) return error;
+  const command = safeString(step.metadata?.command);
+  if (command) return command;
+  const tool = safeString(step.metadata?.tool);
+  if (tool) return tool;
+  const files = Array.isArray(step.metadata?.files)
+    ? step.metadata.files.filter((file): file is string => typeof file === 'string')
+    : [];
+  if (files.length > 0) return files.slice(0, 3).join(', ');
+  return undefined;
 }
 
 function telemetryTitle(event: AnyTelemetryEvent): string {
@@ -358,6 +425,63 @@ function metadataForTaskPrompt(task: Task, trace?: AgentRunTrace): Record<string
     workspaceId: trace?.metadata?.workspaceId,
     sessionKey: trace?.metadata?.sessionKey,
     runKey: trace?.metadata?.runKey || task.attempt?.id,
+  };
+}
+
+interface TimelineRunSummary {
+  status: string;
+  durationMs?: number;
+  totalTokens?: number;
+  cost?: number;
+  finalResult?: string;
+}
+
+function summarizeTimelineRun(
+  task: Task,
+  trace: AgentRunTrace | undefined,
+  telemetryEvents: AnyTelemetryEvent[],
+  selectedAttemptId: string | null
+): TimelineRunSummary {
+  const attempt =
+    task.attempt?.id === selectedAttemptId || (!selectedAttemptId && task.attempt)
+      ? task.attempt
+      : task.attempts?.find((candidate) => candidate.id === selectedAttemptId);
+  const relevantRunEvents = telemetryEvents.filter(isRunEvent).filter((event) => {
+    if (event.taskId !== task.id) return false;
+    return !selectedAttemptId || getEventAttemptId(event) === selectedAttemptId;
+  });
+  const completionEvent = [...relevantRunEvents]
+    .reverse()
+    .find((event) => event.type === 'run.completed' || event.type === 'run.error');
+  const usageEvent = [...relevantRunEvents].reverse().find((event) => event.type === 'run.tokens');
+  const traceResultStep = [...(trace?.steps ?? [])]
+    .reverse()
+    .find((step) => step.type === 'complete' || step.type === 'error');
+  const startedAt = attempt?.started ? new Date(attempt.started).getTime() : undefined;
+  const endedAt = attempt?.ended ? new Date(attempt.ended).getTime() : undefined;
+  const attemptDuration =
+    startedAt !== undefined && endedAt !== undefined && Number.isFinite(endedAt - startedAt)
+      ? endedAt - startedAt
+      : undefined;
+
+  return {
+    status:
+      trace?.status ||
+      attempt?.status ||
+      (completionEvent?.type === 'run.error' || completionEvent?.success === false
+        ? 'failed'
+        : completionEvent?.type === 'run.completed'
+          ? 'completed'
+          : undefined) ||
+      'unknown',
+    durationMs: trace?.totalDurationMs ?? completionEvent?.durationMs ?? attemptDuration,
+    totalTokens: usageEvent?.totalTokens,
+    cost: usageEvent?.cost,
+    finalResult:
+      safeString(traceResultStep?.metadata?.finalResult) ??
+      safeString(traceResultStep?.metadata?.summary) ??
+      safeString(traceResultStep?.metadata?.error) ??
+      completionEvent?.error,
   };
 }
 
@@ -423,7 +547,7 @@ export function buildAgentRunTimelineEvents({
         source,
         timestamp: step.startedAt,
         title: titleForStep(eventType, step),
-        detail: safeString(step.metadata?.summary),
+        detail: detailForStep(step),
         durationMs: step.durationMs,
         metadata: {
           traceStepType: step.type,
@@ -670,7 +794,7 @@ export function buildAgentRunTimelineEvents({
     if (notification.taskId !== task.id) continue;
     const notificationRunId = sourceRunIdFromRecord(notification.source);
     if (!sourceRunMatches(attemptId, notificationRunId)) continue;
-    const targetHref = safeExternalHref(notification.targetUrl);
+    const targetHref = safeTimelineHref(notification.targetUrl);
     events.push({
       id: `notification-${notification.id}`,
       sequence: nextSequence++,
@@ -918,6 +1042,10 @@ export function AgentRunTimelinePanel({
     () => traces.find((trace) => trace.traceId === selectedAttemptId),
     [selectedAttemptId, traces]
   );
+  const runSummary = useMemo(
+    () => summarizeTimelineRun(task, selectedTrace, telemetryEvents, selectedAttemptId),
+    [selectedAttemptId, selectedTrace, task, telemetryEvents]
+  );
 
   const events = useMemo(
     () =>
@@ -1127,6 +1255,53 @@ export function AgentRunTimelinePanel({
               </Text>
               <Text size="sm" fw={600} truncate>
                 {selectedTrace?.metadata?.policyProfile || task.runMode || 'Default'}
+              </Text>
+            </div>
+          </Group>
+        </Paper>
+      </SimpleGrid>
+
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+        <Paper withBorder p="sm" radius="md">
+          <Group gap="xs" wrap="nowrap">
+            <ClipboardCheck className="h-4 w-4 text-muted-foreground" />
+            <div className="min-w-0">
+              <Text size="xs" c="dimmed">
+                Result
+              </Text>
+              <Group gap="xs" wrap="nowrap">
+                <Badge size="xs" color={runStatusColor(runSummary.status)} variant="light">
+                  {formatRunStatus(runSummary.status)}
+                </Badge>
+                <Text size="sm" fw={600} truncate>
+                  {runSummary.finalResult || 'No final result recorded'}
+                </Text>
+              </Group>
+            </div>
+          </Group>
+        </Paper>
+        <Paper withBorder p="sm" radius="md">
+          <Group gap="xs" wrap="nowrap">
+            <Timer className="h-4 w-4 text-muted-foreground" />
+            <div className="min-w-0">
+              <Text size="xs" c="dimmed">
+                Duration
+              </Text>
+              <Text size="sm" fw={600} truncate>
+                {formatDurationMs(runSummary.durationMs)}
+              </Text>
+            </div>
+          </Group>
+        </Paper>
+        <Paper withBorder p="sm" radius="md">
+          <Group gap="xs" wrap="nowrap">
+            <Terminal className="h-4 w-4 text-muted-foreground" />
+            <div className="min-w-0">
+              <Text size="xs" c="dimmed">
+                Usage / cost
+              </Text>
+              <Text size="sm" fw={600} truncate>
+                {formatTokenCount(runSummary.totalTokens)} / {formatCost(runSummary.cost)}
               </Text>
             </div>
           </Group>


### PR DESCRIPTION
## Summary
- Adds redacted provider event metadata for commands, tools, files, usage, errors, and final results in agent run traces.
- Records explicit completion/failure trace steps so live and stored replay have consistent terminal events.
- Adds timeline result, duration, and usage/cost summary cards plus safe app deep-link handling for notification targets.

## Verification
- pnpm --filter @veritas-kanban/web test -- agent-run-timeline-mantine.test.tsx
- pnpm --filter @veritas-kanban/server test -- codex-provider-service.test.ts
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web lint (warnings only)
- pnpm --filter @veritas-kanban/server lint (warnings only)

Refs #360