### PR TITLE
Ignore runtime storage roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ tasks/archive/*.md
 tasks/backlog/*.md
 tasks/attachments/
 tasks/archive-attachments/
+storage/
+server/storage/
 .veritas-kanban/*
 !.veritas-kanban/.gitkeep
 .veritas-desktop-dev/


### PR DESCRIPTION
## Summary
- Ignore local `storage/` and `server/storage/` runtime data roots.
- Keep clean-install smoke data on disk without polluting `git status`.

## Verification
- `git check-ignore -v storage server/storage`
- `./node_modules/.bin/tsc` in `shared/`
- `./node_modules/.bin/tsc` in `server/`
- `./node_modules/.bin/tsc -b` in `web/`
- `./node_modules/.bin/tsc` in `cli/`
- `./node_modules/.bin/tsc` in `mcp/`
- `./node_modules/.bin/vite build` in `web/`
- `./node_modules/.bin/electron-vite build` in `desktop/`
- `node ../scripts/prepare-desktop-release.mjs` in `desktop/`
- `node ./node_modules/electron-builder/cli.js --mac dir --publish never --config.mac.identity=null --config.mac.notarize=false` in `desktop/`
- `git diff --check`

Closes #678
