### PR TITLE
Restrict work product source link schemes

### DIFF
--- a/server/src/__tests__/work-product-schemas.test.ts
+++ b/server/src/__tests__/work-product-schemas.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CreateWorkProductBodySchema,
+  UpdateWorkProductBodySchema,
+} from '../schemas/work-product-schemas.js';
+
+const baseCreateBody = {
+  kind: 'markdown',
+  title: 'Safe source links',
+  render: { schemaVersion: 1, kind: 'markdown', markdown: '# Report' },
+} as const;
+
+describe('work product schemas', () => {
+  it.each([
+    ['https://example.com/report', 'https://example.com/report'],
+    ['HTTP://EXAMPLE.COM/report', 'http://example.com/report'],
+    ['mailto:owner@example.com', 'mailto:owner@example.com'],
+    ['veritas://task/task-1?tab=work-products', 'veritas://task/task-1?tab=work-products'],
+    ['/tasks/task-1', '/tasks/task-1'],
+    ['#work-products', '#work-products'],
+  ])('allows and normalizes safe source link href %s', (href, normalized) => {
+    const parsed = CreateWorkProductBodySchema.safeParse({
+      ...baseCreateBody,
+      sourceLinks: [{ label: 'Source', href, type: 'url' }],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.sourceLinks?.[0]?.href).toBe(normalized);
+    }
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'JaVaScRiPt:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'file:///etc/passwd',
+    'java\nscript:alert(1)',
+    '//evil.example/path',
+  ])('rejects unsafe source link href %s', (href) => {
+    const createParsed = CreateWorkProductBodySchema.safeParse({
+      ...baseCreateBody,
+      sourceLinks: [{ label: 'Source', href, type: 'url' }],
+    });
+    const updateParsed = UpdateWorkProductBodySchema.safeParse({
+      sourceLinks: [{ label: 'Source', href, type: 'url' }],
+    });
+
+    expect(createParsed.success).toBe(false);
+    expect(updateParsed.success).toBe(false);
+  });
+});

--- a/server/src/schemas/work-product-schemas.ts
+++ b/server/src/schemas/work-product-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { normalizeSafeHref } from '@veritas-kanban/shared';
 
 const PrimitiveSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
 
@@ -26,7 +27,21 @@ const RedactionSchema = z.object({
 
 const SourceLinkSchema = z.object({
   label: z.string().min(1).max(120),
-  href: z.string().min(1).max(1000),
+  href: z
+    .string()
+    .min(1)
+    .max(1000)
+    .transform((href, ctx) => {
+      const normalized = normalizeSafeHref(href);
+      if (!normalized) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'source link href must use an allowed URL scheme',
+        });
+        return z.NEVER;
+      }
+      return normalized;
+    }),
   type: z.enum(['task', 'run', 'file', 'url', 'pr', 'other']).optional(),
 });
 

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -5,6 +5,7 @@
 export * from './path.js';
 export * from './format.js';
 export * from './constants.js';
+export * from './safe-href.js';
 export * from './api-permissions.js';
 export * from './api-client.js';
 export * from './agent-helpers.js';

--- a/shared/src/utils/safe-href.ts
+++ b/shared/src/utils/safe-href.ts
@@ -1,0 +1,40 @@
+const ALLOWED_ABSOLUTE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'veritas:']);
+const EXTERNAL_TARGET_PROTOCOLS = new Set(['http:', 'https:']);
+
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+export function normalizeSafeHref(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const href = value.trim();
+  if (!href || hasControlCharacter(href)) return undefined;
+  if (href.startsWith('/') && !href.startsWith('//')) return href;
+  if (href.startsWith('#') || href.startsWith('?')) return href;
+
+  try {
+    const parsed = new URL(href);
+    return ALLOWED_ABSOLUTE_PROTOCOLS.has(parsed.protocol.toLowerCase())
+      ? parsed.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isExternalTargetHref(value: unknown): boolean {
+  const href = normalizeSafeHref(value);
+  if (!href) return false;
+
+  try {
+    const parsed = new URL(href);
+    return EXTERNAL_TARGET_PROTOCOLS.has(parsed.protocol.toLowerCase());
+  } catch {
+    return false;
+  }
+}

--- a/web/src/__tests__/task-detail-work-products-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-work-products-mantine.test.tsx
@@ -151,6 +151,31 @@ describe('task detail work products surface', () => {
     });
   });
 
