### PR TITLE
Harden docs path containment

### DIFF
--- a/server/src/__tests__/docs-service.test.ts
+++ b/server/src/__tests__/docs-service.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { DocsService } from '../services/docs-service.js';
+
+describe('DocsService', () => {
+  let tmpDir: string;
+  let docsRoot: string;
+  let siblingRoot: string;
+  let service: DocsService;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'docs-service-'));
+    docsRoot = path.join(tmpDir, 'docs');
+    siblingRoot = path.join(tmpDir, 'docs2');
+    await fs.mkdir(docsRoot, { recursive: true });
+    await fs.mkdir(siblingRoot, { recursive: true });
+    service = new DocsService(docsRoot);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('keeps normal docs operations inside the configured root', async () => {
+    const saved = await service.saveFile('guides/intro.md', '# Intro');
+
+    expect(saved.path).toBe('guides/intro.md');
+    expect(saved.content).toBe('# Intro');
+
+    const files = await service.listFiles({ directory: 'guides' });
+    expect(files.map((file) => file.path)).toEqual(['guides/intro.md']);
+
+    const loaded = await service.getFile('guides/intro.md');
+    expect(loaded?.content).toBe('# Intro');
+
+    await expect(service.deleteFile('guides/intro.md')).resolves.toBe(true);
+    await expect(service.getFile('guides/intro.md')).resolves.toBeNull();
+  });
+
+  it('rejects sibling-prefix traversal for read, write, list, and delete operations', async () => {
+    const outsidePath = path.join(siblingRoot, 'secret.md');
+    await fs.writeFile(outsidePath, 'outside', 'utf-8');
+
+    const traversalFile = path.join('..', 'docs2', 'secret.md');
+    const traversalDirectory = path.join('..', 'docs2');
+
+    await expect(service.getFile(traversalFile)).resolves.toBeNull();
+    await expect(service.listFiles({ directory: traversalDirectory })).resolves.toEqual([]);
+    await expect(service.saveFile(traversalFile, 'owned')).rejects.toThrow('Invalid file path');
+    await expect(service.deleteFile(traversalFile)).resolves.toBe(false);
+    await expect(fs.readFile(outsidePath, 'utf-8')).resolves.toBe('outside');
+  });
+
+  it('rejects decoded encoded-separator traversal paths', async () => {
+    const outsidePath = path.join(siblingRoot, 'encoded.md');
+    await fs.writeFile(outsidePath, 'outside', 'utf-8');
+
+    const traversalFile = decodeURIComponent('..%2Fdocs2%2Fencoded.md');
+
+    await expect(service.getFile(traversalFile)).resolves.toBeNull();
+    await expect(service.saveFile(traversalFile, 'owned')).rejects.toThrow('Invalid file path');
+    await expect(fs.readFile(outsidePath, 'utf-8')).resolves.toBe('outside');
+  });
+
+  it('blocks docs-root symlink escapes', async () => {
+    const outsideRoot = path.join(tmpDir, 'outside');
+    const outsidePath = path.join(outsideRoot, 'secret.md');
+    const linkPath = path.join(docsRoot, 'linked');
+    await fs.mkdir(outsideRoot, { recursive: true });
+    await fs.writeFile(outsidePath, 'outside', 'utf-8');
+
+    try {
+      await fs.symlink(outsideRoot, linkPath, 'dir');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EPERM' || code === 'ENOTSUP') return;
+      throw err;
+    }
+
+    await expect(service.getFile('linked/secret.md')).resolves.toBeNull();
+    await expect(service.listFiles({ directory: 'linked' })).resolves.toEqual([]);
+    await expect(service.saveFile('linked/new.md', 'owned')).rejects.toThrow('Invalid file path');
+    await expect(service.deleteFile('linked/secret.md')).resolves.toBe(false);
+    await expect(fs.readFile(outsidePath, 'utf-8')).resolves.toBe('outside');
+    await expect(fs.access(path.join(outsideRoot, 'new.md'))).rejects.toThrow();
+  });
+});

