### PR TITLE
Fix session JWT revocation

### DIFF
--- a/server/src/__tests__/jwt-rotation.test.ts
+++ b/server/src/__tests__/jwt-rotation.test.ts
@@ -63,6 +63,8 @@ import {
   getSecurityConfig,
   getJwtSecret,
   getValidJwtSecrets,
+  getSessionVersion,
+  nextSessionVersion,
   rotateJwtSecret,
   getJwtRotationStatus,
   saveSecurityConfig,
@@ -168,6 +170,16 @@ describe('JWT Secret Rotation', () => {
       const secrets = getValidJwtSecrets();
       expect(secrets).toHaveLength(1);
       expect(secrets[0]).toBe('current-secret');
+    });
+  });
+
+  describe('session version helpers', () => {
+    it('should default missing session version to zero', () => {
+      expect(getSessionVersion({})).toBe(0);
+    });
+
+    it('should increment the current session version for revocation events', () => {
+      expect(nextSessionVersion({ sessionVersion: 2 })).toBe(3);
     });
   });
 

--- a/server/src/__tests__/middleware/auth.test.ts
+++ b/server/src/__tests__/middleware/auth.test.ts
@@ -8,15 +8,23 @@ import type { Request, Response, NextFunction } from 'express';
 import type { IncomingMessage } from 'http';
 
 // Mock the security config module BEFORE importing auth
