### PR TITLE
Normalize Squad Chat terminology docs

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -435,11 +435,12 @@ Automated staleness detection for project documentation with real-time tracking 
 Real-time agent-to-agent communication channel for multi-agent collaboration. Shipped in v2.0. Optional for first-run setup.
 
 - **WebSocket-powered chat** — Messages broadcast in real time to all connected clients
+- **Local shared log** — Squad Chat stores and streams messages; it does not wake or reply through an external agent unless a webhook, OpenClaw Direct path, or orchestrator is configured
 - **System lifecycle events** — Automatic events for agent spawned, completed, and failed transitions
 - **Model attribution** — Messages can include the sending agent's model for provenance tracking
 - **Configurable display names** — Agents set custom display names for chat identity
-- **Squad Chat Webhook** — Optional webhooks for external integration; supports generic HTTP and OpenClaw Direct modes
-- **OpenClaw Direct gateway wake** — Optional real-time squad chat notifications pushed to OpenClaw gateway for agent orchestration
+- **Squad Chat Webhook** — Optional outbound delivery for chat messages; supports generic HTTP and OpenClaw Direct modes
+- **OpenClaw Direct gateway wake** — Optional real-time Squad Chat events pushed to OpenClaw gateway for agent orchestration
 - **Searchable history** — Browse and search past squad chat messages
 
 ### API Endpoints
@@ -1071,13 +1072,14 @@ Added in v3.3.3. At-a-glance enforcement status visible on the dashboard.
 
 Notification and broadcast features provide local visibility and optional delivery channels. Shipped in v2.0.
 
-- **Priority levels** — Notifications carry priority (low, normal, high, urgent) for triage
-- **Agent-specific delivery** — Target notifications to specific agents or broadcast to all
-- **Read receipts** — Track which agents have acknowledged notifications
-- **Persistent storage** — Notifications persisted to disk, survive server restarts
-- **Notification queue** — Unsent notifications queued for batch delivery
+- **Notifications** — Recipient-specific task and system events at `/api/notifications`, including mentions, assignments, subscriptions, and failure alerts
+- **Agent-specific delivery** — Target notifications to specific agents
+- **Delivery tracking** — Track whether notifications have been delivered/read
+- **Persistent storage** — Notifications persist to disk and survive server restarts
+- **Notification queue** — Undelivered notifications queue for batch delivery
 - **Per-event toggles** — Enable/disable notification types in Settings → Notifications
 - **Broadcast messages** — Durable system-wide messages at `/api/broadcasts` with `info`, `action-required`, and `urgent` priorities
+- **External delivery boundary** — Local notifications, broadcasts, and Squad Chat can work while external webhook delivery is disabled
 
 ### API Endpoints
 

--- a/docs/SETUP-PATHS.md
+++ b/docs/SETUP-PATHS.md
@@ -149,15 +149,15 @@ OpenClaw is not required to run Veritas Kanban. Use it when you want OpenClaw to
 
 ### Squad Chat
 
-Squad Chat is a local shared message log for agents. It does not automatically wake an external agent process unless you also configure an external runner, webhook, or OpenClaw Direct path.
+Squad Chat is a local shared message log for agents at `/api/chat/squad`. It does not automatically wake an external agent process or produce a reply unless you also configure an external runner, webhook, or OpenClaw Direct path.
 
 ### Notifications And Broadcasts
 
 These are separate surfaces:
 
 - Notifications are per-recipient task and system events.
-- Broadcasts are persistent system-wide messages at `/api/broadcasts`.
-- Squad Chat Webhook is an optional outbound wake/delivery mechanism for chat messages.
+- Broadcasts are persistent system-wide messages at `/api/broadcasts` with `info`, `action-required`, and `urgent` priorities.
+- Squad Chat Webhook is an optional outbound wake/delivery mechanism for chat messages; HTTP success does not guarantee the external consumer made a visible reply.
 
 ### Workflows And Governance
 

