### PR TITLE
Add mobile responsive task flows

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -11,7 +11,7 @@ const ADMIN_KEY = process.env.VERITAS_ADMIN_KEY || 'dev-admin-key';
  * Backend API base URL. Direct to Express on port 3001 to avoid
  * Vite proxy issues (IPv4/IPv6 binding differences on macOS).
  */
-const API_BASE = process.env.API_BASE_URL || 'http://localhost:3001';
+const API_BASE = process.env.API_BASE_URL || 'http://127.0.0.1:3001';
 
 /**
  * Bypass authentication for E2E tests.
@@ -116,7 +116,7 @@ export async function seedTestTask(
   page: Page,
   overrides: Record<string, unknown> = {}
 ): Promise<Record<string, unknown>> {
-  const { status: desiredStatus, ...rest } = overrides;
+  const { status: desiredStatus, git: desiredGit, ...rest } = overrides;
 
   const taskData = {
     title: `E2E Test Task ${Date.now()}`,
@@ -137,24 +137,33 @@ export async function seedTestTask(
     throw new Error(`Failed to seed task: ${response.status()} ${await response.text()}`);
   }
 
-  const task = await response.json();
+  const createdBody = await response.json();
+  const task = (createdBody as { data?: Record<string, unknown> }).data ?? createdBody;
 
-  // The API always creates tasks as 'todo'. If a different status was
-  // requested, PATCH it after creation.
+  // The API creates tasks as 'todo' and only accepts git/worktree data on PATCH.
   const targetStatus = desiredStatus ?? 'todo';
+  const patchData: Record<string, unknown> = {};
   if (targetStatus !== 'todo') {
+    patchData.status = targetStatus;
+  }
+  if (desiredGit) {
+    patchData.git = desiredGit;
+  }
+
+  if (Object.keys(patchData).length > 0) {
     const patchResponse = await withRetry(() =>
       page.request.patch(`${API_BASE}/api/tasks/${(task as { id: string }).id}`, {
         headers: { 'X-API-Key': ADMIN_KEY, 'Content-Type': 'application/json' },
-        data: { status: targetStatus },
+        data: patchData,
       })
     );
     if (!patchResponse.ok()) {
       throw new Error(
-        `Failed to set task status to ${targetStatus as string}: ${patchResponse.status()}`
+        `Failed to patch seeded task: ${patchResponse.status()} ${await patchResponse.text()}`
       );
     }
-    return patchResponse.json();
+    const patchedBody = await patchResponse.json();
+    return (patchedBody as { data?: Record<string, unknown> }).data ?? patchedBody;
   }
 
   return task;

--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from '@playwright/test';
+import { bypassAuth, cleanupRoutes, deleteTask, seedTestTask } from './helpers/auth';
+
+async function useMobileDeviceContext(page: Page) {
+  await page.route('**/api/auth/context', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        role: 'read-only',
+        isLocalhost: false,
+        actorType: 'device',
+        authMethod: 'device-session',
+        deviceSessionId: 'e2e-mobile-session',
+        deviceId: 'e2e-phone',
+        clientId: 'e2e-mobile-browser',
+        clientMode: 'mobile-pwa',
+        capabilities: [
+          'board:read',
+          'workspace:read',
+          'task:read',
+          'task:write',
+          'comment:write',
+          'workflow:read',
+          'notification:read',
+          'notification:receive',
+        ],
+        permissions: [
+          'workspace:read',
+          'task:read',
+          'task:write',
+          'comment:write',
+          'workflow:read',
+          'work_product:read',
+          'agent:read',
+          'settings:read',
+        ],
+      }),
+    })
+  );
+}
+
+test.describe('mobile responsive flows', () => {
+  let testTaskId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    await bypassAuth(page);
+    await useMobileDeviceContext(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (testTaskId) {
+      await deleteTask(page, testTaskId).catch(() => {});
+      testTaskId = null;
+    }
+    await cleanupRoutes(page);
+  });
+
+  test('supports board, task detail, comments, approval review, notifications, and pairing setup', async ({
+    page,
+  }) => {
+    const taskTitle = `E2E Mobile Responsive Task ${Date.now()}`;
+    const task = await seedTestTask(page, {
+      title: taskTitle,
+      description: 'Verify phone-sized task review and coordination flows.',
+      status: 'todo',
+      priority: 'high',
+      type: 'code',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'mobile-responsive-e2e',
+        baseBranch: 'main',
+        worktreePath: '/tmp/mobile-responsive-e2e',
+      },
+      verificationSteps: [
+        { id: 'mobile-verify', description: 'Mobile responsive e2e passes', checked: false },
+      ],
+    });
+    testTaskId = (task as { id: string }).id;
+
+    await page.goto('/');
+
+    await expect(page.getByRole('navigation', { name: 'Mobile navigation' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Mobile notifications' })).toBeVisible();
+
+    const statusSelect = page.getByRole('combobox', {
+      name: `Change status for ${taskTitle}`,
+    });
+    await expect(statusSelect).toBeVisible();
+    await statusSelect.click();
+    await page.getByRole('option', { name: 'Blocked' }).click();
+    await expect(page.getByText(taskTitle).first()).toBeVisible();
+
+    await page.getByText(taskTitle).first().click();
+    const detail = page.getByTestId('task-detail-panel');
+    await expect(detail).toBeVisible();
+    await expect(detail.getByRole('textbox', { name: 'Task title' })).toHaveValue(taskTitle);
+    const detailBox = await detail.boundingBox();
+    expect(detailBox?.width ?? 0).toBeLessThanOrEqual(page.viewportSize()!.width);
+
+    await detail.getByRole('tab', { name: 'Review', exact: true }).click();
+    await detail.getByRole('button', { name: 'Request Changes' }).click();
+    await detail.getByPlaceholder('Describe the changes needed...').fill('Mobile review works.');
+    await detail.getByRole('button', { name: 'Submit Changes Requested' }).click();
+    await expect(detail.getByText('Mobile review works.')).toBeVisible();
+
+    await detail.getByRole('tab', { name: 'Details' }).click();
+    await detail.getByPlaceholder(/Add a comment/).fill('Mobile comment submitted.');
+    await detail.getByRole('button', { name: 'Add Comment' }).click();
+    await expect(detail.getByText('Mobile comment submitted.')).toBeVisible();
+
+    await detail.getByRole('button', { name: 'Close task details' }).click();
+    await expect(detail).not.toBeVisible();
+
+    await page.getByRole('button', { name: 'Mobile notifications' }).click();
+    const notifications = page.getByLabel('Notifications', { exact: true });
+    await expect(notifications).toBeVisible();
+    await expect(notifications.getByRole('heading', { name: 'Needs Attention' })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(notifications).not.toBeVisible();
+
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent('veritas:open-diagnostics')));
+    await page.getByRole('button', { name: /Remote Server/ }).click();
+    await expect(page.getByLabel('Pairing link')).toBeVisible();
+  });
+
+  test('renders login controls at a phone viewport', async ({ page }) => {
+    await cleanupRoutes(page);
+    await page.route('**/api/auth/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          needsSetup: false,
+          authenticated: false,
+          sessionExpiry: null,
+          authEnabled: true,
+        }),
+      })
+    );
+
+    await page.goto('/');
+
+    await expect(page.getByPlaceholder('Enter your password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Forgot password?' })).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,8 +19,8 @@ if (!process.env.VERITAS_ADMIN_KEY) {
  * Playwright E2E test configuration for Veritas Kanban.
  *
  * Expects the dev server to be running:
- *   - Vite dev server on http://localhost:3000 (serves frontend, proxies API)
- *   - Express API server on http://localhost:3001
+ *   - Vite dev server on http://127.0.0.1:3000 (serves frontend, proxies API)
+ *   - Express API server on http://127.0.0.1:3001
  *
  * Start with: pnpm dev
  */
@@ -34,7 +34,7 @@ export default defineConfig({
   timeout: 30_000,
 
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://127.0.0.1:3000',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // Auth — read admin key from server/.env (loaded via dotenv above)
@@ -47,22 +47,39 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      testIgnore: /mobile-responsive\.spec\.ts/,
+    },
+    {
+      name: 'mobile-chromium',
+      use: { ...devices['Pixel 5'] },
+      testMatch: /mobile-responsive\.spec\.ts/,
     },
   ],
 
   /* Run dev servers before starting tests (if not already running) */
   webServer: [
     {
-      command: 'pnpm --filter server dev',
+      command: 'cd server && node_modules/.bin/tsx src/index.ts',
       port: 3001,
       reuseExistingServer: true,
-      timeout: 15_000,
+      timeout: 30_000,
+      env: {
+        VERITAS_ADMIN_KEY: process.env.VERITAS_ADMIN_KEY || 'dev-admin-key',
+        VERITAS_DISABLE_WATCHERS: '1',
+        VERITAS_AUTH_LOCALHOST_BYPASS: 'true',
+        VERITAS_AUTH_LOCALHOST_ROLE: 'admin',
+      },
     },
     {
-      command: 'pnpm --filter web dev',
-      url: 'http://localhost:3000',
+      command: 'cd web && node_modules/.bin/vite --host 127.0.0.1',
+      url: 'http://127.0.0.1:3000',
       reuseExistingServer: true,
-      timeout: 15_000,
+      timeout: 30_000,
+      env: {
+        VITE_API_URL: 'http://127.0.0.1:3001/api',
+        VITE_API_PROXY_TARGET: 'http://127.0.0.1:3001',
+        VITE_WS_PROXY_TARGET: 'ws://127.0.0.1:3001',
+      },
     },
   ],
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { SkipToContent } from './components/shared/SkipToContent';
 import { LiveAnnouncerProvider } from './components/shared/LiveAnnouncer';
 import { FloatingChat } from './components/chat/FloatingChat';
 import { SystemHealthBar } from './components/layout/SystemHealthBar';
+import { MobileShell } from './components/layout/MobileShell';
 import { VIEW_BY_ID, type AppView } from './lib/views';
 
 // Lazy-load ActivityFeed and BacklogPage to keep initial bundle small
@@ -220,7 +221,8 @@ function AppContent() {
                       component="main"
                       id="main-content"
                       px={{ base: 'md', md: '3.5rem' }}
-                      py="lg"
+                      pt="lg"
+                      pb={{ base: '6rem', md: 'lg' }}
                       tabIndex={-1}
                     >
                       <ErrorBoundary level="section">
@@ -230,6 +232,7 @@ function AppContent() {
                     <Toaster />
                     <CommandPalette />
                     <FloatingChat />
+                    <MobileShell />
                     <DesktopOnboardingDialog
                       open={showDesktopOnboarding}
                       onOpenChange={setShowDesktopOnboarding}

--- a/web/src/__tests__/TaskCard.test.tsx
+++ b/web/src/__tests__/TaskCard.test.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TaskCard } from '@/components/task/TaskCard';
 import { createMockTask } from './test-utils';
 import { MantineRoot } from '@/theme/MantineRoot';
@@ -115,6 +116,21 @@ function ensureMantineBrowserApis() {
       }),
     });
   }
