### PR TITLE
Narrow production CSP style policy

### DIFF
--- a/desktop/src/main/__tests__/status-page.test.ts
+++ b/desktop/src/main/__tests__/status-page.test.ts
@@ -1,0 +1,35 @@
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { statusPage } from '../status-page.js';
+
+function styleHash(style: string): string {
+  return `'sha256-${createHash('sha256').update(style).digest('base64')}'`;
+}
+
+function inlineStyle(html: string): string {
+  const match = html.match(/<style>([\s\S]*?)<\/style>/);
+  if (!match) throw new Error('Expected inline style block');
+  return match[1];
+}
+
+describe('desktop status pages CSP', () => {
+  it('allows the generated status page style block by hash instead of unsafe-inline', () => {
+    const html = statusPage('Starting', 'Preparing runtime');
+    const csp = html.match(/content="([^"]+)"/)?.[1] || '';
+
+    expect(csp).toContain(`style-src ${styleHash(inlineStyle(html))}`);
+    expect(csp).not.toContain("'unsafe-inline'");
+  });
+
+  it('allows the static renderer startup style block by hash instead of unsafe-inline', () => {
+    const testDir = dirname(fileURLToPath(import.meta.url));
+    const html = readFileSync(resolve(testDir, '../../renderer/index.html'), 'utf-8');
+    const csp = html.match(/content="([^"]+)"/)?.[1] || '';
+
+    expect(csp).toContain(`style-src ${styleHash(inlineStyle(html))}`);
+    expect(csp).not.toContain("'unsafe-inline'");
+  });
+});

