### PR TITLE
Add watcher continuation policy gates

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -43,14 +43,15 @@
 30. [Cost Prediction](#cost-prediction)
 31. [Error Learning](#error-learning)
 32. [Tool Policies](#tool-policies)
-33. [Traces](#traces)
-34. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
-35. [Audit](#audit)
-36. [Maintenance Center](#maintenance-center-apiv1maintenance)
-37. [Common Workflows](#common-workflows)
-38. [Versioning & Deprecation](#versioning--deprecation)
-39. [Rate Limits](#rate-limits)
-40. [Additional Endpoint Groups](#additional-endpoint-groups)
+33. [Watcher Continuation Policies](#watcher-continuation-policies)
+34. [Traces](#traces)
+35. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
+36. [Audit](#audit)
+37. [Maintenance Center](#maintenance-center-apiv1maintenance)
+38. [Common Workflows](#common-workflows)
+39. [Versioning & Deprecation](#versioning--deprecation)
+40. [Rate Limits](#rate-limits)
+41. [Additional Endpoint Groups](#additional-endpoint-groups)
 
 ---
 
@@ -2065,6 +2066,69 @@ POST /api/tool-policies/:role/validate
 
 ---
 
+## Watcher Continuation Policies
+
+Deterministic guardrail endpoint for agent runners that want to continue a run.
+The server decides before execution whether the continuation is allowed, needs
+approval, or is blocked by the global kill switch, dispatch filters, risk
+classes, continuation caps, or spend caps. Decisions are written to the
+hash-chained audit log without storing prompt or command payloads.
+
+Mounted at `/api/watcher-policies`.
+
+| Method | Path                             | Description                                      |
+| ------ | -------------------------------- | ------------------------------------------------ |
+| `GET`  | `/api/watcher-policies`          | Return current watcher continuation settings     |
+| `POST` | `/api/watcher-policies/evaluate` | Evaluate one proposed continuation before launch |
+
+### Evaluate Continuation
+
+```
+POST /api/watcher-policies/evaluate
+```
+
+**Body**:
+
+```json
+{
+  "runId": "run_123",
+  "taskId": "task_456",
+  "project": "core",
+  "agent": "codex",
+  "prompt": "Continue with the next test fix.",
+  "continuationCount": 1,
+  "monthlySpendUsd": 1.25,
+  "hasRecentTestFailures": false,
+  "recentProviderErrors": 0
+}
+```
+
+**Response** `200`:
+
+```json
+{
+  "decision": "allow",
+  "mode": "auto",
+  "riskLevel": "low",
+  "riskClasses": [],
+  "reasons": ["Continuation is within policy, dispatch, and cap limits."],
+  "evidence": [],
+  "caps": {
+    "maxContinuations": 3,
+    "spendCapUsd": 5
+  },
+  "auditLogged": true,
+  "evaluatedAt": "2026-06-04T22:00:00.000Z"
+}
+```
+
+Settings live under `features.watcherContinuations` and are updated through
+`PATCH /api/settings/features`. Defaults preserve current behavior:
+continuations are disabled and the global kill switch is active until explicitly
+configured.
+
+---
+
 ## Traces
 
 Distributed execution tracing — record and query traces for agent task attempts.
@@ -2287,6 +2351,7 @@ These endpoints follow the same auth/error patterns documented above:
 | `/api/summary`                   | Board summaries                               |
 | `/api/github`                    | GitHub integration                            |
 | `/api/conflicts`                 | Merge conflict detection                      |
+| `/api/watcher-policies`          | Agent continuation guardrail decisions        |
 | `/api/metrics`                   | Prometheus-style metrics                      |
 | `/api/traces`                    | Distributed tracing                           |
 | `/api/cost-prediction`           | Token cost forecasting                        |

--- a/server/src/__tests__/routes/watcher-policies.test.ts
+++ b/server/src/__tests__/routes/watcher-policies.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../../middleware/error-handler.js';
+import { watcherPolicyRoutes } from '../../routes/watcher-policies.js';
+import {
+  resetWatcherPolicyServiceForTests,
+  WatcherPolicyService,
+} from '../../services/watcher-policy-service.js';
+
+vi.mock('../../services/audit-service.js', () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('watcher policy routes', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    resetWatcherPolicyServiceForTests(
+      new WatcherPolicyService({
+        settings: {
+          enabled: true,
+          globalKillSwitch: false,
+          defaultMode: 'auto',
+          maxContinuationsPerRun: 3,
+          spendCapUsd: 5,
+          riskClasses: [
+            'destructive_command',
+            'credential_reference',
+            'recent_test_failure',
+            'provider_error',
+            'policy_violation',
+          ],
+          dispatchDenyPatterns: ['never auto deploy'],
+          policies: [],
+        },
+      })
+    );
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/watcher-policies', watcherPolicyRoutes);
+    app.use(errorHandler);
+  });
+
+  afterEach(() => {
+    resetWatcherPolicyServiceForTests();
+  });
+
+  it('returns current watcher continuation settings', async () => {
+    const res = await request(app).get('/api/watcher-policies');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      enabled: true,
+      globalKillSwitch: false,
+      defaultMode: 'auto',
+    });
+  });
+
+  it('evaluates continuation requests through the policy service', async () => {
+    const res = await request(app).post('/api/watcher-policies/evaluate').send({
+      runId: 'run-1',
+      agent: 'codex',
+      project: 'core',
+      prompt: 'never auto deploy this to production',
+      continuationCount: 0,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      decision: 'block',
+      mode: 'auto',
+      auditLogged: true,
+    });
+    expect(res.body.evidence.map((item: { code: string }) => item.code)).toContain(
+      'dispatch_filter'
+    );
+  });
+
+  it('rejects unknown fields instead of accepting policy bypass metadata', async () => {
+    const res = await request(app).post('/api/watcher-policies/evaluate').send({
+      runId: 'run-1',
+      agent: 'codex',
+      bypassPolicy: true,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/server/src/__tests__/services/watcher-policy-service.test.ts
+++ b/server/src/__tests__/services/watcher-policy-service.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AuditEvent } from '../../services/audit-service.js';
+import { WatcherPolicyService } from '../../services/watcher-policy-service.js';
+import type { WatcherContinuationSettings } from '@veritas-kanban/shared';
+
+function enabledSettings(
+  patch: Partial<WatcherContinuationSettings> = {}
+): WatcherContinuationSettings {
+  return {
+    enabled: true,
+    globalKillSwitch: false,
+    defaultMode: 'auto',
+    maxContinuationsPerRun: 3,
+    spendCapUsd: 5,
+    riskClasses: [
+      'destructive_command',
+      'credential_reference',
+      'recent_test_failure',
+      'provider_error',
+      'policy_violation',
+    ],
+    dispatchDenyPatterns: [],
+    policies: [],
+    ...patch,
+  };
+}
+
+describe('WatcherPolicyService', () => {
+  it('blocks by default because watcher continuations are disabled and killed', async () => {
+    const service = new WatcherPolicyService({
+      auditWriter: vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const result = await service.evaluateContinuation({ runId: 'run-1', agent: 'codex' });
+
+    expect(result.decision).toBe('block');
+    expect(result.reasons).toContain('Watcher continuations are disabled.');
+    expect(result.auditLogged).toBe(true);
+  });
+
+  it('enforces the global kill switch before allowing clean continuations', async () => {
+    const service = new WatcherPolicyService({
+      settings: enabledSettings({ globalKillSwitch: true }),
+      auditWriter: vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const result = await service.evaluateContinuation({ runId: 'run-1', agent: 'codex' });
+
+    expect(result.decision).toBe('block');
+    expect(result.reasons).toContain('Global watcher kill switch is active.');
+  });
+
+  it('allows clean auto continuations that are inside dispatch and cap limits', async () => {
+    const service = new WatcherPolicyService({
+      settings: enabledSettings(),
+      auditWriter: vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const result = await service.evaluateContinuation({
+      runId: 'run-1',
+      agent: 'codex',
+      project: 'core',
+      prompt: 'Continue with the next non-destructive test fix.',
+      continuationCount: 1,
+      monthlySpendUsd: 1,
+    });
+
+    expect(result.decision).toBe('allow');
+    expect(result.riskClasses).toEqual([]);
+  });
+
+  it('requires approval for risky auto continuations instead of bypassing risk classes', async () => {
+    const service = new WatcherPolicyService({
+      settings: enabledSettings(),
+      auditWriter: vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const result = await service.evaluateContinuation({
+      runId: 'run-1',
+      agent: 'codex',
+      command: 'git reset --hard HEAD',
+      continuationCount: 0,
+    });
+
+    expect(result.decision).toBe('require_approval');
+    expect(result.riskClasses).toContain('destructive_command');
+    expect(result.riskLevel).toBe('critical');
+  });
+
+  it('escalates ask_on_risk policies and records the matched project/agent policy', async () => {
+    const service = new WatcherPolicyService({
+      settings: enabledSettings({
+        defaultMode: 'auto',
+        policies: [
+          {
+            id: 'core-codex',
+            enabled: true,
+            project: 'core',
+            agent: 'codex',
+            mode: 'ask_on_risk',
+          },
+        ],
+      }),
+      auditWriter: vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const result = await service.evaluateContinuation({
+      runId: 'run-1',
+      project: 'core',
+      agent: 'codex',
+      hasRecentTestFailures: true,
+    });
+
+    expect(result.decision).toBe('require_approval');
+    expect(result.matchedPolicyId).toBe('core-codex');
+    expect(result.riskClasses).toContain('recent_test_failure');
+  });
+
+  it('blocks dispatch-filtered continuation payloads', async () => {
+    const service = new WatcherPolicyService({
+      settings: enabledSettings({ dispatchDenyPatterns: ['rotate production secret'] }),
+      auditWriter: vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const result = await service.evaluateContinuation({
+      runId: 'run-1',
+      prompt: 'Please rotate production secret and keep going.',
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.evidence.map((item) => item.code)).toContain('dispatch_filter');
+  });
+
+  it('blocks continuation and spend caps to prevent runaway loops', async () => {
+    const service = new WatcherPolicyService({
+      settings: enabledSettings({ maxContinuationsPerRun: 2, spendCapUsd: 10 }),
+      auditWriter: vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const continuationCap = await service.evaluateContinuation({
+      runId: 'run-1',
+      continuationCount: 2,
+      monthlySpendUsd: 1,
+    });
+    const spendCap = await service.evaluateContinuation({
+      runId: 'run-2',
+      continuationCount: 0,
+      monthlySpendUsd: 10,
+    });
+
+    expect(continuationCap.decision).toBe('block');
+    expect(continuationCap.evidence.map((item) => item.code)).toContain('continuation_cap');
+    expect(spendCap.decision).toBe('block');
+    expect(spendCap.evidence.map((item) => item.code)).toContain('spend_cap');
+  });
+
+  it('writes redacted audit details without prompt or command payloads', async () => {
+    const auditWriter = vi.fn<(_: AuditEvent) => Promise<void>>().mockResolvedValue(undefined);
+    const service = new WatcherPolicyService({
+      settings: enabledSettings(),
+      auditWriter,
+    });
+
+    await service.evaluateContinuation(
+      {
+        runId: 'run-1',
+        taskId: 'task-1',
+        project: 'core',
+        agent: 'codex',
+        prompt: 'Use token super-secret-value to continue.',
+        command: 'echo super-secret-value',
+      },
+      { actor: 'agent-key' }
+    );
+
+    expect(auditWriter).toHaveBeenCalledOnce();
+    const auditEvent = auditWriter.mock.calls[0][0];
+    expect(auditEvent.action).toBe('watcher.continuation.evaluate');
+    expect(JSON.stringify(auditEvent.details)).not.toContain('super-secret-value');
+    expect(auditEvent.details).toMatchObject({
+      decision: 'require_approval',
+      riskClasses: ['credential_reference'],
+      runId: 'run-1',
+      taskId: 'task-1',
+      project: 'core',
+      agent: 'codex',
+    });
+  });
+});

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -4,6 +4,7 @@ import { CodexHealthService } from '../services/codex-health-service.js';
 import { getTelemetryService } from '../services/telemetry-service.js';
 import { getAttachmentService } from '../services/attachment-service.js';
 import { setEnforcementSettings, setHooksSettings } from '../services/hook-service.js';
+import { setWatcherContinuationSettings } from '../services/watcher-policy-service.js';
 import type { FeatureSettings } from '@veritas-kanban/shared';
 import { FeatureSettingsPatchSchema } from '../schemas/feature-settings-schema.js';
 import { strictRateLimit } from '../middleware/rate-limit.js';
@@ -45,6 +46,9 @@ export function syncSettingsToServices(settings: FeatureSettings): void {
 
   // Sync enforcement settings
   setEnforcementSettings(settings.enforcement);
+
+  // Sync watcher continuation policy settings
+  setWatcherContinuationSettings(settings.watcherContinuations);
 
   // Register outbound endpoints from legacy feature settings without exposing secrets.
   void getOutboundIntegrationService()

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -47,6 +47,7 @@ import {
   taskReadAccess,
   telemetryAccess,
   transcriptAccess,
+  watcherPolicyAccess,
   workflowAccess,
   workProductAccess,
   workspaceAccess,
@@ -124,6 +125,7 @@ import { maintenanceRoutes } from '../maintenance.js';
 import { identityRoutes } from '../identity.js';
 import { skillCapabilityRoutes } from '../skill-capabilities.js';
 import { skillSecurityRoutes } from '../skill-security.js';
+import { watcherPolicyRoutes } from '../watcher-policies.js';
 
 const v1Router: IRouter = Router();
 
@@ -215,6 +217,7 @@ v1Router.use('/audit', adminAccess, auditRoutes);
 v1Router.use('/lessons', taskReadAccess, lessonsRoutes);
 v1Router.use('/delegation', delegationAccess, delegationRoutes);
 v1Router.use('/workflows', workflowAccess, workflowRoutes);
+v1Router.use('/watcher-policies', watcherPolicyAccess, watcherPolicyRoutes);
 v1Router.use('/tool-policies', policyAccess, toolPolicyRoutes);
 v1Router.use('/policies', policyAccess, policyRoutes);
 v1Router.use('/skills/capabilities', skillCapabilityAccess, skillCapabilityRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -78,6 +78,10 @@ export const workflowAccess = routeAccess('workflow:read', 'workflow:write', [
   },
 ]);
 
+export const watcherPolicyAccess = routeAccess('policy:read', 'policy:write', [
+  { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
+]);
+
 export const reportRoutesAccess = routeAccess('report:read', 'settings:write', [
   { methods: ['POST'], path: /^\/generate\/?$/, permissions: 'report:read' },
 ]);

--- a/server/src/routes/watcher-policies.ts
+++ b/server/src/routes/watcher-policies.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import type { WatcherContinuationEvaluationRequest } from '@veritas-kanban/shared';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { validate, type ValidatedRequest } from '../middleware/validate.js';
+import { getWatcherPolicyService } from '../services/watcher-policy-service.js';
+import { watcherContinuationEvaluationSchema } from '../schemas/watcher-policy-schemas.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+
+const router = Router();
+
+router.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    res.json(getWatcherPolicyService().getSettings());
+  })
+);
+
+router.post(
+  '/evaluate',
+  validate({ body: watcherContinuationEvaluationSchema }),
+  asyncHandler(
+    async (req: ValidatedRequest<unknown, unknown, WatcherContinuationEvaluationRequest>, res) => {
+      const authReq = req as AuthenticatedRequest;
+      const actor =
+        authReq.auth?.keyName ||
+        authReq.auth?.tokenName ||
+        authReq.auth?.userId ||
+        authReq.auth?.role ||
+        'unknown';
+
+      const result = await getWatcherPolicyService().evaluateContinuation(
+        req.validated.body as WatcherContinuationEvaluationRequest,
+        { actor }
+      );
+
+      res.json(result);
+    }
+  )
+);
+
+export { router as watcherPolicyRoutes };

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -258,6 +258,42 @@ const SquadWebhookSettingsSchema = z
   .strict()
   .optional();
 
+const WatcherRiskClassSchema = z.enum([
+  'destructive_command',
+  'credential_reference',
+  'recent_test_failure',
+  'provider_error',
+  'policy_violation',
+]);
+
+const WatcherContinuationPolicySchema = z
+  .object({
+    id: z.string().min(1).max(120),
+    enabled: z.boolean(),
+    project: z.string().min(1).max(160).optional(),
+    agent: z.string().min(1).max(120).optional(),
+    mode: z.enum(['ask_always', 'ask_on_risk', 'auto']).optional(),
+    maxContinuations: z.number().int().min(0).max(100).optional(),
+    spendCapUsd: z.number().min(0).max(100000).optional(),
+    riskClasses: z.array(WatcherRiskClassSchema).max(20).optional(),
+    dispatchDenyPatterns: z.array(z.string().min(1).max(200)).max(100).optional(),
+  })
+  .strict();
+
+const WatcherContinuationSettingsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    globalKillSwitch: z.boolean().optional(),
+    defaultMode: z.enum(['ask_always', 'ask_on_risk', 'auto']).optional(),
+    maxContinuationsPerRun: z.number().int().min(0).max(100).optional(),
+    spendCapUsd: z.number().min(0).max(100000).optional(),
+    riskClasses: z.array(WatcherRiskClassSchema).max(20).optional(),
+    dispatchDenyPatterns: z.array(z.string().min(1).max(200)).max(100).optional(),
+    policies: z.array(WatcherContinuationPolicySchema).max(200).optional(),
+  })
+  .strict()
+  .optional();
+
 const SharedResourcesSettingsSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -286,6 +322,7 @@ const FeatureSettingsPatchObjectSchema = z
     sharedResources: SharedResourcesSettingsSchema,
     docFreshness: DocFreshnessSettingsSchema,
     squadWebhook: SquadWebhookSettingsSchema,
+    watcherContinuations: WatcherContinuationSettingsSchema,
   })
   .strict()
   .refine((val) => !hasDangerousKeys(val), {

--- a/server/src/schemas/watcher-policy-schemas.ts
+++ b/server/src/schemas/watcher-policy-schemas.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const watcherRiskClassSchema = z.enum([
+  'destructive_command',
+  'credential_reference',
+  'recent_test_failure',
+  'provider_error',
+  'policy_violation',
+]);
+
+export const watcherContinuationEvaluationSchema = z
+  .object({
+    runId: z.string().min(1).max(200).optional(),
+    taskId: z.string().min(1).max(200).optional(),
+    project: z.string().min(1).max(160).optional(),
+    agent: z.string().min(1).max(120).optional(),
+    prompt: z.string().max(20000).optional(),
+    command: z.string().max(4000).optional(),
+    toolName: z.string().max(160).optional(),
+    continuationCount: z.number().int().min(0).max(10000).optional(),
+    monthlySpendUsd: z.number().min(0).max(1000000).optional(),
+    hasRecentTestFailures: z.boolean().optional(),
+    recentProviderErrors: z.number().int().min(0).max(10000).optional(),
+    policyViolations: z.array(z.string().min(1).max(200)).max(100).optional(),
+    riskHints: z.array(watcherRiskClassSchema).max(20).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();

--- a/server/src/services/watcher-policy-service.ts
+++ b/server/src/services/watcher-policy-service.ts
@@ -1,0 +1,410 @@
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type WatcherContinuationDecision,
+  type WatcherContinuationEvaluationRequest,
+  type WatcherContinuationEvaluationResult,
+  type WatcherContinuationEvidence,
+  type WatcherContinuationMode,
+  type WatcherContinuationPolicy,
+  type WatcherContinuationSettings,
+  type WatcherRiskClass,
+  type WatcherRiskLevel,
+} from '@veritas-kanban/shared';
+import { auditLog, type AuditEvent } from './audit-service.js';
+
+type AuditWriter = (event: AuditEvent) => Promise<void>;
+
+interface EffectiveWatcherPolicy {
+  mode: WatcherContinuationMode;
+  maxContinuations: number;
+  spendCapUsd: number;
+  riskClasses: WatcherRiskClass[];
+  dispatchDenyPatterns: string[];
+  matchedPolicyId?: string;
+}
+
+export interface WatcherPolicyServiceOptions {
+  settings?: WatcherContinuationSettings;
+  auditWriter?: AuditWriter;
+}
+
+const DESTRUCTIVE_COMMAND_PATTERNS = [
+  /\brm\s+-[^\n]*r[^\n]*f\b/i,
+  /\bgit\s+reset\s+--hard\b/i,
+  /\bgit\s+clean\s+-[^\n]*f/i,
+  /\bterraform\s+destroy\b/i,
+  /\bkubectl\s+delete\b/i,
+  /\bdocker\s+system\s+prune\b/i,
+  /\bdiskutil\s+erase/i,
+  /\bmkfs(?:\.\w+)?\b/i,
+  /\bdd\s+if=/i,
+  /\bDROP\s+TABLE\b/i,
+  /\bTRUNCATE\s+TABLE\b/i,
+];
+
+const CREDENTIAL_PATTERNS = [
+  /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password|passphrase)\b/i,
+  /BEGIN [A-Z ]*PRIVATE KEY/i,
+  /\bAWS_SECRET_ACCESS_KEY\b/i,
+  /\bGITHUB_TOKEN\b/i,
+  /\bSUPABASE_SERVICE_ROLE_KEY\b/i,
+];
+
+const RISK_LEVEL_BY_CLASS: Record<WatcherRiskClass, WatcherRiskLevel> = {
+  destructive_command: 'critical',
+  credential_reference: 'high',
+  recent_test_failure: 'medium',
+  provider_error: 'medium',
+  policy_violation: 'high',
+};
+
+const RISK_LEVEL_WEIGHT: Record<WatcherRiskLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
+
+export class WatcherPolicyService {
+  private settings: WatcherContinuationSettings;
+  private readonly auditWriter: AuditWriter;
+
+  constructor(options: WatcherPolicyServiceOptions = {}) {
+    this.settings = normalizeSettings(
+      options.settings ?? DEFAULT_FEATURE_SETTINGS.watcherContinuations
+    );
+    this.auditWriter = options.auditWriter ?? auditLog;
+  }
+
+  configure(settings: WatcherContinuationSettings | undefined): void {
+    this.settings = normalizeSettings(settings ?? DEFAULT_FEATURE_SETTINGS.watcherContinuations);
+  }
+
+  getSettings(): WatcherContinuationSettings {
+    return cloneJson(this.settings);
+  }
+
+  async evaluateContinuation(
+    input: WatcherContinuationEvaluationRequest,
+    options: { actor?: string; audit?: boolean } = {}
+  ): Promise<WatcherContinuationEvaluationResult> {
+    const result = this.evaluate(input);
+
+    if (options.audit !== false) {
+      await this.auditWriter({
+        action: 'watcher.continuation.evaluate',
+        actor: options.actor ?? 'system',
+        resource: input.runId ?? input.taskId ?? 'watcher-continuation',
+        details: {
+          decision: result.decision,
+          mode: result.mode,
+          riskLevel: result.riskLevel,
+          riskClasses: result.riskClasses,
+          matchedPolicyId: result.matchedPolicyId,
+          reasons: result.reasons,
+          runId: input.runId,
+          taskId: input.taskId,
+          project: input.project,
+          agent: input.agent,
+          continuationCount: input.continuationCount,
+          monthlySpendUsd: input.monthlySpendUsd,
+        },
+      });
+    }
+
+    return { ...result, auditLogged: options.audit !== false };
+  }
+
+  private evaluate(
+    input: WatcherContinuationEvaluationRequest
+  ): WatcherContinuationEvaluationResult {
+    const effective = this.resolvePolicy(input);
+    const evidence: WatcherContinuationEvidence[] = [];
+    const reasons: string[] = [];
+    let decision: WatcherContinuationDecision = 'allow';
+
+    if (!this.settings.enabled) {
+      return this.blockedResult(
+        effective,
+        input,
+        ['Watcher continuations are disabled.'],
+        [
+          {
+            code: 'watchers_disabled',
+            message: 'Continuation watchers are disabled in feature settings.',
+          },
+        ]
+      );
+    }
+
+    if (this.settings.globalKillSwitch) {
+      return this.blockedResult(
+        effective,
+        input,
+        ['Global watcher kill switch is active.'],
+        [
+          {
+            code: 'global_kill_switch',
+            message: 'The global kill switch blocks all watcher continuations.',
+          },
+        ]
+      );
+    }
+
+    const riskClasses = this.classifyRisk(input, evidence);
+    const riskLevel = riskLevelFor(riskClasses);
+    const filteredRiskClasses = riskClasses.filter((riskClass) =>
+      effective.riskClasses.includes(riskClass)
+    );
+
+    const matchedDispatchFilter = this.findDispatchFilterMatch(
+      input,
+      effective.dispatchDenyPatterns
+    );
+    if (matchedDispatchFilter !== null) {
+      return this.blockedResult(
+        effective,
+        input,
+        ['Continuation prompt matched dispatch filter.'],
+        [
+          ...evidence,
+          {
+            code: 'dispatch_filter',
+            message: `Dispatch deny pattern #${matchedDispatchFilter + 1} matched the continuation payload.`,
+          },
+        ],
+        riskClasses
+      );
+    }
+
+    if (
+      typeof input.continuationCount === 'number' &&
+      input.continuationCount >= effective.maxContinuations
+    ) {
+      return this.blockedResult(
+        effective,
+        input,
+        ['Continuation cap reached for this run.'],
+        [
+          ...evidence,
+          {
+            code: 'continuation_cap',
+            message: `Continuation count ${input.continuationCount} reached cap ${effective.maxContinuations}.`,
+          },
+        ],
+        riskClasses
+      );
+    }
+
+    if (
+      effective.spendCapUsd > 0 &&
+      typeof input.monthlySpendUsd === 'number' &&
+      input.monthlySpendUsd >= effective.spendCapUsd
+    ) {
+      return this.blockedResult(
+        effective,
+        input,
+        ['Watcher spend cap reached.'],
+        [
+          ...evidence,
+          {
+            code: 'spend_cap',
+            message: `Monthly watcher spend ${input.monthlySpendUsd} reached cap ${effective.spendCapUsd}.`,
+          },
+        ],
+        riskClasses
+      );
+    }
+
+    if (effective.mode === 'ask_always') {
+      decision = 'require_approval';
+      reasons.push('Policy mode ask_always requires approval for every continuation.');
+    } else if (filteredRiskClasses.length > 0) {
+      decision = 'require_approval';
+      reasons.push('Continuation has monitored risk classes and requires approval.');
+    } else {
+      reasons.push('Continuation is within policy, dispatch, and cap limits.');
+    }
+
+    return {
+      decision,
+      mode: effective.mode,
+      riskLevel,
+      riskClasses,
+      ...(effective.matchedPolicyId ? { matchedPolicyId: effective.matchedPolicyId } : {}),
+      reasons,
+      evidence,
+      caps: {
+        maxContinuations: effective.maxContinuations,
+        spendCapUsd: effective.spendCapUsd,
+      },
+      auditLogged: false,
+      evaluatedAt: new Date().toISOString(),
+    };
+  }
+
+  private blockedResult(
+    effective: EffectiveWatcherPolicy,
+    input: WatcherContinuationEvaluationRequest,
+    reasons: string[],
+    evidence: WatcherContinuationEvidence[],
+    classifiedRiskClasses?: WatcherRiskClass[]
+  ): WatcherContinuationEvaluationResult {
+    const riskClasses = classifiedRiskClasses ?? this.classifyRisk(input, evidence);
+    return {
+      decision: 'block',
+      mode: effective.mode,
+      riskLevel: riskLevelFor(riskClasses),
+      riskClasses,
+      ...(effective.matchedPolicyId ? { matchedPolicyId: effective.matchedPolicyId } : {}),
+      reasons,
+      evidence,
+      caps: {
+        maxContinuations: effective.maxContinuations,
+        spendCapUsd: effective.spendCapUsd,
+      },
+      auditLogged: false,
+      evaluatedAt: new Date().toISOString(),
+    };
+  }
+
+  private classifyRisk(
+    input: WatcherContinuationEvaluationRequest,
+    evidence: WatcherContinuationEvidence[]
+  ): WatcherRiskClass[] {
+    const riskClasses = new Set<WatcherRiskClass>(input.riskHints ?? []);
+    const payload = [input.prompt, input.command, input.toolName].filter(Boolean).join('\n');
+
+    if (DESTRUCTIVE_COMMAND_PATTERNS.some((pattern) => pattern.test(payload))) {
+      riskClasses.add('destructive_command');
+      evidence.push({
+        riskClass: 'destructive_command',
+        code: 'destructive_command_detected',
+        message: 'Continuation payload contains destructive command syntax.',
+      });
+    }
+
+    if (CREDENTIAL_PATTERNS.some((pattern) => pattern.test(payload))) {
+      riskClasses.add('credential_reference');
+      evidence.push({
+        riskClass: 'credential_reference',
+        code: 'credential_reference_detected',
+        message: 'Continuation payload references credential-like material.',
+      });
+    }
+
+    if (input.hasRecentTestFailures) {
+      riskClasses.add('recent_test_failure');
+      evidence.push({
+        riskClass: 'recent_test_failure',
+        code: 'recent_test_failure',
+        message: 'Recent test failures are attached to this run.',
+      });
+    }
+
+    if ((input.recentProviderErrors ?? 0) > 0) {
+      riskClasses.add('provider_error');
+      evidence.push({
+        riskClass: 'provider_error',
+        code: 'provider_error',
+        message: 'Recent AI/provider errors are attached to this run.',
+      });
+    }
+
+    if ((input.policyViolations?.length ?? 0) > 0) {
+      riskClasses.add('policy_violation');
+      evidence.push({
+        riskClass: 'policy_violation',
+        code: 'policy_violation',
+        message: 'Policy violations are attached to this continuation request.',
+      });
+    }
+
+    return Array.from(riskClasses);
+  }
+
+  private findDispatchFilterMatch(
+    input: WatcherContinuationEvaluationRequest,
+    patterns: string[]
+  ): number | null {
+    if (patterns.length === 0) return null;
+    const payload = [input.prompt, input.command, input.toolName]
+      .filter(Boolean)
+      .join('\n')
+      .toLowerCase();
+
+    return patterns.findIndex((pattern) => {
+      const normalized = pattern.trim().toLowerCase();
+      return normalized.length > 0 && payload.includes(normalized);
+    });
+  }
+
+  private resolvePolicy(input: WatcherContinuationEvaluationRequest): EffectiveWatcherPolicy {
+    const matched = [...this.settings.policies]
+      .filter((policy) => policy.enabled && policyMatches(policy, input))
+      .sort((a, b) => policySpecificity(b) - policySpecificity(a))[0];
+
+    return {
+      mode: matched?.mode ?? this.settings.defaultMode,
+      maxContinuations: matched?.maxContinuations ?? this.settings.maxContinuationsPerRun,
+      spendCapUsd: matched?.spendCapUsd ?? this.settings.spendCapUsd,
+      riskClasses: matched?.riskClasses ?? this.settings.riskClasses,
+      dispatchDenyPatterns: [
+        ...this.settings.dispatchDenyPatterns,
+        ...(matched?.dispatchDenyPatterns ?? []),
+      ],
+      ...(matched ? { matchedPolicyId: matched.id } : {}),
+    };
+  }
+}
+
+let watcherPolicyService: WatcherPolicyService | null = null;
+
+export function getWatcherPolicyService(): WatcherPolicyService {
+  if (!watcherPolicyService) {
+    watcherPolicyService = new WatcherPolicyService();
+  }
+  return watcherPolicyService;
+}
+
+export function setWatcherContinuationSettings(
+  settings: WatcherContinuationSettings | undefined
+): void {
+  getWatcherPolicyService().configure(settings);
+}
+
+export function resetWatcherPolicyServiceForTests(service?: WatcherPolicyService): void {
+  watcherPolicyService = service ?? null;
+}
+
+function policyMatches(
+  policy: WatcherContinuationPolicy,
+  input: WatcherContinuationEvaluationRequest
+): boolean {
+  if (policy.project && policy.project !== input.project) return false;
+  if (policy.agent && policy.agent !== input.agent) return false;
+  return true;
+}
+
+function policySpecificity(policy: WatcherContinuationPolicy): number {
+  return Number(Boolean(policy.project)) + Number(Boolean(policy.agent));
+}
+
+function riskLevelFor(riskClasses: WatcherRiskClass[]): WatcherRiskLevel {
+  return riskClasses.reduce<WatcherRiskLevel>((max, riskClass) => {
+    const level = RISK_LEVEL_BY_CLASS[riskClass];
+    return RISK_LEVEL_WEIGHT[level] > RISK_LEVEL_WEIGHT[max] ? level : max;
+  }, 'low');
+}
+
+function normalizeSettings(settings: WatcherContinuationSettings): WatcherContinuationSettings {
+  return {
+    ...DEFAULT_FEATURE_SETTINGS.watcherContinuations,
+    ...cloneJson(settings),
+    policies: settings.policies?.map((policy) => ({ ...policy })) ?? [],
+  };
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -2,6 +2,7 @@
 
 import type { AgentType, TaskPriority } from './task.types.js';
 import type { TelemetryConfig } from './telemetry.types.js';
+import type { WatcherContinuationSettings } from './watcher-policy.types.js';
 
 export interface DevServerConfig {
   command: string; // e.g., "pnpm dev" or "npm run dev"
@@ -365,6 +366,9 @@ export interface SquadWebhookSettings {
   openclawGatewayToken?: string; // Auth token
 }
 
+/** Watcher continuation policy settings. Disabled by default. */
+export type { WatcherContinuationSettings } from './watcher-policy.types.js';
+
 /** All feature settings combined */
 export interface FeatureSettings {
   general: GeneralSettings;
@@ -382,6 +386,7 @@ export interface FeatureSettings {
   sharedResources: SharedResourcesSettings;
   docFreshness: DocFreshnessSettings;
   squadWebhook: SquadWebhookSettings;
+  watcherContinuations: WatcherContinuationSettings;
 }
 
 /** Default feature settings — matches current app behavior */
@@ -498,5 +503,21 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     notifyOnAgent: false,
     openclawGatewayUrl: '',
     openclawGatewayToken: '',
+  },
+  watcherContinuations: {
+    enabled: false,
+    globalKillSwitch: true,
+    defaultMode: 'ask_always',
+    maxContinuationsPerRun: 3,
+    spendCapUsd: 5,
+    riskClasses: [
+      'destructive_command',
+      'credential_reference',
+      'recent_test_failure',
+      'provider_error',
+      'policy_violation',
+    ],
+    dispatchDenyPatterns: [],
+    policies: [],
   },
 };

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -27,3 +27,4 @@ export * from './maintenance.types.js';
 export * from './governance-trace.types.js';
 export * from './skill-capability.types.js';
 export * from './skill-security.types.js';
+export * from './watcher-policy.types.js';

--- a/shared/src/types/watcher-policy.types.ts
+++ b/shared/src/types/watcher-policy.types.ts
@@ -1,0 +1,74 @@
+export type WatcherContinuationMode = 'ask_always' | 'ask_on_risk' | 'auto';
+
+export type WatcherRiskClass =
+  | 'destructive_command'
+  | 'credential_reference'
+  | 'recent_test_failure'
+  | 'provider_error'
+  | 'policy_violation';
+
+export type WatcherContinuationDecision = 'allow' | 'require_approval' | 'block';
+
+export type WatcherRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface WatcherContinuationPolicy {
+  id: string;
+  enabled: boolean;
+  project?: string;
+  agent?: string;
+  mode?: WatcherContinuationMode;
+  maxContinuations?: number;
+  spendCapUsd?: number;
+  riskClasses?: WatcherRiskClass[];
+  dispatchDenyPatterns?: string[];
+}
+
+export interface WatcherContinuationSettings {
+  enabled: boolean;
+  globalKillSwitch: boolean;
+  defaultMode: WatcherContinuationMode;
+  maxContinuationsPerRun: number;
+  spendCapUsd: number;
+  riskClasses: WatcherRiskClass[];
+  dispatchDenyPatterns: string[];
+  policies: WatcherContinuationPolicy[];
+}
+
+export interface WatcherContinuationEvaluationRequest {
+  runId?: string;
+  taskId?: string;
+  project?: string;
+  agent?: string;
+  prompt?: string;
+  command?: string;
+  toolName?: string;
+  continuationCount?: number;
+  monthlySpendUsd?: number;
+  hasRecentTestFailures?: boolean;
+  recentProviderErrors?: number;
+  policyViolations?: string[];
+  riskHints?: WatcherRiskClass[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface WatcherContinuationEvidence {
+  riskClass?: WatcherRiskClass;
+  code: string;
+  message: string;
+}
+
+export interface WatcherContinuationEvaluationResult {
+  decision: WatcherContinuationDecision;
+  mode: WatcherContinuationMode;
+  riskLevel: WatcherRiskLevel;
+  riskClasses: WatcherRiskClass[];
+  matchedPolicyId?: string;
+  reasons: string[];
+  evidence: WatcherContinuationEvidence[];
+  caps: {
+    maxContinuations: number;
+    spendCapUsd: number;
+  };
+  auditLogged: boolean;
+  evaluatedAt: string;
+}

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -239,6 +239,14 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     ],
   },
   {
+    prefix: '/api/watcher-policies',
+    read: 'policy:read',
+    write: 'policy:write',
+    overrides: [
+      { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
+    ],
+  },
+  {
     prefix: '/api/tool-policies',
     read: 'policy:read',
     overrides: [


### PR DESCRIPTION
## Summary
- Adds watcher continuation settings, types, validation, and conservative defaults with continuations disabled and the global kill switch active.
- Adds a deterministic watcher policy service plus /api/watcher-policies endpoints for allow / require_approval / block decisions before runner continuation.
- Records redacted hash-chained audit events for every continuation evaluation without storing prompt or command payloads.
- Documents the API contract and adds service/route coverage for risk classes, dispatch filters, caps, kill switch, policy matching, and audit redaction.

Closes #583

## Verification
- pnpm exec vitest run server/src/__tests__/services/watcher-policy-service.test.ts server/src/__tests__/routes/watcher-policies.test.ts
- pnpm typecheck
- pnpm build
- pnpm exec eslint shared/src/types/watcher-policy.types.ts shared/src/types/config.types.ts shared/src/types/index.ts shared/src/utils/api-permissions.ts server/src/services/watcher-policy-service.ts server/src/routes/watcher-policies.ts server/src/schemas/watcher-policy-schemas.ts server/src/routes/settings.ts server/src/routes/v1/index.ts server/src/routes/v1/permissions.ts server/src/schemas/feature-settings-schema.ts server/src/__tests__/services/watcher-policy-service.test.ts server/src/__tests__/routes/watcher-policies.test.ts
- pnpm audit --prod
- pnpm qa:mantine
- git diff --check

## Risk
- Adds policy evaluation only. No autonomous runner loop is introduced.
- Existing installs keep current behavior because watcher continuations default to disabled with kill switch active.