### PR TITLE
Harden v5 security review surfaces

### DIFF
--- a/desktop/src/main/__tests__/navigation.test.ts
+++ b/desktop/src/main/__tests__/navigation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Shell } from 'electron';
+
+import { hasSameOriginNavigation, openValidatedExternalUrl } from '../navigation.js';
+
+function shell(): Shell {
+  return {
+    openExternal: vi.fn(async () => undefined),
+  } as unknown as Shell;
+}
+
+describe('desktop navigation guards', () => {
+  it('compares parsed origins instead of string prefixes', () => {
+    expect(hasSameOriginNavigation('http://127.0.0.1:3000/tasks', 'http://127.0.0.1:3000')).toBe(
+      true
+    );
+    expect(
+      hasSameOriginNavigation(
+        'http://127.0.0.1:3000@attacker.example/tasks',
+        'http://127.0.0.1:3000'
+      )
+    ).toBe(false);
+    expect(hasSameOriginNavigation('not a url', 'http://127.0.0.1:3000')).toBe(false);
+  });
+
+  it('reuses the safe external URL validator before opening OS handlers', async () => {
+    const fakeShell = shell();
+
+    await expect(openValidatedExternalUrl(fakeShell, 'https://example.com/docs')).resolves.toBe(
+      true
+    );
+    await expect(
+      openValidatedExternalUrl(fakeShell, 'file:///Users/bradgroux/.ssh/id_ed25519')
+    ).resolves.toBe(false);
+    await expect(
+      openValidatedExternalUrl(fakeShell, 'https://user:pass@example.com')
+    ).resolves.toBe(false);
+
+    expect(fakeShell.openExternal).toHaveBeenCalledTimes(1);
+    expect(fakeShell.openExternal).toHaveBeenCalledWith('https://example.com/docs');
+  });
+});

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import { registerDesktopBridge } from './bridge.js';
 import { DesktopCommandDispatcher } from './commands.js';
 import { extractDeepLinkFromArgv, parseDesktopDeepLink } from './deep-links.js';
 import { configureDesktopMenu, dispatchDesktopMenuCommand } from './menu.js';
+import { hasSameOriginNavigation, openValidatedExternalUrl } from './navigation.js';
 import { DesktopNotificationCenter, ElectronNotificationAdapter } from './notifications.js';
 import { createDesktopPaths, resolveRepoRoot } from './paths.js';
 import { findAvailablePort } from './ports.js';
