### PR TITLE
Add board-first setup readiness levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000) — that's it. The board auto-seeds with example tasks on first run so you can explore right away.
 
+A working board means the UI loads and `http://localhost:3001/api/health` returns healthy. Agent-ready and external wake/delivery-ready are separate setup levels; use [Setup Paths](docs/SETUP-PATHS.md#readiness-levels) before adding those layers.
+
 **Do not configure these on day one unless you already know you need them:**
 
 - OpenClaw gateway or browser relay

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -6,6 +6,8 @@ Whether you are standing up the board for yourself or for a fleet of agents, thi
 
 If you are evaluating VK for the first time, start with the board-only path. MCP, OpenClaw, Squad Chat webhooks, notification delivery, workflow gates, and governance policies are optional layers. The setup paths are broken out in [Setup Paths](SETUP-PATHS.md).
 
+A working board is not the same as agent-ready or external wake/delivery-ready. First verify the UI and API health endpoint, then use the [readiness levels](SETUP-PATHS.md#readiness-levels) to decide whether CLI, MCP, runners, webhooks, or notifications are actually needed.
+
 ---
 
 ## Table of Contents

--- a/docs/SETUP-PATHS.md
+++ b/docs/SETUP-PATHS.md
@@ -14,6 +14,19 @@ Veritas Kanban starts as a local board. The agent, MCP, OpenClaw, Squad Chat, no
 | Board plus OpenClaw | You want OpenClaw to run or wake agents                         | Board setup, OpenClaw config, optional browser relay or direct webhook |
 | Self-hosted         | You want remote access                                          | Production env, reverse proxy, auth keys, backups                      |
 
+## Readiness Levels
+
+Use these as stop points. Do not move to the next level until the current one is verified.
+
+| Level                        | You are done when                                                                     | Not included yet                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Working board                | UI loads at `localhost:3000`; API health works at `localhost:3001/api/health`         | CLI writes, MCP, agents, webhooks, workflows, notifications |
+| CLI-ready                    | CLI is built/linked; `vk list` works; write smoke test passes when using a key        | MCP tools or autonomous agent execution                     |
+| MCP read-ready               | MCP server builds; `tools/list` and read tools work from the client                   | Write tools, agent execution, external wake/delivery        |
+| MCP write-ready              | MCP write smoke test creates and deletes a temporary task with `VK_API_KEY`           | A runner/provider that performs agent work                  |
+| Agent-ready                  | A configured runner/provider consumes VK agent requests and updates task state        | Squad Chat webhooks or notification delivery                |
+| External wake/delivery-ready | Squad Chat Webhook, OpenClaw Direct, or notification channel is configured and tested | Board, API, CLI, and MCP basics are already separate        |
+
 ## Minimal Local Setup
 
 ```bash


### PR DESCRIPTION
## Summary
- add explicit readiness levels for working board, CLI-ready, MCP read/write-ready, agent-ready, and external wake/delivery-ready
- point README and Getting Started at the readiness levels before users add optional integrations
- keep first-run setup separate from agent runners, webhooks, workflows, and notifications

## Verification
- pnpm exec prettier --check README.md docs/GETTING-STARTED.md docs/SETUP-PATHS.md
- git diff --check

Closes #384