### PR TITLE
Enforce webhook response body limits while streaming

### DIFF
--- a/server/src/__tests__/outbound-integration-service.test.ts
+++ b/server/src/__tests__/outbound-integration-service.test.ts
@@ -111,6 +111,64 @@ describe('OutboundIntegrationService', () => {
     }
   });
 
+  it('cancels response body reads after responseBodyLimit is exceeded', async () => {
+    let chunksWritten = 0;
+    let responseClosed = false;
+    const { server, port } = await listenLocalServer((_req, res) => {
+      let interval: ReturnType<typeof setInterval> | undefined;
+      const stop = () => {
+        if (interval) clearInterval(interval);
+      };
+      const writeChunk = () => {
+        chunksWritten += 1;
+        res.write('x'.repeat(64));
+        if (chunksWritten >= 100) {
+          stop();
+          res.end();
+        }
+      };
+
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.on('close', () => {
+        responseClosed = true;
+        stop();
+      });
+      interval = setInterval(writeChunk, 5);
+      writeChunk();
+    });
+    mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+    const service = new OutboundIntegrationService({ persist: false, audit });
+
+    try {
+      const result = await service.deliver(
+        {
+          id: 'limited.response',
+          type: 'policy-webhook',
+          displayName: 'Limited response webhook',
+          url: `http://hook.test:${port}/stream`,
+          owner: { source: 'policy', resourceId: 'policy_1' },
+          validationOptions: { allowHttp: true, allowLocalhost: true },
+        },
+        {
+          method: 'POST',
+          responseBodyLimit: 128,
+          timeoutMs: 1_000,
+        }
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'success',
+        responseStatus: 200,
+        responseText: 'x'.repeat(128),
+      });
+      await vi.waitFor(() => expect(responseClosed).toBe(true));
+      expect(chunksWritten).toBeLessThan(100);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it('blocks private IP destinations before fetch', async () => {
     const fetchSpy = stubGlobalFetch();
     const service = new OutboundIntegrationService({ persist: false, audit });

--- a/server/src/services/outbound-integration-service.ts
+++ b/server/src/services/outbound-integration-service.ts
@@ -117,6 +117,62 @@ function openClawGatewayValidationOptions(): UrlValidationOptions {
   };
 }
 
+async function cancelResponseReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason: string
+): Promise<void> {
+  try {
+    await reader.cancel(reason);
+  } catch {
+    // The body may already be closed by the remote endpoint.
+  }
+}
+
+async function readLimitedResponseText(
+  response: Response,
+  limitBytes?: number
+): Promise<string | undefined> {
+  if (!limitBytes || limitBytes <= 0) {
+    return undefined;
+  }
+  if (!response.body) {
+    return '';
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let text = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remaining = limitBytes - bytesRead;
+      if (remaining <= 0) {
+        await cancelResponseReader(reader, 'Response body limit exceeded');
+        break;
+      }
+
+      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+      text += decoder.decode(chunk, { stream: true });
+      bytesRead += chunk.byteLength;
+
+      if (value.byteLength > remaining) {
+        await cancelResponseReader(reader, 'Response body limit exceeded');
+        break;
+      }
+    }
+  } finally {
+    text += decoder.decode();
+    reader.releaseLock();
+  }
+
+  return text;
+}
+
 export class OutboundIntegrationService {
   private readonly storageDir: string;
   private readonly persist: boolean;
@@ -251,10 +307,7 @@ export class OutboundIntegrationService {
         };
       }
 
-      const responseText =
-        request.responseBodyLimit && request.responseBodyLimit > 0
-          ? await response.text().catch(() => '')
-          : undefined;
+      const responseText = await readLimitedResponseText(response, request.responseBodyLimit);
       const status: OutboundDeliveryStatus = response.ok ? 'success' : 'failed';
       const attempt = await this.recordDelivery({
         endpoint: registered,
@@ -272,7 +325,7 @@ export class OutboundIntegrationService {
         status,
         attemptId: attempt.id,
         responseStatus: response.status,
-        responseText: responseText?.slice(0, request.responseBodyLimit),
+        responseText,
       };
     } catch (err) {
       const message = this.sanitizeError(err, endpoint.url);

--- a/server/src/utils/url-validation.ts
+++ b/server/src/utils/url-validation.ts
@@ -15,6 +15,7 @@ import { lookup } from 'node:dns/promises';
 import { request as httpRequest, type IncomingHttpHeaders, type RequestOptions } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { isIP } from 'node:net';
+import { Readable } from 'node:stream';
 import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('url-validation');
@@ -425,21 +426,19 @@ async function fetchPinnedUrl(
 
   return new Promise((resolve, reject) => {
     const req = request(requestOptions, (res) => {
-      const chunks: Buffer[] = [];
+      const status = res.statusCode ?? 500;
+      const responseBody =
+        status === 204 || status === 304
+          ? null
+          : (Readable.toWeb(res) as unknown as ConstructorParameters<typeof Response>[0]);
 
-      res.on('data', (chunk: Buffer | string) => {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      });
-      res.on('end', () => {
-        resolve(
-          new Response(Buffer.concat(chunks), {
-            status: res.statusCode ?? 500,
-            statusText: res.statusMessage,
-            headers: headersFromResponse(res.headers),
-          })
-        );
-      });
-      res.on('error', reject);
+      resolve(
+        new Response(responseBody, {
+          status,
+          statusText: res.statusMessage,
+          headers: headersFromResponse(res.headers),
+        })
+      );
     });
 
     req.on('error', reject);


### PR DESCRIPTION
## Summary
- Stream pinned outbound HTTP responses instead of buffering the full body before returning a Response.
- Read webhook response text with a bounded byte counter and cancel the body once responseBodyLimit is exceeded.
- Add regression coverage proving a large streaming webhook response is closed before the full body is sent.

## Verification
- pnpm --filter @veritas-kanban/server test -- src/__tests__/outbound-integration-service.test.ts src/__tests__/url-validation.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server exec eslint src/services/outbound-integration-service.ts src/utils/url-validation.ts src/__tests__/outbound-integration-service.test.ts src/__tests__/url-validation.test.ts
- pnpm --filter @veritas-kanban/server build

Closes #610