### PR TITLE
Split oversized frontend chunks

### DIFF
--- a/docs/testing/frontend-chunk-budget.md
+++ b/docs/testing/frontend-chunk-budget.md
@@ -1,0 +1,40 @@
+# Frontend Chunk Budget
+
+Veritas uses Vite's production chunk warning as the first-line bundle guard.
+
+## Budget
+
+- Individual minified JavaScript chunks should stay under 400 KiB.
+- `web/vite.config.ts` sets `build.chunkSizeWarningLimit` to `400`.
+- Do not raise this limit without documenting the specific chunk, why it is not avoidable, and what would be required to reduce it.
+
+## Expected Large Chunks
+
+These chunks are expected to be among the largest after the v5 route split:
+
+- Chart chunks generated from lazy chart modules such as `TrendsCharts`, `DriftMonitor`, or `ScoreExplorer`. They should be loaded by chart-heavy surfaces, not by the initial board route.
+- `vendor-mantine`: Mantine UI runtime. Shared by the primary app shell and dialogs.
+- `TaskDetailPanel`: Task drawer shell and the always-present work/details tab surfaces.
+- `index`: Authenticated app shell, board, header, providers, and core routing.
+
+## Loading Rules
+
+- Board rendering must not statically import dashboard/chart-heavy code.
+- Dashboard trend charts are deferred until the chart section approaches the viewport.
+- Settings dialog tabs stay lazy-loaded by active tab.
+- Workflow dashboard and scoring explorer panels stay lazy-loaded behind their explicit UI entry points.
+
+## Verification
+
+For bundle work, use:
+
+```bash
+pnpm --filter @veritas-kanban/web build
+```
+
+Then confirm the build has no avoidable chunk-size warning and smoke these rendered paths:
+
+- board load
+- dashboard render and deferred trends section
+- settings dialog
+- task detail drawer

--- a/web/src/__tests__/governance-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/governance-surfaces-mantine.test.tsx
@@ -519,10 +519,11 @@ describe('governance surfaces Mantine migration', () => {
     expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Textarea-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
+    expect(screen.queryByText('Composite Score Trend')).toBeNull();
 
     await user.click(screen.getByRole('tab', { name: /score explorer/i }));
 
-    expect(screen.getByText('Composite Score Trend')).toBeDefined();
+    expect(await screen.findByText('Composite Score Trend')).toBeDefined();
     expect(baseElement.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(2);
     expectNoLegacySlots(baseElement);
   });

--- a/web/src/__tests__/lazy-on-visible.test.tsx
+++ b/web/src/__tests__/lazy-on-visible.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+
+import { LazyOnVisible } from '@/components/shared/LazyOnVisible';
+
+describe('LazyOnVisible', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders children only after the container enters the viewport', () => {
+    let observerCallback: IntersectionObserverCallback | undefined;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+
+    class MockIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        observerCallback = callback;
+      }
+
+      observe = observe;
+      disconnect = disconnect;
+    }
+
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
+    render(
+      <LazyOnVisible fallback={<span>Deferred section</span>}>
+        <span>Loaded section</span>
+      </LazyOnVisible>
+    );
+
+    expect(screen.getByText('Deferred section')).toBeDefined();
+    expect(screen.queryByText('Loaded section')).toBeNull();
+    expect(observe).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      observerCallback?.(
+        [
+          {
+            isIntersecting: true,
+            intersectionRatio: 1,
+          } as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver
+      );
+    });
+
+    expect(screen.getByText('Loaded section')).toBeDefined();
+    expect(screen.queryByText('Deferred section')).toBeNull();
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -23,13 +23,14 @@ import { CheckSquare } from 'lucide-react';
 import { Button } from '@mantine/core';
 import { ArchiveSuggestionBanner } from './ArchiveSuggestionBanner';
 import FeatureErrorBoundary from '@/components/shared/FeatureErrorBoundary';
+import { LazyOnVisible } from '@/components/shared/LazyOnVisible';
 import { useLiveAnnouncer } from '@/components/shared/LiveAnnouncer';
 import { useView } from '@/contexts/ViewContext';
 import { useIdentity } from '@/hooks/useIdentity';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
 
