### PR TITLE
Add task completion packets

### DIFF
--- a/server/src/__tests__/storage/sqlite-work-products.test.ts
+++ b/server/src/__tests__/storage/sqlite-work-products.test.ts
@@ -5,6 +5,7 @@ import {
   resetWorkProductServiceForTests,
 } from '../../services/work-product-service.js';
 import { getSearchService } from '../../services/search-service.js';
+import type { Task } from '@veritas-kanban/shared';
 
 describe('SQLite work products', () => {
   it('persists durable work products with version history, restore, preview redaction, and search', async () => {
@@ -104,6 +105,114 @@ describe('SQLite work products', () => {
           agent: 'codex',
         },
       });
+
+      const completedTask: Task = {
+        id: 'task_20260602_packet',
+        title: 'Ship completion packets',
+        description: 'Generate a durable handoff artifact when task work is done.',
+        type: 'code',
+        status: 'done',
+        priority: 'high',
+        project: 'veritas',
+        created: '2026-06-02T10:00:00.000Z',
+        updated: '2026-06-02T11:00:00.000Z',
+        revision: 7,
+        agent: 'codex',
+        git: {
+          repo: 'BradGroux/veritas-kanban',
+          branch: 'v5-completion-packets',
+          baseBranch: 'main',
+          worktreePath: '/Users/bradgroux/private/veritas-kanban',
+          prUrl: 'https://github.com/BradGroux/veritas-kanban/pull/999',
+          prNumber: 999,
+        },
+        attempt: {
+          id: 'attempt_packet',
+          agent: 'codex',
+          status: 'complete',
+          started: '2026-06-02T10:10:00.000Z',
+          ended: '2026-06-02T10:20:00.000Z',
+          model: 'gpt-5',
+        },
+        verificationSteps: [
+          {
+            id: 'verify_1',
+            description: 'pnpm --filter @veritas-kanban/server test -- completion-packets',
+            checked: true,
+            checkedAt: '2026-06-02T10:45:00.000Z',
+          },
+        ],
+        deliverables: [
+          {
+            id: 'deliverable_1',
+            title: 'Completion packet service',
+            type: 'code',
+            path: 'server/src/services/work-product-service.ts',
+            status: 'attached',
+            sourceRunId: 'attempt_packet',
+            created: '2026-06-02T10:40:00.000Z',
+          },
+        ],
+        attachments: [
+          {
+            id: 'attachment_1',
+            filename: 'packet-preview.png',
+            originalName: 'packet-preview.png',
+            mimeType: 'image/png',
+            size: 1200,
+            uploaded: '2026-06-02T10:50:00.000Z',
+            validationStatus: 'valid',
+          },
+        ],
+        review: {
+          decision: 'approved',
+          decidedAt: '2026-06-02T10:55:00.000Z',
+          summary: 'Ready to hand off',
+        },
+        timeTracking: {
+          entries: [],
+          totalSeconds: 900,
+          isRunning: false,
+        },
+        actualCost: 0.18,
+      };
+
+      const packet = await restarted.generateCompletionPacket(completedTask);
+      expect(packet).toMatchObject({
+        kind: 'report',
+        title: 'Completion Packet: Ship completion packets',
+        taskId: completedTask.id,
+        sourceRunId: 'attempt_packet',
+        metadata: {
+          packetType: 'completion_packet',
+          generatedFromRevision: 7,
+          verificationPassed: 1,
+        },
+      });
+      expect(packet.sourceLinks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'Run timeline',
+            href: expect.stringContaining('tab=timeline'),
+          }),
+          expect.objectContaining({ type: 'pr' }),
+        ])
+      );
+      expect(restarted.exportProduct(packet)).toContain('Verification Evidence');
+      expect(restarted.exportProduct(packet)).not.toContain('/Users/bradgroux/private');
+
+      const regenerated = await restarted.generateCompletionPacket({
+        ...completedTask,
+        updated: '2026-06-02T12:00:00.000Z',
+        revision: 8,
+        verificationSteps: [
+          ...(completedTask.verificationSteps ?? []),
+          { id: 'verify_2', description: 'Manual smoke test', checked: false },
+        ],
+      });
+      expect(regenerated.id).toBe(packet.id);
+      expect(regenerated.version).toBe(2);
+      await expect(restarted.listVersions(packet.id)).resolves.toHaveLength(2);
     } finally {
       service?.dispose();
       resetWorkProductServiceForTests();

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -30,6 +30,7 @@ import {
   createTaskSyncToken,
   type TaskSyncContext,
 } from './agent-registry-service.js';
+import { getWorkProductService } from './work-product-service.js';
 import { getTasksActiveDir, getTasksArchiveDir } from '../utils/paths.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteTaskRepository } from '../storage/sqlite/task-repository.js';
@@ -695,6 +696,7 @@ export class TaskService {
     const filepath = path.join(this.tasksDir, newFilename);
 
     let updatedTask!: Task;
+    let shouldGenerateCompletionPacket = false;
     const runMutation = async (callback: () => Promise<void>): Promise<void> => {
       if (this.sqliteTasks) {
         await this.runSqliteMutation(callback);
@@ -1004,8 +1006,18 @@ export class TaskService {
         ).catch((err) => {
           log.warn({ taskId: updatedTask.id }, 'Post-transition actions failed: %s', err);
         });
+
+        shouldGenerateCompletionPacket = updatedTask.status === 'done' && previousStatus !== 'done';
       }
     });
+
+    if (shouldGenerateCompletionPacket) {
+      try {
+        await getWorkProductService().generateCompletionPacket(updatedTask);
+      } catch (err) {
+        log.warn({ taskId: updatedTask.id }, 'Completion packet generation failed: %s', err);
+      }
+    }
 
     return updatedTask;
   }

