### PR TITLE
Security: enforce local agent control capability

### DIFF
--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -1,0 +1,95 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthContext, AuthenticatedRequest } from '../../middleware/auth.js';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+const { mockStartAgent, mockStopAgent } = vi.hoisted(() => ({
+  mockStartAgent: vi.fn(),
+  mockStopAgent: vi.fn(),
+}));
+
+vi.mock('../../services/clawdbot-agent-service.js', () => ({
+  AgentReadinessError: class AgentReadinessError extends Error {
+    readiness: unknown;
+  },
+  clawdbotAgentService: {
+    startAgent: mockStartAgent,
+    stopAgent: mockStopAgent,
+    completeAgent: vi.fn(),
+    getAgentStatus: vi.fn(),
+    listPendingRequests: vi.fn(),
+    listAttempts: vi.fn(),
+    getAttemptLog: vi.fn(),
+  },
+}));
+
+import { agentRoutes } from '../../routes/agents.js';
+
+function auth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    role: 'agent',
+    isLocalhost: false,
+    authMethod: 'device-session',
+    permissions: ['agent:write'],
+    clientMode: 'desktop-remote',
+    capabilities: ['desktop:remote', 'agent:run:scoped'],
+    ...overrides,
+  };
+}
+
+function createApp(authContext: AuthContext | undefined) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as AuthenticatedRequest).auth = authContext;
+    next();
+  });
+  app.use('/api/agents', agentRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('agent local capability enforcement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartAgent.mockResolvedValue({ taskId: 'task_1', agent: 'codex', status: 'running' });
+    mockStopAgent.mockResolvedValue(undefined);
+  });
+
+  it('rejects remote sessions without a local-agent capability before starting agents', async () => {
+    const response = await request(createApp(auth()))
+      .post('/api/agents/task_1/start')
+      .send({ agent: 'codex' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'Local agent controls are disabled for this session',
+    });
+    expect(mockStartAgent).not.toHaveBeenCalled();
+  });
+
+  it('allows local desktop sessions to start agents', async () => {
+    const response = await request(
+      createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }))
+    )
+      .post('/api/agents/task_1/start')
+      .send({ agent: 'codex' });
+
+    expect(response.status).toBe(201);
+    expect(mockStartAgent).toHaveBeenCalledWith('task_1', 'codex', { overrideReason: undefined });
+  });
+
+  it('allows explicitly authorized remote sessions to stop agents', async () => {
+    const response = await request(
+      createApp(auth({ capabilities: ['desktop:remote', 'agent:run:local'] }))
+    )
+      .post('/api/agents/task_1/stop')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ stopped: true });
+    expect(mockStopAgent).toHaveBeenCalledWith('task_1');
+  });
+});

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { NextFunction, Response } from 'express';
-import type { AuthenticatedRequest } from '../../middleware/auth.js';
+import type { AuthenticatedRequest, AuthPermission } from '../../middleware/auth.js';
 import {
   activityAccess,
   agentPermissionAccess,
   agentRegistryAccess,
   agentRoutingAccess,
+  agentTaskAccess,
   diffAccess,
   policyAccess,
   previewAccess,
@@ -22,12 +23,13 @@ type AccessGuard = (req: AuthenticatedRequest, res: Response, next: NextFunction
 function mockRequest(
   method: string,
   path: string,
-  role: 'admin' | 'agent' | 'read-only' = 'agent'
+  role: 'admin' | 'agent' | 'read-only' = 'agent',
+  permissions?: AuthPermission[]
 ): AuthenticatedRequest {
   return {
     method,
     path,
-    auth: { role, isLocalhost: false },
+    auth: { role, isLocalhost: false, permissions },
   } as unknown as AuthenticatedRequest;
 }
 
@@ -198,6 +200,23 @@ describe('v1 REST permission guard presets', () => {
       runGuard(agentPermissionAccess, mockRequest('POST', '/approvals')).next
     ).toHaveBeenCalled();
     expect(runGuard(agentRoutingAccess, mockRequest('POST', '/route')).next).toHaveBeenCalled();
+
+    expect(
+      runGuard(agentRoutingAccess, mockRequest('POST', '/task_1/start', 'agent', ['agent:write']))
+        .next
+    ).toHaveBeenCalled();
+    expect(
+      runGuard(agentTaskAccess, mockRequest('POST', '/task_1/stop', 'agent', ['agent:write'])).next
+    ).toHaveBeenCalled();
+
+    const missingAgentWrite = runGuard(agentTaskAccess, mockRequest('POST', '/task_1/start'));
+    expect(missingAgentWrite.next).not.toHaveBeenCalled();
+    expect(missingAgentWrite.res.status).toHaveBeenCalledWith(403);
+    expect(missingAgentWrite.res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['agent:write'] }),
+      })
+    );
 
     const readOnlyApproval = runGuard(
       agentPermissionAccess,

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { getApiPermissionRequirement } from '../../../shared/src/utils/api-permissions.js';
 
 describe('shared API permission metadata', () => {
+  it('requires agent write permission for local agent start and stop routes', () => {
+    expect(
+      getApiPermissionRequirement('/api/agents/task_1/start', { method: 'POST' }).permissions
+    ).toEqual(['agent:write']);
+    expect(
+      getApiPermissionRequirement('/api/v1/agents/task_1/stop', { method: 'POST' }).permissions
+    ).toEqual(['agent:write']);
+  });
+
   it('requires workflow execution for Codex review diff posts', () => {
     expect(
       getApiPermissionRequirement('/api/diff/task_1/codex-review', { method: 'POST' }).permissions

--- a/server/src/middleware/local-agent-capability.ts
+++ b/server/src/middleware/local-agent-capability.ts
@@ -1,0 +1,46 @@
+import type { NextFunction, Response } from 'express';
+import type { AuthenticatedRequest, AuthContext } from './auth.js';
+import { ForbiddenError, UnauthorizedError } from './error-handler.js';
+
+const LOCAL_AGENT_CAPABILITIES = new Set([
+  'desktop:local',
+  'agent:run:local',
+  'agent:run:unrestricted',
+  'local-agent:run',
+]);
+
+const LOCAL_CLIENT_MODES = new Set(['desktop-local', 'cli']);
+
+export function authAllowsLocalAgentControls(auth: AuthContext | undefined): boolean {
+  if (!auth) return false;
+  if (auth.authMethod === 'localhost-bypass') return true;
+  if (auth.isLocalhost) return true;
+  if (auth.capabilities?.some((capability) => LOCAL_AGENT_CAPABILITIES.has(capability))) {
+    return true;
+  }
+
+  return !!auth.clientMode && LOCAL_CLIENT_MODES.has(auth.clientMode);
+}
+
+export function requireLocalAgentCapability(
+  req: AuthenticatedRequest,
+  _res: Response,
+  next: NextFunction
+): void {
+  if (!req.auth) {
+    return next(new UnauthorizedError());
+  }
+
+  if (!authAllowsLocalAgentControls(req.auth)) {
+    return next(
+      new ForbiddenError('Local agent controls are disabled for this session', {
+        requiredCapabilities: [...LOCAL_AGENT_CAPABILITIES],
+        allowedClientModes: [...LOCAL_CLIENT_MODES],
+        clientMode: req.auth.clientMode ?? 'remote',
+        authMethod: req.auth.authMethod,
+      })
+    );
+  }
+
+  next();
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -6,6 +6,7 @@ import { getTaskService } from '../services/task-service.js';
 import type { AgentType, TokenTelemetryEvent } from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { requireLocalAgentCapability } from '../middleware/local-agent-capability.js';
 
 const router: RouterType = Router();
 
@@ -35,6 +36,7 @@ const reportTokensSchema = z.object({
 // POST /api/agents/:taskId/start - Start agent on task (delegates to Clawdbot)
 router.post(
   '/:taskId/start',
+  requireLocalAgentCapability,
   asyncHandler(async (req, res) => {
     let agent: AgentType | undefined;
     let overrideReason: string | undefined;
@@ -94,6 +96,7 @@ router.post(
 // POST /api/agents/:taskId/stop - Stop running agent
 router.post(
   '/:taskId/stop',
+  requireLocalAgentCapability,
   asyncHandler(async (req, res) => {
     await clawdbotAgentService.stopAgent(req.params.taskId as string);
     res.json({ stopped: true });

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -30,8 +30,11 @@ export const agentPermissionAccess = routeAccess('agent:read', 'admin:manage', [
 ]);
 export const agentRoutingAccess = routeAccess('agent:read', 'admin:manage', [
   { methods: ['POST'], path: /^\/route\/?$/, permissions: 'agent:read' },
+  { methods: ['POST'], path: /^\/[^/]+\/(start|stop)\/?$/, permissions: 'agent:write' },
 ]);
-export const agentTaskAccess = routeAccess('agent:read', 'task:write');
+export const agentTaskAccess = routeAccess('agent:read', 'task:write', [
+  { methods: ['POST'], path: /^\/[^/]+\/(start|stop)\/?$/, permissions: 'agent:write' },
+]);
 export const agentStatusAccess = routeAccess('agent:read', 'telemetry:write');
 export const reportAccess = routeAccess('report:read', 'report:read');
 export const telemetryAccess = routeAccess('telemetry:read', 'telemetry:write');

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -174,7 +174,10 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     prefix: '/api/agents',
     read: 'agent:read',
     write: 'admin:manage',
-    overrides: [{ methods: ['POST'], path: /^\/route\/?$/, permissions: 'agent:read' }],
+    overrides: [
+      { methods: ['POST'], path: /^\/route\/?$/, permissions: 'agent:read' },
+      { methods: ['POST'], path: /^\/[^/]+\/(start|stop)\/?$/, permissions: 'agent:write' },
+    ],
   },
   {
     prefix: '/api/diff',


### PR DESCRIPTION
## Summary
- require agent:write for local agent start/stop routes in both server v1 guards and shared API permission metadata
- add server middleware that blocks local agent controls unless the session is localhost, localhost-bypass, desktop-local/CLI, or has an explicit local-agent capability
- apply the local capability check to agent start and stop routes before the Clawdbot service is invoked
- add regression coverage for remote desktop sessions, allowed local/explicit-capability sessions, and shared permission metadata

## Notes
- I did not find a separate HTTP agent message endpoint in the current server route surface; this PR covers the start/stop controls that can launch or interrupt local worktree agents.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/routes/agents-local-capability.test.ts src/__tests__/routes/v1-permission-guards.test.ts src/__tests__/shared-api-permissions.test.ts
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/server lint

Closes #602