### PR TITLE
Add saved board views

### DIFF
--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -265,6 +265,55 @@ describe('Feature Settings Schema', () => {
     expect(result.board?.showDashboard).toBe(true);
   });
 
+  it('should accept board saved views with URL-backed filters', () => {
+    const result = FeatureSettingsPatchSchema.parse({
+      board: {
+        savedViews: [
+          {
+            id: 'view-review',
+            name: 'Review Queue',
+            filters: {
+              search: 'review',
+              project: 'veritas',
+              type: 'bug',
+              agent: 'codex',
+            },
+            createdAt: '2026-06-03T12:00:00.000Z',
+            updatedAt: '2026-06-03T12:00:00.000Z',
+          },
+        ],
+        defaultSavedViewId: 'view-review',
+      },
+    });
+
+    expect(result.board?.savedViews?.[0]?.filters.project).toBe('veritas');
+    expect(result.board?.defaultSavedViewId).toBe('view-review');
+  });
+
+  it('should reject saved board views with unexpected filter keys', () => {
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        board: {
+          savedViews: [
+            {
+              id: 'view-review',
+              name: 'Review Queue',
+              filters: {
+                search: 'review',
+                project: null,
+                type: null,
+                agent: null,
+                sprint: 'current',
+              },
+              createdAt: '2026-06-03T12:00:00.000Z',
+              updatedAt: '2026-06-03T12:00:00.000Z',
+            },
+          ],
+        },
+      })
+    ).toThrow();
+  });
+
   it('should accept valid task behavior settings', () => {
     const result = FeatureSettingsPatchSchema.parse({
       tasks: { enableTimeTracking: true, defaultPriority: 'high' },

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -58,6 +58,25 @@ const DashboardWidgetSettingsSchema = z
   .strict()
   .optional();
 
+const BoardSavedViewFiltersSchema = z
+  .object({
+    search: z.string().max(200),
+    project: z.string().min(1).max(120).nullable(),
+    type: z.string().min(1).max(80).nullable(),
+    agent: z.string().min(1).max(80).nullable(),
+  })
+  .strict();
+
+const BoardSavedViewSchema = z
+  .object({
+    id: z.string().min(1).max(100),
+    name: z.string().min(1).max(80),
+    filters: BoardSavedViewFiltersSchema,
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
 const BoardSettingsSchema = z
   .object({
     showDashboard: z.boolean().optional(),
@@ -68,6 +87,8 @@ const BoardSettingsSchema = z
     showSprintBadges: z.boolean().optional(),
     enableDragAndDrop: z.boolean().optional(),
     showDoneMetrics: z.boolean().optional(),
+    savedViews: z.array(BoardSavedViewSchema).max(50).optional(),
+    defaultSavedViewId: z.string().min(1).max(100).nullable().optional(),
     dashboardWidgets: DashboardWidgetSettingsSchema,
   })
   .strict()

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -197,6 +197,21 @@ export interface ProductModeSettings {
   dismissedHints: string[];
 }
 
+export interface BoardSavedViewFilters {
+  search: string;
+  project: string | null;
+  type: string | null;
+  agent: string | null;
+}
+
+export interface BoardSavedView {
+  id: string;
+  name: string;
+  filters: BoardSavedViewFilters;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /** Board display settings */
 export interface BoardSettings {
   showDashboard: boolean;
@@ -207,6 +222,8 @@ export interface BoardSettings {
   showSprintBadges: boolean;
   enableDragAndDrop: boolean;
   showDoneMetrics: boolean;
+  savedViews: BoardSavedView[];
+  defaultSavedViewId: string | null;
   dashboardWidgets: DashboardWidgetSettings;
 }
 
@@ -385,6 +402,8 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     showSprintBadges: true,
     enableDragAndDrop: true,
     showDoneMetrics: true,
+    savedViews: [],
+    defaultSavedViewId: null,
     dashboardWidgets: {
       showTokenUsage: true,
       showRunDuration: true,

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -4,11 +4,11 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { screen, cleanup } from '@testing-library/react';
+import { screen, cleanup, waitFor } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import { KanbanBoard } from '@/components/board/KanbanBoard';
 import { createMockTask, renderWithProviders } from './test-utils';
-import type { Task } from '@veritas-kanban/shared';
+import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings, type Task } from '@veritas-kanban/shared';
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -19,6 +19,26 @@ const mockTasks: Task[] = [
 ];
 
 let mockUseTasks: () => { data: Task[] | undefined; isLoading: boolean; error: Error | null };
+let mockFeatureSettingsResult: { isPlaceholderData: boolean; settings: FeatureSettings } = {
+  isPlaceholderData: false,
+  settings: createFeatureSettings(),
+};
+
+function createFeatureSettings(
+  boardOverrides: Partial<FeatureSettings['board']> = {}
+): FeatureSettings {
+  return {
+    ...DEFAULT_FEATURE_SETTINGS,
+    board: {
+      ...DEFAULT_FEATURE_SETTINGS.board,
+      enableDragAndDrop: false,
+      showDashboard: false,
+      showArchiveSuggestions: false,
+      showDoneMetrics: false,
+      ...boardOverrides,
+    },
+  };
+}
 
 vi.mock('@/hooks/useTasks', () => ({
   useTasks: () => mockUseTasks(),
@@ -64,25 +84,10 @@ vi.mock('@/hooks/useKeyboard', () => ({
 }));
 
 vi.mock('@/hooks/useFeatureSettings', () => ({
-  useFeatureSettings: () => ({
-    settings: {
-      board: {
-        enableDragAndDrop: false,
-        showDashboard: false,
-        showArchiveSuggestions: false,
-        cardDensity: 'normal',
-        showPriorityIndicators: true,
-        showProjectBadges: true,
-        showSprintBadges: true,
-        showDoneMetrics: false,
-      },
-      budget: {
-        enabled: false,
-        monthlyTokenLimit: 1_000_000,
-        monthlyCostLimit: 100,
-        warningThreshold: 0.8,
-      },
-    },
+  useFeatureSettings: () => mockFeatureSettingsResult,
+  useUpdateFeatureSettings: () => ({
+    mutate: vi.fn(),
+    isPending: false,
   }),
 }));
 
@@ -139,12 +144,17 @@ vi.mock('@/components/task/TaskDetailPanel', () => ({
   TaskDetailPanel: () => null,
 }));
 
-vi.mock('@/components/board/FilterBar', () => ({
-  FilterBar: () => null,
-  filterTasks: (tasks: Task[]) => tasks,
-  filtersToSearchParams: () => new URLSearchParams(),
-  searchParamsToFilters: () => ({ search: '', project: null, type: null, agent: null }),
-}));
+vi.mock('@/components/board/FilterBar', async () => {
+  const actual = await vi.importActual<typeof import('@/components/board/FilterBar')>(
+    '@/components/board/FilterBar'
+  );
+  return {
+    FilterBar: () => null,
+    filterTasks: actual.filterTasks,
+    filtersToSearchParams: actual.filtersToSearchParams,
+    searchParamsToFilters: actual.searchParamsToFilters,
+  };
+});
 
 vi.mock('@/components/board/BulkActionsBar', () => ({
   BulkActionsBar: () => null,
@@ -191,6 +201,11 @@ function setOnline(value: boolean) {
 afterEach(() => {
   cleanup();
   setOnline(true);
+  mockFeatureSettingsResult = {
+    isPlaceholderData: false,
+    settings: createFeatureSettings(),
+  };
+  window.history.replaceState({}, '', '/');
 });
 
 // ── Tests ────────────────────────────────────────────────────
@@ -255,5 +270,56 @@ describe('KanbanBoard', () => {
 
     expect(screen.getByTestId('column-todo').dataset.canChangeStatus).toBe('false');
     expect(screen.getByTestId('column-in-progress').dataset.canChangeStatus).toBe('false');
+  });
+
+  it('applies the default saved view when no board filters are in the URL', async () => {
+    mockUseTasks = () => ({ data: mockTasks, isLoading: false, error: null });
+    mockFeatureSettingsResult = {
+      isPlaceholderData: false,
+      settings: createFeatureSettings({
+        savedViews: [
+          {
+            id: 'view-review',
+            name: 'Review Queue',
+            filters: { search: 'review', project: 'veritas', type: null, agent: null },
+            createdAt: '2026-06-03T12:00:00.000Z',
+            updatedAt: '2026-06-03T12:00:00.000Z',
+          },
+        ],
+        defaultSavedViewId: 'view-review',
+      }),
+    };
+
+    renderBoard();
+
+    await waitFor(() => {
+      expect(window.location.search).toBe('?q=review&project=veritas');
+    });
+  });
+
+  it('keeps explicit URL filters instead of applying the default saved view', async () => {
+    window.history.replaceState({}, '', '/?q=existing');
+    mockUseTasks = () => ({ data: mockTasks, isLoading: false, error: null });
+    mockFeatureSettingsResult = {
+      isPlaceholderData: false,
+      settings: createFeatureSettings({
+        savedViews: [
+          {
+            id: 'view-review',
+            name: 'Review Queue',
+            filters: { search: 'review', project: 'veritas', type: null, agent: null },
+            createdAt: '2026-06-03T12:00:00.000Z',
+            updatedAt: '2026-06-03T12:00:00.000Z',
+          },
+        ],
+        defaultSavedViewId: 'view-review',
+      }),
+    };
+
+    renderBoard();
+
+    await waitFor(() => {
+      expect(window.location.search).toBe('?q=existing');
+    });
   });
 });

--- a/web/src/__tests__/board-chrome-mantine.test.tsx
+++ b/web/src/__tests__/board-chrome-mantine.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FilterBar, type FilterState } from '@/components/board/FilterBar';
 import { BulkActionsBar } from '@/components/board/BulkActionsBar';
 import {
@@ -8,7 +9,7 @@ import {
   createMockTaskType,
   renderWithProviders,
 } from './test-utils';
-import type { AgentConfig, AgentType } from '@veritas-kanban/shared';
+import type { AgentConfig, AgentType, BoardSavedView } from '@veritas-kanban/shared';
 
 const agents: AgentConfig[] = [
   {
@@ -92,6 +93,7 @@ function defaultFilters(overrides: Partial<FilterState> = {}): FilterState {
 
 describe('Board chrome Mantine migration', () => {
   beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
     mocks.useProjects.mockReturnValue({
       data: [createMockProject({ id: 'veritas', label: 'Veritas' })],
       isLoading: false,
@@ -165,6 +167,100 @@ describe('Board chrome Mantine migration', () => {
       type: null,
       agent: null,
     });
+  });
+
+  it('manages saved board views through Mantine primitives', () => {
+    const savedView: BoardSavedView = {
+      id: 'view-review',
+      name: 'Review Queue',
+      filters: defaultFilters({ search: 'review' }),
+      createdAt: '2026-06-03T12:00:00.000Z',
+      updatedAt: '2026-06-03T12:00:00.000Z',
+    };
+    const onApplySavedView = vi.fn();
+    const onSaveSavedView = vi.fn();
+    const onUpdateSavedView = vi.fn();
+    const onRenameSavedView = vi.fn();
+    const onDeleteSavedView = vi.fn();
+    const onSetDefaultSavedView = vi.fn();
+
+    const { baseElement } = renderWithProviders(
+      <FilterBar
+        tasks={[]}
+        filters={defaultFilters({ search: 'review', project: 'veritas' })}
+        onFiltersChange={vi.fn()}
+        savedViews={[savedView]}
+        selectedSavedViewId={savedView.id}
+        hasUnsavedSavedViewChanges
+        onApplySavedView={onApplySavedView}
+        onSaveSavedView={onSaveSavedView}
+        onUpdateSavedView={onUpdateSavedView}
+        onRenameSavedView={onRenameSavedView}
+        onDeleteSavedView={onDeleteSavedView}
+        onSetDefaultSavedView={onSetDefaultSavedView}
+      />
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Saved board view' })).toBeDefined();
+    expect(screen.getByText('Modified')).toBeDefined();
+    expect(baseElement.querySelectorAll('.mantine-Select-root').length).toBe(4);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update saved view' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Set saved view as default' }));
+
+    expect(onUpdateSavedView).toHaveBeenCalledWith('view-review');
+    expect(onSetDefaultSavedView).toHaveBeenCalledWith('view-review');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename saved view' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'View name' }), {
+      target: { value: 'Review Focus' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    expect(onRenameSavedView).toHaveBeenCalledWith('view-review', 'Review Focus');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete saved view' }));
+    expect(screen.getByText('Delete saved view?')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(onDeleteSavedView).toHaveBeenCalledWith('view-review');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save view' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'View name' }), {
+      target: { value: 'Project Bugs' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSaveSavedView).toHaveBeenCalledWith('Project Bugs');
+    expect(onApplySavedView).not.toHaveBeenCalled();
+  });
+
+  it('applies a saved board view from the saved view selector', async () => {
+    const user = userEvent.setup();
+    const savedView: BoardSavedView = {
+      id: 'view-review',
+      name: 'Review Queue',
+      filters: defaultFilters({ search: 'review' }),
+      createdAt: '2026-06-03T12:00:00.000Z',
+      updatedAt: '2026-06-03T12:00:00.000Z',
+    };
+    const onApplySavedView = vi.fn();
+
+    renderWithProviders(
+      <FilterBar
+        tasks={[]}
+        filters={defaultFilters()}
+        onFiltersChange={vi.fn()}
+        savedViews={[savedView]}
+        onSaveSavedView={vi.fn()}
+        onApplySavedView={onApplySavedView}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'Saved board view' }));
+    await user.click(screen.getByRole('option', { name: 'Review Queue' }));
+
+    expect(onApplySavedView).toHaveBeenCalledWith('view-review');
   });
 
   it('renders bulk selection actions through direct Mantine primitives', () => {

--- a/web/src/__tests__/board-saved-views.test.ts
+++ b/web/src/__tests__/board-saved-views.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBoardSavedView,
+  deleteBoardSavedView,
+  findBoardSavedViewByFilters,
+  renameBoardSavedView,
+  updateBoardSavedViewFilters,
+} from '@/lib/board-saved-views';
+import { filtersToSearchParams, searchParamsToFilters } from '@/components/board/FilterBar';
+
+describe('board saved views', () => {
+  it('creates normalized saved views that round-trip through board URL filters', () => {
+    const view = createBoardSavedView({
+      name: '  Sprint Focus  ',
+      filters: {
+        search: ' docs ',
+        project: ' veritas ',
+        type: ' feature ',
+        agent: ' codex ',
+      },
+      now: new Date('2026-06-03T12:30:45.000Z'),
+    });
+
+    expect(view).toEqual({
+      id: 'view-20260603123045-sprint-focus',
+      name: 'Sprint Focus',
+      filters: {
+        search: 'docs',
+        project: 'veritas',
+        type: 'feature',
+        agent: 'codex',
+      },
+      createdAt: '2026-06-03T12:30:45.000Z',
+      updatedAt: '2026-06-03T12:30:45.000Z',
+    });
+
+    const params = filtersToSearchParams(view.filters);
+
+    expect(params.toString()).toBe('q=docs&project=veritas&type=feature&agent=codex');
+    expect(searchParamsToFilters(params)).toEqual(view.filters);
+  });
+
+  it('finds, renames, and updates views by normalized filters', () => {
+    const created = createBoardSavedView({
+      name: 'Needs Review',
+      filters: { search: ' review ', project: null, type: null, agent: null },
+      now: new Date('2026-06-03T12:30:45.000Z'),
+    });
+
+    const renamed = renameBoardSavedView(
+      [created],
+      created.id,
+      'Review Queue',
+      new Date('2026-06-03T12:35:00.000Z')
+    );
+    const updated = updateBoardSavedViewFilters(
+      renamed,
+      created.id,
+      { search: 'review', project: 'veritas', type: 'bug', agent: null },
+      new Date('2026-06-03T12:40:00.000Z')
+    );
+
+    expect(updated[0]).toMatchObject({
+      name: 'Review Queue',
+      filters: { search: 'review', project: 'veritas', type: 'bug', agent: null },
+      updatedAt: '2026-06-03T12:40:00.000Z',
+    });
+    expect(
+      findBoardSavedViewByFilters(updated, {
+        search: ' review ',
+        project: ' veritas ',
+        type: ' bug ',
+      })?.id
+    ).toBe(created.id);
+  });
+
+  it('clears the default pointer when deleting the default saved view', () => {
+    const defaultView = createBoardSavedView({
+      name: 'Default',
+      filters: { search: '', project: 'veritas', type: null, agent: null },
+      now: new Date('2026-06-03T12:30:45.000Z'),
+    });
+    const otherView = createBoardSavedView({
+      name: 'Other',
+      filters: { search: 'docs', project: null, type: null, agent: null },
+      existingIds: [defaultView.id],
+      now: new Date('2026-06-03T12:31:45.000Z'),
+    });
+
+    const result = deleteBoardSavedView([defaultView, otherView], defaultView.id, defaultView.id);
+
+    expect(result.savedViews).toEqual([otherView]);
+    expect(result.defaultSavedViewId).toBeNull();
+  });
+});

--- a/web/src/components/board/FilterBar.tsx
+++ b/web/src/components/board/FilterBar.tsx
@@ -1,6 +1,18 @@
-import { Search, X, Filter } from 'lucide-react';
-import { ActionIcon, Badge, Button, Select, TextInput } from '@mantine/core';
-import type { Task, TaskType } from '@veritas-kanban/shared';
+import { useState } from 'react';
+import { Bookmark, Edit3, Filter, Save, Search, Star, StarOff, Trash2, X } from 'lucide-react';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import type { BoardSavedView, Task, TaskType } from '@veritas-kanban/shared';
 import { useTaskTypes } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useConfig } from '@/hooks/useConfig';
@@ -16,13 +28,57 @@ interface FilterBarProps {
   tasks: Task[];
   filters: FilterState;
   onFiltersChange: (filters: FilterState) => void;
+  savedViews?: BoardSavedView[];
+  selectedSavedViewId?: string | null;
+  defaultSavedViewId?: string | null;
+  hasUnsavedSavedViewChanges?: boolean;
+  isSavingSavedView?: boolean;
+  onApplySavedView?: (viewId: string) => void;
+  onClearSelectedSavedView?: () => void;
+  onSaveSavedView?: (name: string) => void;
+  onUpdateSavedView?: (viewId: string) => void;
+  onRenameSavedView?: (viewId: string, name: string) => void;
+  onDeleteSavedView?: (viewId: string) => void;
+  onSetDefaultSavedView?: (viewId: string | null) => void;
 }
 
-export function FilterBar({ filters, onFiltersChange }: FilterBarProps) {
+type SavedViewNameModalMode = 'create' | 'rename' | null;
+
+export function FilterBar({
+  filters,
+  onFiltersChange,
+  savedViews = [],
+  selectedSavedViewId = null,
+  defaultSavedViewId = null,
+  hasUnsavedSavedViewChanges = false,
+  isSavingSavedView = false,
+  onApplySavedView,
+  onClearSelectedSavedView,
+  onSaveSavedView,
+  onUpdateSavedView,
+  onRenameSavedView,
+  onDeleteSavedView,
+  onSetDefaultSavedView,
+}: FilterBarProps) {
   const { data: taskTypes = [], isLoading: typesLoading } = useTaskTypes();
   const { data: projects = [], isLoading: projectsLoading } = useProjects();
   const { data: config } = useConfig();
+  const [nameModalMode, setNameModalMode] = useState<SavedViewNameModalMode>(null);
+  const [viewName, setViewName] = useState('');
+  const [deleteViewId, setDeleteViewId] = useState<string | null>(null);
   const agents = config?.agents || [];
+  const selectedSavedView = savedViews.find((view) => view.id === selectedSavedViewId) ?? null;
+  const deleteSavedView = savedViews.find((view) => view.id === deleteViewId) ?? null;
+  const isSelectedSavedViewDefault =
+    selectedSavedView !== null && selectedSavedView.id === defaultSavedViewId;
+  const savedViewOptions = [
+    { value: 'custom', label: 'Current filters' },
+    ...savedViews.map((view) => ({
+      value: view.id,
+      label: view.id === defaultSavedViewId ? `${view.name} (default)` : view.name,
+    })),
+  ];
+  const shouldShowSavedViews = Boolean(onSaveSavedView || savedViews.length > 0);
   const projectOptions = [
     { value: 'all', label: 'All Projects' },
     ...projects.map((project) => ({ value: project.id, label: project.label })),
@@ -51,102 +107,290 @@ export function FilterBar({ filters, onFiltersChange }: FilterBarProps) {
     onFiltersChange({ ...filters, search: value });
   };
 
+  const openCreateSavedView = () => {
+    setViewName(`Board view ${savedViews.length + 1}`);
+    setNameModalMode('create');
+  };
+
+  const openRenameSavedView = () => {
+    if (!selectedSavedView) return;
+    setViewName(selectedSavedView.name);
+    setNameModalMode('rename');
+  };
+
+  const closeNameModal = () => {
+    setNameModalMode(null);
+    setViewName('');
+  };
+
+  const submitSavedViewName = () => {
+    const name = viewName.trim();
+    if (!name) return;
+
+    if (nameModalMode === 'create') {
+      onSaveSavedView?.(name);
+    } else if (nameModalMode === 'rename' && selectedSavedView) {
+      onRenameSavedView?.(selectedSavedView.id, name);
+    }
+
+    closeNameModal();
+  };
+
+  const handleSavedViewChange = (value: string | null) => {
+    if (!value || value === 'custom') {
+      onClearSelectedSavedView?.();
+      return;
+    }
+    onApplySavedView?.(value);
+  };
+
+  const confirmDeleteSavedView = () => {
+    if (!deleteViewId) return;
+    onDeleteSavedView?.(deleteViewId);
+    setDeleteViewId(null);
+  };
+
   return (
-    <div
-      className="flex w-full flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-3"
-      role="search"
-      aria-label="Filter tasks"
-    >
-      {/* Search */}
-      <div className="relative w-full sm:max-w-sm sm:flex-1">
-        <TextInput
-          id="task-search"
-          aria-label="Search tasks"
-          placeholder="Search tasks..."
-          value={filters.search}
-          onChange={(e) => updateSearch(e.target.value)}
-          leftSection={<Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
-          rightSectionPointerEvents="auto"
-          rightSection={
-            filters.search ? (
-              <ActionIcon
-                aria-label="Clear search"
-                variant="subtle"
-                size="sm"
-                onClick={() => updateSearch('')}
-              >
-                <X className="h-4 w-4" aria-hidden="true" />
-              </ActionIcon>
-            ) : null
+    <div className="flex w-full flex-col items-stretch gap-2">
+      <div
+        className="flex w-full flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-3"
+        role="search"
+        aria-label="Filter tasks"
+      >
+        {/* Search */}
+        <div className="relative w-full sm:max-w-sm sm:flex-1">
+          <TextInput
+            id="task-search"
+            aria-label="Search tasks"
+            placeholder="Search tasks..."
+            value={filters.search}
+            onChange={(e) => updateSearch(e.target.value)}
+            leftSection={<Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+            rightSectionPointerEvents="auto"
+            rightSection={
+              filters.search ? (
+                <ActionIcon
+                  aria-label="Clear search"
+                  variant="subtle"
+                  size="sm"
+                  onClick={() => updateSearch('')}
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </ActionIcon>
+              ) : null
+            }
+            aria-describedby={activeFilterCount > 0 ? 'active-filter-count' : undefined}
+          />
+        </div>
+
+        {/* Project filter */}
+        <Select
+          value={filters.project || 'all'}
+          onChange={(value) =>
+            onFiltersChange({ ...filters, project: value && value !== 'all' ? value : null })
           }
-          aria-describedby={activeFilterCount > 0 ? 'active-filter-count' : undefined}
+          disabled={projectsLoading}
+          data={projectOptions}
+          aria-label="Filter by project"
+          className="w-full sm:w-[160px]"
+          allowDeselect={false}
         />
+
+        {/* Type filter */}
+        <Select
+          value={filters.type || 'all'}
+          onChange={(value) =>
+            onFiltersChange({
+              ...filters,
+              type: value && value !== 'all' ? (value as TaskType) : null,
+            })
+          }
+          disabled={typesLoading}
+          data={typeOptions}
+          aria-label="Filter by type"
+          className="w-full sm:w-[160px]"
+          allowDeselect={false}
+        />
+
+        {/* Agent filter */}
+        <Select
+          value={filters.agent || 'all'}
+          onChange={(value) =>
+            onFiltersChange({ ...filters, agent: value && value !== 'all' ? value : null })
+          }
+          data={agentOptions}
+          aria-label="Filter by agent"
+          className="w-full sm:w-[160px]"
+          allowDeselect={false}
+        />
+
+        {/* Active filter indicator & clear */}
+        {activeFilterCount > 0 && (
+          <div className="flex items-center gap-2">
+            <Badge
+              id="active-filter-count"
+              variant="light"
+              color="gray"
+              leftSection={<Filter className="h-3 w-3" aria-hidden="true" />}
+              aria-live="polite"
+            >
+              {activeFilterCount} active {activeFilterCount === 1 ? 'filter' : 'filters'}
+            </Badge>
+            <Button
+              variant="subtle"
+              size="xs"
+              onClick={clearAllFilters}
+              aria-label="Clear all filters"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Clear all
+            </Button>
+          </div>
+        )}
       </div>
 
-      {/* Project filter */}
-      <Select
-        value={filters.project || 'all'}
-        onChange={(value) =>
-          onFiltersChange({ ...filters, project: value && value !== 'all' ? value : null })
-        }
-        disabled={projectsLoading}
-        data={projectOptions}
-        aria-label="Filter by project"
-        className="w-full sm:w-[160px]"
-        allowDeselect={false}
-      />
-
-      {/* Type filter */}
-      <Select
-        value={filters.type || 'all'}
-        onChange={(value) =>
-          onFiltersChange({
-            ...filters,
-            type: value && value !== 'all' ? (value as TaskType) : null,
-          })
-        }
-        disabled={typesLoading}
-        data={typeOptions}
-        aria-label="Filter by type"
-        className="w-full sm:w-[160px]"
-        allowDeselect={false}
-      />
-
-      {/* Agent filter */}
-      <Select
-        value={filters.agent || 'all'}
-        onChange={(value) =>
-          onFiltersChange({ ...filters, agent: value && value !== 'all' ? value : null })
-        }
-        data={agentOptions}
-        aria-label="Filter by agent"
-        className="w-full sm:w-[160px]"
-        allowDeselect={false}
-      />
-
-      {/* Active filter indicator & clear */}
-      {activeFilterCount > 0 && (
-        <div className="flex items-center gap-2">
-          <Badge
-            id="active-filter-count"
-            variant="light"
-            color="gray"
-            leftSection={<Filter className="h-3 w-3" aria-hidden="true" />}
-            aria-live="polite"
-          >
-            {activeFilterCount} active {activeFilterCount === 1 ? 'filter' : 'filters'}
-          </Badge>
-          <Button
-            variant="subtle"
-            size="xs"
-            onClick={clearAllFilters}
-            aria-label="Clear all filters"
-            className="text-muted-foreground hover:text-foreground"
-          >
-            Clear all
-          </Button>
+      {shouldShowSavedViews && (
+        <div
+          className="flex w-full flex-col items-stretch gap-2 sm:flex-row sm:items-center"
+          aria-label="Saved board views"
+        >
+          <Select
+            value={selectedSavedView?.id ?? 'custom'}
+            onChange={handleSavedViewChange}
+            data={savedViewOptions}
+            aria-label="Saved board view"
+            className="w-full sm:w-[220px]"
+            allowDeselect={false}
+            leftSection={<Bookmark className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+          />
+          <Group gap="xs" wrap="nowrap" className="min-w-0">
+            <Button
+              variant="light"
+              size="xs"
+              leftSection={<Save className="h-3.5 w-3.5" aria-hidden="true" />}
+              onClick={openCreateSavedView}
+              loading={isSavingSavedView && nameModalMode === 'create'}
+            >
+              Save view
+            </Button>
+            {selectedSavedView && (
+              <>
+                <Tooltip label="Update saved view">
+                  <ActionIcon
+                    variant={hasUnsavedSavedViewChanges ? 'filled' : 'subtle'}
+                    size="sm"
+                    aria-label="Update saved view"
+                    onClick={() => onUpdateSavedView?.(selectedSavedView.id)}
+                    loading={isSavingSavedView}
+                  >
+                    <Save className="h-4 w-4" aria-hidden="true" />
+                  </ActionIcon>
+                </Tooltip>
+                <Tooltip label="Rename saved view">
+                  <ActionIcon
+                    variant="subtle"
+                    size="sm"
+                    aria-label="Rename saved view"
+                    onClick={openRenameSavedView}
+                  >
+                    <Edit3 className="h-4 w-4" aria-hidden="true" />
+                  </ActionIcon>
+                </Tooltip>
+                <Tooltip
+                  label={
+                    isSelectedSavedViewDefault
+                      ? 'Clear default saved view'
+                      : 'Set saved view as default'
+                  }
+                >
+                  <ActionIcon
+                    variant={isSelectedSavedViewDefault ? 'light' : 'subtle'}
+                    size="sm"
+                    aria-label={
+                      isSelectedSavedViewDefault
+                        ? 'Clear default saved view'
+                        : 'Set saved view as default'
+                    }
+                    onClick={() =>
+                      onSetDefaultSavedView?.(
+                        isSelectedSavedViewDefault ? null : selectedSavedView.id
+                      )
+                    }
+                  >
+                    {isSelectedSavedViewDefault ? (
+                      <StarOff className="h-4 w-4" aria-hidden="true" />
+                    ) : (
+                      <Star className="h-4 w-4" aria-hidden="true" />
+                    )}
+                  </ActionIcon>
+                </Tooltip>
+                <Tooltip label="Delete saved view">
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    size="sm"
+                    aria-label="Delete saved view"
+                    onClick={() => setDeleteViewId(selectedSavedView.id)}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                  </ActionIcon>
+                </Tooltip>
+                {hasUnsavedSavedViewChanges && (
+                  <Badge variant="light" color="yellow">
+                    Modified
+                  </Badge>
+                )}
+              </>
+            )}
+          </Group>
         </div>
       )}
+
+      <Modal
+        opened={nameModalMode !== null}
+        onClose={closeNameModal}
+        title={nameModalMode === 'rename' ? 'Rename saved view' : 'Save board view'}
+        size="sm"
+      >
+        <Stack gap="sm">
+          <TextInput
+            label="View name"
+            value={viewName}
+            onChange={(event) => setViewName(event.currentTarget.value)}
+            data-autofocus
+            maxLength={80}
+          />
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={closeNameModal}>
+              Cancel
+            </Button>
+            <Button onClick={submitSavedViewName} disabled={!viewName.trim()}>
+              {nameModalMode === 'rename' ? 'Rename' : 'Save'}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      <Modal
+        opened={Boolean(deleteSavedView)}
+        onClose={() => setDeleteViewId(null)}
+        title="Delete saved view?"
+        size="sm"
+      >
+        <Stack gap="sm">
+          <Text size="sm">
+            Delete "{deleteSavedView?.name}"? Current filters and shared URLs stay unchanged.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={() => setDeleteViewId(null)}>
+              Cancel
+            </Button>
+            <Button color="red" onClick={confirmDeleteSavedView}>
+              Delete
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </div>
   );
 }

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -2,11 +2,16 @@ import { useTasks, useTasksByStatus, useUpdateTask, useReorderTasks } from '@/ho
 import { useBoardDragDrop } from '@/hooks/useBoardDragDrop';
 import { KanbanColumn } from './KanbanColumn';
 import { BoardLoadingSkeleton } from './BoardLoadingSkeleton';
-import type { TaskStatus, Task } from '@veritas-kanban/shared';
-import { useFeatureSettings } from '@/hooks/useFeatureSettings';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type BoardSavedView,
+  type TaskStatus,
+  type Task,
+} from '@veritas-kanban/shared';
+import { useFeatureSettings, useUpdateFeatureSettings } from '@/hooks/useFeatureSettings';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
 import { TaskCard } from '@/components/task/TaskCard';
 import { useKeyboard } from '@/hooks/useKeyboard';
 import {
@@ -19,6 +24,15 @@ import {
 import { BulkActionsBar } from './BulkActionsBar';
 import { BoardSidebar } from './BoardSidebar';
 import { useBulkActions } from '@/hooks/useBulkActions';
+import {
+  areBoardViewFiltersEqual,
+  createBoardSavedView,
+  deleteBoardSavedView,
+  findBoardSavedViewByFilters,
+  hasBoardFilterSearchParams,
+  renameBoardSavedView,
+  updateBoardSavedViewFilters,
+} from '@/lib/board-saved-views';
 import { CheckSquare } from 'lucide-react';
 import { Button } from '@mantine/core';
 import { ArchiveSuggestionBanner } from './ArchiveSuggestionBanner';
@@ -51,22 +65,28 @@ const COLUMNS: { id: TaskStatus; title: string }[] = [
 ];
 
 const STATUS_OPTIONS = COLUMNS.map((column) => ({ value: column.id, label: column.title }));
+const EMPTY_SAVED_VIEWS: BoardSavedView[] = [];
 
 export function KanbanBoard() {
   const { data: tasks, isLoading, error } = useTasks();
-  const { settings: featureSettings } = useFeatureSettings();
+  const { settings: featureSettings, isPlaceholderData } = useFeatureSettings();
+  const updateFeatureSettings = useUpdateFeatureSettings();
+  const boardSettings = featureSettings.board ?? DEFAULT_FEATURE_SETTINGS.board;
+  const savedViews = boardSettings.savedViews ?? EMPTY_SAVED_VIEWS;
+  const defaultSavedViewId = boardSettings.defaultSavedViewId ?? null;
   const { announce } = useLiveAnnouncer();
   const { hasPermission } = useIdentity();
   const { isOnline } = useNetworkStatus();
   const canWriteTasks = hasPermission('task:write');
   const isMobileLayout = useMediaQuery('(max-width: 767px)', false);
   const canDragTasks =
-    featureSettings.board.enableDragAndDrop && canWriteTasks && isOnline && !isMobileLayout;
+    boardSettings.enableDragAndDrop && canWriteTasks && isOnline && !isMobileLayout;
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailPanelMounted, setDetailPanelMounted] = useState(false);
   const [detailNavigationTarget, setDetailNavigationTarget] =
     useState<TaskDetailNavigationTarget | null>(null);
+  const defaultSavedViewAppliedRef = useRef(false);
 
   // Initialize filters from URL
   const [filters, setFilters] = useState<FilterState>(() => {
@@ -75,10 +95,115 @@ export function KanbanBoard() {
     }
     return { search: '', project: null, type: null, agent: null };
   });
+  const [selectedSavedViewId, setSelectedSavedViewId] = useState<string | null>(null);
 
   const { selectedTaskId, setTasks, setOnOpenTask, setOnMoveTask } = useKeyboard();
   const { isSelecting, toggleSelecting } = useBulkActions();
   const { pendingTaskId, pendingTaskTarget, clearPendingTask } = useView();
+
+  const matchingSavedView = useMemo(
+    () => findBoardSavedViewByFilters(savedViews, filters),
+    [filters, savedViews]
+  );
+  const selectedSavedView = useMemo(
+    () => savedViews.find((view) => view.id === selectedSavedViewId) ?? null,
+    [savedViews, selectedSavedViewId]
+  );
+  const activeSavedView = selectedSavedView ?? matchingSavedView ?? null;
+  const hasUnsavedSavedViewChanges = Boolean(
+    selectedSavedView && !areBoardViewFiltersEqual(selectedSavedView.filters, filters)
+  );
+
+  const persistBoardSavedViews = useCallback(
+    (nextSavedViews: BoardSavedView[], nextDefaultSavedViewId = defaultSavedViewId) => {
+      updateFeatureSettings.mutate({
+        board: {
+          savedViews: nextSavedViews,
+          defaultSavedViewId: nextDefaultSavedViewId,
+        },
+      });
+    },
+    [defaultSavedViewId, updateFeatureSettings]
+  );
+
+  const handleFiltersChange = useCallback(
+    (nextFilters: FilterState) => {
+      setFilters(nextFilters);
+      const nextMatchingView = findBoardSavedViewByFilters(savedViews, nextFilters);
+      if (nextMatchingView) {
+        setSelectedSavedViewId(nextMatchingView.id);
+      }
+    },
+    [savedViews]
+  );
+
+  const handleApplySavedView = useCallback(
+    (viewId: string) => {
+      const view = savedViews.find((savedView) => savedView.id === viewId);
+      if (!view) return;
+      setSelectedSavedViewId(view.id);
+      setFilters({
+        search: view.filters.search,
+        project: view.filters.project,
+        type: view.filters.type,
+        agent: view.filters.agent,
+      });
+    },
+    [savedViews]
+  );
+
+  const handleSaveSavedView = useCallback(
+    (name: string) => {
+      const view = createBoardSavedView({
+        name,
+        filters,
+        existingIds: savedViews.map((savedView) => savedView.id),
+      });
+      persistBoardSavedViews([...savedViews, view]);
+      setSelectedSavedViewId(view.id);
+    },
+    [filters, persistBoardSavedViews, savedViews]
+  );
+
+  const handleUpdateSavedView = useCallback(
+    (viewId: string) => {
+      persistBoardSavedViews(updateBoardSavedViewFilters(savedViews, viewId, filters));
+      setSelectedSavedViewId(viewId);
+    },
+    [filters, persistBoardSavedViews, savedViews]
+  );
+
+  const handleRenameSavedView = useCallback(
+    (viewId: string, name: string) => {
+      persistBoardSavedViews(renameBoardSavedView(savedViews, viewId, name));
+      setSelectedSavedViewId(viewId);
+    },
+    [persistBoardSavedViews, savedViews]
+  );
+
+  const handleDeleteSavedView = useCallback(
+    (viewId: string) => {
+      const result = deleteBoardSavedView(savedViews, defaultSavedViewId, viewId);
+      persistBoardSavedViews(result.savedViews, result.defaultSavedViewId);
+      if (selectedSavedViewId === viewId) {
+        setSelectedSavedViewId(null);
+      }
+    },
+    [defaultSavedViewId, persistBoardSavedViews, savedViews, selectedSavedViewId]
+  );
+
+  const handleSetDefaultSavedView = useCallback(
+    (viewId: string | null) => {
+      persistBoardSavedViews(savedViews, viewId);
+    },
+    [persistBoardSavedViews, savedViews]
+  );
+
+  useEffect(() => {
+    if (selectedSavedViewId && !savedViews.some((view) => view.id === selectedSavedViewId)) {
+      setSelectedSavedViewId(null);
+    }
+  }, [savedViews, selectedSavedViewId]);
 
   // Handle navigation from other views (e.g., Activity page clicking on a task)
   useEffect(() => {
@@ -114,6 +239,40 @@ export function KanbanBoard() {
 
     openPendingTask();
   }, [pendingTaskId, pendingTaskTarget, tasks, clearPendingTask]);
+
+  // Apply the configured default saved view only when the current URL has no board filters.
+  useEffect(() => {
+    if (defaultSavedViewAppliedRef.current || isPlaceholderData) return;
+    if (typeof window === 'undefined') {
+      defaultSavedViewAppliedRef.current = true;
+      return;
+    }
+
+    if (hasBoardFilterSearchParams(new URLSearchParams(window.location.search))) {
+      defaultSavedViewAppliedRef.current = true;
+      return;
+    }
+
+    if (!defaultSavedViewId) {
+      defaultSavedViewAppliedRef.current = true;
+      return;
+    }
+
+    const defaultView = savedViews.find((view) => view.id === defaultSavedViewId);
+    if (!defaultView) {
+      defaultSavedViewAppliedRef.current = true;
+      return;
+    }
+
+    setSelectedSavedViewId(defaultView.id);
+    setFilters({
+      search: defaultView.filters.search,
+      project: defaultView.filters.project,
+      type: defaultView.filters.type,
+      agent: defaultView.filters.agent,
+    });
+    defaultSavedViewAppliedRef.current = true;
+  }, [defaultSavedViewId, isPlaceholderData, savedViews]);
 
   // Sync filters to URL
   useEffect(() => {
@@ -286,7 +445,23 @@ export function KanbanBoard() {
   return (
     <>
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
-        <FilterBar tasks={tasks || []} filters={filters} onFiltersChange={setFilters} />
+        <FilterBar
+          tasks={tasks || []}
+          filters={filters}
+          onFiltersChange={handleFiltersChange}
+          savedViews={savedViews}
+          selectedSavedViewId={activeSavedView?.id ?? null}
+          defaultSavedViewId={defaultSavedViewId}
+          hasUnsavedSavedViewChanges={hasUnsavedSavedViewChanges}
+          isSavingSavedView={updateFeatureSettings.isPending}
+          onApplySavedView={handleApplySavedView}
+          onClearSelectedSavedView={() => setSelectedSavedViewId(null)}
+          onSaveSavedView={handleSaveSavedView}
+          onUpdateSavedView={handleUpdateSavedView}
+          onRenameSavedView={handleRenameSavedView}
+          onDeleteSavedView={handleDeleteSavedView}
+          onSetDefaultSavedView={handleSetDefaultSavedView}
+        />
         {!isSelecting && (
           <Button
             variant="subtle"
@@ -304,7 +479,7 @@ export function KanbanBoard() {
 
       <BulkActionsBar tasks={filteredTasks} />
 
-      {featureSettings.board.showArchiveSuggestions && <ArchiveSuggestionBanner />}
+      {boardSettings.showArchiveSuggestions && <ArchiveSuggestionBanner />}
 
       <FeatureErrorBoundary fallbackTitle="Board failed to render">
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-5">
@@ -381,7 +556,7 @@ export function KanbanBoard() {
           />
         </div>
 
-        {featureSettings.board.showDashboard && (
+        {boardSettings.showDashboard && (
           <LazyOnVisible
             className="mt-6 border-t pt-4"
             fallback={<DashboardLoadingFallback />}

--- a/web/src/lib/board-saved-views.ts
+++ b/web/src/lib/board-saved-views.ts
@@ -1,0 +1,140 @@
+import type { BoardSavedView, BoardSavedViewFilters } from '@veritas-kanban/shared';
+
+export const EMPTY_BOARD_VIEW_FILTERS: BoardSavedViewFilters = {
+  search: '',
+  project: null,
+  type: null,
+  agent: null,
+};
+
+export function normalizeBoardViewFilters(
+  filters: Partial<BoardSavedViewFilters>
+): BoardSavedViewFilters {
+  return {
+    search: filters.search?.trim() ?? '',
+    project: normalizeNullableFilter(filters.project),
+    type: normalizeNullableFilter(filters.type),
+    agent: normalizeNullableFilter(filters.agent),
+  };
+}
+
+export function areBoardViewFiltersEqual(
+  a: Partial<BoardSavedViewFilters>,
+  b: Partial<BoardSavedViewFilters>
+): boolean {
+  const normalizedA = normalizeBoardViewFilters(a);
+  const normalizedB = normalizeBoardViewFilters(b);
+  return (
+    normalizedA.search === normalizedB.search &&
+    normalizedA.project === normalizedB.project &&
+    normalizedA.type === normalizedB.type &&
+    normalizedA.agent === normalizedB.agent
+  );
+}
+
+export function hasBoardViewFilters(filters: Partial<BoardSavedViewFilters>): boolean {
+  const normalized = normalizeBoardViewFilters(filters);
+  return Boolean(normalized.search || normalized.project || normalized.type || normalized.agent);
+}
+
+export function hasBoardFilterSearchParams(params: URLSearchParams): boolean {
+  return ['q', 'project', 'type', 'agent'].some((key) => params.has(key));
+}
+
+export function findBoardSavedViewByFilters(
+  savedViews: BoardSavedView[],
+  filters: Partial<BoardSavedViewFilters>
+): BoardSavedView | undefined {
+  return savedViews.find((view) => areBoardViewFiltersEqual(view.filters, filters));
+}
+
+export function createBoardSavedView({
+  name,
+  filters,
+  existingIds = [],
+  now = new Date(),
+}: {
+  name: string;
+  filters: Partial<BoardSavedViewFilters>;
+  existingIds?: string[];
+  now?: Date;
+}): BoardSavedView {
+  const normalizedName = normalizeBoardViewName(name);
+  const timestamp = now.toISOString();
+  return {
+    id: uniqueBoardSavedViewId(normalizedName, existingIds, now),
+    name: normalizedName,
+    filters: normalizeBoardViewFilters(filters),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+export function renameBoardSavedView(
+  savedViews: BoardSavedView[],
+  viewId: string,
+  name: string,
+  now = new Date()
+): BoardSavedView[] {
+  const normalizedName = normalizeBoardViewName(name);
+  return savedViews.map((view) =>
+    view.id === viewId ? { ...view, name: normalizedName, updatedAt: now.toISOString() } : view
+  );
+}
+
+export function updateBoardSavedViewFilters(
+  savedViews: BoardSavedView[],
+  viewId: string,
+  filters: Partial<BoardSavedViewFilters>,
+  now = new Date()
+): BoardSavedView[] {
+  return savedViews.map((view) =>
+    view.id === viewId
+      ? { ...view, filters: normalizeBoardViewFilters(filters), updatedAt: now.toISOString() }
+      : view
+  );
+}
+
+export function deleteBoardSavedView(
+  savedViews: BoardSavedView[],
+  defaultSavedViewId: string | null,
+  viewId: string
+): { savedViews: BoardSavedView[]; defaultSavedViewId: string | null } {
+  return {
+    savedViews: savedViews.filter((view) => view.id !== viewId),
+    defaultSavedViewId: defaultSavedViewId === viewId ? null : defaultSavedViewId,
+  };
+}
+
+function normalizeNullableFilter(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function normalizeBoardViewName(name: string): string {
+  const normalized = name.trim().replace(/\s+/g, ' ');
+  if (!normalized) {
+    throw new Error('Saved board view name is required');
+  }
+  return normalized.slice(0, 80);
+}
+
+function uniqueBoardSavedViewId(name: string, existingIds: string[], now: Date): string {
+  const existing = new Set(existingIds);
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40);
+  const stamp = now.toISOString().replace(/\D/g, '').slice(0, 14);
+  const base = `view-${stamp}-${slug || 'board'}`;
+  let candidate = base;
+  let index = 2;
+
+  while (existing.has(candidate)) {
+    candidate = `${base}-${index}`;
+    index += 1;
+  }
+
+  return candidate;
+}


### PR DESCRIPTION
## Summary
- Add URL-backed saved board view settings for search, project, type, and agent filters
- Add board filter UI to save, apply, update, rename, delete, and set default views
- Validate saved view settings on the server and cover serialization/default/delete flows

Closes #401

## Verification
- pnpm --filter @veritas-kanban/web test -- board-saved-views.test.ts board-chrome-mantine.test.tsx KanbanBoard.test.tsx
- pnpm --filter @veritas-kanban/server test -- schemas.test.ts
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/shared typecheck
- pnpm lint:budget
- pnpm --filter @veritas-kanban/web build
- git diff --check
- Local settings API smoke: persisted and restored a temporary saved view/default through /api/settings/features

## Notes
- Browser board smoke was blocked by first-run auth setup in this local checkout, so persistence was verified through the live settings API and UI behavior through focused Mantine tests.
- Existing untracked server/storage/ and storage/ directories were left untouched.