### PR TITLE
Capture agent stream and retry trace events

### DIFF
--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -74,9 +74,29 @@ vi.mock('../services/circuit-registry.js', () => ({
 }));
 
 import { AgentReadinessError, ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
-import type { Task } from '@veritas-kanban/shared';
+import type { AgentConfig, Task } from '@veritas-kanban/shared';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
+
+type TestableClawdbotAgentService = ClawdbotAgentService & {
+  logsDir: string;
+  handleCodexEvent(
+    event: Record<string, unknown>,
+    logPath: string,
+    task?: Task,
+    attemptId?: string,
+    agentConfig?: Partial<AgentConfig>
+  ): {
+    summary?: string;
+    usage?: { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string };
+  };
+};
+
+function testableService(tmpDir: string): TestableClawdbotAgentService {
+  const service = new ClawdbotAgentService() as unknown as TestableClawdbotAgentService;
+  service.logsDir = tmpDir;
+  return service;
+}
 
 function createFakeChild(fixturePath: string, exitCode = 0) {
   const child = new EventEmitter() as EventEmitter & {
@@ -102,6 +122,25 @@ function createFakeChild(fixturePath: string, exitCode = 0) {
     setTimeout(() => child.emit('close', exitCode, null), 10);
   });
 
+  return child;
+}
+
+function createControllableChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    pid: number;
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.pid = 12345;
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
   return child;
 }
 
