### PR TITLE
Enforce v5 password-session boundary

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -61,12 +61,12 @@ VK supports three authentication methods. All are optional when running locally 
 
 ### Methods
 
-| Method                 | Header / Param                    | Use Case                          |
-| ---------------------- | --------------------------------- | --------------------------------- |
-| **Bearer Token** (JWT) | `Authorization: Bearer <token>`   | Browser sessions, UI login        |
-| **API Key**            | `X-API-Key: <key>`                | Agent integrations, scripts       |
-| **Device Session**     | `Authorization: Bearer vk_dev_…`  | Paired desktop/mobile/PWA clients |
-| **WS Query Param**     | `ws://host:port/ws?api_key=<key>` | WebSocket connections             |
+| Method             | Header / Param                    | Use Case                          |
+| ------------------ | --------------------------------- | --------------------------------- |
+| **Session Cookie** | `veritas_session` cookie          | Local-owner browser UI login      |
+| **API Key**        | `X-API-Key: <key>`                | Agent integrations, scripts       |
+| **Device Session** | `Authorization: Bearer vk_dev_…`  | Paired desktop/mobile/PWA clients |
+| **WS Query Param** | `ws://host:port/ws?api_key=<key>` | WebSocket connections             |
 
 ### Roles
 
@@ -86,6 +86,11 @@ a current workspace role downgrade trimmed the approved scopes. Existing
 endpoints still accept the compatibility roles above, but new v5 route work
 should declare the specific permission it requires, such as `task:read`,
 `task:write`, `workflow:execute`, or `admin:manage`.
+
+Password sessions are intentionally local-owner only for v5 GA. Remote,
+server-mode, PWA, CLI, MCP, and multi-user clients must use device sessions or
+scoped API tokens; those credentials are revalidated against workspace
+membership and revocation state.
 
 ### Localhost Bypass
 

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -84,6 +84,12 @@ Then verify a WebSocket upgrade to `wss://kanban.example.com/ws` from the same
 origin. Keep `VERITAS_AUTH_ENABLED=true` and
 `VERITAS_AUTH_LOCALHOST_BYPASS=false` for remote/server mode.
 
+Do not use browser password sessions as the remote access boundary. In v5 GA the
+password session cookie is accepted only for local-owner loopback clients.
+Remote browsers, mobile/PWA clients, CLI/MCP clients, and multi-user workflows
+must use trusted device sessions or scoped API tokens so workspace membership,
+role, revocation, and downgraded scopes are revalidated.
+
 Use safe LAN, VPN, Tailscale, or reverse-proxy examples from
 `docs/guides/SELF_HOST.md`. Split-origin deployments require exact CORS,
 WebSocket, service-worker, cookie, and token handling as described in ADR 0002.

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,18 +99,24 @@ elevation require `admin:manage`.
 Authenticated REST requests and WebSocket connections now carry a shared auth
 context for the v5 RBAC migration:
 
-| Field         | Description                                               |
-| ------------- | --------------------------------------------------------- |
-| `role`        | Current compatibility role: `admin`, `agent`, `read-only` |
-| `userId`      | Local fallback user ID until persisted users are enforced |
-| `workspaceId` | Local fallback workspace ID until workspace scoping lands |
-| `actorType`   | `user`, `agent`, `service`, or `localhost-bypass`         |
-| `authMethod`  | `disabled`, `session`, `api-key`, or `localhost-bypass`   |
-| `tokenName`   | API key name when authenticated with a configured key     |
-| `permissions` | Role-derived permission list used by new route guards     |
+| Field         | Description                                                               |
+| ------------- | ------------------------------------------------------------------------- |
+| `role`        | Current compatibility role: `admin`, `agent`, `read-only`                 |
+| `userId`      | Local fallback user ID until persisted users are enforced                 |
+| `workspaceId` | Local fallback workspace ID until workspace scoping lands                 |
+| `actorType`   | `user`, `agent`, `service`, or `localhost-bypass`                         |
+| `authMethod`  | `disabled`, `session`, `api-key`, `device-session`, or `localhost-bypass` |
+| `tokenName`   | API key name when authenticated with a configured key                     |
+| `permissions` | Role-derived permission list used by new route guards                     |
 
 New v5 endpoints should prefer explicit permission guards over broad role
 checks. Legacy role guards remain supported while route coverage is migrated.
+
+Browser password sessions are local-owner only in v5 GA. The server accepts the
+session cookie only on loopback requests with loopback `Host`/`Origin`/`Referer`
+metadata. Remote, server, PWA, and multi-user clients must authenticate with a
+trusted device session or scoped API token so active workspace membership, role,
+revocation, and downgraded scopes are revalidated.
 
 The v5 authority surface is tracked in
 [`docs/security/permission-coverage.json`](security/permission-coverage.json).