+
+  if (typeof window.ResizeObserver !== 'function') {
+    Object.defineProperty(window, 'ResizeObserver', {
+      configurable: true,
+      value: class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    });
+  }
+
+  if (typeof Element.prototype.scrollIntoView !== 'function') {
+    Element.prototype.scrollIntoView = () => {};
+  }
 }
 
 function renderCard(task: Task, props: Partial<React.ComponentProps<typeof TaskCard>> = {}) {
@@ -181,6 +197,32 @@ describe('TaskCard', () => {
     const card = screen.getByRole('article');
     fireEvent.click(card);
     expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('supports touch status changes without opening the task card', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const onStatusChange = vi.fn();
+    const task = createMockTask({ title: 'Touch status task', status: 'todo' });
+
+    renderCard(task, {
+      canChangeStatus: true,
+      onClick,
+      onStatusChange,
+      showStatusControl: true,
+      statusOptions: [
+        { value: 'todo', label: 'To Do' },
+        { value: 'in-progress', label: 'In Progress' },
+        { value: 'blocked', label: 'Blocked' },
+        { value: 'done', label: 'Done' },
+      ],
+    });
+
+    await user.click(screen.getByRole('combobox', { name: 'Change status for Touch status task' }));
+    await user.click(await screen.findByRole('option', { name: 'In Progress' }));
+
+    expect(onStatusChange).toHaveBeenCalledWith('in-progress');
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it('handles Enter key press', () => {

--- a/web/src/__tests__/mobile-shell.test.tsx
+++ b/web/src/__tests__/mobile-shell.test.tsx
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { MobileShell } from '@/components/layout/MobileShell';
+import { ViewProvider } from '@/contexts/ViewContext';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  identity: {
+    authContext: {
+      authMethod: 'device-session',
+      clientMode: 'mobile-pwa',
+      isLocalhost: false,
+      permissions: ['workspace:read', 'task:read', 'comment:write'],
+      role: 'read-only',
+    },
+    hasPermission: vi.fn((permission: string) => permission === 'settings:read'),
+  },
+}));
+
+vi.mock('@/hooks/useIdentity', () => ({
+  useIdentity: () => mocks.identity,
+}));
+
+vi.mock('@/components/dashboard/NeedsAttentionQueue', () => ({
+  NeedsAttentionQueue: ({ onOpenTask }: { onOpenTask?: (taskId: string) => void }) => (
+    <button type="button" onClick={() => onOpenTask?.('task-mobile')}>
+      Open mobile approval
+    </button>
+  ),
+}));
+
+function renderMobileShell() {
+  return renderWithProviders(
+    <ViewProvider>
+      <MobileShell />
+    </ViewProvider>
+  );
+}
+
+describe('mobile shell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders mobile navigation with inbox, runs, work products, and settings-lite actions', async () => {
+    const user = userEvent.setup();
+    const settingsListener = vi.fn();
+    const searchListener = vi.fn();
+    window.addEventListener('veritas:open-settings', settingsListener);
+    window.addEventListener('veritas:open-search', searchListener);
+
+    renderMobileShell();
+
+    expect(screen.getByRole('navigation', { name: 'Mobile navigation' })).toBeDefined();
+    expect(screen.getByText('mobile-pwa')).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: 'Mobile notifications' }));
+    expect(await screen.findByText('Open mobile approval')).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: 'Mobile runs' }));
+    expect(window.location.pathname).toBe('/workflows');
+
+    await user.click(screen.getByRole('button', { name: 'Mobile work' }));
+    expect(searchListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { collections: ['work-products'] },
+      })
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Mobile settings' }));
+    expect(settingsListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { section: 'general' },
+      })
+    );
+
+    window.removeEventListener('veritas:open-settings', settingsListener);
+    window.removeEventListener('veritas:open-search', searchListener);
+  });
+});