--- a/server/src/services/work-product-service.ts
+++ b/server/src/services/work-product-service.ts
@@ -7,9 +7,11 @@ import type {
   WorkProduct,
   WorkProductListOptions,
   WorkProductPreview,
+  WorkProductPrimitive,
   WorkProductRedaction,
   WorkProductRender,
   WorkProductVersion,
+  Task,
 } from '@veritas-kanban/shared';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteWorkProductRepository } from '../storage/sqlite/work-product-repository.js';
@@ -215,6 +217,39 @@ export class WorkProductService {
     return this.list({ query, limit });
   }
 
+  async generateCompletionPacket(
+    task: Task,
+    options: { sourceRunId?: string; changeSummary?: string } = {}
+  ): Promise<WorkProduct> {
+    const sourceRunId = options.sourceRunId ?? this.completionPacketSourceRunId(task);
+    const input = this.buildCompletionPacketInput(task, sourceRunId);
+    const existing = (
+      await this.list({
+        taskId: task.id,
+        kind: 'report',
+        includeArchived: true,
+        limit: 200,
+      })
+    ).find((product) => product.metadata?.packetType === 'completion_packet');
+
+    if (existing) {
+      const updated = await this.update(existing.id, {
+        ...input,
+        status: 'active',
+        changeType: 'regenerate',
+        changeSummary:
+          options.changeSummary ??
+          `Regenerated completion packet for task revision ${task.revision ?? 'unknown'}`,
+      });
+      if (updated) return updated;
+    }
+
+    return this.create({
+      ...input,
+      changeSummary: options.changeSummary ?? 'Generated completion packet',
+    });
+  }
+
   toPreview(product: WorkProduct): WorkProductPreview {
     const rawText = this.extractSearchText(product);
     const redactedText = this.redactText(rawText, product.redaction);
@@ -265,6 +300,282 @@ export class WorkProductService {
       body,
     ].filter((line): line is string => line !== null);
     return `${lines.join('\n')}\n`;
+  }
+
+  private buildCompletionPacketInput(task: Task, sourceRunId?: string): CreateWorkProductInput {
+    const sourceLinks = this.buildCompletionPacketSourceLinks(task, sourceRunId);
+    const render: WorkProductRender = {
+      schemaVersion: 1,
+      kind: 'report',
+      summary: this.completionSummary(task),
+      sections: [
+        { heading: 'Delivered', body: this.deliveredSection(task) },
+        { heading: 'Changed Files And Sources', body: this.changedFilesSection(task) },
+        { heading: 'Verification Evidence', body: this.verificationSection(task) },
+        { heading: 'Review And Approval', body: this.reviewSection(task) },
+        { heading: 'Cost And Duration', body: this.costDurationSection(task) },
+        { heading: 'Deliverables And Attachments', body: this.deliverablesSection(task) },
+        { heading: 'Unresolved Risks', body: this.risksSection(task) },
+      ],
+    };
+
+    return {
+      kind: 'report',
+      title: `Completion Packet: ${task.title}`,
+      render,
+      taskId: task.id,
+      sourceRunId,
+      agent: task.attempt?.agent ?? (task.agent === 'auto' ? undefined : task.agent),
+      model: task.attempt?.model,
+      redaction: {
+        level: 'standard',
+        containsSensitiveContent: false,
+        sensitiveFields: ['local paths', 'tokens', 'secrets'],
+        notes: [
+          'Completion packets intentionally summarize evidence instead of embedding raw logs.',
+        ],
+        exportDefault: 'redacted',
+      },
+      sourceLinks,
+      metadata: this.completionPacketMetadata(task, sourceRunId),
+    };
+  }
+
+  private completionPacketSourceRunId(task: Task): string | undefined {
+    if (task.attempt?.id) return task.attempt.id;
+    return [...(task.attempts ?? [])].reverse().find((attempt) => attempt.status === 'complete')
+      ?.id;
+  }
+
+  private completionPacketMetadata(
+    task: Task,
+    sourceRunId?: string
+  ): Record<string, WorkProductPrimitive> {
+    return {
+      packetType: 'completion_packet',
+      taskStatus: task.status,
+      generatedFromRevision: task.revision ?? null,
+      generatedFromTaskUpdatedAt: task.updated,
+      sourceRunId: sourceRunId ?? null,
+      verificationTotal: task.verificationSteps?.length ?? 0,
+      verificationPassed: task.verificationSteps?.filter((step) => step.checked).length ?? 0,
+      deliverableCount: task.deliverables?.length ?? 0,
+      attachmentCount: task.attachments?.length ?? 0,
+      reviewDecision: task.review?.decision ?? null,
+      qaGatePassed: task.qaGate?.passed ?? null,
+    };
+  }
+
+  private buildCompletionPacketSourceLinks(
+    task: Task,
+    sourceRunId?: string
+  ): CreateWorkProductInput['sourceLinks'] {
+    const links: NonNullable<CreateWorkProductInput['sourceLinks']> = [
+      {
+        label: 'Task',
+        href: `veritas://task/${encodeURIComponent(task.id)}?tab=work-products`,
+        type: 'task',
+      },
+    ];
+
+    if (sourceRunId) {
+      links.push({
+        label: 'Run timeline',
+        href: `veritas://task/${encodeURIComponent(task.id)}?tab=timeline&attempt=${encodeURIComponent(sourceRunId)}`,
+        type: 'run',
+      });
+    }
+
+    if (task.git?.prUrl) {
+      links.push({
+        label: `PR ${task.git.prNumber ?? ''}`.trim(),
+        href: task.git.prUrl,
+        type: 'pr',
+      });
+    }
+
+    if (task.github?.url) {
+      links.push({
+        label: `Issue #${task.github.issueNumber}`,
+        href: task.github.url,
+        type: 'url',
+      });
+    }
+
+    return links;
+  }
+
+  private completionSummary(task: Task): string {
+    const status = task.status === 'done' ? 'completed' : task.status;
+    const review = task.review?.decision ? ` Review: ${task.review.decision}.` : '';
+    const verificationTotal = task.verificationSteps?.length ?? 0;
+    const verificationPassed = task.verificationSteps?.filter((step) => step.checked).length ?? 0;
+    const verification =
+      verificationTotal > 0
+        ? ` Verification: ${verificationPassed}/${verificationTotal} checks complete.`
+        : ' Verification evidence is missing.';
+    return this.packetText(`${task.title} is ${status}.${review}${verification}`);
+  }
+
+  private deliveredSection(task: Task): string {
+    const lines = [
+      `Task: ${task.title}`,
+      task.description ? `Objective: ${task.description}` : 'Objective: No description recorded.',
+      task.automation?.result ? `Agent result: ${task.automation.result}` : null,
+      task.attempt?.status ? `Latest attempt: ${task.attempt.status}` : null,
+    ].filter((line): line is string => Boolean(line));
+    return this.packetText(lines.join('\n'));
+  }
+
+  private changedFilesSection(task: Task): string {
+    const changedFiles = new Set<string>();
+    for (const deliverable of task.deliverables ?? []) {
+      if (deliverable.path) changedFiles.add(deliverable.path);
+    }
+    for (const comment of task.reviewComments ?? []) {
+      if (comment.file) changedFiles.add(`${comment.file}:${comment.line}`);
+    }
+
+    const lines = [
+      task.git?.repo ? `Repository: ${task.git.repo}` : 'Repository: Not recorded.',
+      task.git?.branch || task.git?.baseBranch
+        ? `Branch: ${task.git.branch || task.git.baseBranch}`
+        : 'Branch: Not recorded.',
+      task.git?.prUrl ? `Pull request: ${task.git.prUrl}` : 'Pull request: Not recorded.',
+      task.git?.worktreePath ? `Worktree: ${task.git.worktreePath}` : 'Worktree: Not recorded.',
+      '',
+      changedFiles.size > 0
+        ? this.markdownList([...changedFiles].slice(0, 50))
+        : 'No changed files were recorded on the task.',
+    ];
+    return this.packetText(lines.join('\n'));
+  }
+
+  private verificationSection(task: Task): string {
+    const steps = task.verificationSteps ?? [];
+    if (steps.length === 0) {
+      return 'No verification steps were recorded. Treat this completion packet as missing verification evidence.';
+    }
+
+    const lines = steps.map(
+      (step) =>
+        `${step.checked ? '[x]' : '[ ]'} ${step.description}${step.checkedAt ? ` (${step.checkedAt})` : ''}`
+    );
+    const unchecked = steps.filter((step) => !step.checked).length;
+    if (unchecked > 0) {
+      lines.push(
+        '',
+        `${unchecked} verification step${unchecked === 1 ? '' : 's'} still unchecked.`
+      );
+    }
+    return this.packetText(lines.join('\n'));
+  }
+
+  private reviewSection(task: Task): string {
+    const lines = [
+      task.review?.decision ? `Decision: ${task.review.decision}` : 'Decision: Not recorded.',
+      task.review?.summary ? `Summary: ${task.review.summary}` : null,
+      task.reviewScores ? `Review scores: ${task.reviewScores.join('/')}` : null,
+      `Review comments: ${task.reviewComments?.length ?? 0}`,
+      task.qaGate?.required
+        ? `QA gate: ${task.qaGate.passed ? 'passed' : 'required and not passed'}`
+        : 'QA gate: Not required.',
+    ].filter((line): line is string => Boolean(line));
+    return this.packetText(lines.join('\n'));
+  }
+
+  private costDurationSection(task: Task): string {
+    const attemptDurationMs =
+      task.attempt?.started && task.attempt?.ended
+        ? new Date(task.attempt.ended).getTime() - new Date(task.attempt.started).getTime()
+        : undefined;
+    const lines = [
+      `Tracked time: ${this.formatDurationSeconds(task.timeTracking?.totalSeconds)}`,
+      `Attempt duration: ${this.formatDurationMs(attemptDurationMs)}`,
+      `Actual cost: ${this.formatCost(task.actualCost)}`,
+      task.costPrediction
+        ? `Predicted cost: ${this.formatCost(task.costPrediction.estimatedCost)} (${task.costPrediction.confidence} confidence)`
+        : 'Predicted cost: Not recorded.',
+    ];
+    return this.packetText(lines.join('\n'));
+  }
+
+  private deliverablesSection(task: Task): string {
+    const deliverables = task.deliverables ?? [];
+    const attachments = task.attachments ?? [];
+    const lines = [
+      'Deliverables:',
+      deliverables.length > 0
+        ? this.markdownList(
+            deliverables.map(
+              (deliverable) =>
+                `${deliverable.title} (${deliverable.status})${deliverable.path ? ` - ${deliverable.path}` : ''}`
+            )
+          )
+        : 'No deliverables recorded.',
+      '',
+      'Attachments:',
+      attachments.length > 0
+        ? this.markdownList(
+            attachments.map(
+              (attachment) =>
+                `${attachment.originalName || attachment.filename} (${attachment.mimeType}, ${attachment.validationStatus ?? 'unknown'})`
+            )
+          )
+        : 'No attachments recorded.',
+    ];
+    return this.packetText(lines.join('\n'));
+  }
+
+  private risksSection(task: Task): string {
+    const risks = [
+      task.blockedReason
+        ? `Blocked reason remains recorded: ${task.blockedReason.category}${task.blockedReason.note ? ` - ${task.blockedReason.note}` : ''}`
+        : null,
+      task.qaGate?.required && !task.qaGate.passed ? 'QA gate is required and not passed.' : null,
+      ...(task.verificationSteps ?? [])
+        .filter((step) => !step.checked)
+        .map((step) => `Unchecked verification: ${step.description}`),
+      task.review?.decision && task.review.decision !== 'approved'
+        ? `Review decision is ${task.review.decision}.`
+        : null,
+    ].filter((risk): risk is string => Boolean(risk));
+
+    return this.packetText(
+      risks.length > 0 ? this.markdownList(risks) : 'No unresolved risks were recorded.'
+    );
+  }
+
+  private markdownList(items: string[]): string {
+    return items.map((item) => `- ${item}`).join('\n');
+  }
+
+  private packetText(text: string): string {
+    return this.redactText(text, {
+      level: 'standard',
+      sensitiveFields: ['tokens', 'secrets', 'local paths'],
+    });
+  }
+
+  private formatCost(value?: number): string {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return 'Not recorded.';
+    if (value === 0) return '$0';
+    return value < 0.01 ? `$${value.toFixed(4)}` : `$${value.toFixed(2)}`;
+  }
+
+  private formatDurationMs(value?: number): string {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return 'Not recorded.';
+    return this.formatDurationSeconds(Math.round(value / 1000));
+  }
+
+  private formatDurationSeconds(value?: number): string {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 'Not recorded.';
+    const hours = Math.floor(value / 3600);
+    const minutes = Math.floor((value % 3600) / 60);
+    const seconds = Math.floor(value % 60);
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    if (minutes > 0) return `${minutes}m ${seconds}s`;
+    return `${seconds}s`;
   }
 
   dispose(): void {

--- a/web/src/__tests__/task-detail-work-products-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-work-products-mantine.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   exportWorkProduct: vi.fn(),
   listForTask: vi.fn(),
   listVersions: vi.fn(),
+  updateWorkProduct: vi.fn(),
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -21,6 +22,7 @@ vi.mock('@/lib/api', () => ({
       export: mocks.exportWorkProduct,
       listForTask: mocks.listForTask,
       listVersions: mocks.listVersions,
+      update: mocks.updateWorkProduct,
     },
   },
 }));
