### PR TITLE
Reduce Mantine initial JS payload

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,15 +12,10 @@ import { WebSocketStatusProvider } from './contexts/WebSocketContext';
 import { ViewProvider, useView } from './contexts/ViewContext';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { IdentityProvider } from './hooks/useIdentity';
-import { AuthGuard } from './components/auth';
-import { DesktopOnboardingDialog } from './components/auth/DesktopOnboarding';
+import { AuthGuard } from './components/auth/AuthGuard';
 import { ErrorBoundary } from './components/shared/ErrorBoundary';
 import { SkipToContent } from './components/shared/SkipToContent';
 import { LiveAnnouncerProvider } from './components/shared/LiveAnnouncer';
-import { FloatingChat } from './components/chat/FloatingChat';
-import { SystemHealthBar } from './components/layout/SystemHealthBar';
-import { MobileShell } from './components/layout/MobileShell';
-import { PwaStatusBanner } from './components/layout/PwaStatusBanner';
 import { NAVIGATION_VIEWS, VIEW_BY_ID, type AppView, type NavigationView } from './lib/views';
 import { usePendingProductMode } from './hooks/usePendingProductMode';
 
@@ -32,6 +27,36 @@ const LAZY_VIEW_COMPONENTS = Object.fromEntries(
     return [definition.view, lazy(definition.loadComponent)];
   })
 ) as Record<NavigationView, ReturnType<typeof lazy>>;
