### PR TITLE
Fix desktop shell chrome and panels

### DIFF
--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/preload/index.ts'),
         },
+        output: {
+          format: 'cjs',
+          entryFileNames: '[name].cjs',
+        },
       },
     },
   },

--- a/desktop/src/main/bridge.ts
+++ b/desktop/src/main/bridge.ts
@@ -27,6 +27,7 @@ import {
   type DesktopBridgeResponse,
   type DesktopConnectionConfigRequest,
   type DesktopConnectionValidationResult,
+  type DesktopWindowToggleMaximizeResult,
 } from '../shared/desktop-bridge-contracts.js';
 
 type MaybePromise<T> = T | Promise<T>;
@@ -36,6 +37,10 @@ export type DesktopBridgeHandlerMap = {
     request: DesktopBridgeRequest<Method>
   ) => MaybePromise<DesktopBridgeResponse<Method>>;
 };
+
+export interface DesktopWindowControls {
+  toggleMaximize(): DesktopWindowToggleMaximizeResult;
+}
 
 async function remoteConnectionDestinationError(serverUrl: string): Promise<string | null> {
   const parsed = new URL(serverUrl);
@@ -200,7 +205,8 @@ export function createDesktopBridgeHandlers(
   shell: Shell,
   packaged: boolean,
   commandDispatcher?: DesktopCommandDispatcher,
-  updateService?: DesktopUpdateService
+  updateService?: DesktopUpdateService,
+  windowControls?: DesktopWindowControls
 ): DesktopBridgeHandlerMap {
   const appInfo = (): DesktopAppInfo => ({
     name: DESKTOP_APP_NAME,
@@ -289,6 +295,7 @@ export function createDesktopBridgeHandlers(
       await shell.openExternal(url);
       return undefined;
     },
+    toggleWindowMaximize: () => windowControls?.toggleMaximize() ?? { maximized: false },
   };
 }
 
@@ -298,14 +305,16 @@ export function registerDesktopBridge(
   shell: Shell,
   packaged: boolean,
   commandDispatcher?: DesktopCommandDispatcher,
-  updateService?: DesktopUpdateService
+  updateService?: DesktopUpdateService,
+  windowControls?: DesktopWindowControls
 ): void {
   const handlers = createDesktopBridgeHandlers(
     runtime,
     shell,
     packaged,
     commandDispatcher,
-    updateService
+    updateService,
+    windowControls
   );
 
   for (const method of DESKTOP_BRIDGE_METHOD_NAMES) {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -70,7 +70,7 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 function createMainWindow(savedState: DesktopWindowState): BrowserWindow {
-  const preloadPath = path.join(__dirname, '../preload/index.mjs');
+  const preloadPath = path.join(__dirname, '../preload/index.cjs');
   const windowBounds = applyDesktopWindowState(savedState);
 
   const window = new BrowserWindow({
@@ -79,6 +79,7 @@ function createMainWindow(savedState: DesktopWindowState): BrowserWindow {
     minHeight: DESKTOP_MIN_WINDOW.height,
     ...windowBounds,
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+    trafficLightPosition: process.platform === 'darwin' ? { x: 16, y: 18 } : undefined,
     backgroundColor: '#111318',
     show: false,
     webPreferences: {
@@ -280,7 +281,19 @@ async function boot(): Promise<void> {
     },
   });
 
-  registerDesktopBridge(ipcMain, runtime, shell, packaged, commandDispatcher, updateService);
+  registerDesktopBridge(ipcMain, runtime, shell, packaged, commandDispatcher, updateService, {
+    toggleMaximize: () => {
+      if (!mainWindow) {
+        return { maximized: false };
+      }
+      if (mainWindow.isMaximized()) {
+        mainWindow.unmaximize();
+      } else {
+        mainWindow.maximize();
+      }
+      return { maximized: mainWindow.isMaximized() };
+    },
+  });
   refreshDesktopMenu();
   runtime.on('status', (status) => {
     mainWindow?.webContents.send(DESKTOP_BRIDGE_EVENTS.serverStatus.channel, status);

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,29 +1,72 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 import type { DesktopAppInfo, DesktopStatusSnapshot } from '../main/types.js';
-import {
-  createDesktopBridgeEventCleanup,
-  DESKTOP_RESTART_CONFIRMATION,
-  DESKTOP_BRIDGE_EVENTS,
-  DESKTOP_BRIDGE_METHODS,
-  type DesktopBridgeEvent,
-  type DesktopBridgeEventPayload,
-  type DesktopCommandDispatchRequest,
-  type DesktopCommandDispatchResult,
-  type DesktopConnectionConfigRequest,
-  type DesktopConnectionValidationResult,
-  type DesktopDiagnosticsBundleRequest,
-  type DesktopDiagnosticsBundleResult,
-  type DesktopFilePickerRequest,
-  type DesktopFilePickerResult,
-  type DesktopNotificationActionRequest,
-  type DesktopNotificationActionResult,
-  type DesktopSetupDiagnostics,
-  type DesktopSupportSnapshot,
-  type DesktopUpdateStatus,
-  type DesktopWorkProductExportRequest,
-  type DesktopWorkProductExportResult,
+import type {
+  DesktopBridgeEventPayload,
+  DesktopCommandDispatchRequest,
+  DesktopCommandDispatchResult,
+  DesktopConnectionConfigRequest,
+  DesktopConnectionValidationResult,
+  DesktopDiagnosticsBundleRequest,
+  DesktopDiagnosticsBundleResult,
+  DesktopFilePickerRequest,
+  DesktopFilePickerResult,
+  DesktopNotificationActionRequest,
+  DesktopNotificationActionResult,
+  DesktopSetupDiagnostics,
+  DesktopSupportSnapshot,
+  DesktopUpdateStatus,
+  DesktopWindowToggleMaximizeResult,
+  DesktopWorkProductExportRequest,
+  DesktopWorkProductExportResult,
 } from '../shared/desktop-bridge-contracts.js';
+
+const DESKTOP_RESTART_CONFIRMATION = 'restart-local-server';
+
+const DESKTOP_BRIDGE_METHODS = {
+  getAppInfo: { channel: 'desktop:get-app-info' },
+  getConnectionStatus: { channel: 'desktop:get-connection-status' },
+  getSetupDiagnostics: { channel: 'desktop:get-setup-diagnostics' },
+  validateConnectionConfig: { channel: 'desktop:validate-connection-config' },
+  restartLocalServer: { channel: 'desktop:restart-local-server' },
+  getSupportSnapshot: { channel: 'desktop:get-support-snapshot' },
+  getUpdateStatus: { channel: 'desktop:get-update-status' },
+  dispatchCommand: { channel: 'desktop:dispatch-command' },
+  pickUploadFiles: { channel: 'desktop:pick-upload-files' },
+  createDiagnosticsBundle: { channel: 'desktop:create-diagnostics-bundle' },
+  performNotificationAction: { channel: 'desktop:perform-notification-action' },
+  exportWorkProduct: { channel: 'desktop:export-work-product' },
+  openExternal: { channel: 'desktop:open-external' },
+  toggleWindowMaximize: { channel: 'desktop:toggle-window-maximize' },
+} as const;
+
+const DESKTOP_BRIDGE_EVENTS = {
+  setupProgress: { channel: 'desktop:setup-progress' },
+  communicationCheck: { channel: 'desktop:communication-check' },
+  serverStatus: { channel: 'desktop:server-status' },
+  runProgress: { channel: 'desktop:run-progress' },
+  updateStatus: { channel: 'desktop:update-status' },
+  notificationAction: { channel: 'desktop:notification-action' },
+  menuCommand: { channel: 'desktop:menu-command' },
+  uploadProgress: { channel: 'desktop:upload-progress' },
+  workProductExportProgress: { channel: 'desktop:work-product-export-progress' },
+  externalDeliveryVerification: { channel: 'desktop:external-delivery-verification' },
+} as const;
+
+type DesktopBridgeEvent = keyof typeof DESKTOP_BRIDGE_EVENTS;
+
+function createDesktopBridgeEventCleanup<Handler>(
+  channel: string,
+  handler: Handler,
+  detach: (channel: string, handler: Handler) => void
+): () => void {
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    detach(channel, handler);
+  };
+}
 
 export interface VeritasDesktopApi {
   getAppInfo(): Promise<DesktopAppInfo>;
@@ -47,6 +90,7 @@ export interface VeritasDesktopApi {
     request: DesktopWorkProductExportRequest
   ): Promise<DesktopWorkProductExportResult>;
   openExternal(url: string): Promise<void>;
+  toggleWindowMaximize(): Promise<DesktopWindowToggleMaximizeResult>;
   onSetupProgress(listener: BridgeEventListener<'setupProgress'>): () => void;
   onCommunicationCheck(listener: BridgeEventListener<'communicationCheck'>): () => void;
   onServerStatus(listener: (status: DesktopStatusSnapshot) => void): () => void;
@@ -131,6 +175,10 @@ const api: VeritasDesktopApi = {
     ),
   openExternal: (url: string) =>
     invokeDesktop<void>(DESKTOP_BRIDGE_METHODS.openExternal.channel, { url }),
+  toggleWindowMaximize: () =>
+    invokeDesktop<DesktopWindowToggleMaximizeResult>(
+      DESKTOP_BRIDGE_METHODS.toggleWindowMaximize.channel
+    ),
   onSetupProgress: (listener) => onDesktopEvent('setupProgress', listener),
   onCommunicationCheck: (listener) => onDesktopEvent('communicationCheck', listener),
   onServerStatus: (listener) => onDesktopEvent('serverStatus', listener),

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -203,6 +203,10 @@ export interface DesktopWorkProductExportResult {
   warnings: string[];
 }
 
+export interface DesktopWindowToggleMaximizeResult {
+  maximized: boolean;
+}
+
 export const DESKTOP_BRIDGE_METHODS = {
   getAppInfo: {
     capability: 'setup',
@@ -290,6 +294,12 @@ export const DESKTOP_BRIDGE_METHODS = {
     dangerous: true,
     validator: 'openExternal',
   },
+  toggleWindowMaximize: {
+    capability: 'shell',
+    channel: 'desktop:toggle-window-maximize',
+    desktopOnly: true,
+    dangerous: false,
+  },
 } as const satisfies Record<string, DesktopBridgeMethodDefinition>;
 
 export const DESKTOP_BRIDGE_METHOD_NAMES = [
@@ -306,6 +316,7 @@ export const DESKTOP_BRIDGE_METHOD_NAMES = [
   'performNotificationAction',
   'exportWorkProduct',
   'openExternal',
+  'toggleWindowMaximize',
 ] as const;
 
 export type DesktopBridgeMethod = (typeof DESKTOP_BRIDGE_METHOD_NAMES)[number];
@@ -413,6 +424,7 @@ export interface DesktopBridgeRequestMap {
   performNotificationAction: DesktopNotificationActionRequest;
   exportWorkProduct: DesktopWorkProductExportRequest;
   openExternal: OpenExternalRequest;
+  toggleWindowMaximize: undefined;
 }
 
 export interface DesktopBridgeResponseMap {
@@ -429,6 +441,7 @@ export interface DesktopBridgeResponseMap {
   performNotificationAction: DesktopNotificationActionResult;
   exportWorkProduct: DesktopWorkProductExportResult;
   openExternal: undefined;
+  toggleWindowMaximize: DesktopWindowToggleMaximizeResult;
 }
 
 export interface DesktopBridgeEventPayloadMap {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,9 @@ import { SkipToContent } from './components/shared/SkipToContent';
 import { LiveAnnouncerProvider } from './components/shared/LiveAnnouncer';
 import { NAVIGATION_VIEWS, VIEW_BY_ID, type AppView, type NavigationView } from './lib/views';
 import { usePendingProductMode } from './hooks/usePendingProductMode';
+import { DesktopShellProvider, useDesktopShell } from './components/layout/DesktopShellContext';
+import { DesktopLeftSidebar } from './components/layout/DesktopLeftSidebar';
+import { DesktopBottomPanel } from './components/layout/DesktopBottomPanel';
 
 const LAZY_VIEW_COMPONENTS = Object.fromEntries(
   NAVIGATION_VIEWS.map((definition) => {
@@ -80,6 +83,66 @@ function MainContent() {
   );
 }
 
+function DesktopAwareAppShell({
+  authStatus,
+  refreshStatus,
+  showDesktopOnboarding,
+  setShowDesktopOnboarding,
+}: {
+  authStatus: ReturnType<typeof useAuth>['status'];
+  refreshStatus: ReturnType<typeof useAuth>['refreshStatus'];
+  showDesktopOnboarding: boolean;
+  setShowDesktopOnboarding: (open: boolean) => void;
+}) {
+  const { isDesktopClient, bottomPanel } = useDesktopShell();
+
+  return (
+    <Box className="desktop-app-shell min-h-screen bg-background">
+      <SkipToContent />
+      <Header />
+      <Suspense fallback={<div className="h-7 border-b border-border bg-muted/30" aria-hidden />}>
+        <SystemHealthBar />
+      </Suspense>
+      <Suspense fallback={null}>
+        <PwaStatusBanner sessionExpiry={authStatus?.sessionExpiry} onRefreshAuth={refreshStatus} />
+      </Suspense>
+      <div className="desktop-workbench">
+        <DesktopLeftSidebar />
+        <Box
+          component="main"
+          id="main-content"
+          px={isDesktopClient ? 'md' : { base: 'md', md: '3.5rem' }}
+          pt={isDesktopClient ? 'md' : 'lg'}
+          pb={isDesktopClient ? (bottomPanel ? 'md' : 'lg') : { base: '6rem', md: 'lg' }}
+          tabIndex={-1}
+          className="desktop-main-content"
+        >
+          <ErrorBoundary level="section">
+            <MainContent />
+          </ErrorBoundary>
+        </Box>
+      </div>
+      <DesktopBottomPanel />
+      <Toaster />
+      <CommandPalette />
+      {!isDesktopClient && (
+        <Suspense fallback={null}>
+          <FloatingChat />
+        </Suspense>
+      )}
+      <Suspense fallback={null}>{!isDesktopClient && <MobileShell />}</Suspense>
+      {showDesktopOnboarding && (
+        <Suspense fallback={null}>
+          <DesktopOnboardingDialog
+            open={showDesktopOnboarding}
+            onOpenChange={setShowDesktopOnboarding}
+          />
+        </Suspense>
+      )}
+    </Box>
+  );
+}
+
 // Main app content (only rendered when authenticated)
 function AppContent() {
   // Connect to WebSocket for real-time task updates
@@ -129,51 +192,14 @@ function AppContent() {
             <TaskConfigProvider>
               <ViewProvider>
                 <IdentityProvider>
-                  <Box className="min-h-screen bg-background">
-                    <SkipToContent />
-                    <Header />
-                    <Suspense
-                      fallback={
-                        <div className="h-7 border-b border-border bg-muted/30" aria-hidden />
-                      }
-                    >
-                      <SystemHealthBar />
-                    </Suspense>
-                    <Suspense fallback={null}>
-                      <PwaStatusBanner
-                        sessionExpiry={authStatus?.sessionExpiry}
-                        onRefreshAuth={refreshStatus}
-                      />
-                    </Suspense>
-                    <Box
-                      component="main"
-                      id="main-content"
-                      px={{ base: 'md', md: '3.5rem' }}
-                      pt="lg"
-                      pb={{ base: '6rem', md: 'lg' }}
-                      tabIndex={-1}
-                    >
-                      <ErrorBoundary level="section">
-                        <MainContent />
-                      </ErrorBoundary>
-                    </Box>
-                    <Toaster />
-                    <CommandPalette />
-                    <Suspense fallback={null}>
-                      <FloatingChat />
-                    </Suspense>
-                    <Suspense fallback={null}>
-                      <MobileShell />
-                    </Suspense>
-                    {showDesktopOnboarding && (
-                      <Suspense fallback={null}>
-                        <DesktopOnboardingDialog
-                          open={showDesktopOnboarding}
-                          onOpenChange={setShowDesktopOnboarding}
-                        />
-                      </Suspense>
-                    )}
-                  </Box>
+                  <DesktopShellProvider>
+                    <DesktopAwareAppShell
+                      authStatus={authStatus}
+                      refreshStatus={refreshStatus}
+                      showDesktopOnboarding={showDesktopOnboarding}
+                      setShowDesktopOnboarding={setShowDesktopOnboarding}
+                    />
+                  </DesktopShellProvider>
                 </IdentityProvider>
               </ViewProvider>
             </TaskConfigProvider>

--- a/web/src/__tests__/KanbanBoard.test.tsx
+++ b/web/src/__tests__/KanbanBoard.test.tsx
@@ -9,6 +9,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { KanbanBoard } from '@/components/board/KanbanBoard';
 import { createMockTask, renderWithProviders } from './test-utils';
 import { DEFAULT_FEATURE_SETTINGS, type FeatureSettings, type Task } from '@veritas-kanban/shared';
+import { DesktopShellProvider } from '@/components/layout/DesktopShellContext';
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -195,6 +196,27 @@ function renderBoard() {
   return renderWithProviders(<KanbanBoard />, { queryClient });
 }
 
+function renderDesktopBoard() {
+  Object.defineProperty(window, 'veritasDesktop', {
+    configurable: true,
+    value: {
+      toggleWindowMaximize: vi.fn(),
+    },
+  });
+  window.localStorage.setItem('veritas.desktop.rightRailOpen', 'false');
+  document.documentElement.dataset.client = 'desktop';
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderWithProviders(
+    <DesktopShellProvider>
+      <KanbanBoard />
+    </DesktopShellProvider>,
+    { queryClient }
+  );
+}
+
 function setOnline(value: boolean) {
   Object.defineProperty(window.navigator, 'onLine', {
     configurable: true,
@@ -205,6 +227,9 @@ function setOnline(value: boolean) {
 afterEach(() => {
   cleanup();
   setOnline(true);
+  delete (window as Window & { veritasDesktop?: unknown }).veritasDesktop;
+  delete document.documentElement.dataset.client;
+  window.localStorage.removeItem('veritas.desktop.rightRailOpen');
   mockFeatureSettingsResult = {
     isPlaceholderData: false,
     settings: createFeatureSettings(),
@@ -294,6 +319,23 @@ describe('KanbanBoard', () => {
     // Columns should still exist
     expect(screen.getByTestId('column-todo')).toBeDefined();
     expect(screen.getByTestId('column-done')).toBeDefined();
+  });
+
+  it('collapses the board right rail in desktop mode by default', () => {
+    mockUseTasks = () => ({ data: [], isLoading: false, error: null });
+    renderDesktopBoard();
+
+    expect(screen.getByTestId('column-todo')).toBeDefined();
+    expect(screen.queryByLabelText('Board right sidebar')).toBeNull();
+  });
+
+  it('fits configured board columns across the desktop shell', () => {
+    mockUseTasks = () => ({ data: [], isLoading: false, error: null });
+    renderDesktopBoard();
+
+    expect(screen.getByRole('group', { name: 'Kanban columns' }).style.gridTemplateColumns).toBe(
+      'repeat(4, minmax(0, 1fr))'
+    );
   });
 
   it('disables explicit status changes while the browser is offline', () => {

--- a/web/src/__tests__/activity-chat-mantine.test.tsx
+++ b/web/src/__tests__/activity-chat-mantine.test.tsx
@@ -270,4 +270,19 @@ describe('activity and chat Mantine migration', () => {
     expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
   });
+
+  it('renders chat panels inline for the desktop bottom panel', () => {
+    const { baseElement } = renderWithProviders(
+      <>
+        <ChatPanel open={true} onOpenChange={vi.fn()} variant="inline" />
+        <SquadChatPanel open={true} onOpenChange={vi.fn()} variant="inline" />
+      </>
+    );
+
+    expect(screen.getByLabelText('Board Chat')).toBeDefined();
+    expect(screen.getByLabelText('Squad Chat')).toBeDefined();
+    expect(screen.getByLabelText('Close chat panel')).toBeDefined();
+    expect(screen.getByLabelText('Close squad chat panel')).toBeDefined();
+    expect(baseElement.querySelector('.mantine-Drawer-root')).toBeNull();
+  });
 });

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { ViewProvider } from '@/contexts/ViewContext';
 import { KeyboardProvider } from '@/hooks/useKeyboard';
 import { Header } from '@/components/layout/Header';
+import { DesktopShellProvider } from '@/components/layout/DesktopShellContext';
 import { UserMenu } from '@/components/layout/UserMenu';
 import { WorkspaceSwitcher } from '@/components/layout/WorkspaceSwitcher';
 import { WebSocketIndicator } from '@/components/shared/WebSocketIndicator';
@@ -136,6 +137,26 @@ function renderHeaderChrome() {
   );
 }
 
+function renderDesktopHeaderChrome() {
+  Object.defineProperty(window, 'veritasDesktop', {
+    configurable: true,
+    value: {
+      toggleWindowMaximize: vi.fn(),
+    },
+  });
+  document.documentElement.dataset.client = 'desktop';
+
+  return renderWithProviders(
+    <KeyboardProvider>
+      <ViewProvider>
+        <DesktopShellProvider>
+          <Header />
+        </DesktopShellProvider>
+      </ViewProvider>
+    </KeyboardProvider>
+  );
+}
+
 describe('layout chrome Mantine migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -145,6 +166,8 @@ describe('layout chrome Mantine migration', () => {
 
   afterEach(() => {
     cleanup();
+    delete (window as Window & { veritasDesktop?: unknown }).veritasDesktop;
+    delete document.documentElement.dataset.client;
   });
 
   it('renders the header actions, workspace switcher, and user menu through direct Mantine controls', () => {
@@ -218,5 +241,20 @@ describe('layout chrome Mantine migration', () => {
     expect(screen.getByText('Real-time sync active')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Popover-dropdown')).toBeDefined();
     expect(baseElement.querySelector('[data-slot="popover-content"]')).toBeNull();
+  });
+
+  it('renders desktop shell controls and app icon branding in desktop mode', () => {
+    renderDesktopHeaderChrome();
+
+    expect(screen.getByRole('button', { name: 'Collapse left sidebar' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Expand right sidebar' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Open bottom panel' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Board Chat' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Squad Chat' })).toBeDefined();
+
+    const brandIcon = screen
+      .getByRole('button', { name: 'Refresh page' })
+      .querySelector('img[src="/icons/pwa-icon-192.png"]');
+    expect(brandIcon).toBeDefined();
   });
 });

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -44,6 +44,8 @@ import { useView } from '@/contexts/ViewContext';
 import { useIdentity } from '@/hooks/useIdentity';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import type { TaskDetailNavigationTarget } from '@/components/task/TaskDetailPanel';
+import { useDesktopShell } from '@/components/layout/DesktopShellContext';
+import { cn } from '@/lib/utils';
 
 // Lazy-load Dashboard so board startup does not include dashboard-heavy code paths.
 const Dashboard = lazy(() =>
@@ -84,6 +86,7 @@ export function KanbanBoard() {
   const { announce } = useLiveAnnouncer();
   const { hasPermission } = useIdentity();
   const { isOnline } = useNetworkStatus();
+  const { isDesktopClient, rightRailOpen } = useDesktopShell();
   const canWriteTasks = hasPermission('task:write');
   const isMobileLayout = useMediaQuery('(max-width: 767px)', false);
   const canDragTasks =
@@ -297,6 +300,17 @@ export function KanbanBoard() {
 
   // Group filtered tasks by status
   const tasksByStatus = useTasksByStatus(filteredTasks, columns);
+  const boardColumnGridStyle = isMobileLayout
+    ? undefined
+    : {
+        gridTemplateColumns: isDesktopClient
+          ? `repeat(${Math.max(columns.length, 1)}, minmax(0, 1fr))`
+          : 'repeat(auto-fit, minmax(220px, 1fr))',
+      };
+  const boardColumnGridClassName = cn(
+    'grid grid-cols-1 gap-4',
+    !isDesktopClient && 'md:grid-cols-2'
+  );
 
   // Register filtered tasks with keyboard context
   useEffect(() => {
@@ -513,10 +527,16 @@ export function KanbanBoard() {
       {boardSettings.showArchiveSuggestions && <ArchiveSuggestionBanner />}
 
       <FeatureErrorBoundary fallbackTitle="Board failed to render">
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-5">
+        <div
+          className={cn(
+            'grid grid-cols-1 gap-4',
+            !isDesktopClient && 'xl:grid-cols-5',
+            isDesktopClient && rightRailOpen && 'desktop-board-with-right-rail'
+          )}
+        >
           <section
             id="mobile-board-columns"
-            className="min-w-0 xl:col-span-4"
+            className={cn('min-w-0', !isDesktopClient && 'xl:col-span-4')}
             aria-label={`Kanban board, ${filteredTasks.length} tasks`}
           >
             {canDragTasks ? (
@@ -528,12 +548,8 @@ export function KanbanBoard() {
                 onDragEnd={handleDragEnd}
               >
                 <div
-                  className="grid grid-cols-1 gap-4 md:grid-cols-2"
-                  style={
-                    isMobileLayout
-                      ? undefined
-                      : { gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }
-                  }
+                  className={boardColumnGridClassName}
+                  style={boardColumnGridStyle}
                   role="group"
                   aria-label="Kanban columns"
                 >
@@ -561,12 +577,8 @@ export function KanbanBoard() {
               </DndContext>
             ) : (
               <div
-                className="grid grid-cols-1 gap-4 md:grid-cols-2"
-                style={
-                  isMobileLayout
-                    ? undefined
-                    : { gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }
-                }
+                className={boardColumnGridClassName}
+                style={boardColumnGridStyle}
                 role="group"
                 aria-label="Kanban columns"
               >
@@ -590,17 +602,21 @@ export function KanbanBoard() {
             )}
           </section>
 
-          <Suspense
-            fallback={
-              <aside className="min-h-24 rounded-md border border-dashed border-border/70" />
-            }
-          >
-            <BoardSidebar
-              onTaskClick={(taskId) => {
-                void handleTaskIdClick(taskId);
-              }}
-            />
-          </Suspense>
+          {(!isDesktopClient || rightRailOpen) && (
+            <Suspense
+              fallback={
+                <aside className="min-h-24 rounded-md border border-dashed border-border/70" />
+              }
+            >
+              <aside className="min-w-0" aria-label="Board right sidebar">
+                <BoardSidebar
+                  onTaskClick={(taskId) => {
+                    void handleTaskIdClick(taskId);
+                  }}
+                />
+              </aside>
+            </Suspense>
+          )}
         </div>
 
         {boardSettings.showDashboard && (

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -20,6 +20,7 @@ import {
   User,
   Trash2,
   Download,
+  X,
 } from 'lucide-react';
 import {
   useChatSession,
@@ -30,14 +31,23 @@ import {
 } from '@/hooks/useChat';
 import { useTask } from '@/hooks/useTasks';
 import type { ChatMessage } from '@veritas-kanban/shared';
+import { cn } from '@/lib/utils';
 
 interface ChatPanelProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   taskId?: string;
+  variant?: 'drawer' | 'inline';
+  className?: string;
 }
 
-export function ChatPanel({ open, onOpenChange, taskId }: ChatPanelProps) {
+export function ChatPanel({
+  open,
+  onOpenChange,
+  taskId,
+  variant = 'drawer',
+  className,
+}: ChatPanelProps) {
   const [message, setMessage] = useState('');
   const [mode, setMode] = useState<'ask' | 'build'>('ask');
   const [currentSessionId, setCurrentSessionId] = useState<string | undefined>();
@@ -115,158 +125,183 @@ export function ChatPanel({ open, onOpenChange, taskId }: ChatPanelProps) {
     }
   }, [filteredSessions, currentSessionId, taskId]);
 
+  const exportChat = () => {
+    if (!session?.messages?.length) return;
+    const title = taskId && task ? task.title : 'Board Chat';
+    const date = new Date().toLocaleString();
+    const lines = [`# Chat Export — ${title}`, `*Exported: ${date}*`, ''];
+    for (const msg of session.messages) {
+      const role =
+        msg.role === 'user' ? '👤 User' : msg.role === 'assistant' ? '🤖 Assistant' : '⚙️ System';
+      const time = new Date(msg.timestamp).toLocaleString();
+      lines.push('---', '', `### ${role}`, `*${time}*`, '', msg.content, '');
+    }
+    const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `chat-${taskId || 'board'}-${new Date().toISOString().slice(0, 10)}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const titleContent = (
+    <Group justify="space-between" wrap="nowrap" className="w-full pr-8">
+      <Stack gap={4}>
+        <Group gap="xs" wrap="nowrap">
+          <Bot className="h-5 w-5" />
+          <Text fw={600}>{taskId ? 'Task Chat' : 'Board Chat'}</Text>
+        </Group>
+        {taskId && task && (
+          <Group gap="xs" className="border-t border-border/50 pt-2">
+            <MessageSquare className="h-3 w-3" />
+            <Text size="xs" c="dimmed">
+              Task: {task.title}
+            </Text>
+          </Group>
+        )}
+      </Stack>
+      <Group gap={4} wrap="nowrap">
+        {currentSessionId && session?.messages && session.messages.length > 0 && (
+          <>
+            <ActionIcon variant="subtle" aria-label="Export chat" onClick={exportChat}>
+              <Download className="h-4 w-4" />
+            </ActionIcon>
+            <ActionIcon
+              variant="subtle"
+              color="red"
+              aria-label="Clear chat"
+              onClick={() => setClearConfirmOpen(true)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </ActionIcon>
+          </>
+        )}
+        {variant === 'inline' && (
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            aria-label="Close chat panel"
+            onClick={() => onOpenChange(false)}
+          >
+            <X className="h-4 w-4" />
+          </ActionIcon>
+        )}
+      </Group>
+    </Group>
+  );
+
+  const chatContent = (
+    <>
+      <ScrollArea
+        className="min-h-0 flex-1 px-4"
+        onScrollCapture={handleScroll}
+        ref={scrollAreaRef}
+      >
+        <div className="py-4 space-y-4">
+          {session?.messages.map((msg) => (
+            <ChatMessageBubble key={msg.id} message={msg} />
+          ))}
+          {streamingMessage && (
+            <ChatMessageBubble
+              message={{
+                id: 'streaming',
+                role: 'assistant',
+                content: streamingMessage.content || '',
+                timestamp: new Date().toISOString(),
+              }}
+              isStreaming
+            />
+          )}
+          {(!session || session.messages.length === 0) && !streamingMessage && (
+            <div className="text-center text-muted-foreground py-8">
+              <Bot className="h-12 w-12 mx-auto mb-2 opacity-50" />
+              <p className="text-sm">
+                {taskId ? 'Start a conversation about this task' : 'Start a new chat session'}
+              </p>
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+      </ScrollArea>
+
+      <div className="border-t border-border p-4 flex-shrink-0 space-y-3">
+        <div className="flex items-center gap-2">
+          <TextInput
+            ref={inputRef}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyDown={handleKeyPress}
+            placeholder="Type a message..."
+            disabled={isPending}
+            className="flex-1"
+            autoFocus
+          />
+          <ActionIcon
+            onClick={handleSend}
+            disabled={!message.trim() || isPending}
+            aria-label="Send chat message"
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+          </ActionIcon>
+        </div>
+
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted-foreground">Mode:</span>
+          <Button
+            variant={mode === 'ask' ? 'filled' : 'outline'}
+            size="xs"
+            onClick={() => setMode('ask')}
+          >
+            Ask
+          </Button>
+          <Button
+            variant={mode === 'build' ? 'filled' : 'outline'}
+            size="xs"
+            onClick={() => setMode('build')}
+          >
+            Build
+          </Button>
+          <span className="text-muted-foreground ml-1">
+            {mode === 'ask' ? '· Read-only queries' : '· Changes, files, commands'}
+          </span>
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <>
-      <Drawer
-        opened={open}
-        onClose={() => onOpenChange(false)}
-        position="right"
-        size={500}
-        padding={0}
-        title={
-          <Group justify="space-between" wrap="nowrap" className="w-full pr-8">
-            <Stack gap={4}>
-              <Group gap="xs" wrap="nowrap">
-                <Bot className="h-5 w-5" />
-                <Text fw={600}>{taskId ? 'Task Chat' : 'Board Chat'}</Text>
-              </Group>
-              {taskId && task && (
-                <Group gap="xs" className="border-t border-border/50 pt-2">
-                  <MessageSquare className="h-3 w-3" />
-                  <Text size="xs" c="dimmed">
-                    Task: {task.title}
-                  </Text>
-                </Group>
-              )}
-            </Stack>
-            {currentSessionId && session?.messages && session.messages.length > 0 && (
-              <Group gap={4} wrap="nowrap">
-                <ActionIcon
-                  variant="subtle"
-                  aria-label="Export chat"
-                  onClick={() => {
-                    if (!session?.messages?.length) return;
-                    const title = taskId && task ? task.title : 'Board Chat';
-                    const date = new Date().toLocaleString();
-                    const lines = [`# Chat Export — ${title}`, `*Exported: ${date}*`, ''];
-                    for (const msg of session.messages) {
-                      const role =
-                        msg.role === 'user'
-                          ? '👤 User'
-                          : msg.role === 'assistant'
-                            ? '🤖 Assistant'
-                            : '⚙️ System';
-                      const time = new Date(msg.timestamp).toLocaleString();
-                      lines.push('---', '', `### ${role}`, `*${time}*`, '', msg.content, '');
-                    }
-                    const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = `chat-${taskId || 'board'}-${new Date()
-                      .toISOString()
-                      .slice(0, 10)}.md`;
-                    a.click();
-                    URL.revokeObjectURL(url);
-                  }}
-                >
-                  <Download className="h-4 w-4" />
-                </ActionIcon>
-                <ActionIcon
-                  variant="subtle"
-                  color="red"
-                  aria-label="Clear chat"
-                  onClick={() => setClearConfirmOpen(true)}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </ActionIcon>
-              </Group>
-            )}
-          </Group>
-        }
-        styles={{
-          content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
-          body: { display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 },
-        }}
-      >
-        {/* Messages */}
-        <ScrollArea className="flex-1 px-4" onScrollCapture={handleScroll} ref={scrollAreaRef}>
-          <div className="py-4 space-y-4">
-            {session?.messages.map((msg) => (
-              <ChatMessageBubble key={msg.id} message={msg} />
-            ))}
-            {streamingMessage && (
-              <ChatMessageBubble
-                message={{
-                  id: 'streaming',
-                  role: 'assistant',
-                  content: streamingMessage.content || '',
-                  timestamp: new Date().toISOString(),
-                }}
-                isStreaming
-              />
-            )}
-            {(!session || session.messages.length === 0) && !streamingMessage && (
-              <div className="text-center text-muted-foreground py-8">
-                <Bot className="h-12 w-12 mx-auto mb-2 opacity-50" />
-                <p className="text-sm">
-                  {taskId ? 'Start a conversation about this task' : 'Start a new chat session'}
-                </p>
-              </div>
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-        </ScrollArea>
-
-        {/* Input Area */}
-        <div className="border-t border-border p-4 flex-shrink-0 space-y-3">
-          <div className="flex items-center gap-2">
-            <TextInput
-              ref={inputRef}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              onKeyDown={handleKeyPress}
-              placeholder="Type a message..."
-              disabled={isPending}
-              className="flex-1"
-              autoFocus
-            />
-            <ActionIcon
-              onClick={handleSend}
-              disabled={!message.trim() || isPending}
-              aria-label="Send chat message"
-            >
-              {isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Send className="h-4 w-4" />
-              )}
-            </ActionIcon>
-          </div>
-
-          {/* Mode Toggle */}
-          <div className="flex items-center gap-2 text-xs">
-            <span className="text-muted-foreground">Mode:</span>
-            <Button
-              variant={mode === 'ask' ? 'filled' : 'outline'}
-              size="xs"
-              onClick={() => setMode('ask')}
-            >
-              Ask
-            </Button>
-            <Button
-              variant={mode === 'build' ? 'filled' : 'outline'}
-              size="xs"
-              onClick={() => setMode('build')}
-            >
-              Build
-            </Button>
-            <span className="text-muted-foreground ml-1">
-              {mode === 'ask' ? '· Read-only queries' : '· Changes, files, commands'}
-            </span>
-          </div>
-        </div>
-      </Drawer>
+      {variant === 'inline' ? (
+        open && (
+          <section
+            className={cn('flex h-full min-h-0 flex-col', className)}
+            aria-label="Board Chat"
+          >
+            <div className="desktop-no-drag border-b border-border px-4 py-3">{titleContent}</div>
+            <div className="flex min-h-0 flex-1 flex-col">{chatContent}</div>
+          </section>
+        )
+      ) : (
+        <Drawer
+          opened={open}
+          onClose={() => onOpenChange(false)}
+          position="right"
+          size={500}
+          padding={0}
+          title={titleContent}
+          styles={{
+            content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+            body: { display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 },
+          }}
+        >
+          {chatContent}
+        </Drawer>
+      )}
       <Modal
         opened={clearConfirmOpen}
         onClose={() => setClearConfirmOpen(false)}

--- a/web/src/components/chat/SquadChatPanel.tsx
+++ b/web/src/components/chat/SquadChatPanel.tsx
@@ -9,15 +9,18 @@ import {
   Text,
   TextInput,
 } from '@mantine/core';
-import { Send, Loader2, Users, Filter, Settings2 } from 'lucide-react';
+import { Send, Loader2, Users, Filter, Settings2, X } from 'lucide-react';
 import { useSquadMessages, useSendSquadMessage, useSquadStream } from '@/hooks/useChat';
 import { useConfig } from '@/hooks/useConfig';
 import { useFeatureSetting } from '@/hooks/useFeatureSettings';
 import type { SquadMessage } from '@veritas-kanban/shared';
+import { cn } from '@/lib/utils';
 
 interface SquadChatPanelProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  variant?: 'drawer' | 'inline';
+  className?: string;
 }
 
 // Agent colors for visual distinction
@@ -52,7 +55,12 @@ function writeIncludeSystemPreference(includeSystem: boolean): void {
   }
 }
 
-export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
+export function SquadChatPanel({
+  open,
+  onOpenChange,
+  variant = 'drawer',
+  className,
+}: SquadChatPanelProps) {
   const humanDisplayName = useFeatureSetting('general', 'humanDisplayName');
   const { data: config } = useConfig();
 
@@ -169,134 +177,155 @@ export function SquadChatPanel({ open, onOpenChange }: SquadChatPanelProps) {
   // Get unique agents from messages
   const uniqueAgents = Array.from(new Set(messages.map((m) => m.agent))).sort();
 
-  return (
+  const titleContent = (
+    <Group justify="space-between" wrap="nowrap" className="w-full pr-8">
+      <div>
+        <Group gap="xs" wrap="nowrap">
+          <Users className="h-5 w-5" />
+          <Text fw={600}>Squad Chat</Text>
+        </Group>
+        <Text size="xs" c="dimmed" pt={4}>
+          Agent-to-agent communication channel
+        </Text>
+      </div>
+      {variant === 'inline' && (
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          aria-label="Close squad chat panel"
+          onClick={() => onOpenChange(false)}
+        >
+          <X className="h-4 w-4" />
+        </ActionIcon>
+      )}
+    </Group>
+  );
+
+  const panelContent = (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Filter Bar */}
+      <div className="border-b border-border px-4 py-2 flex items-center gap-2 flex-shrink-0">
+        <Filter className="h-4 w-4 text-muted-foreground" />
+        <Select
+          value={agentFilter}
+          onChange={(value) => setAgentFilter(value ?? 'all')}
+          allowDeselect={false}
+          size="xs"
+          w={150}
+          data={[
+            { value: 'all', label: 'All Agents' },
+            ...uniqueAgents.map((agent) => ({ value: agent, label: agent })),
+          ]}
+          aria-label="Filter by agent"
+        />
+        <Button
+          variant={includeSystem ? 'filled' : 'outline'}
+          size="xs"
+          onClick={() => setIncludeSystem(!includeSystem)}
+          className="ml-auto gap-1.5"
+          title={includeSystem ? 'Hide system messages' : 'Show system messages'}
+          leftSection={<Settings2 className="h-3.5 w-3.5" />}
+        >
+          {includeSystem ? 'Hide' : 'Show'} System
+        </Button>
+      </div>
+
+      {/* Messages */}
+      <ScrollArea
+        className="flex-1 min-h-0 px-4"
+        onScrollCapture={handleScroll}
+        ref={scrollAreaRef}
+      >
+        <div className="py-4 space-y-3">
+          {isLoading && (
+            <div className="text-center text-muted-foreground py-8">
+              <Loader2 className="h-8 w-8 mx-auto mb-2 animate-spin" />
+              <p className="text-sm">Loading messages...</p>
+            </div>
+          )}
+          {!isLoading && filteredMessages.length === 0 && (
+            <div className="text-center text-muted-foreground py-8">
+              <Users className="h-12 w-12 mx-auto mb-2 opacity-50" />
+              <p className="text-sm">
+                {agentFilter === 'all'
+                  ? 'No messages yet. Be the first to say something!'
+                  : `No messages from ${agentFilter}`}
+              </p>
+            </div>
+          )}
+          {filteredMessages.map((msg) =>
+            msg.system ? (
+              <SystemMessageDivider key={msg.id} message={msg} />
+            ) : (
+              <SquadMessageBubble key={msg.id} message={msg} humanDisplayName={humanDisplayName} />
+            )
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+      </ScrollArea>
+
+      {/* Input Area */}
+      <div className="border-t border-border p-4 flex-shrink-0 space-y-2">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xs text-muted-foreground">Sending as:</span>
+          <Select
+            value={selectedAgent}
+            onChange={(value) => setSelectedAgent(value ?? humanDisplayName ?? 'Human')}
+            allowDeselect={false}
+            size="xs"
+            w={140}
+            data={availableAgents.map((agent) => ({ value: agent, label: agent }))}
+            aria-label="Sending as"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <TextInput
+            ref={inputRef}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyDown={handleKeyPress}
+            placeholder="Send a message to the squad..."
+            disabled={isPending}
+            className="flex-1"
+            autoFocus
+          />
+          <ActionIcon
+            onClick={handleSend}
+            disabled={!message.trim() || isPending}
+            aria-label="Send squad message"
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+          </ActionIcon>
+        </div>
+      </div>
+    </div>
+  );
+
+  return variant === 'inline' ? (
+    open && (
+      <section className={cn('flex h-full min-h-0 flex-col', className)} aria-label="Squad Chat">
+        <div className="desktop-no-drag border-b border-border px-4 py-3">{titleContent}</div>
+        {panelContent}
+      </section>
+    )
+  ) : (
     <Drawer
       opened={open}
       onClose={() => onOpenChange(false)}
       position="right"
       size={500}
       padding={0}
-      title={
-        <div>
-          <Group gap="xs" wrap="nowrap">
-            <Users className="h-5 w-5" />
-            <Text fw={600}>Squad Chat</Text>
-          </Group>
-          <Text size="xs" c="dimmed" pt={4}>
-            Agent-to-agent communication channel
-          </Text>
-        </div>
-      }
+      title={titleContent}
       styles={{
         content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
         body: { display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 },
       }}
     >
-      <div className="flex min-h-0 flex-1 flex-col">
-        {/* Filter Bar */}
-        <div className="border-b border-border px-4 py-2 flex items-center gap-2 flex-shrink-0">
-          <Filter className="h-4 w-4 text-muted-foreground" />
-          <Select
-            value={agentFilter}
-            onChange={(value) => setAgentFilter(value ?? 'all')}
-            allowDeselect={false}
-            size="xs"
-            w={150}
-            data={[
-              { value: 'all', label: 'All Agents' },
-              ...uniqueAgents.map((agent) => ({ value: agent, label: agent })),
-            ]}
-            aria-label="Filter by agent"
-          />
-          <Button
-            variant={includeSystem ? 'filled' : 'outline'}
-            size="xs"
-            onClick={() => setIncludeSystem(!includeSystem)}
-            className="ml-auto gap-1.5"
-            title={includeSystem ? 'Hide system messages' : 'Show system messages'}
-            leftSection={<Settings2 className="h-3.5 w-3.5" />}
-          >
-            {includeSystem ? 'Hide' : 'Show'} System
-          </Button>
-        </div>
-
-        {/* Messages */}
-        <ScrollArea
-          className="flex-1 min-h-0 px-4"
-          onScrollCapture={handleScroll}
-          ref={scrollAreaRef}
-        >
-          <div className="py-4 space-y-3">
-            {isLoading && (
-              <div className="text-center text-muted-foreground py-8">
-                <Loader2 className="h-8 w-8 mx-auto mb-2 animate-spin" />
-                <p className="text-sm">Loading messages...</p>
-              </div>
-            )}
-            {!isLoading && filteredMessages.length === 0 && (
-              <div className="text-center text-muted-foreground py-8">
-                <Users className="h-12 w-12 mx-auto mb-2 opacity-50" />
-                <p className="text-sm">
-                  {agentFilter === 'all'
-                    ? 'No messages yet. Be the first to say something!'
-                    : `No messages from ${agentFilter}`}
-                </p>
-              </div>
-            )}
-            {filteredMessages.map((msg) =>
-              msg.system ? (
-                <SystemMessageDivider key={msg.id} message={msg} />
-              ) : (
-                <SquadMessageBubble
-                  key={msg.id}
-                  message={msg}
-                  humanDisplayName={humanDisplayName}
-                />
-              )
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-        </ScrollArea>
-
-        {/* Input Area */}
-        <div className="border-t border-border p-4 flex-shrink-0 space-y-2">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="text-xs text-muted-foreground">Sending as:</span>
-            <Select
-              value={selectedAgent}
-              onChange={(value) => setSelectedAgent(value ?? humanDisplayName ?? 'Human')}
-              allowDeselect={false}
-              size="xs"
-              w={140}
-              data={availableAgents.map((agent) => ({ value: agent, label: agent }))}
-              aria-label="Sending as"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <TextInput
-              ref={inputRef}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              onKeyDown={handleKeyPress}
-              placeholder="Send a message to the squad..."
-              disabled={isPending}
-              className="flex-1"
-              autoFocus
-            />
-            <ActionIcon
-              onClick={handleSend}
-              disabled={!message.trim() || isPending}
-              aria-label="Send squad message"
-            >
-              {isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Send className="h-4 w-4" />
-              )}
-            </ActionIcon>
-          </div>
-        </div>
-      </div>
+      {panelContent}
     </Drawer>
   );
 }

--- a/web/src/components/layout/DesktopBottomPanel.tsx
+++ b/web/src/components/layout/DesktopBottomPanel.tsx
@@ -1,0 +1,91 @@
+import { lazy, Suspense } from 'react';
+import { ActionIcon, Group, SegmentedControl, Text } from '@mantine/core';
+import { MessageSquare, PanelBottomClose, Users } from 'lucide-react';
+
+import {
+  useDesktopShell,
+  type DesktopBottomPanel as DesktopBottomPanelId,
+} from './DesktopShellContext';
+
+const ChatPanel = lazy(() =>
+  import('@/components/chat/ChatPanel').then((mod) => ({
+    default: mod.ChatPanel,
+  }))
+);
+
+const SquadChatPanel = lazy(() =>
+  import('@/components/chat/SquadChatPanel').then((mod) => ({
+    default: mod.SquadChatPanel,
+  }))
+);
+
+const PANEL_OPTIONS = [
+  { label: 'Board Chat', value: 'board-chat' },
+  { label: 'Squad Chat', value: 'squad-chat' },
+] satisfies Array<{ label: string; value: DesktopBottomPanelId }>;
+
+export function DesktopBottomPanel() {
+  const { isDesktopClient, bottomPanel, openBottomPanel, closeBottomPanel } = useDesktopShell();
+
+  if (!isDesktopClient || !bottomPanel) return null;
+
+  return (
+    <section
+      className="desktop-bottom-panel border-t border-border bg-card"
+      aria-label="Desktop bottom panel"
+    >
+      <Group
+        justify="space-between"
+        wrap="nowrap"
+        className="desktop-no-drag h-11 border-b border-border px-3"
+      >
+        <Group gap="xs" wrap="nowrap">
+          {bottomPanel === 'board-chat' ? (
+            <MessageSquare className="h-4 w-4 text-primary" aria-hidden="true" />
+          ) : (
+            <Users className="h-4 w-4 text-primary" aria-hidden="true" />
+          )}
+          <Text size="sm" fw={600}>
+            Workbench
+          </Text>
+          <SegmentedControl
+            size="xs"
+            value={bottomPanel}
+            onChange={(value) => openBottomPanel(value as DesktopBottomPanelId)}
+            data={PANEL_OPTIONS}
+            aria-label="Bottom panel"
+          />
+        </Group>
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          size={30}
+          onClick={closeBottomPanel}
+          aria-label="Close bottom panel"
+          title="Close bottom panel"
+        >
+          <PanelBottomClose className="h-4 w-4" aria-hidden="true" />
+        </ActionIcon>
+      </Group>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <Suspense
+          fallback={
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Loading panel...
+            </div>
+          }
+        >
+          {bottomPanel === 'board-chat' ? (
+            <ChatPanel open onOpenChange={(open) => !open && closeBottomPanel()} variant="inline" />
+          ) : (
+            <SquadChatPanel
+              open
+              onOpenChange={(open) => !open && closeBottomPanel()}
+              variant="inline"
+            />
+          )}
+        </Suspense>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/layout/DesktopLeftSidebar.tsx
+++ b/web/src/components/layout/DesktopLeftSidebar.tsx
@@ -1,0 +1,100 @@
+import { ScrollArea, Text } from '@mantine/core';
+import {
+  Activity,
+  Archive,
+  Clock,
+  ClipboardList,
+  FileText,
+  GitBranch,
+  Inbox,
+  LayoutDashboard,
+  ListOrdered,
+  Scale,
+  ShieldAlert,
+  Workflow,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { useView } from '@/contexts/ViewContext';
+import { useBacklogCount } from '@/hooks/useBacklog';
+import { VIEW_DEFINITIONS, type ViewIcon } from '@/lib/views';
+import { cn } from '@/lib/utils';
+import { useDesktopShell } from './DesktopShellContext';
+
+const VIEW_ICONS: Record<ViewIcon, LucideIcon> = {
+  Activity,
+  Archive,
+  Clock,
+  ClipboardList,
+  FileText,
+  GitBranch,
+  Inbox,
+  LayoutDashboard,
+  ListOrdered,
+  Scale,
+  ShieldAlert,
+  Workflow,
+};
+
+const DESKTOP_NAV_ITEMS = VIEW_DEFINITIONS.filter(
+  (item) => item.view === 'board' || item.showInNavigation
+);
+
+export function DesktopLeftSidebar() {
+  const { isDesktopClient, leftRailOpen } = useDesktopShell();
+  const { view, setView } = useView();
+  const { data: backlogCount = 0 } = useBacklogCount();
+
+  if (!isDesktopClient) return null;
+
+  return (
+    <aside
+      aria-label="Desktop navigation"
+      className={cn(
+        'desktop-left-sidebar border-r border-border bg-card/80 transition-[width] duration-150',
+        leftRailOpen ? 'w-56' : 'w-12'
+      )}
+    >
+      <ScrollArea className="h-full">
+        <nav className="flex flex-col gap-1 p-2">
+          {DESKTOP_NAV_ITEMS.map((item) => {
+            const Icon = VIEW_ICONS[item.icon];
+            const active = view === item.view;
+            const badge = item.view === 'backlog' && backlogCount > 0 ? backlogCount : null;
+
+            return (
+              <button
+                key={item.view}
+                type="button"
+                title={item.title ?? item.label}
+                aria-current={active ? 'page' : undefined}
+                onClick={() => setView(item.view)}
+                className={cn(
+                  'desktop-no-drag flex min-h-9 items-center gap-2 rounded-md px-2 text-left text-sm transition-colors',
+                  active
+                    ? 'bg-primary/15 text-primary'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  !leftRailOpen && 'justify-center px-0'
+                )}
+              >
+                <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                {leftRailOpen && (
+                  <>
+                    <Text component="span" size="sm" className="min-w-0 flex-1 truncate">
+                      {item.title ?? item.label}
+                    </Text>
+                    {badge !== null && (
+                      <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                        {badge > 99 ? '99+' : badge}
+                      </span>
+                    )}
+                  </>
+                )}
+              </button>
+            );
+          })}
+        </nav>
+      </ScrollArea>
+    </aside>
+  );
+}

--- a/web/src/components/layout/DesktopShellContext.tsx
+++ b/web/src/components/layout/DesktopShellContext.tsx
@@ -1,0 +1,168 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type DesktopBottomPanel = 'board-chat' | 'squad-chat';
+
+interface DesktopShellContextValue {
+  isDesktopClient: boolean;
+  leftRailOpen: boolean;
+  rightRailOpen: boolean;
+  bottomPanel: DesktopBottomPanel | null;
+  setLeftRailOpen: (open: boolean) => void;
+  setRightRailOpen: (open: boolean) => void;
+  openBottomPanel: (panel: DesktopBottomPanel) => void;
+  closeBottomPanel: () => void;
+  toggleBottomPanel: (panel?: DesktopBottomPanel) => void;
+}
+
+const LEFT_RAIL_STORAGE_KEY = 'veritas.desktop.leftRailOpen';
+const RIGHT_RAIL_STORAGE_KEY = 'veritas.desktop.rightRailOpen';
+const BOTTOM_PANEL_STORAGE_KEY = 'veritas.desktop.bottomPanel';
+
+const DEFAULT_CONTEXT: DesktopShellContextValue = {
+  isDesktopClient: false,
+  leftRailOpen: false,
+  rightRailOpen: false,
+  bottomPanel: null,
+  setLeftRailOpen: () => undefined,
+  setRightRailOpen: () => undefined,
+  openBottomPanel: () => undefined,
+  closeBottomPanel: () => undefined,
+  toggleBottomPanel: () => undefined,
+};
+
+const DesktopShellContext = createContext<DesktopShellContextValue>(DEFAULT_CONTEXT);
+
+function isDesktopClient(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    Boolean((window as Window & { veritasDesktop?: unknown }).veritasDesktop)
+  );
+}
+
+function readStoredBoolean(key: string, fallback: boolean): boolean {
+  if (typeof window === 'undefined') return fallback;
+
+  try {
+    const value = window.localStorage.getItem(key);
+    if (value === null) return fallback;
+    return value === 'true';
+  } catch {
+    return fallback;
+  }
+}
+
+function readStoredBottomPanel(): DesktopBottomPanel | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const value = window.localStorage.getItem(BOTTOM_PANEL_STORAGE_KEY);
+    return value === 'board-chat' || value === 'squad-chat' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredValue(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Local storage can be unavailable in hardened test/browser environments.
+  }
+}
+
+export function DesktopShellProvider({ children }: { children: ReactNode }) {
+  const desktopClient = isDesktopClient();
+  const [leftRailOpen, setLeftRailOpenState] = useState(() =>
+    readStoredBoolean(LEFT_RAIL_STORAGE_KEY, true)
+  );
+  const [rightRailOpen, setRightRailOpenState] = useState(() =>
+    readStoredBoolean(RIGHT_RAIL_STORAGE_KEY, false)
+  );
+  const [bottomPanel, setBottomPanel] = useState<DesktopBottomPanel | null>(() =>
+    readStoredBottomPanel()
+  );
+
+  const setLeftRailOpen = useCallback(
+    (open: boolean) => {
+      setLeftRailOpenState(open);
+      if (desktopClient) writeStoredValue(LEFT_RAIL_STORAGE_KEY, String(open));
+    },
+    [desktopClient]
+  );
+
+  const setRightRailOpen = useCallback(
+    (open: boolean) => {
+      setRightRailOpenState(open);
+      if (desktopClient) writeStoredValue(RIGHT_RAIL_STORAGE_KEY, String(open));
+    },
+    [desktopClient]
+  );
+
+  const openBottomPanel = useCallback(
+    (panel: DesktopBottomPanel) => {
+      setBottomPanel(panel);
+      if (desktopClient) writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, panel);
+    },
+    [desktopClient]
+  );
+
+  const closeBottomPanel = useCallback(() => {
+    setBottomPanel(null);
+    if (desktopClient) writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, 'closed');
+  }, [desktopClient]);
+
+  const toggleBottomPanel = useCallback(
+    (panel: DesktopBottomPanel = 'board-chat') => {
+      setBottomPanel((current) => {
+        const next = current === panel ? null : panel;
+        if (desktopClient) writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, next ?? 'closed');
+        return next;
+      });
+    },
+    [desktopClient]
+  );
+
+  useEffect(() => {
+    if (!desktopClient || typeof document === 'undefined') return;
+    document.documentElement.dataset.client = 'desktop';
+  }, [desktopClient]);
+
+  const value = useMemo<DesktopShellContextValue>(
+    () => ({
+      isDesktopClient: desktopClient,
+      leftRailOpen: desktopClient ? leftRailOpen : false,
+      rightRailOpen: desktopClient ? rightRailOpen : false,
+      bottomPanel: desktopClient ? bottomPanel : null,
+      setLeftRailOpen,
+      setRightRailOpen,
+      openBottomPanel,
+      closeBottomPanel,
+      toggleBottomPanel,
+    }),
+    [
+      bottomPanel,
+      closeBottomPanel,
+      desktopClient,
+      leftRailOpen,
+      openBottomPanel,
+      rightRailOpen,
+      setLeftRailOpen,
+      setRightRailOpen,
+      toggleBottomPanel,
+    ]
+  );
+
+  return <DesktopShellContext.Provider value={value}>{children}</DesktopShellContext.Provider>;
+}
+
+export function useDesktopShell() {
+  return useContext(DesktopShellContext);
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -28,6 +28,13 @@ import {
   LayoutDashboard,
   ListOrdered,
   MoreHorizontal,
+  MessageSquare,
+  PanelBottom,
+  PanelBottomClose,
+  PanelLeft,
+  PanelLeftClose,
+  PanelRight,
+  PanelRightClose,
   Scale,
   ShieldAlert,
   type LucideIcon,
@@ -37,7 +44,7 @@ import {
 import { UserMenu } from './UserMenu';
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 import { WebSocketIndicator } from '@/components/shared/WebSocketIndicator';
-import { lazy, Suspense, useState, useCallback, useEffect } from 'react';
+import { lazy, Suspense, useState, useCallback, useEffect, type MouseEvent } from 'react';
 import { useKeyboard } from '@/hooks/useKeyboard';
 import { useView } from '@/contexts/ViewContext';
 import { useBacklogCount } from '@/hooks/useBacklog';
@@ -46,6 +53,7 @@ import { useIdentity } from '@/hooks/useIdentity';
 import type { SearchCollection } from '@/lib/api';
 import { NAVIGATION_VIEWS, type ViewIcon } from '@/lib/views';
 import { cn } from '@/lib/utils';
+import { useDesktopShell } from './DesktopShellContext';
 
 const CreateTaskDialog = lazy(() =>
   import('@/components/task/CreateTaskDialog').then((mod) => ({
@@ -116,13 +124,12 @@ function VeritasMark({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        'relative grid h-8 w-8 shrink-0 place-items-center overflow-hidden rounded-lg border border-primary/30 bg-primary/15 text-primary shadow-sm',
+        'relative grid h-8 w-8 shrink-0 place-items-center overflow-hidden rounded-lg border border-white/10 bg-card shadow-sm',
         className
       )}
       aria-hidden="true"
     >
-      <span className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.25),transparent_45%)]" />
-      <Scale className="relative h-[18px] w-[18px]" strokeWidth={2.25} />
+      <img src="/icons/pwa-icon-192.png" alt="" className="h-full w-full object-cover" />
     </span>
   );
 }
@@ -145,9 +152,16 @@ export function Header() {
   const { hasPermission } = useIdentity();
   const canCreateTask = hasPermission('task:write');
   const canOpenSettings = hasPermission('settings:read') || hasPermission('admin:manage');
-  const isDesktopClient =
-    typeof window !== 'undefined' &&
-    Boolean((window as Window & { veritasDesktop?: unknown }).veritasDesktop);
+  const {
+    isDesktopClient,
+    leftRailOpen,
+    rightRailOpen,
+    bottomPanel,
+    setLeftRailOpen,
+    setRightRailOpen,
+    openBottomPanel,
+    toggleBottomPanel,
+  } = useDesktopShell();
 
   const toggleView = useCallback(
     (nextView: NavigationItem['view']) => setView(view === nextView ? 'board' : nextView),
@@ -170,9 +184,13 @@ export function Header() {
   }, [markPanelLoaded]);
 
   const openChatPanel = useCallback(() => {
+    if (isDesktopClient) {
+      openBottomPanel('board-chat');
+      return;
+    }
     markPanelLoaded('chat');
     setChatOpen(true);
-  }, [markPanelLoaded]);
+  }, [isDesktopClient, markPanelLoaded, openBottomPanel]);
 
   const openSearchDialog = useCallback(
     (preset?: SearchPreset) => {
@@ -184,9 +202,13 @@ export function Header() {
   );
 
   const openSquadChatPanel = useCallback(() => {
+    if (isDesktopClient) {
+      openBottomPanel('squad-chat');
+      return;
+    }
     markPanelLoaded('squadChat');
     setSquadChatOpen(true);
-  }, [markPanelLoaded]);
+  }, [isDesktopClient, markPanelLoaded, openBottomPanel]);
 
   const openSettingsDialog = useCallback(
     (section?: string) => {
@@ -284,6 +306,26 @@ export function Header() {
     return () => window.removeEventListener('veritas:open-search', handleOpenSearch);
   }, [openSearchDialog]);
 
+  const handleChromeDoubleClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      if (!isDesktopClient) return;
+      const target = event.target as HTMLElement;
+      if (
+        target.closest(
+          'button, a, input, textarea, select, [role="button"], [role="combobox"], .desktop-no-drag'
+        )
+      ) {
+        return;
+      }
+      void (
+        window as Window & {
+          veritasDesktop?: { toggleWindowMaximize?: () => Promise<{ maximized: boolean }> };
+        }
+      ).veritasDesktop?.toggleWindowMaximize?.();
+    },
+    [isDesktopClient]
+  );
+
   // Register the create dialog and chat panel openers with keyboard context (refs, no useEffect needed)
   setOpenCreateDialog(openCreateDialog);
   setOpenChatPanel(openChatPanel);
@@ -291,7 +333,7 @@ export function Header() {
   return (
     <Box
       component="header"
-      className="sticky top-0 z-50 border-b border-border bg-card"
+      className="desktop-app-header sticky top-0 z-50 border-b border-border bg-card"
       role="banner"
     >
       <Container fluid px={{ base: 'xs', sm: 'md' }}>
@@ -301,18 +343,14 @@ export function Header() {
           h={58}
           justify="space-between"
           wrap="nowrap"
-          className="min-w-0"
+          className="desktop-window-drag min-w-0"
+          onDoubleClick={handleChromeDoubleClick}
         >
-          <Group
-            gap="sm"
-            wrap="nowrap"
-            miw={0}
-            className={cn('min-w-0 flex-1', isDesktopClient && 'pl-[4.75rem]')}
-          >
+          <Group gap="sm" wrap="nowrap" miw={0} className="desktop-header-leading min-w-0 flex-1">
             <Box
               component="button"
               type="button"
-              className="flex shrink-0 items-center gap-2 transition-opacity hover:opacity-80"
+              className="desktop-no-drag flex shrink-0 items-center gap-2 transition-opacity hover:opacity-80"
               onClick={() => window.location.reload()}
               aria-label="Refresh page"
               title="Refresh page"
@@ -344,6 +382,55 @@ export function Header() {
             aria-label="Board actions"
             className="min-w-0 shrink-0"
           >
+            {isDesktopClient && (
+              <Group gap={4} wrap="nowrap" className="desktop-no-drag">
+                <ActionIcon
+                  variant={leftRailOpen ? 'light' : 'subtle'}
+                  color={leftRailOpen ? 'veritas' : 'gray'}
+                  size={32}
+                  onClick={() => setLeftRailOpen(!leftRailOpen)}
+                  aria-label={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
+                  aria-pressed={leftRailOpen}
+                  title={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
+                >
+                  {leftRailOpen ? (
+                    <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <PanelLeft className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </ActionIcon>
+                <ActionIcon
+                  variant={rightRailOpen ? 'light' : 'subtle'}
+                  color={rightRailOpen ? 'veritas' : 'gray'}
+                  size={32}
+                  onClick={() => setRightRailOpen(!rightRailOpen)}
+                  aria-label={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
+                  aria-pressed={rightRailOpen}
+                  title={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
+                >
+                  {rightRailOpen ? (
+                    <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <PanelRight className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </ActionIcon>
+                <ActionIcon
+                  variant={bottomPanel ? 'light' : 'subtle'}
+                  color={bottomPanel ? 'veritas' : 'gray'}
+                  size={32}
+                  onClick={() => toggleBottomPanel('board-chat')}
+                  aria-label={bottomPanel ? 'Close bottom panel' : 'Open bottom panel'}
+                  aria-pressed={Boolean(bottomPanel)}
+                  title={bottomPanel ? 'Close bottom panel' : 'Open bottom panel'}
+                >
+                  {bottomPanel ? (
+                    <PanelBottomClose className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <PanelBottom className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </ActionIcon>
+              </Group>
+            )}
             <Button
               variant="filled"
               size="sm"
@@ -355,9 +442,11 @@ export function Header() {
             >
               New Task
             </Button>
-            <Group gap={4} wrap="nowrap" className="hidden xl:flex">
-              {PRIMARY_NAVIGATION_VIEWS.map(renderNavigationAction)}
-            </Group>
+            {!isDesktopClient && (
+              <Group gap={4} wrap="nowrap" className="hidden xl:flex">
+                {PRIMARY_NAVIGATION_VIEWS.map(renderNavigationAction)}
+              </Group>
+            )}
             <Menu position="bottom-end" shadow="md" withinPortal>
               <Menu.Target>
                 <ActionIcon
@@ -384,6 +473,16 @@ export function Header() {
               title="Search"
             >
               <Search className="h-4 w-4" aria-hidden="true" />
+            </ActionIcon>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size={32}
+              onClick={openChatPanel}
+              aria-label="Board Chat"
+              title="Board Chat"
+            >
+              <MessageSquare className="h-4 w-4" aria-hidden="true" />
             </ActionIcon>
             <ActionIcon
               variant="subtle"

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "tw-animate-css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
 @custom-variant dark (&:is(.dark *));
 @config "../tailwind.config.js";
 
@@ -24,61 +24,61 @@
 }
 
 @custom-variant data-open {
-  &:where([data-state="open"]),
-  &:where([data-open]:not([data-open="false"])) {
+  &:where([data-state='open']),
+  &:where([data-open]:not([data-open='false'])) {
     @slot;
   }
 }
 
 @custom-variant data-closed {
-  &:where([data-state="closed"]),
-  &:where([data-closed]:not([data-closed="false"])) {
+  &:where([data-state='closed']),
+  &:where([data-closed]:not([data-closed='false'])) {
     @slot;
   }
 }
 
 @custom-variant data-checked {
-  &:where([data-state="checked"]),
-  &:where([data-checked]:not([data-checked="false"])) {
+  &:where([data-state='checked']),
+  &:where([data-checked]:not([data-checked='false'])) {
     @slot;
   }
 }
 
 @custom-variant data-unchecked {
-  &:where([data-state="unchecked"]),
-  &:where([data-unchecked]:not([data-unchecked="false"])) {
+  &:where([data-state='unchecked']),
+  &:where([data-unchecked]:not([data-unchecked='false'])) {
     @slot;
   }
 }
 
 @custom-variant data-selected {
-  &:where([data-selected="true"]) {
+  &:where([data-selected='true']) {
     @slot;
   }
 }
 
 @custom-variant data-disabled {
-  &:where([data-disabled="true"]),
-  &:where([data-disabled]:not([data-disabled="false"])) {
+  &:where([data-disabled='true']),
+  &:where([data-disabled]:not([data-disabled='false'])) {
     @slot;
   }
 }
 
 @custom-variant data-active {
-  &:where([data-state="active"]),
-  &:where([data-active]:not([data-active="false"])) {
+  &:where([data-state='active']),
+  &:where([data-active]:not([data-active='false'])) {
     @slot;
   }
 }
 
 @custom-variant data-horizontal {
-  &:where([data-orientation="horizontal"]) {
+  &:where([data-orientation='horizontal']) {
     @slot;
   }
 }
 
 @custom-variant data-vertical {
-  &:where([data-orientation="vertical"]) {
+  &:where([data-orientation='vertical']) {
     @slot;
   }
 }
@@ -118,6 +118,89 @@
   /* WCAG 2.1 SC 2.4.7 — Visible focus indicators */
   :focus-visible {
     @apply outline-2 outline-offset-2 outline-ring;
+  }
+}
+
+html[data-client='desktop'],
+html[data-client='desktop'] body,
+html[data-client='desktop'] #root {
+  height: 100%;
+  overflow: hidden;
+}
+
+html[data-client='desktop'] .desktop-app-shell {
+  display: flex;
+  height: 100vh;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+html[data-client='desktop'] .desktop-app-header {
+  flex: 0 0 auto;
+  user-select: none;
+}
+
+html[data-client='desktop'] .desktop-window-drag {
+  -webkit-app-region: drag;
+}
+
+html[data-client='desktop'] .desktop-no-drag,
+html[data-client='desktop'] button,
+html[data-client='desktop'] input,
+html[data-client='desktop'] textarea,
+html[data-client='desktop'] select,
+html[data-client='desktop'] [role='button'],
+html[data-client='desktop'] [role='menu'],
+html[data-client='desktop'] [role='menuitem'],
+html[data-client='desktop'] [role='combobox'],
+html[data-client='desktop'] .mantine-Input-input {
+  -webkit-app-region: no-drag;
+}
+
+html[data-client='desktop'] .desktop-header-leading {
+  padding-left: 6rem;
+}
+
+html[data-client='desktop'] .desktop-workbench {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+html[data-client='desktop'] .desktop-left-sidebar {
+  min-height: 0;
+  flex: 0 0 auto;
+}
+
+html[data-client='desktop'] .desktop-main-content {
+  min-height: 0;
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+html[data-client='desktop'] .desktop-bottom-panel {
+  display: flex;
+  min-height: 240px;
+  max-height: 34vh;
+  flex: 0 0 clamp(240px, 30vh, 360px);
+  flex-direction: column;
+  overflow: hidden;
+}
+
+html[data-client='desktop'] .desktop-board-with-right-rail {
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+}
+
+@media (max-width: 900px) {
+  html[data-client='desktop'] .desktop-header-leading {
+    padding-left: 5.5rem;
+  }
+
+  html[data-client='desktop'] .desktop-board-with-right-rail {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace the web-style desktop surface with a native desktop shell: macOS-safe header spacing, drag/double-click maximize support, left navigation rail, collapsible right rail, and docked bottom workbench panel.
- Move Board Chat and Squad Chat into bounded inline desktop panels instead of off-screen drawers/floating controls.
- Package the Electron preload as CommonJS so the desktop bridge loads in signed/packaged app runs, fixing clean-install readiness and setup diagnostics.
- Keep empty clean-install boards stable and fit all configured board columns at the desktop minimum size.

Closes #674.
Closes #675.
Closes #676.

## Verification
- `node_modules/.bin/tsc --noEmit` from `web/`
- `node_modules/.bin/vitest run --testTimeout 15000 src/__tests__/layout-chrome-mantine.test.tsx src/__tests__/activity-chat-mantine.test.tsx src/__tests__/KanbanBoard.test.tsx` from `web/`
- `node_modules/.bin/tsc --noEmit` from `desktop/`
- `node_modules/.bin/vitest run --config vitest.config.ts` from `desktop/`
- `node_modules/.bin/eslint ...` on all touched files
- `node_modules/.bin/tsc -b && node_modules/.bin/vite build` from `web/`
- `node_modules/.bin/electron-vite build` from `desktop/`
- `node ../scripts/prepare-desktop-release.mjs && node ./node_modules/electron-builder/cli.js --mac dir --publish never --config.mac.identity=null --config.mac.notarize=false` from `desktop/`
- Packaged app smoke with isolated desktop profile and Chromium remote debugging:
  - `window.veritasDesktop` present on first-run setup
  - readiness checks reached Ready/Stable instead of Desktop Bridge Unsupported
  - clean setup completed with 0-task board and no fetch failure
  - 1180x768 board rendered all four columns in bounds
  - bottom Board Chat panel rendered inside viewport
  - right rail expanded inside viewport
  - `window.veritasDesktop.toggleWindowMaximize()` returned `{ maximized: true }`

## Notes
- Local mac directory package is intentionally unsigned for smoke validation because the command sets `--config.mac.identity=null`.
- The working tree still has existing untracked local storage folders; they are not part of this PR.
