### PR TITLE
Add mobile PWA install and offline shell

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -273,8 +273,9 @@ headers. This is required for accurate rate limiting and security logging.
 
 Reverse proxy deployments should follow the trusted-host model from
 [ADR 0002](architecture/ADR-0002-v5-remote-server-security-posture.md): route
-the web app, `/api`, `/ws`, `/health`, and future PWA assets through the same
-public origin whenever possible.
+the web app, `/api`, `/ws`, `/health`, and PWA assets through the same public
+origin whenever possible. See [PWA install](guides/PWA_INSTALL.md) for mobile
+install and offline-shell behavior.
 
 Common values:
 

--- a/docs/guides/PWA_INSTALL.md
+++ b/docs/guides/PWA_INSTALL.md
@@ -1,0 +1,50 @@
+# Veritas Kanban PWA Install
+
+Veritas can be installed from a trusted remote/server host as a browser PWA. Use this only with HTTPS, auth enabled, localhost bypass disabled, and the web app, `/api`, `/ws`, manifest, icons, and service worker served from the same public origin or subpath.
+
+## Install On iPhone Or iPad
+
+1. Open the trusted Veritas URL in Safari.
+2. Sign in or pair the device session.
+3. Tap Share.
+4. Tap Add to Home Screen.
+5. Confirm the name and tap Add.
+
+iOS uses Safari's Add to Home Screen flow instead of the browser install prompt. The installed shell keeps the Veritas origin and session behavior from Safari.
+
+## Install On Android Chrome
+
+1. Open the trusted Veritas URL in Chrome.
+2. Sign in or pair the device session.
+3. Tap the browser install prompt, or open the three-dot menu and tap Install app.
+4. Confirm Install.
+
+Chrome shows the install prompt only when the manifest and service worker are reachable from the current origin.
+
+## Offline Behavior
+
+The service worker caches only the static app shell, manifest, icons, and same-origin static assets. It does not cache `/api` responses, WebSocket traffic, task data, work products, tokens, comments, or mutation responses.
+
+When the device is offline or realtime sync is reconnecting:
+
+- Veritas shows an offline or stale-data banner in the mobile shell.
+- The board disables mobile status changes while the browser reports offline.
+- Writes are not queued for later replay.
+- Failed writes must return a server error or auth error before the UI treats them as saved.
+
+## Subpath And Reverse Proxy Requirements
+
+For a subpath deployment such as `https://kanban.example.com/veritas/`, build and serve the web app with `VITE_BASE_PATH=/veritas/`. The manifest uses relative `start_url` and `scope`, and the service worker registers under the same base path.
+
+Reverse proxies should route these paths to the same Veritas host:
+
+- `/`
+- `/api`
+- `/ws`
+- `/manifest.webmanifest`
+- `/sw.js`
+- `/favicon.svg`
+- `/icons/*`
+- `/assets/*`
+
+If the app is served under a subpath, apply the same subpath prefix to each route.

--- a/docs/guides/SELF_HOST.md
+++ b/docs/guides/SELF_HOST.md
@@ -492,6 +492,8 @@ When exposing Veritas beyond loopback, also use `NODE_ENV=production` and keep
 the web client, `/api`, `/ws`, health endpoints, PWA assets, and service-worker
 scope on one trusted origin whenever possible. Split-origin deployments must set
 exact `CORS_ORIGINS` entries and confirm WebSocket origin/upgrade behavior.
+Mobile install steps and offline-shell behavior are documented in
+[PWA install](PWA_INSTALL.md).
 
 ### API keys for agents
 

