### PR TITLE
Separate OpenClaw localhost and private IP policy

### DIFF
--- a/server/src/__tests__/outbound-integration-service.test.ts
+++ b/server/src/__tests__/outbound-integration-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createServer, type Server } from 'node:http';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import { OutboundIntegrationService } from '../services/outbound-integration-service.js';
 
 const mockLookup = vi.hoisted(() => vi.fn());
@@ -151,6 +152,40 @@ describe('OutboundIntegrationService', () => {
 
     expect(result.status).toBe('blocked');
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit opt-in before registering OpenClaw wake endpoints for private IPs', async () => {
+    const originalOpenClawAllowPrivate = process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE;
+    delete process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE;
+    const service = new OutboundIntegrationService({ persist: false, audit });
+
+    try {
+      await service.syncFeatureSettings({
+        ...DEFAULT_FEATURE_SETTINGS,
+        squadWebhook: {
+          ...DEFAULT_FEATURE_SETTINGS.squadWebhook,
+          enabled: true,
+          mode: 'openclaw',
+          openclawGatewayUrl: 'http://127.0.0.1:18789',
+          openclawGatewayToken: 'token',
+        },
+      });
+
+      const endpoints = await service.listEndpoints();
+      expect(endpoints.find((endpoint) => endpoint.id === 'squad.openclawWake')).toMatchObject({
+        validationPolicy: {
+          allowHttp: true,
+          allowLocalhost: true,
+          allowPrivateIp: false,
+        },
+      });
+    } finally {
+      if (originalOpenClawAllowPrivate === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE;
+      } else {
+        process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE = originalOpenClawAllowPrivate;
+      }
+    }
   });
 
   it('skips disabled endpoints and records history', async () => {

--- a/server/src/__tests__/squad-webhook-service.test.ts
+++ b/server/src/__tests__/squad-webhook-service.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import crypto from 'crypto';
+import type { SquadMessage, SquadWebhookSettings } from '@veritas-kanban/shared';
 
 const mockValidateWebhookUrl = vi.fn();
 const mockSafeFetch = vi.fn();
@@ -11,15 +12,22 @@ vi.mock('../utils/url-validation.js', () => ({
 
 describe('squad webhook service', () => {
   let fetchSpy: any;
+  const originalOpenClawAllowPrivate = process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE;
 
   beforeEach(() => {
     vi.resetModules();
+    delete process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE;
     mockValidateWebhookUrl.mockReturnValue({ valid: true });
     fetchSpy = vi.spyOn(globalThis, 'fetch' as any);
     mockSafeFetch.mockImplementation((url: string, init: RequestInit) => fetch(url, init));
   });
 
   afterEach(() => {
+    if (originalOpenClawAllowPrivate === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE;
+    } else {
+      process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE = originalOpenClawAllowPrivate;
+    }
     fetchSpy.mockRestore();
     vi.clearAllMocks();
   });
@@ -112,7 +120,7 @@ describe('squad webhook service', () => {
     expect(mockSafeFetch).toHaveBeenCalledWith(
       'https://gateway.test/tools/invoke',
       expect.objectContaining({ method: 'POST' }),
-      expect.objectContaining({ allowHttp: true, allowLocalhost: true })
+      expect.objectContaining({ allowHttp: true, allowLocalhost: true, allowPrivateIp: false })
     );
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toBe('https://gateway.test/tools/invoke');
@@ -120,6 +128,35 @@ describe('squad webhook service', () => {
       tool: 'cron',
       args: { action: 'wake', mode: 'now' },
     });
+  });
+
+  it('passes OpenClaw private-network opt-in only when enabled', async () => {
+    process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE = 'true';
+    fetchSpy.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
+    const mod = await import('../services/squad-webhook-service.js');
+    const message: SquadMessage = {
+      id: 'm1',
+      agent: 'TARS',
+      displayName: 'TARS',
+      message: 'hello',
+      timestamp: '2026-03-01T00:00:00.000Z',
+    };
+    const settings: SquadWebhookSettings = {
+      enabled: true,
+      notifyOnHuman: true,
+      notifyOnAgent: true,
+      mode: 'openclaw',
+      openclawGatewayUrl: 'https://gateway.test',
+      openclawGatewayToken: 'token',
+    };
+
+    await mod.fireSquadWebhook(message, settings);
+
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      'https://gateway.test/tools/invoke',
+      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({ allowHttp: true, allowLocalhost: true, allowPrivateIp: true })
+    );
   });
 
   it('skips invalid OpenClaw or incomplete config and tolerates failed responses', async () => {

--- a/server/src/__tests__/url-validation.test.ts
+++ b/server/src/__tests__/url-validation.test.ts
@@ -57,6 +57,55 @@ describe('url validation', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('allows loopback addresses when localhost destinations are explicitly allowed', async () => {
+    const { server, port } = await listenLocalServer((_req, res) => {
+      res.writeHead(202, { 'content-type': 'text/plain' });
+      res.end('accepted');
+    });
+
+    try {
+      const response = await safeFetch(
+        `http://127.0.0.1:${port}/hook`,
+        { method: 'POST', body: 'payload' },
+        { allowHttp: true, allowLocalhost: true }
+      );
+
+      expect(response?.status).toBe(202);
+      await expect(response?.text()).resolves.toBe('accepted');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it.each(['10.0.0.1', '172.16.0.1', '192.168.0.1'])(
+    'does not treat allowLocalhost as private-network approval for %s',
+    async (address) => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+      const url = `http://${address}/hook`;
+      const validationOptions = { allowHttp: true, allowLocalhost: true, logFailures: false };
+
+      expect(validateWebhookUrl(url, validationOptions).valid).toBe(false);
+      await expect(safeFetch(url, undefined, validationOptions)).resolves.toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not treat allowLocalhost as DNS approval for resolved private addresses', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    mockLookup.mockResolvedValue([{ address: '192.168.1.20', family: 4 }]);
+
+    await expect(
+      safeFetch('http://hooks.example.test/hook', undefined, {
+        allowHttp: true,
+        allowLocalhost: true,
+        logFailures: false,
+      })
+    ).resolves.toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('pins outbound fetches to the validated DNS answer', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);

--- a/server/src/services/outbound-integration-service.ts
+++ b/server/src/services/outbound-integration-service.ts
@@ -109,6 +109,14 @@ const DEFAULT_AUTH: OutboundEndpointAuth = { type: 'none' };
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_DELIVERIES = 500;
 
+function openClawGatewayValidationOptions(): UrlValidationOptions {
+  return {
+    allowHttp: true,
+    allowLocalhost: true,
+    allowPrivateIp: process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE === 'true',
+  };
+}
+
 export class OutboundIntegrationService {
   private readonly storageDir: string;
   private readonly persist: boolean;
@@ -354,7 +362,7 @@ export class OutboundIntegrationService {
             hasSecret: Boolean(settings.squadWebhook.openclawGatewayToken),
           },
           owner: { source: 'feature-settings', resourceId: 'squadWebhook.openclawGatewayUrl' },
-          validationOptions: { allowHttp: true, allowLocalhost: true },
+          validationOptions: openClawGatewayValidationOptions(),
         })
       );
     }

--- a/server/src/services/squad-webhook-service.ts
+++ b/server/src/services/squad-webhook-service.ts
@@ -8,9 +8,18 @@
 import crypto from 'crypto';
 import type { SquadMessage, SquadWebhookSettings } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
+import type { UrlValidationOptions } from '../utils/url-validation.js';
 import { getOutboundIntegrationService } from './outbound-integration-service.js';
 
 const log = createLogger('squad-webhook');
+
+function openClawWakeValidationOptions(): UrlValidationOptions {
+  return {
+    allowHttp: true,
+    allowLocalhost: true,
+    allowPrivateIp: process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE === 'true',
+  };
+}
 
 interface WebhookPayload {
   event: 'squad.message';
@@ -100,7 +109,7 @@ async function fireOpenClawWake(
           hasSecret: Boolean(settings.openclawGatewayToken),
         },
         owner: { source: 'feature-settings', resourceId: 'squadWebhook.openclawGatewayUrl' },
-        validationOptions: { allowHttp: true, allowLocalhost: true },
+        validationOptions: openClawWakeValidationOptions(),
       },
       {
         method: 'POST',

--- a/server/src/utils/url-validation.ts
+++ b/server/src/utils/url-validation.ts
@@ -24,19 +24,34 @@ const log = createLogger('url-validation');
 /**
  * IPv4 private/reserved ranges that should be blocked for outbound requests
  */
-const BLOCKED_IPV4_RANGES: Array<{ start: number; end: number; name: string }> = [
+type BlockedAddressClass = 'local' | 'private' | 'link-local' | 'cgnat' | 'unique-local';
+
+interface BlockedAddressCheck {
+  blocked: boolean;
+  reason?: string;
+  addressClass?: BlockedAddressClass;
+}
+
+const BLOCKED_IPV4_RANGES: Array<{
+  start: number;
+  end: number;
+  name: string;
+  addressClass: BlockedAddressClass;
+}> = [
+  // Unspecified local address
+  { start: 0x00000000, end: 0x00000000, name: 'unspecified-local', addressClass: 'local' },
   // Loopback (127.0.0.0/8)
-  { start: 0x7f000000, end: 0x7fffffff, name: 'loopback' },
+  { start: 0x7f000000, end: 0x7fffffff, name: 'loopback', addressClass: 'local' },
   // Private Class A (10.0.0.0/8)
-  { start: 0x0a000000, end: 0x0affffff, name: 'private-A' },
+  { start: 0x0a000000, end: 0x0affffff, name: 'private-A', addressClass: 'private' },
   // Private Class B (172.16.0.0/12)
-  { start: 0xac100000, end: 0xac1fffff, name: 'private-B' },
+  { start: 0xac100000, end: 0xac1fffff, name: 'private-B', addressClass: 'private' },
   // Private Class C (192.168.0.0/16)
-  { start: 0xc0a80000, end: 0xc0a8ffff, name: 'private-C' },
+  { start: 0xc0a80000, end: 0xc0a8ffff, name: 'private-C', addressClass: 'private' },
   // Link-local (169.254.0.0/16) - includes AWS/GCP/Azure metadata
-  { start: 0xa9fe0000, end: 0xa9feffff, name: 'link-local' },
+  { start: 0xa9fe0000, end: 0xa9feffff, name: 'link-local', addressClass: 'link-local' },
   // Carrier-grade NAT (100.64.0.0/10)
-  { start: 0x64400000, end: 0x647fffff, name: 'cgnat' },
+  { start: 0x64400000, end: 0x647fffff, name: 'cgnat', addressClass: 'cgnat' },
 ];
 
 /**
@@ -58,7 +73,7 @@ function ipv4ToInt(ip: string): number | null {
 /**
  * Check if an IPv4 address is in a blocked range
  */
-function isBlockedIPv4(ip: string): { blocked: boolean; reason?: string } {
+function isBlockedIPv4(ip: string): BlockedAddressCheck {
   const ipInt = ipv4ToInt(ip);
   if (ipInt === null) {
     return { blocked: false }; // Invalid IP, let URL parsing handle it
@@ -66,7 +81,11 @@ function isBlockedIPv4(ip: string): { blocked: boolean; reason?: string } {
 
   for (const range of BLOCKED_IPV4_RANGES) {
     if (ipInt >= range.start && ipInt <= range.end) {
-      return { blocked: true, reason: `IP in ${range.name} range` };
+      return {
+        blocked: true,
+        reason: `IP in ${range.name} range`,
+        addressClass: range.addressClass,
+      };
     }
   }
 
@@ -76,17 +95,17 @@ function isBlockedIPv4(ip: string): { blocked: boolean; reason?: string } {
 /**
  * Check if a hostname is a blocked IPv6 address
  */
-function isBlockedIPv6(host: string): { blocked: boolean; reason?: string } {
+function isBlockedIPv6(host: string): BlockedAddressCheck {
   const normalized = host.toLowerCase();
 
   // Loopback
   if (normalized === '::1' || normalized === '[::1]') {
-    return { blocked: true, reason: 'IPv6 loopback' };
+    return { blocked: true, reason: 'IPv6 loopback', addressClass: 'local' };
   }
 
   // Link-local (fe80::/10)
   if (normalized.startsWith('fe8') || normalized.startsWith('[fe8')) {
-    return { blocked: true, reason: 'IPv6 link-local' };
+    return { blocked: true, reason: 'IPv6 link-local', addressClass: 'link-local' };
   }
 
   // Unique local (fc00::/7)
@@ -96,26 +115,33 @@ function isBlockedIPv6(host: string): { blocked: boolean; reason?: string } {
     normalized.startsWith('[fc') ||
     normalized.startsWith('[fd')
   ) {
-    return { blocked: true, reason: 'IPv6 unique-local' };
+    return { blocked: true, reason: 'IPv6 unique-local', addressClass: 'unique-local' };
   }
 
   return { blocked: false };
 }
 
-function isBlockedIpAddress(
-  address: string,
-  opts: UrlValidationOptions
-): { blocked: boolean; reason?: string } {
+function isAllowedBlockedAddress(check: BlockedAddressCheck, opts: UrlValidationOptions): boolean {
+  if (!check.blocked) {
+    return true;
+  }
+  if (opts.allowPrivateIp) {
+    return true;
+  }
+  return Boolean(opts.allowLocalhost && check.addressClass === 'local');
+}
+
+function isBlockedIpAddress(address: string, opts: UrlValidationOptions): BlockedAddressCheck {
   if (isIP(address) === 4) {
     const check = isBlockedIPv4(address);
-    if (check.blocked && !opts.allowPrivateIp && !opts.allowLocalhost) {
+    if (!isAllowedBlockedAddress(check, opts)) {
       return check;
     }
   }
 
   if (isIP(address) === 6) {
     const check = isBlockedIPv6(address);
-    if (check.blocked && !opts.allowPrivateIp && !opts.allowLocalhost) {
+    if (!isAllowedBlockedAddress(check, opts)) {
       return check;
     }
   }
@@ -156,7 +182,7 @@ interface ResolvedUrlValidationResult extends UrlValidationResult {
 export interface UrlValidationOptions {
   /** Allow http:// in addition to https:// (default: false in production) */
   allowHttp?: boolean;
-  /** Allow localhost/127.0.0.1 (default: true in development only) */
+  /** Allow localhost/loopback addresses only (default: true in development only) */
   allowLocalhost?: boolean;
   /** Allow private IP ranges (default: false) */
   allowPrivateIp?: boolean;
@@ -229,7 +255,7 @@ export function validateWebhookUrl(
 
   // IPv4 private range check
   const ipv4Check = isBlockedIPv4(hostname);
-  if (ipv4Check.blocked && !opts.allowPrivateIp && !opts.allowLocalhost) {
+  if (!isAllowedBlockedAddress(ipv4Check, opts)) {
     const result = { valid: false, reason: ipv4Check.reason };
     if (opts.logFailures) {
       log.warn({ url: parsed.origin, reason: result.reason }, 'Webhook URL blocked');
@@ -239,7 +265,7 @@ export function validateWebhookUrl(
 
   // IPv6 check
   const ipv6Check = isBlockedIPv6(hostname);
-  if (ipv6Check.blocked && !opts.allowPrivateIp && !opts.allowLocalhost) {
+  if (!isAllowedBlockedAddress(ipv6Check, opts)) {
     const result = { valid: false, reason: ipv6Check.reason };
     if (opts.logFailures) {
       log.warn({ url: parsed.origin, reason: result.reason }, 'Webhook URL blocked');


### PR DESCRIPTION
## Summary
- Separate loopback/local address allowance from private, link-local, CGNAT, and IPv6 unique-local blocking in outbound URL validation.
- Keep OpenClaw wake private-network access behind the explicit OPENCLAW_GATEWAY_ALLOW_PRIVATE opt-in.
- Add regression coverage for loopback, direct private IPs, and DNS-resolved private addresses under allowLocalhost.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/url-validation.test.ts src/__tests__/squad-webhook-service.test.ts src/__tests__/outbound-integration-service.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server exec eslint src/utils/url-validation.ts src/services/squad-webhook-service.ts src/services/outbound-integration-service.ts src/__tests__/url-validation.test.ts src/__tests__/squad-webhook-service.test.ts src/__tests__/outbound-integration-service.test.ts (existing any warnings only)
- pnpm --filter @veritas-kanban/server build

Closes #609