### PR TITLE
Add v5 data lifecycle controls

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2717,11 +2717,29 @@ POST /api/v1/sqlite/export
 ```json
 {
   "sqlitePath": "/path/to/.veritas-kanban/veritas.db",
-  "outputDir": "/path/to/backup-bundle"
+  "outputDir": "/path/to/backup-bundle",
+  "workspaceId": "local"
 }
 ```
 
 Writes raw SQLite table snapshots plus human-readable Markdown/JSON/YAML files.
+Omit `workspaceId` for a full database export. When `workspaceId` is supplied,
+the export includes only rows scoped to that workspace plus member user records;
+global app configuration tables are exported as empty arrays. Derived task
+Markdown and workflow YAML files use the same workspace boundary, and unscoped
+derived files such as global settings JSON are omitted.
+
+The generated `manifest.json` includes table row counts, data lifecycle classes,
+retention/export/delete behavior, sensitivity flags, scope, and redaction state.
+
+#### Data Lifecycle Policy
+
+```
+GET /api/v1/sqlite/lifecycle-policy
+```
+
+Returns the machine-readable v5 lifecycle policy used by backup manifests and
+future Maintenance Center cleanup previews.
 
 #### Import Backup Bundle
 

--- a/docs/DATA-LIFECYCLE.md
+++ b/docs/DATA-LIFECYCLE.md
@@ -1,0 +1,103 @@
+# v5.0 Data Lifecycle, Retention, and Privacy Controls
+
+This document defines the durable data classes introduced or expanded in v5.0
+and the rules that Maintenance Center, backup/export, workspace deletion, and
+support bundles must follow.
+
+## Core Rules
+
+- Full SQLite backup bundles are raw admin exports. They can include private
+  paths, prompts, generated content, user content, and operational history.
+- Support/debug bundles are redacted by default. They must not include token
+  values, token hashes, cookies, private keys, credentialed URLs, local path
+  prefixes, raw prompts, raw chat content, or generated sensitive text unless a
+  user explicitly opts in.
+- Workspace-scoped exports include only rows for the requested workspace plus
+  member user records. Global app configuration is excluded from scoped exports
+  until a dedicated per-workspace settings model exists.
+- Cleanup previews must show counts, links, age, status, and storage estimates
+  before deletion. They should avoid showing full user content.
+- Audit/governance evidence is retained separately from operational cleanup
+  candidates. Operational cleanup must not silently delete audit history.
+- Device sessions, pairing codes, API token secrets, and hashes are not included
+  in SQLite backup table exports by default.
+
+## Data Classes
+
+| Data class                                          | Primary tables                                                                                                                                                                                                | Default retention                                                | Export/delete policy                                                                        |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Workspace identity and membership                   | `workspaces`, `users`, `workspace_memberships`, `workspace_invitations`                                                                                                                                       | Until admin removal or workspace archival                        | Scoped exports include selected workspace, memberships, invitations, and member users only. |
+| Tasks and task metadata                             | `tasks`                                                                                                                                                                                                       | Active/backlog until archived or deleted; archived until cleanup | Preview linked artifacts before deletion. Included in full and scoped exports.              |
+| Task comments and discussion                        | `tasks` JSON                                                                                                                                                                                                  | Follows parent task                                              | Included with task export. Cleanup follows parent task unless comment-level delete is used. |
+| Uploads and attachment metadata                     | `task_attachments`                                                                                                                                                                                            | While linked to a task unless cleanup-eligible                   | Preview parent task, path, size, MIME type, and orphan status before deletion.              |
+| Work products and versions                          | `work_products`, `work_product_versions`, `task_deliverables`                                                                                                                                                 | Until task/workspace cleanup or version retention                | Preview source task/run, status, version count, and redaction state.                        |
+| Telemetry and metrics events                        | `telemetry_events`                                                                                                                                                                                            | 30 days by default                                               | Purge only by explicit range/workspace preview.                                             |
+| Workflow definitions, runs, and scheduled snapshots | `workflow_definitions`, `workflow_acls`, `workflow_audit_events`, `workflow_runs`, `scheduled_deliverables`, `scheduled_deliverable_runs`                                                                     | Definitions until deleted; runs/snapshots by admin retention     | Never delete active runs or current scheduled state silently.                               |
+| Notifications and subscriptions                     | `notifications`, `thread_subscriptions`                                                                                                                                                                       | Until read/dismissed history cleanup                             | Preview delivered/read state, target category, source task, and age.                        |
+| Chat and squad messages                             | `chat_sessions`, `chat_messages`, `squad_messages`                                                                                                                                                            | Until session/workspace cleanup                                  | Preview session, task link, message count, agents, and age.                                 |
+| Audit, governance, and policy records               | `activity_events`, `status_history`, `decision_records`, `feedback_records`, `scoring_profiles`, `scoring_evaluations`, `drift_alerts`, `drift_baselines`, `audit_entries`, `agent_policies`, `tool_policies` | Longer-lived audit evidence                                      | Do not silently delete through operational cleanup.                                         |
+| Device sessions and API tokens                      | excluded from backup table exports                                                                                                                                                                            | Until expiration or revocation                                   | Revoke before deletion. Never print secret values or hashes.                                |
+| Configuration and registries                        | `app_config_documents`, `managed_list_items`, `task_templates`, `prompt_templates`, `prompt_versions`, `prompt_usage`                                                                                         | Until changed or deleted                                         | Full exports include them. Scoped exports exclude global app config.                        |
+| Backups, imports, and exports                       | filesystem bundles and manifests                                                                                                                                                                              | Until admin removes files                                        | Every export includes a manifest with data classes, row counts, and redaction state.        |
+| Diagnostics and debug bundles                       | filesystem bundle output                                                                                                                                                                                      | Generated on demand                                              | Redacted by default and includes an included-category manifest.                             |
+
+The canonical machine-readable policy is exposed by:
+
+```text
+GET /api/v1/sqlite/lifecycle-policy
+```
+
+## Backup Manifest
+
+SQLite export manifests use `formatVersion: 2` and include:
+
+- `scope`: `database` or `workspace`
+- `tables`: row counts by SQLite table
+- `dataClasses`: lifecycle entries with row counts, retention/export/delete
+  behavior, sensitivity flags, and workspace scope
+- `redaction`: whether the backup is raw or redacted
+
+Workspace-scoped export example:
+
+```json
+{
+  "sqlitePath": "/path/to/veritas.db",
+  "outputDir": "/path/to/workspace-a-export",
+  "workspaceId": "workspace-a"
+}
+```
+
+Workspace exports include rows where `workspace_id` matches the requested
+workspace, the matching `workspaces` row, and users who are members of that
+workspace. Derived task Markdown and workflow YAML files follow the same
+workspace boundary. Tables and derived files without a workspace boundary are
+exported as empty arrays or omitted to avoid leaking global state.
+
+## Maintenance Center Requirements
+
+Cleanup and diagnostics surfaces must use this policy instead of ad hoc delete
+rules:
+
+- show active, archived, restorable, generated, and safe-to-remove categories
+  separately
+- list retained reasons for large uploads, work products, chat sessions,
+  telemetry ranges, notifications, and workflow snapshots
+- require explicit confirmation for destructive cleanup
+- preserve active worktrees and current run state by default
+- emit audit/activity records for admin cleanup, export, import, restore, and
+  retention-setting changes
+
+## Verification
+
+Regression coverage:
+
+```bash
+pnpm --filter @veritas-kanban/server test -- sqlite-portability-service.test.ts
+```
+
+The tests verify:
+
+- export manifests include lifecycle data classes and redaction metadata
+- workspace-scoped exports exclude another workspace's tasks and telemetry
+- member user rows are scoped to the exported workspace
+- global app configuration is excluded from workspace-scoped exports

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -12,6 +12,9 @@ operator checklist for final release verification.
       recover through the rollback drill.
 - [ ] Backup and restore verifies SQLite data, task files, settings, templates,
       attachments, workflow state, and audit history.
