### PR TITLE
Add agent host routing health

### DIFF
--- a/server/src/__tests__/agent-host-service.test.ts
+++ b/server/src/__tests__/agent-host-service.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { AgentHostService } from '../services/agent-host-service';
+import type { RegisteredAgent } from '../services/agent-registry-service';
+
+function agent(
+  id: string,
+  overrides: Partial<RegisteredAgent> = {},
+  metadata: Record<string, unknown> = {}
+): RegisteredAgent {
+  return {
+    id,
+    name: id,
+    model: 'gpt-5',
+    provider: 'codex-cli',
+    capabilities: [{ name: 'code' }],
+    status: 'idle',
+    registeredAt: '2026-06-01T12:00:00.000Z',
+    lastHeartbeat: '2026-06-01T12:00:00.000Z',
+    metadata: {
+      hostId: `host-${id}`,
+      hostName: `${id} host`,
+      authState: 'authenticated',
+      workspaceRoots: ['/Users/bradgroux/Projects/veritas-kanban'],
+      maxQueueDepth: 2,
+      ...metadata,
+    },
+    ...overrides,
+  };
+}
+
+function serviceFor(agents: RegisteredAgent[]): AgentHostService {
+  return new AgentHostService({
+    list: () => agents,
+  });
+}
+
+describe('AgentHostService', () => {
+  const now = new Date('2026-06-01T12:05:00.000Z');
+
+  it('derives public host health without exposing raw workspace roots', () => {
+    const service = serviceFor([agent('codex')]);
+
+    const health = service.getHealth(now);
+
+    expect(health.summary.connected).toBe(1);
+    expect(health.hosts[0]).toMatchObject({
+      id: 'host-codex',
+      name: 'codex host',
+      posture: 'connected',
+      workspaceLabels: ['workspace:veritas-kanban'],
+    });
+    expect(JSON.stringify(health.hosts)).not.toContain('/Users/bradgroux');
+  });
+
+  it('selects the first connected compatible host and excludes stale, overloaded, and incompatible hosts', () => {
+    const service = serviceFor([
+      agent('codex', {}, { hostId: 'host-a', hostName: 'A Host' }),
+      agent(
+        'stale-codex',
+        { lastHeartbeat: '2026-06-01T11:40:00.000Z' },
+        { hostId: 'host-b', hostName: 'B Host', supportedAgents: ['codex'] }
+      ),
+      agent(
+        'busy-codex',
+        { status: 'busy' },
+        { hostId: 'host-c', hostName: 'C Host', supportedAgents: ['codex'], maxQueueDepth: 1 }
+      ),
+      agent(
+        'other',
+        { provider: 'openclaw', model: 'other-model' },
+        { hostId: 'host-d', hostName: 'D Host', supportedAgents: ['other'] }
+      ),
+    ]);
+
+    const preview = service.preview(
+      {
+        agent: 'codex',
+        provider: 'codex-cli',
+        model: 'gpt-5',
+        workspacePath: '/Users/bradgroux/Projects/veritas-kanban/server',
+        requiredTools: ['code'],
+      },
+      now
+    );
+
+    expect(preview.decision).toMatchObject({
+      policy: 'first-capable-healthy',
+      selectedHostId: 'host-a',
+    });
+    expect(preview.decision.excludedHostIds).toHaveLength(3);
+    expect(preview.decision.excludedHostIds).toEqual(
+      expect.arrayContaining(['host-b', 'host-c', 'host-d'])
+    );
+    expect(preview.previews.find((item) => item.hostId === 'host-c')?.reasons).toContain(
+      'Host posture is degraded.'
+    );
+    expect(preview.previews.find((item) => item.hostId === 'host-d')?.reasons).toContain(
+      'Provider "codex-cli" is not registered on this host.'
+    );
+  });
+
+  it('does not select an incompatible manual host', () => {
+    const service = serviceFor([
+      agent(
+        'codex',
+        { lastHeartbeat: '2026-06-01T11:40:00.000Z' },
+        { hostId: 'host-stale', hostName: 'Stale Host' }
+      ),
+    ]);
+
+    const preview = service.preview({ agent: 'codex', manualHostId: 'host-stale' }, now);
+
+    expect(preview.decision.policy).toBe('manual');
+    expect(preview.decision.selectedHostId).toBeUndefined();
+    expect(preview.decision.reason).toContain('not compatible');
+  });
+
+  it('disables auto-routing when no host is registered', () => {
+    const service = serviceFor([]);
+
+    const preview = service.preview({ agent: 'codex' }, now);
+
+    expect(preview.decision).toMatchObject({
+      policy: 'disabled',
+      reason: 'No agent hosts are registered.',
+    });
+  });
+});

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -200,6 +200,9 @@ describe('v1 REST permission guard presets', () => {
       runGuard(agentPermissionAccess, mockRequest('POST', '/approvals')).next
     ).toHaveBeenCalled();
     expect(runGuard(agentRoutingAccess, mockRequest('POST', '/route')).next).toHaveBeenCalled();
+    expect(
+      runGuard(agentRoutingAccess, mockRequest('POST', '/hosts/preview')).next
+    ).toHaveBeenCalled();
 
     expect(
       runGuard(agentRoutingAccess, mockRequest('POST', '/task_1/start', 'agent', ['agent:write']))

--- a/server/src/routes/agent-routing.ts
+++ b/server/src/routes/agent-routing.ts
@@ -9,6 +9,7 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { getAgentRoutingService } from '../services/agent-routing-service.js';
+import { getAgentHostService } from '../services/agent-host-service.js';
 import { getGovernanceTraceService } from '../services/governance-trace-service.js';
 import { getTaskService } from '../services/task-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
@@ -56,6 +57,18 @@ const routingConfigSchema = z.object({
   defaultModel: z.string().max(50).optional(),
   fallbackOnFailure: z.boolean(),
   maxRetries: z.number().int().min(0).max(3),
+});
+
+const hostPreviewSchema = z.object({
+  agent: z.string().max(100).optional(),
+  provider: z.string().max(80).optional(),
+  model: z.string().max(100).optional(),
+  workspacePath: z.string().max(1000).optional(),
+  requiredTools: z.array(z.string().max(80)).max(50).optional(),
+  verificationGates: z.array(z.string().max(200)).max(50).optional(),
+  manualHostId: z.string().max(120).optional(),
+  projectDefaultHostId: z.string().max(120).optional(),
+  autoRouting: z.boolean().optional(),
 });
 
 // ─── Routes ──────────────────────────────────────────────────────
@@ -107,6 +120,35 @@ router.post(
     }
 
     throw new ValidationError('Provide either { taskId } or { type, priority, ... }');
+  })
+);
+
+/**
+ * GET /api/agents/hosts
+ *
+ * Return supervisor/host health and routing posture derived from the agent registry.
+ */
+router.get(
+  '/hosts',
+  asyncHandler(async (_req, res) => {
+    res.json(getAgentHostService().getHealth());
+  })
+);
+
+/**
+ * POST /api/agents/hosts/preview
+ *
+ * Preview deterministic host compatibility and the host routing decision before launch.
+ */
+router.post(
+  '/hosts/preview',
+  asyncHandler(async (req, res) => {
+    const parsed = hostPreviewSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new ValidationError('Invalid host preview request', parsed.error.issues);
+    }
+
+    res.json(getAgentHostService().preview(parsed.data));
   })
 );
 

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -30,6 +30,7 @@ export const agentPermissionAccess = routeAccess('agent:read', 'admin:manage', [
 ]);
 export const agentRoutingAccess = routeAccess('agent:read', 'admin:manage', [
   { methods: ['POST'], path: /^\/route\/?$/, permissions: 'agent:read' },
+  { methods: ['POST'], path: /^\/hosts\/preview\/?$/, permissions: 'agent:read' },
   { methods: ['POST'], path: /^\/[^/]+\/(start|stop)\/?$/, permissions: 'agent:write' },
 ]);
 export const agentTaskAccess = routeAccess('agent:read', 'task:write', [

--- a/server/src/services/agent-host-service.ts
+++ b/server/src/services/agent-host-service.ts
@@ -1,0 +1,630 @@
+import path from 'path';
+import type {
+  AgentHostAuthState,
+  AgentHostCompatibilityCheck,
+  AgentHostCompatibilityPreview,
+  AgentHostCompatibilityResponse,
+  AgentHostHealthResponse,
+  AgentHostPosture,
+  AgentHostPreviewRequest,
+  AgentHostRecord,
+  AgentHostRoutingDecision,
+} from '@veritas-kanban/shared';
+import { getAgentRegistryService, type RegisteredAgent } from './agent-registry-service.js';
+
+const STALE_HEARTBEAT_MS = 10 * 60 * 1000;
+const DISCONNECTED_HEARTBEAT_MS = 30 * 60 * 1000;
+
+interface AgentHostRegistryReader {
+  list(): RegisteredAgent[];
+}
+
+interface HostAccumulator {
+  id: string;
+  name: string;
+  supervisorType: string;
+  os?: string;
+  authState: AgentHostAuthState;
+  supportedAgents: Set<string>;
+  supportedProviders: Set<string>;
+  supportedModels: Set<string>;
+  supportedTools: Set<string>;
+  workspaceLabels: Set<string>;
+  workspaceRoots: string[];
+  activeSessions: number;
+  queueDepth: number;
+  maxQueueDepth: number;
+  lastHeartbeat?: string;
+  lastFailure?: string;
+  statuses: RegisteredAgent['status'][];
+  registeredAgentIds: string[];
+  diagnostics: Set<string>;
+}
+
+interface ResolvedAgentHost extends AgentHostRecord {
+  workspaceRoots: string[];
+}
+
+export class AgentHostService {
+  constructor(private readonly registry: AgentHostRegistryReader = getAgentRegistryService()) {}
+
+  getHealth(now = new Date()): AgentHostHealthResponse {
+    const hosts = this.buildHosts(now);
+    return {
+      generatedAt: now.toISOString(),
+      hosts: hosts.map(stripInternalHostFields),
+      summary: summarizeHosts(hosts),
+    };
+  }
+
+  preview(request: AgentHostPreviewRequest, now = new Date()): AgentHostCompatibilityResponse {
+    const hosts = this.buildHosts(now);
+    const previews = hosts.map((host) => this.previewHost(host, request));
+    return {
+      generatedAt: now.toISOString(),
+      request: normalizeRequest(request),
+      previews,
+      decision: this.resolveDecision(previews, request),
+    };
+  }
+
+  private buildHosts(now: Date): ResolvedAgentHost[] {
+    const byHost = new Map<string, HostAccumulator>();
+
+    for (const agent of this.registry.list()) {
+      const metadata = safeMetadata(agent.metadata);
+      const hostId =
+        stringValue(metadata.hostId) ??
+        stringValue(metadata.supervisorId) ??
+        stringValue(metadata.machineId) ??
+        `agent:${agent.id}`;
+      const host = getOrCreateHost(byHost, hostId, agent, metadata);
+
+      host.supportedAgents.add(agent.id);
+      host.supportedAgents.add(agent.name);
+      for (const item of stringArray(metadata.supportedAgents)) host.supportedAgents.add(item);
+      for (const capability of agent.capabilities) {
+        host.supportedTools.add(capability.name);
+      }
+
+      if (agent.provider) host.supportedProviders.add(agent.provider);
+      for (const item of stringArray(metadata.providers)) host.supportedProviders.add(item);
+
+      if (agent.model) host.supportedModels.add(agent.model);
+      for (const item of stringArray(metadata.models)) host.supportedModels.add(item);
+
+      for (const item of stringArray(metadata.tools)) host.supportedTools.add(item);
+      for (const item of stringArray(metadata.requiredTools)) host.supportedTools.add(item);
+
+      const rawRoots = stringArray(metadata.workspaceRoots);
+      for (const root of rawRoots) {
+        host.workspaceRoots.push(root);
+        host.workspaceLabels.add(safeWorkspaceLabel(root));
+      }
+      for (const label of stringArray(metadata.workspaceLabels)) {
+        host.workspaceLabels.add(safeWorkspaceLabel(label));
+      }
+
+      const activeSessions = numberValue(metadata.activeSessions);
+      host.activeSessions += activeSessions ?? (agent.status === 'busy' ? 1 : 0);
+      const queueDepth = numberValue(metadata.queueDepth);
+      host.queueDepth += queueDepth ?? (agent.status === 'busy' ? 1 : 0);
+      host.maxQueueDepth = Math.max(host.maxQueueDepth, numberValue(metadata.maxQueueDepth) ?? 1);
+      host.lastHeartbeat = latestIso(host.lastHeartbeat, agent.lastHeartbeat);
+      host.lastFailure = latestIso(
+        host.lastFailure,
+        stringValue(metadata.lastFailure) ?? stringValue(metadata.lastErrorAt)
+      );
+      host.statuses.push(agent.status);
+      host.registeredAgentIds.push(agent.id);
+
+      const agentAuth = authState(metadata);
+      host.authState = mergeAuthState(host.authState, agentAuth);
+    }
+
+    return Array.from(byHost.values())
+      .map((host) => finalizeHost(host, now))
+      .sort((a, b) => {
+        const postureDelta = postureRank(a.posture) - postureRank(b.posture);
+        if (postureDelta !== 0) return postureDelta;
+        return a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+      });
+  }
+
+  private previewHost(
+    host: ResolvedAgentHost,
+    request: AgentHostPreviewRequest
+  ): AgentHostCompatibilityPreview {
+    const checks: AgentHostCompatibilityCheck[] = [
+      {
+        id: 'heartbeat',
+        label: 'Heartbeat',
+        passed: host.posture === 'connected',
+        detail:
+          host.posture === 'connected'
+            ? 'Host has a current heartbeat.'
+            : `Host posture is ${host.posture}.`,
+      },
+      {
+        id: 'capacity',
+        label: 'Capacity',
+        passed: !host.overloaded,
+        detail: host.overloaded
+          ? `Queue is ${host.queueDepth}/${host.maxQueueDepth}.`
+          : `Queue is ${host.queueDepth}/${host.maxQueueDepth}.`,
+      },
+      this.workspaceCheck(host, request.workspacePath),
+      this.membershipCheck(
+        'provider-available',
+        'Provider',
+        request.provider,
+        host.supportedProviders,
+        'No provider requirement supplied.'
+      ),
+      this.membershipCheck(
+        'model-supported',
+        'Model',
+        request.model,
+        host.supportedModels,
+        'No model requirement supplied.'
+      ),
+      this.requiredToolsCheck(host, request.requiredTools),
+      {
+        id: 'verification-gates',
+        label: 'Verification gates',
+        passed: true,
+        detail: request.verificationGates?.length
+          ? `${request.verificationGates.length} gate(s) will be recorded with the launch.`
+          : 'No verification gates supplied.',
+      },
+    ];
+
+    if (request.agent) {
+      checks.push(
+        this.membershipCheck(
+          'agent-supported',
+          'Agent',
+          request.agent,
+          host.supportedAgents,
+          'No agent requirement supplied.'
+        )
+      );
+    }
+
+    const reasons = checks.filter((check) => !check.passed).map((check) => check.detail);
+    const warnings = [
+      ...host.diagnostics,
+      ...checks
+        .filter(
+          (check) => check.passed && /unknown|not supplied|will be recorded/i.test(check.detail)
+        )
+        .map((check) => check.detail),
+    ];
+
+    return {
+      hostId: host.id,
+      hostName: host.name,
+      posture: host.posture,
+      compatible: reasons.length === 0,
+      checks,
+      reasons,
+      warnings: uniqueSorted(warnings),
+    };
+  }
+
+  private workspaceCheck(
+    host: ResolvedAgentHost,
+    workspacePath?: string
+  ): AgentHostCompatibilityCheck {
+    if (!workspacePath) {
+      return {
+        id: 'workspace-access',
+        label: 'Workspace access',
+        passed: true,
+        detail: 'No workspace requirement supplied.',
+      };
+    }
+
+    const roots = host.workspaceRoots;
+    if (roots.length === 0) {
+      return {
+        id: 'workspace-access',
+        label: 'Workspace access',
+        passed: true,
+        detail: 'Workspace access is unknown because the host has no registered roots.',
+      };
+    }
+
+    const accessible = roots.some((root) => pathContains(root, workspacePath));
+    return {
+      id: 'workspace-access',
+      label: 'Workspace access',
+      passed: accessible,
+      detail: accessible
+        ? 'Workspace is under a registered host root.'
+        : 'Workspace is outside the registered host roots.',
+    };
+  }
+
+  private membershipCheck(
+    id: AgentHostCompatibilityCheck['id'],
+    label: string,
+    value: string | undefined,
+    supported: string[],
+    emptyDetail: string
+  ): AgentHostCompatibilityCheck {
+    if (!value) {
+      return { id, label, passed: true, detail: emptyDetail };
+    }
+    if (supported.length === 0) {
+      return {
+        id,
+        label,
+        passed: true,
+        detail: `${label} support is unknown for this host.`,
+      };
+    }
+    const matched = supported.some((candidate) => normalize(candidate) === normalize(value));
+    return {
+      id,
+      label,
+      passed: matched,
+      detail: matched
+        ? `${label} "${value}" is supported.`
+        : `${label} "${value}" is not registered on this host.`,
+    };
+  }
+
+  private requiredToolsCheck(
+    host: AgentHostRecord,
+    requiredTools: string[] | undefined
+  ): AgentHostCompatibilityCheck {
+    const tools = (requiredTools ?? []).map((tool) => tool.trim()).filter(Boolean);
+    if (tools.length === 0) {
+      return {
+        id: 'required-tools',
+        label: 'Required tools',
+        passed: true,
+        detail: 'No required tools supplied.',
+      };
+    }
+    const supported = new Set(host.supportedTools.map(normalize));
+    const missing = tools.filter((tool) => !supported.has(normalize(tool)));
+    return {
+      id: 'required-tools',
+      label: 'Required tools',
+      passed: missing.length === 0,
+      detail:
+        missing.length === 0
+          ? 'Required tools are registered on this host.'
+          : `Missing required tools: ${missing.join(', ')}.`,
+    };
+  }
+
+  private resolveDecision(
+    previews: AgentHostCompatibilityPreview[],
+    request: AgentHostPreviewRequest
+  ): AgentHostRoutingDecision {
+    const excludedHostIds = previews
+      .filter((preview) => !preview.compatible || preview.posture !== 'connected')
+      .map((preview) => preview.hostId);
+
+    if (previews.length === 0) {
+      return {
+        policy: 'disabled',
+        reason: 'No agent hosts are registered.',
+        fallbackBehavior: 'Existing local execution can continue, but auto-routing is disabled.',
+        excludedHostIds,
+      };
+    }
+
+    if (request.manualHostId) {
+      const manual = previews.find((preview) => preview.hostId === request.manualHostId);
+      if (manual?.compatible) {
+        return selectedDecision('manual', manual, 'Manual host target selected.', excludedHostIds);
+      }
+      return {
+        policy: 'manual',
+        reason: manual
+          ? `Manual host "${manual.hostName}" is not compatible.`
+          : `Manual host "${request.manualHostId}" is not registered.`,
+        fallbackBehavior: 'Do not launch until the selected host is compatible.',
+        excludedHostIds,
+      };
+    }
+
+    if (request.projectDefaultHostId) {
+      const projectDefault = previews.find(
+        (preview) => preview.hostId === request.projectDefaultHostId
+      );
+      if (projectDefault?.compatible && projectDefault.posture === 'connected') {
+        return selectedDecision(
+          'project-default',
+          projectDefault,
+          'Project default host selected.',
+          excludedHostIds
+        );
+      }
+    }
+
+    if (request.autoRouting === false) {
+      return {
+        policy: 'disabled',
+        reason: 'Automatic host routing is disabled for this launch.',
+        fallbackBehavior: 'Use a manual host target to dispatch.',
+        excludedHostIds,
+      };
+    }
+
+    const selected = previews.find(
+      (preview) => preview.compatible && preview.posture === 'connected'
+    );
+    if (selected) {
+      return selectedDecision(
+        'first-capable-healthy',
+        selected,
+        'Selected first capable connected host.',
+        excludedHostIds
+      );
+    }
+
+    return {
+      policy: 'disabled',
+      reason: 'No connected compatible host qualifies for automatic routing.',
+      fallbackBehavior: 'Keep the launch queued or choose a compatible manual host.',
+      excludedHostIds,
+    };
+  }
+}
+
+export function getAgentHostService(): AgentHostService {
+  return new AgentHostService();
+}
+
+function getOrCreateHost(
+  byHost: Map<string, HostAccumulator>,
+  hostId: string,
+  agent: RegisteredAgent,
+  metadata: Record<string, unknown>
+): HostAccumulator {
+  const existing = byHost.get(hostId);
+  if (existing) return existing;
+
+  const host: HostAccumulator = {
+    id: hostId,
+    name:
+      stringValue(metadata.hostName) ??
+      stringValue(metadata.supervisorName) ??
+      stringValue(metadata.hostname) ??
+      agent.name,
+    supervisorType:
+      stringValue(metadata.supervisorType) ?? stringValue(metadata.hostType) ?? 'local-agent',
+    os: stringValue(metadata.os),
+    authState: 'unknown',
+    supportedAgents: new Set(),
+    supportedProviders: new Set(),
+    supportedModels: new Set(),
+    supportedTools: new Set(),
+    workspaceLabels: new Set(),
+    workspaceRoots: [],
+    activeSessions: 0,
+    queueDepth: 0,
+    maxQueueDepth: 1,
+    statuses: [],
+    registeredAgentIds: [],
+    diagnostics: new Set(),
+  };
+  byHost.set(hostId, host);
+  return host;
+}
+
+function finalizeHost(host: HostAccumulator, now: Date): ResolvedAgentHost {
+  const overloaded = host.queueDepth >= host.maxQueueDepth;
+  const posture = resolvePosture(host, overloaded, now);
+  if (overloaded) {
+    host.diagnostics.add(`Queue depth ${host.queueDepth} reached capacity ${host.maxQueueDepth}.`);
+  }
+  if (host.authState === 'unauthenticated') {
+    host.diagnostics.add('Supervisor authentication is unavailable.');
+  }
+  if (posture === 'stale') {
+    host.diagnostics.add('Supervisor heartbeat is stale.');
+  }
+  if (posture === 'disconnected') {
+    host.diagnostics.add('Supervisor is disconnected.');
+  }
+  if (host.lastFailure) {
+    host.diagnostics.add('Supervisor reported a recent failure.');
+  }
+
+  return {
+    id: host.id,
+    name: host.name,
+    supervisorType: host.supervisorType,
+    os: host.os,
+    posture,
+    authState: host.authState,
+    supportedAgents: uniqueSorted(Array.from(host.supportedAgents)),
+    supportedProviders: uniqueSorted(Array.from(host.supportedProviders)),
+    supportedModels: uniqueSorted(Array.from(host.supportedModels)),
+    supportedTools: uniqueSorted(Array.from(host.supportedTools)),
+    workspaceLabels: uniqueSorted(Array.from(host.workspaceLabels)),
+    activeSessions: host.activeSessions,
+    queueDepth: host.queueDepth,
+    maxQueueDepth: host.maxQueueDepth,
+    overloaded,
+    lastHeartbeat: host.lastHeartbeat,
+    lastFailure: host.lastFailure,
+    diagnostics: uniqueSorted(Array.from(host.diagnostics)),
+    registeredAgentIds: uniqueSorted(host.registeredAgentIds),
+    workspaceRoots: uniqueSorted(host.workspaceRoots),
+  };
+}
+
+function resolvePosture(host: HostAccumulator, overloaded: boolean, now: Date): AgentHostPosture {
+  if (!host.lastHeartbeat) return 'unknown';
+  const age = now.getTime() - Date.parse(host.lastHeartbeat);
+  if (!Number.isFinite(age)) return 'unknown';
+  if (host.statuses.every((status) => status === 'offline') || age > DISCONNECTED_HEARTBEAT_MS) {
+    return 'disconnected';
+  }
+  if (host.authState === 'unauthenticated') return 'risky';
+  if (age > STALE_HEARTBEAT_MS) return 'stale';
+  if (overloaded || host.statuses.includes('busy') || host.lastFailure) return 'degraded';
+  return 'connected';
+}
+
+function summarizeHosts(
+  hosts: Pick<AgentHostRecord, 'posture' | 'overloaded'>[]
+): AgentHostHealthResponse['summary'] {
+  const summary: AgentHostHealthResponse['summary'] = {
+    total: hosts.length,
+    connected: 0,
+    stale: 0,
+    degraded: 0,
+    disconnected: 0,
+    risky: 0,
+    unknown: 0,
+    overloaded: 0,
+  };
+  for (const host of hosts) {
+    summary[host.posture]++;
+    if (host.overloaded) summary.overloaded++;
+  }
+  return summary;
+}
+
+function stripInternalHostFields(host: ResolvedAgentHost): AgentHostRecord {
+  const { workspaceRoots: _workspaceRoots, ...publicHost } = host;
+  return publicHost;
+}
+
+function normalizeRequest(request: AgentHostPreviewRequest): AgentHostPreviewRequest {
+  return {
+    agent: trimOptional(request.agent),
+    provider: trimOptional(request.provider),
+    model: trimOptional(request.model),
+    workspacePath: trimOptional(request.workspacePath),
+    requiredTools: uniqueSorted(request.requiredTools ?? []),
+    verificationGates: uniqueSorted(request.verificationGates ?? []),
+    manualHostId: trimOptional(request.manualHostId),
+    projectDefaultHostId: trimOptional(request.projectDefaultHostId),
+    autoRouting: request.autoRouting,
+  };
+}
+
+function selectedDecision(
+  policy: AgentHostRoutingDecision['policy'],
+  preview: AgentHostCompatibilityPreview,
+  reason: string,
+  excludedHostIds: string[]
+): AgentHostRoutingDecision {
+  return {
+    policy,
+    selectedHostId: preview.hostId,
+    selectedHostName: preview.hostName,
+    reason,
+    excludedHostIds,
+  };
+}
+
+function safeMetadata(metadata: RegisteredAgent['metadata']): Record<string, unknown> {
+  return metadata && typeof metadata === 'object' ? metadata : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function trimOptional(value: string | undefined): string | undefined {
+  return value?.trim() || undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function numberValue(value: unknown): number | undefined {
+  const parsed =
+    typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function authState(metadata: Record<string, unknown>): AgentHostAuthState {
+  const state = stringValue(metadata.authState);
+  if (
+    state === 'authenticated' ||
+    state === 'unauthenticated' ||
+    state === 'not-required' ||
+    state === 'unknown'
+  ) {
+    return state;
+  }
+  const authenticated = booleanValue(metadata.authenticated);
+  if (authenticated === true) return 'authenticated';
+  if (authenticated === false) return 'unauthenticated';
+  return 'unknown';
+}
+
+function mergeAuthState(current: AgentHostAuthState, next: AgentHostAuthState): AgentHostAuthState {
+  if (current === 'unauthenticated' || next === 'unauthenticated') return 'unauthenticated';
+  if (current === 'authenticated' || next === 'authenticated') return 'authenticated';
+  if (current === 'not-required' || next === 'not-required') return 'not-required';
+  return 'unknown';
+}
+
+function latestIso(current: string | undefined, next: string | undefined): string | undefined {
+  if (!next) return current;
+  if (!current) return next;
+  return Date.parse(next) > Date.parse(current) ? next : current;
+}
+
+function safeWorkspaceLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return 'workspace';
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    return `workspace:${path.basename(trimmed) || 'root'}`;
+  }
+  return trimmed.slice(0, 80);
+}
+
+function pathContains(root: string, workspacePath: string): boolean {
+  const resolvedRoot = path.resolve(root);
+  const resolvedWorkspace = path.resolve(workspacePath);
+  const relative = path.relative(resolvedRoot, resolvedWorkspace);
+  return (
+    relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+  );
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((a, b) =>
+    a.localeCompare(b)
+  );
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function postureRank(posture: AgentHostPosture): number {
+  switch (posture) {
+    case 'connected':
+      return 0;
+    case 'degraded':
+      return 1;
+    case 'stale':
+      return 2;
+    case 'risky':
+      return 3;
+    case 'unknown':
+      return 4;
+    case 'disconnected':
+      return 5;
+  }
+}

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -7,6 +7,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import sanitizeFilename from 'sanitize-filename';
 import yaml from 'yaml';
+import type { AgentHostRoutingDecision } from '@veritas-kanban/shared';
 import type {
   WorkflowStep,
   WorkflowRun,
@@ -29,6 +30,7 @@ import {
   type OpenClawWorkflowSessionResult,
 } from './openclaw-workflow-adapter.js';
 import { getToolPolicyService } from './tool-policy-service.js';
+import { getAgentHostService } from './agent-host-service.js';
 
 const log = createLogger('workflow-step-executor');
 
@@ -97,6 +99,15 @@ export class WorkflowStepExecutor {
 
     // Get tool policy filter for this agent role (#110)
     const toolPolicyFilter = await this.getToolPolicyForAgent(agentDef);
+    const hostPreview = getAgentHostService().preview({
+      agent: step.agent,
+      provider: agentDef?.provider,
+      model: agentDef?.model,
+      workspacePath: this.expandPath(this.getWorkflowWorkingDirectory(run)),
+      requiredTools: this.routingTools(agentDef, toolPolicyFilter),
+      verificationGates: step.acceptance_criteria,
+    });
+    this.recordAgentHostRouting(run, step, hostPreview.decision, hostPreview.generatedAt);
 
     log.info(
       {
@@ -108,6 +119,7 @@ export class WorkflowStepExecutor {
         sessionContext: sessionConfig.context,
         sessionCleanup: sessionConfig.cleanup,
         toolPolicy: toolPolicyFilter,
+        hostRouting: hostPreview.decision,
       },
       'Agent step execution configured'
     );
@@ -119,7 +131,8 @@ export class WorkflowStepExecutor {
         agentDef,
         prompt,
         sessionConfig,
-        toolPolicyFilter
+        toolPolicyFilter,
+        hostPreview.decision
       );
     }
 
@@ -130,7 +143,8 @@ export class WorkflowStepExecutor {
       prompt,
       sessionConfig,
       sessionContext,
-      toolPolicyFilter
+      toolPolicyFilter,
+      hostPreview.decision
     );
   }
 
@@ -141,7 +155,8 @@ export class WorkflowStepExecutor {
     prompt: string,
     sessionConfig: StepSessionConfig,
     sessionContext: Record<string, unknown>,
-    toolPolicyFilter: { allowed?: string[]; denied?: string[] }
+    toolPolicyFilter: { allowed?: string[]; denied?: string[] },
+    hostRouting: AgentHostRoutingDecision
   ): Promise<StepExecutionResult> {
     const agentId = step.agent || agentDef?.id || step.id;
     const sessionMap = (run.context._sessions as Record<string, string> | undefined) || {};
@@ -200,7 +215,8 @@ export class WorkflowStepExecutor {
         run,
         agentDef,
         adapterResult,
-        sessionConfig
+        sessionConfig,
+        hostRouting
       );
       const parsed = this.parseStepOutput(result, step);
       await this.validateAcceptanceCriteria(step, result, parsed);
@@ -252,6 +268,49 @@ export class WorkflowStepExecutor {
     }
   }
 
+  private recordAgentHostRouting(
+    run: WorkflowRun,
+    step: WorkflowStep,
+    decision: AgentHostRoutingDecision,
+    recordedAt: string
+  ): void {
+    const existing =
+      run.context.agentHostRouting &&
+      typeof run.context.agentHostRouting === 'object' &&
+      !Array.isArray(run.context.agentHostRouting)
+        ? (run.context.agentHostRouting as Record<string, unknown>)
+        : {};
+
+    run.context.agentHostRouting = {
+      ...existing,
+      [step.id]: {
+        stepId: step.id,
+        agent: step.agent,
+        recordedAt,
+        selectedHostId: decision.selectedHostId,
+        selectedHostName: decision.selectedHostName,
+        policy: decision.policy,
+        reason: decision.reason,
+        fallbackBehavior: decision.fallbackBehavior,
+        excludedHostIds: decision.excludedHostIds,
+      },
+    };
+  }
+
+  private routingTools(
+    agentDef: WorkflowAgent | null,
+    toolPolicyFilter: { allowed?: string[]; denied?: string[] }
+  ): string[] {
+    const tools = new Set<string>();
+    for (const tool of agentDef?.tools ?? []) {
+      tools.add(tool);
+    }
+    for (const tool of toolPolicyFilter.allowed ?? []) {
+      if (tool !== '*') tools.add(tool);
+    }
+    return Array.from(tools).sort((a, b) => a.localeCompare(b));
+  }
+
   private assertOpenClawResult(
     step: WorkflowStep,
     result: OpenClawWorkflowSessionResult | undefined
@@ -278,7 +337,8 @@ export class WorkflowStepExecutor {
     run: WorkflowRun,
     agentDef: WorkflowAgent | null,
     result: OpenClawWorkflowSessionResult,
-    sessionConfig: StepSessionConfig
+    sessionConfig: StepSessionConfig,
+    hostRouting: AgentHostRoutingDecision
   ): string {
     const output = result.output?.trim() || 'OpenClaw completed without a final response.';
     const hasStatus = /\bSTATUS\s*:/i.test(output);
@@ -293,6 +353,9 @@ export class WorkflowStepExecutor {
       `OpenClaw run: ${result.runId || run.id}`,
       `Session mode: ${sessionConfig.mode}`,
       `Session cleanup: ${sessionConfig.cleanup}`,
+      `Host routing: ${hostRouting.policy}`,
+      `Selected host: ${hostRouting.selectedHostName || hostRouting.selectedHostId || 'none'}`,
+      `Routing reason: ${hostRouting.reason}`,
       '',
       '## Final Response',
       '',
@@ -344,7 +407,8 @@ export class WorkflowStepExecutor {
     agentDef: WorkflowAgent | null,
     prompt: string,
     sessionConfig: StepSessionConfig,
-    toolPolicyFilter: { allowed?: string[]; denied?: string[] }
+    toolPolicyFilter: { allowed?: string[]; denied?: string[] },
+    hostRouting: AgentHostRoutingDecision
   ): Promise<StepExecutionResult> {
     this.assertCodexToolPolicySupported(step, agentDef, toolPolicyFilter);
 
@@ -415,6 +479,9 @@ export class WorkflowStepExecutor {
       `Model: ${agentDef?.model || 'default'}`,
       `Thread: ${threadId || 'unknown'}`,
       `Working directory: ${workingDirectory}`,
+      `Host routing: ${hostRouting.policy}`,
+      `Selected host: ${hostRouting.selectedHostName || hostRouting.selectedHostId || 'none'}`,
+      `Routing reason: ${hostRouting.reason}`,
       '',
       '## Prompt',
       '',

--- a/shared/src/types/agent-host.types.ts
+++ b/shared/src/types/agent-host.types.ts
@@ -1,0 +1,101 @@
+export type AgentHostPosture =
+  | 'connected'
+  | 'stale'
+  | 'degraded'
+  | 'disconnected'
+  | 'risky'
+  | 'unknown';
+
+export type AgentHostAuthState = 'authenticated' | 'unauthenticated' | 'not-required' | 'unknown';
+
+export type AgentHostRoutingPolicy =
+  | 'manual'
+  | 'project-default'
+  | 'first-capable-healthy'
+  | 'disabled';
+
+export interface AgentHostRecord {
+  id: string;
+  name: string;
+  supervisorType: string;
+  os?: string;
+  posture: AgentHostPosture;
+  authState: AgentHostAuthState;
+  supportedAgents: string[];
+  supportedProviders: string[];
+  supportedModels: string[];
+  supportedTools: string[];
+  workspaceLabels: string[];
+  activeSessions: number;
+  queueDepth: number;
+  maxQueueDepth: number;
+  overloaded: boolean;
+  lastHeartbeat?: string;
+  lastFailure?: string;
+  diagnostics: string[];
+  registeredAgentIds: string[];
+}
+
+export interface AgentHostHealthResponse {
+  generatedAt: string;
+  hosts: AgentHostRecord[];
+  summary: Record<AgentHostPosture, number> & {
+    total: number;
+    overloaded: number;
+  };
+}
+
+export type AgentHostCompatibilityCheckId =
+  | 'heartbeat'
+  | 'capacity'
+  | 'workspace-access'
+  | 'provider-available'
+  | 'model-supported'
+  | 'agent-supported'
+  | 'required-tools'
+  | 'verification-gates';
+
+export interface AgentHostCompatibilityCheck {
+  id: AgentHostCompatibilityCheckId;
+  label: string;
+  passed: boolean;
+  detail: string;
+}
+
+export interface AgentHostCompatibilityPreview {
+  hostId: string;
+  hostName: string;
+  posture: AgentHostPosture;
+  compatible: boolean;
+  checks: AgentHostCompatibilityCheck[];
+  reasons: string[];
+  warnings: string[];
+}
+
+export interface AgentHostPreviewRequest {
+  agent?: string;
+  provider?: string;
+  model?: string;
+  workspacePath?: string;
+  requiredTools?: string[];
+  verificationGates?: string[];
+  manualHostId?: string;
+  projectDefaultHostId?: string;
+  autoRouting?: boolean;
+}
+
+export interface AgentHostRoutingDecision {
+  policy: AgentHostRoutingPolicy;
+  selectedHostId?: string;
+  selectedHostName?: string;
+  reason: string;
+  fallbackBehavior?: string;
+  excludedHostIds: string[];
+}
+
+export interface AgentHostCompatibilityResponse {
+  generatedAt: string;
+  request: AgentHostPreviewRequest;
+  previews: AgentHostCompatibilityPreview[];
+  decision: AgentHostRoutingDecision;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -13,6 +13,7 @@ export * from './changes.types.js';
 export * from './broadcast.types.js';
 export * from './agent-registry.types.js';
 export * from './agent-health-classifier.types.js';
+export * from './agent-host.types.js';
 export * from './shared-resources.types.js';
 export * from './doc-freshness.types.js';
 export * from './drift.types.js';

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -176,6 +176,7 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     write: 'admin:manage',
     overrides: [
       { methods: ['POST'], path: /^\/route\/?$/, permissions: 'agent:read' },
+      { methods: ['POST'], path: /^\/hosts\/preview\/?$/, permissions: 'agent:read' },
       { methods: ['POST'], path: /^\/[^/]+\/(start|stop)\/?$/, permissions: 'agent:write' },
     ],
   },

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   debouncedUpdate: vi.fn(),
   refetchCodexHealth: vi.fn(),
   refetchProviderHealth: vi.fn(),
+  refetchHostHealth: vi.fn(),
   updateAgents: vi.fn(),
   updateRouting: vi.fn(),
 }));
@@ -158,6 +159,80 @@ vi.mock('@/hooks/useRouting', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useAgent', () => ({
+  useAgentHosts: () => ({
+    data: {
+      generatedAt: '2026-06-01T12:02:00.000Z',
+      summary: {
+        total: 1,
+        connected: 1,
+        degraded: 0,
+        stale: 0,
+        disconnected: 0,
+        risky: 0,
+        unknown: 0,
+        overloaded: 0,
+      },
+      hosts: [
+        {
+          id: 'host-local',
+          name: 'Local Supervisor',
+          supervisorType: 'local-agent',
+          os: 'darwin',
+          posture: 'connected',
+          authState: 'authenticated',
+          supportedAgents: ['codex'],
+          supportedProviders: ['codex-cli'],
+          supportedModels: ['gpt-5'],
+          supportedTools: ['code'],
+          workspaceLabels: ['workspace:veritas-kanban'],
+          activeSessions: 0,
+          queueDepth: 0,
+          maxQueueDepth: 2,
+          overloaded: false,
+          lastHeartbeat: '2026-06-01T12:01:59.000Z',
+          diagnostics: [],
+          registeredAgentIds: ['codex'],
+        },
+      ],
+    },
+    isFetching: false,
+    refetch: mocks.refetchHostHealth,
+  }),
+  useAgentHostPreview: () => ({
+    data: {
+      generatedAt: '2026-06-01T12:02:00.000Z',
+      request: { agent: 'codex', provider: 'codex-cli' },
+      decision: {
+        policy: 'first-capable-healthy',
+        selectedHostId: 'host-local',
+        selectedHostName: 'Local Supervisor',
+        reason: 'Selected first capable connected host.',
+        excludedHostIds: [],
+      },
+      previews: [
+        {
+          hostId: 'host-local',
+          hostName: 'Local Supervisor',
+          posture: 'connected',
+          compatible: true,
+          reasons: [],
+          warnings: [],
+          checks: [
+            {
+              id: 'heartbeat',
+              label: 'Heartbeat',
+              passed: true,
+              detail: 'Host has a current heartbeat.',
+            },
+          ],
+        },
+      ],
+    },
+    isFetching: false,
+  }),
+}));
+
 describe('Agents settings Mantine migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -173,11 +248,15 @@ describe('Agents settings Mantine migration', () => {
     expect(screen.getByText('Installed Agents')).toBeDefined();
     expect(screen.getByText('Codex Health')).toBeDefined();
     expect(screen.getByText('Context Provider Health')).toBeDefined();
+    expect(screen.getByText('Agent Host Health')).toBeDefined();
+    expect(screen.getByText('Launch Compatibility')).toBeDefined();
+    expect(screen.getAllByText('Local Supervisor').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('OpenClaw')).toBeDefined();
     expect(screen.getByText('Risky')).toBeDefined();
     expect(screen.getByText('Agent Routing')).toBeDefined();
     expect(screen.getByText('CLI installed')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Refresh Codex health' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Refresh host health' })).toBeDefined();
     expect(screen.getByRole('switch', { name: 'Enable Claude Code' })).toBeDefined();
     expect(screen.getByRole('combobox', { name: 'Default Agent' })).toBeDefined();
     expect(screen.getByRole('textbox', { name: 'Default Model' })).toBeDefined();
@@ -198,10 +277,12 @@ describe('Agents settings Mantine migration', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh Codex health' }));
     fireEvent.click(screen.getByRole('button', { name: 'Refresh provider health' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh host health' }));
     fireEvent.click(screen.getByRole('switch', { name: 'Enable Claude Code' }));
 
     expect(mocks.refetchCodexHealth).toHaveBeenCalledTimes(1);
     expect(mocks.refetchProviderHealth).toHaveBeenCalledTimes(1);
+    expect(mocks.refetchHostHealth).toHaveBeenCalledTimes(1);
     expect(mocks.updateAgents).toHaveBeenCalledWith([
       agents[0],
       expect.objectContaining({ type: 'claude-code', enabled: true }),

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { ActionIcon, Badge, Button, Modal, Select, Switch, Text, TextInput } from '@mantine/core';
 import { useCodexHealth, useConfig, useProviderHealth, useUpdateAgents } from '@/hooks/useConfig';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { useRoutingConfig, useUpdateRoutingConfig } from '@/hooks/useRouting';
+import { useAgentHostPreview, useAgentHosts } from '@/hooks/useAgent';
 import {
   Bot,
   Plus,
@@ -16,9 +17,15 @@ import {
   Loader2,
   RefreshCw,
   ShieldAlert,
+  Server,
 } from 'lucide-react';
 import type {
   AgentConfig,
+  AgentHostCompatibilityResponse,
+  AgentHostHealthResponse,
+  AgentHostPosture,
+  AgentHostPreviewRequest,
+  AgentHostRecord,
   AgentType,
   RoutingRule,
   AgentRoutingConfig,
@@ -160,6 +167,8 @@ export function AgentsTab() {
         isFetching={isProviderHealthFetching}
         onRefresh={() => refetchProviderHealth()}
       />
+
+      <AgentHostHealthPanel agents={config?.agents || []} />
 
       {/* Agent Behavior */}
       <div className="space-y-4">
@@ -365,6 +374,271 @@ function ProviderHealthItem({ provider }: { provider: ContextProviderHealth }) {
             <li key={recommendation}>{recommendation}</li>
           ))}
         </ul>
+      )}
+    </div>
+  );
+}
+
+function hostPostureColor(posture: AgentHostPosture): string {
+  switch (posture) {
+    case 'connected':
+      return 'green';
+    case 'degraded':
+    case 'stale':
+      return 'yellow';
+    case 'risky':
+    case 'disconnected':
+      return 'red';
+    case 'unknown':
+      return 'gray';
+  }
+}
+
+function AgentHostHealthPanel({ agents }: { agents: AgentConfig[] }) {
+  const { data: health, isFetching, refetch } = useAgentHosts();
+  const enabledAgents = agents.filter((agent) => agent.enabled);
+  const firstEnabledAgent = enabledAgents[0]?.type || '';
+  const [selectedAgent, setSelectedAgent] = useState<string>(firstEnabledAgent);
+  const [selectedHostId, setSelectedHostId] = useState<string>('auto');
+
+  useEffect(() => {
+    if (!selectedAgent && firstEnabledAgent) {
+      setSelectedAgent(firstEnabledAgent);
+    }
+  }, [firstEnabledAgent, selectedAgent]);
+
+  const selectedAgentConfig = agents.find((agent) => agent.type === selectedAgent);
+  const previewRequest = useMemo<AgentHostPreviewRequest>(
+    () => ({
+      agent: selectedAgent || undefined,
+      provider: selectedAgentConfig?.provider,
+      model: selectedAgentConfig?.model,
+      manualHostId: selectedHostId === 'auto' ? undefined : selectedHostId,
+    }),
+    [selectedAgent, selectedAgentConfig?.provider, selectedAgentConfig?.model, selectedHostId]
+  );
+  const { data: preview, isFetching: isPreviewFetching } = useAgentHostPreview(
+    previewRequest,
+    !!selectedAgent || (health?.hosts.length ?? 0) > 0
+  );
+
+  return (
+    <div className="rounded-md border bg-card p-3 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">Agent Host Health</h3>
+          <p className="text-xs text-muted-foreground">
+            {health?.generatedAt
+              ? `Checked ${new Date(health.generatedAt).toLocaleTimeString()}`
+              : 'Checking supervisor posture'}
+          </p>
+        </div>
+        <ActionIcon
+          variant="subtle"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          aria-label="Refresh host health"
+        >
+          {isFetching ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+        </ActionIcon>
+      </div>
+
+      <AgentHostSummary health={health} />
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="space-y-2">
+          {(health?.hosts ?? []).map((host) => (
+            <AgentHostItem key={host.id} host={host} />
+          ))}
+          {!health?.hosts?.length && (
+            <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+              No agent supervisors have registered host metadata yet.
+            </div>
+          )}
+        </div>
+
+        <AgentHostPreviewPanel
+          agents={enabledAgents}
+          hosts={health?.hosts ?? []}
+          preview={preview}
+          selectedAgent={selectedAgent}
+          selectedHostId={selectedHostId}
+          isFetching={isPreviewFetching}
+          onAgentChange={setSelectedAgent}
+          onHostChange={setSelectedHostId}
+        />
+      </div>
+    </div>
+  );
+}
+
+function AgentHostSummary({ health }: { health?: AgentHostHealthResponse }) {
+  if (!health) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="outline" color="gray">
+          Loading hosts
+        </Badge>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Badge variant="light" color="gray">
+        {health.summary.total} hosts
+      </Badge>
+      <Badge variant="light" color="green">
+        {health.summary.connected} connected
+      </Badge>
+      <Badge variant="light" color={health.summary.degraded > 0 ? 'yellow' : 'gray'}>
+        {health.summary.degraded} degraded
+      </Badge>
+      <Badge variant="light" color={health.summary.stale > 0 ? 'yellow' : 'gray'}>
+        {health.summary.stale} stale
+      </Badge>
+      <Badge variant="light" color={health.summary.overloaded > 0 ? 'red' : 'gray'}>
+        {health.summary.overloaded} overloaded
+      </Badge>
+    </div>
+  );
+}
+
+function AgentHostItem({ host }: { host: AgentHostRecord }) {
+  return (
+    <div className="rounded-md border bg-background/60 p-3 space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Server className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">{host.name}</span>
+            <Badge size="xs" color={hostPostureColor(host.posture)} variant="light">
+              {formatProviderState(host.posture)}
+            </Badge>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {host.supervisorType}
+            {host.os ? ` · ${host.os}` : ''}
+          </p>
+        </div>
+        <Badge size="xs" color={host.overloaded ? 'red' : 'gray'} variant="outline">
+          Queue {host.queueDepth}/{host.maxQueueDepth}
+        </Badge>
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {host.supportedAgents.slice(0, 4).map((agent) => (
+          <Badge key={agent} size="xs" variant="outline" color="gray">
+            {agent}
+          </Badge>
+        ))}
+        {host.supportedProviders.slice(0, 3).map((provider) => (
+          <Badge key={provider} size="xs" variant="light" color="gray">
+            {provider}
+          </Badge>
+        ))}
+      </div>
+
+      {host.workspaceLabels.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Workspaces: {host.workspaceLabels.slice(0, 3).join(', ')}
+        </p>
+      )}
+
+      {host.diagnostics.length > 0 && (
+        <ul className="space-y-1 text-xs text-muted-foreground">
+          {host.diagnostics.slice(0, 3).map((diagnostic) => (
+            <li key={diagnostic}>{diagnostic}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function AgentHostPreviewPanel({
+  agents,
+  hosts,
+  preview,
+  selectedAgent,
+  selectedHostId,
+  isFetching,
+  onAgentChange,
+  onHostChange,
+}: {
+  agents: AgentConfig[];
+  hosts: AgentHostRecord[];
+  preview?: AgentHostCompatibilityResponse;
+  selectedAgent: string;
+  selectedHostId: string;
+  isFetching: boolean;
+  onAgentChange: (value: string) => void;
+  onHostChange: (value: string) => void;
+}) {
+  const selectedHost = preview?.decision.selectedHostName || preview?.decision.selectedHostId;
+  const selectedPreview = preview?.decision.selectedHostId
+    ? preview.previews.find((item) => item.hostId === preview.decision.selectedHostId)
+    : undefined;
+
+  return (
+    <div className="rounded-md border bg-background/60 p-3 space-y-3">
+      <div>
+        <h4 className="text-sm font-medium">Launch Compatibility</h4>
+        <p className="text-xs text-muted-foreground">
+          {isFetching ? 'Resolving host route' : preview?.decision.reason || 'No route resolved'}
+        </p>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Select
+          label="Preview Agent"
+          value={selectedAgent}
+          onChange={(value) => onAgentChange(value || '')}
+          data={agents.map((agent) => ({ value: agent.type, label: agent.name }))}
+          placeholder="Select agent"
+          size="xs"
+        />
+        <Select
+          label="Target Host"
+          value={selectedHostId}
+          onChange={(value) => onHostChange(value || 'auto')}
+          data={[
+            { value: 'auto', label: 'Auto route' },
+            ...hosts.map((host) => ({ value: host.id, label: host.name })),
+          ]}
+          size="xs"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="light" color={selectedHost ? 'green' : 'gray'}>
+          {selectedHost || 'No host selected'}
+        </Badge>
+        <Badge variant="outline" color="gray">
+          {preview?.decision.policy || 'disabled'}
+        </Badge>
+      </div>
+
+      {selectedPreview && (
+        <div className="space-y-1">
+          {selectedPreview.checks.slice(0, 5).map((check) => (
+            <div key={check.id} className="flex items-start justify-between gap-2 text-xs">
+              <span className="text-muted-foreground">{check.label}</span>
+              <Badge size="xs" color={check.passed ? 'green' : 'red'} variant="light">
+                {check.passed ? 'Pass' : 'Block'}
+              </Badge>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!selectedPreview && preview?.decision.fallbackBehavior && (
+        <p className="text-xs text-muted-foreground">{preview.decision.fallbackBehavior}</p>
       )}
     </div>
   );

--- a/web/src/hooks/useAgent.ts
+++ b/web/src/hooks/useAgent.ts
@@ -3,7 +3,11 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api, AgentOutput } from '@/lib/api';
 import { apiFetch, API_BASE } from '@/lib/api/helpers';
 import { useWebSocket, type WebSocketMessage } from './useWebSocket';
-import type { AgentHealthClassificationResponse, AgentType } from '@veritas-kanban/shared';
+import type {
+  AgentHealthClassificationResponse,
+  AgentHostPreviewRequest,
+  AgentType,
+} from '@veritas-kanban/shared';
 
 export interface StartAgentInput {
   taskId: string;
@@ -113,6 +117,24 @@ export function useAgentHealthClassifications() {
       apiFetch<AgentHealthClassificationResponse>(`${API_BASE}/agents/register/health`),
     staleTime: 30_000,
     refetchInterval: 60_000,
+  });
+}
+
+export function useAgentHosts() {
+  return useQuery({
+    queryKey: ['agent', 'hosts'],
+    queryFn: api.agentHosts.getHealth,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}
+
+export function useAgentHostPreview(request: AgentHostPreviewRequest, enabled = true) {
+  return useQuery({
+    queryKey: ['agent', 'hosts', 'preview', request],
+    queryFn: () => api.agentHosts.preview(request),
+    enabled,
+    staleTime: 15_000,
   });
 }
 

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -1,7 +1,14 @@
 /**
  * Agent, worktree, and preview API endpoints.
  */
-import type { AgentType, AgentRoutingConfig, RoutingResult } from '@veritas-kanban/shared';
+import type {
+  AgentHostCompatibilityResponse,
+  AgentHostHealthResponse,
+  AgentHostPreviewRequest,
+  AgentType,
+  AgentRoutingConfig,
+  RoutingResult,
+} from '@veritas-kanban/shared';
 import { API_BASE, handleResponse } from './helpers';
 
 export interface StartAgentRequest {
@@ -204,6 +211,23 @@ export const routingApi = {
       body: JSON.stringify(metadata),
     });
     return handleResponse<RoutingResult>(response);
+  },
+};
+
+export const agentHostApi = {
+  getHealth: async (): Promise<AgentHostHealthResponse> => {
+    const response = await fetch(`${API_BASE}/agents/hosts`);
+    return handleResponse<AgentHostHealthResponse>(response);
+  },
+
+  preview: async (request: AgentHostPreviewRequest): Promise<AgentHostCompatibilityResponse> => {
+    const response = await fetch(`${API_BASE}/agents/hosts/preview`, {
+      credentials: 'include',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+    return handleResponse<AgentHostCompatibilityResponse>(response);
   },
 };
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -7,7 +7,7 @@
 import { tasksApi } from './tasks';
 import { backlogApi } from './backlog';
 import { settingsApi, configApi } from './config';
-import { agentApi, registryApi, worktreeApi, previewApi } from './agent';
+import { agentApi, agentHostApi, registryApi, worktreeApi, previewApi } from './agent';
 import { diffApi, conflictsApi, githubApi } from './diff';
 import { templatesApi, taskTypesApi, sprintsApi, activityApi, attachmentsApi } from './entities';
 import { timeApi, statusHistoryApi } from './time';
@@ -36,6 +36,7 @@ export const api = {
   config: configApi,
   worktree: worktreeApi,
   agent: agentApi,
+  agentHosts: agentHostApi,
   registry: registryApi,
   diff: diffApi,
   templates: templatesApi,


### PR DESCRIPTION
## Summary
- Adds a shared host/supervisor health and compatibility model for agent launch routing.
- Exposes host health and compatibility preview APIs under /api/agents/hosts with agent-read preview permissions.
- Records host routing decisions in workflow run context and step output, and surfaces host posture plus launch compatibility in Settings > Agents.

Closes #586

## Verification
- pnpm --filter @veritas-kanban/server test -- agent-host-service.test.ts
- pnpm --dir web exec vitest run src/__tests__/settings-agents-mantine.test.tsx --testTimeout 15000
- pnpm --dir web exec vitest run src/__tests__/task-detail-mantine.test.tsx --testTimeout 15000
- pnpm --filter @veritas-kanban/web test
- pnpm typecheck
- node scripts/check-permission-coverage.mjs
- pnpm lint:budget
- pnpm build

## Notes
- Host health redacts raw workspace roots from API responses; only workspace labels are returned.
- Existing local workflow execution continues when no supervisor host has registered yet, but the run metadata records that auto host routing was disabled.