### PR TITLE
Add agent event search timeline targets

### DIFF
--- a/server/src/__tests__/search-service.test.ts
+++ b/server/src/__tests__/search-service.test.ts
@@ -2,12 +2,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import type { AnyTelemetryEvent } from '@veritas-kanban/shared';
 import { SearchService } from '../services/search-service.js';
 
 const execFileMock = vi.hoisted(() => vi.fn());
+const telemetryEventsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
   execFile: execFileMock,
+}));
+
+vi.mock('../services/telemetry-service.js', () => ({
+  getTelemetryService: () => ({
+    getEvents: telemetryEventsMock,
+  }),
 }));
 
 describe('SearchService', () => {
@@ -23,6 +31,8 @@ describe('SearchService', () => {
     process.env.VERITAS_SEARCH_ROOT = root;
     process.env.VERITAS_SEARCH_BACKEND = 'keyword';
     execFileMock.mockReset();
+    telemetryEventsMock.mockReset();
+    telemetryEventsMock.mockResolvedValue([]);
   });
 
   afterEach(async () => {
@@ -134,6 +144,66 @@ describe('SearchService', () => {
       score: 0.92,
       collection: 'tasks-active',
     });
+  });
+
+  it('searches telemetry events as agent run results with timeline targets', async () => {
+    const telemetryEvents: AnyTelemetryEvent[] = [
+      {
+        id: 'evt-error-1',
+        type: 'run.error',
+        timestamp: '2026-06-04T18:00:00.000Z',
+        taskId: 'task_20260604_search',
+        project: 'veritas',
+        agent: 'codex',
+        attemptId: 'attempt-search-1',
+        error: 'Playwright login failed token=super-secret-value',
+        stackTrace: 'Error: Playwright login failed',
+      },
+      {
+        id: 'evt-tokens-1',
+        type: 'run.tokens',
+        timestamp: '2026-06-04T18:01:00.000Z',
+        taskId: 'task_20260604_search',
+        project: 'veritas',
+        agent: 'codex',
+        attemptId: 'attempt-search-1',
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      },
+    ];
+    telemetryEventsMock.mockResolvedValue(telemetryEvents);
+
+    const result = await new SearchService().search({
+      query: 'playwright login',
+      collections: ['agent-runs'],
+      limit: 5,
+    });
+
+    expect(telemetryEventsMock).toHaveBeenCalledWith({ limit: 250 });
+    expect(result.results[0]).toMatchObject({
+      id: 'telemetry:evt-error-1',
+      title: 'codex run.error for task_20260604_search',
+      collection: 'agent-runs',
+      metadata: {
+        source: 'telemetry-event',
+        eventId: 'evt-error-1',
+        eventType: 'run.error',
+        taskId: 'task_20260604_search',
+        agent: 'codex',
+        attemptId: 'attempt-search-1',
+        target: {
+          type: 'task',
+          taskId: 'task_20260604_search',
+          tab: 'timeline',
+          timelineAttemptId: 'attempt-search-1',
+          timelineEventId: 'evt-error-1',
+        },
+      },
+    });
+    expect(result.results[0].snippet).toContain('Playwright login failed');
+    expect(result.results[0].snippet).toContain('token: [redacted]');
+    expect(result.results[0].snippet).not.toContain('super-secret-value');
   });
 
   it('refreshes qmd index and embeddings', async () => {

--- a/server/src/services/search-service.ts
+++ b/server/src/services/search-service.ts
@@ -1,12 +1,14 @@
 import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import type { AnyTelemetryEvent } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { getNotificationService, NotificationService } from './notification-service.js';
 import {
   getScheduledDeliverablesService,
   ScheduledDeliverablesService,
 } from './scheduled-deliverables-service.js';
+import { getTelemetryService, TelemetryService } from './telemetry-service.js';
 import { getWorkProductService, WorkProductService } from './work-product-service.js';
 import { getWorkflowService, WorkflowService } from './workflow-service.js';
 import { getWorkflowRunService, WorkflowRunService } from './workflow-run-service.js';
@@ -106,6 +108,14 @@ const DATA_FILE_EXTENSIONS = [
 ] as const;
 const SKIPPED_DIRECTORIES = new Set(['.git', 'node_modules', 'backups', 'worktrees']);
 const MAX_FILES_PER_SOURCE = Number(process.env.VERITAS_SEARCH_MAX_FILES_PER_SOURCE || 1_500);
+const CONFIGURED_MAX_TELEMETRY_SEARCH_EVENTS = Number(
+  process.env.VERITAS_SEARCH_MAX_TELEMETRY_EVENTS
+);
+const MAX_TELEMETRY_SEARCH_EVENTS =
+  Number.isFinite(CONFIGURED_MAX_TELEMETRY_SEARCH_EVENTS) &&
+  CONFIGURED_MAX_TELEMETRY_SEARCH_EVENTS > 0
+    ? CONFIGURED_MAX_TELEMETRY_SEARCH_EVENTS
+    : 2_000;
 
 class SearchService {
   async search(request: SearchRequest): Promise<SearchResponse> {
@@ -372,6 +382,10 @@ class SearchService {
 
     if (collections.has('workflow-runs')) {
       results.push(...(await this.searchWorkflowRuns(query, terms, limit)));
+    }
+
+    if (collections.has('agent-runs')) {
+      results.push(...(await this.searchTelemetryEvents(query, terms, limit)));
     }
 
     if (collections.has('notifications')) {
@@ -675,6 +689,80 @@ class SearchService {
     return this.rankResults(results).slice(0, limit);
   }
 
+  private async searchTelemetryEvents(
+    query: string,
+    terms: string[],
+    limit: number
+  ): Promise<SearchResult[]> {
+    const events = await this.telemetryService().getEvents({
+      limit: Math.min(Math.max(limit * 50, 250), MAX_TELEMETRY_SEARCH_EVENTS),
+    });
+    const results: SearchResult[] = [];
+
+    for (const event of events) {
+      const eventId = this.firstString(event.id) ?? this.telemetryEventFallbackId(event);
+      const attemptId = this.telemetryEventAttemptId(event);
+      const title = this.telemetryEventTitle(event);
+      const content = this.telemetryEventSearchText(event);
+      const pathValue = `/agent-runs/${encodeURIComponent(attemptId ?? eventId)}`;
+      const score = this.scoreText({
+        title,
+        pathValue,
+        content,
+        terms,
+        query,
+        timestamp: event.timestamp,
+      });
+
+      if (score.textScore === 0) continue;
+
+      const target = event.taskId
+        ? {
+            type: 'task',
+            taskId: event.taskId,
+            tab: 'timeline',
+            timelineAttemptId: attemptId,
+            timelineEventId: eventId,
+            href: `veritas://task/${encodeURIComponent(event.taskId)}?tab=timeline${
+              attemptId ? `&attempt=${encodeURIComponent(attemptId)}` : ''
+            }&event=${encodeURIComponent(eventId)}`,
+          }
+        : { type: 'diagnostics', href: '/diagnostics' };
+
+      results.push({
+        id: `telemetry:${eventId}`,
+        title,
+        path: pathValue,
+        collection: 'agent-runs',
+        snippet: this.extractSnippet(content, terms),
+        score: score.score,
+        metadata: {
+          source: 'telemetry-event',
+          eventId,
+          eventType: event.type,
+          taskId: event.taskId,
+          project: event.project,
+          agent: this.telemetryEventAgent(event),
+          attemptId,
+          timestamp: event.timestamp,
+          highlight: {
+            timelineEventId: eventId,
+            timelineAttemptId: attemptId,
+          },
+          target,
+          actions: this.actionsForTarget(target, 'agent-runs'),
+          ranking: {
+            textScore: score.textScore,
+            recencyBoost: score.recencyBoost,
+            usageFrequency: 0,
+          },
+        },
+      });
+    }
+
+    return this.rankResults(results).slice(0, limit);
+  }
+
   private async searchNotifications(
     query: string,
     terms: string[],
@@ -963,6 +1051,71 @@ class SearchService {
     }
 
     return results;
+  }
+
+  private telemetryEventSearchText(event: AnyTelemetryEvent): string {
+    const parts = [
+      event.id,
+      event.type,
+      event.timestamp,
+      event.taskId,
+      event.project,
+      this.telemetryEventAgent(event),
+      this.telemetryEventAttemptId(event),
+      this.firstString(
+        this.recordValue(event, 'model'),
+        this.recordValue(event, 'status'),
+        this.recordValue(event, 'previousStatus')
+      ),
+      this.firstString(this.recordValue(event, 'error'), this.recordValue(event, 'summary')),
+      this.firstString(this.recordValue(event, 'tool'), this.recordValue(event, 'toolName')),
+      this.firstString(this.recordValue(event, 'artifact'), this.recordValue(event, 'artifactUrl')),
+      this.telemetryUsageSummary(event),
+    ];
+
+    return this.redactSnippet(parts.filter(Boolean).join('\n'));
+  }
+
+  private telemetryEventTitle(event: AnyTelemetryEvent): string {
+    const agent = this.telemetryEventAgent(event);
+    const subject = [agent, event.type].filter(Boolean).join(' ');
+    if (event.taskId) return `${subject || event.type} for ${event.taskId}`;
+    return subject || event.type;
+  }
+
+  private telemetryEventAgent(event: AnyTelemetryEvent): string | undefined {
+    return this.firstString(this.recordValue(event, 'agent'), this.recordValue(event, 'actor'));
+  }
+
+  private telemetryEventAttemptId(event: AnyTelemetryEvent): string | undefined {
+    return this.firstString(
+      this.recordValue(event, 'attemptId'),
+      this.recordValue(event, 'traceId'),
+      this.recordValue(event, 'runId')
+    );
+  }
+
+  private telemetryEventFallbackId(event: AnyTelemetryEvent): string {
+    return [event.type, event.taskId, event.timestamp].filter(Boolean).join(':');
+  }
+
+  private telemetryUsageSummary(event: AnyTelemetryEvent): string | undefined {
+    const inputTokens = this.firstNumber(this.recordValue(event, 'inputTokens'));
+    const outputTokens = this.firstNumber(this.recordValue(event, 'outputTokens'));
+    const totalTokens = this.firstNumber(this.recordValue(event, 'totalTokens'));
+    const cost = this.firstNumber(this.recordValue(event, 'cost'));
+    const values = [
+      inputTokens === undefined ? undefined : `input tokens ${inputTokens}`,
+      outputTokens === undefined ? undefined : `output tokens ${outputTokens}`,
+      totalTokens === undefined ? undefined : `total tokens ${totalTokens}`,
+      cost === undefined ? undefined : `cost ${cost}`,
+    ].filter(Boolean);
+
+    return values.length > 0 ? values.join(' ') : undefined;
+  }
+
+  private recordValue(record: object, key: string): unknown {
+    return (record as Record<string, unknown>)[key];
   }
 
   private normalizeCollections(collections?: SearchCollection[]): SearchCollection[] {
@@ -1305,6 +1458,10 @@ class SearchService {
       });
     }
     return getWorkflowRunService();
+  }
+
+  private telemetryService(): TelemetryService {
+    return getTelemetryService();
   }
 
   private firstString(...values: unknown[]): string | undefined {

--- a/web/src/__tests__/SearchDialog.test.tsx
+++ b/web/src/__tests__/SearchDialog.test.tsx
@@ -162,6 +162,7 @@ describe('SearchDialog', () => {
               taskId: 'task_20260504_abc123',
               tab: 'timeline',
               timelineAttemptId: 'attempt-1',
+              timelineEventId: 'evt-1',
             },
           },
         },
@@ -177,6 +178,7 @@ describe('SearchDialog', () => {
     expect(onTaskOpen).toHaveBeenCalledWith('task_20260504_abc123', {
       tab: 'timeline',
       timelineAttemptId: 'attempt-1',
+      timelineEventId: 'evt-1',
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });

--- a/web/src/__tests__/agent-run-timeline-mantine.test.tsx
+++ b/web/src/__tests__/agent-run-timeline-mantine.test.tsx
@@ -467,6 +467,21 @@ describe('agent run timeline Mantine surface', () => {
     expect(mocks.onOpenTab).toHaveBeenCalledWith('work-products');
   });
 
+  it('highlights a deep-linked telemetry event', () => {
+    renderWithProviders(
+      <AgentRunTimelinePanel
+        task={task}
+        initialAttemptId="attempt-1"
+        initialEventId="evt-tokens"
+        onOpenTab={mocks.onOpenTab}
+      />
+    );
+
+    const highlighted = screen.getByTestId('highlighted-timeline-event');
+    expect(highlighted.textContent).toContain('Token usage recorded');
+    expect(highlighted.querySelector('[data-highlighted="true"]')).toBeDefined();
+  });
+
   it('pages long timelines so replay rendering stays bounded', async () => {
     const user = userEvent.setup();
     const longTrace: AgentRunTrace = {

--- a/web/src/components/search/SearchDialog.tsx
+++ b/web/src/components/search/SearchDialog.tsx
@@ -117,6 +117,7 @@ function taskNavigationTarget(target: SearchTarget): TaskDetailNavigationTarget 
   return {
     tab,
     timelineAttemptId: target.timelineAttemptId ?? null,
+    timelineEventId: target.timelineEventId ?? null,
   };
 }
 

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Badge,
   Button,
@@ -57,6 +57,7 @@ const BASE_PATH = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
 interface AgentRunTimelinePanelProps {
   task: Task;
   initialAttemptId?: string | null;
+  initialEventId?: string | null;
   onOpenTab?: (target: TimelineTabTarget) => void;
   onOpenWorkflow?: (runId?: string) => void;
 }
@@ -913,10 +914,12 @@ function governanceTraceHrefForEvent(event: AgentRunTimelineEvent): string | nul
 
 function EventRow({
   event,
+  highlighted,
   onOpenTab,
   onOpenWorkflow,
 }: {
   event: AgentRunTimelineEvent;
+  highlighted?: boolean;
   onOpenTab?: (target: TimelineTabTarget) => void;
   onOpenWorkflow?: (runId?: string) => void;
 }) {
@@ -930,7 +933,13 @@ function EventRow({
   const governanceTraceHref = governanceTraceHrefForEvent(event);
 
   return (
-    <Paper withBorder p="sm" radius="md">
+    <Paper
+      withBorder
+      p="sm"
+      radius="md"
+      className={highlighted ? 'border-primary bg-primary/5 shadow-sm' : undefined}
+      data-highlighted={highlighted ? 'true' : undefined}
+    >
       <Stack gap="xs">
         <Group justify="space-between" align="flex-start" wrap="nowrap">
           <Group gap="sm" align="flex-start" wrap="nowrap" className="min-w-0">
@@ -1023,6 +1032,7 @@ function EventRow({
 export function AgentRunTimelinePanel({
   task,
   initialAttemptId,
+  initialEventId,
   onOpenTab,
   onOpenWorkflow,
 }: AgentRunTimelinePanelProps) {
@@ -1046,6 +1056,7 @@ export function AgentRunTimelinePanel({
   );
   const [filter, setFilter] = useState<AgentRunTimelineEventType | 'all'>('all');
   const [visibleCount, setVisibleCount] = useState(TIMELINE_PAGE_SIZE);
+  const highlightedEventRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (initialAttemptId) {
@@ -1105,6 +1116,13 @@ export function AgentRunTimelinePanel({
       selectedAttemptId,
     ]
   );
+  const highlightedEventId = useMemo(() => {
+    if (!initialEventId) return null;
+    if (events.some((event) => event.id === initialEventId)) return initialEventId;
+    const telemetryEventId = `telemetry-${initialEventId}`;
+    if (events.some((event) => event.id === telemetryEventId)) return telemetryEventId;
+    return initialEventId;
+  }, [events, initialEventId]);
 
   const filteredEvents = useMemo(
     () => (filter === 'all' ? events : events.filter((event) => event.type === filter)),
@@ -1128,6 +1146,25 @@ export function AgentRunTimelinePanel({
   useEffect(() => {
     setVisibleCount(TIMELINE_PAGE_SIZE);
   }, [filter, selectedAttemptId, events.length]);
+
+  useEffect(() => {
+    if (!highlightedEventId) return;
+    if (filter !== 'all') {
+      setFilter('all');
+    }
+
+    const eventIndex = events.findIndex((event) => event.id === highlightedEventId);
+    if (eventIndex >= visibleCount) {
+      setVisibleCount(Math.max(TIMELINE_PAGE_SIZE, eventIndex + 1));
+    }
+  }, [events, filter, highlightedEventId, visibleCount]);
+
+  useEffect(() => {
+    if (!highlightedEventId) return;
+    const highlightedElement = highlightedEventRef.current;
+    if (typeof highlightedElement?.scrollIntoView !== 'function') return;
+    highlightedElement.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [highlightedEventId, visibleEvents.length]);
 
   return (
     <Stack gap="md">
@@ -1370,14 +1407,23 @@ export function AgentRunTimelinePanel({
       <ScrollArea.Autosize mah={520} type="auto">
         <Stack gap="xs" pr="xs">
           {visibleEvents.length > 0 ? (
-            visibleEvents.map((event) => (
-              <EventRow
-                key={event.id}
-                event={event}
-                onOpenTab={onOpenTab}
-                onOpenWorkflow={onOpenWorkflow}
-              />
-            ))
+            visibleEvents.map((event) => {
+              const highlighted = event.id === highlightedEventId;
+              return (
+                <div
+                  key={event.id}
+                  ref={highlighted ? highlightedEventRef : undefined}
+                  data-testid={highlighted ? 'highlighted-timeline-event' : undefined}
+                >
+                  <EventRow
+                    event={event}
+                    highlighted={highlighted}
+                    onOpenTab={onOpenTab}
+                    onOpenWorkflow={onOpenWorkflow}
+                  />
+                </div>
+              );
+            })
           ) : (
             <Paper withBorder p="md" radius="md">
               <Group gap="xs">

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -68,6 +68,7 @@ export function TaskDetailPanel({
   const [taskChatOpen, setTaskChatOpen] = useState(false);
   const [workflowOpen, setWorkflowOpen] = useState(false);
   const [timelineAttemptId, setTimelineAttemptId] = useState<string | null>(null);
+  const [timelineEventId, setTimelineEventId] = useState<string | null>(null);
   const lastDefaultedTaskIdRef = useRef<string | undefined>(undefined);
   const addObservation = useAddObservation();
   const deleteObservation = useDeleteObservation();
@@ -129,11 +130,13 @@ export function TaskDetailPanel({
     if (!activeTaskId) {
       lastDefaultedTaskIdRef.current = undefined;
       setTimelineAttemptId(null);
+      setTimelineEventId(null);
       return;
     }
     if (lastDefaultedTaskIdRef.current === activeTaskId) return;
     lastDefaultedTaskIdRef.current = activeTaskId;
     setTimelineAttemptId(null);
+    setTimelineEventId(null);
     setActiveTab(fallbackTab);
   }, [activeTaskId, fallbackTab]);
 
@@ -141,6 +144,12 @@ export function TaskDetailPanel({
     if (!activeTaskId || !navigationTarget) return;
     if (navigationTarget.timelineAttemptId !== undefined) {
       setTimelineAttemptId(navigationTarget.timelineAttemptId ?? null);
+      if (navigationTarget.timelineEventId === undefined) {
+        setTimelineEventId(null);
+      }
+    }
+    if (navigationTarget.timelineEventId !== undefined) {
+      setTimelineEventId(navigationTarget.timelineEventId ?? null);
     }
     if (navigationTarget.tab && isTaskDetailTabAvailable(visibleTabs, navigationTarget.tab)) {
       setActiveTab(navigationTarget.tab);
@@ -148,6 +157,11 @@ export function TaskDetailPanel({
   }, [activeTaskId, navigationTarget, visibleTabs]);
 
   if (!localTask) return null;
+
+  const setTimelineAttemptTarget = (attemptId: string | null) => {
+    setTimelineAttemptId(attemptId);
+    setTimelineEventId(null);
+  };
 
   // Get current type info
   const currentType = taskTypes.find((t) => t.id === localTask.type);
@@ -158,13 +172,14 @@ export function TaskDetailPanel({
     task: localTask,
     readOnly,
     timelineAttemptId,
+    timelineEventId,
     updateField,
     onClose: () => onOpenChange(false),
     onRestore,
     setActiveTab,
     openTaskChat: () => setTaskChatOpen(true),
     openWorkflow: () => setWorkflowOpen(true),
-    setTimelineAttemptId,
+    setTimelineAttemptId: setTimelineAttemptTarget,
     addObservation: addObservationForTask,
     deleteObservation: deleteObservationForTask,
   };

--- a/web/src/components/task/task-detail-tabs.tsx
+++ b/web/src/components/task/task-detail-tabs.tsx
@@ -72,6 +72,7 @@ export interface TaskDetailRenderContext extends TaskDetailAvailabilityContext {
   task: Task;
   readOnly: boolean;
   timelineAttemptId: string | null;
+  timelineEventId: string | null;
   updateField: <K extends keyof Task>(field: K, value: Task[K]) => void;
   onClose: () => void;
   onRestore?: (taskId: string) => void;
@@ -147,10 +148,11 @@ const TAB_RENDERERS: Record<TaskDetailTabId, (context: TaskDetailRenderContext) 
       }}
     />
   ),
-  timeline: ({ task, timelineAttemptId, setActiveTab, openWorkflow }) => (
+  timeline: ({ task, timelineAttemptId, timelineEventId, setActiveTab, openWorkflow }) => (
     <AgentRunTimelinePanel
       task={task}
       initialAttemptId={timelineAttemptId}
+      initialEventId={timelineEventId}
       onOpenTab={setActiveTab}
       onOpenWorkflow={openWorkflow}
     />

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -25,6 +25,7 @@ export type SearchTarget =
       taskId: string;
       tab?: string;
       timelineAttemptId?: string;
+      timelineEventId?: string;
       href?: string;
     }
   | {

--- a/web/src/lib/task-detail-tabs.ts
+++ b/web/src/lib/task-detail-tabs.ts
@@ -15,6 +15,7 @@ export type TaskDetailTabId =
 export interface TaskDetailNavigationTarget {
   tab?: TaskDetailTabId;
   timelineAttemptId?: string | null;
+  timelineEventId?: string | null;
 }
 
 export interface TaskDetailAvailabilityContext {


### PR DESCRIPTION
## Summary
- Add structured telemetry event results to the existing Universal Search `agent-runs` collection.
- Return task timeline targets with attempt and event ids so results can open and highlight the matching timeline event.
- Carry the event highlight through Search Dialog, Task Detail, and Agent Run Timeline.

Closes #587

## Verification
- pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/search-service.test.ts
- pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/SearchDialog.test.tsx src/__tests__/agent-run-timeline-mantine.test.tsx
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm exec eslint server/src/services/search-service.ts server/src/__tests__/search-service.test.ts web/src/lib/api/search.ts web/src/lib/task-detail-tabs.ts web/src/components/search/SearchDialog.tsx web/src/components/task/TaskDetailPanel.tsx web/src/components/task/task-detail-tabs.tsx web/src/components/task/AgentRunTimelinePanel.tsx web/src/__tests__/SearchDialog.test.tsx web/src/__tests__/agent-run-timeline-mantine.test.tsx

## Notes
- This uses the current SearchService structured-provider architecture. A materialized SQLite FTS/BM25 index should be a separate follow-up only if real telemetry volume or ranking quality requires it.