-// Lazy-load Dashboard to split recharts + d3 (~800KB) out of main bundle
+// Lazy-load Dashboard so board startup does not include dashboard-heavy code paths.
 const Dashboard = lazy(() =>
   import('@/components/dashboard/Dashboard').then((mod) => ({
     default: mod.Dashboard,
@@ -381,24 +382,20 @@ export function KanbanBoard() {
         </div>
 
         {featureSettings.board.showDashboard && (
-          <Suspense
-            fallback={
-              <div
-                className="mt-6 border-t pt-4 flex items-center justify-center py-8 text-muted-foreground"
-                role="status"
-              >
-                Loading dashboard…
-              </div>
-            }
+          <LazyOnVisible
+            className="mt-6 border-t pt-4"
+            fallback={<DashboardLoadingFallback />}
+            minHeight={192}
+            rootMargin="0px 0px"
           >
-            <div className="mt-6 border-t pt-4">
+            <Suspense fallback={<DashboardLoadingFallback />}>
               <Dashboard
                 onTaskClick={(taskId, target) => {
                   void handleTaskIdClick(taskId, target);
                 }}
               />
-            </div>
-          </Suspense>
+            </Suspense>
+          </LazyOnVisible>
         )}
       </FeatureErrorBoundary>
 
@@ -414,5 +411,16 @@ export function KanbanBoard() {
         </Suspense>
       )}
     </>
+  );
+}
+
+function DashboardLoadingFallback() {
+  return (
+    <div
+      className="flex min-h-48 items-center justify-center py-8 text-muted-foreground"
+      role="status"
+    >
+      Loading dashboard…
+    </div>
   );
 }

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { Skeleton } from '@mantine/core';
 import {
   useMetrics,
@@ -22,7 +22,6 @@ import { TasksDrillDown } from './TasksDrillDown';
 import { ErrorsDrillDown } from './ErrorsDrillDown';
 import { TokensDrillDown } from './TokensDrillDown';
 import { DurationDrillDown } from './DurationDrillDown';
-import { TrendsCharts } from './TrendsCharts';
 import { StatusTimeline } from './StatusTimeline';
 import { AgentComparison } from './AgentComparison';
 import { WhereTimeWent } from './WhereTimeWent';
@@ -34,6 +33,11 @@ import { EnforcementIndicator } from './EnforcementIndicator';
 import { NeedsAttentionQueue } from './NeedsAttentionQueue';
 import { useView } from '@/contexts/ViewContext';
 import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
+import { LazyOnVisible } from '@/components/shared/LazyOnVisible';
+
+const LazyTrendsCharts = lazy(() =>
+  import('./TrendsCharts').then((mod) => ({ default: mod.TrendsCharts }))
+);
 
 // Trend indicator component
 // direction: 'up' always means improvement, 'down' means decline (from backend)
@@ -114,6 +118,15 @@ function StatRow({ label, value, subLabel, highlight }: StatRowProps) {
         <span className={cn('font-semibold', highlight && 'text-primary')}>{value}</span>
         {subLabel && <span className="text-xs text-muted-foreground ml-1">({subLabel})</span>}
       </div>
+    </div>
+  );
+}
+
+function DeferredDashboardSection({ title }: { title: string }) {
+  return (
+    <div className="rounded-lg border bg-card p-4" role="status" aria-label={`Loading ${title}`}>
+      <div className="mb-3 text-sm font-medium text-muted-foreground">{title}</div>
+      <Skeleton className="h-[260px] rounded-md" />
     </div>
   );
 }
@@ -465,9 +478,16 @@ export function Dashboard({ onTaskClick }: DashboardProps = {}) {
 
       {/* Historical Trends Charts (full width) */}
       {widgets.showTrendsCharts && (
-        <div className="col-span-full">
-          <TrendsCharts project={project} />
-        </div>
+        <LazyOnVisible
+          className="col-span-full"
+          minHeight={320}
+          rootMargin="0px 0px"
+          fallback={<DeferredDashboardSection title="Historical Trends" />}
+        >
+          <Suspense fallback={<DeferredDashboardSection title="Historical Trends" />}>
+            <LazyTrendsCharts project={project} />
+          </Suspense>
+        </LazyOnVisible>
       )}
 
       {/* Drill-Down Panel */}

--- a/web/src/components/scoring/ScoringProfiles.tsx
+++ b/web/src/components/scoring/ScoringProfiles.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import type {
   CreateScoringProfileInput,
   EvaluationRequest,
@@ -25,7 +25,10 @@ import {
   useScoringProfiles,
   useUpdateScoringProfile,
 } from '@/hooks/useScoring';
-import { ScoreExplorer } from './ScoreExplorer';
+
+const ScoreExplorer = lazy(() =>
+  import('./ScoreExplorer').then((mod) => ({ default: mod.ScoreExplorer }))
+);
 
 interface ScoringProfilesProps {
   onBack: () => void;
@@ -269,6 +272,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
         <Tabs
           value={activeTab}
           onChange={(value) => setActiveTab(value ?? 'profiles')}
+          keepMounted={false}
           className="flex h-full flex-col gap-4"
         >
           <Tabs.List className="w-fit">
@@ -746,7 +750,15 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
           </Tabs.Panel>
 
           <Tabs.Panel value="explorer" className="m-0 min-h-0 flex-1 overflow-auto">
-            <ScoreExplorer profiles={profiles} />
+            <Suspense
+              fallback={
+                <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+                  Loading score explorer...
+                </div>
+              }
+            >
+              <ScoreExplorer profiles={profiles} />
+            </Suspense>
           </Tabs.Panel>
         </Tabs>
       </div>

--- a/web/src/components/shared/LazyOnVisible.tsx
+++ b/web/src/components/shared/LazyOnVisible.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+
+interface LazyOnVisibleProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  rootMargin?: string;
+  className?: string;
+  minHeight?: CSSProperties['minHeight'];
+}
+
+export function LazyOnVisible({
+  children,
+  fallback = null,
+  rootMargin = '320px 0px',
+  className,
+  minHeight,
+}: LazyOnVisibleProps) {
+  const [shouldRender, setShouldRender] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (shouldRender) return;
+
+    const node = containerRef.current;
+    if (!node) return;
+
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+      setShouldRender(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting || entry.intersectionRatio > 0)) {
+          setShouldRender(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [rootMargin, shouldRender]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={!shouldRender && minHeight ? { minHeight } : undefined}
+    >
+      {shouldRender ? children : fallback}
+    </div>
+  );
+}

--- a/web/src/components/workflows/WorkflowsPage.tsx
+++ b/web/src/components/workflows/WorkflowsPage.tsx
@@ -9,7 +9,7 @@
  * - Empty state when no workflows exist
  */
 
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { lazy, Suspense, useState, useMemo, useEffect, useCallback } from 'react';
 import {
   Badge,
   Button,
@@ -25,10 +25,13 @@ import {
 import { ArrowLeft, Search, Play, Users, ListOrdered, BarChart3 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { WorkflowRunList } from './WorkflowRunList';
-import { WorkflowDashboard } from './WorkflowDashboard';
 import { WorkflowAuthoringPanel } from './WorkflowAuthoringPanel';
 import { useIdentity } from '@/hooks/useIdentity';
 import { workflowsApi, type WorkflowSummary } from '@/lib/api/workflows';
+
+const WorkflowDashboard = lazy(() =>
+  import('./WorkflowDashboard').then((mod) => ({ default: mod.WorkflowDashboard }))
+);
 
 interface WorkflowsPageProps {
   onBack: () => void;
@@ -99,7 +102,19 @@ export function WorkflowsPage({ onBack }: WorkflowsPageProps) {
   };
 
   if (showDashboard) {
-    return <WorkflowDashboard onBack={() => setShowDashboard(false)} />;
+    return (
+      <Suspense
+        fallback={
+          <Stack gap="md">
+            <Skeleton h={36} w={240} />
+            <Skeleton h={160} />
+            <Skeleton h={240} />
+          </Stack>
+        }
+      >
+        <WorkflowDashboard onBack={() => setShowDashboard(false)} />
+      </Suspense>
+    );
   }
 
   if (selectedWorkflowId) {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
     testTimeout: 15_000,
   },
   build: {
+    chunkSizeWarningLimit: 400,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Summary
- Defers the optional board dashboard shell and dashboard trend charts until their sections enter the viewport.
- Splits workflow dashboard and scoring score explorer panels behind their explicit UI entry points.
- Adds a reusable visibility gate plus chunk-budget documentation and regression coverage for the lazy boundaries.

## Verification
- `pnpm --filter @veritas-kanban/web test -- lazy-on-visible.test.tsx KanbanBoard.test.tsx dashboard-widgets-mantine.test.tsx workflow-surfaces-mantine.test.tsx governance-surfaces-mantine.test.tsx settings-governance-mantine.test.tsx task-detail-mantine.test.tsx`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm lint:budget`
- `pnpm exec prettier --check web/src/__tests__/lazy-on-visible.test.tsx web/src/__tests__/governance-surfaces-mantine.test.tsx web/src/components/shared/LazyOnVisible.tsx web/src/components/board/KanbanBoard.tsx web/src/components/dashboard/Dashboard.tsx web/src/components/workflows/WorkflowsPage.tsx web/src/components/scoring/ScoringProfiles.tsx web/vite.config.ts docs/testing/frontend-chunk-budget.md`
- `git diff --check`
- Browser smoke on `http://127.0.0.1:4178/`: board load, settings dialog, task detail drawer, dashboard scroll/trends, Workflows dashboard action, and Scoring Score Explorer tab.

## Notes
- Production build has no chunk-size warning. Largest emitted chart dependency chunk is `CartesianChart` at 330.66 KiB, under the documented 400 KiB budget.
- Initial board asset inventory contains no `Dashboard`, `TrendsCharts`, `LineChart`, `CartesianChart`, `DriftMonitor`, `ScoreExplorer`, or `vendor-charts` chunks.
- Browser screenshot capture timed out in the in-app browser backend; DOM, console, and asset inventory checks passed.

Closes #402
