### PR TITLE
Use pnpm for desktop release packaging

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,6 +7,7 @@
   "author": "Brad Groux <brad@digitalmeld.io>",
   "license": "MIT",
   "type": "module",
+  "packageManager": "pnpm@11.1.1",
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",


### PR DESCRIPTION
## Summary
- Add `packageManager: pnpm@11.1.1` to the desktop package so electron-builder detects pnpm during release packaging.
- Prevent the signed release workflow from falling back to npm module collection inside the pnpm workspace.

## Why
The signed Desktop Release workflow reached the publish step but failed during electron-builder module collection after reporting npm fallback from `desktop/`. Local packaging now reports `pm=pnpm` and completes the macOS app directory package path.

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('desktop/package.json','utf8')); console.log('desktop package json ok')"`
- `./node_modules/.bin/electron-vite build` in `desktop/`
- `node ./node_modules/electron-builder/cli.js --mac dir --publish never --config.mac.identity=null --config.mac.notarize=false` in `desktop/`
- `git diff --check`

Refs #680
