### PR TITLE
Add skill risk gates

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1544,13 +1544,16 @@ Reads require `policy:read`; scans require `admin:manage` because scan requests
 read local filesystem paths. Scan evidence is redacted before it is returned or
 persisted.
 
-| Method | Path                                   | Description                                 |
-| ------ | -------------------------------------- | ------------------------------------------- |
-| `GET`  | `/api/skills/security/patterns`        | List scanner pattern definitions            |
-| `POST` | `/api/skills/security/scan`            | Scan a skill path and optionally persist it |
-| `GET`  | `/api/skills/security/scans`           | List persisted scan summaries               |
-| `GET`  | `/api/skills/security/scans/:id`       | Get one persisted JSON report               |
-| `POST` | `/api/maintenance/skill-security/scan` | Maintenance action alias for scan execution |
+| Method | Path                                                       | Description                                 |
+| ------ | ---------------------------------------------------------- | ------------------------------------------- |
+| `GET`  | `/api/skills/security/patterns`                            | List scanner pattern definitions            |
+| `GET`  | `/api/skills/security/inventory`                           | List shared skill risk inventory            |
+| `POST` | `/api/skills/security/inventory/:skillId/remediation-task` | Create a task for a risky skill             |
+| `POST` | `/api/skills/security/inventory/:skillId/exceptions`       | Add a reviewed temporary install exception  |
+| `POST` | `/api/skills/security/scan`                                | Scan a skill path and optionally persist it |
+| `GET`  | `/api/skills/security/scans`                               | List persisted scan summaries               |
+| `GET`  | `/api/skills/security/scans/:id`                           | Get one persisted JSON report               |
+| `POST` | `/api/maintenance/skill-security/scan`                     | Maintenance action alias for scan execution |
 
 The scanner emits JSON plus a Markdown report when `persist` is not `false`.
 Persisted artifacts are written under
@@ -1621,6 +1624,58 @@ by default.
 Recommendation values are `safe`, `caution`, and `do-not-install`. A scan also
 writes an audit event with scan id, severity, risk score, recommendation, and
 finding count.
+
+### Risk Inventory and Install Decisions
+
+```http
+GET /api/skills/security/inventory
+```
+
+Returns every shared resource with `type: "skill"` joined to its capability
+profile, latest persisted scan, open remediation task, and active exception.
+Each item includes `scanStatus`, `riskScore`, `severity`, `recommendation`,
+`installDecision`, `declaredCapabilities`, `observedCapabilities`, `mismatches`,
+`findingCount`, and `highOrCriticalFindingCount`.
+
+`installDecision` values:
+
+- `allow`: no blocking scanner or capability findings, or an active reviewed
+  exception exists.
+- `warn`: medium risk or caution findings require acknowledgement or reviewer
+  approval.
+- `block`: high, critical, or `do-not-install` risk blocks install and workflow
+  use by default.
+
+Reviewed exceptions are temporary and require an owner, reason, and future
+expiration:
+
+```http
+POST /api/skills/security/inventory/shared_123/exceptions
+```
+
+```json
+{
+  "owner": "platform",
+  "reason": "Reviewed for the current release candidate.",
+  "expiresAt": "2026-06-10T18:00:00.000Z"
+}
+```
+
+Risk remediation tasks can be created directly from the inventory:
+
+```http
+POST /api/skills/security/inventory/shared_123/remediation-task
+```
+
+```json
+{
+  "project": "Security",
+  "sprint": "v5-ga",
+  "priority": "high"
+}
+```
+
+Both actions write audit events and return the refreshed inventory item.
 
 ---
 

--- a/docs/API-WORKFLOWS.md
+++ b/docs/API-WORKFLOWS.md
@@ -372,6 +372,79 @@ curl -X DELETE http://localhost:3001/api/workflows/hello-world
 
 ---
 
+## Workflow Authoring
+
+### POST /api/workflows/authoring/dry-run
+
+Validate an unsaved workflow without starting a run. The response includes lint
+messages, executable checks, and a skill audit for referenced shared skills.
+
+**Request**:
+
+```bash
+curl -X POST http://localhost:3001/api/workflows/authoring/dry-run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workflow": {
+      "id": "release-helper",
+      "name": "Release Helper",
+      "version": 1,
+      "description": "Uses a shared release skill",
+      "agents": [
+        {
+          "id": "runner",
+          "name": "Runner",
+          "role": "developer",
+          "tools": ["Read", "skill:release-helper"]
+        }
+      ],
+      "steps": [{ "id": "run", "name": "Run", "type": "agent", "agent": "runner" }]
+    },
+    "context": { "clientMode": "remote" }
+  }'
+```
+
+**Response excerpt**:
+
+```json
+{
+  "status": "blocked",
+  "canRun": false,
+  "checks": [{ "id": "skill", "label": "Skill audit", "status": "fail" }],
+  "messages": [
+    {
+      "category": "skill",
+      "severity": "error",
+      "message": "Skill Release Helper has no persisted scan and cannot run in remote mode."
+    }
+  ],
+  "skillAudit": {
+    "status": "fail",
+    "mode": "remote",
+    "references": [
+      {
+        "reference": "release-helper",
+        "skillId": "release-helper",
+        "status": "blocked",
+        "message": "Skill Release Helper has no persisted scan and cannot run in remote mode."
+      }
+    ]
+  }
+}
+```
+
+The skill audit recognizes `skill:<id>` and `skill/<id>` references in agents,
+tools, steps, variables, inputs, and descriptions. Local mode warns on unscanned
+skills. Remote and cloud modes fail missing, unscanned, or blocked skills unless
+the skill has an active reviewed exception.
+
+### POST /api/workflows/:id/dry-run
+
+Dry-run a saved workflow definition with the same response shape and context
+rules as `/api/workflows/authoring/dry-run`.
+
+---
+
 ## Workflow Runs
 
 ### POST /api/workflows/:id/runs
@@ -384,12 +457,13 @@ Start a new workflow run.
 curl -X POST http://localhost:3001/api/workflows/feature-dev/runs \
   -H "Content-Type: application/json" \
   -d '{
-    "taskId": "US-42",
-    "context": {
-      "priority": "high",
-      "deadline": "2026-02-15"
-    }
-  }'
+  "taskId": "US-42",
+  "context": {
+    "clientMode": "remote",
+    "priority": "high",
+    "deadline": "2026-02-15"
+  }
+}'
 ```
 
 **Request Body**:
@@ -397,9 +471,17 @@ curl -X POST http://localhost:3001/api/workflows/feature-dev/runs \
 ```typescript
 {
   taskId?: string;           // Optional: VK task ID to associate with run
-  context?: Record<string, unknown>;  // Optional: Additional context variables
+  context?: {
+    clientMode?: "local" | "remote" | "cloud"; // Optional: workflow skill gate mode
+    [key: string]: unknown;
+  };
 }
 ```
+
+Before a run starts, the server dry-runs the saved workflow and blocks remote or
+cloud execution when a referenced shared skill is missing, unscanned, or blocked.
+The run context includes the resulting `skillAudit` summary when execution is
+allowed.
 
 **Response**:
 

--- a/docs/SOP-shared-resources.md
+++ b/docs/SOP-shared-resources.md
@@ -206,9 +206,15 @@ Rules:
   credential handling, or persistence hooks. Use
   `POST /api/skills/security/scan` or the Maintenance action
   `POST /api/maintenance/skill-security/scan`.
+- Review Settings -> Shared Resources -> Skill Risk Dashboard before enabling
+  a shared skill. The dashboard joins declared capabilities, observed behavior,
+  persisted scan reports, exceptions, and remediation tasks into one install
+  decision.
 - If the profile reports observed behavior that exceeds declarations, create a
   remediation task from the Shared Resources panel and either narrow the skill or
   add a reviewer-approved declaration.
+- Treat `block` install decisions as hard stops for remote and cloud workflows
+  unless there is a named owner, clear reason, and future-dated exception.
 - Evidence snippets are redacted, but skill authors should still avoid embedding
   example secrets or real customer data in shared skill text.
 

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -41,8 +41,10 @@ operator checklist for final release verification.
       and the Shared Resources UI exposes declared, observed, and mismatch state.
 - [ ] Skill security scanner verifies local skill directories and single
       `SKILL.md` files, produces redacted JSON and Markdown reports, persists
-      audit artifacts, exposes an admin-only maintenance scan action, and keeps
-      malicious plus benign fixture contracts in CI.
+      audit artifacts, exposes an admin-only maintenance scan action, feeds the
+      Shared Resources Skill Risk Dashboard, creates remediation tasks and
+      temporary exceptions, blocks unsafe install decisions in remote/cloud
+      workflow gates, and keeps malicious plus benign fixture contracts in CI.
 - [ ] Performance/load review covers SQLite read/write paths, dashboard queries,
       WebSocket fan-out, workflow run updates, and remote/mobile clients. Track
       evidence and limits in

--- a/docs/security/skill-security-scanner.md
+++ b/docs/security/skill-security-scanner.md
@@ -24,6 +24,30 @@ Maintenance callers can use the equivalent admin-only action:
 POST /api/maintenance/skill-security/scan
 ```
 
+## Risk Inventory and Workflow Gates
+
+Persisted scans feed the shared skill risk inventory:
+
+```http
+GET /api/skills/security/inventory
+```
+
+The inventory is shown in Settings -> Shared Resources -> Skill Risk Dashboard.
+It combines shared skill metadata, declared-vs-observed capability mismatches,
+latest scan summaries, remediation task links, and temporary exceptions.
+
+Install decisions are intentionally conservative:
+
+- `allow`: no blocking risk or an active reviewed exception.
+- `warn`: medium or caution risk that needs acknowledgement.
+- `block`: high, critical, or `do-not-install` risk.
+
+Workflow authoring dry-runs include a `skillAudit` summary for `skill:<id>` and
+`skill/<id>` references found in agents, tools, steps, variables, inputs, and
+descriptions. Local workflows warn on unscanned skills; remote and cloud
+workflows block unscanned, missing, or blocked skills unless an active exception
+exists.
+
 ## Detector Scope
 
 The scanner currently detects:

--- a/server/src/__tests__/routes/workflow-authoring.test.ts
+++ b/server/src/__tests__/routes/workflow-authoring.test.ts
@@ -174,6 +174,81 @@ describe('workflow authoring routes', () => {
     );
   });
 
