### PR TITLE
Add context provider health shell

### DIFF
--- a/server/src/__tests__/context-provider-health-service.test.ts
+++ b/server/src/__tests__/context-provider-health-service.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AppConfig } from '@veritas-kanban/shared';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import { ContextProviderHealthService } from '../services/context-provider-health-service.js';
+
+describe('ContextProviderHealthService', () => {
+  it('maps OpenClaw config posture without exposing secrets', async () => {
+    const getConfig = vi.fn().mockResolvedValue({
+      agents: [
+        {
+          type: 'openclaw',
+          name: 'OpenClaw',
+          command: 'openclaw',
+          args: ['run', '--approval-never'],
+          enabled: true,
+          provider: 'openclaw',
+        },
+      ],
+    } as Partial<AppConfig>);
+    const getFeatureSettings = vi.fn().mockResolvedValue({
+      ...DEFAULT_FEATURE_SETTINGS,
+      squadWebhook: {
+        ...DEFAULT_FEATURE_SETTINGS.squadWebhook,
+        enabled: true,
+        mode: 'openclaw',
+        openclawGatewayUrl: 'http://127.0.0.1:18789',
+        openclawGatewayToken: 'super-secret-token',
+      },
+    });
+    const getHealth = vi.fn().mockResolvedValue({
+      checkedAt: '2026-06-05T00:00:00.000Z',
+      cli: { installed: true, authenticated: true },
+      sdk: { available: true },
+      agents: { codexCli: true, codexSdk: true, codexCloud: false, enabled: ['codex'] },
+      ready: { cli: true, sdk: true, cloud: false, overall: true },
+      recommendations: [],
+    });
+
+    const service = new ContextProviderHealthService({
+      configService: { getConfig, getFeatureSettings },
+      codexHealthService: { getHealth },
+    });
+
+    const result = await service.getHealth();
+    const openClaw = result.providers.find((provider) => provider.id === 'openclaw');
+
+    expect(openClaw).toMatchObject({
+      state: 'unknown',
+      risk: 'risky',
+      boundary: 'local',
+      writeCapability: true,
+    });
+    expect(openClaw?.postureFlags).toContain('Risky exec/elevated argument detected');
+    expect(JSON.stringify(openClaw)).not.toContain('super-secret-token');
+    expect(result.summary.risky).toBe(1);
+  });
+});

--- a/server/src/__tests__/routes/settings-codex-health.test.ts
+++ b/server/src/__tests__/routes/settings-codex-health.test.ts
@@ -3,8 +3,11 @@ import express from 'express';
 import request from 'supertest';
 import { errorHandler } from '../../middleware/error-handler.js';
 