@@ -185,8 +224,7 @@ describe('ClawdbotAgentService Codex providers', () => {
 
   it('runs the Codex CLI adapter against mocked JSONL and records telemetry', async () => {
     mockSpawn.mockReturnValue(createFakeChild(path.join(fixtureDir, 'success.jsonl')));
-    const service = new ClawdbotAgentService();
-    (service as any).logsDir = tmpDir;
+    const service = testableService(tmpDir);
 
     const status = await service.startAgent(task.id, 'codex');
 
@@ -223,6 +261,27 @@ describe('ClawdbotAgentService Codex providers', () => {
     });
     expect(mockStartStep).toHaveBeenCalledWith(
       expect.any(String),
+      'stream',
+      expect.objectContaining({
+        eventType: 'stream.stdout',
+        stream: 'stdout',
+        provider: 'codex-cli',
+        chunkBytes: expect.any(Number),
+      })
+    );
+    expect(mockStartStep).toHaveBeenCalledWith(
+      expect.any(String),
+      'finalize',
+      expect.objectContaining({
+        eventType: 'run.finalizing',
+        exitCode: 0,
+        signal: null,
+        success: true,
+        provider: 'codex-cli',
+      })
+    );
+    expect(mockStartStep).toHaveBeenCalledWith(
+      expect.any(String),
       'complete',
       expect.objectContaining({
         eventType: 'turn.completed',
@@ -244,12 +303,11 @@ describe('ClawdbotAgentService Codex providers', () => {
   });
 
   it('maps Codex file events to task deliverables linked to the attempt', async () => {
-    const service = new ClawdbotAgentService();
-    (service as any).logsDir = tmpDir;
+    const service = testableService(tmpDir);
     const logPath = path.join(tmpDir, 'codex.md');
     await fs.writeFile(logPath, '# log\n');
 
-    (service as any).handleCodexEvent(
+    service.handleCodexEvent(
       {
         type: 'item.completed',
         item: {
@@ -296,6 +354,76 @@ describe('ClawdbotAgentService Codex providers', () => {
     );
   });
 
+  it('classifies streamed output, retry, and abort lifecycle events in traces', async () => {
+    const service = testableService(tmpDir);
+    const logPath = path.join(tmpDir, 'codex.md');
+    await fs.writeFile(logPath, '# log\n');
+
+    service.handleCodexEvent(
+      {
+        type: 'response.output_text.delta',
+        delta: 'partial output OPENAI_API_KEY=sk-supersecret123456',
+        stream: 'stdout',
+      },
+      logPath,
+      task,
+      'attempt_fixture',
+      { type: 'codex', provider: 'codex-cli', model: 'gpt-5.5' }
+    );
+    service.handleCodexEvent(
+      {
+        type: 'turn.retrying',
+        message: 'Retrying after rate limit',
+        retryAttempt: 2,
+        retryDelayMs: 1250,
+      },
+      logPath,
+      task,
+      'attempt_fixture',
+      { type: 'codex', provider: 'codex-cli', model: 'gpt-5.5' }
+    );
+
+    expect(mockStartStep).toHaveBeenCalledWith(
+      'attempt_fixture',
+      'stream',
+      expect.objectContaining({
+        eventType: 'response.output_text.delta',
+        stream: 'stdout',
+        content: 'partial output OPENAI_API_KEY=[REDACTED]',
+      })
+    );
+    expect(mockStartStep).toHaveBeenCalledWith(
+      'attempt_fixture',
+      'retry',
+      expect.objectContaining({
+        eventType: 'turn.retrying',
+        summary: 'Retrying after rate limit',
+        retryAttempt: 2,
+        retryDelayMs: 1250,
+      })
+    );
+  });
+
+  it('records user stop requests as abort trace steps before completing the attempt', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+
+    await service.startAgent(task.id, 'codex');
+    await service.stopAgent(task.id);
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mockStartStep).toHaveBeenCalledWith(
+      expect.any(String),
+      'abort',
+      expect.objectContaining({
+        eventType: 'run.aborted',
+        reason: 'Stopped by user',
+        provider: 'codex-cli',
+      })
+    );
+  });
+
   it('requires and records a readiness override for incomplete task starts', async () => {
     task = {
       ...task,
@@ -306,8 +434,7 @@ describe('ClawdbotAgentService Codex providers', () => {
     } as Task;
     mockGetTask.mockResolvedValue(task);
 
-    const service = new ClawdbotAgentService();
-    (service as any).logsDir = tmpDir;
+    const service = testableService(tmpDir);
 
     await expect(service.startAgent(task.id, 'codex')).rejects.toBeInstanceOf(AgentReadinessError);
 

--- a/server/src/__tests__/trace-service.test.ts
+++ b/server/src/__tests__/trace-service.test.ts
@@ -108,6 +108,39 @@ describe('TraceService', () => {
       const trace = service.getActiveTrace('attempt-1');
       expect(trace!.steps).toHaveLength(1);
     });
+
+    it('should preserve stream, retry, abort, and finalize lifecycle steps', () => {
+      service.startTrace('attempt-lifecycle', 'task-1', 'veritas');
+      service.startStep('attempt-lifecycle', 'stream', {
+        eventType: 'stream.stdout',
+        content: 'partial output',
+      });
+      service.endStep('attempt-lifecycle', 'stream');
+      service.startStep('attempt-lifecycle', 'retry', {
+        eventType: 'turn.retrying',
+        retryAttempt: 2,
+      });
+      service.endStep('attempt-lifecycle', 'retry');
+      service.startStep('attempt-lifecycle', 'abort', {
+        eventType: 'run.aborted',
+        reason: 'Stopped by user',
+      });
+      service.endStep('attempt-lifecycle', 'abort');
+      service.startStep('attempt-lifecycle', 'finalize', {
+        eventType: 'run.finalizing',
+        exitCode: 143,
+      });
+      service.endStep('attempt-lifecycle', 'finalize');
+
+      const trace = service.getActiveTrace('attempt-lifecycle');
+      expect(trace!.steps.map((step) => step.type)).toEqual([
+        'stream',
+        'retry',
+        'abort',
+        'finalize',
+      ]);
+      expect(trace!.steps.every((step) => step.endedAt)).toBe(true);
+    });
   });
 
   describe('endStep', () => {

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -29,6 +29,7 @@ import type {
   Task,
   AgentType,
   AgentConfig,
+  AgentRunTraceStepType,
   AgentRunTraceMetadata,
   TaskAttempt,
   AttemptStatus,
@@ -304,6 +305,14 @@ export class ClawdbotAgentService {
       });
     } catch (error: any) {
       pendingAgents.delete(taskId);
+      this.recordTraceStep(attemptId, 'error', {
+        eventType: 'run.start_failed',
+        error: this.redactTraceText(error.message || `Failed to start ${adapter.label}`),
+        provider,
+        agent,
+        model: agentConfig?.model,
+      });
+      await getTraceService().completeTrace(attemptId, 'error');
       await this.taskService.updateTask(taskId, {
         status: 'todo',
         attempt: { ...attempt, status: 'failed', ended: new Date().toISOString() },
@@ -410,7 +419,7 @@ export class ClawdbotAgentService {
 
     const task = await this.taskService.getTask(taskId);
     const completionStepType = result.success ? 'complete' : 'error';
-    getTraceService().startStep(attemptId, completionStepType, {
+    this.recordTraceStep(attemptId, completionStepType, {
       eventType: result.success ? 'run.completed' : 'run.failed',
       summary: this.redactTraceText(summary),
       success: result.success,
@@ -421,7 +430,6 @@ export class ClawdbotAgentService {
       provider: pending.provider,
       model: pending.model,
     });
-    getTraceService().endStep(attemptId, completionStepType);
     await getTelemetryService().emit<RunCompletedEvent>({
       type: 'run.completed',
       taskId,
@@ -476,6 +484,14 @@ export class ClawdbotAgentService {
     }
 
     await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
+    this.recordTraceStep(pending.attemptId, 'abort', {
+      eventType: 'run.aborted',
+      summary: 'Stopped by user',
+      reason: 'Stopped by user',
+      agent: pending.agent,
+      provider: pending.provider,
+      model: pending.model,
+    });
 
     // Mark as failed/stopped
     await this.completeAgent(taskId, {
@@ -627,6 +643,7 @@ export class ClawdbotAgentService {
 
     child.stdout.setEncoding('utf-8');
     child.stdout.on('data', (chunk: string) => {
+      this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stdout', chunk);
       stdoutBuffer += chunk;
       const lines = stdoutBuffer.split(/\r?\n/);
       stdoutBuffer = lines.pop() || '';
@@ -640,10 +657,18 @@ export class ClawdbotAgentService {
     child.stderr.setEncoding('utf-8');
     child.stderr.on('data', (chunk: string) => {
       stderrBuffer += chunk;
+      this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stderr', chunk);
       void this.appendLog(logPath, `\n### stderr\n\n\`\`\`\n${chunk.trimEnd()}\n\`\`\`\n`);
     });
 
     child.on('error', (error) => {
+      this.recordTraceStep(attemptId, 'error', {
+        eventType: 'process.error',
+        error: this.redactTraceText(error.message),
+        provider: 'codex-cli',
+        agent: agentConfig?.type || 'codex',
+        model: agentConfig?.model,
+      });
       void this.appendLog(logPath, `\n## Codex Process Error\n\n${error.message}\n`);
       emitter.emit('error', error);
     });
@@ -685,6 +710,16 @@ export class ClawdbotAgentService {
           logPath,
           `\n## Codex Exit\n\n**Exit code:** ${code ?? 'none'}\n**Signal:** ${signal ?? 'none'}\n**Duration:** ${Date.now() - new Date(startedAt).getTime()}ms\n`
         );
+        this.recordTraceStep(attemptId, 'finalize', {
+          eventType: 'run.finalizing',
+          exitCode: code,
+          signal,
+          success: code === 0,
+          durationMs: Date.now() - new Date(startedAt).getTime(),
+          provider: 'codex-cli',
+          agent: agentConfig?.type || 'codex',
+          model: agentConfig?.model,
+        });
 
         await this.completeAgent(task.id, {
           success: code === 0,
@@ -889,6 +924,39 @@ export class ClawdbotAgentService {
     );
   }
 
+  private recordTraceStep(
+    attemptId: string,
+    stepType: AgentRunTraceStepType,
+    metadata?: Record<string, unknown>
+  ): void {
+    const traceService = getTraceService();
+    traceService.startStep(attemptId, stepType, metadata);
+    traceService.endStep(attemptId, stepType);
+  }
+
+  private recordStreamChunk(
+    task: Task,
+    attemptId: string,
+    agentConfig: AgentConfig | undefined,
+    provider: AgentProvider,
+    stream: 'stdout' | 'stderr',
+    chunk: string
+  ): void {
+    const content = this.redactTraceText(chunk.trimEnd());
+    if (!content.trim()) return;
+    this.recordTraceStep(attemptId, 'stream', {
+      eventType: `stream.${stream}`,
+      stream,
+      summary: content,
+      content,
+      chunkBytes: Buffer.byteLength(chunk, 'utf-8'),
+      lineCount: chunk.split(/\r?\n/).filter((line) => line.trim()).length,
+      provider,
+      agent: agentConfig?.type || task.agent || 'codex',
+      model: agentConfig?.model,
+    });
+  }
+
   private buildTraceMetadata(
     task: Task,
     attemptId: string,
@@ -940,22 +1008,26 @@ export class ClawdbotAgentService {
     const tool = this.extractCodexTool(event, type);
     const error = this.extractCodexError(event, type);
     const sanitizedSummary = summary ? this.redactTraceText(summary) : undefined;
-    const stepType = this.codexTraceStepType(type);
-    getTraceService().startStep(attemptId, stepType, {
+    const stepType = this.codexTraceStepType(type, event);
+    const stream = this.extractCodexStream(event, type);
+    this.recordTraceStep(attemptId, stepType, {
       provider: agentConfig?.provider || 'codex-cli',
       eventType: type,
       summary: sanitizedSummary,
+      content: stepType === 'stream' ? sanitizedSummary : undefined,
+      stream,
       command: command ? this.redactTraceText(command) : undefined,
       tool,
       files,
       error: error ? this.redactTraceText(error) : undefined,
+      retryAttempt: this.extractCodexNumber(event, ['retryAttempt', 'retry_attempt', 'attempt']),
+      retryDelayMs: this.extractCodexNumber(event, ['retryDelayMs', 'retry_delay_ms', 'delayMs']),
       inputTokens: usage?.inputTokens,
       outputTokens: usage?.outputTokens,
       totalTokens: usage?.totalTokens,
       model: usage?.model || agentConfig?.model,
       finalResult: stepType === 'complete' ? sanitizedSummary : undefined,
     });
-    getTraceService().endStep(attemptId, stepType);
 
     if (this.shouldLogCodexActivity(type)) {
       await activityService.logActivity(
@@ -977,7 +1049,25 @@ export class ClawdbotAgentService {
     }
   }
 
-  private codexTraceStepType(type: string): 'execute' | 'complete' | 'error' {
+  private codexTraceStepType(type: string, event?: Record<string, unknown>): AgentRunTraceStepType {
+    const normalized = type.toLowerCase();
+    if (normalized.includes('retry')) return 'retry';
+    if (normalized.includes('abort') || normalized.includes('cancel')) return 'abort';
+    if (normalized.includes('failed') || normalized === 'error') return 'error';
+    if (normalized.includes('finaliz')) return 'finalize';
+    if (
+      normalized.includes('delta') ||
+      normalized.includes('stream') ||
+      normalized.includes('output') ||
+      normalized.includes('stdout') ||
+      normalized.includes('stderr')
+    ) {
+      return 'stream';
+    }
+    if (event && typeof event.item === 'object' && event.item !== null) {
+      const itemType = String((event.item as Record<string, unknown>).type || '').toLowerCase();
+      if (itemType.includes('delta') || itemType.includes('message_delta')) return 'stream';
+    }
     if (type.includes('failed') || type === 'error') return 'error';
     if (type === 'turn.completed' || type === 'response.completed') return 'complete';
     return 'execute';
@@ -988,6 +1078,8 @@ export class ClawdbotAgentService {
       type.includes('command') ||
       type.includes('tool') ||
       type.includes('file') ||
+      type.includes('retry') ||
+      type.includes('abort') ||
       type.includes('completed') ||
       type.includes('failed') ||
       type === 'error'
@@ -1066,6 +1158,49 @@ export class ClawdbotAgentService {
     if (!type.includes('failed') && type !== 'error') return undefined;
     const error = this.findCodexString(event, ['error', 'message']);
     return error;
+  }
+
+  private extractCodexStream(
+    event: Record<string, unknown>,
+    type: string
+  ): 'stdout' | 'stderr' | undefined {
+    const stream = this.findCodexString(event, ['stream', 'channel', 'fd']);
+    if (stream === 'stdout' || stream === 'stderr') return stream;
+    if (/stderr|error/i.test(type)) return 'stderr';
+    if (/stdout|delta|output|stream/i.test(type)) return 'stdout';
+    return undefined;
+  }
+
+  private extractCodexNumber(event: unknown, keys: string[]): number | undefined {
+    const wanted = new Set(keys);
+    const seen = new Set<unknown>();
+
+    const visit = (value: unknown, key?: string): number | undefined => {
+      if (!value) return undefined;
+      if (typeof value === 'number') {
+        return key && wanted.has(key) ? value : undefined;
+      }
+      if (typeof value === 'string' && key && wanted.has(key)) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+      }
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          const result = visit(item, key);
+          if (result !== undefined) return result;
+        }
+        return undefined;
+      }
+      if (typeof value !== 'object' || seen.has(value)) return undefined;
+      seen.add(value);
+      for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+        const result = visit(childValue, childKey);
+        if (result !== undefined) return result;
+      }
+      return undefined;
+    };
+
+    return visit(event);
   }
 
   private findCodexString(event: unknown, keys: string[]): string | undefined {
@@ -1249,6 +1384,9 @@ export class ClawdbotAgentService {
         'final_message',
         'message',
         'text',
+        'delta',
+        'chunk',
+        'content',
         'output',
       ]) {
         const candidate = record[key];

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -107,7 +107,15 @@ export interface TelemetryConfig {
 }
 
 /** Low-level trace step types captured during an agent attempt. */
-export type AgentRunTraceStepType = 'init' | 'execute' | 'complete' | 'error';
+export type AgentRunTraceStepType =
+  | 'init'
+  | 'execute'
+  | 'stream'
+  | 'retry'
+  | 'abort'
+  | 'finalize'
+  | 'complete'
+  | 'error';
 
 /** Additional run context persisted with each trace for replay/audit surfaces. */
 export interface AgentRunTraceMetadata {

--- a/web/src/__tests__/agent-run-timeline-mantine.test.tsx
+++ b/web/src/__tests__/agent-run-timeline-mantine.test.tsx
@@ -162,8 +162,46 @@ const trace: AgentRunTrace = {
       },
     },
     {
-      type: 'complete',
+      type: 'stream',
       sequence: 4,
+      startedAt: '2026-06-01T10:02:10.000Z',
+      endedAt: '2026-06-01T10:02:11.000Z',
+      durationMs: 1000,
+      metadata: {
+        eventType: 'stream.stdout',
+        stream: 'stdout',
+        summary: 'Running pnpm test with redacted output',
+        chunkBytes: 42,
+      },
+    },
+    {
+      type: 'retry',
+      sequence: 5,
+      startedAt: '2026-06-01T10:02:20.000Z',
+      endedAt: '2026-06-01T10:02:20.000Z',
+      durationMs: 0,
+      metadata: {
+        eventType: 'turn.retrying',
+        summary: 'Retrying after transient provider failure',
+        retryAttempt: 2,
+        retryDelayMs: 1250,
+      },
+    },
+    {
+      type: 'finalize',
+      sequence: 6,
+      startedAt: '2026-06-01T10:04:59.000Z',
+      endedAt: '2026-06-01T10:05:00.000Z',
+      durationMs: 1000,
+      metadata: {
+        eventType: 'run.finalizing',
+        exitCode: 0,
+        success: true,
+      },
+    },
+    {
+      type: 'complete',
+      sequence: 7,
       startedAt: '2026-06-01T10:05:00.000Z',
       endedAt: '2026-06-01T10:05:00.000Z',
       durationMs: 0,
@@ -312,7 +350,14 @@ describe('agent run timeline Mantine surface', () => {
     expect(events.some((event) => event.title.includes('Workflow blocked'))).toBe(true);
     expect(events.some((event) => event.title.includes('Deliverable attached'))).toBe(true);
     expect(events.some((event) => event.title.includes('Timeline notification'))).toBe(true);
+    expect(events.some((event) => event.title.includes('stream.stdout'))).toBe(true);
+    expect(events.some((event) => event.title.includes('turn.retrying'))).toBe(true);
+    expect(events.some((event) => event.title.includes('run.finalizing'))).toBe(true);
     expect(getTimelineEventType('execute', { eventType: 'tool.progress' })).toBe('tool');
+    expect(getTimelineEventType('stream', { eventType: 'stream.stdout' })).toBe('command');
+    expect(getTimelineEventType('retry', { eventType: 'turn.retrying' })).toBe('tool');
+    expect(getTimelineEventType('abort', { eventType: 'run.aborted' })).toBe('error');
+    expect(getTimelineEventType('finalize', { eventType: 'run.finalizing' })).toBe('result');
     expect(getTimelineEventType('error', { summary: 'failed' })).toBe('error');
   });
 
@@ -393,6 +438,9 @@ describe('agent run timeline Mantine surface', () => {
     expect(screen.getByText('Run Timeline')).toBeDefined();
     expect(screen.getByText('Stored replay')).toBeDefined();
     expect(screen.getByText('command.completed')).toBeDefined();
+    expect(screen.getByText('stream.stdout')).toBeDefined();
+    expect(screen.getByText('turn.retrying')).toBeDefined();
+    expect(screen.getByText('run.finalizing')).toBeDefined();
     expect(
       screen.getAllByText('Timeline replay captured with final result evidence.').length
     ).toBeGreaterThan(0);

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -321,14 +321,21 @@ export function getTimelineEventType(
 ): AgentRunTimelineEventType {
   const text = `${stepType} ${eventText(metadata)}`.toLowerCase();
 
-  if (stepType === 'error' || /error|failed|failure|abort|exception/.test(text)) return 'error';
-  if (stepType === 'complete') return 'result';
+  if (
+    stepType === 'error' ||
+    stepType === 'abort' ||
+    /error|failed|failure|abort|exception/.test(text)
+  )
+    return 'error';
+  if (stepType === 'complete' || stepType === 'finalize') return 'result';
   if (/approval|approve|denied|deny|permission request/.test(text)) return 'approval';
   if (/policy|permission|sandbox|security|guard/.test(text)) return 'policy';
   if (/file|diff|patch|write|edit|created|modified|deleted/.test(text)) return 'file';
   if (/\b(command|shell|terminal|stdout|stderr)\b|exec[.:_-]/.test(text)) return 'command';
   if (/token|usage|cost|input_tokens|output_tokens/.test(text)) return 'usage';
+  if (stepType === 'stream') return 'command';
   if (/tool|function|mcp/.test(text)) return 'tool';
+  if (stepType === 'retry') return 'tool';
   if (/completed|final|result|finish/.test(text)) return 'result';
   return stepType === 'init' ? 'prompt' : 'tool';
 }


### PR DESCRIPTION
## Summary
- Extend agent run traces with explicit stream, retry, abort, and finalization lifecycle steps.
- Record redacted Codex CLI stdout/stderr chunks, process errors, stop/abort requests, finalization details, SDK/JSON retry events, and stream delta content as sequenced trace evidence.
- Map the new trace step types into the existing run timeline filters and add focused server/web regression coverage.

## Verification
- pnpm --filter @veritas-kanban/server test -- codex-provider-service.test.ts trace-service.test.ts
- pnpm --filter @veritas-kanban/web test -- agent-run-timeline-mantine.test.tsx
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/shared typecheck
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server lint (passes with existing warnings)
- pnpm --filter @veritas-kanban/web lint (passes with existing warnings)

Closes #360