### PR TITLE
Security: pass minimal env to Codex sessions

### DIFF
--- a/server/src/__tests__/codex-env.test.ts
+++ b/server/src/__tests__/codex-env.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSafeCodexEnv, isSensitiveCodexEnvKey } from '../utils/codex-env.js';
+
+describe('Codex environment filtering', () => {
+  it('keeps Codex auth and operational variables while dropping ambient secrets', () => {
+    const env = buildSafeCodexEnv({
+      CODEX_API_KEY: 'test-codex-key',
+      OPENAI_API_KEY: 'test-openai-key',
+      VK_API_URL: 'http://127.0.0.1:3001',
+      PATH: '/usr/bin',
+      GITHUB_TOKEN: 'test-github-token',
+      DATABASE_URL: 'postgres://test-secret',
+      VERITAS_ADMIN_KEY: 'test-admin-key',
+    });
+
+    expect(env).toEqual({
+      CODEX_API_KEY: 'test-codex-key',
+      OPENAI_API_KEY: 'test-openai-key',
+      PATH: '/usr/bin',
+      VK_API_URL: 'http://127.0.0.1:3001',
+    });
+  });
+
+  it('defaults VK_API_URL without forwarding disallowed variables', () => {
+    expect(buildSafeCodexEnv({ RANDOM_VALUE: 'ignored' })).toEqual({
+      VK_API_URL: 'http://localhost:3001',
+    });
+  });
+
+  it('does not classify the required Codex auth keys as sensitive', () => {
+    expect(isSensitiveCodexEnvKey('OPENAI_API_KEY')).toBe(false);
+    expect(isSensitiveCodexEnvKey('CODEX_API_KEY')).toBe(false);
+    expect(isSensitiveCodexEnvKey('GITHUB_TOKEN')).toBe(true);
+    expect(isSensitiveCodexEnvKey('SUPABASE_SERVICE_ROLE_KEY')).toBe(true);
+  });
+});

