### PR TITLE
Refresh v5 desktop release artifacts

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -44,12 +44,12 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
           missing=0
-          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER; do
             if [ -z "${!name}" ]; then
               echo "::error::$name is required for signed/notarized desktop releases"
               missing=1
@@ -66,13 +66,29 @@ jobs:
       - name: Prepare desktop runtime payload
         run: pnpm --filter @veritas-kanban/desktop package:prepare
 
+      - name: Write App Store Connect API key
+        id: notary-key
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        run: |
+          key_path="${RUNNER_TEMP}/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8"
+          umask 077
+          printf '%s' "${APPLE_API_KEY_BASE64}" | base64 --decode > "${key_path}"
+
+          if ! grep -q "BEGIN PRIVATE KEY" "${key_path}"; then
+            echo "::error::APPLE_API_KEY_BASE64 does not decode to an App Store Connect API private key"
+            exit 1
+          fi
+
+          echo "key_path=${key_path}" >> "${GITHUB_OUTPUT}"
+
       - name: Build, sign, notarize, and publish macOS artifacts
         working-directory: desktop
         env:
           GH_TOKEN: ${{ github.token }}
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ steps.notary-key.outputs.key_path }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: node ./node_modules/electron-builder/cli.js --mac dmg zip --publish always

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,7 +43,7 @@
   "build": {
     "appId": "io.digitalmeld.veritas-kanban",
     "productName": "Veritas Kanban",
-    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "artifactName": "Veritas-Kanban-${version}-${os}-${arch}.${ext}",
     "asar": true,
     "afterPack": "../scripts/desktop-after-pack.mjs",
     "directories": {

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -88,13 +88,14 @@ Configure these repository secrets before running `Desktop Release`:
 - `MACOS_CSC_LINK`: base64 encoded `.p12` Developer ID Application certificate
   or a secure URL accepted by electron-builder `CSC_LINK`.
 - `MACOS_CSC_KEY_PASSWORD`: password for the `.p12` signing identity.
-- `APPLE_ID`: Apple Developer account email for notarization.
-- `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for notarization.
-- `APPLE_TEAM_ID`: Apple Developer team ID.
+- `APPLE_API_KEY_BASE64`: base64 encoded App Store Connect API `.p8` key.
+- `APPLE_API_KEY_ID`: App Store Connect API key ID.
+- `APPLE_API_ISSUER`: App Store Connect API issuer UUID.
 
 The workflow maps those secrets to electron-builder's `CSC_LINK`,
-`CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and
-`APPLE_TEAM_ID` environment variables.
+`CSC_KEY_PASSWORD`, `APPLE_API_KEY`, `APPLE_API_KEY_ID`, and
+`APPLE_API_ISSUER` environment variables. The API key is decoded into a
+temporary file during the release job and is not written to the repository.
 
 Windows releases need a separate code-signing certificate before the first
 supported Windows artifact is published. Use `WINDOWS_CSC_LINK` and

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -78,11 +78,11 @@ The v5.0.0 stable release includes:
 
 | Artifact                                                                                                                                                        | SHA-256                                                            |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [Veritas-Kanban-5.0.0-mac-arm64.dmg](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.dmg)                   | `ea0c98d5e8a57cf9352602a198d840678aeae427d4a5d51c8418f2219cf0c35d` |
-| [Veritas-Kanban-5.0.0-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.zip)                   | `ea492c71c3276de8c44c15e1ccb51fc7d713b5b4f8b8c9f302c0f5dd54e14c32` |
-| [Veritas-Kanban-5.0.0-mac-arm64.dmg.blockmap](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.dmg.blockmap) | `8a24eeed35f09313488e4fd6feecefada5f4218a97c03879c9d81e7fc43869a7` |
-| [Veritas-Kanban-5.0.0-mac-arm64.zip.blockmap](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.zip.blockmap) | `0ba0660ff9e82c32c120bf3ec828a5b363db5946df6117cc2073a03cc275981e` |
-| [latest-mac.yml](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/latest-mac.yml)                                                           | `60baa09d4eb3b93c419178536e639aff74ecd8e5ee72e628f461cd027f945501` |
+| [Veritas-Kanban-5.0.0-mac-arm64.dmg](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.dmg)                   | `566be0697ab52c6c6ea2e6123ce159737e8b90d026253b4af02c3868dc221133` |
+| [Veritas-Kanban-5.0.0-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.zip)                   | `67bf02a36fa070df029108c9e36fb4f9ee9e014972e1dd08dbadd85dc123a810` |
+| [Veritas-Kanban-5.0.0-mac-arm64.dmg.blockmap](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.dmg.blockmap) | `248d8b441428a98819b9434d7cef88f8432f0dbff04695d549fd41444861e018` |
+| [Veritas-Kanban-5.0.0-mac-arm64.zip.blockmap](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.zip.blockmap) | `910e72bf0c8af94b7f44f95eee6563f031bf80ec5eeebfdb537ada10c8fd6d54` |
+| [latest-mac.yml](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/latest-mac.yml)                                                           | `073802613fcbe609ff42e2aa6c44cb419cc7eb347f4b9fb0538dcb47bcb79c33` |
 
 Checksum sidecars are published as
 [`Veritas-Kanban-5.0.0-mac-arm64.dmg.sha256`](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.dmg.sha256)


### PR DESCRIPTION
## Summary
- Pin macOS release artifact names to the published `Veritas-Kanban-${version}-${os}-${arch}` convention.
- Switch the desktop release workflow to App Store Connect API-key notarization secrets.
- Update desktop release docs and v5 release artifact hashes for the refreshed signed/notarized artifacts.

Closes #672.

## Verification
- `CI=true npm_config_confirm_modules_purge=false pnpm build`
- `CI=true npm_config_confirm_modules_purge=false pnpm --filter @veritas-kanban/desktop test`
- Local Developer ID signed and Apple-notarized macOS ZIP/DMG build from this branch.
- `codesign --verify --deep --strict` on packaged and installed app.
- `xcrun stapler validate` on app, extracted ZIP app, and DMG.
- `spctl -a -vvv -t exec` on packaged, extracted, and installed app.
- Clean isolated desktop profile first-run setup and empty-board smoke.

## Release Notes
- Veritas repo release secrets are now configured for Developer ID signing and App Store Connect API-key notarization.
- The existing `v5.0.0` GitHub release assets still need replacement after this PR merges.
