### PR TITLE
Centralize outbound delivery registry

### DIFF
--- a/server/src/__tests__/outbound-integration-service.test.ts
+++ b/server/src/__tests__/outbound-integration-service.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OutboundIntegrationService } from '../services/outbound-integration-service.js';
+
+const mockLookup = vi.hoisted(() => vi.fn());
+
+vi.mock('node:dns/promises', () => ({
+  lookup: mockLookup,
+}));
+
+function mockFetch(response: { ok: boolean; status?: number; text?: () => Promise<string> }) {
+  const fn = vi.fn().mockResolvedValue({
+    status: response.status ?? (response.ok ? 200 : 500),
+    ok: response.ok,
+    text: response.text ?? vi.fn().mockResolvedValue(''),
+  });
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+describe('OutboundIntegrationService', () => {
+  const audit = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    audit.mockClear();
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+  });
+
+  it('records sanitized endpoints and delivery attempts without exposing secrets', async () => {
+    const fetchSpy = mockFetch({
+      ok: true,
+      status: 202,
+      text: vi.fn().mockResolvedValue('accepted'),
+    });
+    const service = new OutboundIntegrationService({ persist: false, audit });
+
+    const result = await service.deliver(
+      {
+        id: 'squad.webhook',
+        type: 'squad-webhook',
+        displayName: 'Squad webhook',
+        url: 'https://hook.test/endpoint?token=secret-token',
+        auth: {
+          type: 'bearer',
+          secretRef: 'featureSettings.squadWebhook.secret',
+          hasSecret: true,
+        },
+        owner: { source: 'feature-settings', resourceId: 'squadWebhook.url' },
+      },
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer raw-token-value',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ok: true }),
+        responseBodyLimit: 100,
+      }
+    );
+
+    expect(result).toMatchObject({ ok: true, status: 'success', responseStatus: 202 });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    const endpoints = await service.listEndpoints();
+    expect(endpoints[0]).toMatchObject({
+      id: 'squad.webhook',
+      url: 'https://hook.test/endpoint',
+      auth: {
+        type: 'bearer',
+        secretRef: 'featureSettings.squadWebhook.secret',
+        hasSecret: true,
+      },
+    });
+
+    const deliveries = await service.listDeliveries();
+    expect(deliveries[0]).toMatchObject({
+      endpointId: 'squad.webhook',
+      sanitizedUrl: 'https://hook.test/endpoint',
+      status: 'success',
+      responseStatus: 202,
+      responseClass: '2xx',
+    });
+
+    const auditPayload = JSON.stringify(audit.mock.calls);
+    expect(auditPayload).not.toContain('raw-token-value');
+    expect(auditPayload).not.toContain('secret-token');
+  });
+
+  it('blocks private IP destinations before fetch', async () => {
+    const fetchSpy = mockFetch({ ok: true });
+    const service = new OutboundIntegrationService({ persist: false, audit });
+
+    const result = await service.deliver(
+      {
+        id: 'blocked.private',
+        type: 'broadcast-webhook',
+        displayName: 'Blocked private endpoint',
+        url: 'https://10.0.0.5/hook',
+        owner: { source: 'runtime', resourceId: 'test' },
+      },
+      { method: 'POST' }
+    );
+
+    expect(result.status).toBe('blocked');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect((await service.listDeliveries())[0]).toMatchObject({
+      endpointId: 'blocked.private',
+      status: 'blocked',
+    });
+  });
+
+  it('blocks DNS rebinding destinations before fetch', async () => {
+    mockLookup.mockResolvedValue([{ address: '10.0.0.10', family: 4 }]);
+    const fetchSpy = mockFetch({ ok: true });
+    const service = new OutboundIntegrationService({ persist: false, audit });
+
+    const result = await service.deliver(
+      {
+        id: 'blocked.dns',
+        type: 'policy-webhook',
+        displayName: 'Blocked DNS endpoint',
+        url: 'https://hook.test/endpoint',
+        owner: { source: 'policy', resourceId: 'policy_1' },
+      },
+      { method: 'POST' }
+    );
+
+    expect(result.status).toBe('blocked');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips disabled endpoints and records history', async () => {
+    const fetchSpy = mockFetch({ ok: true });
+    const service = new OutboundIntegrationService({ persist: false, audit });
+
+    const result = await service.deliver(
+      {
+        id: 'disabled.endpoint',
+        type: 'failure-alert-webhook',
+        displayName: 'Disabled endpoint',
+        url: 'https://hook.test/endpoint',
+        enabled: false,
+        owner: { source: 'feature-settings', resourceId: 'notifications.webhookUrl' },
+      },
+      { method: 'POST' }
+    );
+
+    expect(result.status).toBe('skipped');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect((await service.listDeliveries())[0]).toMatchObject({
+      endpointId: 'disabled.endpoint',
+      status: 'skipped',
+      error: 'Endpoint disabled',
+    });
+  });
+});

--- a/server/src/__tests__/routes/integrations.test.ts
+++ b/server/src/__tests__/routes/integrations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 
@@ -23,15 +23,21 @@ vi.mock('../../services/config-service.js', () => ({
 }));
 
 import { integrationsRoutes } from '../../routes/integrations.js';
+import { getOutboundIntegrationService } from '../../services/outbound-integration-service.js';
 
 describe('integrations routes', () => {
   let app: express.Express;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
     mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
     app = express();
     app.use('/api/integrations', integrationsRoutes);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('blocks localhost/private targets (SSRF guard)', async () => {
@@ -90,5 +96,68 @@ describe('integrations routes', () => {
       expect.objectContaining({ method: 'HEAD', redirect: 'manual' })
     );
     fetchSpy.mockRestore();
+  });
+
+  it('exposes sanitized outbound endpoint and delivery history', async () => {
+    const endpointId = `route-test.${Date.now()}`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 202,
+        text: vi.fn().mockResolvedValue('accepted'),
+      })
+    );
+
+    const delivery = await getOutboundIntegrationService().deliver(
+      {
+        id: endpointId,
+        type: 'squad-webhook',
+        displayName: 'Route test webhook',
+        url: 'https://example.com/outbound?token=query-secret',
+        auth: {
+          type: 'bearer',
+          secretRef: 'featureSettings.squadWebhook.secret',
+          hasSecret: true,
+        },
+        owner: { source: 'runtime', resourceId: 'route-test' },
+      },
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer raw-token-value' },
+        body: '{}',
+      }
+    );
+
+    expect(delivery.ok).toBe(true);
+
+    const endpointsRes = await request(app).get('/api/integrations/outbound/endpoints');
+    expect(endpointsRes.status).toBe(200);
+    const endpoint = endpointsRes.body.find((entry: { id: string }) => entry.id === endpointId);
+    expect(endpoint).toMatchObject({
+      id: endpointId,
+      url: 'https://example.com/outbound',
+      auth: {
+        type: 'bearer',
+        secretRef: 'featureSettings.squadWebhook.secret',
+        hasSecret: true,
+      },
+    });
+
+    const deliveriesRes = await request(app).get('/api/integrations/outbound/deliveries?limit=10');
+    expect(deliveriesRes.status).toBe(200);
+    const attempt = deliveriesRes.body.find(
+      (entry: { endpointId: string }) => entry.endpointId === endpointId
+    );
+    expect(attempt).toMatchObject({
+      endpointId,
+      sanitizedUrl: 'https://example.com/outbound',
+      status: 'success',
+      responseStatus: 202,
+    });
+
+    const responsePayload = JSON.stringify({ endpoint, attempt });
+    expect(responsePayload).not.toContain('query-secret');
+    expect(responsePayload).not.toContain('raw-token-value');
   });
 });

