### PR TITLE
Add v5 performance load coverage

### DIFF
--- a/.github/workflows/scheduled-qa.yml
+++ b/.github/workflows/scheduled-qa.yml
@@ -112,7 +112,7 @@ jobs:
           mkdir -p k6-results
 
           if [ "$K6_PROFILE" = "full" ]; then
-            scripts="smoke read-load write-load mixed-load ws-stress"
+            scripts="smoke read-load write-load mixed-load ws-stress v5-remote-mix"
           else
             scripts="smoke"
           fi
@@ -122,6 +122,12 @@ jobs:
               -e BASE_URL=http://127.0.0.1:3001 \
               -e WS_URL=ws://127.0.0.1:3001/ws \
               -e API_KEY="$VERITAS_ADMIN_KEY" \
+              -e V5_SEED_TASKS=120 \
+              -e V5_SEED_CHATS=12 \
+              -e V5_HTTP_VUS=20 \
+              -e V5_WS_VUS=30 \
+              -e V5_DURATION=45s \
+              -e V5_WS_HOLD_MS=40000 \
               -v "$PWD:/work" \
               -w /work \
               grafana/k6:latest run \

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -26,7 +26,9 @@ operator checklist for final release verification.
       multi-user/server-mode GA, or the release must explicitly limit password
       sessions to single-owner local deployments.
 - [ ] Performance/load review covers SQLite read/write paths, dashboard queries,
-      WebSocket fan-out, workflow run updates, and remote/mobile clients.
+      WebSocket fan-out, workflow run updates, and remote/mobile clients. Track
+      evidence and limits in
+      [v5.0 performance and load test notes](testing/v5-performance-load.md).
 - [ ] Docs cover upgrade, desktop install, remote access, admin operations,
       backup/restore, diagnostics, and known platform limits, with ADR 0002 as
       the remote/server-mode security baseline.

--- a/docs/testing/v5-performance-load.md
+++ b/docs/testing/v5-performance-load.md
@@ -1,0 +1,119 @@
+# v5.0 Performance and Load Test Notes
+
+Review date: 2026-06-03
+
+This note records the v5.0 performance/load evidence for SQLite-backed local
+mode and trusted-host remote/mobile access.
+
+## Target Dataset
+
+| Surface                  | GA representative target |
+| ------------------------ | -----------------------: |
+| Active tasks             |                    1,500 |
+| Task comments            |                    3,000 |
+| Attachment metadata rows |                      600 |
+| Telemetry events         |                    6,000 |
+| Workflow runs            |                    1,200 |
+| Chat sessions            |                       60 |
+| Chat messages            |                    3,000 |
+
+These targets represent a heavy solo/local board or a small team/agent-heavy
+trusted-host deployment. Larger hosted or SaaS-style deployments are outside the
+v5.0 GA scope and should run the full k6 profile with larger seed values before
+being treated as supported.
+
+## SQLite Benchmark Evidence
+
+Command:
+
+```bash
+pnpm --filter @veritas-kanban/server test -- sqlite-performance.test.ts --reporter verbose
+```
+
+Recorded local result:
+
+| Read path                  | Dataset exercised                                        | Result |   Budget |
+| -------------------------- | -------------------------------------------------------- | -----: | -------: |
+| Board task list            | 1,500 active tasks with comments and attachment metadata | 2.3 ms | 2,000 ms |
+| Task search                | FTS-backed active task lookup                            | 0.5 ms |   750 ms |
+| Dashboard telemetry window | 6,000 telemetry events                                   | 2.5 ms | 1,500 ms |
+| Workflow running list      | 1,200 workflow runs                                      | 0.5 ms |   750 ms |
+| Chat session history       | 50 messages in a task-scoped session                     | 0.1 ms |   750 ms |
+
+The test also verifies representative query plans use the expected indexes:
+
+- `idx_tasks_workspace_state_updated`
+- `idx_telemetry_type_created`
+- `idx_workflow_runs_status_started`
+- `idx_chat_messages_session_created`
+
+The query cleanup in this review removed `datetime(...)` wrappers from hot
+SQLite ordering paths where ISO timestamp strings already preserve chronological
+order. That lets SQLite use index-ordered scans for task lists, telemetry
+windows, workflow run lists, and chat history.
+
+## Remote and WebSocket Load Evidence
+
+The full k6 profile now runs:
+
+```bash
+pnpm test:load
+```
+
+The scheduled QA workflow also runs the same full profile when dispatched with
+`load_profile=full`.
+
+Full profile scripts:
+
+- `smoke`
+- `read-load`
+- `write-load`
+- `mixed-load`
+- `ws-stress`
+- `v5-remote-mix`
+
+`v5-remote-mix` defaults:
+
+| Setting                 |    Default |
+| ----------------------- | ---------: |
+| Seed tasks              |        120 |
+| Seed chat sessions      |         12 |
+| HTTP virtual users      |         20 |
+| WebSocket virtual users |         30 |
+| Duration                | 45 seconds |
+| WebSocket hold time     | 40 seconds |
+
+The profile covers:
+
+- board list and task detail reads
+- task search
+- dashboard metrics
+- workflow run metadata
+- chat history
+- task create/update/delete churn
+- WebSocket task, workflow, agent-output, and chat-session subscriptions
+
+Thresholds keep p95 read/write paths between 250 ms and 750 ms and require
+HTTP errors below 1 percent plus WebSocket connection errors below 5 percent.
+
+## Recommended Limits
+
+- Treat the target dataset above as the supported v5.0 GA local/small-team
+  baseline until larger full-profile k6 runs are attached to release notes.
+- Keep telemetry retention at the default 30 days for active local installs.
+- Archive or prune old workflow runs, chat sessions, completed work products,
+  and attachment metadata through the maintenance/data-lifecycle work in #367
+  and #421 before claiming larger long-lived datasets.
+- Remote/mobile access remains a trusted-host scenario. The browser
+  password-session blocker documented in the v5 security review still has to be
+  resolved or explicitly scoped before multi-user/server-mode GA.
+
+## Remaining Risks
+
+- `v5-remote-mix` validates API, dashboard, search, workflow, chat, and
+  WebSocket server behavior. It does not measure native mobile browser rendering
+  performance.
+- Scheduled k6 runs use generated seed data. Before GA, attach the workflow
+  artifacts from a `load_profile=full` run against the release candidate.
+- Large-team or SaaS-style deployments need follow-up load profiles with higher
+  seed counts and longer soak windows.