--- a/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
@@ -27,6 +27,10 @@ const mocks = vi.hoisted(() => ({
   updateTaskMutateAsync: vi.fn(),
   useTaskMetrics: vi.fn(),
   applyTemplateActivity: vi.fn(),
+  identity: {
+    authContext: null as unknown,
+    hasPermission: vi.fn((_permission: string) => true),
+  },
 }));
 
 vi.mock('@/hooks/useConfig', () => ({
@@ -73,6 +77,10 @@ vi.mock('@/hooks/useTasks', () => ({
 
 vi.mock('@/hooks/useTaskMetrics', () => ({
   useTaskMetrics: mocks.useTaskMetrics,
+}));
+
+vi.mock('@/hooks/useIdentity', () => ({
+  useIdentity: () => mocks.identity,
 }));
 
 vi.mock('@/components/dashboard/ExportDialog', () => ({
@@ -183,6 +191,8 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
       isLoading: false,
       error: null,
     });
+    mocks.identity.authContext = null;
+    mocks.identity.hasPermission.mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -266,6 +276,32 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
       },
       { onSuccess: expect.any(Function) }
     );
+  });
+
+  it('hides agent start controls for mobile device sessions without agent write permission', () => {
+    mocks.identity.authContext = {
+      authMethod: 'device-session',
+      clientMode: 'mobile-pwa',
+      isLocalhost: false,
+      permissions: ['workspace:read', 'task:read', 'agent:read'],
+      role: 'read-only',
+    };
+    mocks.identity.hasPermission.mockImplementation(
+      (permission: string) => permission !== 'agent:write'
+    );
+    const task = createMockTask({
+      id: 'task-agent-mobile',
+      title: 'Review mobile run',
+      description: 'Review the run history from a paired mobile client.',
+      type: 'code',
+      git: { repo: 'veritas', branch: 'feature/mobile', baseBranch: 'main', worktreePath: '/tmp' },
+    });
+
+    renderWithProviders(<AgentPanel task={task} />);
+
+    expect(screen.getByText('Agent controls unavailable for this client')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Start' })).toBeNull();
+    expect(screen.queryByRole('combobox', { name: 'Agent' })).toBeNull();
   });
 
   it('keeps running-agent message send and stop confirmation wired through Mantine modal', async () => {

--- a/web/src/__tests__/task-work-view-mantine.test.tsx
+++ b/web/src/__tests__/task-work-view-mantine.test.tsx
@@ -20,6 +20,10 @@ const mocks = vi.hoisted(() => ({
   useActiveRuns: vi.fn(),
   useRecentRuns: vi.fn(),
   useTaskWorkProducts: vi.fn(),
+  identity: {
+    authContext: null as unknown,
+    hasPermission: vi.fn((_permission: string) => true),
+  },
 }));
 
 vi.mock('@/hooks/useAgent', () => ({
@@ -38,6 +42,10 @@ vi.mock('@/hooks/useWorkProducts', () => ({
 vi.mock('@/hooks/useWorkflowStats', () => ({
   useActiveRuns: mocks.useActiveRuns,
   useRecentRuns: mocks.useRecentRuns,
+}));
+
+vi.mock('@/hooks/useIdentity', () => ({
+  useIdentity: () => mocks.identity,
 }));
 
 const product: WorkProductPreview = {
@@ -82,6 +90,8 @@ describe('task work view Mantine surface', () => {
     mocks.useActiveRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useTaskWorkProducts.mockReturnValue({ data: [], isLoading: false });
+    mocks.identity.authContext = null;
+    mocks.identity.hasPermission.mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -286,5 +296,61 @@ describe('task work view Mantine surface', () => {
     expect(readiness.every((check) => check.passed)).toBe(true);
     expect(shouldDefaultTaskDetailToWork(task)).toBe(true);
     expect(shouldDefaultTaskDetailToWork(createMockTask({ type: 'feature' }))).toBe(false);
+  });
+
+  it('routes mobile device sessions to review-safe actions instead of agent controls', async () => {
+    const user = userEvent.setup();
+    mocks.identity.authContext = {
+      authMethod: 'device-session',
+      clientMode: 'mobile-pwa',
+      isLocalhost: false,
+      permissions: ['workspace:read', 'task:read', 'comment:write', 'agent:read'],
+      role: 'read-only',
+    };
+    mocks.identity.hasPermission.mockImplementation(
+      (permission: string) => permission !== 'agent:write'
+    );
+    const task = createMockTask({
+      id: 'task-mobile-work',
+      title: 'Review from phone',
+      description:
+        'Review the task from a mobile client without exposing local agent execution controls and capture the evidence artifact.',
+      type: 'code',
+      status: 'todo',
+      agent: 'veritas',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'mobile-review',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-worktree',
+      },
+      attempt: {
+        id: 'attempt-mobile',
+        agent: 'veritas',
+        status: 'running',
+        model: 'gpt-5',
+        provider: 'openai',
+        started: '2026-06-01T11:00:00.000Z',
+      },
+      subtasks: [
+        {
+          id: 'sub-mobile',
+          title: 'Confirm mobile review path',
+          completed: false,
+          created: '2026-06-01T11:00:00.000Z',
+          acceptanceCriteria: ['Mobile path opens timeline instead of agent start'],
+        },
+      ],
+      verificationSteps: [{ id: 'verify-mobile', description: 'Run mobile test', checked: false }],
+    });
+
+    renderWorkView(task);
+
+    expect(screen.getByText(/Agent start, stop, and retry controls are hidden/)).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Open Agent' })).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Review timeline' }));
+
+    expect(mocks.onOpenTab).toHaveBeenCalledWith('timeline');
   });
 });

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -5,6 +5,7 @@ import { BoardLoadingSkeleton } from './BoardLoadingSkeleton';
 import type { TaskStatus, Task } from '@veritas-kanban/shared';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
 import { TaskCard } from '@/components/task/TaskCard';
 import { useKeyboard } from '@/hooks/useKeyboard';
@@ -47,12 +48,16 @@ const COLUMNS: { id: TaskStatus; title: string }[] = [
   { id: 'done', title: 'Done' },
 ];
 
+const STATUS_OPTIONS = COLUMNS.map((column) => ({ value: column.id, label: column.title }));
+
 export function KanbanBoard() {
   const { data: tasks, isLoading, error } = useTasks();
   const { settings: featureSettings } = useFeatureSettings();
   const { announce } = useLiveAnnouncer();
   const { hasPermission } = useIdentity();
   const canWriteTasks = hasPermission('task:write');
+  const isMobileLayout = useMediaQuery('(max-width: 767px)', false);
+  const canDragTasks = featureSettings.board.enableDragAndDrop && canWriteTasks && !isMobileLayout;
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailPanelMounted, setDetailPanelMounted] = useState(false);
@@ -296,10 +301,11 @@ export function KanbanBoard() {
       <FeatureErrorBoundary fallbackTitle="Board failed to render">
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-5">
           <section
+            id="mobile-board-columns"
             className="min-w-0 xl:col-span-4"
             aria-label={`Kanban board, ${filteredTasks.length} tasks`}
           >
-            {featureSettings.board.enableDragAndDrop && canWriteTasks ? (
+            {canDragTasks ? (
               <DndContext
                 sensors={sensors}
                 collisionDetection={collisionDetection}
@@ -320,8 +326,12 @@ export function KanbanBoard() {
                       tasks={liveTasksByStatus[column.id]}
                       allTasks={filteredTasks}
                       onTaskClick={handleTaskClick}
+                      onTaskStatusChange={handleMoveTask}
                       selectedTaskId={selectedTaskId}
+                      canChangeStatus={canWriteTasks}
+                      dragEnabled={canDragTasks}
                       isDragActive={isDragActive}
+                      statusOptions={STATUS_OPTIONS}
                     />
                   ))}
                 </div>
@@ -344,7 +354,12 @@ export function KanbanBoard() {
                     tasks={tasksByStatus[column.id]}
                     allTasks={filteredTasks}
                     onTaskClick={handleTaskClick}
+                    onTaskStatusChange={handleMoveTask}
                     selectedTaskId={selectedTaskId}
+                    canChangeStatus={canWriteTasks}
+                    dragEnabled={false}
+                    showStatusControls={isMobileLayout}
+                    statusOptions={STATUS_OPTIONS}
                   />
                 ))}
               </div>

--- a/web/src/components/board/KanbanColumn.tsx
+++ b/web/src/components/board/KanbanColumn.tsx
@@ -16,8 +16,13 @@ interface KanbanColumnProps {
   tasks: Task[];
   allTasks: Task[];
   onTaskClick?: (task: Task) => void;
+  onTaskStatusChange?: (taskId: string, status: TaskStatus) => void;
   selectedTaskId?: string | null;
+  canChangeStatus?: boolean;
+  dragEnabled?: boolean;
   isDragActive?: boolean;
+  showStatusControls?: boolean;
+  statusOptions?: Array<{ value: TaskStatus; label: string }>;
 }
 
 const columnColors: Record<TaskStatus, string> = {
@@ -34,10 +39,15 @@ export function KanbanColumn({
   tasks,
   allTasks,
   onTaskClick,
+  onTaskStatusChange,
   selectedTaskId,
+  canChangeStatus = true,
+  dragEnabled = true,
   isDragActive,
+  showStatusControls = false,
+  statusOptions,
 }: KanbanColumnProps) {
-  const { setNodeRef, isOver } = useDroppable({ id });
+  const { setNodeRef, isOver } = useDroppable({ id, disabled: !dragEnabled });
   const { settings: featureSettings } = useFeatureSettings();
   const { isSelecting, selectedIds, toggleGroup } = useBulkActions();
   const showDoneMetrics = featureSettings.board.showDoneMetrics;
@@ -67,7 +77,7 @@ export function KanbanColumn({
       className={cn(
         'flex flex-col rounded-lg bg-muted/50 border-t-2 transition-all',
         columnColors[id],
-        isOver && 'ring-2 ring-primary/50 bg-muted/70'
+        dragEnabled && isOver && 'ring-2 ring-primary/50 bg-muted/70'
       )}
     >
       <div className="flex items-center justify-between px-3 py-2">
@@ -98,15 +108,15 @@ export function KanbanColumn({
       </div>
 
       <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-        <div className="flex-1 p-2 space-y-2 min-h-[calc(100vh-200px)] overflow-y-auto">
+        <div className="flex-1 p-2 space-y-2 min-h-24 overflow-y-auto md:min-h-[calc(100vh-200px)]">
           {tasks.length === 0 ? (
             <div
               className={cn(
                 'flex items-center justify-center h-24 text-sm text-muted-foreground rounded-md border-2 border-dashed',
-                isOver && 'border-primary/50 bg-primary/5'
+                dragEnabled && isOver && 'border-primary/50 bg-primary/5'
               )}
             >
-              {isOver ? 'Drop here' : 'No tasks'}
+              {dragEnabled && isOver ? 'Drop here' : 'No tasks'}
             </div>
           ) : (
             tasks.map((task) => {
@@ -118,12 +128,17 @@ export function KanbanColumn({
                 <ErrorBoundary key={task.id} level="widget">
                   <TaskCard
                     task={task}
+                    dragEnabled={dragEnabled}
                     onClick={() => onTaskClick?.(task)}
+                    onStatusChange={(status) => onTaskStatusChange?.(task.id, status)}
                     isSelected={task.id === selectedTaskId}
                     isBlocked={blocked}
                     blockerTitles={blockers.map((b) => b.title)}
                     cardMetrics={taskMetrics}
+                    canChangeStatus={canChangeStatus}
                     isDragActive={isDragActive}
+                    showStatusControl={showStatusControls}
+                    statusOptions={statusOptions}
                   />
                 </ErrorBoundary>
               );

--- a/web/src/components/chat/FloatingChat.tsx
+++ b/web/src/components/chat/FloatingChat.tsx
@@ -56,6 +56,7 @@ export function FloatingChat() {
         variant="filled"
         className={cn(
           'fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full shadow-lg',
+          'max-md:bottom-24',
           'bg-primary hover:bg-primary/90 text-primary-foreground',
           'transition-all duration-200 hover:scale-105',
           open && 'hidden'

--- a/web/src/components/dashboard/NeedsAttentionQueue.tsx
+++ b/web/src/components/dashboard/NeedsAttentionQueue.tsx
@@ -770,7 +770,10 @@ export function NeedsAttentionQueue({
   };
 
   return (
-    <section className="rounded-lg border bg-card p-4" aria-labelledby="needs-attention-title">
+    <section
+      className="rounded-lg border bg-card p-3 sm:p-4"
+      aria-labelledby="needs-attention-title"
+    >
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <div className="flex items-center gap-2">
@@ -787,7 +790,7 @@ export function NeedsAttentionQueue({
           </p>
         </div>
 
-        <div className="grid grid-cols-2 gap-2 md:grid-cols-5 lg:min-w-[680px]">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-5 lg:min-w-[680px]">
           <Select
             aria-label="Filter needs attention by severity"
             data={severityOptions}
@@ -907,12 +910,13 @@ export function NeedsAttentionQueue({
                   </div>
                 </button>
 
-                <Group gap="xs" justify="flex-end" wrap="nowrap">
+                <Group gap="xs" justify="flex-end" wrap="wrap" className="w-full md:w-auto">
                   <Button
                     leftSection={<ExternalLink className="h-3.5 w-3.5" />}
                     size="compact-xs"
                     variant="light"
                     onClick={() => openItem(item)}
+                    className="w-full sm:w-auto"
                   >
                     {item.nextAction}
                   </Button>
@@ -925,7 +929,12 @@ export function NeedsAttentionQueue({
                           : 'Dismiss'
                     }
                   >
-                    <Button size="compact-xs" variant="subtle" onClick={() => dismissItem(item)}>
+                    <Button
+                      size="compact-xs"
+                      variant="subtle"
+                      onClick={() => dismissItem(item)}
+                      className="w-full sm:w-auto"
+                    >
                       {item.notificationId
                         ? 'Mark read'
                         : item.driftAlertId

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -39,6 +39,7 @@ import { useView } from '@/contexts/ViewContext';
 import { useBacklogCount } from '@/hooks/useBacklog';
 import { useTheme } from '@/hooks/useTheme';
 import { useIdentity } from '@/hooks/useIdentity';
+import type { SearchCollection } from '@/lib/api';
 import { NAVIGATION_VIEWS, type ViewIcon } from '@/lib/views';
 
 const CreateTaskDialog = lazy(() =>
@@ -73,6 +74,11 @@ const SearchDialog = lazy(() =>
 
 type LazyPanel = 'chat' | 'create' | 'search' | 'settings' | 'squadChat';
 
+interface SearchPreset {
+  query?: string;
+  collections?: SearchCollection[];
+}
+
 const VIEW_ICONS: Record<ViewIcon, LucideIcon> = {
   Activity,
   Archive,
@@ -91,6 +97,7 @@ export function Header() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<string | undefined>();
   const [searchOpen, setSearchOpen] = useState(false);
+  const [searchPreset, setSearchPreset] = useState<SearchPreset | undefined>();
   // activityOpen removed — sidebar merged into feed (GH-66)
   // archiveOpen removed — archive is now a full page view
   const [chatOpen, setChatOpen] = useState(false);
@@ -124,10 +131,14 @@ export function Header() {
     setChatOpen(true);
   }, [markPanelLoaded]);
 
-  const openSearchDialog = useCallback(() => {
-    markPanelLoaded('search');
-    setSearchOpen(true);
-  }, [markPanelLoaded]);
+  const openSearchDialog = useCallback(
+    (preset?: SearchPreset) => {
+      markPanelLoaded('search');
+      setSearchPreset(preset);
+      setSearchOpen(true);
+    },
+    [markPanelLoaded]
+  );
 
   const openSquadChatPanel = useCallback(() => {
     markPanelLoaded('squadChat');
@@ -164,6 +175,16 @@ export function Header() {
     window.addEventListener('veritas:open-settings', handleOpenSettings);
     return () => window.removeEventListener('veritas:open-settings', handleOpenSettings);
   }, [openSettingsDialog]);
+
+  useEffect(() => {
+    const handleOpenSearch = (event: Event) => {
+      const detail = (event as CustomEvent<SearchPreset>).detail;
+      openSearchDialog(detail);
+    };
+
+    window.addEventListener('veritas:open-search', handleOpenSearch);
+    return () => window.removeEventListener('veritas:open-search', handleOpenSearch);
+  }, [openSearchDialog]);
 
   // Register the create dialog and chat panel openers with keyboard context (refs, no useEffect needed)
   setOpenCreateDialog(openCreateDialog);
@@ -253,7 +274,7 @@ export function Header() {
               variant="subtle"
               color="gray"
               size={32}
-              onClick={openSearchDialog}
+              onClick={() => openSearchDialog()}
               aria-label="Search"
               title="Search"
             >
@@ -343,6 +364,8 @@ export function Header() {
             onTaskOpen={navigateToTask}
             onViewOpen={setView}
             onSettingsOpen={openSettingsDialog}
+            initialQuery={searchPreset?.query}
+            initialCollections={searchPreset?.collections}
           />
         )}
       </Suspense>

--- a/web/src/components/layout/MobileShell.tsx
+++ b/web/src/components/layout/MobileShell.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import { ActionIcon, Badge, Drawer, Group, Stack } from '@mantine/core';
+import { Bell, Columns3, Files, Home, Settings, Workflow } from 'lucide-react';
+import { NeedsAttentionQueue } from '@/components/dashboard/NeedsAttentionQueue';
+import { useIdentity } from '@/hooks/useIdentity';
+import { useView } from '@/contexts/ViewContext';
+
+function scrollToBoardColumns() {
+  window.setTimeout(() => {
+    document.getElementById('mobile-board-columns')?.scrollIntoView({ block: 'start' });
+  }, 0);
+}
+
+export function MobileShell() {
+  const [inboxOpen, setInboxOpen] = useState(false);
+  const { authContext, hasPermission } = useIdentity();
+  const { navigateToTask, setView, view } = useView();
+  const clientMode = authContext?.clientMode;
+
+  const openBoardHome = () => {
+    setView('board');
+    window.setTimeout(() => window.scrollTo({ top: 0, behavior: 'smooth' }), 0);
+  };
+
+  const openBoardColumns = () => {
+    setView('board');
+    scrollToBoardColumns();
+  };
+
+  const openSettingsLite = () => {
+    window.dispatchEvent(
+      new CustomEvent('veritas:open-settings', { detail: { section: 'general' } })
+    );
+  };
+
+  const openWorkProducts = () => {
+    window.dispatchEvent(
+      new CustomEvent('veritas:open-search', { detail: { collections: ['work-products'] } })
+    );
+  };
+
+  const openRuns = () => {
+    setView('workflows');
+  };
+
+  const navItems = [
+    {
+      label: 'Home',
+      active: false,
+      icon: Home,
+      onClick: openBoardHome,
+    },
+    {
+      label: 'Board',
+      active: view === 'board',
+      icon: Columns3,
+      onClick: openBoardColumns,
+    },
+    {
+      label: 'Notifications',
+      active: inboxOpen,
+      icon: Bell,
+      onClick: () => setInboxOpen(true),
+    },
+    {
+      label: 'Runs',
+      active: view === 'workflows',
+      icon: Workflow,
+      onClick: openRuns,
+    },
+    {
+      label: 'Work',
+      active: false,
+      icon: Files,
+      onClick: openWorkProducts,
+    },
+    {
+      label: 'Settings',
+      active: false,
+      icon: Settings,
+      onClick: openSettingsLite,
+      disabled: !hasPermission('settings:read') && !hasPermission('admin:manage'),
+    },
+  ];
+
+  return (
+    <>
+      <nav
+        aria-label="Mobile navigation"
+        className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 px-2 pb-[calc(env(safe-area-inset-bottom)+0.35rem)] pt-1.5 shadow-lg backdrop-blur md:hidden"
+      >
+        {clientMode && (
+          <div className="mb-1 flex justify-center">
+            <Badge size="xs" variant="light" color="gray">
+              {clientMode}
+            </Badge>
+          </div>
+        )}
+        <div className="grid grid-cols-6 gap-1">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.label}
+                type="button"
+                aria-label={`Mobile ${item.label.toLowerCase()}`}
+                aria-current={item.active ? 'page' : undefined}
+                disabled={item.disabled}
+                onClick={item.onClick}
+                className={[
+                  'flex min-h-12 flex-col items-center justify-center rounded-md px-1 text-[11px] leading-tight text-muted-foreground transition-colors',
+                  item.active
+                    ? 'bg-primary/15 text-primary'
+                    : 'hover:bg-muted hover:text-foreground',
+                  item.disabled ? 'cursor-not-allowed opacity-40' : '',
+                ].join(' ')}
+              >
+                <Icon className="mb-0.5 h-4 w-4" aria-hidden="true" />
+                <span className="truncate">{item.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+
+      <Drawer
+        opened={inboxOpen}
+        onClose={() => setInboxOpen(false)}
+        position="bottom"
+        size="92%"
+        title="Notifications"
+        classNames={{
+          body: 'px-3 pb-4',
+          content: 'rounded-t-xl',
+          header: 'border-b',
+        }}
+      >
+        <Stack gap="sm">
+          <Group justify="space-between" wrap="nowrap">
+            <ActionIcon
+              variant="subtle"
+              aria-label="Open workflows"
+              onClick={() => {
+                setInboxOpen(false);
+                setView('workflows');
+              }}
+            >
+              <Workflow className="h-4 w-4" />
+            </ActionIcon>
+          </Group>
+          <NeedsAttentionQueue
+            period="7d"
+            onOpenTask={(taskId, target) => {
+              setInboxOpen(false);
+              navigateToTask(taskId, target);
+            }}
+            onOpenWorkflows={() => {
+              setInboxOpen(false);
+              setView('workflows');
+            }}
+          />
+        </Stack>
+      </Drawer>
+    </>
+  );
+}

--- a/web/src/components/search/SearchDialog.tsx
+++ b/web/src/components/search/SearchDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Archive,
   Bell,
@@ -67,6 +67,8 @@ const COLLECTION_LABELS = new Map(
   COLLECTIONS.map((collection) => [collection.id, collection.label])
 );
 
+const ALL_COLLECTION_IDS = COLLECTIONS.map((collection) => collection.id);
+
 const BACKENDS: { id: SearchBackend; label: string }[] = [
   { id: 'auto', label: 'Auto' },
   { id: 'keyword', label: 'Keyword' },
@@ -95,6 +97,8 @@ interface SearchDialogProps {
   onViewOpen?: (view: AppView) => void;
   onSettingsOpen?: (section?: string) => void;
   onDiagnosticsOpen?: () => void;
+  initialQuery?: string;
+  initialCollections?: SearchCollection[];
 }
 
 function collectionIcon(collection: string) {
@@ -175,15 +179,25 @@ export function SearchDialog({
   onViewOpen,
   onSettingsOpen,
   onDiagnosticsOpen,
+  initialQuery,
+  initialCollections,
 }: SearchDialogProps) {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(initialQuery ?? '');
   const [backend, setBackend] = useState<SearchBackend>('auto');
   const [collections, setCollections] = useState<SearchCollection[]>(
-    COLLECTIONS.map((collection) => collection.id)
+    initialCollections?.length ? initialCollections : ALL_COLLECTION_IDS
   );
   const [response, setResponse] = useState<SearchResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isSearching, setIsSearching] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery(initialQuery ?? '');
+    setCollections(initialCollections?.length ? initialCollections : ALL_COLLECTION_IDS);
+    setResponse(null);
+    setError(null);
+  }, [initialCollections, initialQuery, open]);
 
   const trimmedQuery = query.trim();
   const canSearch = trimmedQuery.length > 0 && collections.length > 0 && !isSearching;

--- a/web/src/components/task/AgentPanel.tsx
+++ b/web/src/components/task/AgentPanel.tsx
@@ -41,12 +41,15 @@ import {
   CheckCircle2,
   XCircle,
   Clock,
+  ShieldAlert,
 } from 'lucide-react';
 import { evaluateTaskReadiness } from '@veritas-kanban/shared';
 import type { Task, AgentType, AttemptStatus } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
 import { sanitizeText } from '@/lib/sanitize';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
+import { useIdentity } from '@/hooks/useIdentity';
+import { clientAllowsLocalAgentControls } from '@/lib/client-policy';
 
 interface AgentPanelProps {
   task: Task;
@@ -66,6 +69,7 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
   const { outputs, isConnected, isRunning, clearOutputs } = useAgentStream(task.id);
   const { data: attempts, refetch: refetchAttempts } = useAgentAttempts(task.id);
   const { data: routingResult } = useResolveAgent(task.id);
+  const { authContext, hasPermission } = useIdentity();
 
   const startAgent = useStartAgent();
   const stopAgent = useStopAgent();
@@ -178,7 +182,9 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
   };
 
   // Check if we can start an agent
-  const canStart = task.git?.worktreePath && !isRunning && !agentStatus?.running;
+  const canControlAgent =
+    clientAllowsLocalAgentControls(authContext) && hasPermission('agent:write');
+  const canStart = canControlAgent && task.git?.worktreePath && !isRunning && !agentStatus?.running;
   const isAgentRunning = isRunning || agentStatus?.running;
 
   if (!task.git?.worktreePath) {
@@ -228,6 +234,20 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
         </Group>
 
         <Paper className="overflow-hidden bg-muted/30" radius="md" withBorder>
+          {!canControlAgent && (
+            <Alert
+              color="blue"
+              icon={<ShieldAlert className="h-4 w-4" />}
+              title="Agent controls unavailable for this client"
+              className="m-2"
+            >
+              <Text size="sm">
+                This client can inspect run history and live output, but start, stop, retry, and
+                message controls require an agent-capable desktop or CLI session.
+              </Text>
+            </Alert>
+          )}
+
           {!isAgentRunning && !readinessSummary.ready && (
             <Alert
               color="yellow"
@@ -246,69 +266,71 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
           )}
 
           {/* Controls */}
-          <Group gap="xs" className="border-b bg-card p-2">
-            {!isAgentRunning ? (
-              <>
-                {routingResult && !selectedAgent && (
-                  <Text
+          {canControlAgent && (
+            <Group gap="xs" className="border-b bg-card p-2">
+              {!isAgentRunning ? (
+                <>
+                  {routingResult && !selectedAgent && (
+                    <Text
+                      size="xs"
+                      c="dimmed"
+                      truncate
+                      className="max-w-[200px]"
+                      title={routingResult.reason}
+                    >
+                      Rec:{' '}
+                      {enabledAgents.find((a) => a.type === routingResult.agent)?.name ||
+                        routingResult.agent}
+                      {routingResult.model ? ` (${routingResult.model})` : ''}
+                    </Text>
+                  )}
+                  <Select
+                    value={resolvedAgent}
+                    onChange={(value) => setSelectedAgent(value as AgentType)}
+                    data={agentOptions}
+                    placeholder="Select agent..."
+                    aria-label="Agent"
+                    className="w-[180px]"
                     size="xs"
-                    c="dimmed"
-                    truncate
-                    className="max-w-[200px]"
-                    title={routingResult.reason}
+                    checkIconPosition="right"
+                  />
+                  <Select
+                    value={selectedModel || routingResult?.model || 'sonnet'}
+                    onChange={(value) => setSelectedModel(value ?? undefined)}
+                    data={modelOptions}
+                    placeholder="Model..."
+                    aria-label="Model"
+                    className="w-[100px]"
+                    size="xs"
+                    checkIconPosition="right"
+                  />
+                  <Button
+                    size="sm"
+                    onClick={handleStart}
+                    disabled={!canStart || startAgent.isPending}
+                    leftSection={
+                      startAgent.isPending ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Play className="h-4 w-4" />
+                      )
+                    }
                   >
-                    Rec:{' '}
-                    {enabledAgents.find((a) => a.type === routingResult.agent)?.name ||
-                      routingResult.agent}
-                    {routingResult.model ? ` (${routingResult.model})` : ''}
-                  </Text>
-                )}
-                <Select
-                  value={resolvedAgent}
-                  onChange={(value) => setSelectedAgent(value as AgentType)}
-                  data={agentOptions}
-                  placeholder="Select agent..."
-                  aria-label="Agent"
-                  className="w-[180px]"
-                  size="xs"
-                  checkIconPosition="right"
-                />
-                <Select
-                  value={selectedModel || routingResult?.model || 'sonnet'}
-                  onChange={(value) => setSelectedModel(value ?? undefined)}
-                  data={modelOptions}
-                  placeholder="Model..."
-                  aria-label="Model"
-                  className="w-[100px]"
-                  size="xs"
-                  checkIconPosition="right"
-                />
+                    Start
+                  </Button>
+                </>
+              ) : (
                 <Button
                   size="sm"
-                  onClick={handleStart}
-                  disabled={!canStart || startAgent.isPending}
-                  leftSection={
-                    startAgent.isPending ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Play className="h-4 w-4" />
-                    )
-                  }
+                  color="red"
+                  leftSection={<Square className="h-4 w-4" />}
+                  onClick={() => setStopDialogOpen(true)}
                 >
-                  Start
+                  Stop
                 </Button>
-              </>
-            ) : (
-              <Button
-                size="sm"
-                color="red"
-                leftSection={<Square className="h-4 w-4" />}
-                onClick={() => setStopDialogOpen(true)}
-              >
-                Stop
-              </Button>
-            )}
-          </Group>
+              )}
+            </Group>
+          )}
 
           {/* Output */}
           <div
@@ -341,7 +363,7 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
           </div>
 
           {/* Input */}
-          {isAgentRunning && (
+          {isAgentRunning && canControlAgent && (
             <form onSubmit={handleSendMessage} className="flex gap-2 p-2 border-t bg-card">
               <TextInput
                 value={message}
@@ -359,7 +381,8 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
         {/* New Attempt button for completed/failed tasks */}
         {task.attempt &&
           ['complete', 'failed'].includes(task.attempt.status) &&
-          !isAgentRunning && (
+          !isAgentRunning &&
+          canControlAgent && (
             <Button
               variant="outline"
               size="sm"

--- a/web/src/components/task/CommentsSection.tsx
+++ b/web/src/components/task/CommentsSection.tsx
@@ -86,12 +86,12 @@ function CommentItem({
 
   return (
     <>
-      <Paper className="group flex gap-3 bg-muted/30 p-3" radius="md">
+      <Paper className="group flex flex-col gap-3 bg-muted/30 p-3 sm:flex-row" radius="md">
         <Avatar color="violet" radius="xl" size="sm" className="flex-shrink-0">
           {getInitials(comment.author)}
         </Avatar>
         <Box className="min-w-0 flex-1">
-          <Group align="baseline" gap="xs" className="mb-1">
+          <Group align="baseline" gap="xs" className="mb-1" wrap="wrap">
             <Text size="sm" fw={500}>
               {comment.author}
             </Text>
@@ -99,7 +99,10 @@ function CommentItem({
               {formatRelativeTime(comment.timestamp)}
             </Text>
             {/* Edit/Delete buttons - visible on hover */}
-            <Group gap={4} className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
+            <Group
+              gap={4}
+              className="ml-auto opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+            >
               <ActionIcon
                 variant="subtle"
                 color="gray"
@@ -292,7 +295,7 @@ export function CommentsSection({ task }: CommentsSectionProps) {
             value={author}
             onChange={(e) => setAuthor(e.currentTarget.value)}
             placeholder="Your name"
-            className="text-sm max-w-[150px]"
+            className="w-full text-sm sm:max-w-[180px]"
             disabled={isAdding}
             aria-label="Comment author"
           />
@@ -327,6 +330,7 @@ export function CommentsSection({ task }: CommentsSectionProps) {
               void handleAddComment();
             }}
             disabled={!text.trim() || !author.trim() || isAdding}
+            className="w-full sm:w-auto"
           >
             Add Comment
           </Button>

--- a/web/src/components/task/ReviewPanel.tsx
+++ b/web/src/components/task/ReviewPanel.tsx
@@ -1,5 +1,16 @@
 import { useState } from 'react';
-import { Button, Code, Group, Modal, Paper, Stack, Text, Textarea, ThemeIcon } from '@mantine/core';
+import {
+  Button,
+  Code,
+  Group,
+  Modal,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+  Textarea,
+  ThemeIcon,
+} from '@mantine/core';
 import { CheckCircle, XCircle, RefreshCcw, MessageSquare, GitMerge, Loader2 } from 'lucide-react';
 import { useMergeWorktree } from '@/hooks/useWorktree';
 import type { Task, ReviewDecision, ReviewState } from '@veritas-kanban/shared';
@@ -148,7 +159,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
               }
               minRows={3}
             />
-            <Group gap="xs">
+            <Group gap="xs" className="flex-col items-stretch sm:flex-row sm:items-center">
               <Button
                 onClick={() => submitReview(pendingDecision, summary || undefined)}
                 color={pendingDecision === 'rejected' ? 'red' : undefined}
@@ -172,7 +183,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
 
       {/* Action buttons */}
       {!currentReview?.decision && !showSummary && (
-        <Group gap="xs" grow>
+        <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="xs">
           <Button
             onClick={() => handleDecision('approved')}
             color="green"
@@ -194,7 +205,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
           >
             Reject
           </Button>
-        </Group>
+        </SimpleGrid>
       )}
 
       <Modal

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react';
-import { Tooltip } from '@mantine/core';
+import { Select, Tooltip } from '@mantine/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
@@ -60,13 +60,18 @@ const blockedCategoryInfo: Record<
 
 interface TaskCardProps {
   task: Task;
+  dragEnabled?: boolean;
   isDragging?: boolean;
   isDragActive?: boolean;
   onClick?: () => void;
+  onStatusChange?: (status: Task['status']) => void;
   isSelected?: boolean;
   isBlocked?: boolean;
   blockerTitles?: string[];
   cardMetrics?: TaskCardMetrics;
+  canChangeStatus?: boolean;
+  showStatusControl?: boolean;
+  statusOptions?: Array<{ value: Task['status']; label: string }>;
 }
 
 /**
@@ -77,11 +82,15 @@ interface TaskCardProps {
  */
 function areTaskCardPropsEqual(prev: TaskCardProps, next: TaskCardProps): boolean {
   // Simple scalar/boolean props
+  if (prev.dragEnabled !== next.dragEnabled) return false;
   if (prev.isDragging !== next.isDragging) return false;
   if (prev.isDragActive !== next.isDragActive) return false;
   if (prev.isSelected !== next.isSelected) return false;
   if (prev.isBlocked !== next.isBlocked) return false;
+  if (prev.canChangeStatus !== next.canChangeStatus) return false;
+  if (prev.showStatusControl !== next.showStatusControl) return false;
   // onClick is intentionally skipped — always a new closure but functionally equivalent
+  // onStatusChange is also skipped for the same reason.
 
   // Task object — compare fields that affect rendering rather than reference
   const pt = prev.task;
@@ -181,13 +190,18 @@ const priorityColors: Record<TaskPriority, string> = {
 
 export const TaskCard = memo(function TaskCard({
   task,
+  dragEnabled = true,
   isDragging,
   isDragActive,
   onClick,
+  onStatusChange,
   isSelected,
   isBlocked,
   blockerTitles,
   cardMetrics,
+  canChangeStatus = true,
+  showStatusControl = false,
+  statusOptions,
 }: TaskCardProps) {
   const { taskTypes, projects, sprints } = useTaskConfig();
   const {
@@ -199,6 +213,7 @@ export const TaskCard = memo(function TaskCard({
     isDragging: isCurrentlyDragging,
   } = useSortable({
     id: task.id,
+    disabled: !dragEnabled,
   });
   const { isSelecting, toggleSelect, isSelected: isBulkSelected } = useBulkActions();
   const isChecked = isBulkSelected(task.id);
@@ -216,10 +231,12 @@ export const TaskCard = memo(function TaskCard({
     [descriptionPreview]
   );
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
+  const style = dragEnabled
+    ? {
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }
+    : undefined;
 
   const handleClick = () => {
     if (isCurrentlyDragging || isDragging) return;
@@ -321,15 +338,16 @@ export const TaskCard = memo(function TaskCard({
       <div
         ref={setNodeRef}
         style={style}
-        {...listeners}
-        {...attributes}
+        {...(dragEnabled ? listeners : {})}
+        {...(dragEnabled ? attributes : {})}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         role="article"
         tabIndex={0}
         aria-label={`Task: ${task.title}, Priority: ${task.priority}${readinessAria}${isBlocked ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}`}
         className={cn(
-          'group bg-card border border-border rounded-md cursor-grab active:cursor-grabbing',
+          'group bg-card border border-border rounded-md',
+          dragEnabled ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
           isCompact ? 'p-2' : 'p-3',
           'hover:border-muted-foreground/50 hover:bg-card/80 transition-all',
           'border-l-2',
@@ -707,6 +725,29 @@ export const TaskCard = memo(function TaskCard({
             </>
           )}
         </div>
+
+        {showStatusControl && statusOptions && statusOptions.length > 0 && (
+          <div
+            className="mt-3 md:hidden"
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
+            onPointerDown={(event) => event.stopPropagation()}
+          >
+            <Select
+              aria-label={`Change status for ${task.title}`}
+              data={statusOptions}
+              value={task.status}
+              onChange={(value) => {
+                if (value && value !== task.status) onStatusChange?.(value as Task['status']);
+              }}
+              disabled={!canChangeStatus}
+              size="sm"
+              allowDeselect={false}
+              checkIconPosition="right"
+            />
+          </div>
+        )}
       </div>
     </Tooltip>
   );

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -31,6 +31,8 @@ import { WorkProductsSection } from './WorkProductsSection';
 import { AgentRunTimelinePanel } from './AgentRunTimelinePanel';
 import { shouldDefaultTaskDetailToWork, TaskWorkView } from './TaskWorkView';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
+import { useIdentity } from '@/hooks/useIdentity';
+import { clientAllowsLocalAgentControls } from '@/lib/client-policy';
 import {
   BriefcaseBusiness,
   GitBranch,
@@ -179,8 +181,10 @@ export function TaskDetailPanel({
 }: TaskDetailPanelProps) {
   const { data: taskTypes = [] } = useTaskTypes();
   const { settings: featureSettings } = useFeatureSettings();
+  const { authContext } = useIdentity();
   const taskSettings = featureSettings.tasks;
   const agentSettings = featureSettings.agents;
+  const canUseLocalAgentControls = clientAllowsLocalAgentControls(authContext);
   const { localTask, updateField, isDirty } = useDebouncedSave(task);
   const [activeTab, setActiveTab] = useState<TaskDetailTabId>('details');
   const [previewOpen, setPreviewOpen] = useState(false);
@@ -374,11 +378,12 @@ export function TaskDetailPanel({
         <Drawer.Overlay className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
         <Drawer.Content
           aria-label={`Task details: ${localTask.title}`}
-          className="flex h-full w-[700px] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:max-w-[700px]"
+          data-testid="task-detail-panel"
+          className="flex h-full max-h-[100dvh] w-[min(100vw,700px)] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:max-w-[700px]"
         >
           <Drawer.Body className="contents">
             <Stack gap={0} className="h-full overflow-hidden">
-              <header className="flex-shrink-0 border-b px-6 py-4 pr-12">
+              <header className="flex-shrink-0 border-b px-4 py-4 pr-12 sm:px-6">
                 <Group
                   gap="xs"
                   justify="space-between"
@@ -416,9 +421,9 @@ export function TaskDetailPanel({
                     </ActionIcon>
                   </Group>
                 </Group>
-                <Drawer.Title className="mt-1 pr-8 text-xl font-semibold text-foreground">
+                <Drawer.Title className="mt-1 pr-8 text-lg font-semibold text-foreground sm:text-xl">
                   {readOnly ? (
-                    <Text component="span" size="xl" fw={600}>
+                    <Text component="span" size="lg" fw={600} className="sm:text-xl">
                       {localTask.title}
                     </Text>
                   ) : (
@@ -429,7 +434,7 @@ export function TaskDetailPanel({
                       placeholder="Task title..."
                       aria-label="Task title"
                       classNames={{
-                        input: 'text-xl font-semibold text-foreground',
+                        input: 'text-lg font-semibold text-foreground sm:text-xl',
                       }}
                     />
                   )}
@@ -437,10 +442,14 @@ export function TaskDetailPanel({
               </header>
 
               {/* Action buttons above tabs */}
-              <SimpleGrid cols={3} spacing="xs" className="flex-shrink-0 px-6 pt-4">
+              <SimpleGrid
+                cols={{ base: 2, sm: 3 }}
+                spacing="xs"
+                className="flex-shrink-0 px-4 pt-3 sm:px-6 sm:pt-4"
+              >
                 <Button
                   variant="outline"
-                  size="xs"
+                  size="sm"
                   onClick={() => setTaskChatOpen(true)}
                   leftSection={<MessageSquare className="h-3 w-3" />}
                 >
@@ -450,7 +459,7 @@ export function TaskDetailPanel({
                   <>
                     <Button
                       variant="outline"
-                      size="xs"
+                      size="sm"
                       onClick={() => setApplyTemplateOpen(true)}
                       leftSection={<FileCode className="h-3 w-3" />}
                     >
@@ -458,7 +467,7 @@ export function TaskDetailPanel({
                     </Button>
                     <Button
                       variant="outline"
-                      size="xs"
+                      size="sm"
                       onClick={() => setWorkflowOpen(true)}
                       leftSection={<Workflow className="h-3 w-3" />}
                     >
@@ -471,17 +480,21 @@ export function TaskDetailPanel({
                     <div />
                   </>
                 )}
-                {!readOnly && isCodeTask && localTask.git?.repo && agentSettings.enablePreview && (
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    onClick={() => setPreviewOpen(true)}
-                    className="col-span-2"
-                    leftSection={<Monitor className="h-3 w-3" />}
-                  >
-                    Preview
-                  </Button>
-                )}
+                {!readOnly &&
+                  isCodeTask &&
+                  localTask.git?.repo &&
+                  agentSettings.enablePreview &&
+                  canUseLocalAgentControls && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setPreviewOpen(true)}
+                      className="col-span-2"
+                      leftSection={<Monitor className="h-3 w-3" />}
+                    >
+                      Preview
+                    </Button>
+                  )}
               </SimpleGrid>
 
               <Tabs
@@ -489,7 +502,7 @@ export function TaskDetailPanel({
                 onChange={(value) => {
                   if (value) setActiveTab(value as TaskDetailTabId);
                 }}
-                className="flex flex-1 flex-col overflow-hidden px-6 pt-3 pb-6"
+                className="flex flex-1 flex-col overflow-hidden px-4 pt-3 pb-6 sm:px-6"
               >
                 <Tabs.List className="w-full flex-shrink-0 justify-start overflow-x-auto">
                   {visibleTabs.map((tab) => {

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -34,6 +34,7 @@ import {
   Route,
   ShieldCheck,
   Square,
+  Smartphone,
   Terminal,
   RotateCcw,
   Workflow,
@@ -47,6 +48,7 @@ import {
 } from '@veritas-kanban/shared';
 import type { Task, TaskAttempt, TaskReadinessCheck, TaskStatus } from '@veritas-kanban/shared';
 import { useAgentStatus, useAgentStream, useStopAgent } from '@/hooks/useAgent';
+import { useIdentity } from '@/hooks/useIdentity';
 import { useTaskWorkProducts } from '@/hooks/useWorkProducts';
 import {
   useActiveRuns,
@@ -55,6 +57,7 @@ import {
   type WorkflowRunStatus,
 } from '@/hooks/useWorkflowStats';
 import { sanitizeText } from '@/lib/sanitize';
+import { clientAllowsLocalAgentControls } from '@/lib/client-policy';
 
 export function getTaskReadinessChecks(task: Task, isCodeTask: boolean): TaskReadinessCheck[] {
   return getSharedTaskReadinessChecks(task, { isCodeTask });
@@ -365,6 +368,9 @@ export function TaskWorkView({
   const { data: activeWorkflowRuns = [], isLoading: activeWorkflowRunsLoading } = useActiveRuns();
   const { data: recentWorkflowRuns = [], isLoading: recentWorkflowRunsLoading } = useRecentRuns();
   const stopAgent = useStopAgent();
+  const { authContext, hasPermission } = useIdentity();
+  const canControlAgents =
+    clientAllowsLocalAgentControls(authContext) && hasPermission('agent:write');
   const readinessSummary = useMemo(
     () => evaluateTaskReadiness(task, { isCodeTask }),
     [task, isCodeTask]
@@ -396,6 +402,17 @@ export function TaskWorkView({
   const workflowProgress = getWorkflowProgress(workflowRun);
   const workflowDuration = getWorkflowDurationMs(workflowRun);
   const workflowLoading = activeWorkflowRunsLoading || recentWorkflowRunsLoading;
+  const nextActionRestricted =
+    nextAction.target === 'agent' || (nextAction.target === 'git' && !canControlAgents);
+  const effectiveNextAction =
+    nextActionRestricted && !canControlAgents
+      ? {
+          label: isCodeTask ? 'Review timeline' : 'Review details',
+          detail:
+            'This client can review task state, comments, gates, and run history. Agent execution is unavailable for this client mode.',
+          target: isCodeTask ? ('timeline' as const) : ('details' as const),
+        }
+      : nextAction;
   const currentStep =
     latestOutputs.length > 0
       ? sanitizeText(latestOutputs[latestOutputs.length - 1].content).slice(0, 180)
@@ -406,15 +423,15 @@ export function TaskWorkView({
           : 'No live output is available.';
 
   const openNextAction = () => {
-    if (nextAction.target === 'workflow') {
+    if (effectiveNextAction.target === 'workflow') {
       onOpenWorkflow();
       return;
     }
-    if (nextAction.target === 'chat') {
+    if (effectiveNextAction.target === 'chat') {
       onOpenChat();
       return;
     }
-    onOpenTab(nextAction.target);
+    onOpenTab(effectiveNextAction.target);
   };
 
   const handleStopAgent = () => {
@@ -441,16 +458,23 @@ export function TaskWorkView({
                 </Badge>
               </Group>
               <Text size="sm" c="dimmed" mt={6}>
-                {nextAction.detail}
+                {effectiveNextAction.detail}
               </Text>
             </div>
             {!readOnly && (
               <Button size="xs" onClick={openNextAction}>
-                {nextAction.label}
+                {effectiveNextAction.label}
               </Button>
             )}
           </Group>
         </Paper>
+
+        {!canControlAgents && (
+          <Alert color="blue" icon={<Smartphone className="h-4 w-4" />}>
+            Agent start, stop, and retry controls are hidden for this client. Review, comments,
+            gates, timelines, and work products remain available.
+          </Alert>
+        )}
 
         <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
           <Paper withBorder p="md" radius="md">
@@ -489,14 +513,16 @@ export function TaskWorkView({
                 </Text>
               )}
               <Group gap="xs" mt="xs">
-                <Button
-                  size="compact-xs"
-                  variant="light"
-                  leftSection={<Play className="h-3 w-3" />}
-                  onClick={() => onOpenTab('agent')}
-                >
-                  Open Agent
-                </Button>
+                {canControlAgents && (
+                  <Button
+                    size="compact-xs"
+                    variant="light"
+                    leftSection={<Play className="h-3 w-3" />}
+                    onClick={() => onOpenTab('agent')}
+                  >
+                    Open Agent
+                  </Button>
+                )}
                 {isCodeTask && (
                   <Button
                     size="compact-xs"
@@ -507,7 +533,7 @@ export function TaskWorkView({
                     Timeline
                   </Button>
                 )}
-                {retryableRun && (
+                {retryableRun && canControlAgents && (
                   <Button
                     size="compact-xs"
                     variant="subtle"
@@ -611,7 +637,7 @@ export function TaskWorkView({
                 </Text>
               </div>
               <Group gap="xs" wrap="wrap" justify="flex-end">
-                {activeRun && !readOnly && (
+                {activeRun && !readOnly && canControlAgents && (
                   <Button
                     size="compact-xs"
                     color="red"
@@ -623,7 +649,7 @@ export function TaskWorkView({
                     Stop
                   </Button>
                 )}
-                {retryableRun && !activeRun && !readOnly && (
+                {retryableRun && !activeRun && !readOnly && canControlAgents && (
                   <Button
                     size="compact-xs"
                     variant="light"

--- a/web/src/components/task/WorkflowSection.tsx
+++ b/web/src/components/task/WorkflowSection.tsx
@@ -10,8 +10,10 @@
 import { useState, useEffect } from 'react';
 import { API_BASE } from '@/lib/config';
 import { Badge, Button, Group, Loader, Modal, Paper, ScrollArea, Stack, Text } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { Play, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
+import { useIdentity } from '@/hooks/useIdentity';
 import type { Task } from '@veritas-kanban/shared';
 
 interface WorkflowSectionProps {
@@ -58,6 +60,9 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
   const [isLoading, setIsLoading] = useState(true);
   const [isStarting, setIsStarting] = useState<string | null>(null);
   const { toast } = useToast();
+  const { hasPermission } = useIdentity();
+  const isMobile = useMediaQuery('(max-width: 767px)', false);
+  const canExecuteWorkflows = hasPermission('workflow:execute');
 
   useEffect(() => {
     if (!open) return;
@@ -127,6 +132,7 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
       title="Run Workflow"
       centered
       size="xl"
+      fullScreen={isMobile}
     >
       <Stack gap="md">
         <Text size="sm" c="dimmed">
@@ -187,7 +193,7 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
                       radius="md"
                       withBorder
                     >
-                      <Group align="flex-start" justify="space-between" gap="md" wrap="nowrap">
+                      <Group align="flex-start" justify="space-between" gap="md" wrap="wrap">
                         <Stack gap={4} className="min-w-0 flex-1">
                           <Group gap="xs">
                             <Text size="sm" fw={500}>
@@ -212,7 +218,12 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
                         <Button
                           size="sm"
                           onClick={() => handleStartWorkflow(workflow.id)}
-                          disabled={isStarting === workflow.id}
+                          disabled={!canExecuteWorkflows || isStarting === workflow.id}
+                          title={
+                            canExecuteWorkflows
+                              ? 'Start run'
+                              : 'Workflow execute permission required'
+                          }
                           leftSection={
                             isStarting === workflow.id ? (
                               <Loader2 className="h-3 w-3 animate-spin" />

--- a/web/src/lib/__tests__/client-policy.test.ts
+++ b/web/src/lib/__tests__/client-policy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { ClientAuthContext } from '@veritas-kanban/shared';
+import { clientAllowsLocalAgentControls } from '@/lib/client-policy';
+
+function authContext(overrides: Partial<ClientAuthContext> = {}): ClientAuthContext {
+  return {
+    role: 'read-only',
+    isLocalhost: false,
+    authMethod: 'device-session',
+    permissions: ['workspace:read', 'task:read', 'agent:read'],
+    ...overrides,
+  };
+}
+
+describe('clientAllowsLocalAgentControls', () => {
+  it('allows legacy local contexts and localhost bypass', () => {
+    expect(clientAllowsLocalAgentControls(null)).toBe(true);
+    expect(
+      clientAllowsLocalAgentControls(
+        authContext({ authMethod: 'localhost-bypass', isLocalhost: true })
+      )
+    ).toBe(true);
+    expect(clientAllowsLocalAgentControls(authContext({ isLocalhost: true }))).toBe(true);
+  });
+
+  it('allows explicit local capabilities and local client modes', () => {
+    expect(clientAllowsLocalAgentControls(authContext({ capabilities: ['local-agent:run'] }))).toBe(
+      true
+    );
+    expect(clientAllowsLocalAgentControls(authContext({ clientMode: 'desktop-local' }))).toBe(true);
+    expect(clientAllowsLocalAgentControls(authContext({ clientMode: 'cli' }))).toBe(true);
+  });
+
+  it('blocks remote mobile and unknown client modes by default', () => {
+    expect(clientAllowsLocalAgentControls(authContext({ clientMode: 'mobile-pwa' }))).toBe(false);
+    expect(clientAllowsLocalAgentControls(authContext({ clientMode: 'desktop-remote' }))).toBe(
+      false
+    );
+    expect(clientAllowsLocalAgentControls(authContext())).toBe(false);
+  });
+});

--- a/web/src/lib/client-policy.ts
+++ b/web/src/lib/client-policy.ts
@@ -1,0 +1,29 @@
+import type { ClientAuthContext } from '@veritas-kanban/shared';
+
+const LOCAL_AGENT_CAPABILITIES = new Set([
+  'desktop:local',
+  'agent:run:local',
+  'agent:run:unrestricted',
+  'local-agent:run',
+]);
+
+const LOCAL_CLIENT_MODES = new Set(['desktop-local', 'cli']);
+
+export function clientAllowsLocalAgentControls(authContext: ClientAuthContext | null): boolean {
+  if (!authContext) return true;
+  if (authContext.authMethod === 'localhost-bypass') return true;
+  if (authContext.isLocalhost) return true;
+
+  const capabilities = authContext.capabilities ?? [];
+  if (capabilities.some((capability) => LOCAL_AGENT_CAPABILITIES.has(capability))) {
+    return true;
+  }
+
+  if (!authContext.clientMode) return false;
+  return LOCAL_CLIENT_MODES.has(authContext.clientMode);
+}
+
+export function describeLocalAgentRestriction(authContext: ClientAuthContext | null): string {
+  const mode = authContext?.clientMode ?? 'remote';
+  return `Local agent controls are disabled for this ${mode} session. Use a local desktop session or an explicitly allowed device capability to start or stop local agents.`;
+}


### PR DESCRIPTION
## Summary
- Adds a phone-first mobile shell with bottom navigation for home, board, notifications, work search, runs, and settings.
- Makes board, task detail, approvals, comments, notifications, workflow actions, and local-agent controls responsive for device-session clients.
- Adds mobile E2E coverage plus focused component and policy tests for the responsive flows.

## Verification
- pnpm exec playwright test e2e/mobile-responsive.spec.ts --project=mobile-chromium
- pnpm --filter @veritas-kanban/web test -- TaskCard.test.tsx mobile-shell.test.tsx client-policy.test.ts task-detail-agent-template-metrics-mantine.test.tsx task-work-view-mantine.test.tsx task-detail-mantine.test.tsx needs-attention-queue-mantine.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm exec playwright test e2e/task-detail.spec.ts --project=chromium
- git diff --check

Closes #346