--- a/server/src/services/docs-service.ts
+++ b/server/src/services/docs-service.ts
@@ -55,12 +55,14 @@ export interface DocsStats {
 
 // ─── Service ─────────────────────────────────────────────────────
 
-class DocsService {
+export class DocsService {
   private docsRoot: string;
 
-  constructor() {
+  constructor(docsRoot?: string) {
     // Default to <storage>/../docs, configurable via VK_DOCS_DIR
-    this.docsRoot = process.env.VK_DOCS_DIR || path.join(DATA_DIR, '..', 'docs');
+    this.docsRoot = path.resolve(
+      docsRoot || process.env.VK_DOCS_DIR || path.join(DATA_DIR, '..', 'docs')
+    );
   }
 
   /**
@@ -74,8 +76,10 @@ class DocsService {
   }): Promise<DocFile[]> {
     const files: DocFile[] = [];
     const root = options?.directory
-      ? path.join(this.docsRoot, options.directory)
+      ? await this.resolveDocsDirectory(options.directory)
       : this.docsRoot;
+
+    if (!root) return [];
 
     try {
       await this.scanDirectory(root, files);
@@ -116,14 +120,8 @@ class DocsService {
    * Get a specific file with content.
    */
   async getFile(filePath: string): Promise<DocFile | null> {
-    const fullPath = path.join(this.docsRoot, filePath);
-
-    // Security: prevent path traversal
-    const resolved = path.resolve(fullPath);
-    if (!resolved.startsWith(path.resolve(this.docsRoot))) {
-      log.warn({ filePath }, 'Path traversal attempt blocked');
-      return null;
-    }
+    const fullPath = await this.resolveExistingFilePath(filePath);
+    if (!fullPath) return null;
 
     try {
       const stat = await fs.stat(fullPath);
@@ -148,11 +146,8 @@ class DocsService {
    * Create or update a file.
    */
   async saveFile(filePath: string, content: string): Promise<DocFile> {
-    const fullPath = path.join(this.docsRoot, filePath);
-
-    // Security: prevent path traversal
-    const resolved = path.resolve(fullPath);
-    if (!resolved.startsWith(path.resolve(this.docsRoot))) {
+    const fullPath = await this.resolveWritableFilePath(filePath);
+    if (!fullPath) {
       throw new Error('Invalid file path');
     }
 
@@ -179,12 +174,8 @@ class DocsService {
    * Delete a file.
    */
   async deleteFile(filePath: string): Promise<boolean> {
-    const fullPath = path.join(this.docsRoot, filePath);
-
-    const resolved = path.resolve(fullPath);
-    if (!resolved.startsWith(path.resolve(this.docsRoot))) {
-      return false;
-    }
+    const fullPath = await this.resolveExistingFilePath(filePath);
+    if (!fullPath) return false;
 
     try {
       await fs.unlink(fullPath);
@@ -214,7 +205,8 @@ class DocsService {
 
       // Check content match
       try {
-        const fullPath = path.join(this.docsRoot, file.path);
+        const fullPath = await this.resolveExistingFilePath(file.path);
+        if (!fullPath) continue;
         const content = await fs.readFile(fullPath, 'utf-8');
         const lines = content.split('\n');
         const matches: DocSearchResult['matches'] = [];
@@ -280,6 +272,124 @@ class DocsService {
   }
 
   // ─── Private ─────────────────────────────────────────────────
+
+  private isWithinDocsRoot(candidatePath: string, root = this.docsRoot): boolean {
+    const relative = path.relative(root, candidatePath);
+    return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+  }
+
+  private resolveLogicalDocsPath(filePath: string): string | null {
+    const resolved = path.resolve(this.docsRoot, filePath);
+    if (!this.isWithinDocsRoot(resolved)) {
+      log.warn({ filePath }, 'Docs path traversal attempt blocked');
+      return null;
+    }
+    return resolved;
+  }
+
+  private async realDocsRoot(): Promise<string> {
+    try {
+      return await fs.realpath(this.docsRoot);
+    } catch {
+      return this.docsRoot;
+    }
+  }
+
+  private async resolveDocsDirectory(directory: string): Promise<string | null> {
+    const resolved = this.resolveLogicalDocsPath(directory);
+    if (!resolved) return null;
+
+    try {
+      const [realRoot, realDirectory] = await Promise.all([
+        this.realDocsRoot(),
+        fs.realpath(resolved),
+      ]);
+      if (!this.isWithinDocsRoot(realDirectory, realRoot)) {
+        log.warn({ directory }, 'Docs directory symlink escape blocked');
+        return null;
+      }
+    } catch {
+      // Missing directories are handled by scanDirectory as an empty result.
+    }
+
+    return resolved;
+  }
+
+  private async resolveExistingFilePath(filePath: string): Promise<string | null> {
+    const resolved = this.resolveLogicalDocsPath(filePath);
+    if (!resolved) return null;
+
+    try {
+      const [realRoot, realFile] = await Promise.all([this.realDocsRoot(), fs.realpath(resolved)]);
+      if (!this.isWithinDocsRoot(realFile, realRoot)) {
+        log.warn({ filePath }, 'Docs file symlink escape blocked');
+        return null;
+      }
+    } catch {
+      return null;
+    }
+
+    return resolved;
+  }
+
+  private async resolveWritableFilePath(filePath: string): Promise<string | null> {
+    const resolved = this.resolveLogicalDocsPath(filePath);
+    if (!resolved) return null;
+
+    try {
+      await fs.mkdir(this.docsRoot, { recursive: true });
+      const parent = path.dirname(resolved);
+      const parentReady = await this.ensureWritableDirectory(parent, filePath);
+      if (!parentReady) return null;
+
+      const [realRoot, realParent] = await Promise.all([
+        fs.realpath(this.docsRoot),
+        fs.realpath(parent),
+      ]);
+      if (!this.isWithinDocsRoot(realParent, realRoot)) {
+        log.warn({ filePath }, 'Docs write symlink escape blocked');
+        return null;
+      }
+
+      try {
+        const existing = await fs.lstat(resolved);
+        if (existing.isSymbolicLink()) {
+          log.warn({ filePath }, 'Docs write to symlink blocked');
+          return null;
+        }
+      } catch {
+        // New file; parent containment is enough.
+      }
+    } catch {
+      return null;
+    }
+
+    return resolved;
+  }
+
+  private async ensureWritableDirectory(directory: string, filePath: string): Promise<boolean> {
+    const relativeParent = path.relative(this.docsRoot, directory);
+    const segments =
+      relativeParent && relativeParent !== '.'
+        ? relativeParent.split(path.sep).filter(Boolean)
+        : [];
+    let current = this.docsRoot;
+
+    for (const segment of segments) {
+      current = path.join(current, segment);
+      try {
+        const existing = await fs.lstat(current);
+        if (existing.isSymbolicLink() || !existing.isDirectory()) {
+          log.warn({ filePath }, 'Docs write through unsafe parent blocked');
+          return false;
+        }
+      } catch {
+        await fs.mkdir(current);
+      }
+    }
+
+    return true;
+  }
 
   private async scanDirectory(dir: string, files: DocFile[]): Promise<void> {
     let entries;


### PR DESCRIPTION
## Summary
- Replace docs path prefix checks with separator-aware `path.relative(...)` containment.
- Apply containment to file read/write/delete, directory listing inputs, and search file reads.
- Block symlink escapes and unsafe parent-directory writes before following symlinks.
- Add regression coverage for sibling-prefix traversal, decoded separator traversal, and symlink escapes.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/docs-service.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server exec eslint src/services/docs-service.ts src/__tests__/docs-service.test.ts
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/server lint (0 errors, 537 warnings)

Closes #605