--- a/e2e/pwa-offline.spec.ts
+++ b/e2e/pwa-offline.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, type Page } from '@playwright/test';
+import { bypassAuth, cleanupRoutes } from './helpers/auth';
+
+async function useMobileDeviceContext(page: Page) {
+  await page.route('**/api/auth/context', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        role: 'read-only',
+        isLocalhost: false,
+        actorType: 'device',
+        authMethod: 'device-session',
+        deviceSessionId: 'e2e-pwa-session',
+        deviceId: 'e2e-pwa-phone',
+        clientId: 'e2e-pwa-browser',
+        clientMode: 'mobile-pwa',
+        capabilities: [
+          'board:read',
+          'workspace:read',
+          'task:read',
+          'comment:write',
+          'workflow:read',
+          'notification:read',
+          'notification:receive',
+        ],
+        permissions: [
+          'workspace:read',
+          'task:read',
+          'comment:write',
+          'workflow:read',
+          'work_product:read',
+          'agent:read',
+          'settings:read',
+        ],
+      }),
+    })
+  );
+}
+
+test.describe('mobile PWA offline behavior', () => {
+  test.beforeEach(async ({ page }) => {
+    await bypassAuth(page);
+    await useMobileDeviceContext(page);
+  });
+
+  test.afterEach(async ({ page, context }) => {
+    await context.setOffline(false);
+    await cleanupRoutes(page);
+  });
+
+  test('serves install metadata and a static-only service worker', async ({ page }) => {
+    await page.goto('/');
+
+    const manifestHref = await page.locator('link[rel="manifest"]').getAttribute('href');
+    expect(manifestHref).toBeTruthy();
+
+    const manifestResponse = await page.request.get(new URL(manifestHref!, page.url()).toString());
+    expect(manifestResponse.ok()).toBe(true);
+    const manifest = (await manifestResponse.json()) as {
+      display: string;
+      start_url: string;
+      scope: string;
+      icons: Array<{ src: string; purpose?: string }>;
+    };
+    expect(manifest.display).toBe('standalone');
+    expect(manifest.start_url).toBe('.');
+    expect(manifest.scope).toBe('.');
+    expect(manifest.icons.some((icon) => icon.purpose === 'maskable')).toBe(true);
+
+    const serviceWorkerResponse = await page.request.get(new URL('/sw.js', page.url()).toString());
+    expect(serviceWorkerResponse.ok()).toBe(true);
+    const serviceWorker = await serviceWorkerResponse.text();
+    expect(serviceWorker).toContain("request.method !== 'GET'");
+    expect(serviceWorker).toContain("scopedPath.startsWith('api/')");
+    expect(serviceWorker).toContain("scopedPath.startsWith('ws/')");
+  });
+
+  test('shows a remote-safe offline warning in the mobile shell', async ({ page, context }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('navigation', { name: 'Mobile navigation' })).toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    await context.setOffline(true);
+    await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+
+    await expect(page.getByRole('status', { name: 'Offline' })).toBeVisible();
+    await expect(page.getByText(/Cached shell only/)).toBeVisible();
+    await expect(page.getByText(/Task data and changes require the trusted server/)).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,12 +47,12 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: /mobile-responsive\.spec\.ts/,
+      testIgnore: /(mobile-responsive|pwa-offline)\.spec\.ts/,
     },
     {
       name: 'mobile-chromium',
       use: { ...devices['Pixel 5'] },
-      testMatch: /mobile-responsive\.spec\.ts/,
+      testMatch: /(mobile-responsive|pwa-offline)\.spec\.ts/,
     },
   ],
 

--- a/web/index.html
+++ b/web/index.html
@@ -18,8 +18,16 @@
       })();
     </script>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="%BASE_URL%icons/pwa-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="application-name" content="Veritas Kanban" />
+    <meta name="apple-mobile-web-app-title" content="Veritas" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="theme-color" content="#15171f" />
     <title>Veritas Kanban</title>
   </head>
   <body>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <circle cx="32" cy="32" r="32" fill="#7c3aed"/>
+  <g fill="white" stroke="white" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="32" cy="14" r="2.5" fill="white" stroke="none"/>
+    <rect x="30.5" y="16" width="3" height="28" rx="1.5" stroke="none"/>
+    <rect x="23" y="46" width="18" height="3" rx="1.5" stroke="none"/>
+    <rect x="27" y="43.5" width="10" height="3.5" rx="1.5" stroke="none"/>
+    <line x1="11" y1="21" x2="53" y2="17" stroke-width="2.5"/>
+    <line x1="11" y1="21" x2="11" y2="30" stroke-width="1.5"/>
+    <line x1="5" y1="30" x2="11" y2="30" stroke-width="1.5"/>
+    <line x1="11" y1="30" x2="17" y2="30" stroke-width="1.5"/>
+    <path d="M4 30 C4 36, 11 38, 11 38 C11 38, 18 36, 18 30" fill="white" stroke="none"/>
+    <line x1="53" y1="17" x2="53" y2="24" stroke-width="1.5"/>
+    <line x1="47" y1="24" x2="53" y2="24" stroke-width="1.5"/>
+    <line x1="53" y1="24" x2="59" y2="24" stroke-width="1.5"/>
+    <path d="M46 24 C46 30, 53 32, 53 32 C53 32, 60 30, 60 24" fill="white" stroke="none"/>
+  </g>
+</svg>