+  it('adds skill audit status to dry-run checks and blocks risky skills in remote mode', async () => {
+    const runtimeDir = path.join(testRoot, '.veritas-kanban');
+    await fs.mkdir(runtimeDir, { recursive: true });
+    await fs.writeFile(
+      path.join(runtimeDir, 'shared-resources.json'),
+      JSON.stringify(
+        [
+          {
+            id: 'skill_risky',
+            name: 'Risky Skill',
+            type: 'skill',
+            content:
+              "# Risky Skill\n\nRead files and call fetch('https://example.invalid') with process.env.SECRET_TOKEN.",
+            tags: [],
+            mountedIn: [],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            version: 1,
+          },
+        ],
+        null,
+        2
+      )
+    );
+    const draft = workflow({
+      agents: [
+        {
+          id: 'worker',
+          name: 'Worker',
+          role: 'developer',
+          description: 'Uses skill:skill_risky',
+          tools: ['Read', 'skill:skill_risky'],
+        },
+      ],
+    });
+
+    const local = await request(app)
+      .post('/api/workflows/authoring/dry-run')
+      .send({ workflow: draft, context: { clientMode: 'local' } });
+
+    expect(local.status).toBe(200);
+    expect(local.body.skillAudit.status).toBe('warn');
+    expect(local.body.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'skill', label: 'Skill audit', status: 'warn' }),
+      ])
+    );
+
+    const remote = await request(app)
+      .post('/api/workflows/authoring/dry-run')
+      .send({ workflow: draft, context: { clientMode: 'remote' } });
+
+    expect(remote.status).toBe(200);
+    expect(remote.body.status).toBe('blocked');
+    expect(remote.body.canRun).toBe(false);
+    expect(remote.body.skillAudit.status).toBe('fail');
+    expect(remote.body.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: 'skill',
+          message: 'Skill Risky Skill has no persisted scan and cannot run in remote mode.',
+        }),
+      ])
+    );
+
+    const create = await request(app).post('/api/workflows').send(draft);
+    expect(create.status).toBe(201);
+
+    const blockedStart = await request(app)
+      .post('/api/workflows/authoring-route-workflow/runs')
+      .send({ context: { clientMode: 'remote' } });
+    expect(blockedStart.status).toBe(400);
+    expect(blockedStart.body.message).toContain('cannot run in remote mode');
+  });
+
   it('dry-runs YAML edits and saved workflow definitions without starting a run', async () => {
     const yamlDryRun = await request(app)
       .post('/api/workflows/authoring/dry-run')
@@ -206,6 +281,7 @@ describe('workflow authoring routes', () => {
 
     expect(yamlDryRun.status).toBe(200);
     expect(yamlDryRun.body.canRun).toBe(true);
+    expect(yamlDryRun.body.skillAudit).toMatchObject({ status: 'pass', references: [] });
     expect(yamlDryRun.body.workflow.id).toBe('yaml-authoring-workflow');
 
     const create = await request(app).post('/api/workflows').send(workflow());

--- a/server/src/__tests__/skill-security-service.test.ts
+++ b/server/src/__tests__/skill-security-service.test.ts
@@ -4,10 +4,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
+  SharedResource,
   SkillSecurityRecommendation,
   SkillSecurityScanReport,
   SkillSecuritySeverity,
+  Task,
 } from '@veritas-kanban/shared';
+import type { WorkflowDefinition } from '../types/workflow.js';
 import { SkillSecurityService } from '../services/skill-security-service.js';
 
 vi.mock('../services/audit-service.js', () => ({
@@ -52,6 +55,64 @@ async function tempReportDir(tempDirs: string[]): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'skillscan-'));
   tempDirs.push(dir);
   return dir;
+}
+
+async function tempServiceState(tempDirs: string[]) {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'skillsec-state-'));
+  tempDirs.push(root);
+  return {
+    reportDir: path.join(root, 'reports'),
+    statePath: path.join(root, 'state.json'),
+  };
+}
+
+function resource(overrides: Partial<SharedResource>): SharedResource {
+  return {
+    id: 'skill_safe',
+    name: 'Safe Skill',
+    type: 'skill',
+    content: '# Safe Skill',
+    tags: [],
+    mountedIn: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    version: 1,
+    ...overrides,
+  };
+}
+
+function serviceForResources(
+  paths: { reportDir: string; statePath: string },
+  resources: SharedResource[]
+) {
+  const tasks: Task[] = [];
+  const service = new SkillSecurityService(
+    paths.reportDir,
+    paths.statePath,
+    {
+      async listResources(filters) {
+        return resources.filter((item) => !filters?.type || item.type === filters.type);
+      },
+    },
+    {
+      async createTask(input) {
+        const task = {
+          id: `task_${tasks.length + 1}`,
+          title: input.title,
+          description: input.description ?? '',
+          type: input.type ?? 'security',
+          status: 'todo',
+          priority: input.priority ?? 'medium',
+          created: '2026-01-01T00:00:00.000Z',
+          updated: '2026-01-01T00:00:00.000Z',
+          revision: 1,
+        } as Task;
+        tasks.push(task);
+        return task;
+      },
+    }
+  );
+  return { service, tasks };
 }
 
 async function readExpectation(fixturePath: string): Promise<FixtureExpectation> {
@@ -167,5 +228,141 @@ describe('SkillSecurityService', () => {
         'dependency.unpinned',
       ])
     );
+  });
+
+  it('builds skill risk inventory from shared skills and persisted scan reports', async () => {
+    const paths = await tempServiceState(tempDirs);
+    const { service } = serviceForResources(paths, [
+      resource({
+        id: 'skill_reported',
+        name: 'Exfiltration Collector',
+        content: '# Exfiltration Collector\n\n## Declared Capabilities\n\n- filesystem.read',
+      }),
+      resource({
+        id: 'skill_mismatch',
+        name: 'Mismatch Skill',
+        content:
+          "# Mismatch Skill\n\nRead files and call fetch('https://example.invalid') with process.env.SECRET_TOKEN.",
+      }),
+    ]);
+
+    await service.scan({ path: path.join(fixturesRoot, 'malicious/exfiltration'), persist: true });
+    const inventory = await service.listInventory();
+    const reported = inventory.items.find((item) => item.skillId === 'skill_reported');
+    const mismatch = inventory.items.find((item) => item.skillId === 'skill_mismatch');
+
+    expect(inventory.totals.skills).toBe(2);
+    expect(reported).toMatchObject({
+      scanStatus: 'scanned',
+      recommendation: 'do-not-install',
+      installDecision: 'block',
+    });
+    expect(mismatch).toMatchObject({
+      scanStatus: 'unscanned',
+      severity: 'critical',
+      installDecision: 'block',
+    });
+    expect(mismatch?.observedCapabilities.map((item) => item.capability)).toEqual(
+      expect.arrayContaining(['credential.access', 'network.egress'])
+    );
+  });
+
+  it('records reviewed exceptions and persists remediation task links', async () => {
+    const paths = await tempServiceState(tempDirs);
+    const { service, tasks } = serviceForResources(paths, [
+      resource({
+        id: 'skill_mismatch',
+        name: 'Mismatch Skill',
+        content:
+          "# Mismatch Skill\n\nRead files and call fetch('https://example.invalid') with process.env.SECRET_TOKEN.",
+      }),
+    ]);
+
+    const excepted = await service.createException(
+      'skill_mismatch',
+      {
+        owner: 'security-reviewer',
+        reason: 'Temporary reviewed exception for fixture coverage.',
+        expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+      },
+      'tester'
+    );
+    expect(excepted.installDecision).toBe('allow');
+    expect(excepted.exception?.owner).toBe('security-reviewer');
+
+    const result = await service.createRiskRemediationTask(
+      'skill_mismatch',
+      { project: 'Security' },
+      'tester'
+    );
+
+    expect(result.task.id).toBe('task_1');
+    expect(result.item.remediationTaskId).toBe('task_1');
+    expect(tasks[0].description).toContain('Skill: Mismatch Skill');
+  });
+
+  it('audits workflow skill references across warn, block, missing, and exception paths', async () => {
+    const paths = await tempServiceState(tempDirs);
+    const { service } = serviceForResources(paths, [
+      resource({
+        id: 'skill_mismatch',
+        name: 'Mismatch Skill',
+        content:
+          "# Mismatch Skill\n\nRead files and call fetch('https://example.invalid') with process.env.SECRET_TOKEN.",
+      }),
+    ]);
+    const workflow = {
+      id: 'wf_skill',
+      name: 'Skill workflow',
+      version: 1,
+      description: 'Uses a shared skill.',
+      agents: [
+        {
+          id: 'worker',
+          name: 'Worker',
+          role: 'developer',
+          description: 'Uses skill:mismatch-skill.',
+          tools: ['skill:skill_mismatch'],
+        },
+      ],
+      steps: [{ id: 'run', name: 'Run', type: 'agent', agent: 'worker' }],
+    } as WorkflowDefinition;
+
+    const local = await service.auditWorkflowSkills(workflow, 'local');
+    expect(local.status).toBe('warn');
+    expect(local.references[0]).toMatchObject({ status: 'unscanned' });
+
+    const remote = await service.auditWorkflowSkills(workflow, 'remote');
+    expect(remote.status).toBe('fail');
+    expect(remote.references[0]).toMatchObject({ status: 'blocked' });
+
+    const missing = await service.auditWorkflowSkills(
+      {
+        ...workflow,
+        agents: [
+          {
+            ...workflow.agents[0],
+            description: 'Uses a missing skill.',
+            tools: ['skill:missing-skill'],
+          },
+        ],
+      },
+      'local'
+    );
+    expect(missing.status).toBe('fail');
+    expect(missing.references[0]).toMatchObject({ status: 'missing' });
+
+    await service.createException(
+      'skill_mismatch',
+      {
+        owner: 'workflow-owner',
+        reason: 'Reviewed for workflow exception coverage.',
+        expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+      },
+      'tester'
+    );
+    const excepted = await service.auditWorkflowSkills(workflow, 'remote');
+    expect(excepted.status).toBe('pass');
+    expect(excepted.references[0]).toMatchObject({ status: 'allowed' });
   });
 });