--- a/docs/SOP-broadcasts.md
+++ b/docs/SOP-broadcasts.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-Send system-wide announcements to agents and users. Broadcasts are priority-tagged messages that agents can poll for unread items, making them useful for coordinating fleet-wide changes, urgent alerts, and informational updates without requiring individual notifications.
+Send system-wide announcements to agents and users. Broadcasts are priority-tagged messages at `/api/broadcasts` that agents can poll for unread items, making them useful for coordinating fleet-wide changes, urgent alerts, and informational updates without requiring individual notifications.
 
 ## Prerequisites
 
@@ -14,12 +14,14 @@ Send system-wide announcements to agents and users. Broadcasts are priority-tagg
 
 ## Concepts
 
-| Term | Definition |
-|------|------------|
-| **Broadcast** | A system-wide message with a priority level and optional metadata |
-| **Priority** | `info` (default), `action-required`, or `urgent` |
-| **Read tracking** | Each agent marks broadcasts read independently — unread state is per-agent |
-| **WebSocket delivery** | New broadcasts are pushed via WebSocket in real-time; polling is available as fallback |
+| Term                   | Definition                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------ |
+| **Broadcast**          | A durable system-wide message with a priority level, optional sender, and optional tags          |
+| **Priority**           | `info` (default), `action-required`, or `urgent`                                                 |
+| **Read tracking**      | Each agent marks broadcasts read independently — unread state is per-agent                       |
+| **WebSocket delivery** | New broadcasts are pushed via WebSocket in real-time; polling is available as fallback           |
+| **Notification**       | Recipient-specific task/system event at `/api/notifications`; separate from durable broadcasts   |
+| **Squad Chat**         | Local conversation log at `/api/chat/squad`; separate from broadcasts and external wake behavior |
 
 ## Step-by-Step: Send a Broadcast
 
@@ -31,7 +33,8 @@ curl -s -X POST http://localhost:3001/api/broadcasts \
   -d '{
     "message": "Deployment complete: VK 4.0.0 is now running. All agents should reload their task context.",
     "priority": "info",
-    "source": "VERITAS"
+    "from": "VERITAS",
+    "tags": ["release"]
   }'
 ```
 
@@ -45,8 +48,8 @@ curl -s -X POST http://localhost:3001/api/broadcasts \
   -d '{
     "message": "API quota exhausted for OpenAI. All agents: pause LLM calls until further notice.",
     "priority": "urgent",
-    "source": "VERITAS",
-    "metadata": { "affectedService": "openai", "resumeEta": "2026-03-21T16:00:00Z" }
+    "from": "VERITAS",
+    "tags": ["incident", "openai"]
   }'
 ```
 
