### PR TITLE
Add orchestrator pipelines and product modes

### DIFF
--- a/docs/API-WORKFLOWS.md
+++ b/docs/API-WORKFLOWS.md
@@ -438,6 +438,23 @@ tools, steps, variables, inputs, and descriptions. Local mode warns on unscanned
 skills. Remote and cloud modes fail missing, unscanned, or blocked skills unless
 the skill has an active reviewed exception.
 
+Dry-run responses may include `pipelineSummary` when a workflow declares
+`pipeline`. Pipeline lint validates the parent agent, subagent role references,
+deliverable contracts, verification steps, dependencies, and whether each role is
+used by a workflow step or parallel substep.
+
+### GET /api/workflows/recipes
+
+Returns reusable workflow recipes. v5 recipes include `.openclaw Audit`, which
+materializes an orchestrated pipeline with config, storage, security, docs, and
+follow-up task subagent roles.
+
+### POST /api/workflows/recipes/:recipeId/materialize
+
+Materializes a recipe into workflow JSON/YAML and a preview. When a recipe has a
+pipeline, `preview.pipeline` contains role, status, scope, deliverable,
+dependency, verification, and telemetry-budget metadata for the authoring UI.
+
 ### POST /api/workflows/:id/dry-run
 
 Dry-run a saved workflow definition with the same response shape and context
@@ -481,7 +498,8 @@ curl -X POST http://localhost:3001/api/workflows/feature-dev/runs \
 Before a run starts, the server dry-runs the saved workflow and blocks remote or
 cloud execution when a referenced shared skill is missing, unscanned, or blocked.
 The run context includes the resulting `skillAudit` summary when execution is
-allowed.
+allowed. Workflows with `pipeline` metadata also include `context.pipeline`,
+which rolls subagent role status and time/token telemetry into the run record.
 
 **Response**:
 

--- a/docs/PRODUCT-MODES.md
+++ b/docs/PRODUCT-MODES.md
@@ -1,0 +1,23 @@
+# Product Modes
+
+Product modes are persisted UX preferences for focused Veritas workflows. They tune the default mental model for dashboards, task templates, visible panels, and command shortcuts without changing API access or deleting user configuration.
+
+## Modes
+
+| Mode                | Best for                   | Default emphasis                                     |
+| ------------------- | -------------------------- | ---------------------------------------------------- |
+| Board Only          | Simple local task tracking | Board, backlog, archive, basic search                |
+| Agent Ready         | Local agent work           | Agent panel, templates, work products, run history   |
+| Solo Coding         | Implementation tasks       | Repo, branch, QA gate, completion packet surfaces    |
+| PM Orchestration    | Coordinated delivery       | Workflows, decisions, policy traces, dashboards      |
+| QA Review           | Verification and handoff   | Needs Attention, QA gates, evidence, workflow runs   |
+| Research            | Read-heavy work            | Search, shared resources, notes, decision records    |
+| Operations          | Runtime management         | Maintenance, health, backup, remote-session surfaces |
+| Advanced / Operator | Full control plane         | All surfaces visible                                 |
+| Custom              | Manual tuning              | Records preference only                              |
+
+## Persistence
+
+The selected mode is stored in `features.productMode.selectedMode`. Existing users default to `advanced` so no current panels are hidden on upgrade. First-run desktop onboarding records a pending mode in local storage, then applies it to settings after password setup and authentication.
+
+Modes should hide or de-emphasize optional surfaces in the UI only. Route handlers, APIs, troubleshooting controls, and stored user data remain available.

--- a/docs/SOP-orchestrator-pipelines.md
+++ b/docs/SOP-orchestrator-pipelines.md
@@ -1,0 +1,24 @@
+# SOP: Orchestrator Pipelines
+
+Use workflow `pipeline` metadata when a parent agent delegates work to scoped subagents and needs a reconciled handoff.
+
+## Workflow Shape
+
+A pipeline declares:
+
+- `mode`: `orchestrated`
+- `parentAgent`: workflow agent that owns scope, handoff, and final reconciliation
+- `completion`: `all-required`, `any-success`, or `manual-review`
+- `roles`: subagent contracts with `scope`, `taskBrief`, `deliverable`, `verification`, optional `dependsOn`, and optional token/time telemetry budgets
+
+The workflow steps still do the execution. Roles should be referenced by normal agent steps or by `parallel.steps[]` substeps. Dry-run lint blocks missing parent agents, missing role agents, missing deliverables, missing verification, and invalid dependencies.
+
+## Runtime Behavior
+
+Run context stores `context.pipeline` with role status and telemetry rollups. Parallel substep output is reconciled into role status after the parent step completes. The run detail view shows role, status, scope, deliverable, dependencies, verification count, and time/token telemetry when present.
+
+Completion packets include an Orchestration Pipeline section when the task attempt has an orchestration summary.
+
+## Built-in Recipe
+
+The `.openclaw Audit` recipe fans out an audit across config, storage, security, docs, and follow-up task roles, then reconciles findings into a work product and completion packet.

