### PR TITLE
Add workflow recipe authoring and dry-run linting

### DIFF
--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -148,6 +148,9 @@ describe('v1 REST permission guard presets', () => {
     expect(
       runGuard(workflowAccess, mockRequest('POST', '/workflow-1/runs')).next
     ).toHaveBeenCalled();
+    expect(
+      runGuard(workflowAccess, mockRequest('POST', '/workflow-1/dry-run')).next
+    ).toHaveBeenCalled();
 
     const { res, next } = runGuard(workflowAccess, mockRequest('POST', '/'));
     expect(next).not.toHaveBeenCalled();

--- a/server/src/__tests__/routes/workflow-authoring.test.ts
+++ b/server/src/__tests__/routes/workflow-authoring.test.ts
@@ -1,0 +1,222 @@
+import express from 'express';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AuthenticatedRequest } from '../../middleware/auth.js';
+import type { WorkflowDefinition } from '../../types/workflow.js';
+
+function workflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    id: 'authoring-route-workflow',
+    name: 'Authoring Route Workflow',
+    version: 1,
+    description: 'Workflow authoring route fixture',
+    outputTargets: [
+      {
+        type: 'work-product',
+        label: 'Work product',
+        path: 'work-products/authoring-route.md',
+      },
+    ],
+    schedule: { mode: 'manual', enabled: false },
+    agents: [
+      {
+        id: 'worker',
+        name: 'Worker',
+        role: 'developer',
+        description: 'Runs the workflow.',
+        tools: ['Read', 'Edit', 'exec'],
+      },
+    ],
+    steps: [
+      {
+        id: 'work',
+        name: 'Do work',
+        type: 'agent',
+        agent: 'worker',
+        input: 'Do the work.',
+        output: { file: 'authoring-route.md' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('workflow authoring routes', () => {
+  let app: express.Express;
+  let testRoot: string;
+  let disposeWorkflowService: (() => void) | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-workflow-authoring-'));
+    process.env.VERITAS_DATA_DIR = testRoot;
+    process.env.DATA_DIR = testRoot;
+    process.env.VERITAS_DISABLE_WATCHERS = '1';
+
+    const [{ workflowRoutes }, workflowService, { errorHandler }] = await Promise.all([
+      import('../../routes/workflows.js'),
+      import('../../services/workflow-service.js'),
+      import('../../middleware/error-handler.js'),
+    ]);
+    disposeWorkflowService = workflowService.disposeWorkflowService;
+
+    app = express();
+    app.use(express.json());
+    app.use((req: AuthenticatedRequest, _res, next) => {
+      req.auth = {
+        role: 'admin',
+        keyName: 'workflow-authoring-test',
+        isLocalhost: false,
+        userId: 'workflow-authoring-user',
+        workspaceId: 'local',
+        actorType: 'user',
+        authMethod: 'session',
+        permissions: ['*'],
+      };
+      next();
+    });
+    app.use('/api/workflows', workflowRoutes);
+    app.use(errorHandler);
+  });
+
+  afterEach(async () => {
+    disposeWorkflowService?.();
+    delete process.env.VERITAS_DATA_DIR;
+    delete process.env.DATA_DIR;
+    delete process.env.VERITAS_DISABLE_WATCHERS;
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('lists recipes and materializes inspectable workflow YAML', async () => {
+    const recipes = await request(app).get('/api/workflows/recipes');
+    expect(recipes.status).toBe(200);
+    expect(recipes.body.map((recipe: { id: string }) => recipe.id)).toContain(
+      'task-implementation'
+    );
+
+    const materialized = await request(app)
+      .post('/api/workflows/recipes/task-implementation/materialize')
+      .send({
+        inputs: {
+          workflowName: 'Task Implementation Test',
+          taskId: 'task_123',
+          outputPath: 'work-products/task-123.md',
+        },
+        context: { taskId: 'task_123', clientMode: 'local' },
+      });
+
+    expect(materialized.status).toBe(200);
+    expect(materialized.body.workflow).toMatchObject({
+      id: 'task-implementation-test',
+      name: 'Task Implementation Test',
+    });
+    expect(
+      materialized.body.preview.outputTargets.map((target: { type: string }) => target.type)
+    ).toEqual(['task-update', 'work-product', 'completion-packet']);
+    expect(materialized.body.yaml).toContain('outputTargets:');
+    expect(materialized.body.lint.ok).toBe(true);
+  });
+
+  it('dry-runs drafts and reports missing context, policies, secrets, and schedules', async () => {
+    const draft = workflow({
+      id: 'unsafe-draft',
+      name: 'Unsafe Draft',
+      agents: [
+        {
+          id: 'planner',
+          name: 'Planner',
+          role: 'planner',
+          description: 'Plans with a denied write tool.',
+          tools: ['Write'],
+        },
+      ],
+      steps: [
+        {
+          id: 'plan',
+          name: 'Plan',
+          type: 'agent',
+          agent: 'planner',
+          input: 'Use {{ secrets.MISSING_TOKEN }} to plan.',
+          output: { file: 'plan.md' },
+        },
+      ],
+      outputTargets: [{ type: 'task-update', label: 'Task update' }],
+      schedule: { mode: 'custom', enabled: true },
+    });
+
+    const response = await request(app)
+      .post('/api/workflows/authoring/dry-run')
+      .send({
+        workflow: draft,
+        context: {
+          clientMode: 'remote',
+          permissions: ['workflow:read'],
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('blocked');
+    expect(response.body.canRun).toBe(false);
+    expect(response.body.messages.map((item: { category: string }) => item.category)).toEqual(
+      expect.arrayContaining(['context', 'policy', 'secret', 'schedule'])
+    );
+    expect(response.body.messages.map((item: { message: string }) => item.message)).toEqual(
+      expect.arrayContaining([
+        'Task update output requires task context.',
+        'Tool Write is denied for role planner.',
+        'Secret MISSING_TOKEN is referenced but unavailable.',
+        'Custom schedule is missing a cron expression.',
+      ])
+    );
+  });
+
+  it('dry-runs YAML edits and saved workflow definitions without starting a run', async () => {
+    const yamlDryRun = await request(app)
+      .post('/api/workflows/authoring/dry-run')
+      .send({
+        yaml: [
+          'id: yaml-authoring-workflow',
+          'name: YAML Authoring Workflow',
+          'version: 1',
+          'description: YAML route fixture',
+          'outputTargets:',
+          '  - type: work-product',
+          '    path: work-products/yaml.md',
+          'agents:',
+          '  - id: worker',
+          '    name: Worker',
+          '    role: developer',
+          '    description: Runs the YAML workflow.',
+          '    tools:',
+          '      - Read',
+          'steps:',
+          '  - id: work',
+          '    name: Do work',
+          '    type: agent',
+          '    agent: worker',
+          '    input: Do work.',
+          '    output:',
+          '      file: yaml.md',
+        ].join('\n'),
+      });
+
+    expect(yamlDryRun.status).toBe(200);
+    expect(yamlDryRun.body.canRun).toBe(true);
+    expect(yamlDryRun.body.workflow.id).toBe('yaml-authoring-workflow');
+
+    const create = await request(app).post('/api/workflows').send(workflow());
+    expect(create.status).toBe(201);
+
+    const savedDryRun = await request(app)
+      .post('/api/workflows/authoring-route-workflow/dry-run')
+      .send({ context: { clientMode: 'local' } });
+
+    expect(savedDryRun.status).toBe(200);
+    expect(savedDryRun.body.status).toBe('ready');
+    expect(savedDryRun.body.workflow.id).toBe('authoring-route-workflow');
+  });
+});

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -56,6 +56,7 @@ export const searchAccess = routeAccess('task:read', 'settings:write', [
 
 export const workflowAccess = routeAccess('workflow:read', 'workflow:write', [
   { methods: ['POST'], path: /^\/[^/]+\/runs\/?$/, permissions: 'workflow:execute' },
+  { methods: ['POST'], path: /^\/[^/]+\/dry-run\/?$/, permissions: 'workflow:execute' },
   { methods: ['POST'], path: /^\/runs\/[^/]+\/resume\/?$/, permissions: 'workflow:execute' },
   {
     methods: ['POST'],

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import type { WorkflowDefinition, WorkflowACL } from '../types/workflow.js';
 import { getWorkflowService } from '../services/workflow-service.js';
 import { getWorkflowRunService } from '../services/workflow-run-service.js';
+import { getWorkflowAuthoringService } from '../services/workflow-authoring-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { NotFoundError, ValidationError, BadRequestError } from '../middleware/error-handler.js';
@@ -18,6 +19,7 @@ import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../ut
 const router = Router();
 const workflowService = getWorkflowService();
 const workflowRunService = getWorkflowRunService();
+const workflowAuthoringService = getWorkflowAuthoringService();
 
 // Helper to extract string param (handles Express types)
 function getStringParam(param: string | string[] | undefined): string {
@@ -30,6 +32,10 @@ function getUserId(req: AuthenticatedRequest): string {
   return req.auth?.userId || req.auth?.keyName || 'unknown';
 }
 
+function getRequestPermissions(req: AuthenticatedRequest): string[] | undefined {
+  return req.auth?.permissions;
+}
+
 // Validation schemas
 const startRunSchema = z.object({
   taskId: z.string().optional(),
@@ -40,6 +46,26 @@ const resumeRunSchema = z.object({
   context: z.record(z.string(), z.unknown()).optional(),
 });
 
+const authoringContextSchema = z
+  .object({
+    taskId: z.string().optional(),
+    clientMode: z.enum(['local', 'remote', 'cloud']).optional(),
+    availableSecrets: z.array(z.string()).optional(),
+    now: z.string().optional(),
+  })
+  .optional();
+
+const recipeMaterializeSchema = z.object({
+  inputs: z.record(z.string(), z.unknown()).optional(),
+  context: authoringContextSchema,
+});
+
+const authoringInputSchema = z.object({
+  workflow: z.record(z.string(), z.unknown()).optional(),
+  yaml: z.string().optional(),
+  context: authoringContextSchema,
+});
+
 // Basic input validation - detailed validation happens in WorkflowService
 const workflowCreateSchema = z.object({
   id: z.string().min(1).max(100),
@@ -47,6 +73,8 @@ const workflowCreateSchema = z.object({
   version: z.number().int().min(0),
   description: z.string().max(2000),
   config: z.unknown().optional(),
+  outputTargets: z.array(z.record(z.string(), z.unknown())).max(12).optional(),
+  schedule: z.record(z.string(), z.unknown()).optional(),
   agents: z.array(z.unknown()).min(1).max(20),
   steps: z.array(z.unknown()).min(1).max(50),
   variables: z.record(z.string(), z.unknown()).optional(),
@@ -82,6 +110,91 @@ router.get(
   })
 );
 
+// ==================== Workflow Authoring Routes ====================
+
+/**
+ * GET /api/workflows/recipes — List reusable workflow recipes
+ */
+router.get(
+  '/recipes',
+  asyncHandler(async (_req: AuthenticatedRequest, res) => {
+    res.json(workflowAuthoringService.listRecipes());
+  })
+);
+
+/**
+ * POST /api/workflows/recipes/:recipeId/materialize — Build a workflow from a recipe
+ */
+router.post(
+  '/recipes/:recipeId/materialize',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const recipeId = getStringParam(req.params.recipeId);
+    const { inputs, context } = recipeMaterializeSchema.parse(req.body);
+    const materialized = await workflowAuthoringService.materializeRecipe(recipeId, inputs ?? {}, {
+      ...context,
+      permissions: getRequestPermissions(req),
+    });
+    if (!materialized) {
+      throw new NotFoundError(`Workflow recipe ${recipeId} not found`);
+    }
+    res.json(materialized);
+  })
+);
+
+/**
+ * POST /api/workflows/authoring/lint — Validate unsaved workflow YAML or JSON
+ */
+router.post(
+  '/authoring/lint',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const input = authoringInputSchema.parse(req.body);
+    const result = await workflowAuthoringService.lint({
+      workflow: input.workflow as unknown as WorkflowDefinition | undefined,
+      yaml: input.yaml,
+      context: {
+        ...input.context,
+        permissions: getRequestPermissions(req),
+      },
+    });
+    res.json(result);
+  })
+);
+
+/**
+ * POST /api/workflows/authoring/dry-run — Dry-run unsaved workflow YAML or JSON
+ */
+router.post(
+  '/authoring/dry-run',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const input = authoringInputSchema.parse(req.body);
+    const result = await workflowAuthoringService.dryRun({
+      workflow: input.workflow as unknown as WorkflowDefinition | undefined,
+      yaml: input.yaml,
+      context: {
+        ...input.context,
+        permissions: getRequestPermissions(req),
+      },
+    });
+    res.json(result);
+  })
+);
+
+/**
+ * POST /api/workflows/authoring/yaml — Render canonical YAML for a visual definition
+ */
+router.post(
+  '/authoring/yaml',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const input = authoringInputSchema.parse(req.body);
+    if (!input.workflow) {
+      throw new BadRequestError('workflow is required');
+    }
+    res.json({
+      yaml: workflowAuthoringService.toYaml(input.workflow as unknown as WorkflowDefinition),
+    });
+  })
+);
+
 /**
  * GET /api/workflows/:id — Get a specific workflow
  */
@@ -104,6 +217,33 @@ router.get(
 
     setRevisionHeaders(res, 'workflow', workflow.id, workflow.version);
     res.json(workflow);
+  })
+);
+
+/**
+ * POST /api/workflows/:id/dry-run — Dry-run a saved workflow definition
+ */
+router.post(
+  '/:id/dry-run',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const workflowId = getStringParam(req.params.id);
+    const userId = getUserId(req);
+    const input = z.object({ context: authoringContextSchema }).parse(req.body);
+
+    await assertWorkflowPermission(workflowId, userId, 'execute');
+    const workflow = await workflowService.loadWorkflow(workflowId);
+    if (!workflow) {
+      throw new NotFoundError(`Workflow ${workflowId} not found`);
+    }
+
+    const result = await workflowAuthoringService.dryRun({
+      workflow,
+      context: {
+        ...input.context,
+        permissions: getRequestPermissions(req),
+      },
+    });
+    res.json(result);
   })
 );
 

--- a/server/src/services/workflow-authoring-service.ts
+++ b/server/src/services/workflow-authoring-service.ts
@@ -1,0 +1,1353 @@
+import yaml from 'yaml';
+import type {
+  ToolPolicy,
+  WorkflowDefinition,
+  WorkflowOutputTarget,
+  WorkflowOutputTargetType,
+  WorkflowSchedule,
+  WorkflowStep,
+} from '../types/workflow.js';
+import { getToolPolicyService, type ToolPolicyService } from './tool-policy-service.js';
+
+export type WorkflowRecipeInputType = 'text' | 'textarea' | 'select' | 'boolean';
+export type WorkflowLintSeverity = 'error' | 'warning' | 'info';
+export type WorkflowLintCategory =
+  | 'definition'
+  | 'input'
+  | 'context'
+  | 'permission'
+  | 'policy'
+  | 'secret'
+  | 'client'
+  | 'output'
+  | 'schedule';
+
+export interface WorkflowRecipeInput {
+  id: string;
+  label: string;
+  type: WorkflowRecipeInputType;
+  required: boolean;
+  defaultValue?: string | boolean;
+  placeholder?: string;
+  helpText?: string;
+  options?: Array<{ value: string; label: string }>;
+}
+
+export interface WorkflowRecipe {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  inputs: WorkflowRecipeInput[];
+  defaultOutputTargets: WorkflowOutputTarget[];
+  schedule?: WorkflowSchedule;
+}
+
+interface WorkflowRecipeDefinition extends WorkflowRecipe {
+  build: (inputs: WorkflowRecipeInputValues) => WorkflowDefinition;
+}
+
+export interface WorkflowRecipeInputValues {
+  [key: string]: unknown;
+}
+
+export interface WorkflowRecipeMaterialization {
+  recipe: WorkflowRecipe;
+  workflow: WorkflowDefinition;
+  yaml: string;
+  missingInputs: string[];
+  lint: WorkflowLintResult;
+  preview: {
+    steps: Array<{ id: string; name: string; type: WorkflowStep['type']; agent?: string }>;
+    outputTargets: WorkflowOutputTarget[];
+    schedule?: WorkflowSchedule;
+  };
+}
+
+export interface WorkflowDryRunContext {
+  taskId?: string;
+  clientMode?: 'local' | 'remote' | 'cloud';
+  permissions?: string[];
+  availableSecrets?: string[];
+  now?: string;
+}
+
+export interface WorkflowLintMessage {
+  id: string;
+  severity: WorkflowLintSeverity;
+  category: WorkflowLintCategory;
+  path: string;
+  message: string;
+  remediation: string;
+}
+
+export interface WorkflowLintResult {
+  ok: boolean;
+  yaml?: string;
+  messages: WorkflowLintMessage[];
+  summary: {
+    errors: number;
+    warnings: number;
+    info: number;
+  };
+}
+
+export interface WorkflowDryRunCheck {
+  id: string;
+  label: string;
+  status: 'pass' | 'warn' | 'fail';
+  detail: string;
+}
+
+export interface WorkflowDryRunResult extends WorkflowLintResult {
+  status: 'ready' | 'attention' | 'blocked';
+  canRun: boolean;
+  checks: WorkflowDryRunCheck[];
+  workflow?: WorkflowDefinition;
+}
+
+export interface WorkflowAuthoringInput {
+  workflow?: WorkflowDefinition;
+  yaml?: string;
+  context?: WorkflowDryRunContext;
+}
+
+const OUTPUT_TARGET_TYPES: WorkflowOutputTargetType[] = [
+  'task-update',
+  'work-product',
+  'completion-packet',
+  'notification',
+  'dashboard-queue-item',
+  'scheduled-snapshot',
+];
+
+const STEP_TYPES: WorkflowStep['type'][] = ['agent', 'loop', 'gate', 'parallel'];
+const SCHEDULED_MODES = new Set(['daily', 'weekly', 'biweekly', 'monthly', 'custom']);
+
+const SECRET_PATTERNS = [
+  /\{\{\s*secrets\.([A-Z][A-Z0-9_]*)\s*\}\}/g,
+  /\$\{\{\s*secrets\.([A-Z][A-Z0-9_]*)\s*\}\}/g,
+  /\bprocess\.env\.([A-Z][A-Z0-9_]*)\b/g,
+  /\benv\.([A-Z][A-Z0-9_]*)\b/g,
+];
+
+function publicRecipe(recipe: WorkflowRecipeDefinition): WorkflowRecipe {
+  const { build: _build, ...rest } = recipe;
+  return rest;
+}
+
+function inputString(inputs: WorkflowRecipeInputValues, key: string, fallback = ''): string {
+  const value = inputs[key];
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return fallback;
+}
+
+function inputBoolean(inputs: WorkflowRecipeInputValues, key: string, fallback = false): boolean {
+  const value = inputs[key];
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function workflowId(value: string, fallback: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 90);
+  return slug || fallback;
+}
+
+function workflowName(inputs: WorkflowRecipeInputValues, fallback: string): string {
+  return inputString(inputs, 'workflowName', fallback) || fallback;
+}
+
+function targetPath(inputs: WorkflowRecipeInputValues, fallback: string): string {
+  return inputString(inputs, 'outputPath', fallback) || fallback;
+}
+
+function manualSchedule(): WorkflowSchedule {
+  return { mode: 'manual', enabled: false };
+}
+
+function outputTarget(
+  type: WorkflowOutputTargetType,
+  label: string,
+  extra = {}
+): WorkflowOutputTarget {
+  return { type, label, ...extra };
+}
+
+function stepPreview(step: WorkflowStep) {
+  return {
+    id: step.id,
+    name: step.name,
+    type: step.type,
+    agent: step.agent,
+  };
+}
+
+function message(
+  severity: WorkflowLintSeverity,
+  category: WorkflowLintCategory,
+  path: string,
+  text: string,
+  remediation: string
+): WorkflowLintMessage {
+  return {
+    id: `${category}:${path}:${text}`
+      .toLowerCase()
+      .replace(/[^a-z0-9:.-]+/g, '-')
+      .slice(0, 140),
+    severity,
+    category,
+    path,
+    message: text,
+    remediation,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOutputTargetType(value: unknown): value is WorkflowOutputTargetType {
+  return (
+    typeof value === 'string' && OUTPUT_TARGET_TYPES.includes(value as WorkflowOutputTargetType)
+  );
+}
+
+function hasPermission(permissions: string[] | undefined, permission: string): boolean {
+  if (!permissions) return true;
+  return permissions.includes('*') || permissions.includes(permission);
+}
+
+function toArray<T>(value: T[] | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function duplicateValues(values: string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates];
+}
+
+function collectText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(collectText).join('\n');
+  if (!isRecord(value)) return '';
+  return Object.values(value).map(collectText).join('\n');
+}
+
+function referencedSecrets(workflow: WorkflowDefinition): string[] {
+  const content = collectText(workflow);
+  const secrets = new Set<string>();
+  for (const pattern of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(content))) {
+      secrets.add(match[1]);
+    }
+  }
+  return [...secrets].sort();
+}
+
+function parseDate(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+const RECIPES: WorkflowRecipeDefinition[] = [
+  {
+    id: 'task-implementation',
+    name: 'Task Implementation',
+    description: 'Plan, implement, review, and package a task with inspectable work products.',
+    tags: ['task', 'implementation', 'review'],
+    inputs: [
+      {
+        id: 'workflowName',
+        label: 'Workflow name',
+        type: 'text',
+        required: true,
+        defaultValue: 'Task Implementation Workflow',
+      },
+      {
+        id: 'taskId',
+        label: 'Task ID',
+        type: 'text',
+        required: false,
+        placeholder: 'task_123',
+        helpText: 'Optional now; required before running against a task-update output.',
+      },
+      {
+        id: 'outputPath',
+        label: 'Work product path',
+        type: 'text',
+        required: true,
+        defaultValue: 'work-products/implementation-summary.md',
+      },
+    ],
+    defaultOutputTargets: [
+      outputTarget('task-update', 'Task update', { required: true, taskField: 'notes' }),
+      outputTarget('work-product', 'Implementation summary', {
+        required: true,
+        path: 'work-products/implementation-summary.md',
+      }),
+      outputTarget('completion-packet', 'Completion packet'),
+    ],
+    schedule: manualSchedule(),
+    build: (inputs) => {
+      const name = workflowName(inputs, 'Task Implementation Workflow');
+      return {
+        id: workflowId(inputString(inputs, 'workflowId', name), 'task-implementation'),
+        name,
+        version: 1,
+        description: 'Plan, implement, review, and package a task into stable outputs.',
+        schedule: manualSchedule(),
+        variables: {
+          taskId: inputString(inputs, 'taskId'),
+          recipe: 'task-implementation',
+        },
+        outputTargets: [
+          outputTarget('task-update', 'Task update', { required: true, taskField: 'notes' }),
+          outputTarget('work-product', 'Implementation summary', {
+            required: true,
+            path: targetPath(inputs, 'work-products/implementation-summary.md'),
+          }),
+          outputTarget('completion-packet', 'Completion packet'),
+        ],
+        agents: [
+          {
+            id: 'planner',
+            name: 'Planner',
+            role: 'planner',
+            description: 'Reads the task and turns it into an implementation plan.',
+            tools: ['Read', 'web_search'],
+          },
+          {
+            id: 'developer',
+            name: 'Developer',
+            role: 'developer',
+            description: 'Makes the scoped implementation changes and records proof.',
+            tools: ['Read', 'Edit', 'exec'],
+          },
+          {
+            id: 'reviewer',
+            name: 'Reviewer',
+            role: 'reviewer',
+            description: 'Checks the diff, risks, and verification before completion.',
+            tools: ['Read', 'exec'],
+          },
+        ],
+        steps: [
+          {
+            id: 'plan',
+            name: 'Plan implementation',
+            type: 'agent',
+            agent: 'planner',
+            input: 'Inspect task {{ task.id }} and produce a scoped implementation plan.',
+            output: { file: 'plan.md' },
+          },
+          {
+            id: 'implement',
+            name: 'Implement changes',
+            type: 'agent',
+            agent: 'developer',
+            input: 'Use the plan and task context to implement the requested change.',
+            output: { file: 'implementation-summary.md' },
+          },
+          {
+            id: 'review',
+            name: 'Review and package',
+            type: 'agent',
+            agent: 'reviewer',
+            input: 'Review the implementation, verification output, and completion packet.',
+            output: { file: 'completion-packet.md' },
+          },
+        ],
+      };
+    },
+  },
+  {
+    id: 'review-and-qa',
+    name: 'Review and QA',
+    description: 'Run review and QA agents against a task or work product before completion.',
+    tags: ['review', 'qa', 'verification'],
+    inputs: [
+      {
+        id: 'workflowName',
+        label: 'Workflow name',
+        type: 'text',
+        required: true,
+        defaultValue: 'Review and QA Workflow',
+      },
+      {
+        id: 'outputPath',
+        label: 'QA report path',
+        type: 'text',
+        required: true,
+        defaultValue: 'work-products/qa-report.md',
+      },
+    ],
+    defaultOutputTargets: [
+      outputTarget('work-product', 'QA report', {
+        required: true,
+        path: 'work-products/qa-report.md',
+      }),
+      outputTarget('completion-packet', 'Completion packet'),
+    ],
+    schedule: manualSchedule(),
+    build: (inputs) => {
+      const name = workflowName(inputs, 'Review and QA Workflow');
+      return {
+        id: workflowId(inputString(inputs, 'workflowId', name), 'review-and-qa'),
+        name,
+        version: 1,
+        description: 'Review a change, execute QA checks, and produce an inspectable report.',
+        schedule: manualSchedule(),
+        outputTargets: [
+          outputTarget('work-product', 'QA report', {
+            required: true,
+            path: targetPath(inputs, 'work-products/qa-report.md'),
+          }),
+          outputTarget('completion-packet', 'Completion packet'),
+        ],
+        agents: [
+          {
+            id: 'reviewer',
+            name: 'Reviewer',
+            role: 'reviewer',
+            description: 'Inspects code and risk.',
+            tools: ['Read', 'exec'],
+          },
+          {
+            id: 'tester',
+            name: 'Tester',
+            role: 'tester',
+            description: 'Runs targeted checks and records proof.',
+            tools: ['Read', 'exec', 'browser'],
+          },
+        ],
+        steps: [
+          {
+            id: 'review',
+            name: 'Review diff and risk',
+            type: 'agent',
+            agent: 'reviewer',
+            input: 'Review the available change context and list blockers first.',
+            output: { file: 'review-findings.md' },
+          },
+          {
+            id: 'qa',
+            name: 'Run QA checks',
+            type: 'agent',
+            agent: 'tester',
+            input: 'Run focused QA checks for the reviewed change and summarize proof.',
+            output: { file: 'qa-report.md' },
+          },
+        ],
+      };
+    },
+  },
+  {
+    id: 'weekly-snapshot',
+    name: 'Weekly Snapshot',
+    description:
+      'Create a scheduled weekly snapshot with stable dashboard and work-product output.',
+    tags: ['scheduled', 'snapshot', 'report'],
+    inputs: [
+      {
+        id: 'workflowName',
+        label: 'Workflow name',
+        type: 'text',
+        required: true,
+        defaultValue: 'Weekly Snapshot Workflow',
+      },
+      {
+        id: 'timezone',
+        label: 'Timezone',
+        type: 'text',
+        required: true,
+        defaultValue: 'America/Chicago',
+      },
+      {
+        id: 'cronExpr',
+        label: 'Cron expression',
+        type: 'text',
+        required: true,
+        defaultValue: '0 9 * * 1',
+      },
+      {
+        id: 'notify',
+        label: 'Notify after snapshot',
+        type: 'boolean',
+        required: false,
+        defaultValue: true,
+      },
+    ],
+    defaultOutputTargets: [
+      outputTarget('scheduled-snapshot', 'Stable weekly snapshot', {
+        required: true,
+        retentionDays: 90,
+      }),
+      outputTarget('work-product', 'Weekly report', {
+        required: true,
+        path: 'work-products/weekly-snapshot.md',
+      }),
+      outputTarget('notification', 'Snapshot notification', { channel: 'dashboard' }),
+    ],
+    schedule: {
+      mode: 'weekly',
+      enabled: true,
+      cronExpr: '0 9 * * 1',
+      timezone: 'America/Chicago',
+      snapshotRetention: 90,
+    },
+    build: (inputs) => {
+      const name = workflowName(inputs, 'Weekly Snapshot Workflow');
+      const notify = inputBoolean(inputs, 'notify', true);
+      const outputTargets: WorkflowOutputTarget[] = [
+        outputTarget('scheduled-snapshot', 'Stable weekly snapshot', {
+          required: true,
+          retentionDays: 90,
+        }),
+        outputTarget('work-product', 'Weekly report', {
+          required: true,
+          path: targetPath(inputs, 'work-products/weekly-snapshot.md'),
+        }),
+      ];
+      if (notify) {
+        outputTargets.push(
+          outputTarget('notification', 'Snapshot notification', { channel: 'dashboard' })
+        );
+      }
+      return {
+        id: workflowId(inputString(inputs, 'workflowId', name), 'weekly-snapshot'),
+        name,
+        version: 1,
+        description: 'Collect weekly board state and write stable snapshot outputs.',
+        schedule: {
+          mode: 'weekly',
+          enabled: true,
+          cronExpr: inputString(inputs, 'cronExpr', '0 9 * * 1'),
+          timezone: inputString(inputs, 'timezone', 'America/Chicago'),
+          snapshotRetention: 90,
+        },
+        outputTargets,
+        agents: [
+          {
+            id: 'writer',
+            name: 'Snapshot Writer',
+            role: 'content-writer',
+            description: 'Produces concise weekly status and stable work products.',
+            tools: ['Read', 'Write'],
+          },
+        ],
+        steps: [
+          {
+            id: 'collect',
+            name: 'Collect state',
+            type: 'agent',
+            agent: 'writer',
+            input: 'Collect weekly task, workflow, notification, and risk state.',
+            output: { file: 'weekly-snapshot-source.md' },
+          },
+          {
+            id: 'publish',
+            name: 'Publish snapshot',
+            type: 'agent',
+            agent: 'writer',
+            input: 'Write the stable weekly snapshot and summary work product.',
+            output: { file: 'weekly-snapshot.md' },
+          },
+        ],
+      };
+    },
+  },
+  {
+    id: 'policy-audit',
+    name: 'Policy Audit',
+    description: 'Inspect workflow policy gates, tool access, and drift before risky execution.',
+    tags: ['policy', 'audit', 'risk'],
+    inputs: [
+      {
+        id: 'workflowName',
+        label: 'Workflow name',
+        type: 'text',
+        required: true,
+        defaultValue: 'Policy Audit Workflow',
+      },
+      {
+        id: 'scope',
+        label: 'Audit scope',
+        type: 'textarea',
+        required: true,
+        defaultValue: 'Workflow policies, tools, schedules, and output targets',
+      },
+    ],
+    defaultOutputTargets: [
+      outputTarget('dashboard-queue-item', 'Dashboard queue item', { required: true }),
+      outputTarget('work-product', 'Policy audit report', {
+        required: true,
+        path: 'work-products/policy-audit.md',
+      }),
+    ],
+    schedule: manualSchedule(),
+    build: (inputs) => {
+      const name = workflowName(inputs, 'Policy Audit Workflow');
+      return {
+        id: workflowId(inputString(inputs, 'workflowId', name), 'policy-audit'),
+        name,
+        version: 1,
+        description: 'Audit workflow policy gates, tools, schedules, and outputs before execution.',
+        schedule: manualSchedule(),
+        variables: {
+          scope: inputString(
+            inputs,
+            'scope',
+            'Workflow policies, tools, schedules, and output targets'
+          ),
+        },
+        outputTargets: [
+          outputTarget('dashboard-queue-item', 'Dashboard queue item', { required: true }),
+          outputTarget('work-product', 'Policy audit report', {
+            required: true,
+            path: targetPath(inputs, 'work-products/policy-audit.md'),
+          }),
+        ],
+        agents: [
+          {
+            id: 'auditor',
+            name: 'Auditor',
+            role: 'reviewer',
+            description: 'Runs read-only policy and configuration checks.',
+            tools: ['Read', 'exec'],
+          },
+        ],
+        steps: [
+          {
+            id: 'audit',
+            name: 'Audit policies',
+            type: 'agent',
+            agent: 'auditor',
+            input: 'Audit {{ workflow.variables.scope }} and return blockers first.',
+            output: { file: 'policy-audit.md' },
+          },
+        ],
+      };
+    },
+  },
+];
+
+export class WorkflowAuthoringService {
+  constructor(private readonly toolPolicyService: ToolPolicyService = getToolPolicyService()) {}
+
+  listRecipes(): WorkflowRecipe[] {
+    return RECIPES.map(publicRecipe);
+  }
+
+  getRecipe(id: string): WorkflowRecipe | null {
+    const recipe = RECIPES.find((candidate) => candidate.id === id);
+    return recipe ? publicRecipe(recipe) : null;
+  }
+
+  async materializeRecipe(
+    id: string,
+    inputs: WorkflowRecipeInputValues = {},
+    context: WorkflowDryRunContext = {}
+  ): Promise<WorkflowRecipeMaterialization | null> {
+    const recipe = RECIPES.find((candidate) => candidate.id === id);
+    if (!recipe) return null;
+
+    const mergedInputs: WorkflowRecipeInputValues = {};
+    for (const input of recipe.inputs) {
+      mergedInputs[input.id] = inputs[input.id] ?? input.defaultValue ?? '';
+    }
+    mergedInputs.workflowId =
+      inputString(inputs, 'workflowId') ||
+      workflowId(inputString(mergedInputs, 'workflowName'), recipe.id);
+
+    const missingInputs = recipe.inputs
+      .filter((input) => input.required && !inputString(mergedInputs, input.id))
+      .map((input) => input.id);
+
+    const workflow = recipe.build(mergedInputs);
+    const lint = await this.lintWorkflow(workflow, {
+      ...context,
+      taskId: context.taskId || inputString(mergedInputs, 'taskId') || undefined,
+    });
+
+    return {
+      recipe: publicRecipe(recipe),
+      workflow,
+      yaml: this.toYaml(workflow),
+      missingInputs,
+      lint,
+      preview: {
+        steps: workflow.steps.map(stepPreview),
+        outputTargets: workflow.outputTargets ?? [],
+        schedule: workflow.schedule,
+      },
+    };
+  }
+
+  async lint(input: WorkflowAuthoringInput): Promise<WorkflowLintResult> {
+    const parsed = this.parseWorkflowInput(input);
+    if (!parsed.workflow) {
+      return this.resultFromMessages([
+        message(
+          'error',
+          'definition',
+          'yaml',
+          parsed.error ?? 'Workflow definition is required',
+          'Provide a workflow definition or valid YAML.'
+        ),
+      ]);
+    }
+    return this.lintWorkflow(parsed.workflow, input.context ?? {});
+  }
+
+  async dryRun(input: WorkflowAuthoringInput): Promise<WorkflowDryRunResult> {
+    const parsed = this.parseWorkflowInput(input);
+    if (!parsed.workflow) {
+      const lint = this.resultFromMessages([
+        message(
+          'error',
+          'definition',
+          'yaml',
+          parsed.error ?? 'Workflow definition is required',
+          'Provide a workflow definition or valid YAML.'
+        ),
+      ]);
+      return {
+        ...lint,
+        status: 'blocked',
+        canRun: false,
+        checks: this.buildChecks(lint.messages),
+      };
+    }
+
+    const lint = await this.lintWorkflow(parsed.workflow, input.context ?? {});
+    const status =
+      lint.summary.errors > 0 ? 'blocked' : lint.summary.warnings > 0 ? 'attention' : 'ready';
+    return {
+      ...lint,
+      status,
+      canRun: lint.summary.errors === 0,
+      checks: this.buildChecks(lint.messages),
+      workflow: parsed.workflow,
+    };
+  }
+
+  toYaml(workflow: WorkflowDefinition): string {
+    return yaml.stringify(workflow);
+  }
+
+  parseWorkflowYaml(content: string): WorkflowDefinition {
+    return yaml.parse(content) as WorkflowDefinition;
+  }
+
+  private async lintWorkflow(
+    workflow: WorkflowDefinition,
+    context: WorkflowDryRunContext
+  ): Promise<WorkflowLintResult> {
+    const messages: WorkflowLintMessage[] = [];
+
+    this.lintDefinition(workflow, messages);
+    await this.lintToolPolicies(workflow, messages);
+    this.lintSecrets(workflow, context, messages);
+    this.lintClientMode(workflow, context, messages);
+    this.lintOutputTargets(workflow, context, messages);
+    this.lintSchedule(workflow, messages);
+    this.lintPermissions(context, messages);
+
+    return {
+      ...this.resultFromMessages(messages),
+      yaml: this.toYaml(workflow),
+    };
+  }
+
+  private parseWorkflowInput(input: WorkflowAuthoringInput): {
+    workflow?: WorkflowDefinition;
+    error?: string;
+  } {
+    if (input.yaml && input.yaml.trim()) {
+      try {
+        const parsed = this.parseWorkflowYaml(input.yaml);
+        if (!isRecord(parsed)) {
+          return { error: 'YAML must parse to a workflow object' };
+        }
+        return { workflow: parsed };
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : 'Invalid YAML' };
+      }
+    }
+    if (input.workflow && isRecord(input.workflow)) {
+      return { workflow: input.workflow };
+    }
+    return { error: 'Workflow definition is required' };
+  }
+
+  private resultFromMessages(messages: WorkflowLintMessage[]): WorkflowLintResult {
+    const summary = {
+      errors: messages.filter((item) => item.severity === 'error').length,
+      warnings: messages.filter((item) => item.severity === 'warning').length,
+      info: messages.filter((item) => item.severity === 'info').length,
+    };
+    return {
+      ok: summary.errors === 0,
+      messages,
+      summary,
+    };
+  }
+
+  private lintDefinition(workflow: WorkflowDefinition, messages: WorkflowLintMessage[]): void {
+    if (!workflow.id) {
+      messages.push(
+        message(
+          'error',
+          'definition',
+          'id',
+          'Workflow ID is required.',
+          'Add a stable workflow id before saving.'
+        )
+      );
+    }
+    if (!workflow.name) {
+      messages.push(
+        message(
+          'error',
+          'definition',
+          'name',
+          'Workflow name is required.',
+          'Add a user-facing workflow name.'
+        )
+      );
+    }
+    if (workflow.version === undefined) {
+      messages.push(
+        message(
+          'error',
+          'definition',
+          'version',
+          'Workflow version is required.',
+          'Set version to 1 for new workflows.'
+        )
+      );
+    }
+
+    const agents = toArray(workflow.agents);
+    const steps = toArray(workflow.steps);
+    if (agents.length === 0) {
+      messages.push(
+        message(
+          'error',
+          'definition',
+          'agents',
+          'At least one agent is required.',
+          'Add an agent role before saving.'
+        )
+      );
+    }
+    if (steps.length === 0) {
+      messages.push(
+        message(
+          'error',
+          'definition',
+          'steps',
+          'At least one step is required.',
+          'Add a supported workflow step.'
+        )
+      );
+    }
+
+    for (const duplicate of duplicateValues(agents.map((agent) => agent.id).filter(Boolean))) {
+      messages.push(
+        message(
+          'error',
+          'definition',
+          `agents.${duplicate}`,
+          `Duplicate agent ID ${duplicate}.`,
+          'Use unique agent IDs.'
+        )
+      );
+    }
+    for (const duplicate of duplicateValues(steps.map((step) => step.id).filter(Boolean))) {
+      messages.push(
+        message(
+          'error',
+          'definition',
+          `steps.${duplicate}`,
+          `Duplicate step ID ${duplicate}.`,
+          'Use unique step IDs.'
+        )
+      );
+    }
+
+    const agentIds = new Set(agents.map((agent) => agent.id));
+    const stepIds = new Set(steps.map((step) => step.id));
+    for (const [index, agent] of agents.entries()) {
+      if (!agent.id) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `agents[${index}].id`,
+            'Agent ID is required.',
+            'Add a stable agent ID.'
+          )
+        );
+      }
+      if (!agent.role) {
+        messages.push(
+          message(
+            'warning',
+            'policy',
+            `agents[${index}].role`,
+            `Agent ${agent.id || index} has no role.`,
+            'Assign a role so tool policies can be evaluated.'
+          )
+        );
+      }
+    }
+
+    for (const [index, step] of steps.entries()) {
+      const path = `steps[${index}]`;
+      if (!step.id) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.id`,
+            'Step ID is required.',
+            'Add a stable step ID.'
+          )
+        );
+      }
+      if (!STEP_TYPES.includes(step.type)) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.type`,
+            `Unsupported step type ${String(step.type)}.`,
+            'Choose agent, loop, gate, or parallel.'
+          )
+        );
+      }
+      if (
+        (step.type === 'agent' || step.type === 'loop') &&
+        (!step.agent || !agentIds.has(step.agent))
+      ) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.agent`,
+            `Step ${step.id || index} references a missing agent.`,
+            'Select an existing agent for this step.'
+          )
+        );
+      }
+      if (step.type === 'loop' && !step.loop?.over) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.loop.over`,
+            `Loop step ${step.id || index} has no iterator.`,
+            'Set loop.over to the collection expression.'
+          )
+        );
+      }
+      if (step.type === 'gate' && !step.condition) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.condition`,
+            `Gate step ${step.id || index} has no condition.`,
+            'Add the gate condition expression.'
+          )
+        );
+      }
+      if (step.type === 'gate' && !step.on_false) {
+        messages.push(
+          message(
+            'warning',
+            'definition',
+            `${path}.on_false`,
+            `Gate step ${step.id || index} has no false-path policy.`,
+            'Add on_false so failed gates have clear remediation.'
+          )
+        );
+      }
+      if (step.type === 'parallel' && (!step.parallel?.steps || step.parallel.steps.length === 0)) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.parallel.steps`,
+            `Parallel step ${step.id || index} has no substeps.`,
+            'Add at least one parallel substep.'
+          )
+        );
+      }
+      if (step.on_fail?.retry_step && !stepIds.has(step.on_fail.retry_step)) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.on_fail.retry_step`,
+            `Step ${step.id || index} retries a missing step.`,
+            'Point retry_step at an existing step ID.'
+          )
+        );
+      }
+      if (step.loop?.verify_step && !stepIds.has(step.loop.verify_step)) {
+        messages.push(
+          message(
+            'error',
+            'definition',
+            `${path}.loop.verify_step`,
+            `Loop step ${step.id || index} verifies with a missing step.`,
+            'Point verify_step at an existing step ID.'
+          )
+        );
+      }
+    }
+  }
+
+  private async lintToolPolicies(
+    workflow: WorkflowDefinition,
+    messages: WorkflowLintMessage[]
+  ): Promise<void> {
+    for (const [index, agent] of toArray(workflow.agents).entries()) {
+      if (!agent.role) continue;
+      const policy = await this.toolPolicyService.getToolPolicy(agent.role);
+      if (!policy) {
+        messages.push(
+          message(
+            'warning',
+            'policy',
+            `agents[${index}].role`,
+            `No tool policy exists for role ${agent.role}.`,
+            'Create a tool policy or choose an existing role before execution.'
+          )
+        );
+        continue;
+      }
+      for (const tool of agent.tools ?? []) {
+        if (!this.isToolAllowed(policy, tool)) {
+          messages.push(
+            message(
+              'error',
+              'policy',
+              `agents[${index}].tools`,
+              `Tool ${tool} is denied for role ${agent.role}.`,
+              'Remove the tool or update the role policy intentionally.'
+            )
+          );
+        }
+      }
+    }
+  }
+
+  private isToolAllowed(policy: ToolPolicy, tool: string): boolean {
+    if (policy.denied.includes(tool)) return false;
+    return policy.allowed.includes('*') || policy.allowed.includes(tool);
+  }
+
+  private lintSecrets(
+    workflow: WorkflowDefinition,
+    context: WorkflowDryRunContext,
+    messages: WorkflowLintMessage[]
+  ): void {
+    const available = new Set(context.availableSecrets ?? []);
+    for (const secret of referencedSecrets(workflow)) {
+      if (!available.has(secret) && !process.env[secret]) {
+        messages.push(
+          message(
+            'error',
+            'secret',
+            'secrets',
+            `Secret ${secret} is referenced but unavailable.`,
+            'Add the secret to the runtime environment before execution.'
+          )
+        );
+      }
+    }
+  }
+
+  private lintClientMode(
+    workflow: WorkflowDefinition,
+    context: WorkflowDryRunContext,
+    messages: WorkflowLintMessage[]
+  ): void {
+    const clientMode = context.clientMode ?? 'local';
+    for (const [index, agent] of toArray(workflow.agents).entries()) {
+      const provider = agent.provider ?? '';
+      const command = agent.command ?? '';
+      if (
+        (clientMode === 'remote' || clientMode === 'cloud') &&
+        (provider === 'codex-cli' || command.includes('codex'))
+      ) {
+        messages.push(
+          message(
+            'warning',
+            'client',
+            `agents[${index}].provider`,
+            `Agent ${agent.id} uses a local client in ${clientMode} mode.`,
+            'Use a remote-capable provider or run this workflow in local client mode.'
+          )
+        );
+      }
+      if (clientMode === 'local' && provider === 'codex-cloud') {
+        messages.push(
+          message(
+            'info',
+            'client',
+            `agents[${index}].provider`,
+            `Agent ${agent.id} targets Codex Cloud.`,
+            'Confirm this workflow is intended to leave local execution.'
+          )
+        );
+      }
+    }
+  }
+
+  private lintOutputTargets(
+    workflow: WorkflowDefinition,
+    context: WorkflowDryRunContext,
+    messages: WorkflowLintMessage[]
+  ): void {
+    const targets = toArray(workflow.outputTargets);
+    if (targets.length === 0) {
+      messages.push(
+        message(
+          'warning',
+          'output',
+          'outputTargets',
+          'Workflow has no expected output targets.',
+          'Declare task update, work product, completion packet, notification, dashboard queue item, or scheduled snapshot outputs.'
+        )
+      );
+      return;
+    }
+
+    const stepOutputs = toArray(workflow.steps).flatMap((step) =>
+      step.output?.file ? [step.output.file] : []
+    );
+    for (const [index, target] of targets.entries()) {
+      const path = `outputTargets[${index}]`;
+      if (!isOutputTargetType(target.type)) {
+        messages.push(
+          message(
+            'error',
+            'output',
+            `${path}.type`,
+            `Unsupported output target ${String(target.type)}.`,
+            `Choose one of: ${OUTPUT_TARGET_TYPES.join(', ')}.`
+          )
+        );
+        continue;
+      }
+      if (target.type === 'task-update' && !context.taskId && !workflow.variables?.taskId) {
+        messages.push(
+          message(
+            'error',
+            'context',
+            path,
+            'Task update output requires task context.',
+            'Provide a taskId before dry-run or run.'
+          )
+        );
+      }
+      if (target.type === 'work-product' && !target.path && stepOutputs.length === 0) {
+        messages.push(
+          message(
+            'warning',
+            'output',
+            path,
+            'Work product output has no path or step output file.',
+            'Set outputTargets[].path or add step output files.'
+          )
+        );
+      }
+      if (target.type === 'notification' && !target.channel) {
+        messages.push(
+          message(
+            'warning',
+            'output',
+            `${path}.channel`,
+            'Notification output has no channel.',
+            'Set the notification channel or dashboard destination.'
+          )
+        );
+      }
+      if (target.type === 'scheduled-snapshot' && !this.isScheduled(workflow.schedule)) {
+        messages.push(
+          message(
+            'error',
+            'schedule',
+            path,
+            'Scheduled snapshot output requires an enabled schedule.',
+            'Enable a schedule or remove the scheduled snapshot target.'
+          )
+        );
+      }
+    }
+  }
+
+  private lintSchedule(workflow: WorkflowDefinition, messages: WorkflowLintMessage[]): void {
+    const schedule = workflow.schedule;
+    if (!this.isScheduled(schedule)) return;
+
+    const targets = toArray(workflow.outputTargets);
+    if (schedule.mode === 'custom' && !schedule.cronExpr) {
+      messages.push(
+        message(
+          'error',
+          'schedule',
+          'schedule.cronExpr',
+          'Custom schedule is missing a cron expression.',
+          'Add cronExpr or choose a standard schedule mode.'
+        )
+      );
+    }
+    if (!schedule.timezone) {
+      messages.push(
+        message(
+          'warning',
+          'schedule',
+          'schedule.timezone',
+          'Scheduled workflow has no timezone.',
+          'Set timezone so recurring runs are stable.'
+        )
+      );
+    }
+    if (!targets.some((target) => target.type === 'scheduled-snapshot')) {
+      messages.push(
+        message(
+          'error',
+          'schedule',
+          'outputTargets',
+          'Scheduled workflow has no scheduled snapshot target.',
+          'Add a scheduled-snapshot output target so views read stable run snapshots.'
+        )
+      );
+    }
+    if (!targets.some((target) => target.type === 'work-product')) {
+      messages.push(
+        message(
+          'warning',
+          'schedule',
+          'outputTargets',
+          'Scheduled workflow has no work product target.',
+          'Add a work-product target for inspectable scheduled output.'
+        )
+      );
+    }
+    if (schedule.snapshotRetention !== undefined && schedule.snapshotRetention <= 0) {
+      messages.push(
+        message(
+          'error',
+          'schedule',
+          'schedule.snapshotRetention',
+          'Snapshot retention must be positive.',
+          'Use a positive retention count or omit the field.'
+        )
+      );
+    }
+
+    const lastVerifiedAt = parseDate(schedule.lastVerifiedAt);
+    const now = Date.now();
+    if (lastVerifiedAt && now - lastVerifiedAt > 30 * 24 * 60 * 60 * 1000) {
+      messages.push(
+        message(
+          'warning',
+          'schedule',
+          'schedule.lastVerifiedAt',
+          'Schedule configuration has stale verification.',
+          'Run dry-run again before enabling this schedule.'
+        )
+      );
+    }
+  }
+
+  private lintPermissions(context: WorkflowDryRunContext, messages: WorkflowLintMessage[]): void {
+    if (!hasPermission(context.permissions, 'workflow:execute')) {
+      messages.push(
+        message(
+          'error',
+          'permission',
+          'permissions',
+          'Current identity cannot execute workflows.',
+          'Grant workflow:execute or use an identity that can run this workflow.'
+        )
+      );
+    }
+    if (!hasPermission(context.permissions, 'workflow:write')) {
+      messages.push(
+        message(
+          'warning',
+          'permission',
+          'permissions',
+          'Current identity cannot save workflow changes.',
+          'Grant workflow:write before saving this workflow.'
+        )
+      );
+    }
+  }
+
+  private isScheduled(schedule: WorkflowSchedule | undefined): schedule is WorkflowSchedule {
+    return Boolean(schedule?.enabled && SCHEDULED_MODES.has(schedule.mode));
+  }
+
+  private buildChecks(messages: WorkflowLintMessage[]): WorkflowDryRunCheck[] {
+    return [
+      this.checkFor('definition', 'Definition schema', messages),
+      this.checkFor('input', 'Recipe inputs', messages),
+      this.checkFor('context', 'Task context', messages),
+      this.checkFor('permission', 'Permissions', messages),
+      this.checkFor('policy', 'Policy gates and tools', messages),
+      this.checkFor('secret', 'Secrets', messages),
+      this.checkFor('client', 'Client mode', messages),
+      this.checkFor('output', 'Output targets', messages),
+      this.checkFor('schedule', 'Schedule', messages),
+    ];
+  }
+
+  private checkFor(
+    category: WorkflowLintCategory,
+    label: string,
+    messages: WorkflowLintMessage[]
+  ): WorkflowDryRunCheck {
+    const categoryMessages = messages.filter((item) => item.category === category);
+    const error = categoryMessages.find((item) => item.severity === 'error');
+    const warning = categoryMessages.find((item) => item.severity === 'warning');
+    const info = categoryMessages.find((item) => item.severity === 'info');
+    if (error) return { id: category, label, status: 'fail', detail: error.message };
+    if (warning) return { id: category, label, status: 'warn', detail: warning.message };
+    if (info) return { id: category, label, status: 'pass', detail: info.message };
+    return { id: category, label, status: 'pass', detail: 'No issues found.' };
+  }
+}
+
+let workflowAuthoringServiceInstance: WorkflowAuthoringService | null = null;
+
+export function getWorkflowAuthoringService(): WorkflowAuthoringService {
+  if (!workflowAuthoringServiceInstance) {
+    workflowAuthoringServiceInstance = new WorkflowAuthoringService();
+  }
+  return workflowAuthoringServiceInstance;
+}
+
+export function resetWorkflowAuthoringService(): void {
+  workflowAuthoringServiceInstance = null;
+}

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -13,6 +13,8 @@ export interface WorkflowDefinition {
   version: number;
   description: string;
   config?: WorkflowConfig;
+  outputTargets?: WorkflowOutputTarget[];
+  schedule?: WorkflowSchedule;
   agents: WorkflowAgent[];
   steps: WorkflowStep[];
   variables?: Record<string, unknown>;
@@ -28,6 +30,44 @@ export interface WorkflowConfig {
   fresh_session_default?: boolean;
   progress_file?: string;
   telemetry_tags?: string[];
+}
+
+export type WorkflowOutputTargetType =
+  | 'task-update'
+  | 'work-product'
+  | 'completion-packet'
+  | 'notification'
+  | 'dashboard-queue-item'
+  | 'scheduled-snapshot';
+
+export interface WorkflowOutputTarget {
+  type: WorkflowOutputTargetType;
+  label?: string;
+  required?: boolean;
+  path?: string;
+  taskField?: string;
+  channel?: string;
+  deliverableId?: string;
+  retentionDays?: number;
+}
+
+export type WorkflowScheduleMode =
+  | 'manual'
+  | 'daily'
+  | 'weekly'
+  | 'biweekly'
+  | 'monthly'
+  | 'custom';
+
+export interface WorkflowSchedule {
+  mode: WorkflowScheduleMode;
+  enabled: boolean;
+  cronExpr?: string;
+  timezone?: string;
+  startAt?: string;
+  endAt?: string;
+  snapshotRetention?: number;
+  lastVerifiedAt?: string;
 }
 
 export interface WorkflowAgent {

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -11,6 +11,8 @@ export interface WorkflowDefinition {
   version: number;
   description: string;
   config?: WorkflowConfig;
+  outputTargets?: WorkflowOutputTarget[];
+  schedule?: WorkflowSchedule;
   agents: WorkflowAgent[];
   steps: WorkflowStep[];
   variables?: Record<string, unknown>;
@@ -26,6 +28,44 @@ export interface WorkflowConfig {
   fresh_session_default?: boolean;
   progress_file?: string;
   telemetry_tags?: string[];
+}
+
+export type WorkflowOutputTargetType =
+  | 'task-update'
+  | 'work-product'
+  | 'completion-packet'
+  | 'notification'
+  | 'dashboard-queue-item'
+  | 'scheduled-snapshot';
+
+export interface WorkflowOutputTarget {
+  type: WorkflowOutputTargetType;
+  label?: string;
+  required?: boolean;
+  path?: string;
+  taskField?: string;
+  channel?: string;
+  deliverableId?: string;
+  retentionDays?: number;
+}
+
+export type WorkflowScheduleMode =
+  | 'manual'
+  | 'daily'
+  | 'weekly'
+  | 'biweekly'
+  | 'monthly'
+  | 'custom';
+
+export interface WorkflowSchedule {
+  mode: WorkflowScheduleMode;
+  enabled: boolean;
+  cronExpr?: string;
+  timezone?: string;
+  startAt?: string;
+  endAt?: string;
+  snapshotRetention?: number;
+  lastVerifiedAt?: string;
 }
 
 export interface WorkflowAgent {

--- a/web/src/__tests__/workflow-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/workflow-surfaces-mantine.test.tsx
@@ -129,6 +129,9 @@ describe('workflow surfaces Mantine migration', () => {
           },
         ]);
       }
+      if (url.endsWith('/workflows/recipes') && !init?.method) {
+        return jsonResponse([]);
+      }
       if (url.endsWith('/workflows/wf-release/runs') && init?.method === 'POST') {
         return jsonResponse({ id: 'run-1' });
       }
@@ -154,6 +157,97 @@ describe('workflow surfaces Mantine migration', () => {
       expect.objectContaining({ method: 'POST' })
     );
     expect(await screen.findByText('Workflow Runs')).toBeDefined();
+  });
+
+  it('builds a recipe through structured inputs and saves the materialized workflow', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/workflows') && !init?.method) {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/workflows/recipes') && !init?.method) {
+        return jsonResponse([
+          {
+            id: 'task-implementation',
+            name: 'Task Implementation',
+            description: 'Plan, implement, review, and package a task.',
+            tags: ['task', 'implementation'],
+            inputs: [
+              {
+                id: 'workflowName',
+                label: 'Workflow name',
+                type: 'text',
+                required: true,
+                defaultValue: 'Task Implementation Workflow',
+              },
+              {
+                id: 'taskId',
+                label: 'Task ID',
+                type: 'text',
+                required: false,
+                defaultValue: 'task_123',
+              },
+            ],
+            defaultOutputTargets: [{ type: 'task-update', label: 'Task update' }],
+          },
+        ]);
+      }
+      if (url.endsWith('/workflows/recipes/task-implementation/materialize')) {
+        return jsonResponse({
+          recipe: { id: 'task-implementation', name: 'Task Implementation' },
+          workflow: {
+            id: 'task-implementation-workflow',
+            name: 'Task Implementation Workflow',
+            version: 1,
+            description: 'Plan and ship a task.',
+            outputTargets: [
+              { type: 'task-update', label: 'Task update' },
+              { type: 'work-product', label: 'Work product', path: 'work-products/task.md' },
+            ],
+            schedule: { mode: 'manual', enabled: false },
+            agents: [{ id: 'worker', name: 'Worker', role: 'developer', description: 'Work' }],
+            steps: [{ id: 'work', name: 'Do work', type: 'agent', agent: 'worker' }],
+          },
+          yaml: 'id: task-implementation-workflow\noutputTargets: []\n',
+          missingInputs: [],
+          lint: { ok: true, messages: [], summary: { errors: 0, warnings: 0, info: 0 } },
+          preview: {
+            steps: [{ id: 'work', name: 'Do work', type: 'agent', agent: 'worker' }],
+            outputTargets: [
+              { type: 'task-update', label: 'Task update' },
+              { type: 'work-product', label: 'Work product', path: 'work-products/task.md' },
+            ],
+            schedule: { mode: 'manual', enabled: false },
+          },
+        });
+      }
+      if (url.endsWith('/workflows') && init?.method === 'POST') {
+        return jsonResponse({ success: true, workflowId: 'task-implementation-workflow' });
+      }
+      return jsonResponse(null, false);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    renderWithProviders(<WorkflowsPage onBack={vi.fn()} />);
+
+    await user.click(await screen.findByRole('tab', { name: 'Author' }));
+    expect((await screen.findAllByText('Task Implementation')).length).toBeGreaterThanOrEqual(1);
+
+    await user.click(screen.getByRole('button', { name: 'Build Recipe' }));
+
+    expect((await screen.findAllByText('Task update')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('No lint messages.')).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: 'Save Workflow' }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/workflows',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"outputTargets"'),
+      })
+    );
   });
 
   it('renders workflow dashboard lists and filters through direct Mantine primitives', () => {

--- a/web/src/components/workflows/WorkflowAuthoringPanel.tsx
+++ b/web/src/components/workflows/WorkflowAuthoringPanel.tsx
@@ -1,0 +1,1180 @@
+import { useEffect, useMemo, useState } from 'react';
+import type {
+  WorkflowAgent,
+  WorkflowDefinition,
+  WorkflowOutputTarget,
+  WorkflowOutputTargetType,
+  WorkflowSchedule,
+  WorkflowStep,
+} from '@veritas-kanban/shared';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Button,
+  Checkbox,
+  Divider,
+  Group,
+  NumberInput,
+  Paper,
+  ScrollArea,
+  Select,
+  SimpleGrid,
+  Stack,
+  Switch,
+  Tabs,
+  Text,
+  TextInput,
+  Textarea,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import {
+  AlertTriangle,
+  BookOpen,
+  Calendar,
+  CheckCircle2,
+  FileText,
+  GitBranch,
+  Plus,
+  Save,
+  Trash2,
+  Wand2,
+  XCircle,
+} from 'lucide-react';
+import { useToast } from '@/hooks/useToast';
+import {
+  workflowsApi,
+  type WorkflowDryRunResult,
+  type WorkflowLintMessage,
+  type WorkflowRecipe,
+  type WorkflowRecipeInput,
+  type WorkflowRecipeMaterialization,
+} from '@/lib/api/workflows';
+
+interface WorkflowAuthoringPanelProps {
+  canSaveWorkflow: boolean;
+  onWorkflowCreated: () => void;
+}
+
+type BuilderContext = {
+  taskId: string;
+  clientMode: 'local' | 'remote' | 'cloud';
+};
+
+const OUTPUT_TARGETS: Array<{ value: WorkflowOutputTargetType; label: string }> = [
+  { value: 'task-update', label: 'Task update' },
+  { value: 'work-product', label: 'Work product' },
+  { value: 'completion-packet', label: 'Completion packet' },
+  { value: 'notification', label: 'Notification' },
+  { value: 'dashboard-queue-item', label: 'Dashboard queue item' },
+  { value: 'scheduled-snapshot', label: 'Scheduled snapshot' },
+];
+
+const STEP_TYPE_OPTIONS: Array<{ value: WorkflowStep['type']; label: string }> = [
+  { value: 'agent', label: 'Agent' },
+  { value: 'loop', label: 'Loop' },
+  { value: 'gate', label: 'Gate' },
+  { value: 'parallel', label: 'Parallel' },
+];
+
+const SCHEDULE_OPTIONS: Array<{ value: WorkflowSchedule['mode']; label: string }> = [
+  { value: 'manual', label: 'Manual' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'biweekly', label: 'Biweekly' },
+  { value: 'monthly', label: 'Monthly' },
+  { value: 'custom', label: 'Custom' },
+];
+
+const CLIENT_MODE_OPTIONS: Array<{ value: BuilderContext['clientMode']; label: string }> = [
+  { value: 'local', label: 'Local' },
+  { value: 'remote', label: 'Remote' },
+  { value: 'cloud', label: 'Cloud' },
+];
+
+function defaultWorkflow(): WorkflowDefinition {
+  return {
+    id: 'custom-workflow',
+    name: 'Custom Workflow',
+    version: 1,
+    description: 'Custom workflow definition',
+    schedule: { mode: 'manual', enabled: false },
+    outputTargets: [
+      { type: 'work-product', label: 'Work product', path: 'work-products/output.md' },
+    ],
+    agents: [
+      {
+        id: 'worker',
+        name: 'Worker',
+        role: 'developer',
+        description: 'Runs the workflow step.',
+        tools: ['Read', 'Edit', 'exec'],
+      },
+    ],
+    steps: [
+      {
+        id: 'work',
+        name: 'Do work',
+        type: 'agent',
+        agent: 'worker',
+        input: 'Use the provided task context and produce the requested output.',
+        output: { file: 'output.md' },
+      },
+    ],
+  };
+}
+
+function recipeInputDefault(input: WorkflowRecipeInput): string | boolean {
+  if (input.defaultValue !== undefined) return input.defaultValue;
+  return input.type === 'boolean' ? false : '';
+}
+
+function messageColor(severity: WorkflowLintMessage['severity']): string {
+  if (severity === 'error') return 'red';
+  if (severity === 'warning') return 'yellow';
+  return 'blue';
+}
+
+function messageIcon(severity: WorkflowLintMessage['severity']) {
+  if (severity === 'error') return <XCircle className="h-4 w-4" />;
+  if (severity === 'warning') return <AlertTriangle className="h-4 w-4" />;
+  return <CheckCircle2 className="h-4 w-4" />;
+}
+
+function compactContext(context: BuilderContext) {
+  return {
+    taskId: context.taskId.trim() || undefined,
+    clientMode: context.clientMode,
+  };
+}
+
+function splitTools(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function targetLabel(type: WorkflowOutputTargetType): string {
+  return OUTPUT_TARGETS.find((target) => target.value === type)?.label ?? type;
+}
+
+function upsertTarget(
+  targets: WorkflowOutputTarget[] | undefined,
+  type: WorkflowOutputTargetType,
+  patch: Partial<WorkflowOutputTarget>
+): WorkflowOutputTarget[] {
+  const existing = targets ?? [];
+  if (existing.some((target) => target.type === type)) {
+    return existing.map((target) => (target.type === type ? { ...target, ...patch } : target));
+  }
+  return [...existing, { type, label: targetLabel(type), ...patch }];
+}
+
+export function WorkflowAuthoringPanel({
+  canSaveWorkflow,
+  onWorkflowCreated,
+}: WorkflowAuthoringPanelProps) {
+  const { toast } = useToast();
+  const [recipes, setRecipes] = useState<WorkflowRecipe[]>([]);
+  const [recipesLoading, setRecipesLoading] = useState(true);
+  const [selectedRecipeId, setSelectedRecipeId] = useState<string>('');
+  const [recipeInputs, setRecipeInputs] = useState<Record<string, string | boolean>>({});
+  const [materialized, setMaterialized] = useState<WorkflowRecipeMaterialization | null>(null);
+  const [recipeBusy, setRecipeBusy] = useState(false);
+
+  const [builderWorkflow, setBuilderWorkflow] = useState<WorkflowDefinition>(() =>
+    defaultWorkflow()
+  );
+  const [builderContext, setBuilderContext] = useState<BuilderContext>({
+    taskId: '',
+    clientMode: 'local',
+  });
+  const [builderDryRun, setBuilderDryRun] = useState<WorkflowDryRunResult | null>(null);
+  const [yamlDraft, setYamlDraft] = useState('');
+  const [yamlDryRun, setYamlDryRun] = useState<WorkflowDryRunResult | null>(null);
+  const [builderBusy, setBuilderBusy] = useState(false);
+  const [yamlBusy, setYamlBusy] = useState(false);
+
+  const selectedRecipe = useMemo(
+    () => recipes.find((recipe) => recipe.id === selectedRecipeId) ?? null,
+    [recipes, selectedRecipeId]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    workflowsApi
+      .recipes()
+      .then((data) => {
+        if (cancelled) return;
+        setRecipes(data);
+        setSelectedRecipeId((current) => current || data[0]?.id || '');
+      })
+      .catch((error: unknown) => {
+        toast({
+          title: 'Failed to load workflow recipes',
+          description: error instanceof Error ? error.message : 'Unknown error',
+        });
+      })
+      .finally(() => {
+        if (!cancelled) setRecipesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [toast]);
+
+  useEffect(() => {
+    if (!selectedRecipe) return;
+    const nextInputs: Record<string, string | boolean> = {};
+    for (const input of selectedRecipe.inputs) {
+      nextInputs[input.id] = recipeInputDefault(input);
+    }
+    setRecipeInputs(nextInputs);
+    setMaterialized(null);
+  }, [selectedRecipe]);
+
+  const materializeRecipe = async () => {
+    if (!selectedRecipe) return;
+    setRecipeBusy(true);
+    try {
+      const result = await workflowsApi.materializeRecipe(selectedRecipe.id, recipeInputs, {
+        taskId: typeof recipeInputs.taskId === 'string' ? recipeInputs.taskId : undefined,
+        clientMode: builderContext.clientMode,
+      });
+      setMaterialized(result);
+      setYamlDraft(result.yaml);
+      setYamlDryRun(null);
+    } catch (error) {
+      toast({
+        title: 'Failed to build recipe',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setRecipeBusy(false);
+    }
+  };
+
+  const saveWorkflow = async (workflow: WorkflowDefinition) => {
+    if (!canSaveWorkflow) {
+      toast({
+        title: 'Workflow write permission required',
+        description: 'The current identity cannot save workflow definitions.',
+      });
+      return;
+    }
+    await workflowsApi.create(workflow);
+    toast({
+      title: 'Workflow saved',
+      description: `${workflow.name} is available for runs.`,
+    });
+    onWorkflowCreated();
+  };
+
+  const runBuilderDryRun = async () => {
+    setBuilderBusy(true);
+    try {
+      const result = await workflowsApi.dryRun({
+        workflow: builderWorkflow,
+        context: compactContext(builderContext),
+      });
+      setBuilderDryRun(result);
+      if (result.yaml) setYamlDraft(result.yaml);
+    } catch (error) {
+      toast({
+        title: 'Dry-run failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setBuilderBusy(false);
+    }
+  };
+
+  const renderBuilderYaml = async () => {
+    setBuilderBusy(true);
+    try {
+      const result = await workflowsApi.renderYaml(builderWorkflow);
+      setYamlDraft(result.yaml);
+    } catch (error) {
+      toast({
+        title: 'YAML render failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setBuilderBusy(false);
+    }
+  };
+
+  const runYamlDryRun = async () => {
+    setYamlBusy(true);
+    try {
+      const result = await workflowsApi.dryRun({
+        yaml: yamlDraft,
+        context: compactContext(builderContext),
+      });
+      setYamlDryRun(result);
+      if (result.workflow) setBuilderWorkflow(result.workflow);
+    } catch (error) {
+      toast({
+        title: 'YAML dry-run failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setYamlBusy(false);
+    }
+  };
+
+  return (
+    <Tabs defaultValue="recipes" className="w-full">
+      <Tabs.List className="w-fit">
+        <Tabs.Tab value="recipes" leftSection={<BookOpen className="h-4 w-4" />}>
+          Recipes
+        </Tabs.Tab>
+        <Tabs.Tab value="builder" leftSection={<GitBranch className="h-4 w-4" />}>
+          Builder
+        </Tabs.Tab>
+        <Tabs.Tab value="yaml" leftSection={<FileText className="h-4 w-4" />}>
+          YAML
+        </Tabs.Tab>
+      </Tabs.List>
+
+      <Tabs.Panel value="recipes" pt="md">
+        <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
+          <Stack gap="md">
+            <Group justify="space-between" align="center">
+              <Title order={2} className="text-lg">
+                Recipe Gallery
+              </Title>
+              <Badge variant="light">{recipes.length} recipes</Badge>
+            </Group>
+
+            {recipesLoading ? (
+              <Text c="dimmed">Loading recipes...</Text>
+            ) : (
+              <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+                {recipes.map((recipe) => (
+                  <Paper
+                    key={recipe.id}
+                    className="p-4 transition-colors hover:bg-accent/50"
+                    radius="md"
+                    withBorder
+                  >
+                    <Stack gap="sm">
+                      <Group justify="space-between" align="flex-start">
+                        <Title order={3} className="text-base">
+                          {recipe.name}
+                        </Title>
+                        <Button
+                          size="xs"
+                          variant={selectedRecipeId === recipe.id ? 'filled' : 'light'}
+                          onClick={() => setSelectedRecipeId(recipe.id)}
+                        >
+                          Select
+                        </Button>
+                      </Group>
+                      <Text size="sm" c="dimmed">
+                        {recipe.description}
+                      </Text>
+                      <Group gap={6}>
+                        {recipe.tags.map((tag) => (
+                          <Badge key={tag} size="xs" variant="outline">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </Group>
+                    </Stack>
+                  </Paper>
+                ))}
+              </SimpleGrid>
+            )}
+          </Stack>
+
+          <Stack gap="md">
+            <Title order={2} className="text-lg">
+              Recipe Inputs
+            </Title>
+            {selectedRecipe ? (
+              <Paper className="p-4" radius="md" withBorder>
+                <Stack gap="sm">
+                  <Group justify="space-between" align="center">
+                    <Text fw={600}>{selectedRecipe.name}</Text>
+                    <Badge variant="outline">{selectedRecipe.id}</Badge>
+                  </Group>
+                  {selectedRecipe.inputs.map((input) => (
+                    <RecipeInputControl
+                      key={input.id}
+                      input={input}
+                      value={recipeInputs[input.id] ?? recipeInputDefault(input)}
+                      onChange={(value) =>
+                        setRecipeInputs((current) => ({ ...current, [input.id]: value }))
+                      }
+                    />
+                  ))}
+                  <Group justify="flex-end">
+                    <Button
+                      leftSection={<Wand2 className="h-4 w-4" />}
+                      loading={recipeBusy}
+                      onClick={materializeRecipe}
+                    >
+                      Build Recipe
+                    </Button>
+                  </Group>
+                </Stack>
+              </Paper>
+            ) : (
+              <Text c="dimmed">No recipe selected</Text>
+            )}
+
+            {materialized && (
+              <WorkflowMaterializationPreview
+                materialized={materialized}
+                canSaveWorkflow={canSaveWorkflow}
+                onSave={() => saveWorkflow(materialized.workflow)}
+              />
+            )}
+          </Stack>
+        </SimpleGrid>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="builder" pt="md">
+        <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="md">
+          <Stack gap="md">
+            <WorkflowDefinitionEditor workflow={builderWorkflow} onChange={setBuilderWorkflow} />
+          </Stack>
+
+          <Stack gap="md">
+            <ContextEditor context={builderContext} onChange={setBuilderContext} />
+            <BuilderActions
+              canSaveWorkflow={canSaveWorkflow}
+              isBusy={builderBusy}
+              onDryRun={runBuilderDryRun}
+              onRenderYaml={renderBuilderYaml}
+              onSave={() => saveWorkflow(builderWorkflow)}
+            />
+            {builderDryRun && <DryRunResultPanel result={builderDryRun} />}
+          </Stack>
+        </SimpleGrid>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="yaml" pt="md">
+        <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="md">
+          <Stack gap="md">
+            <Group justify="space-between" align="center">
+              <Title order={2} className="text-lg">
+                YAML Editor
+              </Title>
+              <Button
+                variant="light"
+                size="sm"
+                leftSection={<FileText className="h-4 w-4" />}
+                loading={builderBusy}
+                onClick={renderBuilderYaml}
+              >
+                Render from Builder
+              </Button>
+            </Group>
+            <Textarea
+              value={yamlDraft}
+              onChange={(event) => setYamlDraft(event.currentTarget.value)}
+              minRows={24}
+              className="font-mono"
+              placeholder="Render a workflow or paste workflow YAML"
+            />
+            <Group justify="flex-end">
+              <Button
+                variant="outline"
+                leftSection={<Wand2 className="h-4 w-4" />}
+                loading={yamlBusy}
+                onClick={runYamlDryRun}
+              >
+                Dry Run YAML
+              </Button>
+              <Button
+                leftSection={<Save className="h-4 w-4" />}
+                disabled={!canSaveWorkflow || !yamlDryRun?.workflow || !yamlDryRun.canRun}
+                onClick={() => yamlDryRun?.workflow && saveWorkflow(yamlDryRun.workflow)}
+              >
+                Save YAML Workflow
+              </Button>
+            </Group>
+          </Stack>
+
+          <Stack gap="md">
+            <ContextEditor context={builderContext} onChange={setBuilderContext} />
+            {yamlDryRun ? (
+              <DryRunResultPanel result={yamlDryRun} />
+            ) : (
+              <Alert color="blue" icon={<FileText className="h-4 w-4" />}>
+                YAML dry-run results will appear here.
+              </Alert>
+            )}
+          </Stack>
+        </SimpleGrid>
+      </Tabs.Panel>
+    </Tabs>
+  );
+}
+
+function RecipeInputControl({
+  input,
+  value,
+  onChange,
+}: {
+  input: WorkflowRecipeInput;
+  value: string | boolean;
+  onChange: (value: string | boolean) => void;
+}) {
+  if (input.type === 'boolean') {
+    return (
+      <Checkbox
+        label={input.label}
+        checked={Boolean(value)}
+        onChange={(event) => onChange(event.currentTarget.checked)}
+      />
+    );
+  }
+  if (input.type === 'textarea') {
+    return (
+      <Textarea
+        label={input.label}
+        value={String(value ?? '')}
+        placeholder={input.placeholder}
+        description={input.helpText}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        minRows={3}
+      />
+    );
+  }
+  if (input.type === 'select') {
+    return (
+      <Select
+        label={input.label}
+        value={String(value ?? '')}
+        data={input.options ?? []}
+        placeholder={input.placeholder}
+        description={input.helpText}
+        onChange={(next) => onChange(next ?? '')}
+      />
+    );
+  }
+  return (
+    <TextInput
+      label={input.label}
+      value={String(value ?? '')}
+      placeholder={input.placeholder}
+      description={input.helpText}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  );
+}
+
+function WorkflowMaterializationPreview({
+  materialized,
+  canSaveWorkflow,
+  onSave,
+}: {
+  materialized: WorkflowRecipeMaterialization;
+  canSaveWorkflow: boolean;
+  onSave: () => void;
+}) {
+  return (
+    <Paper className="p-4" radius="md" withBorder>
+      <Stack gap="sm">
+        <Group justify="space-between" align="center">
+          <Title order={3} className="text-base">
+            {materialized.workflow.name}
+          </Title>
+          <Button
+            size="sm"
+            leftSection={<Save className="h-4 w-4" />}
+            disabled={!canSaveWorkflow || !materialized.lint.ok}
+            onClick={onSave}
+          >
+            Save Workflow
+          </Button>
+        </Group>
+
+        <Group gap="sm">
+          <Badge variant="outline">{materialized.preview.steps.length} steps</Badge>
+          <Badge variant="outline">{materialized.preview.outputTargets.length} outputs</Badge>
+          <Badge color={materialized.lint.ok ? 'green' : 'red'} variant="light">
+            {materialized.lint.ok ? 'Ready' : `${materialized.lint.summary.errors} errors`}
+          </Badge>
+        </Group>
+
+        <Divider />
+
+        <Stack gap={6}>
+          {materialized.preview.steps.map((step) => (
+            <Group key={step.id} justify="space-between">
+              <Text size="sm">{step.name}</Text>
+              <Badge size="xs" variant="outline">
+                {step.type}
+              </Badge>
+            </Group>
+          ))}
+        </Stack>
+
+        <Divider />
+
+        <Group gap={6}>
+          {materialized.preview.outputTargets.map((target) => (
+            <Badge key={target.type} size="sm" variant="light">
+              {target.label ?? targetLabel(target.type)}
+            </Badge>
+          ))}
+        </Group>
+
+        <MessageList messages={materialized.lint.messages} />
+      </Stack>
+    </Paper>
+  );
+}
+
+function WorkflowDefinitionEditor({
+  workflow,
+  onChange,
+}: {
+  workflow: WorkflowDefinition;
+  onChange: (workflow: WorkflowDefinition) => void;
+}) {
+  const agentOptions = workflow.agents.map((agent) => ({
+    value: agent.id,
+    label: agent.name || agent.id,
+  }));
+  const schedule = workflow.schedule ?? { mode: 'manual', enabled: false };
+
+  const update = (patch: Partial<WorkflowDefinition>) => onChange({ ...workflow, ...patch });
+
+  const updateAgent = (index: number, patch: Partial<WorkflowAgent>) => {
+    update({
+      agents: workflow.agents.map((agent, candidateIndex) =>
+        candidateIndex === index ? { ...agent, ...patch } : agent
+      ),
+    });
+  };
+
+  const updateStep = (index: number, patch: Partial<WorkflowStep>) => {
+    update({
+      steps: workflow.steps.map((step, candidateIndex) =>
+        candidateIndex === index ? { ...step, ...patch } : step
+      ),
+    });
+  };
+
+  const selectedTargetTypes = (workflow.outputTargets ?? []).map((target) => target.type);
+
+  return (
+    <Stack gap="md">
+      <Paper className="p-4" radius="md" withBorder>
+        <Stack gap="sm">
+          <Title order={2} className="text-lg">
+            Workflow Definition
+          </Title>
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+            <TextInput
+              label="ID"
+              value={workflow.id}
+              onChange={(event) => update({ id: event.currentTarget.value })}
+            />
+            <TextInput
+              label="Name"
+              value={workflow.name}
+              onChange={(event) => update({ name: event.currentTarget.value })}
+            />
+          </SimpleGrid>
+          <Textarea
+            label="Description"
+            value={workflow.description}
+            onChange={(event) => update({ description: event.currentTarget.value })}
+            minRows={2}
+          />
+        </Stack>
+      </Paper>
+
+      <Paper className="p-4" radius="md" withBorder>
+        <Stack gap="sm">
+          <Group justify="space-between" align="center">
+            <Title order={2} className="text-lg">
+              Agents
+            </Title>
+            <Button
+              size="xs"
+              variant="light"
+              leftSection={<Plus className="h-3 w-3" />}
+              onClick={() =>
+                update({
+                  agents: [
+                    ...workflow.agents,
+                    {
+                      id: `agent-${workflow.agents.length + 1}`,
+                      name: `Agent ${workflow.agents.length + 1}`,
+                      role: 'developer',
+                      description: 'Workflow agent',
+                      tools: ['Read'],
+                    },
+                  ],
+                })
+              }
+            >
+              Add Agent
+            </Button>
+          </Group>
+
+          {workflow.agents.map((agent, index) => (
+            <div key={`${agent.id}-${index}`} className="border-t pt-3 first:border-t-0 first:pt-0">
+              <SimpleGrid cols={{ base: 1, md: 3 }} spacing="sm">
+                <TextInput
+                  label="ID"
+                  value={agent.id}
+                  onChange={(event) => updateAgent(index, { id: event.currentTarget.value })}
+                />
+                <TextInput
+                  label="Name"
+                  value={agent.name}
+                  onChange={(event) => updateAgent(index, { name: event.currentTarget.value })}
+                />
+                <TextInput
+                  label="Role"
+                  value={agent.role}
+                  onChange={(event) => updateAgent(index, { role: event.currentTarget.value })}
+                />
+              </SimpleGrid>
+              <Group align="end" mt="sm">
+                <TextInput
+                  className="flex-1"
+                  label="Tools"
+                  value={(agent.tools ?? []).join(', ')}
+                  onChange={(event) =>
+                    updateAgent(index, { tools: splitTools(event.currentTarget.value) })
+                  }
+                />
+                <Tooltip label="Remove agent">
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    aria-label={`Remove agent ${agent.name}`}
+                    onClick={() =>
+                      update({
+                        agents: workflow.agents.filter(
+                          (_, candidateIndex) => candidateIndex !== index
+                        ),
+                      })
+                    }
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            </div>
+          ))}
+        </Stack>
+      </Paper>
+
+      <Paper className="p-4" radius="md" withBorder>
+        <Stack gap="sm">
+          <Group justify="space-between" align="center">
+            <Title order={2} className="text-lg">
+              Steps
+            </Title>
+            <Button
+              size="xs"
+              variant="light"
+              leftSection={<Plus className="h-3 w-3" />}
+              onClick={() =>
+                update({
+                  steps: [
+                    ...workflow.steps,
+                    {
+                      id: `step-${workflow.steps.length + 1}`,
+                      name: `Step ${workflow.steps.length + 1}`,
+                      type: 'agent',
+                      agent: workflow.agents[0]?.id,
+                      input: '',
+                      output: { file: `step-${workflow.steps.length + 1}.md` },
+                    },
+                  ],
+                })
+              }
+            >
+              Add Step
+            </Button>
+          </Group>
+
+          {workflow.steps.map((step, index) => (
+            <div key={`${step.id}-${index}`} className="border-t pt-3 first:border-t-0 first:pt-0">
+              <Stack gap="sm">
+                <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+                  <TextInput
+                    label="ID"
+                    value={step.id}
+                    onChange={(event) => updateStep(index, { id: event.currentTarget.value })}
+                  />
+                  <TextInput
+                    label="Name"
+                    value={step.name}
+                    onChange={(event) => updateStep(index, { name: event.currentTarget.value })}
+                  />
+                  <Select
+                    label="Type"
+                    value={step.type}
+                    data={STEP_TYPE_OPTIONS}
+                    onChange={(next) =>
+                      updateStep(index, { type: (next ?? 'agent') as WorkflowStep['type'] })
+                    }
+                  />
+                  <Select
+                    label="Agent"
+                    value={step.agent ?? null}
+                    data={agentOptions}
+                    disabled={step.type === 'gate' || step.type === 'parallel'}
+                    onChange={(next) => updateStep(index, { agent: next ?? undefined })}
+                  />
+                </SimpleGrid>
+                <Textarea
+                  label="Input"
+                  value={step.input ?? ''}
+                  onChange={(event) => updateStep(index, { input: event.currentTarget.value })}
+                  minRows={2}
+                />
+                <Group align="end">
+                  <TextInput
+                    className="flex-1"
+                    label="Output file"
+                    value={step.output?.file ?? ''}
+                    onChange={(event) =>
+                      updateStep(index, {
+                        output: event.currentTarget.value
+                          ? { file: event.currentTarget.value }
+                          : undefined,
+                      })
+                    }
+                  />
+                  <Tooltip label="Remove step">
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      aria-label={`Remove step ${step.name}`}
+                      onClick={() =>
+                        update({
+                          steps: workflow.steps.filter(
+                            (_, candidateIndex) => candidateIndex !== index
+                          ),
+                        })
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </ActionIcon>
+                  </Tooltip>
+                </Group>
+              </Stack>
+            </div>
+          ))}
+        </Stack>
+      </Paper>
+
+      <Paper className="p-4" radius="md" withBorder>
+        <Stack gap="sm">
+          <Title order={2} className="text-lg">
+            Outputs and Schedule
+          </Title>
+          <Checkbox.Group
+            value={selectedTargetTypes}
+            onChange={(types) =>
+              update({
+                outputTargets: types.map((type) => {
+                  const typed = type as WorkflowOutputTargetType;
+                  return (
+                    workflow.outputTargets?.find((target) => target.type === typed) ?? {
+                      type: typed,
+                      label: targetLabel(typed),
+                    }
+                  );
+                }),
+              })
+            }
+          >
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+              {OUTPUT_TARGETS.map((target) => (
+                <Checkbox key={target.value} value={target.value} label={target.label} />
+              ))}
+            </SimpleGrid>
+          </Checkbox.Group>
+
+          {selectedTargetTypes.includes('work-product') && (
+            <TextInput
+              label="Work product path"
+              value={
+                workflow.outputTargets?.find((target) => target.type === 'work-product')?.path ?? ''
+              }
+              onChange={(event) =>
+                update({
+                  outputTargets: upsertTarget(workflow.outputTargets, 'work-product', {
+                    path: event.currentTarget.value,
+                  }),
+                })
+              }
+            />
+          )}
+
+          {selectedTargetTypes.includes('notification') && (
+            <TextInput
+              label="Notification channel"
+              value={
+                workflow.outputTargets?.find((target) => target.type === 'notification')?.channel ??
+                ''
+              }
+              onChange={(event) =>
+                update({
+                  outputTargets: upsertTarget(workflow.outputTargets, 'notification', {
+                    channel: event.currentTarget.value,
+                  }),
+                })
+              }
+            />
+          )}
+
+          <Divider />
+
+          <Group justify="space-between" align="center">
+            <Group gap="xs">
+              <Calendar className="h-4 w-4" />
+              <Text fw={600}>Schedule</Text>
+            </Group>
+            <Switch
+              checked={Boolean(schedule.enabled)}
+              onChange={(event) =>
+                update({
+                  schedule: {
+                    ...schedule,
+                    enabled: event.currentTarget.checked,
+                    mode:
+                      event.currentTarget.checked && schedule.mode === 'manual'
+                        ? 'weekly'
+                        : schedule.mode,
+                  },
+                })
+              }
+            />
+          </Group>
+
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+            <Select
+              label="Mode"
+              value={schedule.mode}
+              data={SCHEDULE_OPTIONS}
+              disabled={!schedule.enabled}
+              onChange={(next) =>
+                update({
+                  schedule: { ...schedule, mode: (next ?? 'manual') as WorkflowSchedule['mode'] },
+                })
+              }
+            />
+            <TextInput
+              label="Timezone"
+              value={schedule.timezone ?? ''}
+              disabled={!schedule.enabled}
+              onChange={(event) =>
+                update({ schedule: { ...schedule, timezone: event.currentTarget.value } })
+              }
+            />
+            <TextInput
+              label="Cron"
+              value={schedule.cronExpr ?? ''}
+              disabled={!schedule.enabled}
+              onChange={(event) =>
+                update({ schedule: { ...schedule, cronExpr: event.currentTarget.value } })
+              }
+            />
+            <NumberInput
+              label="Snapshot retention"
+              value={schedule.snapshotRetention ?? ''}
+              min={1}
+              disabled={!schedule.enabled}
+              onChange={(value) =>
+                update({
+                  schedule: {
+                    ...schedule,
+                    snapshotRetention: typeof value === 'number' ? value : undefined,
+                  },
+                })
+              }
+            />
+          </SimpleGrid>
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+}
+
+function ContextEditor({
+  context,
+  onChange,
+}: {
+  context: BuilderContext;
+  onChange: (context: BuilderContext) => void;
+}) {
+  return (
+    <Paper className="p-4" radius="md" withBorder>
+      <Stack gap="sm">
+        <Title order={2} className="text-lg">
+          Dry Run Context
+        </Title>
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+          <TextInput
+            label="Task ID"
+            value={context.taskId}
+            onChange={(event) => onChange({ ...context, taskId: event.currentTarget.value })}
+          />
+          <Select
+            label="Client mode"
+            value={context.clientMode}
+            data={CLIENT_MODE_OPTIONS}
+            onChange={(next) =>
+              onChange({
+                ...context,
+                clientMode: (next ?? 'local') as BuilderContext['clientMode'],
+              })
+            }
+          />
+        </SimpleGrid>
+      </Stack>
+    </Paper>
+  );
+}
+
+function BuilderActions({
+  canSaveWorkflow,
+  isBusy,
+  onDryRun,
+  onRenderYaml,
+  onSave,
+}: {
+  canSaveWorkflow: boolean;
+  isBusy: boolean;
+  onDryRun: () => void;
+  onRenderYaml: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <Paper className="p-4" radius="md" withBorder>
+      <Group justify="flex-end">
+        <Button
+          variant="light"
+          leftSection={<FileText className="h-4 w-4" />}
+          loading={isBusy}
+          onClick={onRenderYaml}
+        >
+          Render YAML
+        </Button>
+        <Button
+          variant="outline"
+          leftSection={<Wand2 className="h-4 w-4" />}
+          loading={isBusy}
+          onClick={onDryRun}
+        >
+          Dry Run
+        </Button>
+        <Button
+          leftSection={<Save className="h-4 w-4" />}
+          disabled={!canSaveWorkflow}
+          onClick={onSave}
+        >
+          Save Workflow
+        </Button>
+      </Group>
+    </Paper>
+  );
+}
+
+function DryRunResultPanel({ result }: { result: WorkflowDryRunResult }) {
+  const statusColor =
+    result.status === 'ready' ? 'green' : result.status === 'attention' ? 'yellow' : 'red';
+  return (
+    <Paper className="p-4" radius="md" withBorder>
+      <Stack gap="sm">
+        <Group justify="space-between" align="center">
+          <Title order={2} className="text-lg">
+            Dry Run
+          </Title>
+          <Badge color={statusColor} variant="light">
+            {result.status}
+          </Badge>
+        </Group>
+        <Group gap="sm">
+          <Badge color={result.summary.errors ? 'red' : 'gray'} variant="outline">
+            {result.summary.errors} errors
+          </Badge>
+          <Badge color={result.summary.warnings ? 'yellow' : 'gray'} variant="outline">
+            {result.summary.warnings} warnings
+          </Badge>
+          <Badge color={result.canRun ? 'green' : 'red'} variant="outline">
+            {result.canRun ? 'Can run' : 'Blocked'}
+          </Badge>
+        </Group>
+
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xs">
+          {result.checks.map((check) => (
+            <Alert
+              key={check.id}
+              color={check.status === 'fail' ? 'red' : check.status === 'warn' ? 'yellow' : 'green'}
+              icon={
+                check.status === 'fail' ? (
+                  <XCircle className="h-4 w-4" />
+                ) : check.status === 'warn' ? (
+                  <AlertTriangle className="h-4 w-4" />
+                ) : (
+                  <CheckCircle2 className="h-4 w-4" />
+                )
+              }
+            >
+              <Text fw={600} size="sm">
+                {check.label}
+              </Text>
+              <Text size="sm">{check.detail}</Text>
+            </Alert>
+          ))}
+        </SimpleGrid>
+
+        <MessageList messages={result.messages} />
+      </Stack>
+    </Paper>
+  );
+}
+
+function MessageList({ messages }: { messages: WorkflowLintMessage[] }) {
+  if (messages.length === 0) {
+    return (
+      <Alert color="green" icon={<CheckCircle2 className="h-4 w-4" />}>
+        No lint messages.
+      </Alert>
+    );
+  }
+  return (
+    <ScrollArea.Autosize mah={280}>
+      <Stack gap="xs">
+        {messages.map((item) => (
+          <Alert
+            key={item.id}
+            color={messageColor(item.severity)}
+            icon={messageIcon(item.severity)}
+          >
+            <Group gap="xs" mb={4}>
+              <Badge size="xs" variant="outline">
+                {item.category}
+              </Badge>
+              <Text size="sm" fw={600}>
+                {item.path}
+              </Text>
+            </Group>
+            <Text size="sm">{item.message}</Text>
+            <Text size="xs" c="dimmed" mt={4}>
+              {item.remediation}
+            </Text>
+          </Alert>
+        ))}
+      </Stack>
+    </ScrollArea.Autosize>
+  );
+}

--- a/web/src/components/workflows/WorkflowsPage.tsx
+++ b/web/src/components/workflows/WorkflowsPage.tsx
@@ -4,12 +4,12 @@
  * Features:
  * - List all workflows with metadata
  * - Start workflow runs
+ * - Author recipes, visual definitions, dry-runs, and YAML
  * - View active runs per workflow
  * - Empty state when no workflows exist
  */
 
-import { useState, useMemo, useEffect } from 'react';
-import { API_BASE } from '@/lib/config';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import {
   Badge,
   Button,
@@ -17,6 +17,7 @@ import {
   Paper,
   Skeleton,
   Stack,
+  Tabs,
   Text,
   TextInput,
   Title,
@@ -25,51 +26,45 @@ import { ArrowLeft, Search, Play, Users, ListOrdered, BarChart3 } from 'lucide-r
 import { useToast } from '@/hooks/useToast';
 import { WorkflowRunList } from './WorkflowRunList';
 import { WorkflowDashboard } from './WorkflowDashboard';
+import { WorkflowAuthoringPanel } from './WorkflowAuthoringPanel';
 import { useIdentity } from '@/hooks/useIdentity';
+import { workflowsApi, type WorkflowSummary } from '@/lib/api/workflows';
 
 interface WorkflowsPageProps {
   onBack: () => void;
 }
 
-interface Workflow {
-  id: string;
-  name: string;
-  version: number;
-  description: string;
-  agents: Array<{ id: string; name: string; role: string }>;
-  steps: Array<{ id: string; name: string }>;
-  activeRunCount?: number;
-}
-
 export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
   const [search, setSearch] = useState('');
-  const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [showDashboard, setShowDashboard] = useState(false);
+  const [activeTab, setActiveTab] = useState<string | null>('browse');
   const { toast } = useToast();
   const { hasPermission } = useIdentity();
   const canExecuteWorkflows = hasPermission('workflow:execute');
+  const canWriteWorkflows = hasPermission('workflow:write');
+
+  const fetchWorkflows = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const json = await workflowsApi.list();
+      setWorkflows(json);
+    } catch (error) {
+      toast({
+        title: 'Failed to load workflows',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [toast]);
 
   // Fetch workflows on mount
   useEffect(() => {
-    const fetchWorkflows = async () => {
-      try {
-        const response = await fetch(`${API_BASE}/workflows`);
-        if (!response.ok) throw new Error('Failed to fetch workflows');
-        const json = await response.json();
-        setWorkflows(json.data ?? json);
-      } catch (error) {
-        toast({
-          title: '❌ Failed to load workflows',
-          description: error instanceof Error ? error.message : 'Unknown error',
-        });
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchWorkflows();
-  }, [toast]);
+    void fetchWorkflows();
+  }, [fetchWorkflows]);
 
   // Filter workflows
   const filteredWorkflows = useMemo(() => {
@@ -87,15 +82,7 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
       if (!canExecuteWorkflows) {
         throw new Error('Workflow execute permission required');
       }
-      const response = await fetch(`${API_BASE}/workflows/${workflowId}/runs`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-
-      if (!response.ok) throw new Error('Failed to start workflow run');
-
-      const run = await response.json();
+      const run = await workflowsApi.startRun(workflowId);
       toast({
         title: 'Workflow run started',
         description: `Run ID: ${run.id}`,
@@ -148,45 +135,66 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
         </Button>
       </Group>
 
-      {/* Search */}
-      <TextInput
-        className="max-w-md"
-        leftSection={<Search className="h-4 w-4" />}
-        placeholder="Search workflows..."
-        value={search}
-        onChange={(event) => setSearch(event.currentTarget.value)}
-      />
+      <Tabs value={activeTab} onChange={setActiveTab} className="w-full">
+        <Tabs.List className="w-fit">
+          <Tabs.Tab value="browse">Browse</Tabs.Tab>
+          <Tabs.Tab value="author">Author</Tabs.Tab>
+        </Tabs.List>
 
-      {/* Workflow List */}
-      {isLoading ? (
-        <Stack gap="sm">
-          {[...Array(3)].map((_, i) => (
-            <Skeleton key={i} h={128} />
-          ))}
-        </Stack>
-      ) : filteredWorkflows.length === 0 ? (
-        <Text ta="center" c="dimmed" py="xl">
-          {search ? 'No workflows match your search' : 'No workflows available'}
-        </Text>
-      ) : (
-        <Stack gap="md">
-          {filteredWorkflows.map((workflow) => (
-            <WorkflowCard
-              key={workflow.id}
-              workflow={workflow}
-              onStartRun={() => handleStartRun(workflow.id)}
-              onViewRuns={() => setSelectedWorkflowId(workflow.id)}
-              canStartRun={canExecuteWorkflows}
+        <Tabs.Panel value="browse" pt="md">
+          <Stack gap="md">
+            {/* Search */}
+            <TextInput
+              className="max-w-md"
+              leftSection={<Search className="h-4 w-4" />}
+              placeholder="Search workflows..."
+              value={search}
+              onChange={(event) => setSearch(event.currentTarget.value)}
             />
-          ))}
-        </Stack>
-      )}
+
+            {/* Workflow List */}
+            {isLoading ? (
+              <Stack gap="sm">
+                {[...Array(3)].map((_, i) => (
+                  <Skeleton key={i} h={128} />
+                ))}
+              </Stack>
+            ) : filteredWorkflows.length === 0 ? (
+              <Text ta="center" c="dimmed" py="xl">
+                {search ? 'No workflows match your search' : 'No workflows available'}
+              </Text>
+            ) : (
+              <Stack gap="md">
+                {filteredWorkflows.map((workflow) => (
+                  <WorkflowCard
+                    key={workflow.id}
+                    workflow={workflow}
+                    onStartRun={() => handleStartRun(workflow.id)}
+                    onViewRuns={() => setSelectedWorkflowId(workflow.id)}
+                    canStartRun={canExecuteWorkflows}
+                  />
+                ))}
+              </Stack>
+            )}
+          </Stack>
+        </Tabs.Panel>
+
+        <Tabs.Panel value="author" pt="md">
+          <WorkflowAuthoringPanel
+            canSaveWorkflow={canWriteWorkflows}
+            onWorkflowCreated={() => {
+              void fetchWorkflows();
+              setActiveTab('browse');
+            }}
+          />
+        </Tabs.Panel>
+      </Tabs>
     </Stack>
   );
 }
 
 interface WorkflowCardProps {
-  workflow: Workflow;
+  workflow: WorkflowSummary;
   onStartRun: () => void;
   onViewRuns: () => void;
   canStartRun: boolean;

--- a/web/src/lib/api/workflows.ts
+++ b/web/src/lib/api/workflows.ts
@@ -1,0 +1,195 @@
+import type {
+  WorkflowDefinition,
+  WorkflowOutputTarget,
+  WorkflowSchedule,
+  WorkflowStep,
+} from '@veritas-kanban/shared';
+import { API_BASE, apiFetch } from './helpers';
+
+export type WorkflowRecipeInputType = 'text' | 'textarea' | 'select' | 'boolean';
+export type WorkflowLintSeverity = 'error' | 'warning' | 'info';
+export type WorkflowLintCategory =
+  | 'definition'
+  | 'input'
+  | 'context'
+  | 'permission'
+  | 'policy'
+  | 'secret'
+  | 'client'
+  | 'output'
+  | 'schedule';
+
+export interface WorkflowSummary {
+  id: string;
+  name: string;
+  version: number;
+  description: string;
+  agents?: Array<{ id: string; name: string; role?: string }>;
+  steps?: Array<{ id: string; name: string }>;
+  activeRunCount?: number;
+}
+
+export interface WorkflowRecipeInput {
+  id: string;
+  label: string;
+  type: WorkflowRecipeInputType;
+  required: boolean;
+  defaultValue?: string | boolean;
+  placeholder?: string;
+  helpText?: string;
+  options?: Array<{ value: string; label: string }>;
+}
+
+export interface WorkflowRecipe {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  inputs: WorkflowRecipeInput[];
+  defaultOutputTargets: WorkflowOutputTarget[];
+  schedule?: WorkflowSchedule;
+}
+
+export interface WorkflowLintMessage {
+  id: string;
+  severity: WorkflowLintSeverity;
+  category: WorkflowLintCategory;
+  path: string;
+  message: string;
+  remediation: string;
+}
+
+export interface WorkflowLintResult {
+  ok: boolean;
+  yaml?: string;
+  messages: WorkflowLintMessage[];
+  summary: {
+    errors: number;
+    warnings: number;
+    info: number;
+  };
+}
+
+export interface WorkflowDryRunCheck {
+  id: string;
+  label: string;
+  status: 'pass' | 'warn' | 'fail';
+  detail: string;
+}
+
+export interface WorkflowDryRunResult extends WorkflowLintResult {
+  status: 'ready' | 'attention' | 'blocked';
+  canRun: boolean;
+  checks: WorkflowDryRunCheck[];
+  workflow?: WorkflowDefinition;
+}
+
+export interface WorkflowAuthoringContext {
+  taskId?: string;
+  clientMode?: 'local' | 'remote' | 'cloud';
+  availableSecrets?: string[];
+  now?: string;
+}
+
+export interface WorkflowRecipeMaterialization {
+  recipe: WorkflowRecipe;
+  workflow: WorkflowDefinition;
+  yaml: string;
+  missingInputs: string[];
+  lint: WorkflowLintResult;
+  preview: {
+    steps: Array<{ id: string; name: string; type: WorkflowStep['type']; agent?: string }>;
+    outputTargets: WorkflowOutputTarget[];
+    schedule?: WorkflowSchedule;
+  };
+}
+
+export interface WorkflowRunStartResponse {
+  id: string;
+}
+
+function unwrapData<T>(value: T | { data: T }): T {
+  if (value && typeof value === 'object' && 'data' in value) {
+    return (value as { data: T }).data;
+  }
+  return value as T;
+}
+
+export const workflowsApi = {
+  list: async (): Promise<WorkflowSummary[]> => {
+    const response = await apiFetch<WorkflowSummary[] | { data: WorkflowSummary[] }>(
+      `${API_BASE}/workflows`
+    );
+    return unwrapData(response);
+  },
+
+  create: async (workflow: WorkflowDefinition): Promise<{ success: true; workflowId: string }> =>
+    apiFetch(`${API_BASE}/workflows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(workflow),
+    }),
+
+  startRun: async (workflowId: string): Promise<WorkflowRunStartResponse> => {
+    const response = await apiFetch<WorkflowRunStartResponse | { data: WorkflowRunStartResponse }>(
+      `${API_BASE}/workflows/${encodeURIComponent(workflowId)}/runs`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      }
+    );
+    return unwrapData(response);
+  },
+
+  recipes: async (): Promise<WorkflowRecipe[]> => {
+    const response = await apiFetch<WorkflowRecipe[] | { data: WorkflowRecipe[] }>(
+      `${API_BASE}/workflows/recipes`
+    );
+    return unwrapData(response);
+  },
+
+  materializeRecipe: async (
+    recipeId: string,
+    inputs: Record<string, unknown>,
+    context?: WorkflowAuthoringContext
+  ): Promise<WorkflowRecipeMaterialization> => {
+    const response = await apiFetch<
+      WorkflowRecipeMaterialization | { data: WorkflowRecipeMaterialization }
+    >(`${API_BASE}/workflows/recipes/${encodeURIComponent(recipeId)}/materialize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ inputs, context }),
+    });
+    return unwrapData(response);
+  },
+
+  lint: async (input: {
+    workflow?: WorkflowDefinition;
+    yaml?: string;
+    context?: WorkflowAuthoringContext;
+  }): Promise<WorkflowLintResult> =>
+    apiFetch<WorkflowLintResult>(`${API_BASE}/workflows/authoring/lint`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  dryRun: async (input: {
+    workflow?: WorkflowDefinition;
+    yaml?: string;
+    context?: WorkflowAuthoringContext;
+  }): Promise<WorkflowDryRunResult> =>
+    apiFetch<WorkflowDryRunResult>(`${API_BASE}/workflows/authoring/dry-run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  renderYaml: async (workflow: WorkflowDefinition): Promise<{ yaml: string }> =>
+    apiFetch<{ yaml: string }>(`${API_BASE}/workflows/authoring/yaml`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workflow }),
+    }),
+};


### PR DESCRIPTION
## Summary
- adds workflow recipe authoring endpoints with materialization, canonical YAML, lint, and dry-run checks for context, permissions, tool policies, secrets, client mode, outputs, and schedules
- extends workflow definitions with optional output target and schedule metadata while leaving execution unchanged
- adds Workflows Author UI for recipe forms, visual builder, YAML editing, and dry-run results

## Verification
- pnpm --filter @veritas-kanban/shared typecheck
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server test -- routes/workflow-authoring.test.ts routes/v1-permission-guards.test.ts
- pnpm --filter @veritas-kanban/web test -- workflow-surfaces-mantine.test.tsx
- pnpm --filter @veritas-kanban/server lint
- pnpm --filter @veritas-kanban/web lint
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/web build
- Browser smoke on temporary runtime: Workflows Author recipes, builder, and YAML dry-run ready; only dev websocket keepalive warnings observed

## Notes
- Device/session runtime scheduling remains unchanged; this adds authoring metadata, validation, and stable output declarations without changing workflow execution.

Closes #365