### PR TITLE
Security: require execute permission for Codex review

### DIFF
--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -6,6 +6,7 @@ import {
   agentPermissionAccess,
   agentRegistryAccess,
   agentRoutingAccess,
+  diffAccess,
   policyAccess,
   previewAccess,
   scoringAccess,
@@ -159,6 +160,34 @@ describe('v1 REST permission guard presets', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         details: expect.objectContaining({ required: ['workflow:write'] }),
+      })
+    );
+  });
+
+  it('requires workflow execution before Codex review can launch from diff routes', () => {
+    expect(runGuard(diffAccess, mockRequest('GET', '/task_1')).next).toHaveBeenCalled();
+    expect(
+      runGuard(diffAccess, mockRequest('POST', '/task_1/codex-review')).next
+    ).toHaveBeenCalled();
+
+    const readOnlyReview = runGuard(
+      diffAccess,
+      mockRequest('POST', '/task_1/codex-review', 'read-only')
+    );
+    expect(readOnlyReview.next).not.toHaveBeenCalled();
+    expect(readOnlyReview.res.status).toHaveBeenCalledWith(403);
+    expect(readOnlyReview.res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['workflow:execute'] }),
+      })
+    );
+
+    const genericMutation = runGuard(diffAccess, mockRequest('POST', '/task_1/other', 'read-only'));
+    expect(genericMutation.next).not.toHaveBeenCalled();
+    expect(genericMutation.res.status).toHaveBeenCalledWith(403);
+    expect(genericMutation.res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['task:write'] }),
       })
     );
   });

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { getApiPermissionRequirement } from '../../../shared/src/utils/api-permissions.js';
+
+describe('shared API permission metadata', () => {
+  it('requires workflow execution for Codex review diff posts', () => {
+    expect(
+      getApiPermissionRequirement('/api/diff/task_1/codex-review', { method: 'POST' }).permissions
+    ).toEqual(['workflow:execute']);
+  });
+
+  it('keeps diff reads task-read scoped', () => {
+    expect(getApiPermissionRequirement('/api/diff/task_1/full').permissions).toEqual(['task:read']);
+  });
+
+  it('normalizes v1 diff paths before checking permissions', () => {
+    expect(
+      getApiPermissionRequirement('/api/v1/diff/task_1/codex-review', { method: 'POST' })
+        .permissions
+    ).toEqual(['workflow:execute']);
+  });
+});

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -29,6 +29,7 @@ import {
   configAccess,
   costPredictionAccess,
   delegationAccess,
+  diffAccess,
   feedbackAccess,
   notificationAccess,
   policyAccess,
@@ -180,7 +181,7 @@ v1Router.use('/agents/register', agentRegistryAccess, agentRegistryRoutes); // B
 v1Router.use('/agents/permissions', agentPermissionAccess, agentPermissionRoutes);
 v1Router.use('/agents', agentRoutingAccess, agentRoutingRoutes); // Must be before agentRoutes (/:taskId would match "route"/"routing")
 v1Router.use('/agents', agentTaskAccess, agentRoutes);
-v1Router.use('/diff', taskReadAccess, diffRoutes);
+v1Router.use('/diff', diffAccess, diffRoutes);
 v1Router.use('/automation', taskAccess, automationRoutes);
 v1Router.use('/summary', reportAccess, summaryRoutes);
 v1Router.use('/notifications', notificationAccess, notificationRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -18,6 +18,9 @@ export const taskAccess = routeAccess('task:read', 'task:write');
 export const taskReadAccess = routeAccess('task:read', 'task:read');
 export const taskCommentAccess = routeAccess('task:read', 'comment:write');
 export const workProductAccess = routeAccess('work_product:read', 'work_product:write');
+export const diffAccess = routeAccess('task:read', 'task:write', [
+  { methods: ['POST'], path: /^\/[^/]+\/codex-review\/?$/, permissions: 'workflow:execute' },
+]);
 export const settingsAccess = routeAccess('settings:read', 'settings:write');
 export const adminAccess = routeAccess('admin:manage', 'admin:manage');
 export const agentRegistryAccess = routeAccess('agent:read', 'telemetry:write');

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -176,7 +176,14 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     write: 'admin:manage',
     overrides: [{ methods: ['POST'], path: /^\/route\/?$/, permissions: 'agent:read' }],
   },
-  { prefix: '/api/diff', read: 'task:read' },
+  {
+    prefix: '/api/diff',
+    read: 'task:read',
+    write: 'task:write',
+    overrides: [
+      { methods: ['POST'], path: /^\/[^/]+\/codex-review\/?$/, permissions: 'workflow:execute' },
+    ],
+  },
   { prefix: '/api/automation', read: 'task:read', write: 'task:write' },
   { prefix: '/api/summary', read: 'report:read' },
   { prefix: '/api/notifications', read: 'agent:read', write: 'comment:write' },


### PR DESCRIPTION
## Summary
- add a dedicated diff route permission guard that keeps diff reads at task:read while requiring workflow:execute for POST /:taskId/codex-review
- mount diff routes through the new guard instead of taskReadAccess
- mirror the Codex review permission requirement in shared API permission metadata for clients
- add regression coverage for the server guard and shared permission resolver

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/routes/v1-permission-guards.test.ts src/__tests__/shared-api-permissions.test.ts src/__tests__/routes/codex-review.test.ts
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/server lint

Closes #601