### PR TITLE
Add operations digest UI and scheduled delivery controls

### DIFF
--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -452,6 +452,14 @@
       "denialReason": "Workflow navigation leads to workflow read APIs."
     },
     {
+      "id": "command-palette:go-operations",
+      "kind": "command-palette",
+      "classification": "authenticated-read",
+      "permissions": ["task:read", "telemetry:read", "workflow_run:read"],
+      "source": "web/src/lib/views.ts",
+      "denialReason": "Operations digest navigation leads to task, telemetry, and scheduled deliverable read APIs."
+    },
+    {
       "id": "command-palette:go-drift",
       "kind": "command-palette",
       "classification": "authenticated-read",

--- a/server/src/__tests__/digest-service.test.ts
+++ b/server/src/__tests__/digest-service.test.ts
@@ -236,6 +236,85 @@ describe('DigestService', () => {
       });
       expect(digest.totals.openApprovals).toBe(1);
     });
+
+    it('filters deterministic operations by repository and cwd', async () => {
+      const makeTask = (id: string, repo: string, worktreePath: string): Task => ({
+        id,
+        title: `${repo} task`,
+        description: `${repo} task`,
+        type: 'feature',
+        status: 'in-progress',
+        priority: 'medium',
+        project: 'platform',
+        created: '2026-06-04T08:00:00.000Z',
+        updated: '2026-06-04T11:00:00.000Z',
+        git: {
+          repo,
+          branch: `feature/${id}`,
+          baseBranch: 'main',
+          worktreePath,
+        },
+      });
+      const tasks = [
+        makeTask('task_match', 'veritas-kanban', '/worktrees/platform'),
+        makeTask('task_other', 'other-repo', '/worktrees/other'),
+      ];
+      const telemetry = {
+        getEvents: vi.fn().mockResolvedValue([
+          {
+            id: 'tokens_match',
+            type: 'run.tokens',
+            timestamp: '2026-06-04T11:30:00.000Z',
+            taskId: 'task_match',
+            agent: 'codex',
+            inputTokens: 25,
+            outputTokens: 15,
+            totalTokens: 40,
+            cost: 0.004,
+          } satisfies TokenTelemetryEvent,
+          {
+            id: 'tokens_other',
+            type: 'run.tokens',
+            timestamp: '2026-06-04T11:35:00.000Z',
+            taskId: 'task_other',
+            agent: 'codex',
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            cost: 0.015,
+          } satisfies TokenTelemetryEvent,
+        ]),
+      };
+      const taskService = { listTasks: vi.fn().mockResolvedValue(tasks) };
+      const serviceOverrides = service as unknown as {
+        telemetry: typeof telemetry;
+        taskService: typeof taskService;
+      };
+      serviceOverrides.telemetry = telemetry;
+      serviceOverrides.taskService = taskService;
+
+      const digest = await service.generateOperationsDigest({
+        from: '2026-06-04T00:00:00.000Z',
+        to: '2026-06-04T12:00:00.000Z',
+        project: 'platform',
+        repo: 'veritas-kanban',
+        cwd: '/worktrees/platform',
+      });
+
+      expect(digest.groups).toHaveLength(1);
+      expect(digest.groups[0]).toMatchObject({
+        project: 'platform',
+        repo: 'veritas-kanban',
+        cwd: '/worktrees/platform',
+        totals: {
+          active: 1,
+          totalTokens: 40,
+        },
+      });
+      expect(digest.groups[0].sourceLinks.activeTasks).toHaveLength(1);
+      expect(digest.groups[0].sourceLinks.tokenEvents[0]?.id).toBe('tokens_match');
+      expect(digest.totals.totalTokens).toBe(40);
+    });
   });
 
   describe('formatForTeams', () => {

--- a/server/src/__tests__/routes/misc-routes-coverage.test.ts
+++ b/server/src/__tests__/routes/misc-routes-coverage.test.ts
@@ -468,10 +468,17 @@ describe('Digest Routes', () => {
       groups: [],
       hasActivity: false,
     });
-    const res = await request(app).get('/api/digest/operations?hours=12&project=platform');
+    const res = await request(app).get(
+      '/api/digest/operations?hours=12&project=platform&repo=veritas-kanban&cwd=%2Fworktrees%2Fplatform'
+    );
     expect(res.status).toBe(200);
     expect(mockDigestService.generateOperationsDigest).toHaveBeenCalledWith(
-      expect.objectContaining({ windowHours: 12, project: 'platform' })
+      expect.objectContaining({
+        windowHours: 12,
+        project: 'platform',
+        repo: 'veritas-kanban',
+        cwd: '/worktrees/platform',
+      })
     );
   });
 

--- a/server/src/routes/digest.ts
+++ b/server/src/routes/digest.ts
@@ -14,6 +14,8 @@ const router: RouterType = Router();
  * - hours: window size when from/to are not supplied (default: 24)
  * - from/to: ISO timestamp range
  * - project: optional project filter
+ * - repo: optional repository filter
+ * - cwd: optional worktree/current-working-directory filter
  */
 router.get(
   '/operations',
@@ -24,6 +26,8 @@ router.get(
       from: qStr(req.query.from),
       to: qStr(req.query.to),
       project: qStr(req.query.project),
+      repo: qStr(req.query.repo),
+      cwd: qStr(req.query.cwd),
     });
 
     if (qStrD(req.query.format, 'json') === 'markdown') {
@@ -49,6 +53,8 @@ router.get(
       from: qStr(req.query.from),
       to: qStr(req.query.to),
       project: qStr(req.query.project),
+      repo: qStr(req.query.repo),
+      cwd: qStr(req.query.cwd),
     });
     const message = digestService.formatOperationsDigestMarkdown(digest);
 

