### PR TITLE
Add Work View workflow state summary

### DIFF
--- a/web/src/__tests__/command-registry.test.ts
+++ b/web/src/__tests__/command-registry.test.ts
@@ -47,4 +47,12 @@ describe('command registry', () => {
 
     expect(boardCommand?.disabledReason).toBe('Select a task on the board to use this shortcut.');
   });
+
+  it('makes the selected-task Work View path discoverable from command search', () => {
+    const commands = createCommandRegistry({ theme: 'dark' });
+    const openTask = commands.find((command) => command.id === 'open-task');
+
+    expect(openTask?.keywords).toEqual(expect.arrayContaining(['work', 'work view']));
+    expect(openTask?.aliases).toEqual(expect.arrayContaining(['open work view', 'task work']));
+  });
 });

--- a/web/src/__tests__/task-work-view-mantine.test.tsx
+++ b/web/src/__tests__/task-work-view-mantine.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   stopAgentMutate: vi.fn(),
   useAgentStatus: vi.fn(),
   useAgentStream: vi.fn(),
+  useActiveRuns: vi.fn(),
+  useRecentRuns: vi.fn(),
   useTaskWorkProducts: vi.fn(),
 }));
 
@@ -31,6 +33,11 @@ vi.mock('@/hooks/useAgent', () => ({
 
 vi.mock('@/hooks/useWorkProducts', () => ({
   useTaskWorkProducts: mocks.useTaskWorkProducts,
+}));
+
+vi.mock('@/hooks/useWorkflowStats', () => ({
+  useActiveRuns: mocks.useActiveRuns,
+  useRecentRuns: mocks.useRecentRuns,
 }));
 
 const product: WorkProductPreview = {
@@ -72,6 +79,8 @@ describe('task work view Mantine surface', () => {
       isConnected: true,
       isRunning: false,
     });
+    mocks.useActiveRuns.mockReturnValue({ data: [], isLoading: false });
+    mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useTaskWorkProducts.mockReturnValue({ data: [], isLoading: false });
   });
 
@@ -126,6 +135,29 @@ describe('task work view Mantine surface', () => {
       ],
       isConnected: true,
       isRunning: true,
+    });
+    mocks.useActiveRuns.mockReturnValue({
+      data: [
+        {
+          id: 'workflow-run-1',
+          workflowId: 'release-flow',
+          workflowVersion: 2,
+          taskId: 'task-work',
+          status: 'running',
+          currentStep: 'build',
+          startedAt: '2026-06-01T10:55:00.000Z',
+          steps: [
+            {
+              stepId: 'plan',
+              status: 'completed',
+              startedAt: '2026-06-01T10:55:00.000Z',
+              completedAt: '2026-06-01T10:59:00.000Z',
+            },
+            { stepId: 'build', status: 'running', startedAt: '2026-06-01T11:00:00.000Z' },
+          ],
+        },
+      ],
+      isLoading: false,
     });
     const task = createMockTask({
       id: 'task-work',
@@ -197,6 +229,11 @@ describe('task work view Mantine surface', () => {
     expect(screen.getByText('Installing dependencies')).toBeDefined();
     expect(screen.getByText('1h 30m')).toBeDefined();
     expect(screen.getByText('$0.04')).toBeDefined();
+    expect(screen.getByText('Workflow State')).toBeDefined();
+    expect(screen.getByText('Workflow release-flow v2')).toBeDefined();
+    expect(screen.getByText('workflow-run-1')).toBeDefined();
+    expect(screen.getByText('build')).toBeDefined();
+    expect(screen.getByText('Steps 1/2')).toBeDefined();
     expect(screen.getByText('Release readiness report')).toBeDefined();
     expect(screen.getByText('v3 | report | run run-456')).toBeDefined();
     expect(
@@ -206,6 +243,7 @@ describe('task work view Mantine surface', () => {
     ).toBe('/runs/run-456');
 
     await user.click(screen.getByRole('button', { name: 'Open Agent' }));
+    await user.click(screen.getByRole('button', { name: 'Open Workflow' }));
     await user.click(screen.getByRole('button', { name: 'Work Products' }));
     await user.click(screen.getByRole('button', { name: 'Workflow' }));
     await user.click(screen.getByRole('button', { name: 'Stop' }));

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -48,6 +48,12 @@ import {
 import type { Task, TaskAttempt, TaskReadinessCheck, TaskStatus } from '@veritas-kanban/shared';
 import { useAgentStatus, useAgentStream, useStopAgent } from '@/hooks/useAgent';
 import { useTaskWorkProducts } from '@/hooks/useWorkProducts';
+import {
+  useActiveRuns,
+  useRecentRuns,
+  type WorkflowRun,
+  type WorkflowRunStatus,
+} from '@/hooks/useWorkflowStats';
 import { sanitizeText } from '@/lib/sanitize';
 
 export function getTaskReadinessChecks(task: Task, isCodeTask: boolean): TaskReadinessCheck[] {
@@ -247,6 +253,90 @@ function getReviewLabel(task: Task): string {
   return 'not started';
 }
 
+function getWorkflowStatusColor(status?: WorkflowRunStatus): string {
+  switch (status) {
+    case 'running':
+      return 'blue';
+    case 'blocked':
+      return 'yellow';
+    case 'completed':
+      return 'green';
+    case 'failed':
+      return 'red';
+    case 'pending':
+      return 'gray';
+    default:
+      return 'gray';
+  }
+}
+
+function getWorkflowStatusLabel(status?: WorkflowRunStatus): string {
+  switch (status) {
+    case 'running':
+      return 'Running';
+    case 'blocked':
+      return 'Blocked';
+    case 'completed':
+      return 'Completed';
+    case 'failed':
+      return 'Failed';
+    case 'pending':
+      return 'Pending';
+    default:
+      return 'No run';
+  }
+}
+
+function workflowRunMatchesTask(run: WorkflowRun, taskId: string): boolean {
+  const contextTaskId = run.context?.taskId ?? run.context?.task_id;
+  return run.taskId === taskId || contextTaskId === taskId;
+}
+
+function getWorkflowDurationMs(run?: WorkflowRun): number | undefined {
+  if (!run?.startedAt) return undefined;
+  const start = new Date(run.startedAt).getTime();
+  if (Number.isNaN(start)) return undefined;
+  const end = run.completedAt ? new Date(run.completedAt).getTime() : Date.now();
+  if (Number.isNaN(end) || end < start) return undefined;
+  return end - start;
+}
+
+function getWorkflowProgress(run?: WorkflowRun): {
+  complete: number;
+  total: number;
+  percent: number;
+} {
+  const steps = run?.steps ?? [];
+  const total = steps.length;
+  const complete = steps.filter((step) => step.status === 'completed').length;
+  return {
+    complete,
+    total,
+    percent: total > 0 ? Math.round((complete / total) * 100) : 0,
+  };
+}
+
+function workflowRunSortWeight(status: WorkflowRunStatus): number {
+  switch (status) {
+    case 'running':
+      return 0;
+    case 'blocked':
+      return 1;
+    case 'pending':
+      return 2;
+    case 'failed':
+      return 3;
+    case 'completed':
+      return 4;
+  }
+}
+
+function compareWorkflowRuns(a: WorkflowRun, b: WorkflowRun): number {
+  const statusDelta = workflowRunSortWeight(a.status) - workflowRunSortWeight(b.status);
+  if (statusDelta !== 0) return statusDelta;
+  return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime();
+}
+
 export function shouldDefaultTaskDetailToWork(task: Task): boolean {
   if (task.type !== 'code') return false;
   return Boolean(
@@ -272,6 +362,8 @@ export function TaskWorkView({
   const { data: workProducts = [], isLoading: workProductsLoading } = useTaskWorkProducts(task.id);
   const { data: agentStatus } = useAgentStatus(task.id);
   const { outputs, isConnected, isRunning } = useAgentStream(task.id);
+  const { data: activeWorkflowRuns = [], isLoading: activeWorkflowRunsLoading } = useActiveRuns();
+  const { data: recentWorkflowRuns = [], isLoading: recentWorkflowRunsLoading } = useRecentRuns();
   const stopAgent = useStopAgent();
   const readinessSummary = useMemo(
     () => evaluateTaskReadiness(task, { isCodeTask }),
@@ -293,6 +385,17 @@ export function TaskWorkView({
   const attemptDuration = getAttemptDurationMs(task.attempt);
   const trackedTime = formatTrackedSeconds(task.timeTracking?.totalSeconds);
   const runCost = formatCost(task.actualCost);
+  const taskWorkflowRuns = useMemo(() => {
+    const byId = new Map<string, WorkflowRun>();
+    for (const run of [...activeWorkflowRuns, ...recentWorkflowRuns]) {
+      if (workflowRunMatchesTask(run, task.id)) byId.set(run.id, run);
+    }
+    return [...byId.values()].sort(compareWorkflowRuns);
+  }, [activeWorkflowRuns, recentWorkflowRuns, task.id]);
+  const workflowRun = taskWorkflowRuns[0];
+  const workflowProgress = getWorkflowProgress(workflowRun);
+  const workflowDuration = getWorkflowDurationMs(workflowRun);
+  const workflowLoading = activeWorkflowRunsLoading || recentWorkflowRunsLoading;
   const currentStep =
     latestOutputs.length > 0
       ? sanitizeText(latestOutputs[latestOutputs.length - 1].content).slice(0, 180)
@@ -629,6 +732,81 @@ export function TaskWorkView({
                 </Stack>
               </ScrollArea>
             </div>
+          </Stack>
+        </Paper>
+
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="sm">
+            <Group justify="space-between" align="flex-start" gap="sm">
+              <div className="min-w-0">
+                <Group gap="xs" wrap="wrap">
+                  <Workflow className="h-4 w-4 text-muted-foreground" />
+                  <Text fw={600}>Workflow State</Text>
+                  <Badge color={getWorkflowStatusColor(workflowRun?.status)} variant="light">
+                    {getWorkflowStatusLabel(workflowRun?.status)}
+                  </Badge>
+                </Group>
+                <Text size="xs" c="dimmed" mt={4}>
+                  {workflowRun
+                    ? `Workflow ${workflowRun.workflowId} v${workflowRun.workflowVersion}`
+                    : 'No workflow run has been recorded for this task.'}
+                </Text>
+              </div>
+              <Button
+                size="compact-xs"
+                variant="light"
+                leftSection={<Workflow className="h-3 w-3" />}
+                onClick={onOpenWorkflow}
+              >
+                Open Workflow
+              </Button>
+            </Group>
+
+            {workflowLoading ? (
+              <Group gap="xs">
+                <Loader size="xs" />
+                <Text size="xs" c="dimmed">
+                  Loading workflow state...
+                </Text>
+              </Group>
+            ) : workflowRun ? (
+              <Stack gap="xs">
+                <Group gap="xs" wrap="wrap">
+                  <Badge variant="outline" className="font-mono">
+                    {workflowRun.id}
+                  </Badge>
+                  {workflowRun.currentStep && (
+                    <Badge variant="light" color="blue">
+                      {workflowRun.currentStep}
+                    </Badge>
+                  )}
+                </Group>
+                <Group gap="md" wrap="wrap">
+                  <Text size="xs" c="dimmed">
+                    Steps {workflowProgress.complete}/{workflowProgress.total}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    Duration {formatDurationMs(workflowDuration)}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    Started {formatDate(workflowRun.startedAt)}
+                  </Text>
+                </Group>
+                <Progress
+                  value={workflowProgress.percent}
+                  color={getWorkflowStatusColor(workflowRun.status)}
+                />
+                {workflowRun.error && (
+                  <Alert color="red" icon={<AlertTriangle className="h-4 w-4" />}>
+                    {workflowRun.error}
+                  </Alert>
+                )}
+              </Stack>
+            ) : (
+              <Text size="sm" c="dimmed">
+                Open Workflow to start a recipe or inspect available workflow runs.
+              </Text>
+            )}
           </Stack>
         </Paper>
 

--- a/web/src/lib/command-registry.ts
+++ b/web/src/lib/command-registry.ts
@@ -111,7 +111,8 @@ const BOARD_SHORTCUTS: readonly CommandDescriptor[] = [
     icon: 'Keyboard',
     category: 'Board',
     action: { type: 'board-shortcut', shortcut: 'open-task' },
-    keywords: ['view', 'detail', 'open'],
+    keywords: ['view', 'detail', 'open', 'work', 'work view'],
+    aliases: ['open work view', 'task work'],
     disabledReason: SELECTED_TASK_REQUIRED,
   },
 ];


### PR DESCRIPTION
## Summary
- Add task-scoped workflow state to the Work View using existing active/recent workflow run data.
- Show workflow run status, current step, step progress, duration, start time, and errors with an Open Workflow action.
- Add Work View command-search terms for the selected-task command path.

## Verification
- pnpm --filter @veritas-kanban/web test -- task-work-view-mantine.test.tsx command-registry.test.ts
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web lint (passes with existing warnings)

Closes #359