@@ -98,14 +99,14 @@ function createMainWindow(savedState: DesktopWindowState): BrowserWindow {
     }
   });
   window.webContents.setWindowOpenHandler(({ url }) => {
-    void shell.openExternal(url);
+    void openValidatedExternalUrl(shell, url);
     return { action: 'deny' };
   });
   window.webContents.on('will-navigate', (event, url) => {
     const current = runtime?.getRendererOrigin();
-    if (current && !url.startsWith(current)) {
+    if (current && !hasSameOriginNavigation(url, current)) {
       event.preventDefault();
-      void shell.openExternal(url);
+      void openValidatedExternalUrl(shell, url);
     }
   });
   window.webContents.on('did-fail-load', (_event, _code, description) => {

--- a/desktop/src/main/navigation.ts
+++ b/desktop/src/main/navigation.ts
@@ -1,0 +1,25 @@
+import type { Shell } from 'electron';
+
+import {
+  redactDesktopBridgeError,
+  validateOpenExternalRequest,
+} from '../shared/desktop-bridge-contracts.js';
+
+export function hasSameOriginNavigation(url: string, trustedRendererOrigin: string): boolean {
+  try {
+    return new URL(url).origin === new URL(trustedRendererOrigin).origin;
+  } catch {
+    return false;
+  }
+}
+
+export async function openValidatedExternalUrl(shell: Shell, rawUrl: string): Promise<boolean> {
+  try {
+    const { url } = validateOpenExternalRequest({ url: rawUrl });
+    await shell.openExternal(url);
+    return true;
+  } catch (error) {
+    console.warn('Blocked unsafe external navigation', redactDesktopBridgeError(error));
+    return false;
+  }
+}

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -20,6 +20,11 @@ operator checklist for final release verification.
       proxy headers, service-worker assumptions, and local-only secret handling.
 - [ ] Security review covers desktop bridge calls, auth/session handling,
       scoped tokens, remote access, workflow execution, and agent tool gates.
+      Track evidence and blockers in
+      [v5.0 security review notes](security/v5-security-review.md). Browser
+      password sessions must become persisted per-user sessions before
+      multi-user/server-mode GA, or the release must explicitly limit password
+      sessions to single-owner local deployments.
 - [ ] Performance/load review covers SQLite read/write paths, dashboard queries,
       WebSocket fan-out, workflow run updates, and remote/mobile clients.
 - [ ] Docs cover upgrade, desktop install, remote access, admin operations,

--- a/docs/security.md
+++ b/docs/security.md
@@ -119,6 +119,11 @@ prefix, WebSocket event, CLI command, MCP tool, workflow step/action type,
 command palette action, or tracked background job is added without a permission
 classification.
 
+The v5.0 hardening review is recorded in
+[`docs/security/v5-security-review.md`](security/v5-security-review.md),
+including fixed high/critical findings, accepted hardening risks, and the
+remaining browser-session GA blocker.
+
 ## Configuration Reference
 
 ### Environment Variables

--- a/docs/security/v5-security-review.md
+++ b/docs/security/v5-security-review.md
@@ -1,0 +1,68 @@
+# Veritas Kanban v5.0 Security Review Notes
+
+Review date: 2026-06-03
+
+Scope: #350, covering multi-user auth, remote pairing, WebSocket scoping, desktop bridge/native surfaces, migration/import, attachments, preview processes, diagnostics, and release gates.
+
+## Review Outcome
+
+The review fixed five high or critical implementation issues in the #350 implementation PR. One additional high issue remains a GA blocker and is called out below.
+
+| Finding                                                                                                                                                                                         | Severity | Outcome                                                                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Desktop `will-navigate` trusted renderer checks used a string prefix, so `http://127.0.0.1:3000@attacker.example` could load attacker-controlled content in the Electron window.                | Critical | Fixed. Desktop navigation now compares parsed URL origins and covers the userinfo bypass in `desktop/src/main/__tests__/navigation.test.ts`.                       |
+| Desktop `setWindowOpenHandler` and `will-navigate` opened external URLs directly instead of using the typed bridge validator.                                                                   | High     | Fixed. External navigation now reuses `validateOpenExternalRequest`, blocking unsafe protocols and credentialed URLs before calling Electron `shell.openExternal`. |
+| WebSocket chat broadcasts were channel-scoped but not chat-session-scoped. A subscribed or legacy authenticated client could receive live chat deltas for other sessions in the same workspace. | High     | Fixed. Chat delivery now requires an explicit matching session subscription, with broadcast regression coverage.                                                   |
+| Revoked API tokens and device sessions stopped new authentication but did not close already-open WebSocket connections.                                                                         | High     | Fixed. WebSocket auth now retains token/session identifiers and identity revocation routes close matching live sockets.                                            |
+| Preview start/stop routes used read permissions while starting local child processes for repo preview servers.                                                                                  | High     | Fixed. Preview status/output remain readable with `task:read`, but start/stop now require `admin:manage`; preview process output is redacted before retention.     |
+
+## GA Blocker
+
+Browser password sessions still use the compatibility local-owner model. The JWT proves only that a password login happened; it does not carry a persisted user subject, session id, workspace membership, disabled-user state, or membership downgrade check. `authMethod: "session"` maps to the local admin authority.
+
+This blocks multi-user/server-mode GA unless one of these is true before release:
+
+- Browser sessions are migrated to persisted per-user sessions that revalidate active membership and role on every request and WebSocket connect.
+- The GA release explicitly limits password-session mode to single-owner local deployments, with remote/multi-user access requiring device sessions or scoped API tokens.
+
+## Accepted Hardening Risks For This Review
+
+These were not treated as #350 blockers after the fixes above, but they should be triaged before #353 final release sign-off:
+
+| Area                                 | Risk                                                                                                                        | Rationale                                                                                                                                                                                |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| API token and pairing lifetimes      | API tokens can be non-expiring and pairing-created device sessions accept future expirations without a server-side maximum. | Admin-created credentials are already revocable and scoped, but GA should set maximum recommended lifetimes for remote deployments.                                                      |
+| WebSocket `api_key` query fallback   | Query-string credentials are easier to leak via logs/proxies than cookies or headers.                                       | Kept only for WebSocket clients that cannot set upgrade headers. HTTP does not accept query API keys.                                                                                    |
+| Production origins                   | If `CORS_ORIGINS` is unset, defaults still include loopback development origins.                                            | Remote docs require exact trusted origins. GA packaging/deployment checks should warn or fail on ambiguous production origin config.                                                     |
+| Desktop command dispatch             | The renderer can invoke the typed `dispatchCommand` enum, including native restart/update/quit/copy-diagnostics commands.   | The critical remote-content path is fixed by origin enforcement. A future hardening pass should split menu-only native commands from renderer commands or add main-issued intent tokens. |
+| Desktop connection validation        | The desktop bridge can fetch renderer-supplied `http`/`https` hosts to validate remote config.                              | This is a limited network oracle by design. Keep scheme and credential validation, and consider private-address confirmation before public remote GA.                                    |
+| SQLite portability paths             | Admin restore/import APIs accept filesystem paths and can copy/replace targets.                                             | Admin-only, but final GA should add canonical base-directory and symlink policy tests before broad backup/restore support is advertised.                                                 |
+| SVG attachments                      | SVG is accepted as an image type while image previews render `image/*` URLs.                                                | Downloads use attachment disposition and MIME validation exists. GA should either isolate/sanitize SVG previews or remove SVG from inline-previewable types.                             |
+| Desktop child logs and debug bundles | Desktop process supervisor writes raw child stdout/stderr.                                                                  | Server logs are redacted and diagnostics bundle creation is stubbed/redacted today. Any debug-bundle implementation must redact process logs before export.                              |
+| Future filesystem bridge methods     | Current validators require absolute local paths but do not enforce workspace/bookmark boundaries.                           | The exposed file-picker/export handlers are currently stubbed. Implement boundary checks before enabling real filesystem writes.                                                         |
+| macOS entitlements                   | Electron entitlements include unsigned executable memory and disabled library validation.                                   | Common Electron tradeoff, but release packaging should trim entitlements if the final build allows it.                                                                                   |
+
+## Controls Verified
+
+- REST v1 route groups use explicit permission guards, with a route-map parity gate in `scripts/check-permission-coverage.mjs`.
+- WebSocket connections validate origin, authenticate before accepting events, filter event delivery by workspace and permission, close backpressured clients, and now require matching chat-session subscriptions for chat streams.
+- Device pairing uses random codes, server-side hashes, signed payloads, TTL, attempt locking, one-use redemption, revocation, downgraded-scope clamping, and device-session auth for REST/WebSocket.
+- Desktop renderer runs with `nodeIntegration: false`, `contextIsolation: true`, and `sandbox: true`.
+- Desktop bridge methods are declared in a typed registry. Dangerous methods require validators, event cleanup is covered, and unsupported client modes cannot call desktop-only bridge methods.
+- Desktop safeStorage has no plaintext fallback for runtime secrets.
+- Attachments sanitize filenames/task ids, validate resolved paths stay under attachment roots, validate MIME type using content where possible, and serve downloads with attachment content disposition.
+- Diagnostics/support snapshots and preview output have redaction coverage for tokens, API keys, bearer values, and private local paths.
+
+## Regression Evidence
+
+Focused tests added or exercised by the review:
+
+- `pnpm --filter @veritas-kanban/desktop test -- navigation.test.ts bridge-contracts.test.ts`
+- `pnpm --filter @veritas-kanban/server test -- broadcast-service.test.ts v1-permission-guards.test.ts preview-service.test.ts`
+
+Full release gates should still run before merging the #350 PR:
+
+- `node scripts/check-permission-coverage.mjs`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm build`

--- a/server/src/__tests__/broadcast-service.test.ts
+++ b/server/src/__tests__/broadcast-service.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { AnyTelemetryEvent } from '@veritas-kanban/shared';
 import type { WebSocketServer } from 'ws';
 import {
+  broadcastChatMessage,
+  closeWebSocketClientsForRevokedCredential,
   initBroadcast,
   broadcastTaskChange,
   broadcastTelemetryEvent,
@@ -17,6 +19,8 @@ type MockAuth = {
   role: 'admin' | 'agent' | 'read-only';
   isLocalhost: boolean;
   workspaceId?: string;
+  apiTokenId?: string;
+  deviceSessionId?: string;
 };
 
 type MockClient = {
@@ -24,9 +28,16 @@ type MockClient = {
   auth?: MockAuth;
   bufferedAmount: number;
   subscribedChannels?: Set<WebSocketEventChannel>;
+  subscribedChatSessionIds?: Set<string>;
   sent: string[];
   send: (data: string) => void;
   close: ReturnType<typeof vi.fn>;
+};
+
+type MockClientOptions = {
+  bufferedAmount?: number;
+  subscribedChannels?: Set<WebSocketEventChannel>;
+  subscribedChatSessionIds?: Set<string>;
 };
 
 // Minimal mock WebSocket server
@@ -39,7 +50,7 @@ function createMockWss() {
     addClient(
       readyState = 1,
       auth: MockAuth = { role: 'admin', isLocalhost: false, workspaceId: 'local' },
-      options: { bufferedAmount?: number; subscribedChannels?: Set<WebSocketEventChannel> } = {}
+      options: MockClientOptions = {}
     ) {
       const sent: string[] = [];
       const client = {
@@ -47,6 +58,7 @@ function createMockWss() {
         auth,
         bufferedAmount: options.bufferedAmount ?? 0,
         subscribedChannels: options.subscribedChannels,
+        subscribedChatSessionIds: options.subscribedChatSessionIds,
         sent,
         send: (data: string) => {
           sent.push(data);
@@ -215,6 +227,74 @@ describe('BroadcastService', () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(wss.sentMessages).toHaveLength(75);
+    });
+  });
+
+  describe('broadcastChatMessage()', () => {
+    it('delivers chat events only to clients subscribed to the matching session', () => {
+      const wss = createMockWss();
+      const sessionSubscriber = wss.addClient(1, undefined, {
+        subscribedChannels: new Set(['chat']),
+        subscribedChatSessionIds: new Set(['session_a']),
+      });
+      const otherSessionSubscriber = wss.addClient(1, undefined, {
+        subscribedChannels: new Set(['chat']),
+        subscribedChatSessionIds: new Set(['session_b']),
+      });
+      const chatChannelOnly = wss.addClient(1, undefined, {
+        subscribedChannels: new Set(['chat']),
+      });
+      const legacyUnsubscribed = wss.addClient(1);
+      initBroadcast(asWebSocketServer(wss));
+
+      broadcastChatMessage('session_a', {
+        type: 'chat:delta',
+        sessionId: 'session_a',
+        text: 'private response',
+      });
+
+      expect(sessionSubscriber.sent).toHaveLength(1);
+      expect(JSON.parse(sessionSubscriber.sent[0])).toMatchObject({
+        type: 'chat:delta',
+        sessionId: 'session_a',
+        text: 'private response',
+      });
+      expect(otherSessionSubscriber.sent).toHaveLength(0);
+      expect(chatChannelOnly.sent).toHaveLength(0);
+      expect(legacyUnsubscribed.sent).toHaveLength(0);
+      expect(wss.sentMessages).toHaveLength(1);
+    });
+  });
+
+  describe('closeWebSocketClientsForRevokedCredential()', () => {
+    it('closes active clients that authenticated with a revoked API token or device session', () => {
+      const wss = createMockWss();
+      const apiTokenClient = wss.addClient(1, {
+        role: 'agent',
+        isLocalhost: false,
+        workspaceId: 'local',
+        apiTokenId: 'token_1',
+      });
+      const deviceSessionClient = wss.addClient(1, {
+        role: 'read-only',
+        isLocalhost: false,
+        workspaceId: 'local',
+        deviceSessionId: 'session_1',
+      });
+      const unrelatedClient = wss.addClient(1, {
+        role: 'read-only',
+        isLocalhost: false,
+        workspaceId: 'local',
+        apiTokenId: 'token_2',
+      });
+      initBroadcast(asWebSocketServer(wss));
+
+      expect(closeWebSocketClientsForRevokedCredential({ apiTokenId: 'token_1' })).toBe(1);
+      expect(closeWebSocketClientsForRevokedCredential({ deviceSessionId: 'session_1' })).toBe(1);
+
+      expect(apiTokenClient.close).toHaveBeenCalledWith(4001, 'Credential revoked');
+      expect(deviceSessionClient.close).toHaveBeenCalledWith(4001, 'Credential revoked');
+      expect(unrelatedClient.close).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/__tests__/preview-service.test.ts
+++ b/server/src/__tests__/preview-service.test.ts
@@ -124,6 +124,29 @@ describe('PreviewService', () => {
       const output = service.getPreviewOutput('nonexistent-task');
       expect(output).toEqual([]);
     });
+
+    it('redacts secrets before retaining preview process output', () => {
+      const info = {
+        taskId: 'task_1',
+        repoName: 'repo',
+        pid: 123,
+        port: 3000,
+        url: 'http://localhost:3000',
+        status: 'running',
+        startedAt: '2026-06-02T00:00:00.000Z',
+        output: [],
+      };
+
+      (service as any).recordOutput(
+        info,
+        'dev server started with Authorization: Bearer abcdefghijklmnop and key vk_secret123456789'
+      );
+
+      expect(info.output[0]).toContain('Bearer [REDACTED]');
+      expect(info.output[0]).toContain('[REDACTED_API_KEY]');
+      expect(info.output[0]).not.toContain('abcdefghijklmnop');
+      expect(info.output[0]).not.toContain('vk_secret123456789');
+    });
   });
 
   describe('stopPreview', () => {

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -7,6 +7,7 @@ import {
   agentRegistryAccess,
   agentRoutingAccess,
   policyAccess,
+  previewAccess,
   scoringAccess,
   searchAccess,
   settingsAccess,
@@ -213,6 +214,23 @@ describe('v1 REST permission guard presets', () => {
         details: expect.objectContaining({ required: ['admin:manage'] }),
       })
     );
+  });
+
+  it('requires admin permission before preview routes can start local processes', () => {
+    expect(runGuard(previewAccess, mockRequest('GET', '/task_1')).next).toHaveBeenCalled();
+
+    const startAsAgent = runGuard(previewAccess, mockRequest('POST', '/task_1/start'));
+    expect(startAsAgent.next).not.toHaveBeenCalled();
+    expect(startAsAgent.res.status).toHaveBeenCalledWith(403);
+    expect(startAsAgent.res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['admin:manage'] }),
+      })
+    );
+
+    expect(
+      runGuard(previewAccess, mockRequest('POST', '/task_1/start', 'admin')).next
+    ).toHaveBeenCalled();
   });
 
   it('keeps scoring evaluation read-like while guarding scoring profile mutations', () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -63,7 +63,9 @@ import { metricsCollector } from './middleware/metrics-collector.js';
 import { getStorageTypeFromEnv, initStorage, shutdownStorage } from './storage/index.js';
 import {
   canReceiveWebSocketEvent,
+  subscribeWebSocketChatSession,
   subscribeWebSocketChannel,
+  unsubscribeWebSocketChatSession,
   type WebSocketEventChannel,
 } from './services/websocket-permissions.js';
 
@@ -743,6 +745,13 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
     authMethod: authResult.authMethod,
     tokenName: authResult.tokenName,
     permissions: authResult.permissions,
+    apiTokenId: authResult.apiTokenId,
+    deviceSessionId: authResult.deviceSessionId,
+    deviceId: authResult.deviceId,
+    clientId: authResult.clientId,
+    clientMode: authResult.clientMode,
+    capabilities: authResult.capabilities,
+    degradedReason: authResult.degradedReason,
   };
 
   // ---- Heartbeat: mark alive on connect and on pong ----
@@ -858,10 +867,10 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
           sendWebSocketForbidden(ws, 'chat:subscribe', permissions, workspaceId);
           return;
         }
-        subscribeWebSocketChannel(ws, 'chat');
 
         // Unsubscribe from previous chat session
         if (subscribedChatSession) {
+          unsubscribeWebSocketChatSession(ws, subscribedChatSession);
           const subs = chatSubscriptions.get(subscribedChatSession);
           if (subs) {
             subs.delete(ws);
@@ -874,6 +883,7 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
         // Subscribe to new chat session
         const sessionId: string = message.sessionId;
         subscribedChatSession = sessionId;
+        subscribeWebSocketChatSession(ws, sessionId);
         let sessionSubscribers = chatSubscriptions.get(sessionId);
         if (!sessionSubscribers) {
           sessionSubscribers = new Set();
@@ -1037,6 +1047,7 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
 
     // Clean up chat subscriptions
     if (subscribedChatSession) {
+      unsubscribeWebSocketChatSession(ws, subscribedChatSession);
       const subs = chatSubscriptions.get(subscribedChatSession);
       if (subs) {
         subs.delete(ws);

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -80,6 +80,7 @@ export interface AuthContext {
   authMethod?: AuthMethod;
   tokenName?: string;
   permissions?: AuthPermission[];
+  apiTokenId?: string;
   deviceSessionId?: string;
   deviceId?: string;
   clientId?: string;
@@ -671,6 +672,7 @@ export interface WebSocketAuthResult {
   authMethod?: AuthMethod;
   tokenName?: string;
   permissions?: AuthPermission[];
+  apiTokenId?: string;
   deviceSessionId?: string;
   deviceId?: string;
   clientId?: string;

--- a/server/src/routes/identity.ts
+++ b/server/src/routes/identity.ts
@@ -16,6 +16,7 @@ import {
   getDeviceSessionService,
   type DeviceSessionService,
 } from '../services/device-session-service.js';
+import { closeWebSocketClientsForRevokedCredential } from '../services/broadcast-service.js';
 import {
   getIdentityService,
   type IdentityActor,
@@ -238,6 +239,7 @@ export function createIdentityRoutes(
         actorFromRequest(req as AuthenticatedRequest),
         String(req.params.workspaceId)
       );
+      closeWebSocketClientsForRevokedCredential({ apiTokenId: token.id });
       res.json(token);
     })
   );
@@ -251,6 +253,7 @@ export function createIdentityRoutes(
         actorFromRequest(req as AuthenticatedRequest),
         String(req.params.workspaceId)
       );
+      closeWebSocketClientsForRevokedCredential({ apiTokenId: String(req.params.tokenId) });
       res.status(201).json(result);
     })
   );
@@ -302,6 +305,7 @@ export function createIdentityRoutes(
         actorFromRequest(req as AuthenticatedRequest),
         String(req.params.workspaceId)
       );
+      closeWebSocketClientsForRevokedCredential({ deviceSessionId: session.id });
       res.json(session);
     })
   );

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -32,6 +32,7 @@ import {
   feedbackAccess,
   notificationAccess,
   policyAccess,
+  previewAccess,
   promptRegistryAccess,
   reportAccess,
   reportRoutesAccess,
@@ -182,7 +183,7 @@ v1Router.use('/projects', settingsAccess, projectRoutes);
 v1Router.use('/sprints', settingsAccess, sprintRoutes);
 v1Router.use('/activity', activityAccess, activityRoutes);
 v1Router.use('/github', taskAccess, githubRoutes);
-v1Router.use('/preview', taskReadAccess, previewRoutes);
+v1Router.use('/preview', previewAccess, previewRoutes);
 v1Router.use('/conflicts', taskAccess, conflictRoutes);
 v1Router.use('/telemetry', telemetryAccess, telemetryRoutes);
 v1Router.use('/metrics', reportAccess, metricsRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -36,6 +36,7 @@ export const policyAccess = routeAccess('policy:read', 'policy:read', [
   { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
 ]);
 export const backupAccess = routeAccess('backup:read', 'backup:write');
+export const previewAccess = routeAccess('task:read', 'admin:manage');
 export const workspaceAccess = routeAccess('workspace:read', 'admin:manage');
 export const notificationAccess = routeAccess('agent:read', 'comment:write');
 export const broadcastAccess = routeAccess('task:read', 'comment:write');

--- a/server/src/services/api-token-service.ts
+++ b/server/src/services/api-token-service.ts
@@ -234,6 +234,7 @@ export class ApiTokenService {
         authMethod: 'api-key',
         tokenName: token.name,
         permissions: token.scopes,
+        apiTokenId: token.id,
       },
     };
   }

--- a/server/src/services/broadcast-service.ts
+++ b/server/src/services/broadcast-service.ts
@@ -1,5 +1,6 @@
 import type { WebSocketServer, WebSocket } from 'ws';
 import type { AnyTelemetryEvent, SquadMessage } from '@veritas-kanban/shared';
+import type { AuthenticatedWebSocket } from '../middleware/auth.js';
 import {
   notifyTaskChange,
   notifyChatMessage,
@@ -25,6 +26,11 @@ let websocketEventSequence = 0;
 let workflowStatusFlushTimer: ReturnType<typeof setTimeout> | null = null;
 const pendingWorkflowStatusEvents = new Map<string, WorkflowStatusEvent>();
 
+export interface RevokedWebSocketCredential {
+  apiTokenId?: string;
+  deviceSessionId?: string;
+}
+
 export function initBroadcast(wss: WebSocketServer): void {
   wssRef = wss;
 }
@@ -33,6 +39,30 @@ export function nextWebSocketEventSequence(): number {
   websocketEventSequence =
     websocketEventSequence >= Number.MAX_SAFE_INTEGER ? 1 : websocketEventSequence + 1;
   return websocketEventSequence;
+}
+
+export function closeWebSocketClientsForRevokedCredential(
+  credential: RevokedWebSocketCredential
+): number {
+  if (!wssRef) return 0;
+  if (!credential.apiTokenId && !credential.deviceSessionId) return 0;
+
+  let closed = 0;
+  for (const client of wssRef.clients) {
+    const auth = (client as AuthenticatedWebSocket).auth;
+    if (!auth) continue;
+    const matchesApiToken =
+      credential.apiTokenId !== undefined && auth.apiTokenId === credential.apiTokenId;
+    const matchesDeviceSession =
+      credential.deviceSessionId !== undefined &&
+      auth.deviceSessionId === credential.deviceSessionId;
+    if (matchesApiToken || matchesDeviceSession) {
+      client.close(4001, 'Credential revoked');
+      closed++;
+    }
+  }
+
+  return closed;
 }
 
 function normalizeWorkspaceId(workspaceId?: string): string {
@@ -163,7 +193,12 @@ export function broadcastChatMessage(
     workspaceId: event.workspaceId ?? workspaceId,
   });
 
-  broadcastToClients(payload, { permissions: ['task:read'], workspaceId, channel: 'chat' });
+  broadcastToClients(payload, {
+    permissions: ['task:read'],
+    workspaceId,
+    channel: 'chat',
+    chatSessionId: sessionId,
+  });
 
   // Also notify via webhook (fire-and-forget)
   notifyChatMessage(

--- a/server/src/services/preview-service.ts
+++ b/server/src/services/preview-service.ts
@@ -1,8 +1,8 @@
 import { spawn, ChildProcess } from 'child_process';
 import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
-import type { Task } from '@veritas-kanban/shared';
 import { expandPath } from '@veritas-kanban/shared';
+import { redactString } from '../lib/redact.js';
 
 export interface PreviewServer {
   taskId: string;
@@ -102,6 +102,30 @@ export class PreviewService {
     return readyPatterns.some((p) => p.test(output));
   }
 
+  private recordOutput(info: PreviewServer, output: string): void {
+    info.output.push(redactString(output));
+
+    // Calculate total output size
+    const totalSize = info.output.reduce((sum, line) => sum + line.length, 0);
+
+    // Enforce size limit
+    if (totalSize > this.MAX_OUTPUT_SIZE) {
+      // Truncate from the beginning, keep recent output
+      while (
+        info.output.length > 0 &&
+        info.output.reduce((sum, line) => sum + line.length, 0) > this.MAX_OUTPUT_SIZE * 0.8
+      ) {
+        info.output.shift();
+      }
+      info.output.unshift('...[output truncated due to size limit]...\n');
+    }
+
+    // Keep only last 100 lines as secondary limit
+    if (info.output.length > 100) {
+      info.output = info.output.slice(-100);
+    }
+  }
+
   /**
    * Start a preview server for a task
    */
@@ -177,27 +201,7 @@ export class PreviewService {
         // Collect output
         const handleOutput = (data: Buffer) => {
           const text = data.toString();
-          info.output.push(text);
-
-          // Calculate total output size
-          const totalSize = info.output.reduce((sum, line) => sum + line.length, 0);
-
-          // Enforce size limit
-          if (totalSize > this.MAX_OUTPUT_SIZE) {
-            // Truncate from the beginning, keep recent output
-            while (
-              info.output.length > 0 &&
-              info.output.reduce((sum, line) => sum + line.length, 0) > this.MAX_OUTPUT_SIZE * 0.8
-            ) {
-              info.output.shift();
-            }
-            info.output.unshift('...[output truncated due to size limit]...\n');
-          }
-
-          // Keep only last 100 lines as secondary limit
-          if (info.output.length > 100) {
-            info.output = info.output.slice(-100);
-          }
+          this.recordOutput(info, text);
 
           // Try to extract port if not set
           if (!info.port) {
@@ -228,9 +232,9 @@ export class PreviewService {
 
         proc.on('error', (err) => {
           info.status = 'error';
-          info.error = err.message;
+          info.error = redactString(err.message);
           runningServers.delete(taskId);
-          reject(new Error(`Failed to start dev server: ${err.message}`));
+          reject(new Error(`Failed to start dev server: ${redactString(err.message)}`));
         });
 
         proc.on('exit', (code) => {

--- a/server/src/services/websocket-permissions.ts
+++ b/server/src/services/websocket-permissions.ts
@@ -23,16 +23,29 @@ export interface WebSocketDeliveryOptions {
   workspaceId?: string;
   permissions?: AuthPermission[];
   channel?: WebSocketEventChannel;
+  chatSessionId?: string;
 }
 
 export interface SubscribedWebSocket extends AuthenticatedWebSocket {
   subscribedChannels?: Set<WebSocketEventChannel>;
+  subscribedChatSessionIds?: Set<string>;
 }
 
 export function subscribeWebSocketChannel(client: WebSocket, channel: WebSocketEventChannel): void {
   const ws = client as SubscribedWebSocket;
   ws.subscribedChannels ??= new Set();
   ws.subscribedChannels.add(channel);
+}
+
+export function subscribeWebSocketChatSession(client: WebSocket, sessionId: string): void {
+  const ws = client as SubscribedWebSocket;
+  subscribeWebSocketChannel(client, 'chat');
+  ws.subscribedChatSessionIds ??= new Set();
+  ws.subscribedChatSessionIds.add(sessionId);
+}
+
+export function unsubscribeWebSocketChatSession(client: WebSocket, sessionId: string): void {
+  (client as SubscribedWebSocket).subscribedChatSessionIds?.delete(sessionId);
 }
 
 function hasChannelSubscription(client: WebSocket, channel?: WebSocketEventChannel): boolean {
@@ -42,6 +55,11 @@ function hasChannelSubscription(client: WebSocket, channel?: WebSocketEventChann
   // events if workspace and permission checks allow them.
   if (!subscriptions || subscriptions.size === 0) return true;
   return subscriptions.has(channel);
+}
+
+function hasChatSessionSubscription(client: WebSocket, sessionId?: string): boolean {
+  if (!sessionId) return true;
+  return (client as SubscribedWebSocket).subscribedChatSessionIds?.has(sessionId) === true;
 }
 
 export function isWebSocketBackpressured(client: WebSocket): boolean {
@@ -57,6 +75,7 @@ export function canReceiveWebSocketEvent(
   const auth = (client as AuthenticatedWebSocket).auth;
   if (!auth) return false;
   if (!hasChannelSubscription(client, options.channel)) return false;
+  if (!hasChatSessionSubscription(client, options.chatSessionId)) return false;
 
   const eventWorkspaceId = options.workspaceId ?? DEFAULT_WORKSPACE_ID;
   if (auth.role !== 'admin' && auth.workspaceId !== eventWorkspaceId) {

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -40,6 +40,7 @@ export interface ClientAuthContext {
   authMethod?: ClientAuthMethod;
   tokenName?: string;
   permissions?: ClientAuthPermission[];
+  apiTokenId?: string;
   deviceSessionId?: string;
   deviceId?: string;
   clientId?: string;
@@ -186,7 +187,7 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
   { prefix: '/api/sprints', read: 'settings:read', write: 'settings:write' },
   { prefix: '/api/activity', read: 'telemetry:read', write: 'admin:manage' },
   { prefix: '/api/github', read: 'task:read', write: 'task:write' },
-  { prefix: '/api/preview', read: 'task:read' },
+  { prefix: '/api/preview', read: 'task:read', write: 'admin:manage' },
   { prefix: '/api/conflicts', read: 'task:read', write: 'task:write' },
   { prefix: '/api/telemetry', read: 'telemetry:read', write: 'telemetry:write' },
   { prefix: '/api/metrics', read: 'report:read' },


### PR DESCRIPTION
## Summary
- Adds v5 security review notes and GA checklist linkage.
- Hardens desktop navigation and external URL handling against origin and userinfo bypasses.
- Scopes chat WebSocket delivery by session, closes active sockets on credential revocation, and tightens preview start/stop permissions with redacted process output.

## Tests
- pnpm --filter @veritas-kanban/desktop test -- navigation.test.ts bridge-contracts.test.ts
- pnpm --filter @veritas-kanban/server test -- broadcast-service.test.ts v1-permission-guards.test.ts preview-service.test.ts
- node scripts/check-permission-coverage.mjs
- pnpm typecheck
- git diff --check
- pnpm lint
- pnpm build

## Risks / follow-ups
- Browser password sessions remain a documented GA blocker for multi-user/server-mode release until per-user sessions or a single-owner deployment limit lands.

Closes #350