### PR TITLE
Add work product maintenance preview

### DIFF
--- a/server/src/__tests__/storage/sqlite-work-products.test.ts
+++ b/server/src/__tests__/storage/sqlite-work-products.test.ts
@@ -213,6 +213,31 @@ describe('SQLite work products', () => {
       expect(regenerated.id).toBe(packet.id);
       expect(regenerated.version).toBe(2);
       await expect(restarted.listVersions(packet.id)).resolves.toHaveLength(2);
+
+      await restarted.archive(packet.id);
+      const maintenancePreview = await restarted.maintenancePreview();
+      expect(maintenancePreview.totals).toMatchObject({
+        products: 3,
+        active: 2,
+        archived: 1,
+        cleanupCandidates: 1,
+      });
+      expect(maintenancePreview.totals.versions).toBeGreaterThanOrEqual(6);
+      expect(maintenancePreview.totals.estimatedBytes).toBeGreaterThan(0);
+      expect(maintenancePreview.cleanupCandidates[0]).toMatchObject({
+        id: packet.id,
+        status: 'archived',
+        cleanupEligible: true,
+        taskId: completedTask.id,
+        sourceRunId: 'attempt_packet',
+        versionCount: 2,
+      });
+      expect(maintenancePreview.retained.map((item) => item.id)).toContain(created.id);
+      expect(maintenancePreview.byKind.find((group) => group.kind === 'report')).toMatchObject({
+        products: 1,
+        versions: 2,
+      });
+      expect(maintenancePreview.notes.join(' ')).toContain('Preview only');
     } finally {
       service?.dispose();
       resetWorkProductServiceForTests();

--- a/server/src/routes/work-products.ts
+++ b/server/src/routes/work-products.ts
@@ -60,6 +60,13 @@ router.post(
 );
 
 router.get(
+  '/maintenance-preview',
+  asyncHandler(async (_req, res) => {
+    res.json(await getWorkProductService().maintenancePreview());
+  })
+);
+
+router.get(
   '/:id',
   asyncHandler(async (req, res) => {
     const product = await getWorkProductService().get(req.params.id as string);

--- a/server/src/services/work-product-service.ts
+++ b/server/src/services/work-product-service.ts
@@ -6,6 +6,8 @@ import type {
   UpdateWorkProductInput,
   WorkProduct,
   WorkProductListOptions,
+  WorkProductMaintenancePreview,
+  WorkProductMaintenancePreviewItem,
   WorkProductPreview,
   WorkProductPrimitive,
   WorkProductRedaction,
@@ -217,6 +219,54 @@ export class WorkProductService {
     return this.list({ query, limit });
   }
 
+  async maintenancePreview(): Promise<WorkProductMaintenancePreview> {
+    const products = await this.listMaintenanceProducts();
+    const items = await Promise.all(
+      products.map(async (product) => this.toMaintenancePreviewItem(product))
+    );
+    const byKind = Array.from(
+      items
+        .reduce((groups, item) => {
+          const current = groups.get(item.kind) ?? {
+            kind: item.kind,
+            products: 0,
+            versions: 0,
+            estimatedBytes: 0,
+          };
+          current.products += 1;
+          current.versions += item.versionCount;
+          current.estimatedBytes += item.estimatedBytes;
+          groups.set(item.kind, current);
+          return groups;
+        }, new Map<WorkProduct['kind'], WorkProductMaintenancePreview['byKind'][number]>())
+        .values()
+    ).sort((a, b) => b.estimatedBytes - a.estimatedBytes || a.kind.localeCompare(b.kind));
+
+    const cleanupCandidates = items.filter((item) => item.cleanupEligible);
+    const retained = items.filter((item) => !item.cleanupEligible);
+
+    return {
+      generatedAt: new Date().toISOString(),
+      workspaceId: 'local',
+      totals: {
+        products: items.length,
+        active: items.filter((item) => item.status === 'active').length,
+        archived: items.filter((item) => item.status === 'archived').length,
+        versions: items.reduce((sum, item) => sum + item.versionCount, 0),
+        cleanupCandidates: cleanupCandidates.length,
+        estimatedBytes: items.reduce((sum, item) => sum + item.estimatedBytes, 0),
+      },
+      byKind,
+      cleanupCandidates,
+      retained,
+      notes: [
+        'Preview only. No work products or version history are deleted by this endpoint.',
+        'Archived work products are cleanup candidates; active work products are retained.',
+        'Byte counts are JSON storage estimates for product metadata, render payloads, and versions.',
+      ],
+    };
+  }
+
   async generateCompletionPacket(
     task: Task,
     options: { sourceRunId?: string; changeSummary?: string } = {}
@@ -271,6 +321,66 @@ export class WorkProductService {
       createdAt: product.createdAt,
       updatedAt: product.updatedAt,
     };
+  }
+
+  private async listMaintenanceProducts(): Promise<WorkProduct[]> {
+    if (this.repository) {
+      return this.repository.listForMaintenance();
+    }
+
+    await this.ensureLoaded();
+    return [...this.fileState.products].sort(
+      (a, b) =>
+        a.status.localeCompare(b.status) ||
+        a.updatedAt.localeCompare(b.updatedAt) ||
+        a.id.localeCompare(b.id)
+    );
+  }
+
+  private async toMaintenancePreviewItem(
+    product: WorkProduct
+  ): Promise<WorkProductMaintenancePreviewItem> {
+    const versions = await this.listVersions(product.id);
+    const redacted = this.toPreview(product).redacted;
+    const cleanupEligible = product.status === 'archived';
+
+    return {
+      id: product.id,
+      workspaceId: product.workspaceId,
+      title: product.title,
+      kind: product.kind,
+      status: product.status,
+      taskId: product.taskId,
+      sourceRunId: product.sourceRunId,
+      version: product.version,
+      versionCount: versions.length,
+      sourceLinkCount: product.sourceLinks?.length ?? 0,
+      redacted,
+      cleanupEligible,
+      retainedReason: this.maintenanceRetainedReason(product, versions.length),
+      estimatedBytes: this.estimateWorkProductBytes(product, versions),
+      createdAt: product.createdAt,
+      updatedAt: product.updatedAt,
+      archivedAt: product.archivedAt,
+    };
+  }
+
+  private maintenanceRetainedReason(product: WorkProduct, versionCount: number): string {
+    if (product.status === 'active') {
+      if (product.taskId) return 'Active work product linked to a task.';
+      if (product.sourceRunId) return 'Active work product linked to a run.';
+      return 'Active work product.';
+    }
+
+    if (versionCount > 1) return 'Archived work product with restorable version history.';
+    return 'Archived generated output eligible for explicit cleanup.';
+  }
+
+  private estimateWorkProductBytes(product: WorkProduct, versions: WorkProductVersion[]): number {
+    return (
+      Buffer.byteLength(JSON.stringify(product), 'utf8') +
+      versions.reduce((sum, version) => sum + Buffer.byteLength(JSON.stringify(version), 'utf8'), 0)
+    );
   }
 
   exportProduct(

--- a/server/src/storage/sqlite/work-product-repository.ts
+++ b/server/src/storage/sqlite/work-product-repository.ts
@@ -30,6 +30,23 @@ export class SqliteWorkProductRepository {
     return rows.map((row) => JSON.parse(row.product_json) as WorkProduct);
   }
 
+  listForMaintenance(): WorkProduct[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `
+          SELECT product_json
+          FROM work_products
+          WHERE workspace_id = 'local'
+            AND deleted_at IS NULL
+          ORDER BY status DESC, datetime(updated_at) ASC, id ASC
+        `
+      )
+      .all() as unknown as WorkProductRow[];
+
+    return rows.map((row) => JSON.parse(row.product_json) as WorkProduct);
+  }
+
   get(id: string): WorkProduct | null {
     const row = this.database
       .getConnection()

--- a/shared/src/types/work-product.types.ts
+++ b/shared/src/types/work-product.types.ts
@@ -195,3 +195,45 @@ export interface WorkProductListOptions {
   includeArchived?: boolean;
   limit?: number;
 }
+
+export interface WorkProductMaintenancePreviewItem {
+  id: string;
+  workspaceId: string;
+  title: string;
+  kind: WorkProductKind;
+  status: WorkProductStatus;
+  taskId?: string;
+  sourceRunId?: string;
+  version: number;
+  versionCount: number;
+  sourceLinkCount: number;
+  redacted: boolean;
+  cleanupEligible: boolean;
+  retainedReason: string;
+  estimatedBytes: number;
+  createdAt: string;
+  updatedAt: string;
+  archivedAt?: string;
+}
+
+export interface WorkProductMaintenancePreview {
+  generatedAt: string;
+  workspaceId: string;
+  totals: {
+    products: number;
+    active: number;
+    archived: number;
+    versions: number;
+    cleanupCandidates: number;
+    estimatedBytes: number;
+  };
+  byKind: Array<{
+    kind: WorkProductKind;
+    products: number;
+    versions: number;
+    estimatedBytes: number;
+  }>;
+  cleanupCandidates: WorkProductMaintenancePreviewItem[];
+  retained: WorkProductMaintenancePreviewItem[];
+  notes: string[];
+}

--- a/web/src/lib/api/work-products.ts
+++ b/web/src/lib/api/work-products.ts
@@ -1,6 +1,7 @@
 import type {
   UpdateWorkProductInput,
   WorkProduct,
+  WorkProductMaintenancePreview,
   WorkProductPreview,
   WorkProductVersion,
 } from '@veritas-kanban/shared';
@@ -44,6 +45,13 @@ function getErrorMessage(body: unknown, status: number): string {
 }
 
 export const workProductsApi = {
+  maintenancePreview: async (): Promise<WorkProductMaintenancePreview> => {
+    const response = await fetch(`${API_BASE}/work-products/maintenance-preview`, {
+      credentials: 'include',
+    });
+    return handleResponse<WorkProductMaintenancePreview>(response);
+  },
+
   listForTask: async (
     taskId: string,
     options: { includeArchived?: boolean; limit?: number } = {}


### PR DESCRIPTION
## Summary
- Add a read-only work-product maintenance preview contract with active/archived totals, version counts, storage estimates, cleanup candidates, retained items, and by-kind totals.
- Expose the preview through the work-products API and web API helper without adding any destructive cleanup action.
- Cover SQLite work products so archived completion packets appear as cleanup candidates while active products remain retained with version-history estimates.

## Verification
- pnpm --filter @veritas-kanban/server test -- sqlite-work-products.test.ts
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server lint (passes with existing warnings)
- pnpm --filter @veritas-kanban/web lint (passes with existing warnings)
- pnpm --filter @veritas-kanban/shared typecheck

Closes #403