### PR TITLE
Apply desktop remote destination policy

### DIFF
--- a/desktop/src/main/__tests__/bridge-contracts.test.ts
+++ b/desktop/src/main/__tests__/bridge-contracts.test.ts
@@ -1,5 +1,11 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IpcMain, Shell } from 'electron';
+
+const mockLookup = vi.hoisted(() => vi.fn());
+
+vi.mock('node:dns/promises', () => ({
+  lookup: mockLookup,
+}));
 
 import {
   createDesktopBridgeHandlers,
@@ -91,6 +97,11 @@ function handlers(): DesktopBridgeHandlerMap {
 }
 
 describe('desktop bridge contracts', () => {
+  beforeEach(() => {
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -214,11 +225,23 @@ describe('desktop bridge contracts', () => {
       workspaceId: 'workspace-1',
     });
     expect(() =>
-      validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'ftp://example.com' })
-    ).toThrow('protocol is not allowed');
+      validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'http://example.com' })
+    ).toThrow('must use HTTPS');
     expect(() =>
       validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'https://user@example.com' })
     ).toThrow('credentials are not allowed');
+    expect(() =>
+      validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'https://10.0.0.1' })
+    ).toThrow('private IPv4 address');
+    expect(() =>
+      validateConnectionConfigRequest({ mode: 'remote', serverUrl: 'https://169.254.169.254' })
+    ).toThrow('link-local address');
+    expect(() =>
+      validateConnectionConfigRequest({
+        mode: 'remote',
+        serverUrl: 'https://metadata.google.internal',
+      })
+    ).toThrow('cloud metadata destination');
     expect(() =>
       validateConnectionConfigRequest({
         mode: 'remote',
@@ -250,6 +273,53 @@ describe('desktop bridge contracts', () => {
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
       headers: { Authorization: 'Bearer vk_pat_secret' },
     });
+  });
+
+  it('blocks remote connection destinations that resolve to private addresses before fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    mockLookup.mockResolvedValue([{ address: '192.168.1.10', family: 4 }]);
+
+    const result = await handlers().validateConnectionConfig({
+      mode: 'remote',
+      serverUrl: 'https://remote.example/veritas',
+      serverToken: 'vk_pat_secret',
+    });
+
+    expect(result).toMatchObject({
+      mode: 'remote',
+      valid: false,
+      normalizedServerUrl: 'https://remote.example/veritas',
+      errors: [expect.stringContaining('private IPv4 address')],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks direct private and metadata remote connection URLs before fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const bridgeHandlers = handlers();
+
+    await expect(
+      bridgeHandlers.validateConnectionConfig({
+        mode: 'remote',
+        serverUrl: 'https://10.0.0.1',
+      })
+    ).rejects.toThrow('private IPv4 address');
+    await expect(
+      bridgeHandlers.validateConnectionConfig({
+        mode: 'remote',
+        serverUrl: 'https://169.254.169.254',
+      })
+    ).rejects.toThrow('link-local address');
+    await expect(
+      bridgeHandlers.validateConnectionConfig({
+        mode: 'remote',
+        serverUrl: 'https://metadata.google.internal',
+      })
+    ).rejects.toThrow('cloud metadata destination');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('validates command names, file paths, notification actions, and work product exports', () => {

--- a/desktop/src/main/bridge.ts
+++ b/desktop/src/main/bridge.ts
@@ -1,4 +1,6 @@
 import type { IpcMain, Shell } from 'electron';
+import { lookup } from 'node:dns/promises';
+import { blockedRemoteConnectionDestinationReason } from '@veritas-kanban/shared';
 
 import { DESKTOP_APP_ID, DESKTOP_APP_NAME } from './app-metadata.js';
 import type { DesktopCommandDispatcher } from './commands.js';
@@ -35,6 +37,28 @@ export type DesktopBridgeHandlerMap = {
   ) => MaybePromise<DesktopBridgeResponse<Method>>;
 };
 
+async function remoteConnectionDestinationError(serverUrl: string): Promise<string | null> {
+  const parsed = new URL(serverUrl);
+  const directReason = blockedRemoteConnectionDestinationReason(parsed.hostname);
+  if (directReason) {
+    return `Remote server URL cannot target ${directReason}`;
+  }
+
+  try {
+    const records = await lookup(parsed.hostname, { all: true, verbatim: true });
+    for (const record of records) {
+      const reason = blockedRemoteConnectionDestinationReason(record.address);
+      if (reason) {
+        return `Remote server URL resolves to ${reason}`;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 async function validateRemoteConnection(
   config: DesktopConnectionConfigRequest
 ): Promise<DesktopConnectionValidationResult> {
@@ -50,6 +74,16 @@ async function validateRemoteConnection(
 
   let serverToken = config.serverToken;
   const warnings: string[] = [];
+  const destinationError = await remoteConnectionDestinationError(config.serverUrl);
+  if (destinationError) {
+    return {
+      mode: 'remote',
+      valid: false,
+      normalizedServerUrl: config.serverUrl,
+      warnings,
+      errors: [destinationError],
+    };
+  }
 
   if (!serverToken && config.pairingPayload) {
     const paired = await exchangeRemotePairingPayload(config.serverUrl, config.pairingPayload);

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -1,4 +1,5 @@
 import type { DesktopAppInfo, DesktopStatusSnapshot } from '../main/types.js';
+import { blockedRemoteConnectionDestinationReason } from '@veritas-kanban/shared';
 
 export const DESKTOP_REDACTED_VALUE = '[redacted]';
 export const DESKTOP_RESTART_CONFIRMATION = 'restart-local-server';
@@ -523,7 +524,7 @@ export function createDesktopBridgeEventCleanup<Handler>(
 }
 
 const SAFE_EXTERNAL_PROTOCOLS = new Set(['https:', 'http:', 'mailto:']);
-const SAFE_CONNECTION_PROTOCOLS = new Set(['https:', 'http:']);
+const SAFE_CONNECTION_PROTOCOLS = new Set(['https:']);
 const SAFE_COMMAND_SOURCES = new Set<DesktopCommandSource>([
   'renderer',
   'menu',
@@ -711,11 +712,16 @@ export function validateConnectionConfigRequest(payload: unknown): DesktopConnec
   }
 
   if (!SAFE_CONNECTION_PROTOCOLS.has(parsed.protocol)) {
-    throw new Error(`Remote server URL protocol is not allowed: ${parsed.protocol}`);
+    throw new Error('Remote server URL must use HTTPS in remote mode');
   }
 
   if (parsed.username || parsed.password) {
     throw new Error('Remote server URL credentials are not allowed');
+  }
+
+  const blockedDestination = blockedRemoteConnectionDestinationReason(parsed.hostname);
+  if (blockedDestination) {
+    throw new Error(`Remote server URL cannot target ${blockedDestination}`);
   }
 
   return {

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './path.js';
 export * from './format.js';
 export * from './constants.js';
 export * from './safe-href.js';
+export * from './remote-destination-policy.js';
 export * from './api-permissions.js';
 export * from './api-client.js';
 export * from './agent-helpers.js';

--- a/shared/src/utils/remote-destination-policy.ts
+++ b/shared/src/utils/remote-destination-policy.ts
@@ -1,0 +1,78 @@
+const BLOCKED_IPV4_RANGES: Array<{ start: number; end: number; reason: string }> = [
+  { start: 0x00000000, end: 0x00000000, reason: 'unspecified local address' },
+  { start: 0x0a000000, end: 0x0affffff, reason: 'private IPv4 address' },
+  { start: 0x7f000000, end: 0x7fffffff, reason: 'loopback address' },
+  { start: 0xa9fe0000, end: 0xa9feffff, reason: 'link-local address' },
+  { start: 0xac100000, end: 0xac1fffff, reason: 'private IPv4 address' },
+  { start: 0xc0a80000, end: 0xc0a8ffff, reason: 'private IPv4 address' },
+  { start: 0x64400000, end: 0x647fffff, reason: 'carrier-grade NAT address' },
+];
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+
+  let result = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    const num = Number.parseInt(part, 10);
+    if (Number.isNaN(num) || num < 0 || num > 255) return null;
+    result = (result << 8) | num;
+  }
+  return result >>> 0;
+}
+
+function blockedIPv4Reason(ip: string): string | null {
+  const ipInt = ipv4ToInt(ip);
+  if (ipInt === null) return null;
+
+  for (const range of BLOCKED_IPV4_RANGES) {
+    if (ipInt >= range.start && ipInt <= range.end) return range.reason;
+  }
+  return null;
+}
+
+function firstIPv6Hextet(address: string): number | null {
+  const normalized = address.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+  const first = normalized.split(':', 1)[0];
+  if (!first || !/^[0-9a-f]{1,4}$/.test(first)) return null;
+  return Number.parseInt(first, 16);
+}
+
+function blockedIPv6Reason(hostname: string): string | null {
+  const normalized = hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+  if (normalized === '::') return 'IPv6 unspecified address';
+  if (normalized === '::1') return 'IPv6 loopback address';
+
+  if (normalized.startsWith('::ffff:')) {
+    const mappedReason = blockedIPv4Reason(normalized.slice('::ffff:'.length));
+    if (mappedReason) return `IPv4-mapped ${mappedReason}`;
+  }
+
+  const firstHextet = firstIPv6Hextet(normalized);
+  if (firstHextet === null) return null;
+
+  if (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) {
+    return 'IPv6 link-local address';
+  }
+  if (firstHextet >= 0xfc00 && firstHextet <= 0xfdff) {
+    return 'IPv6 unique-local address';
+  }
+  return null;
+}
+
+export function blockedRemoteConnectionDestinationReason(hostnameOrAddress: string): string | null {
+  const hostname = hostnameOrAddress.toLowerCase();
+  if (
+    hostname === 'localhost' ||
+    hostname === 'localhost.localdomain' ||
+    hostname.endsWith('.localhost')
+  ) {
+    return 'localhost destination';
+  }
+  if (hostname === 'metadata.google.internal') {
+    return 'cloud metadata destination';
+  }
+  if (hostname.includes(':')) return blockedIPv6Reason(hostname);
+  return blockedIPv4Reason(hostname);
+}

--- a/web/src/__tests__/desktop-onboarding.test.tsx
+++ b/web/src/__tests__/desktop-onboarding.test.tsx
@@ -96,11 +96,25 @@ describe('desktop onboarding', () => {
 
     fireEvent.click(screen.getByTestId('setup-mode-remote'));
     fireEvent.change(screen.getByLabelText('Server URL'), {
-      target: { value: 'http://127.0.0.1:3001' },
+      target: { value: 'https://remote.example' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Validate Remote' }));
 
     expect(await screen.findByText('URL syntax is valid.')).toBeDefined();
     expect(screen.getByText('Live reachability checks require the desktop app.')).toBeDefined();
+  });
+
+  it('blocks browser-only remote checks for local destinations', async () => {
+    renderWithProviders(<DesktopOnboardingPanel onContinue={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('setup-mode-remote'));
+    fireEvent.change(screen.getByLabelText('Server URL'), {
+      target: { value: 'https://127.0.0.1:3001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Validate Remote' }));
+
+    expect(
+      await screen.findByText('Remote server URL cannot target loopback address.')
+    ).toBeDefined();
   });
 });

--- a/web/src/components/auth/DesktopOnboarding.tsx
+++ b/web/src/components/auth/DesktopOnboarding.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheck,
   Upload,
 } from 'lucide-react';
+import { blockedRemoteConnectionDestinationReason } from '@veritas-kanban/shared';
 
 import { cn } from '@/lib/utils';
 import { persistPendingProductMode, productModeForSetupMode } from '@/lib/product-modes';
@@ -202,11 +203,15 @@ async function validateRemoteWithoutDesktop(
 ): Promise<DesktopConnectionValidationResult> {
   try {
     const parsed = new URL(serverUrl);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      throw new Error('Remote server URL protocol is not allowed.');
+    if (parsed.protocol !== 'https:') {
+      throw new Error('Remote server URL must use HTTPS in remote mode.');
     }
     if (parsed.username || parsed.password) {
       throw new Error('Remote server URL credentials are not allowed.');
+    }
+    const blockedDestination = blockedRemoteConnectionDestinationReason(parsed.hostname);
+    if (blockedDestination) {
+      throw new Error(`Remote server URL cannot target ${blockedDestination}.`);
     }
     return {
       mode: 'remote',


### PR DESCRIPTION
Summary:
- Enforces HTTPS-only remote desktop connection URLs.
- Blocks localhost, private, link-local, metadata, CGNAT, IPv6 local, and DNS-resolved private destinations before validation fetches.
- Reuses the destination policy in the browser fallback onboarding path.
- Updates browser-only onboarding tests for valid HTTPS remotes and blocked local destinations.

Verification:
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/desktop test -- src/main/__tests__/bridge-contracts.test.ts
- pnpm --filter @veritas-kanban/web test -- src/__tests__/desktop-onboarding.test.tsx
- pnpm test:unit
- node_modules/.bin/eslint shared/src/utils/remote-destination-policy.ts shared/src/utils/index.ts desktop/src/shared/desktop-bridge-contracts.ts desktop/src/main/bridge.ts desktop/src/main/__tests__/bridge-contracts.test.ts web/src/components/auth/DesktopOnboarding.tsx web/src/__tests__/desktop-onboarding.test.tsx
- pnpm --filter @veritas-kanban/shared typecheck
- pnpm --filter @veritas-kanban/desktop typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/desktop build
- pnpm --filter @veritas-kanban/web build

Closes #612