### PR TITLE
Protect workflow run context keys

### DIFF
--- a/server/src/__tests__/workflow-run-service.test.ts
+++ b/server/src/__tests__/workflow-run-service.test.ts
@@ -94,6 +94,25 @@ describe('WorkflowRunService', () => {
     expect(mockBroadcastWorkflowStatus).toHaveBeenCalled();
   });
 
+  it('rejects initial context that overrides server-owned workflow run keys', async () => {
+    mockGetTask.mockResolvedValue({
+      id: 'task-1',
+      title: 'Trusted task',
+      git: { worktreePath: '/trusted/worktree' },
+    });
+
+    await expect(
+      service.startRun('wf-1', 'task-1', {
+        task: {
+          id: 'attacker-task',
+          git: { worktreePath: '/attacker/worktree' },
+        },
+        _sessions: { codex: 'thread_attacker' },
+      })
+    ).rejects.toThrow('reserved workflow context keys: task, _sessions');
+    expect(mockExecuteStep).not.toHaveBeenCalled();
+  });
+
   it('rolls orchestrated pipeline roles into workflow run context', async () => {
     mockLoadWorkflow.mockResolvedValue(
       makeWorkflow({
@@ -269,6 +288,38 @@ describe('WorkflowRunService', () => {
     await expect(service.resumeRun(run.id, {})).rejects.toThrow(/not blocked/);
   });
 
+  it('rejects resume context that overrides server-owned workflow run keys', async () => {
+    mockLoadWorkflow.mockResolvedValue(
+      makeWorkflow({
+        steps: [
+          {
+            id: 'step-1',
+            type: 'agent',
+            agent: 'agent-1',
+            prompt: 'x',
+            on_fail: { escalate_to: 'human', escalate_message: 'blocked' },
+          },
+        ],
+      })
+    );
+    mockExecuteStep.mockRejectedValueOnce(new Error('blocked'));
+
+    const run = await service.startRun('wf-1');
+    await vi.waitFor(async () => expect((await service.getRun(run.id)).status).toBe('blocked'));
+    mockExecuteStep.mockClear();
+
+    await expect(
+      service.resumeRun(run.id, {
+        task: { git: { worktreePath: '/attacker/worktree' } },
+        pipeline: { mode: 'attacker' },
+      })
+    ).rejects.toThrow('reserved workflow context keys: task, pipeline');
+
+    const saved = await service.getRun(run.id);
+    expect(saved.status).toBe('blocked');
+    expect(mockExecuteStep).not.toHaveBeenCalled();
+  });
+
   it('lists runs and metadata with filters while skipping invalid or broken entries', async () => {
     const run1 = await service.startRun('wf-1', 'task-1');
     const run2 = await service.startRun('wf-1', 'task-2');
@@ -279,7 +330,14 @@ describe('WorkflowRunService', () => {
 
     await expect(service.listRuns({ taskId: 'task-1' })).rejects.toThrow();
     const meta = await service.listRunsMetadata({ workflowId: 'wf-1' });
-    expect(meta.map((m: any) => m.id)).toEqual([run2.id, run1.id]);
+    const expectedIds = [run1, run2]
+      .sort(
+        (a: any, b: any) =>
+          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime() ||
+          b.id.localeCompare(a.id)
+      )
+      .map((run: any) => run.id);
+    expect(meta.map((m: any) => m.id)).toEqual(expectedIds);
   });
 
   it('calculates stats using workflow permissions', async () => {

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -28,6 +28,14 @@ const log = createLogger('workflow-run');
 const MAX_CONCURRENT_RUNS = 10;
 let activeRunCount = 0;
 const RUN_ID_PATTERN = /^run_\d{10,}_[a-zA-Z0-9_-]{6,}$/;
+const RESERVED_CONTEXT_KEYS = new Set([
+  'task',
+  'workflow',
+  'run',
+  'pipeline',
+  '_sessions',
+  '_retryContext',
+]);
 
 class NotFoundError extends Error {
   constructor(message: string) {
@@ -219,6 +227,7 @@ export class WorkflowRunService {
     // Load full task payload if taskId provided
     const taskService = getTaskService();
     const task = taskId ? await taskService.getTask(taskId) : null;
+    const safeInitialContext = this.validateExternalContext(initialContext, 'Initial context');
 
     const runId = `run_${Date.now()}_${nanoid(8)}`;
     const now = new Date().toISOString();
@@ -234,11 +243,11 @@ export class WorkflowRunService {
         // Workflow variables
         ...workflow.variables,
 
+        // Custom initial context (from API caller)
+        ...safeInitialContext,
+
         // Task payload (if provided)
         ...(task ? { task } : {}),
-
-        // Custom initial context (from API caller)
-        ...initialContext,
 
         // Orchestrator/subagent pipeline summary for run views and completion handoff.
         ...(workflow.pipeline ? { pipeline: buildWorkflowPipelineSummary(workflow) } : {}),
@@ -645,8 +654,11 @@ export class WorkflowRunService {
       throw new ValidationError(`Run ${runId} is not blocked (status: ${run.status})`);
     }
 
-    // Merge resume context
-    run.context = { ...run.context, ...resumeContext };
+    // Merge resume context after rejecting attempts to replace server-owned context.
+    run.context = {
+      ...run.context,
+      ...this.validateExternalContext(resumeContext, 'Resume context'),
+    };
     run.status = 'running';
     await this.saveRun(run);
 
@@ -666,6 +678,22 @@ export class WorkflowRunService {
     });
 
     return run;
+  }
+
+  private validateExternalContext(
+    context: Record<string, unknown> | undefined,
+    source: string
+  ): Record<string, unknown> {
+    if (!context) return {};
+
+    const blockedKeys = Object.keys(context).filter((key) => RESERVED_CONTEXT_KEYS.has(key));
+    if (blockedKeys.length > 0) {
+      throw new ValidationError(
+        `${source} cannot set reserved workflow context keys: ${blockedKeys.join(', ')}`
+      );
+    }
+
+    return context;
   }
 
   /**


### PR DESCRIPTION
## Summary

- reject caller-provided workflow run context that tries to set server-owned keys such as task, pipeline, workflow, run, or session metadata
- merge trusted task and run metadata after custom context so server-owned execution state remains authoritative
- add regression coverage for initial run context and resume context override attempts
- stabilize the touched workflow run metadata ordering assertion when runs share a timestamp

## Verification

- pnpm --filter @veritas-kanban/server test -- src/__tests__/workflow-run-service.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/server lint

Closes #599