--- a/server/src/services/digest-service.ts
+++ b/server/src/services/digest-service.ts
@@ -73,6 +73,8 @@ export interface AgentOperationsDigestOptions {
   from?: string;
   to?: string;
   project?: string;
+  repo?: string;
+  cwd?: string;
 }
 
 export interface AgentOperationsSourceLink {
@@ -277,14 +279,15 @@ export class DigestService {
   async generateOperationsDigest(
     options: AgentOperationsDigestOptions = {}
   ): Promise<AgentOperationsDigest> {
-    const period = resolveOperationsPeriod(options);
+    const filters = normalizeOperationsOptions(options);
+    const period = resolveOperationsPeriod(filters);
     const [tasks, events, approvals] = await Promise.all([
       this.taskService.listTasks(),
       this.telemetry.getEvents({
         since: period.start,
         until: period.end,
         type: ['run.completed', 'run.error', 'run.tokens'],
-        project: options.project,
+        project: filters.project,
         limit: 10000,
       }),
       getAgentPermissionService().getPendingApprovals(),
@@ -332,7 +335,7 @@ export class DigestService {
     };
 
     for (const task of tasks) {
-      if (options.project && task.project !== options.project) continue;
+      if (!matchesOperationsFilters(taskOperationsContext(task), filters)) continue;
       const group = getGroup(task.project, task.git?.repo, task.git?.worktreePath);
       const taskLink = taskSourceLink(task);
 
@@ -363,7 +366,18 @@ export class DigestService {
 
     for (const event of events) {
       const task = event.taskId ? taskById.get(event.taskId) : undefined;
-      if (options.project && (task?.project ?? event.project) !== options.project) continue;
+      if (
+        !matchesOperationsFilters(
+          {
+            project: task?.project ?? event.project,
+            repo: task?.git?.repo,
+            cwd: task?.git?.worktreePath,
+          },
+          filters
+        )
+      ) {
+        continue;
+      }
       const group = getGroup(
         task?.project ?? event.project,
         task?.git?.repo,
@@ -410,7 +424,7 @@ export class DigestService {
 
     for (const approval of approvals) {
       const task = approval.taskId ? taskById.get(approval.taskId) : undefined;
-      if (options.project && task?.project !== options.project) continue;
+      if (!matchesOperationsFilters(taskOperationsContext(task), filters)) continue;
       const group = getGroup(task?.project, task?.git?.repo, task?.git?.worktreePath);
       const approvalLink = approvalSourceLink(approval);
       pushUnique(group.openApprovals, approvalLink);
@@ -723,6 +737,59 @@ function taskSourceLink(task: Task): AgentOperationsSourceLink {
     timestamp: task.updated,
     taskId: task.id,
   };
+}
+
+function taskOperationsContext(task?: Task): {
+  project?: string;
+  repo?: string;
+  cwd?: string;
+} {
+  return {
+    project: task?.project,
+    repo: task?.git?.repo,
+    cwd: task?.git?.worktreePath,
+  };
+}
+
+function matchesOperationsFilters(
+  candidate: { project?: string; repo?: string; cwd?: string },
+  options: AgentOperationsDigestOptions
+): boolean {
+  return (
+    matchesOperationsFilter(normalizeProject(candidate.project), options.project) &&
+    matchesOperationsFilter(normalizeRepo(candidate.repo), options.repo) &&
+    matchesOperationsFilter(candidate.cwd, options.cwd)
+  );
+}
+
+function normalizeOperationsOptions(
+  options: AgentOperationsDigestOptions
+): AgentOperationsDigestOptions {
+  return {
+    ...options,
+    project: normalizeOptionalFilter(options.project),
+    repo: normalizeOptionalFilter(options.repo),
+    cwd: normalizeOptionalFilter(options.cwd),
+  };
+}
+
+function matchesOperationsFilter(candidate: string | undefined, filter: string | undefined) {
+  const normalizedFilter = normalizeOptionalFilter(filter);
+  if (!normalizedFilter) return true;
+  return candidate === normalizedFilter;
+}
+
+function normalizeOptionalFilter(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeProject(value: string | undefined): string {
+  return normalizeOptionalFilter(value) ?? 'unassigned';
+}
+
+function normalizeRepo(value: string | undefined): string {
+  return normalizeOptionalFilter(value) ?? 'unknown';
 }
 
 function runSourceLink(event: RunTelemetryEvent): AgentOperationsSourceLink {

--- a/web/src/__tests__/operations-digest-mantine.test.tsx
+++ b/web/src/__tests__/operations-digest-mantine.test.tsx
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { OperationsDigestPage } from '@/components/digest/OperationsDigestPage';
+import { renderWithProviders } from './test-utils';
+import type { AgentOperationsDigest, ScheduledDeliverable } from '@/lib/api';
+
+const mocks = vi.hoisted(() => ({
+  useProjects: vi.fn(),
+  useOperationsDigest: vi.fn(),
+  useOperationsDigestMarkdown: vi.fn(),
+  useOperationsDigestSchedule: vi.fn(),
+  useCreateOperationsDigestSchedule: vi.fn(),
+  useRecordOperationsDigestSnapshot: vi.fn(),
+  digestRefetch: vi.fn(),
+  markdownRefetch: vi.fn(),
+  scheduleRefetch: vi.fn(),
+  createSchedule: vi.fn(),
+  recordSnapshot: vi.fn(),
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProjects: mocks.useProjects,
+}));
+
+vi.mock('@/hooks/useOperationsDigest', () => ({
+  normalizeOperationsDigestFilters: (filters: Record<string, unknown>) =>
+    Object.fromEntries(Object.entries(filters).filter(([, value]) => value !== undefined)),
+  useOperationsDigest: mocks.useOperationsDigest,
+  useOperationsDigestMarkdown: mocks.useOperationsDigestMarkdown,
+  useOperationsDigestSchedule: mocks.useOperationsDigestSchedule,
+  useCreateOperationsDigestSchedule: mocks.useCreateOperationsDigestSchedule,
+  useRecordOperationsDigestSnapshot: mocks.useRecordOperationsDigestSnapshot,
+}));
+
+vi.mock('@/components/ui/MarkdownRenderer', () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => (
+    <div data-testid="markdown">{content}</div>
+  ),
+}));
+
+const digest: AgentOperationsDigest = {
+  period: {
+    start: '2026-06-04T00:00:00.000Z',
+    end: '2026-06-05T00:00:00.000Z',
+    windowHours: 24,
+  },
+  generatedAt: '2026-06-05T00:01:00.000Z',
+  hasActivity: true,
+  totals: {
+    active: 1,
+    blocked: 1,
+    stuck: 0,
+    completed: 2,
+    failed: 1,
+    runs: 3,
+    tokenCost: 0.045,
+    inputTokens: 100,
+    outputTokens: 50,
+    totalTokens: 150,
+    wallTimeMs: 3_600_000,
+    activeTimeMs: 600_000,
+    openApprovals: 1,
+    groups: 1,
+  },
+  groups: [
+    {
+      key: 'platform::veritas-kanban::/worktrees/platform',
+      project: 'platform',
+      repo: 'veritas-kanban',
+      cwd: '/worktrees/platform',
+      totals: {
+        active: 1,
+        blocked: 1,
+        stuck: 0,
+        completed: 2,
+        failed: 1,
+        runs: 3,
+        tokenCost: 0.045,
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        wallTimeMs: 3_600_000,
+        activeTimeMs: 600_000,
+      },
+      sourceLinks: {
+        activeTasks: [
+          {
+            kind: 'task',
+            id: 'task_active',
+            label: 'Active task',
+            taskId: 'task_active',
+            timestamp: '2026-06-04T12:00:00.000Z',
+          },
+        ],
+        blockedTasks: [
+          {
+            kind: 'task',
+            id: 'task_blocked',
+            label: 'Blocked task',
+            taskId: 'task_blocked',
+            timestamp: '2026-06-04T12:30:00.000Z',
+          },
+        ],
+        stuckTasks: [],
+        completedTasks: [
+          {
+            kind: 'task',
+            id: 'task_done',
+            label: 'Completed task',
+            taskId: 'task_done',
+            timestamp: '2026-06-04T13:00:00.000Z',
+          },
+        ],
+        failedRuns: [
+          {
+            kind: 'run',
+            id: 'attempt_failed',
+            label: 'Failed run',
+            taskId: 'task_active',
+            timestamp: '2026-06-04T13:30:00.000Z',
+          },
+        ],
+        tokenEvents: [
+          {
+            kind: 'telemetry',
+            id: 'tokens_1',
+            label: 'Token usage',
+            taskId: 'task_active',
+            timestamp: '2026-06-04T13:45:00.000Z',
+          },
+        ],
+      },
+      topPlanCompletions: [
+        {
+          kind: 'task',
+          id: 'task_done',
+          label: 'Completed task',
+          taskId: 'task_done',
+          timestamp: '2026-06-04T13:00:00.000Z',
+        },
+      ],
+      notableFailures: [
+        {
+          kind: 'run',
+          id: 'attempt_failed',
+          label: 'Failed run',
+          taskId: 'task_active',
+          timestamp: '2026-06-04T13:30:00.000Z',
+          agent: 'codex',
+          error: 'Tests failed',
+        },
+      ],
+      openApprovals: [
+        {
+          kind: 'approval',
+          id: 'approval_1',
+          label: 'codex approval',
+          taskId: 'task_blocked',
+          timestamp: '2026-06-04T14:00:00.000Z',
+          agent: 'codex',
+          action: 'push_branch',
+        },
+      ],
+    },
+  ],
+  refresh: {
+    manual: true,
+    schedule: 'daily-ready',
+    narrative: 'deterministic-only',
+  },
+};
+
+const scheduledDeliverable: ScheduledDeliverable = {
+  id: 'del_ops',
+  name: 'Operations Digest',
+  description: 'Daily digest',
+  schedule: 'daily',
+  scheduleDescription: 'Every day',
+  enabled: true,
+  agent: 'veritas',
+  outputPath: 'operations/digests',
+  tags: ['operations-digest'],
+  createdAt: '2026-06-01T00:00:00.000Z',
+  lastRunAt: '2026-06-04T09:00:00.000Z',
+  nextRunAt: '2026-06-05T09:00:00.000Z',
+  totalRuns: 4,
+};
+
+describe('OperationsDigestPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.digestRefetch.mockResolvedValue({});
+    mocks.markdownRefetch.mockResolvedValue({});
+    mocks.scheduleRefetch.mockResolvedValue({});
+    mocks.createSchedule.mockResolvedValue(scheduledDeliverable);
+    mocks.recordSnapshot.mockResolvedValue({});
+    mocks.useProjects.mockReturnValue({
+      data: [{ id: 'platform', label: 'Platform', order: 1 }],
+    });
+    mocks.useOperationsDigest.mockReturnValue({
+      data: digest,
+      error: null,
+      isLoading: false,
+      isFetching: false,
+      refetch: mocks.digestRefetch,
+    });
+    mocks.useOperationsDigestMarkdown.mockReturnValue({
+      data: { isEmpty: false, markdown: '# Agent Operations Digest\n\n- Counts: 1 active' },
+      error: null,
+      isLoading: false,
+      isFetching: false,
+      refetch: mocks.markdownRefetch,
+    });
+    mocks.useOperationsDigestSchedule.mockReturnValue({
+      data: [scheduledDeliverable],
+      refetch: mocks.scheduleRefetch,
+    });
+    mocks.useCreateOperationsDigestSchedule.mockReturnValue({
+      mutateAsync: mocks.createSchedule,
+      isPending: false,
+    });
+    mocks.useRecordOperationsDigestSnapshot.mockReturnValue({
+      mutateAsync: mocks.recordSnapshot,
+      isPending: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders deterministic digest groups, markdown, and scheduled delivery controls', async () => {
+    const user = userEvent.setup();
+    const onTaskClick = vi.fn();
+    const { container } = renderWithProviders(
+      <OperationsDigestPage onBack={vi.fn()} onTaskClick={onTaskClick} />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Operations Digest' })).toBeDefined();
+    expect(screen.getByText('platform / veritas-kanban / /worktrees/platform')).toBeDefined();
+    expect(screen.getByText('Daily Delivery')).toBeDefined();
+    expect(screen.getByText('Configured')).toBeDefined();
+    expect(screen.getByTestId('markdown').textContent).toContain('Agent Operations Digest');
+    expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThan(4);
+    expect(container.querySelector('[data-slot="button"]')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /Active: 1/i }));
+
+    expect(onTaskClick).toHaveBeenCalledWith('task_active');
+  });
+
+  it('passes repo and cwd filters into digest queries', async () => {
+    renderWithProviders(<OperationsDigestPage onBack={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('Repository'), {
+      target: { value: 'veritas-kanban' },
+    });
+    fireEvent.change(screen.getByLabelText('CWD / worktree'), {
+      target: { value: '/worktrees/platform' },
+    });
+
+    await waitFor(() =>
+      expect(mocks.useOperationsDigest).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          repo: 'veritas-kanban',
+          cwd: '/worktrees/platform',
+        })
+      )
+    );
+  });
+});

--- a/web/src/components/digest/OperationsDigestPage.tsx
+++ b/web/src/components/digest/OperationsDigestPage.tsx
@@ -1,0 +1,723 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Code,
+  Group,
+  Select,
+  Text,
+  TextInput,
+  Textarea,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CalendarClock,
+  CheckCircle2,
+  ClipboardList,
+  Copy,
+  Download,
+  ExternalLink,
+  FileText,
+  RefreshCw,
+  Search,
+} from 'lucide-react';
+import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
+import { useProjects } from '@/hooks/useProjects';
+import {
+  normalizeOperationsDigestFilters,
+  useCreateOperationsDigestSchedule,
+  useOperationsDigest,
+  useOperationsDigestMarkdown,
+  useOperationsDigestSchedule,
+  useRecordOperationsDigestSnapshot,
+} from '@/hooks/useOperationsDigest';
+import type {
+  AgentOperationsDigest,
+  AgentOperationsDigestFilters,
+  AgentOperationsDigestGroup,
+  AgentOperationsSourceLink,
+  SearchCollection,
+} from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+interface OperationsDigestPageProps {
+  onBack: () => void;
+  onTaskClick?: (taskId: string) => void;
+}
+
+type WindowPreset = '24' | '72' | '168' | 'custom';
+
+const WINDOW_OPTIONS: Array<{ value: WindowPreset; label: string }> = [
+  { value: '24', label: '24 hours' },
+  { value: '72', label: '3 days' },
+  { value: '168', label: '7 days' },
+  { value: 'custom', label: 'Custom range' },
+];
+
+const SOURCE_COLLECTIONS: SearchCollection[] = ['tasks-active', 'agent-runs', 'scheduled-runs'];
+
+export function OperationsDigestPage({ onBack, onTaskClick }: OperationsDigestPageProps) {
+  const [windowPreset, setWindowPreset] = useState<WindowPreset>('24');
+  const [from, setFrom] = useState(() => toLocalDateTimeInput(hoursAgo(24)));
+  const [to, setTo] = useState(() => toLocalDateTimeInput(new Date()));
+  const [project, setProject] = useState('all');
+  const [repo, setRepo] = useState('');
+  const [cwd, setCwd] = useState('');
+
+  const filters = useMemo<AgentOperationsDigestFilters>(() => {
+    const base =
+      windowPreset === 'custom'
+        ? {
+            from: localDateTimeInputToIso(from),
+            to: localDateTimeInputToIso(to),
+          }
+        : {
+            hours: Number(windowPreset),
+          };
+
+    return normalizeOperationsDigestFilters({
+      ...base,
+      project: project === 'all' ? undefined : project,
+      repo,
+      cwd,
+    });
+  }, [cwd, from, project, repo, to, windowPreset]);
+
+  const { data: projects = [] } = useProjects();
+  const digestQuery = useOperationsDigest(filters);
+  const markdownQuery = useOperationsDigestMarkdown(filters);
+  const scheduleQuery = useOperationsDigestSchedule();
+  const createSchedule = useCreateOperationsDigestSchedule();
+  const recordSnapshot = useRecordOperationsDigestSnapshot();
+
+  const digest = digestQuery.data;
+  const markdown = markdownQuery.data?.markdown ?? '';
+  const scheduledDeliverable = scheduleQuery.data?.[0];
+  const isLoading = digestQuery.isLoading || markdownQuery.isLoading;
+  const isRefreshing = digestQuery.isFetching || markdownQuery.isFetching;
+
+  const projectOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All projects' },
+      ...projects.map((item) => ({ value: item.id, label: item.label || item.id })),
+    ],
+    [projects]
+  );
+
+  const refresh = async () => {
+    await Promise.all([digestQuery.refetch(), markdownQuery.refetch(), scheduleQuery.refetch()]);
+  };
+
+  const copyMarkdown = async () => {
+    if (!markdown) return;
+    await navigator.clipboard.writeText(markdown);
+    notifications.show({
+      title: 'Digest copied',
+      message: 'Markdown briefing is on the clipboard.',
+      color: 'green',
+    });
+  };
+
+  const exportMarkdown = () => {
+    if (!markdown) return;
+    downloadText(`operations-digest-${dateStamp()}.md`, markdown, 'text/markdown;charset=utf-8');
+  };
+
+  const exportJson = () => {
+    if (!digest) return;
+    downloadText(
+      `operations-digest-${dateStamp()}.json`,
+      JSON.stringify(digest, null, 2),
+      'application/json;charset=utf-8'
+    );
+  };
+
+  const ensureDailySchedule = async () => {
+    await createSchedule.mutateAsync();
+    notifications.show({
+      title: 'Daily digest scheduled',
+      message: 'The operations digest is registered as a daily scheduled deliverable.',
+      color: 'green',
+    });
+  };
+
+  const recordScheduledSnapshot = async () => {
+    if (!scheduledDeliverable || !digest) return;
+    await recordSnapshot.mutateAsync({
+      deliverableId: scheduledDeliverable.id,
+      run: {
+        status: digest.hasActivity ? 'success' : 'skipped',
+        summary: markdown || markdownQuery.data?.message || 'No operations activity.',
+        snapshotMetadata: digestSnapshotMetadata(digest, filters),
+      },
+    });
+    notifications.show({
+      title: 'Snapshot recorded',
+      message: 'The current digest was stored in scheduled deliverable history.',
+      color: 'green',
+    });
+  };
+
+  const openSources = (items: AgentOperationsSourceLink[]) => {
+    const uniqueTaskIds = Array.from(new Set(items.map((item) => item.taskId).filter(isString)));
+    if (uniqueTaskIds.length === 1 && onTaskClick) {
+      onTaskClick(uniqueTaskIds[0]);
+      return;
+    }
+
+    const query = Array.from(
+      new Set(items.flatMap((item) => [item.taskId, item.id]).filter(isString))
+    )
+      .slice(0, 12)
+      .join(' ');
+    if (!query) return;
+
+    window.dispatchEvent(
+      new CustomEvent('veritas:open-search', {
+        detail: {
+          query,
+          collections: SOURCE_COLLECTIONS,
+        },
+      })
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex min-w-0 items-start gap-4">
+          <Button variant="subtle" size="sm" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Board
+          </Button>
+          <div className="min-w-0">
+            <Group gap="xs" wrap="wrap">
+              <h1 className="text-2xl font-bold">Operations Digest</h1>
+              <Badge
+                variant="light"
+                color={digest?.hasActivity ? 'green' : 'gray'}
+                tt="none"
+                leftSection={<ClipboardList className="h-3 w-3" />}
+              >
+                {digest?.hasActivity ? `${digest.totals.groups} active groups` : 'No activity'}
+              </Badge>
+            </Group>
+            <p className="text-sm text-muted-foreground">
+              Deterministic standup and briefing output from agent tasks, runs, tokens, and
+              approvals.
+            </p>
+          </div>
+        </div>
+
+        <Group gap="xs" wrap="wrap">
+          <Button
+            variant="light"
+            size="sm"
+            onClick={() => void refresh()}
+            leftSection={<RefreshCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />}
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="light"
+            size="sm"
+            onClick={() => void copyMarkdown()}
+            disabled={!markdown}
+            leftSection={<Copy className="h-4 w-4" />}
+          >
+            Copy
+          </Button>
+          <Button
+            variant="light"
+            size="sm"
+            onClick={exportMarkdown}
+            disabled={!markdown}
+            leftSection={<Download className="h-4 w-4" />}
+          >
+            Markdown
+          </Button>
+          <Button
+            variant="light"
+            size="sm"
+            onClick={exportJson}
+            disabled={!digest}
+            leftSection={<Download className="h-4 w-4" />}
+          >
+            JSON
+          </Button>
+        </Group>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[180px_1fr_1fr] xl:grid-cols-[180px_220px_1fr_1fr_1fr]">
+        <Select
+          value={windowPreset}
+          onChange={(value) => setWindowPreset((value ?? '24') as WindowPreset)}
+          data={WINDOW_OPTIONS}
+          allowDeselect={false}
+          label="Window"
+        />
+        <Select
+          value={project}
+          onChange={(value) => setProject(value ?? 'all')}
+          data={projectOptions}
+          allowDeselect={false}
+          searchable
+          label="Project"
+        />
+        <TextInput
+          value={repo}
+          onChange={(event) => setRepo(event.currentTarget.value)}
+          label="Repository"
+          placeholder="Any repository"
+          leftSection={<Search className="h-4 w-4 text-muted-foreground" />}
+        />
+        <TextInput
+          value={cwd}
+          onChange={(event) => setCwd(event.currentTarget.value)}
+          label="CWD / worktree"
+          placeholder="Any worktree path"
+          leftSection={<Search className="h-4 w-4 text-muted-foreground" />}
+        />
+      </div>
+
+      {windowPreset === 'custom' && (
+        <div className="grid gap-3 md:grid-cols-2">
+          <TextInput
+            type="datetime-local"
+            value={from}
+            onChange={(event) => setFrom(event.currentTarget.value)}
+            label="From"
+          />
+          <TextInput
+            type="datetime-local"
+            value={to}
+            onChange={(event) => setTo(event.currentTarget.value)}
+            label="To"
+          />
+        </div>
+      )}
+
+      {digestQuery.error || markdownQuery.error ? (
+        <Alert color="red" variant="light" icon={<AlertTriangle className="h-4 w-4" />}>
+          {(digestQuery.error as Error | undefined)?.message ||
+            (markdownQuery.error as Error | undefined)?.message ||
+            'Failed to load operations digest.'}
+        </Alert>
+      ) : null}
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+        <Metric label="Active" value={digest?.totals.active} tone="green" />
+        <Metric label="Blocked" value={digest?.totals.blocked} tone="orange" />
+        <Metric label="Stuck" value={digest?.totals.stuck} tone="yellow" />
+        <Metric label="Completed" value={digest?.totals.completed} tone="blue" />
+        <Metric label="Failed" value={digest?.totals.failed} tone="red" />
+        <Metric label="Open approvals" value={digest?.totals.openApprovals} tone="violet" />
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[1fr_380px]">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Source Groups</h2>
+              <p className="text-sm text-muted-foreground">
+                Counts use the same filtered source bundle as the briefing output.
+              </p>
+            </div>
+            <Badge variant="light" color="gray" tt="none">
+              {isLoading ? 'Loading' : `${digest?.groups.length ?? 0} groups`}
+            </Badge>
+          </div>
+
+          {isLoading ? (
+            <div className="rounded-lg border bg-card px-4 py-10 text-center text-sm text-muted-foreground">
+              Loading operations digest...
+            </div>
+          ) : digest?.groups.length ? (
+            digest.groups.map((group) => (
+              <DigestGroupCard key={group.key} group={group} onOpenSources={openSources} />
+            ))
+          ) : (
+            <div className="rounded-lg border bg-card px-4 py-10 text-center text-sm text-muted-foreground">
+              No operations activity matches the current filters.
+            </div>
+          )}
+        </div>
+
+        <aside className="space-y-4">
+          <div className="rounded-lg border bg-card p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold">Daily Delivery</h2>
+                <p className="text-sm text-muted-foreground">
+                  Uses scheduled deliverables for recurring digest records.
+                </p>
+              </div>
+              <Badge
+                variant="light"
+                color={scheduledDeliverable?.enabled ? 'green' : 'gray'}
+                tt="none"
+                leftSection={
+                  scheduledDeliverable ? (
+                    <CheckCircle2 className="h-3 w-3" />
+                  ) : (
+                    <CalendarClock className="h-3 w-3" />
+                  )
+                }
+              >
+                {scheduledDeliverable ? 'Configured' : 'Not scheduled'}
+              </Badge>
+            </div>
+
+            <div className="mt-4 space-y-2 text-sm">
+              {scheduledDeliverable ? (
+                <>
+                  <ScheduleFact label="Name" value={scheduledDeliverable.name} />
+                  <ScheduleFact label="Cadence" value={scheduledDeliverable.scheduleDescription} />
+                  <ScheduleFact
+                    label="Last run"
+                    value={formatDateTime(scheduledDeliverable.lastRunAt)}
+                  />
+                  <ScheduleFact
+                    label="Next run"
+                    value={formatDateTime(scheduledDeliverable.nextRunAt)}
+                  />
+                  <ScheduleFact label="Runs" value={String(scheduledDeliverable.totalRuns)} />
+                </>
+              ) : (
+                <Text size="sm" c="dimmed">
+                  Register the digest as a daily deliverable before recording recurring snapshots.
+                </Text>
+              )}
+            </div>
+
+            <Group mt="md" gap="xs" wrap="wrap">
+              <Button
+                size="sm"
+                variant="light"
+                onClick={() => void ensureDailySchedule()}
+                loading={createSchedule.isPending}
+                disabled={Boolean(scheduledDeliverable)}
+                leftSection={<CalendarClock className="h-4 w-4" />}
+              >
+                Enable Daily
+              </Button>
+              <Button
+                size="sm"
+                variant="light"
+                onClick={() => void recordScheduledSnapshot()}
+                loading={recordSnapshot.isPending}
+                disabled={!scheduledDeliverable || !digest}
+                leftSection={<FileText className="h-4 w-4" />}
+              >
+                Record Snapshot
+              </Button>
+            </Group>
+          </div>
+
+          <div className="rounded-lg border bg-card p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold">Briefing Markdown</h2>
+                <p className="text-sm text-muted-foreground">
+                  Deterministic output for standups and handoff notes.
+                </p>
+              </div>
+              <Badge variant="light" color="gray" tt="none">
+                {digest?.refresh.narrative === 'deterministic-only' ? 'No LLM' : 'Narrative'}
+              </Badge>
+            </div>
+
+            <Textarea
+              mt="md"
+              value={markdown || markdownQuery.data?.message || ''}
+              readOnly
+              minRows={12}
+              aria-label="Operations digest markdown"
+              classNames={{
+                input: 'font-mono text-xs',
+              }}
+            />
+          </div>
+        </aside>
+      </section>
+
+      {markdown ? (
+        <section className="rounded-lg border bg-card p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h2 className="text-base font-semibold">Rendered Briefing</h2>
+            <Badge variant="light" color="gray" tt="none">
+              {formatDateTime(digest?.generatedAt)}
+            </Badge>
+          </div>
+          <MarkdownRenderer content={markdown} className="text-sm" />
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value?: number;
+  tone: 'green' | 'orange' | 'yellow' | 'blue' | 'red' | 'violet';
+}) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="text-sm text-muted-foreground">{label}</div>
+      <div className="mt-2 text-2xl font-semibold tabular-nums">{formatNumber(value ?? 0)}</div>
+      <div className={cn('mt-3 h-1 rounded-full', toneClass(tone))} />
+    </div>
+  );
+}
+
+function DigestGroupCard({
+  group,
+  onOpenSources,
+}: {
+  group: AgentOperationsDigestGroup;
+  onOpenSources: (items: AgentOperationsSourceLink[]) => void;
+}) {
+  const heading = [group.project, group.repo, group.cwd].filter(Boolean).join(' / ');
+  const totals = group.totals;
+
+  return (
+    <article className="rounded-lg border bg-card p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <h3 className="truncate text-base font-semibold">{heading}</h3>
+          <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span>{formatNumber(totals.runs)} runs</span>
+            <span>{formatDuration(totals.activeTimeMs)} active</span>
+            <span>{formatDuration(totals.wallTimeMs)} observed</span>
+            <span>{formatNumber(totals.totalTokens)} tokens</span>
+            <span>${totals.tokenCost.toFixed(4)}</span>
+          </div>
+        </div>
+        <Group gap="xs" wrap="wrap">
+          <SourceButton
+            label="Active"
+            count={totals.active}
+            items={group.sourceLinks.activeTasks}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Blocked"
+            count={totals.blocked}
+            items={group.sourceLinks.blockedTasks}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Stuck"
+            count={totals.stuck}
+            items={group.sourceLinks.stuckTasks}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Done"
+            count={totals.completed}
+            items={group.sourceLinks.completedTasks}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Failed"
+            count={totals.failed}
+            items={group.sourceLinks.failedRuns}
+            onOpenSources={onOpenSources}
+          />
+        </Group>
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-3">
+        <SourceList
+          title="Plan completions"
+          items={group.topPlanCompletions}
+          empty="No completed plans in this window."
+        />
+        <SourceList
+          title="Notable failures"
+          items={group.notableFailures}
+          empty="No failures in this group."
+        />
+        <SourceList
+          title="Open approvals"
+          items={group.openApprovals}
+          empty="No pending approvals."
+        />
+      </div>
+    </article>
+  );
+}
+
+function SourceButton({
+  label,
+  count,
+  items,
+  onOpenSources,
+}: {
+  label: string;
+  count: number;
+  items: AgentOperationsSourceLink[];
+  onOpenSources: (items: AgentOperationsSourceLink[]) => void;
+}) {
+  const canOpen = items.length > 0;
+  return (
+    <Button
+      variant="subtle"
+      color="gray"
+      size="compact-sm"
+      onClick={() => onOpenSources(items)}
+      disabled={!canOpen}
+      rightSection={canOpen ? <ExternalLink className="h-3 w-3" /> : undefined}
+    >
+      {label}: {formatNumber(count)}
+    </Button>
+  );
+}
+
+function SourceList({
+  title,
+  items,
+  empty,
+}: {
+  title: string;
+  items: AgentOperationsSourceLink[];
+  empty: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <h4 className="text-sm font-medium">{title}</h4>
+      {items.length ? (
+        <div className="mt-2 space-y-2">
+          {items.slice(0, 5).map((item) => (
+            <div key={`${item.kind}:${item.id}`} className="min-w-0 text-sm">
+              <div className="truncate">{item.label}</div>
+              <div className="mt-0.5 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                <Code className="truncate" color="dark">
+                  {item.id}
+                </Code>
+                <span className="shrink-0">{formatDateTime(item.timestamp)}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <Text mt="xs" size="sm" c="dimmed">
+          {empty}
+        </Text>
+      )}
+    </div>
+  );
+}
+
+function ScheduleFact({ label, value }: { label: string; value?: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="truncate text-right font-medium">{value || 'None'}</span>
+    </div>
+  );
+}
+
+function toneClass(tone: 'green' | 'orange' | 'yellow' | 'blue' | 'red' | 'violet') {
+  switch (tone) {
+    case 'green':
+      return 'bg-green-500/70';
+    case 'orange':
+      return 'bg-orange-500/70';
+    case 'yellow':
+      return 'bg-yellow-500/70';
+    case 'blue':
+      return 'bg-blue-500/70';
+    case 'red':
+      return 'bg-red-500/70';
+    case 'violet':
+      return 'bg-violet-500/70';
+  }
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    notation: Math.abs(value) >= 10_000 ? 'compact' : 'standard',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatDuration(ms: number): string {
+  if (!ms || ms <= 0) return '0m';
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${Math.max(1, minutes)}m`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest ? `${hours}h ${rest}m` : `${hours}h`;
+}
+
+function formatDateTime(value?: string): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function hoursAgo(hours: number): Date {
+  return new Date(Date.now() - hours * 60 * 60 * 1000);
+}
+
+function toLocalDateTimeInput(date: Date): string {
+  const offsetDate = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return offsetDate.toISOString().slice(0, 16);
+}
+
+function localDateTimeInputToIso(value: string): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+}
+
+function dateStamp(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function downloadText(filename: string, content: string, type: string) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function digestSnapshotMetadata(
+  digest: AgentOperationsDigest,
+  filters: AgentOperationsDigestFilters
+): Record<string, string | number | boolean | null> {
+  return {
+    generatedAt: digest.generatedAt,
+    periodStart: digest.period.start,
+    periodEnd: digest.period.end,
+    windowHours: digest.period.windowHours,
+    groups: digest.totals.groups,
+    active: digest.totals.active,
+    blocked: digest.totals.blocked,
+    stuck: digest.totals.stuck,
+    completed: digest.totals.completed,
+    failed: digest.totals.failed,
+    runs: digest.totals.runs,
+    totalTokens: digest.totals.totalTokens,
+    tokenCost: digest.totals.tokenCost,
+    project: filters.project ?? null,
+    repo: filters.repo ?? null,
+    cwd: filters.cwd ?? null,
+  };
+}
+
+function isString(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/web/src/components/layout/CommandPalette.tsx
+++ b/web/src/components/layout/CommandPalette.tsx
@@ -23,6 +23,7 @@ import { useKeyboard } from '@/hooks/useKeyboard';
 import { useView } from '@/contexts/ViewContext';
 import {
   Plus,
+  ClipboardList,
   LayoutDashboard,
   ListOrdered,
   Inbox,
@@ -59,6 +60,7 @@ const SearchDialog = lazy(() =>
 const VIEW_ICONS: Record<ViewIcon, LucideIcon> = {
   Activity,
   Archive,
+  ClipboardList,
   FileText,
   GitBranch,
   Inbox,

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -14,6 +14,7 @@ import {
   Settings,
   Search,
   Archive,
+  ClipboardList,
   Inbox,
   Sun,
   Moon,
@@ -82,6 +83,7 @@ interface SearchPreset {
 const VIEW_ICONS: Record<ViewIcon, LucideIcon> = {
   Activity,
   Archive,
+  ClipboardList,
   FileText,
   GitBranch,
   Inbox,

--- a/web/src/hooks/useOperationsDigest.ts
+++ b/web/src/hooks/useOperationsDigest.ts
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type { AgentOperationsDigestFilters, ScheduledDeliverableRunInput } from '@/lib/api';
+
+export const OPERATIONS_DIGEST_DELIVERABLE_TAG = 'operations-digest';
+
+export function normalizeOperationsDigestFilters(
+  filters: AgentOperationsDigestFilters
+): AgentOperationsDigestFilters {
+  const next: AgentOperationsDigestFilters = {};
+  if (typeof filters.hours === 'number') next.hours = filters.hours;
+  if (filters.from?.trim()) next.from = filters.from.trim();
+  if (filters.to?.trim()) next.to = filters.to.trim();
+  if (filters.project?.trim()) next.project = filters.project.trim();
+  if (filters.repo?.trim()) next.repo = filters.repo.trim();
+  if (filters.cwd?.trim()) next.cwd = filters.cwd.trim();
+  return next;
+}
+
+export function useOperationsDigest(filters: AgentOperationsDigestFilters) {
+  const normalizedFilters = normalizeOperationsDigestFilters(filters);
+
+  return useQuery({
+    queryKey: ['operations-digest', normalizedFilters],
+    queryFn: () => api.digest.operations(normalizedFilters),
+    placeholderData: (previousData) => previousData,
+    staleTime: 30_000,
+  });
+}
+
+export function useOperationsDigestMarkdown(filters: AgentOperationsDigestFilters) {
+  const normalizedFilters = normalizeOperationsDigestFilters(filters);
+
+  return useQuery({
+    queryKey: ['operations-digest-markdown', normalizedFilters],
+    queryFn: () => api.digest.operationsMarkdown(normalizedFilters),
+    placeholderData: (previousData) => previousData,
+    staleTime: 30_000,
+  });
+}
+
+export function useOperationsDigestSchedule() {
+  return useQuery({
+    queryKey: ['scheduled-deliverables', OPERATIONS_DIGEST_DELIVERABLE_TAG],
+    queryFn: () =>
+      api.scheduledDeliverables.list({
+        tag: OPERATIONS_DIGEST_DELIVERABLE_TAG,
+      }),
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateOperationsDigestSchedule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () =>
+      api.scheduledDeliverables.create({
+        name: 'Operations Digest',
+        description: 'Daily deterministic agent operations digest for standups and briefings.',
+        schedule: 'daily',
+        scheduleDescription: 'Every day',
+        agent: 'veritas',
+        outputPath: 'operations/digests',
+        tags: [OPERATIONS_DIGEST_DELIVERABLE_TAG, 'standup', 'briefing'],
+        enabled: true,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['scheduled-deliverables', OPERATIONS_DIGEST_DELIVERABLE_TAG],
+      });
+    },
+  });
+}
+
+export function useRecordOperationsDigestSnapshot() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      deliverableId,
+      run,
+    }: {
+      deliverableId: string;
+      run: ScheduledDeliverableRunInput;
+    }) => api.scheduledDeliverables.recordRun(deliverableId, run),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['scheduled-deliverables', OPERATIONS_DIGEST_DELIVERABLE_TAG],
+      });
+    },
+  });
+}

--- a/web/src/lib/api/deliverables.ts
+++ b/web/src/lib/api/deliverables.ts
@@ -1,0 +1,98 @@
+import { API_BASE, apiFetch } from './helpers';
+
+export type DeliverableSchedule = 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'custom';
+export type DeliverableRunStatus = 'success' | 'failed' | 'skipped';
+
+export interface ScheduledDeliverable {
+  id: string;
+  name: string;
+  description: string;
+  schedule: DeliverableSchedule;
+  cronExpr?: string;
+  scheduleDescription: string;
+  enabled: boolean;
+  agent?: string;
+  outputPath?: string;
+  tags: string[];
+  createdAt: string;
+  lastRunAt?: string;
+  nextRunAt?: string;
+  totalRuns: number;
+}
+
+export interface ScheduledDeliverableRunSnapshot {
+  status: DeliverableRunStatus;
+  capturedAt: string;
+  sourceRunId?: string;
+  workflowId?: string;
+  outputFile?: string;
+  summary?: string;
+  durationMs?: number;
+  error?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface ScheduledDeliverableRun {
+  id: string;
+  deliverableId: string;
+  status: DeliverableRunStatus;
+  outputFile?: string;
+  summary?: string;
+  durationMs?: number;
+  error?: string;
+  sourceRunId?: string;
+  workflowId?: string;
+  snapshot?: ScheduledDeliverableRunSnapshot;
+  runAt: string;
+}
+
+export interface ScheduledDeliverableCreateInput {
+  name: string;
+  description: string;
+  schedule: DeliverableSchedule;
+  cronExpr?: string;
+  scheduleDescription?: string;
+  agent?: string;
+  outputPath?: string;
+  tags?: string[];
+  enabled?: boolean;
+}
+
+export interface ScheduledDeliverableRunInput {
+  status: DeliverableRunStatus;
+  outputFile?: string;
+  summary?: string;
+  durationMs?: number;
+  error?: string;
+  sourceRunId?: string;
+  workflowId?: string;
+  snapshotMetadata?: Record<string, string | number | boolean | null>;
+}
+
+export const scheduledDeliverablesApi = {
+  list: (filters: { enabled?: boolean; agent?: string; tag?: string } = {}) => {
+    const params = new URLSearchParams();
+    if (typeof filters.enabled === 'boolean') params.set('enabled', String(filters.enabled));
+    if (filters.agent) params.set('agent', filters.agent);
+    if (filters.tag) params.set('tag', filters.tag);
+    const query = params.toString();
+    return apiFetch<ScheduledDeliverable[]>(`${API_BASE}/deliverables${query ? `?${query}` : ''}`);
+  },
+
+  create: (input: ScheduledDeliverableCreateInput) =>
+    apiFetch<ScheduledDeliverable>(`${API_BASE}/deliverables`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  recordRun: (deliverableId: string, input: ScheduledDeliverableRunInput) =>
+    apiFetch<ScheduledDeliverableRun>(
+      `${API_BASE}/deliverables/${encodeURIComponent(deliverableId)}/runs`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    ),
+};

--- a/web/src/lib/api/digest.ts
+++ b/web/src/lib/api/digest.ts
@@ -1,0 +1,110 @@
+import { API_BASE, apiFetch } from './helpers';
+
+export interface AgentOperationsDigestFilters {
+  hours?: number;
+  from?: string;
+  to?: string;
+  project?: string;
+  repo?: string;
+  cwd?: string;
+}
+
+export interface AgentOperationsSourceLink {
+  kind: 'approval' | 'run' | 'task' | 'telemetry';
+  id: string;
+  label: string;
+  timestamp?: string;
+  taskId?: string;
+}
+
+export interface AgentOperationsFailure extends AgentOperationsSourceLink {
+  agent?: string;
+  error?: string;
+}
+
+export interface AgentOperationsApproval extends AgentOperationsSourceLink {
+  agent: string;
+  action: string;
+  details?: string;
+}
+
+export interface AgentOperationsDigestGroup {
+  key: string;
+  project: string;
+  repo: string;
+  cwd?: string;
+  totals: {
+    active: number;
+    blocked: number;
+    stuck: number;
+    completed: number;
+    failed: number;
+    runs: number;
+    tokenCost: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    wallTimeMs: number;
+    activeTimeMs: number;
+  };
+  sourceLinks: {
+    activeTasks: AgentOperationsSourceLink[];
+    blockedTasks: AgentOperationsSourceLink[];
+    stuckTasks: AgentOperationsSourceLink[];
+    completedTasks: AgentOperationsSourceLink[];
+    failedRuns: AgentOperationsSourceLink[];
+    tokenEvents: AgentOperationsSourceLink[];
+  };
+  topPlanCompletions: AgentOperationsSourceLink[];
+  notableFailures: AgentOperationsFailure[];
+  openApprovals: AgentOperationsApproval[];
+}
+
+export interface AgentOperationsDigest {
+  period: {
+    start: string;
+    end: string;
+    windowHours: number;
+  };
+  generatedAt: string;
+  hasActivity: boolean;
+  groups: AgentOperationsDigestGroup[];
+  totals: AgentOperationsDigestGroup['totals'] & {
+    openApprovals: number;
+    groups: number;
+  };
+  refresh: {
+    manual: boolean;
+    schedule: 'daily-ready';
+    narrative: 'deterministic-only';
+  };
+}
+
+export interface AgentOperationsMarkdown {
+  isEmpty: boolean;
+  markdown?: string;
+  message?: string;
+}
+
+function digestQuery(filters: AgentOperationsDigestFilters, format?: 'markdown'): string {
+  const params = new URLSearchParams();
+  if (format) params.set('format', format);
+  if (typeof filters.hours === 'number') params.set('hours', String(filters.hours));
+  if (filters.from) params.set('from', filters.from);
+  if (filters.to) params.set('to', filters.to);
+  if (filters.project) params.set('project', filters.project);
+  if (filters.repo) params.set('repo', filters.repo);
+  if (filters.cwd) params.set('cwd', filters.cwd);
+  const query = params.toString();
+  return `${API_BASE}/digest/operations${query ? `?${query}` : ''}`;
+}
+
+export const digestApi = {
+  operations: (filters: AgentOperationsDigestFilters = {}): Promise<AgentOperationsDigest> =>
+    apiFetch<AgentOperationsDigest>(digestQuery(filters)),
+
+  operationsMarkdown: (
+    filters: AgentOperationsDigestFilters = {}
+  ): Promise<AgentOperationsMarkdown> =>
+    apiFetch<AgentOperationsMarkdown>(digestQuery(filters, 'markdown')),
+};

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -23,6 +23,8 @@ import { maintenanceApi } from './maintenance';
 import { skillCapabilitiesApi } from './skill-capabilities';
 import { skillSecurityApi } from './skill-security';
 import { integrationsApi } from './integrations';
+import { digestApi } from './digest';
+import { scheduledDeliverablesApi } from './deliverables';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -56,6 +58,8 @@ export const api = {
   integrations: integrationsApi,
   skillCapabilities: skillCapabilitiesApi,
   skillSecurity: skillSecurityApi,
+  digest: digestApi,
+  scheduledDeliverables: scheduledDeliverablesApi,
 };
 
 export type {
@@ -77,6 +81,24 @@ export type {
   OutboundEndpointRecord,
   OutboundEndpointType,
 } from './integrations';
+export type {
+  AgentOperationsApproval,
+  AgentOperationsDigest,
+  AgentOperationsDigestFilters,
+  AgentOperationsDigestGroup,
+  AgentOperationsFailure,
+  AgentOperationsMarkdown,
+  AgentOperationsSourceLink,
+} from './digest';
+export type {
+  DeliverableRunStatus,
+  DeliverableSchedule,
+  ScheduledDeliverable,
+  ScheduledDeliverableCreateInput,
+  ScheduledDeliverableRun,
+  ScheduledDeliverableRunInput,
+  ScheduledDeliverableRunSnapshot,
+} from './deliverables';
 
 // Re-export managed list helper
 export { managedList } from './managed-list';

--- a/web/src/lib/views.ts
+++ b/web/src/lib/views.ts
@@ -7,6 +7,7 @@ export type AppView =
   | 'archive'
   | 'templates'
   | 'workflows'
+  | 'operations'
   | 'policies'
   | 'drift'
   | 'decisions'
@@ -17,6 +18,7 @@ export type NavigationView = Exclude<AppView, 'board'>;
 export type ViewIcon =
   | 'Activity'
   | 'Archive'
+  | 'ClipboardList'
   | 'FileText'
   | 'GitBranch'
   | 'Inbox'
@@ -130,6 +132,22 @@ const VIEW_DEFINITION_LIST = [
     loadComponent: () =>
       import('@/components/workflows/WorkflowsPage').then((mod) => ({
         default: mod.WorkflowsPage,
+      })),
+  },
+  {
+    view: 'operations',
+    path: '/operations',
+    label: 'Operations',
+    order: 55,
+    showInNavigation: true,
+    title: 'Operations Digest',
+    commandLabel: 'Go to Operations',
+    loadingLabel: 'Loading operations digest...',
+    icon: 'ClipboardList',
+    keywords: ['digest', 'standup', 'briefing', 'operations', 'schedule'],
+    loadComponent: () =>
+      import('@/components/digest/OperationsDigestPage').then((mod) => ({
+        default: mod.OperationsDigestPage,
       })),
   },
   {


### PR DESCRIPTION
## Summary
- Adds a lazy operations digest view with time, project, repo, and cwd filters.
- Adds copy, markdown export, JSON export, refresh, source navigation, and rendered briefing preview.
- Extends the digest API client and server route to carry repo and cwd filters through the deterministic digest service.
- Adds scheduled-deliverable controls for daily digest registration and manual snapshot recording.

## Tests
- pnpm --filter @veritas-kanban/server test -- digest-service.test.ts misc-routes-coverage.test.ts
- pnpm --filter @veritas-kanban/web test -- operations-digest-mantine.test.tsx view-registry.test.ts command-registry.test.ts
- pnpm typecheck
- pnpm --filter @veritas-kanban/web lint
- pnpm lint:budget
- pnpm build
- pnpm test:unit

## Notes
- Existing lint warning debt remains under the configured budget.
- Automatic due execution for scheduled deliverables is tracked separately in #631.

Closes #585