@@ -122,7 +128,7 @@ classification.
 The v5.0 hardening review is recorded in
 [`docs/security/v5-security-review.md`](security/v5-security-review.md),
 including fixed high/critical findings, accepted hardening risks, and the
-remaining browser-session GA blocker.
+password-session local-owner boundary.
 
 Release compatibility, stale-client behavior, update channels, and rollback
 limits are tracked in

--- a/docs/security/v5-security-review.md
+++ b/docs/security/v5-security-review.md
@@ -16,14 +16,18 @@ The review fixed five high or critical implementation issues in the #350 impleme
 | Revoked API tokens and device sessions stopped new authentication but did not close already-open WebSocket connections.                                                                         | High     | Fixed. WebSocket auth now retains token/session identifiers and identity revocation routes close matching live sockets.                                            |
 | Preview start/stop routes used read permissions while starting local child processes for repo preview servers.                                                                                  | High     | Fixed. Preview status/output remain readable with `task:read`, but start/stop now require `admin:manage`; preview process output is redacted before retention.     |
 
-## GA Blocker
+## GA Blocker Resolution
 
 Browser password sessions still use the compatibility local-owner model. The JWT proves only that a password login happened; it does not carry a persisted user subject, session id, workspace membership, disabled-user state, or membership downgrade check. `authMethod: "session"` maps to the local admin authority.
 
-This blocks multi-user/server-mode GA unless one of these is true before release:
+The v5 GA release resolves this by taking the smaller safe boundary: password
+sessions are explicitly local-owner only. The server accepts a password-session
+cookie only on loopback requests with loopback `Host`, `Origin`, `Referer`, and
+forwarded-host metadata. Remote/server, PWA, CLI/MCP, and multi-user workflows
+must use trusted device sessions or scoped API tokens instead.
 
-- Browser sessions are migrated to persisted per-user sessions that revalidate active membership and role on every request and WebSocket connect.
-- The GA release explicitly limits password-session mode to single-owner local deployments, with remote/multi-user access requiring device sessions or scoped API tokens.
+Persisted per-user browser sessions remain the future path if password login is
+ever promoted to a remote or multi-user auth method.
 
 ## Accepted Hardening Risks For This Review
 