--- a/server/src/routes/skill-security.ts
+++ b/server/src/routes/skill-security.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { getSkillSecurityService } from '../services/skill-security-service.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { actorFromRequest } from '../utils/concurrency.js';
 
 const router: RouterType = Router();
 
@@ -12,6 +14,18 @@ const scanSchema = z.object({
   path: pathSchema,
   persist: z.boolean().optional(),
   includeReferencedFiles: z.boolean().optional(),
+});
+
+const exceptionSchema = z.object({
+  owner: z.string().min(1).max(120),
+  reason: z.string().min(8).max(1000),
+  expiresAt: z.string().datetime(),
+});
+
+const remediationSchema = z.object({
+  project: z.string().min(1).max(100).optional(),
+  sprint: z.string().min(1).max(100).optional(),
+  priority: z.enum(['low', 'medium', 'high', 'critical']).optional(),
 });
 
 function parse<T>(schema: z.ZodSchema<T>, input: unknown): T {
@@ -35,6 +49,51 @@ router.get(
   '/patterns',
   asyncHandler(async (_req, res) => {
     res.json(getSkillSecurityService().getPatterns());
+  })
+);
+
+router.get(
+  '/inventory',
+  asyncHandler(async (_req, res) => {
+    res.json(await getSkillSecurityService().listInventory());
+  })
+);
+
+router.post(
+  '/inventory/:skillId/remediation-task',
+  asyncHandler(async (req, res) => {
+    const input = parse(remediationSchema, req.body ?? {});
+    try {
+      const result = await getSkillSecurityService().createRiskRemediationTask(
+        String(req.params.skillId),
+        input,
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.status(201).json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Skill security remediation failed';
+      if (message.includes('not found')) throw new NotFoundError(message);
+      throw new ValidationError(message);
+    }
+  })
+);
+
+router.post(
+  '/inventory/:skillId/exceptions',
+  asyncHandler(async (req, res) => {
+    const input = parse(exceptionSchema, req.body ?? {});
+    try {
+      const result = await getSkillSecurityService().createException(
+        String(req.params.skillId),
+        input,
+        actorFromRequest(req as AuthenticatedRequest)
+      );
+      res.status(201).json(result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Skill security exception failed';
+      if (message.includes('not found')) throw new NotFoundError(message);
+      throw new ValidationError(message);
+    }
   })
 );
 

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -390,9 +390,40 @@ router.post(
 
     // Validate input
     const { taskId, context } = startRunSchema.parse(req.body);
+    const workflow = await workflowService.loadWorkflow(workflowId);
+    if (!workflow) {
+      throw new NotFoundError(`Workflow ${workflowId} not found`);
+    }
+
+    const dryRun = await workflowAuthoringService.dryRun({
+      workflow,
+      context: {
+        taskId,
+        clientMode:
+          context?.clientMode === 'remote' || context?.clientMode === 'cloud'
+            ? context.clientMode
+            : 'local',
+        permissions: getRequestPermissions(req),
+      },
+    });
+    const skillBlocker = dryRun.messages.find(
+      (item) => item.category === 'skill' && item.severity === 'error'
+    );
+    if (skillBlocker) {
+      throw new ValidationError(skillBlocker.message, [
+        {
+          code: 'WORKFLOW_SKILL_AUDIT_BLOCKED',
+          message: skillBlocker.remediation,
+          path: [skillBlocker.path],
+        },
+      ]);
+    }
 
     // Start run
-    const run = await workflowRunService.startRun(workflowId, taskId, context);
+    const run = await workflowRunService.startRun(workflowId, taskId, {
+      ...context,
+      skillAudit: dryRun.skillAudit,
+    });
 
     // Audit log
     await workflowService.auditChange({

--- a/server/src/services/skill-security-service.ts
+++ b/server/src/services/skill-security-service.ts
@@ -2,24 +2,38 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import type {
+  CreateTaskInput,
   SharedResource,
   SkillCapabilityFinding,
+  SkillCapabilityProfile,
   SkillSecurityEvidence,
+  SkillSecurityDecision,
+  SkillSecurityException,
+  SkillSecurityExceptionInput,
   SkillSecurityFinding,
   SkillSecurityFindingCategory,
   SkillSecurityPatternDefinition,
   SkillSecurityRecommendation,
+  SkillRiskInventoryItem,
+  SkillRiskInventorySummary,
+  SkillRiskRemediationTaskInput,
+  SkillRiskRemediationTaskResult,
   SkillSecurityScanInput,
   SkillSecurityScanReport,
   SkillSecurityScanSummary,
   SkillSecurityScannedFile,
   SkillSecuritySeverity,
   SkillSecurityScanTargetType,
+  Task,
+  WorkflowSkillAuditSummary,
 } from '@veritas-kanban/shared';
+import type { WorkflowDefinition } from '../types/workflow.js';
 import { getRuntimeDir } from '../utils/paths.js';
 import { redactString } from '../lib/redact.js';
 import { auditLog } from './audit-service.js';
 import { profileSkillResource } from './skill-capability-service.js';
+import { getSharedResourcesService } from './shared-resources-service.js';
+import { getTaskService } from './task-service.js';
 
 const MAX_FILES = 80;
 const MAX_FILE_BYTES = 200_000;
@@ -41,6 +55,19 @@ interface Detector {
   remediation: string;
   pattern: RegExp;
   fileRoles?: SkillSecurityScannedFile['role'][];
+}
+
+interface SkillResourceProvider {
+  listResources(filters?: { type?: 'skill' }): Promise<SharedResource[]>;
+}
+
+interface TaskCreator {
+  createTask(input: CreateTaskInput): Promise<Task>;
+}
+
+interface SkillSecurityState {
+  exceptions: SkillSecurityException[];
+  remediationTasks: Record<string, string>;
 }
 
 const SEVERITY_RANK: Record<SkillSecuritySeverity, number> = {
@@ -438,6 +465,154 @@ function riskScoreFor(findings: SkillSecurityFinding[]): number {
   );
 }
 
+function severityFromScore(
+  profile: SkillCapabilityProfile,
+  latestReport?: SkillSecurityScanSummary
+): SkillSecuritySeverity {
+  const severities = [
+    profile.severity,
+    ...(latestReport ? [latestReport.severity] : []),
+  ] as SkillSecuritySeverity[];
+  return severityMax(severities);
+}
+
+function sourcePathFor(resource: SharedResource): string {
+  return `shared-resource:${resource.id}`;
+}
+
+function normalizedSkillToken(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^skill[:/]/, '')
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '');
+}
+
+function latestReportFor(
+  resource: SharedResource,
+  reports: SkillSecurityScanSummary[]
+): SkillSecurityScanSummary | undefined {
+  const resourceName = normalizedSkillToken(resource.name);
+  return reports.find((report) => {
+    const reportName = normalizedSkillToken(report.skillName);
+    const target = report.targetPath.toLowerCase();
+    return reportName === resourceName || target.includes(resource.id.toLowerCase());
+  });
+}
+
+function activeExceptionFor(
+  skillId: string,
+  exceptions: SkillSecurityException[],
+  now = Date.now()
+): SkillSecurityException | undefined {
+  return exceptions.find((exception) => {
+    if (exception.skillId !== skillId) return false;
+    const expires = Date.parse(exception.expiresAt);
+    return Number.isFinite(expires) && expires > now;
+  });
+}
+
+function installDecisionFor(
+  severity: SkillSecuritySeverity,
+  riskScore: number,
+  recommendation: SkillSecurityRecommendation,
+  exception?: SkillSecurityException
+): { decision: SkillSecurityDecision; reason: string } {
+  if (exception) {
+    return {
+      decision: 'allow',
+      reason: `Exception ${exception.id} expires ${exception.expiresAt}.`,
+    };
+  }
+  if (severity === 'critical' || severity === 'high' || recommendation === 'do-not-install') {
+    return {
+      decision: 'block',
+      reason: `${severity} skill risk blocks install and workflow use by default.`,
+    };
+  }
+  if (severity === 'medium' || riskScore >= 30 || recommendation === 'caution') {
+    return {
+      decision: 'warn',
+      reason: 'Medium skill risk requires acknowledgement or reviewer approval.',
+    };
+  }
+  return { decision: 'allow', reason: 'No blocking scanner or capability findings.' };
+}
+
+function changedFilesFor(
+  resource: SharedResource,
+  latestReport?: SkillSecurityScanSummary
+): string[] {
+  if (!latestReport) return [];
+  return Date.parse(resource.updatedAt) > Date.parse(latestReport.scannedAt)
+    ? [sourcePathFor(resource)]
+    : [];
+}
+
+function riskFindingsForInventory(
+  profile: SkillCapabilityProfile,
+  latestReport?: SkillSecurityScanSummary
+): SkillSecurityFinding[] {
+  const capabilityFindings = scanCapabilityMismatch(profile);
+  if (!latestReport) return capabilityFindings;
+  const reportFinding: SkillSecurityFinding = {
+    id: `scan-summary:${latestReport.id}`,
+    patternId: 'scan.summary',
+    category: 'capability-mismatch',
+    severity: latestReport.severity,
+    confidence: 1,
+    title: 'Latest persisted scan summary',
+    description: `${latestReport.findingCount} findings in latest persisted scan.`,
+    remediation: 'Open the persisted scan report and remediate blocking findings.',
+    evidence: [
+      {
+        file: latestReport.persistedJsonPath ?? latestReport.targetPath,
+        line: 1,
+        excerpt: latestReport.recommendation,
+      },
+    ],
+  };
+  return [...capabilityFindings, reportFinding];
+}
+
+function scanStatusFor(
+  resource: SharedResource,
+  latestReport?: SkillSecurityScanSummary
+): SkillRiskInventoryItem['scanStatus'] {
+  if (!latestReport) return 'unscanned';
+  return changedFilesFor(resource, latestReport).length > 0 ? 'changed' : 'scanned';
+}
+
+function extractSkillReferences(workflow: WorkflowDefinition): string[] {
+  const refs = new Set<string>();
+  const collect = (value: unknown): void => {
+    if (typeof value === 'string') {
+      const direct = value.match(/^skill[:/](.+)$/i);
+      if (direct) refs.add(direct[1]);
+      const regex = /\bskill[:/]([A-Za-z0-9._:-]+)/gi;
+      let match: RegExpExecArray | null;
+      while ((match = regex.exec(value))) refs.add(match[1]);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(collect);
+      return;
+    }
+    if (!value || typeof value !== 'object') return;
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (/^skill(ids?)?$/i.test(key)) collect(nested);
+      if (key === 'tools') collect(nested);
+      if (key === 'input' || key === 'description') collect(nested);
+    }
+  };
+
+  collect(workflow.agents);
+  collect(workflow.steps);
+  collect(workflow.variables);
+  return [...refs].map(normalizedSkillToken).filter(Boolean).sort();
+}
+
 function renderMarkdown(report: Omit<SkillSecurityScanReport, 'reportMarkdown'>): string {
   const lines = [
     `# Skill Security Scan: ${report.skillName}`,
@@ -474,7 +649,12 @@ function renderMarkdown(report: Omit<SkillSecurityScanReport, 'reportMarkdown'>)
 }
 
 export class SkillSecurityService {
-  constructor(private readonly reportRoot = path.join(getRuntimeDir(), REPORT_DIR)) {}
+  constructor(
+    private readonly reportRoot = path.join(getRuntimeDir(), REPORT_DIR),
+    private readonly statePath = path.join(getRuntimeDir(), 'skill-security-state.json'),
+    private readonly resourceProvider?: SkillResourceProvider,
+    private readonly taskCreator?: TaskCreator
+  ) {}
 
   getPatterns(): SkillSecurityPatternDefinition[] {
     return [
@@ -617,6 +797,272 @@ export class SkillSecurityService {
     }
   }
 
+  async listInventory(): Promise<SkillRiskInventorySummary> {
+    const [resources, reports, state] = await Promise.all([
+      this.resources().listResources({ type: 'skill' }),
+      this.listReports(),
+      this.readState(),
+    ]);
+    const now = Date.now();
+    const items = resources.map((resource) => {
+      const profile = profileSkillResource(resource);
+      const latestReport = latestReportFor(resource, reports);
+      const findings = riskFindingsForInventory(profile, latestReport);
+      const severity = severityFromScore(profile, latestReport);
+      const riskScore = latestReport?.riskScore ?? riskScoreFor(findings);
+      const recommendation = latestReport?.recommendation ?? recommendationFor(severity, riskScore);
+      const exception = activeExceptionFor(resource.id, state.exceptions, now);
+      const decision = installDecisionFor(severity, riskScore, recommendation, exception);
+      const changedFiles = changedFilesFor(resource, latestReport);
+      const item: SkillRiskInventoryItem = {
+        skillId: resource.id,
+        name: resource.name,
+        version: resource.version,
+        sourcePath: sourcePathFor(resource),
+        tags: resource.tags,
+        mountedIn: resource.mountedIn,
+        updatedAt: resource.updatedAt,
+        lastScannedAt: latestReport?.scannedAt,
+        scanStatus: scanStatusFor(resource, latestReport),
+        changedFiles,
+        severity,
+        riskScore,
+        recommendation,
+        installDecision: decision.decision,
+        installReason: decision.reason,
+        declaredCapabilities: profile.declaredCapabilities,
+        observedCapabilities: profile.observedCapabilities,
+        mismatches: profile.findings,
+        findingCount: findings.length,
+        highOrCriticalFindingCount: findings.filter((finding) =>
+          ['high', 'critical'].includes(finding.severity)
+        ).length,
+        latestReportId: latestReport?.id,
+        latestReportPath: latestReport?.persistedJsonPath,
+        remediationTaskId: state.remediationTasks[resource.id],
+        exception,
+      };
+      return item;
+    });
+
+    return {
+      generatedAt: new Date().toISOString(),
+      items,
+      totals: {
+        skills: items.length,
+        blocked: items.filter((item) => item.installDecision === 'block').length,
+        warnings: items.filter((item) => item.installDecision === 'warn').length,
+        unscanned: items.filter((item) => item.scanStatus === 'unscanned').length,
+        exceptions: items.filter((item) => item.exception).length,
+      },
+    };
+  }
+
+  async createException(
+    skillId: string,
+    input: SkillSecurityExceptionInput,
+    actor: string
+  ): Promise<SkillRiskInventoryItem> {
+    const inventory = await this.listInventory();
+    const item = inventory.items.find((candidate) => candidate.skillId === skillId);
+    if (!item) throw new Error(`Skill ${skillId} not found`);
+    const expiresAt = Date.parse(input.expiresAt);
+    if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+      throw new Error('Skill security exception expiration must be in the future');
+    }
+
+    const state = await this.readState();
+    state.exceptions = state.exceptions.filter(
+      (exception) => exception.skillId !== skillId || Date.parse(exception.expiresAt) > Date.now()
+    );
+    state.exceptions.push({
+      id: `skillsec_exception_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`,
+      skillId,
+      owner: input.owner,
+      reason: input.reason,
+      expiresAt: input.expiresAt,
+      createdAt: new Date().toISOString(),
+      createdBy: actor,
+    });
+    await this.writeState(state);
+
+    await auditLog({
+      action: 'skill.security.exception.created',
+      actor,
+      resource: skillId,
+      details: {
+        owner: input.owner,
+        reason: input.reason,
+        expiresAt: input.expiresAt,
+      },
+    });
+
+    return (await this.listInventory()).items.find((candidate) => candidate.skillId === skillId)!;
+  }
+
+  async createRiskRemediationTask(
+    skillId: string,
+    input: SkillRiskRemediationTaskInput,
+    actor: string
+  ): Promise<SkillRiskRemediationTaskResult> {
+    const inventory = await this.listInventory();
+    const item = inventory.items.find((candidate) => candidate.skillId === skillId);
+    if (!item) throw new Error(`Skill ${skillId} not found`);
+
+    const priority = input.priority ?? (item.severity === 'critical' ? 'critical' : 'high');
+    const task = await this.tasks().createTask({
+      title: `Review skill security risk: ${item.name}`,
+      description: [
+        `Skill: ${item.name} (${item.skillId})`,
+        `Decision: ${item.installDecision}`,
+        `Severity: ${item.severity}`,
+        `Risk score: ${item.riskScore}`,
+        `Recommendation: ${item.recommendation}`,
+        `Scan status: ${item.scanStatus}`,
+        `Declared: ${item.declaredCapabilities.join(', ') || 'none'}`,
+        `Observed: ${item.observedCapabilities.map((observed) => observed.capability).join(', ') || 'none'}`,
+        `Reason: ${item.installReason}`,
+        item.latestReportPath ? `Latest report: ${item.latestReportPath}` : 'Latest report: none',
+      ].join('\n'),
+      type: 'security',
+      priority,
+      project: input.project,
+      sprint: input.sprint,
+      createdBy: actor,
+      updatedBy: actor,
+    });
+
+    const state = await this.readState();
+    state.remediationTasks[skillId] = task.id;
+    await this.writeState(state);
+
+    await auditLog({
+      action: 'skill.security.remediation_task.created',
+      actor,
+      resource: skillId,
+      details: {
+        taskId: task.id,
+        severity: item.severity,
+        riskScore: item.riskScore,
+      },
+    });
+
+    const refreshed = (await this.listInventory()).items.find(
+      (candidate) => candidate.skillId === skillId
+    );
+    return { item: refreshed ?? { ...item, remediationTaskId: task.id }, task };
+  }
+
+  async auditWorkflowSkills(
+    workflow: WorkflowDefinition,
+    mode: 'local' | 'remote' | 'cloud' = 'local'
+  ): Promise<WorkflowSkillAuditSummary> {
+    const references = extractSkillReferences(workflow);
+    if (references.length === 0) return { status: 'pass', mode, references: [] };
+
+    const inventory = await this.listInventory();
+    const byToken = new Map<string, SkillRiskInventoryItem>();
+    for (const item of inventory.items) {
+      byToken.set(normalizedSkillToken(item.skillId), item);
+      byToken.set(normalizedSkillToken(item.name), item);
+    }
+
+    const results = references.map((reference) => {
+      const item = byToken.get(reference);
+      if (!item) {
+        return {
+          reference,
+          status: 'missing' as const,
+          message: `Referenced skill ${reference} is not installed as a shared skill resource.`,
+        };
+      }
+      if (item.exception) {
+        return {
+          reference,
+          skillId: item.skillId,
+          name: item.name,
+          status: 'allowed' as const,
+          severity: item.severity,
+          riskScore: item.riskScore,
+          recommendation: item.recommendation,
+          installDecision: item.installDecision,
+          findingCount: item.findingCount,
+          exception: item.exception,
+          message: `Skill ${item.name} is allowed by an active exception.`,
+        };
+      }
+      if (item.scanStatus === 'unscanned') {
+        const blocks = mode !== 'local';
+        return {
+          reference,
+          skillId: item.skillId,
+          name: item.name,
+          status: blocks ? ('blocked' as const) : ('unscanned' as const),
+          severity: item.severity,
+          riskScore: item.riskScore,
+          recommendation: item.recommendation,
+          installDecision: item.installDecision,
+          findingCount: item.findingCount,
+          exception: item.exception,
+          message: blocks
+            ? `Skill ${item.name} has no persisted scan and cannot run in ${mode} mode.`
+            : `Skill ${item.name} has no persisted scan.`,
+        };
+      }
+      if (item.installDecision === 'block') {
+        return {
+          reference,
+          skillId: item.skillId,
+          name: item.name,
+          status: 'blocked' as const,
+          severity: item.severity,
+          riskScore: item.riskScore,
+          recommendation: item.recommendation,
+          installDecision: item.installDecision,
+          findingCount: item.findingCount,
+          exception: item.exception,
+          message: `Skill ${item.name} is blocked by ${item.severity} risk.`,
+        };
+      }
+      if (item.installDecision === 'warn') {
+        return {
+          reference,
+          skillId: item.skillId,
+          name: item.name,
+          status: 'warning' as const,
+          severity: item.severity,
+          riskScore: item.riskScore,
+          recommendation: item.recommendation,
+          installDecision: item.installDecision,
+          findingCount: item.findingCount,
+          exception: item.exception,
+          message: `Skill ${item.name} requires acknowledgement before use.`,
+        };
+      }
+      return {
+        reference,
+        skillId: item.skillId,
+        name: item.name,
+        status: 'matched' as const,
+        severity: item.severity,
+        riskScore: item.riskScore,
+        recommendation: item.recommendation,
+        installDecision: item.installDecision,
+        findingCount: item.findingCount,
+        message: `Skill ${item.name} passed skill audit.`,
+      };
+    });
+
+    const status = results.some(
+      (result) => result.status === 'blocked' || result.status === 'missing'
+    )
+      ? 'fail'
+      : results.some((result) => result.status === 'warning' || result.status === 'unscanned')
+        ? 'warn'
+        : 'pass';
+    return { status, mode, references: results };
+  }
+
   private async collectFiles(
     targetPath: string,
     targetType: SkillSecurityScanTargetType,
@@ -660,6 +1106,35 @@ export class SkillSecurityService {
     await fs.writeFile(jsonPath, JSON.stringify(persisted, null, 2), 'utf8');
     await fs.writeFile(markdownPath, persisted.reportMarkdown, 'utf8');
     return persisted;
+  }
+
+  private async readState(): Promise<SkillSecurityState> {
+    try {
+      const content = await fs.readFile(this.statePath, 'utf8');
+      const parsed = JSON.parse(content) as Partial<SkillSecurityState>;
+      return {
+        exceptions: parsed.exceptions ?? [],
+        remediationTasks: parsed.remediationTasks ?? {},
+      };
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { exceptions: [], remediationTasks: {} };
+      }
+      throw err;
+    }
+  }
+
+  private async writeState(state: SkillSecurityState): Promise<void> {
+    await fs.mkdir(path.dirname(this.statePath), { recursive: true });
+    await fs.writeFile(this.statePath, JSON.stringify(state, null, 2), 'utf8');
+  }
+
+  private resources(): SkillResourceProvider {
+    return this.resourceProvider ?? getSharedResourcesService();
+  }
+
+  private tasks(): TaskCreator {
+    return this.taskCreator ?? getTaskService();
   }
 }
 

--- a/server/src/services/workflow-authoring-service.ts
+++ b/server/src/services/workflow-authoring-service.ts
@@ -1,4 +1,5 @@
 import yaml from 'yaml';
+import type { WorkflowSkillAuditSummary } from '@veritas-kanban/shared';
 import type {
   ToolPolicy,
   WorkflowDefinition,
@@ -8,6 +9,7 @@ import type {
   WorkflowStep,
 } from '../types/workflow.js';
 import { getToolPolicyService, type ToolPolicyService } from './tool-policy-service.js';
+import { getSkillSecurityService, type SkillSecurityService } from './skill-security-service.js';
 
 export type WorkflowRecipeInputType = 'text' | 'textarea' | 'select' | 'boolean';
 export type WorkflowLintSeverity = 'error' | 'warning' | 'info';
@@ -18,6 +20,7 @@ export type WorkflowLintCategory =
   | 'permission'
   | 'policy'
   | 'secret'
+  | 'skill'
   | 'client'
   | 'output'
   | 'schedule';
@@ -103,6 +106,7 @@ export interface WorkflowDryRunResult extends WorkflowLintResult {
   status: 'ready' | 'attention' | 'blocked';
   canRun: boolean;
   checks: WorkflowDryRunCheck[];
+  skillAudit?: WorkflowSkillAuditSummary;
   workflow?: WorkflowDefinition;
 }
 
@@ -645,7 +649,10 @@ const RECIPES: WorkflowRecipeDefinition[] = [
 ];
 
 export class WorkflowAuthoringService {
-  constructor(private readonly toolPolicyService: ToolPolicyService = getToolPolicyService()) {}
+  constructor(
+    private readonly toolPolicyService: ToolPolicyService = getToolPolicyService(),
+    private readonly skillSecurityService: SkillSecurityService = getSkillSecurityService()
+  ) {}
 
   listRecipes(): WorkflowRecipe[] {
     return RECIPES.map(publicRecipe);
@@ -740,6 +747,7 @@ export class WorkflowAuthoringService {
       status,
       canRun: lint.summary.errors === 0,
       checks: this.buildChecks(lint.messages),
+      skillAudit: lint.skillAudit,
       workflow: parsed.workflow,
     };
   }
@@ -755,11 +763,12 @@ export class WorkflowAuthoringService {
   private async lintWorkflow(
     workflow: WorkflowDefinition,
     context: WorkflowDryRunContext
-  ): Promise<WorkflowLintResult> {
+  ): Promise<WorkflowLintResult & { skillAudit?: WorkflowSkillAuditSummary }> {
     const messages: WorkflowLintMessage[] = [];
 
     this.lintDefinition(workflow, messages);
     await this.lintToolPolicies(workflow, messages);
+    const skillAudit = await this.lintSkillAudit(workflow, context, messages);
     this.lintSecrets(workflow, context, messages);
     this.lintClientMode(workflow, context, messages);
     this.lintOutputTargets(workflow, context, messages);
@@ -769,6 +778,7 @@ export class WorkflowAuthoringService {
     return {
       ...this.resultFromMessages(messages),
       yaml: this.toYaml(workflow),
+      skillAudit,
     };
   }
 
@@ -1305,6 +1315,53 @@ export class WorkflowAuthoringService {
     }
   }
 
+  private async lintSkillAudit(
+    workflow: WorkflowDefinition,
+    context: WorkflowDryRunContext,
+    messages: WorkflowLintMessage[]
+  ): Promise<WorkflowSkillAuditSummary> {
+    const audit = await this.skillSecurityService.auditWorkflowSkills(
+      workflow,
+      context.clientMode ?? 'local'
+    );
+    for (const reference of audit.references) {
+      if (reference.status === 'blocked' || reference.status === 'missing') {
+        messages.push(
+          message(
+            'error',
+            'skill',
+            `skills.${reference.reference}`,
+            reference.message,
+            reference.status === 'missing'
+              ? 'Install the referenced shared skill or remove it from the workflow.'
+              : 'Remediate the skill finding or create an expiring reviewed exception.'
+          )
+        );
+      } else if (reference.status === 'warning' || reference.status === 'unscanned') {
+        messages.push(
+          message(
+            'warning',
+            'skill',
+            `skills.${reference.reference}`,
+            reference.message,
+            'Scan the skill, acknowledge medium findings, or create an expiring reviewed exception.'
+          )
+        );
+      } else if (reference.exception) {
+        messages.push(
+          message(
+            'info',
+            'skill',
+            `skills.${reference.reference}`,
+            reference.message,
+            'Review the exception before the expiration date.'
+          )
+        );
+      }
+    }
+    return audit;
+  }
+
   private isScheduled(schedule: WorkflowSchedule | undefined): schedule is WorkflowSchedule {
     return Boolean(schedule?.enabled && SCHEDULED_MODES.has(schedule.mode));
   }
@@ -1316,6 +1373,7 @@ export class WorkflowAuthoringService {
       this.checkFor('context', 'Task context', messages),
       this.checkFor('permission', 'Permissions', messages),
       this.checkFor('policy', 'Policy gates and tools', messages),
+      this.checkFor('skill', 'Skill audit', messages),
       this.checkFor('secret', 'Secrets', messages),
       this.checkFor('client', 'Client mode', messages),
       this.checkFor('output', 'Output targets', messages),

--- a/shared/src/types/skill-security.types.ts
+++ b/shared/src/types/skill-security.types.ts
@@ -1,7 +1,9 @@
 import type { SkillCapabilityProfile } from './skill-capability.types.js';
+import type { Task } from './task.types.js';
 
 export type SkillSecuritySeverity = 'low' | 'medium' | 'high' | 'critical';
 export type SkillSecurityRecommendation = 'safe' | 'caution' | 'do-not-install';
+export type SkillSecurityDecision = 'allow' | 'warn' | 'block';
 export type SkillSecurityScanTargetType = 'skill-file' | 'skill-directory';
 export type SkillSecurityFindingCategory =
   | 'prompt-injection'
@@ -72,4 +74,90 @@ export interface SkillSecurityPatternDefinition {
   severity: SkillSecuritySeverity;
   title: string;
   description: string;
+}
+
+export interface SkillSecurityException {
+  id: string;
+  skillId: string;
+  owner: string;
+  reason: string;
+  expiresAt: string;
+  createdAt: string;
+  createdBy: string;
+}
+
+export interface SkillSecurityExceptionInput {
+  owner: string;
+  reason: string;
+  expiresAt: string;
+}
+
+export interface SkillRiskRemediationTaskInput {
+  project?: string;
+  sprint?: string;
+  priority?: 'low' | 'medium' | 'high' | 'critical';
+}
+
+export interface SkillRiskRemediationTaskResult {
+  item: SkillRiskInventoryItem;
+  task: Task;
+}
+
+export interface SkillRiskInventoryItem {
+  skillId: string;
+  name: string;
+  version: number;
+  sourcePath: string;
+  tags: string[];
+  mountedIn: string[];
+  updatedAt: string;
+  lastScannedAt?: string;
+  scanStatus: 'scanned' | 'changed' | 'unscanned';
+  changedFiles: string[];
+  severity: SkillSecuritySeverity;
+  riskScore: number;
+  recommendation: SkillSecurityRecommendation;
+  installDecision: SkillSecurityDecision;
+  installReason: string;
+  declaredCapabilities: SkillCapabilityProfile['declaredCapabilities'];
+  observedCapabilities: SkillCapabilityProfile['observedCapabilities'];
+  mismatches: SkillCapabilityProfile['findings'];
+  findingCount: number;
+  highOrCriticalFindingCount: number;
+  latestReportId?: string;
+  latestReportPath?: string;
+  remediationTaskId?: string;
+  exception?: SkillSecurityException;
+}
+
+export interface SkillRiskInventorySummary {
+  generatedAt: string;
+  items: SkillRiskInventoryItem[];
+  totals: {
+    skills: number;
+    blocked: number;
+    warnings: number;
+    unscanned: number;
+    exceptions: number;
+  };
+}
+
+export interface WorkflowSkillAuditReference {
+  reference: string;
+  skillId?: string;
+  name?: string;
+  status: 'matched' | 'missing' | 'unscanned' | 'warning' | 'blocked' | 'allowed';
+  severity?: SkillSecuritySeverity;
+  riskScore?: number;
+  recommendation?: SkillSecurityRecommendation;
+  installDecision?: SkillSecurityDecision;
+  findingCount?: number;
+  exception?: SkillSecurityException;
+  message: string;
+}
+
+export interface WorkflowSkillAuditSummary {
+  status: 'pass' | 'warn' | 'fail';
+  mode: 'local' | 'remote' | 'cloud';
+  references: WorkflowSkillAuditReference[];
 }

--- a/web/src/__tests__/needs-attention-queue-mantine.test.tsx
+++ b/web/src/__tests__/needs-attention-queue-mantine.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { SkillRiskInventoryItem } from '@veritas-kanban/shared';
 
 import {
   buildNeedsAttentionItems,
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   useMarkNotificationDelivered: vi.fn(),
   usePendingAgentApprovals: vi.fn(),
   useRecentRuns: vi.fn(),
+  useSkillRiskInventory: vi.fn(),
   useTaskCost: vi.fn(),
   useTasks: vi.fn(),
   useUndeliveredNotifications: vi.fn(),
@@ -53,6 +55,10 @@ vi.mock('@/hooks/useAgent', () => ({
 vi.mock('@/hooks/useNotifications', () => ({
   useMarkNotificationDelivered: mocks.useMarkNotificationDelivered,
   useUndeliveredNotifications: mocks.useUndeliveredNotifications,
+}));
+
+vi.mock('@/hooks/useSkillSecurity', () => ({
+  useSkillRiskInventory: mocks.useSkillRiskInventory,
 }));
 
 const tasks = [
@@ -194,6 +200,30 @@ const notifications = [
   },
 ];
 
+const skillRisks: SkillRiskInventoryItem[] = [
+  {
+    skillId: 'skill-risky',
+    name: 'Risky Skill',
+    version: 1,
+    sourcePath: 'shared-resource:skill-risky',
+    tags: [],
+    mountedIn: [],
+    updatedAt: '2026-06-01T12:00:00Z',
+    scanStatus: 'unscanned' as const,
+    changedFiles: [],
+    severity: 'high' as const,
+    riskScore: 60,
+    recommendation: 'caution' as const,
+    installDecision: 'block' as const,
+    installReason: 'high skill risk blocks install and workflow use by default.',
+    declaredCapabilities: ['filesystem.read'],
+    observedCapabilities: [{ capability: 'network.egress', confidence: 0.85, evidence: [] }],
+    mismatches: [],
+    findingCount: 2,
+    highOrCriticalFindingCount: 1,
+  },
+];
+
 function ensureLocalStorage() {
   if (window.localStorage) return;
 
@@ -233,6 +263,10 @@ function mockQueueData() {
   mocks.useDriftAlerts.mockReturnValue({ data: driftAlerts, isLoading: false });
   mocks.usePendingAgentApprovals.mockReturnValue({ data: approvals, isLoading: false });
   mocks.useUndeliveredNotifications.mockReturnValue({ data: notifications, isLoading: false });
+  mocks.useSkillRiskInventory.mockReturnValue({
+    data: { generatedAt: '2026-06-01T12:00:00Z', items: skillRisks, totals: {} },
+    isLoading: false,
+  });
   mocks.useAcknowledgeDriftAlert.mockReturnValue({ mutate: mocks.acknowledgeDriftMutate });
   mocks.useMarkNotificationDelivered.mockReturnValue({
     mutate: mocks.markNotificationDeliveredMutate,
@@ -262,6 +296,7 @@ describe('needs attention queue', () => {
         notifications,
         project: 'platform',
         recentRuns: [],
+        skillRisks,
         taskCost,
         tasks,
       },
@@ -275,6 +310,7 @@ describe('needs attention queue', () => {
         'expensive-run',
         'failed-run',
         'notification',
+        'skill-risk',
         'stale-task',
         'stale-worktree',
         'stuck-workflow',
@@ -292,6 +328,9 @@ describe('needs attention queue', () => {
     expect(items.find((item) => item.source === 'notification')?.destinationLabel).toBe(
       'timeline:attempt-review-1'
     );
+    expect(items.find((item) => item.source === 'skill-risk')?.title).toBe(
+      'Skill risk: Risky Skill'
+    );
   });
 
   it('renders queue items through Mantine controls and opens task targets', async () => {
@@ -305,6 +344,7 @@ describe('needs attention queue', () => {
     expect(screen.getByText('Needs Attention')).toBeDefined();
     expect(screen.getAllByText('Blocked queue task').length).toBeGreaterThan(0);
     expect(screen.getByText('Review notification')).toBeDefined();
+    expect(screen.getByText('Skill risk: Risky Skill')).toBeDefined();
     expect(screen.getAllByText('Stale running task').length).toBeGreaterThan(0);
     expect(container.querySelectorAll('.mantine-Select-root')).toHaveLength(5);
     expect(container.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThan(3);
@@ -345,6 +385,10 @@ describe('needs attention queue', () => {
     mocks.useDriftAlerts.mockReturnValue({ data: [], isLoading: false });
     mocks.usePendingAgentApprovals.mockReturnValue({ data: [], isLoading: false });
     mocks.useUndeliveredNotifications.mockReturnValue({ data: [], isLoading: false });
+    mocks.useSkillRiskInventory.mockReturnValue({
+      data: { totals: { total: 0, blocked: 0, warned: 0, unscanned: 0 }, items: [] },
+      isLoading: false,
+    });
 
     renderWithProviders(<NeedsAttentionQueue period="7d" project="platform" />);
 

--- a/web/src/__tests__/settings-governance-mantine.test.tsx
+++ b/web/src/__tests__/settings-governance-mantine.test.tsx
@@ -74,6 +74,43 @@ const skillProfiles = [
   },
 ];
 
+const skillInventory = {
+  generatedAt: '2026-06-03T00:00:00.000Z',
+  totals: {
+    skills: 1,
+    blocked: 1,
+    warnings: 0,
+    unscanned: 1,
+    exceptions: 0,
+  },
+  items: [
+    {
+      skillId: 'skill_1',
+      name: 'Review Helper',
+      version: 1,
+      sourcePath: 'shared-resource:skill_1',
+      tags: ['review'],
+      mountedIn: [],
+      updatedAt: '2026-06-03T00:00:00.000Z',
+      scanStatus: 'unscanned',
+      changedFiles: [],
+      severity: 'high',
+      riskScore: 60,
+      recommendation: 'caution',
+      installDecision: 'block',
+      installReason: 'high skill risk blocks install and workflow use by default.',
+      declaredCapabilities: ['filesystem.read'],
+      observedCapabilities: [
+        { capability: 'filesystem.read', confidence: 0.9, evidence: [] },
+        { capability: 'network.egress', confidence: 0.85, evidence: [] },
+      ],
+      mismatches: skillProfiles[0].findings,
+      findingCount: 2,
+      highOrCriticalFindingCount: 1,
+    },
+  ],
+};
+
 vi.mock('@/lib/api/helpers', () => ({
   apiFetch: mocks.apiFetch,
 }));
@@ -98,6 +135,9 @@ describe('Settings governance Mantine controls', () => {
     mocks.apiFetch.mockImplementation(async (url: string) => {
       if (url === '/api/skills/capabilities') {
         return skillProfiles;
+      }
+      if (url === '/api/skills/security/inventory') {
+        return skillInventory;
       }
       if (url === '/api/skills/capabilities/skill_1/remediation-task') {
         return { profile: skillProfiles[0], task: { id: 'task_1', title: 'Review skill' } };
@@ -132,9 +172,12 @@ describe('Settings governance Mantine controls', () => {
     });
 
     expect(await screen.findByText('Skill Capability Profiles')).toBeDefined();
-    expect(await screen.findByText('Review Helper')).toBeDefined();
+    expect(await screen.findByText('Skill Risk Dashboard')).toBeDefined();
+    expect((await screen.findAllByText('Review Helper')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('block')).toBeDefined();
+    expect(screen.getByText('score 60 · 2 findings')).toBeDefined();
     expect(screen.getByText('mismatch')).toBeDefined();
-    expect(screen.getByText('network.egress')).toBeDefined();
+    expect(screen.getAllByText('network.egress').length).toBeGreaterThanOrEqual(1);
     expect(container.querySelector('.mantine-Table-root')).toBeDefined();
   });
 

--- a/web/src/components/dashboard/NeedsAttentionQueue.tsx
+++ b/web/src/components/dashboard/NeedsAttentionQueue.tsx
@@ -13,7 +13,7 @@ import {
   ShieldAlert,
   Workflow,
 } from 'lucide-react';
-import type { DriftAlert, Task } from '@veritas-kanban/shared';
+import type { DriftAlert, SkillRiskInventoryItem, Task } from '@veritas-kanban/shared';
 import { usePendingAgentApprovals, type AgentApprovalRequest } from '@/hooks/useAgent';
 import { useDriftAlerts, useAcknowledgeDriftAlert } from '@/hooks/useDrift';
 import {
@@ -30,6 +30,7 @@ import {
 } from '@/hooks/useNotifications';
 import { useTasks } from '@/hooks/useTasks';
 import { useActiveRuns, useRecentRuns, type WorkflowRun } from '@/hooks/useWorkflowStats';
+import { useSkillRiskInventory } from '@/hooks/useSkillSecurity';
 import { cn } from '@/lib/utils';
 
 const DISMISSED_STORAGE_KEY = 'veritas-needs-attention-dismissed-v1';
@@ -49,6 +50,7 @@ type NeedsAttentionSource =
   | 'expensive-run'
   | 'failed-run'
   | 'notification'
+  | 'skill-risk'
   | 'stale-task'
   | 'stale-worktree'
   | 'stuck-workflow'
@@ -89,6 +91,7 @@ export interface BuildNeedsAttentionInput {
   notifications?: AgentNotification[];
   project?: string;
   recentRuns?: WorkflowRun[];
+  skillRisks?: SkillRiskInventoryItem[];
   taskCost?: TaskCostMetrics;
   tasks?: Task[];
 }
@@ -118,6 +121,7 @@ const SOURCE_LABELS: Record<NeedsAttentionSource, string> = {
   'expensive-run': 'Cost',
   'failed-run': 'Failed run',
   notification: 'Notification',
+  'skill-risk': 'Skill risk',
   'stale-task': 'Stale task',
   'stale-worktree': 'Worktree',
   'stuck-workflow': 'Workflow',
@@ -131,6 +135,7 @@ const SOURCE_ICONS: Record<NeedsAttentionSource, typeof AlertTriangle> = {
   'expensive-run': DollarSign,
   'failed-run': AlertTriangle,
   notification: Bell,
+  'skill-risk': ShieldAlert,
   'stale-task': Hourglass,
   'stale-worktree': GitPullRequest,
   'stuck-workflow': Workflow,
@@ -537,6 +542,30 @@ export function buildNeedsAttentionItems(
     });
   }
 
+  for (const skill of input.skillRisks ?? []) {
+    const needsAttention =
+      skill.installDecision === 'block' ||
+      skill.severity === 'critical' ||
+      skill.severity === 'high';
+    if (!needsAttention) continue;
+
+    addItem(items, {
+      id: `skill-risk:${skill.skillId}`,
+      dedupeKey: `skill-risk:${skill.skillId}:${skill.updatedAt}:${skill.lastScannedAt ?? 'unscanned'}`,
+      title: `Skill risk: ${skill.name}`,
+      reason: skill.installReason,
+      nextAction: 'Open Shared Resources',
+      severity: skill.severity === 'critical' ? 'critical' : 'high',
+      source: 'skill-risk',
+      sourceLabel: SOURCE_LABELS['skill-risk'],
+      timestamp: skill.lastScannedAt ?? skill.updatedAt,
+      owner: skill.exception?.owner,
+      agent: skill.name,
+      destination: 'workflows',
+      destinationLabel: `skill:${skill.skillId}`,
+    });
+  }
+
   return [...items.values()].sort((a, b) => {
     const severityDelta = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
     if (severityDelta !== 0) return severityDelta;
@@ -638,6 +667,7 @@ export function NeedsAttentionQueue({
   const { data: approvals = [], isLoading: approvalsLoading } = usePendingAgentApprovals();
   const { data: notifications = [], isLoading: notificationsLoading } =
     useUndeliveredNotifications(50);
+  const { data: skillInventory, isLoading: skillRiskLoading } = useSkillRiskInventory();
   const acknowledgeDrift = useAcknowledgeDriftAlert();
   const markNotificationDelivered = useMarkNotificationDelivered();
 
@@ -652,6 +682,7 @@ export function NeedsAttentionQueue({
           notifications,
           project,
           recentRuns,
+          skillRisks: skillInventory?.items,
           taskCost,
           tasks,
         },
@@ -665,6 +696,7 @@ export function NeedsAttentionQueue({
       notifications,
       project,
       recentRuns,
+      skillInventory?.items,
       taskCost,
       tasks,
       now,
@@ -698,7 +730,8 @@ export function NeedsAttentionQueue({
     recentRunsLoading ||
     driftLoading ||
     approvalsLoading ||
-    notificationsLoading;
+    notificationsLoading ||
+    skillRiskLoading;
 
   const severityOptions = [
     { value: 'all', label: 'All severity' },

--- a/web/src/components/settings/tabs/SharedResourcesTab.tsx
+++ b/web/src/components/settings/tabs/SharedResourcesTab.tsx
@@ -3,6 +3,7 @@ import { Checkbox, NumberInput } from '@mantine/core';
 import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings } from '@veritas-kanban/shared';
 import { ToggleRow, SectionHeader, SaveIndicator, SettingRow } from '../shared';
 import { SkillCapabilityProfilesPanel } from './SkillCapabilityProfilesPanel';
+import { SkillRiskDashboardPanel } from './SkillRiskDashboardPanel';
 
 const TYPE_OPTIONS: Array<{
   key: 'prompt' | 'guideline' | 'skill' | 'config' | 'template';
@@ -100,6 +101,8 @@ export function SharedResourcesTab() {
           </div>
         </div>
       )}
+
+      {sharedResources.enabled && allowedTypes.includes('skill') && <SkillRiskDashboardPanel />}
 
       {sharedResources.enabled && allowedTypes.includes('skill') && (
         <SkillCapabilityProfilesPanel />

--- a/web/src/components/settings/tabs/SkillRiskDashboardPanel.tsx
+++ b/web/src/components/settings/tabs/SkillRiskDashboardPanel.tsx
@@ -1,0 +1,371 @@
+import { useMemo, useState } from 'react';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Modal,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Textarea,
+  Tooltip,
+} from '@mantine/core';
+import { AlertTriangle, ClipboardList, RefreshCw, ShieldAlert } from 'lucide-react';
+import type {
+  SkillCapabilityId,
+  SkillRiskInventoryItem,
+  SkillSecurityDecision,
+  SkillSecuritySeverity,
+} from '@veritas-kanban/shared';
+import {
+  useCreateSkillRiskRemediationTask,
+  useCreateSkillSecurityException,
+  useSkillRiskInventory,
+} from '@/hooks/useSkillSecurity';
+import { useToast } from '@/hooks/useToast';
+
+const SEVERITY_COLORS: Record<SkillSecuritySeverity, string> = {
+  low: 'gray',
+  medium: 'yellow',
+  high: 'orange',
+  critical: 'red',
+};
+
+const DECISION_COLORS: Record<SkillSecurityDecision, string> = {
+  allow: 'green',
+  warn: 'yellow',
+  block: 'red',
+};
+
+function formatDate(value?: string): string {
+  if (!value) return 'never';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value));
+}
+
+function defaultExpiration(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 14);
+  return date.toISOString().slice(0, 16);
+}
+
+function toIsoDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : value;
+}
+
+function CapabilityBadges({ values }: { values: SkillCapabilityId[] }) {
+  if (values.length === 0) {
+    return (
+      <Text size="xs" c="dimmed">
+        none
+      </Text>
+    );
+  }
+  return (
+    <Group gap={4}>
+      {values.slice(0, 3).map((value) => (
+        <Badge key={value} size="xs" variant="light" color="blue">
+          {value}
+        </Badge>
+      ))}
+      {values.length > 3 && (
+        <Badge size="xs" variant="light" color="gray">
+          +{values.length - 3}
+        </Badge>
+      )}
+    </Group>
+  );
+}
+
+function observedCapabilities(item: SkillRiskInventoryItem): SkillCapabilityId[] {
+  return item.observedCapabilities.map((observation) => observation.capability);
+}
+
+export function SkillRiskDashboardPanel() {
+  const { toast } = useToast();
+  const inventoryQuery = useSkillRiskInventory();
+  const createTask = useCreateSkillRiskRemediationTask();
+  const createException = useCreateSkillSecurityException();
+  const inventory = inventoryQuery.data;
+  const [exceptionSkill, setExceptionSkill] = useState<SkillRiskInventoryItem | null>(null);
+  const [exceptionOwner, setExceptionOwner] = useState('');
+  const [exceptionReason, setExceptionReason] = useState('');
+  const [exceptionExpiresAt, setExceptionExpiresAt] = useState(defaultExpiration);
+
+  const sortedItems = useMemo(
+    () =>
+      [...(inventory?.items ?? [])].sort((a, b) => {
+        if (a.installDecision !== b.installDecision) {
+          const rank: Record<SkillSecurityDecision, number> = { block: 3, warn: 2, allow: 1 };
+          return rank[b.installDecision] - rank[a.installDecision];
+        }
+        return b.riskScore - a.riskScore;
+      }),
+    [inventory?.items]
+  );
+
+  const openException = (item: SkillRiskInventoryItem) => {
+    setExceptionSkill(item);
+    setExceptionOwner(item.exception?.owner ?? '');
+    setExceptionReason(item.exception?.reason ?? '');
+    setExceptionExpiresAt(item.exception?.expiresAt?.slice(0, 16) ?? defaultExpiration());
+  };
+
+  const handleCreateTask = (item: SkillRiskInventoryItem) => {
+    createTask.mutate(
+      { skillId: item.skillId },
+      {
+        onSuccess: (result) => {
+          toast({ title: 'Skill risk task created', description: result.task.title });
+        },
+        onError: (error) => {
+          toast({
+            title: 'Failed to create skill risk task',
+            description: error instanceof Error ? error.message : 'Unknown error',
+            variant: 'destructive',
+            duration: Infinity,
+          });
+        },
+      }
+    );
+  };
+
+  const handleCreateException = () => {
+    if (!exceptionSkill) return;
+    createException.mutate(
+      {
+        skillId: exceptionSkill.skillId,
+        input: {
+          owner: exceptionOwner,
+          reason: exceptionReason,
+          expiresAt: toIsoDateTime(exceptionExpiresAt),
+        },
+      },
+      {
+        onSuccess: () => {
+          toast({ title: 'Skill exception recorded', description: exceptionSkill.name });
+          setExceptionSkill(null);
+        },
+        onError: (error) => {
+          toast({
+            title: 'Failed to record skill exception',
+            description: error instanceof Error ? error.message : 'Unknown error',
+            variant: 'destructive',
+            duration: Infinity,
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <Paper withBorder radius="md" p="md">
+      <Stack gap="md">
+        <Group justify="space-between" gap="sm">
+          <Group gap="xs">
+            <ShieldAlert className="h-4 w-4 text-muted-foreground" />
+            <Text fw={600}>Skill Risk Dashboard</Text>
+            <Badge color={inventory?.totals.blocked ? 'red' : 'green'} variant="light">
+              {inventory?.totals.blocked ?? 0} blocked
+            </Badge>
+          </Group>
+          <Tooltip label="Refresh skill risk inventory">
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              aria-label="Refresh skill risk inventory"
+              onClick={() => inventoryQuery.refetch()}
+            >
+              {inventoryQuery.isFetching ? <Loader size="xs" /> : <RefreshCw className="h-4 w-4" />}
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+
+        {inventoryQuery.isLoading ? (
+          <Group gap="xs">
+            <Loader size="sm" />
+            <Text size="sm" c="dimmed">
+              Loading skill risk inventory...
+            </Text>
+          </Group>
+        ) : !inventory || sortedItems.length === 0 ? (
+          <Text size="sm" c="dimmed">
+            No shared skill resources found.
+          </Text>
+        ) : (
+          <>
+            <SimpleGrid cols={{ base: 2, md: 5 }} spacing="xs">
+              <Badge variant="light" color="gray">
+                {inventory.totals.skills} skills
+              </Badge>
+              <Badge variant="light" color="red">
+                {inventory.totals.blocked} blocked
+              </Badge>
+              <Badge variant="light" color="yellow">
+                {inventory.totals.warnings} warnings
+              </Badge>
+              <Badge variant="light" color="orange">
+                {inventory.totals.unscanned} unscanned
+              </Badge>
+              <Badge variant="light" color="blue">
+                {inventory.totals.exceptions} exceptions
+              </Badge>
+            </SimpleGrid>
+
+            <Table striped highlightOnHover withTableBorder>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Skill</Table.Th>
+                  <Table.Th>Scan</Table.Th>
+                  <Table.Th>Risk</Table.Th>
+                  <Table.Th>Capabilities</Table.Th>
+                  <Table.Th>Install gate</Table.Th>
+                  <Table.Th>Action</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {sortedItems.map((item) => (
+                  <Table.Tr key={item.skillId}>
+                    <Table.Td>
+                      <Text size="sm" fw={600}>
+                        {item.name}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        v{item.version} · {item.sourcePath}
+                      </Text>
+                      {item.remediationTaskId && (
+                        <Badge size="xs" color="blue" variant="light">
+                          task {item.remediationTaskId}
+                        </Badge>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Group gap={4}>
+                        <Badge
+                          color={item.scanStatus === 'scanned' ? 'green' : 'orange'}
+                          variant="light"
+                        >
+                          {item.scanStatus}
+                        </Badge>
+                        {item.changedFiles.length > 0 && (
+                          <Badge color="yellow" variant="light" size="xs">
+                            changed
+                          </Badge>
+                        )}
+                      </Group>
+                      <Text size="xs" c="dimmed">
+                        {formatDate(item.lastScannedAt)}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={SEVERITY_COLORS[item.severity]} variant="light">
+                        {item.severity}
+                      </Badge>
+                      <Text size="xs" c="dimmed">
+                        score {item.riskScore} · {item.findingCount} findings
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Stack gap={4}>
+                        <Group gap={4}>
+                          <Text size="xs" c="dimmed">
+                            declared
+                          </Text>
+                          <CapabilityBadges values={item.declaredCapabilities} />
+                        </Group>
+                        <Group gap={4}>
+                          <Text size="xs" c="dimmed">
+                            observed
+                          </Text>
+                          <CapabilityBadges values={observedCapabilities(item)} />
+                        </Group>
+                      </Stack>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={DECISION_COLORS[item.installDecision]} variant="light">
+                        {item.installDecision}
+                      </Badge>
+                      <Text size="xs" c="dimmed">
+                        {item.exception
+                          ? `${item.exception.owner} until ${formatDate(item.exception.expiresAt)}`
+                          : item.installReason}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Group gap="xs" wrap="nowrap">
+                        <Button
+                          size="xs"
+                          variant="light"
+                          leftSection={<ClipboardList className="h-3.5 w-3.5" />}
+                          loading={createTask.isPending}
+                          onClick={() => handleCreateTask(item)}
+                        >
+                          Task
+                        </Button>
+                        <Button
+                          size="xs"
+                          variant="subtle"
+                          color={item.installDecision === 'block' ? 'red' : 'gray'}
+                          leftSection={<AlertTriangle className="h-3.5 w-3.5" />}
+                          onClick={() => openException(item)}
+                        >
+                          Exception
+                        </Button>
+                      </Group>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </>
+        )}
+      </Stack>
+
+      <Modal
+        opened={Boolean(exceptionSkill)}
+        onClose={() => setExceptionSkill(null)}
+        title={exceptionSkill ? `Exception for ${exceptionSkill.name}` : 'Skill exception'}
+      >
+        <Stack gap="sm">
+          <TextInput
+            label="Owner"
+            value={exceptionOwner}
+            onChange={(event) => setExceptionOwner(event.currentTarget.value)}
+            placeholder="security reviewer"
+          />
+          <TextInput
+            label="Expires"
+            type="datetime-local"
+            value={exceptionExpiresAt}
+            onChange={(event) => setExceptionExpiresAt(event.currentTarget.value)}
+          />
+          <Textarea
+            label="Reason"
+            value={exceptionReason}
+            minRows={3}
+            onChange={(event) => setExceptionReason(event.currentTarget.value)}
+            placeholder="Why this skill is allowed temporarily"
+          />
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={() => setExceptionSkill(null)}>
+              Cancel
+            </Button>
+            <Button loading={createException.isPending} onClick={handleCreateException}>
+              Save Exception
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Paper>
+  );
+}

--- a/web/src/components/workflows/WorkflowAuthoringPanel.tsx
+++ b/web/src/components/workflows/WorkflowAuthoringPanel.tsx
@@ -1114,6 +1114,49 @@ function DryRunResultPanel({ result }: { result: WorkflowDryRunResult }) {
           </Badge>
         </Group>
 
+        {result.skillAudit && (
+          <Stack gap={4}>
+            <Group gap="xs">
+              <Badge
+                color={
+                  result.skillAudit.status === 'fail'
+                    ? 'red'
+                    : result.skillAudit.status === 'warn'
+                      ? 'yellow'
+                      : 'green'
+                }
+                variant="light"
+              >
+                Skill audit {result.skillAudit.status}
+              </Badge>
+              <Text size="xs" c="dimmed">
+                {result.skillAudit.references.length} referenced skills · {result.skillAudit.mode}{' '}
+                mode
+              </Text>
+            </Group>
+            {result.skillAudit.references.length > 0 && (
+              <Group gap={4}>
+                {result.skillAudit.references.slice(0, 4).map((reference) => (
+                  <Badge
+                    key={reference.reference}
+                    size="xs"
+                    color={
+                      reference.status === 'blocked' || reference.status === 'missing'
+                        ? 'red'
+                        : reference.status === 'warning' || reference.status === 'unscanned'
+                          ? 'yellow'
+                          : 'green'
+                    }
+                    variant="light"
+                  >
+                    {reference.name ?? reference.reference}: {reference.status}
+                  </Badge>
+                ))}
+              </Group>
+            )}
+          </Stack>
+        )}
+
         <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xs">
           {result.checks.map((check) => (
             <Alert

--- a/web/src/hooks/useSkillSecurity.ts
+++ b/web/src/hooks/useSkillSecurity.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type {
+  SkillSecurityExceptionInput,
+  SkillRiskRemediationTaskInput,
+} from '@veritas-kanban/shared';
+
+export function useSkillRiskInventory() {
+  return useQuery({
+    queryKey: ['skill-security', 'inventory'],
+    queryFn: api.skillSecurity.inventory,
+  });
+}
+
+export function useCreateSkillRiskRemediationTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ skillId, input }: { skillId: string; input?: SkillRiskRemediationTaskInput }) =>
+      api.skillSecurity.createRemediationTask(skillId, input ?? {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['skill-security', 'inventory'] });
+    },
+  });
+}
+
+export function useCreateSkillSecurityException() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ skillId, input }: { skillId: string; input: SkillSecurityExceptionInput }) =>
+      api.skillSecurity.createException(skillId, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['skill-security', 'inventory'] });
+    },
+  });
+}

--- a/web/src/lib/api/skill-security.ts
+++ b/web/src/lib/api/skill-security.ts
@@ -1,8 +1,12 @@
 import type {
   SkillSecurityPatternDefinition,
+  SkillSecurityExceptionInput,
   SkillSecurityScanInput,
   SkillSecurityScanReport,
   SkillSecurityScanSummary,
+  SkillRiskInventorySummary,
+  SkillRiskRemediationTaskInput,
+  SkillRiskRemediationTaskResult,
 } from '@veritas-kanban/shared';
 import { apiFetch } from './helpers';
 
@@ -29,4 +33,30 @@ export const skillSecurityApi = {
 
   getReport: (id: string): Promise<SkillSecurityScanReport> =>
     apiFetch<SkillSecurityScanReport>(`/api/skills/security/scans/${encodeURIComponent(id)}`),
+
+  inventory: (): Promise<SkillRiskInventorySummary> =>
+    apiFetch<SkillRiskInventorySummary>('/api/skills/security/inventory'),
+
+  createRemediationTask: (
+    skillId: string,
+    input: SkillRiskRemediationTaskInput = {}
+  ): Promise<SkillRiskRemediationTaskResult> =>
+    apiFetch<SkillRiskRemediationTaskResult>(
+      `/api/skills/security/inventory/${encodeURIComponent(skillId)}/remediation-task`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    ),
+
+  createException: (skillId: string, input: SkillSecurityExceptionInput) =>
+    apiFetch<SkillRiskInventorySummary['items'][number]>(
+      `/api/skills/security/inventory/${encodeURIComponent(skillId)}/exceptions`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    ),
 };

--- a/web/src/lib/api/workflows.ts
+++ b/web/src/lib/api/workflows.ts
@@ -3,6 +3,7 @@ import type {
   WorkflowOutputTarget,
   WorkflowSchedule,
   WorkflowStep,
+  WorkflowSkillAuditSummary,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -15,6 +16,7 @@ export type WorkflowLintCategory =
   | 'permission'
   | 'policy'
   | 'secret'
+  | 'skill'
   | 'client'
   | 'output'
   | 'schedule';
@@ -81,6 +83,7 @@ export interface WorkflowDryRunResult extends WorkflowLintResult {
   status: 'ready' | 'attention' | 'blocked';
   canRun: boolean;
   checks: WorkflowDryRunCheck[];
+  skillAudit?: WorkflowSkillAuditSummary;
   workflow?: WorkflowDefinition;
 }
 


### PR DESCRIPTION
## Summary
- Add shared skill risk inventory with install decisions, active exceptions, and remediation task creation.
- Surface the Skill Risk Dashboard in Shared Resources and add high-risk skill items to Needs Attention.
- Add workflow skill audits to authoring dry-runs and block remote/cloud runs that reference missing, unscanned, or blocked skills.
- Document the new API endpoints, workflow dry-run behavior, and v5 release gate language.

Closes #409
Closes #410

## Verification
- pnpm --filter @veritas-kanban/server test -- skill-security-service.test.ts routes/workflow-authoring.test.ts
- pnpm --filter @veritas-kanban/web test -- settings-governance-mantine.test.tsx needs-attention-queue-mantine.test.tsx workflow-surfaces-mantine.test.tsx
- node scripts/check-permission-coverage.mjs
- pnpm typecheck
- pnpm exec eslint . --quiet
- git diff --check
- pnpm build
- Headless Playwright smoke loaded http://localhost:3000 without runtime errors; local first-run setup prevented reaching authenticated Settings surfaces without mutating auth setup.