### PR TITLE
Document v5 remote server security posture

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -56,11 +56,11 @@ VK supports three authentication methods. All are optional when running locally 
 
 ### Methods
 
-| Method                 | Header / Param                  | Use Case                    |
-| ---------------------- | ------------------------------- | --------------------------- |
-| **Bearer Token** (JWT) | `Authorization: Bearer <token>` | Browser sessions, UI login  |
-| **API Key**            | `X-API-Key: <key>`              | Agent integrations, scripts |
-| **WS Query Param**     | `ws://host:port/ws?token=<key>` | WebSocket connections       |
+| Method                 | Header / Param                    | Use Case                    |
+| ---------------------- | --------------------------------- | --------------------------- |
+| **Bearer Token** (JWT) | `Authorization: Bearer <token>`   | Browser sessions, UI login  |
+| **API Key**            | `X-API-Key: <key>`                | Agent integrations, scripts |
+| **WS Query Param**     | `ws://host:port/ws?api_key=<key>` | WebSocket connections       |
 
 ### Roles
 
@@ -778,7 +778,7 @@ Three-tier health check system for container orchestration.
 ### Connection
 
 ```javascript
-const ws = new WebSocket('ws://localhost:3001/ws?token=YOUR_API_KEY');
+const ws = new WebSocket('ws://localhost:3001/ws?api_key=YOUR_API_KEY');
 ```
 
 - Max connections: 50
@@ -787,7 +787,9 @@ const ws = new WebSocket('ws://localhost:3001/ws?token=YOUR_API_KEY');
 
 ### Authentication
 
-Pass API key as `token` query parameter, or rely on localhost bypass if enabled.
+Pass API key as `api_key` query parameter only for WebSocket clients that cannot
+send headers during the upgrade. HTTP requests must use `Authorization: Bearer`
+or `X-API-Key`. In production, do not rely on localhost bypass.
 
 ### Client → Server Messages
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -53,6 +53,12 @@ Data is persisted in a Docker named volume (`kanban-data`), so it survives conta
 
 > **⚠️ Important:** Do not set `NODE_ENV=development` in your Docker environment — the UI won't load. See [NODE_ENV & Docker](#node_env--docker) for details.
 
+> **Remote security posture:** Exposing Veritas beyond loopback is v5 server
+> mode. Keep auth enabled, disable localhost bypass, use HTTPS/VPN/tunnel
+> protection for browser/mobile access, and prefer one trusted origin for `/`,
+> `/api`, and `/ws`. See
+> [ADR 0002](architecture/ADR-0002-v5-remote-server-security-posture.md).
+
 ---
 
 ## Docker Configuration
@@ -264,6 +270,11 @@ The server:
 When running behind nginx (or any reverse proxy), set the `TRUST_PROXY` environment
 variable so Express can correctly detect the real client IP from `X-Forwarded-*`
 headers. This is required for accurate rate limiting and security logging.
+
+Reverse proxy deployments should follow the trusted-host model from
+[ADR 0002](architecture/ADR-0002-v5-remote-server-security-posture.md): route
+the web app, `/api`, `/ws`, `/health`, and future PWA assets through the same
+public origin whenever possible.
 
 Common values:
 