+- [ ] Data lifecycle controls define retention, export, deletion, privacy, and
+      support-bundle redaction policy for durable v5 data classes. Track the
+      contract in [v5.0 data lifecycle controls](DATA-LIFECYCLE.md).
 - [ ] Multi-user mode verifies workspace switching, memberships, invitations,
       scoped API tokens, actor attribution, and RBAC denial paths.
 - [ ] Remote mode verifies the

--- a/server/src/__tests__/sqlite-portability-service.test.ts
+++ b/server/src/__tests__/sqlite-portability-service.test.ts
@@ -9,6 +9,7 @@ import { SqliteDatabase } from '../storage/sqlite/database.js';
 import { SqliteTaskRepository } from '../storage/sqlite/task-repository.js';
 import { SqliteSettingsRepository } from '../storage/sqlite/settings-repository.js';
 import { createDefaultConfig, normalizeAppConfig } from '../services/config-service.js';
+import { listDataLifecyclePolicies } from '../services/data-lifecycle-policy.js';
 import type { Task } from '@veritas-kanban/shared';
 import type { WorkflowDefinition, WorkflowRun } from '../types/workflow.js';
 
@@ -497,6 +498,26 @@ describe('SqlitePortabilityService', () => {
     });
     expect(exportReport.counts.find((count) => count.entity === 'table.tasks')?.written).toBe(1);
     expect(await exists(path.join(bundleDir, 'manifest.json'))).toBe(true);
