### PR TITLE
Add v5 RC evidence packet template

### DIFF
--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -4,6 +4,11 @@ This checklist tracks the release evidence that must be true before v5.0 GA.
 The GitHub epic remains the source of scheduling truth; this document is the
 operator checklist for final release verification.
 
+Use [v5 Release Candidate Evidence Packet](V5-RC-EVIDENCE-PACKET.md) as the
+single evidence target for each release candidate. The packet is the place to
+link command output, workflow runs, signed artifact URLs, checksums,
+notarization proof, load results, mobile/PWA smoke proof, and accepted limits.
+
 ## Required Release Gates
 
 - [ ] Fresh install verifies the desktop app can start the bundled server, load
@@ -126,10 +131,12 @@ pnpm validate:release -- --github --repo BradGroux/veritas-kanban
 Signed stable publishing requires the `Desktop Release` workflow with the Apple
 signing/notarization secrets from [Desktop Release](DESKTOP-RELEASE.md). Record
 the workflow run URL, artifact URLs, and updater metadata URLs in the release
-notes before marking GA complete.
+notes and the [v5 Release Candidate Evidence Packet](V5-RC-EVIDENCE-PACKET.md)
+before marking GA complete.
 
 ## Final Sign-Off Notes
 
 Each GA release candidate should link the PRs or workflow runs that satisfy the
-gates above. If a gate is intentionally deferred, link the follow-up issue and
-state the user-visible risk in release notes.
+gates above from [v5 Release Candidate Evidence Packet](V5-RC-EVIDENCE-PACKET.md).
+If a gate is intentionally deferred, link the follow-up issue and state the
+user-visible risk in release notes.

--- a/docs/V5-RC-EVIDENCE-PACKET.md
+++ b/docs/V5-RC-EVIDENCE-PACKET.md
@@ -1,0 +1,187 @@
+# v5 Release Candidate Evidence Packet
+
+Use this packet for each v5 release candidate before marking GA complete. Keep
+links to GitHub workflow runs, release assets, screenshots, logs, and command
+output artifacts here or in the linked GitHub issue. Do not paste secrets,
+tokens, private keys, raw chat/task content, or unredacted local private paths.
+The filled packet is the evidence target for #644.
+
+## Candidate Identity
+
+| Field                 | Value |
+| --------------------- | ----- |
+| RC label              |       |
+| Release version       |       |
+| Git tag               |       |
+| Commit SHA            |       |
+| GitHub release URL    |       |
+| Desktop Release run   |       |
+| Desktop Artifacts run |       |
+| CI run                |       |
+| Evidence owner        |       |
+| Review date           |       |
+
+Version checks:
+
+- [ ] `package.json` version:
+- [ ] `shared/package.json` version:
+- [ ] `server/package.json` version:
+- [ ] `web/package.json` version:
+- [ ] `cli/package.json` version:
+- [ ] `mcp/package.json` version:
+- [ ] `desktop/package.json` version:
+- [ ] `GET /api/health.version`:
+- [ ] `vk --version`:
+- [ ] MCP package/version output:
+
+## Release Validation
+
+Record command output locations or workflow URLs.
+
+| Gate                                | Result | Evidence |
+| ----------------------------------- | ------ | -------- |
+| `pnpm install --frozen-lockfile`    |        |          |
+| `pnpm typecheck`                    |        |          |
+| `pnpm lint:budget`                  |        |          |
+| `pnpm test:unit`                    |        |          |
+| `pnpm build`                        |        |          |
+| `pnpm validate:release`             |        |          |
+| `pnpm validate:release -- --github` |        |          |
+| `pnpm smoke:cli-mcp`                |        |          |
+| `pnpm desktop:package:mac:unsigned` |        |          |
+| `pnpm test:load`                    |        |          |
+
+## macOS Artifact Inventory
+
+Stable v5 GA requires signed and notarized macOS artifacts.
+
+| Asset                  | URL | SHA-256 | Notes |
+| ---------------------- | --- | ------- | ----- |
+| signed DMG             |     |         |       |
+| signed ZIP             |     |         |       |
+| blockmap               |     |         |       |
+| stable update metadata |     |         |       |
+| source archive         |     |         |       |
+| changelog entry        |     |         |       |
+
+Notarization and Gatekeeper:
+
+- [ ] `spctl --assess --type open --verbose` passed:
+- [ ] Notarization log URL or artifact:
+- [ ] Clean Mac install screenshot or recording:
+- [ ] First-run profile/workspace data path verified:
+
+## Signed Update And Rollback Drill
+
+This section satisfies the evidence target for #649.
+
+| Step                                     | Result | Evidence |
+| ---------------------------------------- | ------ | -------- |
+| Install signed baseline build            |        |          |
+| Launch and verify local server health    |        |          |
+| Publish or expose higher RC update       |        |          |
+| Check for update from native menu        |        |          |
+| Download update                          |        |          |
+| Install update                           |        |          |
+| Verify updated app/server/web versions   |        |          |
+| Reinstall previous signed DMG            |        |          |
+| Verify rollback behavior                 |        |          |
+| Restore backup if schema is incompatible |        |          |
+| Record admin recovery notes              |        |          |
+
+Rollback notes:
+
+```text
+
+```
+
+## Migration, Backup, And Restore
+
+| Gate                                     | Result | Evidence |
+| ---------------------------------------- | ------ | -------- |
+| v4 file-backed backup preserved          |        |          |
+| SQLite migration dry-run                 |        |          |
+| SQLite migration run                     |        |          |
+| Migration journal/report preserved       |        |          |
+| Board/task/search/workflow/chat verified |        |          |
+| Backup/export created                    |        |          |
+| Restore/import verified                  |        |          |
+| Older app refuses newer SQLite schema    |        |          |
+
+Accepted migration risks:
+
+```text
+
+```
+
+## Load, Remote, Mobile, And PWA Evidence
+
+This section satisfies the evidence target for #646.
+
+Full load profile:
+
+| Field                | Value |
+| -------------------- | ----- |
+| Target origin        |       |
+| Seed profile         |       |
+| k6 command           |       |
+| k6 output artifact   |       |
+| HTTP p95             |       |
+| HTTP error rate      |       |
+| WebSocket error rate |       |
+| Known scale ceiling  |       |
+
+Remote/mobile smoke:
+
+| Client               | Device/OS | Browser version | Result | Evidence |
+| -------------------- | --------- | --------------- | ------ | -------- |
+| Safari-class browser |           |                 |        |          |
+| Chrome-class browser |           |                 |        |          |
+| Installed PWA        |           |                 |        |          |
+
+PWA stale-client checks:
+
+- [ ] Static shell can load from cache:
+- [ ] API data is not cached for offline replay:
+- [ ] Offline writes are not queued:
+- [ ] Stale client refresh blocks or refreshes before write:
+- [ ] Same-origin `/api`, `/ws`, manifest, service worker, and static assets
+      verified:
+
+Known limits to include in release notes:
+
+```text
+
+```
+
+## Security And Diagnostics
+
+| Gate                                     | Result | Evidence |
+| ---------------------------------------- | ------ | -------- |
+| Security audit reviewed                  |        |          |
+| Debug bundle redaction negative fixtures |        |          |
+| Scoped API token smoke                   |        |          |
+| Password-session boundary smoke          |        |          |
+| WebSocket auth/reconnect smoke           |        |          |
+| Support bundle contains no private data  |        |          |
+
+Security release notes:
+
+```text
+
+```
+
+## Final Decision
+
+| Question                                             | Answer |
+| ---------------------------------------------------- | ------ |
+| Are all critical/high v5 release blockers closed?    |        |
+| Are all deferred items linked as post-GA issues?     |        |
+| Are user-visible limits documented in release notes? |        |
+| Is this RC approved for stable publication?          |        |
+
+Decision notes:
+
+```text
+
+```