@@ -28,6 +30,7 @@ vi.mock('@/lib/api', () => ({
 const listForTaskMock = vi.mocked(api.workProducts.listForTask);
 const exportWorkProductMock = vi.mocked(api.workProducts.export);
 const listVersionsMock = vi.mocked(api.workProducts.listVersions);
+const updateWorkProductMock = vi.mocked(api.workProducts.update);
 
 const product: WorkProductPreview = {
   id: 'wp_launch_readiness',
@@ -81,6 +84,21 @@ describe('task detail work products surface', () => {
     listForTaskMock.mockResolvedValue([product]);
     listVersionsMock.mockResolvedValue(versions);
     exportWorkProductMock.mockResolvedValue('# Redacted launch report');
+    updateWorkProductMock.mockResolvedValue({
+      id: product.id,
+      workspaceId: product.workspaceId,
+      kind: 'markdown',
+      title: 'Edited launch report',
+      status: 'active',
+      render: { schemaVersion: 1, kind: 'markdown', markdown: '# Edited launch report' },
+      version: 3,
+      taskId: product.taskId,
+      sourceRunId: product.sourceRunId,
+      agent: product.agent,
+      model: product.model,
+      createdAt: product.createdAt,
+      updatedAt: '2026-06-01T12:00:00.000Z',
+    });
     mocks.clipboardWrite.mockResolvedValue(undefined);
     mocks.execCommand.mockReturnValue(true);
 
@@ -166,6 +184,49 @@ describe('task detail work products surface', () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:work-product');
     expect(appendSpy).toHaveBeenCalled();
     expect(removeSpy).toHaveBeenCalled();
+  });
+
+  it('loads redacted markdown for manual edits and saves a new version', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<WorkProductsSection taskId="task-work-products" />);
+
+    await user.click(await screen.findByRole('button', { name: /edit launch readiness report/i }));
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Edit: Launch readiness report',
+    });
+    await waitFor(() =>
+      expect(exportWorkProductMock).toHaveBeenCalledWith(product.id, {
+        format: 'markdown',
+        redacted: true,
+      })
+    );
+
+    const title = within(dialog).getByLabelText('Title');
+    await user.clear(title);
+    await user.type(title, 'Edited launch report');
+
+    const body = within(dialog).getByLabelText('Redacted markdown');
+    await user.clear(body);
+    await user.type(body, '# Edited launch report');
+
+    await user.click(within(dialog).getByRole('button', { name: 'Save Version' }));
+
+    await waitFor(() =>
+      expect(updateWorkProductMock).toHaveBeenCalledWith(
+        product.id,
+        expect.objectContaining({
+          title: 'Edited launch report',
+          render: {
+            schemaVersion: 1,
+            kind: 'markdown',
+            markdown: '# Edited launch report',
+          },
+          changeType: 'manual',
+          changeSummary: 'Manual edit before handoff',
+        })
+      )
+    );
   });
 
   it('opens version history without rendering raw version payloads', async () => {

--- a/web/src/components/task/WorkProductsSection.tsx
+++ b/web/src/components/task/WorkProductsSection.tsx
@@ -12,9 +12,12 @@ import {
   Stack,
   Table,
   Text,
+  Textarea,
+  TextInput,
   ThemeIcon,
   Tooltip,
 } from '@mantine/core';
+import { useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { useTaskWorkProducts, useWorkProductVersions } from '@/hooks/useWorkProducts';
 import { toast } from '@/hooks/useToast';
@@ -25,6 +28,7 @@ import {
   ExternalLink,
   FileText,
   History,
+  Pencil,
   Sparkles,
 } from 'lucide-react';
 import type {
@@ -91,8 +95,14 @@ async function writeClipboardText(content: string): Promise<void> {
 }
 
 export function WorkProductsSection({ taskId }: WorkProductsSectionProps) {
+  const queryClient = useQueryClient();
   const { data: products = [], isLoading, error } = useTaskWorkProducts(taskId);
   const [historyProduct, setHistoryProduct] = useState<WorkProductPreview | null>(null);
+  const [editProduct, setEditProduct] = useState<WorkProductPreview | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editBody, setEditBody] = useState('');
+  const [editLoading, setEditLoading] = useState(false);
+  const [editSaving, setEditSaving] = useState(false);
   const { data: versions = [], isLoading: versionsLoading } = useWorkProductVersions(
     historyProduct?.id ?? null
   );
@@ -118,6 +128,74 @@ export function WorkProductsSection({ taskId }: WorkProductsSectionProps) {
         description: err instanceof Error ? err.message : 'Could not copy work product.',
         variant: 'destructive',
       });
+    }
+  };
+
+  const openEditor = async (product: WorkProductPreview) => {
+    setEditProduct(product);
+    setEditTitle(product.title);
+    setEditBody('');
+    setEditLoading(true);
+    try {
+      const content = await api.workProducts.export(product.id, {
+        format: 'markdown',
+        redacted: true,
+      });
+      setEditBody(content);
+    } catch (err) {
+      toast({
+        title: 'Edit load failed',
+        description:
+          err instanceof Error ? err.message : 'Could not load editable work product content.',
+        variant: 'destructive',
+      });
+      setEditProduct(null);
+    } finally {
+      setEditLoading(false);
+    }
+  };
+
+  const saveEdit = async () => {
+    if (!editProduct) return;
+    const title = editTitle.trim();
+    const markdown = editBody.trimEnd();
+    if (!title || !markdown) {
+      toast({
+        title: 'Edit not saved',
+        description: 'Title and content are required.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setEditSaving(true);
+    try {
+      await api.workProducts.update(editProduct.id, {
+        title,
+        render: {
+          schemaVersion: 1,
+          kind: 'markdown',
+          markdown,
+        },
+        changeType: 'manual',
+        changeSummary: 'Manual edit before handoff',
+      });
+      await queryClient.invalidateQueries({ queryKey: ['tasks', taskId, 'work-products'] });
+      toast({
+        title: 'Work product updated',
+        description: `${title} was saved as a new version.`,
+      });
+      setEditProduct(null);
+      setEditTitle('');
+      setEditBody('');
+    } catch (err) {
+      toast({
+        title: 'Save failed',
+        description: err instanceof Error ? err.message : 'Could not save work product edit.',
+        variant: 'destructive',
+      });
+    } finally {
+      setEditSaving(false);
     }
   };
 
@@ -246,6 +324,15 @@ export function WorkProductsSection({ taskId }: WorkProductsSectionProps) {
                           <Clipboard className="h-4 w-4" />
                         </ActionIcon>
                       </Tooltip>
+                      <Tooltip label="Edit redacted markdown">
+                        <ActionIcon
+                          aria-label={`Edit ${product.title}`}
+                          variant="subtle"
+                          onClick={() => openEditor(product)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </ActionIcon>
+                      </Tooltip>
                       <Tooltip label="Export redacted markdown">
                         <ActionIcon
                           aria-label={`Export redacted ${product.title}`}
@@ -345,6 +432,48 @@ export function WorkProductsSection({ taskId }: WorkProductsSectionProps) {
               </Table.Tbody>
             </Table>
           </ScrollArea>
+        )}
+      </Modal>
+
+      <Modal
+        opened={Boolean(editProduct)}
+        onClose={() => {
+          if (!editSaving) setEditProduct(null);
+        }}
+        title={editProduct ? `Edit: ${editProduct.title}` : 'Edit work product'}
+        size="xl"
+      >
+        {editLoading ? (
+          <Group gap="sm">
+            <Loader size="sm" />
+            <Text size="sm" c="dimmed">
+              Loading editable content...
+            </Text>
+          </Group>
+        ) : (
+          <Stack gap="sm">
+            <TextInput
+              label="Title"
+              value={editTitle}
+              onChange={(event) => setEditTitle(event.currentTarget.value)}
+              disabled={editSaving}
+            />
+            <Textarea
+              label="Redacted markdown"
+              minRows={14}
+              value={editBody}
+              onChange={(event) => setEditBody(event.currentTarget.value)}
+              disabled={editSaving}
+            />
+            <Group justify="flex-end" gap="xs">
+              <Button variant="subtle" onClick={() => setEditProduct(null)} disabled={editSaving}>
+                Cancel
+              </Button>
+              <Button onClick={saveEdit} loading={editSaving}>
+                Save Version
+              </Button>
+            </Group>
+          </Stack>
         )}
       </Modal>
     </>

--- a/web/src/lib/api/work-products.ts
+++ b/web/src/lib/api/work-products.ts
@@ -1,4 +1,9 @@
-import type { WorkProductPreview, WorkProductVersion } from '@veritas-kanban/shared';
+import type {
+  UpdateWorkProductInput,
+  WorkProduct,
+  WorkProductPreview,
+  WorkProductVersion,
+} from '@veritas-kanban/shared';
 import { API_BASE, handleResponse } from './helpers';
 
 export type WorkProductExportFormat = 'markdown' | 'json';
@@ -62,6 +67,16 @@ export const workProductsApi = {
       credentials: 'include',
     });
     return handleResponse<WorkProductVersion[]>(response);
+  },
+
+  update: async (id: string, input: UpdateWorkProductInput): Promise<WorkProduct> => {
+    const response = await fetch(`${API_BASE}/work-products/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(input),
+    });
+    return handleResponse<WorkProduct>(response);
   },
 
   export: async (id: string, options: WorkProductExportOptions = {}): Promise<string> => {


### PR DESCRIPTION
## Summary
- Generates completion packets as durable, versioned report work products when tasks move to done, including agent-completed tasks through the shared task update path.
- Includes task summary, git/PR/run timeline source links, verification evidence, review state, cost/duration, deliverables, attachments, and unresolved risks with redacted export defaults.
- Adds a Work Products edit flow that loads redacted markdown and saves manual edits as a new version before copy/export.

## Verification
- pnpm --filter @veritas-kanban/server test -- sqlite-work-products.test.ts
- pnpm --filter @veritas-kanban/web test -- task-detail-work-products-mantine.test.tsx
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server lint (warnings only)
- pnpm --filter @veritas-kanban/web lint (warnings only)

Closes #363