### PR TITLE
Add session template recommendations

### DIFF
--- a/server/src/__tests__/session-template-service.test.ts
+++ b/server/src/__tests__/session-template-service.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  AgentHostCompatibilityResponse,
+  CreateTemplateInput,
+  Task,
+  TaskTemplate,
+} from '@veritas-kanban/shared';
+import { SessionTemplateService } from '../services/session-template-service.js';
+import type { WorkflowDefinition, WorkflowRun } from '../types/workflow.js';
+
+const now = '2026-06-05T12:00:00.000Z';
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task_584',
+    title: 'Add session template recommendations',
+    description: 'Distill successful workflow launches into reviewable draft templates.',
+    type: 'feature',
+    status: 'done',
+    priority: 'critical',
+    project: 'veritas-kanban',
+    created: '2026-06-05T10:00:00.000Z',
+    updated: now,
+    git: {
+      repo: 'veritas-kanban',
+      branch: 'feature/session-template-recommendations-584',
+      baseBranch: 'main',
+      worktreePath: '/Users/bradgroux/Projects/veritas-kanban',
+    },
+    ...overrides,
+  };
+}
+
+function workflow(): WorkflowDefinition {
+  return {
+    id: 'workflow_launch',
+    name: 'Launch workflow',
+    version: 1,
+    description: 'Run a verified launch workflow.',
+    variables: {
+      cwd: '/Users/bradgroux/Projects/veritas-kanban',
+    },
+    outputTargets: [
+      {
+        type: 'work-product',
+        label: 'PR summary',
+        required: true,
+        path: 'artifacts/pr-summary.md',
+      },
+    ],
+    agents: [
+      {
+        id: 'builder',
+        name: 'Builder',
+        role: 'developer',
+        model: 'gpt-5',
+        provider: 'codex-cli',
+        description: 'Implements the workflow.',
+      },
+    ],
+    steps: [
+      {
+        id: 'implement',
+        name: 'Implement',
+        type: 'agent',
+        agent: 'builder',
+        input: 'Implement the task and preserve existing architecture.',
+        acceptance_criteria: ['pnpm typecheck', 'pnpm build'],
+        session: {
+          mode: 'fresh',
+          context: 'custom',
+          cleanup: 'keep',
+          timeout: 3600,
+          includeOutputsFrom: ['plan'],
+        },
+        output: { file: 'implementation.md' },
+      },
+      {
+        id: 'verify',
+        name: 'Verify',
+        type: 'gate',
+        condition: 'steps.implement.status == "completed"',
+        acceptance_criteria: ['All required gates pass'],
+      },
+    ],
+  };
+}
+
+function completedRun(sourceTask = task()): WorkflowRun {
+  return {
+    id: 'run_success_584',
+    workflowId: 'workflow_launch',
+    workflowVersion: 1,
+    taskId: sourceTask.id,
+    status: 'completed',
+    context: {
+      task: sourceTask,
+      cwd: '/Users/bradgroux/Projects/veritas-kanban',
+      rawProviderOutput: 'SECRET_PROVIDER_PAYLOAD_SHOULD_NOT_BE_DISTILLED',
+    },
+    startedAt: '2026-06-05T10:30:00.000Z',
+    completedAt: now,
+    steps: [
+      {
+        stepId: 'implement',
+        status: 'completed',
+        agent: 'builder',
+        startedAt: '2026-06-05T10:30:00.000Z',
+        completedAt: '2026-06-05T11:30:00.000Z',
+        retries: 1,
+        output: '/tmp/veritas/step-outputs/implementation.md',
+      },
+      {
+        stepId: 'verify',
+        status: 'completed',
+        retries: 0,
+      },
+    ],
+  };
+}
+
+function hostPreview(): AgentHostCompatibilityResponse {
+  return {
+    generatedAt: now,
+    request: {
+      agent: 'builder',
+      model: 'gpt-5',
+      workspacePath: '/Users/bradgroux/Projects/veritas-kanban',
+      autoRouting: true,
+    },
+    decision: {
+      policy: 'first-capable-healthy',
+      selectedHostId: 'host-local',
+      selectedHostName: 'Local host',
+      reason: 'Selected first compatible host.',
+      excludedHostIds: [],
+    },
+    previews: [
+      {
+        hostId: 'host-local',
+        hostName: 'Local host',
+        posture: 'connected',
+        compatible: true,
+        checks: [],
+        reasons: [],
+        warnings: [],
+      },
+    ],
+  };
+}
+
+describe('SessionTemplateService', () => {
+  it('distills a completed verified run into a review-required launch template', async () => {
+    const sourceWorkflow = workflow();
+    const sourceRun = completedRun();
+    const createTemplate = vi.fn(async (input: CreateTemplateInput): Promise<TaskTemplate> => {
+      return {
+        id: 'template_launch_584',
+        version: 1,
+        created: now,
+        updated: now,
+        ...input,
+      };
+    });
+    const service = new SessionTemplateService({
+      templateService: {
+        createTemplate,
+        getTemplates: vi.fn().mockResolvedValue([]),
+      },
+      workflowRunService: {
+        getRun: vi.fn().mockResolvedValue(sourceRun),
+        listRuns: vi.fn().mockResolvedValue([]),
+      },
+      workflowService: {
+        loadWorkflow: vi.fn().mockResolvedValue(sourceWorkflow),
+      },
+      agentHostService: {
+        preview: vi.fn().mockReturnValue(hostPreview()),
+      },
+      taskService: {
+        getTask: vi.fn().mockResolvedValue(task()),
+      },
+    });
+
+    const template = await service.distillTemplateFromRun({ runId: sourceRun.id });
+
+    expect(createTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Draft: Launch workflow',
+        category: 'workflow-launch',
+        taskDefaults: expect.objectContaining({
+          type: 'feature',
+          priority: 'high',
+          project: 'veritas-kanban',
+          agent: 'builder',
+        }),
+      })
+    );
+    expect(template.launch).toMatchObject({
+      status: 'draft',
+      distilledFromRunId: sourceRun.id,
+      sourceWorkflowId: sourceWorkflow.id,
+      sourceTaskId: 'task_584',
+      promptTemplate: 'Implement the task and preserve existing architecture.',
+      session: {
+        agent: 'builder',
+        model: 'gpt-5',
+        cwd: '/Users/bradgroux/Projects/veritas-kanban',
+        mode: 'fresh',
+        context: 'custom',
+        cleanup: 'keep',
+      },
+      inheritsProjectDefaults: true,
+    });
+    expect(template.launch?.contextRequirements).toContain('Output from plan');
+    expect(template.launch?.verificationGates).toEqual(
+      expect.arrayContaining([
+        'Implement: pnpm typecheck',
+        'Implement: pnpm build',
+        'Gate passed: Verify',
+        'Required output: PR summary',
+      ])
+    );
+    expect(template.launch?.expectedArtifacts).toEqual(
+      expect.arrayContaining(['implementation.md', 'artifacts/pr-summary.md'])
+    );
+    expect(template.launch?.knownGotchas).toContain('implement required 1 retry.');
+    expect(template.launch?.provenance).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'run', id: sourceRun.id }),
+        expect.objectContaining({ type: 'workflow', id: sourceWorkflow.id }),
+        expect.objectContaining({ type: 'task', id: 'task_584' }),
+        expect.objectContaining({ type: 'artifact', id: 'implementation.md' }),
+      ])
+    );
+    expect(JSON.stringify(template)).not.toContain(
+      'SECRET_PROVIDER_PAYLOAD_SHOULD_NOT_BE_DISTILLED'
+    );
+  });
+
+  it('recommends templates, agents, models, and compatible hosts with advisory override data', async () => {
+    const sourceWorkflow = workflow();
+    const sourceRun = completedRun();
+    const launchTemplate: TaskTemplate = {
+      id: 'template_launch_584',
+      name: 'Reviewed launch template',
+      version: 1,
+      category: 'workflow-launch',
+      taskDefaults: {
+        type: 'feature',
+        priority: 'high',
+        project: 'veritas-kanban',
+        agent: 'builder',
+      },
+      launch: {
+        status: 'active',
+        distilledFromRunId: sourceRun.id,
+        sourceWorkflowId: sourceWorkflow.id,
+        sourceTaskId: 'task_584',
+        session: {
+          agent: 'builder',
+          model: 'gpt-5',
+          cwd: '/Users/bradgroux/Projects/veritas-kanban',
+        },
+        verificationGates: ['pnpm typecheck'],
+        reasonCodes: ['source-run:completed'],
+        provenance: [{ type: 'run', id: sourceRun.id, label: sourceWorkflow.id }],
+      },
+      created: now,
+      updated: now,
+    };
+    const preview = vi.fn().mockReturnValue(hostPreview());
+    const service = new SessionTemplateService({
+      templateService: {
+        createTemplate: vi.fn(),
+        getTemplates: vi.fn().mockResolvedValue([launchTemplate]),
+      },
+      workflowRunService: {
+        getRun: vi.fn(),
+        listRuns: vi.fn().mockResolvedValue([sourceRun]),
+      },
+      workflowService: {
+        loadWorkflow: vi.fn().mockResolvedValue(sourceWorkflow),
+      },
+      agentHostService: { preview },
+      taskService: {
+        getTask: vi.fn().mockResolvedValue(task()),
+      },
+    });
+
+    const result = await service.getLaunchRecommendations({
+      workflowId: sourceWorkflow.id,
+      taskId: 'task_584',
+      project: 'veritas-kanban',
+      taskType: 'feature',
+      cwd: '/Users/bradgroux/Projects/veritas-kanban',
+      verificationGates: ['Implement: pnpm typecheck'],
+    });
+
+    expect(preview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'builder',
+        model: 'gpt-5',
+        workspacePath: '/Users/bradgroux/Projects/veritas-kanban',
+        autoRouting: true,
+        verificationGates: ['Implement: pnpm typecheck'],
+      })
+    );
+    expect(result.context).toMatchObject({
+      workflowId: sourceWorkflow.id,
+      taskId: 'task_584',
+      project: 'veritas-kanban',
+      taskType: 'feature',
+      cwd: '/Users/bradgroux/Projects/veritas-kanban',
+    });
+    expect(result.recommendations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'template',
+          templateId: launchTemplate.id,
+          templateStatus: 'active',
+          overrides: expect.objectContaining({ templateId: launchTemplate.id, agent: 'builder' }),
+          provenance: expect.arrayContaining([
+            expect.objectContaining({ type: 'run', id: sourceRun.id }),
+          ]),
+          reasonCodes: expect.arrayContaining(['source-run:matched', 'template-status:active']),
+        }),
+        expect.objectContaining({
+          kind: 'agent',
+          agent: 'builder',
+          overrides: { agent: 'builder' },
+          reasonCodes: expect.arrayContaining(['agent:source-run', 'workflow:matched']),
+        }),
+        expect.objectContaining({
+          kind: 'model',
+          model: 'gpt-5',
+          overrides: { model: 'gpt-5' },
+        }),
+        expect.objectContaining({
+          kind: 'host',
+          hostId: 'host-local',
+          hostName: 'Local host',
+          overrides: { hostId: 'host-local' },
+          reasonCodes: expect.arrayContaining(['host:compatible', 'host-posture:connected']),
+        }),
+      ])
+    );
+    expect(
+      result.recommendations.every((item) => item.confidence >= 0.2 && item.confidence <= 0.95)
+    ).toBe(true);
+  });
+});

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -1,11 +1,13 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { TemplateService } from '../services/template-service.js';
+import { getSessionTemplateService } from '../services/session-template-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 
 const router: RouterType = Router();
 const templateService = new TemplateService();
