### PR TITLE
Add skill capability profiles

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -37,18 +37,19 @@
 24. [Agent Permissions](#agent-permissions)
 25. [Agent Routing](#agent-routing)
 26. [Shared Resources](#shared-resources)
-27. [Doc Freshness](#doc-freshness)
-28. [Cost Prediction](#cost-prediction)
-29. [Error Learning](#error-learning)
-30. [Tool Policies](#tool-policies)
-31. [Traces](#traces)
-32. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
-33. [Audit](#audit)
-34. [Maintenance Center](#maintenance-center-apiv1maintenance)
-35. [Common Workflows](#common-workflows)
-36. [Versioning & Deprecation](#versioning--deprecation)
-37. [Rate Limits](#rate-limits)
-38. [Additional Endpoint Groups](#additional-endpoint-groups)
+27. [Skill Capability Profiles](#skill-capability-profiles-apiskillscapabilities)
+28. [Doc Freshness](#doc-freshness)
+29. [Cost Prediction](#cost-prediction)
+30. [Error Learning](#error-learning)
+31. [Tool Policies](#tool-policies)
+32. [Traces](#traces)
+33. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
+34. [Audit](#audit)
+35. [Maintenance Center](#maintenance-center-apiv1maintenance)
+36. [Common Workflows](#common-workflows)
+37. [Versioning & Deprecation](#versioning--deprecation)
+38. [Rate Limits](#rate-limits)
+39. [Additional Endpoint Groups](#additional-endpoint-groups)
 
 ---
 
@@ -1420,6 +1421,118 @@ POST /api/shared-resources/:id/unmount
   "projectIds": ["rubicon", "brainmeld"]
 }
 ```
+
+---
+
+## Skill Capability Profiles (`/api/skills/capabilities`)
+
+Declared-vs-observed capability profiles for shared resources with `type:
+"skill"`. Reads require `policy:read`. Creating remediation tasks requires
+`policy:write` and `task:write`.
+
+| Method | Path                                                 | Description                                 |
+| ------ | ---------------------------------------------------- | ------------------------------------------- |
+| `GET`  | `/api/skills/capabilities/taxonomy`                  | List canonical skill capability definitions |
+| `GET`  | `/api/skills/capabilities`                           | List skill profiles with optional filters   |
+| `GET`  | `/api/skills/capabilities/:skillId`                  | Get one skill capability profile            |
+| `POST` | `/api/skills/capabilities/:skillId/remediation-task` | Create a task for capability mismatches     |
+
+List filters:
+
+- `status`: `aligned`, `mismatch`, or `missing-declaration`
+- `severity`: minimum severity, one of `low`, `medium`, `high`, `critical`
+- `capability`: a taxonomy id such as `network.egress`
+- `q`: skill name, id, tag, or finding text search
+
+### Skill Declaration Syntax
+
+Skills declare capabilities in frontmatter:
+
+```markdown
+---
+capabilities:
+  - filesystem.read
+  - network.egress
+---
+```
+
+or in a Markdown section:
+
+```markdown
+## Declared Capabilities
+
+- `filesystem.read`
+- `browser.session`
+```
+
+Canonical capability ids:
+
+| Capability          | Meaning                                      |
+| ------------------- | -------------------------------------------- |
+| `filesystem.read`   | Reads local files or repository content      |
+| `filesystem.write`  | Writes, edits, moves, or deletes files       |
+| `shell.execute`     | Runs shell commands or subprocesses          |
+| `network.egress`    | Calls remote URLs, APIs, or webhooks         |
+| `credential.access` | Reads secrets, tokens, env vars, or keychain |
+| `external.message`  | Sends messages, comments, issues, or PRs     |
+| `memory.write`      | Writes durable agent memory                  |
+| `task.mutate`       | Creates or changes tasks, issues, or PRs     |
+| `schedule.persist`  | Creates recurring or background execution    |
+| `browser.session`   | Uses browser automation or sessions          |
+| `mcp.tool`          | Invokes MCP/plugin/tool runtimes             |
+
+### Profile Response
+
+```json
+{
+  "skillId": "shared_123",
+  "name": "Review Helper",
+  "declaredCapabilities": ["filesystem.read"],
+  "observedCapabilities": [
+    {
+      "capability": "filesystem.read",
+      "confidence": 0.82,
+      "evidence": [{ "source": "content-pattern", "label": "File read reference" }]
+    },
+    {
+      "capability": "network.egress",
+      "confidence": 0.86,
+      "evidence": [{ "source": "content-pattern", "label": "Remote network call reference" }]
+    }
+  ],
+  "undeclaredObservedCapabilities": ["network.egress"],
+  "status": "mismatch",
+  "severity": "high",
+  "findings": [
+    {
+      "kind": "undeclared-observed",
+      "capability": "network.egress",
+      "severity": "high",
+      "message": "network.egress is observed but not declared."
+    }
+  ]
+}
+```
+
+Mismatch detection writes an audit event once per skill version and finding
+signature. Evidence snippets are redacted before they are returned.
+
+### Create Remediation Task
+
+```http
+POST /api/skills/capabilities/shared_123/remediation-task
+```
+
+**Body**:
+
+```json
+{
+  "project": "Security",
+  "priority": "high"
+}
+```
+
+Returns the refreshed profile and created task.
 
 ---
 

--- a/docs/SOP-shared-resources.md
+++ b/docs/SOP-shared-resources.md
@@ -155,6 +155,60 @@ Publish shared resources as a package:
 
 ---
 
+## Skill Capability Declarations
+
+Shared resources with `type: skill` should declare the capabilities they need.
+Veritas compares declared capabilities with observed static behavior and shows
+the result in Settings -> Shared Resources -> Skill Capability Profiles.
+
+Preferred frontmatter:
+
+```markdown
+---
+capabilities:
+  - filesystem.read
+  - network.egress
+---
+```
+
+Markdown section alternative:
+
+```markdown
+## Declared Capabilities
+
+- `filesystem.read`
+- `browser.session`
+```
+
+Canonical ids:
+
+| Capability          | Use when the skill needs to...               |
+| ------------------- | -------------------------------------------- |
+| `filesystem.read`   | Read local files or repository content       |
+| `filesystem.write`  | Create, edit, move, or delete files          |
+| `shell.execute`     | Run shell commands, package scripts, or CLIs |
+| `network.egress`    | Call remote APIs, webhooks, or downloads     |
+| `credential.access` | Read env vars, tokens, secrets, or keychains |
+| `external.message`  | Send chat, email, comments, issues, or PRs   |
+| `memory.write`      | Write durable agent memory                   |
+| `task.mutate`       | Create or change tasks, issues, or PRs       |
+| `schedule.persist`  | Create recurring jobs or background watchers |
+| `browser.session`   | Use browser automation or authenticated tabs |
+| `mcp.tool`          | Invoke MCP servers, plugins, or connectors   |
+
+Rules:
+
+- Avoid `*` or `all`; wildcard declarations are treated as review findings.
+- Keep declarations narrower than the agent role. The skill declares what it
+  needs, not what the operator could technically grant.
+- If the profile reports observed behavior that exceeds declarations, create a
+  remediation task from the Shared Resources panel and either narrow the skill or
+  add a reviewer-approved declaration.
+- Evidence snippets are redacted, but skill authors should still avoid embedding
+  example secrets or real customer data in shared skill text.
+
+---
+
 ## Referencing Shared Resources
 
 ### In Task Descriptions

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -35,6 +35,10 @@ operator checklist for final release verification.
       routing, and workflow-gate decisions include matched rules, remediation,
       redacted raw detail, API access through `/api/governance/traces`, and UI
       drilldown from the Decision Audit Trail.
+- [ ] Skill capability profiles verify shared skill resources declare required
+      capabilities, observed static behavior is classified through the canonical
+      taxonomy, mismatches write audit events, remediation tasks can be created,
+      and the Shared Resources UI exposes declared, observed, and mismatch state.
 - [ ] Performance/load review covers SQLite read/write paths, dashboard queries,
       WebSocket fan-out, workflow run updates, and remote/mobile clients. Track
       evidence and limits in

--- a/server/src/__tests__/skill-capability-service.test.ts
+++ b/server/src/__tests__/skill-capability-service.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import type { SharedResource, Task } from '@veritas-kanban/shared';
+import { SkillCapabilityService } from '../services/skill-capability-service.js';
+
+function skill(overrides: Partial<SharedResource>): SharedResource {
+  return {
+    id: 'skill_1',
+    name: 'Review Helper',
+    type: 'skill',
+    content: '# Review Helper',
+    tags: [],
+    mountedIn: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    version: 1,
+    ...overrides,
+  };
+}
+
+function serviceFor(resources: SharedResource[]) {
+  const tasks: Task[] = [];
+  const service = new SkillCapabilityService(
+    {
+      async listResources(filters) {
+        return resources.filter((resource) => !filters?.type || resource.type === filters.type);
+      },
+      async getResource(id) {
+        return resources.find((resource) => resource.id === id) ?? null;
+      },
+    },
+    {
+      async createTask(input) {
+        const task = {
+          id: `task_${tasks.length + 1}`,
+          title: input.title,
+          description: input.description ?? '',
+          type: input.type ?? 'security',
+          status: 'todo',
+          priority: input.priority ?? 'medium',
+          created: '2026-01-01T00:00:00.000Z',
+          updated: '2026-01-01T00:00:00.000Z',
+          revision: 1,
+        } as Task;
+        tasks.push(task);
+        return task;
+      },
+    }
+  );
+  return { service, tasks };
+}
+
+describe('SkillCapabilityService', () => {
+  it('compares declared and observed capabilities with redacted evidence', async () => {
+    const { service } = serviceFor([
+      skill({
+        content: `---
+capabilities:
+  - filesystem.read
+---
+
+# Review Helper
+
+Read files and call fetch('https://example.invalid/report?token=sk_test_abcdef12345678').
+Use process.env.SECRET_TOKEN when available.
+`,
+      }),
+    ]);
+
+    const [profile] = await service.listProfiles();
+
+    expect(profile.declaredCapabilities).toEqual(['filesystem.read']);
+    expect(profile.matchedCapabilities).toEqual(['filesystem.read']);
+    expect(profile.undeclaredObservedCapabilities).toEqual(['credential.access', 'network.egress']);
+    expect(profile.status).toBe('mismatch');
+    expect(profile.severity).toBe('critical');
+    expect(profile.findings.map((finding) => finding.id)).toContain(
+      'undeclared-observed:credential.access'
+    );
+    expect(JSON.stringify(profile.findings)).toContain('[REDACTED_API_KEY]');
+  });
+
+  it('marks skills with observed behavior and no declarations as missing declaration', async () => {
+    const { service } = serviceFor([
+      skill({
+        content: `# Installer
+
+Run pnpm install and write files into the repo.
+`,
+      }),
+    ]);
+
+    const [profile] = await service.listProfiles({ status: 'missing-declaration' });
+
+    expect(profile.status).toBe('missing-declaration');
+    expect(profile.findings.some((finding) => finding.kind === 'missing-declaration')).toBe(true);
+  });
+
+  it('tracks overdeclared and wildcard declarations', async () => {
+    const { service } = serviceFor([
+      skill({
+        id: 'skill_over',
+        content: `# Browser Helper
+
+## Declared Capabilities
+- browser.session
+- credential.access
+
+Uses Playwright to inspect a logged-in page.
+`,
+      }),
+      skill({
+        id: 'skill_wild',
+        content: `---
+capabilities: [*]
+---
+
+# Wildcard
+Run shell commands.
+`,
+      }),
+    ]);
+
+    const profiles = await service.listProfiles();
+    const over = profiles.find((profile) => profile.skillId === 'skill_over');
+    const wild = profiles.find((profile) => profile.skillId === 'skill_wild');
+
+    expect(over?.declaredUnobservedCapabilities).toEqual(['credential.access']);
+    expect(over?.findings.some((finding) => finding.kind === 'declared-unobserved')).toBe(true);
+    expect(wild?.findings.some((finding) => finding.kind === 'wildcard-declaration')).toBe(true);
+  });
+
+  it('creates remediation tasks for profiles with findings', async () => {
+    const { service, tasks } = serviceFor([
+      skill({
+        content: `# Installer
+
+Run pnpm install and write files.
+`,
+      }),
+    ]);
+
+    const result = await service.createRemediationTask(
+      'skill_1',
+      { project: 'Security' },
+      'tester'
+    );
+
+    expect(result.task.id).toBe('task_1');
+    expect(result.task.title).toContain('Review skill capability mismatch');
+    expect(result.task.description).toContain('Declared: none');
+    expect(result.profile.remediationTaskId).toBe('task_1');
+    expect(tasks).toHaveLength(1);
+  });
+});

--- a/server/src/routes/skill-capabilities.ts
+++ b/server/src/routes/skill-capabilities.ts
@@ -1,0 +1,104 @@
+import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import {
+  SKILL_CAPABILITY_TAXONOMY,
+  getSkillCapabilityService,
+} from '../services/skill-capability-service.js';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { actorFromRequest } from '../utils/concurrency.js';
+import type { SkillCapabilityId, SkillCapabilityListFilters } from '@veritas-kanban/shared';
+
+const router: RouterType = Router();
+
+const capabilityIds = SKILL_CAPABILITY_TAXONOMY.map((definition) => definition.id) as [
+  string,
+  ...string[],
+];
+
+const listQuerySchema = z.object({
+  status: z.enum(['aligned', 'mismatch', 'missing-declaration']).optional(),
+  severity: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+  capability: z.enum(capabilityIds).optional(),
+  q: z.string().min(1).max(120).optional(),
+});
+
+const remediationSchema = z.object({
+  project: z.string().min(1).max(100).optional(),
+  sprint: z.string().min(1).max(100).optional(),
+  priority: z.enum(['low', 'medium', 'high']).optional(),
+});
+
+router.get(
+  '/taxonomy',
+  asyncHandler(async (_req, res) => {
+    const service = getSkillCapabilityService();
+    res.json(service.getTaxonomy());
+  })
+);
+
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    let query;
+    try {
+      query = listQuerySchema.parse(req.query);
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) {
+        throw new ValidationError('Validation error', err.issues);
+      }
+      throw err;
+    }
+
+    const service = getSkillCapabilityService();
+    const filters: SkillCapabilityListFilters = {
+      ...query,
+      capability: query.capability as SkillCapabilityId | undefined,
+    };
+    res.json(await service.listProfiles(filters));
+  })
+);
+
+router.get(
+  '/:skillId',
+  asyncHandler(async (req, res) => {
+    const service = getSkillCapabilityService();
+    const profile = await service.getProfile(String(req.params.skillId));
+    if (!profile) throw new NotFoundError('Skill capability profile not found');
+    res.json(profile);
+  })
+);
+
+router.post(
+  '/:skillId/remediation-task',
+  asyncHandler(async (req, res) => {
+    let input;
+    try {
+      input = remediationSchema.parse(req.body ?? {});
+    } catch (err: unknown) {
+      if (err instanceof z.ZodError) {
+        throw new ValidationError('Validation error', err.issues);
+      }
+      throw err;
+    }
+
+    const service = getSkillCapabilityService();
+    try {
+      const result = await service.createRemediationTask(
+        String(req.params.skillId),
+        input,
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.status(201).json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Skill capability remediation failed';
+      if (message.includes('not found')) {
+        throw new NotFoundError(message);
+      }
+      throw new ValidationError(message);
+    }
+  })
+);
+
+export { router as skillCapabilityRoutes };

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -32,6 +32,7 @@ import {
   feedbackAccess,
   notificationAccess,
   policyAccess,
+  skillCapabilityAccess,
   previewAccess,
   promptRegistryAccess,
   reportAccess,
@@ -120,6 +121,7 @@ import promptRegistryRoutes from '../prompt-registry.js';
 import { sqlitePortabilityRoutes } from '../sqlite-portability.js';
 import { maintenanceRoutes } from '../maintenance.js';
 import { identityRoutes } from '../identity.js';
+import { skillCapabilityRoutes } from '../skill-capabilities.js';
 
 const v1Router: IRouter = Router();
 
@@ -213,6 +215,7 @@ v1Router.use('/delegation', delegationAccess, delegationRoutes);
 v1Router.use('/workflows', workflowAccess, workflowRoutes);
 v1Router.use('/tool-policies', policyAccess, toolPolicyRoutes);
 v1Router.use('/policies', policyAccess, policyRoutes);
+v1Router.use('/skills/capabilities', skillCapabilityAccess, skillCapabilityRoutes);
 v1Router.use('/integrations', settingsAccess, integrationsRoutes);
 v1Router.use('/transcripts', transcriptAccess, transcriptRoutes);
 v1Router.use('/scoring', scoringAccess, scoringRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -35,6 +35,13 @@ export const telemetryAccess = routeAccess('telemetry:read', 'telemetry:write');
 export const policyAccess = routeAccess('policy:read', 'policy:read', [
   { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
 ]);
+export const skillCapabilityAccess = routeAccess('policy:read', 'policy:write', [
+  {
+    methods: ['POST'],
+    path: /^\/[^/]+\/remediation-task\/?$/,
+    permissions: ['policy:write', 'task:write'],
+  },
+]);
 export const backupAccess = routeAccess('backup:read', 'backup:write');
 export const previewAccess = routeAccess('task:read', 'admin:manage');
 export const workspaceAccess = routeAccess('workspace:read', 'admin:manage');

--- a/server/src/services/skill-capability-service.ts
+++ b/server/src/services/skill-capability-service.ts
@@ -1,0 +1,710 @@
+import type {
+  CreateTaskInput,
+  SharedResource,
+  SkillCapabilityDefinition,
+  SkillCapabilityEvidence,
+  SkillCapabilityFinding,
+  SkillCapabilityId,
+  SkillCapabilityListFilters,
+  SkillCapabilityObservation,
+  SkillCapabilityProfile,
+  SkillCapabilityRemediationTaskInput,
+  SkillCapabilityRisk,
+  SkillCapabilitySource,
+  Task,
+} from '@veritas-kanban/shared';
+import { auditLog } from './audit-service.js';
+import { getSharedResourcesService } from './shared-resources-service.js';
+import { getTaskService } from './task-service.js';
+import { redactString } from '../lib/redact.js';
+
+interface SkillResourceProvider {
+  listResources(filters?: { type?: 'skill' }): Promise<SharedResource[]>;
+  getResource(id: string): Promise<SharedResource | null>;
+}
+
+interface TaskCreator {
+  createTask(input: CreateTaskInput): Promise<Task>;
+}
+
+interface CapabilityPattern {
+  id: string;
+  capability: SkillCapabilityId;
+  source: SkillCapabilitySource;
+  confidence: number;
+  pattern: RegExp;
+  label: string;
+}
+
+export const SKILL_CAPABILITY_TAXONOMY: SkillCapabilityDefinition[] = [
+  {
+    id: 'filesystem.read',
+    label: 'Filesystem Read',
+    description: 'Reads local files, directories, manifests, or repository content.',
+    risk: 'medium',
+  },
+  {
+    id: 'filesystem.write',
+    label: 'Filesystem Write',
+    description: 'Creates, edits, deletes, or moves local files.',
+    risk: 'high',
+  },
+  {
+    id: 'shell.execute',
+    label: 'Shell Execution',
+    description: 'Runs shell commands, subprocesses, interpreters, or package scripts.',
+    risk: 'high',
+  },
+  {
+    id: 'network.egress',
+    label: 'Network Egress',
+    description: 'Calls remote URLs, APIs, webhooks, or downloads external resources.',
+    risk: 'high',
+  },
+  {
+    id: 'credential.access',
+    label: 'Credential Access',
+    description: 'Reads tokens, API keys, environment variables, secrets, or keychains.',
+    risk: 'critical',
+  },
+  {
+    id: 'external.message',
+    label: 'External Messaging',
+    description: 'Sends email, chat, comments, posts, issues, pull requests, or public replies.',
+    risk: 'high',
+  },
+  {
+    id: 'memory.write',
+    label: 'Memory Write',
+    description: 'Writes persistent agent memory, durable notes, or long-lived instructions.',
+    risk: 'medium',
+  },
+  {
+    id: 'task.mutate',
+    label: 'Task Mutation',
+    description:
+      'Creates or changes Veritas tasks, projects, issues, PR metadata, or workflow state.',
+    risk: 'medium',
+  },
+  {
+    id: 'schedule.persist',
+    label: 'Persistent Scheduling',
+    description:
+      'Creates recurring jobs, daemons, watchers, cron entries, or background automation.',
+    risk: 'high',
+  },
+  {
+    id: 'browser.session',
+    label: 'Browser Session',
+    description: 'Uses browser automation, cookies, authenticated tabs, or session storage.',
+    risk: 'high',
+  },
+  {
+    id: 'mcp.tool',
+    label: 'MCP or Tool Access',
+    description: 'Invokes plugins, connectors, MCP tools, or delegated tool runtimes.',
+    risk: 'medium',
+  },
+];
+
+const TAXONOMY_BY_ID = new Map(
+  SKILL_CAPABILITY_TAXONOMY.map((definition) => [definition.id, definition])
+);
+const CAPABILITY_IDS = new Set(SKILL_CAPABILITY_TAXONOMY.map((definition) => definition.id));
+const RISK_RANK: Record<SkillCapabilityRisk, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+const DECLARED_HEADING = /^#{2,4}\s+declared capabilities\b/i;
+const NEXT_HEADING = /^#{1,4}\s+/;
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+const CAPABILITY_ALIASES: Record<string, SkillCapabilityId> = {
+  all: 'mcp.tool',
+  '*': 'mcp.tool',
+  'fs.read': 'filesystem.read',
+  'file.read': 'filesystem.read',
+  'filesystem.read': 'filesystem.read',
+  'fs.write': 'filesystem.write',
+  'file.write': 'filesystem.write',
+  'filesystem.write': 'filesystem.write',
+  shell: 'shell.execute',
+  'shell.execute': 'shell.execute',
+  command: 'shell.execute',
+  network: 'network.egress',
+  'network.egress': 'network.egress',
+  http: 'network.egress',
+  credentials: 'credential.access',
+  secrets: 'credential.access',
+  'credential.access': 'credential.access',
+  messaging: 'external.message',
+  'external.message': 'external.message',
+  memory: 'memory.write',
+  'memory.write': 'memory.write',
+  tasks: 'task.mutate',
+  'task.mutate': 'task.mutate',
+  schedule: 'schedule.persist',
+  'schedule.persist': 'schedule.persist',
+  browser: 'browser.session',
+  'browser.session': 'browser.session',
+  mcp: 'mcp.tool',
+  tool: 'mcp.tool',
+  'mcp.tool': 'mcp.tool',
+};
+
+const OBSERVED_PATTERNS: CapabilityPattern[] = [
+  {
+    id: 'node-fs-read',
+    capability: 'filesystem.read',
+    source: 'content-pattern',
+    confidence: 0.82,
+    pattern:
+      /\b(readFile|readdir|createReadStream|glob|grep|ripgrep|rg\s+|cat\s+|find\s+|list files|read files)\b/i,
+    label: 'File read or enumeration reference',
+  },
+  {
+    id: 'node-fs-write',
+    capability: 'filesystem.write',
+    source: 'content-pattern',
+    confidence: 0.85,
+    pattern:
+      /\b(writeFile|appendFile|unlink|rm\s+-rf|mv\s+|apply_patch|edit files|write files|delete files)\b/i,
+    label: 'File write or deletion reference',
+  },
+  {
+    id: 'subprocess',
+    capability: 'shell.execute',
+    source: 'content-pattern',
+    confidence: 0.9,
+    pattern:
+      /\b(child_process|execFile|spawn|subprocess|shell command|bash|zsh|powershell|pnpm\s+|npm\s+|python\s+|node\s+)\b/i,
+    label: 'Shell or subprocess reference',
+  },
+  {
+    id: 'remote-network',
+    capability: 'network.egress',
+    source: 'content-pattern',
+    confidence: 0.86,
+    pattern: /\b(fetch|axios|curl|wget|webhook|remote API|https?:\/\/|POST to|download from)\b/i,
+    label: 'Remote network call reference',
+  },
+  {
+    id: 'credential-reference',
+    capability: 'credential.access',
+    source: 'content-pattern',
+    confidence: 0.92,
+    pattern:
+      /\b(process\.env|environment variable|env var|secret|token|api[_ -]?key|credential|authorization|keychain|password)\b/i,
+    label: 'Credential or secret reference',
+  },
+  {
+    id: 'external-send',
+    capability: 'external.message',
+    source: 'content-pattern',
+    confidence: 0.84,
+    pattern:
+      /\b(send email|post message|send message|reply in|slack|teams|discord|twitter|tweet|github comment|create issue|create pull request|gh issue|gh pr)\b/i,
+    label: 'External message or public write reference',
+  },
+  {
+    id: 'memory-write',
+    capability: 'memory.write',
+    source: 'content-pattern',
+    confidence: 0.78,
+    pattern:
+      /\b(write memory|update memory|remember this|persisted note|durable memory|memory folder)\b/i,
+    label: 'Persistent memory reference',
+  },
+  {
+    id: 'task-mutation',
+    capability: 'task.mutate',
+    source: 'content-pattern',
+    confidence: 0.8,
+    pattern:
+      /\b(create task|update task|close issue|open issue|merge PR|create PR|kanban mutation|change status)\b/i,
+    label: 'Task or issue mutation reference',
+  },
+  {
+    id: 'persistent-schedule',
+    capability: 'schedule.persist',
+    source: 'content-pattern',
+    confidence: 0.85,
+    pattern:
+      /\b(cron|schedule recurring|recurring automation|daemon|launchd|systemd|background job|watcher|keep running)\b/i,
+    label: 'Persistent schedule reference',
+  },
+  {
+    id: 'browser-session',
+    capability: 'browser.session',
+    source: 'content-pattern',
+    confidence: 0.82,
+    pattern:
+      /\b(playwright|browser session|chrome|authenticated browser|cookies?|localStorage|sessionStorage)\b/i,
+    label: 'Browser or session reference',
+  },
+  {
+    id: 'mcp-tool',
+    capability: 'mcp.tool',
+    source: 'content-pattern',
+    confidence: 0.75,
+    pattern: /\b(MCP|connector|plugin|tool call|tool runtime|use tool|invoke tool)\b/i,
+    label: 'MCP or tool runtime reference',
+  },
+  {
+    id: 'script-reference',
+    capability: 'shell.execute',
+    source: 'script-reference',
+    confidence: 0.7,
+    pattern: /\b(scripts?\/[A-Za-z0-9._/-]+|\.sh\b|\.py\b|\.mjs\b|\.js\b)\b/i,
+    label: 'Referenced executable script',
+  },
+];
+
+function normalizeToken(value: string): string {
+  return value
+    .trim()
+    .replace(/^[-*`'"\s]+|[`'"\s,]+$/g, '')
+    .replace(/_/g, '.')
+    .toLowerCase();
+}
+
+function normalizeCapability(value: string): SkillCapabilityId | '*' | null {
+  const raw = value.trim().replace(/^`|`$/g, '');
+  if (raw === '*' || raw.toLowerCase() === 'all') return '*';
+  const token = normalizeToken(value);
+  if (token === '*' || token === 'all') return '*';
+  if (CAPABILITY_IDS.has(token as SkillCapabilityId)) return token as SkillCapabilityId;
+  return CAPABILITY_ALIASES[token] ?? null;
+}
+
+function uniqueCapabilities(
+  values: Array<SkillCapabilityId | '*' | null>
+): Array<SkillCapabilityId | '*'> {
+  return Array.from(
+    new Set(values.filter((value): value is SkillCapabilityId | '*' => value !== null))
+  );
+}
+
+function parseInlineCapabilities(value: string): Array<SkillCapabilityId | '*'> {
+  const cleaned = value
+    .replace(/^\s*capabilities\s*:\s*/i, '')
+    .trim()
+    .replace(/^\[|\]$/g, '');
+  return uniqueCapabilities(cleaned.split(/[,\s]+/).map(normalizeCapability));
+}
+
+function parseDeclaredCapabilities(content: string): {
+  capabilities: SkillCapabilityId[];
+  wildcard: boolean;
+  sources: SkillCapabilitySource[];
+} {
+  const declared: Array<SkillCapabilityId | '*'> = [];
+  const sources = new Set<SkillCapabilitySource>();
+
+  const frontmatter = content.match(FRONTMATTER);
+  if (frontmatter) {
+    const lines = frontmatter[1].split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (/^\s*(capabilities|declaredCapabilities|declared_capabilities)\s*:/i.test(line)) {
+        sources.add('frontmatter');
+        declared.push(...parseInlineCapabilities(line.replace(/^[^:]+:/, '')));
+        for (let nextIndex = index + 1; nextIndex < lines.length; nextIndex += 1) {
+          const nextLine = lines[nextIndex];
+          if (/^\S/.test(nextLine)) break;
+          const bullet = nextLine.match(/^\s*-\s*(.+)$/);
+          if (bullet) {
+            const capability = normalizeCapability(bullet[1]);
+            if (capability) declared.push(capability);
+          }
+        }
+      }
+    }
+  }
+
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!DECLARED_HEADING.test(lines[index])) continue;
+    sources.add('declared-section');
+    for (let nextIndex = index + 1; nextIndex < lines.length; nextIndex += 1) {
+      const line = lines[nextIndex];
+      if (NEXT_HEADING.test(line)) break;
+      const matches = line.match(
+        /`([^`]+)`|[-*]\s*([A-Za-z0-9.*_-]+)|\b([A-Za-z]+(?:[._-][A-Za-z]+)+)\b/g
+      );
+      if (!matches) continue;
+      for (const match of matches) {
+        const capability = normalizeCapability(match.replace(/^[-*]\s*/, '').replace(/`/g, ''));
+        if (capability) declared.push(capability);
+      }
+    }
+  }
+
+  const unique = uniqueCapabilities(declared);
+  const wildcard = unique.includes('*');
+  return {
+    capabilities: unique.filter((value): value is SkillCapabilityId => value !== '*'),
+    wildcard,
+    sources: Array.from(sources),
+  };
+}
+
+function stripDeclaredCapabilityText(content: string): string {
+  const withoutFrontmatter = content.replace(FRONTMATTER, '');
+  const lines = withoutFrontmatter.split(/\r?\n/);
+  const kept: string[] = [];
+  let inDeclaredSection = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (DECLARED_HEADING.test(line)) {
+      inDeclaredSection = true;
+      continue;
+    }
+
+    if (inDeclaredSection) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        inDeclaredSection = false;
+        kept.push(line);
+        continue;
+      }
+      if (NEXT_HEADING.test(line)) {
+        inDeclaredSection = false;
+        kept.push(line);
+        continue;
+      }
+      if (/^[-*]\s+/.test(trimmed) || /`[A-Za-z0-9.*_-]+`/.test(trimmed)) {
+        continue;
+      }
+      inDeclaredSection = false;
+    }
+
+    kept.push(line);
+  }
+
+  return kept.join('\n');
+}
+
+function evidenceForPattern(
+  content: string,
+  pattern: CapabilityPattern
+): SkillCapabilityEvidence | null {
+  const lines = content.split(/\r?\n/);
+  const index = lines.findIndex((line) => pattern.pattern.test(line));
+  if (index === -1) return null;
+  const excerpt = redactString(lines[index].trim()).slice(0, 220);
+  return {
+    source: pattern.source,
+    label: `${pattern.label} on line ${index + 1}`,
+    excerpt,
+    patternId: pattern.id,
+  };
+}
+
+function observeCapabilities(content: string): SkillCapabilityObservation[] {
+  const observableContent = stripDeclaredCapabilityText(content);
+  const byCapability = new Map<SkillCapabilityId, SkillCapabilityObservation>();
+
+  for (const pattern of OBSERVED_PATTERNS) {
+    const evidence = evidenceForPattern(observableContent, pattern);
+    if (!evidence) continue;
+
+    const existing = byCapability.get(pattern.capability);
+    if (existing) {
+      existing.confidence = Math.max(existing.confidence, pattern.confidence);
+      existing.evidence.push(evidence);
+    } else {
+      byCapability.set(pattern.capability, {
+        capability: pattern.capability,
+        confidence: pattern.confidence,
+        evidence: [evidence],
+      });
+    }
+  }
+
+  return Array.from(byCapability.values()).sort((a, b) => a.capability.localeCompare(b.capability));
+}
+
+function severityFor(
+  capability: SkillCapabilityId | undefined,
+  fallback: SkillCapabilityRisk
+): SkillCapabilityRisk {
+  if (!capability) return fallback;
+  return TAXONOMY_BY_ID.get(capability)?.risk ?? fallback;
+}
+
+function maxSeverity(values: SkillCapabilityRisk[]): SkillCapabilityRisk {
+  return values.reduce<SkillCapabilityRisk>(
+    (max, value) => (RISK_RANK[value] > RISK_RANK[max] ? value : max),
+    'low'
+  );
+}
+
+function findingId(kind: string, capability?: SkillCapabilityId): string {
+  return capability ? `${kind}:${capability}` : kind;
+}
+
+function buildFindings(input: {
+  declared: SkillCapabilityId[];
+  observed: SkillCapabilityObservation[];
+  wildcard: boolean;
+  matched: SkillCapabilityId[];
+  undeclared: SkillCapabilityId[];
+  unobserved: SkillCapabilityId[];
+}): SkillCapabilityFinding[] {
+  const evidenceByCapability = new Map(
+    input.observed.map((observation) => [observation.capability, observation.evidence])
+  );
+  const findings: SkillCapabilityFinding[] = [];
+
+  if (input.declared.length === 0 && !input.wildcard && input.observed.length > 0) {
+    findings.push({
+      id: findingId('missing-declaration'),
+      kind: 'missing-declaration',
+      severity: 'medium',
+      message: 'Skill has observed capabilities but no declared capability block.',
+      remediation:
+        'Add a declared capabilities frontmatter block or Declared Capabilities section before install or execution review.',
+      evidence: [{ source: 'missing-declaration', label: 'No declaration found' }],
+    });
+  }
+
+  if (input.wildcard) {
+    findings.push({
+      id: findingId('wildcard-declaration'),
+      kind: 'wildcard-declaration',
+      severity: 'medium',
+      message: 'Skill declares wildcard capability access.',
+      remediation:
+        'Replace wildcard access with the narrow capability list the skill actually needs.',
+      evidence: [{ source: 'wildcard', label: 'Wildcard capability declaration' }],
+    });
+  }
+
+  for (const capability of input.undeclared) {
+    findings.push({
+      id: findingId('undeclared-observed', capability),
+      kind: 'undeclared-observed',
+      capability,
+      severity: severityFor(capability, 'high'),
+      message: `${capability} is observed but not declared.`,
+      remediation: `Declare ${capability} or remove the behavior before the skill is approved.`,
+      evidence: evidenceByCapability.get(capability) ?? [],
+    });
+  }
+
+  for (const capability of input.unobserved) {
+    findings.push({
+      id: findingId('declared-unobserved', capability),
+      kind: 'declared-unobserved',
+      capability,
+      severity: 'low',
+      message: `${capability} is declared but not observed in the current static profile.`,
+      remediation:
+        'Remove unused capability declarations or add reviewer notes explaining the need.',
+      evidence: [],
+    });
+  }
+
+  return findings;
+}
+
+function profileMatches(
+  profile: SkillCapabilityProfile,
+  filters: SkillCapabilityListFilters
+): boolean {
+  if (filters.status && profile.status !== filters.status) return false;
+  if (filters.severity && RISK_RANK[profile.severity] < RISK_RANK[filters.severity]) return false;
+  if (
+    filters.capability &&
+    !profile.declaredCapabilities.includes(filters.capability) &&
+    !profile.observedCapabilities.some((observed) => observed.capability === filters.capability)
+  ) {
+    return false;
+  }
+  if (filters.q) {
+    const query = filters.q.toLowerCase();
+    const haystack = [
+      profile.name,
+      profile.skillId,
+      profile.tags.join(' '),
+      profile.findings.map((finding) => finding.message).join(' '),
+    ]
+      .join(' ')
+      .toLowerCase();
+    if (!haystack.includes(query)) return false;
+  }
+  return true;
+}
+
+export class SkillCapabilityService {
+  private auditedSignatures = new Set<string>();
+
+  constructor(
+    private readonly resources: SkillResourceProvider = getSharedResourcesService(),
+    private readonly tasks: TaskCreator = getTaskService()
+  ) {}
+
+  getTaxonomy(): SkillCapabilityDefinition[] {
+    return SKILL_CAPABILITY_TAXONOMY;
+  }
+
+  async listProfiles(filters: SkillCapabilityListFilters = {}): Promise<SkillCapabilityProfile[]> {
+    const resources = await this.resources.listResources({ type: 'skill' });
+    const profiles = resources.map((resource) => this.profileResource(resource));
+    await this.auditMismatches(profiles);
+    return profiles.filter((profile) => profileMatches(profile, filters));
+  }
+
+  async getProfile(skillId: string): Promise<SkillCapabilityProfile | null> {
+    const resource = await this.resources.getResource(skillId);
+    if (!resource || resource.type !== 'skill') return null;
+    const profile = this.profileResource(resource);
+    await this.auditMismatches([profile]);
+    return profile;
+  }
+
+  async createRemediationTask(
+    skillId: string,
+    input: SkillCapabilityRemediationTaskInput,
+    actor = 'system'
+  ): Promise<{ profile: SkillCapabilityProfile; task: Task }> {
+    const profile = await this.getProfile(skillId);
+    if (!profile) {
+      throw new Error('Skill capability profile not found');
+    }
+    if (profile.findings.length === 0) {
+      throw new Error('Skill capability profile has no findings to remediate');
+    }
+
+    const priority =
+      input.priority ?? (RISK_RANK[profile.severity] >= RISK_RANK.high ? 'high' : 'medium');
+    const description = [
+      `Review declared-vs-observed capability mismatch for skill ${profile.name}.`,
+      '',
+      `Skill ID: ${profile.skillId}`,
+      `Status: ${profile.status}`,
+      `Severity: ${profile.severity}`,
+      `Declared: ${profile.declaredCapabilities.join(', ') || 'none'}`,
+      `Observed: ${profile.observedCapabilities.map((item) => item.capability).join(', ') || 'none'}`,
+      '',
+      'Findings:',
+      ...profile.findings.map((finding) => `- ${finding.message} ${finding.remediation}`),
+    ].join('\n');
+
+    const task = await this.tasks.createTask({
+      title: `Review skill capability mismatch: ${profile.name}`,
+      description,
+      type: 'security',
+      priority,
+      project: input.project,
+      sprint: input.sprint,
+      createdBy: actor,
+      updatedBy: actor,
+    });
+
+    await auditLog({
+      action: 'skill.capability.remediation_task.create',
+      actor,
+      resource: profile.skillId,
+      details: {
+        taskId: task.id,
+        status: profile.status,
+        severity: profile.severity,
+        findings: profile.findings.map((finding) => finding.id),
+      },
+    });
+
+    return { profile: { ...profile, remediationTaskId: task.id }, task };
+  }
+
+  private profileResource(resource: SharedResource): SkillCapabilityProfile {
+    const declaration = parseDeclaredCapabilities(resource.content);
+    const observed = observeCapabilities(resource.content);
+    const observedIds = observed.map((item) => item.capability);
+    const declaredSet = new Set(declaration.capabilities);
+    const observedSet = new Set(observedIds);
+    const matched = declaration.wildcard
+      ? [...observedSet]
+      : [...observedSet].filter((capability) => declaredSet.has(capability));
+    const undeclared = declaration.wildcard
+      ? []
+      : [...observedSet].filter((capability) => !declaredSet.has(capability));
+    const unobserved = [...declaredSet].filter((capability) => !observedSet.has(capability));
+    const findings = buildFindings({
+      declared: declaration.capabilities,
+      observed,
+      wildcard: declaration.wildcard,
+      matched,
+      undeclared,
+      unobserved,
+    });
+    const status =
+      declaration.capabilities.length === 0 && !declaration.wildcard && observed.length > 0
+        ? 'missing-declaration'
+        : findings.some((finding) => finding.kind !== 'declared-unobserved')
+          ? 'mismatch'
+          : 'aligned';
+
+    return {
+      id: `skillcap_${resource.id}`,
+      skillId: resource.id,
+      name: resource.name,
+      version: resource.version,
+      tags: resource.tags,
+      mountedIn: resource.mountedIn,
+      scannedAt: new Date().toISOString(),
+      declaredCapabilities: declaration.capabilities,
+      observedCapabilities: observed,
+      matchedCapabilities: matched.sort(),
+      undeclaredObservedCapabilities: undeclared.sort(),
+      declaredUnobservedCapabilities: unobserved.sort(),
+      declarationSources: declaration.sources,
+      status,
+      severity: findings.length ? maxSeverity(findings.map((finding) => finding.severity)) : 'low',
+      findings,
+    };
+  }
+
+  private async auditMismatches(profiles: SkillCapabilityProfile[]): Promise<void> {
+    await Promise.all(
+      profiles
+        .filter((profile) => profile.findings.length > 0)
+        .map(async (profile) => {
+          const signature = `${profile.skillId}:${profile.version}:${profile.findings
+            .map((finding) => finding.id)
+            .sort()
+            .join('|')}`;
+          if (this.auditedSignatures.has(signature)) return;
+          this.auditedSignatures.add(signature);
+          await auditLog({
+            action: 'skill.capability.mismatch.detected',
+            actor: 'system',
+            resource: profile.skillId,
+            details: {
+              skillName: profile.name,
+              status: profile.status,
+              severity: profile.severity,
+              declared: profile.declaredCapabilities,
+              observed: profile.observedCapabilities.map((observed) => observed.capability),
+              findings: profile.findings.map((finding) => finding.id),
+            },
+          });
+        })
+    );
+  }
+}
+
+let instance: SkillCapabilityService | null = null;
+
+export function getSkillCapabilityService(): SkillCapabilityService {
+  if (!instance) {
+    instance = new SkillCapabilityService();
+  }
+  return instance;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -25,3 +25,4 @@ export * from './workflow.js';
 export * from './work-product.types.js';
 export * from './maintenance.types.js';
 export * from './governance-trace.types.js';
+export * from './skill-capability.types.js';

--- a/shared/src/types/skill-capability.types.ts
+++ b/shared/src/types/skill-capability.types.ts
@@ -1,0 +1,90 @@
+export type SkillCapabilityId =
+  | 'filesystem.read'
+  | 'filesystem.write'
+  | 'shell.execute'
+  | 'network.egress'
+  | 'credential.access'
+  | 'external.message'
+  | 'memory.write'
+  | 'task.mutate'
+  | 'schedule.persist'
+  | 'browser.session'
+  | 'mcp.tool';
+
+export type SkillCapabilityRisk = 'low' | 'medium' | 'high' | 'critical';
+export type SkillCapabilitySource =
+  | 'frontmatter'
+  | 'declared-section'
+  | 'content-pattern'
+  | 'script-reference'
+  | 'missing-declaration'
+  | 'wildcard';
+export type SkillCapabilityStatus = 'aligned' | 'mismatch' | 'missing-declaration';
+export type SkillCapabilityFindingKind =
+  | 'undeclared-observed'
+  | 'declared-unobserved'
+  | 'missing-declaration'
+  | 'wildcard-declaration';
+
+export interface SkillCapabilityDefinition {
+  id: SkillCapabilityId;
+  label: string;
+  description: string;
+  risk: SkillCapabilityRisk;
+}
+
+export interface SkillCapabilityEvidence {
+  source: SkillCapabilitySource;
+  label: string;
+  excerpt?: string;
+  patternId?: string;
+}
+
+export interface SkillCapabilityObservation {
+  capability: SkillCapabilityId;
+  confidence: number;
+  evidence: SkillCapabilityEvidence[];
+}
+
+export interface SkillCapabilityFinding {
+  id: string;
+  kind: SkillCapabilityFindingKind;
+  capability?: SkillCapabilityId;
+  severity: SkillCapabilityRisk;
+  message: string;
+  remediation: string;
+  evidence: SkillCapabilityEvidence[];
+}
+
+export interface SkillCapabilityProfile {
+  id: string;
+  skillId: string;
+  name: string;
+  version: number;
+  tags: string[];
+  mountedIn: string[];
+  scannedAt: string;
+  declaredCapabilities: SkillCapabilityId[];
+  observedCapabilities: SkillCapabilityObservation[];
+  matchedCapabilities: SkillCapabilityId[];
+  undeclaredObservedCapabilities: SkillCapabilityId[];
+  declaredUnobservedCapabilities: SkillCapabilityId[];
+  declarationSources: SkillCapabilitySource[];
+  status: SkillCapabilityStatus;
+  severity: SkillCapabilityRisk;
+  findings: SkillCapabilityFinding[];
+  remediationTaskId?: string;
+}
+
+export interface SkillCapabilityListFilters {
+  status?: SkillCapabilityStatus;
+  severity?: SkillCapabilityRisk;
+  capability?: SkillCapabilityId;
+  q?: string;
+}
+
+export interface SkillCapabilityRemediationTaskInput {
+  project?: string;
+  sprint?: string;
+  priority?: 'low' | 'medium' | 'high';
+}

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -252,6 +252,18 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
       { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
     ],
   },
+  {
+    prefix: '/api/skills/capabilities',
+    read: 'policy:read',
+    write: 'policy:write',
+    overrides: [
+      {
+        methods: ['POST'],
+        path: /^\/[^/]+\/remediation-task\/?$/,
+        permissions: ['policy:write', 'task:write'],
+      },
+    ],
+  },
   { prefix: '/api/integrations', read: 'settings:read', write: 'settings:write' },
   { prefix: '/api/transcripts', read: 'workspace:read', write: 'workflow:execute' },
   {

--- a/web/src/__tests__/settings-governance-mantine.test.tsx
+++ b/web/src/__tests__/settings-governance-mantine.test.tsx
@@ -32,6 +32,48 @@ const policies = [
   },
 ];
 
+const skillProfiles = [
+  {
+    id: 'skillcap_skill_1',
+    skillId: 'skill_1',
+    name: 'Review Helper',
+    version: 1,
+    tags: ['review'],
+    mountedIn: [],
+    scannedAt: '2026-06-03T00:00:00.000Z',
+    declaredCapabilities: ['filesystem.read'],
+    observedCapabilities: [
+      {
+        capability: 'filesystem.read',
+        confidence: 0.9,
+        evidence: [],
+      },
+      {
+        capability: 'network.egress',
+        confidence: 0.85,
+        evidence: [],
+      },
+    ],
+    matchedCapabilities: ['filesystem.read'],
+    undeclaredObservedCapabilities: ['network.egress'],
+    declaredUnobservedCapabilities: [],
+    declarationSources: ['frontmatter'],
+    status: 'mismatch',
+    severity: 'high',
+    findings: [
+      {
+        id: 'undeclared-observed:network.egress',
+        kind: 'undeclared-observed',
+        capability: 'network.egress',
+        severity: 'high',
+        message: 'network.egress is observed but not declared.',
+        remediation: 'Declare network.egress or remove the behavior.',
+        evidence: [],
+      },
+    ],
+  },
+];
+
 vi.mock('@/lib/api/helpers', () => ({
   apiFetch: mocks.apiFetch,
 }));
@@ -54,6 +96,12 @@ describe('Settings governance Mantine controls', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.apiFetch.mockImplementation(async (url: string) => {
+      if (url === '/api/skills/capabilities') {
+        return skillProfiles;
+      }
+      if (url === '/api/skills/capabilities/skill_1/remediation-task') {
+        return { profile: skillProfiles[0], task: { id: 'task_1', title: 'Review skill' } };
+      }
       if (url === '/api/tool-policies') {
         return policies;
       }
@@ -65,7 +113,7 @@ describe('Settings governance Mantine controls', () => {
     cleanup();
   });
 
-  it('renders Shared Resources checkbox and number controls through direct Mantine primitives', () => {
+  it('renders Shared Resources checkbox, number, and skill capability controls through direct Mantine primitives', async () => {
     const { container } = renderWithProviders(<SharedResourcesTab />);
 
     expect(screen.getByRole('textbox', { name: 'Max Resources' })).toBeDefined();
@@ -82,6 +130,12 @@ describe('Settings governance Mantine controls', () => {
         allowedTypes: ['prompt', 'skill', 'template'],
       }),
     });
+
+    expect(await screen.findByText('Skill Capability Profiles')).toBeDefined();
+    expect(await screen.findByText('Review Helper')).toBeDefined();
+    expect(screen.getByText('mismatch')).toBeDefined();
+    expect(screen.getByText('network.egress')).toBeDefined();
+    expect(container.querySelector('.mantine-Table-root')).toBeDefined();
   });
 
   it('renders Tool Policies list and editor through direct Mantine primitives', async () => {

--- a/web/src/components/settings/tabs/SharedResourcesTab.tsx
+++ b/web/src/components/settings/tabs/SharedResourcesTab.tsx
@@ -2,6 +2,7 @@ import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatur
 import { Checkbox, NumberInput } from '@mantine/core';
 import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings } from '@veritas-kanban/shared';
 import { ToggleRow, SectionHeader, SaveIndicator, SettingRow } from '../shared';
+import { SkillCapabilityProfilesPanel } from './SkillCapabilityProfilesPanel';
 
 const TYPE_OPTIONS: Array<{
   key: 'prompt' | 'guideline' | 'skill' | 'config' | 'template';
@@ -98,6 +99,10 @@ export function SharedResourcesTab() {
             ))}
           </div>
         </div>
+      )}
+
+      {sharedResources.enabled && allowedTypes.includes('skill') && (
+        <SkillCapabilityProfilesPanel />
       )}
     </div>
   );

--- a/web/src/components/settings/tabs/SkillCapabilityProfilesPanel.tsx
+++ b/web/src/components/settings/tabs/SkillCapabilityProfilesPanel.tsx
@@ -1,0 +1,197 @@
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Table,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import { AlertTriangle, ClipboardList, RefreshCw, ShieldCheck } from 'lucide-react';
+import type {
+  SkillCapabilityId,
+  SkillCapabilityProfile,
+  SkillCapabilityRisk,
+  SkillCapabilityStatus,
+} from '@veritas-kanban/shared';
+import {
+  useCreateSkillCapabilityRemediationTask,
+  useSkillCapabilityProfiles,
+} from '@/hooks/useSkillCapabilities';
+import { useToast } from '@/hooks/useToast';
+
+const STATUS_COLORS: Record<SkillCapabilityStatus, string> = {
+  aligned: 'green',
+  mismatch: 'yellow',
+  'missing-declaration': 'orange',
+};
+
+const SEVERITY_COLORS: Record<SkillCapabilityRisk, string> = {
+  low: 'gray',
+  medium: 'yellow',
+  high: 'orange',
+  critical: 'red',
+};
+
+function CapabilityBadges({ values }: { values: SkillCapabilityId[] }) {
+  if (values.length === 0) {
+    return (
+      <Text size="xs" c="dimmed">
+        none
+      </Text>
+    );
+  }
+
+  return (
+    <Group gap={4}>
+      {values.slice(0, 4).map((value) => (
+        <Badge key={value} size="xs" variant="light" color="blue">
+          {value}
+        </Badge>
+      ))}
+      {values.length > 4 && (
+        <Badge size="xs" variant="light" color="gray">
+          +{values.length - 4}
+        </Badge>
+      )}
+    </Group>
+  );
+}
+
+function profileObservedCapabilities(profile: SkillCapabilityProfile): SkillCapabilityId[] {
+  return profile.observedCapabilities.map((observation) => observation.capability);
+}
+
+export function SkillCapabilityProfilesPanel() {
+  const { toast } = useToast();
+  const profilesQuery = useSkillCapabilityProfiles();
+  const createTask = useCreateSkillCapabilityRemediationTask();
+  const profiles = profilesQuery.data ?? [];
+
+  const handleCreateTask = (profile: SkillCapabilityProfile) => {
+    createTask.mutate(
+      { skillId: profile.skillId },
+      {
+        onSuccess: (result) => {
+          toast({
+            title: 'Remediation task created',
+            description: result.task.title,
+          });
+        },
+        onError: (error) => {
+          toast({
+            title: 'Failed to create remediation task',
+            description: error instanceof Error ? error.message : 'Unknown error',
+            variant: 'destructive',
+            duration: Infinity,
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <Paper withBorder radius="md" p="md">
+      <Stack gap="md">
+        <Group justify="space-between" gap="sm">
+          <Group gap="xs">
+            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+            <Text fw={600}>Skill Capability Profiles</Text>
+            <Badge color="gray" variant="light">
+              {profiles.length}
+            </Badge>
+          </Group>
+          <Tooltip label="Refresh profiles">
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              aria-label="Refresh skill capability profiles"
+              onClick={() => profilesQuery.refetch()}
+            >
+              {profilesQuery.isFetching ? <Loader size="xs" /> : <RefreshCw className="h-4 w-4" />}
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+
+        {profilesQuery.isLoading ? (
+          <Group gap="xs">
+            <Loader size="sm" />
+            <Text size="sm" c="dimmed">
+              Loading profiles...
+            </Text>
+          </Group>
+        ) : profiles.length === 0 ? (
+          <Text size="sm" c="dimmed">
+            No shared skill resources found.
+          </Text>
+        ) : (
+          <Table striped highlightOnHover withTableBorder>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Skill</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Severity</Table.Th>
+                <Table.Th>Declared</Table.Th>
+                <Table.Th>Observed</Table.Th>
+                <Table.Th>Findings</Table.Th>
+                <Table.Th>Action</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {profiles.map((profile) => (
+                <Table.Tr key={profile.skillId}>
+                  <Table.Td>
+                    <Text size="sm" fw={600}>
+                      {profile.name}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      v{profile.version} · {profile.skillId}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge color={STATUS_COLORS[profile.status]} variant="light">
+                      {profile.status}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge color={SEVERITY_COLORS[profile.severity]} variant="light">
+                      {profile.severity}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    <CapabilityBadges values={profile.declaredCapabilities} />
+                  </Table.Td>
+                  <Table.Td>
+                    <CapabilityBadges values={profileObservedCapabilities(profile)} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap={4}>
+                      {profile.findings.length > 0 && (
+                        <AlertTriangle className="h-4 w-4 text-amber-500" />
+                      )}
+                      <Text size="sm">{profile.findings.length}</Text>
+                    </Group>
+                  </Table.Td>
+                  <Table.Td>
+                    <Button
+                      size="xs"
+                      variant="light"
+                      leftSection={<ClipboardList className="h-3.5 w-3.5" />}
+                      disabled={profile.findings.length === 0 || createTask.isPending}
+                      onClick={() => handleCreateTask(profile)}
+                    >
+                      Create task
+                    </Button>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Stack>
+    </Paper>
+  );
+}

--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -58,3 +58,4 @@ export * from './useToast';
 export * from './useWebSocket';
 export * from './useWorktree';
 export * from './useStatusHistory';
+export * from './useSkillCapabilities';

--- a/web/src/hooks/useSkillCapabilities.ts
+++ b/web/src/hooks/useSkillCapabilities.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type {
+  SkillCapabilityListFilters,
+  SkillCapabilityRemediationTaskInput,
+} from '@veritas-kanban/shared';
+
+export function useSkillCapabilityProfiles(filters: SkillCapabilityListFilters = {}) {
+  return useQuery({
+    queryKey: ['skill-capabilities', filters],
+    queryFn: () => api.skillCapabilities.list(filters),
+  });
+}
+
+export function useSkillCapabilityTaxonomy() {
+  return useQuery({
+    queryKey: ['skill-capabilities', 'taxonomy'],
+    queryFn: api.skillCapabilities.taxonomy,
+  });
+}
+
+export function useCreateSkillCapabilityRemediationTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      skillId,
+      input,
+    }: {
+      skillId: string;
+      input?: SkillCapabilityRemediationTaskInput;
+    }) => api.skillCapabilities.createRemediationTask(skillId, input ?? {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['skill-capabilities'] });
+    },
+  });
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -20,6 +20,7 @@ import { identityApi } from './identity';
 import { workProductsApi } from './work-products';
 import { tracesApi } from './traces';
 import { maintenanceApi } from './maintenance';
+import { skillCapabilitiesApi } from './skill-capabilities';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -50,6 +51,7 @@ export const api = {
   workProducts: workProductsApi,
   traces: tracesApi,
   maintenance: maintenanceApi,
+  skillCapabilities: skillCapabilitiesApi,
 };
 
 export type {

--- a/web/src/lib/api/skill-capabilities.ts
+++ b/web/src/lib/api/skill-capabilities.ts
@@ -1,0 +1,42 @@
+import type {
+  SkillCapabilityDefinition,
+  SkillCapabilityListFilters,
+  SkillCapabilityProfile,
+  SkillCapabilityRemediationTaskInput,
+  Task,
+} from '@veritas-kanban/shared';
+import { apiFetch } from './helpers';
+
+function toQuery(filters: SkillCapabilityListFilters = {}): string {
+  const params = new URLSearchParams();
+  if (filters.status) params.set('status', filters.status);
+  if (filters.severity) params.set('severity', filters.severity);
+  if (filters.capability) params.set('capability', filters.capability);
+  if (filters.q) params.set('q', filters.q);
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+export const skillCapabilitiesApi = {
+  taxonomy: (): Promise<SkillCapabilityDefinition[]> =>
+    apiFetch<SkillCapabilityDefinition[]>('/api/skills/capabilities/taxonomy'),
+
+  list: (filters: SkillCapabilityListFilters = {}): Promise<SkillCapabilityProfile[]> =>
+    apiFetch<SkillCapabilityProfile[]>(`/api/skills/capabilities${toQuery(filters)}`),
+
+  get: (skillId: string): Promise<SkillCapabilityProfile> =>
+    apiFetch<SkillCapabilityProfile>(`/api/skills/capabilities/${encodeURIComponent(skillId)}`),
+
+  createRemediationTask: (
+    skillId: string,
+    input: SkillCapabilityRemediationTaskInput = {}
+  ): Promise<{ profile: SkillCapabilityProfile; task: Task }> =>
+    apiFetch<{ profile: SkillCapabilityProfile; task: Task }>(
+      `/api/skills/capabilities/${encodeURIComponent(skillId)}/remediation-task`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    ),
+};


### PR DESCRIPTION
## Summary
- Add a canonical skill capability taxonomy and declared-vs-observed profile model for shared skill resources.
- Infer observed capabilities from static skill content patterns, compare them with frontmatter or Markdown declarations, redact evidence, and audit mismatches.
- Expose `/api/skills/capabilities` taxonomy, list/detail, and remediation-task endpoints with policy/task permission coverage.
- Add a Shared Resources settings panel that shows declared, observed, mismatch, severity, and finding counts with a remediation task action.
- Document declaration syntax, taxonomy, API shape, and the v5 GA gate.

## Verification
- `pnpm --filter @veritas-kanban/server test -- skill-capability-service.test.ts`
- `pnpm --filter @veritas-kanban/web test -- settings-governance-mantine.test.tsx`
- `node scripts/check-permission-coverage.mjs`
- `pnpm typecheck`
- `pnpm exec eslint . --quiet`
- `pnpm build`
- `git diff --check`
- Rendered smoke: temporarily enabled shared skill resources, created a temporary shared skill, opened Settings > Shared Resources, verified the capability profile mismatch row, confirmed no framework overlay or app console errors, then deleted the skill and restored settings.

## Risk
- This is a deterministic first-pass capability model, not the full scanner planned for #408.
- Existing local `server/storage/` remains untracked and is not part of this PR.