--- a/server/src/__tests__/routes/workflow-authoring.test.ts
+++ b/server/src/__tests__/routes/workflow-authoring.test.ts
@@ -97,6 +97,7 @@ describe('workflow authoring routes', () => {
     expect(recipes.body.map((recipe: { id: string }) => recipe.id)).toContain(
       'task-implementation'
     );
+    expect(recipes.body.map((recipe: { id: string }) => recipe.id)).toContain('openclaw-audit');
 
     const materialized = await request(app)
       .post('/api/workflows/recipes/task-implementation/materialize')
@@ -119,6 +120,85 @@ describe('workflow authoring routes', () => {
     ).toEqual(['task-update', 'work-product', 'completion-packet']);
     expect(materialized.body.yaml).toContain('outputTargets:');
     expect(materialized.body.lint.ok).toBe(true);
+  });
+
+  it('materializes the OpenClaw audit recipe with an orchestrated subagent pipeline', async () => {
+    const materialized = await request(app)
+      .post('/api/workflows/recipes/openclaw-audit/materialize')
+      .send({
+        inputs: {
+          workflowName: '.openclaw Audit Test',
+          outputPath: 'work-products/openclaw-audit-test.md',
+        },
+        context: { clientMode: 'local' },
+      });
+
+    expect(materialized.status).toBe(200);
+    expect(materialized.body.workflow.pipeline).toMatchObject({
+      mode: 'orchestrated',
+      parentAgent: 'orchestrator',
+    });
+    expect(materialized.body.preview.pipeline).toMatchObject({
+      totals: { roles: 5, required: 5 },
+    });
+    expect(materialized.body.preview.pipeline.roles.map((role: { id: string }) => role.id)).toEqual(
+      expect.arrayContaining(['config-auditor', 'security-auditor', 'task-creator'])
+    );
+    expect(materialized.body.lint.ok).toBe(true);
+    expect(materialized.body.yaml).toContain('pipeline:');
+  });
+
+  it('dry-runs pipeline contracts and reports missing role dependencies', async () => {
+    const draft = workflow({
+      pipeline: {
+        mode: 'orchestrated',
+        parentAgent: 'missing-parent',
+        roles: [
+          {
+            id: 'researcher',
+            label: 'Researcher',
+            agent: 'missing-agent',
+            scope: '',
+            taskBrief: '',
+            deliverable: '',
+            verification: [],
+            dependsOn: ['missing-role'],
+          },
+        ],
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/workflows/authoring/dry-run')
+      .send({ workflow: draft, context: { clientMode: 'local' } });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('blocked');
+    expect(response.body.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'pipeline',
+          label: 'Orchestration pipeline',
+          status: 'fail',
+        }),
+      ])
+    );
+    expect(response.body.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: 'pipeline',
+          message: 'Orchestrated pipeline references a missing parent agent.',
+        }),
+        expect.objectContaining({
+          category: 'pipeline',
+          message: 'Pipeline role researcher references a missing agent.',
+        }),
+        expect.objectContaining({
+          category: 'pipeline',
+          message: 'Pipeline role researcher depends on missing role missing-role.',
+        }),
+      ])
+    );
   });
 
   it('dry-runs drafts and reports missing context, policies, secrets, and schedules', async () => {

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -279,6 +279,17 @@ describe('Feature Settings Schema', () => {
     expect(result.agents?.timeoutMinutes).toBe(30);
   });
 
+  it('should accept product mode settings', () => {
+    const result = FeatureSettingsPatchSchema.parse({
+      productMode: {
+        selectedMode: 'qa-review',
+        lastSelectedAt: '2026-06-03T12:00:00.000Z',
+        dismissedHints: ['workflow-panel'],
+      },
+    });
+    expect(result.productMode?.selectedMode).toBe('qa-review');
+  });
+
   it('should accept telemetry settings', () => {
     const result = FeatureSettingsPatchSchema.parse({
       telemetry: { enabled: true, retentionDays: 30 },

--- a/server/src/__tests__/storage/sqlite-work-products.test.ts
+++ b/server/src/__tests__/storage/sqlite-work-products.test.ts
@@ -133,6 +133,47 @@ describe('SQLite work products', () => {
           started: '2026-06-02T10:10:00.000Z',
           ended: '2026-06-02T10:20:00.000Z',
           model: 'gpt-5',
+          orchestration: {
+            mode: 'orchestrated',
+            parentAgent: 'orchestrator',
+            completion: 'all-required',
+            handoff: 'Subagents returned findings for reconciliation.',
+            totals: {
+              roles: 2,
+              required: 2,
+              completed: 1,
+              blocked: 1,
+              failed: 0,
+            },
+            roles: [
+              {
+                id: 'researcher',
+                label: 'Researcher',
+                agent: 'researcher',
+                scope: 'Inspect source material.',
+                taskBrief: 'Find relevant facts.',
+                deliverable: 'Research findings.',
+                verification: ['Cites source material.'],
+                dependsOn: [],
+                required: true,
+                status: 'completed',
+                telemetry: { durationSeconds: 120, tokensUsed: 1200 },
+              },
+              {
+                id: 'reviewer',
+                label: 'Reviewer',
+                agent: 'reviewer',
+                scope: 'Check the research.',
+                taskBrief: 'Validate findings.',
+                deliverable: 'Review notes.',
+                verification: ['Lists blockers first.'],
+                dependsOn: ['researcher'],
+                required: true,
+                status: 'blocked',
+                telemetry: { durationSeconds: 60 },
+              },
+            ],
+          },
         },
         verificationSteps: [
           {
@@ -187,6 +228,8 @@ describe('SQLite work products', () => {
           packetType: 'completion_packet',
           generatedFromRevision: 7,
           verificationPassed: 1,
+          orchestrationRoles: 2,
+          orchestrationBlocked: 1,
         },
       });
       expect(packet.sourceLinks).toEqual(
@@ -199,6 +242,8 @@ describe('SQLite work products', () => {
         ])
       );
       expect(restarted.exportProduct(packet)).toContain('Verification Evidence');
+      expect(restarted.exportProduct(packet)).toContain('Orchestration Pipeline');
+      expect(restarted.exportProduct(packet)).toContain('Reviewer is blocked');
       expect(restarted.exportProduct(packet)).not.toContain('/Users/bradgroux/private');
 
       const regenerated = await restarted.generateCompletionPacket({

--- a/server/src/__tests__/workflow-run-service.test.ts
+++ b/server/src/__tests__/workflow-run-service.test.ts
@@ -94,6 +94,88 @@ describe('WorkflowRunService', () => {
     expect(mockBroadcastWorkflowStatus).toHaveBeenCalled();
   });
 
+  it('rolls orchestrated pipeline roles into workflow run context', async () => {
+    mockLoadWorkflow.mockResolvedValue(
+      makeWorkflow({
+        agents: [
+          { id: 'orchestrator', name: 'Orchestrator' },
+          { id: 'researcher', name: 'Researcher' },
+          { id: 'reviewer', name: 'Reviewer' },
+        ],
+        pipeline: {
+          mode: 'orchestrated',
+          parentAgent: 'orchestrator',
+          completion: 'all-required',
+          roles: [
+            {
+              id: 'researcher',
+              label: 'Researcher',
+              agent: 'researcher',
+              scope: 'Inspect source material.',
+              taskBrief: 'Find relevant facts.',
+              deliverable: 'Research findings.',
+              verification: ['Cites source material.'],
+            },
+            {
+              id: 'reviewer',
+              label: 'Reviewer',
+              agent: 'reviewer',
+              scope: 'Check the research.',
+              taskBrief: 'Validate findings.',
+              deliverable: 'Review notes.',
+              verification: ['Lists blockers first.'],
+              dependsOn: ['researcher'],
+            },
+          ],
+        },
+        steps: [
+          {
+            id: 'delegate',
+            type: 'parallel',
+            parallel: {
+              completion: 'all',
+              steps: [
+                { id: 'research', agent: 'researcher', input: 'Research.' },
+                { id: 'review', agent: 'reviewer', input: 'Review.' },
+              ],
+            },
+          },
+        ],
+      })
+    );
+    mockExecuteStep.mockImplementation(async (step: any) => ({
+      output: {
+        subSteps: step.parallel.steps.map((subStep: any) => ({
+          id: subStep.id,
+          status: 'fulfilled',
+          output: `done ${subStep.id}`,
+        })),
+        completed: step.parallel.steps.length,
+        failed: 0,
+      },
+      outputPath: `/tmp/${step.id}.json`,
+    }));
+
+    const run = await service.startRun('wf-1');
+
+    expect(run.context.pipeline).toMatchObject({
+      totals: { roles: 2, completed: 0 },
+    });
+
+    await vi.waitFor(async () => {
+      const saved = await service.getRun(run.id);
+      expect(saved.context.pipeline).toMatchObject({
+        totals: { roles: 2, completed: 2, failed: 0 },
+      });
+      expect(saved.context.pipeline.roles).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'researcher', status: 'completed' }),
+          expect.objectContaining({ id: 'reviewer', status: 'completed' }),
+        ])
+      );
+    });
+  });
+
   it('handles retry, retry_step, skip, block, and workflow failure', async () => {
     const delaySpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((fn: any) => {
       fn();

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -73,6 +73,7 @@ const workflowCreateSchema = z.object({
   version: z.number().int().min(0),
   description: z.string().max(2000),
   config: z.unknown().optional(),
+  pipeline: z.record(z.string(), z.unknown()).optional(),
   outputTargets: z.array(z.record(z.string(), z.unknown())).max(12).optional(),
   schedule: z.record(z.string(), z.unknown()).optional(),
   agents: z.array(z.unknown()).min(1).max(20),

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -19,6 +19,27 @@ const GeneralSettingsSchema = z
   .strict()
   .optional();
 
+const ProductModeSettingsSchema = z
+  .object({
+    selectedMode: z
+      .enum([
+        'board-only',
+        'agent-ready',
+        'solo-coding',
+        'pm-orchestration',
+        'qa-review',
+        'research',
+        'operations',
+        'advanced',
+        'custom',
+      ])
+      .optional(),
+    lastSelectedAt: z.string().datetime().optional(),
+    dismissedHints: z.array(z.string().max(80)).max(50).optional(),
+  })
+  .strict()
+  .optional();
+
 const DashboardWidgetSettingsSchema = z
   .object({
     showTokenUsage: z.boolean().optional(),
@@ -230,6 +251,7 @@ const SharedResourcesSettingsSchema = z
 const FeatureSettingsPatchObjectSchema = z
   .object({
     general: GeneralSettingsSchema,
+    productMode: ProductModeSettingsSchema,
     board: BoardSettingsSchema,
     tasks: TaskBehaviorSettingsSchema,
     markdown: MarkdownSettingsSchema,

--- a/server/src/services/work-product-service.ts
+++ b/server/src/services/work-product-service.ts
@@ -14,6 +14,7 @@ import type {
   WorkProductRender,
   WorkProductVersion,
   Task,
+  WorkflowPipelineSummary,
 } from '@veritas-kanban/shared';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteWorkProductRepository } from '../storage/sqlite/work-product-repository.js';
@@ -422,6 +423,7 @@ export class WorkProductService {
         { heading: 'Delivered', body: this.deliveredSection(task) },
         { heading: 'Changed Files And Sources', body: this.changedFilesSection(task) },
         { heading: 'Verification Evidence', body: this.verificationSection(task) },
+        { heading: 'Orchestration Pipeline', body: this.orchestrationSection(task) },
         { heading: 'Review And Approval', body: this.reviewSection(task) },
         { heading: 'Cost And Duration', body: this.costDurationSection(task) },
         { heading: 'Deliverables And Attachments', body: this.deliverablesSection(task) },
@@ -473,6 +475,9 @@ export class WorkProductService {
       attachmentCount: task.attachments?.length ?? 0,
       reviewDecision: task.review?.decision ?? null,
       qaGatePassed: task.qaGate?.passed ?? null,
+      orchestrationRoles: task.attempt?.orchestration?.totals.roles ?? 0,
+      orchestrationBlocked: task.attempt?.orchestration?.totals.blocked ?? 0,
+      orchestrationFailed: task.attempt?.orchestration?.totals.failed ?? 0,
     };
   }
 
@@ -579,6 +584,47 @@ export class WorkProductService {
       );
     }
     return this.packetText(lines.join('\n'));
+  }
+
+  private orchestrationSection(task: Task): string {
+    const orchestration = task.attempt?.orchestration;
+    if (!orchestration) {
+      return 'No orchestrator/subagent pipeline summary was recorded for this task attempt.';
+    }
+
+    const lines = [
+      `Mode: ${orchestration.mode}`,
+      orchestration.parentAgent ? `Parent agent: ${orchestration.parentAgent}` : null,
+      `Completion policy: ${orchestration.completion}`,
+      orchestration.handoff ? `Handoff: ${orchestration.handoff}` : null,
+      `Roles: ${orchestration.totals.completed}/${orchestration.totals.roles} completed, ${orchestration.totals.blocked} blocked, ${orchestration.totals.failed} failed.`,
+      '',
+      ...orchestration.roles.map((role) => this.orchestrationRoleLine(role)),
+    ].filter((line): line is string => line !== null);
+
+    const blockers = orchestration.roles.filter(
+      (role) => role.status === 'blocked' || role.status === 'failed'
+    );
+    if (blockers.length > 0) {
+      lines.push(
+        '',
+        'Blockers:',
+        this.markdownList(
+          blockers.map((role) => `${role.label} is ${role.status}: ${role.deliverable}`)
+        )
+      );
+    }
+
+    return this.packetText(lines.join('\n'));
+  }
+
+  private orchestrationRoleLine(role: WorkflowPipelineSummary['roles'][number]): string {
+    const verification =
+      role.verification.length > 0
+        ? `${role.verification.length} verification step(s)`
+        : 'no verification steps';
+    const duration = this.formatDurationSeconds(role.telemetry.durationSeconds);
+    return `- ${role.label} (${role.agent}) is ${role.status}. Scope: ${role.scope}. Deliverable: ${role.deliverable}. Verification: ${verification}. Duration: ${duration}`;
   }
 
   private reviewSection(task: Task): string {

--- a/server/src/services/workflow-authoring-service.ts
+++ b/server/src/services/workflow-authoring-service.ts
@@ -1,5 +1,9 @@
 import yaml from 'yaml';
-import type { WorkflowSkillAuditSummary } from '@veritas-kanban/shared';
+import {
+  buildWorkflowPipelineSummary,
+  type WorkflowPipelineSummary,
+  type WorkflowSkillAuditSummary,
+} from '@veritas-kanban/shared';
 import type {
   ToolPolicy,
   WorkflowDefinition,
@@ -21,6 +25,7 @@ export type WorkflowLintCategory =
   | 'policy'
   | 'secret'
   | 'skill'
+  | 'pipeline'
   | 'client'
   | 'output'
   | 'schedule';
@@ -62,6 +67,7 @@ export interface WorkflowRecipeMaterialization {
   lint: WorkflowLintResult;
   preview: {
     steps: Array<{ id: string; name: string; type: WorkflowStep['type']; agent?: string }>;
+    pipeline?: WorkflowPipelineSummary;
     outputTargets: WorkflowOutputTarget[];
     schedule?: WorkflowSchedule;
   };
@@ -88,6 +94,7 @@ export interface WorkflowLintResult {
   ok: boolean;
   yaml?: string;
   messages: WorkflowLintMessage[];
+  pipelineSummary?: WorkflowPipelineSummary;
   summary: {
     errors: number;
     warnings: number;
@@ -107,6 +114,7 @@ export interface WorkflowDryRunResult extends WorkflowLintResult {
   canRun: boolean;
   checks: WorkflowDryRunCheck[];
   skillAudit?: WorkflowSkillAuditSummary;
+  pipelineSummary?: WorkflowPipelineSummary;
   workflow?: WorkflowDefinition;
 }
 
@@ -372,6 +380,264 @@ const RECIPES: WorkflowRecipeDefinition[] = [
             agent: 'reviewer',
             input: 'Review the implementation, verification output, and completion packet.',
             output: { file: 'completion-packet.md' },
+          },
+        ],
+      };
+    },
+  },
+  {
+    id: 'openclaw-audit',
+    name: '.openclaw Audit',
+    description:
+      'Delegate an OpenClaw configuration audit across scoped subagents and reconcile the findings.',
+    tags: ['openclaw', 'audit', 'orchestrator', 'subagents'],
+    inputs: [
+      {
+        id: 'workflowName',
+        label: 'Workflow name',
+        type: 'text',
+        required: true,
+        defaultValue: '.openclaw Audit Workflow',
+      },
+      {
+        id: 'scope',
+        label: 'Audit scope',
+        type: 'textarea',
+        required: true,
+        defaultValue:
+          '.openclaw config, gateway routing, storage retention, session cache, docs, and task follow-ups',
+      },
+      {
+        id: 'outputPath',
+        label: 'Audit report path',
+        type: 'text',
+        required: true,
+        defaultValue: 'work-products/openclaw-audit.md',
+      },
+    ],
+    defaultOutputTargets: [
+      outputTarget('dashboard-queue-item', 'OpenClaw audit queue item', { required: true }),
+      outputTarget('work-product', 'OpenClaw audit report', {
+        required: true,
+        path: 'work-products/openclaw-audit.md',
+      }),
+      outputTarget('completion-packet', 'Completion packet'),
+    ],
+    schedule: manualSchedule(),
+    build: (inputs) => {
+      const name = workflowName(inputs, '.openclaw Audit Workflow');
+      const scope = inputString(
+        inputs,
+        'scope',
+        '.openclaw config, gateway routing, storage retention, session cache, docs, and task follow-ups'
+      );
+      return {
+        id: workflowId(inputString(inputs, 'workflowId', name), 'openclaw-audit'),
+        name,
+        version: 1,
+        description:
+          'Fan out an OpenClaw audit to scoped subagents, reconcile evidence, and create follow-up tasks.',
+        pipeline: {
+          mode: 'orchestrated',
+          parentAgent: 'orchestrator',
+          completion: 'all-required',
+          handoff:
+            'Subagents return findings, evidence, task suggestions, and blockers to the orchestrator for reconciliation.',
+          roles: [
+            {
+              id: 'config-auditor',
+              label: 'Config Auditor',
+              agent: 'config-auditor',
+              scope: '.openclaw config, gateway, and channel routing settings.',
+              taskBrief:
+                'Inspect documented config paths and report drift, missing keys, or unsafe defaults.',
+              deliverable: 'Config findings with source file references and remediation notes.',
+              verification: [
+                'Config keys are source-backed.',
+                'No secret values are copied into findings.',
+              ],
+              telemetry: { timeBudgetMinutes: 20, tokenBudget: 12000 },
+            },
+            {
+              id: 'storage-auditor',
+              label: 'Storage Auditor',
+              agent: 'storage-auditor',
+              scope: 'Persistence, retention, cache, and backup behavior.',
+              taskBrief: 'Review storage lifecycle, cache cleanup, and backup portability notes.',
+              deliverable: 'Storage risk table with retained, cleanup, and blocked states.',
+              verification: [
+                'Retention claims cite code or docs.',
+                'Data deletion is not performed.',
+              ],
+              telemetry: { timeBudgetMinutes: 20, tokenBudget: 10000 },
+            },
+            {
+              id: 'security-auditor',
+              label: 'Security Auditor',
+              agent: 'security-auditor',
+              scope: 'Auth, permissions, tokens, logs, and remote gateway exposure.',
+              taskBrief:
+                'Find security regressions and secret leakage risks in the OpenClaw surface.',
+              deliverable: 'Security blockers first, followed by warnings and mitigations.',
+              verification: [
+                'Secrets are redacted.',
+                'Findings include affected route, config, or log surface.',
+              ],
+              telemetry: { timeBudgetMinutes: 25, tokenBudget: 14000 },
+            },
+            {
+              id: 'docs-auditor',
+              label: 'Docs Auditor',
+              agent: 'docs-auditor',
+              scope: 'README, SOP, config reference, and troubleshooting docs.',
+              taskBrief:
+                'Compare docs against the inspected runtime and list stale or missing guidance.',
+              deliverable: 'Docs freshness findings and suggested patch targets.',
+              verification: [
+                'Each docs issue names a source doc.',
+                'No external vendor references are invented.',
+              ],
+              telemetry: { timeBudgetMinutes: 15, tokenBudget: 8000 },
+            },
+            {
+              id: 'task-creator',
+              label: 'Follow-up Task Creator',
+              agent: 'task-creator',
+              scope: 'Confirmed audit findings only.',
+              taskBrief:
+                'Turn confirmed blockers and high-confidence warnings into actionable Veritas tasks.',
+              deliverable:
+                'Candidate task list with title, owner surface, priority, and acceptance criteria.',
+              verification: [
+                'Every task traces to a finding.',
+                'Duplicate tasks are called out instead of recreated.',
+              ],
+              dependsOn: ['config-auditor', 'storage-auditor', 'security-auditor', 'docs-auditor'],
+              telemetry: { timeBudgetMinutes: 15, tokenBudget: 8000 },
+            },
+          ],
+        },
+        schedule: manualSchedule(),
+        variables: {
+          scope,
+          recipe: 'openclaw-audit',
+        },
+        outputTargets: [
+          outputTarget('dashboard-queue-item', 'OpenClaw audit queue item', { required: true }),
+          outputTarget('work-product', 'OpenClaw audit report', {
+            required: true,
+            path: targetPath(inputs, 'work-products/openclaw-audit.md'),
+          }),
+          outputTarget('completion-packet', 'Completion packet'),
+        ],
+        agents: [
+          {
+            id: 'orchestrator',
+            name: 'Orchestrator',
+            role: 'planner',
+            description: 'Owns scope, delegation, synthesis, and final handoff.',
+            tools: ['Read', 'web_search'],
+          },
+          {
+            id: 'config-auditor',
+            name: 'Config Auditor',
+            role: 'reviewer',
+            description: 'Reviews OpenClaw config and gateway routing.',
+            tools: ['Read', 'exec', 'web_search'],
+          },
+          {
+            id: 'storage-auditor',
+            name: 'Storage Auditor',
+            role: 'reviewer',
+            description: 'Reviews storage lifecycle, cache, and backup behavior.',
+            tools: ['Read', 'exec', 'web_search'],
+          },
+          {
+            id: 'security-auditor',
+            name: 'Security Auditor',
+            role: 'reviewer',
+            description: 'Reviews auth, permissions, remote exposure, and redaction risks.',
+            tools: ['Read', 'exec', 'web_search'],
+          },
+          {
+            id: 'docs-auditor',
+            name: 'Docs Auditor',
+            role: 'reviewer',
+            description: 'Checks docs freshness against runtime behavior.',
+            tools: ['Read', 'web_search'],
+          },
+          {
+            id: 'task-creator',
+            name: 'Task Creator',
+            role: 'planner',
+            description: 'Creates issue-ready follow-up task candidates.',
+            tools: ['Read', 'web_search'],
+          },
+        ],
+        steps: [
+          {
+            id: 'brief',
+            name: 'Prepare delegation brief',
+            type: 'agent',
+            agent: 'orchestrator',
+            input: 'Prepare scoped audit briefs for {{ workflow.variables.scope }}.',
+            output: { file: 'openclaw-audit-brief.md' },
+          },
+          {
+            id: 'delegated-audit',
+            name: 'Run delegated audit',
+            type: 'parallel',
+            parallel: {
+              completion: 'all',
+              fail_fast: false,
+              timeout: 1800,
+              steps: [
+                {
+                  id: 'config-audit',
+                  agent: 'config-auditor',
+                  input:
+                    'Use the audit brief to inspect OpenClaw config and gateway routing. Return findings, evidence, verification, and blockers.',
+                },
+                {
+                  id: 'storage-audit',
+                  agent: 'storage-auditor',
+                  input:
+                    'Use the audit brief to inspect storage retention, caches, backups, and cleanup behavior. Return findings, evidence, verification, and blockers.',
+                },
+                {
+                  id: 'security-audit',
+                  agent: 'security-auditor',
+                  input:
+                    'Use the audit brief to inspect auth, permissions, remote exposure, and redaction risks. Return blockers first.',
+                },
+                {
+                  id: 'docs-audit',
+                  agent: 'docs-auditor',
+                  input:
+                    'Use the audit brief to inspect docs freshness and troubleshooting coverage. Return stale, missing, or risky guidance.',
+                },
+              ],
+            },
+            output: { file: 'delegated-audit-results.json' },
+            acceptance_criteria: ['completed'],
+          },
+          {
+            id: 'follow-up-tasks',
+            name: 'Prepare follow-up tasks',
+            type: 'agent',
+            agent: 'task-creator',
+            input:
+              'Read delegated audit results and produce issue-ready tasks only for confirmed findings.',
+            output: { file: 'openclaw-follow-up-tasks.md' },
+          },
+          {
+            id: 'reconcile',
+            name: 'Reconcile completion packet',
+            type: 'agent',
+            agent: 'orchestrator',
+            input:
+              'Reconcile subagent findings, evidence, follow-up tasks, verification, and blockers into the final audit report and completion packet.',
+            output: { file: 'openclaw-audit.md' },
           },
         ],
       };
@@ -697,6 +963,7 @@ export class WorkflowAuthoringService {
       lint,
       preview: {
         steps: workflow.steps.map(stepPreview),
+        pipeline: lint.pipelineSummary,
         outputTargets: workflow.outputTargets ?? [],
         schedule: workflow.schedule,
       },
@@ -748,6 +1015,7 @@ export class WorkflowAuthoringService {
       canRun: lint.summary.errors === 0,
       checks: this.buildChecks(lint.messages),
       skillAudit: lint.skillAudit,
+      pipelineSummary: lint.pipelineSummary,
       workflow: parsed.workflow,
     };
   }
@@ -763,10 +1031,16 @@ export class WorkflowAuthoringService {
   private async lintWorkflow(
     workflow: WorkflowDefinition,
     context: WorkflowDryRunContext
-  ): Promise<WorkflowLintResult & { skillAudit?: WorkflowSkillAuditSummary }> {
+  ): Promise<
+    WorkflowLintResult & {
+      skillAudit?: WorkflowSkillAuditSummary;
+      pipelineSummary?: WorkflowPipelineSummary;
+    }
+  > {
     const messages: WorkflowLintMessage[] = [];
 
     this.lintDefinition(workflow, messages);
+    const pipelineSummary = this.lintPipeline(workflow, messages);
     await this.lintToolPolicies(workflow, messages);
     const skillAudit = await this.lintSkillAudit(workflow, context, messages);
     this.lintSecrets(workflow, context, messages);
@@ -779,6 +1053,7 @@ export class WorkflowAuthoringService {
       ...this.resultFromMessages(messages),
       yaml: this.toYaml(workflow),
       skillAudit,
+      pipelineSummary,
     };
   }
 
@@ -1008,6 +1283,34 @@ export class WorkflowAuthoringService {
           )
         );
       }
+      if (step.type === 'parallel' && step.parallel?.steps) {
+        for (const duplicate of duplicateValues(
+          step.parallel.steps.map((subStep) => subStep.id).filter(Boolean)
+        )) {
+          messages.push(
+            message(
+              'error',
+              'definition',
+              `${path}.parallel.steps.${duplicate}`,
+              `Parallel step ${step.id || index} has duplicate substep ID ${duplicate}.`,
+              'Use unique parallel substep IDs.'
+            )
+          );
+        }
+        for (const [subIndex, subStep] of step.parallel.steps.entries()) {
+          if (!subStep.agent || !agentIds.has(subStep.agent)) {
+            messages.push(
+              message(
+                'error',
+                'definition',
+                `${path}.parallel.steps[${subIndex}].agent`,
+                `Parallel substep ${subStep.id || subIndex} references a missing agent.`,
+                'Select an existing agent for this parallel substep.'
+              )
+            );
+          }
+        }
+      }
       if (step.on_fail?.retry_step && !stepIds.has(step.on_fail.retry_step)) {
         messages.push(
           message(
@@ -1031,6 +1334,183 @@ export class WorkflowAuthoringService {
         );
       }
     }
+  }
+
+  private lintPipeline(
+    workflow: WorkflowDefinition,
+    messages: WorkflowLintMessage[]
+  ): WorkflowPipelineSummary | undefined {
+    const pipeline = workflow.pipeline;
+    if (!pipeline) return undefined;
+
+    if (pipeline.mode !== 'single-agent' && pipeline.mode !== 'orchestrated') {
+      messages.push(
+        message(
+          'error',
+          'pipeline',
+          'pipeline.mode',
+          `Unsupported pipeline mode ${String(pipeline.mode)}.`,
+          'Choose single-agent or orchestrated.'
+        )
+      );
+      return buildWorkflowPipelineSummary(workflow);
+    }
+
+    if (pipeline.mode === 'single-agent') {
+      return buildWorkflowPipelineSummary(workflow);
+    }
+
+    const agentIds = new Set(toArray(workflow.agents).map((agent) => agent.id));
+    const stepAgentIds = new Set(
+      toArray(workflow.steps).flatMap((step) => [
+        ...(step.agent ? [step.agent] : []),
+        ...(step.parallel?.steps ?? []).map((subStep) => subStep.agent),
+      ])
+    );
+    const roles = pipeline.roles ?? [];
+
+    if (!pipeline.parentAgent || !agentIds.has(pipeline.parentAgent)) {
+      messages.push(
+        message(
+          'error',
+          'pipeline',
+          'pipeline.parentAgent',
+          'Orchestrated pipeline references a missing parent agent.',
+          'Set pipeline.parentAgent to an existing workflow agent.'
+        )
+      );
+    }
+
+    if (roles.length === 0) {
+      messages.push(
+        message(
+          'error',
+          'pipeline',
+          'pipeline.roles',
+          'Orchestrated pipeline has no subagent roles.',
+          'Add scoped subagent roles with briefs, deliverables, and verification steps.'
+        )
+      );
+    }
+
+    for (const duplicate of duplicateValues(roles.map((role) => role.id).filter(Boolean))) {
+      messages.push(
+        message(
+          'error',
+          'pipeline',
+          `pipeline.roles.${duplicate}`,
+          `Duplicate pipeline role ID ${duplicate}.`,
+          'Use unique role IDs so handoffs and telemetry can be reconciled.'
+        )
+      );
+    }
+
+    const roleIds = new Set(roles.map((role) => role.id));
+    for (const [index, role] of roles.entries()) {
+      const path = `pipeline.roles[${index}]`;
+      if (!role.id) {
+        messages.push(
+          message(
+            'error',
+            'pipeline',
+            `${path}.id`,
+            'Pipeline role ID is required.',
+            'Add a stable role ID.'
+          )
+        );
+      }
+      if (!role.label) {
+        messages.push(
+          message(
+            'warning',
+            'pipeline',
+            `${path}.label`,
+            `Pipeline role ${role.id || index} has no label.`,
+            'Add a user-facing role label for run views.'
+          )
+        );
+      }
+      if (!role.agent || !agentIds.has(role.agent)) {
+        messages.push(
+          message(
+            'error',
+            'pipeline',
+            `${path}.agent`,
+            `Pipeline role ${role.id || index} references a missing agent.`,
+            'Attach each subagent role to an existing workflow agent.'
+          )
+        );
+      } else if (!stepAgentIds.has(role.agent)) {
+        messages.push(
+          message(
+            'warning',
+            'pipeline',
+            `${path}.agent`,
+            `Pipeline role ${role.id || index} is not used by a workflow step.`,
+            'Add an agent or parallel substep that delegates work to this role.'
+          )
+        );
+      }
+      if (!role.scope) {
+        messages.push(
+          message(
+            'error',
+            'pipeline',
+            `${path}.scope`,
+            `Pipeline role ${role.id || index} has no scope.`,
+            'Define the subagent scope so the orchestrator can delegate safely.'
+          )
+        );
+      }
+      if (!role.taskBrief) {
+        messages.push(
+          message(
+            'error',
+            'pipeline',
+            `${path}.taskBrief`,
+            `Pipeline role ${role.id || index} has no task brief.`,
+            'Add the brief template the subagent receives.'
+          )
+        );
+      }
+      if (role.required !== false && !role.deliverable) {
+        messages.push(
+          message(
+            'error',
+            'pipeline',
+            `${path}.deliverable`,
+            `Required pipeline role ${role.id || index} has no deliverable contract.`,
+            'Describe the output the orchestrator must reconcile.'
+          )
+        );
+      }
+      if (role.required !== false && (!role.verification || role.verification.length === 0)) {
+        messages.push(
+          message(
+            'error',
+            'pipeline',
+            `${path}.verification`,
+            `Required pipeline role ${role.id || index} has no verification steps.`,
+            'Add at least one verification step for the role output.'
+          )
+        );
+      }
+      for (const dependency of role.dependsOn ?? []) {
+        if (!roleIds.has(dependency)) {
+          messages.push(
+            message(
+              'error',
+              'pipeline',
+              `${path}.dependsOn`,
+              `Pipeline role ${role.id || index} depends on missing role ${dependency}.`,
+              'Point dependencies at existing pipeline role IDs.'
+            )
+          );
+        }
+      }
+    }
+
+    return buildWorkflowPipelineSummary(workflow);
   }
 
   private async lintToolPolicies(
@@ -1374,6 +1854,7 @@ export class WorkflowAuthoringService {
       this.checkFor('permission', 'Permissions', messages),
       this.checkFor('policy', 'Policy gates and tools', messages),
       this.checkFor('skill', 'Skill audit', messages),
+      this.checkFor('pipeline', 'Orchestration pipeline', messages),
       this.checkFor('secret', 'Secrets', messages),
       this.checkFor('client', 'Client mode', messages),
       this.checkFor('output', 'Output targets', messages),

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -6,6 +6,12 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { nanoid } from 'nanoid';
+import {
+  buildWorkflowPipelineSummary,
+  type WorkflowPipelineRoleStatusPatch,
+  type WorkflowSubagentRunStatus,
+  type WorkflowSubagentTelemetry,
+} from '@veritas-kanban/shared';
 import type { WorkflowRun, StepRun, WorkflowDefinition, WorkflowStep } from '../types/workflow.js';
 import { getWorkflowService } from './workflow-service.js';
 import { WorkflowStepExecutor } from './workflow-step-executor.js';
@@ -88,6 +94,108 @@ export class WorkflowRunService {
     return trimmed;
   }
 
+  private syncPipelineSummary(run: WorkflowRun, workflow: WorkflowDefinition): void {
+    const baseSummary = buildWorkflowPipelineSummary(workflow);
+    if (!baseSummary) return;
+
+    const patches: WorkflowPipelineRoleStatusPatch = {};
+    for (const role of baseSummary.roles) {
+      patches[role.id] = this.pipelineRoleStatusPatch(role.agent, run, workflow);
+    }
+    run.context.pipeline = buildWorkflowPipelineSummary(workflow, patches);
+  }
+
+  private pipelineRoleStatusPatch(
+    agentId: string,
+    run: WorkflowRun,
+    workflow: WorkflowDefinition
+  ): { status: WorkflowSubagentRunStatus; telemetry: WorkflowSubagentTelemetry } {
+    const statuses: WorkflowSubagentRunStatus[] = [];
+    const telemetry: WorkflowSubagentTelemetry = {};
+    let durationSeconds = 0;
+
+    for (const step of workflow.steps) {
+      const stepRun = run.steps.find((candidate) => candidate.stepId === step.id);
+      if (!stepRun) continue;
+
+      if (step.agent === agentId) {
+        statuses.push(this.stepStatusForPipeline(stepRun, run));
+        this.mergeStepTelemetry(telemetry, stepRun);
+        durationSeconds += stepRun.duration ?? 0;
+      }
+
+      for (const subStep of step.parallel?.steps ?? []) {
+        if (subStep.agent !== agentId) continue;
+        statuses.push(this.parallelSubstepStatus(step, subStep.id, stepRun, run));
+        this.mergeStepTelemetry(telemetry, stepRun);
+        durationSeconds += stepRun.duration ?? 0;
+      }
+    }
+
+    if (durationSeconds > 0) {
+      telemetry.durationSeconds = durationSeconds;
+    }
+
+    return {
+      status: this.resolvePipelineStatus(statuses),
+      telemetry,
+    };
+  }
+
+  private stepStatusForPipeline(stepRun: StepRun, run: WorkflowRun): WorkflowSubagentRunStatus {
+    if (run.status === 'blocked' && run.currentStep === stepRun.stepId) return 'blocked';
+    return stepRun.status;
+  }
+
+  private parallelSubstepStatus(
+    step: WorkflowStep,
+    subStepId: string,
+    stepRun: StepRun,
+    run: WorkflowRun
+  ): WorkflowSubagentRunStatus {
+    const output = run.context[step.id];
+    const subSteps =
+      output &&
+      typeof output === 'object' &&
+      Array.isArray((output as { subSteps?: unknown }).subSteps)
+        ? (output as { subSteps: Array<{ id?: string; status?: string }> }).subSteps
+        : [];
+    const subStepOutput = subSteps.find((candidate) => candidate.id === subStepId);
+    if (subStepOutput?.status === 'fulfilled') return 'completed';
+    if (subStepOutput?.status === 'rejected') return 'failed';
+    if (run.status === 'blocked' && run.currentStep === step.id) return 'blocked';
+    if (stepRun.status === 'running') return 'running';
+    if (stepRun.status === 'failed') return 'failed';
+    if (stepRun.status === 'skipped') return 'skipped';
+    return 'pending';
+  }
+
+  private resolvePipelineStatus(statuses: WorkflowSubagentRunStatus[]): WorkflowSubagentRunStatus {
+    if (statuses.length === 0) return 'pending';
+    if (statuses.includes('failed')) return 'failed';
+    if (statuses.includes('blocked')) return 'blocked';
+    if (statuses.includes('running')) return 'running';
+    if (statuses.every((status) => status === 'completed')) return 'completed';
+    if (statuses.every((status) => status === 'skipped')) return 'skipped';
+    if (statuses.includes('completed')) return 'completed';
+    return 'pending';
+  }
+
+  private mergeStepTelemetry(telemetry: WorkflowSubagentTelemetry, stepRun: StepRun): void {
+    if (stepRun.startedAt) {
+      telemetry.startedAt =
+        !telemetry.startedAt || stepRun.startedAt < telemetry.startedAt
+          ? stepRun.startedAt
+          : telemetry.startedAt;
+    }
+    if (stepRun.completedAt) {
+      telemetry.completedAt =
+        !telemetry.completedAt || stepRun.completedAt > telemetry.completedAt
+          ? stepRun.completedAt
+          : telemetry.completedAt;
+    }
+  }
+
   /**
    * Start a new workflow run
    */
@@ -131,6 +239,9 @@ export class WorkflowRunService {
 
         // Custom initial context (from API caller)
         ...initialContext,
+
+        // Orchestrator/subagent pipeline summary for run views and completion handoff.
+        ...(workflow.pipeline ? { pipeline: buildWorkflowPipelineSummary(workflow) } : {}),
 
         // Run metadata
         workflow: {
@@ -197,6 +308,7 @@ export class WorkflowRunService {
         const stepRun = existingStepRun;
         stepRun.status = 'running';
         stepRun.startedAt = new Date().toISOString();
+        this.syncPipelineSummary(run, workflow);
         await this.saveRun(run);
 
         try {
@@ -213,6 +325,7 @@ export class WorkflowRunService {
           // Merge step output into run context
           run.context[step.id] = result.output;
 
+          this.syncPipelineSummary(run, workflow);
           await this.saveRun(run);
           broadcastWorkflowStatus(run);
         } catch (err: unknown) {
@@ -220,6 +333,7 @@ export class WorkflowRunService {
           stepRun.status = 'failed';
           stepRun.error = err instanceof Error ? err.message : 'Unknown error';
           stepRun.completedAt = new Date().toISOString();
+          this.syncPipelineSummary(run, workflow);
           await this.saveRun(run);
           broadcastWorkflowStatus(run);
 
@@ -245,6 +359,7 @@ export class WorkflowRunService {
       // All steps completed
       run.status = 'completed';
       run.completedAt = new Date().toISOString();
+      this.syncPipelineSummary(run, workflow);
       await this.saveRun(run);
       broadcastWorkflowStatus(run);
 
@@ -253,6 +368,7 @@ export class WorkflowRunService {
       run.status = 'failed';
       run.error = err instanceof Error ? err.message : 'Unknown error';
       run.completedAt = new Date().toISOString();
+      this.syncPipelineSummary(run, workflow);
       await this.saveRun(run);
       broadcastWorkflowStatus(run);
 
@@ -295,6 +411,7 @@ export class WorkflowRunService {
       // Re-queue this step at the front
       stepQueue.unshift(step.id);
 
+      this.syncPipelineSummary(run, workflow);
       await this.saveRun(run);
       log.info({ stepId: step.id, retry: stepRun.retries }, 'Retrying step');
       return true;
@@ -328,6 +445,7 @@ export class WorkflowRunService {
         retries: stepRun.retries,
       };
 
+      this.syncPipelineSummary(run, workflow);
       await this.saveRun(run);
       log.info({ failedStep: step.id, retryStep: retryStep.id }, 'Routing to retry step');
       return true;
@@ -337,6 +455,7 @@ export class WorkflowRunService {
     if (policy.escalate_to === 'human') {
       run.status = 'blocked';
       run.error = policy.escalate_message || `Step ${step.id} failed`;
+      this.syncPipelineSummary(run, workflow);
       await this.saveRun(run);
 
       log.warn({ runId: run.id, stepId: step.id }, 'Workflow blocked');
@@ -345,6 +464,7 @@ export class WorkflowRunService {
 
     if (policy.escalate_to === 'skip') {
       stepRun.status = 'skipped';
+      this.syncPipelineSummary(run, workflow);
       await this.saveRun(run);
       log.info({ stepId: step.id }, 'Skipping failed step');
       return true;
@@ -418,7 +538,11 @@ export class WorkflowRunService {
     }
 
     // Sort by startedAt descending
-    runs.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+    runs.sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime() ||
+        b.id.localeCompare(a.id)
+    );
 
     return runs;
   }
@@ -498,7 +622,11 @@ export class WorkflowRunService {
     }
 
     // Sort by startedAt descending
-    metadata.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+    metadata.sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime() ||
+        b.id.localeCompare(a.id)
+    );
 
     log.info({ count: metadata.length }, 'Listed run metadata');
     return metadata;
@@ -527,6 +655,9 @@ export class WorkflowRunService {
     if (!workflow) {
       throw new NotFoundError(`Workflow ${run.workflowId} not found`);
     }
+
+    this.syncPipelineSummary(run, workflow);
+    await this.saveRun(run);
 
     log.info({ runId }, 'Resuming workflow run');
 

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -853,7 +853,7 @@ export class WorkflowStepExecutor {
     const prompt = this.renderTemplate(subStep.input, context);
 
     // Placeholder: Simulate agent execution
-    const result = `Agent ${subStep.agent} executed sub-step ${subStep.id}\n\nPrompt:\n${prompt}\n\nSTATUS: done\nOUTPUT: Sub-step ${subStep.id} complete`;
+    const result = `Delegation event: ${parentStepId} -> ${subStep.id} (${subStep.agent})\n\nAgent ${subStep.agent} executed sub-step ${subStep.id}\n\nPrompt:\n${prompt}\n\nSTATUS: done\nOUTPUT: Sub-step ${subStep.id} complete`;
 
     // Parse output
     const parsed = this.parseStepOutput(result, {

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -13,6 +13,7 @@ export interface WorkflowDefinition {
   version: number;
   description: string;
   config?: WorkflowConfig;
+  pipeline?: WorkflowPipeline;
   outputTargets?: WorkflowOutputTarget[];
   schedule?: WorkflowSchedule;
   agents: WorkflowAgent[];
@@ -30,6 +31,46 @@ export interface WorkflowConfig {
   fresh_session_default?: boolean;
   progress_file?: string;
   telemetry_tags?: string[];
+}
+
+export type WorkflowPipelineMode = 'single-agent' | 'orchestrated';
+export type WorkflowPipelineCompletion = 'all-required' | 'any-success' | 'manual-review';
+export type WorkflowSubagentRunStatus =
+  | 'pending'
+  | 'running'
+  | 'blocked'
+  | 'completed'
+  | 'failed'
+  | 'skipped';
+
+export interface WorkflowSubagentTelemetry {
+  tokenBudget?: number;
+  tokensUsed?: number;
+  timeBudgetMinutes?: number;
+  durationSeconds?: number;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface WorkflowSubagentRole {
+  id: string;
+  label: string;
+  agent: string;
+  scope: string;
+  taskBrief: string;
+  deliverable: string;
+  verification: string[];
+  dependsOn?: string[];
+  required?: boolean;
+  telemetry?: WorkflowSubagentTelemetry;
+}
+
+export interface WorkflowPipeline {
+  mode: WorkflowPipelineMode;
+  parentAgent?: string;
+  completion?: WorkflowPipelineCompletion;
+  handoff?: string;
+  roles?: WorkflowSubagentRole[];
 }
 
 export type WorkflowOutputTargetType =

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -180,6 +180,23 @@ export interface GeneralSettings {
   humanDisplayName: string; // Display name for human user in Squad Chat (default: "Human")
 }
 
+export type ProductModeId =
+  | 'board-only'
+  | 'agent-ready'
+  | 'solo-coding'
+  | 'pm-orchestration'
+  | 'qa-review'
+  | 'research'
+  | 'operations'
+  | 'advanced'
+  | 'custom';
+
+export interface ProductModeSettings {
+  selectedMode: ProductModeId;
+  lastSelectedAt?: string;
+  dismissedHints: string[];
+}
+
 /** Board display settings */
 export interface BoardSettings {
   showDashboard: boolean;
@@ -334,6 +351,7 @@ export interface SquadWebhookSettings {
 /** All feature settings combined */
 export interface FeatureSettings {
   general: GeneralSettings;
+  productMode: ProductModeSettings;
   board: BoardSettings;
   tasks: TaskBehaviorSettings;
   markdown: MarkdownSettings;
@@ -353,6 +371,10 @@ export interface FeatureSettings {
 export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
   general: {
     humanDisplayName: 'Human',
+  },
+  productMode: {
+    selectedMode: 'advanced',
+    dismissedHints: [],
   },
   board: {
     showDashboard: true,

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -52,6 +52,7 @@ export interface TaskAttempt {
   threadId?: string;
   cloudUrl?: string;
   cloudTarget?: string;
+  orchestration?: import('./workflow.js').WorkflowPipelineSummary;
 }
 
 export interface Subtask {

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -11,6 +11,7 @@ export interface WorkflowDefinition {
   version: number;
   description: string;
   config?: WorkflowConfig;
+  pipeline?: WorkflowPipeline;
   outputTargets?: WorkflowOutputTarget[];
   schedule?: WorkflowSchedule;
   agents: WorkflowAgent[];
@@ -29,6 +30,76 @@ export interface WorkflowConfig {
   progress_file?: string;
   telemetry_tags?: string[];
 }
+
+export type WorkflowPipelineMode = 'single-agent' | 'orchestrated';
+export type WorkflowPipelineCompletion = 'all-required' | 'any-success' | 'manual-review';
+export type WorkflowSubagentRunStatus =
+  | 'pending'
+  | 'running'
+  | 'blocked'
+  | 'completed'
+  | 'failed'
+  | 'skipped';
+
+export interface WorkflowSubagentTelemetry {
+  tokenBudget?: number;
+  tokensUsed?: number;
+  timeBudgetMinutes?: number;
+  durationSeconds?: number;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface WorkflowSubagentRole {
+  id: string;
+  label: string;
+  agent: string;
+  scope: string;
+  taskBrief: string;
+  deliverable: string;
+  verification: string[];
+  dependsOn?: string[];
+  required?: boolean;
+  telemetry?: WorkflowSubagentTelemetry;
+}
+
+export interface WorkflowPipeline {
+  mode: WorkflowPipelineMode;
+  parentAgent?: string;
+  completion?: WorkflowPipelineCompletion;
+  handoff?: string;
+  roles?: WorkflowSubagentRole[];
+}
+
+export interface WorkflowSubagentRoleSummary extends WorkflowSubagentRole {
+  status: WorkflowSubagentRunStatus;
+  telemetry: WorkflowSubagentTelemetry;
+}
+
+export interface WorkflowPipelineSummary {
+  mode: WorkflowPipelineMode;
+  parentAgent?: string;
+  completion: WorkflowPipelineCompletion;
+  handoff?: string;
+  roles: WorkflowSubagentRoleSummary[];
+  totals: {
+    roles: number;
+    required: number;
+    completed: number;
+    blocked: number;
+    failed: number;
+  };
+}
+
+export type WorkflowPipelineRoleStatusPatch = Partial<
+  Record<
+    string,
+    {
+      status?: WorkflowSubagentRunStatus;
+      telemetry?: WorkflowSubagentTelemetry;
+    }
+  >
+>;
 
 export type WorkflowOutputTargetType =
   | 'task-update'

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from './api-permissions.js';
 export * from './api-client.js';
 export * from './agent-helpers.js';
 export * from './task-readiness.js';
+export * from './workflow-pipeline.js';

--- a/shared/src/utils/workflow-pipeline.ts
+++ b/shared/src/utils/workflow-pipeline.ts
@@ -1,0 +1,55 @@
+import type {
+  WorkflowDefinition,
+  WorkflowPipelineRoleStatusPatch,
+  WorkflowPipelineSummary,
+  WorkflowSubagentRole,
+  WorkflowSubagentTelemetry,
+} from '../types/workflow.js';
+
+function mergeTelemetry(
+  roleTelemetry: WorkflowSubagentTelemetry | undefined,
+  patchTelemetry: WorkflowSubagentTelemetry | undefined
+): WorkflowSubagentTelemetry {
+  return {
+    ...(roleTelemetry ?? {}),
+    ...(patchTelemetry ?? {}),
+  };
+}
+
+function workflowRoles(workflow: WorkflowDefinition): WorkflowSubagentRole[] {
+  return workflow.pipeline?.roles ?? [];
+}
+
+export function buildWorkflowPipelineSummary(
+  workflow: WorkflowDefinition,
+  statuses: WorkflowPipelineRoleStatusPatch = {}
+): WorkflowPipelineSummary | undefined {
+  if (!workflow.pipeline) return undefined;
+
+  const roles = workflowRoles(workflow).map((role) => {
+    const patch = statuses[role.id] ?? {};
+    return {
+      ...role,
+      required: role.required ?? true,
+      dependsOn: role.dependsOn ?? [],
+      verification: role.verification ?? [],
+      status: patch.status ?? 'pending',
+      telemetry: mergeTelemetry(role.telemetry, patch.telemetry),
+    };
+  });
+
+  return {
+    mode: workflow.pipeline.mode,
+    parentAgent: workflow.pipeline.parentAgent,
+    completion: workflow.pipeline.completion ?? 'all-required',
+    handoff: workflow.pipeline.handoff,
+    roles,
+    totals: {
+      roles: roles.length,
+      required: roles.filter((role) => role.required !== false).length,
+      completed: roles.filter((role) => role.status === 'completed').length,
+      blocked: roles.filter((role) => role.status === 'blocked').length,
+      failed: roles.filter((role) => role.status === 'failed').length,
+    },
+  };
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { SystemHealthBar } from './components/layout/SystemHealthBar';
 import { MobileShell } from './components/layout/MobileShell';
 import { PwaStatusBanner } from './components/layout/PwaStatusBanner';
 import { VIEW_BY_ID, type AppView } from './lib/views';
+import { usePendingProductMode } from './hooks/usePendingProductMode';
 
 // Lazy-load ActivityFeed and BacklogPage to keep initial bundle small
 const ActivityFeed = lazy(() =>
@@ -174,6 +175,7 @@ function AppContent() {
   const { isConnected, connectionState, reconnectAttempt, reconnect } = useTaskSync();
   const { status: authStatus, refreshStatus } = useAuth();
   const [showDesktopOnboarding, setShowDesktopOnboarding] = useState(false);
+  usePendingProductMode();
 
   useEffect(() => {
     const openDiagnostics = () => setShowDesktopOnboarding(true);

--- a/web/src/__tests__/desktop-onboarding.test.tsx
+++ b/web/src/__tests__/desktop-onboarding.test.tsx
@@ -6,6 +6,7 @@ import {
   DESKTOP_ONBOARDING_STORAGE_KEY,
   DesktopOnboardingPanel,
 } from '@/components/auth/DesktopOnboarding';
+import { PRODUCT_MODE_PENDING_STORAGE_KEY } from '@/lib/product-modes';
 import { SetupScreen } from '@/components/auth/SetupScreen';
 import { AuthProvider } from '@/hooks/useAuth';
 
@@ -51,6 +52,7 @@ describe('desktop onboarding', () => {
 
     expect(screen.getByText('Secure Your Board')).toBeDefined();
     expect(window.localStorage.getItem(DESKTOP_ONBOARDING_STORAGE_KEY)).toBe('true');
+    expect(window.localStorage.getItem(PRODUCT_MODE_PENDING_STORAGE_KEY)).toBe('board-only');
   });
 
   it('validates a remote URL through the desktop bridge', async () => {

--- a/web/src/__tests__/settings-general-mantine.test.tsx
+++ b/web/src/__tests__/settings-general-mantine.test.tsx
@@ -51,6 +51,7 @@ vi.mock('@/hooks/useFeatureSettings', () => ({
   useFeatureSettings: () => ({
     settings: {
       general: { humanDisplayName: 'Human' },
+      productMode: { selectedMode: 'advanced', dismissedHints: [] },
     },
   }),
   useDebouncedFeatureUpdate: () => ({
@@ -68,6 +69,7 @@ vi.mock('@/hooks/useTheme', () => ({
 describe('General settings Mantine migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
     mocks.validatePath.mockResolvedValue({ valid: true, branches: ['main', 'develop'] });
   });
 
@@ -75,10 +77,12 @@ describe('General settings Mantine migration', () => {
     cleanup();
   });
 
-  it('renders the base general settings controls through direct Mantine primitives', () => {
+  it('renders the base general settings controls through direct Mantine primitives', async () => {
     const { container } = renderWithProviders(<GeneralTab />);
 
     expect(screen.getByRole('switch', { name: 'Toggle dark mode' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Product Mode' })).toBeDefined();
+    expect(screen.getAllByText('Advanced / Operator').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByRole('textbox', { name: 'Display Name (Squad Chat)' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Add Repo' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Default' })).toBeDefined();
@@ -90,6 +94,13 @@ describe('General settings Mantine migration', () => {
     fireEvent.click(screen.getByRole('switch', { name: 'Toggle dark mode' }));
 
     expect(mocks.setTheme).toHaveBeenCalledWith('light');
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Product Mode' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'QA Review' }));
+
+    expect(mocks.debouncedUpdate).toHaveBeenCalledWith({
+      productMode: expect.objectContaining({ selectedMode: 'qa-review' }),
+    });
   });
 
   it('renders add repository controls and branch selection through Mantine inputs', async () => {

--- a/web/src/__tests__/workflow-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/workflow-surfaces-mantine.test.tsx
@@ -40,6 +40,42 @@ const workflowRun = {
   status: 'running' as const,
   currentStep: 'build',
   startedAt: '2026-06-01T10:00:00Z',
+  context: {
+    pipeline: {
+      mode: 'orchestrated',
+      parentAgent: 'orchestrator',
+      completion: 'all-required',
+      roles: [
+        {
+          id: 'builder',
+          label: 'Builder',
+          agent: 'codex',
+          scope: 'Build the release artifact.',
+          taskBrief: 'Build the artifact.',
+          deliverable: 'Release artifact',
+          verification: ['Artifact exists.'],
+          dependsOn: [],
+          required: true,
+          status: 'completed',
+          telemetry: { durationSeconds: 120 },
+        },
+        {
+          id: 'smoke',
+          label: 'Smoke Tester',
+          agent: 'codex',
+          scope: 'Run smoke coverage.',
+          taskBrief: 'Smoke the artifact.',
+          deliverable: 'Smoke report',
+          verification: ['Smoke test passes.'],
+          dependsOn: ['builder'],
+          required: true,
+          status: 'running',
+          telemetry: {},
+        },
+      ],
+      totals: { roles: 2, required: 2, completed: 1, blocked: 0, failed: 0 },
+    },
+  },
   steps: [
     {
       stepId: 'build',
@@ -220,6 +256,27 @@ describe('workflow surfaces Mantine migration', () => {
           missingInputs: [],
           lint: { ok: true, messages: [], summary: { errors: 0, warnings: 0, info: 0 } },
           preview: {
+            pipeline: {
+              mode: 'orchestrated',
+              parentAgent: 'orchestrator',
+              completion: 'all-required',
+              roles: [
+                {
+                  id: 'builder',
+                  label: 'Builder',
+                  agent: 'worker',
+                  scope: 'Build the task.',
+                  taskBrief: 'Implement the task.',
+                  deliverable: 'Implementation summary',
+                  verification: ['Tests pass.'],
+                  dependsOn: [],
+                  required: true,
+                  status: 'pending',
+                  telemetry: {},
+                },
+              ],
+              totals: { roles: 1, required: 1, completed: 0, blocked: 0, failed: 0 },
+            },
             steps: [{ id: 'work', name: 'Do work', type: 'agent', agent: 'worker' }],
             outputTargets: [
               { type: 'task-update', label: 'Task update' },
@@ -244,6 +301,8 @@ describe('workflow surfaces Mantine migration', () => {
     await user.click(screen.getByRole('button', { name: 'Build Recipe' }));
 
     expect((await screen.findAllByText('Task update')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Orchestration Pipeline')).toBeDefined();
+    expect(screen.getByText(/Implementation summary/)).toBeDefined();
     expect(screen.getByText('No lint messages.')).toBeDefined();
 
     await user.click(screen.getByRole('button', { name: 'Save Workflow' }));
@@ -317,6 +376,8 @@ describe('workflow surfaces Mantine migration', () => {
 
     expect(await screen.findByText('Release workflow')).toBeDefined();
     expect(screen.getByText('Overall Progress')).toBeDefined();
+    expect(screen.getByText('Orchestration Pipeline')).toBeDefined();
+    expect(screen.getByText(/Smoke report/)).toBeDefined();
     expect(screen.queryByText('artifact ready')).toBeNull();
     expect(container.querySelector('.mantine-Progress-root')).toBeDefined();
     expect(container.querySelectorAll('.mantine-Paper-root').length).toBeGreaterThanOrEqual(3);

--- a/web/src/components/auth/DesktopOnboarding.tsx
+++ b/web/src/components/auth/DesktopOnboarding.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { persistPendingProductMode, productModeForSetupMode } from '@/lib/product-modes';
 
 export const DESKTOP_ONBOARDING_STORAGE_KEY = 'veritas-desktop-onboarding-complete';
 
@@ -578,6 +579,7 @@ export function DesktopOnboardingPanel({
               className="sm:min-w-44"
               disabled={!canContinue}
               onClick={() => {
+                persistPendingProductMode(productModeForSetupMode(selectedMode));
                 markDesktopOnboardingComplete();
                 onContinue();
               }}

--- a/web/src/components/settings/tabs/GeneralTab.tsx
+++ b/web/src/components/settings/tabs/GeneralTab.tsx
@@ -6,6 +6,7 @@ import {
   Group,
   Modal,
   Select,
+  SimpleGrid,
   Stack,
   Switch,
   Text,
@@ -32,10 +33,16 @@ import {
   Sun,
   User,
 } from 'lucide-react';
-import type { RepoConfig, AgentConfig } from '@veritas-kanban/shared';
+import type { RepoConfig, AgentConfig, ProductModeId } from '@veritas-kanban/shared';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/hooks/useTheme';
+import { PRODUCT_MODE_DEFINITIONS, productModeDefinition } from '@/lib/product-modes';
+
+const PRODUCT_MODE_OPTIONS = PRODUCT_MODE_DEFINITIONS.map((mode) => ({
+  value: mode.id,
+  label: mode.label,
+}));
 
 export function GeneralTab() {
   const { data: config, isLoading } = useConfig();
@@ -43,6 +50,9 @@ export function GeneralTab() {
   const { theme, setTheme } = useTheme();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate } = useDebouncedFeatureUpdate();
+  const selectedProductMode =
+    settings.productMode?.selectedMode ?? DEFAULT_FEATURE_SETTINGS.productMode.selectedMode;
+  const activeProductMode = productModeDefinition(selectedProductMode);
   const [localDisplayName, setLocalDisplayName] = useState(
     settings.general?.humanDisplayName ?? DEFAULT_FEATURE_SETTINGS.general.humanDisplayName
   );
@@ -72,6 +82,50 @@ export function GeneralTab() {
             aria-label="Toggle dark mode"
             size="sm"
           />
+        </div>
+      </div>
+
+      {/* Product Mode */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium">Product Mode</h3>
+        <div className="rounded-md border p-4 bg-card space-y-4">
+          <Group justify="space-between" align="flex-start" gap="md">
+            <div className="min-w-0 flex-1 space-y-1">
+              <Group gap={8}>
+                <Badge variant="light" color={selectedProductMode === 'advanced' ? 'gray' : 'cyan'}>
+                  {activeProductMode.label}
+                </Badge>
+                <Text size="sm" fw={600}>
+                  Focus preset
+                </Text>
+              </Group>
+              <Text size="sm" c="dimmed">
+                {activeProductMode.description}
+              </Text>
+            </div>
+            <Select
+              label="Product Mode"
+              value={selectedProductMode}
+              data={PRODUCT_MODE_OPTIONS}
+              allowDeselect={false}
+              maw={260}
+              onChange={(value) => {
+                if (!value) return;
+                debouncedUpdate({
+                  productMode: {
+                    selectedMode: value as ProductModeId,
+                    lastSelectedAt: new Date().toISOString(),
+                  },
+                });
+              }}
+            />
+          </Group>
+
+          <SimpleGrid cols={{ base: 1, md: 3 }} spacing="sm">
+            <ModeDetail label="Surfaces" items={activeProductMode.visibleSurfaces} />
+            <ModeDetail label="Task Template" items={[activeProductMode.defaultTaskTemplate]} />
+            <ModeDetail label="Shortcuts" items={activeProductMode.commandShortcuts} />
+          </SimpleGrid>
         </div>
       </div>
 
@@ -154,6 +208,23 @@ export function GeneralTab() {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function ModeDetail({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className="rounded-md border bg-background/50 p-3">
+      <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+        {label}
+      </Text>
+      <Group gap={6} mt={8}>
+        {items.slice(0, 4).map((item) => (
+          <Badge key={item} size="xs" variant="outline" color="gray">
+            {item}
+          </Badge>
+        ))}
+      </Group>
     </div>
   );
 }

--- a/web/src/components/workflows/WorkflowAuthoringPanel.tsx
+++ b/web/src/components/workflows/WorkflowAuthoringPanel.tsx
@@ -3,6 +3,7 @@ import type {
   WorkflowAgent,
   WorkflowDefinition,
   WorkflowOutputTarget,
+  WorkflowPipelineSummary,
   WorkflowOutputTargetType,
   WorkflowSchedule,
   WorkflowStep,
@@ -605,6 +606,13 @@ function WorkflowMaterializationPreview({
 
         <Divider />
 
+        {materialized.preview.pipeline && (
+          <>
+            <PipelineSummaryPanel pipeline={materialized.preview.pipeline} />
+            <Divider />
+          </>
+        )}
+
         <Stack gap={6}>
           {materialized.preview.steps.map((step) => (
             <Group key={step.id} justify="space-between">
@@ -629,6 +637,54 @@ function WorkflowMaterializationPreview({
         <MessageList messages={materialized.lint.messages} />
       </Stack>
     </Paper>
+  );
+}
+
+function PipelineSummaryPanel({ pipeline }: { pipeline: WorkflowPipelineSummary }) {
+  return (
+    <Stack gap="xs">
+      <Group justify="space-between" align="center">
+        <Text fw={600} size="sm">
+          Orchestration Pipeline
+        </Text>
+        <Group gap={6}>
+          <Badge size="xs" variant="light">
+            {pipeline.mode}
+          </Badge>
+          <Badge size="xs" variant="outline">
+            {pipeline.totals.roles} roles
+          </Badge>
+        </Group>
+      </Group>
+      {pipeline.roles.slice(0, 6).map((role) => (
+        <Paper key={role.id} p="xs" radius="sm" withBorder>
+          <Group justify="space-between" align="flex-start" gap="sm">
+            <div className="min-w-0">
+              <Text size="sm" fw={600}>
+                {role.label}
+              </Text>
+              <Text size="xs" c="dimmed" lineClamp={2}>
+                {role.scope}
+              </Text>
+              <Text size="xs" c="dimmed" lineClamp={2}>
+                Deliverable: {role.deliverable}
+              </Text>
+            </div>
+            <Stack gap={4} align="flex-end">
+              <Badge size="xs" variant="outline">
+                {role.agent}
+              </Badge>
+              <Badge size="xs" color={role.status === 'failed' ? 'red' : 'gray'} variant="light">
+                {role.status}
+              </Badge>
+              <Text size="xs" c="dimmed">
+                {role.verification.length} checks
+              </Text>
+            </Stack>
+          </Group>
+        </Paper>
+      ))}
+    </Stack>
   );
 }
 
@@ -1156,6 +1212,8 @@ function DryRunResultPanel({ result }: { result: WorkflowDryRunResult }) {
             )}
           </Stack>
         )}
+
+        {result.pipelineSummary && <PipelineSummaryPanel pipeline={result.pipelineSummary} />}
 
         <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xs">
           {result.checks.map((check) => (

--- a/web/src/components/workflows/WorkflowRunView.tsx
+++ b/web/src/components/workflows/WorkflowRunView.tsx
@@ -10,6 +10,12 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
+import {
+  buildWorkflowPipelineSummary,
+  type WorkflowDefinition as SharedWorkflowDefinition,
+  type WorkflowPipelineSummary,
+  type WorkflowSubagentRunStatus,
+} from '@veritas-kanban/shared';
 import { API_BASE } from '@/lib/config';
 import {
   Alert,
@@ -34,6 +40,7 @@ import {
   Clock,
   Pause,
   History,
+  Users,
 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/utils';
@@ -78,6 +85,7 @@ interface WorkflowDefinition {
   id: string;
   name: string;
   version: number;
+  pipeline?: SharedWorkflowDefinition['pipeline'];
   steps: Array<{
     id: string;
     name: string;
@@ -106,6 +114,32 @@ function workflowTimelineAttemptId(run: WorkflowRun): string {
   return (
     safeContextString(run.context?.attemptId) ?? safeContextString(run.context?.runId) ?? run.id
   );
+}
+
+function isWorkflowPipelineSummary(value: unknown): value is WorkflowPipelineSummary {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as { roles?: unknown }).roles) &&
+    typeof (value as { totals?: unknown }).totals === 'object'
+  );
+}
+
+function pipelineStatusColor(status: WorkflowSubagentRunStatus): string {
+  if (status === 'completed') return 'green';
+  if (status === 'failed') return 'red';
+  if (status === 'blocked') return 'yellow';
+  if (status === 'running') return 'blue';
+  if (status === 'skipped') return 'gray';
+  return 'gray';
+}
+
+function formatPipelineDuration(seconds?: number): string {
+  if (!seconds || seconds <= 0) return 'time pending';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${minutes}m ${remainder}s`;
 }
 
 export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
@@ -281,6 +315,11 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
 
   const config = statusConfig[run.status];
   const Icon = config.icon;
+  const pipelineSummary = isWorkflowPipelineSummary(run.context?.pipeline)
+    ? run.context.pipeline
+    : workflow?.pipeline
+      ? buildWorkflowPipelineSummary(workflow as SharedWorkflowDefinition)
+      : undefined;
 
   return (
     <Stack gap="lg">
@@ -372,6 +411,8 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
         </Stack>
       </Paper>
 
+      {pipelineSummary && <WorkflowPipelineCard pipeline={pipelineSummary} />}
+
       {/* Step Timeline */}
       <Stack gap="sm">
         <Title order={2} className="text-lg">
@@ -396,6 +437,87 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
         })}
       </Stack>
     </Stack>
+  );
+}
+
+function WorkflowPipelineCard({ pipeline }: { pipeline: WorkflowPipelineSummary }) {
+  return (
+    <Paper className="p-6" radius="md" withBorder>
+      <Stack gap="md">
+        <Group justify="space-between" align="flex-start">
+          <div className="space-y-1">
+            <Group gap="xs">
+              <ThemeIcon variant="light" color="cyan">
+                <Users className="h-4 w-4" />
+              </ThemeIcon>
+              <Title order={2} className="text-lg">
+                Orchestration Pipeline
+              </Title>
+            </Group>
+            <Text size="sm" c="dimmed">
+              {pipeline.parentAgent ? `Parent: ${pipeline.parentAgent}` : 'No parent agent'} ·{' '}
+              {pipeline.completion}
+            </Text>
+          </div>
+          <Group gap="xs">
+            <Badge variant="light">{pipeline.mode}</Badge>
+            <Badge variant="outline">
+              {pipeline.totals.completed}/{pipeline.totals.roles} complete
+            </Badge>
+          </Group>
+        </Group>
+
+        {pipeline.handoff && (
+          <Text size="sm" c="dimmed">
+            {pipeline.handoff}
+          </Text>
+        )}
+
+        <Stack gap="xs">
+          {pipeline.roles.map((role) => (
+            <div key={role.id} className="rounded-md border bg-background/50 p-3">
+              <Group justify="space-between" align="flex-start" gap="md">
+                <div className="min-w-0 space-y-1">
+                  <Group gap="xs">
+                    <Text fw={600}>{role.label}</Text>
+                    <Badge size="xs" variant="outline">
+                      {role.agent}
+                    </Badge>
+                    {role.required !== false && (
+                      <Badge size="xs" variant="light" color="gray">
+                        required
+                      </Badge>
+                    )}
+                  </Group>
+                  <Text size="sm" c="dimmed">
+                    {role.scope}
+                  </Text>
+                  <Text size="sm">Deliverable: {role.deliverable}</Text>
+                  <Text size="xs" c="dimmed">
+                    {role.verification.length} verification step
+                    {role.verification.length === 1 ? '' : 's'}
+                    {role.dependsOn?.length ? ` · depends on ${role.dependsOn.join(', ')}` : ''}
+                  </Text>
+                </div>
+                <Stack gap={4} align="flex-end">
+                  <Badge color={pipelineStatusColor(role.status)} variant="light">
+                    {role.status}
+                  </Badge>
+                  <Text size="xs" c="dimmed">
+                    {formatPipelineDuration(role.telemetry.durationSeconds)}
+                  </Text>
+                  {role.telemetry.tokensUsed !== undefined && (
+                    <Text size="xs" c="dimmed">
+                      {role.telemetry.tokensUsed.toLocaleString()} tokens
+                    </Text>
+                  )}
+                </Stack>
+              </Group>
+            </div>
+          ))}
+        </Stack>
+      </Stack>
+    </Paper>
   );
 }
 

--- a/web/src/hooks/usePendingProductMode.ts
+++ b/web/src/hooks/usePendingProductMode.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import { useFeatureSettings, useUpdateFeatureSettings } from '@/hooks/useFeatureSettings';
+import { clearPendingProductMode, readPendingProductMode } from '@/lib/product-modes';
+
+export function usePendingProductMode(): void {
+  const { settings, isLoading } = useFeatureSettings();
+  const update = useUpdateFeatureSettings();
+  const selectedMode =
+    settings.productMode?.selectedMode ?? DEFAULT_FEATURE_SETTINGS.productMode.selectedMode;
+
+  useEffect(() => {
+    if (isLoading || update.isPending) return;
+    const pendingMode = readPendingProductMode();
+    if (!pendingMode) return;
+
+    if (pendingMode === selectedMode) {
+      clearPendingProductMode();
+      return;
+    }
+
+    update.mutate(
+      {
+        productMode: {
+          selectedMode: pendingMode,
+          lastSelectedAt: new Date().toISOString(),
+        },
+      },
+      {
+        onSuccess: clearPendingProductMode,
+      }
+    );
+  }, [isLoading, selectedMode, update]);
+}

--- a/web/src/lib/api/workflows.ts
+++ b/web/src/lib/api/workflows.ts
@@ -1,6 +1,7 @@
 import type {
   WorkflowDefinition,
   WorkflowOutputTarget,
+  WorkflowPipelineSummary,
   WorkflowSchedule,
   WorkflowStep,
   WorkflowSkillAuditSummary,
@@ -17,6 +18,7 @@ export type WorkflowLintCategory =
   | 'policy'
   | 'secret'
   | 'skill'
+  | 'pipeline'
   | 'client'
   | 'output'
   | 'schedule';
@@ -84,6 +86,7 @@ export interface WorkflowDryRunResult extends WorkflowLintResult {
   canRun: boolean;
   checks: WorkflowDryRunCheck[];
   skillAudit?: WorkflowSkillAuditSummary;
+  pipelineSummary?: WorkflowPipelineSummary;
   workflow?: WorkflowDefinition;
 }
 
@@ -102,6 +105,7 @@ export interface WorkflowRecipeMaterialization {
   lint: WorkflowLintResult;
   preview: {
     steps: Array<{ id: string; name: string; type: WorkflowStep['type']; agent?: string }>;
+    pipeline?: WorkflowPipelineSummary;
     outputTargets: WorkflowOutputTarget[];
     schedule?: WorkflowSchedule;
   };

--- a/web/src/lib/product-modes.ts
+++ b/web/src/lib/product-modes.ts
@@ -1,0 +1,145 @@
+import type { ProductModeId } from '@veritas-kanban/shared';
+
+export const PRODUCT_MODE_PENDING_STORAGE_KEY = 'veritas-product-mode-pending';
+
+export interface ProductModeDefinition {
+  id: ProductModeId;
+  label: string;
+  description: string;
+  focus: string[];
+  visibleSurfaces: string[];
+  defaultTaskTemplate: string;
+  commandShortcuts: string[];
+}
+
+export const PRODUCT_MODE_DEFINITIONS: ProductModeDefinition[] = [
+  {
+    id: 'board-only',
+    label: 'Board Only',
+    description:
+      'Focused local board with optional agent, workflow, and remote surfaces de-emphasized.',
+    focus: ['Board', 'task detail', 'basic search'],
+    visibleSurfaces: ['board', 'backlog', 'archive'],
+    defaultTaskTemplate: 'Simple task',
+    commandShortcuts: ['New task', 'Search tasks'],
+  },
+  {
+    id: 'agent-ready',
+    label: 'Agent Ready',
+    description: 'Board plus agent runs, templates, work products, and local diagnostics.',
+    focus: ['board', 'agent panel', 'run history'],
+    visibleSurfaces: ['board', 'templates', 'workflows', 'settings agents'],
+    defaultTaskTemplate: 'Agent-ready task',
+    commandShortcuts: ['Start agent', 'Open run timeline'],
+  },
+  {
+    id: 'solo-coding',
+    label: 'Solo Coding',
+    description:
+      'Code-heavy flow with repo, branch, QA gate, and completion packet surfaces nearby.',
+    focus: ['repository', 'run mode', 'QA gate'],
+    visibleSurfaces: ['board', 'task work', 'workflow runs', 'work products'],
+    defaultTaskTemplate: 'Implementation task',
+    commandShortcuts: ['Assign agent', 'Open PR', 'Generate packet'],
+  },
+  {
+    id: 'pm-orchestration',
+    label: 'PM Orchestration',
+    description:
+      'Planning and delegation flow with workflows, decisions, policy traces, and dashboards.',
+    focus: ['roadmap', 'delegation', 'decision traces'],
+    visibleSurfaces: ['board', 'workflows', 'decisions', 'policies'],
+    defaultTaskTemplate: 'Coordinated delivery task',
+    commandShortcuts: ['Build workflow', 'Open decisions'],
+  },
+  {
+    id: 'qa-review',
+    label: 'QA Review',
+    description: 'Review-focused flow with risk queues, QA gates, verification, and run evidence.',
+    focus: ['needs attention', 'QA gate', 'verification'],
+    visibleSurfaces: ['board', 'needs attention', 'workflow runs', 'work products'],
+    defaultTaskTemplate: 'Review and QA task',
+    commandShortcuts: ['Open QA gate', 'Open evidence'],
+  },
+  {
+    id: 'research',
+    label: 'Research',
+    description:
+      'Read-heavy workflow for notes, references, decision records, and stale-doc follow-up.',
+    focus: ['notes', 'references', 'docs freshness'],
+    visibleSurfaces: ['board', 'decisions', 'shared resources', 'search'],
+    defaultTaskTemplate: 'Research task',
+    commandShortcuts: ['Open search', 'Record decision'],
+  },
+  {
+    id: 'operations',
+    label: 'Operations',
+    description:
+      'Operational flow with maintenance, storage, health, remote sessions, and recovery surfaces.',
+    focus: ['maintenance', 'health', 'backup'],
+    visibleSurfaces: ['settings maintenance', 'system health', 'multi-user', 'notifications'],
+    defaultTaskTemplate: 'Operational task',
+    commandShortcuts: ['Open maintenance', 'Run health check'],
+  },
+  {
+    id: 'advanced',
+    label: 'Advanced / Operator',
+    description:
+      'All surfaces visible by default for operators who want the full v5 control plane.',
+    focus: ['all dashboards', 'all settings', 'all workflow controls'],
+    visibleSurfaces: ['all'],
+    defaultTaskTemplate: 'Advanced task',
+    commandShortcuts: ['Command palette', 'Open settings'],
+  },
+  {
+    id: 'custom',
+    label: 'Custom',
+    description: 'Manual configuration. Veritas records the preference without applying a preset.',
+    focus: ['manual layout', 'manual controls'],
+    visibleSurfaces: ['configured surfaces'],
+    defaultTaskTemplate: 'Custom task',
+    commandShortcuts: ['Command palette'],
+  },
+];
+
+export function productModeDefinition(id: ProductModeId): ProductModeDefinition {
+  return (
+    PRODUCT_MODE_DEFINITIONS.find((definition) => definition.id === id) ??
+    PRODUCT_MODE_DEFINITIONS.find((definition) => definition.id === 'advanced')!
+  );
+}
+
+export function productModeForSetupMode(
+  mode: 'board' | 'agent' | 'remote' | 'restore'
+): ProductModeId {
+  if (mode === 'board') return 'board-only';
+  if (mode === 'agent') return 'agent-ready';
+  return 'operations';
+}
+
+export function persistPendingProductMode(mode: ProductModeId): void {
+  try {
+    window.localStorage.setItem(PRODUCT_MODE_PENDING_STORAGE_KEY, mode);
+  } catch {
+    // Storage can be unavailable in restricted contexts.
+  }
+}
+
+export function readPendingProductMode(): ProductModeId | null {
+  try {
+    const value = window.localStorage.getItem(PRODUCT_MODE_PENDING_STORAGE_KEY);
+    return PRODUCT_MODE_DEFINITIONS.some((definition) => definition.id === value)
+      ? (value as ProductModeId)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingProductMode(): void {
+  try {
+    window.localStorage.removeItem(PRODUCT_MODE_PENDING_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable in restricted contexts.
+  }
+}


### PR DESCRIPTION
## Summary
- Add first-class workflow pipeline metadata for orchestrator and subagent runs, including lint, recipe materialization, run context rollups, run-detail UI, and completion packet reconciliation.
- Add the `.openclaw Audit` orchestrated recipe with scoped subagent roles and verification contracts.
- Add persisted product modes with first-run onboarding capture, post-auth settings persistence, and General Settings controls.

## Tests
- `pnpm --filter @veritas-kanban/server test -- routes/workflow-authoring.test.ts workflow-run-service.test.ts schemas.test.ts storage/sqlite-work-products.test.ts`
- `pnpm --filter @veritas-kanban/web test -- settings-general-mantine.test.tsx workflow-surfaces-mantine.test.tsx desktop-onboarding.test.tsx`
- `pnpm exec eslint . --quiet`
- `pnpm typecheck`
- `git diff --check`
- `node scripts/check-permission-coverage.mjs`
- `pnpm build`
- Headless Playwright smoke against `http://localhost:3000`: title matched, first-run setup rendered nonblank, no framework overlay, no console errors, Refresh diagnostics interaction worked.

## Notes
- Product modes are non-destructive preferences. They persist the selected mode and do not remove API access or rewrite existing feature toggles.
- Local smoke created and rotated `.veritas-kanban` runtime backups. No tracked runtime files changed.

Closes #413.
Closes #368.
