### PR TITLE
Allowlist Codex workflow commands

### DIFF
--- a/docs/CODEX-INTEGRATION.md
+++ b/docs/CODEX-INTEGRATION.md
@@ -127,6 +127,10 @@ agents:
     description: Codex workflow implementer
 ```
 
+Workflow definitions should normally omit `command` for Codex agents. Command overrides are
+rejected unless they are `codex`, match `VERITAS_CODEX_EXECUTABLE` or `CODEX_PATH`, or the server
+is intentionally started with `VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES=1`.
+
 ## Review Actions
 
 Codex review actions run against the task worktree diff in read-only SDK mode and map structured findings into Veritas review comments:

--- a/server/src/__tests__/routes/workflow-authoring.test.ts
+++ b/server/src/__tests__/routes/workflow-authoring.test.ts
@@ -254,6 +254,68 @@ describe('workflow authoring routes', () => {
     );
   });
 
+  it('dry-runs drafts and blocks unsafe Codex command overrides', async () => {
+    const originalEnv = {
+      VERITAS_CODEX_EXECUTABLE: process.env.VERITAS_CODEX_EXECUTABLE,
+      CODEX_PATH: process.env.CODEX_PATH,
+      VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES:
+        process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES,
+    };
+    delete process.env.VERITAS_CODEX_EXECUTABLE;
+    delete process.env.CODEX_PATH;
+    delete process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES;
+
+    try {
+      const draft = workflow({
+        agents: [
+          {
+            id: 'codex',
+            name: 'Codex',
+            role: 'developer',
+            provider: 'codex-sdk',
+            command: '/tmp/not-the-codex-binary',
+            description: 'Runs Codex.',
+          },
+        ],
+        steps: [
+          {
+            id: 'implement',
+            name: 'Implement',
+            type: 'agent',
+            agent: 'codex',
+            input: 'Implement the task.',
+          },
+        ],
+      });
+
+      const response = await request(app)
+        .post('/api/workflows/authoring/dry-run')
+        .send({ workflow: draft, context: { clientMode: 'local' } });
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('blocked');
+      expect(response.body.canRun).toBe(false);
+      expect(response.body.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            severity: 'error',
+            category: 'definition',
+            path: 'agents[0].command',
+            message: 'Agent codex has an unsafe Codex command override.',
+          }),
+        ])
+      );
+    } finally {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
   it('adds skill audit status to dry-run checks and blocks risky skills in remote mode', async () => {
     const runtimeDir = path.join(testRoot, '.veritas-kanban');
     await fs.mkdir(runtimeDir, { recursive: true });

--- a/server/src/__tests__/workflow-service.test.ts
+++ b/server/src/__tests__/workflow-service.test.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 
 import { WorkflowService } from '../services/workflow-service.js';
-import { ValidationError } from '../types/workflow.js';
+import { ValidationError, type WorkflowDefinition } from '../types/workflow.js';
 
 function workflow(overrides: Record<string, any> = {}) {
   return {
@@ -22,13 +22,34 @@ function workflow(overrides: Record<string, any> = {}) {
 describe('WorkflowService', () => {
   let tmpDir: string;
   let service: WorkflowService;
+  let originalCodexEnv: {
+    VERITAS_CODEX_EXECUTABLE?: string;
+    CODEX_PATH?: string;
+    VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES?: string;
+  };
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workflow-service-'));
     service = new WorkflowService(tmpDir);
+    originalCodexEnv = {
+      VERITAS_CODEX_EXECUTABLE: process.env.VERITAS_CODEX_EXECUTABLE,
+      CODEX_PATH: process.env.CODEX_PATH,
+      VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES:
+        process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES,
+    };
+    delete process.env.VERITAS_CODEX_EXECUTABLE;
+    delete process.env.CODEX_PATH;
+    delete process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES;
   });
 
   afterEach(async () => {
+    for (const [key, value] of Object.entries(originalCodexEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -188,6 +209,29 @@ describe('WorkflowService', () => {
         }) as any
       )
     ).rejects.toThrow(/exceeds maximum of 50 tools/);
+  });
+
+  it('rejects arbitrary Codex command overrides unless explicitly allowlisted', async () => {
+    const codexWorkflow = workflow({
+      agents: [
+        {
+          id: 'codex',
+          name: 'Codex',
+          role: 'developer',
+          provider: 'codex-sdk',
+          command: '/tmp/not-the-codex-binary',
+          description: 'Runs Codex.',
+        },
+      ],
+      steps: [{ id: 'step-1', type: 'agent', agent: 'codex', prompt: 'x' }],
+    }) as WorkflowDefinition;
+
+    await expect(service.saveWorkflow(codexWorkflow)).rejects.toThrow(
+      /unsafe Codex command override/
+    );
+
+    process.env.VERITAS_CODEX_EXECUTABLE = '/tmp/not-the-codex-binary';
+    await expect(service.saveWorkflow(codexWorkflow)).resolves.toBeUndefined();
   });
 
   it('saves ACLs and audit entries', async () => {

--- a/server/src/__tests__/workflow-step-executor-codex.test.ts
+++ b/server/src/__tests__/workflow-step-executor-codex.test.ts
@@ -53,6 +53,25 @@ async function* codexEvents() {
   };
 }
 
+function captureCodexCommandEnv() {
+  return {
+    VERITAS_CODEX_EXECUTABLE: process.env.VERITAS_CODEX_EXECUTABLE,
+    CODEX_PATH: process.env.CODEX_PATH,
+    VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES:
+      process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES,
+  };
+}
+
+function restoreCodexCommandEnv(env: ReturnType<typeof captureCodexCommandEnv>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
 describe('WorkflowStepExecutor Codex integration', () => {
   let tmpDir: string;
 
@@ -198,6 +217,118 @@ describe('WorkflowStepExecutor Codex integration', () => {
           process.env[key] = value;
         }
       }
+    }
+  });
+
+  it('rejects unsafe Codex command overrides before starting SDK sessions', async () => {
+    const originalEnv = captureCodexCommandEnv();
+    delete process.env.VERITAS_CODEX_EXECUTABLE;
+    delete process.env.CODEX_PATH;
+    delete process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES;
+
+    try {
+      const executor = new WorkflowStepExecutor(tmpDir);
+      const step: WorkflowStep = {
+        id: 'implement',
+        name: 'Implement',
+        type: 'agent',
+        agent: 'codex',
+        input: 'Work on {{task.title}}',
+        output: { file: 'implement.md' },
+      };
+      const run: WorkflowRun = {
+        id: 'run_1234567890_command',
+        workflowId: 'wf-codex-command',
+        workflowVersion: 1,
+        status: 'running',
+        context: {
+          task: {
+            id: 'task_1',
+            title: 'Codex command policy',
+            git: { worktreePath: tmpDir },
+          },
+          workflow: {
+            agents: [
+              {
+                id: 'codex',
+                name: 'Codex',
+                role: 'developer',
+                provider: 'codex-sdk',
+                command: '/tmp/not-the-codex-binary',
+                description: 'Codex developer',
+              },
+            ],
+          },
+          _sessions: {},
+        },
+        startedAt: new Date().toISOString(),
+        steps: [{ stepId: 'implement', status: 'running', retries: 0 }],
+      };
+
+      await expect(executor.executeStep(step, run)).rejects.toThrow(
+        'Codex command overrides must be "codex"'
+      );
+      expect(mockCodexConstructorOptions).not.toHaveBeenCalled();
+      expect(mockStartThread).not.toHaveBeenCalled();
+      expect(mockResumeThread).not.toHaveBeenCalled();
+    } finally {
+      restoreCodexCommandEnv(originalEnv);
+    }
+  });
+
+  it('passes configured Codex executable overrides to SDK sessions', async () => {
+    const originalEnv = captureCodexCommandEnv();
+    process.env.VERITAS_CODEX_EXECUTABLE = '/tmp/allowed-codex';
+    delete process.env.CODEX_PATH;
+    delete process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES;
+
+    try {
+      const executor = new WorkflowStepExecutor(tmpDir);
+      const step: WorkflowStep = {
+        id: 'implement',
+        name: 'Implement',
+        type: 'agent',
+        agent: 'codex',
+        input: 'Work on {{task.title}}',
+        output: { file: 'implement.md' },
+      };
+      const run: WorkflowRun = {
+        id: 'run_1234567890_allowed_command',
+        workflowId: 'wf-codex-allowed-command',
+        workflowVersion: 1,
+        status: 'running',
+        context: {
+          task: {
+            id: 'task_1',
+            title: 'Codex command policy',
+            git: { worktreePath: tmpDir },
+          },
+          workflow: {
+            agents: [
+              {
+                id: 'codex',
+                name: 'Codex',
+                role: 'developer',
+                provider: 'codex-sdk',
+                command: '/tmp/allowed-codex',
+                description: 'Codex developer',
+              },
+            ],
+          },
+          _sessions: {},
+        },
+        startedAt: new Date().toISOString(),
+        steps: [{ stepId: 'implement', status: 'running', retries: 0 }],
+      };
+
+      await executor.executeStep(step, run);
+
+      expect(mockCodexConstructorOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ codexPathOverride: '/tmp/allowed-codex' })
+      );
+      expect(mockStartThread).toHaveBeenCalled();
+    } finally {
+      restoreCodexCommandEnv(originalEnv);
     }
   });
 

--- a/server/src/services/workflow-authoring-service.ts
+++ b/server/src/services/workflow-authoring-service.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types/workflow.js';
 import { getToolPolicyService, type ToolPolicyService } from './tool-policy-service.js';
 import { getSkillSecurityService, type SkillSecurityService } from './skill-security-service.js';
+import { evaluateCodexCommandPolicy, isCodexWorkflowAgent } from '../utils/codex-command-policy.js';
 
 export type WorkflowRecipeInputType = 'text' | 'textarea' | 'select' | 'boolean';
 export type WorkflowLintSeverity = 'error' | 'warning' | 'info';
@@ -1040,6 +1041,7 @@ export class WorkflowAuthoringService {
     const messages: WorkflowLintMessage[] = [];
 
     this.lintDefinition(workflow, messages);
+    this.lintCodexCommandOverrides(workflow, messages);
     const pipelineSummary = this.lintPipeline(workflow, messages);
     await this.lintToolPolicies(workflow, messages);
     const skillAudit = await this.lintSkillAudit(workflow, context, messages);
@@ -1333,6 +1335,26 @@ export class WorkflowAuthoringService {
           )
         );
       }
+    }
+  }
+
+  private lintCodexCommandOverrides(
+    workflow: WorkflowDefinition,
+    messages: WorkflowLintMessage[]
+  ): void {
+    for (const [index, agent] of toArray(workflow.agents).entries()) {
+      if (!isCodexWorkflowAgent(agent)) continue;
+      const commandPolicy = evaluateCodexCommandPolicy(agent.command);
+      if (commandPolicy.allowed) continue;
+      messages.push(
+        message(
+          'error',
+          'definition',
+          `agents[${index}].command`,
+          `Agent ${agent.id} has an unsafe Codex command override.`,
+          commandPolicy.reason ?? 'Use the default codex command or configure an allowed path.'
+        )
+      );
     }
   }
 

--- a/server/src/services/workflow-service.ts
+++ b/server/src/services/workflow-service.ts
@@ -12,6 +12,7 @@ import { getWorkflowsDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteWorkflowDefinitionRepository } from '../storage/sqlite/workflow-repositories.js';
+import { evaluateCodexCommandPolicy, isCodexWorkflowAgent } from '../utils/codex-command-policy.js';
 
 const log = createLogger('workflow-service');
 const WORKFLOW_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-_]*$/;
@@ -334,6 +335,15 @@ export class WorkflowService {
         throw new ValidationError(
           `Agent ${agent.id} exceeds maximum of ${MAX_TOOLS_PER_AGENT} tools (has ${agent.tools.length})`
         );
+      }
+
+      if (isCodexWorkflowAgent(agent)) {
+        const commandPolicy = evaluateCodexCommandPolicy(agent.command);
+        if (!commandPolicy.allowed) {
+          throw new ValidationError(
+            `Agent ${agent.id} has unsafe Codex command override: ${commandPolicy.reason}`
+          );
+        }
       }
     }
 

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -16,6 +16,10 @@ import type {
 } from '../types/workflow.js';
 import { getWorkflowRunsDir } from '../utils/paths.js';
 import { buildSafeCodexEnv } from '../utils/codex-env.js';
+import {
+  assertAllowedCodexCommandOverride,
+  isCodexWorkflowAgent,
+} from '../utils/codex-command-policy.js';
 import { createLogger } from '../lib/logger.js';
 import { getGovernanceTraceService } from './governance-trace-service.js';
 import {
@@ -344,11 +348,14 @@ export class WorkflowStepExecutor {
   ): Promise<StepExecutionResult> {
     this.assertCodexToolPolicySupported(step, agentDef, toolPolicyFilter);
 
+    const codexPathOverride = assertAllowedCodexCommandOverride(
+      agentDef?.command,
+      `Workflow agent ${agentDef?.id || step.agent || step.id}`
+    );
     const { Codex } = await import('@openai/codex-sdk');
     const workingDirectory = this.expandPath(this.getWorkflowWorkingDirectory(run));
     const codex = new Codex({
-      codexPathOverride:
-        agentDef?.command && agentDef.command !== 'codex' ? agentDef.command : undefined,
+      codexPathOverride,
       env: buildSafeCodexEnv(),
     });
 
@@ -491,10 +498,7 @@ export class WorkflowStepExecutor {
   }
 
   private isCodexAgent(agentDef: WorkflowAgent | null, agentId?: string): boolean {
-    const marker = `${agentDef?.provider || ''} ${agentDef?.id || ''} ${
-      agentDef?.name || ''
-    } ${agentDef?.role || ''} ${agentId || ''}`.toLowerCase();
-    return marker.includes('codex');
+    return isCodexWorkflowAgent(agentDef ? { ...agentDef, agentId } : { id: agentId });
   }
 
   private getWorkflowWorkingDirectory(run: WorkflowRun): string {

--- a/server/src/utils/codex-command-policy.ts
+++ b/server/src/utils/codex-command-policy.ts
@@ -1,0 +1,90 @@
+const DEFAULT_CODEX_COMMAND = 'codex';
+const CODEX_EXECUTABLE_ENV_KEYS = ['VERITAS_CODEX_EXECUTABLE', 'CODEX_PATH'] as const;
+const UNSAFE_OVERRIDE_ENV = 'VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES';
+const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export interface CodexAgentMarker {
+  id?: string;
+  agentId?: string;
+  name?: string;
+  role?: string;
+  provider?: string;
+  command?: string;
+}
+
+export interface CodexCommandPolicyEvaluation {
+  allowed: boolean;
+  command?: string;
+  codexPathOverride?: string;
+  reason?: string;
+  configuredCommands: string[];
+  unsafeOverridesEnabled: boolean;
+}
+
+export function isCodexWorkflowAgent(agent: CodexAgentMarker | null | undefined): boolean {
+  if (!agent) return false;
+  const marker = [agent.provider, agent.id, agent.agentId, agent.name, agent.role, agent.command]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return marker.includes('codex');
+}
+
+export function configuredCodexExecutableCommands(env: NodeJS.ProcessEnv = process.env): string[] {
+  return CODEX_EXECUTABLE_ENV_KEYS.map((key) => env[key]?.trim()).filter((value): value is string =>
+    Boolean(value)
+  );
+}
+
+export function unsafeCodexCommandOverridesEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return TRUTHY_ENV_VALUES.has((env[UNSAFE_OVERRIDE_ENV] ?? '').trim().toLowerCase());
+}
+
+export function evaluateCodexCommandPolicy(
+  command: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): CodexCommandPolicyEvaluation {
+  const normalized = command?.trim();
+  const configuredCommands = configuredCodexExecutableCommands(env);
+  const unsafeOverridesEnabled = unsafeCodexCommandOverridesEnabled(env);
+
+  if (!normalized || normalized === DEFAULT_CODEX_COMMAND) {
+    return {
+      allowed: true,
+      command: normalized,
+      configuredCommands,
+      unsafeOverridesEnabled,
+    };
+  }
+
+  if (unsafeOverridesEnabled || configuredCommands.includes(normalized)) {
+    return {
+      allowed: true,
+      command: normalized,
+      codexPathOverride: normalized,
+      configuredCommands,
+      unsafeOverridesEnabled,
+    };
+  }
+
+  return {
+    allowed: false,
+    command: normalized,
+    configuredCommands,
+    unsafeOverridesEnabled,
+    reason:
+      'Codex command overrides must be "codex", match VERITAS_CODEX_EXECUTABLE/CODEX_PATH, or be explicitly enabled with VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES=1.',
+  };
+}
+
+export function assertAllowedCodexCommandOverride(
+  command: string | undefined,
+  subject: string,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const evaluation = evaluateCodexCommandPolicy(command, env);
+  if (!evaluation.allowed) {
+    throw new Error(`${subject}: ${evaluation.reason}`);
+  }
+  return evaluation.codexPathOverride;
+}


### PR DESCRIPTION
## Summary
- Add a shared Codex command policy for workflow definitions and execution.
- Block unsafe Codex command overrides in workflow validation and authoring dry-runs.
- Document the allowed override env vars and cover rejection/allowlist behavior.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/workflow-service.test.ts src/__tests__/routes/workflow-authoring.test.ts src/__tests__/workflow-step-executor-codex.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/server lint (0 errors, 537 warnings)

Closes #604