### PR TITLE
Add OpenClaw posture health panel

### DIFF
--- a/server/src/__tests__/context-provider-health-service.test.ts
+++ b/server/src/__tests__/context-provider-health-service.test.ts
@@ -11,7 +11,7 @@ describe('ContextProviderHealthService', () => {
           type: 'openclaw',
           name: 'OpenClaw',
           command: 'openclaw',
-          args: ['run', '--approval-never'],
+          args: ['run', '--approval-never', '--plugin=browser', '--screen-capture'],
           enabled: true,
           provider: 'openclaw',
         },
@@ -39,18 +39,65 @@ describe('ContextProviderHealthService', () => {
     const service = new ContextProviderHealthService({
       configService: { getConfig, getFeatureSettings },
       codexHealthService: { getHealth },
+      agentRegistry: {
+        list: () => [
+          {
+            id: 'openclaw-supervisor',
+            name: 'OpenClaw Supervisor',
+            provider: 'openclaw',
+            capabilities: [{ name: 'sessions_spawn' }],
+            status: 'idle',
+            registeredAt: '2026-06-05T00:00:00.000Z',
+            lastHeartbeat: '2026-06-05T00:00:00.000Z',
+            metadata: {
+              openclawPlugins: ['memory', 'policy'],
+              openclawDoctor: {
+                status: 'normal',
+                checkedAt: '2026-06-05T00:00:00.000Z',
+                detail: 'Doctor checks passed.',
+              },
+              openclawPolicy: {
+                status: 'degraded',
+                checkedAt: '2026-06-05T00:00:00.000Z',
+                detail: 'Policy check found review items.',
+              },
+              allowedSenderCount: 2,
+            },
+          },
+        ],
+      },
     });
 
     const result = await service.getHealth();
     const openClaw = result.providers.find((provider) => provider.id === 'openclaw');
 
     expect(openClaw).toMatchObject({
-      state: 'unknown',
+      state: 'degraded',
       risk: 'risky',
       boundary: 'local',
       writeCapability: true,
     });
-    expect(openClaw?.postureFlags).toContain('Risky exec/elevated argument detected');
+    expect(openClaw?.postureFlags.join(' ')).toContain('exec/elevated allowance signal');
+    expect(openClaw?.postureChecks?.map((check) => check.id)).toEqual([
+      'openclaw.plugins',
+      'openclaw.exec',
+      'openclaw.privacy',
+      'openclaw.doctor',
+      'openclaw.policy',
+    ]);
+    expect(openClaw?.postureChecks?.find((check) => check.id === 'openclaw.plugins')).toMatchObject(
+      {
+        status: 'risky',
+        items: expect.arrayContaining(['browser', 'memory', 'policy']),
+      }
+    );
+    expect(openClaw?.postureChecks?.find((check) => check.id === 'openclaw.exec')).toMatchObject({
+      status: 'risky',
+    });
+    expect(openClaw?.postureChecks?.find((check) => check.id === 'openclaw.policy')).toMatchObject({
+      status: 'degraded',
+      detail: 'Policy check found review items.',
+    });
     expect(JSON.stringify(openClaw)).not.toContain('super-secret-token');
     expect(result.summary.risky).toBe(1);
   });

--- a/server/src/services/context-provider-health-service.ts
+++ b/server/src/services/context-provider-health-service.ts
@@ -1,11 +1,29 @@
 import type { AgentConfig, FeatureSettings } from '@veritas-kanban/shared';
 import { ConfigService } from './config-service.js';
 import { CodexHealthService, type CodexHealthStatus } from './codex-health-service.js';
+import { getAgentRegistryService, type RegisteredAgent } from './agent-registry-service.js';
 
 export type ContextProviderState = 'connected' | 'degraded' | 'stale' | 'disconnected' | 'unknown';
 
 export type ContextProviderRisk = 'safe' | 'normal' | 'risky';
 export type ContextProviderBoundary = 'local' | 'cloud' | 'mixed' | 'unknown';
+export type ContextProviderPostureStatus =
+  | 'safe'
+  | 'normal'
+  | 'risky'
+  | 'degraded'
+  | 'stale'
+  | 'disconnected'
+  | 'unknown';
+
+export interface ContextProviderPostureCheck {
+  id: string;
+  label: string;
+  status: ContextProviderPostureStatus;
+  detail: string;
+  checkedAt?: string;
+  items?: string[];
+}
 
 export interface ContextProviderHealth {
   id: string;
@@ -22,6 +40,7 @@ export interface ContextProviderHealth {
   tools: string[];
   postureFlags: string[];
   recommendations: string[];
+  postureChecks?: ContextProviderPostureCheck[];
 }
 
 export interface ContextProviderHealthResponse {
@@ -42,15 +61,18 @@ export interface ContextProviderHealthResponse {
 export interface ContextProviderHealthServiceOptions {
   configService?: Pick<ConfigService, 'getConfig' | 'getFeatureSettings'>;
   codexHealthService?: Pick<CodexHealthService, 'getHealth'>;
+  agentRegistry?: { list(): RegisteredAgent[] };
 }
 
 export class ContextProviderHealthService {
   private configService: Pick<ConfigService, 'getConfig' | 'getFeatureSettings'>;
   private codexHealthService: Pick<CodexHealthService, 'getHealth'>;
+  private agentRegistry: { list(): RegisteredAgent[] };
 
   constructor(options: ContextProviderHealthServiceOptions = {}) {
     this.configService = options.configService ?? new ConfigService();
     this.codexHealthService = options.codexHealthService ?? new CodexHealthService();
+    this.agentRegistry = options.agentRegistry ?? getAgentRegistryService();
   }
 
   async getHealth(): Promise<ContextProviderHealthResponse> {
@@ -61,9 +83,10 @@ export class ContextProviderHealthService {
       this.codexHealthService.getHealth(),
     ]);
 
+    const registeredAgents = this.agentRegistry.list();
     const providers = [
       this.codexProvider(codexHealth, checkedAt),
-      this.openClawProvider(config.agents, featureSettings, checkedAt),
+      this.openClawProvider(config.agents, featureSettings, registeredAgents, checkedAt),
     ];
 
     return {
@@ -112,23 +135,41 @@ export class ContextProviderHealthService {
   private openClawProvider(
     agents: AgentConfig[],
     featureSettings: FeatureSettings,
+    registeredAgents: RegisteredAgent[],
     checkedAt: string
   ): ContextProviderHealth {
     const openClawAgents = agents.filter((agent) => agent.provider === 'openclaw');
     const enabledAgents = openClawAgents.filter((agent) => agent.enabled);
+    const registeredOpenClawAgents = registeredAgents.filter((agent) =>
+      this.isRegisteredOpenClawAgent(agent)
+    );
     const gatewayConfigured =
       featureSettings.squadWebhook.mode === 'openclaw' &&
       Boolean(featureSettings.squadWebhook.openclawGatewayUrl);
     const riskyArgs = openClawAgents.flatMap((agent) =>
       [agent.command, ...agent.args].filter((value) => this.isRiskyOpenClawArg(value))
     );
-    const state: ContextProviderState =
-      enabledAgents.length > 0 || gatewayConfigured
-        ? 'unknown'
-        : openClawAgents.length > 0
-          ? 'degraded'
-          : 'disconnected';
-    const risk: ContextProviderRisk = riskyArgs.length > 0 ? 'risky' : 'normal';
+    const pluginPosture = this.openClawPluginPosture(openClawAgents, registeredOpenClawAgents);
+    const execPosture = this.openClawExecPosture(openClawAgents, registeredOpenClawAgents);
+    const privacyPosture = this.openClawPrivacyPosture(openClawAgents, registeredOpenClawAgents);
+    const doctorPosture = this.openClawRuntimeCheck('doctor', registeredOpenClawAgents, checkedAt);
+    const policyPosture = this.openClawRuntimeCheck('policy', registeredOpenClawAgents, checkedAt);
+    const postureChecks = [
+      pluginPosture,
+      execPosture,
+      privacyPosture,
+      doctorPosture,
+      policyPosture,
+    ];
+    const configured =
+      enabledAgents.length > 0 || gatewayConfigured || registeredOpenClawAgents.length > 0;
+    const state = this.openClawState(configured, postureChecks);
+    const risk: ContextProviderRisk =
+      postureChecks.some((check) => check.status === 'risky') || riskyArgs.length > 0
+        ? 'risky'
+        : configured
+          ? 'normal'
+          : 'safe';
 
     return {
       id: 'openclaw',
@@ -143,30 +184,39 @@ export class ContextProviderHealthService {
         ? 'Local gateway posture only; tokens and gateway secrets are redacted.'
         : 'No OpenClaw gateway status is configured.',
       lastCheckedAt: checkedAt,
-      detail:
-        enabledAgents.length > 0
-          ? `${enabledAgents.length} enabled OpenClaw agent profile(s) detected.`
-          : gatewayConfigured
-            ? 'OpenClaw gateway is configured for squad wakeups.'
-            : 'No enabled OpenClaw agent profile or gateway was found.',
+      detail: this.openClawDetail(
+        enabledAgents.length,
+        registeredOpenClawAgents.length,
+        gatewayConfigured
+      ),
       tools: [
         gatewayConfigured ? 'gateway' : undefined,
+        ...(pluginPosture.items?.map((plugin) => `plugin:${plugin}`) ?? []),
         ...openClawAgents.map((agent) => `agent:${agent.type}`),
       ].filter((tool): tool is string => Boolean(tool)),
       postureFlags: [
         gatewayConfigured ? 'Gateway configured' : 'Gateway not configured',
         enabledAgents.length > 0 ? 'Write-capable agent profile enabled' : 'No enabled profile',
-        riskyArgs.length > 0 ? 'Risky exec/elevated argument detected' : 'No risky args detected',
-        'Doctor/policy check not yet connected',
+        pluginPosture.detail,
+        execPosture.detail,
+        privacyPosture.detail,
+        doctorPosture.detail,
+        policyPosture.detail,
       ],
       recommendations: [
-        gatewayConfigured || openClawAgents.length > 0
-          ? 'Connect OpenClaw doctor/policy output to replace unknown posture.'
-          : 'Add an OpenClaw profile or gateway before expecting posture checks.',
-        riskyArgs.length > 0
-          ? 'Review OpenClaw exec/elevated arguments before autonomous runs.'
+        !configured
+          ? 'Add an OpenClaw profile or gateway before expecting posture checks.'
+          : doctorPosture.status === 'unknown' || policyPosture.status === 'unknown'
+            ? 'Register redacted OpenClaw doctor/policy summaries to replace unknown posture.'
+            : undefined,
+        execPosture.status === 'risky'
+          ? 'Review OpenClaw exec/elevated posture before autonomous runs.'
+          : undefined,
+        privacyPosture.status === 'risky'
+          ? 'Review node/camera/screen/file-transfer opt-ins before enabling autonomous runs.'
           : undefined,
       ].filter((item): item is string => Boolean(item)),
+      postureChecks,
     };
   }
 
@@ -187,5 +237,311 @@ export class ContextProviderHealthService {
     return /dangerously|skip[-_]?permissions|approval[-_]?never|elevated|allow[-_]?exec/i.test(
       value
     );
+  }
+
+  private openClawDetail(
+    enabledAgentCount: number,
+    registeredAgentCount: number,
+    gatewayConfigured: boolean
+  ): string {
+    if (enabledAgentCount > 0) {
+      return `${enabledAgentCount} enabled OpenClaw agent profile(s) detected.`;
+    }
+    if (registeredAgentCount > 0) {
+      return `${registeredAgentCount} registered OpenClaw supervisor(s) detected.`;
+    }
+    if (gatewayConfigured) {
+      return 'OpenClaw gateway is configured for squad wakeups.';
+    }
+    return 'No enabled OpenClaw agent profile or gateway was found.';
+  }
+
+  private isRegisteredOpenClawAgent(agent: RegisteredAgent): boolean {
+    const metadata = this.metadata(agent);
+    return (
+      agent.provider === 'openclaw' ||
+      String(metadata.provider ?? '').toLowerCase() === 'openclaw' ||
+      Boolean(metadata.openclaw)
+    );
+  }
+
+  private openClawPluginPosture(
+    agents: AgentConfig[],
+    registeredAgents: RegisteredAgent[]
+  ): ContextProviderPostureCheck {
+    const reportedPlugins = new Set<string>();
+    for (const agent of agents) {
+      for (const plugin of this.pluginsFromArgs([agent.command, ...agent.args])) {
+        reportedPlugins.add(plugin);
+      }
+    }
+    for (const agent of registeredAgents) {
+      for (const plugin of [
+        ...this.stringArray(this.metadata(agent).openclawPlugins),
+        ...this.stringArray(this.metadata(agent).plugins),
+        ...this.stringArray(this.metadata(agent).enabledPlugins),
+      ]) {
+        reportedPlugins.add(this.safePluginName(plugin));
+      }
+    }
+
+    const plugins = Array.from(reportedPlugins).filter(Boolean).sort();
+    const sensitive = plugins.filter((plugin) =>
+      /browser|canvas|node|file-transfer|webhook|screen|camera|acp|codex-supervisor/i.test(plugin)
+    );
+    if (plugins.length === 0) {
+      return {
+        id: 'openclaw.plugins',
+        label: 'OpenClaw plugins',
+        status: 'unknown',
+        detail: 'High-impact plugin posture is not reported.',
+      };
+    }
+    return {
+      id: 'openclaw.plugins',
+      label: 'OpenClaw plugins',
+      status: sensitive.length > 0 ? 'risky' : 'normal',
+      detail:
+        sensitive.length > 0
+          ? `${sensitive.length} high-impact plugin opt-in(s) detected.`
+          : `${plugins.length} plugin opt-in(s) detected without high-impact flags.`,
+      items: plugins,
+    };
+  }
+
+  private openClawExecPosture(
+    agents: AgentConfig[],
+    registeredAgents: RegisteredAgent[]
+  ): ContextProviderPostureCheck {
+    const riskyArgCount = agents.reduce(
+      (count, agent) =>
+        count +
+        [agent.command, ...agent.args].filter((value) => this.isRiskyOpenClawArg(value)).length,
+      0
+    );
+    const metadataExecSignals = registeredAgents.filter((agent) => {
+      const metadata = this.metadata(agent);
+      return (
+        this.booleanValue(metadata.execAllowed) ||
+        this.booleanValue(metadata.elevatedAllowed) ||
+        this.booleanValue(metadata.hostSecurityAsk) ||
+        this.numberValue(metadata.allowedSenderCount) > 0
+      );
+    }).length;
+    const riskyCount = riskyArgCount + metadataExecSignals;
+
+    return {
+      id: 'openclaw.exec',
+      label: 'Exec and elevated posture',
+      status:
+        riskyCount > 0
+          ? 'risky'
+          : agents.length > 0 || registeredAgents.length > 0
+            ? 'safe'
+            : 'unknown',
+      detail:
+        riskyCount > 0
+          ? `${riskyCount} exec/elevated allowance signal(s) detected; identities are redacted.`
+          : agents.length > 0 || registeredAgents.length > 0
+            ? 'No exec/elevated allowance signal detected.'
+            : 'Exec/elevated posture is not reported.',
+    };
+  }
+
+  private openClawPrivacyPosture(
+    agents: AgentConfig[],
+    registeredAgents: RegisteredAgent[]
+  ): ContextProviderPostureCheck {
+    const argText = agents.map((agent) => [agent.command, ...agent.args].join(' ')).join(' ');
+    const optIns = new Set<string>();
+    for (const [label, pattern] of [
+      ['node', /\bnode(?:s)?\b/i],
+      ['camera', /\bcamera\b/i],
+      ['screen', /\bscreen(?:-share|-capture)?\b/i],
+      ['file-transfer', /\bfile[-_]?transfer\b/i],
+    ] as const) {
+      if (pattern.test(argText)) optIns.add(label);
+    }
+    for (const agent of registeredAgents) {
+      const metadata = this.metadata(agent);
+      if (this.booleanValue(metadata.nodeAccess)) optIns.add('node');
+      if (this.booleanValue(metadata.cameraAccess)) optIns.add('camera');
+      if (this.booleanValue(metadata.screenAccess)) optIns.add('screen');
+      if (this.booleanValue(metadata.fileTransferAccess)) optIns.add('file-transfer');
+      for (const item of this.stringArray(metadata.privacyOptIns)) {
+        optIns.add(this.safePluginName(item));
+      }
+    }
+
+    const items = Array.from(optIns).sort();
+    return {
+      id: 'openclaw.privacy',
+      label: 'Node privacy posture',
+      status:
+        items.length > 0
+          ? 'risky'
+          : agents.length > 0 || registeredAgents.length > 0
+            ? 'safe'
+            : 'unknown',
+      detail:
+        items.length > 0
+          ? `${items.length} node/camera/screen/file-transfer opt-in(s) detected.`
+          : agents.length > 0 || registeredAgents.length > 0
+            ? 'No node/camera/screen/file-transfer opt-in signal detected.'
+            : 'Node privacy posture is not reported.',
+      items: items.length > 0 ? items : undefined,
+    };
+  }
+
+  private openClawRuntimeCheck(
+    kind: 'doctor' | 'policy',
+    registeredAgents: RegisteredAgent[],
+    checkedAt: string
+  ): ContextProviderPostureCheck {
+    const candidates = registeredAgents
+      .map((agent) =>
+        this.runtimeCheckFromMetadata(kind, this.metadata(agent), agent.lastHeartbeat)
+      )
+      .filter((check): check is ContextProviderPostureCheck => Boolean(check))
+      .sort((a, b) => Date.parse(b.checkedAt ?? '') - Date.parse(a.checkedAt ?? ''));
+
+    if (candidates[0]) return candidates[0];
+
+    return {
+      id: `openclaw.${kind}`,
+      label: kind === 'doctor' ? 'Doctor check' : 'Policy check',
+      status: 'unknown',
+      checkedAt,
+      detail: `OpenClaw ${kind} status is not reported.`,
+    };
+  }
+
+  private runtimeCheckFromMetadata(
+    kind: 'doctor' | 'policy',
+    metadata: Record<string, unknown>,
+    fallbackCheckedAt: string
+  ): ContextProviderPostureCheck | null {
+    const direct = metadata[`openclaw${this.capitalize(kind)}`];
+    const directObject =
+      direct && typeof direct === 'object' ? (direct as Record<string, unknown>) : {};
+    const status =
+      this.postureStatus(directObject.status) ??
+      this.postureStatus(metadata[`${kind}Status`]) ??
+      this.postureStatus(metadata[`openclaw${this.capitalize(kind)}Status`]);
+    if (!status) return null;
+
+    const detail =
+      this.stringValue(directObject.detail) ??
+      this.stringValue(directObject.error) ??
+      this.stringValue(metadata[`${kind}Detail`]) ??
+      this.stringValue(metadata[`${kind}Error`]) ??
+      `OpenClaw ${kind} reported ${status}.`;
+    const checkedAt =
+      this.stringValue(directObject.checkedAt) ??
+      this.stringValue(metadata[`${kind}CheckedAt`]) ??
+      fallbackCheckedAt;
+
+    return {
+      id: `openclaw.${kind}`,
+      label: kind === 'doctor' ? 'Doctor check' : 'Policy check',
+      status,
+      checkedAt,
+      detail,
+    };
+  }
+
+  private openClawState(
+    configured: boolean,
+    checks: ContextProviderPostureCheck[]
+  ): ContextProviderState {
+    if (!configured) return 'disconnected';
+    if (checks.some((check) => check.status === 'disconnected')) return 'disconnected';
+    if (checks.some((check) => check.status === 'stale')) return 'stale';
+    if (checks.some((check) => check.status === 'risky' || check.status === 'degraded')) {
+      return 'degraded';
+    }
+    if (checks.some((check) => check.status === 'unknown')) return 'degraded';
+    return 'connected';
+  }
+
+  private pluginsFromArgs(args: string[]): string[] {
+    const text = args.join(' ');
+    const plugins = new Set<string>();
+    for (const plugin of [
+      'memory',
+      'web-search',
+      'web-extraction',
+      'browser',
+      'canvas',
+      'nodes',
+      'file-transfer',
+      'webhooks',
+      'skill-workshop',
+      'policy',
+      'workboard',
+      'acp',
+      'codex-supervisor',
+    ]) {
+      const pattern = new RegExp(`\\b${plugin.replace('-', '[-_]')}\\b`, 'i');
+      if (pattern.test(text)) plugins.add(plugin);
+    }
+    return Array.from(plugins);
+  }
+
+  private metadata(agent: RegisteredAgent): Record<string, unknown> {
+    return agent.metadata && typeof agent.metadata === 'object' ? agent.metadata : {};
+  }
+
+  private stringArray(value: unknown): string[] {
+    return Array.isArray(value)
+      ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+      : [];
+  }
+
+  private stringValue(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  }
+
+  private booleanValue(value: unknown): boolean {
+    return value === true || value === 'true';
+  }
+
+  private numberValue(value: unknown): number {
+    const parsed =
+      typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : 0;
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  private postureStatus(value: unknown): ContextProviderPostureStatus | undefined {
+    if (typeof value !== 'string') return undefined;
+    const normalized = value.trim().toLowerCase();
+    if (
+      normalized === 'safe' ||
+      normalized === 'normal' ||
+      normalized === 'risky' ||
+      normalized === 'degraded' ||
+      normalized === 'stale' ||
+      normalized === 'disconnected' ||
+      normalized === 'unknown'
+    ) {
+      return normalized;
+    }
+    if (normalized === 'ok' || normalized === 'pass' || normalized === 'passed') return 'normal';
+    if (normalized === 'fail' || normalized === 'failed' || normalized === 'error') {
+      return 'degraded';
+    }
+    return undefined;
+  }
+
+  private safePluginName(value: string): string {
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]/g, '-')
+      .slice(0, 80);
+  }
+
+  private capitalize(value: string): string {
+    return value.charAt(0).toUpperCase() + value.slice(1);
   }
 }

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -81,10 +81,10 @@ vi.mock('@/hooks/useConfig', () => ({
       summary: {
         total: 2,
         connected: 1,
-        degraded: 0,
+        degraded: 1,
         stale: 0,
         disconnected: 0,
-        unknown: 1,
+        unknown: 0,
         risky: 1,
         writeCapable: 2,
       },
@@ -109,7 +109,7 @@ vi.mock('@/hooks/useConfig', () => ({
           id: 'openclaw',
           name: 'OpenClaw',
           provider: 'openclaw',
-          state: 'unknown',
+          state: 'degraded',
           risk: 'risky',
           boundary: 'local',
           readCapability: true,
@@ -117,9 +117,50 @@ vi.mock('@/hooks/useConfig', () => ({
           privacyScope: 'Local gateway posture only; tokens and gateway secrets are redacted.',
           lastCheckedAt: '2026-06-01T12:01:00.000Z',
           detail: '1 enabled OpenClaw agent profile(s) detected.',
-          tools: ['gateway', 'agent:openclaw'],
-          postureFlags: ['Risky exec/elevated argument detected'],
-          recommendations: ['Review OpenClaw exec/elevated arguments before autonomous runs.'],
+          tools: ['gateway', 'plugin:browser', 'agent:openclaw'],
+          postureFlags: [
+            'Gateway configured',
+            'Write-capable agent profile enabled',
+            '2 high-impact plugin opt-in(s) detected.',
+            '1 exec/elevated allowance signal(s) detected; identities are redacted.',
+          ],
+          recommendations: ['Review OpenClaw exec/elevated posture before autonomous runs.'],
+          postureChecks: [
+            {
+              id: 'openclaw.plugins',
+              label: 'OpenClaw plugins',
+              status: 'risky',
+              detail: '2 high-impact plugin opt-in(s) detected.',
+              items: ['browser', 'memory'],
+            },
+            {
+              id: 'openclaw.exec',
+              label: 'Exec and elevated posture',
+              status: 'risky',
+              detail: '1 exec/elevated allowance signal(s) detected; identities are redacted.',
+            },
+            {
+              id: 'openclaw.privacy',
+              label: 'Node privacy posture',
+              status: 'risky',
+              detail: '1 node/camera/screen/file-transfer opt-in(s) detected.',
+              items: ['screen'],
+            },
+            {
+              id: 'openclaw.doctor',
+              label: 'Doctor check',
+              status: 'normal',
+              detail: 'Doctor checks passed.',
+              checkedAt: '2026-06-01T12:01:00.000Z',
+            },
+            {
+              id: 'openclaw.policy',
+              label: 'Policy check',
+              status: 'degraded',
+              detail: 'Policy check found review items.',
+              checkedAt: '2026-06-01T12:01:00.000Z',
+            },
+          ],
         },
       ],
     },
@@ -252,7 +293,12 @@ describe('Agents settings Mantine migration', () => {
     expect(screen.getByText('Launch Compatibility')).toBeDefined();
     expect(screen.getAllByText('Local Supervisor').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('OpenClaw')).toBeDefined();
-    expect(screen.getByText('Risky')).toBeDefined();
+    expect(screen.getAllByText('Risky').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('OpenClaw plugins')).toBeDefined();
+    expect(screen.getByText('Exec and elevated posture')).toBeDefined();
+    expect(screen.getByText('Node privacy posture')).toBeDefined();
+    expect(screen.getByText('Doctor check')).toBeDefined();
+    expect(screen.getByText('Policy check')).toBeDefined();
     expect(screen.getByText('Agent Routing')).toBeDefined();
     expect(screen.getByText('CLI installed')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Refresh Codex health' })).toBeDefined();

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -33,6 +33,7 @@ import type {
 import type {
   CodexHealthStatus,
   ContextProviderHealth,
+  ContextProviderPostureStatus,
   ContextProviderHealthResponse,
 } from '@/lib/api';
 import { DEFAULT_FEATURE_SETTINGS, DEFAULT_ROUTING_CONFIG } from '@veritas-kanban/shared';
@@ -239,6 +240,23 @@ function providerStateColor(state: ContextProviderHealth['state']): string {
   }
 }
 
+function providerPostureStatusColor(status: ContextProviderPostureStatus): string {
+  switch (status) {
+    case 'safe':
+    case 'normal':
+      return 'green';
+    case 'degraded':
+    case 'stale':
+    case 'unknown':
+      return 'yellow';
+    case 'risky':
+    case 'disconnected':
+      return 'red';
+    default:
+      return 'gray';
+  }
+}
+
 function formatProviderState(value: string): string {
   return value
     .split('-')
@@ -367,6 +385,31 @@ function ProviderHealthItem({ provider }: { provider: ContextProviderHealth }) {
           ))}
         </ul>
       )}
+
+      {provider.postureChecks?.length ? (
+        <div className="space-y-2">
+          {provider.postureChecks.slice(0, 5).map((check) => (
+            <div key={check.id} className="rounded-md border bg-card/60 p-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-xs font-medium">{check.label}</span>
+                <Badge size="xs" color={providerPostureStatusColor(check.status)} variant="light">
+                  {formatProviderState(check.status)}
+                </Badge>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">{check.detail}</p>
+              {check.items?.length ? (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {check.items.slice(0, 6).map((item) => (
+                    <Badge key={item} size="xs" variant="outline" color="gray">
+                      {item}
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       {provider.recommendations.length > 0 && (
         <ul className="space-y-1 text-xs text-muted-foreground">

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -70,6 +70,23 @@ export type ContextProviderState = 'connected' | 'degraded' | 'stale' | 'disconn
 
 export type ContextProviderRisk = 'safe' | 'normal' | 'risky';
 export type ContextProviderBoundary = 'local' | 'cloud' | 'mixed' | 'unknown';
+export type ContextProviderPostureStatus =
+  | 'safe'
+  | 'normal'
+  | 'risky'
+  | 'degraded'
+  | 'stale'
+  | 'disconnected'
+  | 'unknown';
+
+export interface ContextProviderPostureCheck {
+  id: string;
+  label: string;
+  status: ContextProviderPostureStatus;
+  detail: string;
+  checkedAt?: string;
+  items?: string[];
+}
 
 export interface ContextProviderHealth {
   id: string;
@@ -86,6 +103,7 @@ export interface ContextProviderHealth {
   tools: string[];
   postureFlags: string[];
   recommendations: string[];
+  postureChecks?: ContextProviderPostureCheck[];
 }
 
 export interface ContextProviderHealthResponse {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -137,6 +137,7 @@ export type {
   ContextProviderBoundary,
   ContextProviderHealth,
   ContextProviderHealthResponse,
+  ContextProviderPostureStatus,
   ContextProviderRisk,
   ContextProviderState,
 } from './config';


### PR DESCRIPTION
## Summary
- Add OpenClaw-specific posture checks to shared context provider health.
- Surface plugin, exec/elevated, node privacy, doctor, and policy posture in the existing Agents provider-health panel.
- Keep OpenClaw secret/token values redacted and cover posture metadata in server and web tests.

## Verification
- pnpm --filter @veritas-kanban/server test -- context-provider-health-service.test.ts
- pnpm --dir web exec vitest run src/__tests__/settings-agents-mantine.test.tsx --testTimeout 15000
- pnpm typecheck
- node scripts/check-permission-coverage.mjs
- pnpm lint:budget
- pnpm --filter @veritas-kanban/web test
- pnpm --dir web exec vitest run src/__tests__/CreateTaskDuplicateDetection.test.tsx src/__tests__/task-detail-mantine.test.tsx --testTimeout 15000
- pnpm build

## Notes
- One full web-suite run produced unrelated concurrent failures in duplicate detection and task detail; both failed files passed isolated, and the full suite passed on rerun.

Closes #594