### PR TITLE
Add prompt template import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ vk setup --json                  # Machine-readable output
 vk doctor                        # Redacted setup health report
 vk doctor --json                 # Support-safe JSON report
 vk snapshot --format markdown    # Redacted runtime support snapshot
+vk prompts import prompt-registry --dry-run
 ```
 
 Validates Node version, server health, API auth, and optionally creates a welcome task to get you started.
@@ -481,6 +482,9 @@ reachability, projects, sprints, agents, global agent status, routing, prompt
 registry counts, task status counts, notification/webhook enabled states, and
 maintenance health. Use `--format json|markdown` and `--output <path>` when
 attaching it to a support handoff.
+`vk prompts import` syncs file-based prompt templates into the runtime registry.
+Run with `--dry-run` first; rerun with `--force` only when you want disk content
+to replace a differing runtime template.
 
 ### Workflow Commands
 

--- a/cli/src/__tests__/prompts.test.ts
+++ b/cli/src/__tests__/prompts.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { PromptTemplate } from '@veritas-kanban/shared';
+import { runPromptTemplateImport } from '../commands/prompts.js';
+
+interface ApiCall {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeTemplate(
+  input: Partial<PromptTemplate> & Pick<PromptTemplate, 'id' | 'name' | 'content'>
+): PromptTemplate {
+  return {
+    category: 'agent',
+    variables: [],
+    created: '2026-06-04T08:00:00.000Z',
+    updated: '2026-06-04T08:00:00.000Z',
+    currentVersionId: `${input.id}_v1`,
+    ...input,
+  };
+}
+
+function promptRegistryFetch(initialTemplates: PromptTemplate[] = []) {
+  const templates = [...initialTemplates];
+  const calls: ApiCall[] = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? 'GET';
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    calls.push({ method, path: url.pathname, body });
+
+    if (url.pathname === '/api/prompt-registry' && method === 'GET') {
+      return jsonResponse(templates);
+    }
+
+    if (url.pathname === '/api/prompt-registry' && method === 'POST') {
+      templates.push(makeTemplate(body as PromptTemplate));
+      return jsonResponse(templates.at(-1), 201);
+    }
+
+    const patchMatch = url.pathname.match(/^\/api\/prompt-registry\/([^/]+)$/);
+    if (patchMatch && method === 'PATCH') {
+      const id = patchMatch[1] as string;
+      const index = templates.findIndex((template) => template.id === id);
+      if (index === -1) return jsonResponse({ error: 'Template not found' }, 404);
+      templates[index] = {
+        ...templates[index],
+        ...(body as Partial<PromptTemplate>),
+        updated: '2026-06-04T08:05:00.000Z',
+      };
+      return jsonResponse(templates[index]);
+    }
+
+    return jsonResponse({ error: `No fixture for ${method} ${url.pathname}` }, 404);
+  }) as unknown as typeof fetch;
+
+  return { fetch: fetchMock, calls, templates };
+}
+
+describe('vk prompts import', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'vk-prompts-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('plans filename-derived templates deterministically in dry-run mode', async () => {
+    await writeFile(
+      path.join(tmpDir, 'worker-handoff.md'),
+      '# Worker Handoff\n\nHello {{agent_name}}.',
+      'utf-8'
+    );
+    await writeFile(path.join(tmpDir, 'README.md'), '# Registry docs', 'utf-8');
+    const api = promptRegistryFetch();
+
+    const report = await runPromptTemplateImport(
+      {
+        sourceDir: tmpDir,
+        apiBase: 'http://vk.test',
+        dryRun: true,
+      },
+      { fetch: api.fetch, env: {} }
+    );
+
+    expect(report.counts).toMatchObject({ total: 1, created: 1, updated: 0, unchanged: 0 });
+    expect(report.items).toEqual([
+      {
+        status: 'created',
+        file: 'worker-handoff.md',
+        id: 'worker-handoff',
+        name: 'Worker Handoff',
+      },
+    ]);
+    expect(api.calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      'GET /api/prompt-registry',
+    ]);
+  });
+
+  it('creates templates with stable frontmatter IDs when not dry-running', async () => {
+    await writeFile(
+      path.join(tmpDir, 'review.md'),
+      [
+        '---',
+        'id: cross-model-review',
+        'name: Cross Model Review',
+        'category: evaluation',
+        'description: Opposite-model review checklist',
+        '---',
+        '# Ignored Heading',
+        '',
+        'Review {{task_id}}.',
+      ].join('\n'),
+      'utf-8'
+    );
+    const api = promptRegistryFetch();
+
+    const report = await runPromptTemplateImport(
+      {
+        sourceDir: tmpDir,
+        apiBase: 'http://vk.test',
+      },
+      { fetch: api.fetch, env: {} }
+    );
+
+    expect(report.counts).toMatchObject({ created: 1, updated: 0, conflict: 0, malformed: 0 });
+    expect(api.calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      'GET /api/prompt-registry',
+      'POST /api/prompt-registry',
+    ]);
+    expect(api.calls[1]?.body).toMatchObject({
+      id: 'cross-model-review',
+      name: 'Cross Model Review',
+      category: 'evaluation',
+      description: 'Opposite-model review checklist',
+      content: '# Ignored Heading\n\nReview {{task_id}}.',
+    });
+  });
+
+  it('reports runtime drift as a conflict unless force mode is enabled', async () => {
+    await writeFile(
+      path.join(tmpDir, 'bug-triage.md'),
+      '# Bug Triage\n\nNew content for {{issue}}.',
+      'utf-8'
+    );
+    const existing = makeTemplate({
+      id: 'bug-triage',
+      name: 'Bug Triage',
+      content: '# Bug Triage\n\nOld content for {{issue}}.',
+    });
+
+    const conflict = await runPromptTemplateImport(
+      {
+        sourceDir: tmpDir,
+        apiBase: 'http://vk.test',
+        dryRun: true,
+      },
+      { fetch: promptRegistryFetch([existing]).fetch, env: {} }
+    );
+
+    expect(conflict.counts).toMatchObject({ conflict: 1, updated: 0 });
+    expect(conflict.items[0]).toMatchObject({
+      status: 'conflict',
+      id: 'bug-triage',
+      changedFields: ['content'],
+    });
+
+    const api = promptRegistryFetch([existing]);
+    const forced = await runPromptTemplateImport(
+      {
+        sourceDir: tmpDir,
+        apiBase: 'http://vk.test',
+        force: true,
+      },
+      { fetch: api.fetch, env: {} }
+    );
+
+    expect(forced.counts).toMatchObject({ conflict: 0, updated: 1 });
+    expect(api.calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      'GET /api/prompt-registry',
+      'PATCH /api/prompt-registry/bug-triage',
+    ]);
+    expect(api.calls[1]?.body).toMatchObject({
+      content: '# Bug Triage\n\nNew content for {{issue}}.',
+      changelog: 'Sync from bug-triage.md',
+    });
+  });
+
+  it('reports unchanged, malformed frontmatter, and name conflicts without writes', async () => {
+    await writeFile(path.join(tmpDir, 'same.md'), '# Same Prompt\n\nSame body.', 'utf-8');
+    await writeFile(path.join(tmpDir, 'bad.md'), '---\nid bad\n---\nBad body.', 'utf-8');
+    await writeFile(path.join(tmpDir, 'duplicate.md'), '# Existing Prompt\n\nNew body.', 'utf-8');
+    const api = promptRegistryFetch([
+      makeTemplate({
+        id: 'same',
+        name: 'Same Prompt',
+        content: '# Same Prompt\n\nSame body.',
+      }),
+      makeTemplate({
+        id: 'runtime-existing',
+        name: 'Existing Prompt',
+        content: '# Existing Prompt\n\nRuntime body.',
+      }),
+    ]);
+
+    const report = await runPromptTemplateImport(
+      {
+        sourceDir: tmpDir,
+        apiBase: 'http://vk.test',
+      },
+      { fetch: api.fetch, env: {} }
+    );
+
+    expect(report.counts).toMatchObject({
+      total: 3,
+      unchanged: 1,
+      malformed: 1,
+      conflict: 1,
+      created: 0,
+      updated: 0,
+    });
+    expect(report.items.map((item) => item.status).sort()).toEqual([
+      'conflict',
+      'malformed',
+      'unchanged',
+    ]);
+    expect(api.calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      'GET /api/prompt-registry',
+    ]);
+  });
+});

--- a/cli/src/commands/prompts.ts
+++ b/cli/src/commands/prompts.ts
@@ -1,0 +1,619 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { API_BASE, buildApiHeaders } from '../utils/api.js';
+import type {
+  CreatePromptTemplateInput,
+  PromptCategory,
+  PromptTemplate,
+  UpdatePromptTemplateInput,
+} from '@veritas-kanban/shared';
+
+const VALID_CATEGORIES = new Set<PromptCategory>(['system', 'agent', 'tool', 'evaluation']);
+
+interface PromptImportOptions {
+  sourceDir: string;
+  apiBase: string;
+  timeoutMs: number;
+  dryRun: boolean;
+  force: boolean;
+  includeReadme: boolean;
+}
+
+interface PromptImportDependencies {
+  fetch: typeof fetch;
+  env: NodeJS.ProcessEnv;
+}
+
+export interface FilePromptTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  category: PromptCategory;
+  content: string;
+  filePath: string;
+  relativePath: string;
+}
+
+export type PromptImportStatus = 'created' | 'updated' | 'unchanged' | 'conflict' | 'malformed';
+
+export interface PromptImportItem {
+  status: PromptImportStatus;
+  file: string;
+  id?: string;
+  name?: string;
+  reason?: string;
+  changedFields?: string[];
+}
+
+export interface PromptImportReport {
+  dryRun: boolean;
+  force: boolean;
+  sourceDirectory: string;
+  counts: Record<PromptImportStatus, number> & { total: number };
+  items: PromptImportItem[];
+}
+
+interface ParsedPromptFile {
+  template?: FilePromptTemplate;
+  item?: PromptImportItem;
+}
+
+interface FrontmatterParseResult {
+  data: Record<string, unknown>;
+  content: string;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function unwrapData<T>(body: unknown): T {
+  if (isRecord(body) && body.success === true && 'data' in body) {
+    return body.data as T;
+  }
+  return body as T;
+}
+
+function normalizeApiBase(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '');
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return trimmed;
+  }
+}
+
+function normalizeContent(value: string): string {
+  return value.replace(/\r\n/g, '\n').trim();
+}
+
+function normalizeOptional(value: string | undefined): string {
+  return value?.trim() ?? '';
+}
+
+function slugifyId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function isValidTemplateId(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value);
+}
+
+function humanizeId(value: string): string {
+  return value
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function frontmatterString(data: Record<string, unknown>, key: string): string | undefined {
+  const value = data[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function parseScalar(value: string): unknown {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const rawItems = trimmed.slice(1, -1).trim();
+    if (!rawItems) return [];
+    return rawItems.split(',').map((item) => String(parseScalar(item)));
+  }
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  return trimmed;
+}
+
+function parseFrontmatter(raw: string): FrontmatterParseResult {
+  const normalized = raw.replace(/\r\n/g, '\n');
+  if (!normalized.startsWith('---\n')) {
+    return { data: {}, content: normalized };
+  }
+
+  const lines = normalized.split('\n');
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (closingIndex === -1) {
+    return { data: {}, content: '', error: 'Missing closing frontmatter delimiter' };
+  }
+
+  const data: Record<string, unknown> = {};
+  let currentListKey: string | null = null;
+
+  for (const line of lines.slice(1, closingIndex)) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    const listMatch = line.match(/^\s*-\s+(.+)$/);
+    if (listMatch && currentListKey) {
+      (data[currentListKey] as unknown[]).push(parseScalar(listMatch[1] ?? ''));
+      continue;
+    }
+
+    const entryMatch = line.match(/^([A-Za-z][\w-]*):(?:\s*(.*))?$/);
+    if (!entryMatch) {
+      return { data: {}, content: '', error: `Malformed frontmatter line: ${line.trim()}` };
+    }
+
+    const key = entryMatch[1] as string;
+    const rawValue = entryMatch[2] ?? '';
+    if (!rawValue.trim()) {
+      data[key] = [];
+      currentListKey = key;
+    } else {
+      data[key] = parseScalar(rawValue);
+      currentListKey = null;
+    }
+  }
+
+  return {
+    data,
+    content: lines.slice(closingIndex + 1).join('\n'),
+  };
+}
+
+function firstMarkdownHeading(content: string): string | undefined {
+  const heading = content
+    .split('\n')
+    .map((line) => line.match(/^#\s+(.+)$/)?.[1]?.trim())
+    .find((line): line is string => Boolean(line));
+  return heading || undefined;
+}
+
+export async function discoverPromptTemplateFiles(
+  sourceDir: string,
+  options: { includeReadme?: boolean } = {}
+): Promise<string[]> {
+  const root = path.resolve(sourceDir);
+  const results: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.toLowerCase().endsWith('.md')) continue;
+      if (!options.includeReadme && entry.name.toLowerCase() === 'readme.md') continue;
+      results.push(fullPath);
+    }
+  }
+
+  await walk(root);
+  return results;
+}
+
+export async function parsePromptTemplateFile(
+  filePath: string,
+  rootDir: string
+): Promise<ParsedPromptFile> {
+  const relativePath = path.relative(path.resolve(rootDir), filePath).replace(/\\/g, '/');
+
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    const parsed = parseFrontmatter(raw);
+    if (parsed.error) {
+      return { item: { status: 'malformed', file: relativePath, reason: parsed.error } };
+    }
+
+    const content = normalizeContent(parsed.content);
+    if (!content) {
+      return {
+        item: { status: 'malformed', file: relativePath, reason: 'Template content is empty' },
+      };
+    }
+
+    const basename = path.basename(filePath, path.extname(filePath));
+    const frontmatterId = frontmatterString(parsed.data, 'id');
+    const id = frontmatterId ?? slugifyId(basename);
+    if (!id || !isValidTemplateId(id)) {
+      return {
+        item: {
+          status: 'malformed',
+          file: relativePath,
+          id,
+          reason: 'Template ID must contain only letters, numbers, dashes, and underscores',
+        },
+      };
+    }
+
+    const category = frontmatterString(parsed.data, 'category') ?? 'agent';
+    if (!VALID_CATEGORIES.has(category as PromptCategory)) {
+      return {
+        item: {
+          status: 'malformed',
+          file: relativePath,
+          id,
+          reason: `Unsupported category: ${category}`,
+        },
+      };
+    }
+
+    const name =
+      frontmatterString(parsed.data, 'name') ??
+      frontmatterString(parsed.data, 'title') ??
+      firstMarkdownHeading(content) ??
+      humanizeId(id);
+    const description = frontmatterString(parsed.data, 'description');
+
+    return {
+      template: {
+        id,
+        name,
+        description,
+        category: category as PromptCategory,
+        content,
+        filePath,
+        relativePath,
+      },
+    };
+  } catch (error) {
+    return {
+      item: {
+        status: 'malformed',
+        file: relativePath,
+        reason: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+function changedFields(fileTemplate: FilePromptTemplate, existing: PromptTemplate): string[] {
+  const fields: string[] = [];
+  if (fileTemplate.name !== existing.name) fields.push('name');
+  if (normalizeOptional(fileTemplate.description) !== normalizeOptional(existing.description)) {
+    fields.push('description');
+  }
+  if (fileTemplate.category !== existing.category) fields.push('category');
+  if (fileTemplate.content !== normalizeContent(existing.content)) fields.push('content');
+  return fields;
+}
+
+function emptyCounts(): PromptImportReport['counts'] {
+  return {
+    total: 0,
+    created: 0,
+    updated: 0,
+    unchanged: 0,
+    conflict: 0,
+    malformed: 0,
+  };
+}
+
+function buildReport(
+  items: PromptImportItem[],
+  options: Pick<PromptImportOptions, 'dryRun' | 'force' | 'sourceDir'>
+): PromptImportReport {
+  const counts = emptyCounts();
+  for (const item of items) {
+    counts.total += 1;
+    counts[item.status] += 1;
+  }
+
+  return {
+    dryRun: options.dryRun,
+    force: options.force,
+    sourceDirectory: path.basename(path.resolve(options.sourceDir)),
+    counts,
+    items,
+  };
+}
+
+export function hasPromptImportBlockers(report: PromptImportReport): boolean {
+  return report.counts.conflict > 0 || report.counts.malformed > 0;
+}
+
+export function planPromptTemplateImport(
+  parsedFiles: ParsedPromptFile[],
+  existingTemplates: PromptTemplate[],
+  options: Pick<PromptImportOptions, 'dryRun' | 'force' | 'sourceDir'>
+): PromptImportReport {
+  const existingById = new Map(existingTemplates.map((template) => [template.id, template]));
+  const existingByName = new Map(
+    existingTemplates.map((template) => [template.name.trim().toLowerCase(), template])
+  );
+  const seenIds = new Set<string>();
+  const items: PromptImportItem[] = [];
+
+  for (const parsed of parsedFiles) {
+    if (parsed.item) {
+      items.push(parsed.item);
+      continue;
+    }
+
+    const fileTemplate = parsed.template;
+    if (!fileTemplate) continue;
+    if (seenIds.has(fileTemplate.id)) {
+      items.push({
+        status: 'conflict',
+        file: fileTemplate.relativePath,
+        id: fileTemplate.id,
+        name: fileTemplate.name,
+        reason: 'Multiple files resolve to the same template ID',
+      });
+      continue;
+    }
+    seenIds.add(fileTemplate.id);
+
+    const existing = existingById.get(fileTemplate.id);
+    if (existing) {
+      const fields = changedFields(fileTemplate, existing);
+      if (fields.length === 0) {
+        items.push({
+          status: 'unchanged',
+          file: fileTemplate.relativePath,
+          id: fileTemplate.id,
+          name: fileTemplate.name,
+        });
+      } else if (options.force) {
+        items.push({
+          status: 'updated',
+          file: fileTemplate.relativePath,
+          id: fileTemplate.id,
+          name: fileTemplate.name,
+          changedFields: fields,
+        });
+      } else {
+        items.push({
+          status: 'conflict',
+          file: fileTemplate.relativePath,
+          id: fileTemplate.id,
+          name: fileTemplate.name,
+          changedFields: fields,
+          reason: 'Runtime template differs; rerun with --force to update',
+        });
+      }
+      continue;
+    }
+
+    const sameName = existingByName.get(fileTemplate.name.trim().toLowerCase());
+    if (sameName) {
+      items.push({
+        status: 'conflict',
+        file: fileTemplate.relativePath,
+        id: fileTemplate.id,
+        name: fileTemplate.name,
+        reason: `Template name already exists with runtime ID ${sameName.id}`,
+      });
+      continue;
+    }
+
+    items.push({
+      status: 'created',
+      file: fileTemplate.relativePath,
+      id: fileTemplate.id,
+      name: fileTemplate.name,
+    });
+  }
+
+  return buildReport(items, options);
+}
+
+async function requestJson<T>(
+  deps: PromptImportDependencies,
+  options: PromptImportOptions,
+  pathName: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+
+  try {
+    const headers = new Headers(init.headers);
+    headers.set('content-type', 'application/json');
+    for (const [key, value] of Object.entries(buildApiHeaders(undefined, deps.env.VK_API_KEY))) {
+      headers.set(key, value);
+    }
+
+    const response = await deps.fetch(`${options.apiBase}${pathName}`, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    const body = text ? JSON.parse(text) : null;
+    if (!response.ok) {
+      const message =
+        isRecord(body) && typeof body.error === 'string'
+          ? body.error
+          : isRecord(body) && typeof body.message === 'string'
+            ? body.message
+            : response.statusText;
+      throw new Error(`${response.status} ${message}`);
+    }
+    return unwrapData<T>(body);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function loadExistingTemplates(
+  deps: PromptImportDependencies,
+  options: PromptImportOptions
+): Promise<PromptTemplate[]> {
+  return requestJson<PromptTemplate[]>(deps, options, '/api/prompt-registry');
+}
+
+async function applyPromptTemplateImport(
+  report: PromptImportReport,
+  parsedFiles: ParsedPromptFile[],
+  deps: PromptImportDependencies,
+  options: PromptImportOptions
+): Promise<void> {
+  const byRelativePath = new Map(
+    parsedFiles
+      .filter((parsed): parsed is ParsedPromptFile & { template: FilePromptTemplate } =>
+        Boolean(parsed.template)
+      )
+      .map((parsed) => [parsed.template.relativePath, parsed.template])
+  );
+
+  for (const item of report.items) {
+    const fileTemplate = byRelativePath.get(item.file);
+    if (!fileTemplate) continue;
+
+    if (item.status === 'created') {
+      const body: CreatePromptTemplateInput = {
+        id: fileTemplate.id,
+        name: fileTemplate.name,
+        description: fileTemplate.description,
+        category: fileTemplate.category,
+        content: fileTemplate.content,
+      };
+      await requestJson<PromptTemplate>(deps, options, '/api/prompt-registry', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+    }
+
+    if (item.status === 'updated') {
+      const body: UpdatePromptTemplateInput = {
+        name: fileTemplate.name,
+        description: fileTemplate.description,
+        category: fileTemplate.category,
+        content: fileTemplate.content,
+        changelog: `Sync from ${fileTemplate.relativePath}`,
+      };
+      await requestJson<PromptTemplate>(deps, options, `/api/prompt-registry/${fileTemplate.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      });
+    }
+  }
+}
+
+export async function runPromptTemplateImport(
+  input: Partial<PromptImportOptions> & { sourceDir: string },
+  depsInput: Partial<PromptImportDependencies> = {}
+): Promise<PromptImportReport> {
+  const options: PromptImportOptions = {
+    sourceDir: input.sourceDir,
+    apiBase: normalizeApiBase(input.apiBase ?? API_BASE),
+    timeoutMs: input.timeoutMs ?? 5000,
+    dryRun: input.dryRun ?? false,
+    force: input.force ?? false,
+    includeReadme: input.includeReadme ?? false,
+  };
+  const deps: PromptImportDependencies = {
+    fetch: depsInput.fetch ?? globalThis.fetch.bind(globalThis),
+    env: depsInput.env ?? process.env,
+  };
+
+  const files = await discoverPromptTemplateFiles(options.sourceDir, {
+    includeReadme: options.includeReadme,
+  });
+  const parsedFiles = await Promise.all(
+    files.map((file) => parsePromptTemplateFile(file, options.sourceDir))
+  );
+  const existingTemplates = await loadExistingTemplates(deps, options);
+  const report = planPromptTemplateImport(parsedFiles, existingTemplates, options);
+
+  if (!options.dryRun && !hasPromptImportBlockers(report)) {
+    await applyPromptTemplateImport(report, parsedFiles, deps, options);
+  }
+
+  return report;
+}
+
+export function formatPromptImportReport(report: PromptImportReport): string {
+  const lines = [
+    `Prompt import ${report.dryRun ? 'dry run' : 'result'}`,
+    `Source: ${report.sourceDirectory}`,
+    `Counts: ${report.counts.created} created, ${report.counts.updated} updated, ${report.counts.unchanged} unchanged, ${report.counts.conflict} conflict, ${report.counts.malformed} malformed`,
+    '',
+  ];
+
+  for (const item of report.items) {
+    const changed = item.changedFields?.length ? ` (${item.changedFields.join(', ')})` : '';
+    const reason = item.reason ? ` - ${item.reason}` : '';
+    lines.push(
+      `- ${item.status}: ${item.id ?? 'unknown'} ${item.file}${changed}${reason}`.trimEnd()
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function parseTimeout(value: string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+}
+
+export function registerPromptCommands(program: Command): void {
+  const prompts = program.command('prompts').description('Prompt registry commands');
+
+  prompts
+    .command('import <dir>')
+    .description('Import file-based prompt templates into the runtime registry')
+    .option('--dry-run', 'Report changes without writing to the runtime registry')
+    .option('--force', 'Update existing runtime templates when file content or metadata differs')
+    .option('--json', 'Output as JSON')
+    .option('--include-readme', 'Include README.md files as templates')
+    .option('--api <url>', 'API base URL', API_BASE)
+    .option('--timeout <ms>', 'Per-request timeout in milliseconds', '5000')
+    .action(async (dir, options) => {
+      try {
+        const report = await runPromptTemplateImport({
+          sourceDir: dir,
+          apiBase: options.api,
+          timeoutMs: parseTimeout(options.timeout),
+          dryRun: Boolean(options.dryRun),
+          force: Boolean(options.force),
+          includeReadme: Boolean(options.includeReadme),
+        });
+
+        if (options.json) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          process.stdout.write(formatPromptImportReport(report));
+        }
+
+        if (hasPromptImportBlockers(report)) {
+          process.exit(1);
+        }
+
+        if (!report.dryRun) {
+          const changed = report.counts.created + report.counts.updated;
+          console.log(chalk.green(`Prompt registry import applied: ${changed} changed`));
+        }
+      } catch (error) {
+        console.error(
+          chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`)
+        );
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,6 +18,7 @@ import { registerUsageCommands } from './commands/usage.js';
 import { registerSprintCommands } from './commands/sprints.js';
 import { registerDoctorCommand } from './commands/doctor.js';
 import { registerSnapshotCommand } from './commands/snapshot.js';
+import { registerPromptCommands } from './commands/prompts.js';
 
 const program = new Command();
 const packageJson = JSON.parse(
@@ -47,5 +48,6 @@ registerUsageCommands(program);
 registerSprintCommands(program);
 registerDoctorCommand(program);
 registerSnapshotCommand(program);
+registerPromptCommands(program);
 
 program.parse();

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -438,6 +438,23 @@ Manage AI agents on code tasks.
 
 ---
 
+### Prompt Commands
+
+Sync file-based prompt templates into the runtime prompt registry.
+
+```bash
+vk prompts import prompt-registry --dry-run
+vk prompts import prompt-registry
+vk prompts import prompt-registry --force --json
+```
+
+`vk prompts import` scans Markdown files, skips `README.md` by default, derives
+stable IDs from frontmatter `id` values or filenames, and reports created,
+updated, unchanged, conflicting, and malformed templates. Runtime templates that
+differ from disk are conflicts unless `--force` is passed.
+
+---
+
 ### Automation Commands
 
 Manage automation tasks.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -263,7 +263,14 @@ prompt-registry/
 
 1. Reference in task descriptions: `See prompt: prompt-registry/cross-model-review.md`
 2. Copy and customize for your team's conventions
-3. When spawning agents (OpenClaw `sessions_spawn`), paste the relevant prompt
+3. Preview runtime registry changes: `vk prompts import prompt-registry --dry-run`
+4. Apply new templates: `vk prompts import prompt-registry`
+5. When spawning agents (OpenClaw `sessions_spawn`), paste the relevant prompt
+
+`vk prompts import` derives stable template IDs from frontmatter `id` values or
+filenames, skips `README.md` by default, and reports created, updated,
+unchanged, conflicting, and malformed files. Existing runtime templates that
+differ from disk are reported as conflicts unless you pass `--force`.
 
 **Multi-repo setup:** See [SOP-shared-resources.md](SOP-shared-resources.md) for patterns on sharing prompts across multiple repositories.
 

--- a/docs/SOP-prompt-registry.md
+++ b/docs/SOP-prompt-registry.md
@@ -157,33 +157,75 @@ curl -X DELETE http://localhost:3001/api/prompt-registry/tmpl_abc123
 
 ---
 
+## Import File-Based Templates
+
+Use the CLI importer when templates live in a repo folder such as
+`prompt-registry/` and need to be synced into the runtime registry:
+
+```bash
+vk prompts import prompt-registry --dry-run
+vk prompts import prompt-registry
+vk prompts import prompt-registry --force
+```
+
+Import rules:
+
+- Markdown files are processed in deterministic path order.
+- `README.md` is skipped unless `--include-readme` is passed.
+- Stable template IDs come from frontmatter `id` or the filename slug.
+- `name` comes from frontmatter `name`, frontmatter `title`, the first H1, or
+  the filename.
+- `category` defaults to `agent`; valid values are `system`, `agent`, `tool`,
+  and `evaluation`.
+- Existing runtime templates that differ from disk are reported as conflicts.
+  Use `--force` to update them and create a new prompt version.
+- Name collisions with a different runtime ID are always conflicts.
+
+Example frontmatter:
+
+```markdown
+---
+id: cross-model-review
+name: Cross Model Review
+category: evaluation
+description: Opposite-model review checklist
+---
+
+# Cross Model Review
+
+Review {{task_id}}.
+```
+
+---
+
 ## API Endpoints
 
-| Method   | Path                                         | Description                          |
-| -------- | -------------------------------------------- | ------------------------------------ |
-| `GET`    | `/api/prompt-registry`                       | List all templates                   |
-| `POST`   | `/api/prompt-registry`                       | Create a new template                |
-| `GET`    | `/api/prompt-registry/:id`                   | Get a template                       |
-| `PATCH`  | `/api/prompt-registry/:id`                   | Update a template (auto-versions)    |
-| `DELETE` | `/api/prompt-registry/:id`                   | Delete a template                    |
-| `GET`    | `/api/prompt-registry/:id/versions`          | List all versions of a template      |
-| `GET`    | `/api/prompt-registry/:id/usage`             | Get usage history                    |
-| `GET`    | `/api/prompt-registry/:id/stats`             | Get usage statistics                 |
-| `GET`    | `/api/prompt-registry/stats/all`             | Aggregate stats across all templates |
-| `POST`   | `/api/prompt-registry/:id/render-preview`    | Render a preview with variables      |
-| `POST`   | `/api/prompt-registry/:id/record-usage`      | Record a usage event                 |
+| Method   | Path                                      | Description                          |
+| -------- | ----------------------------------------- | ------------------------------------ |
+| `GET`    | `/api/prompt-registry`                    | List all templates                   |
+| `POST`   | `/api/prompt-registry`                    | Create a new template                |
+| `GET`    | `/api/prompt-registry/:id`                | Get a template                       |
+| `PATCH`  | `/api/prompt-registry/:id`                | Update a template (auto-versions)    |
+| `DELETE` | `/api/prompt-registry/:id`                | Delete a template                    |
+| `GET`    | `/api/prompt-registry/:id/versions`       | List all versions of a template      |
+| `GET`    | `/api/prompt-registry/:id/usage`          | Get usage history                    |
+| `GET`    | `/api/prompt-registry/:id/stats`          | Get usage statistics                 |
+| `GET`    | `/api/prompt-registry/stats/all`          | Aggregate stats across all templates |
+| `POST`   | `/api/prompt-registry/:id/render-preview` | Render a preview with variables      |
+| `POST`   | `/api/prompt-registry/:id/record-usage`   | Record a usage event                 |
 
 ---
 
 ## Template Schema
 
-| Field         | Type   | Required | Description                                              |
-| ------------- | ------ | -------- | -------------------------------------------------------- |
-| `name`        | string | ✅       | Template name                                            |
-| `description` | string | ❌       | What the template is for                                 |
-| `category`    | enum   | ✅       | `system`, `agent`, `tool`, or `evaluation`               |
-| `content`     | string | ✅       | Template body with `{{variable}}` placeholders           |
-| `changelog`   | string | ❌       | Description of changes (for update operations)           |
+| Field         | Type   | Required | Description                                    |
+| ------------- | ------ | -------- | ---------------------------------------------- |
+| `id`          | string | ❌       | Stable template ID, used by file imports       |
+| `name`        | string | ✅       | Template name                                  |
+| `description` | string | ❌       | What the template is for                       |
+| `category`    | enum   | ✅       | `system`, `agent`, `tool`, or `evaluation`     |
+| `content`     | string | ✅       | Template body with `{{variable}}` placeholders |
+| `changelog`   | string | ❌       | Description of changes (for update operations) |
 
 ---
 

--- a/server/src/__tests__/prompt-registry-service.test.ts
+++ b/server/src/__tests__/prompt-registry-service.test.ts
@@ -44,6 +44,25 @@ describe('PromptRegistryService', () => {
     expect((await service.getVersionHistory(created.id)).map((v) => v.versionNumber)).toEqual([1]);
   });
 
+  it('creates templates with caller-provided stable IDs', async () => {
+    const created = await service.createTemplate({
+      id: 'worker-handoff',
+      name: 'Worker Handoff',
+      category: 'agent',
+      content: 'Hand off {{task_id}}',
+    });
+
+    expect(created.id).toBe('worker-handoff');
+    expect(created.currentVersionId).toBe('worker-handoff_v1');
+    expect(await service.getTemplate('worker-handoff')).toMatchObject({
+      id: 'worker-handoff',
+      name: 'Worker Handoff',
+    });
+    expect((await service.getVersionHistory('worker-handoff')).map((v) => v.versionNumber)).toEqual(
+      [1]
+    );
+  });
+
   it('updates metadata without creating a version and creates a new version on content change', async () => {
     const created = await service.createTemplate({
       name: 'Ops Prompt',

--- a/server/src/__tests__/storage/sqlite-config-repositories.test.ts
+++ b/server/src/__tests__/storage/sqlite-config-repositories.test.ts
@@ -149,10 +149,12 @@ describe('SQLite configuration repositories', () => {
     });
 
     const created = await service.createTemplate({
+      id: 'sqlite-prompt',
       name: 'SQLite Prompt',
       category: 'agent',
       content: 'Hello {{ name }} from {{team}}',
     });
+    expect(created.id).toBe('sqlite-prompt');
     expect(created.variables).toEqual(['name', 'team']);
     expect(
       (await service.getVersionHistory(created.id)).map((version) => version.versionNumber)

--- a/server/src/routes/prompt-registry.ts
+++ b/server/src/routes/prompt-registry.ts
@@ -9,6 +9,14 @@ const promptService = new PromptRegistryService();
 
 // Validation schemas
 const createPromptTemplateSchema = z.object({
+  id: z
+    .string()
+    .min(1, 'Template ID must not be empty')
+    .regex(
+      /^[A-Za-z0-9_-]+$/,
+      'Template ID may contain only letters, numbers, dashes, and underscores'
+    )
+    .optional(),
   name: z.string().min(1, 'Template name is required'),
   description: z.string().optional(),
   category: z.enum(['system', 'agent', 'tool', 'evaluation']),

--- a/server/src/services/prompt-registry-service.ts
+++ b/server/src/services/prompt-registry-service.ts
@@ -217,7 +217,9 @@ export class PromptRegistryService {
 
     await this.ensureDirs();
 
-    const id = `prompt_${this.slugify(input.name)}_${Date.now()}`;
+    const id = input.id
+      ? validatePathSegment(input.id)
+      : `prompt_${this.slugify(input.name)}_${Date.now()}`;
     const now = new Date().toISOString();
     const variables = this.extractVariables(input.content);
 

--- a/server/src/storage/sqlite/prompt-registry-repository.ts
+++ b/server/src/storage/sqlite/prompt-registry-repository.ts
@@ -10,6 +10,7 @@ import type {
 } from '@veritas-kanban/shared';
 import type { PromptRegistryRepository } from '../interfaces.js';
 import type { SqliteDatabase } from './database.js';
+import { validatePathSegment } from '../../utils/sanitize.js';
 
 interface PromptTemplateRow {
   template_json: string;
@@ -51,7 +52,9 @@ export class SqlitePromptRegistryRepository implements PromptRegistryRepository 
   }
 
   async createTemplate(input: CreatePromptTemplateInput): Promise<PromptTemplate> {
-    const id = `prompt_${this.slugify(input.name)}_${Date.now()}`;
+    const id = input.id
+      ? validatePathSegment(input.id)
+      : `prompt_${this.slugify(input.name)}_${Date.now()}`;
     const now = new Date().toISOString();
     const variables = this.extractVariables(input.content);
 

--- a/shared/src/types/prompt-registry.types.ts
+++ b/shared/src/types/prompt-registry.types.ts
@@ -56,6 +56,7 @@ export interface PromptStats {
 
 /** Input for creating a new prompt template */
 export interface CreatePromptTemplateInput {
+  id?: string;
   name: string;
   description?: string;
   category: PromptCategory;


### PR DESCRIPTION
## Summary
- Add `vk prompts import <dir>` with `--dry-run`, `--force`, `--json`, API override, and deterministic reporting
- Parse Markdown prompt files using frontmatter IDs or filename-derived stable IDs, skip README files by default, and report created/updated/unchanged/conflict/malformed outcomes
- Allow optional explicit prompt template IDs through the existing prompt registry API for both file and SQLite storage
- Document the prompt import workflow and conflict rules

## Verification
- `pnpm --filter @veritas-kanban/cli exec vitest run`
- `pnpm --filter @veritas-kanban/server test -- prompt-registry-service.test.ts storage/sqlite-config-repositories.test.ts`
- `pnpm lint:budget`
- `pnpm typecheck`
- `pnpm exec prettier --check cli/src/commands/prompts.ts cli/src/__tests__/prompts.test.ts cli/src/index.ts shared/src/types/prompt-registry.types.ts server/src/routes/prompt-registry.ts server/src/services/prompt-registry-service.ts server/src/storage/sqlite/prompt-registry-repository.ts server/src/__tests__/prompt-registry-service.test.ts server/src/__tests__/storage/sqlite-config-repositories.test.ts README.md docs/GETTING-STARTED.md docs/CLI-GUIDE.md docs/SOP-prompt-registry.md`
- `git diff --check`
- `pnpm --filter @veritas-kanban/cli dev prompts import --help`

## Risk
- Existing runtime templates that differ from disk are conflicts by default. Operators must pass `--force` before the importer updates runtime content and creates a new prompt version.

Closes #381