--- a/server/src/__tests__/squad-webhook-service.test.ts
+++ b/server/src/__tests__/squad-webhook-service.test.ts
@@ -74,7 +74,7 @@ describe('squad webhook service', () => {
       secret: 'shhh',
     } as any);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe('https://example.test/hook');
     const body = init.body as string;
@@ -111,7 +111,8 @@ describe('squad webhook service', () => {
 
     expect(mockSafeFetch).toHaveBeenCalledWith(
       'https://gateway.test/tools/invoke',
-      expect.objectContaining({ method: 'POST' })
+      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({ allowHttp: true, allowLocalhost: true })
     );
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toBe('https://gateway.test/tools/invoke');
@@ -155,7 +156,7 @@ describe('squad webhook service', () => {
       mode: 'generic',
       url: 'https://example.test/hook',
     } as any);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
   });
 
   it('swallows async generic webhook failures but propagates timeout helper behavior through logging path', async () => {

--- a/server/src/routes/integrations.ts
+++ b/server/src/routes/integrations.ts
@@ -11,10 +11,12 @@ import { ConfigService } from '../services/config-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { createLogger } from '../lib/logger.js';
 import type { CoolifyServiceConfig, CoolifyServicesConfig } from '@veritas-kanban/shared';
+import { getOutboundIntegrationService } from '../services/outbound-integration-service.js';
 
 const log = createLogger('integrations');
 const router = Router();
 const configService = new ConfigService();
+const outboundIntegrations = getOutboundIntegrationService();
 
 const SERVICE_NAMES = ['supabase', 'openpanel', 'n8n', 'plane', 'appsmith'] as const;
 type ServiceName = (typeof SERVICE_NAMES)[number];
@@ -147,6 +149,24 @@ router.get(
 
     log.debug({ results }, 'Integration status check complete');
     res.json({ data: results });
+  })
+);
+
+// GET /api/integrations/outbound/endpoints
+router.get(
+  '/outbound/endpoints',
+  asyncHandler(async (_req, res) => {
+    res.json(await outboundIntegrations.listEndpoints());
+  })
+);
+
+// GET /api/integrations/outbound/deliveries?limit=100
+router.get(
+  '/outbound/deliveries',
+  asyncHandler(async (req, res) => {
+    const rawLimit = typeof req.query.limit === 'string' ? Number(req.query.limit) : 100;
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 100;
+    res.json(await outboundIntegrations.listDeliveries(limit));
   })
 );
 

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -11,10 +11,13 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError } from '../middleware/error-handler.js';
 import { auditLog } from '../services/audit-service.js';
 import { authorize, type AuthenticatedRequest } from '../middleware/auth.js';
+import { getOutboundIntegrationService } from '../services/outbound-integration-service.js';
+import { createLogger } from '../lib/logger.js';
 
 const router: RouterType = Router();
 const configService = new ConfigService();
 const codexHealthService = new CodexHealthService();
+const log = createLogger('settings-routes');
 
 /**
  * Sync feature settings to affected server-side services.
@@ -42,6 +45,13 @@ export function syncSettingsToServices(settings: FeatureSettings): void {
 
   // Sync enforcement settings
   setEnforcementSettings(settings.enforcement);
+
+  // Register outbound endpoints from legacy feature settings without exposing secrets.
+  void getOutboundIntegrationService()
+    .syncFeatureSettings(settings)
+    .catch((err) => {
+      log.warn({ err }, 'Failed to sync outbound integration endpoints from feature settings');
+    });
 }
 
 function sanitizeFeatureSettings(settings: FeatureSettings): FeatureSettings {

--- a/server/src/services/clawdbot-webhook-service.ts
+++ b/server/src/services/clawdbot-webhook-service.ts
@@ -13,8 +13,8 @@
 
 import crypto from 'crypto';
 import { createLogger } from '../lib/logger.js';
-import { safeFetch } from '../utils/url-validation.js';
 import type { TaskChangeType } from './broadcast-service.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 
 const log = createLogger('webhook');
 
@@ -104,7 +104,13 @@ export function signPayload(body: string, secret: string): string {
  * POST a JSON payload to `url`. Returns true on 2xx, false on non-2xx,
  * and null when the URL is blocked by outbound URL policy.
  */
-async function postPayload(url: string, body: string, secret?: string): Promise<boolean | null> {
+async function postPayload(
+  url: string,
+  body: string,
+  secret?: string,
+  retryOf?: string,
+  attempt = 1
+): Promise<{ ok: boolean | null; attemptId: string }> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'User-Agent': 'VeritasKanban-Webhook/1.0',
@@ -114,16 +120,38 @@ async function postPayload(url: string, body: string, secret?: string): Promise<
     headers['X-Webhook-Signature'] = signPayload(body, secret);
   }
 
-  const res = await safeFetch(url, {
-    method: 'POST',
-    headers,
-    body,
-    signal: AbortSignal.timeout(10_000), // 10 s hard timeout per attempt
-  });
+  const delivery = await getOutboundIntegrationService().deliver(
+    {
+      id: 'broadcast.webhook',
+      type: 'broadcast-webhook',
+      displayName: 'Task and chat broadcast webhook',
+      url,
+      enabled: true,
+      auth: {
+        type: 'hmac-sha256',
+        headerName: 'X-Webhook-Signature',
+        secretRef: secret ? 'VERITAS_WEBHOOK_SECRET' : undefined,
+        hasSecret: Boolean(secret),
+      },
+      owner: {
+        source: process.env.VERITAS_WEBHOOK_URL ? 'env' : 'feature-settings',
+        resourceId: process.env.VERITAS_WEBHOOK_URL ? 'VERITAS_WEBHOOK_URL' : 'webhookUrl',
+      },
+    },
+    {
+      method: 'POST',
+      headers,
+      body,
+      timeoutMs: 10_000,
+      retryOf,
+      attempt,
+    }
+  );
 