--- a/desktop/src/main/status-page.ts
+++ b/desktop/src/main/status-page.ts
@@ -1,27 +1,7 @@
+import { createHash } from 'crypto';
 import type { DesktopStatusSnapshot } from './types.js';
 
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
-
-export function statusPage(title: string, message: string, status?: DesktopStatusSnapshot): string {
-  const statusJson = status ? escapeHtml(JSON.stringify(status, null, 2)) : '';
-
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; script-src 'none';"
-    />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>${escapeHtml(title)}</title>
-    <style>
+const STATUS_PAGE_CSS = `
       :root {
         color-scheme: dark;
         font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -58,7 +38,34 @@ export function statusPage(title: string, message: string, status?: DesktopStatu
         color: #d8deea;
         font-size: 12px;
       }
-    </style>
+    `;
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function styleHash(style: string): string {
+  return `'sha256-${createHash('sha256').update(style).digest('base64')}'`;
+}
+
+export function statusPage(title: string, message: string, status?: DesktopStatusSnapshot): string {
+  const statusJson = status ? escapeHtml(JSON.stringify(status, null, 2)) : '';
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src ${styleHash(STATUS_PAGE_CSS)}; img-src data:; script-src 'none';"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(title)}</title>
+    <style>${STATUS_PAGE_CSS}</style>
   </head>
   <body>
     <main>

--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -4,14 +4,19 @@
     <meta charset="utf-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; script-src 'none';"
+      content="default-src 'none'; style-src 'sha256-73uqRU+Tsu2ddgLhX3AMG2sgAbLckUuCsmHkbBY3NnM='; img-src data:; script-src 'none';"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Veritas Kanban</title>
     <style>
       :root {
         color-scheme: dark;
-        font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family:
+          Roboto,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
         background: #111318;
         color: #eef1f7;
       }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1564,8 +1564,8 @@ Defense-in-depth security model with multiple authentication methods and hardene
 
 ### Network & Headers
 
-- **CSP headers** — Content Security Policy via [Helmet](https://helmetjs.github.io/) with nonce-based script allowlisting
-- **CSP nonce middleware** — Per-request nonce generation for inline scripts
+- **CSP headers** — Content Security Policy via [Helmet](https://helmetjs.github.io/) with nonce-based script/style allowlisting and a documented `style-src-attr` exception for runtime React style attributes
+- **CSP nonce middleware** — Per-request nonce generation for inline scripts and style elements
 - **Rate limiting** — 300 requests/minute per IP (configurable via `RATE_LIMIT_MAX`); sensitive endpoints (auth, settings) limited to 15/min; localhost exempt
 - **CORS origin validation** — Configurable allowed origins via `CORS_ORIGINS` env var
 - **WebSocket origin validation** — Origin checking on WebSocket upgrade requests

--- a/docs/security/csp-style-policy.md
+++ b/docs/security/csp-style-policy.md
@@ -1,0 +1,40 @@
+# CSP Style Policy
+
+Veritas Kanban production HTTP responses use Helmet CSP with per-request
+nonces. Production `style-src` no longer includes broad `'unsafe-inline'`.
+
+## Runtime Policy
+
+- `script-src` allows same-origin scripts and the per-request nonce.
+- `style-src` and `style-src-elem` allow same-origin stylesheets and
+  nonce-bearing inline `<style>` elements.
+- `style-src-attr` is the only remaining inline style exception and is scoped to
+  style attributes.
+- `/api-docs` removes the CSP header only for Swagger UI, which still ships
+  inline scripts and styles.
+
+## Inline Style Inventory
+
+The React app still uses dynamic `style={...}` attributes for:
+
+- Progress and utilization widths in dashboard, activity, scoring, and task
+  metrics views.
+- Drag/drop transform and sortable item positioning.
+- Runtime status colors, color chips, and chart legend markers.
+- Markdown editor height constraints and attachment preview sizing.
+
+Those values are computed at runtime, so CSP hashes are not practical yet. The
+current policy keeps those attributes working through `style-src-attr` while
+blocking arbitrary inline `<style>` elements unless they carry the server nonce.
+
+## Static Desktop Pages
+
+The desktop startup and failure/status pages are isolated static documents with
+`default-src 'none'` and no scripts. Their inline `<style>` blocks are allowed by
+CSS hashes, not by `'unsafe-inline'`.
+
+## Migration Path
+
+Remove the remaining `style-src-attr 'unsafe-inline'` allowance once the dynamic
+style attributes above have moved to CSS custom properties, data attributes, or
+bounded class mappings.

--- a/server/src/__tests__/csp-policy.test.ts
+++ b/server/src/__tests__/csp-policy.test.ts
@@ -1,0 +1,83 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { apiDocsCspOverride, buildCspDirectives } from '../config/csp.js';
+import { injectCspNonceAttributes } from '../middleware/csp-nonce.js';
+
+function directiveValues(value: unknown): unknown[] {
+  return Array.from(value as Iterable<unknown>);
+}
+
+describe('CSP policy', () => {
+  it('removes broad production style-src unsafe-inline and keeps nonce support', () => {
+    const directives = buildCspDirectives({
+      isDev: false,
+      isDesktopRuntime: false,
+      reportUri: 'https://reports.example.test/csp',
+    });
+
+    const scriptSrc = directiveValues(directives.scriptSrc);
+    const styleSrc = directiveValues(directives.styleSrc);
+    const styleSrcElem = directiveValues(directives.styleSrcElem);
+    const styleSrcAttr = directiveValues(directives.styleSrcAttr);
+
+    expect(scriptSrc).toContain("'self'");
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(scriptSrc.some((value) => typeof value === 'function')).toBe(true);
+    expect(styleSrc).toContain("'self'");
+    expect(styleSrc).not.toContain("'unsafe-inline'");
+    expect(styleSrc.some((value) => typeof value === 'function')).toBe(true);
+    expect(styleSrcElem).toContain("'self'");
+    expect(styleSrcElem).not.toContain("'unsafe-inline'");
+    expect(styleSrcElem.some((value) => typeof value === 'function')).toBe(true);
+    expect(styleSrcAttr).toEqual(["'unsafe-inline'"]);
+    expect(directiveValues(directives.reportUri)).toEqual(['https://reports.example.test/csp']);
+  });
+
+  it('keeps dev-only inline script/style support scoped to dev mode', () => {
+    const directives = buildCspDirectives({
+      isDev: true,
+      isDesktopRuntime: false,
+    });
+
+    expect(directiveValues(directives.scriptSrc)).toContain("'unsafe-inline'");
+    expect(directiveValues(directives.styleSrc)).toContain("'unsafe-inline'");
+    expect(directives.upgradeInsecureRequests).toBeNull();
+  });
+
+  it('injects the same nonce into script and style tags without duplicating existing nonces', () => {
+    const html = [
+      '<script type="module" src="/assets/app.js"></script>',
+      '<style>body{color:red}</style>',
+      '<script nonce="existing" src="/assets/other.js"></script>',
+    ].join('');
+
+    expect(injectCspNonceAttributes(html, 'abc123')).toBe(
+      [
+        '<script nonce="abc123" type="module" src="/assets/app.js"></script>',
+        '<style nonce="abc123">body{color:red}</style>',
+        '<script nonce="existing" src="/assets/other.js"></script>',
+      ].join('')
+    );
+  });
+
+  it('removes CSP headers only for API docs responses', async () => {
+    const app = express();
+    app.use((_req, res, next) => {
+      res.setHeader('Content-Security-Policy', "default-src 'self'");
+      res.setHeader('Content-Security-Policy-Report-Only', "default-src 'self'");
+      next();
+    });
+    app.use('/api-docs', apiDocsCspOverride);
+    app.get('/api-docs', (_req, res) => res.send('docs'));
+    app.get('/not-docs', (_req, res) => res.send('regular'));
+
+    const docs = await request(app).get('/api-docs');
+    expect(docs.headers['content-security-policy']).toBeUndefined();
+    expect(docs.headers['content-security-policy-report-only']).toBeUndefined();
+
+    const regular = await request(app).get('/not-docs');
+    expect(regular.headers['content-security-policy']).toBe("default-src 'self'");
+    expect(regular.headers['content-security-policy-report-only']).toBe("default-src 'self'");
+  });
+});

--- a/server/src/config/csp.ts
+++ b/server/src/config/csp.ts
@@ -1,0 +1,63 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { IncomingMessage, ServerResponse } from 'http';
+import { cspNonceDirective } from '../middleware/csp-nonce.js';
+
+type CspDirectiveValue = string | ((_req: IncomingMessage, res: ServerResponse) => string);
+
+export type CspDirectives = Record<string, null | Iterable<CspDirectiveValue>>;
+
+export interface CspDirectiveOptions {
+  isDev: boolean;
+  isDesktopRuntime: boolean;
+  reportUri?: string | null;
+}
+
+const SELF = "'self'";
+const NONE = "'none'";
+const UNSAFE_INLINE = "'unsafe-inline'";
+
+/**
+ * Production style policy intentionally avoids broad style-src unsafe-inline.
+ *
+ * Runtime React/Mantine surfaces still use dynamic style attributes for layout,
+ * progress bars, drag/drop transforms, and color indicators, so the remaining
+ * inline-style exception is narrowed to style-src-attr. Inline <style> elements
+ * must be same-origin stylesheet assets or carry the per-request nonce.
+ */
+export function buildCspDirectives(options: CspDirectiveOptions): CspDirectives {
+  const nonceDirective = cspNonceDirective();
+  const scriptSrc = options.isDev ? [SELF, UNSAFE_INLINE] : [SELF, nonceDirective];
+  const styleElementSrc = options.isDev ? [SELF, UNSAFE_INLINE] : [SELF, nonceDirective];
+  const directives: CspDirectives = {
+    defaultSrc: [SELF],
+    scriptSrc,
+    styleSrc: styleElementSrc,
+    styleSrcElem: styleElementSrc,
+    styleSrcAttr: [UNSAFE_INLINE],
+    connectSrc: [
+      SELF,
+      'ws://localhost:*',
+      'ws://127.0.0.1:*',
+      ...(options.isDev ? ['http://localhost:*', 'http://127.0.0.1:*'] : []),
+    ],
+    imgSrc: [SELF, 'data:', 'blob:'],
+    fontSrc: [SELF],
+    objectSrc: [NONE],
+    frameSrc: [NONE],
+    baseUri: [SELF],
+    formAction: [SELF],
+    upgradeInsecureRequests: options.isDev || options.isDesktopRuntime ? null : [],
+  };
+
+  if (options.reportUri) {
+    directives.reportUri = [options.reportUri];
+  }
+
+  return directives;
+}
+
+export function apiDocsCspOverride(_req: Request, res: Response, next: NextFunction): void {
+  res.removeHeader('Content-Security-Policy');
+  res.removeHeader('Content-Security-Policy-Report-Only');
+  next();
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -56,7 +56,8 @@ import { apiVersionMiddleware } from './middleware/api-version.js';
 import { apiCacheHeaders } from './middleware/cache-control.js';
 import type { AgentOutput } from './services/clawdbot-agent-service.js';
 import { webhookN8nRouter } from './routes/webhook-n8n.js';
-import { cspNonceMiddleware, cspNonceDirective } from './middleware/csp-nonce.js';
+import { cspNonceMiddleware, injectCspNonceAttributes } from './middleware/csp-nonce.js';
+import { apiDocsCspOverride, buildCspDirectives } from './config/csp.js';
 import { healthRouter, apiHealthRouter, setHealthWss } from './routes/health.js';
 import { getPrometheusCollector } from './services/metrics/prometheus.js';
 import { metricsCollector } from './middleware/metrics-collector.js';
@@ -160,7 +161,8 @@ app.set('etag', 'weak');
 // CSP Directives:
 //   defaultSrc  - Fallback for all resource types: only same-origin
 //   scriptSrc   - Scripts: same-origin only (+ unsafe-inline in dev for Vite HMR)
-//   styleSrc    - Styles: same-origin + inline (Tailwind/JSX inline styles)
+//   styleSrc    - Stylesheets and nonce-tagged style elements only in production
+//   styleSrcAttr - React runtime style attributes only
 //   connectSrc  - XHR/fetch/WebSocket: same-origin + ws://localhost for dev WS
 //   imgSrc      - Images: same-origin + data: URIs (inline SVGs, base64 images)
 //   fontSrc     - Fonts: same-origin
@@ -188,11 +190,13 @@ app.set('etag', 'weak');
 //   only, not to Vite-served HTML. They still matter for any HTML served
 //   directly by Express (e.g., error pages) and as defense-in-depth.
 //
-// PRODUCTION (strict: no unsafe-inline, no unsafe-eval):
+// PRODUCTION:
 //   Scripts require same-origin + nonce. The cspNonceMiddleware generates
-//   a per-request nonce available via res.locals.cspNonce. To serve HTML
-//   with nonce-tagged scripts, inject the nonce attribute on <script> tags
-//   in the SPA fallback handler.
+//   a per-request nonce available via res.locals.cspNonce. Server-served HTML
+//   receives nonce attributes on <script> and <style> tags in the SPA fallback
+//   handler. Inline style attributes remain allowed through style-src-attr only
+//   because the current React UI still uses dynamic style props for progress,
+//   drag/drop transforms, chart widths, and color indicators.
 //
 // == CSP Report-Only Mode ==
 //
@@ -217,49 +221,11 @@ app.use(
       // Report-Only mode: log violations without enforcing (for safe rollout)
       reportOnly: cspReportOnly,
       directives: {
-        defaultSrc: ["'self'"],
-
-        scriptSrc: [
-          "'self'",
-          // DEV ONLY: Vite HMR requires inline scripts. See comment block above.
-          // This is scoped to dev and does NOT include 'unsafe-eval'.
-          ...(isDev ? ["'unsafe-inline'"] : []),
-          // PRODUCTION: Per-request nonce for server-rendered script tags.
-          // Use res.locals.cspNonce when injecting scripts into HTML.
-          ...(!isDev ? [cspNonceDirective()] : []),
-        ],
-
-        styleSrc: [
-          "'self'",
-          // unsafe-inline is needed across both environments for:
-          //   - Tailwind CSS utility classes applied via style attribute
-          //   - Radix UI / shadcn component inline styles
-          //   - React component inline styles (style prop)
-          // TODO: Migrate to nonce-based style injection when CSS-in-JS
-          // libraries and Radix UI support it consistently.
-          "'unsafe-inline'",
-        ],
-
-        connectSrc: [
-          "'self'",
-          'ws://localhost:*',
-          'ws://127.0.0.1:*',
-          ...(isDev ? ['http://localhost:*', 'http://127.0.0.1:*'] : []),
-        ],
-
-        imgSrc: ["'self'", 'data:', 'blob:'],
-        fontSrc: ["'self'"],
-        objectSrc: ["'none'"],
-        frameSrc: ["'none'"],
-        baseUri: ["'self'"],
-        formAction: ["'self'"],
-        // The packaged desktop app serves the SPA over loopback HTTP. Do not
-        // upgrade those local asset requests to HTTPS.
-        upgradeInsecureRequests: isDev || isDesktopRuntime ? null : [],
-
-        // CSP violation reporting — only included when CSP_REPORT_URI is set.
-        // Works with both enforced and report-only modes.
-        ...(cspReportUri ? { reportUri: cspReportUri } : {}),
+        ...buildCspDirectives({
+          isDev,
+          isDesktopRuntime,
+          reportUri: cspReportUri,
+        }),
       },
     },
     // Cross-Origin-Embedder-Policy can break loading of cross-origin resources;
@@ -408,11 +374,8 @@ app.get('/api-docs/swagger.json', (_req, res) => {
   res.send(swaggerSpec);
 });
 
-// Swagger UI needs inline scripts/styles, so override CSP for /api-docs only
-app.use('/api-docs', (_req: express.Request, res: express.Response, next: express.NextFunction) => {
-  res.removeHeader('Content-Security-Policy');
-  next();
-});
+// Swagger UI needs inline scripts/styles, so override CSP for /api-docs only.
+app.use('/api-docs', apiDocsCspOverride);
 app.use(
   '/api-docs',
   swaggerUi.serve,
@@ -497,8 +460,6 @@ if (process.env.NODE_ENV === 'production') {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const webDistPath = path.resolve(__dirname, '../../web/dist');
   const indexHtmlPath = path.join(webDistPath, 'index.html');
-  const injectScriptNonce = (html: string, nonce: string | undefined): string =>
-    nonce ? html.replace(/<script(\s|>)/g, `<script nonce="${nonce}"$1`) : html;
   const sendSpaIndex = async (
     _req: express.Request,
     res: express.Response,
@@ -507,7 +468,7 @@ if (process.env.NODE_ENV === 'production') {
     try {
       const html = await readFile(indexHtmlPath, 'utf-8');
       res.set('Cache-Control', 'no-cache');
-      res.type('html').send(injectScriptNonce(html, res.locals.cspNonce));
+      res.type('html').send(injectCspNonceAttributes(html, res.locals.cspNonce));
     } catch (error) {
       next(error);
     }

--- a/server/src/middleware/csp-nonce.ts
+++ b/server/src/middleware/csp-nonce.ts
@@ -6,7 +6,8 @@
  * `res.locals.cspNonce` and can be:
  *
  *   1. Referenced in Helmet CSP via the `cspNonceDirective()` helper function
- *   2. Injected into HTML responses as `<script nonce="...">` attributes
+ *   2. Injected into HTML responses as `<script nonce="...">` and
+ *      `<style nonce="...">` attributes
  *
  * Nonces are 128-bit (16 bytes) base64-encoded values — sufficient entropy
  * to prevent brute-force attacks within a single request lifetime.
@@ -26,7 +27,7 @@
  *
  * // In HTML template / SPA fallback:
  * const nonce = res.locals.cspNonce;
- * html = html.replace('<script', `<script nonce="${nonce}"`);
+ * html = injectCspNonceAttributes(html, nonce);
  * ```
  *
  * @module
@@ -63,4 +64,16 @@ export function cspNonceDirective(): (_req: IncomingMessage, res: ServerResponse
     const locals = (res as ServerResponse & { locals?: { cspNonce?: string } }).locals;
     return locals?.cspNonce ? `'nonce-${locals.cspNonce}'` : '';
   };
+}
+
+/**
+ * Adds the generated nonce to inline script and style elements in server-served
+ * HTML. Existing nonce attributes are preserved so repeated calls are safe.
+ */
+export function injectCspNonceAttributes(html: string, nonce: string | undefined): string {
+  if (!nonce) return html;
+  return html.replace(
+    /<(script|style)(?=[\s>])(?![^>]*\bnonce=)/gi,
+    (_match, tag: string) => `<${tag} nonce="${nonce}"`
+  );
 }


### PR DESCRIPTION
## Summary
- Moves production CSP construction into a shared helper and removes broad `style-src 'unsafe-inline'` from production responses.
- Adds nonce injection for server-served `<style>` tags, keeps `/api-docs/` CSP-free for Swagger UI, and documents the remaining `style-src-attr 'unsafe-inline'` exception.
- Replaces desktop startup/status page inline-style allowances with CSP hashes.

## Verification
- `pnpm --filter @veritas-kanban/server test -- csp-policy.test.ts`
- `pnpm --filter @veritas-kanban/desktop test -- status-page.test.ts`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/desktop typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm --filter @veritas-kanban/desktop build`
- `pnpm lint:budget`
- `pnpm exec prettier --check ...`
- `git diff --check`
- Production smoke on `127.0.0.1:4178` with isolated `DATA_DIR`: verified board, settings, task detail, and dashboard render with zero browser warn/error console entries and zero CSP violation entries.
- Header assertion: root production CSP includes nonce-based `script-src`, `style-src`, and `style-src-elem`; keeps only `style-src-attr 'unsafe-inline'`; `/api-docs/` has no CSP header.

## Risk
- `style-src-attr 'unsafe-inline'` remains intentionally for React/Mantine runtime `style={...}` attributes. The inventory and migration path are documented in `docs/security/csp-style-policy.md`.
- In-app browser screenshot capture timed out during smoke, but DOM snapshots, console logs, and header assertions passed.

Closes #396