-const { mockCodexHealthService } = vi.hoisted(() => ({
+const { mockCodexHealthService, mockContextProviderHealthService } = vi.hoisted(() => ({
   mockCodexHealthService: {
+    getHealth: vi.fn(),
+  },
+  mockContextProviderHealthService: {
     getHealth: vi.fn(),
   },
 }));
@@ -12,6 +15,12 @@ const { mockCodexHealthService } = vi.hoisted(() => ({
 vi.mock('../../services/codex-health-service.js', () => ({
   CodexHealthService: function () {
     return mockCodexHealthService;
+  },
+}));
+
+vi.mock('../../services/context-provider-health-service.js', () => ({
+  ContextProviderHealthService: function () {
+    return mockContextProviderHealthService;
   },
 }));
 
@@ -52,5 +61,48 @@ describe('Settings Codex health route', () => {
     expect(response.status).toBe(200);
     expect(response.body.ready.overall).toBe(true);
     expect(mockCodexHealthService.getHealth).toHaveBeenCalled();
+  });
+
+  it('returns context provider health', async () => {
+    mockContextProviderHealthService.getHealth.mockResolvedValue({
+      checkedAt: '2026-06-05T00:00:00.000Z',
+      summary: {
+        total: 2,
+        connected: 1,
+        degraded: 0,
+        stale: 0,
+        disconnected: 0,
+        unknown: 1,
+        risky: 1,
+        writeCapable: 2,
+      },
+      providers: [
+        {
+          id: 'openclaw',
+          name: 'OpenClaw',
+          provider: 'openclaw',
+          state: 'unknown',
+          risk: 'risky',
+          boundary: 'local',
+          readCapability: true,
+          writeCapability: true,
+          privacyScope: 'Local gateway posture only.',
+          lastCheckedAt: '2026-06-05T00:00:00.000Z',
+          detail: 'OpenClaw profile detected.',
+          tools: ['gateway'],
+          postureFlags: ['Risky exec/elevated argument detected'],
+          recommendations: ['Review OpenClaw exec/elevated arguments.'],
+        },
+      ],
+    });
+
+    const response = await request(app).get('/api/settings/provider-health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.providers[0]).toMatchObject({
+      id: 'openclaw',
+      risk: 'risky',
+    });
+    expect(mockContextProviderHealthService.getHealth).toHaveBeenCalled();
   });
 });

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,6 +1,7 @@
 import { Router, type Router as RouterType } from 'express';
 import { ConfigService } from '../services/config-service.js';
 import { CodexHealthService } from '../services/codex-health-service.js';
+import { ContextProviderHealthService } from '../services/context-provider-health-service.js';
 import { getTelemetryService } from '../services/telemetry-service.js';
 import { getAttachmentService } from '../services/attachment-service.js';
 import { setEnforcementSettings, setHooksSettings } from '../services/hook-service.js';
@@ -18,6 +19,7 @@ import { createLogger } from '../lib/logger.js';
 const router: RouterType = Router();
 const configService = new ConfigService();
 const codexHealthService = new CodexHealthService();
+const contextProviderHealthService = new ContextProviderHealthService();
 const log = createLogger('settings-routes');
 
 /**
@@ -90,6 +92,15 @@ router.get(
   '/codex/health',
   asyncHandler(async (_req, res) => {
     const health = await codexHealthService.getHealth();
+    res.json(health);
+  })
+);
+
+// GET /api/settings/provider-health — shared context-provider/MCP posture summary
+router.get(
+  '/provider-health',
+  asyncHandler(async (_req, res) => {
+    const health = await contextProviderHealthService.getHealth();
     res.json(health);
   })
 );

--- a/server/src/services/context-provider-health-service.ts
+++ b/server/src/services/context-provider-health-service.ts
@@ -1,0 +1,191 @@
+import type { AgentConfig, FeatureSettings } from '@veritas-kanban/shared';
+import { ConfigService } from './config-service.js';
+import { CodexHealthService, type CodexHealthStatus } from './codex-health-service.js';
+
+export type ContextProviderState = 'connected' | 'degraded' | 'stale' | 'disconnected' | 'unknown';
+
+export type ContextProviderRisk = 'safe' | 'normal' | 'risky';
+export type ContextProviderBoundary = 'local' | 'cloud' | 'mixed' | 'unknown';
+
+export interface ContextProviderHealth {
+  id: string;
+  name: string;
+  provider: 'codex' | 'openclaw' | 'custom';
+  state: ContextProviderState;
+  risk: ContextProviderRisk;
+  boundary: ContextProviderBoundary;
+  readCapability: boolean;
+  writeCapability: boolean;
+  privacyScope: string;
+  lastCheckedAt: string;
+  detail: string;
+  tools: string[];
+  postureFlags: string[];
+  recommendations: string[];
+}
+
+export interface ContextProviderHealthResponse {
+  checkedAt: string;
+  summary: {
+    total: number;
+    connected: number;
+    degraded: number;
+    stale: number;
+    disconnected: number;
+    unknown: number;
+    risky: number;
+    writeCapable: number;
+  };
+  providers: ContextProviderHealth[];
+}
+
+export interface ContextProviderHealthServiceOptions {
+  configService?: Pick<ConfigService, 'getConfig' | 'getFeatureSettings'>;
+  codexHealthService?: Pick<CodexHealthService, 'getHealth'>;
+}
+
+export class ContextProviderHealthService {
+  private configService: Pick<ConfigService, 'getConfig' | 'getFeatureSettings'>;
+  private codexHealthService: Pick<CodexHealthService, 'getHealth'>;
+
+  constructor(options: ContextProviderHealthServiceOptions = {}) {
+    this.configService = options.configService ?? new ConfigService();
+    this.codexHealthService = options.codexHealthService ?? new CodexHealthService();
+  }
+
+  async getHealth(): Promise<ContextProviderHealthResponse> {
+    const checkedAt = new Date().toISOString();
+    const [config, featureSettings, codexHealth] = await Promise.all([
+      this.configService.getConfig(),
+      this.configService.getFeatureSettings(),
+      this.codexHealthService.getHealth(),
+    ]);
+
+    const providers = [
+      this.codexProvider(codexHealth, checkedAt),
+      this.openClawProvider(config.agents, featureSettings, checkedAt),
+    ];
+
+    return {
+      checkedAt,
+      summary: this.summary(providers),
+      providers,
+    };
+  }
+
+  private codexProvider(health: CodexHealthStatus, checkedAt: string): ContextProviderHealth {
+    const state: ContextProviderState = health.ready.overall
+      ? 'connected'
+      : health.cli.installed
+        ? 'degraded'
+        : 'disconnected';
+    const tools = [
+      health.ready.cli ? 'codex-cli' : undefined,
+      health.ready.sdk ? 'codex-sdk' : undefined,
+      health.ready.cloud ? 'codex-cloud' : undefined,
+    ].filter((tool): tool is string => Boolean(tool));
+
+    return {
+      id: 'codex',
+      name: 'Codex',
+      provider: 'codex',
+      state,
+      risk: 'normal',
+      boundary: health.ready.cloud ? 'mixed' : 'local',
+      readCapability: true,
+      writeCapability: tools.length > 0,
+      privacyScope: 'Local CLI/SDK profile with model-provider requests when agents run.',
+      lastCheckedAt: health.checkedAt || checkedAt,
+      detail: health.ready.overall
+        ? 'At least one Codex agent profile is ready.'
+        : 'Codex is configured but not fully ready.',
+      tools,
+      postureFlags: [
+        health.cli.authenticated ? 'CLI authenticated' : 'CLI not authenticated',
+        health.sdk.available ? 'SDK available' : 'SDK unavailable',
+        ...health.agents.enabled.map((agent) => `Enabled profile: ${agent}`),
+      ],
+      recommendations: health.recommendations,
+    };
+  }
+
+  private openClawProvider(
+    agents: AgentConfig[],
+    featureSettings: FeatureSettings,
+    checkedAt: string
+  ): ContextProviderHealth {
+    const openClawAgents = agents.filter((agent) => agent.provider === 'openclaw');
+    const enabledAgents = openClawAgents.filter((agent) => agent.enabled);
+    const gatewayConfigured =
+      featureSettings.squadWebhook.mode === 'openclaw' &&
+      Boolean(featureSettings.squadWebhook.openclawGatewayUrl);
+    const riskyArgs = openClawAgents.flatMap((agent) =>
+      [agent.command, ...agent.args].filter((value) => this.isRiskyOpenClawArg(value))
+    );
+    const state: ContextProviderState =
+      enabledAgents.length > 0 || gatewayConfigured
+        ? 'unknown'
+        : openClawAgents.length > 0
+          ? 'degraded'
+          : 'disconnected';
+    const risk: ContextProviderRisk = riskyArgs.length > 0 ? 'risky' : 'normal';
+
+    return {
+      id: 'openclaw',
+      name: 'OpenClaw',
+      provider: 'openclaw',
+      state,
+      risk,
+      boundary: gatewayConfigured ? 'local' : 'unknown',
+      readCapability: openClawAgents.length > 0 || gatewayConfigured,
+      writeCapability: enabledAgents.length > 0 || gatewayConfigured,
+      privacyScope: gatewayConfigured
+        ? 'Local gateway posture only; tokens and gateway secrets are redacted.'
+        : 'No OpenClaw gateway status is configured.',
+      lastCheckedAt: checkedAt,
+      detail:
+        enabledAgents.length > 0
+          ? `${enabledAgents.length} enabled OpenClaw agent profile(s) detected.`
+          : gatewayConfigured
+            ? 'OpenClaw gateway is configured for squad wakeups.'
+            : 'No enabled OpenClaw agent profile or gateway was found.',
+      tools: [
+        gatewayConfigured ? 'gateway' : undefined,
+        ...openClawAgents.map((agent) => `agent:${agent.type}`),
+      ].filter((tool): tool is string => Boolean(tool)),
+      postureFlags: [
+        gatewayConfigured ? 'Gateway configured' : 'Gateway not configured',
+        enabledAgents.length > 0 ? 'Write-capable agent profile enabled' : 'No enabled profile',
+        riskyArgs.length > 0 ? 'Risky exec/elevated argument detected' : 'No risky args detected',
+        'Doctor/policy check not yet connected',
+      ],
+      recommendations: [
+        gatewayConfigured || openClawAgents.length > 0
+          ? 'Connect OpenClaw doctor/policy output to replace unknown posture.'
+          : 'Add an OpenClaw profile or gateway before expecting posture checks.',
+        riskyArgs.length > 0
+          ? 'Review OpenClaw exec/elevated arguments before autonomous runs.'
+          : undefined,
+      ].filter((item): item is string => Boolean(item)),
+    };
+  }
+
+  private summary(providers: ContextProviderHealth[]): ContextProviderHealthResponse['summary'] {
+    return {
+      total: providers.length,
+      connected: providers.filter((provider) => provider.state === 'connected').length,
+      degraded: providers.filter((provider) => provider.state === 'degraded').length,
+      stale: providers.filter((provider) => provider.state === 'stale').length,
+      disconnected: providers.filter((provider) => provider.state === 'disconnected').length,
+      unknown: providers.filter((provider) => provider.state === 'unknown').length,
+      risky: providers.filter((provider) => provider.risk === 'risky').length,
+      writeCapable: providers.filter((provider) => provider.writeCapability).length,
+    };
+  }
+
+  private isRiskyOpenClawArg(value: string): boolean {
+    return /dangerously|skip[-_]?permissions|approval[-_]?never|elevated|allow[-_]?exec/i.test(
+      value
+    );
+  }
+}

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -45,6 +45,7 @@ const routingConfig: AgentRoutingConfig = {
 const mocks = vi.hoisted(() => ({
   debouncedUpdate: vi.fn(),
   refetchCodexHealth: vi.fn(),
+  refetchProviderHealth: vi.fn(),
   updateAgents: vi.fn(),
   updateRouting: vi.fn(),
 }));
@@ -72,6 +73,57 @@ vi.mock('@/hooks/useConfig', () => ({
     },
     isFetching: false,
     refetch: mocks.refetchCodexHealth,
+  }),
+  useProviderHealth: () => ({
+    data: {
+      checkedAt: '2026-06-01T12:01:00.000Z',
+      summary: {
+        total: 2,
+        connected: 1,
+        degraded: 0,
+        stale: 0,
+        disconnected: 0,
+        unknown: 1,
+        risky: 1,
+        writeCapable: 2,
+      },
+      providers: [
+        {
+          id: 'codex',
+          name: 'Codex',
+          provider: 'codex',
+          state: 'connected',
+          risk: 'normal',
+          boundary: 'mixed',
+          readCapability: true,
+          writeCapability: true,
+          privacyScope: 'Local CLI/SDK profile with model-provider requests when agents run.',
+          lastCheckedAt: '2026-06-01T12:00:00.000Z',
+          detail: 'At least one Codex agent profile is ready.',
+          tools: ['codex-cli'],
+          postureFlags: ['CLI authenticated'],
+          recommendations: [],
+        },
+        {
+          id: 'openclaw',
+          name: 'OpenClaw',
+          provider: 'openclaw',
+          state: 'unknown',
+          risk: 'risky',
+          boundary: 'local',
+          readCapability: true,
+          writeCapability: true,
+          privacyScope: 'Local gateway posture only; tokens and gateway secrets are redacted.',
+          lastCheckedAt: '2026-06-01T12:01:00.000Z',
+          detail: '1 enabled OpenClaw agent profile(s) detected.',
+          tools: ['gateway', 'agent:openclaw'],
+          postureFlags: ['Risky exec/elevated argument detected'],
+          recommendations: ['Review OpenClaw exec/elevated arguments before autonomous runs.'],
+        },
+      ],
+    },
+    isFetching: false,
+    refetch: mocks.refetchProviderHealth,
   }),
   useUpdateAgents: () => ({
     mutate: mocks.updateAgents,
@@ -120,6 +172,9 @@ describe('Agents settings Mantine migration', () => {
 
     expect(screen.getByText('Installed Agents')).toBeDefined();
     expect(screen.getByText('Codex Health')).toBeDefined();
+    expect(screen.getByText('Context Provider Health')).toBeDefined();
+    expect(screen.getByText('OpenClaw')).toBeDefined();
+    expect(screen.getByText('Risky')).toBeDefined();
     expect(screen.getByText('Agent Routing')).toBeDefined();
     expect(screen.getByText('CLI installed')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Refresh Codex health' })).toBeDefined();
@@ -142,9 +197,11 @@ describe('Agents settings Mantine migration', () => {
     expect(baseElement.querySelector('[data-slot="badge"]')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh Codex health' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh provider health' }));
     fireEvent.click(screen.getByRole('switch', { name: 'Enable Claude Code' }));
 
     expect(mocks.refetchCodexHealth).toHaveBeenCalledTimes(1);
+    expect(mocks.refetchProviderHealth).toHaveBeenCalledTimes(1);
     expect(mocks.updateAgents).toHaveBeenCalledWith([
       agents[0],
       expect.objectContaining({ type: 'claude-code', enabled: true }),

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { ActionIcon, Badge, Button, Modal, Select, Switch, Text, TextInput } from '@mantine/core';
-import { useCodexHealth, useConfig, useUpdateAgents } from '@/hooks/useConfig';
+import { useCodexHealth, useConfig, useProviderHealth, useUpdateAgents } from '@/hooks/useConfig';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { useRoutingConfig, useUpdateRoutingConfig } from '@/hooks/useRouting';
 import {
@@ -15,6 +15,7 @@ import {
   ChevronUp,
   Loader2,
   RefreshCw,
+  ShieldAlert,
 } from 'lucide-react';
 import type {
   AgentConfig,
@@ -22,7 +23,11 @@ import type {
   RoutingRule,
   AgentRoutingConfig,
 } from '@veritas-kanban/shared';
-import type { CodexHealthStatus } from '@/lib/api';
+import type {
+  CodexHealthStatus,
+  ContextProviderHealth,
+  ContextProviderHealthResponse,
+} from '@/lib/api';
 import { DEFAULT_FEATURE_SETTINGS, DEFAULT_ROUTING_CONFIG } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
 import { ToggleRow, NumberRow, SectionHeader, SaveIndicator } from '../shared';
@@ -36,6 +41,11 @@ export function AgentsTab() {
     isFetching: isCodexHealthFetching,
     refetch: refetchCodexHealth,
   } = useCodexHealth();
+  const {
+    data: providerHealth,
+    isFetching: isProviderHealthFetching,
+    refetch: refetchProviderHealth,
+  } = useProviderHealth();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
   const updateAgents = useUpdateAgents();
@@ -145,6 +155,12 @@ export function AgentsTab() {
         onRefresh={() => refetchCodexHealth()}
       />
 
+      <ProviderHealthPanel
+        health={providerHealth}
+        isFetching={isProviderHealthFetching}
+        onRefresh={() => refetchProviderHealth()}
+      />
+
       {/* Agent Behavior */}
       <div className="space-y-4">
         <div className="flex items-center justify-between">
@@ -196,6 +212,160 @@ export function AgentsTab() {
 
       {/* Agent Routing Rules */}
       <RoutingRulesSection agents={config?.agents || []} />
+    </div>
+  );
+}
+
+function providerStateColor(state: ContextProviderHealth['state']): string {
+  switch (state) {
+    case 'connected':
+      return 'green';
+    case 'degraded':
+    case 'stale':
+      return 'yellow';
+    case 'disconnected':
+      return 'red';
+    case 'unknown':
+      return 'gray';
+  }
+}
+
+function formatProviderState(value: string): string {
+  return value
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function ProviderHealthPanel({
+  health,
+  isFetching,
+  onRefresh,
+}: {
+  health?: ContextProviderHealthResponse;
+  isFetching: boolean;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="rounded-md border bg-card p-3 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">Context Provider Health</h3>
+          <p className="text-xs text-muted-foreground">
+            {health?.checkedAt
+              ? `Checked ${new Date(health.checkedAt).toLocaleTimeString()}`
+              : 'Checking provider posture'}
+          </p>
+        </div>
+        <ActionIcon
+          variant="subtle"
+          size="sm"
+          onClick={onRefresh}
+          disabled={isFetching}
+          aria-label="Refresh provider health"
+        >
+          {isFetching ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+        </ActionIcon>
+      </div>
+
+      {health && (
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="light" color="gray">
+            {health.summary.total} providers
+          </Badge>
+          <Badge variant="light" color={health.summary.writeCapable > 0 ? 'yellow' : 'gray'}>
+            {health.summary.writeCapable} write-capable
+          </Badge>
+          <Badge variant="light" color={health.summary.risky > 0 ? 'red' : 'green'}>
+            {health.summary.risky} risky
+          </Badge>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {(health?.providers ?? []).map((provider) => (
+          <ProviderHealthItem key={provider.id} provider={provider} />
+        ))}
+        {!health?.providers?.length && (
+          <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+            No provider health data is available yet.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProviderHealthItem({ provider }: { provider: ContextProviderHealth }) {
+  return (
+    <div className="rounded-md border bg-background/60 p-3 space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <ShieldAlert className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">{provider.name}</span>
+            <Badge size="xs" color={providerStateColor(provider.state)} variant="light">
+              {formatProviderState(provider.state)}
+            </Badge>
+            <Badge
+              size="xs"
+              color={provider.risk === 'risky' ? 'red' : 'gray'}
+              variant={provider.risk === 'risky' ? 'light' : 'outline'}
+            >
+              {formatProviderState(provider.risk)}
+            </Badge>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">{provider.detail}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Badge size="xs" variant="outline">
+          {formatProviderState(provider.boundary)}
+        </Badge>
+        <Badge size="xs" variant={provider.readCapability ? 'light' : 'outline'} color="gray">
+          Read {provider.readCapability ? 'on' : 'off'}
+        </Badge>
+        <Badge
+          size="xs"
+          variant={provider.writeCapability ? 'light' : 'outline'}
+          color={provider.writeCapability ? 'yellow' : 'gray'}
+        >
+          Write {provider.writeCapability ? 'on' : 'off'}
+        </Badge>
+      </div>
+
+      <p className="text-xs text-muted-foreground">{provider.privacyScope}</p>
+
+      {provider.tools.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {provider.tools.slice(0, 5).map((tool) => (
+            <Badge key={tool} size="xs" variant="outline" color="gray">
+              {tool}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {provider.postureFlags.length > 0 && (
+        <ul className="space-y-1 text-xs text-muted-foreground">
+          {provider.postureFlags.slice(0, 4).map((flag) => (
+            <li key={flag}>{flag}</li>
+          ))}
+        </ul>
+      )}
+
+      {provider.recommendations.length > 0 && (
+        <ul className="space-y-1 text-xs text-muted-foreground">
+          {provider.recommendations.slice(0, 2).map((recommendation) => (
+            <li key={recommendation}>{recommendation}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -17,6 +17,14 @@ export function useCodexHealth() {
   });
 }
 
+export function useProviderHealth() {
+  return useQuery({
+    queryKey: ['settings', 'provider-health'],
+    queryFn: api.settings.getProviderHealth,
+    staleTime: 30 * 1000,
+  });
+}
+
 export function useRepos() {
   return useQuery({
     queryKey: ['config', 'repos'],

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -21,6 +21,11 @@ export const settingsApi = {
     return handleResponse<CodexHealthStatus>(response);
   },
 
+  getProviderHealth: async (): Promise<ContextProviderHealthResponse> => {
+    const response = await fetch(`${API_BASE}/settings/provider-health`);
+    return handleResponse<ContextProviderHealthResponse>(response);
+  },
+
   updateFeatures: async (patch: Partial<FeatureSettings>): Promise<FeatureSettings> => {
     const response = await fetch(`${API_BASE}/settings/features`, {
       credentials: 'include',
@@ -59,6 +64,43 @@ export interface CodexHealthStatus {
     overall: boolean;
   };
   recommendations: string[];
+}
+
+export type ContextProviderState = 'connected' | 'degraded' | 'stale' | 'disconnected' | 'unknown';
+
+export type ContextProviderRisk = 'safe' | 'normal' | 'risky';
+export type ContextProviderBoundary = 'local' | 'cloud' | 'mixed' | 'unknown';
+
+export interface ContextProviderHealth {
+  id: string;
+  name: string;
+  provider: 'codex' | 'openclaw' | 'custom';
+  state: ContextProviderState;
+  risk: ContextProviderRisk;
+  boundary: ContextProviderBoundary;
+  readCapability: boolean;
+  writeCapability: boolean;
+  privacyScope: string;
+  lastCheckedAt: string;
+  detail: string;
+  tools: string[];
+  postureFlags: string[];
+  recommendations: string[];
+}
+
+export interface ContextProviderHealthResponse {
+  checkedAt: string;
+  summary: {
+    total: number;
+    connected: number;
+    degraded: number;
+    stale: number;
+    disconnected: number;
+    unknown: number;
+    risky: number;
+    writeCapable: number;
+  };
+  providers: ContextProviderHealth[];
 }
 
 export const configApi = {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -84,7 +84,14 @@ export { managedList } from './managed-list';
 // Re-export all types from each module
 export type { ArchiveSuggestion } from './tasks';
 export type { BacklogListResponse, BacklogFilterOptions } from './backlog';
-export type { CodexHealthStatus } from './config';
+export type {
+  CodexHealthStatus,
+  ContextProviderBoundary,
+  ContextProviderHealth,
+  ContextProviderHealthResponse,
+  ContextProviderRisk,
+  ContextProviderState,
+} from './config';
 
 export type {
   AgentStatus,


### PR DESCRIPTION
## Summary
- Add a read-only context-provider health service and `/api/settings/provider-health` endpoint.
- Normalize Codex and OpenClaw posture into shared provider health fields: state, risk, local/cloud boundary, read/write capability, posture flags, and recommendations.
- Add a Context Provider Health panel to Settings > Agents using the existing Mantine settings surface.

Refs #579
Refs #594

## Verification
- pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/context-provider-health-service.test.ts src/__tests__/routes/settings-codex-health.test.ts
- pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/settings-agents-mantine.test.tsx
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm exec eslint server/src/services/context-provider-health-service.ts server/src/routes/settings.ts server/src/__tests__/context-provider-health-service.test.ts server/src/__tests__/routes/settings-codex-health.test.ts web/src/lib/api/config.ts web/src/hooks/useConfig.ts web/src/lib/api/index.ts web/src/components/settings/tabs/AgentsTab.tsx web/src/__tests__/settings-agents-mantine.test.tsx

## Notes
- The OpenClaw adapter is intentionally config/posture-only in this slice. Doctor/policy output parsing remains a follow-up under #594.
- Targeted eslint completed with an existing warning in `web/src/hooks/useConfig.ts` for the repo branch non-null assertion; no new lint errors were introduced.