-  if (!res) return null;
-
-  return res.ok;
+  return {
+    ok: delivery.status === 'blocked' ? null : delivery.ok,
+    attemptId: delivery.attemptId,
+  };
 }
 
 /**
@@ -137,9 +165,11 @@ export async function deliverWebhook(payload: WebhookPayload): Promise<void> {
 
   const body = JSON.stringify(payload);
   const secret = getWebhookSecret();
+  let firstAttemptId: string | undefined;
 
   try {
-    const ok = await postPayload(url, body, secret);
+    const { ok, attemptId } = await postPayload(url, body, secret);
+    firstAttemptId = attemptId;
     if (ok === null) {
       log.warn('Webhook URL blocked (SSRF prevention)');
       return;
@@ -156,7 +186,7 @@ export async function deliverWebhook(payload: WebhookPayload): Promise<void> {
   // --- single retry after 2 s ---
   setTimeout(async () => {
     try {
-      const ok = await postPayload(url, body, secret);
+      const { ok } = await postPayload(url, body, secret, firstAttemptId, 2);
       if (ok === null) {
         log.warn('Webhook retry URL blocked (SSRF prevention)');
         return;

--- a/server/src/services/failure-alert-service.ts
+++ b/server/src/services/failure-alert-service.ts
@@ -14,7 +14,7 @@
 import { getNotificationService, type NotificationService } from './notification-service.js';
 import { getConfigService, type ConfigService } from './config-service.js';
 import type { TelemetryEventIngestion } from '../schemas/telemetry-schemas.js';
-import { safeFetch } from '../utils/url-validation.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 
 // Deduplication cache: taskId -> last alert timestamp
 const recentAlerts = new Map<string, number>();
@@ -205,21 +205,33 @@ export class FailureAlertService {
         return false;
       }
 
-      const response = await safeFetch(webhookUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text: message,
-        }),
-      });
+      const delivery = await getOutboundIntegrationService().deliver(
+        {
+          id: 'notifications.failureAlert',
+          type: 'failure-alert-webhook',
+          displayName: 'Failure alert webhook',
+          url: webhookUrl,
+          enabled: features.notifications.enabled && features.notifications.onAgentFailure,
+          owner: { source: 'feature-settings', resourceId: 'notifications.webhookUrl' },
+        },
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            text: message,
+          }),
+        }
+      );
 
-      if (!response) {
+      if (delivery.status === 'blocked') {
         log.warn('[FailureAlert] Webhook URL blocked by outbound URL policy');
         return false;
       }
 
-      if (!response.ok) {
-        log.warn(`[FailureAlert] Webhook delivery failed: ${response.status}`);
+      if (!delivery.ok) {
+        log.warn(
+          `[FailureAlert] Webhook delivery failed: ${delivery.responseStatus || delivery.status}`
+        );
         return false;
       }
 

--- a/server/src/services/hook-service.ts
+++ b/server/src/services/hook-service.ts
@@ -17,10 +17,10 @@
  */
 
 import { createLogger } from '../lib/logger.js';
-import { safeFetch } from '../utils/url-validation.js';
 import type { Task, EnforcementSettings } from '@veritas-kanban/shared';
 import { getChatService } from './chat-service.js';
 import { getNotificationService } from './notification-service.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 
 const log = createLogger('hooks');
 
@@ -217,49 +217,66 @@ async function fireSquadChat(
  */
 async function fireWebhook(url: string, payload: HookPayload): Promise<void> {
   const body = JSON.stringify(payload);
+  const outbound = getOutboundIntegrationService();
 
-  const doFetch = async (): Promise<boolean> => {
-    const response = await safeFetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-VK-Event': payload.event,
+  const deliver = async (retryOf?: string, attempt = 1) => {
+    return outbound.deliver(
+      {
+        id: `hooks.${payload.event}`,
+        type: 'lifecycle-hook-webhook',
+        displayName: `Lifecycle hook ${payload.event}`,
+        url,
+        owner: { source: 'feature-settings', resourceId: `hooks.${payload.event}` },
       },
-      body,
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (!response) {
-      log.warn({ url }, 'Webhook URL blocked (SSRF prevention)');
-      return false;
-    }
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    }
-
-    return true;
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-VK-Event': payload.event,
+        },
+        body,
+        timeoutMs: 10_000,
+        retryOf,
+        attempt,
+      }
+    );
   };
 
+  const assertDelivered = (result: Awaited<ReturnType<typeof deliver>>): void => {
+    if (result.ok) return;
+    if (result.status === 'blocked' || result.status === 'skipped') {
+      log.warn({ event: payload.event, status: result.status }, 'Webhook delivery skipped');
+      return;
+    }
+    throw new Error(result.error || `HTTP ${result.responseStatus || 'unknown'}`);
+  };
+
+  let firstAttemptId: string | undefined;
+
   try {
-    const delivered = await doFetch();
-    if (!delivered) return;
-    log.debug({ event: payload.event, url }, 'Webhook delivered');
+    const result = await deliver();
+    firstAttemptId = result.attemptId;
+    assertDelivered(result);
+    if (result.ok) {
+      log.debug({ event: payload.event }, 'Webhook delivered');
+    }
   } catch (err) {
     log.warn(
-      { event: payload.event, url, error: (err as Error).message },
+      { event: payload.event, error: (err as Error).message },
       'Webhook failed, retrying in 2s'
     );
 
     // Single retry after 2 seconds
     setTimeout(async () => {
       try {
-        const delivered = await doFetch();
-        if (!delivered) return;
-        log.debug({ event: payload.event, url }, 'Webhook retry succeeded');
+        const result = await deliver(firstAttemptId, 2);
+        assertDelivered(result);
+        if (result.ok) {
+          log.debug({ event: payload.event }, 'Webhook retry succeeded');
+        }
       } catch (retryErr) {
         log.error(
-          { event: payload.event, url, error: (retryErr as Error).message },
+          { event: payload.event, error: (retryErr as Error).message },
           'Webhook retry failed'
         );
       }

--- a/server/src/services/lifecycle-hooks-service.ts
+++ b/server/src/services/lifecycle-hooks-service.ts
@@ -19,6 +19,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { getRuntimeDir } from '../utils/paths.js';
 import { migrateLegacyFiles } from '../utils/migrate-legacy-files.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 const DATA_DIR = getRuntimeDir();
 const LEGACY_DATA_DIR = process.env.DATA_DIR || path.join(process.cwd(), '..', '.veritas-kanban');
 let migrationChecked = false;
@@ -207,7 +208,33 @@ class LifecycleHooksService {
       if (!url) {
         throw new Error('Webhook URL not configured');
       }
-      log.info({ taskId: ctx.taskId, url }, 'Webhook would fire (not implemented in core)');
+      const delivery = await getOutboundIntegrationService().deliver(
+        {
+          id: `lifecycle-hooks.${hook.id}`,
+          type: 'lifecycle-hook-webhook',
+          displayName: hook.name,
+          url,
+          enabled: hook.enabled,
+          owner: { source: 'hook', resourceId: hook.id },
+        },
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            hookId: hook.id,
+            hookName: hook.name,
+            event: hook.event,
+            context: ctx,
+          }),
+          timeoutMs: 10_000,
+        }
+      );
+
+      if (!delivery.ok) {
+        throw new Error(delivery.error || `Webhook delivery failed: ${delivery.status}`);
+      }
+
+      log.info({ taskId: ctx.taskId, hookId: hook.id }, 'Webhook delivered via lifecycle hook');
     });
   }
 

--- a/server/src/services/openclaw-workflow-adapter.ts
+++ b/server/src/services/openclaw-workflow-adapter.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '../lib/logger.js';
-import { safeFetch, type UrlValidationOptions } from '../utils/url-validation.js';
+import type { UrlValidationOptions } from '../utils/url-validation.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 
 const log = createLogger('openclaw-workflow-adapter');
 
