### PR TITLE
Harden realtime sync delivery

### DIFF
--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastReviewed": "2026-05-31",
+  "lastReviewed": "2026-06-03",
   "notes": "Authority surface manifest for v5.0. The REST route-map entry is backed by shared/src/utils/api-permissions.ts, and CI compares it against server/src/routes/v1/index.ts.",
   "surfaces": [
     {
@@ -76,12 +76,36 @@
       "denialReason": "Workflow status events require workflow read access."
     },
     {
+      "id": "websocket:tasks:subscribed",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Task channel subscription confirmations are only sent after task read authorization."
+    },
+    {
+      "id": "websocket:workflow:subscribed",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["workflow:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Workflow subscription confirmations are only sent after workflow read authorization."
+    },
+    {
       "id": "websocket:agent:status",
       "kind": "websocket",
       "classification": "agent-scoped",
       "permissions": ["agent:read"],
       "source": "server/src/routes/agent-status.ts",
       "denialReason": "Agent status events require agent read access."
+    },
+    {
+      "id": "websocket:agent:status:subscribed",
+      "kind": "websocket",
+      "classification": "agent-scoped",
+      "permissions": ["agent:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Agent status subscription confirmations are only sent after agent read authorization."
     },
     {
       "id": "websocket:agent:output",
@@ -138,6 +162,22 @@
       "permissions": ["task:read"],
       "source": "server/src/index.ts",
       "denialReason": "Chat subscriptions require task read access in the requested workspace."
+    },
+    {
+      "id": "websocket-inbound:subscribe:tasks",
+      "kind": "websocket-inbound",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Task event channel subscriptions require task read access in the requested workspace."
+    },
+    {
+      "id": "websocket-inbound:workflow:subscribe",
+      "kind": "websocket-inbound",
+      "classification": "authenticated-read",
+      "permissions": ["workflow:read"],
+      "source": "server/src/index.ts",
+      "denialReason": "Workflow event channel subscriptions require workflow read access in the requested workspace."
     },
     {
       "id": "websocket-inbound:subscribe",

--- a/server/src/__tests__/broadcast-service.test.ts
+++ b/server/src/__tests__/broadcast-service.test.ts
@@ -2,34 +2,57 @@
  * BroadcastService Tests
  * Tests WebSocket broadcast functions for task changes and telemetry.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { AnyTelemetryEvent } from '@veritas-kanban/shared';
 import type { WebSocketServer } from 'ws';
 import {
   initBroadcast,
   broadcastTaskChange,
   broadcastTelemetryEvent,
+  broadcastWorkflowStatus,
 } from '../services/broadcast-service.js';
+import type { WebSocketEventChannel } from '../services/websocket-permissions.js';
+
+type MockAuth = {
+  role: 'admin' | 'agent' | 'read-only';
+  isLocalhost: boolean;
+  workspaceId?: string;
+};
+
+type MockClient = {
+  readyState: number;
+  auth?: MockAuth;
+  bufferedAmount: number;
+  subscribedChannels?: Set<WebSocketEventChannel>;
+  sent: string[];
+  send: (data: string) => void;
+  close: ReturnType<typeof vi.fn>;
+};
 
 // Minimal mock WebSocket server
 function createMockWss() {
   const sentMessages: string[] = [];
-  const clients = new Set<{
-    readyState: number;
-    auth?: { role: 'admin' | 'agent' | 'read-only'; isLocalhost: boolean; workspaceId?: string };
-    send: (data: string) => void;
-  }>();
+  const clients = new Set<MockClient>();
 
   return {
     clients,
     addClient(
       readyState = 1,
-      auth = { role: 'admin' as const, isLocalhost: false, workspaceId: 'local' }
+      auth: MockAuth = { role: 'admin', isLocalhost: false, workspaceId: 'local' },
+      options: { bufferedAmount?: number; subscribedChannels?: Set<WebSocketEventChannel> } = {}
     ) {
+      const sent: string[] = [];
       const client = {
         readyState,
         auth,
-        send: (data: string) => sentMessages.push(data),
+        bufferedAmount: options.bufferedAmount ?? 0,
+        subscribedChannels: options.subscribedChannels,
+        sent,
+        send: (data: string) => {
+          sent.push(data);
+          sentMessages.push(data);
+        },
+        close: vi.fn(),
       };
       clients.add(client);
       return client;
@@ -51,6 +74,30 @@ function telemetryEvent(): AnyTelemetryEvent {
   } as unknown as AnyTelemetryEvent;
 }
 
+function workflowRun(status: string) {
+  return {
+    id: 'run_123',
+    workflowId: 'workflow_456',
+    workflowVersion: 2,
+    taskId: 'task_789',
+    status,
+    startedAt: '2026-01-01T00:00:00Z',
+    completedAt: status === 'completed' ? '2026-01-01T00:00:05Z' : undefined,
+    steps: [
+      {
+        stepId: 'step_1',
+        status,
+        retries: 0,
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  initBroadcast(null as unknown as WebSocketServer);
+});
+
 describe('BroadcastService', () => {
   describe('broadcastTaskChange()', () => {
     it('should broadcast to all connected clients', () => {
@@ -67,6 +114,8 @@ describe('BroadcastService', () => {
       expect(msg.changeType).toBe('created');
       expect(msg.taskId).toBe('task_123');
       expect(msg.timestamp).toBeDefined();
+      expect(msg.sequence).toEqual(expect.any(Number));
+      expect(msg.workspaceId).toBe('local');
     });
 
     it('should skip clients that are not in OPEN state', () => {
@@ -113,6 +162,60 @@ describe('BroadcastService', () => {
 
       expect(wss.sentMessages).toHaveLength(1);
     });
+
+    it('should filter task events by channel subscription while preserving legacy clients', () => {
+      const wss = createMockWss();
+      const workflowOnly = wss.addClient(1, undefined, {
+        subscribedChannels: new Set(['workflows']),
+      });
+      const taskSubscriber = wss.addClient(1, undefined, {
+        subscribedChannels: new Set(['tasks']),
+      });
+      const legacySubscriber = wss.addClient(1);
+      initBroadcast(asWebSocketServer(wss));
+
+      broadcastTaskChange('updated', 'task_456');
+
+      expect(workflowOnly.sent).toHaveLength(0);
+      expect(taskSubscriber.sent).toHaveLength(1);
+      expect(legacySubscriber.sent).toHaveLength(1);
+      expect(wss.sentMessages).toHaveLength(2);
+    });
+
+    it('should close backpressured clients instead of sending task events', () => {
+      const wss = createMockWss();
+      const backpressuredClient = wss.addClient(1, undefined, {
+        bufferedAmount: 1_000_001,
+        subscribedChannels: new Set(['tasks']),
+      });
+      const healthyClient = wss.addClient(1, undefined, {
+        subscribedChannels: new Set(['tasks']),
+      });
+      initBroadcast(asWebSocketServer(wss));
+
+      broadcastTaskChange('updated', 'task_456');
+
+      expect(backpressuredClient.sent).toHaveLength(0);
+      expect(backpressuredClient.close).toHaveBeenCalledWith(1013, 'Client backpressure');
+      expect(healthyClient.sent).toHaveLength(1);
+      expect(wss.sentMessages).toHaveLength(1);
+    });
+
+    it('should batch task broadcasts across many clients', async () => {
+      const wss = createMockWss();
+      for (let index = 0; index < 75; index++) {
+        wss.addClient(1, undefined, { subscribedChannels: new Set(['tasks']) });
+      }
+      initBroadcast(asWebSocketServer(wss));
+
+      broadcastTaskChange('updated', 'task_456');
+
+      expect(wss.sentMessages).toHaveLength(50);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(wss.sentMessages).toHaveLength(75);
+    });
   });
 
   describe('broadcastTelemetryEvent()', () => {
@@ -127,6 +230,9 @@ describe('BroadcastService', () => {
       const msg = JSON.parse(wss.sentMessages[0]);
       expect(msg.type).toBe('telemetry:event');
       expect(msg.event.taskId).toBe('task_789');
+      expect(msg.timestamp).toBeDefined();
+      expect(msg.sequence).toEqual(expect.any(Number));
+      expect(msg.workspaceId).toBe('local');
     });
 
     it('should filter telemetry events by read permission', () => {
@@ -144,6 +250,34 @@ describe('BroadcastService', () => {
       initBroadcast(null as unknown as WebSocketServer);
       // Should not throw
       broadcastTelemetryEvent(telemetryEvent());
+    });
+  });
+
+  describe('broadcastWorkflowStatus()', () => {
+    it('should coalesce high-frequency status updates per workflow run', () => {
+      vi.useFakeTimers();
+      const wss = createMockWss();
+      const workflowSubscriber = wss.addClient(1, undefined, {
+        subscribedChannels: new Set(['workflows']),
+      });
+      initBroadcast(asWebSocketServer(wss));
+
+      broadcastWorkflowStatus(workflowRun('running'));
+      broadcastWorkflowStatus(workflowRun('completed'));
+
+      expect(wss.sentMessages).toHaveLength(0);
+
+      vi.advanceTimersByTime(100);
+
+      expect(workflowSubscriber.sent).toHaveLength(1);
+      expect(wss.sentMessages).toHaveLength(1);
+      const msg = JSON.parse(workflowSubscriber.sent[0]);
+      expect(msg.type).toBe('workflow:status');
+      expect(msg.sequence).toEqual(expect.any(Number));
+      expect(msg.workspaceId).toBe('local');
+      expect(msg.payload.id).toBe('run_123');
+      expect(msg.payload.status).toBe('completed');
+      expect(msg.payload.completedAt).toBe('2026-01-01T00:00:05Z');
     });
   });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,7 +28,7 @@ import { initAgentStatus } from './routes/agent-status.js';
 import { getTelemetryService } from './services/telemetry-service.js';
 import { ConfigService } from './services/config-service.js';
 import { disposeTaskService } from './services/task-service.js';
-import { initBroadcast } from './services/broadcast-service.js';
+import { initBroadcast, nextWebSocketEventSequence } from './services/broadcast-service.js';
 import { runStartupMigrations } from './services/migration-service.js';
 import { getPolicyService } from './services/policy-service.js';
 import { createBackup, runIntegrityChecks } from './services/integrity-service.js';
@@ -61,7 +61,11 @@ import { healthRouter, apiHealthRouter, setHealthWss } from './routes/health.js'
 import { getPrometheusCollector } from './services/metrics/prometheus.js';
 import { metricsCollector } from './middleware/metrics-collector.js';
 import { getStorageTypeFromEnv, initStorage, shutdownStorage } from './storage/index.js';
-import { canReceiveWebSocketEvent } from './services/websocket-permissions.js';
+import {
+  canReceiveWebSocketEvent,
+  subscribeWebSocketChannel,
+  type WebSocketEventChannel,
+} from './services/websocket-permissions.js';
 
 const log = createLogger('server');
 
@@ -620,6 +624,7 @@ const WS_PONG_TIMEOUT_MS = 10_000;
 interface HeartbeatWebSocket extends AuthenticatedWebSocket {
   isAlive?: boolean;
   heartbeatTimer?: ReturnType<typeof setTimeout>;
+  subscribedChannels?: Set<WebSocketEventChannel>;
 }
 
 const wss = new WebSocketServer({
@@ -807,6 +812,44 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
     try {
       const message = JSON.parse(data.toString());
 
+      if (message.type === 'subscribe:tasks') {
+        const workspaceId = getMessageWorkspaceId(message);
+        const permissions: AuthPermission[] = ['task:read'];
+        if (!canReceiveWebSocketEvent(ws, { workspaceId, permissions })) {
+          sendWebSocketForbidden(ws, 'subscribe:tasks', permissions, workspaceId);
+          return;
+        }
+
+        subscribeWebSocketChannel(ws, 'tasks');
+        ws.send(
+          JSON.stringify({
+            type: 'tasks:subscribed',
+            workspaceId,
+            sequence: nextWebSocketEventSequence(),
+            timestamp: new Date().toISOString(),
+          })
+        );
+      }
+
+      if (message.type === 'workflow:subscribe') {
+        const workspaceId = getMessageWorkspaceId(message);
+        const permissions: AuthPermission[] = ['workflow:read'];
+        if (!canReceiveWebSocketEvent(ws, { workspaceId, permissions })) {
+          sendWebSocketForbidden(ws, 'workflow:subscribe', permissions, workspaceId);
+          return;
+        }
+
+        subscribeWebSocketChannel(ws, 'workflows');
+        ws.send(
+          JSON.stringify({
+            type: 'workflow:subscribed',
+            workspaceId,
+            sequence: nextWebSocketEventSequence(),
+            timestamp: new Date().toISOString(),
+          })
+        );
+      }
+
       // Handle subscription to chat session
       if (message.type === 'chat:subscribe' && message.sessionId) {
         const workspaceId = getMessageWorkspaceId(message);
@@ -815,6 +858,7 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
           sendWebSocketForbidden(ws, 'chat:subscribe', permissions, workspaceId);
           return;
         }
+        subscribeWebSocketChannel(ws, 'chat');
 
         // Unsubscribe from previous chat session
         if (subscribedChatSession) {
@@ -848,6 +892,25 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
         log.debug({ sessionId, clients: sessionSubscribers.size }, 'Chat subscription added');
       }
 
+      if (message.type === 'subscribe' && message.channel === 'agent:status') {
+        const workspaceId = getMessageWorkspaceId(message);
+        const permissions: AuthPermission[] = ['agent:read'];
+        if (!canReceiveWebSocketEvent(ws, { workspaceId, permissions })) {
+          sendWebSocketForbidden(ws, 'subscribe', permissions, workspaceId);
+          return;
+        }
+
+        subscribeWebSocketChannel(ws, 'agent-status');
+        ws.send(
+          JSON.stringify({
+            type: 'agent:status:subscribed',
+            workspaceId,
+            sequence: nextWebSocketEventSequence(),
+            timestamp: new Date().toISOString(),
+          })
+        );
+      }
+
       // Handle subscription to agent output
       if (message.type === 'subscribe' && message.taskId) {
         const workspaceId = getMessageWorkspaceId(message);
@@ -856,6 +919,7 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
           sendWebSocketForbidden(ws, 'subscribe', permissions, workspaceId);
           return;
         }
+        subscribeWebSocketChannel(ws, 'agent-output');
 
         // Unsubscribe from previous task
         if (subscribedTaskId) {

--- a/server/src/routes/agent-status.ts
+++ b/server/src/routes/agent-status.ts
@@ -116,7 +116,7 @@ function broadcastAgentStatusChange(): void {
   const payload = JSON.stringify(message);
 
   wssRef.clients.forEach((client: WebSocket) => {
-    sendWebSocketEvent(client, payload, { permissions: ['agent:read'] });
+    sendWebSocketEvent(client, payload, { permissions: ['agent:read'], channel: 'agent-status' });
   });
 }
 

--- a/server/src/services/broadcast-service.ts
+++ b/server/src/services/broadcast-service.ts
@@ -7,6 +7,7 @@ import {
 } from './clawdbot-webhook-service.js';
 import {
   canReceiveWebSocketEvent,
+  sendWebSocketEvent,
   type WebSocketDeliveryOptions,
 } from './websocket-permissions.js';
 
@@ -18,9 +19,24 @@ let wssRef: WebSocketServer | null = null;
 
 // Performance: batch size for WebSocket broadcasts
 const BROADCAST_BATCH_SIZE = 50;
+const WORKFLOW_STATUS_COALESCE_MS = 100;
+const DEFAULT_WORKSPACE_ID = 'local';
+let websocketEventSequence = 0;
+let workflowStatusFlushTimer: ReturnType<typeof setTimeout> | null = null;
+const pendingWorkflowStatusEvents = new Map<string, WorkflowStatusEvent>();
 
 export function initBroadcast(wss: WebSocketServer): void {
   wssRef = wss;
+}
+
+export function nextWebSocketEventSequence(): number {
+  websocketEventSequence =
+    websocketEventSequence >= Number.MAX_SAFE_INTEGER ? 1 : websocketEventSequence + 1;
+  return websocketEventSequence;
+}
+
+function normalizeWorkspaceId(workspaceId?: string): string {
+  return workspaceId && workspaceId.trim() ? workspaceId : DEFAULT_WORKSPACE_ID;
 }
 
 /**
@@ -41,7 +57,7 @@ function broadcastToClients(payload: string, options: WebSocketDeliveryOptions =
   // For small client counts, send synchronously
   if (openClients.length <= BROADCAST_BATCH_SIZE) {
     for (const client of openClients) {
-      client.send(payload);
+      sendWebSocketEvent(client, payload, options);
     }
     return;
   }
@@ -51,7 +67,7 @@ function broadcastToClients(payload: string, options: WebSocketDeliveryOptions =
   const sendBatch = (): void => {
     const end = Math.min(index + BROADCAST_BATCH_SIZE, openClients.length);
     for (let i = index; i < end; i++) {
-      openClients[i].send(payload);
+      sendWebSocketEvent(openClients[i], payload, options);
     }
     index = end;
     if (index < openClients.length) {
@@ -74,11 +90,16 @@ export interface TaskChangeEvent {
   changeType: TaskChangeType;
   taskId?: string;
   timestamp: string;
+  sequence: number;
+  workspaceId: string;
 }
 
 export interface TelemetryBroadcastEvent {
   type: 'telemetry:event';
   event: AnyTelemetryEvent;
+  timestamp: string;
+  sequence: number;
+  workspaceId: string;
 }
 
 /**
@@ -90,20 +111,24 @@ export interface TelemetryBroadcastEvent {
 export function broadcastTaskChange(
   changeType: TaskChangeType,
   taskId?: string,
-  taskContext?: TaskContext
+  taskContext?: TaskContext,
+  options: { workspaceId?: string } = {}
 ): void {
   if (!wssRef) return;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
 
   const message: TaskChangeEvent = {
     type: 'task:changed',
     changeType,
     taskId,
     timestamp: new Date().toISOString(),
+    sequence: nextWebSocketEventSequence(),
+    workspaceId,
   };
 
   const payload = JSON.stringify(message);
 
-  broadcastToClients(payload, { permissions: ['task:read'] });
+  broadcastToClients(payload, { permissions: ['task:read'], workspaceId, channel: 'tasks' });
 
   // Also notify via webhook (fire-and-forget)
   notifyTaskChange(changeType, taskId, taskContext);
@@ -115,17 +140,30 @@ export interface ChatBroadcastEvent {
   text?: string;
   message?: unknown;
   error?: string;
+  timestamp?: string;
+  sequence?: number;
+  workspaceId?: string;
 }
 
 /**
  * Broadcast a chat message/event to all connected WebSocket clients.
  */
-export function broadcastChatMessage(sessionId: string, event: ChatBroadcastEvent): void {
+export function broadcastChatMessage(
+  sessionId: string,
+  event: ChatBroadcastEvent,
+  options: { workspaceId?: string } = {}
+): void {
   if (!wssRef) return;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
 
-  const payload = JSON.stringify(event);
+  const payload = JSON.stringify({
+    ...event,
+    timestamp: event.timestamp ?? new Date().toISOString(),
+    sequence: event.sequence ?? nextWebSocketEventSequence(),
+    workspaceId: event.workspaceId ?? workspaceId,
+  });
 
-  broadcastToClients(payload, { permissions: ['task:read'] });
+  broadcastToClients(payload, { permissions: ['task:read'], workspaceId, channel: 'chat' });
 
   // Also notify via webhook (fire-and-forget)
   notifyChatMessage(
@@ -138,39 +176,60 @@ export function broadcastChatMessage(sessionId: string, event: ChatBroadcastEven
 export interface SquadBroadcastEvent {
   type: 'squad:message';
   message: SquadMessage;
+  timestamp: string;
+  sequence: number;
+  workspaceId: string;
 }
 
 /**
  * Broadcast a squad message to all connected WebSocket clients.
  */
-export function broadcastSquadMessage(message: SquadMessage): void {
+export function broadcastSquadMessage(
+  message: SquadMessage,
+  options: { workspaceId?: string } = {}
+): void {
   if (!wssRef) return;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
 
   const event: SquadBroadcastEvent = {
     type: 'squad:message',
     message,
+    timestamp: new Date().toISOString(),
+    sequence: nextWebSocketEventSequence(),
+    workspaceId,
   };
 
   const payload = JSON.stringify(event);
 
-  broadcastToClients(payload, { permissions: ['agent:read'] });
+  broadcastToClients(payload, { permissions: ['agent:read'], workspaceId, channel: 'squad' });
 }
 
 /**
  * Broadcast a telemetry event to all connected WebSocket clients.
  * Clients can listen for 'telemetry:event' messages for real-time telemetry updates.
  */
-export function broadcastTelemetryEvent(event: AnyTelemetryEvent): void {
+export function broadcastTelemetryEvent(
+  event: AnyTelemetryEvent,
+  options: { workspaceId?: string } = {}
+): void {
   if (!wssRef) return;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
 
   const message: TelemetryBroadcastEvent = {
     type: 'telemetry:event',
     event,
+    timestamp: new Date().toISOString(),
+    sequence: nextWebSocketEventSequence(),
+    workspaceId,
   };
 
   const payload = JSON.stringify(message);
 
-  broadcastToClients(payload, { permissions: ['telemetry:read'] });
+  broadcastToClients(payload, {
+    permissions: ['telemetry:read'],
+    workspaceId,
+    channel: 'telemetry',
+  });
 }
 
 export interface BroadcastMessageEvent {
@@ -184,27 +243,40 @@ export interface BroadcastMessageEvent {
     createdAt: string;
     readBy: Array<{ agent: string; readAt: string }>;
   };
+  timestamp: string;
+  sequence: number;
+  workspaceId: string;
 }
 
 /**
  * Broadcast a new broadcast message to all connected WebSocket clients.
  * Clients can listen for 'broadcast:new' messages to receive real-time notifications.
  */
-export function broadcastNewMessage(broadcast: BroadcastMessageEvent['broadcast']): void {
+export function broadcastNewMessage(
+  broadcast: BroadcastMessageEvent['broadcast'],
+  options: { workspaceId?: string } = {}
+): void {
   if (!wssRef) return;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
 
   const message: BroadcastMessageEvent = {
     type: 'broadcast:new',
     broadcast,
+    timestamp: new Date().toISOString(),
+    sequence: nextWebSocketEventSequence(),
+    workspaceId,
   };
 
   const payload = JSON.stringify(message);
 
-  broadcastToClients(payload, { permissions: ['agent:read'] });
+  broadcastToClients(payload, { permissions: ['agent:read'], workspaceId, channel: 'broadcasts' });
 }
 
 export interface WorkflowStatusEvent {
   type: 'workflow:status';
+  timestamp: string;
+  sequence: number;
+  workspaceId: string;
   payload: {
     id: string;
     workflowId: string;
@@ -230,37 +302,58 @@ export interface WorkflowStatusEvent {
   };
 }
 
+function flushWorkflowStatusEvents(): void {
+  workflowStatusFlushTimer = null;
+  const events = Array.from(pendingWorkflowStatusEvents.values());
+  pendingWorkflowStatusEvents.clear();
+
+  for (const event of events) {
+    broadcastToClients(JSON.stringify(event), {
+      permissions: ['workflow:read'],
+      workspaceId: event.workspaceId,
+      channel: 'workflows',
+    });
+  }
+}
+
 /**
  * Broadcast workflow run status updates to all connected WebSocket clients.
  * Sends full run state to avoid extra HTTP fetches.
  */
-export function broadcastWorkflowStatus(run: {
-  id: string;
-  workflowId: string;
-  workflowVersion: number;
-  taskId?: string;
-  status: string;
-  currentStep?: string;
-  startedAt: string;
-  completedAt?: string;
-  error?: string;
-  steps: Array<{
-    stepId: string;
+export function broadcastWorkflowStatus(
+  run: {
+    id: string;
+    workflowId: string;
+    workflowVersion: number;
+    taskId?: string;
     status: string;
-    agent?: string;
-    sessionKey?: string;
-    startedAt?: string;
+    currentStep?: string;
+    startedAt: string;
     completedAt?: string;
-    duration?: number;
-    retries: number;
-    output?: string;
     error?: string;
-  }>;
-}): void {
+    steps: Array<{
+      stepId: string;
+      status: string;
+      agent?: string;
+      sessionKey?: string;
+      startedAt?: string;
+      completedAt?: string;
+      duration?: number;
+      retries: number;
+      output?: string;
+      error?: string;
+    }>;
+  },
+  options: { workspaceId?: string } = {}
+): void {
   if (!wssRef) return;
+  const workspaceId = normalizeWorkspaceId(options.workspaceId);
 
   const message: WorkflowStatusEvent = {
     type: 'workflow:status',
+    timestamp: new Date().toISOString(),
+    sequence: nextWebSocketEventSequence(),
+    workspaceId,
     payload: {
       id: run.id,
       workflowId: run.workflowId,
@@ -286,7 +379,9 @@ export function broadcastWorkflowStatus(run: {
     },
   };
 
-  const payload = JSON.stringify(message);
+  pendingWorkflowStatusEvents.set(run.id, message);
 
-  broadcastToClients(payload, { permissions: ['workflow:read'] });
+  if (!workflowStatusFlushTimer) {
+    workflowStatusFlushTimer = setTimeout(flushWorkflowStatusEvents, WORKFLOW_STATUS_COALESCE_MS);
+  }
 }

--- a/server/src/services/websocket-permissions.ts
+++ b/server/src/services/websocket-permissions.ts
@@ -7,10 +7,47 @@ import {
 
 const DEFAULT_WORKSPACE_ID = 'local';
 const WEBSOCKET_OPEN = 1;
+const WS_BACKPRESSURE_LIMIT_BYTES = 1_000_000;
+
+export type WebSocketEventChannel =
+  | 'agent-output'
+  | 'agent-status'
+  | 'broadcasts'
+  | 'chat'
+  | 'squad'
+  | 'tasks'
+  | 'telemetry'
+  | 'workflows';
 
 export interface WebSocketDeliveryOptions {
   workspaceId?: string;
   permissions?: AuthPermission[];
+  channel?: WebSocketEventChannel;
+}
+
+export interface SubscribedWebSocket extends AuthenticatedWebSocket {
+  subscribedChannels?: Set<WebSocketEventChannel>;
+}
+
+export function subscribeWebSocketChannel(client: WebSocket, channel: WebSocketEventChannel): void {
+  const ws = client as SubscribedWebSocket;
+  ws.subscribedChannels ??= new Set();
+  ws.subscribedChannels.add(channel);
+}
+
+function hasChannelSubscription(client: WebSocket, channel?: WebSocketEventChannel): boolean {
+  if (!channel) return true;
+  const subscriptions = (client as SubscribedWebSocket).subscribedChannels;
+  // Backward compatible: clients without explicit channel subscriptions still receive
+  // events if workspace and permission checks allow them.
+  if (!subscriptions || subscriptions.size === 0) return true;
+  return subscriptions.has(channel);
+}
+
+export function isWebSocketBackpressured(client: WebSocket): boolean {
+  return (
+    typeof client.bufferedAmount === 'number' && client.bufferedAmount > WS_BACKPRESSURE_LIMIT_BYTES
+  );
 }
 
 export function canReceiveWebSocketEvent(
@@ -19,6 +56,7 @@ export function canReceiveWebSocketEvent(
 ): boolean {
   const auth = (client as AuthenticatedWebSocket).auth;
   if (!auth) return false;
+  if (!hasChannelSubscription(client, options.channel)) return false;
 
   const eventWorkspaceId = options.workspaceId ?? DEFAULT_WORKSPACE_ID;
   if (auth.role !== 'admin' && auth.workspaceId !== eventWorkspaceId) {
@@ -38,6 +76,10 @@ export function sendWebSocketEvent(
 ): boolean {
   if (client.readyState !== WEBSOCKET_OPEN) return false;
   if (!canReceiveWebSocketEvent(client, options)) return false;
+  if (isWebSocketBackpressured(client)) {
+    client.close(1013, 'Client backpressure');
+    return false;
+  }
 
   client.send(payload);
   return true;

--- a/web/src/__tests__/useWebSocket.test.ts
+++ b/web/src/__tests__/useWebSocket.test.ts
@@ -2,7 +2,7 @@
  * Tests for hooks/useWebSocket.ts — WebSocket connection, reconnection, and messaging.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, cleanup } from '@testing-library/react';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { createMockWebSocket } from './test-utils';
 
@@ -20,9 +20,14 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  Object.defineProperty(window.navigator, 'onLine', {
+    value: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
+  cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -209,6 +214,69 @@ describe('useWebSocket', () => {
       ws.latest.simulateClose(1006);
     });
 
+    expect(result.current.connectionState).toBe('disconnected');
+  });
+
+  it('reconnects on browser resume after reconnect attempts are exhausted', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useWebSocket({
+        url: 'ws://test/ws',
+        autoReconnect: true,
+        maxReconnectAttempts: 1,
+      })
+    );
+
+    act(() => {
+      ws.latest.simulateOpen();
+    });
+
+    act(() => {
+      ws.latest.simulateClose(1006);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(ws.instances).toHaveLength(2);
+
+    act(() => {
+      ws.latest.simulateClose(1006);
+    });
+
+    expect(result.current.connectionState).toBe('disconnected');
+
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(ws.instances).toHaveLength(3);
+    expect(result.current.connectionState).toBe('connecting');
+    expect(result.current.reconnectAttempt).toBe(0);
+  });
+
+  it('does not reconnect on browser resume after an intentional disconnect', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://test/ws', autoReconnect: true }));
+
+    act(() => {
+      ws.latest.simulateOpen();
+    });
+
+    act(() => {
+      result.current.disconnect();
+    });
+
+    const connectionCount = ws.instances.length;
+
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(ws.instances).toHaveLength(connectionCount);
     expect(result.current.connectionState).toBe('disconnected');
   });
 

--- a/web/src/__tests__/workflow-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/workflow-surfaces-mantine.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { WorkflowsPage } from '@/components/workflows/WorkflowsPage';
@@ -7,6 +7,7 @@ import { WorkflowDashboard } from '@/components/workflows/WorkflowDashboard';
 import { WorkflowRunView } from '@/components/workflows/WorkflowRunView';
 import { ActiveRunsList } from '@/components/workflows/dashboard/ActiveRunsList';
 import { renderWithProviders } from './test-utils';
+import type { UseWebSocketOptions, WebSocketMessage } from '@/hooks/useWebSocket';
 
 const mocks = vi.hoisted(() => ({
   hasPermission: vi.fn(),
@@ -81,6 +82,8 @@ const workflowStats = {
   ],
 };
 
+let webSocketOptions: UseWebSocketOptions[] = [];
+
 function jsonResponse(data: unknown, ok = true) {
   return {
     ok,
@@ -92,8 +95,12 @@ function jsonResponse(data: unknown, ok = true) {
 describe('workflow surfaces Mantine migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    webSocketOptions = [];
     mocks.hasPermission.mockReturnValue(true);
-    mocks.useWebSocket.mockReturnValue(undefined);
+    mocks.useWebSocket.mockImplementation((options: UseWebSocketOptions = {}) => {
+      webSocketOptions.push(options);
+      return undefined;
+    });
     mocks.useWorkflowStats.mockReturnValue({ data: workflowStats, isLoading: false, error: null });
     mocks.useActiveRuns.mockReturnValue({
       data: [workflowRun],
@@ -320,5 +327,42 @@ describe('workflow surfaces Mantine migration', () => {
     await user.click(screen.getByText('Build artifact'));
 
     await waitFor(() => expect(screen.getByText('artifact ready')).toBeDefined());
+  });
+
+  it('applies workflow run WebSocket payload updates without a full reload', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/workflows/runs/run-1')) {
+        return jsonResponse(workflowRun);
+      }
+      if (url.endsWith('/workflows/wf-release')) {
+        return jsonResponse({
+          id: 'wf-release',
+          name: 'Release workflow',
+          version: 3,
+          steps: [{ id: 'smoke', name: 'Smoke test', agent: 'codex' }],
+        });
+      }
+      return jsonResponse(null, false);
+    }) as typeof fetch;
+
+    renderWithProviders(<WorkflowRunView runId="run-1" onBack={vi.fn()} />);
+
+    expect(await screen.findByText('Release workflow')).toBeDefined();
+    expect(webSocketOptions.at(-1)?.onOpen).toEqual({ type: 'workflow:subscribe', runId: 'run-1' });
+
+    act(() => {
+      webSocketOptions.at(-1)?.onMessage?.({
+        type: 'workflow:status',
+        payload: {
+          ...workflowRun,
+          status: 'completed',
+          completedAt: '2026-06-01T10:05:00Z',
+          steps: workflowRun.steps.map((step) => ({ ...step, status: 'completed' })),
+        },
+      } as WebSocketMessage);
+    });
+
+    await waitFor(() => expect(screen.getByText('Completed')).toBeDefined());
   });
 });

--- a/web/src/components/workflows/WorkflowDashboard.tsx
+++ b/web/src/components/workflows/WorkflowDashboard.tsx
@@ -44,11 +44,11 @@ interface WorkflowDashboardProps {
 
 interface WorkflowStatusMessage extends WebSocketMessage {
   type: 'workflow:status';
-  data: WorkflowRun;
+  payload: WorkflowRun;
 }
 
 function isWorkflowStatusMessage(msg: WebSocketMessage): msg is WorkflowStatusMessage {
-  return msg.type === 'workflow:status' && typeof msg.data === 'object' && msg.data !== null;
+  return msg.type === 'workflow:status' && typeof msg.payload === 'object' && msg.payload !== null;
 }
 
 export function WorkflowDashboard({ onBack }: WorkflowDashboardProps) {
@@ -106,7 +106,7 @@ export function WorkflowDashboard({ onBack }: WorkflowDashboardProps) {
   const handleWebSocketMessage = useCallback(
     (message: WebSocketMessage) => {
       if (isWorkflowStatusMessage(message)) {
-        const updatedRun = message.data;
+        const updatedRun = message.payload;
 
         // Invalidate queries to trigger refetch
         queryClient.invalidateQueries({ queryKey: ['workflow-active-runs'] });
@@ -123,6 +123,7 @@ export function WorkflowDashboard({ onBack }: WorkflowDashboardProps) {
 
   useWebSocket({
     autoConnect: true,
+    onOpen: { type: 'workflow:subscribe' },
     onMessage: handleWebSocketMessage,
   });
 

--- a/web/src/components/workflows/WorkflowRunView.tsx
+++ b/web/src/components/workflows/WorkflowRunView.tsx
@@ -87,11 +87,11 @@ interface WorkflowDefinition {
 
 interface WorkflowStatusMessage extends WebSocketMessage {
   type: 'workflow:status';
-  data: WorkflowRun;
+  payload: WorkflowRun;
 }
 
 function isWorkflowStatusMessage(msg: WebSocketMessage): msg is WorkflowStatusMessage {
-  return msg.type === 'workflow:status' && typeof msg.data === 'object' && msg.data !== null;
+  return msg.type === 'workflow:status' && typeof msg.payload === 'object' && msg.payload !== null;
 }
 
 function safeContextString(value: unknown): string | undefined {
@@ -179,9 +179,9 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
   // WebSocket subscription for live updates
   const handleWebSocketMessage = useCallback(
     (message: WebSocketMessage) => {
-      if (isWorkflowStatusMessage(message) && message.data.id === runId) {
-        console.log('[WorkflowRunView] Received workflow:status update', message.data);
-        setRun(message.data);
+      if (isWorkflowStatusMessage(message) && message.payload.id === runId) {
+        console.log('[WorkflowRunView] Received workflow:status update', message.payload);
+        setRun(message.payload);
       }
     },
     [runId]
@@ -189,6 +189,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
 
   useWebSocket({
     autoConnect: true,
+    onOpen: { type: 'workflow:subscribe', runId },
     onMessage: handleWebSocketMessage,
   });
 

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -258,6 +258,27 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     }
   }, []);
 
+  const reconnectAfterBrowserResume = useCallback(() => {
+    if (!autoConnect || !autoReconnect || intentionalDisconnectRef.current || !mountedRef.current) {
+      return;
+    }
+
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      return;
+    }
+
+    if (
+      wsRef.current?.readyState === WebSocket.OPEN ||
+      wsRef.current?.readyState === WebSocket.CONNECTING
+    ) {
+      return;
+    }
+
+    reconnectAttemptsRef.current = 0;
+    setReconnectAttempt(0);
+    connect();
+  }, [autoConnect, autoReconnect, connect]);
+
   // Connect on mount if autoConnect
   useEffect(() => {
     mountedRef.current = true;
@@ -274,6 +295,26 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       wsRef.current = null;
     };
   }, [autoConnect, connect, clearReconnectTimeout, clearKeepaliveTimeout]);
+
+  useEffect(() => {
+    if (!autoConnect || !autoReconnect) return;
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        reconnectAfterBrowserResume();
+      }
+    };
+
+    window.addEventListener('online', reconnectAfterBrowserResume);
+    window.addEventListener('focus', reconnectAfterBrowserResume);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      window.removeEventListener('online', reconnectAfterBrowserResume);
+      window.removeEventListener('focus', reconnectAfterBrowserResume);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [autoConnect, autoReconnect, reconnectAfterBrowserResume]);
 
   return {
     isConnected: connectionState === 'connected',


### PR DESCRIPTION
## Summary
- Scope realtime WebSocket delivery by workspace, permissions, and explicit event channels.
- Add sequence metadata, backpressure closing, and coalesced workflow status broadcasts.
- Improve browser resume reconnect behavior and align workflow UI consumers with `workflow:status.payload`.
- Add regression coverage for channel filtering, backpressure, many-client batching, high-frequency workflow updates, browser resume reconnects, and live workflow payload updates.

## Verification
- pnpm --filter @veritas-kanban/server test -- broadcast-service.test.ts
- pnpm --filter @veritas-kanban/web test -- useWebSocket.test.ts workflow-surfaces-mantine.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm build
- git diff --check

## Notes
- Lint still reports the existing 673 warnings and 0 errors.
- Build still reports the existing Vite chunk-size warning.

Closes #348