### PR TITLE
Clarify optional integration setup docs

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -290,10 +290,11 @@ First-class support for autonomous coding agents.
 - **Running indicator on cards** — Animated spinner on task cards when an agent is actively working
 - **Agent output stream** — Real-time agent output via WebSocket with auto-scroll and clear
 - **Send message to agent** — Send text messages to running agents
-- **OpenClaw native support** — Built-in integration with [OpenClaw](https://github.com/openclaw/openclaw) (formerly Clawdbot/Moltbot) via gateway URL; sub-agent spawning via `sessions_spawn`
+- **Optional OpenClaw support** — Built-in integration with [OpenClaw](https://github.com/openclaw/openclaw) (formerly Clawdbot/Moltbot) via gateway URL when you want OpenClaw to execute or wake agents
 - **HermesAgent operating support** — v4.3 documents HermesAgent/Hermes Gateway as the active control plane, with Veritas tracking task truth, QA evidence, and GitHub delivery state
 - **OpenAI Codex support** — Local CLI attempts, SDK sessions, GitHub-native Codex Cloud delegation, workflow steps, review actions, Settings health checks, and MCP setup
 - **Platform-agnostic REST API** — Any platform that can make HTTP calls can drive the full agent lifecycle
+- **Agent request tracking** — VK can create and display pending agent requests; a configured external runner/provider must execute the work
 - **Automation tasks** — Separate automation task type with pending/running/complete lifecycle, session key tracking, and sub-agent spawning
 - **Failure alerts** — Dedicated failure alert service for agent run failures
 
@@ -595,7 +596,7 @@ A deterministic multi-step agent orchestration system for repeatable, observable
 
 ### Overview
 
-The workflow engine transforms Veritas Kanban from an ad-hoc task board into a full-featured agent orchestration platform. Define multi-step pipelines as version-controlled YAML files, execute them with loops, gates, and parallel steps, and monitor everything in real time through the dashboard.
+The workflow engine transforms Veritas Kanban from an ad-hoc task board into a full-featured agent orchestration platform. Define multi-step pipelines as version-controlled YAML files, execute them with loops, gates, and parallel steps, and monitor everything in real time through the dashboard. Agent execution requires a configured runner/provider; board visibility, workflow definitions, and governance review still work without OpenClaw.
 
 **What it does:**
 
@@ -607,17 +608,17 @@ The workflow engine transforms Veritas Kanban from an ad-hoc task board into a f
 **What it is NOT:**
 
 - Not a general-purpose workflow engine (Temporal, Airflow) — optimized for AI agents
-- Not a replacement for OpenClaw — workflows invoke OpenClaw sessions
+- Not a replacement for an agent runner — OpenClaw, Codex, or a custom provider executes agent steps
 - Not a programming language — declarative YAML, not imperative scripts
 
 ### Core Principles
 
 1. **Deterministic Execution** — Same workflow + same inputs = same execution path (modulo agent non-determinism)
-2. **Agent-Agnostic** — Workflows don't care which LLM/agent runs steps (OpenClaw handles that)
+2. **Agent-Agnostic** — Workflows resolve steps through configured runners/providers instead of requiring one platform
 3. **YAML-First** — Workflows are version-controlled YAML files, not database records
 4. **Observable** — Every step logs outputs, status broadcasts via WebSocket
 5. **Fail-Safe** — Explicit retry/escalation policies, no silent failures
-6. **Fresh Context by Default** — Each step spawns a fresh OpenClaw session (prevents context bleed)
+6. **Fresh Context by Default** — Each agent step should run in a fresh provider session when the runner supports it
 
 ### Workflow Definitions
 
@@ -1004,7 +1005,7 @@ Real-time monitoring for workflow execution.
 
 ### Known Limitations
 
-1. **OpenClaw integration placeholder** — Step executors have integration points for OpenClaw sessions API but don't yet call `sessions_spawn` (tracked in #110, #111)
+1. **Runner-dependent execution** — Agent steps need a configured provider/runner such as OpenClaw, Codex, or a custom adapter
 2. **Loop verify step not wired** — `loop.verify_step` is parsed but not executed by workflow engine (tracked for Phase 5)
 3. **No schema validation** — Step outputs are not validated against JSON Schema (planned for Phase 5)
 4. **Parallel timeouts not enforced** — Parallel steps don't have a global timeout, only sub-step timeouts (planned for Phase 5)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -19,7 +19,7 @@ If you are evaluating VK for the first time, start with the board-only path. MCP
 7. [Shared Resources & Prompt Registry](#shared-resources--prompt-registry)
 8. [Documentation Freshness & Repo Rules](#documentation-freshness--repo-rules)
 9. [Multi-Repo / Multi-Agent Notes](#multi-repo--multi-agent-notes)
-10. [OpenClaw Browser Relay (Optional but recommended)](#openclaw-browser-relay-optional-but-recommended)
+10. [OpenClaw Browser Relay (Optional)](#openclaw-browser-relay-optional)
 11. [What's Next?](#whats-next)
 
 ---
@@ -149,7 +149,7 @@ CLI commands fully mirror the API and are the fastest way to script agent workfl
 
 ## Connect an Agent + Agent Pickup Checklist
 
-Agents interact through HTTP + WebSocket; nothing is hard-coded to a particular provider. Follow this checklist to verify they can pick up work:
+This section is optional. Agents interact through HTTP + WebSocket; nothing is hard-coded to a particular provider. Creating an agent request records the work VK wants done, but an external runner/provider still has to execute it.
 
 1. **Create an agent API key** in `server/.env`:
    ```
@@ -161,16 +161,17 @@ Agents interact through HTTP + WebSocket; nothing is hard-coded to a particular 
    export VK_API_URL=http://localhost:3001
    export VK_API_KEY=super-secret-key
    ```
-4. **Create an agent request** (UI → Start Agent) or drop a JSON file in `.veritas-kanban/agent-requests/`.
-5. **Watch pending agents** in the UI or via CLI:
+4. **Confirm a runner/provider is installed and running** if you expect autonomous execution. Examples: OpenClaw, Codex CLI/SDK, Codex Cloud, or a custom process that polls VK and updates task state.
+5. **Create an agent request** (UI → Start Agent) or drop a JSON file in `.veritas-kanban/agent-requests/`.
+6. **Watch pending agents** in the UI or via CLI:
    ```bash
    vk agents:pending
    ```
-6. **Agent workflow** (example prompt to an agent runner):
+7. **Agent workflow** (example prompt to an agent runner):
    ```
    Hey Veritas, pick up task <ID>. Set status to in-progress, start the timer, do the work, then call `vk done <id> "summary"` when finished. Use cross-model review if you wrote code.
    ```
-7. **Agent completion**
+8. **Agent completion**
    - Verify `tasks/active/...` reflects status/time tracking
    - Check `.veritas-kanban/logs/agents.log` for run details
    - Confirm UI Agent Status indicator flips back to **Idle**
@@ -206,12 +207,12 @@ Expect `{ "ok": true, "service": "veritas-kanban", ... }`. If the call hangs or 
 
 ### 4. Common failure modes & instant fixes
 
-| Symptom                     | Quick Fix                                                     |
-| --------------------------- | ------------------------------------------------------------- |
-| Ports collide / UI hung     | `pnpm dev:clean`                                              |
-| Health endpoint returns 404 | Wrong project running on 3001 (restart)                       |
-| Auth spamming rate limit    | Ensure request IP is `127.0.0.1` or increase limiter          |
-| Agents "never pick up"      | Verify API key role `agent`, check firewall/Docker networking |
+| Symptom                     | Quick Fix                                                                                         |
+| --------------------------- | ------------------------------------------------------------------------------------------------- |
+| Ports collide / UI hung     | `pnpm dev:clean`                                                                                  |
+| Health endpoint returns 404 | Wrong project running on 3001 (restart)                                                           |
+| Auth spamming rate limit    | Ensure request IP is `127.0.0.1` or increase limiter                                              |
+| Agents "never pick up"      | Verify the external runner/provider is running, API key role is `agent`, and network access works |
 
 For deeper debugging see [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
@@ -280,15 +281,15 @@ Running multiple projects or repos with the same agent pool? Borrow BoardKit's a
 
 ---
 
-## OpenClaw Browser Relay (Optional but Recommended)
+## OpenClaw Browser Relay (Optional)
 
-For auth-required workflows (LinkedIn research, dashboards behind Okta, etc.) you'll want OpenClaw's Browser Relay:
+Use OpenClaw's Browser Relay only for auth-required browser workflows such as research behind Okta, customer dashboards, or other tasks where the runner must use your active browser session:
 
 1. Install the extension + helper from the [OpenClaw docs](https://github.com/openclaw/openclaw).
 2. Launch the relay; attach your tab.
 3. Agents can now run headless instructions through your actual browser session while respecting your credentials.
 
-This is invaluable for Champions-style research tasks or anything needing a real login flow.
+Skip this for board-only use, REST/CLI/MCP task management, or agents that do not need your browser cookies.
 
 ---
 

--- a/docs/SOP-agent-task-workflow.md
+++ b/docs/SOP-agent-task-workflow.md
@@ -2,6 +2,8 @@
 
 Use this playbook anytime an agent (human or LLM) takes a task from **todo** to **done**. It standardizes status changes, time tracking, summaries, and ensures telemetry stays usable.
 
+This SOP assumes an agent or human is already doing the work. Veritas Kanban can create agent requests and track status, but it does not execute model work unless a runner/provider such as OpenClaw, Codex CLI/SDK, Codex Cloud, or a custom process is configured.
+
 ---
 
 ## Roles

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -4,6 +4,14 @@
 
 The Veritas Kanban MCP server lets any [Model Context Protocol](https://modelcontextprotocol.io/) client — Claude Desktop, OpenClaw, Cursor, Cline, Codex, or your own tooling — manage tasks, sprints, projects, comments, agents, automation, notifications, and summaries through a single stdio process.
 
+MCP is optional. The board, REST API, and CLI do not require MCP or OpenClaw. Use MCP only when an assistant needs typed tool access instead of direct REST/CLI calls.
+
+| Mode                   | What works                                                                                    | Required auth                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Local read-only        | Tool discovery, task reads, summaries, resources, and other read operations against localhost | `VK_API_URL`; `VK_API_KEY` can be omitted when localhost bypass grants reads    |
+| Local or remote writes | Creating/updating tasks, comments, agents, automation, notifications, sprints, and projects   | `VK_API_KEY` with an `agent` or `admin` role, or localhost role `agent`/`admin` |
+| External runners       | MCP tools can create agent requests or update task state                                      | A separate runner/provider still has to execute the agent work                  |
+
 ---
 
 ## Table of Contents
@@ -45,6 +53,7 @@ Don't use it when:
 - You just need a quick REST call — use the [REST API](../API-WORKFLOWS.md) directly.
 - You're building a web frontend — use the HTTP API with the TypeScript client.
 - You need WebSocket streaming — the MCP server uses stdio, not SSE/WS.
+- You expect MCP itself to run agents — it can request work, but execution belongs to Codex, OpenClaw, or another configured runner.
 
 ---
 
@@ -97,6 +106,7 @@ Don't use it when:
 - Node.js ≥ 22
 - The Veritas Kanban server running (`pnpm dev` or production)
 - pnpm (for building from source)
+- No OpenClaw requirement unless OpenClaw is the MCP client or agent runner you choose
 
 ### Local Development
 


### PR DESCRIPTION
## Summary
- make MCP optionality, read-only localhost use, and write-auth requirements explicit at the top of the MCP guide
- clarify that agent requests are tracking records until an external runner/provider executes the work
- update feature docs so OpenClaw is presented as one optional runner path, not a prerequisite for workflows or agent features

## Verification
- pnpm exec prettier --check docs/mcp/README.md docs/GETTING-STARTED.md docs/SOP-agent-task-workflow.md docs/FEATURES.md
- git diff --check
- rg stale OpenClaw/MCP prerequisite phrasing across touched docs

Closes #385