+    const manifest = JSON.parse(await fs.readFile(path.join(bundleDir, 'manifest.json'), 'utf-8'));
+    expect(manifest).toMatchObject({
+      formatVersion: 2,
+      scope: { type: 'database' },
+      redaction: { backupBundle: 'raw' },
+    });
+    expect(manifest.dataClasses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'tasks',
+          rowCount: 1,
+          workspaceScoped: true,
+        }),
+        expect.objectContaining({
+          id: 'configuration',
+          rowCount: 1,
+          workspaceScoped: false,
+        }),
+      ])
+    );
     expect(
       await exists(
         path.join(bundleDir, 'tasks', 'active', 'task_20260531_roundtrip-roundtrip-task.md')
@@ -528,6 +549,142 @@ describe('SqlitePortabilityService', () => {
     } finally {
       importedDb.close();
     }
+  });
+
+  it('exports a workspace-scoped SQLite backup without leaking another workspace', async () => {
+    const service = new SqlitePortabilityService();
+    const sourceDbPath = path.join(testRoot, 'workspace-source.db');
+    const sourceDb = new SqliteDatabase({ databasePath: sourceDbPath });
+    sourceDb.open();
+
+    try {
+      seedWorkspace(sourceDb, 'workspace-a', 'Workspace A', 'user-a');
+      seedWorkspace(sourceDb, 'workspace-b', 'Workspace B', 'user-b');
+      seedTaskRow(sourceDb, {
+        workspaceId: 'workspace-a',
+        id: 'task_workspace_a',
+        title: 'Workspace A task',
+      });
+      seedTaskRow(sourceDb, {
+        workspaceId: 'workspace-b',
+        id: 'task_workspace_b',
+        title: 'Workspace B task',
+      });
+      seedTelemetryRow(sourceDb, {
+        workspaceId: 'workspace-a',
+        id: 'evt_workspace_a',
+        taskId: 'task_workspace_a',
+      });
+      seedTelemetryRow(sourceDb, {
+        workspaceId: 'workspace-b',
+        id: 'evt_workspace_b',
+        taskId: 'task_workspace_b',
+      });
+    } finally {
+      sourceDb.close();
+    }
+
+    const bundleDir = path.join(testRoot, 'workspace-bundle');
+    await service.exportSqliteBackup({
+      sqlitePath: sourceDbPath,
+      outputDir: bundleDir,
+      workspaceId: 'workspace-a',
+    });
+
+    const manifest = JSON.parse(await fs.readFile(path.join(bundleDir, 'manifest.json'), 'utf-8'));
+    expect(manifest.scope).toEqual({ type: 'workspace', workspaceId: 'workspace-a' });
+
+    const exportedTasks = JSON.parse(
+      await fs.readFile(path.join(bundleDir, 'data', 'sqlite', 'tasks.json'), 'utf-8')
+    );
+    const exportedTelemetry = JSON.parse(
+      await fs.readFile(path.join(bundleDir, 'data', 'sqlite', 'telemetry_events.json'), 'utf-8')
+    );
+    const exportedUsers = JSON.parse(
+      await fs.readFile(path.join(bundleDir, 'data', 'sqlite', 'users.json'), 'utf-8')
+    );
+    const exportedConfig = JSON.parse(
+      await fs.readFile(
+        path.join(bundleDir, 'data', 'sqlite', 'app_config_documents.json'),
+        'utf-8'
+      )
+    );
+    const workspaceATaskMarkdown = path.join(
+      bundleDir,
+      'tasks',
+      'active',
+      'task_workspace_a-workspace-a-task.md'
+    );
+    const workspaceBTaskMarkdown = path.join(
+      bundleDir,
+      'tasks',
+      'active',
+      'task_workspace_b-workspace-b-task.md'
+    );
+
+    expect(exportedTasks).toHaveLength(1);
+    expect(exportedTasks[0]).toMatchObject({
+      id: 'task_workspace_a',
+      workspace_id: 'workspace-a',
+    });
+    expect(exportedTelemetry).toHaveLength(1);
+    expect(exportedTelemetry[0]).toMatchObject({
+      id: 'evt_workspace_a',
+      workspace_id: 'workspace-a',
+    });
+    expect(exportedUsers).toEqual([
+      expect.objectContaining({
+        id: 'user-a',
+      }),
+    ]);
+    expect(exportedConfig).toEqual([]);
+    expect(await exists(workspaceATaskMarkdown)).toBe(true);
+    expect(await exists(workspaceBTaskMarkdown)).toBe(false);
+    expect(await exists(path.join(bundleDir, 'settings', 'config.json'))).toBe(false);
+    expect(manifest.dataClasses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'tasks',
+          rowCount: 1,
+        }),
+        expect.objectContaining({
+          id: 'telemetry',
+          rowCount: 1,
+        }),
+        expect.objectContaining({
+          id: 'configuration',
+          rowCount: 0,
+        }),
+      ])
+    );
+  });
+
+  it('exposes lifecycle policies for every durable v5 class', () => {
+    const policies = listDataLifecyclePolicies();
+
+    expect(policies.map((policy) => policy.id)).toEqual(
+      expect.arrayContaining([
+        'workspaceIdentity',
+        'tasks',
+        'comments',
+        'uploadsAttachments',
+        'workProducts',
+        'telemetry',
+        'workflowRuns',
+        'notifications',
+        'chat',
+        'audit',
+        'deviceAccess',
+        'configuration',
+        'backupsExports',
+        'debugBundles',
+      ])
+    );
+    expect(policies.every((policy) => policy.exportBehavior && policy.deleteBehavior)).toBe(true);
+    expect(policies.find((policy) => policy.id === 'deviceAccess')?.containsSecrets).toBe(true);
+    expect(policies.find((policy) => policy.id === 'debugBundles')?.containsPrivatePaths).toBe(
+      true
+    );
   });
 });
 
@@ -606,4 +763,124 @@ function rowCount(database: SqliteDatabase, table: string): number {
     .prepare(`SELECT COUNT(*) AS count FROM "${table}"`)
     .get() as { count: number };
   return row.count;
+}
+
+function seedWorkspace(
+  database: SqliteDatabase,
+  workspaceId: string,
+  name: string,
+  userId: string
+): void {
+  const now = '2026-06-03T12:00:00.000Z';
+  const db = database.getConnection();
+
+  db.prepare(
+    `
+      INSERT INTO workspaces (
+        id, slug, name, description, mode, created_by, archived_at, created_at, updated_at
+      )
+      VALUES (?, ?, ?, NULL, 'remote', ?, NULL, ?, ?)
+    `
+  ).run(workspaceId, workspaceId, name, userId, now, now);
+
+  db.prepare(
+    `
+      INSERT INTO users (
+        id, display_name, email, handle, auth_subject, avatar_url, disabled_at, last_seen_at,
+        created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)
+    `
+  ).run(userId, name, `${userId}@example.test`, userId, now, now);
+
+  db.prepare(
+    `
+      INSERT INTO workspace_memberships (
+        workspace_id, user_id, role, status, invited_by, joined_at, disabled_at, created_at, updated_at
+      )
+      VALUES (?, ?, 'owner', 'active', NULL, ?, NULL, ?, ?)
+    `
+  ).run(workspaceId, userId, now, now, now);
+}
+
+function seedTaskRow(
+  database: SqliteDatabase,
+  input: { workspaceId: string; id: string; title: string }
+): void {
+  const now = '2026-06-03T12:00:00.000Z';
+  const task: Task = {
+    id: input.id,
+    title: input.title,
+    description: `${input.title} body`,
+    type: 'feature',
+    status: 'todo',
+    priority: 'medium',
+    created: now,
+    updated: now,
+  };
+
+  database
+    .getConnection()
+    .prepare(
+      `
+        INSERT INTO tasks (
+          id, workspace_id, storage_state, title, description, type, status, priority, project,
+          sprint, position, task_json, created_at, updated_at, archived_at, deleted_at
+        )
+        VALUES (?, ?, 'active', ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?, NULL, NULL)
+      `
+    )
+    .run(
+      task.id,
+      input.workspaceId,
+      task.title,
+      task.description,
+      task.type,
+      task.status,
+      task.priority,
+      JSON.stringify(task),
+      task.created,
+      task.updated
+    );
+}
+
+function seedTelemetryRow(
+  database: SqliteDatabase,
+  input: { workspaceId: string; id: string; taskId: string }
+): void {
+  const now = '2026-06-03T12:00:00.000Z';
+  const event = {
+    id: input.id,
+    type: 'run.completed',
+    timestamp: now,
+    taskId: input.taskId,
+    project: 'workspace-boundary',
+    agent: 'veritas',
+    success: true,
+    durationMs: 100,
+  };
+
+  database
+    .getConnection()
+    .prepare(
+      `
+        INSERT INTO telemetry_events (
+          id, workspace_id, type, task_id, project_id, agent, model, attempt_id, success,
+          duration_ms, exit_code, input_tokens, output_tokens, cache_tokens, total_tokens, cost,
+          error, stack_trace, session_key, payload_json, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, 1, ?, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?)
+      `
+    )
+    .run(
+      event.id,
+      input.workspaceId,
+      event.type,
+      event.taskId,
+      event.project,
+      event.agent,
+      event.durationMs,
+      JSON.stringify(event),
+      now
+    );
 }

