### PR TITLE
Redact settings webhook URLs

### DIFF
--- a/server/src/__tests__/routes/misc-routes-coverage.test.ts
+++ b/server/src/__tests__/routes/misc-routes-coverage.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import type { NextFunction, Request, Response } from 'express';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 
 // ===================== Hoisted Mocks =====================
 
@@ -145,6 +146,13 @@ const injectAdminAuth = (
   req.auth = { role: 'admin', keyName: 'test-admin', isLocalhost: true };
   next();
 };
+
+function featureSettings(overrides: Partial<typeof DEFAULT_FEATURE_SETTINGS> = {}) {
+  return {
+    ...DEFAULT_FEATURE_SETTINGS,
+    ...overrides,
+  };
+}
 
 describe('Activity Routes', () => {
   let app: express.Express;
@@ -288,9 +296,11 @@ describe('Settings Routes', () => {
   });
 
   it('GET /features should return settings', async () => {
-    mockConfigServiceForSettings.getFeatureSettings.mockResolvedValue({
-      telemetry: { enabled: true },
-    });
+    mockConfigServiceForSettings.getFeatureSettings.mockResolvedValue(
+      featureSettings({
+        telemetry: { ...DEFAULT_FEATURE_SETTINGS.telemetry, enabled: true },
+      })
+    );
     const res = await request(app).get('/api/settings/features');
     expect(res.status).toBe(200);
   });
@@ -302,14 +312,20 @@ describe('Settings Routes', () => {
   });
 
   it('PATCH /features should update settings', async () => {
-    const settings = {
-      telemetry: { enabled: false, retentionDays: 30, enableTraces: false },
+    const settings = featureSettings({
+      telemetry: {
+        ...DEFAULT_FEATURE_SETTINGS.telemetry,
+        enabled: false,
+        retentionDays: 30,
+        enableTraces: false,
+      },
       tasks: {
+        ...DEFAULT_FEATURE_SETTINGS.tasks,
         attachmentMaxFileSize: 10000000,
         attachmentMaxPerTask: 20,
         attachmentMaxTotalSize: 50000000,
       },
-    };
+    });
     mockConfigServiceForSettings.updateFeatureSettings.mockResolvedValue(settings);
     const res = await request(app)
       .patch('/api/settings/features')
@@ -326,14 +342,16 @@ describe('Settings Routes', () => {
   });
 
   it('PATCH /features should accept requireDeliverableForDone', async () => {
-    const fullSettings = {
+    const fullSettings = featureSettings({
       telemetry: {
+        ...DEFAULT_FEATURE_SETTINGS.telemetry,
         enabled: true,
         retentionDays: 30,
         enableTraces: false,
         enableActivityTracking: true,
       },
       tasks: {
+        ...DEFAULT_FEATURE_SETTINGS.tasks,
         enableTimeTracking: true,
         enableSubtaskAutoComplete: true,
         enableDependencies: true,
@@ -346,9 +364,9 @@ describe('Settings Routes', () => {
         autoSaveDelayMs: 500,
         requireDeliverableForDone: true,
       },
-      hooks: { enabled: false },
-      enforcement: { squadChat: false },
-    };
+      hooks: { ...DEFAULT_FEATURE_SETTINGS.hooks, enabled: false },
+      enforcement: { ...DEFAULT_FEATURE_SETTINGS.enforcement, squadChat: false },
+    });
     mockConfigServiceForSettings.updateFeatureSettings.mockResolvedValue(fullSettings);
     const res = await request(app)
       .patch('/api/settings/features')
@@ -357,14 +375,16 @@ describe('Settings Routes', () => {
   });
 
   it('PATCH /features should accept requireDeliverableForDone set to false', async () => {
-    const fullSettings = {
+    const fullSettings = featureSettings({
       telemetry: {
+        ...DEFAULT_FEATURE_SETTINGS.telemetry,
         enabled: true,
         retentionDays: 30,
         enableTraces: false,
         enableActivityTracking: true,
       },
       tasks: {
+        ...DEFAULT_FEATURE_SETTINGS.tasks,
         enableTimeTracking: true,
         enableSubtaskAutoComplete: true,
         enableDependencies: true,
@@ -377,9 +397,9 @@ describe('Settings Routes', () => {
         autoSaveDelayMs: 500,
         requireDeliverableForDone: false,
       },
-      hooks: { enabled: false },
-      enforcement: { squadChat: false },
-    };
+      hooks: { ...DEFAULT_FEATURE_SETTINGS.hooks, enabled: false },
+      enforcement: { ...DEFAULT_FEATURE_SETTINGS.enforcement, squadChat: false },
+    });
     mockConfigServiceForSettings.updateFeatureSettings.mockResolvedValue(fullSettings);
     const res = await request(app)
       .patch('/api/settings/features')

--- a/server/src/__tests__/routes/settings-codex-health.test.ts
+++ b/server/src/__tests__/routes/settings-codex-health.test.ts
@@ -1,16 +1,59 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import { errorHandler } from '../../middleware/error-handler.js';
+import type { AuthPermission, AuthenticatedRequest } from '../../middleware/auth.js';
 
-const { mockCodexHealthService, mockContextProviderHealthService } = vi.hoisted(() => ({
-  mockCodexHealthService: {
-    getHealth: vi.fn(),
-  },
-  mockContextProviderHealthService: {
-    getHealth: vi.fn(),
-  },
-}));
+const { mockCodexHealthService, mockConfigService, mockContextProviderHealthService } = vi.hoisted(
+  () => ({
+    mockConfigService: {
+      getFeatureSettings: vi.fn(),
+      updateFeatureSettings: vi.fn(),
+    },
+    mockCodexHealthService: {
+      getHealth: vi.fn(),
+    },
+    mockContextProviderHealthService: {
+      getHealth: vi.fn(),
+    },
+  })
+);
+
+function permissionsFromHeader(value: string | undefined): AuthPermission[] {
+  if (!value) return ['settings:read'];
+  return value
+    .split(',')
+    .map((permission) => permission.trim())
+    .filter((permission): permission is AuthPermission => Boolean(permission));
+}
+
+function featureSettingsWithCredentialedUrls() {
+  return {
+    ...DEFAULT_FEATURE_SETTINGS,
+    notifications: {
+      ...DEFAULT_FEATURE_SETTINGS.notifications,
+      webhookUrl: 'https://hooks.example.test/failures?token=notification-secret',
+    },
+    hooks: {
+      ...DEFAULT_FEATURE_SETTINGS.hooks,
+      enabled: true,
+      onCreated: {
+        enabled: true,
+        webhook: 'https://hooks.example.test/created?token=hook-secret',
+      },
+    },
+    squadWebhook: {
+      ...DEFAULT_FEATURE_SETTINGS.squadWebhook,
+      enabled: true,
+      mode: 'openclaw' as const,
+      url: 'https://hooks.example.test/squad?token=squad-secret',
+      secret: 'squad-webhook-secret-000000',
+      openclawGatewayUrl: 'https://gateway.example.test/wake?token=gateway-secret',
+      openclawGatewayToken: 'openclaw-gateway-token-000000',
+    },
+  };
+}
 
 vi.mock('../../services/codex-health-service.js', () => ({
   CodexHealthService: function () {
@@ -26,10 +69,7 @@ vi.mock('../../services/context-provider-health-service.js', () => ({
 
 vi.mock('../../services/config-service.js', () => ({
   ConfigService: function () {
-    return {
-      getFeatureSettings: vi.fn(),
-      updateFeatureSettings: vi.fn(),
-    };
+    return mockConfigService;
   },
 }));
 
@@ -42,8 +82,74 @@ describe('Settings Codex health route', () => {
     vi.clearAllMocks();
     app = express();
     app.use(express.json());
+    app.use((req: AuthenticatedRequest, _res, next) => {
+      const permissions = permissionsFromHeader(req.header('x-test-permissions') ?? undefined);
+      req.auth = {
+        role: permissions.includes('*') ? 'admin' : 'read-only',
+        isLocalhost: false,
+        permissions,
+      };
+      next();
+    });
     app.use('/api/settings', settingsRoutes);
     app.use(errorHandler);
+  });
+
+  it('redacts credential-bearing feature setting URLs for settings readers', async () => {
+    mockConfigService.getFeatureSettings.mockResolvedValue(featureSettingsWithCredentialedUrls());
+
+    const response = await request(app).get('/api/settings/features');
+
+    expect(response.status).toBe(200);
+    expect(response.body.notifications.webhookUrl).toBeUndefined();
+    expect(response.body.notifications.webhookUrlConfigured).toBe(true);
+    expect(response.body.notifications.webhookUrlRedacted).toBe(true);
+    expect(response.body.hooks.onCreated.webhook).toBeUndefined();
+    expect(response.body.hooks.onCreated.webhookConfigured).toBe(true);
+    expect(response.body.hooks.onCreated.webhookRedacted).toBe(true);
+    expect(response.body.squadWebhook.url).toBeUndefined();
+    expect(response.body.squadWebhook.urlConfigured).toBe(true);
+    expect(response.body.squadWebhook.urlRedacted).toBe(true);
+    expect(response.body.squadWebhook.openclawGatewayUrl).toBeUndefined();
+    expect(response.body.squadWebhook.openclawGatewayUrlConfigured).toBe(true);
+    expect(response.body.squadWebhook.openclawGatewayUrlRedacted).toBe(true);
+    expect(response.body.squadWebhook.secret).toBeUndefined();
+    expect(response.body.squadWebhook.secretConfigured).toBe(true);
+    expect(response.body.squadWebhook.secretRedacted).toBe(true);
+    expect(response.body.squadWebhook.openclawGatewayToken).toBeUndefined();
+    expect(response.body.squadWebhook.openclawGatewayTokenConfigured).toBe(true);
+    expect(response.body.squadWebhook.openclawGatewayTokenRedacted).toBe(true);
+    expect(JSON.stringify(response.body)).not.toContain('notification-secret');
+    expect(JSON.stringify(response.body)).not.toContain('hook-secret');
+    expect(JSON.stringify(response.body)).not.toContain('squad-secret');
+    expect(JSON.stringify(response.body)).not.toContain('gateway-secret');
+    expect(JSON.stringify(response.body)).not.toContain('openclaw-gateway-token');
+  });
+
+  it('returns webhook URLs to settings writers while keeping scalar secrets redacted', async () => {
+    mockConfigService.getFeatureSettings.mockResolvedValue(featureSettingsWithCredentialedUrls());
+
+    const response = await request(app)
+      .get('/api/settings/features')
+      .set('x-test-permissions', 'settings:write');
+
+    expect(response.status).toBe(200);
+    expect(response.body.notifications.webhookUrl).toContain('notification-secret');
+    expect(response.body.notifications.webhookUrlRedacted).toBe(false);
+    expect(response.body.hooks.onCreated.webhook).toContain('hook-secret');
+    expect(response.body.hooks.onCreated.webhookRedacted).toBe(false);
+    expect(response.body.squadWebhook.url).toContain('squad-secret');
+    expect(response.body.squadWebhook.urlRedacted).toBe(false);
+    expect(response.body.squadWebhook.openclawGatewayUrl).toContain('gateway-secret');
+    expect(response.body.squadWebhook.openclawGatewayUrlRedacted).toBe(false);
+    expect(response.body.squadWebhook.secret).toBeUndefined();
+    expect(response.body.squadWebhook.secretConfigured).toBe(true);
+    expect(response.body.squadWebhook.secretRedacted).toBe(true);
+    expect(response.body.squadWebhook.openclawGatewayToken).toBeUndefined();
+    expect(response.body.squadWebhook.openclawGatewayTokenConfigured).toBe(true);
+    expect(response.body.squadWebhook.openclawGatewayTokenRedacted).toBe(true);
+    expect(JSON.stringify(response.body)).not.toContain('squad-webhook-secret');
+    expect(JSON.stringify(response.body)).not.toContain('openclaw-gateway-token');
   });
 
   it('returns Codex install/auth/profile health', async () => {

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -6,13 +6,19 @@ import { getTelemetryService } from '../services/telemetry-service.js';
 import { getAttachmentService } from '../services/attachment-service.js';
 import { setEnforcementSettings, setHooksSettings } from '../services/hook-service.js';
 import { setWatcherContinuationSettings } from '../services/watcher-policy-service.js';
-import type { FeatureSettings } from '@veritas-kanban/shared';
+import type {
+  FeatureSettings,
+  HookConfig,
+  HooksSettings,
+  NotificationSettings,
+  SquadWebhookSettings,
+} from '@veritas-kanban/shared';
 import { FeatureSettingsPatchSchema } from '../schemas/feature-settings-schema.js';
 import { strictRateLimit } from '../middleware/rate-limit.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError } from '../middleware/error-handler.js';
 import { auditLog } from '../services/audit-service.js';
-import { authorize, type AuthenticatedRequest } from '../middleware/auth.js';
+import { authorize, hasPermission, type AuthenticatedRequest } from '../middleware/auth.js';
 import { getOutboundIntegrationService } from '../services/outbound-integration-service.js';
 import { createLogger } from '../lib/logger.js';
 
@@ -60,20 +66,103 @@ export function syncSettingsToServices(settings: FeatureSettings): void {
     });
 }
 
-function sanitizeFeatureSettings(settings: FeatureSettings): FeatureSettings {
+const HOOK_KEYS = ['onCreated', 'onStarted', 'onBlocked', 'onCompleted', 'onArchived'] as const;
+
+function hasConfiguredValue(value?: string): boolean {
+  return Boolean(value?.trim());
+}
+
+function sanitizeNotificationSettings(
+  settings: NotificationSettings,
+  includeSensitiveUrls: boolean
+): NotificationSettings {
+  const sanitized: NotificationSettings = { ...settings };
+  const webhookUrlConfigured = hasConfiguredValue(sanitized.webhookUrl);
+  sanitized.webhookUrlConfigured = webhookUrlConfigured;
+  sanitized.webhookUrlRedacted = webhookUrlConfigured && !includeSensitiveUrls;
+  if (sanitized.webhookUrlRedacted) {
+    delete sanitized.webhookUrl;
+  }
+  return sanitized;
+}
+
+function sanitizeHookConfig(
+  hook: HookConfig | undefined,
+  includeSensitiveUrls: boolean
+): HookConfig | undefined {
+  if (!hook) return hook;
+  const sanitized: HookConfig = { ...hook };
+  const webhookConfigured = hasConfiguredValue(sanitized.webhook);
+  sanitized.webhookConfigured = webhookConfigured;
+  sanitized.webhookRedacted = webhookConfigured && !includeSensitiveUrls;
+  if (sanitized.webhookRedacted) {
+    delete sanitized.webhook;
+  }
+  return sanitized;
+}
+
+function sanitizeHooksSettings(
+  settings: HooksSettings,
+  includeSensitiveUrls: boolean
+): HooksSettings {
+  const sanitized: HooksSettings = { ...settings };
+  for (const key of HOOK_KEYS) {
+    sanitized[key] = sanitizeHookConfig(settings[key], includeSensitiveUrls);
+  }
+  return sanitized;
+}
+
+function sanitizeSquadWebhookSettings(
+  settings: SquadWebhookSettings,
+  includeSensitiveUrls: boolean
+): SquadWebhookSettings {
+  const sanitized: SquadWebhookSettings = { ...settings };
+
+  const urlConfigured = hasConfiguredValue(sanitized.url);
+  sanitized.urlConfigured = urlConfigured;
+  sanitized.urlRedacted = urlConfigured && !includeSensitiveUrls;
+  if (sanitized.urlRedacted) {
+    delete sanitized.url;
+  }
+
+  const openclawGatewayUrlConfigured = hasConfiguredValue(sanitized.openclawGatewayUrl);
+  sanitized.openclawGatewayUrlConfigured = openclawGatewayUrlConfigured;
+  sanitized.openclawGatewayUrlRedacted = openclawGatewayUrlConfigured && !includeSensitiveUrls;
+  if (sanitized.openclawGatewayUrlRedacted) {
+    delete sanitized.openclawGatewayUrl;
+  }
+
+  sanitized.secretConfigured = hasConfiguredValue(sanitized.secret);
+  sanitized.secretRedacted = sanitized.secretConfigured;
+  if ('secret' in sanitized) {
+    delete sanitized.secret;
+  }
+
+  sanitized.openclawGatewayTokenConfigured = hasConfiguredValue(sanitized.openclawGatewayToken);
+  sanitized.openclawGatewayTokenRedacted = sanitized.openclawGatewayTokenConfigured;
+  if ('openclawGatewayToken' in sanitized) {
+    delete sanitized.openclawGatewayToken;
+  }
+
+  return sanitized;
+}
+
+function canViewSensitiveFeatureUrls(req: AuthenticatedRequest): boolean {
+  return hasPermission(req.auth, 'settings:write') || hasPermission(req.auth, 'admin:manage');
+}
+
+function sanitizeFeatureSettings(
+  settings: FeatureSettings,
+  includeSensitiveUrls = false
+): FeatureSettings {
   const sanitized: FeatureSettings = {
     ...settings,
-    squadWebhook: settings.squadWebhook ? { ...settings.squadWebhook } : settings.squadWebhook,
+    notifications: sanitizeNotificationSettings(settings.notifications, includeSensitiveUrls),
+    hooks: sanitizeHooksSettings(settings.hooks, includeSensitiveUrls),
+    squadWebhook: settings.squadWebhook
+      ? sanitizeSquadWebhookSettings(settings.squadWebhook, includeSensitiveUrls)
+      : settings.squadWebhook,
   };
-
-  if (sanitized.squadWebhook) {
-    if ('openclawGatewayToken' in sanitized.squadWebhook) {
-      delete sanitized.squadWebhook.openclawGatewayToken;
-    }
-    if ('secret' in sanitized.squadWebhook) {
-      delete sanitized.squadWebhook.secret;
-    }
-  }
 
   return sanitized;
 }
@@ -81,9 +170,11 @@ function sanitizeFeatureSettings(settings: FeatureSettings): FeatureSettings {
 // GET /api/settings/features — returns full feature settings with defaults merged
 router.get(
   '/features',
-  asyncHandler(async (_req, res) => {
+  asyncHandler(async (req, res) => {
     const features = await configService.getFeatureSettings();
-    res.json(sanitizeFeatureSettings(features));
+    res.json(
+      sanitizeFeatureSettings(features, canViewSensitiveFeatureUrls(req as AuthenticatedRequest))
+    );
   })
 );
 
@@ -130,10 +221,9 @@ router.patch(
     const updated = await configService.updateFeatureSettings(patch);
     syncSettingsToServices(updated);
 
-    const sanitized = sanitizeFeatureSettings(updated);
-
     // Audit log
     const authReq = req as AuthenticatedRequest;
+    const sanitized = sanitizeFeatureSettings(updated, canViewSensitiveFeatureUrls(authReq));
     await auditLog({
       action: 'settings.update',
       actor: authReq.auth?.keyName || 'unknown',

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -273,6 +273,8 @@ export interface NotificationSettings {
   onReviewNeeded: boolean;
   channel: string; // Teams channel ID
   webhookUrl?: string; // Optional: Teams webhook URL for immediate delivery
+  webhookUrlConfigured?: boolean; // Response metadata when URL value is redacted
+  webhookUrlRedacted?: boolean; // True when webhookUrl was omitted from a response
 }
 
 /** Archive settings */
@@ -304,6 +306,8 @@ export interface EnforcementSettings {
 export interface HookConfig {
   enabled: boolean;
   webhook?: string; // URL to POST event payload
+  webhookConfigured?: boolean; // Response metadata when webhook value is redacted
+  webhookRedacted?: boolean; // True when webhook was omitted from a response
   notify?: boolean; // Send notification to configured channel
   logActivity?: boolean; // Record in activity log (default: true)
 }
@@ -358,12 +362,20 @@ export interface SquadWebhookSettings {
   mode: 'webhook' | 'openclaw'; // 'webhook' = generic HTTP POST, 'openclaw' = gateway wake
   // Generic webhook fields:
   url?: string; // Where to POST notifications
+  urlConfigured?: boolean; // Response metadata when URL value is redacted
+  urlRedacted?: boolean; // True when url was omitted from a response
   secret?: string; // Optional HMAC signing secret for verification
+  secretConfigured?: boolean; // Response metadata for secret posture
+  secretRedacted?: boolean; // True when secret was omitted from a response
   notifyOnHuman: boolean; // Fire webhook when human posts (default: true)
   notifyOnAgent: boolean; // Fire webhook when agent posts (default: false)
   // OpenClaw fields:
   openclawGatewayUrl?: string; // e.g., "http://127.0.0.1:18789"
+  openclawGatewayUrlConfigured?: boolean; // Response metadata when URL value is redacted
+  openclawGatewayUrlRedacted?: boolean; // True when openclawGatewayUrl was omitted from a response
   openclawGatewayToken?: string; // Auth token
+  openclawGatewayTokenConfigured?: boolean; // Response metadata for token posture
+  openclawGatewayTokenRedacted?: boolean; // True when token was omitted from a response
 }
 
 /** Watcher continuation policy settings. Disabled by default. */


### PR DESCRIPTION
## Summary
- Redact credential-bearing feature settings webhook URLs for settings-read callers.
- Keep URL presence/posture metadata in responses so clients can show configured/redacted state without exposing secrets.
- Continue to redact scalar squad webhook secrets for all callers, including writers/admins.
- Add route regression coverage for reader redaction and writer URL visibility.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/routes/settings-codex-health.test.ts
- pnpm typecheck
- pnpm --filter @veritas-kanban/server exec eslint src/routes/settings.ts src/__tests__/routes/settings-codex-health.test.ts
- pnpm build
- pnpm --filter @veritas-kanban/server lint (0 errors, 537 warnings)

Closes #606