--- a/server/src/__tests__/middleware/auth.test.ts
+++ b/server/src/__tests__/middleware/auth.test.ts
@@ -57,7 +57,7 @@ import type { IdentityActor } from '../../services/identity-service.js';
 // Helper to create a mock Express request
 function mockRequest(overrides: Partial<Request> = {}): Request {
   const req = {
-    headers: {},
+    headers: { host: 'localhost:3001' },
     cookies: {},
     query: {},
     socket: { remoteAddress: '127.0.0.1' },
@@ -448,7 +448,7 @@ describe('Auth Middleware', () => {
       vi.mocked(getSecurityConfig).mockReturnValue({
         authEnabled: true,
         passwordHash: 'hashed-password',
-      } as any);
+      });
       vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
 
       const req = mockRequest({
@@ -464,6 +464,93 @@ describe('Auth Middleware', () => {
       expect(req.auth?.actorType).toBe('user');
       expect(req.auth?.authMethod).toBe('session');
       expect(req.auth?.workspaceId).toBe('local');
+    });
+
+    it('should reject JWT cookie from remote hosts because password sessions are local-owner only', () => {
+      const secret = 'test-secret-key';
+      const token = jwt.sign({ type: 'session' }, secret, { expiresIn: '1h' });
+
+      vi.mocked(getSecurityConfig).mockReturnValue({
+        authEnabled: true,
+        passwordHash: 'hashed-password',
+      });
+      vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
+
+      const req = mockRequest({
+        cookies: { veritas_session: token },
+        headers: {
+          host: 'kanban.example.com',
+          origin: 'https://kanban.example.com',
+        },
+        socket: { remoteAddress: '203.0.113.10' } as Request['socket'],
+        ip: '203.0.113.10',
+      }) as AuthenticatedRequest;
+      const res = mockResponse();
+      const next = mockNext();
+
+      authenticate(req, res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'PASSWORD_SESSION_LOCAL_ONLY' })
+      );
+    });
+
+    it('should reject JWT cookie through a non-loopback forwarded host', () => {
+      const secret = 'test-secret-key';
+      const token = jwt.sign({ type: 'session' }, secret, { expiresIn: '1h' });
+
+      vi.mocked(getSecurityConfig).mockReturnValue({
+        authEnabled: true,
+        passwordHash: 'hashed-password',
+      });
+      vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
+
+      const req = mockRequest({
+        cookies: { veritas_session: token },
+        headers: {
+          host: 'localhost:3001',
+          'x-forwarded-host': 'kanban.example.com',
+        },
+      }) as AuthenticatedRequest;
+      const res = mockResponse();
+      const next = mockNext();
+
+      authenticate(req, res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'PASSWORD_SESSION_LOCAL_ONLY' })
+      );
+    });
+
+    it('should still allow API key auth when a remote password-session cookie is present', () => {
+      const secret = 'test-secret-key';
+      const token = jwt.sign({ type: 'session' }, secret, { expiresIn: '1h' });
+
+      vi.mocked(getSecurityConfig).mockReturnValue({
+        authEnabled: true,
+        passwordHash: 'hashed-password',
+      });
+      vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
+
+      process.env.VERITAS_ADMIN_KEY = 'fallback-key';
+      const req = mockRequest({
+        cookies: { veritas_session: token },
+        headers: {
+          host: 'kanban.example.com',
+          origin: 'https://kanban.example.com',
+          'x-api-key': 'fallback-key',
+        },
+        socket: { remoteAddress: '203.0.113.10' } as Request['socket'],
+        ip: '203.0.113.10',
+      }) as AuthenticatedRequest;
+      const res = mockResponse();
+      const next = mockNext();
+
+      authenticate(req, res, next);
+      expect(next).toHaveBeenCalled();
+      expect(req.auth?.authMethod).toBe('api-key');
     });
 
     it('should reject JWT cookie when session version is stale', () => {
@@ -970,7 +1057,7 @@ describe('Auth Middleware', () => {
       vi.mocked(getSecurityConfig).mockReturnValue({
         authEnabled: true,
         passwordHash: 'hashed',
-      } as any);
+      });
       vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
 
       const req = {
@@ -979,7 +1066,7 @@ describe('Auth Middleware', () => {
           host: 'localhost:3001',
         },
         url: '/ws',
-        socket: { remoteAddress: '192.168.1.100' },
+        socket: { remoteAddress: '127.0.0.1' },
       } as unknown as IncomingMessage;
 
       const result = authenticateWebSocket(req);
@@ -987,6 +1074,57 @@ describe('Auth Middleware', () => {
       expect(result.role).toBe('admin');
       expect(result.authMethod).toBe('session');
       expect(result.actorType).toBe('user');
+    });
+
+    it('should reject WebSocket JWT cookie from remote hosts', () => {
+      const secret = 'test-secret-key';
+      const token = jwt.sign({ type: 'session' }, secret, { expiresIn: '1h' });
+
+      vi.mocked(getSecurityConfig).mockReturnValue({
+        authEnabled: true,
+        passwordHash: 'hashed',
+      });
+      vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
+
+      const req = {
+        headers: {
+          cookie: `veritas_session=${token}; other=val`,
+          host: 'kanban.example.com',
+          origin: 'https://kanban.example.com',
+        },
+        url: '/ws',
+        socket: { remoteAddress: '203.0.113.10' },
+      } as unknown as IncomingMessage;
+
+      const result = authenticateWebSocket(req);
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toContain('Password sessions are limited to local-owner');
+    });
+
+    it('should allow WebSocket API key fallback when a remote password-session cookie is present', () => {
+      const secret = 'test-secret-key';
+      const token = jwt.sign({ type: 'session' }, secret, { expiresIn: '1h' });
+
+      vi.mocked(getSecurityConfig).mockReturnValue({
+        authEnabled: true,
+        passwordHash: 'hashed',
+      });
+      vi.mocked(getValidJwtSecrets).mockReturnValue([secret]);
+
+      process.env.VERITAS_ADMIN_KEY = 'ws-fallback-key';
+      const req = {
+        headers: {
+          cookie: `veritas_session=${token}; other=val`,
+          host: 'kanban.example.com',
+          'x-api-key': 'ws-fallback-key',
+        },
+        url: '/ws',
+        socket: { remoteAddress: '203.0.113.10' },
+      } as unknown as IncomingMessage;
+
+      const result = authenticateWebSocket(req);
+      expect(result.authenticated).toBe(true);
+      expect(result.authMethod).toBe('api-key');
     });
 
     it('should reject WebSocket JWT cookie when session version is stale', () => {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -294,6 +294,63 @@ function isLocalhostRequest(req: Request | IncomingMessage): boolean {
   );
 }
 
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1' ||
+    normalized === '[::1]'
+  );
+}
+
+function isLoopbackHost(value: string | undefined): boolean {
+  if (!value) return false;
+
+  try {
+    const url = new URL(value.includes('://') ? value : `http://${value}`);
+    return isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function isLoopbackForwardedFor(value: string | undefined): boolean {
+  if (!value) return true;
+  const first = value.split(',')[0]?.trim();
+  if (!first) return false;
+  const normalized = first.replace(/^\[|\]$/g, '');
+  return isLoopbackHostname(normalized);
+}
+
+function isLocalOwnerPasswordSessionRequest(
+  req: Request | IncomingMessage,
+  isLocalhost: boolean
+): boolean {
+  if (!isLocalhost) return false;
+
+  const host = firstHeaderValue(req.headers.host);
+  if (!isLoopbackHost(host)) return false;
+
+  const origin = firstHeaderValue(req.headers.origin);
+  if (origin && !isLoopbackHost(origin)) return false;
+
+  const referer = firstHeaderValue(req.headers.referer);
+  if (referer && !isLoopbackHost(referer)) return false;
+
+  const forwardedHost = firstHeaderValue(req.headers['x-forwarded-host']);
+  if (forwardedHost && !isLoopbackHost(forwardedHost)) return false;
+
+  const forwardedFor = firstHeaderValue(req.headers['x-forwarded-for']);
+  if (!isLoopbackForwardedFor(forwardedFor)) return false;
+
+  return true;
+}
+
 function extractApiKey(
   req: Request | IncomingMessage,
   options: { allowQueryParam?: boolean } = {}
@@ -443,6 +500,7 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
   const config = getAuthConfig();
   const securityConfig = getSecurityConfig();
   const isLocalhost = isLocalhostRequest(req);
+  let blockedPasswordSession = false;
 
   // If password auth not set up yet, check API key auth
   const passwordAuthEnabled = securityConfig.authEnabled && securityConfig.passwordHash;
@@ -457,13 +515,17 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
   if (passwordAuthEnabled) {
     const jwtResult = verifyJwtCookie(req);
     if (jwtResult.valid) {
-      req.auth = buildAuthContext({
-        role: 'admin',
-        keyName: 'session',
-        isLocalhost,
-        authMethod: 'session',
-      });
-      return next();
+      if (!isLocalOwnerPasswordSessionRequest(req, isLocalhost)) {
+        blockedPasswordSession = true;
+      } else {
+        req.auth = buildAuthContext({
+          role: 'admin',
+          keyName: 'session',
+          isLocalhost,
+          authMethod: 'session',
+        });
+        return next();
+      }
     }
   }
 
@@ -503,6 +565,15 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
       authMethod: 'localhost-bypass',
     });
     return next();
+  }
+
+  if (blockedPasswordSession) {
+    res.status(403).json({
+      code: 'PASSWORD_SESSION_LOCAL_ONLY',
+      message:
+        'Password sessions are limited to local-owner loopback clients. Use a device session or scoped API token for remote or multi-user access.',
+    });
+    return;
   }
 
   // No valid auth found
@@ -721,6 +792,7 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
   const config = getAuthConfig();
   const securityConfig = getSecurityConfig();
   const isLocalhost = isLocalhostRequest(req);
+  let blockedPasswordSession = false;
 
   const passwordAuthEnabled = securityConfig.authEnabled && securityConfig.passwordHash;
 
@@ -738,15 +810,19 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
     if (token) {
       const result = verifySessionJwtToken(token);
       if (result.valid) {
-        return {
-          authenticated: true,
-          ...buildAuthContext({
-            role: 'admin',
-            keyName: 'session',
-            isLocalhost,
-            authMethod: 'session',
-          }),
-        };
+        if (!isLocalOwnerPasswordSessionRequest(req, isLocalhost)) {
+          blockedPasswordSession = true;
+        } else {
+          return {
+            authenticated: true,
+            ...buildAuthContext({
+              role: 'admin',
+              keyName: 'session',
+              isLocalhost,
+              authMethod: 'session',
+            }),
+          };
+        }
       }
       // Token invalid or expired, continue to other auth methods
     }
@@ -783,6 +859,15 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
         ...deviceAuth,
       };
     }
+  }
+
+  if (blockedPasswordSession) {
+    return {
+      authenticated: false,
+      isLocalhost,
+      error:
+        'Password sessions are limited to local-owner loopback clients. Use a device session or scoped API token for remote or multi-user access.',
+    };
   }
 
   // 3. Localhost bypass — role is configurable (default: read-only)


### PR DESCRIPTION
## Summary
- Limit password-session cookies to local-owner loopback REST and WebSocket clients.
- Allow scoped API key/device-session auth to proceed when a remote password cookie is present.
- Update v5 security/API/admin docs so remote and multi-user clients use device sessions or scoped API tokens.

Closes #642

## Verification
- pnpm --filter @veritas-kanban/server test -- auth.test.ts ws-origin-validation.test.ts
- pnpm --filter @veritas-kanban/server exec tsc --noEmit --pretty false
- node scripts/check-permission-coverage.mjs
- pnpm exec prettier --check server/src/middleware/auth.ts server/src/__tests__/middleware/auth.test.ts docs/security.md docs/API-REFERENCE.md docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md docs/security/v5-security-review.md
- pnpm lint:budget
- pnpm build

## Risk
- Remote/browser password-cookie access is intentionally blocked for v5 GA. Remote clients must pair a device session or use scoped API tokens.