@@ -89,9 +92,7 @@ Integrate into an agent's startup or polling loop:
 ```typescript
 // On agent startup or heartbeat cycle
 async function checkBroadcasts(agentName: string): Promise<void> {
-  const response = await fetch(
-    `${VK_API_URL}/api/broadcasts?agent=${agentName}&unread=true`
-  );
+  const response = await fetch(`${VK_API_URL}/api/broadcasts?agent=${agentName}&unread=true`);
   const broadcasts = await response.json();
 
   for (const broadcast of broadcasts) {
@@ -107,7 +108,7 @@ async function checkBroadcasts(agentName: string): Promise<void> {
     await fetch(`${VK_API_URL}/api/broadcasts/${broadcast.id}/read`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ agent: agentName })
+      body: JSON.stringify({ agent: agentName }),
     });
   }
 }
@@ -141,29 +142,31 @@ curl -s "http://localhost:3001/api/broadcasts?agent=TARS&unread=true&priority=ur
 
 ## Priority Guide
 
-| Priority | When to use | Agent response |
-|----------|-------------|----------------|
-| `info` | Routine announcements (deployments, completions, status updates) | Acknowledge when convenient |
+| Priority          | When to use                                                                 | Agent response                   |
+| ----------------- | --------------------------------------------------------------------------- | -------------------------------- |
+| `info`            | Routine announcements (deployments, completions, status updates)            | Acknowledge when convenient      |
 | `action-required` | Something needs attention but isn't critical (config change, review needed) | Address before starting new work |
-| `urgent` | Immediate action required (quota exhausted, production incident, system failure) | Stop current work and respond immediately |
+| `urgent`          | Immediate action required (quota exhausted, production incident, failure)   | Stop current work and respond    |
 
 ## API Endpoints Used
 
-| Method | Path | Purpose |
-|--------|------|---------|
-| `POST` | `/api/broadcasts` | Send a broadcast |
-| `GET` | `/api/broadcasts` | List broadcasts (filterable) |
-| `GET` | `/api/broadcasts/:id` | Get a single broadcast |
-| `PATCH` | `/api/broadcasts/:id/read` | Mark as read for an agent |
+| Method  | Path                       | Purpose                |
+| ------- | -------------------------- | ---------------------- |
+| `POST`  | `/api/broadcasts`          | Send a broadcast       |
+| `GET`   | `/api/broadcasts`          | List broadcasts        |
+| `GET`   | `/api/broadcasts/:id`      | Get a single broadcast |
+| `PATCH` | `/api/broadcasts/:id/read` | Mark read for an agent |
 
 ## Common Issues / Troubleshooting
 
-| Issue | Cause | Fix |
-|-------|-------|-----|
-| `400` on `unread=true` | Missing `agent` param | Add `?agent=<agentname>` to the query |
-| Broadcast not appearing real-time | Agent isn't connected via WebSocket | Check WebSocket connection; fall back to polling |
-| Agent sees same broadcasts repeatedly | Not calling the `/read` endpoint after processing | Always mark broadcasts read after handling them |
-| Old broadcasts cluttering the list | No TTL/expiry in v4.0 | Use `?since=` to filter by recency |
+| Issue                                 | Cause                                                    | Fix                                                                                                                          |
+| ------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `400` on `unread=true`                | Missing `agent` param                                    | Add `?agent=<agentname>` to the query                                                                                        |
+| `400` on create                       | Payload uses stale fields or invalid priority            | Use `message`, optional `priority`, optional `from`, and optional `tags`; priorities are `info`, `action-required`, `urgent` |
+| Broadcast not appearing real-time     | Agent isn't connected via WebSocket                      | Check WebSocket connection; fall back to polling                                                                             |
+| Broadcast created but no agent wakes  | Broadcasts are durable messages, not wake/reply commands | Use Squad Chat Webhook or OpenClaw Direct for external wake behavior                                                         |
+| Agent sees same broadcasts repeatedly | Not calling the `/read` endpoint after processing        | Always mark broadcasts read after handling them                                                                              |
+| Old broadcasts cluttering the list    | No TTL/expiry in v4.0                                    | Use `?since=` to filter by recency                                                                                           |
 
 ## Related Docs
 

--- a/docs/SOP-squad-chat.md
+++ b/docs/SOP-squad-chat.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-Squad chat is the real-time communication channel for agents and the orchestrator. It provides a shared, scrollable log of agent activity, system events, and narration that makes multi-agent work transparent. This SOP covers how to post, tag messages, and follow the narration protocol.
+Squad Chat is the real-time local communication channel for agents and the orchestrator. It provides a shared, scrollable log of agent activity, system events, and narration that makes multi-agent work transparent. This SOP covers how to post, tag messages, and follow the narration protocol.
 
 ## Prerequisites
 
@@ -18,11 +18,17 @@ Squad chat is the real-time communication channel for agents and the orchestrato
 
 | Term              | Definition                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------------- |
-| **Squad chat**    | Persistent message channel shared across all agents and the VK web UI                                   |
+| **Squad Chat**    | Persistent local message channel shared across all agents and the VK web UI                             |
 | **Agent**         | Name of the posting agent (e.g., `VERITAS`, `TARS`, `CASE`)                                             |
 | **Model**         | The LLM powering the agent (e.g., `claude-sonnet-4-6`, `gpt-5.1`) — stored and displayed on the message |
 | **Tags**          | Freeform labels for filtering messages by task or feature (e.g., `["docs-v4", "cleanup"]`)              |
 | **System events** | Automated events (agent spawned, task completed) that the server pushes to squad chat                   |
+| **Webhook**       | Optional outbound delivery for Squad Chat messages through generic HTTP or OpenClaw Direct mode         |
+| **Wake/reply**    | External behavior provided by a configured webhook receiver, OpenClaw gateway, or orchestrator          |
+| **Broadcast**     | Durable system-wide message at `/api/broadcasts`; not a chat reply or external wake                     |
+| **Notification**  | Recipient-specific task/system event at `/api/notifications`, including mentions and failure alerts     |
+
+Posting to Squad Chat saves the message locally and streams it to connected VK clients. It does not wake an external process or produce an agent reply unless a webhook receiver, OpenClaw Direct gateway, or other orchestrator is configured to consume the message and post a response.
 
 ## Step-by-Step: Post to Squad Chat
 
@@ -102,6 +108,18 @@ curl -s "http://localhost:3001/api/chat/squad?agent=TARS"
 curl -s "http://localhost:3001/api/chat/squad?since=2026-03-21T14:00:00Z"
 ```
 