--- a/load-tests/k6/v5-remote-mix.js
+++ b/load-tests/k6/v5-remote-mix.js
@@ -1,0 +1,252 @@
+/**
+ * Scenario 6: v5 Remote and SQLite Mix
+ *
+ * Seeds a representative remote dataset, then exercises board reads, task
+ * search, dashboard metrics, workflow run metadata, chat history, write churn,
+ * and WebSocket task/workflow/chat subscriptions.
+ */
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { API_BASE, WS_URL, API_KEY, defaultHeaders, makeTask } from '../config.js';
+
+const errors = new Rate('v5_errors');
+const wsErrors = new Rate('v5_ws_errors');
+const wsMessages = new Counter('v5_ws_messages_received');
+
+const boardDuration = new Trend('v5_board_duration', true);
+const detailDuration = new Trend('v5_detail_duration', true);
+const dashboardDuration = new Trend('v5_dashboard_duration', true);
+const searchDuration = new Trend('v5_search_duration', true);
+const workflowRunsDuration = new Trend('v5_workflow_runs_duration', true);
+const chatHistoryDuration = new Trend('v5_chat_history_duration', true);
+const writeDuration = new Trend('v5_write_duration', true);
+
+const seedTaskCount = Number(__ENV.V5_SEED_TASKS || '120');
+const seedChatCount = Number(__ENV.V5_SEED_CHATS || '12');
+const httpVus = Number(__ENV.V5_HTTP_VUS || '20');
+const wsVus = Number(__ENV.V5_WS_VUS || '30');
+const duration = __ENV.V5_DURATION || '45s';
+const wsHoldMs = Number(__ENV.V5_WS_HOLD_MS || '40000');
+
+export const options = {
+  scenarios: {
+    http_mix: {
+      executor: 'constant-vus',
+      vus: httpVus,
+      duration,
+      exec: 'httpMix',
+    },
+    ws_clients: {
+      executor: 'constant-vus',
+      vus: wsVus,
+      duration,
+      exec: 'wsClients',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    v5_errors: ['rate<0.01'],
+    v5_ws_errors: ['rate<0.05'],
+    v5_board_duration: ['p(95)<350'],
+    v5_detail_duration: ['p(95)<250'],
+    v5_dashboard_duration: ['p(95)<750'],
+    v5_search_duration: ['p(95)<750'],
+    v5_workflow_runs_duration: ['p(95)<500'],
+    v5_chat_history_duration: ['p(95)<500'],
+    v5_write_duration: ['p(95)<750'],
+  },
+};
+
+function parseJson(response) {
+  try {
+    return JSON.parse(response.body);
+  } catch {
+    return null;
+  }
+}
+
+function pick(values) {
+  if (!values || values.length === 0) return null;
+  return values[Math.floor(Math.random() * values.length)];
+}
+
+function record(response, trend, label, expectedStatuses = [200]) {
+  trend.add(response.timings.duration);
+  const ok = check(response, {
+    [label]: (r) => expectedStatuses.includes(r.status),
+  });
+  errors.add(!ok);
+  return ok;
+}
+
+function createTask(prefix) {
+  const response = http.post(`${API_BASE}/tasks`, JSON.stringify(makeTask(prefix)), {
+    headers: defaultHeaders,
+    tags: { name: 'POST /tasks' },
+  });
+  const body = parseJson(response);
+  return response.status === 201 ? body?.id || body?.task?.id || null : null;
+}
+
+export function setup() {
+  const taskIds = [];
+  const sessionIds = [];
+
+  for (let index = 0; index < seedTaskCount; index += 1) {
+    const taskId = createTask('v5-load-seed');
+    if (taskId) {
+      taskIds.push(taskId);
+    }
+  }
+
+  for (let index = 0; index < Math.min(seedChatCount, taskIds.length); index += 1) {
+    const response = http.post(
+      `${API_BASE}/chat/send`,
+      JSON.stringify({
+        taskId: taskIds[index],
+        message: `Seed remote chat history ${index}`,
+        agent: 'veritas',
+        mode: 'ask',
+        includeContext: false,
+      }),
+      {
+        headers: defaultHeaders,
+        tags: { name: 'POST /chat/send' },
+      }
+    );
+    const body = parseJson(response);
+    if (response.status === 200 && body?.sessionId) {
+      sessionIds.push(body.sessionId);
+    }
+  }
+
+  return { taskIds, sessionIds };
+}
+
+export function httpMix(data) {
+  const taskId = pick(data.taskIds);
+  const sessionId = pick(data.sessionIds);
+  const roll = Math.random();
+
+  if (roll < 0.18) {
+    const response = http.get(`${API_BASE}/tasks`, {
+      headers: defaultHeaders,
+      tags: { name: 'GET /tasks' },
+    });
+    record(response, boardDuration, 'board list returns 200');
+  } else if (roll < 0.34 && taskId) {
+    const response = http.get(`${API_BASE}/tasks/${taskId}`, {
+      headers: defaultHeaders,
+      tags: { name: 'GET /tasks/:id' },
+    });
+    record(response, detailDuration, 'task detail returns 200');
+  } else if (roll < 0.5) {
+    const response = http.post(
+      `${API_BASE}/search`,
+      JSON.stringify({
+        query: 'v5-load-seed',
+        limit: 20,
+        backend: 'keyword',
+        collections: ['tasks-active', 'workflows', 'workflow-runs'],
+      }),
+      {
+        headers: defaultHeaders,
+        tags: { name: 'POST /search' },
+      }
+    );
+    record(response, searchDuration, 'search returns 200');
+  } else if (roll < 0.64) {
+    const response = http.get(`${API_BASE}/metrics/all?period=7d`, {
+      headers: defaultHeaders,
+      tags: { name: 'GET /metrics/all' },
+    });
+    record(response, dashboardDuration, 'dashboard metrics returns 200');
+  } else if (roll < 0.76) {
+    const response = http.get(`${API_BASE}/workflows/runs`, {
+      headers: defaultHeaders,
+      tags: { name: 'GET /workflows/runs' },
+    });
+    record(response, workflowRunsDuration, 'workflow runs returns 200');
+  } else if (roll < 0.88 && sessionId) {
+    const response = http.get(`${API_BASE}/chat/sessions/${sessionId}/history`, {
+      headers: defaultHeaders,
+      tags: { name: 'GET /chat/sessions/:id/history' },
+    });
+    record(response, chatHistoryDuration, 'chat history returns 200');
+  } else {
+    const createdTaskId = createTask('v5-load-write');
+    if (!createdTaskId) {
+      errors.add(1);
+      sleep(0.2);
+      return;
+    }
+
+    const updateResponse = http.patch(
+      `${API_BASE}/tasks/${createdTaskId}`,
+      JSON.stringify({
+        priority: 'high',
+        description: 'Updated during v5 remote mix load test',
+      }),
+      {
+        headers: defaultHeaders,
+        tags: { name: 'PATCH /tasks/:id' },
+      }
+    );
+    record(updateResponse, writeDuration, 'task update returns 200');
+
+    const deleteResponse = http.del(`${API_BASE}/tasks/${createdTaskId}`, null, {
+      headers: defaultHeaders,
+      tags: { name: 'DELETE /tasks/:id' },
+    });
+    record(deleteResponse, writeDuration, 'task delete returns 200 or 204', [200, 204]);
+  }
+
+  sleep(0.2);
+}
+
+export function wsClients(data) {
+  const taskId = pick(data.taskIds);
+  const sessionId = pick(data.sessionIds);
+  const url = `${WS_URL}?api_key=${encodeURIComponent(API_KEY)}`;
+
+  const response = ws.connect(url, {}, (socket) => {
+    socket.on('open', () => {
+      socket.send(JSON.stringify({ type: 'subscribe:tasks' }));
+      socket.send(JSON.stringify({ type: 'workflow:subscribe' }));
+      if (taskId) {
+        socket.send(JSON.stringify({ type: 'subscribe', taskId }));
+      }
+      if (sessionId) {
+        socket.send(JSON.stringify({ type: 'chat:subscribe', sessionId }));
+      }
+    });
+
+    socket.on('message', (message) => {
+      wsMessages.add(1);
+      try {
+        JSON.parse(message);
+      } catch {
+        // WebSocket control frames are acceptable for this load profile.
+      }
+    });
+
+    socket.on('error', () => {
+      wsErrors.add(1);
+    });
+
+    socket.setInterval(() => {
+      socket.send(JSON.stringify({ type: 'subscribe:tasks' }));
+    }, 10_000);
+
+    socket.setTimeout(() => {
+      socket.close();
+    }, wsHoldMs);
+  });
+
+  const connected = check(response, {
+    'v5 WS connected (101)': (r) => r && r.status === 101,
+  });
+  wsErrors.add(!connected);
+}

--- a/load-tests/k6/ws-stress.js
+++ b/load-tests/k6/ws-stress.js
@@ -22,7 +22,7 @@ export const options = {
 };
 
 export default function () {
-  const url = `${WS_URL}?apiKey=${API_KEY}`;
+  const url = `${WS_URL}?api_key=${encodeURIComponent(API_KEY)}`;
 
   const res = ws.connect(url, {}, function (socket) {
     socket.on('open', () => {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:e2e:ui": "playwright test --ui",
     "qa:mantine": "node scripts/check-mantine-qa-gate.mjs",
     "test:load:smoke": "k6 run load-tests/k6/smoke.js",
-    "test:load": "k6 run load-tests/k6/smoke.js && k6 run load-tests/k6/read-load.js && k6 run load-tests/k6/write-load.js && k6 run load-tests/k6/mixed-load.js && k6 run load-tests/k6/ws-stress.js",
+    "test:load": "k6 run load-tests/k6/smoke.js && k6 run load-tests/k6/read-load.js && k6 run load-tests/k6/write-load.js && k6 run load-tests/k6/mixed-load.js && k6 run load-tests/k6/ws-stress.js && k6 run load-tests/k6/v5-remote-mix.js",
     "validate:release": "node scripts/validate-release.mjs",
     "clean": "pnpm -r clean && rm -rf node_modules",
     "audit": "pnpm audit --prod",

--- a/server/src/__tests__/storage/sqlite-performance.test.ts
+++ b/server/src/__tests__/storage/sqlite-performance.test.ts
@@ -1,0 +1,548 @@
+import { performance } from 'node:perf_hooks';
+import { describe, expect, it } from 'vitest';
+import type { ChatMessage, ChatSession, Task } from '@veritas-kanban/shared';
+import { createTestSqliteDatabase } from '../../storage/sqlite/test-helpers.js';
+import { SqliteTaskRepository } from '../../storage/sqlite/task-repository.js';
+import { SqliteTelemetryRepository } from '../../storage/sqlite/telemetry-repository.js';
+import { SqliteChatRepository } from '../../storage/sqlite/chat-repository.js';
+import { SqliteWorkflowRunRepository } from '../../storage/sqlite/workflow-repositories.js';
+import type { WorkflowRun, WorkflowRunStatus } from '../../types/workflow.js';
+
+const TASK_COUNT = 1_500;
+const COMMENT_COUNT_PER_TASK = 2;
+const ATTACHMENT_METADATA_COUNT = 600;
+const TELEMETRY_EVENT_COUNT = 6_000;
+const WORKFLOW_RUN_COUNT = 1_200;
+const CHAT_SESSION_COUNT = 60;
+const CHAT_MESSAGES_PER_SESSION = 50;
+
+const PERF_BUDGET_MS = {
+  boardList: 2_000,
+  taskSearch: 750,
+  dashboardTelemetryWindow: 1_500,
+  workflowRunningList: 750,
+  chatHistory: 750,
+};
+
+interface QueryPlanRow {
+  detail: string;
+}
+
+interface Measurement<T> {
+  durationMs: number;
+  value: T;
+}
+
+function isoAt(index: number): string {
+  return new Date(Date.UTC(2026, 5, 1, 12, 0, 0) + index * 1000).toISOString();
+}
+
+function makeTask(index: number): Task {
+  const updated = isoAt(index);
+  return {
+    id: `task_perf_${index.toString().padStart(5, '0')}`,
+    title: `Perf task ${index}`,
+    description: `Representative SQLite performance fixture perf-token-${index}`,
+    type: index % 5 === 0 ? 'research' : 'code',
+    status: ['todo', 'in-progress', 'blocked', 'done'][index % 4] as Task['status'],
+    priority: ['low', 'medium', 'high', 'critical'][index % 4] as Task['priority'],
+    project: `project-${index % 8}`,
+    sprint: `v5-${index % 6}`,
+    position: index,
+    created: isoAt(index - TASK_COUNT),
+    updated,
+    comments: Array.from({ length: COMMENT_COUNT_PER_TASK }, (_, commentIndex) => ({
+      id: `comment_${index}_${commentIndex}`,
+      author: `agent-${commentIndex}`,
+      text: `Representative comment ${commentIndex} for perf task ${index}`,
+      timestamp: isoAt(index + commentIndex),
+    })),
+    attachments:
+      index < ATTACHMENT_METADATA_COUNT
+        ? [
+            {
+              id: `attachment_${index.toString().padStart(5, '0')}`,
+              filename: `attachment_${index.toString().padStart(5, '0')}.txt`,
+              originalName: `Fixture ${index}.txt`,
+              mimeType: 'text/plain',
+              size: 512 + index,
+              uploaded: updated,
+              workspaceId: 'local',
+              uploadedBy: 'perf-fixture',
+              storagePath: `tasks/attachments/task_perf_${index.toString().padStart(5, '0')}/attachment.txt`,
+              validationStatus: 'valid',
+              retentionStatus: 'active',
+              cleanupEligible: index % 5 === 0,
+            },
+          ]
+        : undefined,
+  };
+}
+
+function makeWorkflowRun(index: number): WorkflowRun {
+  const status = ['running', 'completed', 'failed', 'blocked'][index % 4] as WorkflowRunStatus;
+  const startedAt = isoAt(index);
+  const completedAt = status === 'running' || status === 'blocked' ? undefined : isoAt(index + 1);
+
+  return {
+    id: `run_perf_${index.toString().padStart(5, '0')}`,
+    workflowId: `workflow-${index % 12}`,
+    workflowVersion: 1,
+    taskId: `task_perf_${(index % TASK_COUNT).toString().padStart(5, '0')}`,
+    status,
+    currentStep: status === 'running' ? 'step-2' : undefined,
+    context: { fixture: 'v5-performance', index },
+    startedAt,
+    completedAt,
+    error: status === 'failed' ? 'fixture failure' : undefined,
+    steps: [
+      {
+        stepId: 'step-1',
+        status: status === 'failed' ? 'failed' : 'completed',
+        retries: 0,
+        duration: 3,
+      },
+    ],
+  };
+}
+
+function makeChatSession(index: number): ChatSession {
+  const timestamp = isoAt(index);
+  return {
+    id: `chat_perf_${index.toString().padStart(4, '0')}`,
+    taskId: `task_perf_${index.toString().padStart(5, '0')}`,
+    title: `Perf chat ${index}`,
+    messages: [],
+    agent: 'veritas',
+    mode: 'ask',
+    created: timestamp,
+    updated: timestamp,
+  };
+}
+
+function makeChatMessage(session: ChatSession, messageIndex: number): ChatMessage {
+  const timestamp = isoAt(messageIndex);
+  return {
+    id: `${session.id}_msg_${messageIndex.toString().padStart(4, '0')}`,
+    role: messageIndex % 2 === 0 ? 'user' : 'assistant',
+    content: `Representative chat history message ${messageIndex} for ${session.id}`,
+    timestamp,
+    agent: messageIndex % 2 === 0 ? undefined : 'veritas',
+  };
+}
+
+function seedRepresentativeDataset(
+  database: ReturnType<typeof createTestSqliteDatabase>['database']
+) {
+  const db = database.getConnection();
+
+  const insertTask = db.prepare(`
+    INSERT INTO tasks (
+      id,
+      workspace_id,
+      storage_state,
+      title,
+      description,
+      type,
+      status,
+      priority,
+      project,
+      sprint,
+      position,
+      task_json,
+      created_at,
+      updated_at,
+      archived_at,
+      deleted_at
+    )
+    VALUES (?, 'local', 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+  `);
+  const insertTaskSearch = db.prepare(`
+    INSERT INTO task_search (task_id, title, description)
+    VALUES (?, ?, ?)
+  `);
+  const insertAttachment = db.prepare(`
+    INSERT INTO task_attachments (
+      id,
+      workspace_id,
+      task_id,
+      filename,
+      original_name,
+      mime_type,
+      size_bytes,
+      sha256,
+      storage_path,
+      uploaded_at,
+      uploaded_by,
+      session_id,
+      validation_status,
+      validation_error,
+      retention_status,
+      cleanup_eligible,
+      attachment_json,
+      deleted_at
+    )
+    VALUES (?, 'local', ?, ?, ?, ?, ?, NULL, ?, ?, ?, NULL, ?, NULL, ?, ?, ?, NULL)
+  `);
+  const insertTelemetry = db.prepare(`
+    INSERT INTO telemetry_events (
+      id,
+      workspace_id,
+      type,
+      task_id,
+      project_id,
+      agent,
+      model,
+      attempt_id,
+      success,
+      duration_ms,
+      exit_code,
+      input_tokens,
+      output_tokens,
+      cache_tokens,
+      total_tokens,
+      cost,
+      error,
+      stack_trace,
+      session_key,
+      payload_json,
+      created_at
+    )
+    VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+  `);
+  const insertWorkflowRun = db.prepare(`
+    INSERT INTO workflow_runs (
+      id,
+      workspace_id,
+      workflow_id,
+      workflow_version,
+      task_id,
+      status,
+      current_step,
+      run_json,
+      workflow_snapshot_json,
+      started_at,
+      completed_at,
+      last_checkpoint,
+      error
+    )
+    VALUES (?, 'local', ?, ?, ?, ?, ?, ?, NULL, ?, ?, NULL, ?)
+  `);
+  const insertChatSession = db.prepare(`
+    INSERT INTO chat_sessions (
+      id,
+      workspace_id,
+      task_id,
+      title,
+      agent,
+      model,
+      mode,
+      session_json,
+      created_at,
+      updated_at
+    )
+    VALUES (?, 'local', ?, ?, ?, NULL, ?, ?, ?, ?)
+  `);
+  const insertChatMessage = db.prepare(`
+    INSERT INTO chat_messages (
+      id,
+      workspace_id,
+      session_id,
+      task_id,
+      role,
+      agent,
+      model,
+      message_json,
+      created_at
+    )
+    VALUES (?, 'local', ?, ?, ?, ?, NULL, ?, ?)
+  `);
+
+  db.exec('BEGIN IMMEDIATE;');
+  try {
+    for (let index = 0; index < TASK_COUNT; index += 1) {
+      const task = makeTask(index);
+      insertTask.run(
+        task.id,
+        task.title,
+        task.description,
+        task.type,
+        task.status,
+        task.priority,
+        task.project ?? null,
+        task.sprint ?? null,
+        task.position ?? null,
+        JSON.stringify(task),
+        task.created,
+        task.updated
+      );
+      insertTaskSearch.run(task.id, task.title, task.description);
+
+      for (const attachment of task.attachments ?? []) {
+        insertAttachment.run(
+          attachment.id,
+          task.id,
+          attachment.filename,
+          attachment.originalName,
+          attachment.mimeType,
+          attachment.size,
+          attachment.storagePath ?? '',
+          attachment.uploaded,
+          attachment.uploadedBy ?? null,
+          attachment.validationStatus ?? 'unknown',
+          attachment.retentionStatus ?? 'active',
+          attachment.cleanupEligible === true ? 1 : 0,
+          JSON.stringify(attachment)
+        );
+      }
+    }
+
+    for (let index = 0; index < TELEMETRY_EVENT_COUNT; index += 1) {
+      const timestamp = isoAt(index);
+      const type = index % 2 === 0 ? 'run.completed' : 'run.tokens';
+      const taskId = `task_perf_${(index % TASK_COUNT).toString().padStart(5, '0')}`;
+      const event = {
+        id: `evt_perf_${index.toString().padStart(5, '0')}`,
+        type,
+        timestamp,
+        taskId,
+        project: `project-${index % 8}`,
+        agent: `agent-${index % 6}`,
+        model: 'gpt-5',
+        success: index % 7 !== 0,
+        durationMs: 1_000 + (index % 400),
+        inputTokens: 800 + (index % 50),
+        outputTokens: 200 + (index % 40),
+        totalTokens: 1_000 + (index % 90),
+        cost: 0.01 + (index % 10) / 100,
+        sessionKey: `session-${index % 40}`,
+      };
+
+      insertTelemetry.run(
+        event.id,
+        event.type,
+        event.taskId,
+        event.project,
+        event.agent,
+        event.model,
+        `attempt-${index % 20}`,
+        event.success ? 1 : 0,
+        event.durationMs,
+        event.success ? 0 : 1,
+        event.inputTokens,
+        event.outputTokens,
+        0,
+        event.totalTokens,
+        event.cost,
+        event.success ? null : 'fixture failure',
+        event.sessionKey,
+        JSON.stringify(event),
+        timestamp
+      );
+    }
+
+    for (let index = 0; index < WORKFLOW_RUN_COUNT; index += 1) {
+      const run = makeWorkflowRun(index);
+      insertWorkflowRun.run(
+        run.id,
+        run.workflowId,
+        run.workflowVersion,
+        run.taskId ?? null,
+        run.status,
+        run.currentStep ?? null,
+        JSON.stringify(run),
+        run.startedAt,
+        run.completedAt ?? null,
+        run.error ?? null
+      );
+    }
+
+    for (let sessionIndex = 0; sessionIndex < CHAT_SESSION_COUNT; sessionIndex += 1) {
+      const session = makeChatSession(sessionIndex);
+      insertChatSession.run(
+        session.id,
+        session.taskId ?? null,
+        session.title,
+        session.agent,
+        session.mode,
+        JSON.stringify(session),
+        session.created,
+        session.updated
+      );
+
+      for (let messageIndex = 0; messageIndex < CHAT_MESSAGES_PER_SESSION; messageIndex += 1) {
+        const message = makeChatMessage(session, messageIndex);
+        insertChatMessage.run(
+          message.id,
+          session.id,
+          session.taskId ?? null,
+          message.role,
+          message.agent ?? null,
+          JSON.stringify(message),
+          message.timestamp
+        );
+      }
+    }
+
+    db.exec('COMMIT;');
+  } catch (error) {
+    db.exec('ROLLBACK;');
+    throw error;
+  }
+}
+
+function queryPlan(database: ReturnType<typeof createTestSqliteDatabase>['database'], sql: string) {
+  return database
+    .getConnection()
+    .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+    .all() as unknown as QueryPlanRow[];
+}
+
+function expectPlanUsesIndex(plan: QueryPlanRow[], indexName: string) {
+  expect(plan.map((row) => row.detail).join('\n')).toContain(indexName);
+}
+
+async function measure<T>(fn: () => T | Promise<T>): Promise<Measurement<T>> {
+  const startedAt = performance.now();
+  const value = await fn();
+  return {
+    durationMs: performance.now() - startedAt,
+    value,
+  };
+}
+
+describe('SQLite v5 representative performance', () => {
+  it('keeps board, search, dashboard, workflow, and chat reads on indexed plans', () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+
+      expectPlanUsesIndex(
+        queryPlan(
+          fixture.database,
+          `
+            SELECT task_json
+            FROM tasks
+            WHERE workspace_id = 'local'
+              AND storage_state = 'active'
+              AND deleted_at IS NULL
+            ORDER BY updated_at DESC
+          `
+        ),
+        'idx_tasks_workspace_state_updated'
+      );
+
+      expectPlanUsesIndex(
+        queryPlan(
+          fixture.database,
+          `
+            SELECT payload_json
+            FROM telemetry_events
+            WHERE workspace_id = 'local'
+              AND type = 'run.completed'
+              AND created_at >= '2026-06-01T12:00:00.000Z'
+            ORDER BY created_at ASC, id ASC
+          `
+        ),
+        'idx_telemetry_type_created'
+      );
+
+      expectPlanUsesIndex(
+        queryPlan(
+          fixture.database,
+          `
+            SELECT id, workflow_id, workflow_version, task_id, status, started_at, completed_at, error
+            FROM workflow_runs
+            WHERE workspace_id = 'local'
+              AND status = 'running'
+            ORDER BY started_at DESC, id DESC
+          `
+        ),
+        'idx_workflow_runs_status_started'
+      );
+
+      expectPlanUsesIndex(
+        queryPlan(
+          fixture.database,
+          `
+            SELECT message_json
+            FROM chat_messages
+            WHERE workspace_id = 'local'
+              AND session_id = 'chat_perf_0020'
+            ORDER BY created_at ASC, rowid ASC
+          `
+        ),
+        'idx_chat_messages_session_created'
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('records conservative timings on a representative local v5 dataset', async () => {
+    const fixture = createTestSqliteDatabase();
+
+    try {
+      fixture.database.open();
+      seedRepresentativeDataset(fixture.database);
+
+      const taskRepository = new SqliteTaskRepository(fixture.database);
+      const telemetryRepository = new SqliteTelemetryRepository(fixture.database);
+      const workflowRunRepository = new SqliteWorkflowRunRepository(fixture.database);
+      const chatRepository = new SqliteChatRepository(fixture.database);
+
+      const boardList = await measure(() => taskRepository.findAll());
+      const taskSearch = await measure(() => taskRepository.search('perf-token-1499'));
+      const dashboardTelemetryWindow = await measure(() =>
+        telemetryRepository.getEvents({
+          type: 'run.completed',
+          since: '2026-06-01T12:30:00.000Z',
+          limit: 10_000,
+        })
+      );
+      const workflowRunningList = await measure(() =>
+        workflowRunRepository.listMetadata({ status: 'running' })
+      );
+      const chatHistory = await measure(() => chatRepository.getSession('chat_perf_0020'));
+
+      expect(boardList.value).toHaveLength(TASK_COUNT);
+      expect(taskSearch.value[0]?.id).toBe('task_perf_01499');
+      expect(dashboardTelemetryWindow.value.length).toBeGreaterThan(0);
+      expect(workflowRunningList.value.length).toBeGreaterThan(0);
+      expect(chatHistory.value?.messages).toHaveLength(CHAT_MESSAGES_PER_SESSION);
+
+      const measurements = {
+        dataset: {
+          tasks: TASK_COUNT,
+          comments: TASK_COUNT * COMMENT_COUNT_PER_TASK,
+          attachmentMetadataRows: ATTACHMENT_METADATA_COUNT,
+          telemetryEvents: TELEMETRY_EVENT_COUNT,
+          workflowRuns: WORKFLOW_RUN_COUNT,
+          chatSessions: CHAT_SESSION_COUNT,
+          chatMessages: CHAT_SESSION_COUNT * CHAT_MESSAGES_PER_SESSION,
+        },
+        timingsMs: {
+          boardList: Number(boardList.durationMs.toFixed(1)),
+          taskSearch: Number(taskSearch.durationMs.toFixed(1)),
+          dashboardTelemetryWindow: Number(dashboardTelemetryWindow.durationMs.toFixed(1)),
+          workflowRunningList: Number(workflowRunningList.durationMs.toFixed(1)),
+          chatHistory: Number(chatHistory.durationMs.toFixed(1)),
+        },
+        budgetsMs: PERF_BUDGET_MS,
+      };
+
+      console.info(`[v5-sqlite-performance] ${JSON.stringify(measurements)}`);
+
+      expect(boardList.durationMs).toBeLessThan(PERF_BUDGET_MS.boardList);
+      expect(taskSearch.durationMs).toBeLessThan(PERF_BUDGET_MS.taskSearch);
+      expect(dashboardTelemetryWindow.durationMs).toBeLessThan(
+        PERF_BUDGET_MS.dashboardTelemetryWindow
+      );
+      expect(workflowRunningList.durationMs).toBeLessThan(PERF_BUDGET_MS.workflowRunningList);
+      expect(chatHistory.durationMs).toBeLessThan(PERF_BUDGET_MS.chatHistory);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/server/src/services/metrics/telemetry-reader.ts
+++ b/server/src/services/metrics/telemetry-reader.ts
@@ -240,7 +240,7 @@ function visitSqliteTelemetryEvents(
           SELECT payload_json
           FROM telemetry_events
           WHERE ${clauses.join(' AND ')}
-          ORDER BY datetime(created_at) ASC, id ASC
+          ORDER BY created_at ASC, id ASC
         `
       )
       .all(...params) as unknown as SqliteTelemetryPayloadRow[];

--- a/server/src/storage/sqlite/chat-repository.ts
+++ b/server/src/storage/sqlite/chat-repository.ts
@@ -59,7 +59,7 @@ export class SqliteChatRepository {
           FROM chat_sessions
           WHERE workspace_id = 'local'
             AND task_id IS NULL
-          ORDER BY datetime(updated_at) DESC, id DESC
+          ORDER BY updated_at DESC, id DESC
         `
       )
       .all() as unknown as ChatSessionRow[];
@@ -238,7 +238,7 @@ export class SqliteChatRepository {
           SELECT message_json
           FROM squad_messages
           WHERE ${clauses.join(' AND ')}
-          ORDER BY datetime(timestamp) ${limit ? 'DESC' : 'ASC'}, id ${limit ? 'DESC' : 'ASC'}
+          ORDER BY timestamp ${limit ? 'DESC' : 'ASC'}, id ${limit ? 'DESC' : 'ASC'}
           ${limit ? 'LIMIT ?' : ''}
         `
       )
@@ -263,7 +263,7 @@ export class SqliteChatRepository {
           FROM chat_messages
           WHERE workspace_id = 'local'
             AND session_id = ?
-          ORDER BY datetime(created_at) ASC, rowid ASC
+          ORDER BY created_at ASC, rowid ASC
         `
       )
       .all(sessionId) as unknown as ChatMessageRow[];

--- a/server/src/storage/sqlite/task-repository.ts
+++ b/server/src/storage/sqlite/task-repository.ts
@@ -62,7 +62,8 @@ export class SqliteTaskRepository implements TaskRepository {
           `
             SELECT t.task_json
             FROM tasks t
-            WHERE t.storage_state = 'active'
+            WHERE t.workspace_id = 'local'
+              AND t.storage_state = 'active'
               AND t.deleted_at IS NULL
               AND (
                 lower(t.id) LIKE ?
@@ -72,7 +73,7 @@ export class SqliteTaskRepository implements TaskRepository {
                   WHERE task_search MATCH ?
                 )
               )
-            ORDER BY datetime(t.updated_at) DESC
+            ORDER BY t.updated_at DESC
           `
         )
         .all(likeQuery, ftsQuery) as unknown as TaskRow[];
@@ -84,14 +85,15 @@ export class SqliteTaskRepository implements TaskRepository {
           `
             SELECT task_json
             FROM tasks
-            WHERE storage_state = 'active'
+            WHERE workspace_id = 'local'
+              AND storage_state = 'active'
               AND deleted_at IS NULL
               AND (
                 lower(id) LIKE ?
                 OR lower(title) LIKE ?
                 OR lower(description) LIKE ?
               )
-            ORDER BY datetime(updated_at) DESC
+            ORDER BY updated_at DESC
           `
         )
         .all(likeQuery, likeQuery, likeQuery) as unknown as TaskRow[];
@@ -185,9 +187,10 @@ export class SqliteTaskRepository implements TaskRepository {
         `
           SELECT task_json
           FROM tasks
-          WHERE storage_state = ?
+          WHERE workspace_id = 'local'
+            AND storage_state = ?
             AND deleted_at IS NULL
-          ORDER BY datetime(updated_at) DESC
+          ORDER BY updated_at DESC
         `
       )
       .all(state) as unknown as TaskRow[];
@@ -202,7 +205,8 @@ export class SqliteTaskRepository implements TaskRepository {
         `
           SELECT task_json
           FROM tasks
-          WHERE id = ?
+          WHERE workspace_id = 'local'
+            AND id = ?
             AND storage_state = ?
             AND deleted_at IS NULL
         `

--- a/server/src/storage/sqlite/telemetry-repository.ts
+++ b/server/src/storage/sqlite/telemetry-repository.ts
@@ -336,7 +336,7 @@ export class SqliteTelemetryRepository implements TelemetryRepository {
         SELECT payload_json
         FROM telemetry_events
         WHERE ${clauses.join(' AND ')}
-        ORDER BY datetime(created_at) DESC, id DESC
+        ORDER BY created_at DESC, id DESC
         LIMIT ?
       `,
       params,

--- a/server/src/storage/sqlite/workflow-repositories.ts
+++ b/server/src/storage/sqlite/workflow-repositories.ts
@@ -286,7 +286,7 @@ export class SqliteWorkflowRunRepository {
             error
           FROM workflow_runs
           WHERE ${clauses.join(' AND ')}
-          ORDER BY datetime(started_at) DESC, id DESC
+          ORDER BY started_at DESC, id DESC
         `
       )
       .all(...params) as unknown as WorkflowRunMetadataRow[];
@@ -393,7 +393,7 @@ export class SqliteWorkflowRunRepository {
           SELECT run_json
           FROM workflow_runs
           WHERE ${clauses.join(' AND ')}
-          ORDER BY datetime(started_at) DESC, id DESC
+          ORDER BY started_at DESC, id DESC
         `
       )
       .all(...params) as unknown as WorkflowRunRow[];


### PR DESCRIPTION
## Summary
- Adds a representative SQLite performance fixture covering tasks, comments, attachment metadata, telemetry, workflow runs, and chat history.
- Cleans hot SQLite ordering queries so ISO timestamp indexes can be used without per-row datetime wrappers.
- Adds the v5 remote k6 mix for dashboard, search, workflow, chat, write churn, and WebSocket subscriptions, and wires it into full scheduled QA.
- Documents target dataset sizes, benchmark results, k6 defaults, recommended limits, and remaining load risks.

## Tests
- pnpm --filter @veritas-kanban/server test -- sqlite-performance.test.ts --reporter verbose
- pnpm --filter @veritas-kanban/server test -- sqlite-performance.test.ts sqlite-task-repository.test.ts sqlite-dashboard-metrics.test.ts sqlite-workflow-repositories.test.ts
- node --check load-tests/k6/v5-remote-mix.js
- node --check load-tests/k6/ws-stress.js
- pnpm exec prettier --check .github/workflows/scheduled-qa.yml docs/V5-GA-CHECKLIST.md docs/testing/v5-performance-load.md load-tests/k6/ws-stress.js load-tests/k6/v5-remote-mix.js package.json server/src/__tests__/storage/sqlite-performance.test.ts server/src/services/metrics/telemetry-reader.ts server/src/storage/sqlite/chat-repository.ts server/src/storage/sqlite/task-repository.ts server/src/storage/sqlite/telemetry-repository.ts server/src/storage/sqlite/workflow-repositories.ts
- pnpm typecheck
- git diff --check
- pnpm lint
- pnpm build

## Risks / follow-ups
- Local k6 execution could not run because k6 is not installed and the Docker daemon is not running on this machine. The scripts parse cleanly and the full profile is wired into scheduled QA for dispatch.
- Larger hosted or SaaS-style deployments still need higher seed counts and longer soak windows before being treated as supported.

Closes #351