+const sessionTemplateService = getSessionTemplateService();
 
 // Validation schemas
 const subtaskTemplateSchema = z.object({
@@ -22,10 +24,53 @@ const blueprintTaskSchema = z.object({
     priority: z.enum(['low', 'medium', 'high']).optional(),
     project: z.string().optional(),
     descriptionTemplate: z.string().optional(),
-    agent: z.enum(['claude-code', 'amp', 'copilot', 'gemini', 'veritas']).optional(),
+    agent: z.string().min(1).max(80).optional(),
   }),
   subtaskTemplates: z.array(subtaskTemplateSchema).optional(),
   blockedByRefs: z.array(z.string()).optional(),
+});
+
+const provenanceLinkSchema = z.object({
+  type: z.enum(['run', 'workflow', 'task', 'issue', 'timeline', 'artifact']),
+  id: z.string().min(1).max(300),
+  label: z.string().max(300).optional(),
+  url: z.string().max(1000).optional(),
+  path: z.string().max(1000).optional(),
+});
+
+const launchMetadataSchema = z.object({
+  status: z.enum(['draft', 'active', 'archived']),
+  distilledFromRunId: z.string().max(120).optional(),
+  sourceWorkflowId: z.string().max(120).optional(),
+  sourceTaskId: z.string().max(120).optional(),
+  promptTemplate: z.string().max(12000).optional(),
+  contextRequirements: z.array(z.string().max(300)).max(50).optional(),
+  session: z
+    .object({
+      agent: z.string().max(80).optional(),
+      model: z.string().max(120).optional(),
+      provider: z.string().max(80).optional(),
+      hostId: z.string().max(120).optional(),
+      hostName: z.string().max(200).optional(),
+      cwd: z.string().max(1000).optional(),
+      project: z.string().max(200).optional(),
+      sandbox: z.string().max(120).optional(),
+      mode: z.enum(['fresh', 'reuse']).optional(),
+      context: z.enum(['minimal', 'full', 'custom']).optional(),
+      cleanup: z.enum(['delete', 'keep']).optional(),
+      timeout: z.number().int().positive().max(86400).optional(),
+      includeOutputsFrom: z.array(z.string().max(120)).max(50).optional(),
+    })
+    .optional(),
+  verificationGates: z.array(z.string().max(500)).max(50).optional(),
+  expectedArtifacts: z.array(z.string().max(500)).max(50).optional(),
+  knownGotchas: z.array(z.string().max(500)).max(50).optional(),
+  reasonCodes: z.array(z.string().max(120)).max(50).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  provenance: z.array(provenanceLinkSchema).max(100).optional(),
+  inheritsProjectDefaults: z.boolean().optional(),
+  reviewedAt: z.string().max(120).optional(),
+  reviewedBy: z.string().max(120).optional(),
 });
 
 const createTemplateSchema = z.object({
@@ -37,10 +82,11 @@ const createTemplateSchema = z.object({
     priority: z.enum(['low', 'medium', 'high']).optional(),
     project: z.string().optional(),
     descriptionTemplate: z.string().optional(),
-    agent: z.enum(['claude-code', 'amp', 'copilot', 'gemini', 'veritas']).optional(),
+    agent: z.string().min(1).max(80).optional(),
   }),
   subtaskTemplates: z.array(subtaskTemplateSchema).optional(),
   blueprint: z.array(blueprintTaskSchema).optional(),
+  launch: launchMetadataSchema.optional(),
 });
 
 const updateTemplateSchema = z.object({
@@ -53,11 +99,17 @@ const updateTemplateSchema = z.object({
       priority: z.enum(['low', 'medium', 'high']).optional(),
       project: z.string().optional(),
       descriptionTemplate: z.string().optional(),
-      agent: z.enum(['claude-code', 'amp', 'copilot', 'gemini', 'veritas']).optional(),
+      agent: z.string().min(1).max(80).optional(),
     })
     .optional(),
   subtaskTemplates: z.array(subtaskTemplateSchema).optional(),
   blueprint: z.array(blueprintTaskSchema).optional(),
+  launch: launchMetadataSchema.optional(),
+});
+
+const distillTemplateFromRunSchema = z.object({
+  runId: z.string().min(1).max(120),
+  name: z.string().min(1).max(200).optional(),
 });
 
 // GET /api/templates - List all templates
