### PR TITLE
Pin outbound requests to validated DNS answers

### DIFF
--- a/server/src/__tests__/clawdbot-webhook-service.test.ts
+++ b/server/src/__tests__/clawdbot-webhook-service.test.ts
@@ -5,10 +5,12 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-const mockLookup = vi.hoisted(() => vi.fn());
+const mockDeliver = vi.hoisted(() => vi.fn());
 
-vi.mock('node:dns/promises', () => ({
-  lookup: mockLookup,
+vi.mock('../services/outbound-integration-service.js', () => ({
+  getOutboundIntegrationService: () => ({
+    deliver: mockDeliver,
+  }),
 }));
 
 import {
@@ -26,11 +28,21 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Capture calls to global fetch. */
-function mockFetch(response: { ok: boolean; status?: number } = { ok: true, status: 200 }) {
-  const fn = vi.fn().mockResolvedValue(response);
-  vi.stubGlobal('fetch', fn);
-  return fn;
+function mockDelivery(
+  response: { ok: boolean; status?: string; responseStatus?: number; attemptId?: string } = {
+    ok: true,
+    status: 'success',
+    responseStatus: 200,
+    attemptId: 'attempt-1',
+  }
+) {
+  mockDeliver.mockResolvedValue({
+    status: response.status ?? (response.ok ? 'success' : 'failed'),
+    ok: response.ok,
+    responseStatus: response.responseStatus ?? (response.ok ? 200 : 500),
+    attemptId: response.attemptId ?? 'attempt-1',
+  });
+  return mockDeliver;
 }
 
 // ---------------------------------------------------------------------------
@@ -40,8 +52,7 @@ function mockFetch(response: { ok: boolean; status?: number } = { ok: true, stat
 describe('ClawdbotWebhookService', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLookup.mockReset();
-    mockLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+    mockDeliver.mockReset();
     // Clear env overrides
     delete process.env.VERITAS_WEBHOOK_URL;
     delete process.env.VERITAS_WEBHOOK_SECRET;
@@ -111,24 +122,25 @@ describe('ClawdbotWebhookService', () => {
     };
 
     it('does nothing when no webhook URL is configured', async () => {
-      const fetchSpy = mockFetch();
+      mockDelivery();
       await deliverWebhook(samplePayload);
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockDeliver).not.toHaveBeenCalled();
     });
 
     it('POSTs JSON to the configured URL', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = mockFetch();
+      mockDelivery();
 
       await deliverWebhook(samplePayload);
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      const [url, opts] = fetchSpy.mock.calls[0];
-      expect(url).toBe('https://hook.test/endpoint');
-      expect(opts.method).toBe('POST');
-      expect(opts.headers['Content-Type']).toBe('application/json');
+      expect(mockDeliver).toHaveBeenCalledOnce();
+      const [endpoint, request] = mockDeliver.mock.calls[0];
+      expect(endpoint.url).toBe('https://hook.test/endpoint');
+      expect(endpoint.type).toBe('broadcast-webhook');
+      expect(request.method).toBe('POST');
+      expect(request.headers['Content-Type']).toBe('application/json');
 
-      const body = JSON.parse(opts.body);
+      const body = JSON.parse(request.body);
       expect(body.event).toBe('task:created');
       expect(body.taskId).toBe('task_123');
     });
@@ -136,77 +148,80 @@ describe('ClawdbotWebhookService', () => {
     it('includes X-Webhook-Signature when secret is set', async () => {
       setWebhookUrl('https://hook.test/endpoint');
       process.env.VERITAS_WEBHOOK_SECRET = 'my-secret';
-      const fetchSpy = mockFetch();
+      mockDelivery();
 
       await deliverWebhook(samplePayload);
 
-      const [, opts] = fetchSpy.mock.calls[0];
-      expect(opts.headers['X-Webhook-Signature']).toMatch(/^[0-9a-f]{64}$/);
+      const [, request] = mockDeliver.mock.calls[0];
+      expect(request.headers['X-Webhook-Signature']).toMatch(/^[0-9a-f]{64}$/);
     });
 
     it('does NOT include X-Webhook-Signature when no secret', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = mockFetch();
+      mockDelivery();
 
       await deliverWebhook(samplePayload);
 
-      const [, opts] = fetchSpy.mock.calls[0];
-      expect(opts.headers['X-Webhook-Signature']).toBeUndefined();
+      const [, request] = mockDeliver.mock.calls[0];
+      expect(request.headers['X-Webhook-Signature']).toBeUndefined();
     });
 
     it('retries once after 2 s on failure', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = mockFetch({ ok: false, status: 500 });
+      mockDelivery({ ok: false, status: 'failed', responseStatus: 500 });
 
       await deliverWebhook(samplePayload);
 
       // First call already happened
-      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(mockDeliver).toHaveBeenCalledOnce();
 
       // Advance timers to trigger the retry
       await vi.advanceTimersByTimeAsync(2_000);
 
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(mockDeliver).toHaveBeenCalledTimes(2);
     });
 
     it('retries once on fetch error (network failure)', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
-      vi.stubGlobal('fetch', fetchSpy);
+      mockDeliver.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce({
+        status: 'success',
+        ok: true,
+        responseStatus: 200,
+        attemptId: 'attempt-2',
+      });
 
       await deliverWebhook(samplePayload);
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(mockDeliver).toHaveBeenCalledOnce();
 
       // Advance timers to trigger the retry
       await vi.advanceTimersByTimeAsync(2_000);
 
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(mockDeliver).toHaveBeenCalledTimes(2);
     });
 
-    it('does not fetch or retry when outbound URL policy blocks the host', async () => {
+    it('does not retry when outbound URL policy blocks the host', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      mockLookup.mockResolvedValue([{ address: '10.0.0.10', family: 4 }]);
-      const fetchSpy = mockFetch();
+      mockDelivery({ ok: false, status: 'blocked', attemptId: 'blocked-1' });
 
       await deliverWebhook(samplePayload);
       await vi.advanceTimersByTimeAsync(2_000);
 
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockDeliver).toHaveBeenCalledOnce();
     });
 
     it('does NOT retry on success', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = mockFetch({ ok: true });
+      mockDelivery({ ok: true });
 
       await deliverWebhook(samplePayload);
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(mockDeliver).toHaveBeenCalledOnce();
 
       // Advance timers — no retry should fire
       await vi.advanceTimersByTimeAsync(5_000);
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(mockDeliver).toHaveBeenCalledOnce();
     });
   });
 
@@ -217,7 +232,7 @@ describe('ClawdbotWebhookService', () => {
   describe('notifyTaskChange()', () => {
     it('formats a task payload and calls deliverWebhook', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = mockFetch();
+      mockDelivery();
 
       notifyTaskChange('created', 'task_abc', {
         title: 'My Task',
@@ -230,8 +245,8 @@ describe('ClawdbotWebhookService', () => {
       // Allow the promise to resolve
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(mockDeliver).toHaveBeenCalledOnce();
+      const body = JSON.parse(mockDeliver.mock.calls[0][1].body);
       expect(body).toMatchObject({
         event: 'task:created',
         taskId: 'task_abc',
@@ -246,14 +261,14 @@ describe('ClawdbotWebhookService', () => {
 
     it('works without optional context', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = mockFetch();
+      mockDelivery();
 
       notifyTaskChange('deleted', 'task_xyz');
 
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(mockDeliver).toHaveBeenCalledOnce();
+      const body = JSON.parse(mockDeliver.mock.calls[0][1].body);
       expect(body.event).toBe('task:deleted');
       expect(body.taskId).toBe('task_xyz');
     });
@@ -262,14 +277,14 @@ describe('ClawdbotWebhookService', () => {
   describe('notifyChatMessage()', () => {
     it('formats a chat payload and calls deliverWebhook', async () => {
       setWebhookUrl('https://hook.test/endpoint');
-      const fetchSpy = mockFetch();
+      mockDelivery();
 
       notifyChatMessage('session_1', 'chat:message', 'Hello world');
 
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      const body: WebhookChatPayload = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(mockDeliver).toHaveBeenCalledOnce();
+      const body: WebhookChatPayload = JSON.parse(mockDeliver.mock.calls[0][1].body);
       expect(body).toMatchObject({
         event: 'chat:message',
         chatSessionId: 'session_1',

--- a/server/src/__tests__/outbound-integration-service.test.ts
+++ b/server/src/__tests__/outbound-integration-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
 import { OutboundIntegrationService } from '../services/outbound-integration-service.js';
 
 const mockLookup = vi.hoisted(() => vi.fn());
@@ -7,14 +8,30 @@ vi.mock('node:dns/promises', () => ({
   lookup: mockLookup,
 }));
 
-function mockFetch(response: { ok: boolean; status?: number; text?: () => Promise<string> }) {
-  const fn = vi.fn().mockResolvedValue({
-    status: response.status ?? (response.ok ? 200 : 500),
-    ok: response.ok,
-    text: response.text ?? vi.fn().mockResolvedValue(''),
-  });
+function stubGlobalFetch() {
+  const fn = vi.fn();
   vi.stubGlobal('fetch', fn);
   return fn;
+}
+
+async function listenLocalServer(
+  handler: Parameters<typeof createServer>[0]
+): Promise<{ server: Server; port: number }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Test server did not bind to a TCP port');
+  }
+  return { server, port: address.port };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
 }
 
 describe('OutboundIntegrationService', () => {
@@ -29,67 +46,72 @@ describe('OutboundIntegrationService', () => {
   });
 
   it('records sanitized endpoints and delivery attempts without exposing secrets', async () => {
-    const fetchSpy = mockFetch({
-      ok: true,
-      status: 202,
-      text: vi.fn().mockResolvedValue('accepted'),
+    const { server, port } = await listenLocalServer((_req, res) => {
+      res.writeHead(202, { 'content-type': 'text/plain' });
+      res.end('accepted');
     });
+    mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
     const service = new OutboundIntegrationService({ persist: false, audit });
+    const sanitizedUrl = `http://hook.test:${port}/endpoint`;
 
-    const result = await service.deliver(
-      {
+    try {
+      const result = await service.deliver(
+        {
+          id: 'squad.webhook',
+          type: 'squad-webhook',
+          displayName: 'Squad webhook',
+          url: `${sanitizedUrl}?token=secret-token`,
+          auth: {
+            type: 'bearer',
+            secretRef: 'featureSettings.squadWebhook.secret',
+            hasSecret: true,
+          },
+          owner: { source: 'feature-settings', resourceId: 'squadWebhook.url' },
+          validationOptions: { allowHttp: true, allowPrivateIp: true },
+        },
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer raw-token-value',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ ok: true }),
+          responseBodyLimit: 100,
+        }
+      );
+
+      expect(result).toMatchObject({ ok: true, status: 'success', responseStatus: 202 });
+
+      const endpoints = await service.listEndpoints();
+      expect(endpoints[0]).toMatchObject({
         id: 'squad.webhook',
-        type: 'squad-webhook',
-        displayName: 'Squad webhook',
-        url: 'https://hook.test/endpoint?token=secret-token',
+        url: sanitizedUrl,
         auth: {
           type: 'bearer',
           secretRef: 'featureSettings.squadWebhook.secret',
           hasSecret: true,
         },
-        owner: { source: 'feature-settings', resourceId: 'squadWebhook.url' },
-      },
-      {
-        method: 'POST',
-        headers: {
-          Authorization: 'Bearer raw-token-value',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ ok: true }),
-        responseBodyLimit: 100,
-      }
-    );
+      });
 
-    expect(result).toMatchObject({ ok: true, status: 'success', responseStatus: 202 });
-    expect(fetchSpy).toHaveBeenCalledOnce();
+      const deliveries = await service.listDeliveries();
+      expect(deliveries[0]).toMatchObject({
+        endpointId: 'squad.webhook',
+        sanitizedUrl,
+        status: 'success',
+        responseStatus: 202,
+        responseClass: '2xx',
+      });
 
-    const endpoints = await service.listEndpoints();
-    expect(endpoints[0]).toMatchObject({
-      id: 'squad.webhook',
-      url: 'https://hook.test/endpoint',
-      auth: {
-        type: 'bearer',
-        secretRef: 'featureSettings.squadWebhook.secret',
-        hasSecret: true,
-      },
-    });
-
-    const deliveries = await service.listDeliveries();
-    expect(deliveries[0]).toMatchObject({
-      endpointId: 'squad.webhook',
-      sanitizedUrl: 'https://hook.test/endpoint',
-      status: 'success',
-      responseStatus: 202,
-      responseClass: '2xx',
-    });
-
-    const auditPayload = JSON.stringify(audit.mock.calls);
-    expect(auditPayload).not.toContain('raw-token-value');
-    expect(auditPayload).not.toContain('secret-token');
+      const auditPayload = JSON.stringify(audit.mock.calls);
+      expect(auditPayload).not.toContain('raw-token-value');
+      expect(auditPayload).not.toContain('secret-token');
+    } finally {
+      await closeServer(server);
+    }
   });
 
   it('blocks private IP destinations before fetch', async () => {
-    const fetchSpy = mockFetch({ ok: true });
+    const fetchSpy = stubGlobalFetch();
     const service = new OutboundIntegrationService({ persist: false, audit });
 
     const result = await service.deliver(
@@ -113,7 +135,7 @@ describe('OutboundIntegrationService', () => {
 
   it('blocks DNS rebinding destinations before fetch', async () => {
     mockLookup.mockResolvedValue([{ address: '10.0.0.10', family: 4 }]);
-    const fetchSpy = mockFetch({ ok: true });
+    const fetchSpy = stubGlobalFetch();
     const service = new OutboundIntegrationService({ persist: false, audit });
 
     const result = await service.deliver(
@@ -132,7 +154,7 @@ describe('OutboundIntegrationService', () => {
   });
 
   it('skips disabled endpoints and records history', async () => {
-    const fetchSpy = mockFetch({ ok: true });
+    const fetchSpy = stubGlobalFetch();
     const service = new OutboundIntegrationService({ persist: false, audit });
 
     const result = await service.deliver(

--- a/server/src/__tests__/routes/integrations.test.ts
+++ b/server/src/__tests__/routes/integrations.test.ts
@@ -6,9 +6,21 @@ const { mockLookup } = vi.hoisted(() => ({
   mockLookup: vi.fn(),
 }));
 
+const { mockSafeFetch } = vi.hoisted(() => ({
+  mockSafeFetch: vi.fn(),
+}));
+
 vi.mock('node:dns/promises', () => ({
   lookup: mockLookup,
 }));
+
+vi.mock('../../utils/url-validation.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/url-validation.js')>();
+  return {
+    ...actual,
+    safeFetch: mockSafeFetch,
+  };
+});
 
 const { mockGetConfig } = vi.hoisted(() => ({
   mockGetConfig: vi.fn(),
@@ -32,6 +44,11 @@ describe('integrations routes', () => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
     mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    mockSafeFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(''),
+    } as unknown as Response);
     app = express();
     app.use('/api/integrations', integrationsRoutes);
   });
@@ -65,15 +82,11 @@ describe('integrations routes', () => {
       },
     });
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-
     const res = await request(app).get('/api/integrations/status');
     expect(res.status).toBe(200);
     expect(res.body.data.n8n.status).toBe('down');
     expect(res.body.data.n8n.error).toBe('blocked host');
-    expect(fetchSpy).not.toHaveBeenCalled();
-
-    fetchSpy.mockRestore();
+    expect(mockSafeFetch).not.toHaveBeenCalled();
   });
 
   it('marks service up when reachable', async () => {
@@ -85,29 +98,24 @@ describe('integrations routes', () => {
       },
     });
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response);
-
     const res = await request(app).get('/api/integrations/status');
     expect(res.status).toBe(200);
     expect(res.body.data.n8n.status).toBe('up');
     expect(mockLookup).toHaveBeenCalledWith('example.com', { all: true });
-    expect(fetchSpy).toHaveBeenCalledWith(
+    expect(mockSafeFetch).toHaveBeenCalledWith(
       'https://example.com/',
-      expect.objectContaining({ method: 'HEAD', redirect: 'manual' })
+      expect.objectContaining({ method: 'HEAD', redirect: 'manual' }),
+      { allowHttp: true }
     );
-    fetchSpy.mockRestore();
   });
 
   it('exposes sanitized outbound endpoint and delivery history', async () => {
     const endpointId = `route-test.${Date.now()}`;
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 202,
-        text: vi.fn().mockResolvedValue('accepted'),
-      })
-    );
+    mockSafeFetch.mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: vi.fn().mockResolvedValue('accepted'),
+    } as unknown as Response);
 
     const delivery = await getOutboundIntegrationService().deliver(
       {

--- a/server/src/__tests__/url-validation.test.ts
+++ b/server/src/__tests__/url-validation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
 
 const mockLookup = vi.hoisted(() => vi.fn());
 
@@ -7,6 +8,26 @@ vi.mock('node:dns/promises', () => ({
 }));
 
 import { safeFetch, validateWebhookUrl } from '../utils/url-validation.js';
+
+async function listenLocalServer(
+  handler: Parameters<typeof createServer>[0]
+): Promise<{ server: Server; port: number }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Test server did not bind to a TCP port');
+  }
+  return { server, port: address.port };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
 
 describe('url validation', () => {
   beforeEach(() => {
@@ -36,19 +57,48 @@ describe('url validation', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('forces manual redirect handling for allowed outbound fetches', async () => {
-    const response = { ok: true, status: 200 } as Response;
-    const fetchSpy = vi.fn().mockResolvedValue(response);
+  it('pins outbound fetches to the validated DNS answer', async () => {
+    const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
-    mockLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+    const { server, port } = await listenLocalServer((req, res) => {
+      expect(req.headers.host).toBe(`hooks.example.test:${port}`);
+      res.writeHead(202, { 'content-type': 'text/plain' });
+      res.end('accepted');
+    });
+    mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
 
-    await expect(
-      safeFetch('https://hooks.example.test/hook', { method: 'POST', redirect: 'follow' })
-    ).resolves.toBe(response);
+    try {
+      const response = await safeFetch(
+        `http://hooks.example.test:${port}/hook`,
+        { method: 'POST', body: 'payload', redirect: 'follow' },
+        { allowHttp: true, allowPrivateIp: true }
+      );
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'https://hooks.example.test/hook',
-      expect.objectContaining({ method: 'POST', redirect: 'manual' })
-    );
+      expect(response?.status).toBe(202);
+      await expect(response?.text()).resolves.toBe('accepted');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('does not follow redirects for allowed outbound fetches', async () => {
+    const { server, port } = await listenLocalServer((_req, res) => {
+      res.writeHead(302, { location: 'http://127.0.0.1/admin' });
+      res.end();
+    });
+    mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+
+    try {
+      const response = await safeFetch(`http://hooks.example.test:${port}/hook`, undefined, {
+        allowHttp: true,
+        allowPrivateIp: true,
+      });
+
+      expect(response?.status).toBe(302);
+      expect(response?.headers.get('location')).toBe('http://127.0.0.1/admin');
+    } finally {
+      await closeServer(server);
+    }
   });
 });

--- a/server/src/routes/integrations.ts
+++ b/server/src/routes/integrations.ts
@@ -12,6 +12,7 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import { createLogger } from '../lib/logger.js';
 import type { CoolifyServiceConfig, CoolifyServicesConfig } from '@veritas-kanban/shared';
 import { getOutboundIntegrationService } from '../services/outbound-integration-service.js';
+import { safeFetch } from '../utils/url-validation.js';
 
 const log = createLogger('integrations');
 const router = Router();
@@ -104,11 +105,18 @@ async function pingService(service: CoolifyServiceConfig): Promise<ServiceStatus
   const timeout = setTimeout(() => controller.abort(), PING_TIMEOUT_MS);
 
   try {
-    await fetch(validated.href, {
-      method: 'HEAD',
-      signal: controller.signal,
-      redirect: 'manual',
-    });
+    const response = await safeFetch(
+      validated.href,
+      {
+        method: 'HEAD',
+        signal: controller.signal,
+        redirect: 'manual',
+      },
+      { allowHttp: true }
+    );
+    if (!response) {
+      return { status: 'down', error: 'blocked host' };
+    }
     const responseTimeMs = Math.round(performance.now() - start);
 
     // Any response (even 401/403) means the service is up

--- a/server/src/utils/url-validation.ts
+++ b/server/src/utils/url-validation.ts
@@ -12,6 +12,8 @@
  */
 
 import { lookup } from 'node:dns/promises';
+import { request as httpRequest, type IncomingHttpHeaders, type RequestOptions } from 'node:http';
+import { request as httpsRequest } from 'node:https';
 import { isIP } from 'node:net';
 import { createLogger } from '../lib/logger.js';
 
@@ -142,6 +144,15 @@ export interface UrlValidationResult {
   normalized?: string;
 }
 
+interface ResolvedOutboundAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+interface ResolvedUrlValidationResult extends UrlValidationResult {
+  resolvedAddress?: ResolvedOutboundAddress;
+}
+
 export interface UrlValidationOptions {
   /** Allow http:// in addition to https:// (default: false in production) */
   allowHttp?: boolean;
@@ -251,16 +262,28 @@ export function validateWebhookUrl(
 async function validateResolvedHostname(
   parsed: URL,
   opts: UrlValidationOptions
-): Promise<UrlValidationResult> {
+): Promise<ResolvedUrlValidationResult> {
   const hostname = parsed.hostname;
+  const directIpFamily = isIP(hostname);
 
-  if (isIP(hostname) !== 0 || isLocalhostHostname(hostname)) {
-    return { valid: true, normalized: parsed.href };
+  if (directIpFamily === 4 || directIpFamily === 6) {
+    return {
+      valid: true,
+      normalized: parsed.href,
+      resolvedAddress: { address: hostname, family: directIpFamily },
+    };
   }
 
   try {
     const records = await lookup(hostname, { all: true, verbatim: true });
+    const resolvedAddresses: ResolvedOutboundAddress[] = [];
+
     for (const record of records) {
+      const family = isIP(record.address);
+      if (family !== 4 && family !== 6) {
+        continue;
+      }
+
       const check = isBlockedIpAddress(record.address, opts);
       if (check.blocked) {
         const result = {
@@ -272,7 +295,19 @@ async function validateResolvedHostname(
         }
         return result;
       }
+
+      resolvedAddresses.push({ address: record.address, family });
     }
+
+    if (resolvedAddresses.length === 0) {
+      const result = { valid: false, reason: 'Hostname did not resolve to an IP address' };
+      if (opts.logFailures) {
+        log.warn({ url: parsed.origin, reason: result.reason }, 'Webhook URL blocked');
+      }
+      return result;
+    }
+
+    return { valid: true, normalized: parsed.href, resolvedAddress: resolvedAddresses[0] };
   } catch {
     const result = { valid: false, reason: 'Hostname could not be resolved' };
     if (opts.logFailures) {
@@ -280,8 +315,113 @@ async function validateResolvedHostname(
     }
     return result;
   }
+}
 
-  return { valid: true, normalized: parsed.href };
+function headersFromInit(headers: RequestInit['headers'] | undefined): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!headers) return result;
+
+  const normalized = new Headers(headers);
+  normalized.forEach((value, key) => {
+    if (key.toLowerCase() !== 'host') {
+      result[key] = value;
+    }
+  });
+  return result;
+}
+
+function headersFromResponse(headers: IncomingHttpHeaders): Headers {
+  const result = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        result.append(key, item);
+      }
+    } else {
+      result.set(key, String(value));
+    }
+  }
+  return result;
+}
+
+async function bodyFromInit(
+  body: RequestInit['body'] | undefined
+): Promise<string | Uint8Array | undefined> {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === 'string') return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (body instanceof Uint8Array) return body;
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  if (ArrayBuffer.isView(body)) {
+    return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  }
+  if (body instanceof Blob) {
+    return new Uint8Array(await body.arrayBuffer());
+  }
+
+  throw new TypeError('Unsupported outbound request body type');
+}
+
+async function fetchPinnedUrl(
+  parsed: URL,
+  resolvedAddress: ResolvedOutboundAddress,
+  init?: RequestInit
+): Promise<Response> {
+  const pinnedLookup: NonNullable<RequestOptions['lookup']> = (_hostname, options, callback) => {
+    const cb = typeof options === 'function' ? options : callback;
+    if (!cb) {
+      throw new Error('Pinned DNS lookup callback was not provided');
+    }
+    if (typeof options === 'object' && options?.all) {
+      cb(null, [resolvedAddress]);
+      return;
+    }
+    cb(null, resolvedAddress.address, resolvedAddress.family);
+  };
+  const requestBody = await bodyFromInit(init?.body ?? undefined);
+  const requestOptions: RequestOptions & { servername?: string } = {
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    port: parsed.port || undefined,
+    path: `${parsed.pathname}${parsed.search}`,
+    method: init?.method ?? 'GET',
+    headers: headersFromInit(init?.headers),
+    signal: init?.signal ?? undefined,
+    lookup: pinnedLookup,
+  };
+
+  if (parsed.protocol === 'https:') {
+    requestOptions.servername = parsed.hostname;
+  }
+
+  const request = parsed.protocol === 'https:' ? httpsRequest : httpRequest;
+
+  return new Promise((resolve, reject) => {
+    const req = request(requestOptions, (res) => {
+      const chunks: Buffer[] = [];
+
+      res.on('data', (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      res.on('end', () => {
+        resolve(
+          new Response(Buffer.concat(chunks), {
+            status: res.statusCode ?? 500,
+            statusText: res.statusMessage,
+            headers: headersFromResponse(res.headers),
+          })
+        );
+      });
+      res.on('error', reject);
+    });
+
+    req.on('error', reject);
+    if (requestBody !== undefined) {
+      req.write(requestBody);
+    }
+    req.end();
+  });
 }
 
 /**
@@ -305,11 +445,11 @@ export async function safeFetch(
 
   const parsed = new URL(validation.normalized ?? url);
   const resolved = await validateResolvedHostname(parsed, opts);
-  if (!resolved.valid) {
+  if (!resolved.valid || !resolved.resolvedAddress) {
     return null;
   }
 
-  return fetch(validation.normalized ?? url, {
+  return fetchPinnedUrl(parsed, resolved.resolvedAddress, {
     ...init,
     redirect: 'manual',
   });


### PR DESCRIPTION
## Summary
- Replace `safeFetch` raw global fetch calls with a pinned HTTP/HTTPS transport that connects through the DNS answer already validated by the SSRF guard.
- Keep redirects manual and strip caller-supplied Host headers so redirects and host override tricks do not bypass destination policy.
- Route integrations status pings through `safeFetch` so Coolify service health checks use the same outbound destination policy as webhook delivery.
- Add regression coverage proving outbound requests use the validated DNS answer and do not follow redirects.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/url-validation.test.ts src/__tests__/outbound-integration-service.test.ts src/__tests__/routes/integrations.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server exec eslint src/utils/url-validation.ts src/routes/integrations.ts src/__tests__/url-validation.test.ts src/__tests__/outbound-integration-service.test.ts src/__tests__/routes/integrations.test.ts
- pnpm --filter @veritas-kanban/server build

Closes #608