@@ -717,6 +728,13 @@ The server exposes an unauthenticated health endpoint:
 curl http://localhost:3001/health
 # → {"status":"ok","timestamp":"2026-01-29T12:00:00.000Z"}
 ```
+
+Remote clients and desktop onboarding should also validate:
+
+- `GET /api/health` for the canonical Veritas API liveness payload.
+- `GET /health/ready` for storage, memory, and disk readiness.
+- `GET /api/auth/status` for setup/auth/session state.
+- `/ws` upgrade from the same origin used by the web app.
 
 The Docker image includes a built-in health check:
 

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -14,14 +14,17 @@ operator checklist for final release verification.
       attachments, workflow state, and audit history.
 - [ ] Multi-user mode verifies workspace switching, memberships, invitations,
       scoped API tokens, actor attribution, and RBAC denial paths.
-- [ ] Remote mode verifies pairing, trusted host validation, token/session
-      lifecycle, WebSocket sync, and local-only secret handling.
+- [ ] Remote mode verifies the
+      [ADR 0002 remote posture](architecture/ADR-0002-v5-remote-server-security-posture.md):
+      pairing, trusted-host validation, token/session lifecycle, WebSocket sync,
+      proxy headers, service-worker assumptions, and local-only secret handling.
 - [ ] Security review covers desktop bridge calls, auth/session handling,
       scoped tokens, remote access, workflow execution, and agent tool gates.
 - [ ] Performance/load review covers SQLite read/write paths, dashboard queries,
       WebSocket fan-out, workflow run updates, and remote/mobile clients.
 - [ ] Docs cover upgrade, desktop install, remote access, admin operations,
-      backup/restore, diagnostics, and known platform limits.
+      backup/restore, diagnostics, and known platform limits, with ADR 0002 as
+      the remote/server-mode security baseline.
 
 ## Mantine component-system cleanup gate
 

--- a/docs/architecture/ADR-0002-v5-remote-server-security-posture.md
+++ b/docs/architecture/ADR-0002-v5-remote-server-security-posture.md
@@ -1,0 +1,220 @@
+# ADR 0002: v5 Remote Server Mode and Network Security Posture
+
+## Status
+
+Accepted for v5.0 remote foundation.
+
+Date: 2026-06-03
+
+Issue: [#344](https://github.com/BradGroux/veritas-kanban/issues/344)
+
+## Decision
+
+Veritas Kanban v5 remote access will use a trusted-host model by default: the
+Veritas server serves the web or PWA client, REST API, WebSocket endpoint, auth
+cookies, static assets, and health endpoints from one origin. Split-origin
+deployments remain possible for development and explicitly configured
+integrations, but they are not the supported happy path for remote browser,
+desktop remote, or mobile/PWA use.
+
+Remote/server mode must never inherit local-only bypass semantics. Any
+deployment that binds outside loopback or is reachable through a tunnel,
+reverse proxy, LAN, VPN, or public hostname must run with authentication
+enabled, localhost bypass disabled, explicit origin policy, and either HTTPS or
+a trusted private network boundary.
+
+## Operating Modes
+
+| Mode                        | Binding and route model                                                                            | Security posture                                                                                                                                                                                             |
+| --------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Local-only development      | `127.0.0.1` or `localhost`; Vite may run on a separate dev origin                                  | Localhost bypass may be enabled only for local development or single-user local use. Development CORS and WebSocket localhost origin allowances do not apply to production.                                  |
+| Local desktop               | Electron supervises a loopback Veritas server and loads the renderer from that loopback origin     | Local bootstrap credentials are desktop-owned. The renderer does not gain filesystem, process, Keychain, or shell access.                                                                                    |
+| Trusted-host LAN/VPN server | Veritas serves `/`, `/api`, `/ws`, health, and static assets from one host on a trusted LAN or VPN | Auth enabled, bypass disabled, strong admin/session secrets, exact origins if any split-origin client is allowed. HTTPS or VPN/tunnel protection is required for browser/mobile use outside loopback.        |
+| Reverse-proxy/self-hosted   | Proxy terminates TLS and forwards all Veritas routes to the app server                             | `TRUST_PROXY` must be a hop count or explicit trusted subnet. Proxy must preserve `Host`, `X-Forwarded-*`, and WebSocket upgrade headers.                                                                    |
+| Tunnel remote               | Tunnel URL fronts one Veritas origin for web, API, and WebSocket                                   | Treat as remote mode, not localhost. Require auth, disable bypass, verify WebSocket upgrade, and label the connection as tunneled in desktop/mobile diagnostics.                                             |
+| Split-origin integration    | Web client and API/WS are intentionally on different origins                                       | Must configure exact `CORS_ORIGINS`, explicit WebSocket origin handling, token storage rules, and proxy headers. This is an exception for development or controlled integrations, not the default remote UX. |
+
+Unsupported or unsafe modes:
+
+- Public or shared-network access with `VERITAS_AUTH_ENABLED=false`.
+- Non-loopback access with `VERITAS_AUTH_LOCALHOST_BYPASS=true`.
+- Production wildcard CORS.
+- `TRUST_PROXY=true`, because it trusts all proxy headers.
+- Public HTTP for browser, desktop remote, or mobile/PWA sessions.
+- Long-lived credentials embedded in shareable URLs, QR codes, logs, or deep
+  links.
+
+## Network And Auth Defaults
+
+Remote/server mode uses these defaults and warnings:
+
+| Area                  | Required posture                                                                                                                                                                                         |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bind address          | Local mode binds to loopback. Server mode requires an explicit operator action such as `HOST=0.0.0.0`, Docker port publishing, a reverse proxy, or a tunnel.                                             |
+| Auth                  | `VERITAS_AUTH_ENABLED=true` for every remote mode. Setup must create a human session or use scoped tokens before privileged actions.                                                                     |
+| Localhost bypass      | `VERITAS_AUTH_LOCALHOST_BYPASS=false` for LAN, VPN, reverse-proxy, tunnel, desktop remote, and mobile/PWA access.                                                                                        |
+| Admin/session secrets | `VERITAS_ADMIN_KEY` must be strong. `VERITAS_JWT_SECRET` should be stable and managed outside logs so sessions survive restart.                                                                          |
+| Cookies               | Browser sessions use the `veritas_session` cookie with `httpOnly`, `SameSite=Strict`, and `secure` in production. Remote browser/mobile access therefore requires HTTPS or an equivalent trusted tunnel. |
+| CORS                  | Same-origin requires no CORS exception. Split-origin requires exact `CORS_ORIGINS` values with scheme, host, and port. No trailing slash, no wildcard in production.                                     |
+| WebSocket origin      | `/ws` origin validation mirrors CORS. Browser origins must match the allowlist or same-origin deployment. Non-browser clients without `Origin` still require auth.                                       |
+| Reverse proxy         | Use `TRUST_PROXY=1`, `TRUST_PROXY=2`, `loopback`, or an explicit trusted subnet. Forward `Upgrade`, `Connection`, `Host`, `X-Forwarded-For`, and `X-Forwarded-Proto`.                                    |
+| Rate limiting         | Remote rate limits use the real client IP after trusted proxy processing. Auth endpoints keep stricter limits.                                                                                           |
+| CSP                   | Server-delivered web assets keep CSP enforcement. Desktop remote mode must also keep Electron navigation/new-window guards and a sandboxed renderer.                                                     |
+
+## Trusted-Host Same-Origin Contract
+
+The remote happy path is one origin:
+
+```text
+https://kanban.example.com/          web or future PWA app shell
+https://kanban.example.com/api       REST API
+wss://kanban.example.com/ws          WebSocket updates
+https://kanban.example.com/health    liveness alias
+https://kanban.example.com/health/ready
+https://kanban.example.com/api/health
+https://kanban.example.com/api/auth/status
+```
+
+The current web client already defaults API calls to `${BASE_URL}/api` and
+WebSocket connections to `${BASE_URL}/ws`. Sub-path deployments must build with
+`VITE_BASE_PATH` so assets, API calls, WebSocket connections, and any future PWA
+manifest or service-worker scope stay under the same prefix.
+
+When PWA install support lands, the manifest and service worker must be served
+from the same trusted origin and base path as the app shell. Offline behavior
+must not cache privileged API responses, stale auth state, task attachments, or
+work products unless the release defines an explicit encrypted cache and
+revocation model.
+
+## Split-Origin Fallback Contract
+
+Split-origin deployments are allowed only when the operator can state why the
+same-origin model is not possible. They must define:
+
+- Exact `CORS_ORIGINS` for every browser origin.
+- Explicit API base URL and WebSocket URL configuration.
+- WebSocket upgrade support through any proxy in the path.
+- Token handling rules that avoid long-lived bearer tokens in local storage,
+  URLs, screenshots, logs, and copied diagnostics.
+- Cookie expectations. `SameSite=Strict` cookies are same-site only, so
+  cross-site browser sessions may need same-site subdomains, a reverse proxy, or
+  a future device-session/pairing flow instead of raw bearer tokens.
+- CSP connect-src coverage for the API and WebSocket origin if CSP needs to
+  cross origins.
+
+If any of those are missing, the split-origin deployment should be considered
+unsupported for remote/browser/mobile use.
+
+## Remote Discovery And Validation
+
+Desktop onboarding, mobile setup, and operator smoke tests should validate a
+remote origin without leaking credentials:
+
+1. Normalize and display the origin without query strings or fragments.
+2. Fetch `GET /api/health` with a short timeout.
+   Expected public payload:
+   - `ok: true`
+   - `service: "veritas-kanban"`
+   - `version`
+   - `uptimeMs`
+   - `timestamp`
+3. Fetch `GET /health/ready`.
+   Expected public payload:
+   - `status: "ok"` or `"degraded"`
+   - `checks.storage`
+   - `checks.memory`
+   - `checks.disk`
+   - `timestamp`
+4. Fetch `GET /api/auth/status`.
+   Expected public payload:
+   - `needsSetup`
+   - `authenticated`
+   - `sessionExpiry`
+   - `authEnabled`
+5. Attempt a `/ws` upgrade from the same origin and verify the connection can
+   authenticate with the current session or a scoped token.
+6. For a logged-in user or supplied scoped token, fetch `GET /api/auth/context`
+   and show only non-secret metadata: role, actor type, auth method, workspace,
+   token name, and permissions.
+
+Validation must redact `Authorization`, `X-API-Key`, cookies, tokens, query
+strings, recovery keys, invite tokens, local file paths, attachment names unless
+explicitly selected, and user content by default.
+
+## Threat Model
+
+Remote mode expands the attack surface beyond a single loopback browser. The
+design must assume hostile origins, stale credentials, shared networks,
+malicious attachments, and compromised clients.
+
+| Surface                            | Primary risks                                                                                          | Required controls                                                                                                                                                            |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agent execution                    | Remote user or token starts local code, shell, workflow, Git, or OpenClaw actions unexpectedly         | RBAC, workflow readiness gates, policy engine, scoped agent tokens, audit trails, explicit user intent for dangerous actions.                                                |
+| Git and worktrees                  | Remote-triggered branch, commit, PR, merge, or cleanup actions alter repositories                      | Permission gates, workspace scoping, confirmation for destructive actions, actor attribution, no broad service tokens.                                                       |
+| Workflow triggers                  | Remote clients trigger workflows with stale context, denied tools, unsafe outputs, or missing secrets  | Dry-run linting, policy checks, secret availability checks, output target validation, run provenance.                                                                        |
+| WebSockets                         | Cross-site WebSocket hijacking, token leakage, unauthenticated subscriptions, connection fan-out abuse | Origin validation, auth on connect, scoped subscriptions, heartbeat cleanup, rate/connection limits, no secret payloads.                                                     |
+| File attachments and work products | Malware, path traversal, oversized uploads, private data exposure                                      | MIME/path validation, storage scoping, size limits, sanitized previews, explicit download/export, redacted diagnostics.                                                      |
+| Native desktop remote              | Remote origin tries to gain local desktop bridge capabilities                                          | Remote origins get no local-only bridge powers by default. Electron navigation guards, origin allowlist, sandbox, `contextIsolation`, and server-side auth decide authority. |
+| PWA/mobile                         | Stale cached data, lost device, token reuse, shareable URLs                                            | Device sessions/pairing, revocation, safe service-worker scope, no long-lived tokens in URLs, visible remote origin labeling.                                                |
+| Reverse proxy                      | Spoofed client IP/proto, broken WebSocket upgrade, downgraded TLS                                      | Explicit `TRUST_PROXY`, TLS redirect/HSTS, forwarded header handling, proxy smoke tests.                                                                                     |
+| Logs and diagnostics               | Secrets or user content exposed in support bundles                                                     | Default redaction, opt-in user content, query-string stripping, token-pattern scrubbing.                                                                                     |
+
+## Admin Warnings
+
+Settings, desktop onboarding, logs, and docs should warn when a configuration
+suggests accidental exposure:
+
+- `HOST=0.0.0.0` or a non-loopback bind with auth disabled.
+- `VERITAS_AUTH_LOCALHOST_BYPASS=true` while reachable from non-loopback
+  addresses.
+- `CORS_ORIGINS=*` or an origin list that does not include the visible remote
+  host.
+- `TRUST_PROXY=true`.
+- Production HTTP origin for browser/mobile sessions.
+- Missing or weak `VERITAS_ADMIN_KEY`.
+- Missing stable `VERITAS_JWT_SECRET` in a remote deployment.
+- Reverse proxy does not support `/ws` upgrade.
+- Sub-path deployment missing `VITE_BASE_PATH`.
+- Tunnel provider rewrites paths or strips WebSocket upgrade headers.
+
+Warnings should name the unsafe setting and the safer replacement without
+printing secret values.
+
+## Diagnostics And Logging
+
+Remote diagnostics should show:
+
+- Normalized origin label.
+- Connection mode: local, LAN/VPN, reverse-proxy, tunnel, split-origin, or
+  unknown.
+- Health status and readiness checks.
+- Auth mode and setup/authenticated state.
+- WebSocket upgrade status and latency bucket.
+- Proxy trust mode and whether forwarded headers are present.
+- CSP report-only/enforced state when known.
+
+Remote diagnostics must not show:
+
+- Raw cookies, `Authorization`, `X-API-Key`, API tokens, JWTs, recovery keys, or
+  invite tokens.
+- Full URLs with credential-bearing query strings.
+- User task content, attachment content, or work-product content unless the user
+  explicitly includes it in a support bundle.
+- Native filesystem paths from another user's machine unless needed and
+  redacted.
+
+## Implementation Notes
+
+This ADR defines the posture for #344. Follow-up issues should implement the
+missing enforcement and UX pieces:
+
+- #345 device sessions and secure pairing.
+- #346 mobile-responsive remote surfaces.
+- #347 PWA install support and remote-safe offline behavior.
+- #348 realtime sync hardening for multi-client use.
+- #350 security review proof against this ADR.
+- #352 remote access and admin guides.
+
+ADR 0001 remains the desktop shell architecture. This ADR is the network and
+remote trust contract that desktop, browser, mobile/PWA, CLI, MCP, and
+self-hosted deployments must share.

--- a/docs/guides/SELF_HOST.md
+++ b/docs/guides/SELF_HOST.md
@@ -4,6 +4,11 @@ This guide walks you through every self-hosting scenario — from running locall
 
 > **Credit:** This guide was originally contributed by [@xechehot](https://github.com/xechehot) in [PR #126](https://github.com/BradGroux/veritas-kanban/pull/126). It has been expanded here to cover additional deployment patterns.
 
+> **Remote security posture:** v5 remote access is designed around a trusted
+> same-origin host for the web client, `/api`, and `/ws`. Before exposing
+> Veritas beyond loopback, read
+> [ADR 0002: v5 Remote Server Mode and Network Security Posture](../architecture/ADR-0002-v5-remote-server-security-posture.md).
+
 ---
 
 ## Table of Contents
@@ -25,11 +30,11 @@ This guide walks you through every self-hosting scenario — from running locall
 
 ## Prerequisites
 
-| Requirement | Version  | Install                                   |
-|-------------|----------|-------------------------------------------|
-| Node.js     | 22.0.0+  | https://nodejs.org or `nvm install 22`    |
-| pnpm        | 9.0.0+   | `corepack enable && corepack prepare pnpm@9.15.4 --activate` |
-| Git         | any      | https://git-scm.com                       |
+| Requirement | Version | Install                                                      |
+| ----------- | ------- | ------------------------------------------------------------ |
+| Node.js     | 22.0.0+ | https://nodejs.org or `nvm install 22`                       |
+| pnpm        | 9.0.0+  | `corepack enable && corepack prepare pnpm@9.15.4 --activate` |
+| Git         | any     | https://git-scm.com                                          |
 
 Verify:
 
@@ -60,11 +65,11 @@ cp server/.env.example server/.env
 
 The build produces:
 
-| Path              | Contents                              |
-|-------------------|---------------------------------------|
-| `shared/dist/`    | Shared TypeScript types and utilities |
-| `server/dist/`    | Compiled Express API server           |
-| `web/dist/`       | Static React frontend (served by Express in production) |
+| Path           | Contents                                                |
+| -------------- | ------------------------------------------------------- |
+| `shared/dist/` | Shared TypeScript types and utilities                   |
+| `server/dist/` | Compiled Express API server                             |
+| `web/dist/`    | Static React frontend (served by Express in production) |
 
 ---
 
@@ -84,7 +89,12 @@ The app is now available at **http://localhost:3001**.
 - **WebSocket:** `ws://localhost:3001/ws`
 - **API Docs (Swagger):** `http://localhost:3001/api-docs`
 