@@ -181,74 +182,78 @@ export class HttpOpenClawWorkflowAdapter implements OpenClawWorkflowAdapter {
     timeoutSeconds: number
   ): Promise<Record<string, unknown>> {
     const url = `${this.gatewayUrl}/tools/invoke`;
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
-      Math.max(this.requestTimeoutMs, timeoutSeconds * 1000)
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.token) {
+      headers.Authorization = `Bearer ${this.token}`;
+    }
+
+    const delivery = await getOutboundIntegrationService().deliver(
+      {
+        id: 'workflow.openclawGateway',
+        type: 'openclaw-gateway',
+        displayName: 'Workflow OpenClaw gateway',
+        url,
+        enabled: true,
+        auth: {
+          type: 'bearer',
+          secretRef: this.token ? 'OPENCLAW_GATEWAY_TOKEN' : undefined,
+          hasSecret: Boolean(this.token),
+        },
+        owner: { source: 'runtime', resourceId: 'workflow-step-executor' },
+        validationOptions: this.validationOptions,
+      },
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          tool,
+          args,
+          sessionKey: this.sessionKey,
+        }),
+        timeoutMs: Math.max(this.requestTimeoutMs, timeoutSeconds * 1000),
+        responseBodyLimit: 2 * 1024 * 1024,
+      }
     );
 
-    try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      };
-      if (this.token) {
-        headers.Authorization = `Bearer ${this.token}`;
-      }
-
-      const response = await safeFetch(
-        url,
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({
-            tool,
-            args,
-            sessionKey: this.sessionKey,
-          }),
-          signal: controller.signal,
-        },
-        this.validationOptions
-      );
-
-      if (!response) {
-        throw new Error('OpenClaw gateway URL was blocked by outbound URL policy');
-      }
-
-      const body = await this.readJson(response);
-
-      if (!response.ok) {
-        throw new Error(
-          this.extractError(body) || `OpenClaw gateway returned HTTP ${response.status}`
-        );
-      }
-
-      const envelope = this.asRecord(body);
-      if (envelope?.ok === false) {
-        throw new Error(this.extractError(envelope) || `OpenClaw ${tool} failed`);
-      }
-
-      const toolResult = this.unwrapToolResult(envelope?.result ?? body);
-      const status = this.readString(toolResult, 'status')?.toLowerCase();
-      if (status === 'error' || status === 'failed' || status === 'forbidden') {
-        throw new Error(
-          this.readString(toolResult, 'error') || `OpenClaw ${tool} returned ${status}`
-        );
-      }
-
-      return toolResult;
-    } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
-        throw new Error(`OpenClaw ${tool} timed out after ${timeoutSeconds}s`);
-      }
-      throw err;
-    } finally {
-      clearTimeout(timeout);
+    if (delivery.status === 'blocked') {
+      throw new Error('OpenClaw gateway URL was blocked by outbound URL policy');
     }
+    if (delivery.status === 'timeout') {
+      throw new Error(`OpenClaw ${tool} timed out after ${timeoutSeconds}s`);
+    }
+
+    const body = this.parseJson(delivery.responseText);
+
+    if (!delivery.ok) {
+      throw new Error(
+        this.extractError(body) ||
+          `OpenClaw gateway returned HTTP ${delivery.responseStatus || 'unknown'}`
+      );
+    }
+
+    const envelope = this.asRecord(body);
+    if (envelope?.ok === false) {
+      throw new Error(this.extractError(envelope) || `OpenClaw ${tool} failed`);
+    }
+
+    const toolResult = this.unwrapToolResult(envelope?.result ?? body);
+    const status = this.readString(toolResult, 'status')?.toLowerCase();
+    if (status === 'error' || status === 'failed' || status === 'forbidden') {
+      throw new Error(
+        this.readString(toolResult, 'error') || `OpenClaw ${tool} returned ${status}`
+      );
+    }
+
+    return toolResult;
   }
 
