### PR TITLE
Add deterministic agent operations digest API

### DIFF
--- a/server/src/__tests__/digest-service.test.ts
+++ b/server/src/__tests__/digest-service.test.ts
@@ -4,7 +4,10 @@
  * generateDigest requires too many external dependencies to test in isolation.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { RunTelemetryEvent, Task, TokenTelemetryEvent } from '@veritas-kanban/shared';
 import { DigestService, type DailyDigest } from '../services/digest-service.js';
+
+const mockPendingApprovals = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 
 // Mock dependencies
 vi.mock('../services/metrics/index.js', () => ({
@@ -31,6 +34,12 @@ vi.mock('../services/task-service.js', () => ({
     listTasks = vi.fn().mockResolvedValue([]);
     getTask = vi.fn();
   },
+}));
+
+vi.mock('../services/agent-permission-service.js', () => ({
+  getAgentPermissionService: () => ({
+    getPendingApprovals: mockPendingApprovals,
+  }),
 }));
 
 function makeDigest(overrides: Partial<DailyDigest> = {}): DailyDigest {
@@ -87,7 +96,146 @@ describe('DigestService', () => {
   let service: DigestService;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockPendingApprovals.mockResolvedValue([]);
     service = new DigestService();
+  });
+
+  describe('generateOperationsDigest', () => {
+    it('groups deterministic operations counts with source links', async () => {
+      const tasks: Task[] = [
+        {
+          id: 'task_active',
+          title: 'Active work',
+          description: 'Active task',
+          type: 'feature',
+          status: 'in-progress',
+          priority: 'high',
+          project: 'platform',
+          created: '2026-06-04T08:00:00.000Z',
+          updated: '2026-06-04T08:30:00.000Z',
+          git: {
+            repo: 'veritas-kanban',
+            branch: 'feature',
+            baseBranch: 'main',
+            worktreePath: '/worktrees/platform',
+          },
+        },
+        {
+          id: 'task_blocked',
+          title: 'Blocked work',
+          description: 'Blocked task',
+          type: 'bug',
+          status: 'blocked',
+          priority: 'high',
+          project: 'platform',
+          created: '2026-06-04T08:00:00.000Z',
+          updated: '2026-06-04T10:00:00.000Z',
+          git: {
+            repo: 'veritas-kanban',
+            branch: 'blocked',
+            baseBranch: 'main',
+            worktreePath: '/worktrees/platform',
+          },
+        },
+        {
+          id: 'task_done',
+          title: 'Completed work',
+          description: 'Done task',
+          type: 'feature',
+          status: 'done',
+          priority: 'medium',
+          project: 'platform',
+          created: '2026-06-04T08:00:00.000Z',
+          updated: '2026-06-04T11:30:00.000Z',
+          git: {
+            repo: 'veritas-kanban',
+            branch: 'done',
+            baseBranch: 'main',
+            worktreePath: '/worktrees/platform',
+          },
+        },
+      ];
+      const runFailure: RunTelemetryEvent = {
+        id: 'run_failed',
+        type: 'run.completed',
+        timestamp: '2026-06-04T11:45:00.000Z',
+        taskId: 'task_active',
+        agent: 'codex',
+        success: false,
+        durationMs: 60_000,
+        error: 'Tests failed',
+        attemptId: 'attempt_failed',
+      };
+      const tokens: TokenTelemetryEvent = {
+        id: 'tokens_1',
+        type: 'run.tokens',
+        timestamp: '2026-06-04T11:50:00.000Z',
+        taskId: 'task_active',
+        agent: 'codex',
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        cost: 0.0123,
+      };
+      const telemetry = { getEvents: vi.fn().mockResolvedValue([runFailure, tokens]) };
+      const taskService = { listTasks: vi.fn().mockResolvedValue(tasks) };
+      const serviceOverrides = service as unknown as {
+        telemetry: typeof telemetry;
+        taskService: typeof taskService;
+      };
+      serviceOverrides.telemetry = telemetry;
+      serviceOverrides.taskService = taskService;
+      mockPendingApprovals.mockResolvedValue([
+        {
+          id: 'approval_1',
+          agentId: 'codex',
+          action: 'push_branch',
+          taskId: 'task_blocked',
+          details: 'Needs owner approval',
+          status: 'pending',
+          createdAt: '2026-06-04T11:55:00.000Z',
+        },
+      ]);
+
+      const digest = await service.generateOperationsDigest({
+        from: '2026-06-04T00:00:00.000Z',
+        to: '2026-06-04T12:00:00.000Z',
+        project: 'platform',
+      });
+
+      expect(telemetry.getEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project: 'platform',
+          type: ['run.completed', 'run.error', 'run.tokens'],
+        })
+      );
+      expect(digest.hasActivity).toBe(true);
+      expect(digest.groups).toHaveLength(1);
+      expect(digest.groups[0]).toMatchObject({
+        project: 'platform',
+        repo: 'veritas-kanban',
+        cwd: '/worktrees/platform',
+        totals: {
+          active: 1,
+          blocked: 1,
+          stuck: 1,
+          completed: 1,
+          failed: 1,
+          runs: 1,
+          totalTokens: 150,
+          activeTimeMs: 60_000,
+        },
+      });
+      expect(digest.groups[0].sourceLinks.activeTasks[0]?.id).toBe('task_active');
+      expect(digest.groups[0].sourceLinks.failedRuns[0]?.id).toBe('attempt_failed');
+      expect(digest.groups[0].openApprovals[0]).toMatchObject({
+        id: 'approval_1',
+        agent: 'codex',
+        action: 'push_branch',
+      });
+      expect(digest.totals.openApprovals).toBe(1);
+    });
   });
 
   describe('formatForTeams', () => {
@@ -198,7 +346,7 @@ describe('DigestService', () => {
 
   describe('formatNumber (private)', () => {
     const formatNumber = (num: number) => {
-      return (service as any).formatNumber(num);
+      return (service as unknown as { formatNumber(value: number): string }).formatNumber(num);
     };
 
     it('should format small numbers as-is', () => {

--- a/server/src/__tests__/routes/misc-routes-coverage.test.ts
+++ b/server/src/__tests__/routes/misc-routes-coverage.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
 
 // ===================== Hoisted Mocks =====================
 
@@ -48,6 +49,8 @@ const {
   mockDigestService: {
     generateDigest: vi.fn(),
     formatForTeams: vi.fn(),
+    generateOperationsDigest: vi.fn(),
+    formatOperationsDigestMarkdown: vi.fn(),
   },
 }));
 
@@ -123,7 +126,7 @@ vi.mock('../../services/task-service.js', () => ({
 
 // Rate limit mock
 vi.mock('../../middleware/rate-limit.js', () => ({
-  strictRateLimit: (_req: any, _res: any, next: any) => next(),
+  strictRateLimit: (_req: Request, _res: Response, next: NextFunction) => next(),
 }));
 
 import activityRouter from '../../routes/activity.js';
@@ -134,7 +137,11 @@ import digestRouter from '../../routes/digest.js';
 import { errorHandler } from '../../middleware/error-handler.js';
 
 // Helper: inject admin auth for route tests that use authorize() middleware
-const injectAdminAuth = (req: any, _res: any, next: any) => {
+const injectAdminAuth = (
+  req: Request & { auth?: { role: string; keyName: string; isLocalhost: boolean } },
+  _res: Response,
+  next: NextFunction
+) => {
   req.auth = { role: 'admin', keyName: 'test-admin', isLocalhost: true };
   next();
 };
@@ -320,7 +327,12 @@ describe('Settings Routes', () => {
 
   it('PATCH /features should accept requireDeliverableForDone', async () => {
     const fullSettings = {
-      telemetry: { enabled: true, retentionDays: 30, enableTraces: false, enableActivityTracking: true },
+      telemetry: {
+        enabled: true,
+        retentionDays: 30,
+        enableTraces: false,
+        enableActivityTracking: true,
+      },
       tasks: {
         enableTimeTracking: true,
         enableSubtaskAutoComplete: true,
@@ -346,7 +358,12 @@ describe('Settings Routes', () => {
 
   it('PATCH /features should accept requireDeliverableForDone set to false', async () => {
     const fullSettings = {
-      telemetry: { enabled: true, retentionDays: 30, enableTraces: false, enableActivityTracking: true },
+      telemetry: {
+        enabled: true,
+        retentionDays: 30,
+        enableTraces: false,
+        enableActivityTracking: true,
+      },
       tasks: {
         enableTimeTracking: true,
         enableSubtaskAutoComplete: true,
@@ -424,5 +441,39 @@ describe('Digest Routes', () => {
     const res = await request(app).get('/api/digest/daily/preview');
     expect(res.status).toBe(200);
     expect(res.text).toContain('No activity');
+  });
+
+  it('GET /operations should return JSON operations digest', async () => {
+    mockDigestService.generateOperationsDigest.mockResolvedValue({
+      groups: [],
+      hasActivity: false,
+    });
+    const res = await request(app).get('/api/digest/operations?hours=12&project=platform');
+    expect(res.status).toBe(200);
+    expect(mockDigestService.generateOperationsDigest).toHaveBeenCalledWith(
+      expect.objectContaining({ windowHours: 12, project: 'platform' })
+    );
+  });
+
+  it('GET /operations?format=markdown should return markdown payload', async () => {
+    mockDigestService.generateOperationsDigest.mockResolvedValue({ groups: [], hasActivity: true });
+    mockDigestService.formatOperationsDigestMarkdown.mockReturnValue({
+      isEmpty: false,
+      markdown: '# Ops',
+    });
+    const res = await request(app).get('/api/digest/operations?format=markdown');
+    expect(res.status).toBe(200);
+    expect(res.body.markdown).toBe('# Ops');
+  });
+
+  it('GET /operations/preview should return markdown preview', async () => {
+    mockDigestService.generateOperationsDigest.mockResolvedValue({ groups: [], hasActivity: true });
+    mockDigestService.formatOperationsDigestMarkdown.mockReturnValue({
+      isEmpty: false,
+      markdown: '# Ops Preview',
+    });
+    const res = await request(app).get('/api/digest/operations/preview');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('# Ops Preview');
   });
 });

--- a/server/src/routes/digest.ts
+++ b/server/src/routes/digest.ts
@@ -1,9 +1,65 @@
 import { Router, type Router as RouterType } from 'express';
 import { getDigestService } from '../services/digest-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
-import { qStrD } from '../lib/query-helpers.js';
+import { qNumD, qStr, qStrD } from '../lib/query-helpers.js';
 
 const router: RouterType = Router();
+
+/**
+ * GET /api/digest/operations
+ * Get deterministic agent operations digest grouped by project/repo/cwd.
+ *
+ * Query params:
+ * - format: 'json' | 'markdown' (default: 'json')
+ * - hours: window size when from/to are not supplied (default: 24)
+ * - from/to: ISO timestamp range
+ * - project: optional project filter
+ */
+router.get(
+  '/operations',
+  asyncHandler(async (req, res) => {
+    const digestService = getDigestService();
+    const digest = await digestService.generateOperationsDigest({
+      windowHours: qNumD(req.query.hours, 24),
+      from: qStr(req.query.from),
+      to: qStr(req.query.to),
+      project: qStr(req.query.project),
+    });
+
+    if (qStrD(req.query.format, 'json') === 'markdown') {
+      const message = digestService.formatOperationsDigestMarkdown(digest);
+      res.json(message.isEmpty ? { isEmpty: true, message: 'No operations activity' } : message);
+      return;
+    }
+
+    res.json(digest);
+  })
+);
+
+/**
+ * GET /api/digest/operations/preview
+ * Preview operations digest markdown.
+ */
+router.get(
+  '/operations/preview',
+  asyncHandler(async (req, res) => {
+    const digestService = getDigestService();
+    const digest = await digestService.generateOperationsDigest({
+      windowHours: qNumD(req.query.hours, 24),
+      from: qStr(req.query.from),
+      to: qStr(req.query.to),
+      project: qStr(req.query.project),
+    });
+    const message = digestService.formatOperationsDigestMarkdown(digest);
+
+    if (message.isEmpty) {
+      res.type('text/plain').send('No operations activity in the selected window.');
+      return;
+    }
+
+    res.type('text/markdown').send(message.markdown);
+  })
+);
 
 /**
  * GET /api/digest/daily

--- a/server/src/services/digest-service.ts
+++ b/server/src/services/digest-service.ts
@@ -1,7 +1,13 @@
 import { getMetricsService, type MetricsService } from './metrics/index.js';
 import { getTelemetryService, type TelemetryService } from './telemetry-service.js';
 import { TaskService } from './task-service.js';
-import type { TaskTelemetryEvent } from '@veritas-kanban/shared';
+import { getAgentPermissionService, type ApprovalRequest } from './agent-permission-service.js';
+import type {
+  RunTelemetryEvent,
+  Task,
+  TaskTelemetryEvent,
+  TokenTelemetryEvent,
+} from '@veritas-kanban/shared';
 
 export interface DailyDigest {
   period: {
@@ -61,6 +67,93 @@ export interface DigestTeamsMessage {
   markdown: string;
   isEmpty: boolean;
 }
+
+export interface AgentOperationsDigestOptions {
+  windowHours?: number;
+  from?: string;
+  to?: string;
+  project?: string;
+}
+
+export interface AgentOperationsSourceLink {
+  kind: 'approval' | 'run' | 'task' | 'telemetry';
+  id: string;
+  label: string;
+  timestamp?: string;
+  taskId?: string;
+}
+
+export interface AgentOperationsFailure extends AgentOperationsSourceLink {
+  agent?: string;
+  error?: string;
+}
+
+export interface AgentOperationsApproval extends AgentOperationsSourceLink {
+  agent: string;
+  action: string;
+  details?: string;
+}
+
+export interface AgentOperationsDigestGroup {
+  key: string;
+  project: string;
+  repo: string;
+  cwd?: string;
+  totals: {
+    active: number;
+    blocked: number;
+    stuck: number;
+    completed: number;
+    failed: number;
+    runs: number;
+    tokenCost: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    wallTimeMs: number;
+    activeTimeMs: number;
+  };
+  sourceLinks: {
+    activeTasks: AgentOperationsSourceLink[];
+    blockedTasks: AgentOperationsSourceLink[];
+    stuckTasks: AgentOperationsSourceLink[];
+    completedTasks: AgentOperationsSourceLink[];
+    failedRuns: AgentOperationsSourceLink[];
+    tokenEvents: AgentOperationsSourceLink[];
+  };
+  topPlanCompletions: AgentOperationsSourceLink[];
+  notableFailures: AgentOperationsFailure[];
+  openApprovals: AgentOperationsApproval[];
+}
+
+export interface AgentOperationsDigest {
+  period: {
+    start: string;
+    end: string;
+    windowHours: number;
+  };
+  generatedAt: string;
+  hasActivity: boolean;
+  groups: AgentOperationsDigestGroup[];
+  totals: AgentOperationsDigestGroup['totals'] & {
+    openApprovals: number;
+    groups: number;
+  };
+  refresh: {
+    manual: boolean;
+    schedule: 'daily-ready';
+    narrative: 'deterministic-only';
+  };
+}
+
+export interface DigestMarkdownMessage {
+  markdown: string;
+  isEmpty: boolean;
+}
+
+const DEFAULT_OPERATIONS_WINDOW_HOURS = 24;
+const MAX_OPERATIONS_WINDOW_HOURS = 24 * 30;
+const STUCK_TASK_MS = 2 * 60 * 60 * 1000;
 
 /**
  * Service for generating daily digest summaries
@@ -176,6 +269,238 @@ export class DigestService {
         })),
       },
     };
+  }
+
+  /**
+   * Generate a deterministic project/repo/cwd operations digest for standups and briefings.
+   */
+  async generateOperationsDigest(
+    options: AgentOperationsDigestOptions = {}
+  ): Promise<AgentOperationsDigest> {
+    const period = resolveOperationsPeriod(options);
+    const [tasks, events, approvals] = await Promise.all([
+      this.taskService.listTasks(),
+      this.telemetry.getEvents({
+        since: period.start,
+        until: period.end,
+        type: ['run.completed', 'run.error', 'run.tokens'],
+        project: options.project,
+        limit: 10000,
+      }),
+      getAgentPermissionService().getPendingApprovals(),
+    ]);
+
+    const taskById = new Map(tasks.map((task) => [task.id, task]));
+    const groups = new Map<string, AgentOperationsDigestGroup>();
+    const signalTimesByGroup = new Map<string, number[]>();
+
+    const getGroup = (project: string | undefined, repo: string | undefined, cwd?: string) => {
+      const normalizedProject = project || 'unassigned';
+      const normalizedRepo = repo || 'unknown';
+      const key = `${normalizedProject}::${normalizedRepo}::${cwd ?? ''}`;
+      const existing = groups.get(key);
+      if (existing) return existing;
+
+      const group: AgentOperationsDigestGroup = {
+        key,
+        project: normalizedProject,
+        repo: normalizedRepo,
+        cwd,
+        totals: emptyOperationsTotals(),
+        sourceLinks: {
+          activeTasks: [],
+          blockedTasks: [],
+          stuckTasks: [],
+          completedTasks: [],
+          failedRuns: [],
+          tokenEvents: [],
+        },
+        topPlanCompletions: [],
+        notableFailures: [],
+        openApprovals: [],
+      };
+      groups.set(key, group);
+      signalTimesByGroup.set(key, []);
+      return group;
+    };
+
+    const recordSignal = (group: AgentOperationsDigestGroup, timestamp?: string) => {
+      const parsed = timestamp ? Date.parse(timestamp) : Number.NaN;
+      if (Number.isFinite(parsed)) {
+        signalTimesByGroup.get(group.key)?.push(parsed);
+      }
+    };
+
+    for (const task of tasks) {
+      if (options.project && task.project !== options.project) continue;
+      const group = getGroup(task.project, task.git?.repo, task.git?.worktreePath);
+      const taskLink = taskSourceLink(task);
+
+      if (task.status === 'in-progress') {
+        group.totals.active++;
+        pushUnique(group.sourceLinks.activeTasks, taskLink);
+        recordSignal(group, task.updated);
+
+        if (Date.parse(period.end) - Date.parse(task.updated) >= STUCK_TASK_MS) {
+          group.totals.stuck++;
+          pushUnique(group.sourceLinks.stuckTasks, taskLink);
+        }
+      }
+
+      if (task.status === 'blocked') {
+        group.totals.blocked++;
+        pushUnique(group.sourceLinks.blockedTasks, taskLink);
+        recordSignal(group, task.updated);
+      }
+
+      if (task.status === 'done' && inPeriod(task.updated, period.start, period.end)) {
+        group.totals.completed++;
+        pushUnique(group.sourceLinks.completedTasks, taskLink);
+        pushUnique(group.topPlanCompletions, taskLink);
+        recordSignal(group, task.updated);
+      }
+    }
+
+    for (const event of events) {
+      const task = event.taskId ? taskById.get(event.taskId) : undefined;
+      if (options.project && (task?.project ?? event.project) !== options.project) continue;
+      const group = getGroup(
+        task?.project ?? event.project,
+        task?.git?.repo,
+        task?.git?.worktreePath
+      );
+      recordSignal(group, event.timestamp);
+
+      if (event.type === 'run.completed') {
+        const runEvent = event as RunTelemetryEvent;
+        group.totals.runs++;
+        group.totals.activeTimeMs += positiveNumber(runEvent.durationMs);
+        if (isRunSuccess(runEvent)) {
+          pushUnique(group.topPlanCompletions, runSourceLink(runEvent));
+        } else {
+          group.totals.failed++;
+          const failure = runFailureLink(runEvent);
+          pushUnique(group.sourceLinks.failedRuns, failure);
+          pushUnique(group.notableFailures, failure);
+        }
+      }
+
+      if (event.type === 'run.error') {
+        const runEvent = event as RunTelemetryEvent;
+        group.totals.runs++;
+        group.totals.failed++;
+        const failure = runFailureLink(runEvent);
+        pushUnique(group.sourceLinks.failedRuns, failure);
+        pushUnique(group.notableFailures, failure);
+      }
+
+      if (event.type === 'run.tokens') {
+        const tokenEvent = event as TokenTelemetryEvent;
+        group.totals.inputTokens += positiveNumber(tokenEvent.inputTokens);
+        group.totals.outputTokens += positiveNumber(tokenEvent.outputTokens);
+        group.totals.totalTokens +=
+          positiveNumber(tokenEvent.totalTokens) ||
+          positiveNumber(tokenEvent.inputTokens) +
+            positiveNumber(tokenEvent.outputTokens) +
+            positiveNumber(tokenEvent.cacheTokens);
+        group.totals.tokenCost += positiveNumber(tokenEvent.cost);
+        pushUnique(group.sourceLinks.tokenEvents, telemetrySourceLink(tokenEvent));
+      }
+    }
+
+    for (const approval of approvals) {
+      const task = approval.taskId ? taskById.get(approval.taskId) : undefined;
+      if (options.project && task?.project !== options.project) continue;
+      const group = getGroup(task?.project, task?.git?.repo, task?.git?.worktreePath);
+      const approvalLink = approvalSourceLink(approval);
+      pushUnique(group.openApprovals, approvalLink);
+      recordSignal(group, approval.createdAt);
+    }
+
+    for (const group of groups.values()) {
+      const signals = signalTimesByGroup.get(group.key) ?? [];
+      group.totals.wallTimeMs = observedWallTime(signals);
+      group.topPlanCompletions = group.topPlanCompletions.slice(0, 5);
+      group.notableFailures = group.notableFailures.slice(0, 5);
+      group.openApprovals = group.openApprovals.slice(0, 10);
+    }
+
+    const sortedGroups = Array.from(groups.values())
+      .filter((group) => groupHasActivity(group))
+      .sort((a, b) => groupActivityRank(b) - groupActivityRank(a) || a.key.localeCompare(b.key));
+    const totals = rollupOperationsTotals(sortedGroups);
+
+    return {
+      period,
+      generatedAt: new Date().toISOString(),
+      hasActivity: sortedGroups.length > 0,
+      groups: sortedGroups,
+      totals,
+      refresh: {
+        manual: true,
+        schedule: 'daily-ready',
+        narrative: 'deterministic-only',
+      },
+    };
+  }
+
+  /**
+   * Format the operations digest as deterministic markdown for briefings.
+   */
+  formatOperationsDigestMarkdown(digest: AgentOperationsDigest): DigestMarkdownMessage {
+    if (!digest.hasActivity) {
+      return { markdown: '', isEmpty: true };
+    }
+
+    const lines: string[] = [];
+    lines.push(`# Agent Operations Digest`);
+    lines.push('');
+    lines.push(`Window: ${digest.period.start} to ${digest.period.end}`);
+    lines.push(
+      `Totals: ${digest.totals.active} active, ${digest.totals.blocked} blocked, ${digest.totals.stuck} stuck, ${digest.totals.completed} completed, ${digest.totals.failed} failed`
+    );
+    if (digest.totals.totalTokens > 0) {
+      lines.push(
+        `Tokens: ${this.formatNumber(digest.totals.totalTokens)} total, $${digest.totals.tokenCost.toFixed(4)} estimated`
+      );
+    }
+    lines.push('');
+
+    for (const group of digest.groups.slice(0, 10)) {
+      lines.push(`## ${group.project} / ${group.repo}${group.cwd ? ` / ${group.cwd}` : ''}`);
+      lines.push(
+        `- Counts: ${group.totals.active} active, ${group.totals.blocked} blocked, ${group.totals.stuck} stuck, ${group.totals.completed} completed, ${group.totals.failed} failed`
+      );
+      lines.push(
+        `- Runtime: ${formatDurationMs(group.totals.activeTimeMs)} active, ${formatDurationMs(group.totals.wallTimeMs)} observed wall`
+      );
+      if (group.totals.totalTokens > 0) {
+        lines.push(
+          `- Tokens: ${this.formatNumber(group.totals.totalTokens)} total, $${group.totals.tokenCost.toFixed(4)} estimated`
+        );
+      }
+      if (group.topPlanCompletions.length > 0) {
+        lines.push('- Plan completions:');
+        for (const item of group.topPlanCompletions) {
+          lines.push(`  - ${item.label} (${item.id})`);
+        }
+      }
+      if (group.notableFailures.length > 0) {
+        lines.push('- Notable failures:');
+        for (const failure of group.notableFailures) {
+          lines.push(`  - ${failure.label}${failure.error ? `: ${failure.error}` : ''}`);
+        }
+      }
+      if (group.openApprovals.length > 0) {
+        lines.push('- Open approvals:');
+        for (const approval of group.openApprovals) {
+          lines.push(`  - ${approval.agent}: ${approval.action} (${approval.id})`);
+        }
+      }
+      lines.push('');
+    }
+
+    return { markdown: lines.join('\n'), isEmpty: false };
   }
 
   /**
@@ -297,6 +622,183 @@ export class DigestService {
     }
     return num.toString();
   }
+}
+
+function resolveOperationsPeriod(
+  options: AgentOperationsDigestOptions
+): AgentOperationsDigest['period'] {
+  const end = validIso(options.to) ?? new Date().toISOString();
+  const windowHours = clampWindowHours(options.windowHours);
+  const start =
+    validIso(options.from) ??
+    new Date(Date.parse(end) - windowHours * 60 * 60 * 1000).toISOString();
+
+  return {
+    start,
+    end,
+    windowHours: Math.max(1, Math.round((Date.parse(end) - Date.parse(start)) / 3_600_000)),
+  };
+}
+
+function validIso(value?: string): string | undefined {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
+}
+
+function clampWindowHours(value?: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_OPERATIONS_WINDOW_HOURS;
+  return Math.min(MAX_OPERATIONS_WINDOW_HOURS, Math.max(1, Math.round(value as number)));
+}
+
+function emptyOperationsTotals(): AgentOperationsDigestGroup['totals'] {
+  return {
+    active: 0,
+    blocked: 0,
+    stuck: 0,
+    completed: 0,
+    failed: 0,
+    runs: 0,
+    tokenCost: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    wallTimeMs: 0,
+    activeTimeMs: 0,
+  };
+}
+
+function groupHasActivity(group: AgentOperationsDigestGroup): boolean {
+  return (
+    groupActivityRank(group) > 0 ||
+    group.openApprovals.length > 0 ||
+    group.sourceLinks.tokenEvents.length > 0
+  );
+}
+
+function groupActivityRank(group: AgentOperationsDigestGroup): number {
+  const totals = group.totals;
+  return (
+    totals.active +
+    totals.blocked +
+    totals.stuck +
+    totals.completed +
+    totals.failed +
+    totals.runs +
+    totals.totalTokens
+  );
+}
+
+function rollupOperationsTotals(
+  groups: AgentOperationsDigestGroup[]
+): AgentOperationsDigest['totals'] {
+  const totals = groups.reduce(
+    (acc, group) => {
+      acc.active += group.totals.active;
+      acc.blocked += group.totals.blocked;
+      acc.stuck += group.totals.stuck;
+      acc.completed += group.totals.completed;
+      acc.failed += group.totals.failed;
+      acc.runs += group.totals.runs;
+      acc.tokenCost += group.totals.tokenCost;
+      acc.inputTokens += group.totals.inputTokens;
+      acc.outputTokens += group.totals.outputTokens;
+      acc.totalTokens += group.totals.totalTokens;
+      acc.wallTimeMs += group.totals.wallTimeMs;
+      acc.activeTimeMs += group.totals.activeTimeMs;
+      acc.openApprovals += group.openApprovals.length;
+      return acc;
+    },
+    { ...emptyOperationsTotals(), openApprovals: 0, groups: groups.length }
+  );
+  totals.tokenCost = Number(totals.tokenCost.toFixed(6));
+  return totals;
+}
+
+function taskSourceLink(task: Task): AgentOperationsSourceLink {
+  return {
+    kind: 'task',
+    id: task.id,
+    label: task.title,
+    timestamp: task.updated,
+    taskId: task.id,
+  };
+}
+
+function runSourceLink(event: RunTelemetryEvent): AgentOperationsSourceLink {
+  const id = event.attemptId ?? event.id;
+  return {
+    kind: 'run',
+    id,
+    label: `${event.agent || 'agent'} run${event.taskId ? ` for ${event.taskId}` : ''}`,
+    timestamp: event.timestamp,
+    taskId: event.taskId,
+  };
+}
+
+function runFailureLink(event: RunTelemetryEvent): AgentOperationsFailure {
+  return {
+    ...runSourceLink(event),
+    agent: event.agent,
+    error: event.error,
+  };
+}
+
+function telemetrySourceLink(event: TokenTelemetryEvent): AgentOperationsSourceLink {
+  return {
+    kind: 'telemetry',
+    id: event.id,
+    label: `${event.agent || 'agent'} token usage`,
+    timestamp: event.timestamp,
+    taskId: event.taskId,
+  };
+}
+
+function approvalSourceLink(approval: ApprovalRequest): AgentOperationsApproval {
+  return {
+    kind: 'approval',
+    id: approval.id,
+    label: `${approval.agentId} approval: ${approval.action}`,
+    timestamp: approval.createdAt,
+    taskId: approval.taskId,
+    agent: approval.agentId,
+    action: approval.action,
+    details: approval.details,
+  };
+}
+
+function inPeriod(timestamp: string, start: string, end: string): boolean {
+  return timestamp >= start && timestamp <= end;
+}
+
+function positiveNumber(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function isRunSuccess(event: RunTelemetryEvent): boolean {
+  return (
+    event.success === true || (event as unknown as Record<string, unknown>).status === 'success'
+  );
+}
+
+function observedWallTime(timestamps: number[]): number {
+  if (timestamps.length < 2) return 0;
+  return Math.max(0, Math.max(...timestamps) - Math.min(...timestamps));
+}
+
+function pushUnique<T extends { kind: string; id: string }>(items: T[], item: T) {
+  if (!items.some((existing) => existing.kind === item.kind && existing.id === item.id)) {
+    items.push(item);
+  }
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms <= 0) return '0m';
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${Math.max(1, minutes)}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
 }
 
 // Singleton instance


### PR DESCRIPTION
## Summary
- Add a deterministic operations digest grouped by project, repo, and worktree/cwd.
- Include active/blocked/stuck/completed/failed counts, run totals, token/cost totals, observed wall time, active run time, source links, completions, failures, and open approvals.
- Expose `GET /api/digest/operations` with configurable `hours`, `from`, `to`, `project`, and `format=markdown`.
- Add `/api/digest/operations/preview` for markdown standup/briefing previews.

Refs #585

## Verification
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/digest-service.test.ts src/__tests__/routes/misc-routes-coverage.test.ts --testTimeout 15000`
- `pnpm exec eslint server/src/services/digest-service.ts server/src/routes/digest.ts server/src/__tests__/digest-service.test.ts server/src/__tests__/routes/misc-routes-coverage.test.ts`

## Follow-up
- #585 should stay open for scheduled delivery/UI wiring. This PR adds the deterministic digest contract those flows can call.

## Risk
- Server-only additive API. Existing daily digest routes are unchanged.