@@ -66,6 +118,25 @@ router.get(
   asyncHandler(async (_req, res) => {
     const templates = await templateService.getTemplates();
     res.json(templates);
+  })
+);
+
+// POST /api/templates/distill-from-run - Create a review-required draft template from a completed run
+router.post(
+  '/distill-from-run',
+  asyncHandler(async (req, res) => {
+    let input;
+    try {
+      input = distillTemplateFromRunSchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+
+    const template = await sessionTemplateService.distillTemplateFromRun(input);
+    res.status(201).json(template);
   })
 );
 

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -9,6 +9,7 @@ import type { WorkflowDefinition, WorkflowACL } from '../types/workflow.js';
 import { getWorkflowService } from '../services/workflow-service.js';
 import { getWorkflowRunService } from '../services/workflow-run-service.js';
 import { getWorkflowAuthoringService } from '../services/workflow-authoring-service.js';
+import { getSessionTemplateService } from '../services/session-template-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { NotFoundError, ValidationError, BadRequestError } from '../middleware/error-handler.js';
@@ -20,6 +21,7 @@ const router = Router();
 const workflowService = getWorkflowService();
 const workflowRunService = getWorkflowRunService();
 const workflowAuthoringService = getWorkflowAuthoringService();
+const sessionTemplateService = getSessionTemplateService();
 
 // Helper to extract string param (handles Express types)
 function getStringParam(param: string | string[] | undefined): string {
@@ -64,6 +66,15 @@ const authoringInputSchema = z.object({
   workflow: z.record(z.string(), z.unknown()).optional(),
   yaml: z.string().optional(),
   context: authoringContextSchema,
+});
+
+const launchRecommendationsQuerySchema = z.object({
+  workflowId: z.string().optional(),
+  taskId: z.string().optional(),
+  project: z.string().optional(),
+  taskType: z.string().optional(),
+  cwd: z.string().optional(),
+  verificationGates: z.string().optional(),
 });
 
 // Basic input validation - detailed validation happens in WorkflowService
@@ -193,6 +204,34 @@ router.post(
     res.json({
       yaml: workflowAuthoringService.toYaml(input.workflow as unknown as WorkflowDefinition),
     });
+  })
+);
+
+/**
+ * GET /api/workflows/launch-recommendations - Advisory launch recommendations from prior runs
+ */
+router.get(
+  '/launch-recommendations',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const userId = getUserId(req);
+    const query = launchRecommendationsQuerySchema.parse(req.query);
+
+    if (query.workflowId) {
+      await assertWorkflowPermission(query.workflowId, userId, 'view');
+    }
+
+    const result = await sessionTemplateService.getLaunchRecommendations({
+      workflowId: query.workflowId,
+      taskId: query.taskId,
+      project: query.project,
+      taskType: query.taskType,
+      cwd: query.cwd,
+      verificationGates: query.verificationGates
+        ?.split(',')
+        .map((item) => item.trim())
+        .filter(Boolean),
+    });
+    res.json(result);
   })
 );
 

