### PR TITLE
Add universal search command center

### DIFF
--- a/server/src/__tests__/routes/search.test.ts
+++ b/server/src/__tests__/routes/search.test.ts
@@ -10,6 +10,24 @@ const { mockSearch, mockRefreshIndex } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../services/search-service.js', () => ({
+  SEARCH_COLLECTIONS: [
+    'tasks-active',
+    'tasks-archive',
+    'tasks-backlog',
+    'docs',
+    'prompts',
+    'work-products',
+    'workflows',
+    'workflow-runs',
+    'policies',
+    'decisions',
+    'settings',
+    'logs-diagnostics',
+    'agent-runs',
+    'notifications',
+    'maintenance',
+    'scheduled-runs',
+  ],
   getSearchService: () => ({
     search: mockSearch,
     refreshIndex: mockRefreshIndex,
@@ -55,6 +73,29 @@ describe('searchRoutes', () => {
     const res = await request(app).post('/api/search').send({ query: '' });
     expect(res.status).toBe(400);
     expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/search accepts expanded universal search collections', async () => {
+    mockSearch.mockResolvedValue({
+      query: 'runs',
+      backend: 'keyword',
+      degraded: false,
+      elapsedMs: 3,
+      results: [],
+    });
+
+    const res = await request(app)
+      .post('/api/search')
+      .send({ query: 'runs', collections: ['workflow-runs', 'logs-diagnostics', 'settings'] });
+
+    expect(res.status).toBe(200);
+    expect(mockSearch).toHaveBeenCalledWith({
+      query: 'runs',
+      limit: undefined,
+      collections: ['workflow-runs', 'logs-diagnostics', 'settings'],
+      backend: undefined,
+      minScore: undefined,
+    });
   });
 
   it('POST /api/search/index/refresh refreshes the qmd index', async () => {

--- a/server/src/__tests__/search-service.test.ts
+++ b/server/src/__tests__/search-service.test.ts
@@ -50,6 +50,46 @@ describe('SearchService', () => {
     expect(result.results[0].path).toContain('tasks/active/task_1.md');
   });
 
+  it('searches expanded local collections with redacted snippets and targets', async () => {
+    await fs.mkdir(path.join(root, 'tasks', 'backlog'), { recursive: true });
+    await fs.mkdir(path.join(root, 'prompt-registry'), { recursive: true });
+    await fs.mkdir(path.join(root, '.veritas-kanban', 'logs'), { recursive: true });
+    await fs.writeFile(
+      path.join(root, 'tasks', 'backlog', 'task_20260601_abc123-recovery.md'),
+      '# Recovery task\n\nInvestigate recovery flow.',
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(root, 'prompt-registry', 'recovery.md'),
+      '# Recovery Prompt\n\nUse this prompt for recovery handoffs.',
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(root, '.veritas-kanban', 'logs', 'server.log'),
+      'recovery failed token=super-secret-value',
+      'utf-8'
+    );
+
+    const result = await new SearchService().search({
+      query: 'recovery',
+      collections: ['tasks-backlog', 'prompts', 'logs-diagnostics'],
+      limit: 10,
+    });
+
+    expect(result.results.map((item) => item.collection)).toEqual(
+      expect.arrayContaining(['tasks-backlog', 'prompts', 'logs-diagnostics'])
+    );
+    expect(
+      result.results.find((item) => item.collection === 'tasks-backlog')?.metadata?.target
+    ).toMatchObject({
+      type: 'task',
+      taskId: 'task_20260601_abc123',
+    });
+    expect(result.results.find((item) => item.collection === 'logs-diagnostics')?.snippet).toBe(
+      'recovery failed token: [redacted]'
+    );
+  });
+
   it('falls back to keyword search when qmd fails', async () => {
     process.env.VERITAS_SEARCH_BACKEND = 'qmd';
     execFileMock.mockImplementation((_bin, _args, _options, callback) => {

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -3,18 +3,18 @@ import { z } from 'zod';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError } from '../middleware/error-handler.js';
 import { getSearchService } from '../services/search-service.js';
-import type { SearchBackend, SearchCollection } from '../services/search-service.js';
+import {
+  SEARCH_COLLECTIONS,
+  type SearchBackend,
+  type SearchCollection,
+} from '../services/search-service.js';
 
 const router: RouterType = Router();
 
 const SearchBodySchema = z.object({
   query: z.string().trim().min(1).max(500),
   limit: z.number().int().min(1).max(50).optional(),
-  collections: z
-    .array(z.enum(['tasks-active', 'tasks-archive', 'docs', 'work-products']))
-    .min(1)
-    .max(4)
-    .optional(),
+  collections: z.array(z.enum(SEARCH_COLLECTIONS)).min(1).max(SEARCH_COLLECTIONS.length).optional(),
   backend: z.enum(['auto', 'qmd', 'keyword']).optional(),
   minScore: z.number().min(0).max(1).optional(),
 });

--- a/server/src/services/search-service.ts
+++ b/server/src/services/search-service.ts
@@ -2,12 +2,39 @@ import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createLogger } from '../lib/logger.js';
-import { getWorkProductService } from './work-product-service.js';
+import { getNotificationService, NotificationService } from './notification-service.js';
+import {
+  getScheduledDeliverablesService,
+  ScheduledDeliverablesService,
+} from './scheduled-deliverables-service.js';
+import { getWorkProductService, WorkProductService } from './work-product-service.js';
+import { getWorkflowService, WorkflowService } from './workflow-service.js';
+import { getWorkflowRunService, WorkflowRunService } from './workflow-run-service.js';
 
 const log = createLogger('search-service');
 
 export type SearchBackend = 'auto' | 'qmd' | 'keyword';
-export type SearchCollection = 'tasks-active' | 'tasks-archive' | 'docs' | 'work-products';
+
+export const SEARCH_COLLECTIONS = [
+  'tasks-active',
+  'tasks-archive',
+  'tasks-backlog',
+  'docs',
+  'prompts',
+  'work-products',
+  'workflows',
+  'workflow-runs',
+  'policies',
+  'decisions',
+  'settings',
+  'logs-diagnostics',
+  'agent-runs',
+  'notifications',
+  'maintenance',
+  'scheduled-runs',
+] as const;
+
+export type SearchCollection = (typeof SEARCH_COLLECTIONS)[number];
 
 export interface SearchRequest {
   query: string;
@@ -47,16 +74,38 @@ export interface SearchIndexRefreshResponse {
 interface SearchSource {
   collection: SearchCollection;
   dir: string;
+  extensions: readonly string[];
+}
+
+interface SearchFile {
+  path: string;
+  mtimeMs: number;
+}
+
+interface ScoreDetails {
+  score: number;
+  textScore: number;
+  recencyBoost: number;
 }
 
 const PROJECT_ROOT = path.resolve(process.cwd(), '..');
-const DEFAULT_COLLECTIONS: SearchCollection[] = [
-  'tasks-active',
-  'tasks-archive',
-  'docs',
-  'work-products',
-];
+const DEFAULT_COLLECTIONS: SearchCollection[] = [...SEARCH_COLLECTIONS];
+const QMD_COLLECTIONS = new Set<SearchCollection>(['tasks-active', 'tasks-archive', 'docs']);
 const MAX_LIMIT = 50;
+const DEFAULT_FILE_EXTENSIONS = ['.md', '.mdx', '.txt'] as const;
+const DATA_FILE_EXTENSIONS = [
+  '.md',
+  '.mdx',
+  '.txt',
+  '.json',
+  '.jsonl',
+  '.ndjson',
+  '.yaml',
+  '.yml',
+  '.log',
+] as const;
+const SKIPPED_DIRECTORIES = new Set(['.git', 'node_modules', 'backups', 'worktrees']);
+const MAX_FILES_PER_SOURCE = Number(process.env.VERITAS_SEARCH_MAX_FILES_PER_SOURCE || 1_500);
 
 class SearchService {
   async search(request: SearchRequest): Promise<SearchResponse> {
@@ -96,6 +145,7 @@ class SearchService {
         const results = await this.searchKeyword(query, {
           limit,
           collections: request.collections,
+          minScore: request.minScore,
         });
         return {
           query,
@@ -111,6 +161,7 @@ class SearchService {
     const results = await this.searchKeyword(query, {
       limit,
       collections: request.collections,
+      minScore: request.minScore,
     });
     return {
       query,
@@ -160,18 +211,26 @@ class SearchService {
     query: string,
     options: { limit: number; collections: SearchCollection[]; minScore?: number }
   ): Promise<SearchResult[]> {
-    const includeWorkProducts = options.collections.includes('work-products');
-    const qmdCollections = options.collections.filter(
-      (collection) => collection !== 'work-products'
+    const qmdCollections = options.collections.filter((collection) =>
+      QMD_COLLECTIONS.has(collection)
+    );
+    const keywordCollections = options.collections.filter(
+      (collection) => !QMD_COLLECTIONS.has(collection)
     );
     const results: SearchResult[] = [];
 
-    if (includeWorkProducts) {
-      results.push(...(await this.searchWorkProducts(query, options.limit)));
+    if (keywordCollections.length > 0) {
+      results.push(
+        ...(await this.searchKeyword(query, {
+          limit: options.limit,
+          collections: keywordCollections,
+          minScore: options.minScore,
+        }))
+      );
     }
 
     if (qmdCollections.length === 0) {
-      return results.slice(0, options.limit);
+      return this.rankResults(results).slice(0, options.limit);
     }
 
     const args = ['query', query, '--json', '-n', String(options.limit)];
@@ -180,9 +239,7 @@ class SearchService {
       args.push('--min-score', String(options.minScore));
     }
 
-    if (qmdCollections.length > 0) {
-      args.push('--collections', qmdCollections.join(','));
-    }
+    args.push('--collections', qmdCollections.join(','));
 
     const stdout = await this.runQmdCommand(
       args,
@@ -190,9 +247,7 @@ class SearchService {
     );
 
     results.push(...this.normalizeQmdResults(stdout, options.limit));
-    return results
-      .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path))
-      .slice(0, options.limit);
+    return this.rankResults(results).slice(0, options.limit);
   }
 
   private async runQmdCommand(args: string[], timeout: number): Promise<string> {
@@ -229,18 +284,31 @@ class SearchService {
       const snippet =
         this.firstString(item.snippet, item.context, item.text, item.content, item.body) ?? '';
       const collection =
-        this.firstString(item.collection, item.source) ?? this.inferCollection(filePath);
+        this.asSearchCollection(this.firstString(item.collection, item.source)) ??
+        this.inferCollection(filePath);
       const score =
         this.firstNumber(item.score, item.relevance, item.rankScore) ?? 1 - index / limit;
+      const relativePath = this.relativeDisplayPath(filePath);
+      const target = this.targetForPath(collection, relativePath, item);
 
       return {
         id: this.firstString(item.id, item.docid, item.docId) ?? `${filePath || 'result'}:${index}`,
         title,
-        path: filePath,
+        path: relativePath,
         collection,
-        snippet: snippet.slice(0, 500),
+        snippet: this.redactSnippet(snippet).slice(0, 500),
         score,
-        metadata: item,
+        metadata: {
+          ...item,
+          source: 'qmd',
+          target,
+          actions: this.actionsForTarget(target, collection),
+          ranking: {
+            textScore: score,
+            recencyBoost: 0,
+            usageFrequency: 0,
+          },
+        },
       };
     });
   }
@@ -259,87 +327,192 @@ class SearchService {
 
   private async searchKeyword(
     query: string,
-    options: { limit: number; collections?: SearchCollection[] }
+    options: { limit: number; collections?: SearchCollection[]; minScore?: number }
   ): Promise<SearchResult[]> {
-    const terms = query
-      .toLowerCase()
-      .split(/\s+/)
-      .map((term) => term.trim())
-      .filter(Boolean);
-
+    const terms = this.queryTerms(query);
     if (terms.length === 0) return [];
 
+    const selected = this.normalizeCollections(options.collections);
     const results: SearchResult[] = [];
-    const selected = new Set(this.normalizeCollections(options.collections));
-    if (selected.has('work-products')) {
-      results.push(...(await this.searchWorkProducts(query, options.limit)));
-    }
 
-    const sources = this.sources(options.collections);
+    results.push(
+      ...(await this.searchStructuredCollections(query, terms, options.limit, selected))
+    );
 
-    for (const source of sources) {
-      const files = await this.listMarkdownFiles(source.dir);
+    for (const source of this.sources(selected)) {
+      const files = await this.listSearchFiles(source.dir, source.extensions);
       for (const file of files) {
-        const result = await this.scoreFile(file, source, terms);
+        const result = await this.scoreFile(file, source, terms, query);
         if (result) results.push(result);
       }
     }
 
-    return results
-      .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path))
+    const minScore = options.minScore;
+    return this.rankResults(results)
+      .filter((result) => minScore === undefined || result.score >= minScore)
       .slice(0, options.limit);
   }
 
+  private async searchStructuredCollections(
+    query: string,
+    terms: string[],
+    limit: number,
+    selected: SearchCollection[]
+  ): Promise<SearchResult[]> {
+    const results: SearchResult[] = [];
+    const collections = new Set(selected);
+
+    if (collections.has('work-products')) {
+      results.push(...(await this.searchWorkProducts(query, limit)));
+    }
+
+    if (collections.has('workflows')) {
+      results.push(...(await this.searchWorkflows(query, terms, limit)));
+    }
+
+    if (collections.has('workflow-runs')) {
+      results.push(...(await this.searchWorkflowRuns(query, terms, limit)));
+    }
+
+    if (collections.has('notifications')) {
+      results.push(...(await this.searchNotifications(query, terms, limit)));
+    }
+
+    if (collections.has('maintenance')) {
+      results.push(...(await this.searchMaintenance(query, terms, limit)));
+    }
+
+    if (collections.has('scheduled-runs')) {
+      results.push(...(await this.searchScheduledRuns(query, terms, limit)));
+    }
+
+    if (collections.has('settings')) {
+      results.push(...this.searchSettings(query, terms));
+    }
+
+    return results;
+  }
+
   private async scoreFile(
-    filePath: string,
+    file: SearchFile,
     source: SearchSource,
-    terms: string[]
+    terms: string[],
+    query: string
   ): Promise<SearchResult | null> {
     let content: string;
     try {
-      content = await fs.readFile(filePath, 'utf-8');
+      content = await fs.readFile(file.path, 'utf-8');
     } catch {
       return null;
     }
 
-    const haystack = content.toLowerCase();
-    const relativePath = path.relative(this.projectRoot(), filePath);
-    const pathHaystack = relativePath.toLowerCase();
-    let score = 0;
+    const relativePath = this.relativeDisplayPath(file.path);
+    const parsed = this.parseJsonObject(content);
+    const title = this.extractTitle(content, file.path, parsed);
+    const score = this.scoreText({ title, pathValue: relativePath, content, terms, query });
 
-    for (const term of terms) {
-      if (pathHaystack.includes(term)) score += 3;
-      const matches = haystack.match(new RegExp(this.escapeRegExp(term), 'g'))?.length ?? 0;
-      score += matches;
-    }
+    if (score.textScore === 0) return null;
 
-    if (score === 0) return null;
+    const timestamp =
+      this.extractTimestamp(parsed, content) ?? new Date(file.mtimeMs).toISOString();
+    const target = this.targetForPath(source.collection, relativePath, parsed);
+    const snippet = this.extractSnippet(content, terms);
 
     return {
       id: relativePath,
-      title: this.extractTitle(content, filePath),
+      title,
       path: relativePath,
       collection: source.collection,
-      snippet: this.extractSnippet(content, terms),
-      score,
+      snippet: this.redactSnippet(snippet),
+      score: score.score,
+      metadata: {
+        source: 'file',
+        updatedAt: timestamp,
+        target,
+        actions: this.actionsForTarget(target, source.collection),
+        ranking: {
+          textScore: score.textScore,
+          recencyBoost: score.recencyBoost,
+          usageFrequency: 0,
+        },
+      },
     };
   }
 
   private sources(collections?: SearchCollection[]): SearchSource[] {
     const selected = new Set(this.normalizeCollections(collections));
     const root = this.projectRoot();
+    const runtime = this.runtimeDir();
     const candidates: SearchSource[] = [
       {
         collection: 'tasks-active',
         dir: process.env.VERITAS_SEARCH_TASKS_ACTIVE_DIR || path.join(root, 'tasks', 'active'),
+        extensions: DEFAULT_FILE_EXTENSIONS,
       },
       {
         collection: 'tasks-archive',
         dir: process.env.VERITAS_SEARCH_TASKS_ARCHIVE_DIR || path.join(root, 'tasks', 'archive'),
+        extensions: DEFAULT_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'tasks-backlog',
+        dir: process.env.VERITAS_SEARCH_TASKS_BACKLOG_DIR || path.join(root, 'tasks', 'backlog'),
+        extensions: DEFAULT_FILE_EXTENSIONS,
       },
       {
         collection: 'docs',
         dir: process.env.VERITAS_SEARCH_DOCS_DIR || path.join(root, 'docs'),
+        extensions: DEFAULT_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'prompts',
+        dir: path.join(root, 'prompt-registry'),
+        extensions: DEFAULT_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'prompts',
+        dir: path.join(runtime, 'prompt-templates'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'prompts',
+        dir: path.join(runtime, 'templates'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'policies',
+        dir: path.join(runtime, 'storage', 'policies'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'policies',
+        dir: path.join(runtime, 'tool-policies'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'decisions',
+        dir: path.join(root, 'storage', 'decisions'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'logs-diagnostics',
+        dir: path.join(runtime, 'logs'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'logs-diagnostics',
+        dir: path.join(runtime, 'audit'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'agent-runs',
+        dir: path.join(runtime, 'traces'),
+        extensions: DATA_FILE_EXTENSIONS,
+      },
+      {
+        collection: 'agent-runs',
+        dir: path.join(runtime, 'telemetry'),
+        extensions: ['.ndjson', '.jsonl', '.json', '.log'],
       },
     ];
 
@@ -347,17 +520,30 @@ class SearchService {
   }
 
   private async searchWorkProducts(query: string, limit: number): Promise<SearchResult[]> {
-    const service = getWorkProductService();
+    const service = this.workProductService();
     const products = await service.search(query, limit);
     return products.map((product, index) => {
       const preview = service.toPreview(product);
+      const score = limit - index + this.recencyBoost(product.updatedAt);
+      const target = product.taskId
+        ? {
+            type: 'task',
+            taskId: product.taskId,
+            tab: 'work-products',
+            href: `veritas://task/${encodeURIComponent(product.taskId)}?tab=work-products`,
+          }
+        : {
+            type: 'none',
+            disabledReason: 'This work product is not linked to an in-app task yet.',
+          };
+
       return {
         id: product.id,
         title: product.title,
         path: `/work-products/${product.id}`,
         collection: 'work-products',
-        snippet: preview.snippet,
-        score: limit - index,
+        snippet: this.redactSnippet(preview.snippet),
+        score,
         metadata: {
           kind: product.kind,
           taskId: product.taskId,
@@ -367,46 +553,492 @@ class SearchService {
           version: product.version,
           updatedAt: product.updatedAt,
           redacted: preview.redacted,
+          target,
+          actions: this.actionsForTarget(target, 'work-products'),
+          ranking: {
+            textScore: limit - index,
+            recencyBoost: this.recencyBoost(product.updatedAt),
+            usageFrequency: 0,
+          },
         },
       };
     });
   }
 
+  private async searchWorkflows(
+    query: string,
+    terms: string[],
+    limit: number
+  ): Promise<SearchResult[]> {
+    const workflows = await this.workflowService().listWorkflowsMetadata();
+    const results: SearchResult[] = [];
+
+    for (const workflow of workflows) {
+      const content = `${workflow.id}\n${workflow.name}\n${workflow.description ?? ''}\n${
+        workflow.version
+      }`;
+      const score = this.scoreText({
+        title: workflow.name,
+        pathValue: `/workflows/${workflow.id}`,
+        content,
+        terms,
+        query,
+      });
+      if (score.textScore === 0) continue;
+
+      const target = { type: 'view', view: 'workflows', href: '/workflows' };
+      results.push({
+        id: workflow.id,
+        title: workflow.name,
+        path: `/workflows/${workflow.id}`,
+        collection: 'workflows',
+        snippet: this.redactSnippet(workflow.description ?? `Workflow ${workflow.id}`),
+        score: score.score,
+        metadata: {
+          workflowId: workflow.id,
+          version: workflow.version,
+          target,
+          actions: this.actionsForTarget(target, 'workflows'),
+          ranking: {
+            textScore: score.textScore,
+            recencyBoost: score.recencyBoost,
+            usageFrequency: 0,
+          },
+        },
+      });
+    }
+
+    return this.rankResults(results).slice(0, limit);
+  }
+
+  private async searchWorkflowRuns(
+    query: string,
+    terms: string[],
+    limit: number
+  ): Promise<SearchResult[]> {
+    const runs = await this.workflowRunService().listRunsMetadata({});
+    const results: SearchResult[] = [];
+
+    for (const run of runs.slice(0, Math.max(limit * 5, 50))) {
+      const content = `${run.id}\n${run.workflowId}\n${run.taskId}\n${run.status}\n${
+        run.error ?? ''
+      }`;
+      const score = this.scoreText({
+        title: `${run.workflowId} ${run.status}`,
+        pathValue: `/workflows/runs/${run.id}`,
+        content,
+        terms,
+        query,
+        timestamp: run.completedAt ?? run.startedAt,
+      });
+      if (score.textScore === 0) continue;
+
+      const target = run.taskId
+        ? {
+            type: 'task',
+            taskId: run.taskId,
+            tab: 'timeline',
+            timelineAttemptId: run.id,
+            href: `veritas://task/${encodeURIComponent(run.taskId)}?tab=timeline&attempt=${encodeURIComponent(
+              run.id
+            )}`,
+          }
+        : { type: 'view', view: 'workflows', href: '/workflows' };
+
+      results.push({
+        id: run.id,
+        title: `${run.workflowId} run`,
+        path: `/workflows/runs/${run.id}`,
+        collection: 'workflow-runs',
+        snippet: this.redactSnippet(
+          [run.status, run.startedAt, run.error].filter(Boolean).join(' - ')
+        ),
+        score: score.score,
+        metadata: {
+          workflowId: run.workflowId,
+          workflowVersion: run.workflowVersion,
+          taskId: run.taskId,
+          status: run.status,
+          startedAt: run.startedAt,
+          completedAt: run.completedAt,
+          target,
+          actions: this.actionsForTarget(target, 'workflow-runs'),
+          ranking: {
+            textScore: score.textScore,
+            recencyBoost: score.recencyBoost,
+            usageFrequency: 0,
+          },
+        },
+      });
+    }
+
+    return this.rankResults(results).slice(0, limit);
+  }
+
+  private async searchNotifications(
+    query: string,
+    terms: string[],
+    limit: number
+  ): Promise<SearchResult[]> {
+    const notifications = await this.notificationService().getAllNotifications({ limit: 200 });
+    const results: SearchResult[] = [];
+
+    for (const notification of notifications) {
+      const title =
+        notification.title ?? notification.taskTitle ?? `${notification.type} notification`;
+      const content = `${title}\n${notification.content}\n${notification.taskId}\n${notification.targetAgent}\n${notification.fromAgent}\n${notification.type}`;
+      const score = this.scoreText({
+        title,
+        pathValue: notification.targetUrl ?? `/notifications/${notification.id}`,
+        content,
+        terms,
+        query,
+        timestamp: notification.createdAt,
+      });
+      if (score.textScore === 0) continue;
+
+      const target =
+        notification.taskId && notification.taskId !== 'system'
+          ? {
+              type: 'task',
+              taskId: notification.taskId,
+              tab: 'observations',
+              href: `veritas://task/${encodeURIComponent(notification.taskId)}?tab=observations`,
+            }
+          : { type: 'view', view: 'activity', href: '/activity' };
+
+      results.push({
+        id: notification.id,
+        title,
+        path: notification.targetUrl ?? `/notifications/${notification.id}`,
+        collection: 'notifications',
+        snippet: this.redactSnippet(notification.content),
+        score: score.score,
+        metadata: {
+          taskId: notification.taskId,
+          targetAgent: notification.targetAgent,
+          fromAgent: notification.fromAgent,
+          type: notification.type,
+          delivered: notification.delivered,
+          createdAt: notification.createdAt,
+          target,
+          actions: this.actionsForTarget(target, 'notifications'),
+          ranking: {
+            textScore: score.textScore,
+            recencyBoost: score.recencyBoost,
+            usageFrequency: 0,
+          },
+        },
+      });
+    }
+
+    return this.rankResults(results).slice(0, limit);
+  }
+
+  private async searchMaintenance(
+    query: string,
+    terms: string[],
+    limit: number
+  ): Promise<SearchResult[]> {
+    const preview = await this.workProductService().maintenancePreview();
+    const items = [...preview.cleanupCandidates, ...preview.retained];
+    const results: SearchResult[] = [];
+
+    for (const item of items) {
+      const title = `${item.title} maintenance`;
+      const content = `${title}\n${item.kind}\n${item.status}\n${item.id}\n${
+        item.cleanupEligible ? 'cleanup candidate' : 'retained'
+      }`;
+      const score = this.scoreText({
+        title,
+        pathValue: `/work-products/${item.id}/maintenance`,
+        content,
+        terms,
+        query,
+        timestamp: item.updatedAt,
+      });
+      if (score.textScore === 0) continue;
+
+      const target = item.taskId
+        ? {
+            type: 'task',
+            taskId: item.taskId,
+            tab: 'work-products',
+            href: `veritas://task/${encodeURIComponent(item.taskId)}?tab=work-products`,
+          }
+        : { type: 'view', view: 'activity', href: '/activity' };
+
+      results.push({
+        id: `maintenance:${item.id}`,
+        title,
+        path: `/work-products/${item.id}/maintenance`,
+        collection: 'maintenance',
+        snippet: `${item.cleanupEligible ? 'Cleanup candidate' : 'Retained'} - ${
+          item.versionCount
+        } versions, ${item.estimatedBytes} estimated bytes`,
+        score: score.score,
+        metadata: {
+          productId: item.id,
+          kind: item.kind,
+          status: item.status,
+          taskId: item.taskId,
+          cleanupEligible: item.cleanupEligible,
+          versionCount: item.versionCount,
+          estimatedBytes: item.estimatedBytes,
+          updatedAt: item.updatedAt,
+          target,
+          actions: this.actionsForTarget(target, 'maintenance'),
+          ranking: {
+            textScore: score.textScore,
+            recencyBoost: score.recencyBoost,
+            usageFrequency: 0,
+          },
+        },
+      });
+    }
+
+    return this.rankResults(results).slice(0, limit);
+  }
+
+  private async searchScheduledRuns(
+    query: string,
+    terms: string[],
+    limit: number
+  ): Promise<SearchResult[]> {
+    const service = this.scheduledDeliverablesService();
+    const deliverables = await service.list();
+    const results: SearchResult[] = [];
+
+    for (const deliverable of deliverables) {
+      const content = `${deliverable.name}\n${deliverable.description}\n${deliverable.schedule}\n${deliverable.scheduleDescription}\n${deliverable.agent ?? ''}\n${deliverable.tags.join(' ')}`;
+      const score = this.scoreText({
+        title: deliverable.name,
+        pathValue: `/scheduled-runs/${deliverable.id}`,
+        content,
+        terms,
+        query,
+        timestamp: deliverable.lastRunAt ?? deliverable.createdAt,
+      });
+
+      if (score.textScore > 0) {
+        const target = { type: 'view', view: 'workflows', href: '/workflows' };
+        results.push({
+          id: deliverable.id,
+          title: deliverable.name,
+          path: `/scheduled-runs/${deliverable.id}`,
+          collection: 'scheduled-runs',
+          snippet: this.redactSnippet(
+            `${deliverable.scheduleDescription} - ${deliverable.description}`
+          ),
+          score: score.score,
+          metadata: {
+            schedule: deliverable.schedule,
+            enabled: deliverable.enabled,
+            agent: deliverable.agent,
+            lastRunAt: deliverable.lastRunAt,
+            nextRunAt: deliverable.nextRunAt,
+            totalRuns: deliverable.totalRuns,
+            target,
+            actions: this.actionsForTarget(target, 'scheduled-runs'),
+            ranking: {
+              textScore: score.textScore,
+              recencyBoost: score.recencyBoost,
+              usageFrequency: 0,
+            },
+          },
+        });
+      }
+
+      const runs = await service.getRuns(deliverable.id, 20);
+      for (const run of runs) {
+        const runContent = `${deliverable.name}\n${run.id}\n${run.status}\n${run.summary ?? ''}\n${run.error ?? ''}\n${run.workflowId ?? ''}\n${run.sourceRunId ?? ''}`;
+        const runScore = this.scoreText({
+          title: `${deliverable.name} ${run.status}`,
+          pathValue: `/scheduled-runs/${deliverable.id}/${run.id}`,
+          content: runContent,
+          terms,
+          query,
+          timestamp: run.runAt,
+        });
+        if (runScore.textScore === 0) continue;
+
+        const target = { type: 'view', view: 'workflows', href: '/workflows' };
+        results.push({
+          id: run.id,
+          title: `${deliverable.name} run`,
+          path: `/scheduled-runs/${deliverable.id}/${run.id}`,
+          collection: 'scheduled-runs',
+          snippet: this.redactSnippet(
+            [run.status, run.summary, run.error].filter(Boolean).join(' - ')
+          ),
+          score: runScore.score,
+          metadata: {
+            deliverableId: deliverable.id,
+            status: run.status,
+            workflowId: run.workflowId,
+            sourceRunId: run.sourceRunId,
+            runAt: run.runAt,
+            target,
+            actions: this.actionsForTarget(target, 'scheduled-runs'),
+            ranking: {
+              textScore: runScore.textScore,
+              recencyBoost: runScore.recencyBoost,
+              usageFrequency: 0,
+            },
+          },
+        });
+      }
+    }
+
+    return this.rankResults(results).slice(0, limit);
+  }
+
+  private searchSettings(query: string, terms: string[]): SearchResult[] {
+    const settings = [
+      {
+        id: 'settings-features',
+        title: 'Feature Settings',
+        section: 'features',
+        snippet: 'Board, task behavior, agents, notifications, archive, budget, and telemetry.',
+        keywords: 'features board tasks agents notifications archive budget telemetry settings',
+      },
+      {
+        id: 'settings-security',
+        title: 'Security Settings',
+        section: 'security',
+        snippet: 'API access, permissions, authentication, and local mode controls.',
+        keywords: 'security api token permissions authentication local remote mode settings',
+      },
+      {
+        id: 'settings-identity',
+        title: 'Identity and Workspace Settings',
+        section: 'multi-user',
+        snippet: 'Workspace members, invitations, roles, and multi-user access.',
+        keywords: 'identity workspace members invitations roles multi user access settings',
+      },
+      {
+        id: 'settings-codex-health',
+        title: 'Codex Health Diagnostics',
+        section: 'codex',
+        snippet: 'CLI, SDK, cloud provider, and agent readiness diagnostics.',
+        keywords: 'codex health diagnostics cli sdk cloud agents settings',
+      },
+    ];
+
+    const results: SearchResult[] = [];
+
+    for (const setting of settings) {
+      const score = this.scoreText({
+        title: setting.title,
+        pathValue: `/settings/${setting.section}`,
+        content: `${setting.snippet}\n${setting.keywords}`,
+        terms,
+        query,
+      });
+      if (score.textScore === 0) continue;
+
+      const target = {
+        type: 'settings',
+        section: setting.section,
+        href: `/settings/${setting.section}`,
+      };
+      results.push({
+        id: setting.id,
+        title: setting.title,
+        path: `/settings/${setting.section}`,
+        collection: 'settings',
+        snippet: setting.snippet,
+        score: score.score,
+        metadata: {
+          section: setting.section,
+          target,
+          actions: this.actionsForTarget(target, 'settings'),
+          ranking: {
+            textScore: score.textScore,
+            recencyBoost: score.recencyBoost,
+            usageFrequency: 0,
+          },
+        },
+      });
+    }
+
+    return results;
+  }
+
   private normalizeCollections(collections?: SearchCollection[]): SearchCollection[] {
     if (!collections || collections.length === 0) return DEFAULT_COLLECTIONS;
-    const allowed = new Set<SearchCollection>(DEFAULT_COLLECTIONS);
+    const allowed = new Set<SearchCollection>(SEARCH_COLLECTIONS);
     return collections.filter((collection) => allowed.has(collection));
   }
 
-  private async listMarkdownFiles(dir: string): Promise<string[]> {
-    let entries;
-    try {
-      entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
-      return [];
-    }
+  private async listSearchFiles(
+    dir: string,
+    extensions: readonly string[] = DEFAULT_FILE_EXTENSIONS
+  ): Promise<SearchFile[]> {
+    const files: SearchFile[] = [];
+    const allowedExtensions = new Set(extensions.map((extension) => extension.toLowerCase()));
 
-    const files: string[] = [];
-    for (const entry of entries) {
-      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...(await this.listMarkdownFiles(fullPath)));
-      } else if (entry.isFile() && /\.(md|mdx|txt)$/i.test(entry.name)) {
-        files.push(fullPath);
+    const visit = async (currentDir: string): Promise<void> => {
+      if (files.length >= MAX_FILES_PER_SOURCE) return;
+
+      let entries;
+      try {
+        entries = await fs.readdir(currentDir, { withFileTypes: true });
+      } catch {
+        return;
       }
-    }
-    return files;
+
+      for (const entry of entries) {
+        if (files.length >= MAX_FILES_PER_SOURCE) return;
+        if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+
+        const fullPath = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          await visit(fullPath);
+          continue;
+        }
+
+        if (!entry.isFile()) continue;
+
+        const extension = path.extname(entry.name).toLowerCase();
+        if (!allowedExtensions.has(extension)) continue;
+
+        try {
+          const stats = await fs.stat(fullPath);
+          files.push({ path: fullPath, mtimeMs: stats.mtimeMs });
+        } catch {
+          continue;
+        }
+      }
+    };
+
+    await visit(dir);
+    return files.sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, MAX_FILES_PER_SOURCE);
   }
 
-  private extractTitle(content: string, filePath: string): string {
+  private extractTitle(
+    content: string,
+    filePath: string,
+    parsed?: Record<string, unknown> | null
+  ): string {
+    if (parsed) {
+      const title = this.firstString(
+        parsed.title,
+        parsed.name,
+        parsed.taskTitle,
+        parsed.workflowId,
+        parsed.id
+      );
+      if (title) return title;
+    }
+
     const heading = content.match(/^#\s+(.+)$/m)?.[1]?.trim();
     if (heading) return heading;
 
     const titleField = content.match(/^title:\s*['"]?(.+?)['"]?\s*$/m)?.[1]?.trim();
     if (titleField) return titleField;
 
-    return path.basename(filePath).replace(/\.(md|mdx|txt)$/i, '');
+    return path.basename(filePath).replace(/\.(md|mdx|txt|json|jsonl|ndjson|yaml|yml|log)$/i, '');
   }
 
   private extractSnippet(content: string, terms: string[]): string {
@@ -418,14 +1050,261 @@ class SearchService {
     return (match || lines.find((line) => line.trim()) || '').trim().slice(0, 500);
   }
 
+  private targetForPath(
+    collection: SearchCollection,
+    relativePath: string,
+    parsed?: Record<string, unknown> | null
+  ): Record<string, unknown> {
+    const taskId =
+      this.firstString(parsed?.taskId, parsed?.task_id) ?? this.extractTaskId(relativePath);
+    const attemptId = this.firstString(
+      parsed?.attemptId,
+      parsed?.traceId,
+      parsed?.runId,
+      parsed?.id
+    );
+
+    if (collection.startsWith('tasks') && taskId) {
+      return {
+        type: 'task',
+        taskId,
+        href: `veritas://task/${encodeURIComponent(taskId)}`,
+      };
+    }
+
+    if ((collection === 'workflow-runs' || collection === 'agent-runs') && taskId) {
+      return {
+        type: 'task',
+        taskId,
+        tab: 'timeline',
+        timelineAttemptId: attemptId,
+        href: `veritas://task/${encodeURIComponent(taskId)}?tab=timeline${
+          attemptId ? `&attempt=${encodeURIComponent(attemptId)}` : ''
+        }`,
+      };
+    }
+
+    if (collection === 'workflows') {
+      return { type: 'view', view: 'workflows', href: '/workflows' };
+    }
+
+    if (collection === 'policies') {
+      return { type: 'view', view: 'policies', href: '/policies' };
+    }
+
+    if (collection === 'decisions') {
+      return { type: 'view', view: 'decisions', href: '/decisions' };
+    }
+
+    if (collection === 'logs-diagnostics' || collection === 'agent-runs') {
+      return { type: 'diagnostics', href: '/diagnostics' };
+    }
+
+    if (collection === 'prompts') {
+      return { type: 'view', view: 'templates', href: '/templates' };
+    }
+
+    return {
+      type: 'none',
+      disabledReason: 'This result does not have an in-app destination yet.',
+    };
+  }
+
+  private actionsForTarget(
+    target: Record<string, unknown>,
+    collection: SearchCollection
+  ): Array<Record<string, unknown>> {
+    if (target.type === 'none') {
+      return [
+        {
+          id: 'unavailable',
+          label: 'No action available',
+          disabledReason: this.firstString(target.disabledReason) ?? 'No destination is available.',
+        },
+      ];
+    }
+
+    const labelByType: Record<string, string> = {
+      task: target.tab === 'timeline' ? 'Open timeline' : 'Open task',
+      view: 'Open view',
+      settings: 'Open settings',
+      diagnostics: 'Open diagnostics',
+      url: 'Open link',
+    };
+
+    return [
+      {
+        id: `open-${collection}`,
+        label: labelByType[String(target.type)] ?? 'Open',
+        target,
+      },
+    ];
+  }
+
+  private rankResults(results: SearchResult[]): SearchResult[] {
+    return [...results].sort((a, b) => b.score - a.score || a.path.localeCompare(b.path));
+  }
+
+  private scoreText(input: {
+    title: string;
+    pathValue: string;
+    content: string;
+    terms: string[];
+    query: string;
+    timestamp?: string;
+  }): ScoreDetails {
+    const title = input.title.toLowerCase();
+    const pathValue = input.pathValue.toLowerCase();
+    const haystack = input.content.toLowerCase();
+    const exactQuery = input.query.trim().toLowerCase();
+    let textScore = 0;
+
+    if (exactQuery) {
+      if (title.includes(exactQuery)) textScore += 10;
+      if (pathValue.includes(exactQuery)) textScore += 5;
+      if (haystack.includes(exactQuery)) textScore += 4;
+    }
+
+    for (const term of input.terms) {
+      if (title.includes(term)) textScore += 6;
+      if (pathValue.includes(term)) textScore += 3;
+      const matches = haystack.match(new RegExp(this.escapeRegExp(term), 'g'))?.length ?? 0;
+      textScore += Math.min(matches, 10);
+    }
+
+    const recencyBoost = this.recencyBoost(input.timestamp);
+    return {
+      score: textScore > 0 ? textScore + recencyBoost : 0,
+      textScore,
+      recencyBoost,
+    };
+  }
+
+  private recencyBoost(timestamp?: string): number {
+    if (!timestamp) return 0;
+    const time = new Date(timestamp).getTime();
+    if (!Number.isFinite(time)) return 0;
+
+    const ageDays = (Date.now() - time) / 86_400_000;
+    if (ageDays <= 7) return 3;
+    if (ageDays <= 30) return 1.5;
+    if (ageDays <= 90) return 0.5;
+    return 0;
+  }
+
+  private queryTerms(query: string): string[] {
+    return query
+      .toLowerCase()
+      .split(/\s+/)
+      .map((term) => term.trim())
+      .filter(Boolean);
+  }
+
+  private parseJsonObject(content: string): Record<string, unknown> | null {
+    const trimmed = content.trim();
+    if (!trimmed.startsWith('{')) return null;
+
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private extractTimestamp(
+    parsed: Record<string, unknown> | null | undefined,
+    content?: string
+  ): string | undefined {
+    const value = this.firstString(
+      parsed?.updatedAt,
+      parsed?.createdAt,
+      parsed?.startedAt,
+      parsed?.completedAt,
+      parsed?.runAt,
+      parsed?.timestamp
+    );
+    if (value) return value;
+
+    const match = content?.match(/\b20\d{2}-\d{2}-\d{2}T[^\s"']+/);
+    return match?.[0];
+  }
+
+  private extractTaskId(value: string): string | undefined {
+    const fileName = value.split('/').pop() ?? value;
+    const fileMatch = fileName.match(/^(task_[^./]+?)(?:-[^/]*)?\.(?:md|mdx|txt)$/i);
+    if (fileMatch?.[1]) return fileMatch[1];
+
+    return value.match(/task_\d{8}_[A-Za-z0-9_]+/)?.[0];
+  }
+
   private projectRoot(): string {
-    return process.env.VERITAS_SEARCH_ROOT || PROJECT_ROOT;
+    const configured =
+      process.env.VERITAS_SEARCH_ROOT || process.env.DATA_DIR || process.env.VERITAS_DATA_DIR;
+    return configured ? path.resolve(configured) : PROJECT_ROOT;
+  }
+
+  private runtimeDir(): string {
+    return path.join(this.projectRoot(), '.veritas-kanban');
+  }
+
+  private relativeDisplayPath(filePath: string): string {
+    if (!path.isAbsolute(filePath)) return filePath;
+    return path.relative(this.projectRoot(), filePath);
   }
 
   private inferCollection(filePath: string): SearchCollection {
     if (filePath.includes('tasks/archive')) return 'tasks-archive';
+    if (filePath.includes('tasks/backlog')) return 'tasks-backlog';
     if (filePath.includes('tasks/active')) return 'tasks-active';
     return 'docs';
+  }
+
+  private asSearchCollection(value?: string): SearchCollection | undefined {
+    return SEARCH_COLLECTIONS.find((collection) => collection === value);
+  }
+
+  private workProductService(): WorkProductService {
+    if (process.env.VERITAS_SEARCH_ROOT) {
+      return new WorkProductService({ dataDir: this.runtimeDir(), storageType: 'file' });
+    }
+    return getWorkProductService();
+  }
+
+  private notificationService(): NotificationService {
+    if (process.env.VERITAS_SEARCH_ROOT) {
+      return new NotificationService({ dataDir: this.runtimeDir(), storageType: 'file' });
+    }
+    return getNotificationService();
+  }
+
+  private scheduledDeliverablesService(): ScheduledDeliverablesService {
+    if (process.env.VERITAS_SEARCH_ROOT) {
+      return new ScheduledDeliverablesService({ dataDir: this.runtimeDir(), storageType: 'file' });
+    }
+    return getScheduledDeliverablesService();
+  }
+
+  private workflowService(): WorkflowService {
+    if (process.env.VERITAS_SEARCH_ROOT) {
+      return new WorkflowService({
+        workflowsDir: path.join(this.runtimeDir(), 'workflows'),
+        storageType: 'file',
+      });
+    }
+    return getWorkflowService();
+  }
+
+  private workflowRunService(): WorkflowRunService {
+    if (process.env.VERITAS_SEARCH_ROOT) {
+      return new WorkflowRunService({
+        runsDir: path.join(this.runtimeDir(), 'workflow-runs'),
+        storageType: 'file',
+      });
+    }
+    return getWorkflowRunService();
   }
 
   private firstString(...values: unknown[]): string | undefined {
@@ -440,6 +1319,17 @@ class SearchService {
 
   private escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  private redactSnippet(value: string): string {
+    return value
+      .replace(
+        /\b(api[_-]?key|token|secret|password|authorization|cookie)\b\s*[:=]\s*["']?[^"',\s]+/gi,
+        '$1: [redacted]'
+      )
+      .replace(/\b(sk-[A-Za-z0-9_-]{10,})\b/g, '[redacted]')
+      .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, '[redacted]')
+      .slice(0, 500);
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -173,6 +173,7 @@ function AppContent() {
   const [showDesktopOnboarding, setShowDesktopOnboarding] = useState(false);
 
   useEffect(() => {
+    const openDiagnostics = () => setShowDesktopOnboarding(true);
     const desktop = (
       window as Window & {
         veritasDesktop?: {
@@ -181,11 +182,7 @@ function AppContent() {
       }
     ).veritasDesktop;
 
-    if (!desktop?.onMenuCommand) {
-      return undefined;
-    }
-
-    return desktop.onMenuCommand((payload) => {
+    const unsubscribe = desktop?.onMenuCommand?.((payload) => {
       if (
         payload.command === 'open-onboarding' ||
         payload.command === 'show-diagnostics' ||
@@ -194,6 +191,13 @@ function AppContent() {
         setShowDesktopOnboarding(true);
       }
     });
+
+    window.addEventListener('veritas:open-diagnostics', openDiagnostics);
+
+    return () => {
+      unsubscribe?.();
+      window.removeEventListener('veritas:open-diagnostics', openDiagnostics);
+    };
   }, []);
 
   return (

--- a/web/src/__tests__/SearchDialog.test.tsx
+++ b/web/src/__tests__/SearchDialog.test.tsx
@@ -60,37 +60,52 @@ describe('SearchDialog', () => {
 
     const { baseElement } = renderWithProviders(<SearchDialog open onOpenChange={vi.fn()} />);
 
-    expect(
-      screen.getByRole('dialog', { name: 'Search Tasks, Docs, and Work Products' })
-    ).toBeDefined();
-    expect(
-      screen.getByRole('textbox', { name: 'Search tasks, docs, and work products' })
-    ).toBeDefined();
+    expect(screen.getByRole('dialog', { name: 'Universal Search' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Search Veritas' })).toBeDefined();
     expect(screen.getByRole('combobox', { name: 'Search backend' })).toBeDefined();
     expect(screen.getByRole('checkbox', { name: 'Active' })).toBeDefined();
     expect(screen.getByRole('checkbox', { name: 'Work Products' })).toBeDefined();
     expect(baseElement.querySelector('.mantine-Modal-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Select-root')).toBeDefined();
-    expect(baseElement.querySelectorAll('.mantine-Checkbox-root').length).toBe(4);
+    expect(baseElement.querySelectorAll('.mantine-Checkbox-root').length).toBe(16);
     expect(baseElement.querySelector('[data-slot="dialog-content"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="checkbox"]')).toBeNull();
 
-    await userEvent.type(screen.getByPlaceholderText(/search task titles/i), 'qmd');
+    await userEvent.type(screen.getByPlaceholderText(/search tasks/i), 'qmd');
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
 
     await waitFor(() => expect(queryMock).toHaveBeenCalledTimes(1));
     expect(queryMock).toHaveBeenCalledWith({
       query: 'qmd',
       backend: 'auto',
-      collections: ['tasks-active', 'tasks-archive', 'docs', 'work-products'],
-      limit: 12,
+      collections: [
+        'tasks-active',
+        'tasks-archive',
+        'tasks-backlog',
+        'docs',
+        'prompts',
+        'work-products',
+        'workflows',
+        'workflow-runs',
+        'policies',
+        'decisions',
+        'settings',
+        'logs-diagnostics',
+        'agent-runs',
+        'notifications',
+        'maintenance',
+        'scheduled-runs',
+      ],
+      limit: 20,
     });
     expect(await screen.findByText('Build search UI')).toBeDefined();
     expect(await screen.findByText('Search implementation brief')).toBeDefined();
     expect(screen.getByText('/work-products/wp-search-brief')).toBeDefined();
+    expect(screen.getAllByText('Active').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Work Products').length).toBeGreaterThan(0);
     expect(screen.getByText('Fallback')).toBeDefined();
     expect(screen.getByText('qmd unavailable')).toBeDefined();
   });
@@ -117,11 +132,61 @@ describe('SearchDialog', () => {
 
     renderWithProviders(<SearchDialog open onOpenChange={onOpenChange} onTaskOpen={onTaskOpen} />);
 
-    await userEvent.type(screen.getByPlaceholderText(/search task titles/i), 'task');
+    await userEvent.type(screen.getByPlaceholderText(/search tasks/i), 'task');
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
     fireEvent.click(await screen.findByText('Build search UI'));
 
-    expect(onTaskOpen).toHaveBeenCalledWith('task_20260504_abc123');
+    expect(onTaskOpen).toHaveBeenCalledWith('task_20260504_abc123', undefined);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('opens settings results through the supplied settings callback', async () => {
+    const onSettingsOpen = vi.fn();
+    const onOpenChange = vi.fn();
+    queryMock.mockResolvedValue({
+      query: 'security',
+      backend: 'keyword',
+      degraded: false,
+      elapsedMs: 2,
+      results: [
+        {
+          id: 'settings-security',
+          title: 'Security Settings',
+          path: '/settings/security',
+          collection: 'settings',
+          snippet: 'API access and authentication.',
+          score: 4,
+          metadata: {
+            target: {
+              type: 'settings',
+              section: 'security',
+              href: '/settings/security',
+            },
+            actions: [
+              {
+                id: 'open-settings',
+                label: 'Open settings',
+                target: {
+                  type: 'settings',
+                  section: 'security',
+                  href: '/settings/security',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    renderWithProviders(
+      <SearchDialog open onOpenChange={onOpenChange} onSettingsOpen={onSettingsOpen} />
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/search tasks/i), 'security');
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    fireEvent.click(await screen.findByText('Security Settings'));
+
+    expect(onSettingsOpen).toHaveBeenCalledWith('security');
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/web/src/__tests__/command-registry.test.ts
+++ b/web/src/__tests__/command-registry.test.ts
@@ -11,6 +11,8 @@ describe('command registry', () => {
     expect(new Set(ids).size).toBe(ids.length);
     expect(ids).toContain('new-task');
     expect(ids).toContain('open-search');
+    expect(ids).toContain('open-settings');
+    expect(ids).toContain('open-diagnostics');
     expect(ids).toContain('move-todo');
   });
 
@@ -37,7 +39,10 @@ describe('command registry', () => {
       'Switch to Dark Mode'
     );
     expect(darkCommands.find((command) => command.id === 'open-search')?.label).toBe(
-      'Search Tasks, Docs, and Work Products'
+      'Universal Search'
+    );
+    expect(darkCommands.find((command) => command.id === 'open-search')?.keywords).toEqual(
+      expect.arrayContaining(['work products', 'runs', 'policies', 'notifications'])
     );
   });
 
@@ -46,6 +51,16 @@ describe('command registry', () => {
     const boardCommand = commands.find((command) => command.id === 'move-done');
 
     expect(boardCommand?.disabledReason).toBe('Select a task on the board to use this shortcut.');
+  });
+
+  it('exposes diagnostics commands with mode-aware disabled reasons', () => {
+    const commands = createCommandRegistry({ theme: 'dark' });
+    const diagnostics = commands.find((command) => command.id === 'open-diagnostics');
+    const restart = commands.find((command) => command.id === 'restart-local-server');
+
+    expect(diagnostics?.action).toEqual({ type: 'open-diagnostics' });
+    expect(diagnostics?.aliases).toEqual(expect.arrayContaining(['logs', 'diagnostics']));
+    expect(restart?.disabledReason).toContain('desktop bridge');
   });
 
   it('makes the selected-task Work View path discoverable from command search', () => {

--- a/web/src/components/layout/CommandPalette.tsx
+++ b/web/src/components/layout/CommandPalette.tsx
@@ -118,6 +118,14 @@ export function CommandPalette() {
         case 'open-search':
           openSearchDialog();
           return;
+        case 'open-settings':
+          window.dispatchEvent(
+            new CustomEvent('veritas:open-settings', { detail: { section: cmd.action.section } })
+          );
+          return;
+        case 'open-diagnostics':
+          window.dispatchEvent(new CustomEvent('veritas:open-diagnostics'));
+          return;
         case 'navigate-view':
           setView(cmd.action.view);
           return;
@@ -337,6 +345,7 @@ export function CommandPalette() {
             open={searchOpen}
             onOpenChange={setSearchOpen}
             onTaskOpen={navigateToTask}
+            onViewOpen={setView}
           />
         </Suspense>
       )}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -33,7 +33,7 @@ import {
 import { UserMenu } from './UserMenu';
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 import { WebSocketIndicator } from '@/components/shared/WebSocketIndicator';
-import { lazy, Suspense, useState, useCallback } from 'react';
+import { lazy, Suspense, useState, useCallback, useEffect } from 'react';
 import { useKeyboard } from '@/hooks/useKeyboard';
 import { useView } from '@/contexts/ViewContext';
 import { useBacklogCount } from '@/hooks/useBacklog';
@@ -134,10 +134,14 @@ export function Header() {
     setSquadChatOpen(true);
   }, [markPanelLoaded]);
 
-  const openSettingsDialog = useCallback(() => {
-    markPanelLoaded('settings');
-    setSettingsOpen(true);
-  }, [markPanelLoaded]);
+  const openSettingsDialog = useCallback(
+    (section?: string) => {
+      markPanelLoaded('settings');
+      setSettingsTab(section);
+      setSettingsOpen(true);
+    },
+    [markPanelLoaded]
+  );
 
   const openSecuritySettings = useCallback(() => {
     markPanelLoaded('settings');
@@ -150,6 +154,16 @@ export function Header() {
     setSettingsTab('multi-user');
     setSettingsOpen(true);
   }, [markPanelLoaded]);
+
+  useEffect(() => {
+    const handleOpenSettings = (event: Event) => {
+      const section = (event as CustomEvent<{ section?: string }>).detail?.section;
+      openSettingsDialog(section);
+    };
+
+    window.addEventListener('veritas:open-settings', handleOpenSettings);
+    return () => window.removeEventListener('veritas:open-settings', handleOpenSettings);
+  }, [openSettingsDialog]);
 
   // Register the create dialog and chat panel openers with keyboard context (refs, no useEffect needed)
   setOpenCreateDialog(openCreateDialog);
@@ -259,7 +273,7 @@ export function Header() {
               variant="subtle"
               color="gray"
               size={32}
-              onClick={openSettingsDialog}
+              onClick={() => openSettingsDialog()}
               disabled={!canOpenSettings}
               aria-label="Settings"
               title={canOpenSettings ? 'Settings' : 'Settings permission required'}
@@ -327,6 +341,8 @@ export function Header() {
             open={searchOpen}
             onOpenChange={setSearchOpen}
             onTaskOpen={navigateToTask}
+            onViewOpen={setView}
+            onSettingsOpen={openSettingsDialog}
           />
         )}
       </Suspense>

--- a/web/src/components/search/SearchDialog.tsx
+++ b/web/src/components/search/SearchDialog.tsx
@@ -1,9 +1,25 @@
 import { useMemo, useState } from 'react';
-import { Archive, FileText, Loader2, Search, ShieldAlert, Sparkles } from 'lucide-react';
+import {
+  Archive,
+  Bell,
+  Bot,
+  CalendarClock,
+  FileClock,
+  FileText,
+  History,
+  Loader2,
+  Search,
+  Settings,
+  ShieldAlert,
+  Sparkles,
+  Wrench,
+  Workflow,
+} from 'lucide-react';
 import {
   Badge,
   Button,
   Checkbox,
+  Divider,
   Group,
   Modal,
   ScrollArea,
@@ -12,16 +28,44 @@ import {
   Text,
   TextInput,
 } from '@mantine/core';
-import { api, type SearchBackend, type SearchCollection, type SearchResponse } from '@/lib/api';
+import {
+  api,
+  type SearchBackend,
+  type SearchCollection,
+  type SearchResponse,
+  type SearchResult,
+  type SearchTarget,
+} from '@/lib/api';
 import { extractTaskId } from '@/lib/search-utils';
 import { cn } from '@/lib/utils';
+import { VIEW_BY_ID, type AppView } from '@/lib/views';
+import type {
+  TaskDetailNavigationTarget,
+  TaskDetailTabId,
+} from '@/components/task/TaskDetailPanel';
 
 const COLLECTIONS: { id: SearchCollection; label: string }[] = [
   { id: 'tasks-active', label: 'Active' },
   { id: 'tasks-archive', label: 'Archive' },
+  { id: 'tasks-backlog', label: 'Backlog' },
   { id: 'docs', label: 'Docs' },
+  { id: 'prompts', label: 'Prompts' },
   { id: 'work-products', label: 'Work Products' },
+  { id: 'workflows', label: 'Workflows' },
+  { id: 'workflow-runs', label: 'Workflow Runs' },
+  { id: 'policies', label: 'Policies' },
+  { id: 'decisions', label: 'Decisions' },
+  { id: 'settings', label: 'Settings' },
+  { id: 'logs-diagnostics', label: 'Logs' },
+  { id: 'agent-runs', label: 'Agent Runs' },
+  { id: 'notifications', label: 'Notifications' },
+  { id: 'maintenance', label: 'Maintenance' },
+  { id: 'scheduled-runs', label: 'Scheduled Runs' },
 ];
+
+const COLLECTION_LABELS = new Map(
+  COLLECTIONS.map((collection) => [collection.id, collection.label])
+);
 
 const BACKENDS: { id: SearchBackend; label: string }[] = [
   { id: 'auto', label: 'Auto' },
@@ -29,20 +73,109 @@ const BACKENDS: { id: SearchBackend; label: string }[] = [
   { id: 'qmd', label: 'QMD' },
 ];
 
+const TASK_DETAIL_TABS = new Set<TaskDetailTabId>([
+  'work',
+  'details',
+  'progress',
+  'work-products',
+  'observations',
+  'attachments',
+  'git',
+  'agent',
+  'timeline',
+  'changes',
+  'review',
+  'metrics',
+]);
+
 interface SearchDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onTaskOpen?: (taskId: string) => void;
+  onTaskOpen?: (taskId: string, target?: TaskDetailNavigationTarget) => void;
+  onViewOpen?: (view: AppView) => void;
+  onSettingsOpen?: (section?: string) => void;
+  onDiagnosticsOpen?: () => void;
 }
 
 function collectionIcon(collection: string) {
-  if (collection === 'docs') return FileText;
+  if (collection === 'docs' || collection === 'prompts') return FileText;
   if (collection === 'tasks-archive') return Archive;
   if (collection === 'work-products') return Sparkles;
+  if (collection === 'workflows') return Workflow;
+  if (collection === 'workflow-runs') return History;
+  if (collection === 'policies') return ShieldAlert;
+  if (collection === 'settings') return Settings;
+  if (collection === 'logs-diagnostics') return FileClock;
+  if (collection === 'agent-runs') return Bot;
+  if (collection === 'notifications') return Bell;
+  if (collection === 'maintenance') return Wrench;
+  if (collection === 'scheduled-runs') return CalendarClock;
   return Search;
 }
 
-export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogProps) {
+function collectionLabel(collection: string) {
+  return COLLECTION_LABELS.get(collection as SearchCollection) ?? collection;
+}
+
+function isAppView(value: string | undefined): value is AppView {
+  return Boolean(value && value in VIEW_BY_ID);
+}
+
+function taskNavigationTarget(target: SearchTarget): TaskDetailNavigationTarget | undefined {
+  if (target.type !== 'task') return undefined;
+  const tab = TASK_DETAIL_TABS.has(target.tab as TaskDetailTabId)
+    ? (target.tab as TaskDetailTabId)
+    : undefined;
+
+  if (!tab && !target.timelineAttemptId) return undefined;
+
+  return {
+    tab,
+    timelineAttemptId: target.timelineAttemptId ?? null,
+  };
+}
+
+function targetForResult(result: SearchResult): SearchTarget {
+  const metadataTarget = result.metadata?.target;
+  if (metadataTarget?.type) return metadataTarget;
+
+  if (result.collection.startsWith('tasks')) {
+    const taskId = extractTaskId(result.path);
+    if (taskId) {
+      return {
+        type: 'task',
+        taskId,
+        href: `veritas://task/${encodeURIComponent(taskId)}`,
+      };
+    }
+  }
+
+  return {
+    type: 'none',
+    disabledReason: 'This result does not have an in-app destination yet.',
+  };
+}
+
+function actionLabel(target: SearchTarget, result: SearchResult) {
+  const primaryAction = result.metadata?.actions?.find((action) => !action.disabledReason);
+  if (primaryAction?.label) return primaryAction.label;
+
+  if (target.type === 'task') return target.tab === 'timeline' ? 'Open timeline' : 'Open task';
+  if (target.type === 'view') return 'Open view';
+  if (target.type === 'settings') return 'Open settings';
+  if (target.type === 'diagnostics') return 'Open diagnostics';
+  if (target.type === 'url') return 'Open link';
+  return 'Unavailable';
+}
+
+export function SearchDialog({
+  open,
+  onOpenChange,
+  onTaskOpen,
+  onViewOpen,
+  onSettingsOpen,
+  onDiagnosticsOpen,
+}: SearchDialogProps) {
   const [query, setQuery] = useState('');
   const [backend, setBackend] = useState<SearchBackend>('auto');
   const [collections, setCollections] = useState<SearchCollection[]>(
@@ -62,6 +195,25 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
     return `${resultCount} ${noun} from ${response.backend}`;
   }, [response, resultCount]);
 
+  const groupedResults = useMemo(() => {
+    if (!response) return [];
+
+    const groups: Array<{ collection: string; results: SearchResult[] }> = [];
+    const byCollection = new Map<string, SearchResult[]>();
+    for (const result of response.results) {
+      const existing = byCollection.get(result.collection);
+      if (existing) {
+        existing.push(result);
+      } else {
+        const next = [result];
+        byCollection.set(result.collection, next);
+        groups.push({ collection: result.collection, results: next });
+      }
+    }
+
+    return groups;
+  }, [response]);
+
   const runSearch = async () => {
     if (!canSearch) return;
 
@@ -72,7 +224,7 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
         query: trimmedQuery,
         backend,
         collections,
-        limit: 12,
+        limit: 20,
       });
       setResponse(nextResponse);
     } catch (err) {
@@ -90,6 +242,47 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
     });
   };
 
+  const openTarget = (target: SearchTarget) => {
+    if (target.type === 'task') {
+      onTaskOpen?.(target.taskId, taskNavigationTarget(target));
+      onOpenChange(false);
+      return;
+    }
+
+    if (target.type === 'view' && isAppView(target.view)) {
+      onViewOpen?.(target.view);
+      onOpenChange(false);
+      return;
+    }
+
+    if (target.type === 'settings') {
+      if (onSettingsOpen) {
+        onSettingsOpen(target.section);
+      } else {
+        window.dispatchEvent(
+          new CustomEvent('veritas:open-settings', { detail: { section: target.section } })
+        );
+      }
+      onOpenChange(false);
+      return;
+    }
+
+    if (target.type === 'diagnostics') {
+      if (onDiagnosticsOpen) {
+        onDiagnosticsOpen();
+      } else {
+        window.dispatchEvent(new CustomEvent('veritas:open-diagnostics'));
+      }
+      onOpenChange(false);
+      return;
+    }
+
+    if (target.type === 'url' && target.href) {
+      window.open(target.href, '_blank', 'noopener,noreferrer');
+      onOpenChange(false);
+    }
+  };
+
   return (
     <Modal
       opened={open}
@@ -100,18 +293,12 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
         <Group gap="xs">
           <span className="flex items-center gap-2 text-base font-semibold">
             <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
-            Search Tasks, Docs, and Work Products
+            Universal Search
           </span>
         </Group>
       }
       classNames={{ header: 'border-b px-5 py-4', body: 'p-0' }}
     >
-      <div className="border-b px-5 pb-4">
-        <Text size="sm" c="dimmed">
-          Find active work, archived decisions, durable work products, and project documentation.
-        </Text>
-      </div>
-
       <Stack gap="md" className="px-5 py-4">
         <form
           className="flex flex-col gap-3 sm:flex-row"
@@ -124,8 +311,8 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
             <TextInput
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search task titles, notes, docs, work products..."
-              aria-label="Search tasks, docs, and work products"
+              placeholder="Search tasks, runs, policies, settings..."
+              aria-label="Search Veritas"
               leftSection={<Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
               autoFocus
             />
@@ -153,7 +340,7 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
           </Button>
         </form>
 
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex max-h-28 flex-wrap items-center gap-2 overflow-y-auto pr-1">
           {COLLECTIONS.map((collection) => (
             <Checkbox
               key={collection.id}
@@ -182,59 +369,72 @@ export function SearchDialog({ open, onOpenChange, onTaskOpen }: SearchDialogPro
           </div>
         )}
 
-        <ScrollArea h={460} className="rounded-md border">
+        <ScrollArea h={500} className="rounded-md border">
           {!response && !error ? (
             <div className="px-4 py-10 text-center text-sm text-muted-foreground">
-              Search across task markdown, docs, and work products.
+              No search has run yet.
             </div>
           ) : response && response.results.length === 0 ? (
             <div className="px-4 py-10 text-center text-sm text-muted-foreground">
               No matches found.
             </div>
           ) : (
-            response?.results.map((result) => {
-              const Icon = collectionIcon(result.collection);
-              const taskId = result.collection.startsWith('tasks')
-                ? extractTaskId(result.path)
-                : null;
+            groupedResults.map((group) => (
+              <div key={group.collection}>
+                <div className="sticky top-0 z-10 border-b bg-card/95 px-4 py-2 backdrop-blur">
+                  <Text size="xs" fw={700} c="dimmed" tt="uppercase" className="tracking-wider">
+                    {collectionLabel(group.collection)}
+                  </Text>
+                </div>
+                {group.results.map((result, index) => {
+                  const Icon = collectionIcon(result.collection);
+                  const target = targetForResult(result);
+                  const actionable = target.type !== 'none';
 
-              return (
-                <button
-                  key={`${result.collection}:${result.id}`}
-                  type="button"
-                  className={cn(
-                    'flex w-full gap-3 border-b px-4 py-3 text-left transition-colors last:border-b-0',
-                    taskId ? 'hover:bg-muted/60' : 'cursor-default'
-                  )}
-                  onClick={() => {
-                    if (!taskId) return;
-                    onTaskOpen?.(taskId);
-                    onOpenChange(false);
-                  }}
-                >
-                  <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1">
-                    <span className="flex flex-wrap items-center gap-2">
-                      <span className="font-medium text-foreground">{result.title}</span>
-                      <Badge variant="light" color="gray">
-                        {result.collection}
-                      </Badge>
-                    </span>
-                    <span className="mt-1 block break-all text-xs text-muted-foreground">
-                      {result.path}
-                    </span>
-                    {result.snippet && (
-                      <span className="mt-2 block text-sm leading-6 text-muted-foreground">
-                        {result.snippet}
+                  return (
+                    <button
+                      key={`${result.collection}:${result.id}:${index}`}
+                      type="button"
+                      disabled={!actionable}
+                      title={!actionable ? target.disabledReason : actionLabel(target, result)}
+                      className={cn(
+                        'flex w-full gap-3 border-b px-4 py-3 text-left transition-colors',
+                        actionable ? 'hover:bg-muted/60' : 'cursor-not-allowed opacity-70'
+                      )}
+                      onClick={() => {
+                        if (!actionable) return;
+                        openTarget(target);
+                      }}
+                    >
+                      <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 flex-1">
+                        <span className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium text-foreground">{result.title}</span>
+                          <Badge variant="light" color="gray">
+                            {collectionLabel(result.collection)}
+                          </Badge>
+                          <Badge variant={actionable ? 'outline' : 'light'} color="gray">
+                            {actionLabel(target, result)}
+                          </Badge>
+                        </span>
+                        <span className="mt-1 block break-all text-xs text-muted-foreground">
+                          {result.path}
+                        </span>
+                        {result.snippet && (
+                          <span className="mt-2 block text-sm leading-6 text-muted-foreground">
+                            {result.snippet}
+                          </span>
+                        )}
                       </span>
-                    )}
-                  </span>
-                  <span className="text-xs tabular-nums text-muted-foreground">
-                    {Number(result.score).toFixed(2)}
-                  </span>
-                </button>
-              );
-            })
+                      <span className="text-xs tabular-nums text-muted-foreground">
+                        {Number(result.score).toFixed(2)}
+                      </span>
+                    </button>
+                  );
+                })}
+                <Divider />
+              </div>
+            ))
           )}
         </ScrollArea>
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -54,6 +54,8 @@ export type {
   SearchRequest,
   SearchResponse,
   SearchResult,
+  SearchResultAction,
+  SearchTarget,
 } from './search';
 
 export type { WorkProductExportFormat, WorkProductExportOptions } from './work-products';

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -1,7 +1,61 @@
 import { API_BASE, handleResponse } from './helpers';
 
 export type SearchBackend = 'auto' | 'qmd' | 'keyword';
-export type SearchCollection = 'tasks-active' | 'tasks-archive' | 'docs' | 'work-products';
+export type SearchCollection =
+  | 'tasks-active'
+  | 'tasks-archive'
+  | 'tasks-backlog'
+  | 'docs'
+  | 'prompts'
+  | 'work-products'
+  | 'workflows'
+  | 'workflow-runs'
+  | 'policies'
+  | 'decisions'
+  | 'settings'
+  | 'logs-diagnostics'
+  | 'agent-runs'
+  | 'notifications'
+  | 'maintenance'
+  | 'scheduled-runs';
+
+export type SearchTarget =
+  | {
+      type: 'task';
+      taskId: string;
+      tab?: string;
+      timelineAttemptId?: string;
+      href?: string;
+    }
+  | {
+      type: 'view';
+      view: string;
+      href?: string;
+    }
+  | {
+      type: 'settings';
+      section?: string;
+      href?: string;
+    }
+  | {
+      type: 'diagnostics';
+      href?: string;
+    }
+  | {
+      type: 'url';
+      href: string;
+    }
+  | {
+      type: 'none';
+      disabledReason?: string;
+    };
+
+export interface SearchResultAction {
+  id: string;
+  label: string;
+  target?: SearchTarget;
+  disabledReason?: string;
+}
 
 export interface SearchRequest {
   query: string;
@@ -18,7 +72,10 @@ export interface SearchResult {
   collection: SearchCollection | string;
   snippet: string;
   score: number;
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown> & {
+    target?: SearchTarget;
+    actions?: SearchResultAction[];
+  };
 }
 
 export interface SearchResponse {

--- a/web/src/lib/command-registry.ts
+++ b/web/src/lib/command-registry.ts
@@ -2,7 +2,7 @@ import { VIEW_DEFINITIONS, type AppView, type ViewIcon } from './views';
 
 export type ThemeMode = 'dark' | 'light';
 
-export type CommandCategory = 'Actions' | 'Navigation' | 'Board';
+export type CommandCategory = 'Actions' | 'Navigation' | 'Board' | 'Diagnostics';
 
 export type CommandIcon =
   | ViewIcon
@@ -26,6 +26,8 @@ export type CommandAction =
   | { type: 'open-create-task' }
   | { type: 'toggle-theme' }
   | { type: 'open-search' }
+  | { type: 'open-settings'; section?: string }
+  | { type: 'open-diagnostics' }
   | { type: 'navigate-view'; view: AppView }
   | { type: 'board-shortcut'; shortcut: BoardShortcutCommand };
 
@@ -148,12 +150,89 @@ export function createCommandRegistry({
     },
     {
       id: 'open-search',
-      label: 'Search Tasks, Docs, and Work Products',
+      label: 'Universal Search',
       icon: 'Sparkles',
       category: 'Actions',
       action: { type: 'open-search' },
-      keywords: ['qmd', 'semantic', 'retrieval', 'docs', 'archive', 'work products'],
-      aliases: ['find', 'universal search', 'command search'],
+      keywords: [
+        'qmd',
+        'semantic',
+        'retrieval',
+        'docs',
+        'archive',
+        'work products',
+        'runs',
+        'policies',
+        'notifications',
+      ],
+      aliases: ['find', 'search', 'universal search', 'command search', 'jump to'],
+    },
+    {
+      id: 'open-settings',
+      label: 'Open Settings',
+      icon: 'ShieldAlert',
+      category: 'Actions',
+      action: { type: 'open-settings' },
+      keywords: ['configuration', 'features', 'security', 'identity', 'preferences'],
+      aliases: ['settings', 'preferences', 'config'],
+    },
+    {
+      id: 'open-diagnostics',
+      label: 'Open Logs and Diagnostics',
+      icon: 'Activity',
+      category: 'Diagnostics',
+      action: { type: 'open-diagnostics' },
+      keywords: ['logs', 'diagnostics', 'health', 'desktop', 'communication', 'troubleshoot'],
+      aliases: ['logs', 'diagnostics', 'health check'],
+    },
+    {
+      id: 'start-workflow',
+      label: 'Start Workflow',
+      icon: 'Workflow',
+      category: 'Actions',
+      action: { type: 'navigate-view', view: 'workflows' },
+      keywords: ['run', 'automation', 'execute'],
+      aliases: ['run workflow', 'workflow start'],
+    },
+    {
+      id: 'apply-template',
+      label: 'Apply Template to Selected Task',
+      icon: 'FileText',
+      category: 'Board',
+      action: { type: 'board-shortcut', shortcut: 'open-task' },
+      keywords: ['template', 'task', 'apply', 'prompt'],
+      aliases: ['apply template', 'task template'],
+      disabledReason: SELECTED_TASK_REQUIRED,
+    },
+    {
+      id: 'copy-completion-packet',
+      label: 'Copy Completion Packet',
+      icon: 'FileText',
+      category: 'Board',
+      action: { type: 'board-shortcut', shortcut: 'open-task' },
+      keywords: ['completion', 'packet', 'copy', 'summary', 'handoff'],
+      aliases: ['completion packet', 'copy packet'],
+      disabledReason: SELECTED_TASK_REQUIRED,
+    },
+    {
+      id: 'restart-local-server',
+      label: 'Restart Local Server',
+      icon: 'Activity',
+      category: 'Diagnostics',
+      action: { type: 'open-diagnostics' },
+      keywords: ['server', 'restart', 'desktop', 'local'],
+      aliases: ['restart server'],
+      disabledReason: 'The desktop bridge does not expose server restart from the web app yet.',
+    },
+    {
+      id: 'check-for-updates',
+      label: 'Check for Updates',
+      icon: 'Activity',
+      category: 'Diagnostics',
+      action: { type: 'open-diagnostics' },
+      keywords: ['updates', 'release', 'desktop', 'version'],
+      aliases: ['updates', 'check updates'],
+      disabledReason: 'The desktop bridge does not expose update checks from the web app yet.',
     },
     ...VIEW_DEFINITIONS.map(
       (definition): CommandDescriptor => ({


### PR DESCRIPTION
## Summary
- Expand universal search across active/archive/backlog tasks, docs, prompts/templates, work products, workflows, workflow runs, policies, decisions, settings, logs/diagnostics, agent runs, notifications, maintenance, and scheduled run records.
- Add redacted snippets, ranking metadata, and a consistent target/action model for task, view, settings, and diagnostics results.
- Update the command registry and command palette with universal search, settings, workflow, diagnostics, aliases, and explicit disabled reasons for unavailable bridge/task-context actions.

## Verification
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server test -- search-service.test.ts routes/search.test.ts
- pnpm --filter @veritas-kanban/web test -- SearchDialog.test.tsx command-registry.test.ts
- pnpm --filter @veritas-kanban/web build
- pnpm --filter @veritas-kanban/server lint
- pnpm --filter @veritas-kanban/web lint

## Notes
- Device sessions are not indexed because the current app only references future pairing/device-session work in onboarding copy; there is no real local device-session data source to index yet.
- Lint passes with the existing warning baseline.

Closes #364