+
+const FloatingChat = lazy(() =>
+  import('./components/chat/FloatingChat').then((mod) => ({
+    default: mod.FloatingChat,
+  }))
+);
+
+const DesktopOnboardingDialog = lazy(() =>
+  import('./components/auth/DesktopOnboarding').then((mod) => ({
+    default: mod.DesktopOnboardingDialog,
+  }))
+);
+
+const MobileShell = lazy(() =>
+  import('./components/layout/MobileShell').then((mod) => ({
+    default: mod.MobileShell,
+  }))
+);
+
+const PwaStatusBanner = lazy(() =>
+  import('./components/layout/PwaStatusBanner').then((mod) => ({
+    default: mod.PwaStatusBanner,
+  }))
+);
+
+const SystemHealthBar = lazy(() =>
+  import('./components/layout/SystemHealthBar').then((mod) => ({
+    default: mod.SystemHealthBar,
+  }))
+);
 
 function ViewLoading({ view }: { view: AppView }) {
   return (
@@ -107,11 +132,19 @@ function AppContent() {
                   <Box className="min-h-screen bg-background">
                     <SkipToContent />
                     <Header />
-                    <SystemHealthBar />
-                    <PwaStatusBanner
-                      sessionExpiry={authStatus?.sessionExpiry}
-                      onRefreshAuth={refreshStatus}
-                    />
+                    <Suspense
+                      fallback={
+                        <div className="h-7 border-b border-border bg-muted/30" aria-hidden />
+                      }
+                    >
+                      <SystemHealthBar />
+                    </Suspense>
+                    <Suspense fallback={null}>
+                      <PwaStatusBanner
+                        sessionExpiry={authStatus?.sessionExpiry}
+                        onRefreshAuth={refreshStatus}
+                      />
+                    </Suspense>
                     <Box
                       component="main"
                       id="main-content"
@@ -126,12 +159,20 @@ function AppContent() {
                     </Box>
                     <Toaster />
                     <CommandPalette />
-                    <FloatingChat />
-                    <MobileShell />
-                    <DesktopOnboardingDialog
-                      open={showDesktopOnboarding}
-                      onOpenChange={setShowDesktopOnboarding}
-                    />
+                    <Suspense fallback={null}>
+                      <FloatingChat />
+                    </Suspense>
+                    <Suspense fallback={null}>
+                      <MobileShell />
+                    </Suspense>
+                    {showDesktopOnboarding && (
+                      <Suspense fallback={null}>
+                        <DesktopOnboardingDialog
+                          open={showDesktopOnboarding}
+                          onOpenChange={setShowDesktopOnboarding}
+                        />
+                      </Suspense>
+                    )}
                   </Box>
                 </IdentityProvider>
               </ViewProvider>

--- a/web/src/components/auth/AuthGuard.tsx
+++ b/web/src/components/auth/AuthGuard.tsx
@@ -1,11 +1,32 @@
-import { type ReactNode } from 'react';
+import { lazy, Suspense, type ReactNode } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { SetupScreen } from './SetupScreen';
-import { LoginScreen } from './LoginScreen';
 import { Loader2 } from 'lucide-react';
+
+const SetupScreen = lazy(() =>
+  import('./SetupScreen').then((mod) => ({
+    default: mod.SetupScreen,
+  }))
+);
+
+const LoginScreen = lazy(() =>
+  import('./LoginScreen').then((mod) => ({
+    default: mod.LoginScreen,
+  }))
+);
 
 interface AuthGuardProps {
   children: ReactNode;
+}
+
+function AuthSurfaceFallback() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center space-y-4">
+        <Loader2 className="w-8 h-8 animate-spin mx-auto text-primary" />
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    </div>
+  );
 }
 
 export function AuthGuard({ children }: AuthGuardProps) {
@@ -13,14 +34,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
 
   // Loading state
   if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <div className="text-center space-y-4">
-          <Loader2 className="w-8 h-8 animate-spin mx-auto text-primary" />
-          <p className="text-muted-foreground">Loading...</p>
-        </div>
-      </div>
-    );
+    return <AuthSurfaceFallback />;
   }
 
   // Error state
@@ -31,10 +45,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
           <div className="text-destructive text-6xl">⚠️</div>
           <h1 className="text-xl font-bold">Connection Error</h1>
           <p className="text-muted-foreground">{error}</p>
-          <button
-            onClick={() => window.location.reload()}
-            className="text-primary hover:underline"
-          >
+          <button onClick={() => window.location.reload()} className="text-primary hover:underline">
             Try again
           </button>
         </div>
@@ -50,12 +61,20 @@ export function AuthGuard({ children }: AuthGuardProps) {
 
   // Needs setup - show setup screen
   if (status?.needsSetup) {
-    return <SetupScreen />;
+    return (
+      <Suspense fallback={<AuthSurfaceFallback />}>
+        <SetupScreen />
+      </Suspense>
+    );
   }
 
   // Not authenticated - show login screen
   if (status && !status.authenticated) {
-    return <LoginScreen />;
+    return (
+      <Suspense fallback={<AuthSurfaceFallback />}>
+        <LoginScreen />
+      </Suspense>
+    );
   }
 
   // Authenticated - render the app

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -22,7 +22,6 @@ import {
   searchParamsToFilters,
 } from './FilterBar';
 import { BulkActionsBar } from './BulkActionsBar';
-import { BoardSidebar } from './BoardSidebar';
 import { useBulkActions } from '@/hooks/useBulkActions';
 import {
   areBoardViewFiltersEqual,
@@ -54,6 +53,12 @@ const Dashboard = lazy(() =>
 const TaskDetailPanel = lazy(() =>
   import('@/components/task/TaskDetailPanel').then((mod) => ({
     default: mod.TaskDetailPanel,
+  }))
+);
+
+const BoardSidebar = lazy(() =>
+  import('./BoardSidebar').then((mod) => ({
+    default: mod.BoardSidebar,
   }))
 );
 
@@ -549,11 +554,17 @@ export function KanbanBoard() {
             )}
           </section>
 
-          <BoardSidebar
-            onTaskClick={(taskId) => {
-              void handleTaskIdClick(taskId);
-            }}
-          />
+          <Suspense
+            fallback={
+              <aside className="min-h-24 rounded-md border border-dashed border-border/70" />
+            }
+          >
+            <BoardSidebar
+              onTaskClick={(taskId) => {
+                void handleTaskIdClick(taskId);
+              }}
+            />
+          </Suspense>
         </div>
 
         {boardSettings.showDashboard && (


### PR DESCRIPTION
## Summary
- Lazy-load non-critical shell surfaces from the app entry: system health, PWA/mobile shell, floating chat, and desktop onboarding.
- Lazy-load auth setup/login screens only when AuthGuard reaches those states, and avoid the auth barrel so those screens stay out of the authenticated initial path.
- Lazy-load the board sidebar so operational widgets do not inflate first board paint.

Closes #569.

## Verification
- `pnpm --filter @veritas-kanban/web build`
- `pnpm qa:mantine` passes: Initial JS 249.7 KiB gzip, initial CSS 48.7 KiB gzip.
- `pnpm --filter @veritas-kanban/web test -- src/__tests__/mobile-shell.test.tsx src/__tests__/pwa-status-banner.test.tsx src/__tests__/KanbanBoard.test.tsx src/__tests__/auth-screens-mantine.test.tsx`
- `pnpm test:e2e -- e2e/health.spec.ts e2e/dashboard-widgets.spec.ts e2e/mantine-qa-gate.spec.ts e2e/mobile-responsive.spec.ts e2e/pwa-offline.spec.ts`
- `pnpm build`
- `pnpm qa:mantine` after fresh full build
- `pnpm exec eslint web/src/App.tsx web/src/components/auth/AuthGuard.tsx web/src/components/board/KanbanBoard.tsx`
- `git diff --check`

## Notes
- Local untracked `server/storage/` and `storage/` directories were left untouched.