-vi.mock('../../config/security.js', () => ({
-  getSecurityConfig: vi.fn(() => ({
+vi.mock('../../config/security.js', () => {
+  const getSecurityConfig = vi.fn(() => ({
     authEnabled: false,
     passwordHash: null,
     jwtSecret: 'test-secret-key',
-  })),
-  getJwtSecret: vi.fn(() => 'test-secret-key'),
-  getValidJwtSecrets: vi.fn(() => ['test-secret-key']),
-}));
+  }));
+
+  return {
+    getSecurityConfig,
+    getJwtSecret: vi.fn(() => 'test-secret-key'),
+    getValidJwtSecrets: vi.fn(() => ['test-secret-key']),
+    getSessionVersion: vi.fn((config?: { sessionVersion?: number }) => {
+      const source = config ?? getSecurityConfig();
+      return typeof source.sessionVersion === 'number' ? source.sessionVersion : 0;
+    }),
+  };
+});
 
 import {
   authenticate,
@@ -456,6 +464,30 @@ describe('Auth Middleware', () => {
       expect(req.auth?.actorType).toBe('user');
       expect(req.auth?.authMethod).toBe('session');
       expect(req.auth?.workspaceId).toBe('local');
+    });
+
+    it('should reject JWT cookie when session version is stale', () => {
+      const secret = 'test-secret-key';
+      const token = jwt.sign({ type: 'session', sessionVersion: 0 }, secret, { expiresIn: '1h' });
+
+      vi.mocked(getSecurityConfig).mockReturnValue({
+        authEnabled: true,
+        passwordHash: 'hashed-password',
+        sessionVersion: 1,
+      } as any);
+      vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
+
+      const req = mockRequest({
+        cookies: { veritas_session: token },
+        socket: { remoteAddress: '192.168.1.100' } as any,
+        ip: '192.168.1.100',
+      }) as AuthenticatedRequest;
+      const res = mockResponse();
+      const next = mockNext();
+
+      authenticate(req, res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(401);
     });
 
     it('should fall back to API key when JWT is invalid', () => {
@@ -955,6 +987,31 @@ describe('Auth Middleware', () => {
       expect(result.role).toBe('admin');
       expect(result.authMethod).toBe('session');
       expect(result.actorType).toBe('user');
+    });
+
+    it('should reject WebSocket JWT cookie when session version is stale', () => {
+      const secret = 'test-secret-key';
+      const token = jwt.sign({ type: 'session', sessionVersion: 0 }, secret, { expiresIn: '1h' });
+
+      vi.mocked(getSecurityConfig).mockReturnValue({
+        authEnabled: true,
+        passwordHash: 'hashed',
+        sessionVersion: 1,
+      } as any);
+      vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
+
+      const req = {
+        headers: {
+          cookie: `veritas_session=${token}`,
+          host: 'localhost:3001',
+        },
+        url: '/ws',
+        socket: { remoteAddress: '192.168.1.100' },
+      } as unknown as IncomingMessage;
+
+      const result = authenticateWebSocket(req);
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toContain('Authentication required');
     });
 
     it('should allow localhost bypass for WebSocket with read-only role by default', () => {

--- a/server/src/__tests__/routes/auth.test.ts
+++ b/server/src/__tests__/routes/auth.test.ts
@@ -29,6 +29,10 @@ vi.mock('../../config/security.js', () => {
     getValidJwtSecrets: () => [
       securityConfig.jwtSecret || 'test-secret-key-for-jwt-signing-12345678',
     ],
+    getSessionVersion: (config: any = securityConfig) =>
+      typeof config.sessionVersion === 'number' ? config.sessionVersion : 0,
+    nextSessionVersion: (config: any = securityConfig) =>
+      (typeof config.sessionVersion === 'number' ? config.sessionVersion : 0) + 1,
     generateRecoveryKey: () => 'RECOVERY-KEY-12345678',
     hashRecoveryKey: async (key: string) => {
       return crypto.createHash('sha256').update(key).digest('hex');
@@ -67,6 +71,7 @@ describe('Auth Routes', () => {
       authEnabled: false,
       passwordHash: null,
       jwtSecret: 'test-secret-key-for-jwt-signing-12345678',
+      sessionVersion: 0,
     };
 
     app = express();
@@ -78,6 +83,7 @@ describe('Auth Routes', () => {
 
   afterEach(() => {
     resetDeviceSessionServiceForTests();
+    delete process.env.VERITAS_JWT_SECRET;
     delete process.env.VERITAS_SQLITE_PATH;
   });
 
@@ -102,7 +108,11 @@ describe('Auth Routes', () => {
       securityConfig.passwordHash = await bcrypt.hash('test-password', 4);
       securityConfig.authEnabled = true;
 
-      const token = jwt.sign({ type: 'session' }, securityConfig.jwtSecret, { expiresIn: '1h' });
+      const token = jwt.sign(
+        { type: 'session', sessionVersion: securityConfig.sessionVersion },
+        securityConfig.jwtSecret,
+        { expiresIn: '1h' }
+      );
 
       const res = await request(app)
         .get('/api/auth/status')
@@ -317,6 +327,30 @@ describe('Auth Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
       expect(res.body.recoveryKey).toBeDefined(); // New recovery key
+      expect(securityConfig.sessionVersion).toBe(1);
+    });
+
+    it('should revoke existing session cookies after recovery reset even when jwt secret is unchanged', async () => {
+      process.env.VERITAS_JWT_SECRET = 'env-managed-secret';
+      const oldToken = jwt.sign(
+        { type: 'session', sessionVersion: securityConfig.sessionVersion },
+        securityConfig.jwtSecret,
+        { expiresIn: '1h' }
+      );
+      const originalSecret = securityConfig.jwtSecret;
+
+      await request(app)
+        .post('/api/auth/recover')
+        .send({ recoveryKey: 'VALID-RECOVERY-KEY', newPassword: 'newstrongpassword' })
+        .expect(200);
+      expect(securityConfig.jwtSecret).toBe(originalSecret);
+
+      const status = await request(app)
+        .get('/api/auth/status')
+        .set('Cookie', `veritas_session=${oldToken}`);
+
+      expect(status.status).toBe(200);
+      expect(status.body.authenticated).toBe(false);
     });
 
     it('should reject invalid recovery key', async () => {
@@ -389,6 +423,27 @@ describe('Auth Routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
+      expect(securityConfig.sessionVersion).toBe(1);
+    });
+
+    it('should revoke existing session cookies after password change', async () => {
+      const oldToken = jwt.sign(
+        { type: 'session', sessionVersion: securityConfig.sessionVersion },
+        securityConfig.jwtSecret,
+        { expiresIn: '1h' }
+      );
+
+      await request(app)
+        .post('/api/auth/change-password')
+        .send({ currentPassword: 'currentpassword', newPassword: 'newsecurepassword' })
+        .expect(200);
+
+      const status = await request(app)
+        .get('/api/auth/status')
+        .set('Cookie', `veritas_session=${oldToken}`);
+
+      expect(status.status).toBe(200);
+      expect(status.body.authenticated).toBe(false);
     });
 
     it('should reject wrong current password', async () => {

--- a/server/src/config/security.ts
+++ b/server/src/config/security.ts
@@ -80,6 +80,8 @@ export interface SecurityConfig {
   setupCompletedAt?: string;
   /** When password was last changed */
   lastPasswordChange?: string;
+  /** Monotonic version embedded in session JWTs; increment to revoke existing sessions */
+  sessionVersion?: number;
 }
 
 // In-memory cache
@@ -195,6 +197,25 @@ export function getValidJwtSecrets(): string[] {
 
   // Fall back to legacy single secret or runtime secret
   return [getJwtSecret()];
+}
+
+/**
+ * Return the current session token version.
+ * Missing or invalid legacy values are treated as version 0 so existing
+ * sessions remain valid until the first explicit revocation event.
+ */
+export function getSessionVersion(
+  config: Pick<SecurityConfig, 'sessionVersion'> = getSecurityConfig()
+): number {
+  return typeof config.sessionVersion === 'number' &&
+    Number.isFinite(config.sessionVersion) &&
+    config.sessionVersion >= 0
+    ? Math.floor(config.sessionVersion)
+    : 0;
+}
+
+export function nextSessionVersion(config: Pick<SecurityConfig, 'sessionVersion'>): number {
+  return getSessionVersion(config) + 1;
 }
 
 /**

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import { WebSocket } from 'ws';
 import { IncomingMessage } from 'http';
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
-import { getSecurityConfig, getValidJwtSecrets } from '../config/security.js';
+import { getSecurityConfig, getSessionVersion, getValidJwtSecrets } from '../config/security.js';
 import { createLogger } from '../lib/logger.js';
 import { validateScopedApiToken } from '../services/api-token-service.js';
 import { validateDeviceSessionSecret } from '../services/device-session-service.js';
@@ -382,18 +382,33 @@ function requestRemoteAddress(req: Request | IncomingMessage): string | null {
 
 // === JWT Verification ===
 
+export interface SessionJwtPayload extends jwt.JwtPayload {
+  type?: string;
+  sessionVersion?: number;
+}
+
 /**
- * Verify a JWT token against all valid secrets (supports secret rotation).
- * Tries the current secret first, then falls back to previous secrets
- * still within their grace period.
+ * Verify a session JWT against all valid secrets and the current session version.
  */
-function verifyJwtToken(token: string): { valid: boolean; error?: string } {
+export function verifySessionJwtToken(token: string): {
+  valid: boolean;
+  error?: string;
+  payload?: SessionJwtPayload;
+} {
   const secrets = getValidJwtSecrets();
+  const expectedSessionVersion = getSessionVersion();
 
   for (const secret of secrets) {
     try {
-      jwt.verify(token, secret, { algorithms: ['HS256'] });
-      return { valid: true };
+      const payload = jwt.verify(token, secret, { algorithms: ['HS256'] }) as SessionJwtPayload;
+      const tokenSessionVersion =
+        typeof payload.sessionVersion === 'number' ? Math.floor(payload.sessionVersion) : 0;
+
+      if (tokenSessionVersion !== expectedSessionVersion) {
+        return { valid: false, error: 'Session revoked' };
+      }
+
+      return { valid: true, payload };
     } catch (err) {
       // If the token is expired, no point trying other secrets
       if (err instanceof jwt.TokenExpiredError) {
@@ -415,7 +430,7 @@ function verifyJwtCookie(req: Request): { valid: boolean; error?: string } {
     return { valid: false };
   }
 
-  return verifyJwtToken(token);
+  return verifySessionJwtToken(token);
 }
 
 // === Express Middleware ===
@@ -721,7 +736,7 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
   if (passwordAuthEnabled) {
     const token = extractJwtFromWebSocket(req);
     if (token) {
-      const result = verifyJwtToken(token);
+      const result = verifySessionJwtToken(token);
       if (result.valid) {
         return {
           authenticated: true,

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -7,6 +7,8 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import {
   getSecurityConfig,
   getJwtSecret,
+  getSessionVersion,
+  nextSessionVersion,
   saveSecurityConfig,
   SecurityConfig,
   generateRecoveryKey,
@@ -17,6 +19,7 @@ import {
 import {
   authenticate,
   authorize,
+  verifySessionJwtToken,
   type AuthenticatedRequest,
   type AuthPermission,
 } from '../middleware/auth.js';
@@ -184,16 +187,12 @@ router.get(
 
     const token = req.cookies?.veritas_session;
     if (token && !needsSetup) {
-      try {
-        const decoded = jwt.verify(token, getJwtSecret(), {
-          algorithms: ['HS256'],
-        }) as jwt.JwtPayload;
+      const verified = verifySessionJwtToken(token);
+      if (verified.valid && verified.payload) {
         authenticated = true;
-        if (decoded.exp) {
-          sessionExpiry = new Date(decoded.exp * 1000).toISOString();
+        if (verified.payload.exp) {
+          sessionExpiry = new Date(verified.payload.exp * 1000).toISOString();
         }
-      } catch {
-        // Invalid or expired token
       }
     }
 
@@ -379,6 +378,7 @@ router.post(
       passwordHash,
       recoveryKeyHash,
       authEnabled: true,
+      sessionVersion: getSessionVersion(config),
       setupCompletedAt: new Date().toISOString(),
     };
 
@@ -547,6 +547,7 @@ router.post(
       {
         type: 'session',
         iat: Math.floor(Date.now() / 1000),
+        sessionVersion: getSessionVersion(config),
       },
       getJwtSecret(),
       { expiresIn: expiryStr as jwt.SignOptions['expiresIn'] }
@@ -659,19 +660,19 @@ router.post(
     const newRecoveryKey = generateRecoveryKey();
     const newRecoveryKeyHash = await hashRecoveryKey(newRecoveryKey);
 
-    // Build config — rotate jwtSecret in file only if env var is NOT set
+    // Build config and revoke existing sessions regardless of JWT secret source.
     const updatedConfig: SecurityConfig = {
       ...config,
       passwordHash,
       recoveryKeyHash: newRecoveryKeyHash,
       lastPasswordChange: new Date().toISOString(),
+      sessionVersion: nextSessionVersion(config),
     };
 
     // Rotate file-based secret if no env var (invalidates all existing sessions)
     if (!process.env.VERITAS_JWT_SECRET) {
       updatedConfig.jwtSecret = crypto.randomBytes(64).toString('hex');
     }
-    // Note: if using env var, session invalidation requires changing the env var
 
     // Save config
     saveSecurityConfig(updatedConfig);
@@ -739,6 +740,7 @@ router.post(
       ...config,
       passwordHash,
       lastPasswordChange: new Date().toISOString(),
+      sessionVersion: nextSessionVersion(config),
     });
 
     res.json({


### PR DESCRIPTION
## Summary

- add a persisted sessionVersion to security config and include it in session JWTs
- verify session JWTs against valid signing secrets and the current session version
- increment sessionVersion after password changes and recovery resets, including env-managed JWT secret deployments

## Verification

- pnpm --filter @veritas-kanban/server test -- src/__tests__/routes/auth.test.ts src/__tests__/middleware/auth.test.ts src/__tests__/jwt-rotation.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/server lint
- pnpm --filter @veritas-kanban/server test

Closes #597