--- a/web/public/icons/pwa-icon.svg
+++ b/web/public/icons/pwa-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Veritas Kanban">
+  <rect width="512" height="512" rx="96" fill="#15171f"/>
+  <rect x="56" y="64" width="400" height="384" rx="40" fill="#202431"/>
+  <rect x="96" y="112" width="84" height="288" rx="18" fill="#4f46e5"/>
+  <rect x="214" y="112" width="84" height="288" rx="18" fill="#14b8a6"/>
+  <rect x="332" y="112" width="84" height="288" rx="18" fill="#f59e0b"/>
+  <path d="M116 178h44M116 226h44M234 178h44M234 226h44M352 178h44M352 226h44M352 274h44" stroke="#f8fafc" stroke-width="20" stroke-linecap="round"/>
+  <circle cx="256" cy="366" r="42" fill="#f8fafc"/>
+  <path d="M238 367l14 14 27-31" fill="none" stroke="#15171f" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/public/icons/pwa-maskable-icon.svg
+++ b/web/public/icons/pwa-maskable-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Veritas Kanban">
+  <rect width="512" height="512" fill="#15171f"/>
+  <circle cx="256" cy="256" r="224" fill="#202431"/>
+  <rect x="104" y="128" width="72" height="256" rx="18" fill="#4f46e5"/>
+  <rect x="220" y="128" width="72" height="256" rx="18" fill="#14b8a6"/>
+  <rect x="336" y="128" width="72" height="256" rx="18" fill="#f59e0b"/>
+  <path d="M124 190h32M124 238h32M240 190h32M240 238h32M356 190h32M356 238h32M356 286h32" stroke="#f8fafc" stroke-width="18" stroke-linecap="round"/>
+  <circle cx="256" cy="372" r="44" fill="#f8fafc"/>
+  <path d="M237 373l15 15 29-34" fill="none" stroke="#15171f" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,28 @@
+{
+  "name": "Veritas Kanban",
+  "short_name": "Veritas",
+  "description": "Remote-safe task review, workflow, and agent coordination for trusted Veritas hosts.",
+  "id": ".",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone", "browser"],
+  "orientation": "any",
+  "theme_color": "#15171f",
+  "background_color": "#0f1117",
+  "categories": ["business", "productivity", "utilities"],
+  "icons": [
+    {
+      "src": "icons/pwa-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/pwa-maskable-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,104 @@
+/* global caches, fetch, self, URL */
+
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `veritas-kanban-static-${CACHE_VERSION}`;
+const SHELL_URL = new URL('./', self.registration.scope).toString();
+const PRECACHE_URLS = [
+  SHELL_URL,
+  new URL('manifest.webmanifest', self.registration.scope).toString(),
+  new URL('favicon.svg', self.registration.scope).toString(),
+  new URL('icons/pwa-icon.svg', self.registration.scope).toString(),
+  new URL('icons/pwa-maskable-icon.svg', self.registration.scope).toString(),
+];
+const STATIC_DESTINATIONS = new Set(['font', 'image', 'manifest', 'script', 'style', 'worker']);
+
+function isSameOrigin(url) {
+  return url.origin === self.location.origin;
+}
+
+function isPrivateRoute(url) {
+  const scopePath = new URL(self.registration.scope).pathname;
+  const scopedPath = url.pathname.startsWith(scopePath)
+    ? url.pathname.slice(scopePath.length)
+    : url.pathname.replace(/^\//, '');
+  return (
+    scopedPath.startsWith('api/') ||
+    scopedPath === 'api' ||
+    scopedPath.startsWith('ws/') ||
+    scopedPath === 'ws' ||
+    url.pathname.startsWith('/api/') ||
+    url.pathname === '/api' ||
+    url.pathname.startsWith('/ws/') ||
+    url.pathname === '/ws'
+  );
+}
+
+function isCacheableResponse(response) {
+  const cacheControl = response.headers.get('cache-control') || '';
+  return response.ok && !cacheControl.includes('no-store') && response.type !== 'opaqueredirect';
+}
+
+async function networkFirstShell(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  try {
+    const response = await fetch(request);
+    if (isCacheableResponse(response)) {
+      await cache.put(SHELL_URL, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(SHELL_URL);
+    if (cached) return cached;
+    throw error;
+  }
+}
+
+async function cacheFirstStatic(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const response = await fetch(request);
+  if (isCacheableResponse(response)) {
+    await cache.put(request, response.clone());
+  }
+  return response;
+}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((names) =>
+        Promise.all(names.filter((name) => name !== STATIC_CACHE).map((name) => caches.delete(name)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (request.method !== 'GET' || !isSameOrigin(url) || isPrivateRoute(url)) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirstShell(request));
+    return;
+  }
+
+  if (STATIC_DESTINATIONS.has(request.destination)) {
+    event.respondWith(cacheFirstStatic(request));
+  }
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,7 @@ import { useTaskSync } from './hooks/useTaskSync';
 import { TaskConfigProvider } from './contexts/TaskConfigContext';
 import { WebSocketStatusProvider } from './contexts/WebSocketContext';
 import { ViewProvider, useView } from './contexts/ViewContext';
-import { AuthProvider } from './hooks/useAuth';
+import { AuthProvider, useAuth } from './hooks/useAuth';
 import { IdentityProvider } from './hooks/useIdentity';
 import { AuthGuard } from './components/auth';
 import { DesktopOnboardingDialog } from './components/auth/DesktopOnboarding';
@@ -20,6 +20,7 @@ import { LiveAnnouncerProvider } from './components/shared/LiveAnnouncer';
 import { FloatingChat } from './components/chat/FloatingChat';
 import { SystemHealthBar } from './components/layout/SystemHealthBar';
 import { MobileShell } from './components/layout/MobileShell';
+import { PwaStatusBanner } from './components/layout/PwaStatusBanner';
 import { VIEW_BY_ID, type AppView } from './lib/views';
 
 // Lazy-load ActivityFeed and BacklogPage to keep initial bundle small
@@ -170,7 +171,8 @@ function MainContent() {
 // Main app content (only rendered when authenticated)
 function AppContent() {
   // Connect to WebSocket for real-time task updates
-  const { isConnected, connectionState, reconnectAttempt } = useTaskSync();
+  const { isConnected, connectionState, reconnectAttempt, reconnect } = useTaskSync();
+  const { status: authStatus, refreshStatus } = useAuth();
   const [showDesktopOnboarding, setShowDesktopOnboarding] = useState(false);
 
   useEffect(() => {
@@ -206,6 +208,7 @@ function AppContent() {
       isConnected={isConnected}
       connectionState={connectionState}
       reconnectAttempt={reconnectAttempt}
+      reconnect={reconnect}
     >
       <LiveAnnouncerProvider>
         <KeyboardProvider>
@@ -217,6 +220,10 @@ function AppContent() {
                     <SkipToContent />
                     <Header />
                     <SystemHealthBar />
+                    <PwaStatusBanner
+                      sessionExpiry={authStatus?.sessionExpiry}
+                      onRefreshAuth={refreshStatus}
+                    />
                     <Box
                       component="main"
                       id="main-content"

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -109,8 +109,18 @@ vi.mock('@/contexts/TaskConfigContext', () => ({
 
 // Mock KanbanColumn to simplify — just renders task titles
 vi.mock('@/components/board/KanbanColumn', () => ({
-  KanbanColumn: ({ id, title, tasks }: { id: string; title: string; tasks: Task[] }) => (
-    <div data-testid={`column-${id}`}>
+  KanbanColumn: ({
+    id,
+    title,
+    tasks,
+    canChangeStatus,
+  }: {
+    id: string;
+    title: string;
+    tasks: Task[];
+    canChangeStatus?: boolean;
+  }) => (
+    <div data-testid={`column-${id}`} data-can-change-status={String(canChangeStatus)}>
       <h2>{title}</h2>
       {tasks.map((t: Task) => (
         <div key={t.id} data-testid={`task-${t.id}`}>
@@ -171,8 +181,16 @@ function renderBoard() {
   return renderWithProviders(<KanbanBoard />, { queryClient });
 }
 
+function setOnline(value: boolean) {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value,
+  });
+}
+
 afterEach(() => {
   cleanup();
+  setOnline(true);
 });
 
 // ── Tests ────────────────────────────────────────────────────
@@ -227,5 +245,15 @@ describe('KanbanBoard', () => {
     // Columns should still exist
     expect(screen.getByTestId('column-todo')).toBeDefined();
     expect(screen.getByTestId('column-done')).toBeDefined();
+  });
+
+  it('disables explicit status changes while the browser is offline', () => {
+    setOnline(false);
+    mockUseTasks = () => ({ data: mockTasks, isLoading: false, error: null });
+
+    renderBoard();
+
+    expect(screen.getByTestId('column-todo').dataset.canChangeStatus).toBe('false');
+    expect(screen.getByTestId('column-in-progress').dataset.canChangeStatus).toBe('false');
   });
 });

--- a/web/src/__tests__/pwa-status-banner.test.tsx
+++ b/web/src/__tests__/pwa-status-banner.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PwaStatusBanner } from '@/components/layout/PwaStatusBanner';
+import { renderWithProviders } from './test-utils';
+
+function setOnline(value: boolean) {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value,
+  });
+}
+
+describe('PwaStatusBanner', () => {
+  beforeEach(() => {
+    setOnline(true);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    setOnline(true);
+  });
+
+  it('shows a remote-safe offline warning', () => {
+    setOnline(false);
+
+    renderWithProviders(<PwaStatusBanner />);
+
+    expect(screen.getByRole('status', { name: 'Offline' })).toBeDefined();
+    expect(screen.getByText(/Cached shell only/)).toBeDefined();
+    expect(screen.getByText(/Task data and changes require the trusted server/)).toBeDefined();
+  });
+
+  it('shows stale realtime state and lets the user retry reads', async () => {
+    const user = userEvent.setup();
+    const refreshAuth = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(<PwaStatusBanner onRefreshAuth={refreshAuth} />, {
+      wsStatus: {
+        isConnected: false,
+        connectionState: 'reconnecting',
+        reconnectAttempt: 2,
+      },
+    });
+
+    expect(screen.getByRole('status', { name: 'Reconnecting 2' })).toBeDefined();
+    expect(screen.getByText(/Data may be stale/)).toBeDefined();
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(refreshAuth).toHaveBeenCalled();
+  });
+
+  it('shows expired-session state without queuing failed writes', () => {
+    renderWithProviders(<PwaStatusBanner sessionExpiry="2000-01-01T00:00:00.000Z" />);
+
+    expect(screen.getByRole('status', { name: 'Session expired' })).toBeDefined();
+    expect(screen.getByText(/Failed writes are not queued/)).toBeDefined();
+  });
+
+  it('offers install when the browser exposes a PWA install prompt', async () => {
+    const user = userEvent.setup();
+    const prompt = vi.fn().mockResolvedValue(undefined);
+    const installEvent = new Event('beforeinstallprompt', { cancelable: true });
+    Object.defineProperties(installEvent, {
+      prompt: { value: prompt },
+      userChoice: {
+        value: Promise.resolve({ outcome: 'accepted', platform: 'web' }),
+      },
+    });
+
+    renderWithProviders(<PwaStatusBanner />);
+
+    window.dispatchEvent(installEvent);
+    await user.click(await screen.findByRole('button', { name: 'Install' }));
+
+    expect(prompt).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -26,6 +26,7 @@ import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import { useLiveAnnouncer } from '@/components/shared/LiveAnnouncer';
 import { useView } from '@/contexts/ViewContext';
 import { useIdentity } from '@/hooks/useIdentity';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
 
 // Lazy-load Dashboard to split recharts + d3 (~800KB) out of main bundle
@@ -55,9 +56,11 @@ export function KanbanBoard() {
   const { settings: featureSettings } = useFeatureSettings();
   const { announce } = useLiveAnnouncer();
   const { hasPermission } = useIdentity();
+  const { isOnline } = useNetworkStatus();
   const canWriteTasks = hasPermission('task:write');
   const isMobileLayout = useMediaQuery('(max-width: 767px)', false);
-  const canDragTasks = featureSettings.board.enableDragAndDrop && canWriteTasks && !isMobileLayout;
+  const canDragTasks =
+    featureSettings.board.enableDragAndDrop && canWriteTasks && isOnline && !isMobileLayout;
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailPanelMounted, setDetailPanelMounted] = useState(false);
@@ -213,10 +216,14 @@ export function KanbanBoard() {
         announce(`Task ${task?.title || taskId} cannot be moved with the current permissions`);
         return;
       }
+      if (!isOnline) {
+        announce(`Task ${task?.title || taskId} cannot be moved while this client is offline`);
+        return;
+      }
       updateTask.mutate({ id: taskId, input: { status } });
       announce(`Task ${task?.title || taskId} moved to ${columnName}`);
     },
-    [announce, canWriteTasks, filteredTasks, updateTask]
+    [announce, canWriteTasks, filteredTasks, isOnline, updateTask]
   );
 
   // Register callbacks with keyboard context (refs, so no need for useEffect)
@@ -238,11 +245,11 @@ export function KanbanBoard() {
     tasksByStatus,
     columns: COLUMNS,
     onStatusChange: (taskId, status) => {
-      if (!canWriteTasks) return;
+      if (!canWriteTasks || !isOnline) return;
       updateTask.mutate({ id: taskId, input: { status } });
     },
     onReorder: (taskIds) => {
-      if (!canWriteTasks) return;
+      if (!canWriteTasks || !isOnline) return;
       reorderTasks.mutate(taskIds);
     },
   });
@@ -328,7 +335,7 @@ export function KanbanBoard() {
                       onTaskClick={handleTaskClick}
                       onTaskStatusChange={handleMoveTask}
                       selectedTaskId={selectedTaskId}
-                      canChangeStatus={canWriteTasks}
+                      canChangeStatus={canWriteTasks && isOnline}
                       dragEnabled={canDragTasks}
                       isDragActive={isDragActive}
                       statusOptions={STATUS_OPTIONS}
@@ -356,7 +363,7 @@ export function KanbanBoard() {
                     onTaskClick={handleTaskClick}
                     onTaskStatusChange={handleMoveTask}
                     selectedTaskId={selectedTaskId}
-                    canChangeStatus={canWriteTasks}
+                    canChangeStatus={canWriteTasks && isOnline}
                     dragEnabled={false}
                     showStatusControls={isMobileLayout}
                     statusOptions={STATUS_OPTIONS}

--- a/web/src/components/layout/PwaStatusBanner.tsx
+++ b/web/src/components/layout/PwaStatusBanner.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@mantine/core';
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, Download, RefreshCw, WifiOff } from 'lucide-react';
+import { useWebSocketStatus } from '@/contexts/WebSocketContext';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+interface PwaStatusBannerProps {
+  sessionExpiry?: string | null;
+  onRefreshAuth?: () => Promise<void> | void;
+}
+
+function readStandaloneStatus() {
+  if (typeof window === 'undefined') return false;
+  const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
+  return (
+    window.matchMedia?.('(display-mode: standalone)').matches ||
+    navigatorWithStandalone.standalone === true
+  );
+}
+
+function isExpired(expiresAt?: string | null) {
+  if (!expiresAt) return false;
+  const timestamp = Date.parse(expiresAt);
+  return Number.isFinite(timestamp) && timestamp <= Date.now();
+}
+
+export function PwaStatusBanner({ sessionExpiry, onRefreshAuth }: PwaStatusBannerProps) {
+  const queryClient = useQueryClient();
+  const { connectionState, reconnectAttempt, reconnect } = useWebSocketStatus();
+  const { isOnline } = useNetworkStatus();
+  const [standalone, setStandalone] = useState(readStandaloneStatus);
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [isInstalling, setIsInstalling] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia?.('(display-mode: standalone)');
+    const syncStandalone = () => setStandalone(readStandaloneStatus());
+    mediaQuery?.addEventListener?.('change', syncStandalone);
+    return () => mediaQuery?.removeEventListener?.('change', syncStandalone);
+  }, []);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setInstallPrompt(event as BeforeInstallPromptEvent);
+    };
+    const handleInstalled = () => {
+      setStandalone(true);
+      setInstallPrompt(null);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleInstalled);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleInstalled);
+    };
+  }, []);
+
+  const sessionExpired = isExpired(sessionExpiry);
+  const state = useMemo(() => {
+    if (!isOnline) {
+      return {
+        label: 'Offline',
+        description: 'Cached shell only. Task data and changes require the trusted server.',
+        icon: WifiOff,
+        tone: 'border-amber-500/40 bg-amber-500/10 text-amber-100',
+      };
+    }
+
+    if (sessionExpired) {
+      return {
+        label: 'Session expired',
+        description: 'Refresh your session before making changes. Failed writes are not queued.',
+        icon: AlertTriangle,
+        tone: 'border-red-500/40 bg-red-500/10 text-red-100',
+      };
+    }
+
+    if (connectionState === 'connecting' || connectionState === 'reconnecting') {
+      return {
+        label: reconnectAttempt > 0 ? `Reconnecting ${reconnectAttempt}` : 'Reconnecting',
+        description:
+          'Data may be stale while realtime sync restores. Writes still need the server.',
+        icon: RefreshCw,
+        tone: 'border-amber-500/40 bg-amber-500/10 text-amber-100',
+      };
+    }
+
+    if (connectionState === 'disconnected') {
+      return {
+        label: 'Realtime disconnected',
+        description: 'Reads can retry over HTTP, but realtime updates are paused.',
+        icon: WifiOff,
+        tone: 'border-red-500/40 bg-red-500/10 text-red-100',
+      };
+    }
+
+    return null;
+  }, [connectionState, isOnline, reconnectAttempt, sessionExpired]);
+
+  const installAvailable = !!installPrompt && !standalone;
+
+  if (!state && !installAvailable) {
+    return null;
+  }
+
+  const Icon = state?.icon ?? Download;
+
+  const retry = async () => {
+    setIsRetrying(true);
+    try {
+      reconnect?.();
+      await onRefreshAuth?.();
+      await queryClient.invalidateQueries();
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  const install = async () => {
+    if (!installPrompt) return;
+    setIsInstalling(true);
+    try {
+      await installPrompt.prompt();
+      await installPrompt.userChoice.catch(() => null);
+      setInstallPrompt(null);
+    } finally {
+      setIsInstalling(false);
+    }
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={state?.label ?? 'Install available'}
+      className={`md:hidden border-b px-3 py-2 ${state?.tone ?? 'border-border bg-card text-card-foreground'}`}
+    >
+      <div className="flex items-start gap-2">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold leading-tight">
+            {state?.label ?? 'Install available'}
+          </p>
+          <p className="mt-0.5 text-[11px] leading-snug opacity-85">
+            {state?.description ??
+              'Add Veritas to this device for a standalone trusted-host window.'}
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-1">
+          {state && (
+            <Button size="compact-xs" variant="light" onClick={retry} loading={isRetrying}>
+              Retry
+            </Button>
+          )}
+          {installAvailable && (
+            <Button size="compact-xs" variant="filled" onClick={install} loading={isInstalling}>
+              Install
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/contexts/WebSocketContext.tsx
+++ b/web/src/contexts/WebSocketContext.tsx
@@ -8,6 +8,8 @@ interface WebSocketStatus {
   connectionState: ConnectionState;
   /** Current reconnect attempt (0 when connected or idle) */
   reconnectAttempt: number;
+  /** Manually retry the WebSocket connection after a disconnected state */
+  reconnect?: () => void;
 }
 
 const WebSocketStatusContext = createContext<WebSocketStatus>({
@@ -21,15 +23,17 @@ export function WebSocketStatusProvider({
   isConnected,
   connectionState,
   reconnectAttempt,
+  reconnect,
 }: {
   children: ReactNode;
   isConnected: boolean;
   connectionState: ConnectionState;
   reconnectAttempt: number;
+  reconnect?: () => void;
 }) {
   const value = useMemo(
-    () => ({ isConnected, connectionState, reconnectAttempt }),
-    [isConnected, connectionState, reconnectAttempt]
+    () => ({ isConnected, connectionState, reconnectAttempt, reconnect }),
+    [isConnected, connectionState, reconnectAttempt, reconnect]
   );
 
   return (

--- a/web/src/hooks/useNetworkStatus.ts
+++ b/web/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+function readOnlineStatus(): boolean {
+  if (typeof navigator === 'undefined' || typeof navigator.onLine !== 'boolean') {
+    return true;
+  }
+  return navigator.onLine;
+}
+
+export function useNetworkStatus() {
+  const [isOnline, setIsOnline] = useState(readOnlineStatus);
+
+  useEffect(() => {
+    const updateStatus = () => setIsOnline(readOnlineStatus());
+
+    window.addEventListener('online', updateStatus);
+    window.addEventListener('offline', updateStatus);
+
+    return () => {
+      window.removeEventListener('online', updateStatus);
+      window.removeEventListener('offline', updateStatus);
+    };
+  }, []);
+
+  return { isOnline };
+}

--- a/web/src/hooks/useTaskSync.ts
+++ b/web/src/hooks/useTaskSync.ts
@@ -19,6 +19,7 @@ export function useTaskSync(): {
   isConnected: boolean;
   connectionState: ConnectionState;
   reconnectAttempt: number;
+  reconnect: () => void;
 } {
   const queryClient = useQueryClient();
 
@@ -96,11 +97,11 @@ export function useTaskSync(): {
     [queryClient]
   );
 
-  const { isConnected, connectionState, reconnectAttempt } = useWebSocket({
+  const { isConnected, connectionState, reconnectAttempt, connect } = useWebSocket({
     onOpen: { type: 'subscribe:tasks' },
     onMessage: handleMessage,
     maxReconnectAttempts: 20,
   });
 
-  return { isConnected, connectionState, reconnectAttempt };
+  return { isConnected, connectionState, reconnectAttempt, reconnect: connect };
 }

--- a/web/src/lib/__tests__/pwa.test.ts
+++ b/web/src/lib/__tests__/pwa.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerPwaServiceWorker, resolvePwaAssetUrl } from '@/lib/pwa';
+
+describe('pwa helpers', () => {
+  it('resolves service-worker assets relative to the configured base path', () => {
+    expect(resolvePwaAssetUrl('sw.js', '/')).toBe('/sw.js');
+    expect(resolvePwaAssetUrl('/sw.js', '/kanban')).toBe('/kanban/sw.js');
+  });
+
+  it('skips registration when PWA support is disabled', async () => {
+    const register = vi.fn();
+
+    const result = await registerPwaServiceWorker({
+      enabled: false,
+      serviceWorker: { register } as unknown as ServiceWorkerContainer,
+    });
+
+    expect(result).toBeNull();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('registers the service worker under the app base path', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const registration = { update } as unknown as ServiceWorkerRegistration;
+    const register = vi.fn().mockResolvedValue(registration);
+
+    const result = await registerPwaServiceWorker({
+      enabled: true,
+      baseUrl: '/kanban/',
+      serviceWorker: { register } as unknown as ServiceWorkerContainer,
+    });
+
+    expect(result).toBe(registration);
+    expect(register).toHaveBeenCalledWith('/kanban/sw.js', { scope: '/kanban/' });
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/pwa.ts
+++ b/web/src/lib/pwa.ts
@@ -1,0 +1,43 @@
+export interface RegisterPwaServiceWorkerOptions {
+  enabled?: boolean;
+  serviceWorker?: ServiceWorkerContainer;
+  baseUrl?: string;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  if (!baseUrl || baseUrl === '.') return './';
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+}
+
+export function resolvePwaAssetUrl(
+  path: string,
+  baseUrl = import.meta.env.BASE_URL || '/'
+): string {
+  const normalizedBase = normalizeBaseUrl(baseUrl);
+  return `${normalizedBase}${path.replace(/^\//, '')}`;
+}
+
+export async function registerPwaServiceWorker(
+  options: RegisterPwaServiceWorkerOptions = {}
+): Promise<ServiceWorkerRegistration | null> {
+  if (typeof window === 'undefined') return null;
+
+  const serviceWorker = options.serviceWorker ?? navigator.serviceWorker;
+  const enabled =
+    options.enabled ?? (import.meta.env.PROD || import.meta.env.VITE_ENABLE_PWA === 'true');
+
+  if (!enabled || !serviceWorker) {
+    return null;
+  }
+
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? import.meta.env.BASE_URL ?? '/');
+  const registration = await serviceWorker.register(resolvePwaAssetUrl('sw.js', baseUrl), {
+    scope: baseUrl,
+  });
+
+  registration.update().catch((error) => {
+    console.warn('[PWA] Service worker update check failed:', error);
+  });
+
+  return registration;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import { MantineRoot } from './theme/MantineRoot';
+import { registerPwaServiceWorker } from './lib/pwa';
 import '@mantine/core/styles.css';
 import '@mantine/notifications/styles.css';
 import './globals.css';
@@ -25,3 +26,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </QueryClientProvider>
   </React.StrictMode>
 );
+
+void registerPwaServiceWorker().catch((error) => {
+  console.warn('[PWA] Service worker registration failed:', error);
+});

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string;
+  readonly VITE_ENABLE_PWA?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Adds installable PWA metadata, first-party icons, and production service-worker registration that respects `VITE_BASE_PATH`.
- Adds a static-only service worker that caches the shell/assets while bypassing `/api`, `/ws`, and all non-GET mutation requests.
- Adds a mobile PWA status banner for offline, reconnecting, disconnected, expired-session, and install-prompt states, plus offline guards for board status changes.
- Documents iOS Safari and Android Chrome install flow, trusted-host/subpath requirements, and shared-device/offline behavior.

## Verification
- pnpm --filter @veritas-kanban/web test -- pwa.test.ts pwa-status-banner.test.tsx KanbanBoard.test.tsx mobile-shell.test.tsx WebSocketIndicator.test.tsx
- pnpm exec playwright test e2e/pwa-offline.spec.ts --project=mobile-chromium
- pnpm exec playwright test e2e/mobile-responsive.spec.ts e2e/pwa-offline.spec.ts --project=mobile-chromium
- pnpm typecheck
- pnpm lint
- pnpm build
- git diff --check

Closes #347