--- a/server/src/routes/sqlite-portability.ts
+++ b/server/src/routes/sqlite-portability.ts
@@ -4,6 +4,7 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import { authorize } from '../middleware/auth.js';
 import { ValidationError } from '../middleware/error-handler.js';
 import { getSqlitePortabilityService } from '../services/sqlite-portability-service.js';
+import { listDataLifecyclePolicies } from '../services/data-lifecycle-policy.js';
 
 const router: RouterType = Router();
 
@@ -19,6 +20,7 @@ const migrationSchema = z.object({
 const exportSchema = z.object({
   sqlitePath: pathSchema,
   outputDir: pathSchema,
+  workspaceId: z.string().min(1).max(200).optional(),
 });
 
 const importSchema = z.object({
@@ -102,6 +104,17 @@ router.post(
     const input = parseBody(exportSchema, req.body);
     const report = await getSqlitePortabilityService().exportSqliteBackup(input);
     res.json(report);
+  })
+);
+
+router.get(
+  '/lifecycle-policy',
+  authorize('admin'),
+  asyncHandler(async (_req, res) => {
+    res.json({
+      formatVersion: 1,
+      dataClasses: listDataLifecyclePolicies(),
+    });
   })
 );
 

--- a/server/src/services/data-lifecycle-policy.ts
+++ b/server/src/services/data-lifecycle-policy.ts
@@ -1,0 +1,424 @@
+export type DataLifecycleClassId =
+  | 'workspaceIdentity'
+  | 'tasks'
+  | 'comments'
+  | 'uploadsAttachments'
+  | 'workProducts'
+  | 'telemetry'
+  | 'workflowRuns'
+  | 'notifications'
+  | 'chat'
+  | 'audit'
+  | 'deviceAccess'
+  | 'configuration'
+  | 'backupsExports'
+  | 'debugBundles';
+
+export interface DataLifecyclePolicy {
+  id: DataLifecycleClassId;
+  label: string;
+  description: string;
+  tables: string[];
+  defaultRetention: string;
+  userControls: string[];
+  adminControls: string[];
+  exportBehavior: string;
+  deleteBehavior: string;
+  auditBehavior: string;
+  redaction: string;
+  containsSecrets: boolean;
+  containsPrivatePaths: boolean;
+  containsGeneratedContent: boolean;
+  workspaceScoped: boolean;
+  previewSafety: string;
+}
+
+export interface DataLifecycleManifestEntry {
+  id: DataLifecycleClassId;
+  label: string;
+  tables: string[];
+  rowCount: number;
+  defaultRetention: string;
+  exportBehavior: string;
+  deleteBehavior: string;
+  redaction: string;
+  containsSecrets: boolean;
+  containsPrivatePaths: boolean;
+  containsGeneratedContent: boolean;
+  workspaceScoped: boolean;
+}
+
+export interface DataLifecycleManifestOptions {
+  workspaceId?: string;
+  tableCounts: Record<string, number>;
+}
+
+export const DATA_LIFECYCLE_POLICIES: readonly DataLifecyclePolicy[] = [
+  {
+    id: 'workspaceIdentity',
+    label: 'Workspace identity and membership',
+    description: 'Users, workspaces, memberships, invitations, roles, and actor identity.',
+    tables: ['workspaces', 'users', 'workspace_memberships', 'workspace_invitations'],
+    defaultRetention: 'Retained until the workspace, user, or invitation is removed by an admin.',
+    userControls: ['View own identity where exposed by the UI.'],
+    adminControls: ['Manage members, roles, invitations, disabled users, and workspace archival.'],
+    exportBehavior:
+      'Included in full exports. Workspace-scoped exports include the selected workspace, memberships, invitations, and member user records only.',
+    deleteBehavior:
+      'Workspace deletion must cascade through workspace-scoped operational data and preserve audit expectations.',
+    auditBehavior:
+      'Role, membership, and invitation changes should emit actor-aware audit records.',
+    redaction:
+      'Email and handle values are included in admin exports but must be redacted in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: false,
+    containsGeneratedContent: false,
+    workspaceScoped: true,
+    previewSafety: 'Show names, roles, status, and counts before destructive changes.',
+  },
+  {
+    id: 'tasks',
+    label: 'Tasks and task metadata',
+    description:
+      'Active, archived, and backlog tasks plus subtasks, dependencies, criteria, and task fields.',
+    tables: ['tasks'],
+    defaultRetention:
+      'Active and backlog tasks are retained until archived or deleted; archived tasks are retained until cleanup.',
+    userControls: ['Archive, restore, export, and delete task records where permissions allow.'],
+    adminControls: ['Bulk archive, workspace export, workspace deletion, and retention previews.'],
+    exportBehavior: 'Included in full and workspace-scoped exports.',
+    deleteBehavior:
+      'Deletes must not remove active work silently and must show linked artifact counts first.',
+    auditBehavior:
+      'Create, update, archive, restore, and delete actions should carry actor attribution.',
+    redaction:
+      'Task text can include private prompts, paths, and generated content; redact in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety: 'Preview task status, title, linked worktrees, attachments, and work products.',
+  },
+  {
+    id: 'comments',
+    label: 'Task comments and discussion',
+    description: 'Comments embedded in task payloads and review discussion tied to task work.',
+    tables: ['tasks'],
+    defaultRetention: 'Follows parent task retention.',
+    userControls: ['Edit or delete comments where the task UI supports it.'],
+    adminControls: ['Export and delete through parent task/workspace operations.'],
+    exportBehavior: 'Included with task JSON and Markdown task exports.',
+    deleteBehavior: 'Follows parent task deletion unless a future comment-level delete is used.',
+    auditBehavior: 'Comment mutation should remain attributable where actor data exists.',
+    redaction:
+      'Comment text is user content and must be redacted in diagnostics/support bundles by default.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety: 'Show counts and parent task links, not full comment text, in cleanup previews.',
+  },
+  {
+    id: 'uploadsAttachments',
+    label: 'Uploads and attachment metadata',
+    description:
+      'Attachment rows, file metadata, MIME validation status, storage paths, and cleanup state.',
+    tables: ['task_attachments'],
+    defaultRetention:
+      'Retained while linked to an active or archived task unless marked cleanup-eligible.',
+    userControls: ['Download and delete attachments from task context where permissions allow.'],
+    adminControls: ['Storage usage review, orphan detection, and cleanup preview.'],
+    exportBehavior:
+      'Metadata is included in SQLite exports; file blobs require explicit backup/import handling.',
+    deleteBehavior:
+      'Delete only after previewing parent task, path, size, validation status, and orphan status.',
+    auditBehavior: 'Upload and delete actions should be auditable when actor data exists.',
+    redaction: 'Private filenames and storage paths must be redacted from support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: false,
+    workspaceScoped: true,
+    previewSafety: 'Show filename, size, MIME type, validation status, and parent task link.',
+  },
+  {
+    id: 'workProducts',
+    label: 'Work products and versions',
+    description:
+      'Durable work products, version history, source links, redaction metadata, and render data.',
+    tables: ['work_products', 'work_product_versions', 'task_deliverables'],
+    defaultRetention:
+      'Active work products and accepted deliverables are retained until task/workspace cleanup.',
+    userControls: ['Archive, restore, export, and regenerate where supported.'],
+    adminControls: [
+      'Version retention, generated artifact cleanup, workspace export, and workspace deletion.',
+    ],
+    exportBehavior: 'Included in full and workspace-scoped exports with version metadata.',
+    deleteBehavior:
+      'Preview source task, source run, status, version count, and redaction state before cleanup.',
+    auditBehavior:
+      'Creation, regeneration, restore, archive, and delete actions should be traceable.',
+    redaction:
+      'Rendered content may include prompts, private paths, or generated sensitive text; redact in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety:
+      'Show title, kind, status, version count, linked task/run, and storage estimate.',
+  },
+  {
+    id: 'telemetry',
+    label: 'Telemetry and metrics events',
+    description:
+      'Run events, token/cost events, durations, errors, session keys, and dashboard metric inputs.',
+    tables: ['telemetry_events'],
+    defaultRetention: 'Default retention is 30 days unless the admin changes telemetry settings.',
+    userControls: ['Dashboard filtering and telemetry export where permissions allow.'],
+    adminControls: ['Retention window, export, purge preview, and dashboard diagnostics.'],
+    exportBehavior:
+      'Included in full and workspace-scoped exports. CSV/JSON telemetry exports remain separate API flows.',
+    deleteBehavior:
+      'Purge only by explicit range/workspace preview and never as implicit task cleanup.',
+    auditBehavior: 'Retention/purge actions should emit admin audit records.',
+    redaction:
+      'Errors, stack traces, session keys, prompts, and model outputs must be redacted in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety: 'Show event counts by type, date range, project, and agent before purge.',
+  },
+  {
+    id: 'workflowRuns',
+    label: 'Workflow definitions, runs, and scheduled snapshots',
+    description:
+      'Workflow definitions, ACLs, run state, checkpoints, audit events, and scheduled deliverable snapshots.',
+    tables: [
+      'workflow_definitions',
+      'workflow_acls',
+      'workflow_audit_events',
+      'workflow_runs',
+      'scheduled_deliverables',
+      'scheduled_deliverable_runs',
+    ],
+    defaultRetention:
+      'Definitions are retained until deleted; run/snapshot retention is admin-configurable.',
+    userControls: ['View runs, retry/resume where permitted, and export linked outputs.'],
+    adminControls: [
+      'Run retention, scheduled snapshot retention, cleanup preview, and workspace export/delete.',
+    ],
+    exportBehavior: 'Included in full and workspace-scoped exports.',
+    deleteBehavior:
+      'Do not delete active runs or current scheduled state; preview status and linked outputs first.',
+    auditBehavior: 'Workflow mutations, gates, approvals, and run cleanup should remain auditable.',
+    redaction:
+      'Run context and outputs may include prompts, file paths, and generated content; redact in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety:
+      'Show status, workflow, task link, run age, snapshot count, and active/blocked state.',
+  },
+  {
+    id: 'notifications',
+    label: 'Notifications and subscriptions',
+    description:
+      'Notification history, thread subscriptions, delivery state, target URLs, and dedupe keys.',
+    tables: ['notifications', 'thread_subscriptions'],
+    defaultRetention:
+      'Retained until read/dismissed history is cleaned up by user or admin settings.',
+    userControls: ['Mark read, dismiss, and inspect source task/run where exposed.'],
+    adminControls: ['Retention, export, notification history cleanup, and workspace deletion.'],
+    exportBehavior: 'Included in full and workspace-scoped exports.',
+    deleteBehavior:
+      'Preview delivered/read status, target URL category, source task, and age before cleanup.',
+    auditBehavior:
+      'Admin cleanup should be auditable; routine read/dismiss can remain activity-level.',
+    redaction:
+      'Target URLs, titles, and content may reveal private paths or task content; redact in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety: 'Show counts by type, delivered/read state, source task, and age.',
+  },
+  {
+    id: 'chat',
+    label: 'Chat and squad messages',
+    description:
+      'Board/task chat sessions, message history, squad messages, cards, tags, and model metadata.',
+    tables: ['chat_sessions', 'chat_messages', 'squad_messages'],
+    defaultRetention:
+      'Retained with the workspace until explicitly deleted or cleaned by retention policy.',
+    userControls: ['Delete sessions and export task context where supported.'],
+    adminControls: ['Retention by age/session/task, export, and workspace deletion.'],
+    exportBehavior: 'Included in full and workspace-scoped exports.',
+    deleteBehavior: 'Preview session, task link, message count, agents, and age before cleanup.',
+    auditBehavior: 'Session deletion and admin cleanup should be auditable.',
+    redaction:
+      'Chat content may include prompts, paths, or secrets pasted by users; redact in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety: 'Show metadata and counts, not full message content, in cleanup previews.',
+  },
+  {
+    id: 'audit',
+    label: 'Audit, governance, and policy records',
+    description:
+      'Audit entries, policy records, decisions, feedback, scoring, drift, and governance evidence.',
+    tables: [
+      'activity_events',
+      'status_history',
+      'decision_records',
+      'feedback_records',
+      'scoring_profiles',
+      'scoring_evaluations',
+      'drift_alerts',
+      'drift_baselines',
+      'audit_entries',
+      'agent_policies',
+      'tool_policies',
+    ],
+    defaultRetention:
+      'Audit and governance records are retained longer than operational telemetry.',
+    userControls: ['View governance decisions where permissions allow.'],
+    adminControls: [
+      'Export, workspace deletion, and explicit retention review for non-audit operational records.',
+    ],
+    exportBehavior: 'Included in full and workspace-scoped exports.',
+    deleteBehavior: 'Audit logs should not be silently deleted by operational cleanup actions.',
+    auditBehavior:
+      'This class is the audit evidence; cleanup policy changes must themselves be auditable.',
+    redaction:
+      'Evidence details may include private paths, prompts, and model outputs; redact support previews.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: true,
+    previewSafety: 'Show counts, date ranges, policy IDs, and actor IDs before any deletion.',
+  },
+  {
+    id: 'deviceAccess',
+    label: 'Device sessions and API tokens',
+    description:
+      'Pairing codes, device sessions, scoped API tokens, revocation state, and token hashes.',
+    tables: [],
+    defaultRetention:
+      'Active credentials are retained until expiration or revocation; expired records are cleanup candidates.',
+    userControls: ['Revoke own trusted devices or scoped tokens where permitted.'],
+    adminControls: ['Revoke devices/tokens, rotate secrets, and review active sessions.'],
+    exportBehavior:
+      'Credential secret material and token hashes are excluded from SQLite backup exports by default.',
+    deleteBehavior:
+      'Revocation should happen before deletion; active session deletion must close live sockets.',
+    auditBehavior: 'Create, rotate, revoke, and delete events must be auditable.',
+    redaction: 'Never print token values, hashes, pairing codes, or device session secrets.',
+    containsSecrets: true,
+    containsPrivatePaths: false,
+    containsGeneratedContent: false,
+    workspaceScoped: true,
+    previewSafety: 'Show device name, mode, created/last-used/expiry, and revoked state only.',
+  },
+  {
+    id: 'configuration',
+    label: 'Configuration and registries',
+    description:
+      'App settings, managed lists, templates, prompts, routing, policies, and local repository paths.',
+    tables: [
+      'app_config_documents',
+      'managed_list_items',
+      'task_templates',
+      'prompt_templates',
+      'prompt_versions',
+      'prompt_usage',
+    ],
+    defaultRetention: 'Retained until changed or deleted by a user/admin.',
+    userControls: ['Edit settings and templates where permissions allow.'],
+    adminControls: ['Export/import, reset, and review path/provider settings.'],
+    exportBehavior:
+      'Included in full exports. Workspace-scoped exports exclude global app config unless explicitly added later.',
+    deleteBehavior: 'Settings reset/import must preview scope and preserve recovery options.',
+    auditBehavior: 'Admin settings, policy, and prompt registry changes should be attributable.',
+    redaction:
+      'Repository paths, provider names, and prompt text may be private; redact in support bundles.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: false,
+    previewSafety:
+      'Show keys, categories, and counts. Do not show full prompt bodies in support previews.',
+  },
+  {
+    id: 'backupsExports',
+    label: 'Backups, imports, and exports',
+    description:
+      'SQLite backup bundles, migration journals, export manifests, imported files, and restore reports.',
+    tables: [],
+    defaultRetention: 'Retained wherever the admin writes them until manually removed.',
+    userControls: ['Download or move exports created through UI flows.'],
+    adminControls: ['Create, verify, restore, and delete backup bundles.'],
+    exportBehavior:
+      'Exports must include a manifest that lists data classes, row counts, and redaction choices.',
+    deleteBehavior:
+      'Deleting backup bundles is a filesystem operation that requires explicit confirmation.',
+    auditBehavior:
+      'Backup/export/import/restore operations should be recorded with actor and path metadata.',
+    redaction: 'Manifests can list paths, but support bundles should redact private path prefixes.',
+    containsSecrets: false,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: false,
+    previewSafety:
+      'Show bundle path, created time, data classes, and size estimates before deletion.',
+  },
+  {
+    id: 'debugBundles',
+    label: 'Diagnostics and debug bundles',
+    description: 'Health checks, logs, redacted support snapshots, and troubleshooting output.',
+    tables: [],
+    defaultRetention: 'Generated on demand and retained until the user/admin deletes the bundle.',
+    userControls: ['Create and inspect diagnostics where the UI exposes it.'],
+    adminControls: ['Create redacted support bundles and delete old bundles.'],
+    exportBehavior: 'Must be redacted by default and include a manifest of included categories.',
+    deleteBehavior: 'Delete only explicitly generated bundle files after previewing path and size.',
+    auditBehavior: 'Support bundle creation should be logged without storing secret values.',
+    redaction:
+      'Redact tokens, cookies, API keys, private keys, local paths, URLs with credentials, and message content by default.',
+    containsSecrets: true,
+    containsPrivatePaths: true,
+    containsGeneratedContent: true,
+    workspaceScoped: false,
+    previewSafety: 'Show categories and redaction state, not raw log content, before sharing.',
+  },
+] as const;
+
+export function listDataLifecyclePolicies(): DataLifecyclePolicy[] {
+  return DATA_LIFECYCLE_POLICIES.map((policy) => ({
+    ...policy,
+    tables: [...policy.tables],
+    userControls: [...policy.userControls],
+    adminControls: [...policy.adminControls],
+  }));
+}
+
+export function buildDataLifecycleManifest(
+  options: DataLifecycleManifestOptions
+): DataLifecycleManifestEntry[] {
+  return DATA_LIFECYCLE_POLICIES.map((policy) => ({
+    id: policy.id,
+    label: policy.label,
+    tables: [...policy.tables],
+    rowCount: policy.tables.reduce((sum, table) => sum + (options.tableCounts[table] ?? 0), 0),
+    defaultRetention: policy.defaultRetention,
+    exportBehavior: policy.exportBehavior,
+    deleteBehavior: policy.deleteBehavior,
+    redaction: policy.redaction,
+    containsSecrets: policy.containsSecrets,
+    containsPrivatePaths: policy.containsPrivatePaths,
+    containsGeneratedContent: policy.containsGeneratedContent,
+    workspaceScoped: policy.workspaceScoped,
+  }));
+}

--- a/server/src/services/sqlite-portability-service.ts
+++ b/server/src/services/sqlite-portability-service.ts
@@ -3,6 +3,7 @@ import { createReadStream } from 'fs';
 import path from 'path';
 import readline from 'readline';
 import { createGunzip } from 'zlib';
+import type { SQLInputValue } from 'node:sqlite';
 import matter from 'gray-matter';
 import yaml from 'yaml';
 import type {
@@ -39,6 +40,7 @@ import { SqliteWorkflowDefinitionRepository } from '../storage/sqlite/workflow-r
 import { WorkflowService } from './workflow-service.js';
 import { WorkflowRunService } from './workflow-run-service.js';
 import { ChatService } from './chat-service.js';
+import { buildDataLifecycleManifest } from './data-lifecycle-policy.js';
 
 const TASK_ID_REGEX = /^task_(\d{8}_[a-zA-Z0-9_-]{1,20}|[a-zA-Z0-9_-]+)$/;
 
@@ -140,6 +142,7 @@ export interface FileToSqliteMigrationOptions {
 export interface SqliteBackupExportOptions {
   sqlitePath: string;
   outputDir: string;
+  workspaceId?: string;
 }
 
 export interface SqliteBackupImportOptions {
@@ -402,7 +405,7 @@ export class SqlitePortabilityService {
       const dataDir = path.join(bundleDir, 'data', 'sqlite');
       await fs.mkdir(dataDir, { recursive: true });
 
-      const snapshots = this.readSqliteSnapshots(database, warnings);
+      const snapshots = this.readSqliteSnapshots(database, warnings, options.workspaceId);
       const counts: SqlitePortabilityEntityCount[] = [];
 
       for (const snapshot of snapshots) {
@@ -415,14 +418,27 @@ export class SqlitePortabilityService {
         });
       }
 
-      await this.writeHumanReadableBundle(database, bundleDir, warnings);
+      const tableCounts = Object.fromEntries(
+        snapshots.map((snapshot) => [snapshot.table, snapshot.rows.length])
+      );
+      await this.writeHumanReadableBundle(database, bundleDir, warnings, options.workspaceId);
       await this.writeJson(path.join(bundleDir, 'manifest.json'), {
-        formatVersion: 1,
+        formatVersion: 2,
         exportedAt: new Date().toISOString(),
         sqlitePath: path.resolve(options.sqlitePath),
-        tables: Object.fromEntries(
-          snapshots.map((snapshot) => [snapshot.table, snapshot.rows.length])
-        ),
+        scope: options.workspaceId
+          ? { type: 'workspace', workspaceId: options.workspaceId }
+          : { type: 'database' },
+        tables: tableCounts,
+        dataClasses: buildDataLifecycleManifest({
+          workspaceId: options.workspaceId,
+          tableCounts,
+        }),
+        redaction: {
+          backupBundle: 'raw',
+          supportBundles:
+            'redact tokens, cookies, local paths, credentialed URLs, prompts, message content, and generated sensitive text by default',
+        },
       });
 
       return {
@@ -1792,7 +1808,8 @@ export class SqlitePortabilityService {
 
   private readSqliteSnapshots(
     database: SqliteDatabase,
-    warnings: SqlitePortabilityWarning[]
+    warnings: SqlitePortabilityWarning[],
+    workspaceId?: string
   ): TableSnapshot[] {
     const snapshots: TableSnapshot[] = [];
 
@@ -1805,14 +1822,55 @@ export class SqlitePortabilityService {
         continue;
       }
 
+      const query = this.buildSnapshotQuery(database, table, workspaceId);
       const rows = database
         .getConnection()
-        .prepare(`SELECT * FROM ${this.quoteIdentifier(table)}`)
-        .all() as unknown as Record<string, unknown>[];
+        .prepare(query.sql)
+        .all(...query.params) as unknown as Record<string, unknown>[];
       snapshots.push({ table, rows });
     }
 
     return snapshots;
+  }
+
+  private buildSnapshotQuery(
+    database: SqliteDatabase,
+    table: SqliteBackupTable,
+    workspaceId?: string
+  ): { sql: string; params: SQLInputValue[] } {
+    const tableName = this.quoteIdentifier(table);
+
+    if (!workspaceId) {
+      return { sql: `SELECT * FROM ${tableName}`, params: [] };
+    }
+
+    if (table === 'workspaces') {
+      return { sql: `SELECT * FROM ${tableName} WHERE id = ?`, params: [workspaceId] };
+    }
+
+    if (table === 'users') {
+      return {
+        sql: `
+          SELECT *
+          FROM ${tableName}
+          WHERE id IN (
+            SELECT user_id
+            FROM workspace_memberships
+            WHERE workspace_id = ?
+          )
+        `,
+        params: [workspaceId],
+      };
+    }
+
+    if (this.tableHasColumn(database, table, 'workspace_id')) {
+      return {
+        sql: `SELECT * FROM ${tableName} WHERE workspace_id = ?`,
+        params: [workspaceId],
+      };
+    }
+
+    return { sql: `SELECT * FROM ${tableName} WHERE 1 = 0`, params: [] };
   }
 
   private async readBundleSnapshots(
@@ -1942,12 +2000,22 @@ export class SqlitePortabilityService {
   private async writeHumanReadableBundle(
     database: SqliteDatabase,
     bundleDir: string,
-    warnings: SqlitePortabilityWarning[]
+    warnings: SqlitePortabilityWarning[],
+    workspaceId?: string
   ): Promise<void> {
+    const taskQuery = workspaceId
+      ? {
+          sql: 'SELECT storage_state, task_json FROM tasks WHERE workspace_id = ? ORDER BY updated_at DESC',
+          params: [workspaceId],
+        }
+      : {
+          sql: 'SELECT storage_state, task_json FROM tasks ORDER BY updated_at DESC',
+          params: [],
+        };
     const tasks = database
       .getConnection()
-      .prepare('SELECT storage_state, task_json FROM tasks ORDER BY updated_at DESC')
-      .all() as unknown as Array<{ storage_state: string; task_json: string }>;
+      .prepare(taskQuery.sql)
+      .all(...taskQuery.params) as unknown as Array<{ storage_state: string; task_json: string }>;
 
     for (const row of tasks) {
       try {
@@ -1967,10 +2035,12 @@ export class SqlitePortabilityService {
       }
     }
 
-    const configRow = database
-      .getConnection()
-      .prepare("SELECT document_json FROM app_config_documents WHERE key = 'app_config'")
-      .get() as { document_json: string } | undefined;
+    const configRow = workspaceId
+      ? undefined
+      : (database
+          .getConnection()
+          .prepare("SELECT document_json FROM app_config_documents WHERE key = 'app_config'")
+          .get() as { document_json: string } | undefined);
     if (configRow) {
       await this.writeJson(
         path.join(bundleDir, 'settings', 'config.json'),
@@ -1978,10 +2048,23 @@ export class SqlitePortabilityService {
       );
     }
 
-    const workflows = database
-      .getConnection()
-      .prepare('SELECT workflow_json FROM workflow_definitions ORDER BY id ASC')
-      .all() as unknown as Array<{ workflow_json: string }>;
+    const workflowQuery = workspaceId
+      ? this.tableHasColumn(database, 'workflow_definitions', 'workspace_id')
+        ? {
+            sql: 'SELECT workflow_json FROM workflow_definitions WHERE workspace_id = ? ORDER BY id ASC',
+            params: [workspaceId],
+          }
+        : null
+      : {
+          sql: 'SELECT workflow_json FROM workflow_definitions ORDER BY id ASC',
+          params: [],
+        };
+    const workflows = workflowQuery
+      ? (database
+          .getConnection()
+          .prepare(workflowQuery.sql)
+          .all(...workflowQuery.params) as unknown as Array<{ workflow_json: string }>)
+      : [];
     for (const row of workflows) {
       const workflow = JSON.parse(row.workflow_json) as WorkflowDefinition;
       const dir = path.join(bundleDir, 'workflows');
@@ -1996,6 +2079,14 @@ export class SqlitePortabilityService {
       .prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?")
       .get(table) as { name: string } | undefined;
     return row !== undefined;
+  }
+
+  private tableHasColumn(database: SqliteDatabase, table: string, column: string): boolean {
+    const rows = database
+      .getConnection()
+      .prepare(`PRAGMA table_info(${this.quoteIdentifier(table)})`)
+      .all() as unknown as Array<{ name: string }>;
+    return rows.some((row) => row.name === column);
   }
 
   private async readNdjson(


### PR DESCRIPTION
## Summary
- Adds a canonical v5 data lifecycle policy covering durable classes, retention, export, deletion, redaction, sensitivity, and preview guidance.
- Adds formatVersion 2 SQLite backup manifests with lifecycle class row counts, scope, and redaction metadata.
- Adds workspace-scoped SQLite exports that filter raw snapshots and derived task/workflow files while omitting global config.
- Documents the lifecycle contract in the GA checklist and API reference.

Closes #421

## Tests
- pnpm --filter @veritas-kanban/server test -- sqlite-portability-service.test.ts
- pnpm --filter @veritas-kanban/server test -- sqlite-portability-service.test.ts v1-permission-guards.test.ts
- node scripts/check-permission-coverage.mjs
- pnpm typecheck
- git diff --check
- pnpm exec prettier --check docs/DATA-LIFECYCLE.md docs/V5-GA-CHECKLIST.md docs/API-REFERENCE.md server/src/services/data-lifecycle-policy.ts server/src/services/sqlite-portability-service.ts server/src/routes/sqlite-portability.ts server/src/__tests__/sqlite-portability-service.test.ts
- pnpm lint
- pnpm build

## Risks
- `pnpm lint` still reports the existing warning baseline: 673 warnings, 0 errors.
- Backup bundles remain raw admin exports by design; support/debug bundle redaction is documented as the separate safe-sharing path.