### PR TITLE
Add deterministic agent health classifier

### DIFF
--- a/server/src/__tests__/routes/agent-registry.test.ts
+++ b/server/src/__tests__/routes/agent-registry.test.ts
@@ -8,12 +8,34 @@ import request from 'supertest';
 import express from 'express';
 import { errorHandler } from '../../middleware/error-handler.js';
 
+const routeMocks = vi.hoisted(() => ({
+  getAgentStatus: vi.fn(() => ({
+    status: 'idle',
+    activeAgents: [],
+    lastUpdated: '2026-06-04T12:00:00Z',
+  })),
+  getEvents: vi.fn(async () => []),
+  listTasks: vi.fn(async () => []),
+}));
+
 // Mock fs-helpers before importing routes
 vi.mock('../../storage/fs-helpers.js', () => ({
   existsSync: vi.fn().mockReturnValue(false),
   readFileSync: vi.fn().mockReturnValue('{}'),
   writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
+}));
+
+vi.mock('../../services/task-service.js', () => ({
+  getTaskService: () => ({ listTasks: routeMocks.listTasks }),
+}));
+
+vi.mock('../../services/telemetry-service.js', () => ({
+  getTelemetryService: () => ({ getEvents: routeMocks.getEvents }),
+}));
+
+vi.mock('../../routes/agent-status.js', () => ({
+  getAgentStatus: routeMocks.getAgentStatus,
 }));
 
 const { disposeAgentRegistryService } = await import('../../services/agent-registry-service.js');
@@ -24,6 +46,13 @@ describe('Agent Registry Routes', () => {
 
   beforeEach(() => {
     disposeAgentRegistryService();
+    routeMocks.getAgentStatus.mockReturnValue({
+      status: 'idle',
+      activeAgents: [],
+      lastUpdated: '2026-06-04T12:00:00Z',
+    });
+    routeMocks.getEvents.mockResolvedValue([]);
+    routeMocks.listTasks.mockResolvedValue([]);
 
     app = express();
     app.use(express.json());
@@ -206,6 +235,54 @@ describe('Agent Registry Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(1);
       expect(res.body[0].id).toBe('a1');
+    });
+  });
+
+  // ── Health Classifier ────────────────────────────────────────
+
+  describe('GET /api/agents/register/health', () => {
+    it('should return deterministic agent health classifications before ID lookup', async () => {
+      routeMocks.listTasks.mockResolvedValue([
+        {
+          id: 'task_20260604_health',
+          title: 'Health classified task',
+          description: 'Route fixture',
+          type: 'feature',
+          status: 'blocked',
+          priority: 'high',
+          created: '2026-06-04T10:00:00Z',
+          updated: '2026-06-04T11:00:00Z',
+          blockedReason: { category: 'waiting-on-feedback', note: 'Needs owner approval' },
+        },
+      ]);
+
+      await request(app)
+        .post('/api/agents/register')
+        .send({ id: 'codex', name: 'Codex', capabilities: [] });
+
+      await request(app).post('/api/agents/register/codex/heartbeat').send({
+        status: 'busy',
+        currentTaskId: 'task_20260604_health',
+        currentTaskTitle: 'Health classified task',
+      });
+
+      const res = await request(app).get('/api/agents/register/health');
+
+      expect(res.status).toBe(200);
+      expect(res.body.generatedAt).toBeDefined();
+      expect(res.body.classifications).toHaveLength(1);
+      expect(res.body.classifications[0]).toMatchObject({
+        subjectId: 'agent:codex',
+        state: 'blocked',
+        reasonCode: 'hitl_pending',
+        confidence: 0.88,
+      });
+      expect(routeMocks.getEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: ['run.completed', 'run.error'],
+          limit: 5000,
+        })
+      );
     });
   });
 