+  it('does not render unsafe source link hrefs', async () => {
+    listForTaskMock.mockResolvedValue([
+      {
+        ...product,
+        sourceLinks: [
+          { label: 'Unsafe source', href: 'JaVaScRiPt:alert(1)', type: 'url' },
+          { label: 'Safe source', href: 'https://example.com/report', type: 'url' },
+        ],
+      },
+    ]);
+
+    const { container } = renderWithProviders(<WorkProductsSection taskId="task-work-products" />);
+
+    expect(await screen.findByText('Launch readiness report')).toBeDefined();
+    expect(screen.queryByRole('link', { name: /unsafe source/i })).toBeNull();
+    const safeLink = screen.getByRole('link', { name: /safe source/i });
+    expect(safeLink.getAttribute('href')).toBe('https://example.com/report');
+    expect(safeLink.getAttribute('target')).toBe('_blank');
+    expect(
+      Array.from(container.querySelectorAll('a')).some((anchor) =>
+        /^javascript:/i.test(anchor.getAttribute('href') ?? '')
+      )
+    ).toBe(false);
+  });
+
   it('requests redacted markdown when copying', async () => {
     const user = userEvent.setup();
     renderWithProviders(<WorkProductsSection taskId="task-work-products" />);

--- a/web/src/__tests__/task-work-view-mantine.test.tsx
+++ b/web/src/__tests__/task-work-view-mantine.test.tsx
@@ -265,6 +265,37 @@ describe('task work view Mantine surface', () => {
     expect(mocks.stopAgentMutate).toHaveBeenCalledWith('task-work');
   });
 
+  it('skips unsafe work product source links in the Work view', () => {
+    mocks.useTaskWorkProducts.mockReturnValue({
+      data: [
+        {
+          ...product,
+          sourceLinks: [
+            {
+              label: 'Unsafe source',
+              href: 'data:text/html,<script>alert(1)</script>',
+              type: 'url',
+            },
+            { label: 'Safe source', href: '/runs/safe-run', type: 'run' },
+          ],
+        },
+      ],
+      isLoading: false,
+    });
+
+    const { container } = renderWorkView();
+    const sourceLink = screen.getByRole('link', {
+      name: 'Open origin for Release readiness report',
+    });
+
+    expect(sourceLink.getAttribute('href')).toBe('/runs/safe-run');
+    expect(
+      Array.from(container.querySelectorAll('a')).some((anchor) =>
+        /^(?:javascript|data|file):/i.test(anchor.getAttribute('href') ?? '')
+      )
+    ).toBe(false);
+  });
+
   it('keeps readiness and default-tab decisions deterministic', () => {
     const task = createMockTask({
       title: 'Implement run timeline',

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -31,6 +31,7 @@ import {
   Timer,
   Wrench,
 } from 'lucide-react';
+import { normalizeSafeHref } from '@veritas-kanban/shared';
 import type {
   AgentRunTimelineEvent,
   AgentRunTimelineEventSource,
@@ -223,18 +224,6 @@ function safeString(value: unknown): string | undefined {
   return sanitized.length > 0 ? sanitized : undefined;
 }
 
-function safeTimelineHref(value: unknown): string | undefined {
-  const href = safeString(value);
-  if (!href) return undefined;
-  if (href.startsWith('/') && !href.startsWith('//')) return href;
-  try {
-    const parsed = new URL(href);
-    return ['http:', 'https:', 'veritas:'].includes(parsed.protocol) ? href : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function sourceRunIdFromRecord(source?: Record<string, unknown>): string | undefined {
   return (
     safeString(source?.attemptId) ?? safeString(source?.runId) ?? safeString(source?.sourceRunId)
@@ -255,7 +244,7 @@ function workflowStartedAt(run: WorkflowRun): string {
 
 function workProductLink(product: WorkProductPreview): AgentRunTimelineEvent['link'] {
   const sourceLink = product.sourceLinks?.find((link) => link.type === 'pr' || link.type === 'url');
-  const href = safeTimelineHref(sourceLink?.href);
+  const href = normalizeSafeHref(sourceLink?.href);
   if (sourceLink && href) {
     return {
       label: sourceLink.label || 'Open source',
@@ -267,7 +256,7 @@ function workProductLink(product: WorkProductPreview): AgentRunTimelineEvent['li
 }
 
 function deliverableLink(deliverable: Deliverable): AgentRunTimelineEvent['link'] {
-  const href = safeTimelineHref(deliverable.path);
+  const href = normalizeSafeHref(deliverable.path);
   if (href) {
     return { label: 'Open deliverable', href, target: 'external' };
   }
@@ -804,7 +793,7 @@ export function buildAgentRunTimelineEvents({
     if (notification.taskId !== task.id) continue;
     const notificationRunId = sourceRunIdFromRecord(notification.source);
     if (!sourceRunMatches(attemptId, notificationRunId)) continue;
-    const targetHref = safeTimelineHref(notification.targetUrl);
+    const targetHref = normalizeSafeHref(notification.targetUrl);
     events.push({
       id: `notification-${notification.id}`,
       sequence: nextSequence++,

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -45,6 +45,8 @@ import {
 import {
   evaluateTaskReadiness,
   getTaskReadinessChecks as getSharedTaskReadinessChecks,
+  isExternalTargetHref,
+  normalizeSafeHref,
 } from '@veritas-kanban/shared';
 import type { Task, TaskAttempt, TaskReadinessCheck, TaskStatus } from '@veritas-kanban/shared';
 import { useAgentStatus, useAgentStream, useStopAgent } from '@/hooks/useAgent';
@@ -944,41 +946,42 @@ export function TaskWorkView({
                 </Group>
               ) : latestWorkProducts.length > 0 ? (
                 <Stack gap={6}>
-                  {latestWorkProducts.map((product) => (
-                    <Group key={product.id} gap="xs" wrap="nowrap" align="flex-start">
-                      <History className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
-                      <div className="min-w-0 flex-1">
-                        <Text size="sm" truncate>
-                          {product.title}
-                        </Text>
-                        <Text size="xs" c="dimmed" truncate>
-                          v{product.version} | {product.kind}
-                          {product.sourceRunId ? ` | run ${product.sourceRunId}` : ''}
-                        </Text>
-                      </div>
-                      {product.sourceLinks?.[0] && (
-                        <Tooltip label={`Open ${product.sourceLinks[0].label}`}>
-                          <ActionIcon
-                            component="a"
-                            href={product.sourceLinks[0].href}
-                            target={
-                              product.sourceLinks[0].href.startsWith('http') ? '_blank' : undefined
-                            }
-                            rel={
-                              product.sourceLinks[0].href.startsWith('http')
-                                ? 'noopener noreferrer'
-                                : undefined
-                            }
-                            size="sm"
-                            variant="subtle"
-                            aria-label={`Open origin for ${product.title}`}
-                          >
-                            <ExternalLink className="h-3 w-3" />
-                          </ActionIcon>
-                        </Tooltip>
-                      )}
-                    </Group>
-                  ))}
+                  {latestWorkProducts.map((product) => {
+                    const sourceLink = product.sourceLinks?.find((link) =>
+                      normalizeSafeHref(link.href)
+                    );
+                    const href = normalizeSafeHref(sourceLink?.href);
+                    const external = isExternalTargetHref(href);
+                    return (
+                      <Group key={product.id} gap="xs" wrap="nowrap" align="flex-start">
+                        <History className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0 flex-1">
+                          <Text size="sm" truncate>
+                            {product.title}
+                          </Text>
+                          <Text size="xs" c="dimmed" truncate>
+                            v{product.version} | {product.kind}
+                            {product.sourceRunId ? ` | run ${product.sourceRunId}` : ''}
+                          </Text>
+                        </div>
+                        {sourceLink && href && (
+                          <Tooltip label={`Open ${sourceLink.label}`}>
+                            <ActionIcon
+                              component="a"
+                              href={href}
+                              target={external ? '_blank' : undefined}
+                              rel={external ? 'noopener noreferrer' : undefined}
+                              size="sm"
+                              variant="subtle"
+                              aria-label={`Open origin for ${product.title}`}
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                            </ActionIcon>
+                          </Tooltip>
+                        )}
+                      </Group>
+                    );
+                  })}
                 </Stack>
               ) : (
                 <Text size="sm" c="dimmed">

--- a/web/src/components/task/WorkProductsSection.tsx
+++ b/web/src/components/task/WorkProductsSection.tsx
@@ -22,6 +22,13 @@ import { api } from '@/lib/api';
 import { useTaskWorkProducts, useWorkProductVersions } from '@/hooks/useWorkProducts';
 import { toast } from '@/hooks/useToast';
 import {
+  isExternalTargetHref,
+  normalizeSafeHref,
+  type WorkProductKind,
+  type WorkProductPreview,
+  type WorkProductVersion,
+} from '@veritas-kanban/shared';
+import {
   AlertCircle,
   Clipboard,
   Download,
@@ -31,11 +38,6 @@ import {
   Pencil,
   Sparkles,
 } from 'lucide-react';
-import type {
-  WorkProductKind,
-  WorkProductPreview,
-  WorkProductVersion,
-} from '@veritas-kanban/shared';
 
 interface WorkProductsSectionProps {
   taskId: string;
@@ -365,20 +367,25 @@ export function WorkProductsSection({ taskId }: WorkProductsSectionProps) {
                           Run {product.sourceRunId}
                         </Badge>
                       )}
-                      {product.sourceLinks?.map((link) => (
-                        <Button
-                          key={`${product.id}:${link.href}:${link.label}`}
-                          component="a"
-                          href={link.href}
-                          target={link.href.startsWith('http') ? '_blank' : undefined}
-                          rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                          variant="subtle"
-                          size="compact-xs"
-                          rightSection={<ExternalLink className="h-3 w-3" />}
-                        >
-                          {link.label}
-                        </Button>
-                      ))}
+                      {product.sourceLinks?.map((link) => {
+                        const href = normalizeSafeHref(link.href);
+                        if (!href) return null;
+                        const external = isExternalTargetHref(href);
+                        return (
+                          <Button
+                            key={`${product.id}:${href}:${link.label}`}
+                            component="a"
+                            href={href}
+                            target={external ? '_blank' : undefined}
+                            rel={external ? 'noopener noreferrer' : undefined}
+                            variant="subtle"
+                            size="compact-xs"
+                            rightSection={<ExternalLink className="h-3 w-3" />}
+                          >
+                            {link.label}
+                          </Button>
+                        );
+                      })}
                     </Group>
                   )}
                 </Stack>


### PR DESCRIPTION
## Summary
- Add a shared safe href helper for work-product source links and timeline links.
- Validate and normalize work-product sourceLinks.href server-side to allow only http, https, mailto, veritas, and same-app relative links.
- Update WorkProductsSection, TaskWorkView, and AgentRunTimelinePanel to render only sanitized hrefs.
- Add regression tests for javascript:, data:, file:, control characters, mixed-case schemes, and unsafe stored render paths.

## Verification
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server test -- src/__tests__/work-product-schemas.test.ts
- pnpm --filter @veritas-kanban/web test -- src/__tests__/task-detail-work-products-mantine.test.tsx src/__tests__/task-work-view-mantine.test.tsx src/__tests__/agent-run-timeline-mantine.test.tsx
- node_modules/.bin/eslint shared/src/utils/safe-href.ts shared/src/utils/index.ts server/src/schemas/work-product-schemas.ts server/src/__tests__/work-product-schemas.test.ts web/src/components/task/WorkProductsSection.tsx web/src/components/task/TaskWorkView.tsx web/src/components/task/AgentRunTimelinePanel.tsx web/src/__tests__/task-detail-work-products-mantine.test.tsx web/src/__tests__/task-work-view-mantine.test.tsx
- pnpm --filter @veritas-kanban/shared typecheck
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/web build

Closes #611