### PR TITLE
Publish desktop releases as public releases

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -169,7 +169,7 @@
         "provider": "github",
         "owner": "BradGroux",
         "repo": "veritas-kanban",
-        "releaseType": "draft"
+        "releaseType": "release"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Change desktop GitHub publish config from `draft` to `release`.
- Allow the Desktop Release workflow to publish/replace assets on the already-published stable v5.0.0 release.

## Why
The signed release workflow now signs and notarizes successfully, but electron-builder skipped uploading refreshed ZIP/DMG assets because the existing v5.0.0 release is public while the config requested draft publishing.

## Verification
- `node -e "const p=require('./desktop/package.json'); if (p.build.publish[0].releaseType !== 'release') process.exit(1); console.log('desktop publish releaseType ok')"`
- `node ./node_modules/electron-builder/cli.js --mac dir --publish never --config.mac.identity=null --config.mac.notarize=false` in `desktop/`
- `git diff --check`
- Signed release workflow `27063606262` signed and notarized successfully, then skipped upload due `existingType=release publishingType=draft` before this fix.

Refs #680
