### PR TITLE
Add configurable board columns

### DIFF
--- a/cli/src/commands/summary.ts
+++ b/cli/src/commands/summary.ts
@@ -22,10 +22,9 @@ export function registerSummaryCommands(program: Command): void {
         console.log(chalk.bold('\n📊 Veritas Kanban Summary\n'));
 
         console.log(chalk.dim('Status:'));
-        console.log(`  To Do:       ${summary.byStatus.todo}`);
-        console.log(`  In Progress: ${summary.byStatus['in-progress']}`);
-        console.log(`  Blocked:     ${summary.byStatus.blocked}`);
-        console.log(`  Done:        ${summary.byStatus.done}`);
+        Object.entries(summary.byStatus).forEach(([status, count]) => {
+          console.log(`  ${status}: ${count}`);
+        });
 
         const projects = Object.entries(summary.byProject) as [
           string,

--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -11,7 +11,7 @@ export function registerTaskCommands(program: Command): void {
     .command('list')
     .alias('ls')
     .description('List tasks')
-    .option('-s, --status <status>', 'Filter by status (todo, in-progress, blocked, done)')
+    .option('-s, --status <status>', 'Filter by status')
     .option('-t, --type <type>', 'Filter by type (code, research, content, automation)')
     .option('-p, --project <project>', 'Filter by project')
     .option('-S, --sprint <sprint>', 'Filter by sprint')
@@ -93,6 +93,7 @@ export function registerTaskCommands(program: Command): void {
     .option('-S, --sprint <sprint>', 'Sprint name or ID')
     .option('-d, --description <desc>', 'Task description')
     .option('--priority <priority>', 'Priority (low, medium, high)', 'medium')
+    .option('-s, --status <status>', 'Initial status')
     .option('--json', 'Output as JSON')
     .action(async (title, options) => {
       try {
@@ -105,6 +106,7 @@ export function registerTaskCommands(program: Command): void {
             sprint: options.sprint,
             description: options.description || '',
             priority: options.priority,
+            status: options.status,
           }),
         });
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,8 +85,8 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 | ![Main board view](../assets/scr-main_overview_1.png) | ![Board with tasks](../assets/scr-main_overview_2.png) |
 | ![Board columns](../assets/scr-main_overview_3.png)   | ![Board dark mode](../assets/scr-main_overview_4.png)  |
 
-- **Kanban columns** — Four default columns: To Do, In Progress, Blocked, Done
-- **Drag-and-drop** — Move tasks between columns with [@dnd-kit](https://dndkit.com/); reorder within columns; custom collision detection (pointerWithin + rectIntersection fallback) for reliable cross-column moves; tooltips suppressed during drag; local state management for real-time column updates
+- **Kanban columns** — Four default columns for compatibility: To Do, In Progress, Blocked, Done; board columns and the default create status can be customized in Settings -> Board & Display
+- **Drag-and-drop** — Move tasks between configured columns with [@dnd-kit](https://dndkit.com/); reorder within columns; custom collision detection (pointerWithin + rectIntersection fallback) for reliable cross-column moves; tooltips suppressed during drag; local state management for real-time column updates
 
   ![Drag-and-drop demo](../assets/demo-drag_drop.gif)
 

--- a/mcp/src/tools/tasks.ts
+++ b/mcp/src/tools/tasks.ts
@@ -5,7 +5,7 @@ import { Task } from '../utils/types.js';
 
 // Tool input schemas
 const ListTasksSchema = z.object({
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']).optional(),
+  status: z.string().min(1).max(50).optional(),
   type: z.enum(['code', 'research', 'content', 'automation']).optional(),
   project: z.string().optional(),
   sprint: z.string().optional(),
@@ -24,7 +24,7 @@ const UpdateTaskSchema = z.object({
   id: z.string().min(1),
   title: z.string().optional(),
   description: z.string().optional(),
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']).optional(),
+  status: z.string().min(1).max(50).optional(),
   type: z.enum(['code', 'research', 'content', 'automation']).optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
   project: z.string().optional(),
@@ -44,7 +44,6 @@ export const taskTools = [
       properties: {
         status: {
           type: 'string',
-          enum: ['todo', 'in-progress', 'blocked', 'done'],
           description: 'Filter by task status',
         },
         type: {
@@ -133,7 +132,6 @@ export const taskTools = [
         },
         status: {
           type: 'string',
-          enum: ['todo', 'in-progress', 'blocked', 'done'],
           description: 'New status',
         },
         type: {

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -346,6 +346,44 @@ describe('Feature Settings Schema', () => {
     expect(result.telemetry?.enabled).toBe(true);
   });
 
+  it('should accept configurable board columns', () => {
+    const result = FeatureSettingsPatchSchema.parse({
+      board: {
+        columns: [
+          { id: 'triage', title: 'Triage' },
+          { id: 'ready', title: 'Ready' },
+        ],
+        defaultStatus: 'triage',
+      },
+    });
+
+    expect(result.board?.columns?.[0]?.id).toBe('triage');
+  });
+
+  it('should reject duplicate board column IDs', () => {
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        board: {
+          columns: [
+            { id: 'triage', title: 'Triage' },
+            { id: 'triage', title: 'Duplicate' },
+          ],
+        },
+      })
+    ).toThrow();
+  });
+
+  it('should reject a board default status outside supplied columns', () => {
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        board: {
+          columns: [{ id: 'triage', title: 'Triage' }],
+          defaultStatus: 'ready',
+        },
+      })
+    ).toThrow();
+  });
+
   it('should accept notification settings', () => {
     const result = FeatureSettingsPatchSchema.parse({
       notifications: { enabled: true, onTaskComplete: true },

--- a/server/src/__tests__/task-service.test.ts
+++ b/server/src/__tests__/task-service.test.ts
@@ -3,12 +3,14 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { TaskService } from '../services/task-service.js';
+import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings } from '@veritas-kanban/shared';
 
 describe('TaskService', () => {
   let service: TaskService;
   let testRoot: string;
   let tasksDir: string;
   let archiveDir: string;
+  let featureSettings: FeatureSettings;
 
   beforeEach(async () => {
     // Create fresh test directories with unique suffix
@@ -19,10 +21,14 @@ describe('TaskService', () => {
 
     await fs.mkdir(tasksDir, { recursive: true });
     await fs.mkdir(archiveDir, { recursive: true });
+    featureSettings = DEFAULT_FEATURE_SETTINGS;
 
     service = new TaskService({
       tasksDir,
       archiveDir,
+      configService: {
+        getFeatureSettings: async () => featureSettings,
+      },
     });
   });
 
@@ -204,6 +210,39 @@ updated: '2026-01-26T10:00:00.000Z'
       const taskFile = files.find((f) => f.includes(task.id));
       expect(taskFile).toMatch(/test-special-characters-more/);
     });
+
+    it('should use configured default status for new tasks', async () => {
+      featureSettings = {
+        ...DEFAULT_FEATURE_SETTINGS,
+        board: {
+          ...DEFAULT_FEATURE_SETTINGS.board,
+          columns: [
+            { id: 'triage', title: 'Triage' },
+            { id: 'ready', title: 'Ready' },
+          ],
+          defaultStatus: 'triage',
+        },
+      };
+
+      const task = await service.createTask({ title: 'Configured Default' });
+
+      expect(task.status).toBe('triage');
+    });
+
+    it('should reject creates with statuses outside configured columns', async () => {
+      featureSettings = {
+        ...DEFAULT_FEATURE_SETTINGS,
+        board: {
+          ...DEFAULT_FEATURE_SETTINGS.board,
+          columns: [{ id: 'triage', title: 'Triage' }],
+          defaultStatus: 'triage',
+        },
+      };
+
+      await expect(service.createTask({ title: 'Invalid Status', status: 'todo' })).rejects.toThrow(
+        'Invalid task status'
+      );
+    });
   });
 
   describe('Task updates', () => {
@@ -230,6 +269,28 @@ updated: '2026-01-26T10:00:00.000Z'
     it('should return null for non-existent task', async () => {
       const result = await service.updateTask('nonexistent', { title: 'Test' });
       expect(result).toBeNull();
+    });
+
+    it('should validate status updates against configured columns', async () => {
+      featureSettings = {
+        ...DEFAULT_FEATURE_SETTINGS,
+        board: {
+          ...DEFAULT_FEATURE_SETTINGS.board,
+          columns: [
+            { id: 'triage', title: 'Triage' },
+            { id: 'ready', title: 'Ready' },
+          ],
+          defaultStatus: 'triage',
+        },
+      };
+      const task = await service.createTask({ title: 'Config Status Move' });
+
+      const moved = await service.updateTask(task.id, { status: 'ready' });
+      await expect(service.updateTask(task.id, { status: 'done' })).rejects.toThrow(
+        'Invalid task status'
+      );
+
+      expect(moved?.status).toBe('ready');
     });
 
     it('should clear checkpoint when task is marked done', async () => {

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -7,7 +7,12 @@ import { getBlockingService } from '../services/blocking-service.js';
 import { getGitHubSyncService } from '../services/github-sync-service.js';
 import { getDelegationService } from '../services/delegation-service.js';
 import { getProgressService } from '../services/progress-service.js';
-import type { CreateTaskInput, UpdateTaskInput, TaskSummary } from '@veritas-kanban/shared';
+import {
+  BOARD_COLUMN_ID_PATTERN,
+  type CreateTaskInput,
+  type UpdateTaskInput,
+  type TaskSummary,
+} from '@veritas-kanban/shared';
 import { broadcastTaskChange } from '../services/broadcast-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
@@ -53,6 +58,7 @@ const createTaskSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().optional().default(''),
   type: z.string().optional().default('code'),
+  status: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN).optional(),
   priority: z.enum(['low', 'medium', 'high']).optional().default('medium'),
   project: z.string().optional(),
   sprint: z.string().optional(),
@@ -147,7 +153,7 @@ const updateTaskSchema = z.object({
   title: z.string().min(1).max(200).optional(),
   description: z.string().optional(),
   type: z.string().optional(),
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']).optional(),
+  status: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN).optional(),
   priority: z.enum(['low', 'medium', 'high']).optional(),
   project: z.string().optional(),
   sprint: z.string().optional(),
@@ -435,7 +441,7 @@ router.get(
 
     // Get all active tasks and count by status
     const tasks = await taskService.listTasks();
-    const counts = {
+    const counts: Record<string, number> = {
       backlog: 0,
       todo: 0,
       'in-progress': 0,
@@ -446,9 +452,8 @@ router.get(
 
     // Count active tasks by status
     for (const task of tasks) {
-      if (task.status in counts) {
-        counts[task.status as keyof typeof counts]++;
-      }
+      counts[task.status] ??= 0;
+      counts[task.status]++;
     }
 
     // Get backlog count
@@ -1030,7 +1035,7 @@ const bulkUpdateSchema = z.object({
     .array(z.string())
     .min(1, 'At least one task ID is required')
     .max(100, 'Maximum 100 tasks per bulk operation'),
-  status: z.enum(['todo', 'in-progress', 'blocked', 'done']),
+  status: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
 });
 
 const bulkArchiveSchema = z.object({
@@ -1044,7 +1049,7 @@ const bulkArchiveSchema = z.object({
 router.post(
   '/bulk-update',
   asyncHandler(async (req, res) => {
-    let input: { ids: string[]; status: 'todo' | 'in-progress' | 'blocked' | 'done' };
+    let input: { ids: string[]; status: string };
     try {
       input = bulkUpdateSchema.parse(req.body);
     } catch (error) {

--- a/server/src/routes/transition-hooks.ts
+++ b/server/src/routes/transition-hooks.ts
@@ -6,6 +6,7 @@
 
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
+import { BOARD_COLUMN_ID_PATTERN } from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError } from '../middleware/error-handler.js';
 import { authorize } from '../middleware/auth.js';
@@ -64,13 +65,13 @@ const ruleSchema = z.object({
   name: z.string().min(1),
   enabled: z.boolean(),
   from: z.union([
-    z.enum(['todo', 'in-progress', 'blocked', 'done', 'cancelled']),
-    z.array(z.enum(['todo', 'in-progress', 'blocked', 'done', 'cancelled'])),
+    z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
+    z.array(z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN)),
     z.literal('*'),
   ]),
   to: z.union([
-    z.enum(['todo', 'in-progress', 'blocked', 'done', 'cancelled']),
-    z.array(z.enum(['todo', 'in-progress', 'blocked', 'done', 'cancelled'])),
+    z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
+    z.array(z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN)),
     z.literal('*'),
   ]),
   gates: z.array(gateSchema),

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BOARD_COLUMN_ID_PATTERN } from '@veritas-kanban/shared';
 
 // Dangerous keys check
 const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
@@ -77,8 +78,24 @@ const BoardSavedViewSchema = z
   })
   .strict();
 
+const BoardColumnSchema = z
+  .object({
+    id: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN),
+    title: z.string().min(1).max(50),
+  })
+  .strict();
+
 const BoardSettingsSchema = z
   .object({
+    columns: z
+      .array(BoardColumnSchema)
+      .min(1)
+      .max(12)
+      .refine((columns) => new Set(columns.map((column) => column.id)).size === columns.length, {
+        message: 'Board column IDs must be unique',
+      })
+      .optional(),
+    defaultStatus: z.string().min(1).max(50).regex(BOARD_COLUMN_ID_PATTERN).optional(),
     showDashboard: z.boolean().optional(),
     showArchiveSuggestions: z.boolean().optional(),
     cardDensity: z.enum(['normal', 'compact']).optional(),
@@ -92,6 +109,19 @@ const BoardSettingsSchema = z
     dashboardWidgets: DashboardWidgetSettingsSchema,
   })
   .strict()
+  .superRefine((value, ctx) => {
+    if (
+      value.columns &&
+      value.defaultStatus &&
+      !value.columns.some((column) => column.id === value.defaultStatus)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'defaultStatus must reference a configured board column',
+        path: ['defaultStatus'],
+      });
+    }
+  })
   .optional();
 
 const TaskBehaviorSettingsSchema = z

--- a/server/src/services/agent-registry-service.ts
+++ b/server/src/services/agent-registry-service.ts
@@ -80,7 +80,7 @@ export interface TaskSyncUpdate {
   agentRef: string;
   taskId: string;
   taskTitle?: string;
-  taskStatus: 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
+  taskStatus: string;
 }
 
 export interface TaskSyncContext {
@@ -113,7 +113,7 @@ export function isValidSyncToken(context: TaskSyncContext): boolean {
 export interface TaskSyncSnapshot {
   id: string;
   title?: string;
-  status: 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
+  status: string;
   agent?: string;
 }
 

--- a/server/src/services/metrics/task-metrics.ts
+++ b/server/src/services/metrics/task-metrics.ts
@@ -3,7 +3,7 @@
  */
 import fs from 'fs/promises';
 import path from 'path';
-import type { TaskStatus, BlockedCategory } from '@veritas-kanban/shared';
+import type { BlockedCategory } from '@veritas-kanban/shared';
 import { TaskService } from '../task-service.js';
 import { PROJECT_ROOT } from './helpers.js';
 import type {
@@ -50,7 +50,7 @@ export async function computeTaskMetrics(
   }
 
   // Count by status
-  const byStatus: Record<TaskStatus, number> = {
+  const byStatus: Record<string, number> = {
     todo: 0,
     'in-progress': 0,
     blocked: 0,
@@ -68,6 +68,7 @@ export async function computeTaskMetrics(
   };
 
   for (const task of filteredActive) {
+    byStatus[task.status] ??= 0;
     byStatus[task.status]++;
 
     // Count blocked reasons for blocked tasks

--- a/server/src/services/metrics/types.ts
+++ b/server/src/services/metrics/types.ts
@@ -3,7 +3,6 @@
  * All metric interfaces and type aliases used across the metrics modules.
  */
 import type {
-  TaskStatus,
   BlockedCategory,
   TelemetryEventType,
   AnyTelemetryEvent,
@@ -27,7 +26,7 @@ export type MetricsPeriod =
   | 'custom';
 
 export interface TaskMetrics {
-  byStatus: Record<TaskStatus, number>;
+  byStatus: Record<string, number>;
   byBlockedReason: Record<BlockedCategory | 'unspecified', number>;
   total: number;
   completed: number; // done + archived

--- a/server/src/services/summary-service.ts
+++ b/server/src/services/summary-service.ts
@@ -9,12 +9,7 @@ import type { Task, Comment } from '@veritas-kanban/shared';
 import { formatDuration, formatDate } from '@veritas-kanban/shared';
 import type { Activity } from './activity-service.js';
 
-export interface StatusCounts {
-  todo: number;
-  'in-progress': number;
-  blocked: number;
-  done: number;
-}
+export type StatusCounts = Record<string, number>;
 
 export interface ProjectStats {
   total: number;
@@ -72,11 +67,15 @@ export class SummaryService {
    */
   getOverallSummary(tasks: Task[]): OverallSummary {
     const byStatus: StatusCounts = {
-      todo: tasks.filter((t) => t.status === 'todo').length,
-      'in-progress': tasks.filter((t) => t.status === 'in-progress').length,
-      blocked: tasks.filter((t) => t.status === 'blocked').length,
-      done: tasks.filter((t) => t.status === 'done').length,
+      todo: 0,
+      'in-progress': 0,
+      blocked: 0,
+      done: 0,
     };
+    tasks.forEach((task) => {
+      byStatus[task.status] ??= 0;
+      byStatus[task.status]++;
+    });
 
     const byProject: Record<string, ProjectStats> = {};
     tasks.forEach((task) => {

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -12,7 +12,10 @@ import type {
   TimeTracking,
   RunStartedEvent,
   RunCompletedEvent,
+  BoardColumnConfig,
+  TaskStatus,
 } from '@veritas-kanban/shared';
+import { normalizeBoardColumns, normalizeBoardDefaultStatus } from '@veritas-kanban/shared';
 import { getTelemetryService, type TelemetryService } from './telemetry-service.js';
 import { ConfigService } from './config-service.js';
 import { withFileLock } from './file-lock.js';
@@ -64,6 +67,12 @@ function isValidTaskId(id: string): boolean {
   return TASK_ID_REGEX.test(id);
 }
 
+interface BoardStatusConfig {
+  columns: BoardColumnConfig[];
+  defaultStatus: TaskStatus;
+  activeStatusIds: Set<string>;
+}
+
 // Simple slug function to avoid CJS/ESM issues with slugify
 function makeSlug(text: string): string {
   return text
@@ -86,6 +95,7 @@ export interface TaskServiceOptions {
   storageType?: 'file' | 'sqlite';
   sqliteDatabase?: SqliteDatabase;
   sqliteConnectionOptions?: SqliteConnectionOptions;
+  configService?: Pick<ConfigService, 'getFeatureSettings'>;
 }
 
 /** Ignore file-watcher events within this window after our own writes */
@@ -99,6 +109,7 @@ export class TaskService {
   private sqliteDatabase: SqliteDatabase | null = null;
   private sqliteTasks: SqliteTaskRepository | null = null;
   private sqliteMutationQueue: Promise<unknown> = Promise.resolve();
+  private configService: Pick<ConfigService, 'getFeatureSettings'>;
 
   // ============ In-Memory Cache ============
   private cache: Map<string, Task> = new Map();
@@ -116,6 +127,7 @@ export class TaskService {
     this.backlogDir =
       options.backlogDir ?? (options.tasksDir || options.archiveDir ? null : getTasksBacklogDir());
     this.telemetry = options.telemetryService || getTelemetryService();
+    this.configService = options.configService ?? new ConfigService();
     const storageType =
       options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 
@@ -615,8 +627,6 @@ export class TaskService {
   private syncAgentRegistryForStatusTransition(task: Task): void {
     if (!task.agent) return;
 
-    if (!['todo', 'in-progress', 'blocked', 'done', 'cancelled'].includes(task.status)) return;
-
     const registry = getAgentRegistryService();
     registry.syncFromTask(
       {
@@ -627,6 +637,28 @@ export class TaskService {
       },
       TASK_SYNC_CONTEXT
     );
+  }
+
+  private async getBoardStatusConfig(): Promise<BoardStatusConfig> {
+    const settings = await this.configService.getFeatureSettings();
+    const columns = normalizeBoardColumns(settings.board?.columns);
+    const defaultStatus = normalizeBoardDefaultStatus(settings.board?.defaultStatus, columns);
+    return {
+      columns,
+      defaultStatus,
+      activeStatusIds: new Set(columns.map((column) => column.id)),
+    };
+  }
+
+  private assertConfiguredStatus(status: TaskStatus, config: BoardStatusConfig): void {
+    if (config.activeStatusIds.has(status)) return;
+    throw new ValidationError(`Invalid task status "${status}" for the configured board`, [
+      {
+        code: 'INVALID_STATUS',
+        message: `Status "${status}" is not configured as an active board column`,
+        path: ['status'],
+      },
+    ]);
   }
 
   private startTaskSyncReconciler(): void {
@@ -714,13 +746,16 @@ export class TaskService {
 
   async createTask(input: CreateTaskInput): Promise<Task> {
     const now = new Date().toISOString();
+    const boardStatusConfig = await this.getBoardStatusConfig();
+    const status = input.status ?? boardStatusConfig.defaultStatus;
+    this.assertConfiguredStatus(status, boardStatusConfig);
 
     const task: Task = {
       id: this.generateId(),
       title: input.title,
       description: input.description || '',
       type: input.type || 'code',
-      status: 'todo',
+      status,
       priority: input.priority || 'medium',
       project: input.project,
       sprint: input.sprint,
@@ -836,8 +871,13 @@ export class TaskService {
       let settings: Awaited<ReturnType<ConfigService['getFeatureSettings']>> | null = null;
 
       if (statusChanged) {
-        const configService = new ConfigService();
-        settings = await configService.getFeatureSettings();
+        settings = await this.configService.getFeatureSettings();
+        const columns = normalizeBoardColumns(settings.board?.columns);
+        this.assertConfiguredStatus(input.status as TaskStatus, {
+          columns,
+          defaultStatus: normalizeBoardDefaultStatus(settings.board?.defaultStatus, columns),
+          activeStatusIds: new Set(columns.map((column) => column.id)),
+        });
       }
 
       // Validate transition hooks (quality gates) before allowing status change

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -1,6 +1,6 @@
 // Config Types
 
-import type { AgentType, TaskPriority } from './task.types.js';
+import type { AgentType, TaskPriority, TaskStatus } from './task.types.js';
 import type { TelemetryConfig } from './telemetry.types.js';
 import type { WatcherContinuationSettings } from './watcher-policy.types.js';
 
@@ -213,8 +213,15 @@ export interface BoardSavedView {
   updatedAt: string;
 }
 
+export interface BoardColumnConfig {
+  id: TaskStatus;
+  title: string;
+}
+
 /** Board display settings */
 export interface BoardSettings {
+  columns: BoardColumnConfig[];
+  defaultStatus: TaskStatus;
   showDashboard: boolean;
   showArchiveSuggestions: boolean;
   cardDensity: 'normal' | 'compact';
@@ -411,6 +418,13 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     dismissedHints: [],
   },
   board: {
+    columns: [
+      { id: 'todo', title: 'To Do' },
+      { id: 'in-progress', title: 'In Progress' },
+      { id: 'blocked', title: 'Blocked' },
+      { id: 'done', title: 'Done' },
+    ],
+    defaultStatus: 'todo',
     showDashboard: true,
     showArchiveSuggestions: true,
     cardDensity: 'normal',

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -1,7 +1,8 @@
 // Task Types
 
 export type TaskType = string;
-export type TaskStatus = 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
+export type BuiltInTaskStatus = 'todo' | 'in-progress' | 'blocked' | 'done' | 'cancelled';
+export type TaskStatus = BuiltInTaskStatus | (string & {});
 export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
 
 /** Run mode controls the review/QA strategy for a task. */
@@ -349,6 +350,7 @@ export interface CreateTaskInput {
   title: string;
   description?: string;
   type?: TaskType;
+  status?: TaskStatus;
   priority?: TaskPriority;
   project?: string;
   sprint?: string;

--- a/shared/src/utils/board-columns.ts
+++ b/shared/src/utils/board-columns.ts
@@ -1,0 +1,41 @@
+import { DEFAULT_FEATURE_SETTINGS, type BoardColumnConfig, type TaskStatus } from '../types.js';
+
+export const BOARD_COLUMN_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export function isValidBoardColumnId(value: string): boolean {
+  return value.length >= 1 && value.length <= 50 && BOARD_COLUMN_ID_PATTERN.test(value);
+}
+
+export function normalizeBoardColumns(
+  columns: BoardColumnConfig[] | undefined | null
+): BoardColumnConfig[] {
+  const source = columns?.length ? columns : DEFAULT_FEATURE_SETTINGS.board.columns;
+  const seen = new Set<string>();
+  const normalized: BoardColumnConfig[] = [];
+
+  for (const column of source) {
+    const id = String(column.id || '').trim() as TaskStatus;
+    const title = String(column.title || '').trim();
+    if (!id || !isValidBoardColumnId(id) || !title || title.length > 50 || seen.has(id)) continue;
+    normalized.push({ id, title });
+    seen.add(id);
+  }
+
+  return normalized.length > 0 ? normalized : DEFAULT_FEATURE_SETTINGS.board.columns;
+}
+
+export function normalizeBoardDefaultStatus(
+  defaultStatus: TaskStatus | undefined | null,
+  columns: BoardColumnConfig[]
+): TaskStatus {
+  const ids = new Set(columns.map((column) => column.id));
+  if (defaultStatus && ids.has(defaultStatus)) return defaultStatus;
+  return columns[0]?.id ?? DEFAULT_FEATURE_SETTINGS.board.defaultStatus;
+}
+
+export function getBoardStatusLabel(
+  status: TaskStatus,
+  columns: BoardColumnConfig[] | undefined | null
+): string {
+  return normalizeBoardColumns(columns).find((column) => column.id === status)?.title ?? status;
+}

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -5,6 +5,7 @@
 export * from './path.js';
 export * from './format.js';
 export * from './constants.js';
+export * from './board-columns.js';
 export * from './safe-href.js';
 export * from './remote-destination-policy.js';
 export * from './api-permissions.js';

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -42,8 +42,12 @@ function createFeatureSettings(
 
 vi.mock('@/hooks/useTasks', () => ({
   useTasks: () => mockUseTasks(),
-  useTasksByStatus: (tasks: Task[]) => {
-    const result: Record<string, Task[]> = { todo: [], 'in-progress': [], blocked: [], done: [] };
+  useTasksByStatus: (tasks: Task[], columns?: Array<{ id: string }>) => {
+    const result: Record<string, Task[]> = Object.fromEntries(
+      (columns ?? [{ id: 'todo' }, { id: 'in-progress' }, { id: 'blocked' }, { id: 'done' }]).map(
+        (column) => [column.id, [] as Task[]]
+      )
+    );
     for (const t of tasks) {
       if (result[t.status]) result[t.status].push(t);
     }
@@ -251,6 +255,34 @@ describe('KanbanBoard', () => {
     expect(screen.getAllByText('In Progress').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Blocked').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Done').length).toBeGreaterThan(0);
+  });
+
+  it('renders configured custom board columns', () => {
+    mockUseTasks = () => ({
+      data: [
+        createMockTask({ id: 'k-custom', title: 'Ready Task', status: 'ready' }),
+        ...mockTasks,
+      ],
+      isLoading: false,
+      error: null,
+    });
+    mockFeatureSettingsResult = {
+      isPlaceholderData: false,
+      settings: createFeatureSettings({
+        columns: [
+          { id: 'triage', title: 'Triage' },
+          { id: 'ready', title: 'Ready' },
+          { id: 'done', title: 'Done' },
+        ],
+        defaultStatus: 'triage',
+      }),
+    };
+
+    renderBoard();
+
+    expect(screen.getByTestId('column-triage')).toBeDefined();
+    expect(screen.getByTestId('column-ready')).toBeDefined();
+    expect(screen.getByTestId('task-k-custom')).toBeDefined();
   });
 
   it('renders empty board when no tasks', () => {

--- a/web/src/__tests__/board-chrome-mantine.test.tsx
+++ b/web/src/__tests__/board-chrome-mantine.test.tsx
@@ -297,7 +297,7 @@ describe('Board chrome Mantine migration', () => {
     expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Select all tasks' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Select all Todo tasks (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Select all To Do tasks (1)' }));
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     expect(mocks.selectAll).toHaveBeenCalledWith(['VK-1', 'VK-2']);

--- a/web/src/__tests__/settings-tabs-mantine-controls.test.tsx
+++ b/web/src/__tests__/settings-tabs-mantine-controls.test.tsx
@@ -142,6 +142,9 @@ describe('Settings tab Mantine controls', () => {
     const { container: boardContainer } = renderWithProviders(<BoardTab />);
 
     expect(screen.getByRole('combobox', { name: 'Card Density' })).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Default task status' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Column 1 status ID' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Column 1 title' })).toBeDefined();
     expect(boardContainer.querySelector('.mantine-Select-root')).toBeDefined();
 
     cleanup();
@@ -150,6 +153,26 @@ describe('Settings tab Mantine controls', () => {
 
     expect(screen.getByRole('combobox', { name: 'Default Priority' })).toBeDefined();
     expect(tasksContainer.querySelector('.mantine-Select-root')).toBeDefined();
+  });
+
+  it('updates configured board columns from the Board tab', () => {
+    renderWithProviders(<BoardTab />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Column 1 title' }), {
+      target: { value: 'Triage' },
+    });
+
+    expect(mocks.debouncedUpdate).toHaveBeenCalledWith({
+      board: {
+        columns: [
+          { id: 'todo', title: 'Triage' },
+          { id: 'in-progress', title: 'In Progress' },
+          { id: 'blocked', title: 'Blocked' },
+          { id: 'done', title: 'Done' },
+        ],
+        defaultStatus: 'todo',
+      },
+    });
   });
 
   it('renders Notifications text and select controls through direct Mantine primitives', async () => {

--- a/web/src/__tests__/useKeyboard.test.tsx
+++ b/web/src/__tests__/useKeyboard.test.tsx
@@ -15,6 +15,23 @@ vi.mock('@/hooks/useToast', () => ({
   default: vi.fn(),
 }));
 
+const featureSettingsMock = vi.hoisted(() => ({
+  settings: {
+    board: {
+      columns: [
+        { id: 'todo', title: 'To Do' },
+        { id: 'in-progress', title: 'In Progress' },
+        { id: 'blocked', title: 'Blocked' },
+        { id: 'done', title: 'Done' },
+      ],
+    },
+  },
+}));
+
+vi.mock('@/hooks/useFeatureSettings', () => ({
+  useFeatureSettings: () => featureSettingsMock,
+}));
+
 import { KeyboardProvider, useKeyboard } from '@/hooks/useKeyboard';
 
 // ── Test Component ───────────────────────────────────────────
@@ -67,6 +84,16 @@ function renderWithProvider(props: React.ComponentProps<typeof TestConsumer> = {
 describe('KeyboardProvider', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    featureSettingsMock.settings = {
+      board: {
+        columns: [
+          { id: 'todo', title: 'To Do' },
+          { id: 'in-progress', title: 'In Progress' },
+          { id: 'blocked', title: 'Blocked' },
+          { id: 'done', title: 'Done' },
+        ],
+      },
+    };
   });
 
   afterEach(() => {
@@ -187,6 +214,29 @@ describe('KeyboardProvider', () => {
 
     fireEvent.keyDown(window, { key: '4' });
     expect(onMoveTask).toHaveBeenCalledWith('move-test', 'done');
+  });
+
+  it('maps number keys to configured custom column order', () => {
+    featureSettingsMock.settings = {
+      board: {
+        columns: [
+          { id: 'triage', title: 'Triage' },
+          { id: 'todo', title: 'To Do' },
+          { id: 'ready', title: 'Ready' },
+          { id: 'in-progress', title: 'In Progress' },
+          { id: 'done', title: 'Done' },
+        ],
+      },
+    };
+    const tasks = [createMockTask({ id: 'custom-move', title: 'Move Task', status: 'triage' })];
+    const onMoveTask = vi.fn();
+
+    renderWithProvider({ tasks, onMoveTask });
+
+    fireEvent.keyDown(window, { key: 'j' });
+    fireEvent.keyDown(window, { key: '3' });
+
+    expect(onMoveTask).toHaveBeenCalledWith('custom-move', 'ready');
   });
 
   it('clears selection with Escape', () => {

--- a/web/src/components/board/BoardSidebar.tsx
+++ b/web/src/components/board/BoardSidebar.tsx
@@ -6,14 +6,16 @@
  * - Task counters in 2-column grid
  */
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@mantine/core';
 import { useRealtimeAgentStatus } from '@/hooks/useAgentStatus';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { api, Activity } from '@/lib/api';
 import { useTaskCounts } from '@/hooks/useTaskCounts';
+import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import { useView } from '@/contexts/ViewContext';
+import { DEFAULT_FEATURE_SETTINGS, normalizeBoardColumns } from '@veritas-kanban/shared';
 import {
   Clock,
   AlertCircle,
@@ -30,6 +32,7 @@ import {
   ExternalLink,
   GitBranch,
   ShieldAlert,
+  Circle,
 } from 'lucide-react';
 import { BudgetCard } from '@/components/dashboard/BudgetCard';
 import { MultiAgentPanel } from './MultiAgentPanel';
@@ -388,6 +391,17 @@ interface BoardSidebarProps {
 export function BoardSidebar({ onTaskClick }: BoardSidebarProps) {
   const { setView } = useView();
   const { data: counts } = useTaskCounts(); // Use new counts endpoint for sidebar counters
+  const { settings } = useFeatureSettings();
+  const columns = normalizeBoardColumns(
+    settings.board?.columns ?? DEFAULT_FEATURE_SETTINGS.board.columns
+  );
+
+  const columnCounterMeta: Record<string, { icon: ReactNode; color?: string }> = {
+    todo: { icon: <ListTodo className="h-3.5 w-3.5" /> },
+    'in-progress': { icon: <Play className="h-3.5 w-3.5" />, color: 'text-blue-500' },
+    blocked: { icon: <Ban className="h-3.5 w-3.5" />, color: 'text-red-500' },
+    done: { icon: <CheckCircle className="h-3.5 w-3.5" />, color: 'text-green-500' },
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -402,29 +416,20 @@ export function BoardSidebar({ onTaskClick }: BoardSidebarProps) {
             value={counts?.backlog || 0}
             icon={<Inbox className="h-3.5 w-3.5" />}
           />
-          <Counter
-            label="To Do"
-            value={counts?.todo || 0}
-            icon={<ListTodo className="h-3.5 w-3.5" />}
-          />
-          <Counter
-            label="In Progress"
-            value={counts?.['in-progress'] || 0}
-            icon={<Play className="h-3.5 w-3.5" />}
-            color="text-blue-500"
-          />
-          <Counter
-            label="Blocked"
-            value={counts?.blocked || 0}
-            icon={<Ban className="h-3.5 w-3.5" />}
-            color="text-red-500"
-          />
-          <Counter
-            label="Done"
-            value={counts?.done || 0}
-            icon={<CheckCircle className="h-3.5 w-3.5" />}
-            color="text-green-500"
-          />
+          {columns.map((column) => {
+            const meta = columnCounterMeta[column.id] ?? {
+              icon: <Circle className="h-3.5 w-3.5" />,
+            };
+            return (
+              <Counter
+                key={column.id}
+                label={column.title}
+                value={counts?.[column.id] || 0}
+                icon={meta.icon}
+                color={meta.color}
+              />
+            );
+          })}
           <Counter
             label="Archived"
             value={counts?.archived || 0}

--- a/web/src/components/board/BulkActionsBar.tsx
+++ b/web/src/components/board/BulkActionsBar.tsx
@@ -5,37 +5,39 @@ import { useToast } from '@/hooks/useToast';
 import { useBulkActions } from '@/hooks/useBulkActions';
 import { useDeleteTask, useBulkUpdate, useBulkArchiveByIds } from '@/hooks/useTasks';
 import { useBulkDemote } from '@/hooks/useBacklog';
+import { useFeatureSettings } from '@/hooks/useFeatureSettings';
 import { cn } from '@/lib/utils';
-import type { Task, TaskStatus } from '@veritas-kanban/shared';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  normalizeBoardColumns,
+  type BoardColumnConfig,
+  type Task,
+  type TaskStatus,
+} from '@veritas-kanban/shared';
 
-const STATUS_BUTTONS: { id: TaskStatus; label: string; color: string; activeColor: string }[] = [
-  {
-    id: 'todo',
-    label: 'Todo',
+const STATUS_BUTTON_COLORS: Record<string, { color: string; activeColor: string }> = {
+  todo: {
     color: 'border-slate-400 text-slate-600',
     activeColor: 'bg-slate-500 text-white border-slate-500',
   },
-  {
-    id: 'in-progress',
-    label: 'In Progress',
+  'in-progress': {
     color: 'border-blue-400 text-blue-600',
     activeColor: 'bg-blue-500 text-white border-blue-500',
   },
-  {
-    id: 'blocked',
-    label: 'Blocked',
+  blocked: {
     color: 'border-red-400 text-red-600',
     activeColor: 'bg-red-500 text-white border-red-500',
   },
-  {
-    id: 'done',
-    label: 'Done',
+  done: {
     color: 'border-green-400 text-green-600',
     activeColor: 'bg-green-500 text-white border-green-500',
   },
-];
+};
 
-const MOVE_STATUS_OPTIONS = STATUS_BUTTONS.map(({ id, label }) => ({ value: id, label }));
+const DEFAULT_STATUS_BUTTON_COLOR = {
+  color: 'border-primary/60 text-primary',
+  activeColor: 'bg-primary text-primary-foreground border-primary',
+};
 
 interface BulkActionsBarProps {
   tasks: Task[];
@@ -45,6 +47,15 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
   const { selectedIds, isSelecting, toggleSelecting, selectAll, toggleGroup, clearSelection } =
     useBulkActions();
   const { toast } = useToast();
+  const { settings } = useFeatureSettings();
+  const columns = useMemo<BoardColumnConfig[]>(
+    () => normalizeBoardColumns(settings.board?.columns ?? DEFAULT_FEATURE_SETTINGS.board.columns),
+    [settings.board?.columns]
+  );
+  const moveStatusOptions = useMemo(
+    () => columns.map((column) => ({ value: column.id, label: column.title })),
+    [columns]
+  );
 
   const bulkUpdate = useBulkUpdate();
   const deleteTask = useDeleteTask();
@@ -57,20 +68,16 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
 
   // Group task IDs by status
   const taskIdsByStatus = useMemo(() => {
-    const map: Record<TaskStatus, string[]> = {
-      todo: [],
-      'in-progress': [],
-      blocked: [],
-      done: [],
-      cancelled: [],
-    };
+    const map: Record<string, string[]> = Object.fromEntries(
+      columns.map((column) => [column.id, [] as string[]])
+    );
     for (const task of tasks) {
       if (map[task.status]) {
         map[task.status].push(task.id);
       }
     }
     return map;
-  }, [tasks]);
+  }, [columns, tasks]);
 
   const allTaskIds = useMemo(() => tasks.map((t) => t.id), [tasks]);
   const selectedCount = selectedIds.size;
@@ -104,10 +111,9 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
     setIsProcessing(true);
     try {
       const ids = Array.from(selectedIds);
-      // Type assertion since BulkActionsBar only allows the 4 valid statuses
       const result = await bulkUpdate.mutateAsync({
         ids,
-        status: moveTarget as 'todo' | 'in-progress' | 'blocked' | 'done',
+        status: moveTarget,
       });
 
       if (result.failed.length > 0) {
@@ -261,8 +267,9 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
 
           {/* Status filter buttons */}
           <div className="flex items-center gap-1.5 ml-1">
-            {STATUS_BUTTONS.map(({ id, label, color, activeColor }) => {
-              const count = taskIdsByStatus[id].length;
+            {columns.map(({ id, title }) => {
+              const colors = STATUS_BUTTON_COLORS[id] ?? DEFAULT_STATUS_BUTTON_COLOR;
+              const count = taskIdsByStatus[id]?.length ?? 0;
               if (count === 0) return null;
               const fullySelected = isStatusFullySelected(id);
               const partiallySelected = isStatusPartiallySelected(id);
@@ -271,15 +278,19 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
                   key={id}
                   variant="outline"
                   size="xs"
-                  onClick={() => toggleGroup(taskIdsByStatus[id])}
+                  onClick={() => toggleGroup(taskIdsByStatus[id] ?? [])}
                   className={cn(
                     'text-xs h-7 px-2 border transition-colors',
-                    fullySelected ? activeColor : partiallySelected ? `${color} opacity-70` : color
+                    fullySelected
+                      ? colors.activeColor
+                      : partiallySelected
+                        ? `${colors.color} opacity-70`
+                        : colors.color
                   )}
-                  aria-label={`Select all ${label} tasks (${count})`}
+                  aria-label={`Select all ${title} tasks (${count})`}
                   aria-pressed={fullySelected}
                 >
-                  {label} ({count})
+                  {title} ({count})
                 </Button>
               );
             })}
@@ -295,7 +306,7 @@ export function BulkActionsBar({ tasks }: BulkActionsBarProps) {
               value={moveTarget}
               onChange={(value) => setMoveTarget(value as TaskStatus | null)}
               disabled={isProcessing}
-              data={MOVE_STATUS_OPTIONS}
+              data={moveStatusOptions}
               aria-label="Move selected tasks to status"
               placeholder="Move to..."
               className="w-[140px]"

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -5,8 +5,10 @@ import { BoardLoadingSkeleton } from './BoardLoadingSkeleton';
 import {
   DEFAULT_FEATURE_SETTINGS,
   type BoardSavedView,
+  type BoardColumnConfig,
   type TaskStatus,
   type Task,
+  normalizeBoardColumns,
 } from '@veritas-kanban/shared';
 import { useFeatureSettings, useUpdateFeatureSettings } from '@/hooks/useFeatureSettings';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
@@ -62,14 +64,6 @@ const BoardSidebar = lazy(() =>
   }))
 );
 
-const COLUMNS: { id: TaskStatus; title: string }[] = [
-  { id: 'todo', title: 'To Do' },
-  { id: 'in-progress', title: 'In Progress' },
-  { id: 'blocked', title: 'Blocked' },
-  { id: 'done', title: 'Done' },
-];
-
-const STATUS_OPTIONS = COLUMNS.map((column) => ({ value: column.id, label: column.title }));
 const EMPTY_SAVED_VIEWS: BoardSavedView[] = [];
 
 export function KanbanBoard() {
@@ -77,6 +71,14 @@ export function KanbanBoard() {
   const { settings: featureSettings, isPlaceholderData } = useFeatureSettings();
   const updateFeatureSettings = useUpdateFeatureSettings();
   const boardSettings = featureSettings.board ?? DEFAULT_FEATURE_SETTINGS.board;
+  const columns = useMemo<BoardColumnConfig[]>(
+    () => normalizeBoardColumns(boardSettings.columns),
+    [boardSettings.columns]
+  );
+  const statusOptions = useMemo(
+    () => columns.map((column) => ({ value: column.id, label: column.title })),
+    [columns]
+  );
   const savedViews = boardSettings.savedViews ?? EMPTY_SAVED_VIEWS;
   const defaultSavedViewId = boardSettings.defaultSavedViewId ?? null;
   const { announce } = useLiveAnnouncer();
@@ -294,7 +296,7 @@ export function KanbanBoard() {
   }, [tasks, filters]);
 
   // Group filtered tasks by status
-  const tasksByStatus = useTasksByStatus(filteredTasks);
+  const tasksByStatus = useTasksByStatus(filteredTasks, columns);
 
   // Register filtered tasks with keyboard context
   useEffect(() => {
@@ -376,7 +378,7 @@ export function KanbanBoard() {
   const handleMoveTask = useCallback(
     (taskId: string, status: TaskStatus) => {
       const task = filteredTasks.find((t) => t.id === taskId);
-      const columnName = COLUMNS.find((c) => c.id === status)?.title || status;
+      const columnName = columns.find((c) => c.id === status)?.title || status;
       if (!canWriteTasks) {
         announce(`Task ${task?.title || taskId} cannot be moved with the current permissions`);
         return;
@@ -388,7 +390,7 @@ export function KanbanBoard() {
       updateTask.mutate({ id: taskId, input: { status } });
       announce(`Task ${task?.title || taskId} moved to ${columnName}`);
     },
-    [announce, canWriteTasks, filteredTasks, isOnline, updateTask]
+    [announce, canWriteTasks, columns, filteredTasks, isOnline, updateTask]
   );
 
   // Register callbacks with keyboard context (refs, so no need for useEffect)
@@ -408,7 +410,7 @@ export function KanbanBoard() {
   } = useBoardDragDrop({
     tasks: filteredTasks,
     tasksByStatus,
-    columns: COLUMNS,
+    columns,
     onStatusChange: (taskId, status) => {
       if (!canWriteTasks || !isOnline) return;
       updateTask.mutate({ id: taskId, input: { status } });
@@ -433,7 +435,7 @@ export function KanbanBoard() {
     : null;
 
   if (isLoading) {
-    return <BoardLoadingSkeleton columns={COLUMNS} />;
+    return <BoardLoadingSkeleton columns={columns} />;
   }
 
   if (error) {
@@ -502,16 +504,21 @@ export function KanbanBoard() {
                 onDragEnd={handleDragEnd}
               >
                 <div
-                  className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4"
+                  className="grid grid-cols-1 gap-4 md:grid-cols-2"
+                  style={
+                    isMobileLayout
+                      ? undefined
+                      : { gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }
+                  }
                   role="group"
                   aria-label="Kanban columns"
                 >
-                  {COLUMNS.map((column) => (
+                  {columns.map((column) => (
                     <KanbanColumn
                       key={column.id}
                       id={column.id}
                       title={column.title}
-                      tasks={liveTasksByStatus[column.id]}
+                      tasks={liveTasksByStatus[column.id] ?? []}
                       allTasks={filteredTasks}
                       onTaskClick={handleTaskClick}
                       onTaskStatusChange={handleMoveTask}
@@ -519,7 +526,7 @@ export function KanbanBoard() {
                       canChangeStatus={canWriteTasks && isOnline}
                       dragEnabled={canDragTasks}
                       isDragActive={isDragActive}
-                      statusOptions={STATUS_OPTIONS}
+                      statusOptions={statusOptions}
                     />
                   ))}
                 </div>
@@ -530,16 +537,21 @@ export function KanbanBoard() {
               </DndContext>
             ) : (
               <div
-                className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4"
+                className="grid grid-cols-1 gap-4 md:grid-cols-2"
+                style={
+                  isMobileLayout
+                    ? undefined
+                    : { gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }
+                }
                 role="group"
                 aria-label="Kanban columns"
               >
-                {COLUMNS.map((column) => (
+                {columns.map((column) => (
                   <KanbanColumn
                     key={column.id}
                     id={column.id}
                     title={column.title}
-                    tasks={tasksByStatus[column.id]}
+                    tasks={tasksByStatus[column.id] ?? []}
                     allTasks={filteredTasks}
                     onTaskClick={handleTaskClick}
                     onTaskStatusChange={handleMoveTask}
@@ -547,7 +559,7 @@ export function KanbanBoard() {
                     canChangeStatus={canWriteTasks && isOnline}
                     dragEnabled={false}
                     showStatusControls={isMobileLayout}
-                    statusOptions={STATUS_OPTIONS}
+                    statusOptions={statusOptions}
                   />
                 ))}
               </div>

--- a/web/src/components/board/KanbanColumn.tsx
+++ b/web/src/components/board/KanbanColumn.tsx
@@ -25,7 +25,7 @@ interface KanbanColumnProps {
   statusOptions?: Array<{ value: TaskStatus; label: string }>;
 }
 
-const columnColors: Record<TaskStatus, string> = {
+const columnColors: Record<string, string> = {
   todo: 'border-t-slate-500',
   'in-progress': 'border-t-blue-500',
   blocked: 'border-t-red-500',
@@ -76,7 +76,7 @@ export function KanbanColumn({
       aria-roledescription="kanban column"
       className={cn(
         'flex flex-col rounded-lg bg-muted/50 border-t-2 transition-all',
-        columnColors[id],
+        columnColors[id] ?? 'border-t-primary',
         dragEnabled && isOver && 'ring-2 ring-primary/50 bg-muted/70'
       )}
     >

--- a/web/src/components/dashboard/TasksDrillDown.tsx
+++ b/web/src/components/dashboard/TasksDrillDown.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Badge, Group, Paper, Skeleton, Stack, Text } from '@mantine/core';
 import { useTasks } from '@/hooks/useTasks';
 import { useProjects } from '@/hooks/useProjects';
-import { CheckCircle, Play, Ban, ListTodo } from 'lucide-react';
+import { CheckCircle, Play, Ban, ListTodo, Circle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { TaskStatus, Task } from '@veritas-kanban/shared';
 
@@ -13,7 +13,7 @@ interface TasksDrillDownProps {
 }
 
 const statusConfig: Record<
-  TaskStatus,
+  string,
   {
     icon: React.ReactNode;
     color: string;
@@ -53,6 +53,13 @@ const statusConfig: Record<
   },
 };
 
+const defaultStatusConfig = {
+  icon: <Circle className="h-4 w-4" />,
+  color: 'gray',
+  iconClassName: 'text-muted-foreground',
+  label: 'Custom',
+};
+
 export function TasksDrillDown({
   project,
   statusFilter = 'all',
@@ -84,14 +91,17 @@ export function TasksDrillDown({
 
   // Group by status for summary
   const statusCounts = useMemo(() => {
-    const counts: Record<TaskStatus, number> = {
+    const counts: Record<string, number> = {
       todo: 0,
       'in-progress': 0,
       blocked: 0,
       done: 0,
       cancelled: 0,
     };
-    filteredTasks.forEach((t) => counts[t.status]++);
+    filteredTasks.forEach((t) => {
+      counts[t.status] ??= 0;
+      counts[t.status]++;
+    });
     return counts;
   }, [filteredTasks]);
 
@@ -110,7 +120,7 @@ export function TasksDrillDown({
       {/* Summary Stats */}
       <Group gap="xs" wrap="wrap">
         {Object.entries(statusCounts).map(([status, count]) => {
-          const config = statusConfig[status as TaskStatus];
+          const config = statusConfig[status] ?? { ...defaultStatusConfig, label: status };
           return (
             <Badge key={status} variant="light" color={config.color} leftSection={config.icon}>
               {config.label}: {count}

--- a/web/src/components/settings/tabs/BoardTab.tsx
+++ b/web/src/components/settings/tabs/BoardTab.tsx
@@ -1,15 +1,77 @@
-import { Select } from '@mantine/core';
+import { ActionIcon, Button, Group, Select, TextInput } from '@mantine/core';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
-import { DEFAULT_FEATURE_SETTINGS, type DashboardWidgetSettings } from '@veritas-kanban/shared';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  normalizeBoardColumns,
+  normalizeBoardDefaultStatus,
+  type BoardColumnConfig,
+  type DashboardWidgetSettings,
+} from '@veritas-kanban/shared';
 import { SettingRow, ToggleRow, SectionHeader, SaveIndicator } from '../shared';
+import { Plus, Trash2 } from 'lucide-react';
 
 export function BoardTab() {
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const boardSettings = settings.board ?? DEFAULT_FEATURE_SETTINGS.board;
+  const columns = normalizeBoardColumns(boardSettings.columns);
+  const defaultStatus = normalizeBoardDefaultStatus(boardSettings.defaultStatus, columns);
 
   const update = (key: string, value: any) => {
     debouncedUpdate({ board: { [key]: value } });
   };
+
+  const updateBoardColumns = (
+    nextColumns: BoardColumnConfig[],
+    nextDefaultStatus = defaultStatus
+  ) => {
+    const normalizedColumns = normalizeBoardColumns(nextColumns);
+    debouncedUpdate({
+      board: {
+        columns: normalizedColumns,
+        defaultStatus: normalizeBoardDefaultStatus(nextDefaultStatus, normalizedColumns),
+      },
+    });
+  };
+
+  const updateColumn = (index: number, patch: Partial<BoardColumnConfig>) => {
+    const previousId = columns[index]?.id;
+    const nextColumns = columns.map((column, columnIndex) =>
+      columnIndex === index ? { ...column, ...patch } : column
+    );
+    const nextDefaultStatus =
+      previousId && previousId === defaultStatus && patch.id ? patch.id : defaultStatus;
+    updateBoardColumns(nextColumns, nextDefaultStatus);
+  };
+
+  const addColumn = () => {
+    let suffix = columns.length + 1;
+    let id = `column-${suffix}`;
+    const used = new Set(columns.map((column) => column.id));
+    while (used.has(id)) {
+      suffix += 1;
+      id = `column-${suffix}`;
+    }
+    updateBoardColumns([...columns, { id, title: `Column ${suffix}` }]);
+  };
+
+  const removeColumn = (index: number) => {
+    if (columns.length <= 1) return;
+    const removedId = columns[index]?.id;
+    const nextColumns = columns.filter((_, columnIndex) => columnIndex !== index);
+    updateBoardColumns(
+      nextColumns,
+      removedId === defaultStatus ? nextColumns[0]?.id : defaultStatus
+    );
+  };
+
+  const normalizeIdInput = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/^-+/, '')
+      .replace(/-{2,}/g, '-')
+      .slice(0, 50);
 
   const resetBoard = () => {
     debouncedUpdate({ board: DEFAULT_FEATURE_SETTINGS.board });
@@ -25,10 +87,10 @@ export function BoardTab() {
         <ToggleRow
           label="Show Dashboard"
           description="Display the metrics dashboard section above the board"
-          checked={settings.board?.showDashboard ?? DEFAULT_FEATURE_SETTINGS.board.showDashboard}
+          checked={boardSettings.showDashboard ?? DEFAULT_FEATURE_SETTINGS.board.showDashboard}
           onCheckedChange={(v) => update('showDashboard', v)}
         />
-        {(settings.board?.showDashboard ?? DEFAULT_FEATURE_SETTINGS.board.showDashboard) && (
+        {(boardSettings.showDashboard ?? DEFAULT_FEATURE_SETTINGS.board.showDashboard) && (
           <>
             <div className="pl-6 border-l-2 border-muted ml-2 space-y-0 divide-y">
               {(
@@ -56,7 +118,7 @@ export function BoardTab() {
                   label={label}
                   description={desc}
                   checked={
-                    (settings.board.dashboardWidgets ??
+                    (boardSettings.dashboardWidgets ??
                       DEFAULT_FEATURE_SETTINGS.board.dashboardWidgets)?.[
                       key as keyof DashboardWidgetSettings
                     ] ?? true
@@ -65,7 +127,7 @@ export function BoardTab() {
                     debouncedUpdate({
                       board: {
                         dashboardWidgets: {
-                          ...(settings.board?.dashboardWidgets ??
+                          ...(boardSettings.dashboardWidgets ??
                             DEFAULT_FEATURE_SETTINGS.board.dashboardWidgets),
                           [key]: v,
                         },
@@ -81,14 +143,14 @@ export function BoardTab() {
           label="Archive Suggestions"
           description="Show banner when all sprint tasks are complete"
           checked={
-            settings.board?.showArchiveSuggestions ??
+            boardSettings.showArchiveSuggestions ??
             DEFAULT_FEATURE_SETTINGS.board.showArchiveSuggestions
           }
           onCheckedChange={(v) => update('showArchiveSuggestions', v)}
         />
         <SettingRow label="Card Density" description="Compact cards use less space">
           <Select
-            value={settings.board?.cardDensity ?? DEFAULT_FEATURE_SETTINGS.board.cardDensity}
+            value={boardSettings.cardDensity ?? DEFAULT_FEATURE_SETTINGS.board.cardDensity}
             onChange={(value) => value && update('cardDensity', value)}
             data={[
               { value: 'normal', label: 'Normal' },
@@ -100,11 +162,82 @@ export function BoardTab() {
             w={112}
           />
         </SettingRow>
+        <SettingRow
+          label="Default Status"
+          description="Status assigned when a task is created without an explicit status"
+        >
+          <Select
+            value={defaultStatus}
+            onChange={(value) => value && update('defaultStatus', value)}
+            data={columns.map((column) => ({ value: column.id, label: column.title }))}
+            aria-label="Default task status"
+            allowDeselect={false}
+            size="xs"
+            w={160}
+          />
+        </SettingRow>
+        <div className="py-3">
+          <Group justify="space-between" align="center" mb="xs">
+            <div>
+              <div className="text-sm font-medium">Board Columns</div>
+              <div className="text-xs text-muted-foreground">Visible task statuses and order</div>
+            </div>
+            <Button
+              type="button"
+              variant="light"
+              size="xs"
+              leftSection={<Plus className="h-3.5 w-3.5" aria-hidden="true" />}
+              onClick={addColumn}
+              disabled={columns.length >= 12}
+            >
+              Add
+            </Button>
+          </Group>
+          <div className="space-y-2">
+            {columns.map((column, index) => (
+              <div
+                key={`${column.id}-${index}`}
+                className="grid grid-cols-[minmax(120px,1fr)_minmax(120px,1fr)_32px] gap-2"
+              >
+                <TextInput
+                  aria-label={`Column ${index + 1} status ID`}
+                  value={column.id}
+                  onChange={(event) => {
+                    const id = normalizeIdInput(event.currentTarget.value);
+                    if (id) updateColumn(index, { id });
+                  }}
+                  size="xs"
+                  maxLength={50}
+                />
+                <TextInput
+                  aria-label={`Column ${index + 1} title`}
+                  value={column.title}
+                  onChange={(event) => {
+                    const title = event.currentTarget.value.slice(0, 50);
+                    if (title.trim()) updateColumn(index, { title });
+                  }}
+                  size="xs"
+                  maxLength={50}
+                />
+                <ActionIcon
+                  aria-label={`Remove ${column.title}`}
+                  variant="subtle"
+                  color="red"
+                  size="sm"
+                  onClick={() => removeColumn(index)}
+                  disabled={columns.length <= 1}
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
+                </ActionIcon>
+              </div>
+            ))}
+          </div>
+        </div>
         <ToggleRow
           label="Priority Indicators"
           description="Show priority badge on task cards"
           checked={
-            settings.board?.showPriorityIndicators ??
+            boardSettings.showPriorityIndicators ??
             DEFAULT_FEATURE_SETTINGS.board.showPriorityIndicators
           }
           onCheckedChange={(v) => update('showPriorityIndicators', v)}
@@ -113,7 +246,7 @@ export function BoardTab() {
           label="Project Badges"
           description="Show project badge on task cards"
           checked={
-            settings.board?.showProjectBadges ?? DEFAULT_FEATURE_SETTINGS.board.showProjectBadges
+            boardSettings.showProjectBadges ?? DEFAULT_FEATURE_SETTINGS.board.showProjectBadges
           }
           onCheckedChange={(v) => update('showProjectBadges', v)}
         />
@@ -121,7 +254,7 @@ export function BoardTab() {
           label="Sprint Badges"
           description="Show sprint badge on task cards"
           checked={
-            settings.board?.showSprintBadges ?? DEFAULT_FEATURE_SETTINGS.board.showSprintBadges
+            boardSettings.showSprintBadges ?? DEFAULT_FEATURE_SETTINGS.board.showSprintBadges
           }
           onCheckedChange={(v) => update('showSprintBadges', v)}
         />
@@ -129,16 +262,14 @@ export function BoardTab() {
           label="Drag & Drop"
           description="Allow dragging cards between columns"
           checked={
-            settings.board?.enableDragAndDrop ?? DEFAULT_FEATURE_SETTINGS.board.enableDragAndDrop
+            boardSettings.enableDragAndDrop ?? DEFAULT_FEATURE_SETTINGS.board.enableDragAndDrop
           }
           onCheckedChange={(v) => update('enableDragAndDrop', v)}
         />
         <ToggleRow
           label="Done Column Metrics"
           description="Show agent run count, success status, and duration on completed tasks"
-          checked={
-            settings.board?.showDoneMetrics ?? DEFAULT_FEATURE_SETTINGS.board.showDoneMetrics
-          }
+          checked={boardSettings.showDoneMetrics ?? DEFAULT_FEATURE_SETTINGS.board.showDoneMetrics}
           onCheckedChange={(v) => update('showDoneMetrics', v)}
         />
       </div>

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -48,7 +48,7 @@ import {
   isExternalTargetHref,
   normalizeSafeHref,
 } from '@veritas-kanban/shared';
-import type { Task, TaskAttempt, TaskReadinessCheck, TaskStatus } from '@veritas-kanban/shared';
+import type { Task, TaskAttempt, TaskReadinessCheck } from '@veritas-kanban/shared';
 import { useAgentStatus, useAgentStream, useStopAgent } from '@/hooks/useAgent';
 import { useIdentity } from '@/hooks/useIdentity';
 import { useTaskWorkProducts } from '@/hooks/useWorkProducts';
@@ -87,7 +87,7 @@ interface TaskWorkViewProps {
   onOpenWorkflow: () => void;
 }
 
-const STATUS_COLORS: Record<TaskStatus, string> = {
+const STATUS_COLORS: Record<string, string> = {
   blocked: 'red',
   cancelled: 'gray',
   done: 'green',
@@ -452,7 +452,7 @@ export function TaskWorkView({
                   <Route className="h-4 w-4" />
                 </ThemeIcon>
                 <Text fw={700}>Work View</Text>
-                <Badge color={STATUS_COLORS[task.status]} variant="light">
+                <Badge color={STATUS_COLORS[task.status] ?? 'gray'} variant="light">
                   {task.status}
                 </Badge>
                 <Badge color={readinessPercent === 100 ? 'green' : 'yellow'} variant="outline">

--- a/web/src/components/task/detail/TaskMetadataSection.tsx
+++ b/web/src/components/task/detail/TaskMetadataSection.tsx
@@ -4,7 +4,16 @@ import { useTaskTypes, getTypeIcon } from '@/hooks/useTaskTypes';
 import { useProjects } from '@/hooks/useProjects';
 import { useSprints } from '@/hooks/useSprints';
 import { useConfig } from '@/hooks/useConfig';
-import type { Task, TaskStatus, TaskPriority, AgentType } from '@veritas-kanban/shared';
+import { useFeatureSettings } from '@/hooks/useFeatureSettings';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  normalizeBoardColumns,
+  getBoardStatusLabel,
+  type Task,
+  type TaskStatus,
+  type TaskPriority,
+  type AgentType,
+} from '@veritas-kanban/shared';
 import type { ReactNode } from 'react';
 
 interface TaskMetadataSectionProps {
@@ -12,14 +21,6 @@ interface TaskMetadataSectionProps {
   onUpdate: <K extends keyof Task>(field: K, value: Task[K]) => void;
   readOnly?: boolean;
 }
-
-const statusLabels: Record<TaskStatus, string> = {
-  todo: 'To Do',
-  'in-progress': 'In Progress',
-  blocked: 'Blocked',
-  done: 'Done',
-  cancelled: 'Cancelled',
-};
 
 const priorityLabels: Record<TaskPriority, string> = {
   low: 'Low',
@@ -45,6 +46,11 @@ export function TaskMetadataSection({
   const { data: projects = [] } = useProjects();
   const { data: sprints = [] } = useSprints();
   const { data: config } = useConfig();
+  const { settings: featureSettings } = useFeatureSettings();
+  const columns = normalizeBoardColumns(
+    featureSettings.board?.columns ?? DEFAULT_FEATURE_SETTINGS.board.columns
+  );
+  const statusOptions = columns.map((column) => ({ value: column.id, label: column.title }));
   const enabledAgents = config?.agents.filter((a) => a.enabled) || [];
   const [showNewProject, setShowNewProject] = useState(false);
   const [newProjectName, setNewProjectName] = useState('');
@@ -62,12 +68,12 @@ export function TaskMetadataSection({
             Status
           </Text>
           {readOnly ? (
-            <ReadOnlyValue>{statusLabels[task.status]}</ReadOnlyValue>
+            <ReadOnlyValue>{getBoardStatusLabel(task.status, columns)}</ReadOnlyValue>
           ) : (
             <Select
               aria-label="Status"
               allowDeselect={false}
-              data={Object.entries(statusLabels).map(([value, label]) => ({ value, label }))}
+              data={statusOptions}
               value={task.status}
               onChange={(value) => {
                 if (value) onUpdate('status', value as TaskStatus);

--- a/web/src/hooks/useBoardDragDrop.ts
+++ b/web/src/hooks/useBoardDragDrop.ts
@@ -11,12 +11,12 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
-import type { Task, TaskStatus } from '@veritas-kanban/shared';
+import type { BoardColumnConfig, Task, TaskStatus } from '@veritas-kanban/shared';
 
 interface UseBoardDragDropOptions {
   tasks: Task[];
-  tasksByStatus: Record<TaskStatus, Task[]>;
-  columns: { id: TaskStatus; title: string }[];
+  tasksByStatus: Record<string, Task[]>;
+  columns: BoardColumnConfig[];
   onStatusChange: (taskId: string, status: TaskStatus) => void;
   onReorder: (taskIds: string[], onSuccess?: () => void) => void;
 }
@@ -25,7 +25,7 @@ interface UseBoardDragDropReturn {
   activeTask: Task | null;
   isDragActive: boolean;
   /** Use this for rendering columns — reflects real-time drag state */
-  liveTasksByStatus: Record<TaskStatus, Task[]>;
+  liveTasksByStatus: Record<string, Task[]>;
   sensors: ReturnType<typeof useSensors>;
   collisionDetection: CollisionDetection;
   handleDragStart: (event: DragStartEvent) => void;
@@ -43,7 +43,7 @@ export function useBoardDragDrop({
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   // Local copy of tasksByStatus that updates in real-time during drag.
   // null = not dragging, use server state; non-null = mid-drag, use local state
-  const [dragState, setDragState] = useState<Record<TaskStatus, Task[]> | null>(null);
+  const [dragState, setDragState] = useState<Record<string, Task[]> | null>(null);
   const activeIdRef = useRef<string | null>(null);
 
   const sensors = useSensors(
@@ -86,7 +86,7 @@ export function useBoardDragDrop({
 
   // Find which column a task belongs to in the given state
   const findColumn = useCallback(
-    (taskId: string, state: Record<TaskStatus, Task[]>): TaskStatus | null => {
+    (taskId: string, state: Record<string, Task[]>): TaskStatus | null => {
       for (const col of columns) {
         if (state[col.id]?.some((t: Task) => t.id === taskId)) {
           return col.id;
@@ -132,7 +132,7 @@ export function useBoardDragDrop({
         if (!overColumn) return prev;
 
         // Reorder within the same column when hovering over another task.
-        const sourceTasks = prev[activeColumn];
+        const sourceTasks = prev[activeColumn] ?? [];
         const activeIndex = sourceTasks.findIndex((t) => t.id === activeId);
         if (activeIndex === -1) return prev;
 
@@ -149,7 +149,7 @@ export function useBoardDragDrop({
         }
 
         // Move the task from source to destination.
-        const destTasks = prev[overColumn];
+        const destTasks = prev[overColumn] ?? [];
         const movedTask = sourceTasks[activeIndex];
         const newSource = [...sourceTasks];
         newSource.splice(activeIndex, 1);
@@ -201,8 +201,8 @@ export function useBoardDragDrop({
 
       if (originalColumn === finalColumn && !columnIds.includes(overId as TaskStatus)) {
         // Same column — check for reorder
-        const columnTasks = finalState[finalColumn];
-        const origColumnTasks = tasksByStatus[originalColumn];
+        const columnTasks = finalState[finalColumn] ?? [];
+        const origColumnTasks = tasksByStatus[originalColumn] ?? [];
         const oldIndex = origColumnTasks.findIndex((t: Task) => t.id === activeId);
         const newIndex = columnTasks.findIndex((t: Task) => t.id === activeId);
 
@@ -215,7 +215,7 @@ export function useBoardDragDrop({
         onStatusChange(activeId, finalColumn);
 
         // Send the new order for the destination column
-        const newOrder = finalState[finalColumn].map((t: Task) => t.id);
+        const newOrder = (finalState[finalColumn] ?? []).map((t: Task) => t.id);
         onReorder(newOrder);
       }
     },

--- a/web/src/hooks/useKeyboard.tsx
+++ b/web/src/hooks/useKeyboard.tsx
@@ -8,8 +8,14 @@ import {
   useRef,
   type ReactNode,
 } from 'react';
-import type { Task, TaskStatus } from '@veritas-kanban/shared';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  normalizeBoardColumns,
+  type Task,
+  type TaskStatus,
+} from '@veritas-kanban/shared';
 import { toast } from './useToast';
+import { useFeatureSettings } from './useFeatureSettings';
 
 interface KeyboardContextValue {
   // Dialog triggers
@@ -38,17 +44,20 @@ interface KeyboardContextValue {
 
 const KeyboardContext = createContext<KeyboardContextValue | null>(null);
 
-const STATUS_MAP: Record<string, TaskStatus> = {
-  '1': 'todo',
-  '2': 'in-progress',
-  '3': 'blocked',
-  '4': 'done',
-};
+function getColumnForShortcut(key: string, columns: Array<{ id: TaskStatus }>): TaskStatus | null {
+  const index = Number.parseInt(key, 10) - 1;
+  return Number.isInteger(index) && index >= 0 && index < columns.length ? columns[index].id : null;
+}
 
 export function KeyboardProvider({ children }: { children: ReactNode }) {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
+  const { settings } = useFeatureSettings();
+  const columns = useMemo(
+    () => normalizeBoardColumns(settings.board?.columns ?? DEFAULT_FEATURE_SETTINGS.board.columns),
+    [settings.board?.columns]
+  );
 
   // Use refs for callbacks to avoid re-render loops
   const openCreateDialogRef = useRef<(() => void) | null>(null);
@@ -90,14 +99,14 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
 
   // Get flat list of tasks sorted by column then position
   const getTaskList = useCallback(() => {
-    const statusOrder: TaskStatus[] = ['todo', 'in-progress', 'blocked', 'done'];
+    const statusOrder = columns.map((column) => column.id);
     return [...tasks].sort((a, b) => {
       const aIndex = statusOrder.indexOf(a.status);
       const bIndex = statusOrder.indexOf(b.status);
       if (aIndex !== bIndex) return aIndex - bIndex;
       return a.title.localeCompare(b.title);
     });
-  }, [tasks]);
+  }, [columns, tasks]);
 
   // Keyboard event handler
   useEffect(() => {
@@ -183,9 +192,21 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
         case '2':
         case '3':
         case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9': {
           e.preventDefault();
+          const newStatus = getColumnForShortcut(e.key, columns);
+          if (!newStatus) {
+            toast({
+              title: 'No column for shortcut',
+              description: `Column ${e.key} is not configured on this board`,
+            });
+            return;
+          }
           if (selectedTaskId && onMoveTaskRef.current) {
-            const newStatus = STATUS_MAP[e.key];
             onMoveTaskRef.current(selectedTaskId, newStatus);
           } else {
             // Show toast when no task is selected
@@ -195,12 +216,13 @@ export function KeyboardProvider({ children }: { children: ReactNode }) {
             });
           }
           break;
+        }
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [getTaskList, selectedTaskId, isHelpOpen, openCreateDialog, openChatPanel]);
+  }, [getTaskList, selectedTaskId, isHelpOpen, openCreateDialog, openChatPanel, columns]);
 
   const value = useMemo<KeyboardContextValue>(
     () => ({

--- a/web/src/hooks/useTaskCounts.ts
+++ b/web/src/hooks/useTaskCounts.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api/helpers';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 
-export interface TaskCounts {
+export interface TaskCounts extends Record<string, number> {
   backlog: number;
   todo: number;
   'in-progress': number;

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -2,7 +2,16 @@ import { useQuery, useMutation, useQueryClient, QueryClient } from '@tanstack/re
 import { api } from '@/lib/api';
 import { useWebSocketStatus } from '@/contexts/WebSocketContext';
 import { toast } from '@/hooks/useToast';
-import type { Task, CreateTaskInput, UpdateTaskInput } from '@veritas-kanban/shared';
+import { useFeatureSettings } from '@/hooks/useFeatureSettings';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  normalizeBoardColumns,
+  normalizeBoardDefaultStatus,
+  type BoardColumnConfig,
+  type Task,
+  type CreateTaskInput,
+  type UpdateTaskInput,
+} from '@veritas-kanban/shared';
 
 /**
  * Patch a single task in both the list cache (['tasks']) and the individual
@@ -120,6 +129,11 @@ export function useTask(id: string) {
 
 export function useCreateTask() {
   const queryClient = useQueryClient();
+  const { settings } = useFeatureSettings();
+  const boardColumns = normalizeBoardColumns(
+    settings.board?.columns ?? DEFAULT_FEATURE_SETTINGS.board.columns
+  );
+  const defaultStatus = normalizeBoardDefaultStatus(settings.board?.defaultStatus, boardColumns);
 
   return useMutation({
     mutationFn: (input: CreateTaskInput) => api.tasks.create(input),
@@ -137,7 +151,7 @@ export function useCreateTask() {
         title: input.title,
         description: input.description || '',
         type: (input.type || 'code') as Task['type'],
-        status: 'todo',
+        status: input.status ?? defaultStatus,
         priority: input.priority || 'medium',
         project: input.project,
         sprint: input.sprint,
@@ -339,13 +353,8 @@ export function useBulkUpdate() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      ids,
-      status,
-    }: {
-      ids: string[];
-      status: 'todo' | 'in-progress' | 'blocked' | 'done';
-    }) => api.tasks.bulkUpdate(ids, status),
+    mutationFn: ({ ids, status }: { ids: string[]; status: Task['status'] }) =>
+      api.tasks.bulkUpdate(ids, status),
     onMutate: async ({ ids, status }) => {
       // Cancel outgoing refetches
       await queryClient.cancelQueries({ queryKey: ['tasks'] });
@@ -650,24 +659,30 @@ function sortByPosition(tasks: Task[]): Task[] {
   });
 }
 
-export function useTasksByStatus(tasks: Task[] | undefined) {
-  if (!tasks) {
-    return {
-      todo: [],
-      'in-progress': [],
-      blocked: [],
-      done: [],
-      cancelled: [],
-    };
+export function useTasksByStatus(
+  tasks: Task[] | undefined,
+  columns?: BoardColumnConfig[]
+): Record<string, Task[]> {
+  const statuses = normalizeBoardColumns(columns ?? DEFAULT_FEATURE_SETTINGS.board.columns).map(
+    (column) => column.id
+  );
+  const grouped = Object.fromEntries(statuses.map((status) => [status, [] as Task[]])) as Record<
+    string,
+    Task[]
+  >;
+
+  for (const task of tasks ?? []) {
+    if (!grouped[task.status]) {
+      grouped[task.status] = [];
+    }
+    grouped[task.status].push(task);
   }
 
-  return {
-    todo: sortByPosition(tasks.filter((t) => t.status === 'todo')),
-    'in-progress': sortByPosition(tasks.filter((t) => t.status === 'in-progress')),
-    blocked: sortByPosition(tasks.filter((t) => t.status === 'blocked')),
-    done: sortByPosition(tasks.filter((t) => t.status === 'done')),
-    cancelled: sortByPosition(tasks.filter((t) => t.status === 'cancelled')),
-  };
+  for (const status of Object.keys(grouped)) {
+    grouped[status] = sortByPosition(grouped[status]);
+  }
+
+  return grouped;
 }
 
 // Check if a task is blocked by incomplete dependencies

--- a/web/src/lib/api/tasks.ts
+++ b/web/src/lib/api/tasks.ts
@@ -345,7 +345,7 @@ export const tasksApi = {
 
   bulkUpdate: async (
     ids: string[],
-    status: 'todo' | 'in-progress' | 'blocked' | 'done'
+    status: Task['status']
   ): Promise<{ updated: string[]; count: number; failed: string[] }> => {
     const response = await fetch(`${API_BASE}/tasks/bulk-update`, {
       credentials: 'include',


### PR DESCRIPTION
## Summary
- Add shared board column/default-status config, normalization, and server-side schema validation.
- Validate task create/update/bulk statuses against configured active board columns while preserving the four default columns.
- Update board UI, bulk actions, keyboard shortcuts, task detail/status labels, metrics, CLI, MCP, and docs to use dynamic statuses.

## Verification
- pnpm typecheck
- pnpm lint:budget
- pnpm build
- pnpm --filter @veritas-kanban/server test
- pnpm --filter @veritas-kanban/web test
- pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/task-service.test.ts src/__tests__/schemas.test.ts src/__tests__/summary-service.test.ts src/__tests__/routes/task-comments.test.ts src/__tests__/routes/config-coverage.test.ts
- pnpm --dir web exec vitest run src/__tests__/KanbanBoard.test.tsx src/__tests__/useKeyboard.test.tsx src/__tests__/settings-tabs-mantine-controls.test.tsx src/__tests__/board-chrome-mantine.test.tsx --testTimeout 15000
- node scripts/check-permission-coverage.mjs
- git diff --check

Closes #640