### PR TITLE
Centralize web navigation registries

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,63 +21,17 @@ import { FloatingChat } from './components/chat/FloatingChat';
 import { SystemHealthBar } from './components/layout/SystemHealthBar';
 import { MobileShell } from './components/layout/MobileShell';
 import { PwaStatusBanner } from './components/layout/PwaStatusBanner';
-import { VIEW_BY_ID, type AppView } from './lib/views';
+import { NAVIGATION_VIEWS, VIEW_BY_ID, type AppView, type NavigationView } from './lib/views';
 import { usePendingProductMode } from './hooks/usePendingProductMode';
 
-// Lazy-load ActivityFeed and BacklogPage to keep initial bundle small
-const ActivityFeed = lazy(() =>
-  import('./components/activity/ActivityFeed').then((mod) => ({
-    default: mod.ActivityFeed,
-  }))
-);
-
-const BacklogPage = lazy(() =>
-  import('./components/backlog/BacklogPage').then((mod) => ({
-    default: mod.BacklogPage,
-  }))
-);
-
-const ArchivePage = lazy(() =>
-  import('./components/archive/ArchivePage').then((mod) => ({
-    default: mod.ArchivePage,
-  }))
-);
-
-const TemplatesPage = lazy(() =>
-  import('./components/templates/TemplatesPage').then((mod) => ({
-    default: mod.TemplatesPage,
-  }))
-);
-
-const WorkflowsPage = lazy(() =>
-  import('./components/workflows/WorkflowsPage').then((mod) => ({
-    default: mod.WorkflowsPage,
-  }))
-);
-
-const DriftMonitor = lazy(() =>
-  import('./components/drift/DriftMonitor').then((mod) => ({
-    default: mod.DriftMonitor,
-  }))
-);
-
-const DecisionExplorer = lazy(() =>
-  import('./components/decisions/DecisionExplorer').then((mod) => ({
-    default: mod.DecisionExplorer,
-  }))
-);
-
-const ScoringProfiles = lazy(() =>
-  import('./components/scoring/ScoringProfiles').then((mod) => ({
-    default: mod.ScoringProfiles,
-  }))
-);
-
-const PolicyManager = lazy(() =>
-  import('./components/policies/PolicyManager').then((mod) => ({
-    default: mod.PolicyManager,
-  }))
-);
+const LAZY_VIEW_COMPONENTS = Object.fromEntries(
+  NAVIGATION_VIEWS.map((definition) => {
+    if (!definition.loadComponent) {
+      throw new Error(`Navigation view ${definition.view} is missing a lazy component loader.`);
+    }
+    return [definition.view, lazy(definition.loadComponent)];
+  })
+) as Record<NavigationView, ReturnType<typeof lazy>>;
 
 function ViewLoading({ view }: { view: AppView }) {
   return (
@@ -91,82 +45,14 @@ function ViewLoading({ view }: { view: AppView }) {
 function MainContent() {
   const { view, setView, navigateToTask } = useView();
 
-  if (view === 'activity') {
-    return (
-      <Suspense fallback={<ViewLoading view="activity" />}>
-        <ActivityFeed
-          onBack={() => setView('board')}
-          onTaskClick={(taskId) => navigateToTask(taskId)}
-        />
-      </Suspense>
-    );
-  }
+  if (view === 'board') return <KanbanBoard />;
 
-  if (view === 'backlog') {
-    return (
-      <Suspense fallback={<ViewLoading view="backlog" />}>
-        <BacklogPage onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  if (view === 'archive') {
-    return (
-      <Suspense fallback={<ViewLoading view="archive" />}>
-        <ArchivePage onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  if (view === 'templates') {
-    return (
-      <Suspense fallback={<ViewLoading view="templates" />}>
-        <TemplatesPage onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  if (view === 'workflows') {
-    return (
-      <Suspense fallback={<ViewLoading view="workflows" />}>
-        <WorkflowsPage onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  if (view === 'drift') {
-    return (
-      <Suspense fallback={<ViewLoading view="drift" />}>
-        <DriftMonitor onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  if (view === 'decisions') {
-    return (
-      <Suspense fallback={<ViewLoading view="decisions" />}>
-        <DecisionExplorer onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  if (view === 'scoring') {
-    return (
-      <Suspense fallback={<ViewLoading view="scoring" />}>
-        <ScoringProfiles onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  if (view === 'policies') {
-    return (
-      <Suspense fallback={<ViewLoading view="policies" />}>
-        <PolicyManager onBack={() => setView('board')} />
-      </Suspense>
-    );
-  }
-
-  return <KanbanBoard />;
+  const ViewComponent = LAZY_VIEW_COMPONENTS[view];
+  return (
+    <Suspense fallback={<ViewLoading view={view} />}>
+      <ViewComponent onBack={() => setView('board')} onTaskClick={navigateToTask} />
+    </Suspense>
+  );
 }
 
 // Main app content (only rendered when authenticated)

--- a/web/src/__tests__/SearchDialog.test.tsx
+++ b/web/src/__tests__/SearchDialog.test.tsx
@@ -140,6 +140,47 @@ describe('SearchDialog', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('uses the shared task-detail tab registry for task result targets', async () => {
+    const onTaskOpen = vi.fn();
+    const onOpenChange = vi.fn();
+    queryMock.mockResolvedValue({
+      query: 'timeline',
+      backend: 'keyword',
+      degraded: false,
+      elapsedMs: 2,
+      results: [
+        {
+          id: 'task-timeline-result',
+          title: 'Open run timeline',
+          path: 'tasks/active/task_20260504_abc123-run.md',
+          collection: 'tasks-active',
+          snippet: '',
+          score: 2,
+          metadata: {
+            target: {
+              type: 'task',
+              taskId: 'task_20260504_abc123',
+              tab: 'timeline',
+              timelineAttemptId: 'attempt-1',
+            },
+          },
+        },
+      ],
+    });
+
+    renderWithProviders(<SearchDialog open onOpenChange={onOpenChange} onTaskOpen={onTaskOpen} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/search tasks/i), 'timeline');
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    fireEvent.click(await screen.findByText('Open run timeline'));
+
+    expect(onTaskOpen).toHaveBeenCalledWith('task_20260504_abc123', {
+      tab: 'timeline',
+      timelineAttemptId: 'attempt-1',
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it('opens settings results through the supplied settings callback', async () => {
     const onSettingsOpen = vi.fn();
     const onOpenChange = vi.fn();

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -187,6 +187,8 @@ describe('task detail Mantine migration', () => {
     );
     expect(screen.getByRole('tab', { name: 'Work' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Details' })).toBeDefined();
+    expect(screen.queryByRole('tab', { name: 'Git' })).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Timeline' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Chat' })).toBeDefined();
     expect(container.querySelector('.mantine-Drawer-content')).toBeDefined();
     expect(container.querySelector('.mantine-Tabs-root')).toBeDefined();
@@ -209,8 +211,8 @@ describe('task detail Mantine migration', () => {
     await user.click(screen.getByRole('tab', { name: 'Progress' }));
 
     expect(mocks.updateField).toHaveBeenCalledWith('title', 'Renamed task');
-    expect(screen.getByText('Progress Notes')).toBeDefined();
-    expect(screen.getByText('Mantine task detail renders')).toBeDefined();
+    expect(await screen.findByText('Progress Notes')).toBeDefined();
+    expect(await screen.findByText('Mantine task detail renders')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Paper-root')).toBeDefined();
     expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
   });
@@ -252,5 +254,42 @@ describe('task detail Mantine migration', () => {
     expect(screen.getByRole('tab', { name: 'Work' }).getAttribute('aria-selected')).toBe('true');
     expect(screen.getByRole('tab', { name: 'Timeline' })).toBeDefined();
     expect(screen.getByText('Work View')).toBeDefined();
+  });
+
+  it('falls back when the active tab becomes unavailable for the task data', async () => {
+    const user = userEvent.setup();
+    const codeTask = createMockTask({
+      id: 'task-tab-fallback',
+      title: 'Investigate agent run',
+      type: 'code',
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'tab-fallback',
+        baseBranch: 'main',
+      },
+    });
+
+    const { rerender } = renderWithProviders(
+      <TaskDetailPanel task={codeTask} open onOpenChange={mocks.onOpenChange} />
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Timeline' }));
+    expect(screen.getByRole('tab', { name: 'Timeline' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
+
+    const featureTask = {
+      ...codeTask,
+      type: 'feature',
+      git: undefined,
+    };
+    rerender(<TaskDetailPanel task={featureTask} open onOpenChange={mocks.onOpenChange} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: 'Details' }).getAttribute('aria-selected')).toBe(
+        'true'
+      )
+    );
+    expect(screen.queryByRole('tab', { name: 'Timeline' })).toBeNull();
   });
 });

--- a/web/src/__tests__/view-registry.test.ts
+++ b/web/src/__tests__/view-registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  NAVIGATION_VIEWS,
+  VIEW_BY_ID,
+  VIEW_DEFINITIONS,
+  VIEW_PATHS,
+  type AppView,
+} from '@/lib/views';
+
+describe('view registry', () => {
+  it('keeps view ids, paths, and ordering unique', () => {
+    const viewIds = VIEW_DEFINITIONS.map((definition) => definition.view);
+    const paths = VIEW_DEFINITIONS.map((definition) => definition.path);
+    const orders = VIEW_DEFINITIONS.map((definition) => definition.order);
+
+    expect(new Set(viewIds).size).toBe(viewIds.length);
+    expect(new Set(paths).size).toBe(paths.length);
+    expect(new Set(orders).size).toBe(orders.length);
+    expect(orders).toEqual([...orders].sort((a, b) => a - b));
+  });
+
+  it('derives path and id lookups from the shared definitions', () => {
+    for (const definition of VIEW_DEFINITIONS) {
+      expect(VIEW_BY_ID[definition.view as AppView]).toBe(definition);
+      expect(VIEW_PATHS[definition.view as AppView]).toBe(definition.path);
+    }
+  });
+
+  it('requires every visible navigation view to declare a lazy loader and label metadata', () => {
+    const expectedNavigationViews = VIEW_DEFINITIONS.filter(
+      (definition) => definition.showInNavigation && definition.view !== 'board'
+    );
+
+    expect(NAVIGATION_VIEWS).toEqual(expectedNavigationViews);
+    for (const definition of NAVIGATION_VIEWS) {
+      expect(definition.label).toBeTruthy();
+      expect(definition.commandLabel).toContain(definition.label);
+      expect(typeof definition.loadComponent).toBe('function');
+    }
+  });
+});

--- a/web/src/components/search/SearchDialog.tsx
+++ b/web/src/components/search/SearchDialog.tsx
@@ -39,10 +39,8 @@ import {
 import { extractTaskId } from '@/lib/search-utils';
 import { cn } from '@/lib/utils';
 import { VIEW_BY_ID, type AppView } from '@/lib/views';
-import type {
-  TaskDetailNavigationTarget,
-  TaskDetailTabId,
-} from '@/components/task/TaskDetailPanel';
+import type { TaskDetailNavigationTarget, TaskDetailTabId } from '@/lib/task-detail-tabs';
+import { isTaskDetailTabId } from '@/lib/task-detail-tabs';
 
 const COLLECTIONS: { id: SearchCollection; label: string }[] = [
   { id: 'tasks-active', label: 'Active' },
@@ -74,21 +72,6 @@ const BACKENDS: { id: SearchBackend; label: string }[] = [
   { id: 'keyword', label: 'Keyword' },
   { id: 'qmd', label: 'QMD' },
 ];
-
-const TASK_DETAIL_TABS = new Set<TaskDetailTabId>([
-  'work',
-  'details',
-  'progress',
-  'work-products',
-  'observations',
-  'attachments',
-  'git',
-  'agent',
-  'timeline',
-  'changes',
-  'review',
-  'metrics',
-]);
 
 interface SearchDialogProps {
   open: boolean;
@@ -127,9 +110,7 @@ function isAppView(value: string | undefined): value is AppView {
 
 function taskNavigationTarget(target: SearchTarget): TaskDetailNavigationTarget | undefined {
   if (target.type !== 'task') return undefined;
-  const tab = TASK_DETAIL_TABS.has(target.tab as TaskDetailTabId)
-    ? (target.tab as TaskDetailTabId)
-    : undefined;
+  const tab: TaskDetailTabId | undefined = isTaskDetailTabId(target.tab) ? target.tab : undefined;
 
   if (!tab && !target.timelineAttemptId) return undefined;
 

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActionIcon,
   Badge,
@@ -14,47 +14,27 @@ import {
 import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import { useDebouncedSave } from '@/hooks/useDebouncedSave';
-import { TaskDetailsTab } from './detail/TaskDetailsTab';
-import { ProgressTab } from './detail/ProgressTab';
-import { GitSection } from './GitSection';
-import { AgentPanel } from './AgentPanel';
-import { DiffViewer } from './DiffViewer';
-import { ReviewPanel } from './ReviewPanel';
-import { PreviewPanel } from './PreviewPanel';
-import { AttachmentsSection } from './AttachmentsSection';
-import { ObservationsSection } from './ObservationsSection';
 import { ChatPanel } from '@/components/chat/ChatPanel';
 import { ApplyTemplateDialog } from './ApplyTemplateDialog';
-import { TaskMetricsPanel } from './TaskMetricsPanel';
 import { WorkflowSection } from './WorkflowSection';
-import { WorkProductsSection } from './WorkProductsSection';
-import { AgentRunTimelinePanel } from './AgentRunTimelinePanel';
-import { shouldDefaultTaskDetailToWork, TaskWorkView } from './TaskWorkView';
+import { shouldDefaultTaskDetailToWork } from './TaskWorkView';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
 import { useIdentity } from '@/hooks/useIdentity';
 import { clientAllowsLocalAgentControls } from '@/lib/client-policy';
-import {
-  BriefcaseBusiness,
-  GitBranch,
-  Bot,
-  FileDiff,
-  ClipboardCheck,
-  Monitor,
-  FileCode,
-  Paperclip,
-  Archive,
-  BarChart3,
-  MessageSquare,
-  NotebookPen,
-  Workflow,
-  Eye,
-  Files,
-  History,
-  X,
-  type LucideIcon,
-} from 'lucide-react';
-import type { Task, ReviewComment, ReviewState } from '@veritas-kanban/shared';
+import { Monitor, FileCode, Archive, MessageSquare, Workflow, X } from 'lucide-react';
+import type { Task } from '@veritas-kanban/shared';
 import { useAddObservation, useDeleteObservation } from '@/hooks/useTasks';
+import { PreviewPanel } from './PreviewPanel';
+import {
+  getAvailableTaskDetailTabs,
+  getFallbackTaskDetailTabId,
+  isTaskDetailTabAvailable,
+  isTaskDetailTabId,
+  type TaskDetailObservationInput,
+  type TaskDetailNavigationTarget,
+  type TaskDetailRenderContext,
+  type TaskDetailTabId,
+} from './task-detail-tabs';
 
 interface TaskDetailPanelProps {
   task: Task | null;
@@ -65,111 +45,7 @@ interface TaskDetailPanelProps {
   navigationTarget?: TaskDetailNavigationTarget | null;
 }
 
-export type TaskDetailTabId =
-  | 'work'
-  | 'details'
-  | 'progress'
-  | 'work-products'
-  | 'observations'
-  | 'attachments'
-  | 'git'
-  | 'agent'
-  | 'timeline'
-  | 'changes'
-  | 'review'
-  | 'metrics';
-
-export interface TaskDetailNavigationTarget {
-  tab?: TaskDetailTabId;
-  timelineAttemptId?: string | null;
-}
-
-interface TaskDetailTabDefinition {
-  id: TaskDetailTabId;
-  label: string;
-  Icon?: LucideIcon;
-  fallbackTitle?: string;
-  codeOnly?: boolean;
-  feature?: 'attachments';
-  disabledWithoutWorktree?: boolean;
-}
-
-const TASK_DETAIL_TABS: readonly TaskDetailTabDefinition[] = [
-  {
-    id: 'work',
-    label: 'Work',
-    Icon: BriefcaseBusiness,
-    fallbackTitle: 'Work view failed to load',
-  },
-  { id: 'details', label: 'Details' },
-  {
-    id: 'progress',
-    label: 'Progress',
-    Icon: NotebookPen,
-    fallbackTitle: 'Progress section failed to load',
-  },
-  {
-    id: 'work-products',
-    label: 'Work Products',
-    Icon: Files,
-    fallbackTitle: 'Work products section failed to load',
-  },
-  {
-    id: 'observations',
-    label: 'Observations',
-    Icon: Eye,
-    fallbackTitle: 'Observations section failed to load',
-  },
-  {
-    id: 'attachments',
-    label: 'Attachments',
-    Icon: Paperclip,
-    fallbackTitle: 'Attachments section failed to load',
-    feature: 'attachments',
-  },
-  {
-    id: 'git',
-    label: 'Git',
-    Icon: GitBranch,
-    fallbackTitle: 'Git section failed to load',
-    codeOnly: true,
-  },
-  {
-    id: 'agent',
-    label: 'Agent',
-    Icon: Bot,
-    fallbackTitle: 'Agent panel failed to load',
-    codeOnly: true,
-  },
-  {
-    id: 'timeline',
-    label: 'Timeline',
-    Icon: History,
-    fallbackTitle: 'Run timeline failed to load',
-    codeOnly: true,
-  },
-  {
-    id: 'changes',
-    label: 'Changes',
-    Icon: FileDiff,
-    fallbackTitle: 'Changes viewer failed to load',
-    codeOnly: true,
-    disabledWithoutWorktree: true,
-  },
-  {
-    id: 'review',
-    label: 'Review',
-    Icon: ClipboardCheck,
-    fallbackTitle: 'Review panel failed to load',
-    codeOnly: true,
-  },
-  {
-    id: 'metrics',
-    label: 'Metrics',
-    Icon: BarChart3,
-    fallbackTitle: 'Metrics panel failed to load',
-  },
-];
+export type { TaskDetailNavigationTarget, TaskDetailTabId } from './task-detail-tabs';
 
 export function TaskDetailPanel({
   task,
@@ -210,25 +86,44 @@ export function TaskDetailPanel({
   const hasWorktree = !!localTask?.git?.worktreePath;
   const activeTaskId = localTask?.id;
   const defaultTab = localTask && shouldDefaultTaskDetailToWork(localTask) ? 'work' : 'details';
-  const visibleTabs = useMemo(
-    () =>
-      TASK_DETAIL_TABS.filter((tab) => {
-        if (tab.codeOnly && !isCodeTask) return false;
-        if (tab.feature === 'attachments' && !taskSettings.enableAttachments) return false;
-        return true;
-      }).map((tab) => ({
-        ...tab,
-        disabled: tab.disabledWithoutWorktree && !hasWorktree,
-      })),
+  const tabAvailabilityContext = useMemo(
+    () => ({
+      isCodeTask,
+      hasWorktree,
+      attachmentsEnabled: taskSettings.enableAttachments,
+    }),
     [hasWorktree, isCodeTask, taskSettings.enableAttachments]
+  );
+  const visibleTabs = useMemo(
+    () => getAvailableTaskDetailTabs(tabAvailabilityContext),
+    [tabAvailabilityContext]
+  );
+  const fallbackTab = getFallbackTaskDetailTabId(visibleTabs, defaultTab);
+
+  const addObservationForTask = useMemo(
+    () => async (data: TaskDetailObservationInput) => {
+      if (!localTask) return;
+      await addObservation.mutateAsync({ taskId: localTask.id, data });
+    },
+    [addObservation, localTask]
+  );
+  const deleteObservationForTask = useMemo(
+    () => async (observationId: string) => {
+      if (!localTask) return;
+      await deleteObservation.mutateAsync({
+        taskId: localTask.id,
+        observationId,
+      });
+    },
+    [deleteObservation, localTask]
   );
 
   useEffect(() => {
-    const activeTabAvailable = visibleTabs.some((tab) => tab.id === activeTab && !tab.disabled);
+    const activeTabAvailable = isTaskDetailTabAvailable(visibleTabs, activeTab);
     if (!activeTabAvailable) {
-      setActiveTab(defaultTab);
+      setActiveTab(fallbackTab);
     }
-  }, [activeTab, defaultTab, visibleTabs]);
+  }, [activeTab, fallbackTab, visibleTabs]);
 
   useEffect(() => {
     if (!activeTaskId) {
@@ -239,18 +134,15 @@ export function TaskDetailPanel({
     if (lastDefaultedTaskIdRef.current === activeTaskId) return;
     lastDefaultedTaskIdRef.current = activeTaskId;
     setTimelineAttemptId(null);
-    setActiveTab(defaultTab);
-  }, [activeTaskId, defaultTab]);
+    setActiveTab(fallbackTab);
+  }, [activeTaskId, fallbackTab]);
 
   useEffect(() => {
     if (!activeTaskId || !navigationTarget) return;
     if (navigationTarget.timelineAttemptId !== undefined) {
       setTimelineAttemptId(navigationTarget.timelineAttemptId ?? null);
     }
-    if (
-      navigationTarget.tab &&
-      visibleTabs.some((tab) => tab.id === navigationTarget.tab && !tab.disabled)
-    ) {
+    if (navigationTarget.tab && isTaskDetailTabAvailable(visibleTabs, navigationTarget.tab)) {
       setActiveTab(navigationTarget.tab);
     }
   }, [activeTaskId, navigationTarget, visibleTabs]);
@@ -261,106 +153,20 @@ export function TaskDetailPanel({
   const currentType = taskTypes.find((t) => t.id === localTask.type);
   const TypeIconComponent = currentType ? getTypeIcon(currentType.icon) : null;
   const typeLabel = currentType ? currentType.label : localTask.type;
-  const renderTabContent = (tabId: TaskDetailTabId) => {
-    switch (tabId) {
-      case 'work':
-        return (
-          <TaskWorkView
-            task={localTask}
-            isCodeTask={isCodeTask}
-            readOnly={readOnly}
-            onOpenTab={setActiveTab}
-            onOpenChat={() => setTaskChatOpen(true)}
-            onOpenWorkflow={() => setWorkflowOpen(true)}
-          />
-        );
-      case 'details':
-        return (
-          <TaskDetailsTab
-            task={localTask}
-            onUpdate={updateField}
-            onClose={() => onOpenChange(false)}
-            readOnly={readOnly}
-            onRestore={onRestore}
-          />
-        );
-      case 'progress':
-        return <ProgressTab task={localTask} />;
-      case 'work-products':
-        return <WorkProductsSection taskId={localTask.id} />;
-      case 'observations':
-        return (
-          <ObservationsSection
-            task={localTask}
-            onAddObservation={async (data) => {
-              await addObservation.mutateAsync({ taskId: localTask.id, data });
-            }}
-            onDeleteObservation={async (observationId) => {
-              await deleteObservation.mutateAsync({
-                taskId: localTask.id,
-                observationId,
-              });
-            }}
-          />
-        );
-      case 'attachments':
-        return <AttachmentsSection task={localTask} />;
-      case 'git':
-        return (
-          <GitSection
-            task={localTask}
-            onGitChange={(git) => updateField('git', git as Task['git'])}
-          />
-        );
-      case 'agent':
-        return (
-          <AgentPanel
-            task={localTask}
-            onOpenTimeline={(attemptId) => {
-              setTimelineAttemptId(attemptId ?? null);
-              setActiveTab('timeline');
-            }}
-          />
-        );
-      case 'timeline':
-        return (
-          <AgentRunTimelinePanel
-            task={localTask}
-            initialAttemptId={timelineAttemptId}
-            onOpenTab={setActiveTab}
-            onOpenWorkflow={() => setWorkflowOpen(true)}
-          />
-        );
-      case 'changes':
-        if (!hasWorktree) return null;
-        return (
-          <DiffViewer
-            task={localTask}
-            onAddComment={(comment: ReviewComment) => {
-              const newComments = [...(localTask.reviewComments || []), comment];
-              updateField('reviewComments', newComments);
-            }}
-            onRemoveComment={(commentId: string) => {
-              const newComments = (localTask.reviewComments || []).filter(
-                (comment) => comment.id !== commentId
-              );
-              updateField('reviewComments', newComments.length > 0 ? newComments : undefined);
-            }}
-          />
-        );
-      case 'review':
-        return (
-          <ReviewPanel
-            task={localTask}
-            onReview={(review: ReviewState) => {
-              updateField('review', Object.keys(review).length > 0 ? review : undefined);
-            }}
-            onMergeComplete={() => onOpenChange(false)}
-          />
-        );
-      case 'metrics':
-        return <TaskMetricsPanel task={localTask} />;
-    }
+  const tabRenderContext: TaskDetailRenderContext = {
+    ...tabAvailabilityContext,
+    task: localTask,
+    readOnly,
+    timelineAttemptId,
+    updateField,
+    onClose: () => onOpenChange(false),
+    onRestore,
+    setActiveTab,
+    openTaskChat: () => setTaskChatOpen(true),
+    openWorkflow: () => setWorkflowOpen(true),
+    setTimelineAttemptId,
+    addObservation: addObservationForTask,
+    deleteObservation: deleteObservationForTask,
   };
 
   return (
@@ -500,7 +306,7 @@ export function TaskDetailPanel({
               <Tabs
                 value={activeTab}
                 onChange={(value) => {
-                  if (value) setActiveTab(value as TaskDetailTabId);
+                  if (isTaskDetailTabId(value)) setActiveTab(value);
                 }}
                 className="flex flex-1 flex-col overflow-hidden px-4 pt-3 pb-6 sm:px-6"
               >
@@ -522,17 +328,31 @@ export function TaskDetailPanel({
                 </Tabs.List>
 
                 <div className="mt-4 flex-1 overflow-y-auto pr-1">
-                  {visibleTabs.map((tab) => (
-                    <Tabs.Panel key={tab.id} value={tab.id} className="mt-0">
-                      {tab.fallbackTitle ? (
-                        <FeatureErrorBoundary fallbackTitle={tab.fallbackTitle}>
-                          {renderTabContent(tab.id)}
-                        </FeatureErrorBoundary>
-                      ) : (
-                        renderTabContent(tab.id)
-                      )}
-                    </Tabs.Panel>
-                  ))}
+                  {visibleTabs.map((tab) => {
+                    const tabContent = (
+                      <Suspense
+                        fallback={
+                          <Text size="sm" c="dimmed">
+                            Loading {tab.label}...
+                          </Text>
+                        }
+                      >
+                        {tab.render(tabRenderContext)}
+                      </Suspense>
+                    );
+
+                    return (
+                      <Tabs.Panel key={tab.id} value={tab.id} className="mt-0">
+                        {tab.fallbackTitle ? (
+                          <FeatureErrorBoundary fallbackTitle={tab.fallbackTitle}>
+                            {tabContent}
+                          </FeatureErrorBoundary>
+                        ) : (
+                          tabContent
+                        )}
+                      </Tabs.Panel>
+                    );
+                  })}
                 </div>
               </Tabs>
             </Stack>

--- a/web/src/components/task/task-detail-tabs.tsx
+++ b/web/src/components/task/task-detail-tabs.tsx
@@ -1,0 +1,215 @@
+import { lazy, type ReactNode } from 'react';
+import {
+  BarChart3,
+  Bot,
+  BriefcaseBusiness,
+  ClipboardCheck,
+  Eye,
+  FileDiff,
+  Files,
+  GitBranch,
+  History,
+  NotebookPen,
+  Paperclip,
+  type LucideIcon,
+} from 'lucide-react';
+import type { ObservationType, ReviewComment, ReviewState, Task } from '@veritas-kanban/shared';
+import {
+  getAvailableTaskDetailTabMetadata,
+  getFallbackTaskDetailTabId,
+  isTaskDetailTabAvailable,
+  isTaskDetailTabId,
+  TASK_DETAIL_TAB_METADATA,
+  type AvailableTaskDetailTabMetadata,
+  type TaskDetailAvailabilityContext,
+  type TaskDetailTabIcon,
+  type TaskDetailTabId,
+  type TaskDetailTabMetadata,
+} from '@/lib/task-detail-tabs';
+import { TaskDetailsTab } from './detail/TaskDetailsTab';
+import { TaskWorkView } from './TaskWorkView';
+
+const AgentPanel = lazy(() => import('./AgentPanel').then((mod) => ({ default: mod.AgentPanel })));
+const AgentRunTimelinePanel = lazy(() =>
+  import('./AgentRunTimelinePanel').then((mod) => ({ default: mod.AgentRunTimelinePanel }))
+);
+const AttachmentsSection = lazy(() =>
+  import('./AttachmentsSection').then((mod) => ({ default: mod.AttachmentsSection }))
+);
+const DiffViewer = lazy(() => import('./DiffViewer').then((mod) => ({ default: mod.DiffViewer })));
+const GitSection = lazy(() => import('./GitSection').then((mod) => ({ default: mod.GitSection })));
+const ObservationsSection = lazy(() =>
+  import('./ObservationsSection').then((mod) => ({ default: mod.ObservationsSection }))
+);
+const ProgressTab = lazy(() =>
+  import('./detail/ProgressTab').then((mod) => ({ default: mod.ProgressTab }))
+);
+const ReviewPanel = lazy(() =>
+  import('./ReviewPanel').then((mod) => ({ default: mod.ReviewPanel }))
+);
+const TaskMetricsPanel = lazy(() =>
+  import('./TaskMetricsPanel').then((mod) => ({ default: mod.TaskMetricsPanel }))
+);
+const WorkProductsSection = lazy(() =>
+  import('./WorkProductsSection').then((mod) => ({ default: mod.WorkProductsSection }))
+);
+
+export type {
+  TaskDetailAvailabilityContext,
+  TaskDetailNavigationTarget,
+  TaskDetailTabId,
+} from '@/lib/task-detail-tabs';
+export { getFallbackTaskDetailTabId, isTaskDetailTabAvailable, isTaskDetailTabId };
+
+export interface TaskDetailObservationInput {
+  type: ObservationType;
+  content: string;
+  score: number;
+  agent?: string;
+}
+
+export interface TaskDetailRenderContext extends TaskDetailAvailabilityContext {
+  task: Task;
+  readOnly: boolean;
+  timelineAttemptId: string | null;
+  updateField: <K extends keyof Task>(field: K, value: Task[K]) => void;
+  onClose: () => void;
+  onRestore?: (taskId: string) => void;
+  setActiveTab: (tab: TaskDetailTabId) => void;
+  openTaskChat: () => void;
+  openWorkflow: () => void;
+  setTimelineAttemptId: (attemptId: string | null) => void;
+  addObservation: (data: TaskDetailObservationInput) => Promise<void>;
+  deleteObservation: (observationId: string) => Promise<void>;
+}
+
+export interface TaskDetailTabDefinition extends TaskDetailTabMetadata {
+  Icon?: LucideIcon;
+  render: (context: TaskDetailRenderContext) => ReactNode;
+}
+
+export type AvailableTaskDetailTab = TaskDetailTabDefinition &
+  Pick<AvailableTaskDetailTabMetadata, 'disabled'>;
+
+const TAB_ICONS: Record<TaskDetailTabIcon, LucideIcon> = {
+  BarChart3,
+  Bot,
+  BriefcaseBusiness,
+  ClipboardCheck,
+  Eye,
+  FileDiff,
+  Files,
+  GitBranch,
+  History,
+  NotebookPen,
+  Paperclip,
+};
+
+const TAB_RENDERERS: Record<TaskDetailTabId, (context: TaskDetailRenderContext) => ReactNode> = {
+  work: ({ task, isCodeTask, readOnly, setActiveTab, openTaskChat, openWorkflow }) => (
+    <TaskWorkView
+      task={task}
+      isCodeTask={isCodeTask}
+      readOnly={readOnly}
+      onOpenTab={setActiveTab}
+      onOpenChat={openTaskChat}
+      onOpenWorkflow={openWorkflow}
+    />
+  ),
+  details: ({ task, updateField, onClose, readOnly, onRestore }) => (
+    <TaskDetailsTab
+      task={task}
+      onUpdate={updateField}
+      onClose={onClose}
+      readOnly={readOnly}
+      onRestore={onRestore}
+    />
+  ),
+  progress: ({ task }) => <ProgressTab task={task} />,
+  'work-products': ({ task }) => <WorkProductsSection taskId={task.id} />,
+  observations: ({ task, addObservation, deleteObservation }) => (
+    <ObservationsSection
+      task={task}
+      onAddObservation={addObservation}
+      onDeleteObservation={deleteObservation}
+    />
+  ),
+  attachments: ({ task }) => <AttachmentsSection task={task} />,
+  git: ({ task, updateField }) => (
+    <GitSection task={task} onGitChange={(git) => updateField('git', git as Task['git'])} />
+  ),
+  agent: ({ task, setTimelineAttemptId, setActiveTab }) => (
+    <AgentPanel
+      task={task}
+      onOpenTimeline={(attemptId) => {
+        setTimelineAttemptId(attemptId ?? null);
+        setActiveTab('timeline');
+      }}
+    />
+  ),
+  timeline: ({ task, timelineAttemptId, setActiveTab, openWorkflow }) => (
+    <AgentRunTimelinePanel
+      task={task}
+      initialAttemptId={timelineAttemptId}
+      onOpenTab={setActiveTab}
+      onOpenWorkflow={openWorkflow}
+    />
+  ),
+  changes: ({ task, hasWorktree, updateField }) => {
+    if (!hasWorktree) return null;
+    return (
+      <DiffViewer
+        task={task}
+        onAddComment={(comment: ReviewComment) => {
+          const newComments = [...(task.reviewComments || []), comment];
+          updateField('reviewComments', newComments);
+        }}
+        onRemoveComment={(commentId: string) => {
+          const newComments = (task.reviewComments || []).filter(
+            (comment) => comment.id !== commentId
+          );
+          updateField('reviewComments', newComments.length > 0 ? newComments : undefined);
+        }}
+      />
+    );
+  },
+  review: ({ task, updateField, onClose }) => (
+    <ReviewPanel
+      task={task}
+      onReview={(review: ReviewState) => {
+        updateField('review', Object.keys(review).length > 0 ? review : undefined);
+      }}
+      onMergeComplete={onClose}
+    />
+  ),
+  metrics: ({ task }) => <TaskMetricsPanel task={task} />,
+};
+
+export const TASK_DETAIL_TABS: readonly TaskDetailTabDefinition[] = TASK_DETAIL_TAB_METADATA.map(
+  (tab) => ({
+    ...tab,
+    Icon: tab.icon ? TAB_ICONS[tab.icon] : undefined,
+    render: TAB_RENDERERS[tab.id],
+  })
+);
+
+export function getAvailableTaskDetailTabs(
+  context: TaskDetailAvailabilityContext
+): AvailableTaskDetailTab[] {
+  const tabsById = new Map(TASK_DETAIL_TABS.map((tab) => [tab.id, tab]));
+  return getAvailableTaskDetailTabMetadata(context).map((tab) => ({
+    ...getTaskDetailTabDefinition(tabsById, tab.id),
+    disabled: tab.disabled,
+  }));
+}
+
+function getTaskDetailTabDefinition(
+  tabsById: ReadonlyMap<TaskDetailTabId, TaskDetailTabDefinition>,
+  tabId: TaskDetailTabId
+): TaskDetailTabDefinition {
+  const definition = tabsById.get(tabId);
+  if (!definition) {
+    throw new Error(`Task detail tab ${tabId} is missing a renderer.`);
+  }
+  return definition;
+}

--- a/web/src/lib/task-detail-tabs.ts
+++ b/web/src/lib/task-detail-tabs.ts
@@ -1,0 +1,157 @@
+export type TaskDetailTabId =
+  | 'work'
+  | 'details'
+  | 'progress'
+  | 'work-products'
+  | 'observations'
+  | 'attachments'
+  | 'git'
+  | 'agent'
+  | 'timeline'
+  | 'changes'
+  | 'review'
+  | 'metrics';
+
+export interface TaskDetailNavigationTarget {
+  tab?: TaskDetailTabId;
+  timelineAttemptId?: string | null;
+}
+
+export interface TaskDetailAvailabilityContext {
+  isCodeTask: boolean;
+  hasWorktree: boolean;
+  attachmentsEnabled: boolean;
+}
+
+export type TaskDetailTabIcon =
+  | 'BarChart3'
+  | 'Bot'
+  | 'BriefcaseBusiness'
+  | 'ClipboardCheck'
+  | 'Eye'
+  | 'FileDiff'
+  | 'Files'
+  | 'GitBranch'
+  | 'History'
+  | 'NotebookPen'
+  | 'Paperclip';
+
+export interface TaskDetailTabMetadata {
+  id: TaskDetailTabId;
+  label: string;
+  icon?: TaskDetailTabIcon;
+  fallbackTitle?: string;
+  isVisible?: (context: TaskDetailAvailabilityContext) => boolean;
+  isDisabled?: (context: TaskDetailAvailabilityContext) => boolean;
+}
+
+export type AvailableTaskDetailTabMetadata = TaskDetailTabMetadata & { disabled: boolean };
+
+export const TASK_DETAIL_TAB_METADATA: readonly TaskDetailTabMetadata[] = [
+  {
+    id: 'work',
+    label: 'Work',
+    icon: 'BriefcaseBusiness',
+    fallbackTitle: 'Work view failed to load',
+  },
+  { id: 'details', label: 'Details' },
+  {
+    id: 'progress',
+    label: 'Progress',
+    icon: 'NotebookPen',
+    fallbackTitle: 'Progress section failed to load',
+  },
+  {
+    id: 'work-products',
+    label: 'Work Products',
+    icon: 'Files',
+    fallbackTitle: 'Work products section failed to load',
+  },
+  {
+    id: 'observations',
+    label: 'Observations',
+    icon: 'Eye',
+    fallbackTitle: 'Observations section failed to load',
+  },
+  {
+    id: 'attachments',
+    label: 'Attachments',
+    icon: 'Paperclip',
+    fallbackTitle: 'Attachments section failed to load',
+    isVisible: ({ attachmentsEnabled }) => attachmentsEnabled,
+  },
+  {
+    id: 'git',
+    label: 'Git',
+    icon: 'GitBranch',
+    fallbackTitle: 'Git section failed to load',
+    isVisible: ({ isCodeTask }) => isCodeTask,
+  },
+  {
+    id: 'agent',
+    label: 'Agent',
+    icon: 'Bot',
+    fallbackTitle: 'Agent panel failed to load',
+    isVisible: ({ isCodeTask }) => isCodeTask,
+  },
+  {
+    id: 'timeline',
+    label: 'Timeline',
+    icon: 'History',
+    fallbackTitle: 'Run timeline failed to load',
+    isVisible: ({ isCodeTask }) => isCodeTask,
+  },
+  {
+    id: 'changes',
+    label: 'Changes',
+    icon: 'FileDiff',
+    fallbackTitle: 'Changes viewer failed to load',
+    isVisible: ({ isCodeTask }) => isCodeTask,
+    isDisabled: ({ hasWorktree }) => !hasWorktree,
+  },
+  {
+    id: 'review',
+    label: 'Review',
+    icon: 'ClipboardCheck',
+    fallbackTitle: 'Review panel failed to load',
+    isVisible: ({ isCodeTask }) => isCodeTask,
+  },
+  {
+    id: 'metrics',
+    label: 'Metrics',
+    icon: 'BarChart3',
+    fallbackTitle: 'Metrics panel failed to load',
+  },
+];
+
+const TASK_DETAIL_TAB_IDS = new Set(TASK_DETAIL_TAB_METADATA.map((tab) => tab.id));
+
+export function isTaskDetailTabId(value: string | null | undefined): value is TaskDetailTabId {
+  return Boolean(value && TASK_DETAIL_TAB_IDS.has(value as TaskDetailTabId));
+}
+
+export function getAvailableTaskDetailTabMetadata(
+  context: TaskDetailAvailabilityContext
+): AvailableTaskDetailTabMetadata[] {
+  return TASK_DETAIL_TAB_METADATA.filter((tab) => tab.isVisible?.(context) ?? true).map((tab) => ({
+    ...tab,
+    disabled: tab.isDisabled?.(context) ?? false,
+  }));
+}
+
+export function isTaskDetailTabAvailable(
+  tabs: readonly AvailableTaskDetailTabMetadata[],
+  tabId: TaskDetailTabId
+): boolean {
+  return tabs.some((tab) => tab.id === tabId && !tab.disabled);
+}
+
+export function getFallbackTaskDetailTabId(
+  tabs: readonly AvailableTaskDetailTabMetadata[],
+  preferredTab: TaskDetailTabId
+): TaskDetailTabId {
+  if (isTaskDetailTabAvailable(tabs, preferredTab)) return preferredTab;
+  const detailsTab = tabs.find((tab) => tab.id === 'details' && !tab.disabled);
+  if (detailsTab) return detailsTab.id;
+  return tabs.find((tab) => !tab.disabled)?.id ?? 'details';
+}

--- a/web/src/lib/views.ts
+++ b/web/src/lib/views.ts
@@ -1,3 +1,5 @@
+import type { ComponentType } from 'react';
+
 export type AppView =
   | 'board'
   | 'activity'
@@ -24,22 +26,33 @@ export type ViewIcon =
   | 'ShieldAlert'
   | 'Workflow';
 
+export interface ViewComponentProps {
+  onBack: () => void;
+  onTaskClick?: (taskId: string) => void;
+}
+
 export interface ViewDefinition {
   view: AppView;
   path: string;
   label: string;
+  order: number;
+  showInNavigation: boolean;
+  featureFlag?: string;
   title?: string;
   commandLabel: string;
   loadingLabel?: string;
   icon: ViewIcon;
   keywords: readonly string[];
+  loadComponent?: () => Promise<{ default: ComponentType<ViewComponentProps> }>;
 }
 
-export const VIEW_DEFINITIONS: readonly ViewDefinition[] = [
+const VIEW_DEFINITION_LIST = [
   {
     view: 'board',
     path: '/',
     label: 'Board',
+    order: 0,
+    showInNavigation: false,
     commandLabel: 'Go to Board',
     icon: 'LayoutDashboard',
     keywords: ['kanban', 'home', 'main'],
@@ -48,85 +61,143 @@ export const VIEW_DEFINITIONS: readonly ViewDefinition[] = [
     view: 'activity',
     path: '/activity',
     label: 'Activity',
+    order: 10,
+    showInNavigation: true,
     commandLabel: 'Go to Activity',
     loadingLabel: 'Loading activity feed...',
     icon: 'ListOrdered',
     keywords: ['feed', 'log', 'history'],
+    loadComponent: () =>
+      import('@/components/activity/ActivityFeed').then((mod) => ({
+        default: mod.ActivityFeed,
+      })),
   },
   {
     view: 'backlog',
     path: '/backlog',
     label: 'Backlog',
+    order: 20,
+    showInNavigation: true,
     commandLabel: 'Go to Backlog',
     loadingLabel: 'Loading backlog...',
     icon: 'Inbox',
     keywords: ['someday', 'maybe', 'later'],
+    loadComponent: () =>
+      import('@/components/backlog/BacklogPage').then((mod) => ({
+        default: mod.BacklogPage,
+      })),
   },
   {
     view: 'archive',
     path: '/archive',
     label: 'Archive',
+    order: 30,
+    showInNavigation: true,
     commandLabel: 'Go to Archive',
     loadingLabel: 'Loading archive...',
     icon: 'Archive',
     keywords: ['done', 'completed', 'old'],
+    loadComponent: () =>
+      import('@/components/archive/ArchivePage').then((mod) => ({
+        default: mod.ArchivePage,
+      })),
   },
   {
     view: 'templates',
     path: '/templates',
     label: 'Templates',
+    order: 40,
+    showInNavigation: true,
     commandLabel: 'Go to Templates',
     loadingLabel: 'Loading templates...',
     icon: 'FileText',
     keywords: ['templates', 'repeatable', 'task'],
+    loadComponent: () =>
+      import('@/components/templates/TemplatesPage').then((mod) => ({
+        default: mod.TemplatesPage,
+      })),
   },
   {
     view: 'workflows',
     path: '/workflows',
     label: 'Workflows',
+    order: 50,
+    showInNavigation: true,
     commandLabel: 'Go to Workflows',
     loadingLabel: 'Loading workflows...',
     icon: 'Workflow',
     keywords: ['automation', 'runs', 'workflow'],
+    loadComponent: () =>
+      import('@/components/workflows/WorkflowsPage').then((mod) => ({
+        default: mod.WorkflowsPage,
+      })),
   },
   {
     view: 'drift',
     path: '/drift',
     label: 'Drift Monitor',
+    order: 60,
+    showInNavigation: true,
     commandLabel: 'Go to Drift Monitor',
     loadingLabel: 'Loading drift monitor...',
     icon: 'Activity',
     keywords: ['behavior', 'anomaly', 'z-score', 'alerts'],
+    loadComponent: () =>
+      import('@/components/drift/DriftMonitor').then((mod) => ({
+        default: mod.DriftMonitor,
+      })),
   },
   {
     view: 'decisions',
     path: '/decisions',
     label: 'Decisions',
+    order: 70,
+    showInNavigation: true,
     title: 'Decision Audit Trail',
     commandLabel: 'Go to Decisions',
     loadingLabel: 'Loading decisions...',
     icon: 'GitBranch',
     keywords: ['audit', 'reasoning', 'assumptions'],
+    loadComponent: () =>
+      import('@/components/decisions/DecisionExplorer').then((mod) => ({
+        default: mod.DecisionExplorer,
+      })),
   },
   {
     view: 'scoring',
     path: '/scoring',
     label: 'Scoring',
+    order: 80,
+    showInNavigation: true,
     commandLabel: 'Go to Scoring',
     loadingLabel: 'Loading scoring...',
     icon: 'Scale',
     keywords: ['score', 'prioritize', 'value'],
+    loadComponent: () =>
+      import('@/components/scoring/ScoringProfiles').then((mod) => ({
+        default: mod.ScoringProfiles,
+      })),
   },
   {
     view: 'policies',
     path: '/policies',
     label: 'Policies',
+    order: 90,
+    showInNavigation: true,
     commandLabel: 'Go to Policies',
     loadingLabel: 'Loading policies...',
     icon: 'ShieldAlert',
     keywords: ['governance', 'rules', 'guardrails'],
+    loadComponent: () =>
+      import('@/components/policies/PolicyManager').then((mod) => ({
+        default: mod.PolicyManager,
+      })),
   },
-];
+] satisfies ViewDefinition[];
+
+export const VIEW_DEFINITIONS: readonly ViewDefinition[] = VIEW_DEFINITION_LIST.sort(
+  (a, b) => a.order - b.order
+);
 
 export const VIEW_PATHS = Object.fromEntries(
   VIEW_DEFINITIONS.map((definition) => [definition.view, definition.path])
@@ -138,5 +209,5 @@ export const VIEW_BY_ID = Object.fromEntries(
 
 export const NAVIGATION_VIEWS = VIEW_DEFINITIONS.filter(
   (definition): definition is ViewDefinition & { view: NavigationView } =>
-    definition.view !== 'board'
+    definition.showInNavigation && definition.view !== 'board'
 );


### PR DESCRIPTION
## Summary
- Added a shared top-level view registry with route, label, ordering, icon, command metadata, and lazy component loaders.
- Drove app view rendering, header navigation, and command navigation from the shared view definitions.
- Added a task-detail tab metadata registry plus render registry, including availability guards and fallback when a tab becomes hidden or disabled.
- Updated search and regression tests to use the shared task tab metadata.

## Verification
- pnpm --filter @veritas-kanban/web test -- view-registry.test.ts command-registry.test.ts SearchDialog.test.tsx task-detail-mantine.test.tsx
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web build
- pnpm --filter @veritas-kanban/server build
- pnpm exec prettier --check web/src/App.tsx web/src/lib/views.ts web/src/lib/task-detail-tabs.ts web/src/components/task/TaskDetailPanel.tsx web/src/components/task/task-detail-tabs.tsx web/src/components/search/SearchDialog.tsx web/src/__tests__/view-registry.test.ts web/src/__tests__/SearchDialog.test.tsx web/src/__tests__/task-detail-mantine.test.tsx
- git diff --check
- pnpm lint:budget
- Browser smoke on isolated local data dir: board loaded, Activity/Backlog/Policies header routes loaded, command palette navigated to Backlog, code task Timeline tab fell back to Details when reopening a feature task.

## Notes
- Browser smoke observed local WebSocket keepalive reconnect warnings only; no route or task-detail render errors.

Closes #397