--- a/server/src/services/session-template-service.ts
+++ b/server/src/services/session-template-service.ts
@@ -1,0 +1,577 @@
+import path from 'path';
+import type {
+  AgentHostCompatibilityResponse,
+  AgentType,
+  CreateTemplateInput,
+  DistillTemplateFromRunInput,
+  LaunchRecommendation,
+  LaunchRecommendationsResponse,
+  LaunchTemplateMetadata,
+  TaskTemplate,
+  TemplateProvenanceLink,
+} from '@veritas-kanban/shared';
+import type { Task } from '@veritas-kanban/shared';
+import type {
+  StepSessionConfig,
+  WorkflowAgent,
+  WorkflowDefinition,
+  WorkflowRun,
+  WorkflowStep,
+} from '../types/workflow.js';
+import { BadRequestError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { getAgentHostService, AgentHostService } from './agent-host-service.js';
+import { getTaskService } from './task-service.js';
+import { TemplateService } from './template-service.js';
+import { getWorkflowRunService, WorkflowRunService } from './workflow-run-service.js';
+import { getWorkflowService, WorkflowService } from './workflow-service.js';
+
+const MAX_RECOMMENDATION_RUNS = 50;
+const MAX_RECOMMENDATIONS = 6;
+
+interface SessionTemplateServiceOptions {
+  templateService?: Pick<TemplateService, 'createTemplate' | 'getTemplates'>;
+  workflowRunService?: Pick<WorkflowRunService, 'getRun' | 'listRuns'>;
+  workflowService?: Pick<WorkflowService, 'loadWorkflow'>;
+  agentHostService?: Pick<AgentHostService, 'preview'>;
+  taskService?: { getTask(id: string): Promise<Task | null> };
+}
+
+interface RecommendationRequest {
+  workflowId?: string;
+  taskId?: string;
+  project?: string;
+  taskType?: string;
+  cwd?: string;
+  verificationGates?: string[];
+}
+
+interface ScoredRun {
+  run: WorkflowRun;
+  workflow: WorkflowDefinition | null;
+  score: number;
+  reasonCodes: string[];
+  verificationGates: string[];
+  taskProject?: string;
+  taskType?: string;
+  cwd?: string;
+}
+
+export class SessionTemplateService {
+  private readonly templateService: Pick<TemplateService, 'createTemplate' | 'getTemplates'>;
+  private readonly workflowRunService: Pick<WorkflowRunService, 'getRun' | 'listRuns'>;
+  private readonly workflowService: Pick<WorkflowService, 'loadWorkflow'>;
+  private readonly agentHostService: Pick<AgentHostService, 'preview'>;
+  private readonly taskService: { getTask(id: string): Promise<Task | null> };
+
+  constructor(options: SessionTemplateServiceOptions = {}) {
+    this.templateService = options.templateService ?? new TemplateService();
+    this.workflowRunService = options.workflowRunService ?? getWorkflowRunService();
+    this.workflowService = options.workflowService ?? getWorkflowService();
+    this.agentHostService = options.agentHostService ?? getAgentHostService();
+    this.taskService = options.taskService ?? getTaskService();
+  }
+
+  async distillTemplateFromRun(input: DistillTemplateFromRunInput): Promise<TaskTemplate> {
+    const run = await this.workflowRunService.getRun(input.runId);
+    if (!run) {
+      throw new NotFoundError(`Workflow run ${input.runId} not found`);
+    }
+    if (run.status !== 'completed') {
+      throw new ValidationError(`Run ${run.id} must be completed before distillation`);
+    }
+
+    const workflow = await this.workflowService.loadWorkflow(run.workflowId);
+    if (!workflow) {
+      throw new NotFoundError(`Workflow ${run.workflowId} not found`);
+    }
+
+    const sourceStep = firstCompletedAgentStep(run, workflow);
+    if (!sourceStep) {
+      throw new BadRequestError('Completed run does not contain a completed agent step');
+    }
+
+    const agent = workflow.agents.find((item) => item.id === sourceStep.step.agent);
+    const task = await this.taskFromRun(run);
+    const verificationGates = collectVerificationGates(workflow, run);
+    const expectedArtifacts = collectExpectedArtifacts(workflow, run);
+    const promptTemplate = sourceStep.step.input?.trim() || workflow.description;
+    const metadata: LaunchTemplateMetadata = {
+      status: 'draft',
+      distilledFromRunId: run.id,
+      sourceWorkflowId: run.workflowId,
+      sourceTaskId: run.taskId,
+      promptTemplate,
+      contextRequirements: contextRequirements(sourceStep.step.session),
+      session: {
+        agent: (agent?.id ?? sourceStep.step.agent) as AgentType | undefined,
+        model: agent?.model,
+        project: task?.project,
+        cwd: workflowCwd(workflow, run, task),
+        mode: sourceStep.step.session?.mode,
+        context: sourceStep.step.session?.context,
+        cleanup: sourceStep.step.session?.cleanup,
+        timeout: sourceStep.step.session?.timeout ?? sourceStep.step.timeout,
+        includeOutputsFrom: sourceStep.step.session?.includeOutputsFrom,
+      },
+      verificationGates,
+      expectedArtifacts,
+      knownGotchas: collectKnownGotchas(run, verificationGates),
+      reasonCodes: [
+        'source-run:completed',
+        verificationGates.length > 0
+          ? 'verification-pattern:present'
+          : 'verification-pattern:missing',
+        agent?.model ? 'model:source-run' : 'model:unspecified',
+      ],
+      confidence: verificationGates.length > 0 ? 0.78 : 0.62,
+      provenance: provenanceForRun(run, workflow, expectedArtifacts),
+      inheritsProjectDefaults: true,
+    };
+
+    const templateInput: CreateTemplateInput = {
+      name: input.name?.trim() || `Draft: ${workflow.name}`,
+      description: `Draft launch template distilled from workflow run ${run.id}. Review before activation.`,
+      category: 'workflow-launch',
+      taskDefaults: {
+        type: task?.type,
+        priority: normalizePriority(task?.priority),
+        project: task?.project,
+        descriptionTemplate: promptTemplate,
+        agent: (agent?.id ?? sourceStep.step.agent) as AgentType | undefined,
+      },
+      launch: metadata,
+    };
+
+    return this.templateService.createTemplate(templateInput);
+  }
+
+  async getLaunchRecommendations(
+    request: RecommendationRequest
+  ): Promise<LaunchRecommendationsResponse> {
+    const task = request.taskId ? await this.taskService.getTask(request.taskId) : null;
+    const context = {
+      workflowId: request.workflowId,
+      taskId: request.taskId,
+      project: request.project ?? task?.project,
+      taskType: request.taskType ?? task?.type,
+      cwd: request.cwd ?? task?.git?.worktreePath,
+      verificationGates: request.verificationGates ?? [],
+    };
+    const workflow = request.workflowId
+      ? await this.workflowService.loadWorkflow(request.workflowId)
+      : null;
+
+    const completedRuns = (await this.workflowRunService.listRuns({ status: 'completed' })).slice(
+      0,
+      MAX_RECOMMENDATION_RUNS
+    );
+    const scoredRuns = (await Promise.all(completedRuns.map((run) => this.scoreRun(run, context))))
+      .filter((item): item is ScoredRun => item !== null && item.score > 0)
+      .sort((a, b) => b.score - a.score || b.run.startedAt.localeCompare(a.run.startedAt));
+
+    const templates = await this.templateService.getTemplates();
+    const recommendations: LaunchRecommendation[] = [
+      ...this.templateRecommendations(templates, scoredRuns),
+      ...this.agentAndModelRecommendations(workflow, scoredRuns),
+      this.hostRecommendation(workflow, scoredRuns, context),
+    ].filter((item): item is LaunchRecommendation => Boolean(item));
+
+    return {
+      generatedAt: new Date().toISOString(),
+      context,
+      recommendations: recommendations
+        .sort((a, b) => b.confidence - a.confidence || a.label.localeCompare(b.label))
+        .slice(0, MAX_RECOMMENDATIONS),
+    };
+  }
+
+  private async scoreRun(
+    run: WorkflowRun,
+    context: LaunchRecommendationsResponse['context']
+  ): Promise<ScoredRun | null> {
+    const workflow = await this.workflowService.loadWorkflow(run.workflowId);
+    const task = await this.taskFromRun(run);
+    const verificationGates = workflow ? collectVerificationGates(workflow, run) : [];
+    const runCwd = workflow ? workflowCwd(workflow, run, task) : undefined;
+    const reasonCodes = ['source-run:completed'];
+    let score = 0.25;
+
+    if (context.workflowId && run.workflowId === context.workflowId) {
+      score += 0.25;
+      reasonCodes.push('workflow:matched');
+    }
+    if (context.project && task?.project === context.project) {
+      score += 0.18;
+      reasonCodes.push('project:matched');
+    }
+    if (context.taskType && task?.type === context.taskType) {
+      score += 0.14;
+      reasonCodes.push('task-type:matched');
+    }
+    if (context.cwd && runCwd && samePathOrRepo(runCwd, context.cwd)) {
+      score += 0.1;
+      reasonCodes.push('cwd:matched');
+    }
+    if (verificationGates.length > 0) {
+      score += 0.12;
+      reasonCodes.push('verification-pattern:present');
+    }
+    if (
+      context.verificationGates.length > 0 &&
+      intersects(context.verificationGates, verificationGates)
+    ) {
+      score += 0.08;
+      reasonCodes.push('verification-pattern:matched');
+    }
+
+    return {
+      run,
+      workflow,
+      score: Math.min(score, 1),
+      reasonCodes,
+      verificationGates,
+      taskProject: task?.project,
+      taskType: task?.type,
+      cwd: runCwd,
+    };
+  }
+
+  private async taskFromRun(run: WorkflowRun): Promise<Task | null> {
+    const contextTask = recordValue(run.context.task) as Partial<Task> | null;
+    if (contextTask?.id) return contextTask as Task;
+    return run.taskId ? this.taskService.getTask(run.taskId) : null;
+  }
+
+  private templateRecommendations(
+    templates: TaskTemplate[],
+    scoredRuns: ScoredRun[]
+  ): LaunchRecommendation[] {
+    const sourceRunIds = new Set(scoredRuns.map((item) => item.run.id));
+    return templates
+      .filter((template) => template.launch)
+      .map((template): LaunchRecommendation => {
+        const linkedRunId = template.launch?.distilledFromRunId;
+        const linkedRun = scoredRuns.find((item) => item.run.id === linkedRunId);
+        const confidence = clampConfidence(
+          (linkedRun?.score ?? 0.42) +
+            (template.launch?.status === 'active' ? 0.16 : 0) +
+            (linkedRunId && sourceRunIds.has(linkedRunId) ? 0.12 : 0)
+        );
+        const status = template.launch?.status ?? 'active';
+        return {
+          id: `template:${template.id}`,
+          kind: 'template',
+          label: template.name,
+          detail:
+            status === 'draft'
+              ? 'Draft template is available for review before activation.'
+              : 'Active launch template matches prior successful run signals.',
+          confidence,
+          reasonCodes: uniqueSorted([
+            ...(template.launch?.reasonCodes ?? []),
+            linkedRun ? 'source-run:matched' : 'source-run:available',
+            `template-status:${status}`,
+          ]),
+          provenance: template.launch?.provenance ?? [],
+          templateId: template.id,
+          templateStatus: status,
+          overrides: {
+            templateId: template.id,
+            agent: template.launch?.session?.agent ?? template.taskDefaults.agent,
+            model: template.launch?.session?.model,
+            hostId: template.launch?.session?.hostId,
+          },
+        };
+      });
+  }
+
+  private agentAndModelRecommendations(
+    workflow: WorkflowDefinition | null,
+    scoredRuns: ScoredRun[]
+  ): LaunchRecommendation[] {
+    const bestAgent = topAgentSignal(workflow, scoredRuns);
+    if (!bestAgent) return [];
+
+    const provenance = bestAgent.sourceRuns.map((run) => ({
+      type: 'run' as const,
+      id: run.id,
+      label: run.workflowId,
+    }));
+    return [
+      {
+        id: `agent:${bestAgent.agent}`,
+        kind: 'agent',
+        label: bestAgent.agent,
+        detail: 'Recommended from prior successful runs and workflow agent defaults.',
+        confidence: bestAgent.confidence,
+        reasonCodes: bestAgent.reasonCodes,
+        provenance,
+        agent: bestAgent.agent as AgentType,
+        overrides: { agent: bestAgent.agent },
+      },
+      ...(bestAgent.model
+        ? [
+            {
+              id: `model:${bestAgent.model}`,
+              kind: 'model' as const,
+              label: bestAgent.model,
+              detail: 'Recommended model from the best matching workflow agent history.',
+              confidence: Math.max(bestAgent.confidence - 0.08, 0.3),
+              reasonCodes: uniqueSorted([...bestAgent.reasonCodes, 'model:source-run']),
+              provenance,
+              model: bestAgent.model,
+              overrides: { model: bestAgent.model },
+            },
+          ]
+        : []),
+    ];
+  }
+
+  private hostRecommendation(
+    workflow: WorkflowDefinition | null,
+    scoredRuns: ScoredRun[],
+    context: LaunchRecommendationsResponse['context']
+  ): LaunchRecommendation | null {
+    const bestAgent = topAgentSignal(workflow, scoredRuns);
+    const bestRun = scoredRuns[0];
+    const verificationGates = context.verificationGates.length
+      ? context.verificationGates
+      : (bestRun?.verificationGates ?? []);
+    const preview = this.agentHostService.preview({
+      agent: bestAgent?.agent,
+      model: bestAgent?.model,
+      workspacePath: context.cwd ?? bestRun?.cwd,
+      verificationGates,
+      autoRouting: true,
+    });
+    const host = selectedHost(preview);
+    if (!host) return null;
+
+    return {
+      id: `host:${host.hostId}`,
+      kind: 'host',
+      label: host.hostName,
+      detail: host.compatible
+        ? 'Host is compatible with the recommended launch profile.'
+        : 'Host is the best available match but has compatibility warnings.',
+      confidence: host.compatible ? 0.72 : 0.48,
+      reasonCodes: uniqueSorted([
+        host.compatible ? 'host:compatible' : 'host:warnings',
+        `host-posture:${host.posture}`,
+      ]),
+      provenance: bestRun
+        ? [{ type: 'run', id: bestRun.run.id, label: bestRun.run.workflowId }]
+        : [],
+      hostId: host.hostId,
+      hostName: host.hostName,
+      overrides: { hostId: host.hostId },
+    };
+  }
+}
+
+function firstCompletedAgentStep(
+  run: WorkflowRun,
+  workflow: WorkflowDefinition
+): { run: WorkflowRun['steps'][number]; step: WorkflowStep } | null {
+  for (const stepRun of run.steps) {
+    if (stepRun.status !== 'completed') continue;
+    const step = workflow.steps.find((item) => item.id === stepRun.stepId);
+    if (step?.type === 'agent') return { run: stepRun, step };
+  }
+  return null;
+}
+
+function collectVerificationGates(workflow: WorkflowDefinition, run: WorkflowRun): string[] {
+  const completed = new Set(
+    run.steps.filter((step) => step.status === 'completed').map((step) => step.stepId)
+  );
+  const gates = workflow.steps.flatMap((step) => {
+    const criteria = step.acceptance_criteria ?? [];
+    const acceptance = criteria.map((criterion) => `${step.name}: ${criterion}`);
+    const gate =
+      step.type === 'gate' && completed.has(step.id) ? [`Gate passed: ${step.name}`] : [];
+    return [...acceptance, ...gate];
+  });
+  const outputTargets =
+    workflow.outputTargets
+      ?.filter((target) => target.required)
+      .map((target) => `Required output: ${target.label ?? target.type}`) ?? [];
+  return uniqueSorted([...gates, ...outputTargets]).slice(0, 12);
+}
+
+function collectExpectedArtifacts(workflow: WorkflowDefinition, run: WorkflowRun): string[] {
+  const stepArtifacts = run.steps
+    .map((step) => step.output)
+    .filter((item): item is string => Boolean(item))
+    .map((item) => path.basename(item));
+  const workflowArtifacts =
+    workflow.outputTargets
+      ?.map((target) => target.path ?? target.label ?? target.type)
+      .filter((item): item is string => Boolean(item)) ?? [];
+  return uniqueSorted([...stepArtifacts, ...workflowArtifacts]).slice(0, 12);
+}
+
+function collectKnownGotchas(run: WorkflowRun, verificationGates: string[]): string[] {
+  const gotchas = run.steps
+    .filter((step) => step.retries > 0 || step.status === 'skipped')
+    .map((step) =>
+      step.retries > 0
+        ? `${step.stepId} required ${step.retries} retr${step.retries === 1 ? 'y' : 'ies'}.`
+        : `${step.stepId} was skipped.`
+    );
+  if (verificationGates.length === 0) {
+    gotchas.push('No explicit verification gate was recorded on the source run.');
+  }
+  return uniqueSorted(gotchas).slice(0, 8);
+}
+
+function contextRequirements(session?: StepSessionConfig): string[] {
+  if (!session) return ['Task metadata', 'Workflow run metadata'];
+  if (session.context === 'full')
+    return ['Task metadata', 'Workflow variables', 'Prior step outputs'];
+  if (session.context === 'custom') {
+    return [
+      'Task metadata',
+      ...(session.includeOutputsFrom ?? []).map((step) => `Output from ${step}`),
+    ];
+  }
+  return ['Task metadata', 'Workflow run metadata'];
+}
+
+function provenanceForRun(
+  run: WorkflowRun,
+  workflow: WorkflowDefinition,
+  expectedArtifacts: string[]
+): TemplateProvenanceLink[] {
+  return [
+    { type: 'run', id: run.id, label: `Run ${run.id}` },
+    { type: 'workflow', id: workflow.id, label: workflow.name },
+    ...(run.taskId ? [{ type: 'task' as const, id: run.taskId, label: `Task ${run.taskId}` }] : []),
+    ...expectedArtifacts.map((artifact) => ({
+      type: 'artifact' as const,
+      id: artifact,
+      label: artifact,
+      path: artifact,
+    })),
+  ];
+}
+
+function workflowCwd(
+  workflow: WorkflowDefinition,
+  run: WorkflowRun,
+  task?: Task | null
+): string | undefined {
+  return (
+    stringValue(run.context.cwd) ??
+    stringValue(run.context.workspacePath) ??
+    stringValue(workflow.variables?.cwd) ??
+    task?.git?.worktreePath
+  );
+}
+
+function topAgentSignal(workflow: WorkflowDefinition | null, scoredRuns: ScoredRun[]) {
+  const counts = new Map<
+    string,
+    {
+      agent: string;
+      model?: string;
+      score: number;
+      sourceRuns: WorkflowRun[];
+      reasonCodes: string[];
+    }
+  >();
+
+  for (const scored of scoredRuns.slice(0, 12)) {
+    for (const step of scored.run.steps) {
+      if (!step.agent) continue;
+      const key = step.agent;
+      const agentDef = scored.workflow?.agents.find((agent) => agent.id === step.agent);
+      const current = counts.get(key) ?? {
+        agent: key,
+        model: agentDef?.model,
+        score: 0,
+        sourceRuns: [],
+        reasonCodes: [],
+      };
+      current.score += scored.score;
+      if (!current.model && agentDef?.model) current.model = agentDef.model;
+      current.sourceRuns.push(scored.run);
+      current.reasonCodes.push(...scored.reasonCodes, 'agent:source-run');
+      counts.set(key, current);
+    }
+  }
+
+  if (counts.size === 0 && workflow?.agents[0]) {
+    const agent = workflow.agents[0];
+    return {
+      agent: agent.id,
+      model: agent.model,
+      confidence: 0.48,
+      sourceRuns: [],
+      reasonCodes: ['agent:workflow-default'],
+    };
+  }
+
+  const best = Array.from(counts.values()).sort((a, b) => b.score - a.score)[0];
+  if (!best) return null;
+  return {
+    agent: best.agent,
+    model: best.model,
+    confidence: clampConfidence(0.48 + best.score / 4),
+    sourceRuns: best.sourceRuns.slice(0, 3),
+    reasonCodes: uniqueSorted(best.reasonCodes),
+  };
+}
+
+function selectedHost(preview: AgentHostCompatibilityResponse) {
+  const selectedId = preview.decision.selectedHostId;
+  return (
+    preview.previews.find((host) => host.hostId === selectedId) ??
+    preview.previews.find((host) => host.compatible) ??
+    preview.previews[0] ??
+    null
+  );
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function normalizePriority(priority: Task['priority'] | undefined) {
+  return priority === 'critical' ? 'high' : priority;
+}
+
+function samePathOrRepo(left: string, right: string): boolean {
+  return (
+    left === right ||
+    left.includes(right) ||
+    right.includes(left) ||
+    path.basename(left) === path.basename(right)
+  );
+}
+
+function intersects(left: string[], right: string[]): boolean {
+  const rightSet = new Set(right.map((item) => item.toLowerCase()));
+  return left.some((item) => rightSet.has(item.toLowerCase()));
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort();
+}
+
+function clampConfidence(value: number): number {
+  return Math.max(0.2, Math.min(0.95, Number(value.toFixed(2))));
+}
+
+let sessionTemplateServiceInstance: SessionTemplateService | null = null;
+
+export function getSessionTemplateService(): SessionTemplateService {
+  if (!sessionTemplateServiceInstance) {
+    sessionTemplateServiceInstance = new SessionTemplateService();
+  }
+  return sessionTemplateServiceInstance;
+}

--- a/server/src/services/template-service.ts
+++ b/server/src/services/template-service.ts
@@ -118,6 +118,7 @@ export class TemplateService {
       category: undefined,
       subtaskTemplates: undefined,
       blueprint: undefined,
+      launch: undefined,
       created: data.created,
       updated: data.updated,
     };
@@ -191,6 +192,7 @@ export class TemplateService {
       taskDefaults: input.taskDefaults,
       subtaskTemplates: input.subtaskTemplates,
       blueprint: input.blueprint,
+      launch: input.launch,
       created: now,
       updated: now,
     };
@@ -224,6 +226,7 @@ export class TemplateService {
       },
       subtaskTemplates: input.subtaskTemplates ?? existing.subtaskTemplates,
       blueprint: input.blueprint ?? existing.blueprint,
+      launch: input.launch ?? existing.launch,
       updated: new Date().toISOString(),
     };
 

--- a/server/src/storage/sqlite/template-repository.ts
+++ b/server/src/storage/sqlite/template-repository.ts
@@ -50,6 +50,7 @@ export class SqliteTemplateRepository implements TemplateRepository {
       taskDefaults: input.taskDefaults,
       subtaskTemplates: input.subtaskTemplates,
       blueprint: input.blueprint,
+      launch: input.launch,
       created: now,
       updated: now,
     };
@@ -74,6 +75,7 @@ export class SqliteTemplateRepository implements TemplateRepository {
       },
       subtaskTemplates: input.subtaskTemplates ?? existing.subtaskTemplates,
       blueprint: input.blueprint ?? existing.blueprint,
+      launch: input.launch ?? existing.launch,
       updated: new Date().toISOString(),
     };
 