--- a/server/src/__tests__/codex-review-service.test.ts
+++ b/server/src/__tests__/codex-review-service.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetTask = vi.fn();
+const mockUpdateTask = vi.fn();
+const mockDiff = vi.fn();
+const mockStartThread = vi.fn();
+const mockRunStreamed = vi.fn();
+const mockCodexConstructorOptions = vi.fn();
+
+vi.mock('../services/task-service.js', () => ({
+  TaskService: class {
+    getTask = mockGetTask;
+    updateTask = mockUpdateTask;
+  },
+}));
+
+vi.mock('simple-git', () => ({
+  simpleGit: () => ({
+    diff: mockDiff,
+  }),
+}));
+
+vi.mock('@openai/codex-sdk', () => ({
+  Codex: class {
+    constructor(options: unknown) {
+      mockCodexConstructorOptions(options);
+    }
+
+    startThread = mockStartThread;
+  },
+}));
+
+import { CodexReviewService } from '../services/codex-review-service.js';
+
+async function* reviewEvents() {
+  yield { type: 'thread.started', thread_id: 'thread_review_123' };
+  yield {
+    type: 'item.completed',
+    item: {
+      id: 'item_1',
+      type: 'agent_message',
+      text: JSON.stringify({
+        decision: 'approved',
+        summary: 'No blocking findings.',
+        findings: [],
+      }),
+    },
+  };
+}
+
+describe('CodexReviewService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTask.mockResolvedValue({
+      id: 'task_1',
+      title: 'Review task',
+      git: {
+        worktreePath: '/tmp/review-worktree',
+        baseBranch: 'main',
+      },
+      comments: [],
+      reviewComments: [],
+    });
+    mockUpdateTask.mockResolvedValue({});
+    mockDiff.mockResolvedValue('diff --git a/file.ts b/file.ts\n+change');
+    mockRunStreamed.mockResolvedValue({ events: reviewEvents() });
+    mockStartThread.mockReturnValue({ runStreamed: mockRunStreamed });
+  });
+
+  it('passes only a minimal environment to Codex review sessions', async () => {
+    const originalEnv = {
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      DATABASE_URL: process.env.DATABASE_URL,
+      VERITAS_ADMIN_KEY: process.env.VERITAS_ADMIN_KEY,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      VK_API_URL: process.env.VK_API_URL,
+    };
+    process.env.GITHUB_TOKEN = 'test-github-token';
+    process.env.DATABASE_URL = 'postgres://test-secret';
+    process.env.VERITAS_ADMIN_KEY = 'test-admin-key';
+    process.env.OPENAI_API_KEY = 'test-openai-key';
+    process.env.VK_API_URL = 'http://127.0.0.1:3001';
+
+    try {
+      const service = new CodexReviewService();
+      await service.reviewTask({ taskId: 'task_1', save: false });
+
+      const env = (
+        mockCodexConstructorOptions.mock.calls.at(-1)?.[0] as {
+          env?: Record<string, string>;
+        }
+      ).env;
+      expect(env).toMatchObject({
+        OPENAI_API_KEY: 'test-openai-key',
+        VK_API_URL: 'http://127.0.0.1:3001',
+      });
+      expect(env?.GITHUB_TOKEN).toBeUndefined();
+      expect(env?.DATABASE_URL).toBeUndefined();
+      expect(env?.VERITAS_ADMIN_KEY).toBeUndefined();
+    } finally {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+});

--- a/server/src/__tests__/workflow-step-executor-codex.test.ts
+++ b/server/src/__tests__/workflow-step-executor-codex.test.ts
@@ -8,9 +8,14 @@ const mockStartThread = vi.fn();
 const mockResumeThread = vi.fn();
 const mockRecordGovernanceTrace = vi.fn();
 const mockGetToolFilterForRole = vi.fn();
+const mockCodexConstructorOptions = vi.fn();
 
 vi.mock('@openai/codex-sdk', () => ({
   Codex: class {
+    constructor(options: unknown) {
+      mockCodexConstructorOptions(options);
+    }
+
     startThread = mockStartThread;
     resumeThread = mockResumeThread;
   },
@@ -118,6 +123,82 @@ describe('WorkflowStepExecutor Codex integration', () => {
     expect(run.context._sessions).toMatchObject({ codex: 'thread_test_123' });
     expect(result.output).toContain('Implemented workflow Codex step.');
     expect(result.outputPath).toContain('implement.md');
+  });
+
+  it('passes only a minimal environment to Codex workflow sessions', async () => {
+    const originalEnv = {
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      DATABASE_URL: process.env.DATABASE_URL,
+      VERITAS_ADMIN_KEY: process.env.VERITAS_ADMIN_KEY,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      VK_API_URL: process.env.VK_API_URL,
+    };
+    process.env.GITHUB_TOKEN = 'test-github-token';
+    process.env.DATABASE_URL = 'postgres://test-secret';
+    process.env.VERITAS_ADMIN_KEY = 'test-admin-key';
+    process.env.OPENAI_API_KEY = 'test-openai-key';
+    process.env.VK_API_URL = 'http://127.0.0.1:3001';
+
+    try {
+      const executor = new WorkflowStepExecutor(tmpDir);
+      const step: WorkflowStep = {
+        id: 'implement',
+        name: 'Implement',
+        type: 'agent',
+        agent: 'codex',
+        input: 'Work on {{task.title}}',
+        output: { file: 'implement.md' },
+      };
+      const run: WorkflowRun = {
+        id: 'run_1234567890_envsafe',
+        workflowId: 'wf-codex',
+        workflowVersion: 1,
+        status: 'running',
+        context: {
+          task: {
+            id: 'task_1',
+            title: 'Codex env safety',
+            git: { worktreePath: tmpDir },
+          },
+          workflow: {
+            agents: [
+              {
+                id: 'codex',
+                name: 'Codex',
+                role: 'developer',
+                provider: 'codex-sdk',
+                model: 'gpt-5.5',
+                description: 'Codex developer',
+              },
+            ],
+          },
+          _sessions: {},
+        },
+        startedAt: new Date().toISOString(),
+        steps: [{ stepId: 'implement', status: 'running', retries: 0 }],
+      };
+
+      await executor.executeStep(step, run);
+
+      const env = (
+        mockCodexConstructorOptions.mock.calls.at(-1)?.[0] as { env?: Record<string, string> }
+      ).env;
+      expect(env).toMatchObject({
+        OPENAI_API_KEY: 'test-openai-key',
+        VK_API_URL: 'http://127.0.0.1:3001',
+      });
+      expect(env?.GITHUB_TOKEN).toBeUndefined();
+      expect(env?.DATABASE_URL).toBeUndefined();
+      expect(env?.VERITAS_ADMIN_KEY).toBeUndefined();
+    } finally {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
   });
 
   it('blocks Codex workflow agent steps when role tool policy is restricted', async () => {

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -24,6 +24,7 @@ import { getBreaker } from './circuit-registry.js';
 import { activityService } from './activity-service.js';
 import { getTraceService } from './trace-service.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
+import { buildSafeCodexEnv } from '../utils/codex-env.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
 import { evaluateTaskReadiness } from '@veritas-kanban/shared';
 import type {
@@ -808,7 +809,7 @@ export class ClawdbotAgentService {
     const codex = new Codex({
       codexPathOverride:
         agentConfig?.command && agentConfig.command !== 'codex' ? agentConfig.command : undefined,
-      env: this.buildCodexEnv(),
+      env: buildSafeCodexEnv(),
     });
 
     const thread = codex.startThread({
@@ -1396,15 +1397,6 @@ export class ClawdbotAgentService {
         threadId,
       },
     });
-  }
-
-  private buildCodexEnv(): Record<string, string> {
-    const env: Record<string, string> = {};
-    for (const [key, value] of Object.entries(process.env)) {
-      if (typeof value === 'string') env[key] = value;
-    }
-    env.VK_API_URL = process.env.VK_API_URL || 'http://localhost:3001';
-    return env;
   }
 
   private extractCodexSummary(event: unknown): string | undefined {

--- a/server/src/services/codex-review-service.ts
+++ b/server/src/services/codex-review-service.ts
@@ -2,6 +2,7 @@ import { simpleGit } from 'simple-git';
 import { nanoid } from 'nanoid';
 import { TaskService } from './task-service.js';
 import type { ReviewComment, ReviewDecision, Task } from '@veritas-kanban/shared';
+import { buildSafeCodexEnv } from '../utils/codex-env.js';
 
 export interface CodexReviewInput {
   taskId: string;
@@ -51,7 +52,7 @@ export class CodexReviewService {
 
     const prompt = this.buildReviewPrompt(task, diff, input.instructions);
     const { Codex } = await import('@openai/codex-sdk');
-    const codex = new Codex({ env: this.buildCodexEnv() });
+    const codex = new Codex({ env: buildSafeCodexEnv() });
     const thread = codex.startThread({
       workingDirectory: worktreePath,
       skipGitRepoCheck: true,
@@ -210,14 +211,5 @@ export class CodexReviewService {
       content: `[${finding.severity}] ${finding.title}: ${finding.message}`,
       created: new Date().toISOString(),
     };
-  }
-
-  private buildCodexEnv(): Record<string, string> {
-    const env: Record<string, string> = {};
-    for (const [key, value] of Object.entries(process.env)) {
-      if (typeof value === 'string') env[key] = value;
-    }
-    env.VK_API_URL = process.env.VK_API_URL || 'http://localhost:3001';
-    return env;
   }
 }

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -15,6 +15,7 @@ import type {
   StepSessionConfig,
 } from '../types/workflow.js';
 import { getWorkflowRunsDir } from '../utils/paths.js';
+import { buildSafeCodexEnv } from '../utils/codex-env.js';
 import { createLogger } from '../lib/logger.js';
 import { getGovernanceTraceService } from './governance-trace-service.js';
 import {
@@ -348,7 +349,7 @@ export class WorkflowStepExecutor {
     const codex = new Codex({
       codexPathOverride:
         agentDef?.command && agentDef.command !== 'codex' ? agentDef.command : undefined,
-      env: this.buildCodexEnv(),
+      env: buildSafeCodexEnv(),
     });
 
     const sessionKey = step.agent || agentDef?.id || step.id;
@@ -505,15 +506,6 @@ export class WorkflowStepExecutor {
 
   private expandPath(p: string): string {
     return p.replace(/^~/, process.env.HOME || '');
-  }
-
-  private buildCodexEnv(): Record<string, string> {
-    const env: Record<string, string> = {};
-    for (const [key, value] of Object.entries(process.env)) {
-      if (typeof value === 'string') env[key] = value;
-    }
-    env.VK_API_URL = process.env.VK_API_URL || 'http://localhost:3001';
-    return env;
   }
 
   /**

--- a/server/src/utils/codex-env.ts
+++ b/server/src/utils/codex-env.ts
@@ -1,0 +1,50 @@
+const CODEX_ENV_ALLOWLIST = new Set([
+  'CI',
+  'CODEX_API_KEY',
+  'CODEX_HOME',
+  'FORCE_COLOR',
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'LOGNAME',
+  'NODE_EXTRA_CA_CERTS',
+  'NO_COLOR',
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_ORG_ID',
+  'OPENAI_ORGANIZATION',
+  'OPENAI_PROJECT',
+  'PATH',
+  'SHELL',
+  'SSL_CERT_FILE',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'USER',
+  'VK_API_URL',
+]);
+
+const CODEX_AUTH_ENV_KEYS = new Set(['CODEX_API_KEY', 'OPENAI_API_KEY']);
+const SECRET_ENV_KEY_PATTERN =
+  /(?:SECRET|TOKEN|PASSWORD|PASS|CREDENTIAL|COOKIE|SESSION|WEBHOOK|DATABASE|DB_URL|PRIVATE|SERVICE_ROLE|ADMIN_KEY|API_KEYS?|GITHUB|GH_|SUPABASE|STRIPE|AWS_|AZURE_|GCP_|GOOGLE_)/i;
+
+export function isSensitiveCodexEnvKey(key: string): boolean {
+  if (CODEX_AUTH_ENV_KEYS.has(key)) return false;
+  return SECRET_ENV_KEY_PATTERN.test(key);
+}
+
+export function buildSafeCodexEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const key of CODEX_ENV_ALLOWLIST) {
+    const value = source[key];
+    if (typeof value === 'string' && !isSensitiveCodexEnvKey(key)) {
+      env[key] = value;
+    }
+  }
+
+  env.VK_API_URL = source.VK_API_URL || 'http://localhost:3001';
+  return env;
+}


### PR DESCRIPTION
## Summary
- add shared safe Codex env builder that allowlists operational variables and blocks common credential-bearing names
- use the filtered env for workflow Codex sessions, Codex review sessions, and the adjacent Clawdbot Codex SDK path
- add regression coverage proving workflow and review sessions do not receive GitHub/database/admin secret env vars

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/codex-env.test.ts src/__tests__/workflow-step-executor-codex.test.ts src/__tests__/codex-review-service.test.ts src/__tests__/codex-provider-service.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/server lint

Closes #600