-By default, `VERITAS_AUTH_LOCALHOST_BYPASS=true` in `.env.example`, so unauthenticated requests from `localhost` are allowed with the `read-only` role. Set `VERITAS_AUTH_LOCALHOST_ROLE=admin` if you want full access without a key on your local machine.
+The example env file keeps `VERITAS_AUTH_LOCALHOST_BYPASS=true` for local
+development convenience, so unauthenticated loopback requests can use the
+configured local role outside production. In `NODE_ENV=production`, the server
+does not honor localhost bypass for HTTP or WebSocket auth. Set
+`VERITAS_AUTH_LOCALHOST_ROLE=admin` only for trusted local development when you
+want full access without a key on your own machine.
 
 ### Development mode
 
@@ -103,6 +113,11 @@ pnpm dev
 ## LAN Access
 
 Serve Veritas Kanban to other devices on your local network (phones, other laptops, tablets).
+
+LAN access is server mode, not localhost mode. Keep `VERITAS_AUTH_ENABLED=true`,
+set `VERITAS_AUTH_LOCALHOST_BYPASS=false`, and use HTTPS, VPN, or a trusted
+tunnel for browser/mobile sessions unless the network is strictly private and
+temporary.
 
 ### 1. Bind to all interfaces
 
@@ -158,6 +173,10 @@ Your LAN URL will be `http://<your-ip>:3001`.
 ## Tailscale Serve
 
 Tailscale Serve lets you expose Veritas Kanban securely to your tailnet (all your devices) without opening firewall ports. This was the primary use case from [@xechehot's original PR #126](https://github.com/BradGroux/veritas-kanban/pull/126).
+
+Treat the Tailscale URL as a remote origin. Do not rely on localhost bypass for
+tailnet clients, and verify `/api`, `/ws`, `/health/ready`, and
+`/api/auth/status` through the served HTTPS URL.
 
 ### Option A: Root path (simplest)
 
@@ -232,6 +251,11 @@ tailscale funnel 443 on
 ## Reverse Proxy
 
 For production deployments with TLS, use a reverse proxy in front of Veritas Kanban. Always set `TRUST_PROXY` when behind a proxy.
+
+The supported reverse-proxy shape is same-origin: the proxy serves the app shell,
+API, WebSocket, health endpoints, and future PWA assets from the same public
+origin. Split-origin setups require exact `CORS_ORIGINS`, WebSocket upgrade
+testing, and explicit token handling as described in ADR 0002.
 
 ### nginx
 
@@ -386,8 +410,8 @@ services:
       - NODE_ENV=production
       - PORT=3001
       - DATA_DIR=/app/data
-      - VERITAS_ADMIN_KEY=your-secure-admin-key-here  # ≥ 32 chars
-      - VERITAS_JWT_SECRET=your-jwt-secret-here       # prevents session resets on restart
+      - VERITAS_ADMIN_KEY=your-secure-admin-key-here # ≥ 32 chars
+      - VERITAS_JWT_SECRET=your-jwt-secret-here # prevents session resets on restart
       # - CORS_ORIGINS=https://kanban.example.com
       # - TRUST_PROXY=1                               # if behind nginx/Caddy/Traefik
       # - VERITAS_API_KEYS=agent1:key1:agent,readonly:key2:read-only
@@ -464,6 +488,11 @@ VERITAS_JWT_SECRET=<output of openssl rand -hex 64>
 VERITAS_AUTH_LOCALHOST_BYPASS=false
 ```
 
+When exposing Veritas beyond loopback, also use `NODE_ENV=production` and keep
+the web client, `/api`, `/ws`, health endpoints, PWA assets, and service-worker
+scope on one trusted origin whenever possible. Split-origin deployments must set
+exact `CORS_ORIGINS` entries and confirm WebSocket origin/upgrade behavior.
+
 ### API keys for agents
 
 Grant agents scoped access without giving them the admin key:
@@ -476,11 +505,11 @@ VERITAS_API_KEYS=my-agent:vk_abc123:agent,dashboard:vk_xyz456:read-only
 
 Role permissions:
 
-| Role        | Access                                             |
-|-------------|----------------------------------------------------|
-| `admin`     | Full access to all endpoints                       |
-| `agent`     | Read/write tasks, run agents, manage worktrees     |
-| `read-only` | GET endpoints only (view tasks, read config)       |
+| Role        | Access                                         |
+| ----------- | ---------------------------------------------- |
+| `admin`     | Full access to all endpoints                   |
+| `agent`     | Read/write tasks, run agents, manage worktrees |
+| `read-only` | GET endpoints only (view tasks, read config)   |
 
 ### Authentication methods
 
@@ -494,6 +523,12 @@ curl -H "X-API-Key: <api-key>" http://localhost:3001/api/tasks
 # Query parameter (WebSocket)
 wscat -c "ws://localhost:3001/ws?api_key=<api-key>"
 ```
+
+HTTP requests must pass API keys in `Authorization: Bearer <key>` or
+`X-API-Key`. Do not put long-lived credentials in HTTP query strings, bookmarks,
+QR codes, screenshots, reverse-proxy logs, or shareable URLs. The WebSocket
+`api_key` query fallback exists for clients that cannot set headers during the
+upgrade.
 
 ### TRUST_PROXY
 
@@ -515,17 +550,17 @@ All variables live in `server/.env` (copy from `server/.env.example`).
 
 ### Server
 
-| Variable    | Default | Description                                              |
-|-------------|---------|----------------------------------------------------------|
-| `PORT`      | `3001`  | HTTP server port                                         |
-| `HOST`      | `127.0.0.1` | Bind address. Set `0.0.0.0` for LAN/container access |
-| `NODE_ENV`  | —       | `production` for production. **Never `development` in Docker** |
-| `LOG_LEVEL` | `info`  | `trace` / `debug` / `info` / `warn` / `error` / `fatal` |
+| Variable    | Default     | Description                                                    |
+| ----------- | ----------- | -------------------------------------------------------------- |
+| `PORT`      | `3001`      | HTTP server port                                               |
+| `HOST`      | `127.0.0.1` | Bind address. Set `0.0.0.0` for LAN/container access           |
+| `NODE_ENV`  | —           | `production` for production. **Never `development` in Docker** |
+| `LOG_LEVEL` | `info`      | `trace` / `debug` / `info` / `warn` / `error` / `fatal`        |
 
 ### Authentication
 
 | Variable                        | Default     | Description                                                            |
-|---------------------------------|-------------|------------------------------------------------------------------------|
+| ------------------------------- | ----------- | ---------------------------------------------------------------------- |
 | `VERITAS_AUTH_ENABLED`          | `true`      | Enable authentication. Set `false` only for trusted local use          |
 | `VERITAS_ADMIN_KEY`             | —           | Admin API key. **Must be ≥ 32 chars.** Required for production         |
 | `VERITAS_API_KEYS`              | —           | Additional keys. Format: `name:key:role,name2:key2:role2`              |
@@ -535,35 +570,35 @@ All variables live in `server/.env` (copy from `server/.env.example`).
 
 ### Networking
 
-| Variable         | Default                         | Description                                                                 |
-|------------------|---------------------------------|-----------------------------------------------------------------------------|
-| `CORS_ORIGINS`   | `http://localhost:3000,...`     | Comma-separated allowed CORS origins                                        |
-| `TRUST_PROXY`    | —                               | Express proxy trust. Use `1` for single-hop (nginx/Caddy). `true` is blocked |
-| `RATE_LIMIT_MAX` | `300`                           | Max API requests/minute/IP (localhost exempt)                               |
+| Variable         | Default                     | Description                                                                  |
+| ---------------- | --------------------------- | ---------------------------------------------------------------------------- |
+| `CORS_ORIGINS`   | `http://localhost:3000,...` | Comma-separated allowed CORS origins                                         |
+| `TRUST_PROXY`    | —                           | Express proxy trust. Use `1` for single-hop (nginx/Caddy). `true` is blocked |
+| `RATE_LIMIT_MAX` | `300`                       | Max API requests/minute/IP (localhost exempt)                                |
 
 ### Data & Storage
 
-| Variable                   | Default              | Description                                              |
-|----------------------------|----------------------|----------------------------------------------------------|
-| `VERITAS_DATA_DIR`         | `.veritas-kanban`    | Config, logs, internal state (relative to project root)  |
-| `DATA_DIR`                 | `/app/data` (Docker) | Mapped data dir inside Docker container                  |
-| `TELEMETRY_RETENTION_DAYS` | `30`                 | Days to keep telemetry event files                       |
-| `TELEMETRY_COMPRESS_DAYS`  | `7`                  | Days after which telemetry files are gzip-compressed     |
+| Variable                   | Default              | Description                                             |
+| -------------------------- | -------------------- | ------------------------------------------------------- |
+| `VERITAS_DATA_DIR`         | `.veritas-kanban`    | Config, logs, internal state (relative to project root) |
+| `DATA_DIR`                 | `/app/data` (Docker) | Mapped data dir inside Docker container                 |
+| `TELEMETRY_RETENTION_DAYS` | `30`                 | Days to keep telemetry event files                      |
+| `TELEMETRY_COMPRESS_DAYS`  | `7`                  | Days after which telemetry files are gzip-compressed    |
 
 ### Frontend (build-time)
 
-| Variable         | Default | Description                                                                          |
-|------------------|---------|--------------------------------------------------------------------------------------|
-| `VITE_BASE_PATH` | `/`     | Sub-path prefix for the frontend (e.g., `/kanban/`). Set at build time, not runtime |
-| `VITE_ALLOWED_HOSTS` | —   | Comma-separated hostnames allowed by Vite dev server (dev only). `*` allows all      |
+| Variable             | Default | Description                                                                         |
+| -------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `VITE_BASE_PATH`     | `/`     | Sub-path prefix for the frontend (e.g., `/kanban/`). Set at build time, not runtime |
+| `VITE_ALLOWED_HOSTS` | —       | Comma-separated hostnames allowed by Vite dev server (dev only). `*` allows all     |
 
 ### Integration
 
-| Variable                 | Default                      | Description                                      |
-|--------------------------|------------------------------|--------------------------------------------------|
-| `CLAWDBOT_GATEWAY`       | `http://127.0.0.1:18789`     | OpenClaw gateway URL for AI agent orchestration  |
-| `VERITAS_WEBHOOK_URL`    | —                            | Push task/chat events to an external service     |
-| `VERITAS_WEBHOOK_SECRET` | —                            | HMAC-SHA256 secret for webhook payload signing   |
+| Variable                 | Default                  | Description                                     |
+| ------------------------ | ------------------------ | ----------------------------------------------- |
+| `CLAWDBOT_GATEWAY`       | `http://127.0.0.1:18789` | OpenClaw gateway URL for AI agent orchestration |
+| `VERITAS_WEBHOOK_URL`    | —                        | Push task/chat events to an external service    |
+| `VERITAS_WEBHOOK_SECRET` | —                        | HMAC-SHA256 secret for webhook payload signing  |
 
 ---
 
@@ -678,4 +713,4 @@ curl -H "X-API-Key: your-admin-key" http://localhost:3001/api/auth/diagnostics
 
 ---
 
-*For general deployment (Docker, bare metal, systemd, reverse proxy) see also [docs/DEPLOYMENT.md](../DEPLOYMENT.md).*
+_For general deployment (Docker, bare metal, systemd, reverse proxy) see also [docs/DEPLOYMENT.md](../DEPLOYMENT.md)._

--- a/docs/security.md
+++ b/docs/security.md
@@ -16,7 +16,9 @@ VERITAS_AUTH_ENABLED=true
 VERITAS_AUTH_LOCALHOST_BYPASS=true
 ```
 
-This allows unauthenticated requests from `localhost`/`127.0.0.1` while still requiring auth for remote connections.
+This allows unauthenticated requests from `localhost`/`127.0.0.1` while still requiring auth for remote connections during development.
+In `NODE_ENV=production`, localhost bypass is not honored for HTTP or WebSocket
+auth, even if an old `.env` file still enables it.
 
 ### Production
 
@@ -29,6 +31,15 @@ VERITAS_AUTH_LOCALHOST_BYPASS=false
 VERITAS_ADMIN_KEY=your-secure-admin-key
 VERITAS_API_KEYS=agent1:key1:agent,dashboard:key2:read-only
 ```
+
+### Remote/Server Mode
+
+Remote access must follow the v5 remote security posture in
+[ADR 0002](architecture/ADR-0002-v5-remote-server-security-posture.md). In
+short: prefer one trusted origin for the web client, `/api`, and `/ws`; keep
+auth enabled; disable localhost bypass outside loopback; use HTTPS, VPN, or a
+trusted tunnel for browser/mobile sessions; and use exact origins instead of
+wildcard CORS.
 
 ## Authentication Methods
 
@@ -53,6 +64,10 @@ curl -H "X-API-Key: your-api-key" \
 ```javascript
 const ws = new WebSocket('ws://localhost:3001/ws?api_key=your-api-key');
 ```
+
+HTTP requests do not accept API keys in query strings. Use headers for HTTP and
+reserve the WebSocket `api_key` query fallback for clients that cannot send auth
+headers during the upgrade.
 
 ## Roles and Permissions
 
@@ -108,12 +123,12 @@ classification.
 
 ### Environment Variables
 
-| Variable                        | Default | Description                                        |
-| ------------------------------- | ------- | -------------------------------------------------- |
-| `VERITAS_AUTH_ENABLED`          | `true`  | Enable/disable authentication                      |
-| `VERITAS_AUTH_LOCALHOST_BYPASS` | `false` | Allow unauthenticated localhost requests           |
-| `VERITAS_ADMIN_KEY`             | (none)  | Admin API key with full access                     |
-| `VERITAS_API_KEYS`              | (none)  | Comma-separated API keys (format: `name:key:role`) |
+| Variable                        | Default | Description                                             |
+| ------------------------------- | ------- | ------------------------------------------------------- |
+| `VERITAS_AUTH_ENABLED`          | `true`  | Enable/disable authentication                           |
+| `VERITAS_AUTH_LOCALHOST_BYPASS` | `false` | Allow unauthenticated localhost requests in development |
+| `VERITAS_ADMIN_KEY`             | (none)  | Admin API key with full access                          |
+| `VERITAS_API_KEYS`              | (none)  | Comma-separated API keys (format: `name:key:role`)      |
 
 ### API Key Format
 
@@ -225,6 +240,11 @@ ws.onclose = (event) => {
 4. **Principle of least privilege** - Use `read-only` for dashboards, `agent` for automation
 
 5. **Monitor access** - The server logs connection attempts with role information
+
+6. **Keep remote mode explicit** - Binding outside loopback, reverse proxying,
+   tunneling, or serving mobile/PWA clients requires auth enabled, localhost
+   bypass disabled, exact CORS/WebSocket origins, and redacted diagnostics. See
+   [ADR 0002](architecture/ADR-0002-v5-remote-server-security-posture.md).
 
 ## Migrating from No Auth
 


### PR DESCRIPTION
## Summary
- adds ADR 0002 defining the v5 remote/server-mode security posture, including trusted-host same-origin defaults, split-origin fallback requirements, discovery endpoints, threat model, admin warnings, and diagnostics redaction rules
- updates deployment, self-hosting, security, API reference, and GA checklist docs to point at the remote posture and current auth/WebSocket contracts
- corrects stale WebSocket API docs to use the actual api_key query parameter and clarifies HTTP keys must use headers

## Verification
- pnpm --filter @veritas-kanban/server test -- routes/health.test.ts middleware/auth.test.ts ws-origin-validation.test.ts
- pnpm --filter @veritas-kanban/web test -- desktop-onboarding.test.tsx
- git diff --check

## Notes
- No runtime behavior changes. This locks the design contract before #345 through #348 implementation work.

Closes #344