@@ -142,6 +144,7 @@ export class SqliteTemplateRepository implements TemplateRepository {
       category: undefined,
       subtaskTemplates: undefined,
       blueprint: undefined,
+      launch: undefined,
       created: template.created,
       updated: template.updated,
     };

--- a/shared/src/types/template.types.ts
+++ b/shared/src/types/template.types.ts
@@ -24,6 +24,88 @@ export interface BlueprintTask {
   blockedByRefs?: string[]; // References to other BlueprintTask.refIds
 }
 
+export type TemplateReviewStatus = 'draft' | 'active' | 'archived';
+
+export interface TemplateProvenanceLink {
+  type: 'run' | 'workflow' | 'task' | 'issue' | 'timeline' | 'artifact';
+  id: string;
+  label?: string;
+  url?: string;
+  path?: string;
+}
+
+export interface LaunchTemplateSessionMetadata {
+  agent?: AgentType;
+  model?: string;
+  provider?: string;
+  hostId?: string;
+  hostName?: string;
+  cwd?: string;
+  project?: string;
+  sandbox?: string;
+  mode?: 'fresh' | 'reuse';
+  context?: 'minimal' | 'full' | 'custom';
+  cleanup?: 'delete' | 'keep';
+  timeout?: number;
+  includeOutputsFrom?: string[];
+}
+
+export interface LaunchTemplateMetadata {
+  status: TemplateReviewStatus;
+  distilledFromRunId?: string;
+  sourceWorkflowId?: string;
+  sourceTaskId?: string;
+  promptTemplate?: string;
+  contextRequirements?: string[];
+  session?: LaunchTemplateSessionMetadata;
+  verificationGates?: string[];
+  expectedArtifacts?: string[];
+  knownGotchas?: string[];
+  reasonCodes?: string[];
+  confidence?: number;
+  provenance?: TemplateProvenanceLink[];
+  inheritsProjectDefaults?: boolean;
+  reviewedAt?: string;
+  reviewedBy?: string;
+}
+
+export type LaunchRecommendationKind = 'template' | 'agent' | 'model' | 'host';
+
+export interface LaunchRecommendation {
+  id: string;
+  kind: LaunchRecommendationKind;
+  label: string;
+  detail: string;
+  confidence: number;
+  reasonCodes: string[];
+  provenance: TemplateProvenanceLink[];
+  templateId?: string;
+  templateStatus?: TemplateReviewStatus;
+  agent?: AgentType;
+  model?: string;
+  hostId?: string;
+  hostName?: string;
+  overrides?: Record<string, unknown>;
+}
+
+export interface LaunchRecommendationsResponse {
+  generatedAt: string;
+  context: {
+    workflowId?: string;
+    taskId?: string;
+    project?: string;
+    taskType?: string;
+    cwd?: string;
+    verificationGates: string[];
+  };
+  recommendations: LaunchRecommendation[];
+}
+
+export interface DistillTemplateFromRunInput {
+  runId: string;
+  name?: string;
+}
+
 /** Task template with enhanced features */
 export interface TaskTemplate {
   id: string;
@@ -46,6 +128,8 @@ export interface TaskTemplate {
   // NEW in v1: For multi-task blueprints
   blueprint?: BlueprintTask[];
 
+  launch?: LaunchTemplateMetadata;
+
   created: string;
   updated: string;
 }
@@ -64,6 +148,7 @@ export interface CreateTemplateInput {
   };
   subtaskTemplates?: SubtaskTemplate[];
   blueprint?: BlueprintTask[];
+  launch?: LaunchTemplateMetadata;
 }
 
 /** Input for updating an existing template */
