### PR TITLE
Sign and verify desktop DMG releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -111,6 +111,11 @@ jobs:
               exit 1
             fi
 
+            if [ "${file}" = "${dmg}" ]; then
+              codesign --verify --verbose=2 "${file}"
+              spctl -a -vvv -t open --context context:primary-signature "${file}"
+            fi
+
             checksum="$(shasum -a 256 "${file}" | awk '{print $1}')"
             printf '%s  %s\n' "${checksum}" "$(basename "${file}")" > "${file}.sha256"
           done

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -91,7 +91,7 @@
       "notarize": true
     },
     "dmg": {
-      "sign": false,
+      "sign": true,
       "contents": [
         {
           "x": 130,


### PR DESCRIPTION
## Summary
- enable electron-builder DMG signing so the disk image is signed before blockmap/latest metadata generation
- fail the release upload step if the generated DMG does not pass codesign and Gatekeeper open assessment

Part of #680.

## Verification
- `git diff --check`
- `node -e "const p=require('./desktop/package.json'); if (p.build.dmg.sign !== true) process.exit(1); console.log('dmg signing enabled')"`
- `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/desktop-release.yml'); puts data.fetch('jobs').fetch('mac-signed').fetch('steps').last.fetch('run')" | bash -n`

Note: local unsigned packaging smoke exposed a separate existing script/install issue where production deploy prunes root dev tooling outside a TTY; I restored the workspace with `CI=true pnpm install --frozen-lockfile` and left that separate from this release signing PR.
