### PR TITLE
Harden scheduled QA gates

### DIFF
--- a/.github/workflows/scheduled-qa.yml
+++ b/.github/workflows/scheduled-qa.yml
@@ -53,11 +53,14 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright E2E tests
+        env:
+          PLAYWRIGHT_HTML_REPORT: '1'
+          PLAYWRIGHT_HTML_OPEN: never
         run: pnpm test:e2e
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-artifacts
           path: |
@@ -108,7 +111,10 @@ jobs:
           exit 1
 
       - name: Run k6 profile
+        shell: bash
         run: |
+          set -euo pipefail
+
           mkdir -p k6-results
 
           if [ "$K6_PROFILE" = "full" ]; then
@@ -132,7 +138,7 @@ jobs:
               -w /work \
               grafana/k6:latest run \
               --summary-export "k6-results/${script}.json" \
-              "load-tests/k6/${script}.js"
+              "load-tests/k6/${script}.js" 2>&1 | tee "k6-results/${script}.log"
           done
 
       - name: Stop API server
@@ -144,7 +150,7 @@ jobs:
 
       - name: Upload k6 artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: k6-artifacts
           path: |

--- a/docs/testing/scheduled-qa-gates.md
+++ b/docs/testing/scheduled-qa-gates.md
@@ -1,0 +1,120 @@
+# Scheduled QA Gates
+
+Review date: 2026-06-04
+
+The scheduled QA workflow runs heavier browser and load-test coverage outside
+the fast pull-request path. Pull requests stay limited to lint, typecheck,
+workspace unit tests, build, production dependency audit, and the desktop
+artifact gate when relevant.
+
+## Workflow
+
+Workflow file:
+
+```text
+.github/workflows/scheduled-qa.yml
+```
+
+Triggers:
+
+- Weekly schedule: Monday at 08:17 UTC.
+- Manual dispatch: `workflow_dispatch`.
+
+Manual dispatch input:
+
+| Input          | Values          | Default | Effect                                       |
+| -------------- | --------------- | ------- | -------------------------------------------- |
+| `load_profile` | `smoke`, `full` | `smoke` | Chooses either k6 CRUD smoke or all profiles |
+
+## Playwright Gate
+
+The Playwright job runs:
+
+```bash
+pnpm test:e2e
+```
+
+The job installs Chromium only. The Playwright config still owns the test
+matrix, including desktop Chromium and the mobile Chromium project for mobile
+responsive and offline tests.
+
+Scheduled CI sets `PLAYWRIGHT_HTML_REPORT=1`, so the run emits both GitHub
+annotations and an HTML report. This keeps ordinary CI output terse while still
+preserving enough evidence for diagnosis.
+
+Artifacts:
+
+| Path                 | Contents                                      |
+| -------------------- | --------------------------------------------- |
+| `playwright-report/` | HTML report for the scheduled run             |
+| `test-results/`      | Failure screenshots, traces, videos, and logs |
+
+Retention: 7 days.
+
+## k6 Gate
+
+The k6 job starts the built API server, waits for `/api/health`, then runs the
+selected profile through the official k6 Docker image.
+
+Default scheduled profile:
+
+```text
+smoke
+```
+
+Manual `full` profile:
+
+```text
+smoke read-load write-load mixed-load ws-stress v5-remote-mix
+```
+
+Artifacts:
+
+| Path                 | Contents                                  |
+| -------------------- | ----------------------------------------- |
+| `k6-results/*.json`  | k6 `--summary-export` output per script   |
+| `k6-results/*.log`   | Full stdout/stderr per script             |
+| `veritas-server.log` | API startup/runtime log for the k6 server |
+
+Retention: 7 days.
+
+## Thresholds
+
+Thresholds live in the k6 scripts and fail the scheduled job when breached.
+They are intentionally conservative for the generated CI dataset:
+
+| Profile         | Main threshold                                         |
+| --------------- | ------------------------------------------------------ |
+| `smoke`         | All checks must pass                                   |
+| `read-load`     | p95 HTTP duration under 200 ms, errors under 1 percent |
+| `write-load`    | p95 HTTP duration under 500 ms, errors under 1 percent |
+| `mixed-load`    | p95 HTTP duration under 500 ms, errors under 1 percent |
+| `ws-stress`     | WebSocket connection errors under 5 percent            |
+| `v5-remote-mix` | Hot-path p95 budgets from 250 ms to 750 ms by endpoint |
+
+The scheduled run uses generated test data and should catch obvious regression
+signals without pretending to be a production soak test. Release candidates
+should attach a manual `load_profile=full` run before claiming performance
+readiness.
+
+## Local Commands
+
+Playwright:
+
+```bash
+pnpm test:e2e
+```
+
+k6 smoke:
+
+```bash
+pnpm test:load:smoke
+```
+
+k6 full profile:
+
+```bash
+pnpm test:load
+```
+
+The local k6 commands expect an API server at `http://localhost:3001`.

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -56,6 +56,11 @@ k6 run load-tests/k6/smoke.js
 pnpm test:load
 ```
 
+Scheduled CI runs the k6 smoke profile weekly and can run the full profile by
+manual dispatch. See
+[`docs/testing/scheduled-qa-gates.md`](../docs/testing/scheduled-qa-gates.md)
+for the scheduled/manual gate, artifact, and threshold contract.
+
 ### Run a specific scenario
 
 ```bash

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? 'github' : 'html',
+  reporter:
+    process.env.CI && process.env.PLAYWRIGHT_HTML_REPORT === '1'
+      ? [['github'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
+      : process.env.CI
+        ? 'github'
+        : 'html',
   timeout: 30_000,
 
   use: {


### PR DESCRIPTION
## Summary
- Emit a scheduled-only Playwright HTML report while keeping GitHub annotations for failures.
- Capture per-script k6 stdout/stderr logs alongside summary JSON and server logs.
- Document the scheduled/manual QA gate contract, artifacts, retention, and thresholds.
- Keep the fast PR path unchanged.

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/scheduled-qa.yml'); puts 'scheduled-qa.yml ok'"`
- `pnpm exec prettier --check .github/workflows/scheduled-qa.yml docs/testing/scheduled-qa-gates.md load-tests/README.md playwright.config.ts`
- `pnpm exec playwright test --list`
- `pnpm lint:budget`

Closes #400