### PR TITLE
Prove debug bundle redaction coverage

### DIFF
--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -17,7 +17,9 @@ operator checklist for final release verification.
       contract in [v5.0 data lifecycle controls](DATA-LIFECYCLE.md).
 - [ ] Maintenance Center verifies health, storage usage, redacted log tails,
       debug bundles, backup/import reporting, and cleanup previews. Track the
-      contract in [v5.0 Maintenance Center](MAINTENANCE-CENTER.md).
+      contract in [v5.0 Maintenance Center](MAINTENANCE-CENTER.md). Seeded
+      debug-bundle redaction evidence is covered by
+      `server/src/__tests__/maintenance-service.test.ts`.
 - [ ] Multi-user mode verifies workspace switching, memberships, invitations,
       scoped API tokens, actor attribution, and RBAC denial paths.
 - [ ] Remote mode verifies the

--- a/server/src/__tests__/maintenance-service.test.ts
+++ b/server/src/__tests__/maintenance-service.test.ts
@@ -5,6 +5,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { MaintenanceService } from '../services/maintenance-service.js';
 import { resetWorkProductServiceForTests } from '../services/work-product-service.js';
 
+const seededSensitiveValues = [
+  'vk_seededNegativeFixture1234567890',
+  'seededBearerToken1234567890',
+  '/Users/brad/private/customer-board/roadmap.md',
+  String.raw`C:\Users\Brad\private\board\notes.md`,
+  'Write a launch prompt with private roadmap details.',
+  'Customer says launch price is confidential.',
+  'stdout leaked generated summary for private customer.',
+  'stderr failed with customer secret output.',
+  'model returned private generated content.',
+];
+
 describe('MaintenanceService', () => {
   let root: string;
   let originalDataDir: string | undefined;
@@ -20,7 +32,16 @@ describe('MaintenanceService', () => {
       [
         'startup ok',
         'Bearer abcdefghijklmnop token=sk_supersecret1234567890',
+        `api_key=${seededSensitiveValues[0]}`,
+        `Authorization: Bearer ${seededSensitiveValues[1]}`,
         '/Users/brad/private/project/file.txt',
+        seededSensitiveValues[2],
+        seededSensitiveValues[3],
+        `prompt: "${seededSensitiveValues[4]}"`,
+        `chat message: "${seededSensitiveValues[5]}"`,
+        `stdout: "${seededSensitiveValues[6]}"`,
+        `stderr: "${seededSensitiveValues[7]}"`,
+        `model output: "${seededSensitiveValues[8]}"`,
       ].join('\n'),
       'utf-8'
     );
@@ -92,6 +113,7 @@ describe('MaintenanceService', () => {
       'utf-8'
     );
     const summary = await fs.readFile(path.join(bundle.outputPath, 'summary.json'), 'utf-8');
+    const bundleText = await readDirectoryText(bundle.outputPath);
 
     expect(bundle.redacted).toBe(true);
     expect(manifest.includedCategories).toEqual(
@@ -100,5 +122,28 @@ describe('MaintenanceService', () => {
     expect(manifest.files.find((file) => file.id === 'server')?.path).toContain('[redacted-logs]');
     expect(serverLog).not.toContain('sk_supersecret1234567890');
     expect(summary).not.toContain(root);
+    expect(bundleText).toContain('[REDACTED_API_KEY]');
+    expect(bundleText).toContain('Bearer [REDACTED]');
+    expect(bundleText).toContain('[redacted-local-path]');
+    expect(bundleText).toContain('[redacted-prompt]');
+    expect(bundleText).toContain('[redacted-chat-content]');
+    expect(bundleText).toContain('[redacted-process-output]');
+    expect(bundleText).toContain('[redacted-generated-text]');
+    for (const sensitiveValue of seededSensitiveValues) {
+      expect(bundleText).not.toContain(sensitiveValue);
+    }
   });
 });
+
+async function readDirectoryText(dirPath: string): Promise<string> {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const chunks = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) return readDirectoryText(entryPath);
+      if (!entry.isFile()) return '';
+      return fs.readFile(entryPath, 'utf-8');
+    })
+  );
+  return chunks.join('\n');
+}

--- a/server/src/services/maintenance-service.ts
+++ b/server/src/services/maintenance-service.ts
@@ -40,6 +40,25 @@ interface LogSourceDefinition {
 
 const MAX_TAIL_LINES = 500;
 
+const MAINTENANCE_CONTENT_REDACTIONS: [RegExp, string][] = [
+  [
+    /\b((?:system|user|assistant)\s+prompt|prompt)\s*[:=]\s*("[^"]*"|'[^']*'|[^\r\n]+)/gi,
+    '$1: [redacted-prompt]',
+  ],
+  [
+    /\b(raw\s+chat|chat\s+message|user\s+message|assistant\s+message)\s*[:=]\s*("[^"]*"|'[^']*'|[^\r\n]+)/gi,
+    '$1: [redacted-chat-content]',
+  ],
+  [
+    /\b(stdout|stderr|process\s+output|child\s+output)\s*[:=]\s*("[^"]*"|'[^']*'|[^\r\n]+)/gi,
+    '$1: [redacted-process-output]',
+  ],
+  [
+    /\b(model\s+output|assistant\s+output|generated(?:\s+sensitive)?\s+text)\s*[:=]\s*("[^"]*"|'[^']*'|[^\r\n]+)/gi,
+    '$1: [redacted-generated-text]',
+  ],
+];
+
 export class MaintenanceService {
   async buildSummary(): Promise<MaintenanceSummary> {
     const generatedAt = new Date().toISOString();
@@ -557,6 +576,9 @@ export class MaintenanceService {
 
   private redactMaintenanceText(value: string): string {
     let redacted = redactString(value);
+    for (const [pattern, replacement] of MAINTENANCE_CONTENT_REDACTIONS) {
+      redacted = redacted.replace(pattern, replacement);
+    }
     const replacements = [
       [getLogsDir(), '[redacted-logs]'],
       [getRuntimeDir(), '[redacted-runtime]'],


### PR DESCRIPTION
## Summary
- Redact labeled prompt, chat, process-output, and generated-output fields in maintenance text before debug-bundle export.
- Expand the real createDebugBundle() test with seeded API keys, bearer tokens, private macOS/Windows paths, prompt/chat text, and process output.
- Link the seeded bundle evidence from the v5 GA checklist.

Closes #647

## Verification
- pnpm --filter @veritas-kanban/server test -- maintenance-service.test.ts
- pnpm --filter @veritas-kanban/server exec tsc --noEmit --pretty false
- pnpm exec prettier --check server/src/services/maintenance-service.ts server/src/__tests__/maintenance-service.test.ts docs/V5-GA-CHECKLIST.md
- pnpm lint:budget
- pnpm build
