### PR TITLE
Upload desktop release assets explicitly

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -82,7 +82,7 @@ jobs:
 
           echo "key_path=${key_path}" >> "${GITHUB_OUTPUT}"
 
-      - name: Build, sign, notarize, and publish macOS artifacts
+      - name: Build, sign, notarize, and stage macOS artifacts
         working-directory: desktop
         env:
           GH_TOKEN: ${{ github.token }}
@@ -92,3 +92,43 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: node ./node_modules/electron-builder/cli.js --mac dmg zip --publish always
+
+      - name: Upload macOS release assets
+        working-directory: desktop
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          version="$(node -p "require('./package.json').version")"
+          tag="v${version}"
+          dmg="release/Veritas-Kanban-${version}-mac-arm64.dmg"
+          zip="release/Veritas-Kanban-${version}-mac-arm64.zip"
+
+          for file in "${dmg}" "${zip}"; do
+            if [ ! -f "${file}" ]; then
+              echo "::error::Expected release asset missing: ${file}"
+              exit 1
+            fi
+
+            shasum -a 256 "${file}" > "${file}.sha256"
+          done
+
+          assets=(
+            "release/latest-mac.yml"
+            "${dmg}"
+            "${dmg}.blockmap"
+            "${dmg}.sha256"
+            "${zip}"
+            "${zip}.blockmap"
+            "${zip}.sha256"
+          )
+
+          for file in "${assets[@]}"; do
+            if [ ! -f "${file}" ]; then
+              echo "::error::Expected release asset missing: ${file}"
+              exit 1
+            fi
+          done
+
+          gh release upload "${tag}" "${assets[@]}" --clobber


### PR DESCRIPTION
## Summary
- stage signed/notarized macOS desktop artifacts with electron-builder
- generate SHA256 files for the ZIP and DMG
- upload the generated release assets with `gh release upload --clobber` so an existing stable tag can be refreshed intentionally

Closes #680 after the workflow is rerun and the release/tap/docs hashes are updated.

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/desktop-release.yml'); puts data.fetch('jobs').fetch('mac-signed').fetch('steps').last.fetch('run')" | bash -n`