@@ -80,4 +165,5 @@ export interface UpdateTemplateInput {
   };
   subtaskTemplates?: SubtaskTemplate[];
   blueprint?: BlueprintTask[];
+  launch?: LaunchTemplateMetadata;
 }

--- a/web/src/__tests__/settings-manage-mantine.test.tsx
+++ b/web/src/__tests__/settings-manage-mantine.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   deleteItem: vi.fn(),
   reorderItems: vi.fn(),
   createTemplate: vi.fn(),
+  updateTemplate: vi.fn(),
   deleteTemplate: vi.fn(),
   toast: vi.fn(),
 }));
@@ -43,6 +44,27 @@ const taskTemplates: TaskTemplate[] = [
     created: '2026-01-01T00:00:00.000Z',
     updated: '2026-01-01T00:00:00.000Z',
   } as TaskTemplate,
+  {
+    id: 'template-launch-draft',
+    name: 'Launch Draft',
+    category: 'workflow-launch',
+    version: 1,
+    taskDefaults: {
+      type: 'feature',
+      priority: 'high',
+      project: 'veritas-kanban',
+      agent: 'codex',
+    },
+    launch: {
+      status: 'draft',
+      distilledFromRunId: 'run_584',
+      sourceWorkflowId: 'workflow_launch',
+      verificationGates: ['pnpm typecheck'],
+      provenance: [{ type: 'run', id: 'run_584' }],
+    },
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-01T00:00:00.000Z',
+  },
 ];
 
 vi.mock('@/hooks/useConfig', () => ({
@@ -53,6 +75,10 @@ vi.mock('@/hooks/useTemplates', () => ({
   useTemplates: () => ({ data: taskTemplates, isLoading: false }),
   useCreateTemplate: () => ({
     mutateAsync: mocks.createTemplate,
+    isPending: false,
+  }),
+  useUpdateTemplate: () => ({
+    mutate: mocks.updateTemplate,
     isPending: false,
   }),
   useDeleteTemplate: () => ({
@@ -145,6 +171,7 @@ describe('Manage settings Mantine migration', () => {
     mocks.deleteItem.mockResolvedValue({});
     mocks.reorderItems.mockResolvedValue({});
     mocks.createTemplate.mockResolvedValue({});
+    mocks.updateTemplate.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -159,9 +186,11 @@ describe('Manage settings Mantine migration', () => {
     expect(screen.getByRole('textbox', { name: 'Rubicon description' })).toBeDefined();
     expect(screen.getByRole('textbox', { name: 'Sprint 1 description' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Toggle template guide' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Activate Launch Draft' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Delete Bug Fix' })).toBeDefined();
     expect(screen.getByText('Empty Defaults')).toBeDefined();
     expect(screen.getByText('No defaults')).toBeDefined();
+    expect(screen.getByText('draft')).toBeDefined();
     expect(container.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(3);
     expect(container.querySelectorAll('.mantine-TextInput-root').length).toBeGreaterThanOrEqual(5);
     expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThanOrEqual(4);
@@ -173,6 +202,19 @@ describe('Manage settings Mantine migration', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Toggle template guide' }));
 
     expect(screen.getByText('Template Guide')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Activate Launch Draft' }));
+
+    expect(mocks.updateTemplate).toHaveBeenCalledWith({
+      id: 'template-launch-draft',
+      input: {
+        launch: expect.objectContaining({
+          status: 'active',
+          reviewedAt: expect.any(String),
+        }),
+      },
+    });
+    expect(mocks.updateTemplate.mock.calls[0][0].input.launch).not.toHaveProperty('reviewedBy');
   });
 
   it('creates templates through the Mantine form controls', async () => {

--- a/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
@@ -238,6 +238,33 @@ describe('task detail Git and workflow Mantine migration', () => {
           },
         ]);
       }
+      if (url.includes('/workflows/launch-recommendations')) {
+        return createJsonResponse({
+          generatedAt: '2026-06-05T12:00:00.000Z',
+          context: {
+            workflowId: 'workflow-1',
+            taskId: 'task-workflow',
+            project: 'veritas-kanban',
+            taskType: 'feature',
+            cwd: '/tmp/veritas-worktree',
+            verificationGates: [],
+          },
+          recommendations: [
+            {
+              id: 'template:release',
+              kind: 'template',
+              label: 'Reviewed launch template',
+              detail: 'Active launch template matches prior successful run signals.',
+              confidence: 0.86,
+              reasonCodes: ['workflow:matched', 'source-run:matched'],
+              provenance: [{ type: 'run', id: 'run-success' }],
+              templateId: 'template-release',
+              templateStatus: 'active',
+              overrides: { templateId: 'template-release', agent: 'codex' },
+            },
+          ],
+        });
+      }
       return createJsonResponse([
         {
           id: 'run-active',
@@ -250,12 +277,26 @@ describe('task detail Git and workflow Mantine migration', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const task = createMockTask({ id: 'task-workflow' });
+    const task = createMockTask({
+      id: 'task-workflow',
+      type: 'feature',
+      project: 'veritas-kanban',
+      git: {
+        repo: 'veritas',
+        baseBranch: 'main',
+        branch: 'feature/mantine-git',
+        worktreePath: '/tmp/veritas-worktree',
+      },
+    });
     const { baseElement, container } = renderWithProviders(
       <WorkflowSection task={task} open onOpenChange={vi.fn()} />
     );
 
     expect(await screen.findByText('Release Workflow')).toBeDefined();
+    expect(await screen.findByText('Reviewed launch template')).toBeDefined();
+    expect(screen.getByText('86%')).toBeDefined();
+    expect(screen.getByText('workflow:matched')).toBeDefined();
+    expect(screen.getByText('1 source')).toBeDefined();
     expect(screen.getByText('run-active')).toBeDefined();
     expect(container.querySelector('.mantine-Modal-content')).toBeDefined();
     expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
@@ -267,6 +308,12 @@ describe('task detail Git and workflow Mantine migration', () => {
     await user.click(screen.getByRole('button', { name: 'Start' }));
 
     await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '/workflows/launch-recommendations?workflowId=workflow-1&taskId=task-workflow'
+        ),
+        expect.anything()
+      );
       expect(fetchMock).toHaveBeenCalledWith(
         expect.stringContaining('/workflows/workflow-1/runs'),
         expect.objectContaining({

--- a/web/src/__tests__/workflow-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/workflow-surfaces-mantine.test.tsx
@@ -390,6 +390,61 @@ describe('workflow surfaces Mantine migration', () => {
     await waitFor(() => expect(screen.getByText('artifact ready')).toBeDefined());
   });
 
+  it('creates a draft launch template from a completed workflow run', async () => {
+    const user = userEvent.setup();
+    const completedRun = {
+      ...workflowRun,
+      status: 'completed' as const,
+      completedAt: '2026-06-01T10:05:00Z',
+      steps: workflowRun.steps.map((step) => ({ ...step, status: 'completed' as const })),
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/workflows/runs/run-1')) {
+        return jsonResponse(completedRun);
+      }
+      if (url.endsWith('/workflows/wf-release')) {
+        return jsonResponse({
+          id: 'wf-release',
+          name: 'Release workflow',
+          version: 3,
+          steps: [
+            { id: 'build', name: 'Build artifact', agent: 'codex' },
+            { id: 'smoke', name: 'Smoke test', agent: 'codex' },
+          ],
+        });
+      }
+      if (url.endsWith('/templates/distill-from-run') && init?.method === 'POST') {
+        return jsonResponse({
+          id: 'template-run-1',
+          name: 'Draft: Release workflow',
+          version: 1,
+          taskDefaults: {},
+          launch: { status: 'draft', distilledFromRunId: 'run-1' },
+          created: '2026-06-01T10:05:00Z',
+          updated: '2026-06-01T10:05:00Z',
+        });
+      }
+      return jsonResponse(null, false);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    renderWithProviders(<WorkflowRunView runId="run-1" onBack={vi.fn()} />);
+
+    expect(await screen.findByText('Release workflow')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Draft Template' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/templates/distill-from-run',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ runId: 'run-1' }),
+        })
+      );
+    });
+  });
+
   it('applies workflow run WebSocket payload updates without a full reload', async () => {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/web/src/components/settings/tabs/TemplateComponents.tsx
+++ b/web/src/components/settings/tabs/TemplateComponents.tsx
@@ -11,9 +11,14 @@ import {
   Textarea,
   TextInput,
 } from '@mantine/core';
-import { type TaskTemplate, useCreateTemplate, useDeleteTemplate } from '@/hooks/useTemplates';
+import {
+  type TaskTemplate,
+  useCreateTemplate,
+  useDeleteTemplate,
+  useUpdateTemplate,
+} from '@/hooks/useTemplates';
 import { getTypeIcon, useTaskTypesManager } from '@/hooks/useTaskTypes';
-import { FileText, Trash2 } from 'lucide-react';
+import { CheckCircle2, FileText, Trash2 } from 'lucide-react';
 import type { AgentType, TaskPriority } from '@veritas-kanban/shared';
 import { TEMPLATE_CATEGORIES, getCategoryIcon, getCategoryLabel } from '@/lib/template-categories';
 
@@ -183,8 +188,10 @@ export function AddTemplateForm({ onClose }: { onClose: () => void }) {
 
 export function TemplateItem({ template }: { template: TaskTemplate }) {
   const deleteTemplate = useDeleteTemplate();
+  const updateTemplate = useUpdateTemplate();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const taskDefaults = template.taskDefaults ?? {};
+  const isLaunchDraft = template.launch?.status === 'draft';
   const metadata = [
     taskDefaults.type,
     taskDefaults.priority,
@@ -208,23 +215,55 @@ export function TemplateItem({ template }: { template: TaskTemplate }) {
                 {getCategoryIcon(template.category)} {getCategoryLabel(template.category)}
               </Badge>
             )}
+            {isLaunchDraft && (
+              <Badge variant="light" color="yellow" size="xs">
+                draft
+              </Badge>
+            )}
           </div>
           <Text size="xs" c="dimmed">
             {metadata || 'No defaults'}
           </Text>
         </div>
       </div>
-      <ActionIcon
-        type="button"
-        variant="subtle"
-        color="red"
-        size="sm"
-        radius="md"
-        aria-label={`Delete ${template.name}`}
-        onClick={() => setDeleteOpen(true)}
-      >
-        <Trash2 className="h-4 w-4" />
-      </ActionIcon>
+      <Group gap="xs">
+        {isLaunchDraft && (
+          <ActionIcon
+            type="button"
+            variant="subtle"
+            color="green"
+            size="sm"
+            radius="md"
+            aria-label={`Activate ${template.name}`}
+            loading={updateTemplate.isPending}
+            onClick={() => {
+              updateTemplate.mutate({
+                id: template.id,
+                input: {
+                  launch: {
+                    ...template.launch,
+                    status: 'active',
+                    reviewedAt: new Date().toISOString(),
+                  },
+                },
+              });
+            }}
+          >
+            <CheckCircle2 className="h-4 w-4" />
+          </ActionIcon>
+        )}
+        <ActionIcon
+          type="button"
+          variant="subtle"
+          color="red"
+          size="sm"
+          radius="md"
+          aria-label={`Delete ${template.name}`}
+          onClick={() => setDeleteOpen(true)}
+        >
+          <Trash2 className="h-4 w-4" />
+        </ActionIcon>
+      </Group>
       <Modal
         opened={deleteOpen}
         onClose={() => setDeleteOpen(false)}

--- a/web/src/components/task/WorkflowSection.tsx
+++ b/web/src/components/task/WorkflowSection.tsx
@@ -14,7 +14,8 @@ import { useMediaQuery } from '@mantine/hooks';
 import { Play, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { useIdentity } from '@/hooks/useIdentity';
-import type { Task } from '@veritas-kanban/shared';
+import { workflowsApi } from '@/lib/api/workflows';
+import type { LaunchRecommendation, Task } from '@veritas-kanban/shared';
 
 interface WorkflowSectionProps {
   task: Task;
@@ -57,6 +58,9 @@ function getRunStatusColor(status: WorkflowRun['status']) {
 export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionProps) {
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [activeRuns, setActiveRuns] = useState<WorkflowRun[]>([]);
+  const [recommendationsByWorkflow, setRecommendationsByWorkflow] = useState<
+    Record<string, LaunchRecommendation[]>
+  >({});
   const [isLoading, setIsLoading] = useState(true);
   const [isStarting, setIsStarting] = useState<string | null>(null);
   const { toast } = useToast();
@@ -66,14 +70,37 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
 
   useEffect(() => {
     if (!open) return;
+    let isCancelled = false;
 
     const fetchData = async () => {
+      setIsLoading(true);
       try {
         // Fetch available workflows
         const workflowsRes = await fetch(`${API_BASE}/workflows`);
         if (workflowsRes.ok) {
           const wJson = await workflowsRes.json();
-          setWorkflows(wJson.data ?? wJson);
+          const workflowList = (wJson.data ?? wJson) as Workflow[];
+          if (isCancelled) return;
+          setWorkflows(workflowList);
+
+          const recommendationEntries = await Promise.all(
+            workflowList.map(async (workflow) => {
+              try {
+                const result = await workflowsApi.launchRecommendations({
+                  workflowId: workflow.id,
+                  taskId: task.id,
+                  project: task.project,
+                  taskType: task.type,
+                  cwd: task.git?.worktreePath,
+                });
+                return [workflow.id, result.recommendations] as const;
+              } catch {
+                return [workflow.id, []] as const;
+              }
+            })
+          );
+          if (isCancelled) return;
+          setRecommendationsByWorkflow(Object.fromEntries(recommendationEntries));
         }
 
         // Fetch active runs for this task
@@ -81,6 +108,7 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
         if (runsRes.ok) {
           const rJson = await runsRes.json();
           const runs = rJson.data ?? rJson;
+          if (isCancelled) return;
           setActiveRuns(
             runs.filter((r: WorkflowRun) => r.status === 'running' || r.status === 'blocked')
           );
@@ -88,12 +116,15 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
       } catch (error) {
         console.error('Failed to fetch workflows:', error);
       } finally {
-        setIsLoading(false);
+        if (!isCancelled) setIsLoading(false);
       }
     };
 
     fetchData();
-  }, [open, task.id]);
+    return () => {
+      isCancelled = true;
+    };
+  }, [open, task.id, task.project, task.type, task.git?.worktreePath]);
 
   const handleStartWorkflow = async (workflowId: string) => {
     setIsStarting(workflowId);
@@ -214,6 +245,9 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
                               {workflow.steps.length} steps
                             </Text>
                           </Group>
+                          <LaunchRecommendationSummary
+                            recommendations={recommendationsByWorkflow[workflow.id] ?? []}
+                          />
                         </Stack>
                         <Button
                           size="sm"
@@ -244,5 +278,52 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
         )}
       </Stack>
     </Modal>
+  );
+}
+
+function LaunchRecommendationSummary({
+  recommendations,
+}: {
+  recommendations: LaunchRecommendation[];
+}) {
+  const topRecommendations = recommendations.slice(0, 2);
+  if (topRecommendations.length === 0) return null;
+
+  return (
+    <Stack gap={4} className="rounded-md border bg-background/60 p-2">
+      {topRecommendations.map((recommendation) => (
+        <Stack key={recommendation.id} gap={3}>
+          <Group gap="xs" wrap="wrap">
+            <Badge size="xs" variant="light">
+              {recommendation.kind}
+            </Badge>
+            <Text size="xs" className="min-w-0 flex-1">
+              {recommendation.label}
+            </Text>
+            <Badge size="xs" color="green" variant="outline">
+              {Math.round(recommendation.confidence * 100)}%
+            </Badge>
+            {recommendation.templateStatus === 'draft' && (
+              <Badge size="xs" color="yellow" variant="light">
+                draft
+              </Badge>
+            )}
+          </Group>
+          <Group gap={4} wrap="wrap">
+            {recommendation.reasonCodes.slice(0, 3).map((reasonCode) => (
+              <Badge key={reasonCode} size="xs" color="gray" variant="outline">
+                {reasonCode}
+              </Badge>
+            ))}
+            {recommendation.provenance.length > 0 && (
+              <Text size="xs" c="dimmed">
+                {recommendation.provenance.length} source
+                {recommendation.provenance.length === 1 ? '' : 's'}
+              </Text>
+            )}
+          </Group>
+        </Stack>
+      ))}
+    </Stack>
   );
 }

--- a/web/src/components/workflows/WorkflowRunView.tsx
+++ b/web/src/components/workflows/WorkflowRunView.tsx
@@ -41,11 +41,13 @@ import {
   Pause,
   History,
   Users,
+  FileText,
 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/utils';
 import { useWebSocket, type WebSocketMessage } from '@/hooks/useWebSocket';
 import { useView } from '@/contexts/ViewContext';
+import { useDistillTemplateFromRun } from '@/hooks/useTemplates';
 
 interface WorkflowRunViewProps {
   runId: string;
@@ -150,6 +152,7 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
   const [expandedStepId, setExpandedStepId] = useState<string | null>(null);
   const { toast } = useToast();
   const { navigateToTask } = useView();
+  const distillTemplate = useDistillTemplateFromRun();
 
   // Fetch run details
   const fetchRun = useCallback(async () => {
@@ -244,6 +247,22 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
     } catch (error) {
       toast({
         title: '❌ Failed to resume workflow run',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+
+  const handleDistillTemplate = async () => {
+    if (!run) return;
+    try {
+      const template = await distillTemplate.mutateAsync({ runId: run.id });
+      toast({
+        title: 'Draft template created',
+        description: `${template.name} is ready for review.`,
+      });
+    } catch (error) {
+      toast({
+        title: 'Failed to create draft template',
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     }
@@ -356,6 +375,17 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
               onClick={handleResume}
             >
               Resume
+            </Button>
+          )}
+          {run.status === 'completed' && (
+            <Button
+              size="sm"
+              variant="light"
+              leftSection={<FileText className="h-4 w-4" />}
+              loading={distillTemplate.isPending}
+              onClick={handleDistillTemplate}
+            >
+              Draft Template
             </Button>
           )}
           {taskTimelineId && (

--- a/web/src/hooks/useTemplates.ts
+++ b/web/src/hooks/useTemplates.ts
@@ -1,8 +1,13 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
-import type { TaskTemplate, CreateTemplateInput, UpdateTemplateInput } from '@veritas-kanban/shared';
+import type {
+  DistillTemplateFromRunInput,
+  TaskTemplate,
+  CreateTemplateInput,
+  UpdateTemplateInput,
+} from '@veritas-kanban/shared';
 
-export type { TaskTemplate, CreateTemplateInput, UpdateTemplateInput };
+export type { TaskTemplate, CreateTemplateInput, DistillTemplateFromRunInput, UpdateTemplateInput };
 
 export function useTemplates() {
   return useQuery({
@@ -32,7 +37,7 @@ export function useCreateTemplate() {
 export function useUpdateTemplate() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdateTemplateInput }) => 
+    mutationFn: ({ id, input }: { id: string; input: UpdateTemplateInput }) =>
       api.templates.update(id, input),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['templates'] });
@@ -44,6 +49,16 @@ export function useDeleteTemplate() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: api.templates.delete,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] });
+    },
+  });
+}
+
+export function useDistillTemplateFromRun() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: api.templates.distillFromRun,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['templates'] });
     },

--- a/web/src/lib/api/entities.ts
+++ b/web/src/lib/api/entities.ts
@@ -4,6 +4,7 @@
 import type {
   TaskTemplate,
   CreateTemplateInput,
+  DistillTemplateFromRunInput,
   UpdateTemplateInput,
   TaskTypeConfig,
   SprintConfig,
@@ -48,6 +49,16 @@ export const templatesApi = {
       method: 'DELETE',
     });
     return handleResponse<void>(response);
+  },
+
+  distillFromRun: async (input: DistillTemplateFromRunInput): Promise<TaskTemplate> => {
+    const response = await fetch(`${API_BASE}/templates/distill-from-run`, {
+      credentials: 'include',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    return handleResponse<TaskTemplate>(response);
   },
 };
 

--- a/web/src/lib/api/workflows.ts
+++ b/web/src/lib/api/workflows.ts
@@ -1,5 +1,6 @@
 import type {
   WorkflowDefinition,
+  LaunchRecommendationsResponse,
   WorkflowOutputTarget,
   WorkflowPipelineSummary,
   WorkflowSchedule,
@@ -115,6 +116,15 @@ export interface WorkflowRunStartResponse {
   id: string;
 }
 
+export interface WorkflowLaunchRecommendationParams {
+  workflowId?: string;
+  taskId?: string;
+  project?: string;
+  taskType?: string;
+  cwd?: string;
+  verificationGates?: string[];
+}
+
 function unwrapData<T>(value: T | { data: T }): T {
   if (value && typeof value === 'object' && 'data' in value) {
     return (value as { data: T }).data;
@@ -199,4 +209,23 @@ export const workflowsApi = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ workflow }),
     }),
+
+  launchRecommendations: async (
+    params: WorkflowLaunchRecommendationParams
+  ): Promise<LaunchRecommendationsResponse> => {
+    const query = new URLSearchParams();
+    if (params.workflowId) query.set('workflowId', params.workflowId);
+    if (params.taskId) query.set('taskId', params.taskId);
+    if (params.project) query.set('project', params.project);
+    if (params.taskType) query.set('taskType', params.taskType);
+    if (params.cwd) query.set('cwd', params.cwd);
+    if (params.verificationGates?.length) {
+      query.set('verificationGates', params.verificationGates.join(','));
+    }
+    const suffix = query.toString() ? `?${query.toString()}` : '';
+    const response = await apiFetch<
+      LaunchRecommendationsResponse | { data: LaunchRecommendationsResponse }
+    >(`${API_BASE}/workflows/launch-recommendations${suffix}`);
+    return unwrapData(response);
+  },
 };


### PR DESCRIPTION
## Summary
- Add a session template service that distills completed verified workflow runs into review-required launch template drafts with provenance, verification gates, expected artifacts, and gotchas.
- Add advisory launch recommendations for templates, agents, models, and compatible hosts, using prior successful runs and the existing host compatibility preview without changing launch validation.
- Surface recommendations in the task workflow launch modal and add a completed-run action to draft a template from the workflow run detail view.
- Let settings activate reviewed launch drafts while preserving project-default inheritance and per-launch override metadata.

## Verification
- pnpm --filter @veritas-kanban/server test -- session-template-service.test.ts
- pnpm --dir web exec vitest run src/__tests__/task-detail-git-workflow-mantine.test.tsx src/__tests__/workflow-surfaces-mantine.test.tsx src/__tests__/settings-manage-mantine.test.tsx --testTimeout 15000
- pnpm typecheck
- node scripts/check-permission-coverage.mjs
- pnpm lint:budget
- pnpm build
- pnpm --filter @veritas-kanban/web test

## Notes
- Recommendations are advisory only; existing workflow launch validation remains authoritative.
- Host output consumes compatibility preview data only and does not implement routing.

Closes #584