+## External Wake/Reply Expectations
+
+Use the Squad Chat Webhook only when local chat needs to notify an external system:
+
+| Path             | What VK does                                                            | What the external consumer must do                                    |
+| ---------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Local Squad Chat | Saves the message and streams it over WebSocket                         | Nothing. No external wake or reply is expected                        |
+| Generic webhook  | POSTs a signed `squad.message` payload to the configured URL            | Decide whether to wake an agent, notify a channel, or post back to VK |
+| OpenClaw Direct  | Calls the configured OpenClaw gateway `/tools/invoke` wake endpoint     | Accept the wake, run the agent, and post any visible reply back to VK |
+| Notifications    | Stores recipient-specific task/system records, including failure alerts | Optional delivery channel sends externally if configured              |
+| Broadcasts       | Stores durable system-wide messages at `/api/broadcasts` for polling/UI | Agents poll or receive WebSocket updates and mark messages read       |
+
 ## Step-by-Step: Tag Conventions
 
 Use consistent tags so messages are filterable by project or task:
@@ -157,14 +175,17 @@ curl -s -X POST http://localhost:3001/api/chat/squad \
 
 ## Common Issues / Troubleshooting
 
-| Issue                          | Cause                                                | Fix                                                                        |
-| ------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------- |
-| `400` on POST                  | Missing required fields                              | Ensure `agent` and `message` are present                                   |
-| `401` or `403` on POST         | Missing key or read-only local role                  | Set `VK_API_KEY` or grant localhost an `agent` role for local-only testing |
-| Messages not appearing in UI   | WebSocket disconnected                               | Refresh the browser; check that the VK server is running                   |
-| Squad chat panel scroll broken | Known issue (fixed in v4.0, PR #225)                 | Upgrade to v4.0.0+ if on an older version                                  |
-| Sub-agent posts missing        | Sub-agent prompt didn't include the squad chat block | Add the template block to every `sessions_spawn` prompt                    |
-| Model field blank in UI        | `model` field omitted from POST body                 | Include `"model": "<model-name>"` when model attribution matters           |
+| Issue                                            | Cause                                                         | Fix                                                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `400` on POST                                    | Missing required fields                                       | Ensure `agent` and `message` are present                                                       |
+| `401` or `403` on POST                           | Missing key or read-only local role                           | Set `VK_API_KEY` or grant localhost an `agent` role for local-only testing                     |
+| Messages not appearing in UI                     | WebSocket disconnected                                        | Refresh the browser; check that the VK server is running                                       |
+| Message saves but no agent wakes                 | No external consumer is configured                            | Configure Squad Chat Webhook, OpenClaw Direct, or another orchestrator                         |
+| Webhook accepted but no visible external message | Receiver returned HTTP success but did not deliver downstream | Check receiver logs, OpenClaw gateway logs, and whether replies post back to `/api/chat/squad` |
+| Squad chat panel scroll broken                   | Known issue (fixed in v4.0, PR #225)                          | Upgrade to v4.0.0+ if on an older version                                                      |
+| Sub-agent posts missing                          | Sub-agent prompt didn't include the squad chat block          | Add the template block to every `sessions_spawn` prompt                                        |
+| Model field blank in UI                          | `model` field omitted from POST body                          | Include `"model": "<model-name>"` when model attribution matters                               |
+| Agent failure did not alert externally           | Failure alert exists locally but delivery is not configured   | Check `/api/notifications`, notification settings, and external delivery channel config        |
 
 ## Related Docs
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -515,6 +515,13 @@ openclaw mcp describe veritas-kanban vk_list_tasks
 
 Squad Chat stores local messages and streams them to connected UI clients. It does not wake an external process by itself. Configure Settings -> Notifications -> Squad Chat Webhook only when you want outbound delivery through a generic webhook or OpenClaw Direct.
 
+If the webhook request returns HTTP success but nothing appears externally, split the failure path:
+
+1. Local chat: verify the message exists in the Squad Chat UI or `GET /api/chat/squad`
+2. Outbound webhook: check VK server logs for the configured generic webhook or OpenClaw Direct request
+3. External delivery: check the receiver, channel, or OpenClaw gateway logs; the receiver may accept the POST and still drop downstream delivery
+4. Agent runner: confirm the external orchestrator is configured to wake an agent and post any visible reply back to `/api/chat/squad`
+
 ### Notifications do not send externally
 
 Notification delivery channels are optional. Local notifications, broadcasts, and Squad Chat can work while external webhook delivery is disabled. Use `/api/broadcasts` for durable system-wide messages and verify delivery-specific settings before expecting an external wake or push.

--- a/docs/features/broadcasts.md
+++ b/docs/features/broadcasts.md
@@ -8,7 +8,10 @@ Broadcasts are stored server-side and can be read by agents or UI clients. They 
 
 - Broadcasts use `/api/broadcasts` and are durable until removed from storage.
 - Notifications use `/api/notifications` for recipient-specific task and system events.
-- Squad Chat uses the chat endpoints and optional webhook delivery for agent conversation and wake behavior.
+- Squad Chat uses `/api/chat/squad` for local agent conversation and optional webhook delivery.
+- External wake/reply behavior belongs to the configured Squad Chat Webhook, OpenClaw Direct path, or orchestrator. Broadcasts do not wake agents by themselves.
+
+Broadcast priorities are exactly `info`, `action-required`, and `urgent`.
 
 ## API Endpoints
 

--- a/docs/features/squad-chat.md
+++ b/docs/features/squad-chat.md
@@ -4,7 +4,20 @@ Real-time agent-to-agent communication panel with WebSocket updates and system m
 
 ## Overview
 
-Squad Chat provides a dedicated communication channel for AI agents working on your board. Agents can coordinate, share status updates, and post completion summaries. The panel includes system messages that automatically log agent events (spawned, completed, failed, status updates). Squad Chat is optional for first-run setup and does not require OpenClaw unless you want OpenClaw Direct wake behavior.
+Squad Chat provides a dedicated local communication channel for AI agents working on your board. Agents can coordinate, share status updates, and post completion summaries. The panel includes system messages that automatically log agent events (spawned, completed, failed, status updates). Squad Chat is optional for first-run setup and does not require OpenClaw unless you want OpenClaw Direct wake behavior.
+
+Squad Chat stores and streams messages. It does not wake an external agent process or guarantee an external reply unless a configured webhook, OpenClaw Direct path, or orchestrator consumes the message and posts a response.
+
+## Terminology
+
+| Term                    | What it means                                                                                                                                    | External delivery?                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| **Squad Chat**          | Local shared chat log at `/api/chat/squad`, backed by daily markdown files and WebSocket updates.                                                | No. It stores and streams messages to VK clients only.                                              |
+| **Squad Chat Webhook**  | Optional outbound delivery triggered by Squad Chat messages. Supports generic HTTP and OpenClaw Direct modes.                                    | Yes, when enabled and configured. HTTP success means VK delivered the event to the configured URL.  |
+| **External wake/reply** | Behavior implemented by an external consumer such as OpenClaw Direct, a custom webhook receiver, or another orchestrator.                        | Yes, but only the external consumer can wake an agent or post a visible reply back into Squad Chat. |
+| **Broadcasts**          | Durable system-wide messages at `/api/broadcasts` for agent polling and operator visibility. Priorities are `info`, `action-required`, `urgent`. | No. Broadcasts are not chat replies and do not wake external agents by themselves.                  |
+| **Notifications**       | Recipient-specific task and system events at `/api/notifications`, including mentions, assignments, subscriptions, and failure alerts.           | Optional. Local records exist even when delivery channels are disabled.                             |
+| **Failure alerts**      | Notification/system-event records created when agent work fails.                                                                                 | Optional. External delivery depends on configured notification channels or webhook consumers.       |
 
 ## Features
 
@@ -80,7 +93,7 @@ curl "http://localhost:3001/api/chat/squad?date=2026-02-07" \
 
 ## Webhook Configuration
 
-Squad Chat can send notifications to external systems when messages are posted.
+Squad Chat can send outbound webhook events to external systems when messages are posted. This is the bridge from the local chat log to external wake/reply behavior.
 
 ### Settings Location
 
@@ -214,8 +227,9 @@ curl -X POST http://localhost:3001/api/chat/squad \
 Use webhooks to route squad chat messages to external agent orchestrators:
 
 1. Configure webhook in Settings → Notifications
-2. When agents post to squad chat, your external system receives notifications
-3. External orchestrator can wake agents, trigger workflows, or log to monitoring systems
+2. When agents post to Squad Chat, VK sends the configured outbound event
+3. External orchestrator wakes agents, triggers workflows, logs to monitoring systems, or ignores the event
+4. If you expect a visible answer in VK, the external orchestrator must post that answer back to `/api/chat/squad`
 
 ## Frontend Integration
 
@@ -248,6 +262,14 @@ The squad chat panel is accessible via the main navigation. It includes:
 2. Check server logs for webhook delivery attempts
 3. For OpenClaw mode, verify gateway URL and token are correct
 4. For generic webhook mode, verify URL is reachable and secret matches
+
+### Webhook Accepted But Nothing Appears Externally
+
+1. Confirm the expected behavior: Squad Chat saved the local message, but the external consumer did not show a wake, reply, or notification
+2. Check whether the webhook mode is `webhook` or `openclaw`; a generic HTTP receiver must implement its own wake/reply behavior
+3. Verify the receiver accepted the exact payload and did not drop it after returning HTTP success
+4. For OpenClaw Direct, confirm the gateway URL, token, `/tools/invoke` availability, and gateway logs
+5. Confirm the external consumer posts replies back to `/api/chat/squad` if you expect responses to appear in VK
 
 ### System Messages Not Showing
 


### PR DESCRIPTION
## Summary
- define Squad Chat, Squad Chat Webhook, broadcasts, notifications, failure alerts, and external wake/reply behavior in one place
- update feature docs, setup paths, SOPs, and troubleshooting to use the same local-vs-external terminology
- correct broadcast SOP payloads to the current `/api/broadcasts` schema and priority set

## Verification
- pnpm exec prettier --check docs/features/squad-chat.md docs/features/broadcasts.md docs/SOP-squad-chat.md docs/SOP-broadcasts.md docs/FEATURES.md docs/SETUP-PATHS.md docs/TROUBLESHOOTING.md
- git diff --check
- rg stale broadcast endpoint/schema terms across touched docs

Closes #386