### PR TITLE
Continue lint warning ratchet

### DIFF
--- a/docs/testing/lint-warning-debt.md
+++ b/docs/testing/lint-warning-debt.md
@@ -30,14 +30,14 @@ pnpm lint:report
 
 ## Current Budget
 
-Current warning budget: 601.
+Current warning budget: 600.
 
 Baseline after the production unused-value cleanup:
 
 | Package | Warnings |
 | ------- | -------- |
 | server  | 536      |
-| web     | 38       |
+| web     | 37       |
 | mcp     | 25       |
 | shared  | 2        |
 
@@ -48,7 +48,6 @@ Current warning classes:
 | `@typescript-eslint/no-explicit-any`       | 342      |
 | `@typescript-eslint/no-non-null-assertion` | 227      |
 | `@typescript-eslint/no-unused-vars`        | 31       |
-| `react-hooks/exhaustive-deps`              | 1        |
 
 ## Cleanup Order
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev:watchdog": "bash scripts/dev-watchdog.sh",
     "build": "pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/server build && pnpm --filter @veritas-kanban/web build && pnpm --filter @veritas-kanban/cli build && pnpm --filter @veritas-kanban/mcp build && pnpm --filter @veritas-kanban/desktop build",
     "lint": "eslint .",
-    "lint:budget": "node scripts/lint-warning-budget.mjs --max-warnings=601",
+    "lint:budget": "node scripts/lint-warning-budget.mjs --max-warnings=600",
     "lint:report": "node scripts/lint-warning-budget.mjs --all-rules",
     "lint:fix": "eslint . --fix",
     "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",

--- a/web/src/components/shared/AgentStatusIndicator.tsx
+++ b/web/src/components/shared/AgentStatusIndicator.tsx
@@ -182,7 +182,7 @@ export function AgentStatusIndicator({
   const [lastStatus, setLastStatus] = useState<string | null>(null);
   const [statusHistory, setStatusHistory] = useState<StatusHistoryEntry[]>([]);
   const [uptimeStart, setUptimeStart] = useState<Date | null>(null);
-  const [tick, setTick] = useState(0);
+  const [, setTick] = useState(0);
 
   // Fetch recent agent-related activity for status history
   const { data: activities } = useQuery({
@@ -286,10 +286,7 @@ export function AgentStatusIndicator({
   }, [state, data?.subAgentCount, config.label]);
 
   // Calculate uptime
-  const uptimeDisplay = useMemo(() => {
-    if (!uptimeStart) return null;
-    return formatDuration(uptimeStart.toISOString());
-  }, [uptimeStart, tick]); // tick increments every second to trigger recalc
+  const uptimeDisplay = uptimeStart ? formatDuration(uptimeStart.toISOString()) : null;
 
   // Screen reader announcement
   const ariaLabel = useMemo(() => {


### PR DESCRIPTION
## Summary
- remove the stale React hook dependency warning in AgentStatusIndicator
- lower the root lint warning budget from 601 to 600
- update the lint debt ledger with the current package and rule counts

Closes #574

## Verification
- pnpm exec eslint web/src/components/shared/AgentStatusIndicator.tsx
- pnpm lint:report
- pnpm lint:budget
- pnpm --filter @veritas-kanban/web test -- AgentStatusIndicator.test.tsx
- pnpm lint

## Risk
- Low. The uptime interval still forces re-renders through the existing state setter; display calculation now runs during render instead of through a memo with an artificial dependency.