### PR TITLE
Document v5 Homebrew install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Clone and set up veritas-kanban locally using the board-only setup path first. I
 
 Want to do it yourself? Get up and running in under 5 minutes:
 
+For the packaged Mac desktop app:
+
+```bash
+brew tap BradGroux/tap
+brew install --cask veritas-kanban
+```
+
+For local source development:
+
 ```bash
 git clone https://github.com/BradGroux/veritas-kanban.git
 cd veritas-kanban
@@ -50,7 +59,7 @@ cp server/.env.example server/.env   # Edit to change VERITAS_ADMIN_KEY
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) — that's it. The board auto-seeds with example tasks on first run so you can explore right away.
+Open [http://localhost:3000](http://localhost:3000) for source runs, or launch `Veritas Kanban.app` from `/Applications` after the Homebrew install. The board auto-seeds with example tasks on first run so you can explore right away.
 
 A working board means the UI loads and `http://localhost:3001/api/health` returns healthy. Agent-ready and external wake/delivery-ready are separate setup levels; use [Setup Paths](docs/SETUP-PATHS.md#readiness-levels) before adding those layers.
 

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -60,6 +60,27 @@ targets.
 requires the signing secrets below, builds signed/notarized macOS artifacts,
 and publishes update metadata with the GitHub provider.
 
+## Homebrew Cask
+
+The supported packaged install path is the dedicated BradGroux tap:
+
+```bash
+brew tap BradGroux/tap
+brew install --cask veritas-kanban
+```
+
+The cask lives in
+`BradGroux/homebrew-tap/Casks/veritas-kanban.rb` and tracks the signed,
+notarized GitHub release ZIP. After publishing a stable macOS release, update
+the cask version and SHA256, then validate from the registered tap checkout:
+
+```bash
+brew style --cask bradgroux/tap/veritas-kanban
+brew audit --cask --strict --online bradgroux/tap/veritas-kanban
+brew install --cask --dry-run bradgroux/tap/veritas-kanban
+brew livecheck bradgroux/tap/veritas-kanban
+```
+
 ## Required Release Secrets
 
 Configure these repository secrets before running `Desktop Release`:

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -41,7 +41,15 @@ package version and artifact links when the signed stable release is published.
 
 ## Fresh Install
 
-1. Install the signed Mac DMG from the stable release.
+1. Install the signed Mac desktop app:
+
+   ```bash
+   brew tap BradGroux/tap
+   brew install --cask veritas-kanban
+   ```
+
+   Manual install is also supported from the stable GitHub release ZIP.
+
 2. Launch Veritas Kanban and choose Board Only unless you already need agent or
    remote setup.
 3. Save the recovery key.

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -22,16 +22,25 @@ packet before publishing stable.
 
 ## Fresh Mac Desktop Install
 
-1. Download the signed/notarized DMG from the stable GitHub release.
-2. Mount the DMG and drag Veritas Kanban into `/Applications`.
-3. Launch normally. A stable release should not show a Gatekeeper warning.
-4. Pick the first-run path:
+1. Install the signed/notarized desktop app with Homebrew:
+
+   ```bash
+   brew tap BradGroux/tap
+   brew install --cask veritas-kanban
+   ```
+
+   Manual install is also supported from the stable GitHub release by
+   downloading `Veritas-Kanban-5.0.0-mac-arm64.zip`, unzipping it, and moving
+   `Veritas Kanban.app` into `/Applications`.
+
+2. Launch normally. A stable release should not show a Gatekeeper warning.
+3. Pick the first-run path:
    - Board Only for a local board with no agents.
    - Agent Ready for local agent tooling.
    - Remote Server to pair with a trusted host.
    - Restore to import a backup.
-5. Create the admin password and save the recovery key.
-6. Open Settings -> Maintenance and verify health checks, storage, logs, backup,
+4. Create the admin password and save the recovery key.
+5. Open Settings -> Maintenance and verify health checks, storage, logs, backup,
    and debug-bundle previews.
 
 Desktop data lives under:


### PR DESCRIPTION
## Summary
- Add the Homebrew cask install command to README quickstart.
- Update v5 install/admin, release notes, and desktop release docs to treat BradGroux/tap as the supported packaged Mac install path.
- Add cask validation commands to the desktop release guide.

## Verification
- pnpm validate:release -- --github
- ruby -c Casks/veritas-kanban.rb in BradGroux/homebrew-tap
- brew style --cask bradgroux/tap/veritas-kanban
- brew audit --cask --strict --online bradgroux/tap/veritas-kanban
- brew install --cask --dry-run bradgroux/tap/veritas-kanban
- brew livecheck bradgroux/tap/veritas-kanban

Closes #662