--- a/docs/testing/v5-performance-load.md
+++ b/docs/testing/v5-performance-load.md
@@ -3,7 +3,8 @@
 Review date: 2026-06-03
 
 This note records the v5.0 performance/load evidence for SQLite-backed local
-mode and trusted-host remote/mobile access.
+mode and trusted-host remote/mobile access. Release-candidate evidence belongs
+in [v5 Release Candidate Evidence Packet](../V5-RC-EVIDENCE-PACKET.md).
 
 ## Target Dataset
 
@@ -114,6 +115,7 @@ HTTP errors below 1 percent plus WebSocket connection errors below 5 percent.
   WebSocket server behavior. It does not measure native mobile browser rendering
   performance.
 - Scheduled k6 runs use generated seed data. Before GA, attach the workflow
-  artifacts from a `load_profile=full` run against the release candidate.
+  artifacts from a `load_profile=full` run against the release candidate to
+  [v5 Release Candidate Evidence Packet](../V5-RC-EVIDENCE-PACKET.md).
 - Large-team or SaaS-style deployments need follow-up load profiles with higher
   seed counts and longer soak windows.


### PR DESCRIPTION
## Summary

- Adds a v5 release-candidate evidence packet template covering candidate identity, version checks, release validation, signed macOS artifacts, update/rollback drill, migration/restore, load/mobile/PWA evidence, security diagnostics, and final sign-off.
- Links the packet from the GA checklist and performance/load notes so #644, #646, and #649 have a single evidence target.
- Keeps the manual evidence issues open because this PR adds the capture surface, not the signed RC artifacts or real-device evidence.

Refs #644, #646, #649.

## Verification

- pnpm exec prettier --check docs/V5-RC-EVIDENCE-PACKET.md docs/V5-GA-CHECKLIST.md docs/testing/v5-performance-load.md
- pnpm validate:release -- --skip-build-output
- git diff --check
