### PR TITLE
Fail closed for Prometheus metrics exposure

### DIFF
--- a/docs/guides/SELF_HOST.md
+++ b/docs/guides/SELF_HOST.md
@@ -118,6 +118,9 @@ LAN access is server mode, not localhost mode. Keep `VERITAS_AUTH_ENABLED=true`,
 set `VERITAS_AUTH_LOCALHOST_BYPASS=false`, and use HTTPS, VPN, or a trusted
 tunnel for browser/mobile sessions unless the network is strictly private and
 temporary.
+Unauthenticated `/metrics` scrapes are allowed only when
+`PROMETHEUS_METRICS_PUBLIC=true`; otherwise use `PROMETHEUS_METRICS_TOKEN` or
+an API key with telemetry read access.
 
 ### 1. Bind to all interfaces
 
@@ -494,6 +497,9 @@ When exposing Veritas beyond loopback, also use `NODE_ENV=production` and keep
 the web client, `/api`, `/ws`, health endpoints, PWA assets, and service-worker
 scope on one trusted origin whenever possible. Split-origin deployments must set
 exact `CORS_ORIGINS` entries and confirm WebSocket origin/upgrade behavior.
+Prometheus `/metrics` fails closed outside explicit loopback development binds;
+use `PROMETHEUS_METRICS_TOKEN` or `PROMETHEUS_METRICS_PUBLIC=true` for external
+scrapers.
 Mobile install steps and offline-shell behavior are documented in
 [PWA install](PWA_INSTALL.md).
 

--- a/server/src/__tests__/routes/prometheus.test.ts
+++ b/server/src/__tests__/routes/prometheus.test.ts
@@ -9,8 +9,10 @@ async function buildApp(env: Record<string, string | undefined>) {
   process.env = { ...originalEnv };
 
   delete process.env.NODE_ENV;
+  delete process.env.HOST;
   delete process.env.PROMETHEUS_METRICS_PUBLIC;
   delete process.env.PROMETHEUS_METRICS_TOKEN;
+  delete process.env.VERITAS_REMOTE_MODE;
   delete process.env.VERITAS_ADMIN_KEY;
   delete process.env.VERITAS_API_KEYS;
   delete process.env.VERITAS_AUTH_ENABLED;
@@ -55,6 +57,7 @@ describe('Prometheus metrics route', () => {
   it('allows unauthenticated local development scrapes', async () => {
     const app = await buildApp({
       NODE_ENV: 'development',
+      HOST: '127.0.0.1',
       VERITAS_ADMIN_KEY: 'dev-admin-key',
     });
 
@@ -63,6 +66,45 @@ describe('Prometheus metrics route', () => {
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/plain');
     expect(res.text).toContain('veritas_test_metric 1');
+  });
+
+  it('requires authentication when NODE_ENV is unset even with a localhost bind', async () => {
+    const app = await buildApp({
+      HOST: '127.0.0.1',
+      VERITAS_ADMIN_KEY: 'dev-admin-key',
+    });
+
+    const res = await request(app).get('/metrics');
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('AUTH_REQUIRED');
+  });
+
+  it('requires authentication for remote mode even in local development', async () => {
+    const app = await buildApp({
+      NODE_ENV: 'development',
+      HOST: '127.0.0.1',
+      VERITAS_REMOTE_MODE: 'true',
+      VERITAS_ADMIN_KEY: 'dev-admin-key',
+    });
+
+    const res = await request(app).get('/metrics');
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('AUTH_REQUIRED');
+  });
+
+  it('requires authentication for development wildcard binds', async () => {
+    const app = await buildApp({
+      NODE_ENV: 'development',
+      HOST: '0.0.0.0',
+      VERITAS_ADMIN_KEY: 'dev-admin-key',
+    });
+
+    const res = await request(app).get('/metrics');
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('AUTH_REQUIRED');
   });
 
   it('requires authentication in production by default', async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -349,9 +349,9 @@ app.use('/health', healthRouter);
 // Canonical VK API health signal (unauthenticated; used by dev tooling/watchdogs)
 app.use('/api/health', apiHealthRouter);
 
-// Prometheus exposition endpoint. Public in local development; production
-// requires normal auth with telemetry:read, PROMETHEUS_METRICS_TOKEN, or an
-// explicit PROMETHEUS_METRICS_PUBLIC=true opt-in.
+// Prometheus exposition endpoint. Public only for explicit loopback development
+// binds or PROMETHEUS_METRICS_PUBLIC=true; exposed/remote modes require normal
+// auth with telemetry:read or PROMETHEUS_METRICS_TOKEN.
 app.use(prometheusMetricsRouter);
 
 // Metrics collection middleware — records per-request HTTP metrics.

--- a/server/src/routes/prometheus.ts
+++ b/server/src/routes/prometheus.ts
@@ -13,8 +13,21 @@ function envFlagEnabled(name: string): boolean {
   return process.env[name]?.trim().toLowerCase() === 'true';
 }
 
+function isTrustedLocalhostBind(): boolean {
+  const host = process.env.HOST?.trim().toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+}
+
 function publicMetricsAllowed(): boolean {
-  return process.env.NODE_ENV !== 'production' || envFlagEnabled('PROMETHEUS_METRICS_PUBLIC');
+  if (envFlagEnabled('PROMETHEUS_METRICS_PUBLIC')) {
+    return true;
+  }
+
+  if (envFlagEnabled('VERITAS_REMOTE_MODE')) {
+    return false;
+  }
+
+  return process.env.NODE_ENV === 'development' && isTrustedLocalhostBind();
 }
 
 function constantTimeEquals(actual: string, expected: string): boolean {


### PR DESCRIPTION
## Summary
- Restrict unauthenticated Prometheus `/metrics` scrapes to explicit public opt-in or local development bound to loopback.
- Fail closed when `NODE_ENV` is unset, `VERITAS_REMOTE_MODE=true`, or development binds to wildcard/public interfaces.
- Keep bearer-token and authenticated `telemetry:read` access paths intact.
- Document the metrics exposure policy for self-host and LAN deployments.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/routes/prometheus.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server exec eslint src/routes/prometheus.ts src/__tests__/routes/prometheus.test.ts src/index.ts
- pnpm --filter @veritas-kanban/server build

Closes #607