### PR TITLE
Gate agent routing on executable and auth health

### DIFF
--- a/server/src/__tests__/agent-routing-service.test.ts
+++ b/server/src/__tests__/agent-routing-service.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AgentRoutingService } from '../services/agent-routing-service';
-import type { AgentRoutingConfig, AppConfig } from '@veritas-kanban/shared';
+import type { AgentConfig, AgentRoutingConfig, AppConfig } from '@veritas-kanban/shared';
+import type { AgentHealthStatus } from '../services/agent-health-service';
 
 // Mock ConfigService
 const mockGetConfig = vi.fn();
 const mockSaveConfig = vi.fn();
+const mockCheckAgent = vi.fn();
 
 vi.mock('../services/config-service.js', () => {
   return {
@@ -68,13 +70,59 @@ const BASE_CONFIG: AppConfig = {
   },
 };
 
+function healthyAgent(agent: AgentConfig): AgentHealthStatus {
+  return {
+    type: agent.type,
+    name: agent.name,
+    enabled: agent.enabled,
+    configured: true,
+    command: agent.command,
+    executableFound: true,
+    executablePath: `/usr/local/bin/${agent.command}`,
+    authenticated: null,
+    healthy: agent.enabled,
+    checkedAt: '2026-06-03T00:00:00.000Z',
+    reason: agent.enabled ? undefined : 'Agent is disabled',
+  };
+}
+
+function unhealthyAgent(agent: AgentConfig, reason: string): AgentHealthStatus {
+  return {
+    ...healthyAgent(agent),
+    executableFound: !reason.includes('Executable'),
+    authenticated: reason.includes('Authentication') ? false : null,
+    healthy: false,
+    reason,
+  };
+}
+
+function requireRouting(config: AppConfig): AgentRoutingConfig {
+  if (!config.agentRouting) throw new Error('Expected routing config in test fixture');
+  return config.agentRouting;
+}
+
+function requireAgent(config: AppConfig, type: string): AgentConfig {
+  const agent = config.agents.find((candidate) => candidate.type === type);
+  if (!agent) throw new Error(`Expected ${type} agent in test fixture`);
+  return agent;
+}
+
+function requireFallbackResult(
+  result: Awaited<ReturnType<AgentRoutingService['getFallback']>>
+): NonNullable<typeof result> {
+  expect(result).not.toBeNull();
+  if (!result) throw new Error('Expected fallback result');
+  return result;
+}
+
 describe('AgentRoutingService', () => {
   let service: AgentRoutingService;
 
   beforeEach(() => {
     mockGetConfig.mockResolvedValue(structuredClone(BASE_CONFIG));
     mockSaveConfig.mockResolvedValue(undefined);
-    service = new AgentRoutingService();
+    mockCheckAgent.mockImplementation(async (agent: AgentConfig) => healthyAgent(agent));
+    service = new AgentRoutingService(undefined, { checkAgent: mockCheckAgent });
   });
 
   describe('resolveAgent', () => {
@@ -166,7 +214,7 @@ describe('AgentRoutingService', () => {
 
     it('returns default agent when routing is disabled', async () => {
       const config = structuredClone(BASE_CONFIG);
-      config.agentRouting!.enabled = false;
+      requireRouting(config).enabled = false;
       mockGetConfig.mockResolvedValue(config);
 
       const result = await service.resolveAgent({
@@ -189,14 +237,104 @@ describe('AgentRoutingService', () => {
         priority: 'high',
       });
 
-      // Both code rules point to claude-code which is disabled — falls to default
-      // But default is also claude-code (disabled), so it returns the config default anyway
-      expect(result.reason).toContain('No routing rules matched');
+      expect(result.agent).toBe('amp');
+      expect(result.reason).toContain('unavailable');
+      expect(result.reason).toContain('Using fallback');
+    });
+
+    it('uses a healthy fallback when a matched rule target is missing its executable', async () => {
+      mockCheckAgent.mockImplementation(async (agent: AgentConfig) =>
+        agent.type === 'claude-code'
+          ? unhealthyAgent(agent, 'Executable "claude" was not found on PATH')
+          : healthyAgent(agent)
+      );
+
+      const result = await service.resolveAgent({
+        type: 'code',
+        priority: 'high',
+      });
+
+      expect(result.agent).toBe('amp');
+      expect(result.rule).toBe('code-high');
+      expect(result.reason).toContain('Executable "claude" was not found on PATH');
+    });
+
+    it('throws a clear conflict when the primary and fallback agents are unavailable', async () => {
+      const config = structuredClone(BASE_CONFIG);
+      const routing = requireRouting(config);
+      routing.rules = [
+        {
+          id: 'only-code',
+          name: 'Only code route',
+          match: { type: 'code' },
+          agent: 'claude-code',
+          fallback: 'amp',
+          enabled: true,
+        },
+      ];
+      routing.defaultAgent = 'amp';
+      requireAgent(config, 'amp').enabled = false;
+      mockGetConfig.mockResolvedValue(config);
+      mockCheckAgent.mockImplementation(async (agent: AgentConfig) =>
+        agent.type === 'claude-code'
+          ? unhealthyAgent(agent, 'Executable "claude" was not found on PATH')
+          : healthyAgent(agent)
+      );
+
+      await expect(
+        service.resolveAgent({
+          type: 'code',
+          priority: 'high',
+        })
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        code: 'CONFLICT',
+        details: expect.objectContaining({
+          agent: 'amp',
+          reason: 'Agent is disabled',
+        }),
+      });
+    });
+
+    it('routes around an unauthenticated provider when a healthy fallback exists', async () => {
+      const config = structuredClone(BASE_CONFIG);
+      config.agents.push({
+        type: 'codex',
+        name: 'OpenAI Codex',
+        command: 'codex',
+        args: [],
+        enabled: true,
+        provider: 'codex-cli',
+      });
+      requireRouting(config).rules = [
+        {
+          id: 'codex-code',
+          name: 'Codex code route',
+          match: { type: 'code' },
+          agent: 'codex',
+          fallback: 'amp',
+          enabled: true,
+        },
+      ];
+      mockGetConfig.mockResolvedValue(config);
+      mockCheckAgent.mockImplementation(async (agent: AgentConfig) =>
+        agent.type === 'codex'
+          ? unhealthyAgent(agent, 'Authentication check failed: not logged in')
+          : healthyAgent(agent)
+      );
+
+      const result = await service.resolveAgent({
+        type: 'code',
+        priority: 'medium',
+      });
+
+      expect(result.agent).toBe('amp');
+      expect(result.reason).toContain('Authentication check failed');
     });
 
     it('matches array criteria', async () => {
       const config = structuredClone(BASE_CONFIG);
-      config.agentRouting!.rules = [
+      requireRouting(config).rules = [
         {
           id: 'multi-type',
           name: 'Multiple types',
@@ -217,7 +355,7 @@ describe('AgentRoutingService', () => {
 
     it('matches minSubtasks criteria', async () => {
       const config = structuredClone(BASE_CONFIG);
-      config.agentRouting!.rules = [
+      requireRouting(config).rules = [
         {
           id: 'complex',
           name: 'Complex tasks',
@@ -244,7 +382,7 @@ describe('AgentRoutingService', () => {
 
     it('does NOT match when subtasks below threshold', async () => {
       const config = structuredClone(BASE_CONFIG);
-      config.agentRouting!.rules = [
+      requireRouting(config).rules = [
         {
           id: 'complex',
           name: 'Complex tasks',
@@ -269,18 +407,32 @@ describe('AgentRoutingService', () => {
   describe('getFallback', () => {
     it('returns fallback agent from matched rule', async () => {
       const result = await service.getFallback({ type: 'code', priority: 'high' }, 'claude-code');
+      const fallback = requireFallbackResult(result);
 
-      expect(result).not.toBeNull();
-      expect(result!.agent).toBe('amp');
-      expect(result!.reason).toContain('Fallback');
+      expect(fallback.agent).toBe('amp');
+      expect(fallback.reason).toContain('Fallback');
     });
 
     it('returns null when fallback is disabled', async () => {
       const config = structuredClone(BASE_CONFIG);
-      config.agentRouting!.fallbackOnFailure = false;
+      requireRouting(config).fallbackOnFailure = false;
       mockGetConfig.mockResolvedValue(config);
 
       const result = await service.getFallback({ type: 'code', priority: 'high' }, 'claude-code');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the matched fallback profile is disabled', async () => {
+      const config = structuredClone(BASE_CONFIG);
+      const routing = requireRouting(config);
+      const [firstRule] = routing.rules;
+      if (!firstRule) throw new Error('Expected first routing rule in test fixture');
+      routing.rules = [firstRule];
+      requireAgent(config, 'amp').enabled = false;
+      mockGetConfig.mockResolvedValue(config);
+
+      const result = await service.getFallback({ type: 'code', priority: 'high' }, 'claude-code');
+
       expect(result).toBeNull();
     });
 
@@ -298,8 +450,8 @@ describe('AgentRoutingService', () => {
         { type: 'docs', priority: 'low' },
         'amp' // Failed agent is amp, default is claude-code → valid fallback
       );
-      expect(result).not.toBeNull();
-      expect(result!.agent).toBe('claude-code');
+      const fallback = requireFallbackResult(result);
+      expect(fallback.agent).toBe('claude-code');
     });
   });
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetConfig,
   mockGetTask,
   mockUpdateTask,
+  mockCheckAgent,
   mockTelemetryEmit,
   mockLogActivity,
   mockStartTrace,
@@ -22,6 +23,7 @@ const {
   mockGetConfig: vi.fn(),
   mockGetTask: vi.fn(),
   mockUpdateTask: vi.fn(),
+  mockCheckAgent: vi.fn(),
   mockTelemetryEmit: vi.fn(),
   mockLogActivity: vi.fn(),
   mockStartTrace: vi.fn(),
@@ -67,6 +69,12 @@ vi.mock('../services/agent-routing-service.js', () => ({
   getAgentRoutingService: () => ({
     resolveAgent: vi.fn().mockResolvedValue({ agent: 'codex', reason: 'test' }),
   }),
+}));
+
+vi.mock('../services/agent-health-service.js', () => ({
+  AgentHealthService: function () {
+    return { checkAgent: mockCheckAgent };
+  },
 }));
 
 vi.mock('../services/circuit-registry.js', () => ({
@@ -203,6 +211,18 @@ describe('ClawdbotAgentService Codex providers', () => {
       task = { ...task, ...update } as Task;
       return task;
     });
+    mockCheckAgent.mockImplementation(async (agent: AgentConfig) => ({
+      type: agent.type,
+      name: agent.name,
+      enabled: agent.enabled,
+      configured: true,
+      command: agent.command,
+      executableFound: true,
+      executablePath: `/usr/local/bin/${agent.command}`,
+      authenticated: true,
+      healthy: true,
+      checkedAt: '2026-06-03T00:00:00.000Z',
+    }));
     mockGetConfig.mockResolvedValue({
       agents: [
         {
@@ -402,6 +422,32 @@ describe('ClawdbotAgentService Codex providers', () => {
         retryDelayMs: 1250,
       })
     );
+  });
+
+  it('blocks explicit dispatch when the selected agent is unhealthy', async () => {
+    mockCheckAgent.mockImplementation(async (agent: AgentConfig) => ({
+      type: agent.type,
+      name: agent.name,
+      enabled: true,
+      configured: true,
+      command: agent.command,
+      executableFound: false,
+      authenticated: null,
+      healthy: false,
+      checkedAt: '2026-06-03T00:00:00.000Z',
+      reason: 'Executable "codex" was not found on PATH',
+    }));
+    const service = testableService(tmpDir);
+
+    await expect(service.startAgent(task.id, 'codex')).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'CONFLICT',
+      details: expect.objectContaining({
+        agent: 'codex',
+        reason: 'Executable "codex" was not found on PATH',
+      }),
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 
   it('records user stop requests as abort trace steps before completing the attempt', async () => {

--- a/server/src/services/agent-health-service.ts
+++ b/server/src/services/agent-health-service.ts
@@ -1,0 +1,118 @@
+import fs from 'fs/promises';
+import { constants as fsConstants } from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { AgentConfig } from '@veritas-kanban/shared';
+
+const execFileAsync = promisify(execFile);
+
+export interface AgentHealthStatus {
+  type: string;
+  name: string;
+  enabled: boolean;
+  configured: boolean;
+  command: string;
+  executableFound: boolean;
+  executablePath?: string;
+  authenticated: boolean | null;
+  healthy: boolean;
+  checkedAt: string;
+  reason?: string;
+}
+
+export interface AgentHealthChecker {
+  checkAgent(agent: AgentConfig): Promise<AgentHealthStatus>;
+}
+
+export class AgentHealthService implements AgentHealthChecker {
+  async checkAgent(agent: AgentConfig): Promise<AgentHealthStatus> {
+    const checkedAt = new Date().toISOString();
+    const executable = await this.findExecutable(agent.command);
+    const auth = executable.found ? await this.checkAuth(agent) : { authenticated: null };
+    const reason = this.buildReason(agent, executable.found, auth.authenticated, auth.error);
+
+    return {
+      type: agent.type,
+      name: agent.name,
+      enabled: agent.enabled,
+      configured: true,
+      command: agent.command,
+      executableFound: executable.found,
+      executablePath: executable.path,
+      authenticated: auth.authenticated,
+      healthy: agent.enabled && executable.found && auth.authenticated !== false,
+      checkedAt,
+      reason,
+    };
+  }
+
+  private async findExecutable(command: string): Promise<{ found: boolean; path?: string }> {
+    if (!command.trim()) return { found: false };
+
+    if (command.includes(path.sep)) {
+      try {
+        await fs.access(command, fsConstants.X_OK);
+        return { found: true, path: command };
+      } catch {
+        return { found: false };
+      }
+    }
+
+    try {
+      const { stdout } = await execFileAsync('which', [command]);
+      return { found: true, path: stdout.trim() };
+    } catch {
+      return { found: false };
+    }
+  }
+
+  private async checkAuth(
+    agent: AgentConfig
+  ): Promise<{ authenticated: boolean | null; error?: string }> {
+    const command = path.basename(agent.command);
+    const provider = agent.provider ?? '';
+
+    if (provider === 'codex-cloud' || command === 'gh') {
+      return this.runAuthProbe(agent.command, ['auth', 'status'], /logged in/i);
+    }
+
+    if (provider.startsWith('codex') || command === 'codex') {
+      return this.runAuthProbe(agent.command, ['login', 'status'], /logged in/i);
+    }
+
+    return { authenticated: null };
+  }
+
+  private async runAuthProbe(
+    command: string,
+    args: string[],
+    successPattern: RegExp
+  ): Promise<{ authenticated: boolean; error?: string }> {
+    try {
+      const { stdout, stderr } = await execFileAsync(command, args);
+      const output = `${stdout}${stderr}`.trim();
+      return {
+        authenticated: successPattern.test(output),
+        error: successPattern.test(output) ? undefined : output || 'Authentication status unknown',
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Authentication probe failed';
+      return { authenticated: false, error: message };
+    }
+  }
+
+  private buildReason(
+    agent: AgentConfig,
+    executableFound: boolean,
+    authenticated: boolean | null,
+    authError?: string
+  ): string | undefined {
+    if (!agent.enabled) return 'Agent is disabled';
+    if (!executableFound) return `Executable "${agent.command}" was not found on PATH`;
+    if (authenticated === false) {
+      return authError ? `Authentication check failed: ${authError}` : 'Authentication required';
+    }
+    return undefined;
+  }
+}

--- a/server/src/services/agent-routing-service.ts
+++ b/server/src/services/agent-routing-service.ts
@@ -11,6 +11,7 @@
 import { ConfigService } from './config-service.js';
 import {
   DEFAULT_ROUTING_CONFIG,
+  type AgentConfig,
   type CreateGovernanceTraceInput,
   type GovernanceTraceRule,
   type GovernanceTraceStep,
@@ -19,8 +20,14 @@ import {
   type RoutingResult,
   type RoutingMatchCriteria,
 } from '@veritas-kanban/shared';
-import type { Task, AgentType, TaskPriority } from '@veritas-kanban/shared';
+import type { Task, AgentType } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
+import { ConflictError } from '../middleware/error-handler.js';
+import {
+  AgentHealthService,
+  type AgentHealthChecker,
+  type AgentHealthStatus,
+} from './agent-health-service.js';
 
 const log = createLogger('agent-routing');
 
@@ -30,11 +37,20 @@ interface RoutingTraceContext {
   taskId?: string;
 }
 
+interface AgentAvailability {
+  agentConfig?: AgentConfig;
+  health?: AgentHealthStatus;
+  available: boolean;
+  reason: string;
+}
+
 export class AgentRoutingService {
   private configService: ConfigService;
+  private agentHealth: AgentHealthChecker;
 
-  constructor(configService?: ConfigService) {
+  constructor(configService?: ConfigService, agentHealth?: AgentHealthChecker) {
     this.configService = configService || new ConfigService();
+    this.agentHealth = agentHealth || new AgentHealthService();
   }
 
   /**
@@ -58,8 +74,18 @@ export class AgentRoutingService {
 
     // If routing is disabled, return the global default
     if (!routing.enabled) {
+      const defaultAgent = routing.defaultAgent || config.defaultAgent;
+      const defaultAvailability = await this.getAgentAvailability(config.agents, defaultAgent);
+      if (!defaultAvailability.available) {
+        throw new ConflictError('No healthy agent available for routing', {
+          agent: defaultAgent,
+          reason: defaultAvailability.reason,
+          routingEnabled: routing.enabled,
+        });
+      }
+
       const result: RoutingResult = {
-        agent: routing.defaultAgent || config.defaultAgent,
+        agent: defaultAgent,
         model: routing.defaultModel,
         reason: 'Routing disabled, using default agent',
       };
@@ -90,13 +116,9 @@ export class AgentRoutingService {
       }
 
       if (this.matchesRule(task, rule.match)) {
-        // Verify the agent is actually configured and enabled
-        const agentConfig = config.agents.find(
-          (a: { type: string; name: string; command: string; args: string[]; enabled: boolean }) =>
-            a.type === rule.agent
-        );
-        if (!agentConfig?.enabled) {
-          const message = `Rule "${rule.name}" matched but agent "${rule.agent}" is disabled, skipping.`;
+        const availability = await this.getAgentAvailability(config.agents, rule.agent);
+        if (!availability.available) {
+          const message = `Rule "${rule.name}" matched but agent "${rule.agent}" is unavailable: ${availability.reason}.`;
           log.warn(message);
           const skippedRule = this.routingRuleTrace(rule, 'matched', message, 'skipped');
           evaluatedRules.push(skippedRule);
@@ -106,6 +128,49 @@ export class AgentRoutingService {
             status: 'skipped',
             message,
           });
+
+          if (routing.fallbackOnFailure && rule.fallback) {
+            const fallbackAvailability = await this.getAgentAvailability(
+              config.agents,
+              rule.fallback
+            );
+            if (fallbackAvailability.available) {
+              const reason = `${message} Using fallback agent "${rule.fallback}".`;
+              const result: RoutingResult = {
+                agent: rule.fallback,
+                rule: rule.id,
+                reason,
+              };
+              return {
+                result,
+                trace: this.buildRoutingTrace(task, context, result, {
+                  outcome: 'fallback',
+                  evaluatedRules,
+                  matchedRules: [],
+                  steps: [
+                    ...steps,
+                    {
+                      id: `fallback:${rule.id}`,
+                      label: `${rule.name} fallback`,
+                      status: 'matched',
+                      message: `Selected fallback agent ${rule.fallback}.`,
+                    },
+                  ],
+                  routing,
+                }),
+              };
+            }
+
+            const fallbackMessage = `Fallback agent "${rule.fallback}" for rule "${rule.name}" is unavailable: ${fallbackAvailability.reason}.`;
+            log.warn(fallbackMessage);
+            steps.push({
+              id: `fallback:${rule.id}`,
+              label: `${rule.name} fallback`,
+              status: 'skipped',
+              message: fallbackMessage,
+            });
+          }
+
           continue;
         }
 
@@ -160,6 +225,22 @@ export class AgentRoutingService {
       model: routing.defaultModel,
       reason: 'No routing rules matched, using default agent',
     };
+    const defaultAvailability = await this.getAgentAvailability(config.agents, result.agent);
+    if (!defaultAvailability.available) {
+      const message = `Default agent "${result.agent}" is unavailable: ${defaultAvailability.reason}.`;
+      steps.push({
+        id: 'default-agent',
+        label: 'Default agent',
+        status: 'skipped',
+        message,
+      });
+      throw new ConflictError('No healthy agent available for routing', {
+        agent: result.agent,
+        reason: defaultAvailability.reason,
+        routingEnabled: routing.enabled,
+      });
+    }
+
     return {
       result,
       trace: this.buildRoutingTrace(task, context, result, {
@@ -202,12 +283,11 @@ export class AgentRoutingService {
       if (!rule.fallback) continue;
       if (!this.matchesRule(task, rule.match)) continue;
 
-      const fallbackConfig = config.agents.find(
-        (a: { type: string; name: string; command: string; args: string[]; enabled: boolean }) =>
-          a.type === rule.fallback
-      );
-      if (!fallbackConfig?.enabled) {
-        log.warn(`Fallback agent "${rule.fallback}" for rule "${rule.name}" is disabled`);
+      const fallbackAvailability = await this.getAgentAvailability(config.agents, rule.fallback);
+      if (!fallbackAvailability.available) {
+        log.warn(
+          `Fallback agent "${rule.fallback}" for rule "${rule.name}" is unavailable: ${fallbackAvailability.reason}`
+        );
         continue;
       }
 
@@ -222,11 +302,8 @@ export class AgentRoutingService {
     // No specific fallback found — try default if it's different from failed
     const defaultAgent = routing.defaultAgent || config.defaultAgent;
     if (defaultAgent !== failedAgent) {
-      const defaultConfig = config.agents.find(
-        (a: { type: string; name: string; command: string; args: string[]; enabled: boolean }) =>
-          a.type === defaultAgent
-      );
-      if (defaultConfig?.enabled) {
+      const defaultAvailability = await this.getAgentAvailability(config.agents, defaultAgent);
+      if (defaultAvailability.available) {
         return {
           agent: defaultAgent,
           model: routing.defaultModel,
@@ -270,6 +347,44 @@ export class AgentRoutingService {
   }
 
   // ─── Private helpers ───────────────────────────────────────────
+
+  private async getAgentAvailability(
+    agents: AgentConfig[],
+    agent: AgentType
+  ): Promise<AgentAvailability> {
+    const agentConfig = agents.find((candidate) => candidate.type === agent);
+    if (!agentConfig) {
+      return {
+        available: false,
+        reason: 'Agent is not configured',
+      };
+    }
+
+    if (!agentConfig.enabled) {
+      return {
+        agentConfig,
+        available: false,
+        reason: 'Agent is disabled',
+      };
+    }
+
+    const health = await this.agentHealth.checkAgent(agentConfig);
+    if (!health.healthy) {
+      return {
+        agentConfig,
+        health,
+        available: false,
+        reason: health.reason || 'Agent health check failed',
+      };
+    }
+
+    return {
+      agentConfig,
+      health,
+      available: true,
+      reason: 'Agent is healthy',
+    };
+  }
 
   /**
    * Check if a task matches a rule's criteria.

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -19,6 +19,7 @@ import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
 import { getTelemetryService } from './telemetry-service.js';
 import { getAgentRoutingService } from './agent-routing-service.js';
+import { AgentHealthService, type AgentHealthChecker } from './agent-health-service.js';
 import { getBreaker } from './circuit-registry.js';
 import { activityService } from './activity-service.js';
 import { getTraceService } from './trace-service.js';
@@ -41,6 +42,7 @@ import type {
   TaskReadinessSummary,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
+import { ConflictError } from '../middleware/error-handler.js';
 const log = createLogger('clawdbot-agent-service');
 
 const PROJECT_ROOT = path.resolve(process.cwd(), '..');
@@ -139,11 +141,13 @@ const pendingAgents = new Map<string, PendingAgent>();
 export class ClawdbotAgentService {
   private configService: ConfigService;
   private taskService: TaskService;
+  private agentHealth: AgentHealthChecker;
   private logsDir: string;
 
-  constructor() {
+  constructor(agentHealth?: AgentHealthChecker) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
+    this.agentHealth = agentHealth || new AgentHealthService();
     this.logsDir = LOGS_DIR;
     this.ensureLogsDir();
   }
@@ -201,6 +205,7 @@ export class ClawdbotAgentService {
     }
 
     const agentConfig = this.resolveAgentConfig(config.agents, agent);
+    await this.assertAgentAvailable(agent, agentConfig);
     const provider = this.resolveAgentProvider(agentConfig, agent);
     const readiness = evaluateTaskReadiness(task, { isCodeTask: true, selectedAgent: agent });
     const overrideReason = options.overrideReason?.trim();
@@ -502,6 +507,38 @@ export class ClawdbotAgentService {
 
   private resolveAgentConfig(agents: AgentConfig[], agent: AgentType): AgentConfig | undefined {
     return agents.find((a) => a.type === agent);
+  }
+
+  private async assertAgentAvailable(
+    agent: AgentType,
+    agentConfig: AgentConfig | undefined
+  ): Promise<void> {
+    if (!agentConfig) {
+      throw new ConflictError(`Agent "${agent}" is not configured`, {
+        agent,
+        reason: 'Agent is not configured',
+      });
+    }
+
+    if (!agentConfig.enabled) {
+      throw new ConflictError(`Agent "${agent}" is disabled`, {
+        agent,
+        reason: 'Agent is disabled',
+      });
+    }
+
+    const health = await this.agentHealth.checkAgent(agentConfig);
+    if (!health.healthy) {
+      throw new ConflictError(
+        `Agent "${agent}" is unavailable: ${health.reason || 'Agent health check failed'}`,
+        {
+          agent,
+          reason: health.reason || 'Agent health check failed',
+          command: agentConfig.command,
+          provider: agentConfig.provider,
+        }
+      );
+    }
   }
 
   private resolveAgentProvider(


### PR DESCRIPTION
## Summary
- Add an agent health checker for configured agent commands, executable discovery, and detectable auth probes for Codex and GitHub-backed providers.
- Gate routing resolution so matched rules skip unhealthy agents, use healthy configured fallbacks when allowed, and return structured `409 CONFLICT` errors when no healthy agent can be selected.
- Gate explicit agent dispatch before spawning a process, so manually selected unhealthy agents fail loudly instead of starting a guaranteed-bad run.
- Add regression coverage for missing binaries, disabled fallback profiles, unauthenticated providers, and explicit dispatch blocking.

## Tests
- `pnpm --filter @veritas-kanban/server test -- agent-routing-service.test.ts codex-provider-service.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm exec prettier --check server/src/services/agent-health-service.ts server/src/services/agent-routing-service.ts server/src/services/clawdbot-agent-service.ts server/src/__tests__/agent-routing-service.test.ts server/src/__tests__/codex-provider-service.test.ts`
- `git diff --check`

## Notes
- `pnpm lint:budget` passes with existing warnings under budget: 666 warnings, 0 errors.
- Local untracked `server/storage/` runtime files were left untouched.

Closes #378
