### PR TITLE
Write portable desktop release checksums

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -111,7 +111,8 @@ jobs:
               exit 1
             fi
 
-            shasum -a 256 "${file}" > "${file}.sha256"
+            checksum="$(shasum -a 256 "${file}" | awk '{print $1}')"
+            printf '%s  %s\n' "${checksum}" "$(basename "${file}")" > "${file}.sha256"
           done
 
           assets=(


### PR DESCRIPTION
## Summary
- write ZIP and DMG checksum files with asset basenames instead of `release/...` paths
- keep the explicit release asset clobber upload from #683

Part of #680.

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/desktop-release.yml'); puts data.fetch('jobs').fetch('mac-signed').fetch('steps').last.fetch('run')" | bash -n`