-  private async readJson(response: Response): Promise<unknown> {
+  private parseJson(text: string | undefined): unknown {
+    if (!text) return undefined;
     try {
-      return await response.json();
+      return JSON.parse(text);
     } catch {
       return undefined;
     }

--- a/server/src/services/outbound-integration-service.ts
+++ b/server/src/services/outbound-integration-service.ts
@@ -1,0 +1,577 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { nanoid } from 'nanoid';
+import type { FeatureSettings } from '@veritas-kanban/shared';
+import { auditLog, type AuditEvent } from './audit-service.js';
+import {
+  safeFetch,
+  validateWebhookUrl,
+  type UrlValidationOptions,
+} from '../utils/url-validation.js';
+import { getRuntimeDir } from '../utils/paths.js';
+
+export type OutboundEndpointType =
+  | 'broadcast-webhook'
+  | 'lifecycle-hook-webhook'
+  | 'transition-hook-webhook'
+  | 'policy-webhook'
+  | 'squad-webhook'
+  | 'openclaw-wake'
+  | 'openclaw-gateway'
+  | 'failure-alert-webhook';
+
+export type OutboundDeliveryStatus = 'success' | 'failed' | 'blocked' | 'timeout' | 'skipped';
+
+export interface OutboundEndpointAuth {
+  type: 'none' | 'hmac-sha256' | 'bearer' | 'custom-header';
+  secretRef?: string;
+  headerName?: string;
+  hasSecret?: boolean;
+}
+
+export interface OutboundEndpointOwner {
+  source: 'feature-settings' | 'env' | 'policy' | 'hook' | 'runtime';
+  resourceId?: string;
+}
+
+export interface OutboundEndpointInput {
+  id: string;
+  type: OutboundEndpointType;
+  displayName: string;
+  url: string;
+  enabled?: boolean;
+  auth?: OutboundEndpointAuth;
+  owner: OutboundEndpointOwner;
+  validationOptions?: UrlValidationOptions;
+}
+
+export interface OutboundEndpointRecord {
+  id: string;
+  type: OutboundEndpointType;
+  displayName: string;
+  url: string;
+  enabled: boolean;
+  auth: OutboundEndpointAuth;
+  owner: OutboundEndpointOwner;
+  validationPolicy: UrlValidationOptions;
+  validation: {
+    valid: boolean;
+    reason?: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OutboundDeliveryRequest {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: RequestInit['body'];
+  timeoutMs?: number;
+  responseBodyLimit?: number;
+  retryOf?: string;
+  attempt?: number;
+}
+
+export interface OutboundDeliveryAttempt {
+  id: string;
+  endpointId: string;
+  endpointType: OutboundEndpointType;
+  displayName: string;
+  method: string;
+  sanitizedUrl: string;
+  status: OutboundDeliveryStatus;
+  responseStatus?: number;
+  responseClass?: string;
+  durationMs: number;
+  retryOf?: string;
+  attempt: number;
+  error?: string;
+  startedAt: string;
+  completedAt: string;
+}
+
+export interface OutboundDeliveryResult {
+  ok: boolean;
+  status: OutboundDeliveryStatus;
+  attemptId: string;
+  responseStatus?: number;
+  responseText?: string;
+  error?: string;
+}
+
+export interface OutboundIntegrationServiceOptions {
+  storageDir?: string;
+  persist?: boolean;
+  audit?: (event: AuditEvent) => Promise<void>;
+}
+
+const DEFAULT_AUTH: OutboundEndpointAuth = { type: 'none' };
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_DELIVERIES = 500;
+
+export class OutboundIntegrationService {
+  private readonly storageDir: string;
+  private readonly persist: boolean;
+  private readonly audit: (event: AuditEvent) => Promise<void>;
+  private loaded = false;
+  private endpoints = new Map<string, OutboundEndpointRecord>();
+  private deliveries: OutboundDeliveryAttempt[] = [];
+
+  constructor(options: OutboundIntegrationServiceOptions = {}) {
+    this.storageDir = options.storageDir || path.join(getRuntimeDir(), 'outbound-integrations');
+    this.persist = options.persist ?? process.env.VITEST !== 'true';
+    this.audit = options.audit || auditLog;
+  }
+
+  async registerEndpoint(input: OutboundEndpointInput): Promise<OutboundEndpointRecord> {
+    await this.ensureLoaded();
+
+    const now = new Date().toISOString();
+    const existing = this.endpoints.get(input.id);
+    const validationOptions = input.validationOptions || {};
+    const validation = validateWebhookUrl(input.url, validationOptions);
+    const record: OutboundEndpointRecord = {
+      id: input.id,
+      type: input.type,
+      displayName: input.displayName,
+      url: this.sanitizeUrl(input.url),
+      enabled: input.enabled ?? true,
+      auth: this.sanitizeAuth(input.auth),
+      owner: input.owner,
+      validationPolicy: validationOptions,
+      validation: {
+        valid: validation.valid,
+        reason: validation.reason,
+      },
+      createdAt: existing?.createdAt || now,
+      updatedAt: now,
+    };
+
+    const comparableExisting = existing ? { ...existing, updatedAt: record.updatedAt } : null;
+    const changed =
+      !comparableExisting || JSON.stringify(comparableExisting) !== JSON.stringify(record);
+    if (existing && !changed) {
+      return existing;
+    }
+
+    this.endpoints.set(record.id, record);
+    await this.saveEndpoints();
+    await this.auditEndpointChange(record, existing);
+    return record;
+  }
+
+  async deliver(
+    endpoint: OutboundEndpointInput,
+    request: OutboundDeliveryRequest
+  ): Promise<OutboundDeliveryResult> {
+    const registered = await this.registerEndpoint(endpoint);
+    const method = (request.method || 'POST').toUpperCase();
+    const startedAt = new Date().toISOString();
+    const start = performance.now();
+
+    if (!registered.enabled) {
+      const attempt = await this.recordDelivery({
+        endpoint: registered,
+        method,
+        status: 'skipped',
+        startedAt,
+        durationMs: Math.round(performance.now() - start),
+        retryOf: request.retryOf,
+        attempt: request.attempt,
+        error: 'Endpoint disabled',
+      });
+      return {
+        ok: false,
+        status: 'skipped',
+        attemptId: attempt.id,
+        error: attempt.error,
+      };
+    }
+
+    const validation = validateWebhookUrl(endpoint.url, endpoint.validationOptions || {});
+    if (!validation.valid) {
+      const attempt = await this.recordDelivery({
+        endpoint: registered,
+        method,
+        status: 'blocked',
+        startedAt,
+        durationMs: Math.round(performance.now() - start),
+        retryOf: request.retryOf,
+        attempt: request.attempt,
+        error: validation.reason || 'URL blocked by outbound URL policy',
+      });
+      return {
+        ok: false,
+        status: 'blocked',
+        attemptId: attempt.id,
+        error: attempt.error,
+      };
+    }
+
+    const controller = new AbortController();
+    const timeoutMs = request.timeoutMs || DEFAULT_TIMEOUT_MS;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await safeFetch(
+        endpoint.url,
+        {
+          method,
+          headers: request.headers,
+          body: request.body,
+          signal: controller.signal,
+        },
+        endpoint.validationOptions
+      );
+
+      if (!response) {
+        const attempt = await this.recordDelivery({
+          endpoint: registered,
+          method,
+          status: 'blocked',
+          startedAt,
+          durationMs: Math.round(performance.now() - start),
+          retryOf: request.retryOf,
+          attempt: request.attempt,
+          error: 'URL blocked by outbound URL policy',
+        });
+        return {
+          ok: false,
+          status: 'blocked',
+          attemptId: attempt.id,
+          error: attempt.error,
+        };
+      }
+
+      const responseText =
+        request.responseBodyLimit && request.responseBodyLimit > 0
+          ? await response.text().catch(() => '')
+          : undefined;
+      const status: OutboundDeliveryStatus = response.ok ? 'success' : 'failed';
+      const attempt = await this.recordDelivery({
+        endpoint: registered,
+        method,
+        status,
+        startedAt,
+        durationMs: Math.round(performance.now() - start),
+        retryOf: request.retryOf,
+        attempt: request.attempt,
+        responseStatus: response.status,
+      });
+
+      return {
+        ok: response.ok,
+        status,
+        attemptId: attempt.id,
+        responseStatus: response.status,
+        responseText: responseText?.slice(0, request.responseBodyLimit),
+      };
+    } catch (err) {
+      const message = this.sanitizeError(err, endpoint.url);
+      const status: OutboundDeliveryStatus =
+        err instanceof Error && err.name === 'AbortError' ? 'timeout' : 'failed';
+      const attempt = await this.recordDelivery({
+        endpoint: registered,
+        method,
+        status,
+        startedAt,
+        durationMs: Math.round(performance.now() - start),
+        retryOf: request.retryOf,
+        attempt: request.attempt,
+        error: status === 'timeout' ? `Timed out after ${timeoutMs}ms` : message,
+      });
+      return {
+        ok: false,
+        status,
+        attemptId: attempt.id,
+        error: attempt.error,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async listEndpoints(): Promise<OutboundEndpointRecord[]> {
+    await this.ensureLoaded();
+    return Array.from(this.endpoints.values()).sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  async listDeliveries(limit = 100): Promise<OutboundDeliveryAttempt[]> {
+    await this.ensureLoaded();
+    const safeLimit = Math.max(1, Math.min(limit, MAX_DELIVERIES));
+    return this.deliveries.slice(-safeLimit).reverse();
+  }
+
+  async syncFeatureSettings(settings: FeatureSettings): Promise<void> {
+    const registrations: Array<Promise<OutboundEndpointRecord>> = [];
+
+    for (const [event, hook] of Object.entries(settings.hooks || {})) {
+      if (event === 'enabled' || !hook || typeof hook !== 'object') continue;
+      const webhook = (hook as { webhook?: string; enabled?: boolean }).webhook;
+      if (!webhook) continue;
+      registrations.push(
+        this.registerEndpoint({
+          id: `hooks.${event}`,
+          type: 'lifecycle-hook-webhook',
+          displayName: `Lifecycle hook ${event}`,
+          url: webhook,
+          enabled: settings.hooks.enabled && ((hook as { enabled?: boolean }).enabled ?? true),
+          owner: { source: 'feature-settings', resourceId: `hooks.${event}` },
+        })
+      );
+    }
+
+    if (settings.squadWebhook?.url) {
+      registrations.push(
+        this.registerEndpoint({
+          id: 'squad.webhook',
+          type: 'squad-webhook',
+          displayName: 'Squad Chat webhook',
+          url: settings.squadWebhook.url,
+          enabled: settings.squadWebhook.enabled && settings.squadWebhook.mode !== 'openclaw',
+          auth: {
+            type: 'hmac-sha256',
+            headerName: 'X-VK-Signature',
+            secretRef: 'featureSettings.squadWebhook.secret',
+            hasSecret: Boolean(settings.squadWebhook.secret),
+          },
+          owner: { source: 'feature-settings', resourceId: 'squadWebhook.url' },
+        })
+      );
+    }
+
+    if (settings.squadWebhook?.openclawGatewayUrl) {
+      registrations.push(
+        this.registerEndpoint({
+          id: 'squad.openclawWake',
+          type: 'openclaw-wake',
+          displayName: 'Squad Chat OpenClaw wake',
+          url: `${settings.squadWebhook.openclawGatewayUrl.replace(/\/+$/, '')}/tools/invoke`,
+          enabled: settings.squadWebhook.enabled && settings.squadWebhook.mode === 'openclaw',
+          auth: {
+            type: 'bearer',
+            secretRef: 'featureSettings.squadWebhook.openclawGatewayToken',
+            hasSecret: Boolean(settings.squadWebhook.openclawGatewayToken),
+          },
+          owner: { source: 'feature-settings', resourceId: 'squadWebhook.openclawGatewayUrl' },
+          validationOptions: { allowHttp: true, allowLocalhost: true },
+        })
+      );
+    }
+
+    if (settings.notifications?.webhookUrl) {
+      registrations.push(
+        this.registerEndpoint({
+          id: 'notifications.failureAlert',
+          type: 'failure-alert-webhook',
+          displayName: 'Failure alert webhook',
+          url: settings.notifications.webhookUrl,
+          enabled: settings.notifications.enabled && settings.notifications.onAgentFailure,
+          owner: { source: 'feature-settings', resourceId: 'notifications.webhookUrl' },
+        })
+      );
+    }
+
+    await Promise.all(registrations);
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    if (!this.persist) {
+      this.loaded = true;
+      return;
+    }
+
+    await fs.mkdir(this.storageDir, { recursive: true });
+
+    try {
+      const raw = await fs.readFile(this.endpointsPath, 'utf-8');
+      const parsed = JSON.parse(raw) as OutboundEndpointRecord[];
+      this.endpoints = new Map(parsed.map((endpoint) => [endpoint.id, endpoint]));
+    } catch {
+      this.endpoints = new Map();
+    }
+
+    try {
+      const raw = await fs.readFile(this.deliveriesPath, 'utf-8');
+      this.deliveries = JSON.parse(raw) as OutboundDeliveryAttempt[];
+      if (this.deliveries.length > MAX_DELIVERIES) {
+        this.deliveries = this.deliveries.slice(-MAX_DELIVERIES);
+      }
+    } catch {
+      this.deliveries = [];
+    }
+
+    this.loaded = true;
+  }
+
+  private get endpointsPath(): string {
+    return path.join(this.storageDir, 'endpoints.json');
+  }
+
+  private get deliveriesPath(): string {
+    return path.join(this.storageDir, 'deliveries.json');
+  }
+
+  private async saveEndpoints(): Promise<void> {
+    if (!this.persist) return;
+    await fs.mkdir(this.storageDir, { recursive: true });
+    await fs.writeFile(
+      this.endpointsPath,
+      JSON.stringify(Array.from(this.endpoints.values()), null, 2),
+      'utf-8'
+    );
+  }
+
+  private async saveDeliveries(): Promise<void> {
+    if (!this.persist) return;
+    await fs.mkdir(this.storageDir, { recursive: true });
+    await fs.writeFile(this.deliveriesPath, JSON.stringify(this.deliveries, null, 2), 'utf-8');
+  }
+
+  private async recordDelivery(input: {
+    endpoint: OutboundEndpointRecord;
+    method: string;
+    status: OutboundDeliveryStatus;
+    startedAt: string;
+    durationMs: number;
+    responseStatus?: number;
+    retryOf?: string;
+    attempt?: number;
+    error?: string;
+  }): Promise<OutboundDeliveryAttempt> {
+    const completedAt = new Date().toISOString();
+    const attempt: OutboundDeliveryAttempt = {
+      id: `outbound_${Date.now()}_${nanoid(8)}`,
+      endpointId: input.endpoint.id,
+      endpointType: input.endpoint.type,
+      displayName: input.endpoint.displayName,
+      method: input.method,
+      sanitizedUrl: input.endpoint.url,
+      status: input.status,
+      responseStatus: input.responseStatus,
+      responseClass: this.responseClass(input.responseStatus),
+      durationMs: input.durationMs,
+      retryOf: input.retryOf,
+      attempt: input.attempt || 1,
+      error: input.error ? this.sanitizeError(input.error) : undefined,
+      startedAt: input.startedAt,
+      completedAt,
+    };
+
+    this.deliveries.push(attempt);
+    if (this.deliveries.length > MAX_DELIVERIES) {
+      this.deliveries = this.deliveries.slice(-MAX_DELIVERIES);
+    }
+    await this.saveDeliveries();
+    await this.audit({
+      action: 'outbound_endpoint.used',
+      actor: 'system',
+      resource: input.endpoint.id,
+      details: {
+        endpointType: input.endpoint.type,
+        status: attempt.status,
+        responseStatus: attempt.responseStatus,
+        responseClass: attempt.responseClass,
+        durationMs: attempt.durationMs,
+        retryOf: attempt.retryOf,
+        error: attempt.error,
+      },
+    });
+    return attempt;
+  }
+
+  private async auditEndpointChange(
+    record: OutboundEndpointRecord,
+    existing?: OutboundEndpointRecord
+  ): Promise<void> {
+    const action = !existing
+      ? 'outbound_endpoint.created'
+      : record.enabled
+        ? 'outbound_endpoint.changed'
+        : 'outbound_endpoint.disabled';
+    await this.audit({
+      action,
+      actor: 'system',
+      resource: record.id,
+      details: {
+        endpointType: record.type,
+        displayName: record.displayName,
+        owner: record.owner,
+        enabled: record.enabled,
+        validation: record.validation,
+        url: record.url,
+        auth: record.auth,
+      },
+    });
+  }
+
+  private sanitizeAuth(auth?: OutboundEndpointAuth): OutboundEndpointAuth {
+    if (!auth) return DEFAULT_AUTH;
+    return {
+      type: auth.type,
+      secretRef: auth.secretRef,
+      headerName: auth.headerName,
+      hasSecret: auth.hasSecret,
+    };
+  }
+
+  private sanitizeUrl(url: string): string {
+    try {
+      const parsed = new URL(url);
+      parsed.username = '';
+      parsed.password = '';
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString();
+    } catch {
+      return '[invalid-url]';
+    }
+  }
+
+  private sanitizeError(err: unknown, rawUrl?: string): string {
+    let message = err instanceof Error ? err.message : typeof err === 'string' ? err : String(err);
+    if (rawUrl) {
+      message = message.split(rawUrl).join(this.sanitizeUrl(rawUrl));
+    }
+
+    const replacements: Array<[RegExp, string]> = [
+      [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
+      [/\bsk-[A-Za-z0-9_-]{12,}/g, 'sk-[REDACTED]'],
+      [/\bghp_[A-Za-z0-9_]{12,}/g, 'ghp_[REDACTED]'],
+      [/\bgithub_pat_[A-Za-z0-9_]{12,}/g, 'github_pat_[REDACTED]'],
+      [
+        /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*)\s*=\s*([^\s"'`]+)/gi,
+        '$1=[REDACTED]',
+      ],
+      [
+        /\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*([^\s"'`,}]+)/gi,
+        '$1=[REDACTED]',
+      ],
+    ];
+
+    for (const [pattern, replacement] of replacements) {
+      message = message.replace(pattern, replacement);
+    }
+
+    return message.slice(0, 1000);
+  }
+
+  private responseClass(status?: number): string | undefined {
+    if (!status) return undefined;
+    return `${Math.floor(status / 100)}xx`;
+  }
+}
+
+let outboundIntegrationService: OutboundIntegrationService | null = null;
+
+export function getOutboundIntegrationService(): OutboundIntegrationService {
+  if (!outboundIntegrationService) {
+    outboundIntegrationService = new OutboundIntegrationService();
+  }
+  return outboundIntegrationService;
+}
+
+export function _resetOutboundIntegrationService(service?: OutboundIntegrationService): void {
+  outboundIntegrationService = service || null;
+}

--- a/server/src/services/policy-service.ts
+++ b/server/src/services/policy-service.ts
@@ -13,9 +13,9 @@ import { createLogger } from '../lib/logger.js';
 import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { policySchema } from '../schemas/policy-schemas.js';
 import { getPoliciesDir } from '../utils/paths.js';
-import { safeFetch } from '../utils/url-validation.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteAgentPolicyRepository } from '../storage/sqlite/audit-policy-repositories.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 
 const log = createLogger('policy-service');
 const PRESET_TIMESTAMP = new Date().toISOString();
@@ -591,24 +591,39 @@ export class PolicyService {
     policy: Extract<AgentPolicy, { type: 'webhook-check' }>,
     input: PolicyEvaluationRequest
   ): Promise<{ triggered: boolean; message: string; details: Record<string, unknown> }> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), policy.config.timeoutMs ?? 5_000);
     const body = policy.config.sendContext === false ? undefined : JSON.stringify(input);
 
     try {
-      const response = await safeFetch(policy.config.url, {
-        method: policy.config.method ?? 'POST',
-        headers: body ? { 'Content-Type': 'application/json' } : undefined,
-        body,
-        signal: controller.signal,
-      });
+      const delivery = await getOutboundIntegrationService().deliver(
+        {
+          id: `policy.${policy.id}`,
+          type: 'policy-webhook',
+          displayName: `${policy.name} webhook check`,
+          url: policy.config.url,
+          enabled: policy.enabled,
+          owner: { source: 'policy', resourceId: policy.id },
+        },
+        {
+          method: policy.config.method ?? 'POST',
+          headers: body ? { 'Content-Type': 'application/json' } : undefined,
+          body,
+          timeoutMs: policy.config.timeoutMs ?? 5_000,
+          responseBodyLimit: 200,
+        }
+      );
 
-      if (!response) {
+      if (delivery.status === 'blocked') {
         throw new Error('Webhook URL blocked by outbound URL policy');
       }
+      if (delivery.status === 'timeout') {
+        throw new Error('Webhook check timed out');
+      }
+      if (!delivery.responseStatus) {
+        throw new Error(delivery.error || 'Webhook delivery failed');
+      }
 
-      const text = await response.text().catch(() => '');
-      const statusMatches = response.status === (policy.config.expectedStatus ?? 200);
+      const text = delivery.responseText || '';
+      const statusMatches = delivery.responseStatus === (policy.config.expectedStatus ?? 200);
       const bodyMatches = policy.config.expectedBodyContains
         ? text.includes(policy.config.expectedBodyContains)
         : true;
@@ -619,12 +634,13 @@ export class PolicyService {
       return {
         triggered,
         message: triggered
-          ? `${policy.name} webhook ${triggerOn === 'success' ? 'succeeded' : 'failed'} with status ${response.status}.`
+          ? `${policy.name} webhook ${triggerOn === 'success' ? 'succeeded' : 'failed'} with status ${delivery.responseStatus}.`
           : '',
         details: {
-          status: response.status,
+          status: delivery.responseStatus,
           expectedStatus: policy.config.expectedStatus ?? 200,
           bodySnippet: text.slice(0, 200),
+          deliveryAttemptId: delivery.attemptId,
         },
       };
     } catch (error) {
@@ -637,8 +653,6 @@ export class PolicyService {
           error: message,
         },
       };
-    } finally {
-      clearTimeout(timeout);
     }
   }
 

--- a/server/src/services/squad-webhook-service.ts
+++ b/server/src/services/squad-webhook-service.ts
@@ -8,7 +8,7 @@
 import crypto from 'crypto';
 import type { SquadMessage, SquadWebhookSettings } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
-import { safeFetch } from '../utils/url-validation.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 
 const log = createLogger('squad-webhook');
 
@@ -87,29 +87,45 @@ async function fireOpenClawWake(
   const url = `${settings.openclawGatewayUrl}/tools/invoke`;
 
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000); // 5 second timeout
-
-    const response = await safeFetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${settings.openclawGatewayToken}`,
+    const delivery = await getOutboundIntegrationService().deliver(
+      {
+        id: 'squad.openclawWake',
+        type: 'openclaw-wake',
+        displayName: 'Squad Chat OpenClaw wake',
+        url,
+        enabled: settings.enabled && settings.mode === 'openclaw',
+        auth: {
+          type: 'bearer',
+          secretRef: 'featureSettings.squadWebhook.openclawGatewayToken',
+          hasSecret: Boolean(settings.openclawGatewayToken),
+        },
+        owner: { source: 'feature-settings', resourceId: 'squadWebhook.openclawGatewayUrl' },
+        validationOptions: { allowHttp: true, allowLocalhost: true },
       },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
-    });
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${settings.openclawGatewayToken}`,
+        },
+        body: JSON.stringify(payload),
+        timeoutMs: 5_000,
+      }
+    );
 
-    clearTimeout(timeout);
-
-    if (!response) {
-      log.warn({ url }, 'OpenClaw wake call URL blocked (SSRF prevention)');
+    if (delivery.status === 'blocked') {
+      log.warn('OpenClaw wake call URL blocked (SSRF prevention)');
       return;
     }
 
-    if (!response.ok) {
+    if (delivery.status === 'timeout') {
+      log.warn('OpenClaw wake call timed out after 5 seconds');
+      return;
+    }
+
+    if (!delivery.ok) {
       log.warn(
-        { status: response.status, statusText: response.statusText, url },
+        { status: delivery.responseStatus || delivery.status },
         'OpenClaw wake call returned non-2xx status'
       );
       return;
@@ -120,7 +136,7 @@ async function fireOpenClawWake(
     if (err.name === 'AbortError') {
       log.warn({ url }, 'OpenClaw wake call timed out after 5 seconds');
     } else {
-      log.error({ err: err.message, url }, 'OpenClaw wake call failed');
+      log.error({ err: err.message }, 'OpenClaw wake call failed');
     }
   }
 }
@@ -179,38 +195,54 @@ async function fireWebhookAsync(
   }
 
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000); // 5 second timeout
+    const delivery = await getOutboundIntegrationService().deliver(
+      {
+        id: 'squad.webhook',
+        type: 'squad-webhook',
+        displayName: 'Squad Chat webhook',
+        url,
+        enabled: true,
+        auth: {
+          type: 'hmac-sha256',
+          headerName: 'X-VK-Signature',
+          secretRef: secret ? 'featureSettings.squadWebhook.secret' : undefined,
+          hasSecret: Boolean(secret),
+        },
+        owner: { source: 'feature-settings', resourceId: 'squadWebhook.url' },
+      },
+      {
+        method: 'POST',
+        headers,
+        body,
+        timeoutMs: 5_000,
+      }
+    );
 
-    const response = await safeFetch(url, {
-      method: 'POST',
-      headers,
-      body,
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeout);
-
-    if (!response) {
-      log.warn({ url }, 'Squad webhook URL blocked (SSRF prevention)');
+    if (delivery.status === 'blocked') {
+      log.warn('Squad webhook URL blocked (SSRF prevention)');
       return;
     }
 
-    if (!response.ok) {
+    if (delivery.status === 'timeout') {
+      log.warn('Squad webhook timed out after 5 seconds');
+      throw new Error('Webhook timeout');
+    }
+
+    if (!delivery.ok) {
       log.warn(
-        { status: response.status, statusText: response.statusText, url },
+        { status: delivery.responseStatus || delivery.status },
         'Squad webhook returned non-2xx status'
       );
       return;
     }
 
-    log.info({ messageId: payload.message.id, url }, 'Squad webhook fired successfully');
+    log.info({ messageId: payload.message.id }, 'Squad webhook fired successfully');
   } catch (err: any) {
     if (err.name === 'AbortError') {
-      log.warn({ url }, 'Squad webhook timed out after 5 seconds');
+      log.warn('Squad webhook timed out after 5 seconds');
       throw new Error('Webhook timeout');
     }
-    log.error({ err: err.message, url }, 'Squad webhook request failed');
+    log.error({ err: err.message }, 'Squad webhook request failed');
     throw err;
   }
 }

--- a/server/src/services/transition-hooks-service.ts
+++ b/server/src/services/transition-hooks-service.ts
@@ -11,7 +11,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { createLogger } from '../lib/logger.js';
-import { safeFetch } from '../utils/url-validation.js';
+import { getOutboundIntegrationService } from './outbound-integration-service.js';
 import type { Task, TaskStatus } from '@veritas-kanban/shared';
 import type {
   TransitionHooksConfig,
@@ -20,8 +20,6 @@ import type {
   TransitionAction,
   GateCheckResult,
   TransitionValidationResult,
-  GateType,
-  ActionType,
 } from '@veritas-kanban/shared';
 import { DEFAULT_TRANSITION_HOOKS_CONFIG } from '@veritas-kanban/shared';
 
@@ -333,7 +331,7 @@ async function executeAction(
 
       case 'send-webhook':
         if (action.webhookUrl) {
-          await sendWebhook(action.webhookUrl, task, fromStatus, toStatus);
+          await sendWebhook(action, task, fromStatus, toStatus);
         }
         break;
 
@@ -371,11 +369,13 @@ async function executeAction(
  * Send a webhook for a transition.
  */
 async function sendWebhook(
-  url: string,
+  action: TransitionAction,
   task: Task,
   fromStatus: TaskStatus | undefined,
   toStatus: TaskStatus
 ): Promise<void> {
+  if (!action.webhookUrl) return;
+
   const payload = {
     event: 'status_transition',
     taskId: task.id,
@@ -387,26 +387,46 @@ async function sendWebhook(
     timestamp: new Date().toISOString(),
   };
 
-  const response = await safeFetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-VK-Event': 'status_transition',
+  const delivery = await getOutboundIntegrationService().deliver(
+    {
+      id: `transition-hooks.${action.id}`,
+      type: 'transition-hook-webhook',
+      displayName: action.name,
+      url: action.webhookUrl,
+      enabled: action.enabled,
+      owner: { source: 'hook', resourceId: action.id },
     },
-    body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(10_000),
-  });
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-VK-Event': 'status_transition',
+      },
+      body: JSON.stringify(payload),
+      timeoutMs: 10_000,
+    }
+  );
 
-  if (!response) {
-    log.warn({ url }, 'Transition webhook URL blocked (SSRF prevention)');
+  if (delivery.status === 'blocked' || delivery.status === 'skipped') {
+    log.warn(
+      { actionId: action.id, status: delivery.status, deliveryAttemptId: delivery.attemptId },
+      'Transition webhook delivery skipped'
+    );
     return;
   }
 
-  if (!response.ok) {
-    throw new Error(`Webhook failed: ${response.status} ${response.statusText}`);
+  if (!delivery.ok) {
+    throw new Error(
+      delivery.responseStatus
+        ? `Webhook failed: ${delivery.responseStatus}`
+        : delivery.error || `Webhook failed: ${delivery.status}`
+    );
   }
 
-  log.debug({ taskId: task.id, url }, 'Transition webhook delivered');
+  log.debug(
+    { taskId: task.id, actionId: action.id, deliveryAttemptId: delivery.attemptId },
+    'Transition webhook delivered'
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Added a shared outbound integration registry with sanitized endpoint records, delivery history, retry metadata, response classes, validation policy, and audit events.
- Routed broadcast webhooks, lifecycle/transition hooks, policy webhooks, squad webhooks, OpenClaw wake/gateway calls, and failure alerts through the registry boundary.
- Added API surface for outbound endpoints and delivery attempts, plus tests for secret redaction, blocked private hosts, DNS rebinding blocks, disabled endpoint skips, and sanitized route responses.

## Verification
- pnpm --filter @veritas-kanban/server test -- outbound-integration-service.test.ts clawdbot-webhook-service.test.ts squad-webhook-service.test.ts workflow-step-executor-openclaw.test.ts workflow-step-executor-codex.test.ts services/policy-service.test.ts failure-alert-service.test.ts routes/integrations.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm exec prettier --check server/src/services/outbound-integration-service.ts server/src/services/hook-service.ts server/src/services/policy-service.ts server/src/services/failure-alert-service.ts server/src/services/clawdbot-webhook-service.ts server/src/services/squad-webhook-service.ts server/src/services/openclaw-workflow-adapter.ts server/src/services/lifecycle-hooks-service.ts server/src/services/transition-hooks-service.ts server/src/routes/integrations.ts server/src/routes/settings.ts server/src/__tests__/outbound-integration-service.test.ts server/src/__tests__/squad-webhook-service.test.ts server/src/__tests__/routes/integrations.test.ts
- git diff --check
- pnpm lint:budget

## Risk
- Existing settings continue to drive delivery, but delivery attempts now persist through the registry for runtime visibility.

Closes #394
