### PR TITLE
Complete OpenClaw workflow step adapter

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -879,7 +879,7 @@ Role-based tool restrictions for least-privilege security.
 
 **Enforcement:**
 
-- Tool filter passed to OpenClaw `sessions_spawn` (ready for integration)
+- Tool filters are resolved before OpenClaw workflow session execution and passed through the provider-adapter boundary.
 - Denied list takes precedence over allowed list
 
 ### Session Isolation

--- a/server/src/__tests__/workflow-step-executor-openclaw.test.ts
+++ b/server/src/__tests__/workflow-step-executor-openclaw.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import type {
+  OpenClawWorkflowAdapter,
+  OpenClawWorkflowCleanupInput,
+  OpenClawWorkflowSessionInput,
+  OpenClawWorkflowSessionResult,
+  OpenClawWorkflowSpawnInput,
+} from '../services/openclaw-workflow-adapter.js';
+
+const mocks = vi.hoisted(() => ({
+  getToolFilterForRole: vi.fn(),
+  recordGovernanceTrace: vi.fn(),
+}));
+
+vi.mock('../services/tool-policy-service.js', () => ({
+  getToolPolicyService: () => ({
+    getToolFilterForRole: mocks.getToolFilterForRole,
+  }),
+}));
+
+vi.mock('../services/governance-trace-service.js', () => ({
+  getGovernanceTraceService: () => ({
+    record: mocks.recordGovernanceTrace,
+  }),
+}));
+
+import { WorkflowStepExecutor } from '../services/workflow-step-executor.js';
+import type { WorkflowRun, WorkflowStep } from '../types/workflow.js';
+
+type MockOpenClawAdapter = OpenClawWorkflowAdapter & {
+  spawn: ReturnType<
+    typeof vi.fn<(input: OpenClawWorkflowSpawnInput) => Promise<OpenClawWorkflowSessionResult>>
+  >;
+  send: ReturnType<
+    typeof vi.fn<(input: OpenClawWorkflowSessionInput) => Promise<OpenClawWorkflowSessionResult>>
+  >;
+  wait: ReturnType<
+    typeof vi.fn<(input: OpenClawWorkflowSessionInput) => Promise<OpenClawWorkflowSessionResult>>
+  >;
+  cleanup: ReturnType<typeof vi.fn<(input: OpenClawWorkflowCleanupInput) => Promise<void>>>;
+};
+
+function createAdapter(): MockOpenClawAdapter {
+  return {
+    spawn: vi.fn(),
+    send: vi.fn(),
+    wait: vi.fn(),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
+  return {
+    id: 'implement',
+    name: 'Implement',
+    type: 'agent',
+    agent: 'openclaw-dev',
+    input: 'Implement {{task.title}}',
+    output: { file: 'implement.md' },
+    acceptance_criteria: ['STATUS: done'],
+    session: {
+      mode: 'fresh',
+      context: 'minimal',
+      cleanup: 'delete',
+      timeout: 123,
+    },
+    ...overrides,
+  };
+}
+
+function createRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  return {
+    id: 'run_1234567890_openclaw',
+    workflowId: 'wf-openclaw',
+    workflowVersion: 1,
+    taskId: 'task_1',
+    status: 'running',
+    context: {
+      task: {
+        id: 'task_1',
+        title: 'OpenClaw adapter',
+      },
+      workflow: {
+        agents: [
+          {
+            id: 'openclaw-dev',
+            name: 'OpenClaw Developer',
+            role: 'developer',
+            provider: 'openclaw',
+            model: 'claude-sonnet-4',
+            description: 'OpenClaw implementer',
+          },
+        ],
+      },
+      _sessions: {},
+    },
+    startedAt: new Date().toISOString(),
+    steps: [{ stepId: 'implement', status: 'running', retries: 0 }],
+    ...overrides,
+  };
+}
+
+describe('WorkflowStepExecutor OpenClaw integration', () => {
+  let tmpDir: string;
+  let adapter: MockOpenClawAdapter;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workflow-openclaw-'));
+    adapter = createAdapter();
+    mocks.getToolFilterForRole.mockResolvedValue({
+      allowed: ['Read', 'sessions_spawn', 'sessions_send'],
+      denied: ['Write'],
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('spawns and waits for fresh OpenClaw agent steps', async () => {
+    adapter.spawn.mockResolvedValue({
+      sessionKey: 'oc_session_1',
+      runId: 'oc_run_1',
+      status: 'accepted',
+    });
+    adapter.wait.mockResolvedValue({
+      sessionKey: 'oc_session_1',
+      runId: 'oc_run_1',
+      status: 'completed',
+      output: 'STATUS: done\nOUTPUT: Completed via OpenClaw',
+    });
+
+    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const step = createStep();
+    const run = createRun();
+
+    const result = await executor.executeStep(step, run);
+
+    expect(adapter.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowId: 'wf-openclaw',
+        runId: 'run_1234567890_openclaw',
+        stepId: 'implement',
+        taskId: 'task_1',
+        agentId: 'openclaw-dev',
+        agentName: 'OpenClaw Developer',
+        model: 'claude-sonnet-4',
+        prompt: 'Implement OpenClaw adapter',
+        sessionMode: 'fresh',
+        contextMode: 'minimal',
+        cleanup: 'delete',
+        timeoutSeconds: 123,
+        taskContext: expect.objectContaining({ title: 'OpenClaw adapter' }),
+        toolFilter: {
+          allowed: ['Read', 'sessions_spawn', 'sessions_send'],
+          denied: ['Write'],
+        },
+      })
+    );
+    expect(adapter.wait).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: 'oc_session_1',
+        prompt: 'Implement OpenClaw adapter',
+        timeoutSeconds: 123,
+      })
+    );
+    expect(adapter.cleanup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: 'oc_session_1',
+        runId: 'run_1234567890_openclaw',
+        stepId: 'implement',
+      })
+    );
+    expect(run.context._sessions).toMatchObject({ 'openclaw-dev': 'oc_session_1' });
+    expect(run.steps[0].sessionKey).toBe('oc_session_1');
+    expect(result.output).toContain('Completed via OpenClaw');
+
+    const output = await fs.readFile(result.outputPath, 'utf-8');
+    expect(output).toContain('Provider: openclaw');
+    expect(output).not.toContain('Implement OpenClaw adapter');
+  });
+
+  it('reuses an existing OpenClaw session when requested', async () => {
+    adapter.send.mockResolvedValue({
+      sessionKey: 'oc_existing_1',
+      runId: 'oc_run_2',
+      status: 'completed',
+      output: 'STATUS: done\nOUTPUT: Reused existing session',
+    });
+
+    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const step = createStep({
+      session: {
+        mode: 'reuse',
+        context: 'full',
+        cleanup: 'keep',
+        timeout: 60,
+      },
+    });
+    const run = createRun({
+      context: {
+        ...createRun().context,
+        _sessions: { 'openclaw-dev': 'oc_existing_1' },
+      },
+    });
+
+    const result = await executor.executeStep(step, run);
+
+    expect(adapter.spawn).not.toHaveBeenCalled();
+    expect(adapter.wait).not.toHaveBeenCalled();
+    expect(adapter.cleanup).not.toHaveBeenCalled();
+    expect(adapter.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: 'oc_existing_1',
+        prompt: 'Implement OpenClaw adapter',
+        timeoutSeconds: 60,
+      })
+    );
+    expect(run.context._sessions).toMatchObject({ 'openclaw-dev': 'oc_existing_1' });
+    expect(run.steps[0].sessionKey).toBe('oc_existing_1');
+    expect(result.output).toContain('Reused existing session');
+  });
+
+  it('redacts prompt and secret-looking values from OpenClaw failures', async () => {
+    adapter.spawn.mockResolvedValue({
+      sessionKey: 'oc_session_secret',
+      runId: 'oc_run_secret',
+      status: 'accepted',
+    });
+    adapter.wait.mockRejectedValue(
+      new Error(
+        'Gateway rejected: Implement Sensitive token=sk-test-secret-value-123456 OPENCLAW_TOKEN=raw-token'
+      )
+    );
+
+    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const step = createStep({
+      input: 'Implement {{task.title}} token=sk-test-secret-value-123456',
+    });
+    const run = createRun({
+      context: {
+        ...createRun().context,
+        task: {
+          id: 'task_1',
+          title: 'Sensitive',
+        },
+      },
+    });
+
+    await expect(executor.executeStep(step, run)).rejects.toThrow(
+      'OpenClaw workflow step implement failed'
+    );
+
+    try {
+      await executor.executeStep(step, run);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).not.toContain('Implement Sensitive');
+      expect(message).not.toContain('sk-test-secret-value-123456');
+      expect(message).not.toContain('raw-token');
+      expect(message).toContain('[REDACTED_PROMPT]');
+      expect(message).toContain('OPENCLAW_TOKEN=[REDACTED]');
+    }
+  });
+
+  it('treats OpenClaw timeout status as a workflow failure and cleans up owned sessions', async () => {
+    adapter.spawn.mockResolvedValue({
+      sessionKey: 'oc_session_timeout',
+      runId: 'oc_run_timeout',
+      status: 'accepted',
+    });
+    adapter.wait.mockResolvedValue({
+      sessionKey: 'oc_session_timeout',
+      runId: 'oc_run_timeout',
+      status: 'timeout',
+      error: 'Timed out waiting for completion',
+    });
+
+    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+
+    await expect(executor.executeStep(createStep(), createRun())).rejects.toThrow(
+      'OpenClaw session oc_session_timeout timed out'
+    );
+    expect(adapter.cleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: 'oc_session_timeout' })
+    );
+  });
+
+  it('keeps owned OpenClaw sessions when cleanup is disabled', async () => {
+    adapter.spawn.mockResolvedValue({
+      sessionKey: 'oc_session_keep',
+      runId: 'oc_run_keep',
+      status: 'accepted',
+    });
+    adapter.wait.mockResolvedValue({
+      sessionKey: 'oc_session_keep',
+      runId: 'oc_run_keep',
+      status: 'completed',
+      output: 'STATUS: done\nOUTPUT: Kept for debugging',
+    });
+
+    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const step = createStep({
+      session: {
+        mode: 'fresh',
+        context: 'minimal',
+        cleanup: 'keep',
+        timeout: 123,
+      },
+    });
+
+    await executor.executeStep(step, createRun());
+
+    expect(adapter.cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/openclaw-workflow-adapter.ts
+++ b/server/src/services/openclaw-workflow-adapter.ts
@@ -1,0 +1,343 @@
+import { createLogger } from '../lib/logger.js';
+import { safeFetch, type UrlValidationOptions } from '../utils/url-validation.js';
+
+const log = createLogger('openclaw-workflow-adapter');
+
+export interface OpenClawWorkflowToolFilter {
+  allowed?: string[];
+  denied?: string[];
+}
+
+export interface OpenClawWorkflowSpawnInput {
+  workflowId: string;
+  runId: string;
+  stepId: string;
+  taskId?: string;
+  agentId: string;
+  agentName?: string;
+  model?: string;
+  prompt: string;
+  sessionMode: 'fresh' | 'reuse';
+  contextMode: 'minimal' | 'full' | 'custom';
+  cleanup: 'delete' | 'keep';
+  timeoutSeconds: number;
+  taskContext?: unknown;
+  toolFilter?: OpenClawWorkflowToolFilter;
+}
+
+export interface OpenClawWorkflowSessionInput {
+  workflowId: string;
+  runId: string;
+  stepId: string;
+  taskId?: string;
+  agentId: string;
+  sessionKey: string;
+  prompt: string;
+  timeoutSeconds: number;
+  toolFilter?: OpenClawWorkflowToolFilter;
+}
+
+export interface OpenClawWorkflowCleanupInput {
+  workflowId: string;
+  runId: string;
+  stepId: string;
+  taskId?: string;
+  agentId: string;
+  sessionKey: string;
+}
+
+export interface OpenClawWorkflowSessionResult {
+  sessionKey: string;
+  runId?: string;
+  status?: string;
+  output?: string;
+  error?: string;
+  raw?: unknown;
+}
+
+export interface OpenClawWorkflowAdapter {
+  spawn(input: OpenClawWorkflowSpawnInput): Promise<OpenClawWorkflowSessionResult>;
+  send(input: OpenClawWorkflowSessionInput): Promise<OpenClawWorkflowSessionResult>;
+  wait(input: OpenClawWorkflowSessionInput): Promise<OpenClawWorkflowSessionResult>;
+  cleanup(input: OpenClawWorkflowCleanupInput): Promise<void>;
+}
+
+export interface HttpOpenClawWorkflowAdapterOptions {
+  gatewayUrl?: string;
+  token?: string;
+  sessionKey?: string;
+  requestTimeoutMs?: number;
+  validationOptions?: UrlValidationOptions;
+}
+
+export class HttpOpenClawWorkflowAdapter implements OpenClawWorkflowAdapter {
+  private readonly gatewayUrl: string;
+  private readonly token?: string;
+  private readonly sessionKey: string;
+  private readonly requestTimeoutMs: number;
+  private readonly validationOptions: UrlValidationOptions;
+
+  constructor(options: HttpOpenClawWorkflowAdapterOptions = {}) {
+    this.gatewayUrl = (
+      options.gatewayUrl ||
+      process.env.OPENCLAW_GATEWAY_URL ||
+      process.env.CLAWDBOT_GATEWAY ||
+      process.env.CLAWDBOT_GATEWAY_URL ||
+      'http://127.0.0.1:18789'
+    ).replace(/\/+$/, '');
+    this.token =
+      options.token || process.env.OPENCLAW_GATEWAY_TOKEN || process.env.CLAWDBOT_GATEWAY_TOKEN;
+    this.sessionKey = options.sessionKey || process.env.OPENCLAW_GATEWAY_SESSION_KEY || 'main';
+    this.requestTimeoutMs = options.requestTimeoutMs || 30_000;
+    this.validationOptions = {
+      allowHttp: true,
+      allowLocalhost: true,
+      allowPrivateIp: process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE === 'true',
+      ...options.validationOptions,
+    };
+  }
+
+  async spawn(input: OpenClawWorkflowSpawnInput): Promise<OpenClawWorkflowSessionResult> {
+    const args: Record<string, unknown> = {
+      task: input.prompt,
+      taskName: this.buildTaskName(input),
+      label: this.buildLabel(input),
+      runtime: 'subagent',
+      agentId: input.agentId,
+      runTimeoutSeconds: input.timeoutSeconds,
+      mode: 'session',
+      cleanup: input.cleanup,
+      context: input.contextMode === 'full' ? 'fork' : 'isolated',
+    };
+
+    if (input.model) args.model = input.model;
+
+    const result = await this.invokeTool('sessions_spawn', args, input.timeoutSeconds);
+    const sessionKey =
+      this.readString(result, 'childSessionKey') || this.readString(result, 'sessionKey');
+
+    if (!sessionKey) {
+      throw new Error('OpenClaw sessions_spawn did not return a child session key');
+    }
+
+    return {
+      sessionKey,
+      runId: this.readString(result, 'runId'),
+      status: this.readString(result, 'status') || 'accepted',
+      output: this.extractOutput(result),
+      error: this.readString(result, 'error'),
+      raw: result,
+    };
+  }
+
+  async send(input: OpenClawWorkflowSessionInput): Promise<OpenClawWorkflowSessionResult> {
+    const result = await this.invokeTool(
+      'sessions_send',
+      {
+        sessionKey: input.sessionKey,
+        message: input.prompt,
+        timeoutSeconds: input.timeoutSeconds,
+      },
+      input.timeoutSeconds
+    );
+
+    return {
+      sessionKey: this.readString(result, 'sessionKey') || input.sessionKey,
+      runId: this.readString(result, 'runId'),
+      status: this.readString(result, 'status') || 'completed',
+      output: this.extractOutput(result),
+      error: this.readString(result, 'error'),
+      raw: result,
+    };
+  }
+
+  async wait(input: OpenClawWorkflowSessionInput): Promise<OpenClawWorkflowSessionResult> {
+    const waitPrompt = [
+      'Return the final result for this Veritas Kanban workflow step.',
+      `Workflow: ${input.workflowId}`,
+      `Run: ${input.runId}`,
+      `Step: ${input.stepId}`,
+      '',
+      'If the step is complete, respond with STATUS: done and OUTPUT: followed by the result.',
+      'If the step failed, respond with STATUS: failed and OUTPUT: followed by the failure summary.',
+    ].join('\n');
+
+    return this.send({
+      ...input,
+      prompt: waitPrompt,
+    });
+  }
+
+  async cleanup(input: OpenClawWorkflowCleanupInput): Promise<void> {
+    log.debug(
+      { runId: input.runId, stepId: input.stepId, sessionKey: input.sessionKey },
+      'OpenClaw workflow cleanup delegated to sessions_spawn cleanup policy'
+    );
+  }
+
+  private async invokeTool(
+    tool: 'sessions_spawn' | 'sessions_send',
+    args: Record<string, unknown>,
+    timeoutSeconds: number
+  ): Promise<Record<string, unknown>> {
+    const url = `${this.gatewayUrl}/tools/invoke`;
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      Math.max(this.requestTimeoutMs, timeoutSeconds * 1000)
+    );
+
+    try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (this.token) {
+        headers.Authorization = `Bearer ${this.token}`;
+      }
+
+      const response = await safeFetch(
+        url,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            tool,
+            args,
+            sessionKey: this.sessionKey,
+          }),
+          signal: controller.signal,
+        },
+        this.validationOptions
+      );
+
+      if (!response) {
+        throw new Error('OpenClaw gateway URL was blocked by outbound URL policy');
+      }
+
+      const body = await this.readJson(response);
+
+      if (!response.ok) {
+        throw new Error(
+          this.extractError(body) || `OpenClaw gateway returned HTTP ${response.status}`
+        );
+      }
+
+      const envelope = this.asRecord(body);
+      if (envelope?.ok === false) {
+        throw new Error(this.extractError(envelope) || `OpenClaw ${tool} failed`);
+      }
+
+      const toolResult = this.unwrapToolResult(envelope?.result ?? body);
+      const status = this.readString(toolResult, 'status')?.toLowerCase();
+      if (status === 'error' || status === 'failed' || status === 'forbidden') {
+        throw new Error(
+          this.readString(toolResult, 'error') || `OpenClaw ${tool} returned ${status}`
+        );
+      }
+
+      return toolResult;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error(`OpenClaw ${tool} timed out after ${timeoutSeconds}s`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async readJson(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  private unwrapToolResult(value: unknown): Record<string, unknown> {
+    const record = this.asRecord(value);
+    if (!record) return {};
+
+    const details = this.asRecord(record.details);
+    if (details) return details;
+
+    const parsedText = this.parseTextPayload(record.text);
+    if (parsedText) return parsedText;
+
+    const content = Array.isArray(record.content) ? record.content : [];
+    for (const item of content) {
+      const itemRecord = this.asRecord(item);
+      const parsed = this.parseTextPayload(itemRecord?.text);
+      if (parsed) return parsed;
+    }
+
+    return record;
+  }
+
+  private parseTextPayload(text: unknown): Record<string, unknown> | null {
+    if (typeof text !== 'string' || !text.trim()) return null;
+    try {
+      const parsed = JSON.parse(text);
+      return this.asRecord(parsed);
+    } catch {
+      return { output: text };
+    }
+  }
+
+  private extractOutput(record: Record<string, unknown>): string | undefined {
+    for (const key of ['reply', 'output', 'summary', 'result', 'text']) {
+      const value = this.readString(record, key);
+      if (value) return value;
+    }
+    return undefined;
+  }
+
+  private extractError(value: unknown): string | undefined {
+    const record = this.asRecord(value);
+    if (!record) return undefined;
+
+    const direct = this.readString(record, 'message') || this.readString(record, 'error');
+    if (direct) return direct;
+
+    const error = this.asRecord(record.error);
+    return this.readString(error, 'message') || this.readString(error, 'error');
+  }
+
+  private buildTaskName(input: OpenClawWorkflowSpawnInput): string {
+    const raw = `${input.workflowId}_${input.stepId}_${input.runId}`
+      .toLowerCase()
+      .replace(/[^a-z0-9_]+/g, '_')
+      .replace(/_+/g, '_')
+      .replace(/^_+|_+$/g, '');
+    const candidate = raw || `workflow_${input.stepId}`;
+    const withLetter = /^[a-z]/.test(candidate) ? candidate : `w_${candidate}`;
+    return withLetter.slice(0, 64);
+  }
+
+  private buildLabel(input: OpenClawWorkflowSpawnInput): string {
+    return [
+      'Veritas workflow',
+      input.workflowId,
+      input.runId,
+      input.stepId,
+      input.agentName || input.agentId,
+    ]
+      .filter(Boolean)
+      .join(' / ')
+      .slice(0, 180);
+  }
+
+  private readString(
+    record: Record<string, unknown> | null | undefined,
+    key: string
+  ): string | undefined {
+    const value = record?.[key];
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  }
+}

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -1,6 +1,6 @@
 /**
  * WorkflowStepExecutor — Executes individual workflow steps
- * Phase 1: Core Engine (agent steps only, OpenClaw integration placeholder)
+ * Executes workflow steps through provider-specific agent adapters.
  */
 
 import fs from 'fs/promises';
@@ -17,16 +17,28 @@ import type {
 import { getWorkflowRunsDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
 import { getGovernanceTraceService } from './governance-trace-service.js';
+import {
+  HttpOpenClawWorkflowAdapter,
+  type OpenClawWorkflowAdapter,
+  type OpenClawWorkflowSessionInput,
+  type OpenClawWorkflowSessionResult,
+} from './openclaw-workflow-adapter.js';
 import { getToolPolicyService } from './tool-policy-service.js';
 
 const log = createLogger('workflow-step-executor');
 
+interface WorkflowStepExecutorOptions {
+  openClawAdapter?: OpenClawWorkflowAdapter;
+}
+
 export class WorkflowStepExecutor {
   private runsDir: string;
+  private openClawAdapter: OpenClawWorkflowAdapter;
   private appendCountCache?: Map<string, number>; // Performance: Track append counts to reduce stat() calls
 
-  constructor(runsDir?: string) {
+  constructor(runsDir?: string, options: WorkflowStepExecutorOptions = {}) {
     this.runsDir = runsDir || getWorkflowRunsDir();
+    this.openClawAdapter = options.openClawAdapter || new HttpOpenClawWorkflowAdapter();
   }
 
   /**
@@ -50,14 +62,18 @@ export class WorkflowStepExecutor {
   }
 
   /**
-   * Execute an agent step (spawns OpenClaw session)
+   * Execute an agent step through its configured provider.
    * Integrated features: #108 (progress), #110 (tool policies), #111 (session management)
    */
   private async executeAgentStep(
     step: WorkflowStep,
     run: WorkflowRun
   ): Promise<StepExecutionResult> {
-    const agentDef = this.getAgentDefinition(run, step.agent!);
+    if (!step.agent) {
+      throw new Error(`Agent step ${step.id} missing agent`);
+    }
+
+    const agentDef = this.getAgentDefinition(run, step.agent);
     const workflowConfig = run.context.workflow as
       | { config?: { fresh_session_default?: boolean } }
       | undefined;
@@ -95,65 +111,219 @@ export class WorkflowStepExecutor {
       return this.executeCodexAgentStep(step, run, agentDef, prompt, sessionConfig);
     }
 
-    // TODO: OpenClaw integration (sessions_spawn)
-    // This is the placeholder for actual session spawning.
-    // When OpenClaw sessions API is integrated, replace this with:
-    //
-    // if (sessionConfig.mode === 'reuse') {
-    //   const lastSessionKey = run.context._sessions?.[step.agent!];
-    //   if (lastSessionKey) {
-    //     // Continue existing session
-    //     const result = await this.continueSession(lastSessionKey, prompt);
-    //   } else {
-    //     // No existing session, fall back to fresh
-    //     const sessionKey = await this.spawnAgent({
-    //       agentId: step.agent!,
-    //       prompt,
-    //       taskId: run.taskId,
-    //       model: agentDef?.model,
-    //       toolFilter: toolPolicyFilter,
-    //       timeout: sessionConfig.timeout,
-    //     });
-    //     run.context._sessions = { ...run.context._sessions, [step.agent!]: sessionKey };
-    //   }
-    // } else {
-    //   // Fresh session
-    //   const sessionKey = await this.spawnAgent({
-    //     agentId: step.agent!,
-    //     prompt,
-    //     taskId: run.taskId,
-    //     model: agentDef?.model,
-    //     toolFilter: toolPolicyFilter,
-    //     timeout: sessionConfig.timeout,
-    //   });
-    //   run.context._sessions = { ...run.context._sessions, [step.agent!]: sessionKey };
-    // }
-    // const result = await this.waitForSession(sessionKey);
-    //
-    // After session completes:
-    // if (sessionConfig.cleanup === 'delete') {
-    //   await this.cleanupSession(sessionKey);
-    // }
+    return this.executeOpenClawAgentStep(
+      step,
+      run,
+      agentDef,
+      prompt,
+      sessionConfig,
+      sessionContext,
+      toolPolicyFilter
+    );
+  }
 
-    // Placeholder: Simulate agent execution (Phase 1 only)
-    const result = `Agent ${step.agent} (role: ${agentDef?.role || 'unknown'}) executed step ${step.id}\n\nSession Config:\n- Mode: ${sessionConfig.mode}\n- Context: ${sessionConfig.context}\n- Cleanup: ${sessionConfig.cleanup}\n- Timeout: ${sessionConfig.timeout}s\n\nTool Policy:\n- Allowed: ${toolPolicyFilter.allowed?.join(', ') || 'all'}\n- Denied: ${toolPolicyFilter.denied?.join(', ') || 'none'}\n\nPrompt:\n${prompt}\n\nSTATUS: done\nOUTPUT: Placeholder result`;
+  private async executeOpenClawAgentStep(
+    step: WorkflowStep,
+    run: WorkflowRun,
+    agentDef: WorkflowAgent | null,
+    prompt: string,
+    sessionConfig: StepSessionConfig,
+    sessionContext: Record<string, unknown>,
+    toolPolicyFilter: { allowed?: string[]; denied?: string[] }
+  ): Promise<StepExecutionResult> {
+    const agentId = step.agent || agentDef?.id || step.id;
+    const sessionMap = (run.context._sessions as Record<string, string> | undefined) || {};
+    const existingSessionKey = sessionConfig.mode === 'reuse' ? sessionMap[agentId] : undefined;
 
-    // Parse output
-    const parsed = this.parseStepOutput(result, step);
+    let sessionKey = existingSessionKey;
+    let ownedSession = false;
+    let adapterResult: OpenClawWorkflowSessionResult | undefined;
 
-    // Validate acceptance criteria
-    await this.validateAcceptanceCriteria(step, result, parsed);
-
-    // Write output to step-outputs/
-    const outputPath = await this.saveStepOutput(run.id, step.id, result);
-
-    // Append to progress file (#108)
-    await this.appendProgressFile(run.id, step.id, result);
-
-    return {
-      output: parsed,
-      outputPath,
+    const baseInput: Omit<OpenClawWorkflowSessionInput, 'sessionKey' | 'prompt'> = {
+      workflowId: run.workflowId,
+      runId: run.id,
+      stepId: step.id,
+      taskId: run.taskId,
+      agentId,
+      timeoutSeconds: sessionConfig.timeout,
+      toolFilter: toolPolicyFilter,
     };
+
+    try {
+      if (sessionKey) {
+        this.recordWorkflowSession(run, step, agentId, sessionKey);
+        adapterResult = await this.openClawAdapter.send({
+          ...baseInput,
+          sessionKey,
+          prompt,
+        });
+      } else {
+        adapterResult = await this.openClawAdapter.spawn({
+          ...baseInput,
+          agentName: agentDef?.name,
+          model: agentDef?.model,
+          prompt,
+          sessionMode: sessionConfig.mode,
+          contextMode: sessionConfig.context,
+          cleanup: sessionConfig.cleanup,
+          taskContext: sessionContext.task,
+        });
+        sessionKey = adapterResult.sessionKey;
+        ownedSession = true;
+        this.recordWorkflowSession(run, step, agentId, sessionKey);
+
+        if (!adapterResult.output) {
+          adapterResult = await this.openClawAdapter.wait({
+            ...baseInput,
+            sessionKey,
+            prompt,
+          });
+        }
+      }
+
+      this.assertOpenClawResult(step, adapterResult);
+
+      const result = this.buildOpenClawStepResult(
+        step,
+        run,
+        agentDef,
+        adapterResult,
+        sessionConfig
+      );
+      const parsed = this.parseStepOutput(result, step);
+      await this.validateAcceptanceCriteria(step, result, parsed);
+      const outputPath = await this.saveStepOutput(run.id, step.id, result, step.output?.file);
+      await this.appendProgressFile(run.id, step.id, result);
+
+      return {
+        output: parsed,
+        outputPath,
+      };
+    } catch (err) {
+      const message = this.sanitizeProviderError(err, prompt);
+      throw new Error(`OpenClaw workflow step ${step.id} failed: ${message}`);
+    } finally {
+      if (ownedSession && sessionKey && sessionConfig.cleanup === 'delete') {
+        try {
+          await this.openClawAdapter.cleanup({
+            workflowId: run.workflowId,
+            runId: run.id,
+            stepId: step.id,
+            taskId: run.taskId,
+            agentId,
+            sessionKey,
+          });
+        } catch (err) {
+          log.warn(
+            { runId: run.id, stepId: step.id, sessionKey, err },
+            'OpenClaw workflow session cleanup failed'
+          );
+        }
+      }
+    }
+  }
+
+  private recordWorkflowSession(
+    run: WorkflowRun,
+    step: WorkflowStep,
+    agentId: string,
+    sessionKey: string
+  ): void {
+    run.context._sessions = {
+      ...((run.context._sessions as Record<string, string> | undefined) || {}),
+      [agentId]: sessionKey,
+    };
+
+    const stepRun = run.steps.find((s) => s.stepId === step.id);
+    if (stepRun) {
+      stepRun.sessionKey = sessionKey;
+    }
+  }
+
+  private assertOpenClawResult(
+    step: WorkflowStep,
+    result: OpenClawWorkflowSessionResult | undefined
+  ): asserts result is OpenClawWorkflowSessionResult {
+    if (!result) {
+      throw new Error('OpenClaw adapter did not return a result');
+    }
+
+    const status = result.status?.toLowerCase();
+    if (status === 'timeout' || status === 'timed_out') {
+      throw new Error(`OpenClaw session ${result.sessionKey} timed out`);
+    }
+    if (status === 'error' || status === 'failed' || status === 'failure') {
+      throw new Error(result.error || `OpenClaw session ${result.sessionKey} returned ${status}`);
+    }
+
+    if (!result.sessionKey) {
+      throw new Error(`OpenClaw step ${step.id} completed without a session key`);
+    }
+  }
+
+  private buildOpenClawStepResult(
+    step: WorkflowStep,
+    run: WorkflowRun,
+    agentDef: WorkflowAgent | null,
+    result: OpenClawWorkflowSessionResult,
+    sessionConfig: StepSessionConfig
+  ): string {
+    const output = result.output?.trim() || 'OpenClaw completed without a final response.';
+    const hasStatus = /\bSTATUS\s*:/i.test(output);
+    const hasOutput = /\bOUTPUT\s*:/i.test(output);
+    const lines = [
+      `# OpenClaw Workflow Step: ${step.name || step.id}`,
+      '',
+      `Agent: ${agentDef?.name || step.agent}`,
+      `Provider: ${agentDef?.provider || 'openclaw'}`,
+      `Model: ${agentDef?.model || 'default'}`,
+      `Session: ${result.sessionKey}`,
+      `OpenClaw run: ${result.runId || run.id}`,
+      `Session mode: ${sessionConfig.mode}`,
+      `Session cleanup: ${sessionConfig.cleanup}`,
+      '',
+      '## Final Response',
+      '',
+      output,
+    ];
+
+    if (!hasStatus) {
+      lines.push('', 'STATUS: done');
+    }
+    if (!hasOutput) {
+      lines.push(`OUTPUT: ${output}`);
+    }
+
+    return lines.join('\n');
+  }
+
+  private sanitizeProviderError(err: unknown, prompt?: string): string {
+    let message =
+      err instanceof Error ? err.message : typeof err === 'string' ? err : 'Unknown error';
+    if (prompt) {
+      message = message.split(prompt).join('[REDACTED_PROMPT]');
+    }
+
+    const replacements: Array<[RegExp, string]> = [
+      [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
+      [/\bsk-[A-Za-z0-9_-]{12,}/g, 'sk-[REDACTED]'],
+      [/\bghp_[A-Za-z0-9_]{12,}/g, 'ghp_[REDACTED]'],
+      [/\bgithub_pat_[A-Za-z0-9_]{12,}/g, 'github_pat_[REDACTED]'],
+      [
+        /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*)\s*=\s*([^\s"'`]+)/gi,
+        '$1=[REDACTED]',
+      ],
+      [
+        /\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*([^\s"'`,}]+)/gi,
+        '$1=[REDACTED]',
+      ],
+    ];
+
+    for (const [pattern, replacement] of replacements) {
+      message = message.replace(pattern, replacement);
+    }
+
+    return message.slice(0, 1000);
   }
 
   private async executeCodexAgentStep(
@@ -1007,12 +1177,16 @@ export class WorkflowStepExecutor {
   }
 
   /**
-   * Cleanup OpenClaw session (Phase 2 tracked in #110)
+   * Cleanup OpenClaw session.
    */
   async cleanupSession(sessionKey: string): Promise<void> {
-    log.info({ sessionKey }, 'Session cleanup (placeholder)');
-    // Phase 2 (tracked in #110): Call OpenClaw session cleanup API
-    // Will integrate with sessions API for proper resource cleanup
+    await this.openClawAdapter.cleanup({
+      workflowId: 'manual',
+      runId: 'manual',
+      stepId: 'manual',
+      agentId: 'unknown',
+      sessionKey,
+    });
   }
 
   // ==================== Phase 2: Progress File Integration (#108) ====================


### PR DESCRIPTION
## Summary
- Replaced the OpenClaw workflow-step simulation with an injectable provider adapter path.
- Added an HTTP OpenClaw gateway adapter for sessions_spawn, sessions_send, wait/complete, result parsing, and cleanup handoff.
- Persisted OpenClaw session keys for fresh and reuse runs, redacted provider errors, and added mocked workflow coverage.

## Verification
- pnpm --filter @veritas-kanban/server test -- workflow-step-executor-openclaw.test.ts workflow-step-executor-codex.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm exec prettier --check server/src/services/openclaw-workflow-adapter.ts server/src/services/workflow-step-executor.ts server/src/__tests__/workflow-step-executor-openclaw.test.ts docs/FEATURES.md
- git diff --check
- pnpm lint:budget

## Risk
- HTTP OpenClaw execution requires the OpenClaw gateway to allow sessions_spawn and sessions_send through gateway.tools.allow. If it is not enabled, workflow steps now fail clearly instead of returning simulated success.

Closes #395