--- a/server/src/__tests__/services/agent-health-classifier-service.test.ts
+++ b/server/src/__tests__/services/agent-health-classifier-service.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type { AnyTelemetryEvent, Task } from '@veritas-kanban/shared';
+import {
+  AgentHealthClassifierService,
+  type AgentHealthClassifierInput,
+} from '../../services/agent-health-classifier-service.js';
+import type { RegisteredAgent } from '../../services/agent-registry-service.js';
+
+const NOW = new Date('2026-06-04T12:00:00Z');
+
+function makeAgent(overrides: Partial<RegisteredAgent> = {}): RegisteredAgent {
+  return {
+    id: 'codex',
+    name: 'Codex',
+    capabilities: [],
+    status: 'online',
+    registeredAt: '2026-06-04T11:00:00Z',
+    lastHeartbeat: '2026-06-04T11:59:00Z',
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task_20260604_health',
+    title: 'Classify agent health',
+    description: 'Verify deterministic classifier output',
+    type: 'feature',
+    status: 'in-progress',
+    priority: 'high',
+    created: '2026-06-04T09:00:00Z',
+    updated: '2026-06-04T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function classify(input: Omit<AgentHealthClassifierInput, 'now'>) {
+  return new AgentHealthClassifierService().classify({ ...input, now: NOW })[0];
+}
+
+describe('AgentHealthClassifierService', () => {
+  it('marks offline or stale agents as blocked with supervisor evidence', () => {
+    const result = classify({
+      agents: [
+        makeAgent({
+          status: 'offline',
+          lastHeartbeat: '2026-06-04T08:00:00Z',
+        }),
+      ],
+    });
+
+    expect(result).toMatchObject({
+      state: 'blocked',
+      reasonCode: 'supervisor_unavailable',
+      confidence: 0.9,
+    });
+    expect(result.evidence[0]).toMatchObject({ code: 'supervisor_unavailable' });
+  });
+
+  it('marks tasks waiting on feedback as HITL blocked', () => {
+    const task = makeTask({
+      status: 'blocked',
+      blockedReason: { category: 'waiting-on-feedback', note: 'Owner must approve scope' },
+    });
+    const result = classify({
+      agents: [makeAgent({ status: 'busy', currentTaskId: task.id, currentTaskTitle: task.title })],
+      tasks: [task],
+    });
+
+    expect(result).toMatchObject({
+      state: 'blocked',
+      reasonCode: 'hitl_pending',
+    });
+    expect(result.evidence[0]?.message).toBe('Owner must approve scope');
+  });
+
+  it('marks repeated run errors as risky with deterministic evidence', () => {
+    const telemetryEvents: AnyTelemetryEvent[] = [1, 2, 3].map((index) => ({
+      id: `event-${index}`,
+      type: 'run.error',
+      timestamp: `2026-06-04T11:0${index}:00Z`,
+      taskId: 'task_20260604_health',
+      agent: 'codex',
+      error: 'Provider request failed',
+      attemptId: `attempt-${index}`,
+    }));
+
+    const result = classify({
+      agents: [makeAgent()],
+      telemetryEvents,
+    });
+
+    expect(result).toMatchObject({
+      state: 'risky',
+      reasonCode: 'repeated_tool_failures',
+      confidence: 0.86,
+    });
+    expect(result.evidence[0]?.message).toContain('3 run errors');
+  });
+
+  it('marks stale busy agents on in-progress tasks as stuck', () => {
+    const task = makeTask({ updated: '2026-06-04T08:00:00Z' });
+    const result = classify({
+      agents: [makeAgent({ status: 'busy', currentTaskId: task.id, currentTaskTitle: task.title })],
+      tasks: [task],
+    });
+
+    expect(result).toMatchObject({
+      state: 'stuck',
+      reasonCode: 'no_signal',
+      confidence: 0.74,
+    });
+  });
+
+  it('marks successful runs on active tasks as completion candidates', () => {
+    const task = makeTask();
+    const result = classify({
+      agents: [makeAgent({ status: 'busy', currentTaskId: task.id, currentTaskTitle: task.title })],
+      tasks: [task],
+      telemetryEvents: [
+        {
+          id: 'run-complete',
+          type: 'run.completed',
+          timestamp: '2026-06-04T11:30:00Z',
+          taskId: task.id,
+          agent: 'codex',
+          success: true,
+          attemptId: 'attempt-complete',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      state: 'complete_candidate',
+      reasonCode: 'explicit_completion_hint',
+      confidence: 0.68,
+    });
+  });
+
+  it('marks clean online agents as healthy without an LLM signal', () => {
+    const result = classify({ agents: [makeAgent()] });
+
+    expect(result).toMatchObject({
+      state: 'healthy',
+      reasonCode: 'active_ok',
+      confidence: 0.6,
+    });
+    expect(result.updatedAt).toBe(NOW.toISOString());
+    expect(result.evidence).toHaveLength(1);
+  });
+});

--- a/server/src/routes/agent-registry.ts
+++ b/server/src/routes/agent-registry.ts
@@ -6,6 +6,7 @@
  * DELETE /api/agents/register/:id       — Deregister an agent
  * GET    /api/agents/register           — List all registered agents
  * GET    /api/agents/register/:id       — Get specific agent
+ * GET    /api/agents/register/health    — Classify operational health for agents
  * GET    /api/agents/register/stats     — Get registry statistics
  * GET    /api/agents/register/capabilities/:capability — Find agents by capability
  */
@@ -13,8 +14,12 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { getAgentRegistryService } from '../services/agent-registry-service.js';
+import { getAgentHealthClassifierService } from '../services/agent-health-classifier-service.js';
+import { getTaskService } from '../services/task-service.js';
+import { getTelemetryService } from '../services/telemetry-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { getAgentStatus } from './agent-status.js';
 
 const router: RouterType = Router();
 
@@ -67,6 +72,36 @@ router.get(
     const registry = getAgentRegistryService();
     const agents = registry.findByCapability(req.params.capability as string);
     res.json(agents);
+  })
+);
+
+/**
+ * GET /api/agents/register/health
+ * Classify registered agents with deterministic operational health signals
+ */
+router.get(
+  '/health',
+  asyncHandler(async (_req, res) => {
+    const registry = getAgentRegistryService();
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const [tasks, telemetryEvents] = await Promise.all([
+      getTaskService().listTasks(),
+      getTelemetryService().getEvents({
+        since,
+        type: ['run.completed', 'run.error'],
+        limit: 5000,
+      }),
+    ]);
+    const generatedAt = new Date().toISOString();
+    const classifications = getAgentHealthClassifierService().classify({
+      agents: registry.list(),
+      tasks,
+      telemetryEvents,
+      globalStatus: getAgentStatus(),
+      now: new Date(generatedAt),
+    });
+
+    res.json({ classifications, generatedAt });
   })
 );
 

--- a/server/src/services/agent-health-classifier-service.ts
+++ b/server/src/services/agent-health-classifier-service.ts
@@ -1,0 +1,331 @@
+import type {
+  AgentHealthClassification,
+  AgentHealthEvidence,
+  AgentHealthReasonCode,
+  AgentHealthState,
+  AnyTelemetryEvent,
+  RunTelemetryEvent,
+  Task,
+} from '@veritas-kanban/shared';
+import type { AgentStatus } from '../routes/agent-status.js';
+import type { RegisteredAgent } from './agent-registry-service.js';
+
+export interface AgentHealthClassifierInput {
+  agents: RegisteredAgent[];
+  tasks?: Task[];
+  telemetryEvents?: AnyTelemetryEvent[];
+  globalStatus?: AgentStatus;
+  now?: Date;
+}
+
+const STUCK_BUSY_MS = 2 * 60 * 60 * 1000;
+const STALE_HEARTBEAT_MS = 10 * 60 * 1000;
+const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const STATE_RANK: Record<AgentHealthState, number> = {
+  healthy: 0,
+  complete_candidate: 1,
+  stuck: 2,
+  risky: 3,
+  blocked: 4,
+};
+
+export class AgentHealthClassifierService {
+  classify(input: AgentHealthClassifierInput): AgentHealthClassification[] {
+    const now = input.now ?? new Date();
+    const tasks = input.tasks ?? [];
+    const telemetryEvents = input.telemetryEvents ?? [];
+    const taskById = new Map(tasks.map((task) => [task.id, task]));
+    const recentEvents = telemetryEvents.filter((event) => isRecent(event.timestamp, now));
+    const agents = mergeAgentSubjects(input.agents, input.globalStatus);
+
+    return agents
+      .map((agent) => this.classifyAgent(agent, taskById, recentEvents, input.globalStatus, now))
+      .sort((a, b) => {
+        const stateDelta = STATE_RANK[b.state] - STATE_RANK[a.state];
+        if (stateDelta !== 0) return stateDelta;
+        return a.subjectId.localeCompare(b.subjectId);
+      });
+  }
+
+  private classifyAgent(
+    agent: RegisteredAgent,
+    taskById: Map<string, Task>,
+    recentEvents: AnyTelemetryEvent[],
+    globalStatus: AgentStatus | undefined,
+    now: Date
+  ): AgentHealthClassification {
+    const agentEvents = recentEvents.filter((event) => eventAgent(event) === agent.id);
+    const task = agent.currentTaskId ? taskById.get(agent.currentTaskId) : undefined;
+    const evidence: AgentHealthEvidence[] = [];
+    const updatedAt = now.toISOString();
+
+    if (agent.status === 'offline' || isStale(agent.lastHeartbeat, now, STALE_HEARTBEAT_MS)) {
+      evidence.push({
+        code: 'supervisor_unavailable',
+        message: 'Agent heartbeat is stale or offline.',
+        timestamp: agent.lastHeartbeat,
+        taskId: agent.currentTaskId,
+        taskTitle: agent.currentTaskTitle,
+      });
+      return classification(agent, 'blocked', 'supervisor_unavailable', 0.9, evidence, updatedAt);
+    }
+
+    const globalActive = globalStatus?.activeAgents?.find(
+      (active) => normalize(active.agent) === normalize(agent.id)
+    );
+    if (globalActive?.status === 'error' || globalStatus?.status === 'error') {
+      evidence.push({
+        code: 'provider_errors',
+        message: globalStatus?.errorMessage || 'Global agent status reports an error state.',
+        timestamp: globalStatus?.lastUpdated,
+        taskId: globalActive?.taskId ?? agent.currentTaskId,
+        taskTitle: globalActive?.taskTitle ?? agent.currentTaskTitle,
+      });
+      return classification(agent, 'risky', 'provider_errors', 0.82, evidence, updatedAt);
+    }
+
+    if (task?.status === 'blocked' && task.blockedReason?.category === 'waiting-on-feedback') {
+      evidence.push({
+        code: 'hitl_pending',
+        message: task.blockedReason.note || 'Current task is waiting on human feedback.',
+        timestamp: task.updated,
+        taskId: task.id,
+        taskTitle: task.title,
+      });
+      return classification(agent, 'blocked', 'hitl_pending', 0.88, evidence, updatedAt);
+    }
+
+    if (task?.status === 'blocked') {
+      evidence.push({
+        code: 'task_blocked',
+        message: task.blockedReason?.note || 'Current task is blocked.',
+        timestamp: task.updated,
+        taskId: task.id,
+        taskTitle: task.title,
+      });
+      return classification(agent, 'blocked', 'task_blocked', 0.88, evidence, updatedAt);
+    }
+
+    const errorEvents = agentEvents.filter((event) => event.type === 'run.error');
+    const failedRuns = agentEvents.filter(
+      (event) => event.type === 'run.completed' && (event as RunTelemetryEvent).success === false
+    );
+    const recentTestFailure = [...errorEvents, ...failedRuns].find((event) =>
+      /test|assert|spec|vitest|playwright/i.test(eventError(event) ?? '')
+    );
+
+    if (errorEvents.length >= 3) {
+      const firstError = errorEvents[0];
+      evidence.push({
+        code: 'repeated_tool_failures',
+        message: `${errorEvents.length} run errors recorded in the last 24 hours.`,
+        timestamp: firstError?.timestamp,
+        runId: firstError ? eventAttemptId(firstError) : undefined,
+        taskId: firstError?.taskId,
+      });
+      return classification(agent, 'risky', 'repeated_tool_failures', 0.86, evidence, updatedAt);
+    }
+
+    if (recentTestFailure) {
+      evidence.push({
+        code: 'recent_test_failures',
+        message: 'Recent run failure appears test-related.',
+        timestamp: recentTestFailure.timestamp,
+        runId: eventAttemptId(recentTestFailure),
+        taskId: recentTestFailure.taskId,
+      });
+      return classification(agent, 'risky', 'recent_test_failures', 0.78, evidence, updatedAt);
+    }
+
+    if (errorEvents.length > 0 || failedRuns.length > 0) {
+      const event = errorEvents[0] ?? failedRuns[0];
+      evidence.push({
+        code: 'provider_errors',
+        message: eventError(event) || 'Recent run failure recorded.',
+        timestamp: event.timestamp,
+        runId: eventAttemptId(event),
+        taskId: event.taskId,
+      });
+      return classification(agent, 'risky', 'provider_errors', 0.72, evidence, updatedAt);
+    }
+
+    const latestSuccess = agentEvents.find(
+      (event) => event.type === 'run.completed' && (event as RunTelemetryEvent).success === true
+    );
+    if (latestSuccess && task?.status === 'in-progress') {
+      evidence.push({
+        code: 'explicit_completion_hint',
+        message: 'Latest run completed successfully while the task remains in progress.',
+        timestamp: latestSuccess.timestamp,
+        runId: eventAttemptId(latestSuccess),
+        taskId: latestSuccess.taskId,
+        taskTitle: task.title,
+      });
+      return classification(
+        agent,
+        'complete_candidate',
+        'explicit_completion_hint',
+        0.68,
+        evidence,
+        updatedAt
+      );
+    }
+
+    if (
+      agent.status === 'busy' &&
+      task &&
+      task.status === 'in-progress' &&
+      ageMs(task.updated, now) >= STUCK_BUSY_MS
+    ) {
+      evidence.push({
+        code: 'no_signal',
+        message: 'Assigned in-progress task has not been updated recently.',
+        timestamp: task.updated,
+        taskId: task.id,
+        taskTitle: task.title,
+      });
+      return classification(agent, 'stuck', 'no_signal', 0.74, evidence, updatedAt);
+    }
+
+    if (agent.status === 'idle' && latestSuccess) {
+      evidence.push({
+        code: 'idle_after_plan_completion',
+        message: 'Agent is idle after a successful run.',
+        timestamp: latestSuccess.timestamp,
+        runId: eventAttemptId(latestSuccess),
+        taskId: latestSuccess.taskId,
+      });
+      return classification(
+        agent,
+        'complete_candidate',
+        'idle_after_plan_completion',
+        0.62,
+        evidence,
+        updatedAt
+      );
+    }
+
+    evidence.push({
+      code: 'active_ok',
+      message:
+        agent.status === 'busy'
+          ? 'Agent is busy with current signal.'
+          : 'No risky signal detected.',
+      timestamp: agent.lastHeartbeat,
+      taskId: agent.currentTaskId,
+      taskTitle: agent.currentTaskTitle,
+    });
+    return classification(agent, 'healthy', 'active_ok', 0.6, evidence, updatedAt);
+  }
+}
+
+export function getAgentHealthClassifierService(): AgentHealthClassifierService {
+  return new AgentHealthClassifierService();
+}
+
+function classification(
+  agent: RegisteredAgent,
+  state: AgentHealthState,
+  reasonCode: AgentHealthReasonCode,
+  confidence: number,
+  evidence: AgentHealthEvidence[],
+  updatedAt: string
+): AgentHealthClassification {
+  return {
+    subjectId: `agent:${agent.id}`,
+    subjectType: 'agent',
+    agent: agent.id,
+    taskId: agent.currentTaskId,
+    taskTitle: agent.currentTaskTitle,
+    state,
+    reasonCode,
+    explanation: explanationFor(state, reasonCode),
+    confidence,
+    evidence,
+    updatedAt,
+  };
+}
+
+function explanationFor(state: AgentHealthState, reasonCode: AgentHealthReasonCode): string {
+  switch (reasonCode) {
+    case 'supervisor_unavailable':
+      return 'Agent supervisor or heartbeat is unavailable.';
+    case 'task_blocked':
+      return 'Agent is attached to a blocked task.';
+    case 'repeated_tool_failures':
+      return 'Agent has repeated recent run errors.';
+    case 'recent_test_failures':
+      return 'Agent has recent test-related failures.';
+    case 'provider_errors':
+      return 'Agent has recent provider or runtime errors.';
+    case 'no_signal':
+      return 'Agent appears stuck with no recent task progress signal.';
+    case 'explicit_completion_hint':
+      return 'Agent run completed successfully but the task has not moved forward.';
+    case 'idle_after_plan_completion':
+      return 'Agent is idle after completing a recent run.';
+    case 'hitl_pending':
+      return 'Agent is waiting on human input.';
+    case 'active_ok':
+      return state === 'healthy' ? 'Agent has no risky signal.' : 'Agent is active.';
+  }
+}
+
+function mergeAgentSubjects(
+  agents: RegisteredAgent[],
+  globalStatus: AgentStatus | undefined
+): RegisteredAgent[] {
+  const byId = new Map<string, RegisteredAgent>();
+  for (const agent of agents) {
+    byId.set(agent.id, agent);
+  }
+
+  const activeAgents = globalStatus?.activeAgents ?? [];
+  for (const active of activeAgents) {
+    if (byId.has(active.agent)) continue;
+    byId.set(active.agent, {
+      id: active.agent,
+      name: active.agent,
+      capabilities: [],
+      status: active.status === 'idle' ? 'idle' : 'busy',
+      registeredAt: active.startedAt,
+      lastHeartbeat: globalStatus?.lastUpdated ?? active.startedAt,
+      currentTaskId: active.taskId,
+      currentTaskTitle: active.taskTitle,
+    });
+  }
+
+  return Array.from(byId.values());
+}
+
+function eventAgent(event: AnyTelemetryEvent): string | undefined {
+  return 'agent' in event && typeof event.agent === 'string' ? event.agent : undefined;
+}
+
+function eventError(event: AnyTelemetryEvent): string | undefined {
+  if ('error' in event && typeof event.error === 'string') return event.error;
+  return undefined;
+}
+
+function eventAttemptId(event: AnyTelemetryEvent): string | undefined {
+  return 'attemptId' in event && typeof event.attemptId === 'string' ? event.attemptId : undefined;
+}
+
+function isRecent(timestamp: string, now: Date): boolean {
+  return ageMs(timestamp, now) <= RECENT_WINDOW_MS;
+}
+
+function isStale(timestamp: string, now: Date, thresholdMs: number): boolean {
+  return ageMs(timestamp, now) > thresholdMs;
+}
+
+function ageMs(timestamp: string, now: Date): number {
+  const parsed = Date.parse(timestamp);
+  if (!Number.isFinite(parsed)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, now.getTime() - parsed);
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/shared/src/types/agent-health-classifier.types.ts
+++ b/shared/src/types/agent-health-classifier.types.ts
@@ -1,0 +1,42 @@
+export type AgentHealthState = 'healthy' | 'blocked' | 'stuck' | 'risky' | 'complete_candidate';
+
+export type AgentHealthReasonCode =
+  | 'active_ok'
+  | 'explicit_completion_hint'
+  | 'hitl_pending'
+  | 'idle_after_plan_completion'
+  | 'no_signal'
+  | 'provider_errors'
+  | 'recent_test_failures'
+  | 'repeated_tool_failures'
+  | 'supervisor_unavailable'
+  | 'task_blocked';
+
+export interface AgentHealthEvidence {
+  code: AgentHealthReasonCode | string;
+  message: string;
+  timestamp?: string;
+  taskId?: string;
+  taskTitle?: string;
+  runId?: string;
+  url?: string;
+}
+
+export interface AgentHealthClassification {
+  subjectId: string;
+  subjectType: 'agent' | 'run' | 'task';
+  agent?: string;
+  taskId?: string;
+  taskTitle?: string;
+  state: AgentHealthState;
+  reasonCode: AgentHealthReasonCode;
+  explanation: string;
+  confidence: number;
+  evidence: AgentHealthEvidence[];
+  updatedAt: string;
+}
+
+export interface AgentHealthClassificationResponse {
+  classifications: AgentHealthClassification[];
+  generatedAt: string;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -12,6 +12,7 @@ export * from './delegation.types.js';
 export * from './changes.types.js';
 export * from './broadcast.types.js';
 export * from './agent-registry.types.js';
+export * from './agent-health-classifier.types.js';
 export * from './shared-resources.types.js';
 export * from './doc-freshness.types.js';
 export * from './drift.types.js';

--- a/web/src/__tests__/needs-attention-queue-mantine.test.tsx
+++ b/web/src/__tests__/needs-attention-queue-mantine.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { SkillRiskInventoryItem } from '@veritas-kanban/shared';
+import type { AgentHealthClassification, SkillRiskInventoryItem } from '@veritas-kanban/shared';
 
 import {
   buildNeedsAttentionItems,
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   markNotificationDeliveredMutate: vi.fn(),
   useAcknowledgeDriftAlert: vi.fn(),
   useActiveRuns: vi.fn(),
+  useAgentHealthClassifications: vi.fn(),
   useDriftAlerts: vi.fn(),
   useFailedRuns: vi.fn(),
   useMarkNotificationDelivered: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock('@/hooks/useDrift', () => ({
 }));
 
 vi.mock('@/hooks/useAgent', () => ({
+  useAgentHealthClassifications: mocks.useAgentHealthClassifications,
   usePendingAgentApprovals: mocks.usePendingAgentApprovals,
 }));
 
@@ -200,6 +202,29 @@ const notifications = [
   },
 ];
 
+const agentHealth: AgentHealthClassification[] = [
+  {
+    subjectId: 'agent:codex-cloud',
+    subjectType: 'agent',
+    agent: 'codex-cloud',
+    taskId: 'task-review',
+    taskTitle: 'Review generated PR',
+    state: 'risky',
+    reasonCode: 'repeated_tool_failures',
+    explanation: 'Agent has repeated recent run errors.',
+    confidence: 0.86,
+    evidence: [
+      {
+        code: 'repeated_tool_failures',
+        message: '3 run errors recorded in the last 24 hours.',
+        timestamp: '2026-06-01T11:30:00Z',
+        taskId: 'task-review',
+      },
+    ],
+    updatedAt: '2026-06-01T11:45:00Z',
+  },
+];
+
 const skillRisks: SkillRiskInventoryItem[] = [
   {
     skillId: 'skill-risky',
@@ -262,6 +287,10 @@ function mockQueueData() {
   mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
   mocks.useDriftAlerts.mockReturnValue({ data: driftAlerts, isLoading: false });
   mocks.usePendingAgentApprovals.mockReturnValue({ data: approvals, isLoading: false });
+  mocks.useAgentHealthClassifications.mockReturnValue({
+    data: { classifications: agentHealth, generatedAt: '2026-06-01T11:45:00Z' },
+    isLoading: false,
+  });
   mocks.useUndeliveredNotifications.mockReturnValue({ data: notifications, isLoading: false });
   mocks.useSkillRiskInventory.mockReturnValue({
     data: { generatedAt: '2026-06-01T12:00:00Z', items: skillRisks, totals: {} },
@@ -290,6 +319,7 @@ describe('needs attention queue', () => {
     const items = buildNeedsAttentionItems(
       {
         activeRuns,
+        agentHealth,
         approvals,
         driftAlerts,
         failedRuns,
@@ -306,6 +336,7 @@ describe('needs attention queue', () => {
     expect(items.map((item) => item.source)).toEqual(
       expect.arrayContaining([
         'approval',
+        'agent-health',
         'blocked-task',
         'expensive-run',
         'failed-run',
@@ -331,6 +362,9 @@ describe('needs attention queue', () => {
     expect(items.find((item) => item.source === 'skill-risk')?.title).toBe(
       'Skill risk: Risky Skill'
     );
+    const healthItem = items.find((item) => item.source === 'agent-health');
+    expect(healthItem?.healthState).toBe('risky');
+    expect(healthItem?.reason).toContain('3 run errors recorded');
   });
 
   it('renders queue items through Mantine controls and opens task targets', async () => {
@@ -345,8 +379,9 @@ describe('needs attention queue', () => {
     expect(screen.getAllByText('Blocked queue task').length).toBeGreaterThan(0);
     expect(screen.getByText('Review notification')).toBeDefined();
     expect(screen.getByText('Skill risk: Risky Skill')).toBeDefined();
+    expect(screen.getAllByText('Risky').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Stale running task').length).toBeGreaterThan(0);
-    expect(container.querySelectorAll('.mantine-Select-root')).toHaveLength(5);
+    expect(container.querySelectorAll('.mantine-Select-root')).toHaveLength(6);
     expect(container.querySelectorAll('.mantine-Badge-root').length).toBeGreaterThan(3);
     expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
@@ -373,6 +408,18 @@ describe('needs attention queue', () => {
     expect(screen.queryByText('Review notification')).toBeNull();
   });
 
+  it('filters by agent health state and shows classifier evidence', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<NeedsAttentionQueue period="7d" project="platform" />);
+
+    await user.click(screen.getAllByLabelText('Filter needs attention by health state')[0]);
+    await user.click(screen.getByRole('option', { name: 'Risky' }));
+
+    expect(screen.getByText(/3 run errors recorded in the last 24 hours/i)).toBeDefined();
+    expect(screen.queryByText('Review notification')).toBeNull();
+  });
+
   it('renders an empty state when no inputs need attention', () => {
     mocks.useTasks.mockReturnValue({ data: [], isLoading: false });
     mocks.useFailedRuns.mockReturnValue({ data: [], isLoading: false });
@@ -384,6 +431,10 @@ describe('needs attention queue', () => {
     mocks.useRecentRuns.mockReturnValue({ data: [], isLoading: false });
     mocks.useDriftAlerts.mockReturnValue({ data: [], isLoading: false });
     mocks.usePendingAgentApprovals.mockReturnValue({ data: [], isLoading: false });
+    mocks.useAgentHealthClassifications.mockReturnValue({
+      data: { classifications: [], generatedAt: '2026-06-01T12:00:00Z' },
+      isLoading: false,
+    });
     mocks.useUndeliveredNotifications.mockReturnValue({ data: [], isLoading: false });
     mocks.useSkillRiskInventory.mockReturnValue({
       data: { totals: { total: 0, blocked: 0, warned: 0, unscanned: 0 }, items: [] },

--- a/web/src/components/dashboard/NeedsAttentionQueue.tsx
+++ b/web/src/components/dashboard/NeedsAttentionQueue.tsx
@@ -13,8 +13,17 @@ import {
   ShieldAlert,
   Workflow,
 } from 'lucide-react';
-import type { DriftAlert, SkillRiskInventoryItem, Task } from '@veritas-kanban/shared';
-import { usePendingAgentApprovals, type AgentApprovalRequest } from '@/hooks/useAgent';
+import type {
+  AgentHealthClassification,
+  DriftAlert,
+  SkillRiskInventoryItem,
+  Task,
+} from '@veritas-kanban/shared';
+import {
+  useAgentHealthClassifications,
+  usePendingAgentApprovals,
+  type AgentApprovalRequest,
+} from '@/hooks/useAgent';
 import { useDriftAlerts, useAcknowledgeDriftAlert } from '@/hooks/useDrift';
 import {
   useFailedRuns,
@@ -44,6 +53,7 @@ const STUCK_WORKFLOW_MS = 2 * 60 * 60 * 1000;
 type NeedsAttentionSeverity = 'critical' | 'high' | 'medium' | 'low';
 
 type NeedsAttentionSource =
+  | 'agent-health'
   | 'approval'
   | 'blocked-task'
   | 'drift-alert'
@@ -81,10 +91,12 @@ export interface NeedsAttentionItem {
   notificationId?: string;
   driftAlertId?: string;
   workflowRunId?: string;
+  healthState?: AgentHealthClassification['state'];
 }
 
 export interface BuildNeedsAttentionInput {
   activeRuns?: WorkflowRun[];
+  agentHealth?: AgentHealthClassification[];
   approvals?: AgentApprovalRequest[];
   driftAlerts?: DriftAlert[];
   failedRuns?: FailedRunDetails[];
@@ -115,6 +127,7 @@ const SEVERITY_RANK: Record<NeedsAttentionSeverity, number> = {
 };
 
 const SOURCE_LABELS: Record<NeedsAttentionSource, string> = {
+  'agent-health': 'Agent health',
   approval: 'Approval',
   'blocked-task': 'Blocked task',
   'drift-alert': 'Drift',
@@ -129,6 +142,7 @@ const SOURCE_LABELS: Record<NeedsAttentionSource, string> = {
 };
 
 const SOURCE_ICONS: Record<NeedsAttentionSource, typeof AlertTriangle> = {
+  'agent-health': ShieldAlert,
   approval: ShieldAlert,
   'blocked-task': AlertTriangle,
   'drift-alert': ShieldAlert,
@@ -179,6 +193,33 @@ function formatAge(timestamp: string, now: Date): string {
 
 function formatSourceValue(value: string): string {
   return SOURCE_LABELS[value as NeedsAttentionSource] ?? value;
+}
+
+function formatHealthState(value: AgentHealthClassification['state']): string {
+  return value
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function healthSeverity(state: AgentHealthClassification['state']): NeedsAttentionSeverity {
+  switch (state) {
+    case 'blocked':
+    case 'risky':
+      return 'high';
+    case 'stuck':
+      return 'medium';
+    case 'complete_candidate':
+    case 'healthy':
+      return 'low';
+  }
+}
+
+function healthReason(classification: AgentHealthClassification): string {
+  const firstEvidence = classification.evidence[0]?.message;
+  return firstEvidence
+    ? `${classification.explanation} Evidence: ${firstEvidence}`
+    : classification.explanation;
 }
 
 function getTaskOwner(task?: Task): string | undefined {
@@ -344,6 +385,42 @@ export function buildNeedsAttentionItems(
         });
       }
     }
+  }
+
+  for (const classification of input.agentHealth ?? []) {
+    if (classification.state === 'healthy') continue;
+    const task = classification.taskId ? taskById.get(classification.taskId) : undefined;
+    const project = itemProject(task);
+    if (!projectMatches(input.project, project)) continue;
+
+    addItem(items, {
+      id: `agent-health:${classification.subjectId}:${classification.reasonCode}`,
+      dedupeKey: `agent-health:${classification.subjectId}:${classification.reasonCode}:${classification.updatedAt}`,
+      title:
+        task?.title ??
+        `${classification.agent ?? 'Agent'} ${formatHealthState(classification.state)}`,
+      reason: healthReason(classification),
+      nextAction: task
+        ? classification.state === 'complete_candidate'
+          ? 'Review completion'
+          : 'Open task'
+        : 'Review agent',
+      severity: healthSeverity(classification.state),
+      source: 'agent-health',
+      sourceLabel: SOURCE_LABELS['agent-health'],
+      timestamp: classification.updatedAt,
+      owner: classification.agent,
+      agent: classification.agent,
+      taskId: classification.taskId,
+      taskTitle: task?.title ?? classification.taskTitle,
+      taskType: task?.type,
+      project,
+      destination: task ? 'task' : 'workflows',
+      destinationLabel: task
+        ? `task:${task.id}`
+        : `agent:${classification.agent ?? classification.subjectId}`,
+      healthState: classification.state,
+    });
   }
 
   for (const run of input.failedRuns ?? []) {
@@ -605,6 +682,7 @@ function filterItems(
   filters: {
     age: string;
     agent: string;
+    healthState: string;
     severity: string;
     source: string;
     taskType: string;
@@ -616,6 +694,7 @@ function filterItems(
     if (dismissed[item.dedupeKey]) return false;
     if (filters.severity !== 'all' && item.severity !== filters.severity) return false;
     if (filters.source !== 'all' && item.source !== filters.source) return false;
+    if (filters.healthState !== 'all' && item.healthState !== filters.healthState) return false;
     if (filters.agent !== 'all' && item.agent !== filters.agent && item.owner !== filters.agent) {
       return false;
     }
@@ -646,6 +725,7 @@ export function NeedsAttentionQueue({
   const [severityFilter, setSeverityFilter] = useState('all');
   const [sourceFilter, setSourceFilter] = useState('all');
   const [agentFilter, setAgentFilter] = useState('all');
+  const [healthStateFilter, setHealthStateFilter] = useState('all');
   const [taskTypeFilter, setTaskTypeFilter] = useState('all');
   const [ageFilter, setAgeFilter] = useState('all');
   const [dismissed, setDismissed] = useState<Record<string, string>>(() => readDismissedItems());
@@ -665,6 +745,7 @@ export function NeedsAttentionQueue({
     acknowledged: false,
   });
   const { data: approvals = [], isLoading: approvalsLoading } = usePendingAgentApprovals();
+  const { data: agentHealthData, isLoading: agentHealthLoading } = useAgentHealthClassifications();
   const { data: notifications = [], isLoading: notificationsLoading } =
     useUndeliveredNotifications(50);
   const { data: skillInventory, isLoading: skillRiskLoading } = useSkillRiskInventory();
@@ -676,6 +757,7 @@ export function NeedsAttentionQueue({
       buildNeedsAttentionItems(
         {
           activeRuns,
+          agentHealth: agentHealthData?.classifications,
           approvals,
           driftAlerts,
           failedRuns,
@@ -690,6 +772,7 @@ export function NeedsAttentionQueue({
       ),
     [
       activeRuns,
+      agentHealthData?.classifications,
       approvals,
       driftAlerts,
       failedRuns,
@@ -710,6 +793,7 @@ export function NeedsAttentionQueue({
         {
           age: ageFilter,
           agent: agentFilter,
+          healthState: healthStateFilter,
           severity: severityFilter,
           source: sourceFilter,
           taskType: taskTypeFilter,
@@ -717,7 +801,17 @@ export function NeedsAttentionQueue({
         dismissed,
         now
       ),
-    [ageFilter, agentFilter, allItems, dismissed, now, severityFilter, sourceFilter, taskTypeFilter]
+    [
+      ageFilter,
+      agentFilter,
+      allItems,
+      dismissed,
+      healthStateFilter,
+      now,
+      severityFilter,
+      sourceFilter,
+      taskTypeFilter,
+    ]
   );
 
   const visibleLimited = visibleItems.slice(0, MAX_VISIBLE_ITEMS);
@@ -730,6 +824,7 @@ export function NeedsAttentionQueue({
     recentRunsLoading ||
     driftLoading ||
     approvalsLoading ||
+    agentHealthLoading ||
     notificationsLoading ||
     skillRiskLoading;
 
@@ -755,6 +850,16 @@ export function NeedsAttentionQueue({
     allItems.map((item) => item.taskType),
     'All types'
   );
+  const healthStateOptions = uniqueOptions(
+    allItems.map((item) => item.healthState),
+    'All health'
+  ).map((option) => ({
+    value: option.value,
+    label:
+      option.value === 'all'
+        ? option.label
+        : formatHealthState(option.value as AgentHealthClassification['state']),
+  }));
 
   const persistDismissed = (next: Record<string, string>) => {
     setDismissed(next);
@@ -823,7 +928,7 @@ export function NeedsAttentionQueue({
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-5 lg:min-w-[680px]">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-6 lg:min-w-[760px]">
           <Select
             aria-label="Filter needs attention by severity"
             data={severityOptions}
@@ -838,6 +943,14 @@ export function NeedsAttentionQueue({
             data={sourceOptions}
             value={sourceFilter}
             onChange={(value) => setSourceFilter(value ?? 'all')}
+            allowDeselect={false}
+            size="xs"
+          />
+          <Select
+            aria-label="Filter needs attention by health state"
+            data={healthStateOptions}
+            value={healthStateFilter}
+            onChange={(value) => setHealthStateFilter(value ?? 'all')}
             allowDeselect={false}
             size="xs"
           />
@@ -928,6 +1041,11 @@ export function NeedsAttentionQueue({
                         <Badge size="xs" variant="outline">
                           {item.sourceLabel}
                         </Badge>
+                        {item.healthState && (
+                          <Badge size="xs" variant="light">
+                            {formatHealthState(item.healthState)}
+                          </Badge>
+                        )}
                       </div>
                       <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
                         {item.reason}

--- a/web/src/hooks/useAgent.ts
+++ b/web/src/hooks/useAgent.ts
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api, AgentOutput } from '@/lib/api';
 import { apiFetch, API_BASE } from '@/lib/api/helpers';
 import { useWebSocket, type WebSocketMessage } from './useWebSocket';
-import type { AgentType } from '@veritas-kanban/shared';
+import type { AgentHealthClassificationResponse, AgentType } from '@veritas-kanban/shared';
 
 export interface StartAgentInput {
   taskId: string;
@@ -23,10 +23,17 @@ export interface AgentApprovalRequest {
   createdAt: string;
 }
 
+function requiredQueryParam(value: string | undefined, name: string): string {
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
 export function useAgentStatus(taskId: string | undefined) {
   return useQuery({
     queryKey: ['agent', 'status', taskId],
-    queryFn: () => api.agent.status(taskId!),
+    queryFn: () => api.agent.status(requiredQueryParam(taskId, 'taskId')),
     enabled: !!taskId,
     refetchInterval: (query) => (query.state.data?.running ? 2000 : false),
   });
@@ -67,7 +74,7 @@ export function useStopAgent() {
 export function useAgentAttempts(taskId: string | undefined) {
   return useQuery({
     queryKey: ['agent', 'attempts', taskId],
-    queryFn: () => api.agent.listAttempts(taskId!),
+    queryFn: () => api.agent.listAttempts(requiredQueryParam(taskId, 'taskId')),
     enabled: !!taskId,
   });
 }
@@ -75,7 +82,11 @@ export function useAgentAttempts(taskId: string | undefined) {
 export function useAgentLog(taskId: string | undefined, attemptId: string | undefined) {
   return useQuery({
     queryKey: ['agent', 'log', taskId, attemptId],
-    queryFn: () => api.agent.getLog(taskId!, attemptId!),
+    queryFn: () =>
+      api.agent.getLog(
+        requiredQueryParam(taskId, 'taskId'),
+        requiredQueryParam(attemptId, 'attemptId')
+      ),
     enabled: !!taskId && !!attemptId,
   });
 }
@@ -92,6 +103,16 @@ export function usePendingAgentApprovals(agentId?: string) {
       );
     },
     staleTime: 30_000,
+  });
+}
+
+export function useAgentHealthClassifications() {
+  return useQuery({
+    queryKey: ['agent', 'health-classifications'],
+    queryFn: () =>
+      apiFetch<AgentHealthClassificationResponse>(`${API_BASE}/agents/register/health`),
+    staleTime: 30_000,
+    refetchInterval: 60_000,
   });
 }
 


### PR DESCRIPTION
## Summary
- Add shared agent-health classification types and a deterministic server classifier.
- Expose `GET /api/agents/register/health` using registry, task, telemetry, and live agent status signals.
- Surface non-healthy classifications in Needs Attention with health-state badges, evidence text, and filtering.
- Add focused service, route, and UI coverage.

Closes #582

## Verification
- `pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/server typecheck && pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/services/agent-health-classifier-service.test.ts src/__tests__/routes/agent-registry.test.ts`
- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/needs-attention-queue-mantine.test.tsx --testTimeout 15000`
- `pnpm exec eslint shared/src/types/agent-health-classifier.types.ts shared/src/types/index.ts server/src/services/agent-health-classifier-service.ts server/src/routes/agent-registry.ts server/src/__tests__/services/agent-health-classifier-service.test.ts server/src/__tests__/routes/agent-registry.test.ts web/src/hooks/useAgent.ts web/src/components/dashboard/NeedsAttentionQueue.tsx web/src/__tests__/needs-attention-queue-mantine.test.tsx`

## Risk
- The classifier is deterministic and uses existing local signals only. Health labels are intentionally conservative and can be extended with more signals later.