### PR TITLE
Add automatic due-runner for scheduled deliverables

### DIFF
--- a/server/src/__tests__/scheduled-deliverables-runner-service.test.ts
+++ b/server/src/__tests__/scheduled-deliverables-runner-service.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ScheduledDeliverablesService } from '../services/scheduled-deliverables-service.js';
+import {
+  ScheduledDeliverablesRunner,
+  type ScheduledDeliverablesRunnerResult,
+} from '../services/scheduled-deliverables-runner-service.js';
+import type { AgentOperationsDigest } from '../services/digest-service.js';
+import type { Deliverable, DeliverableRun } from '../services/scheduled-deliverables-service.js';
+
+describe('ScheduledDeliverablesService due scheduling', () => {
+  let testRoot: string;
+
+  beforeEach(async () => {
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-scheduled-due-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('sets initial nextRunAt when scheduled deliverables are created', async () => {
+    const service = new ScheduledDeliverablesService({ dataDir: testRoot, storageType: 'file' });
+
+    const deliverable = await service.create({
+      name: 'Daily Operations Digest',
+      description: 'Daily deterministic operations digest.',
+      schedule: 'daily',
+      tags: ['operations-digest'],
+    });
+
+    expect(deliverable.nextRunAt).toEqual(expect.any(String));
+    expect(Date.parse(deliverable.nextRunAt as string)).toBeGreaterThan(
+      Date.parse(deliverable.createdAt)
+    );
+  });
+
+  it('lists only enabled deliverables due at or before the requested time', async () => {
+    const dueNow = '2026-06-05T09:00:00.000Z';
+    await fs.mkdir(testRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(testRoot, 'scheduled-deliverables.json'),
+      JSON.stringify([
+        scheduledDeliverable({
+          id: 'del_due',
+          name: 'Due Digest',
+          nextRunAt: '2026-06-05T08:59:59.000Z',
+          enabled: true,
+        }),
+        scheduledDeliverable({
+          id: 'del_future',
+          name: 'Future Digest',
+          nextRunAt: '2026-06-05T09:00:01.000Z',
+          enabled: true,
+        }),
+        scheduledDeliverable({
+          id: 'del_disabled',
+          name: 'Disabled Digest',
+          nextRunAt: '2026-06-05T08:00:00.000Z',
+          enabled: false,
+        }),
+      ])
+    );
+    await fs.writeFile(path.join(testRoot, 'deliverable-runs.json'), '[]');
+    const service = new ScheduledDeliverablesService({ dataDir: testRoot, storageType: 'file' });
+
+    await expect(service.listDue(new Date(dueNow))).resolves.toEqual([
+      expect.objectContaining({ id: 'del_due' }),
+    ]);
+  });
+});
+
+describe('ScheduledDeliverablesRunner', () => {
+  it('records a successful operations digest run for due digest deliverables', async () => {
+    const runs: Array<Parameters<ScheduledDeliverablesStore['recordRun']>[0]> = [];
+    const deliverablesService = fakeDeliverablesService({
+      due: [
+        scheduledDeliverable({
+          id: 'del_ops',
+          tags: ['operations-digest', 'standup'],
+          outputPath: 'operations/digests',
+        }),
+      ],
+      runs,
+    });
+    const digest = makeOperationsDigest();
+    const digestService = {
+      generateOperationsDigest: vi.fn().mockResolvedValue(digest),
+      formatOperationsDigestMarkdown: vi
+        .fn()
+        .mockReturnValue({ isEmpty: false, markdown: '# Operations Digest' }),
+    };
+    const runner = new ScheduledDeliverablesRunner({
+      deliverablesService,
+      digestService,
+      logger: silentLogger(),
+    });
+
+    await expect(runner.runDue(new Date('2026-06-05T09:00:00.000Z'))).resolves.toMatchObject({
+      checked: 1,
+      executed: 1,
+      skipped: 0,
+      failed: 0,
+      overlapping: false,
+    } satisfies ScheduledDeliverablesRunnerResult);
+    expect(digestService.generateOperationsDigest).toHaveBeenCalledTimes(1);
+    expect(runs).toEqual([
+      expect.objectContaining({
+        deliverableId: 'del_ops',
+        status: 'success',
+        workflowId: 'operations-digest',
+        outputFile: 'operations/digests/operations-digest-2026-06-05.md',
+        summary: 'Operations digest generated, 1 groups, 3 completed, 1 failed, 2 open approvals',
+        snapshotMetadata: expect.objectContaining({
+          generatedAt: '2026-06-05T09:00:00.000Z',
+          completed: 3,
+          failed: 1,
+          openApprovals: 2,
+          markdownBytes: 19,
+        }),
+      }),
+    ]);
+  });
+
+  it('records unsupported due deliverables as skipped so they do not spin every tick', async () => {
+    const runs: Array<Parameters<ScheduledDeliverablesStore['recordRun']>[0]> = [];
+    const runner = new ScheduledDeliverablesRunner({
+      deliverablesService: fakeDeliverablesService({
+        due: [scheduledDeliverable({ id: 'del_unknown', tags: ['weekly-report'] })],
+        runs,
+      }),
+      digestService: fakeDigestService(),
+      logger: silentLogger(),
+    });
+
+    await expect(runner.runDue()).resolves.toMatchObject({
+      checked: 1,
+      executed: 0,
+      skipped: 1,
+      failed: 0,
+    });
+    expect(runs).toEqual([
+      expect.objectContaining({
+        deliverableId: 'del_unknown',
+        status: 'skipped',
+        summary: 'No runner is registered for this scheduled deliverable.',
+      }),
+    ]);
+  });
+
+  it('records failed operations digest generation', async () => {
+    const runs: Array<Parameters<ScheduledDeliverablesStore['recordRun']>[0]> = [];
+    const runner = new ScheduledDeliverablesRunner({
+      deliverablesService: fakeDeliverablesService({
+        due: [scheduledDeliverable({ id: 'del_ops', tags: ['operations-digest'] })],
+        runs,
+      }),
+      digestService: {
+        generateOperationsDigest: vi.fn().mockRejectedValue(new Error('digest unavailable')),
+        formatOperationsDigestMarkdown: vi.fn(),
+      },
+      logger: silentLogger(),
+    });
+
+    await expect(runner.runDue()).resolves.toMatchObject({
+      checked: 1,
+      executed: 0,
+      skipped: 0,
+      failed: 1,
+    });
+    expect(runs).toEqual([
+      expect.objectContaining({
+        deliverableId: 'del_ops',
+        status: 'failed',
+        workflowId: 'operations-digest',
+        summary: 'Operations digest generation failed.',
+        error: 'digest unavailable',
+      }),
+    ]);
+  });
+
+  it('refuses overlapping due passes', async () => {
+    let releaseListDue: (() => void) | undefined;
+    const deliverablesService = {
+      listDue: vi.fn(
+        () =>
+          new Promise<Deliverable[]>((resolve) => {
+            releaseListDue = () => resolve([]);
+          })
+      ),
+      recordRun: vi.fn(),
+    };
+    const runner = new ScheduledDeliverablesRunner({
+      deliverablesService,
+      digestService: fakeDigestService(),
+      logger: silentLogger(),
+    });
+
+    const firstRun = runner.runDue();
+    await expect(runner.runDue()).resolves.toMatchObject({ overlapping: true });
+    releaseListDue?.();
+    await expect(firstRun).resolves.toMatchObject({ overlapping: false });
+  });
+});
+
+interface ScheduledDeliverablesStore {
+  listDue(now?: Date): Promise<Deliverable[]>;
+  recordRun(params: {
+    deliverableId: string;
+    status: DeliverableRun['status'];
+    outputFile?: string;
+    summary?: string;
+    durationMs?: number;
+    error?: string;
+    sourceRunId?: string;
+    workflowId?: string;
+    snapshotMetadata?: Record<string, string | number | boolean | null>;
+  }): Promise<DeliverableRun>;
+}
+
+function scheduledDeliverable(overrides: Partial<Deliverable> = {}): Deliverable {
+  return {
+    id: 'del_default',
+    name: 'Scheduled Deliverable',
+    description: 'Scheduled deliverable fixture.',
+    schedule: 'daily',
+    scheduleDescription: 'Every day',
+    enabled: true,
+    outputPath: 'operations/digests',
+    tags: ['operations-digest'],
+    createdAt: '2026-06-04T09:00:00.000Z',
+    nextRunAt: '2026-06-05T09:00:00.000Z',
+    totalRuns: 0,
+    ...overrides,
+  };
+}
+
+function fakeDeliverablesService({
+  due,
+  runs,
+}: {
+  due: Deliverable[];
+  runs: Array<Parameters<ScheduledDeliverablesStore['recordRun']>[0]>;
+}): ScheduledDeliverablesStore {
+  return {
+    listDue: vi.fn().mockResolvedValue(due),
+    recordRun: vi.fn(async (params) => {
+      runs.push(params);
+      return {
+        id: `run_${runs.length}`,
+        deliverableId: params.deliverableId,
+        status: params.status,
+        outputFile: params.outputFile,
+        summary: params.summary,
+        durationMs: params.durationMs,
+        error: params.error,
+        sourceRunId: params.sourceRunId,
+        workflowId: params.workflowId,
+        snapshot: params.snapshotMetadata
+          ? {
+              status: params.status,
+              capturedAt: '2026-06-05T09:00:00.000Z',
+              metadata: params.snapshotMetadata,
+            }
+          : undefined,
+        runAt: '2026-06-05T09:00:00.000Z',
+      };
+    }),
+  };
+}
+
+function fakeDigestService() {
+  return {
+    generateOperationsDigest: vi.fn().mockResolvedValue(makeOperationsDigest()),
+    formatOperationsDigestMarkdown: vi.fn().mockReturnValue({ isEmpty: false, markdown: '' }),
+  };
+}
+
+function makeOperationsDigest(): AgentOperationsDigest {
+  return {
+    period: {
+      start: '2026-06-04T09:00:00.000Z',
+      end: '2026-06-05T09:00:00.000Z',
+      windowHours: 24,
+    },
+    generatedAt: '2026-06-05T09:00:00.000Z',
+    hasActivity: true,
+    groups: [
+      {
+        key: 'platform::veritas-kanban::/worktrees/veritas',
+        project: 'platform',
+        repo: 'veritas-kanban',
+        cwd: '/worktrees/veritas',
+        totals: {
+          active: 4,
+          blocked: 1,
+          stuck: 1,
+          completed: 3,
+          failed: 1,
+          runs: 5,
+          tokenCost: 0.42,
+          inputTokens: 1000,
+          outputTokens: 500,
+          totalTokens: 1500,
+          wallTimeMs: 120000,
+          activeTimeMs: 90000,
+        },
+        sourceLinks: {
+          activeTasks: [],
+          blockedTasks: [],
+          stuckTasks: [],
+          completedTasks: [],
+          failedRuns: [],
+          tokenEvents: [],
+        },
+        topPlanCompletions: [],
+        notableFailures: [],
+        openApprovals: [],
+      },
+    ],
+    totals: {
+      active: 4,
+      blocked: 1,
+      stuck: 1,
+      completed: 3,
+      failed: 1,
+      runs: 5,
+      tokenCost: 0.42,
+      inputTokens: 1000,
+      outputTokens: 500,
+      totalTokens: 1500,
+      wallTimeMs: 120000,
+      activeTimeMs: 90000,
+      openApprovals: 2,
+      groups: 1,
+    },
+    refresh: {
+      manual: true,
+      schedule: 'daily-ready',
+      narrative: 'deterministic-only',
+    },
+  };
+}
+
+function silentLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,6 +28,10 @@ import { initAgentStatus } from './routes/agent-status.js';
 import { getTelemetryService } from './services/telemetry-service.js';
 import { ConfigService } from './services/config-service.js';
 import { disposeTaskService } from './services/task-service.js';
+import {
+  startScheduledDeliverablesRunner,
+  stopScheduledDeliverablesRunner,
+} from './services/scheduled-deliverables-runner-service.js';
 import { initBroadcast, nextWebSocketEventSequence } from './services/broadcast-service.js';
 import { runStartupMigrations } from './services/migration-service.js';
 import { getPolicyService } from './services/policy-service.js';
@@ -1055,6 +1059,9 @@ async function gracefulShutdown(signal: string) {
   try {
     log.info('Disposing services');
 
+    stopScheduledDeliverablesRunner();
+    log.info('Scheduled deliverables runner stopped');
+
     // Flush pending telemetry writes (timeout: 5s)
     await Promise.race([
       getTelemetryService().flush(),
@@ -1167,4 +1174,6 @@ server.listen(Number(PORT), HOST, () => {
       log.info({ security: 'jwt-secret' }, warning.message);
     }
   }
+
+  startScheduledDeliverablesRunner();
 });

--- a/server/src/services/scheduled-deliverables-runner-service.ts
+++ b/server/src/services/scheduled-deliverables-runner-service.ts
@@ -1,0 +1,251 @@
+import { createLogger } from '../lib/logger.js';
+import {
+  getScheduledDeliverablesService,
+  type Deliverable,
+  type DeliverableRun,
+} from './scheduled-deliverables-service.js';
+import {
+  DigestService,
+  type AgentOperationsDigest,
+  type DigestMarkdownMessage,
+} from './digest-service.js';
+
+const log = createLogger('deliverables-runner');
+const OPERATIONS_DIGEST_TAG = 'operations-digest';
+const DEFAULT_RUNNER_INTERVAL_MS = 60_000;
+
+interface RunnerLogger {
+  info: (data: unknown, message?: string) => void;
+  warn: (data: unknown, message?: string) => void;
+  error: (data: unknown, message?: string) => void;
+}
+
+interface ScheduledDeliverablesStore {
+  listDue(now?: Date): Promise<Deliverable[]>;
+  recordRun(params: {
+    deliverableId: string;
+    status: DeliverableRun['status'];
+    outputFile?: string;
+    summary?: string;
+    durationMs?: number;
+    error?: string;
+    sourceRunId?: string;
+    workflowId?: string;
+    snapshotMetadata?: Record<string, string | number | boolean | null>;
+  }): Promise<DeliverableRun>;
+}
+
+interface OperationsDigestService {
+  generateOperationsDigest(): Promise<AgentOperationsDigest>;
+  formatOperationsDigestMarkdown(digest: AgentOperationsDigest): DigestMarkdownMessage;
+}
+
+export interface ScheduledDeliverablesRunnerResult {
+  checked: number;
+  executed: number;
+  skipped: number;
+  failed: number;
+  overlapping: boolean;
+}
+
+export interface ScheduledDeliverablesRunnerOptions {
+  deliverablesService?: ScheduledDeliverablesStore;
+  digestService?: OperationsDigestService;
+  logger?: RunnerLogger;
+}
+
+export class ScheduledDeliverablesRunner {
+  private running = false;
+  private readonly deliverablesService: ScheduledDeliverablesStore;
+  private readonly digestService: OperationsDigestService;
+  private readonly logger: RunnerLogger;
+
+  constructor(options: ScheduledDeliverablesRunnerOptions = {}) {
+    this.deliverablesService = options.deliverablesService ?? getScheduledDeliverablesService();
+    this.digestService = options.digestService ?? new DigestService();
+    this.logger = options.logger ?? log;
+  }
+
+  async runDue(now = new Date()): Promise<ScheduledDeliverablesRunnerResult> {
+    if (this.running) {
+      this.logger.warn({ now: now.toISOString() }, 'Scheduled deliverables runner already active');
+      return { checked: 0, executed: 0, skipped: 0, failed: 0, overlapping: true };
+    }
+
+    this.running = true;
+    const result: ScheduledDeliverablesRunnerResult = {
+      checked: 0,
+      executed: 0,
+      skipped: 0,
+      failed: 0,
+      overlapping: false,
+    };
+
+    try {
+      const due = await this.deliverablesService.listDue(now);
+      result.checked = due.length;
+
+      for (const deliverable of due) {
+        if (deliverable.tags.includes(OPERATIONS_DIGEST_TAG)) {
+          const status = await this.runOperationsDigestDeliverable(deliverable);
+          result[status] += 1;
+        } else {
+          await this.recordUnsupportedDeliverable(deliverable);
+          result.skipped += 1;
+        }
+      }
+
+      if (result.checked > 0) {
+        this.logger.info(result, 'Scheduled deliverables runner completed due pass');
+      }
+      return result;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async runOperationsDigestDeliverable(
+    deliverable: Deliverable
+  ): Promise<'executed' | 'failed'> {
+    const startedAt = Date.now();
+
+    try {
+      const digest = await this.digestService.generateOperationsDigest();
+      const message = this.digestService.formatOperationsDigestMarkdown(digest);
+      await this.deliverablesService.recordRun({
+        deliverableId: deliverable.id,
+        status: 'success',
+        workflowId: OPERATIONS_DIGEST_TAG,
+        outputFile: operationsDigestOutputFile(deliverable, digest.generatedAt),
+        summary: operationsDigestSummary(digest, message),
+        durationMs: Date.now() - startedAt,
+        snapshotMetadata: operationsDigestMetadata(digest, message),
+      });
+      return 'executed';
+    } catch (error) {
+      const message = errorMessage(error);
+      this.logger.error(
+        { err: error, deliverableId: deliverable.id },
+        'Scheduled operations digest failed'
+      );
+      await this.deliverablesService.recordRun({
+        deliverableId: deliverable.id,
+        status: 'failed',
+        workflowId: OPERATIONS_DIGEST_TAG,
+        summary: 'Operations digest generation failed.',
+        durationMs: Date.now() - startedAt,
+        error: message,
+      });
+      return 'failed';
+    }
+  }
+
+  private async recordUnsupportedDeliverable(deliverable: Deliverable): Promise<void> {
+    await this.deliverablesService.recordRun({
+      deliverableId: deliverable.id,
+      status: 'skipped',
+      summary: 'No runner is registered for this scheduled deliverable.',
+    });
+    this.logger.warn(
+      { deliverableId: deliverable.id, tags: deliverable.tags },
+      'Skipped scheduled deliverable without a registered runner'
+    );
+  }
+}
+
+let runnerTimer: ReturnType<typeof setInterval> | null = null;
+let runnerInstance: ScheduledDeliverablesRunner | null = null;
+
+export function startScheduledDeliverablesRunner(
+  options: {
+    intervalMs?: number;
+    runImmediately?: boolean;
+    runner?: ScheduledDeliverablesRunner;
+  } = {}
+): ScheduledDeliverablesRunner | null {
+  if (process.env.VERITAS_SCHEDULED_DELIVERABLES_RUNNER === 'false') {
+    log.info('Scheduled deliverables runner disabled by environment');
+    return null;
+  }
+  if (runnerTimer) return runnerInstance;
+
+  const intervalMs =
+    options.intervalMs ?? parseRunnerInterval(process.env.SCHEDULED_DELIVERABLES_INTERVAL_MS);
+  const runner = options.runner ?? new ScheduledDeliverablesRunner();
+  runnerInstance = runner;
+
+  const tick = () => {
+    void runner.runDue().catch((error) => {
+      log.error({ err: error }, 'Scheduled deliverables runner tick failed');
+    });
+  };
+
+  if (options.runImmediately ?? true) tick();
+  runnerTimer = setInterval(tick, intervalMs);
+  runnerTimer.unref?.();
+  log.info({ intervalMs }, 'Started scheduled deliverables runner');
+  return runner;
+}
+
+export function stopScheduledDeliverablesRunner(): void {
+  if (!runnerTimer) return;
+  clearInterval(runnerTimer);
+  runnerTimer = null;
+  runnerInstance = null;
+  log.info('Stopped scheduled deliverables runner');
+}
+
+function parseRunnerInterval(value: string | undefined): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 5_000) return DEFAULT_RUNNER_INTERVAL_MS;
+  return parsed;
+}
+
+function operationsDigestOutputFile(deliverable: Deliverable, generatedAt: string): string {
+  const outputDir = (deliverable.outputPath?.trim() || 'operations/digests').replace(/\/+$/, '');
+  return `${outputDir}/operations-digest-${generatedAt.slice(0, 10)}.md`;
+}
+
+function operationsDigestSummary(
+  digest: AgentOperationsDigest,
+  message: DigestMarkdownMessage
+): string {
+  if (message.isEmpty || !digest.hasActivity) {
+    return 'No operations activity found for the scheduled window.';
+  }
+
+  return [
+    'Operations digest generated',
+    `${digest.totals.groups} groups`,
+    `${digest.totals.completed} completed`,
+    `${digest.totals.failed} failed`,
+    `${digest.totals.openApprovals} open approvals`,
+  ].join(', ');
+}
+
+function operationsDigestMetadata(
+  digest: AgentOperationsDigest,
+  message: DigestMarkdownMessage
+): Record<string, string | number | boolean | null> {
+  return {
+    generatedAt: digest.generatedAt,
+    periodStart: digest.period.start,
+    periodEnd: digest.period.end,
+    windowHours: digest.period.windowHours,
+    hasActivity: digest.hasActivity,
+    groups: digest.totals.groups,
+    active: digest.totals.active,
+    blocked: digest.totals.blocked,
+    stuck: digest.totals.stuck,
+    completed: digest.totals.completed,
+    failed: digest.totals.failed,
+    runs: digest.totals.runs,
+    openApprovals: digest.totals.openApprovals,
+    totalTokens: digest.totals.totalTokens,
+    markdownBytes: message.markdown?.length ?? 0,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/server/src/services/scheduled-deliverables-service.ts
+++ b/server/src/services/scheduled-deliverables-service.ts
@@ -209,6 +209,7 @@ export class ScheduledDeliverablesService {
       createdAt: new Date().toISOString(),
       totalRuns: 0,
     };
+    deliverable.nextRunAt = this.calculateNextRun(deliverable, deliverable.createdAt);
 
     this.deliverables.push(deliverable);
     await this.saveDeliverables();
@@ -244,6 +245,9 @@ export class ScheduledDeliverablesService {
     if (update.schedule || update.cronExpr) {
       del.scheduleDescription =
         update.scheduleDescription || this.describeSchedule(del.schedule, del.cronExpr);
+      del.nextRunAt = this.calculateNextRun(del, new Date().toISOString());
+    } else if (update.enabled === true && !del.nextRunAt) {
+      del.nextRunAt = this.calculateNextRun(del, new Date().toISOString());
     }
 
     await this.saveDeliverables();
@@ -311,7 +315,7 @@ export class ScheduledDeliverablesService {
     if (del) {
       del.lastRunAt = run.runAt;
       del.totalRuns++;
-      del.nextRunAt = this.calculateNextRun(del);
+      del.nextRunAt = this.calculateNextRun(del, run.runAt);
       await this.saveDeliverables();
     }
 
@@ -336,11 +340,30 @@ export class ScheduledDeliverablesService {
     if (filters?.agent) {
       results = results.filter((d) => d.agent === filters.agent);
     }
-    if (filters?.tag) {
-      results = results.filter((d) => d.tags.includes(filters.tag!));
+    const tag = filters?.tag;
+    if (tag) {
+      results = results.filter((d) => d.tags.includes(tag));
     }
 
     return results.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async listDue(now = new Date()): Promise<Deliverable[]> {
+    await this.ensureLoaded();
+    const cutoff = now.getTime();
+
+    return this.deliverables
+      .filter((deliverable) => {
+        if (!deliverable.enabled || !deliverable.nextRunAt) return false;
+        const nextRunTime = new Date(deliverable.nextRunAt).getTime();
+        return Number.isFinite(nextRunTime) && nextRunTime <= cutoff;
+      })
+      .sort((a, b) => {
+        const aTime = new Date(a.nextRunAt as string).getTime();
+        const bTime = new Date(b.nextRunAt as string).getTime();
+        if (aTime !== bTime) return aTime - bTime;
+        return a.name.localeCompare(b.name);
+      });
   }
 
   /**
@@ -395,9 +418,10 @@ export class ScheduledDeliverablesService {
     }
   }
 
-  private calculateNextRun(del: Deliverable): string {
-    const lastRun = del.lastRunAt ? new Date(del.lastRunAt) : new Date();
-    const next = new Date(lastRun);
+  private calculateNextRun(del: Deliverable, baseAt?: string): string {
+    const base = baseAt ? new Date(baseAt) : del.lastRunAt ? new Date(del.lastRunAt) : new Date();
+    const normalizedBase = Number.isFinite(base.getTime()) ? base : new Date();
+    const next = new Date(normalizedBase.getTime());
 
     switch (del.schedule) {
       case 'daily':


### PR DESCRIPTION
## Summary
- Sets initial nextRunAt for scheduled deliverables and advances it from the recorded run timestamp.
- Adds listDue support for enabled deliverables whose next run time is due.
- Adds a server-side scheduled deliverables runner with overlap protection.
- Executes operations-digest tagged deliverables by generating the deterministic operations digest and recording a success snapshot.
- Records unsupported due deliverables as skipped and digest failures as failed run history.
- Starts the runner with the server and stops it during graceful shutdown.

## Runtime controls
- VERITAS_SCHEDULED_DELIVERABLES_RUNNER=false disables the runner.
- SCHEDULED_DELIVERABLES_INTERVAL_MS overrides the default 60000 ms tick interval, with a 5000 ms minimum.

## Tests
- pnpm --filter @veritas-kanban/server test -- scheduled-deliverables-runner-service.test.ts sqlite-scheduled-deliverables-repository.test.ts
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/server lint
- pnpm --filter @veritas-kanban/server build
- pnpm lint:budget
- pnpm build

Closes #631