### PR TITLE
Polish settings dialog and workbench chat panels

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -113,7 +113,7 @@ function DesktopAwareAppShell({
           id="main-content"
           px={isDesktopClient ? 'md' : { base: 'md', md: '3.5rem' }}
           pt={isDesktopClient ? 'md' : 'lg'}
-          pb={isDesktopClient ? (bottomPanel ? 'md' : 'lg') : { base: '6rem', md: 'lg' }}
+          pb={bottomPanel ? 'md' : isDesktopClient ? 'lg' : { base: '6rem', md: 'lg' }}
           tabIndex={-1}
           className="desktop-main-content"
         >
@@ -125,7 +125,7 @@ function DesktopAwareAppShell({
       <DesktopBottomPanel />
       <Toaster />
       <CommandPalette />
-      {!isDesktopClient && (
+      {!isDesktopClient && !bottomPanel && (
         <Suspense fallback={null}>
           <FloatingChat />
         </Suspense>

--- a/web/src/components/layout/DesktopBottomPanel.tsx
+++ b/web/src/components/layout/DesktopBottomPanel.tsx
@@ -1,8 +1,17 @@
-import { lazy, Suspense } from 'react';
+import {
+  lazy,
+  Suspense,
+  useRef,
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react';
 import { ActionIcon, Group, SegmentedControl, Text } from '@mantine/core';
-import { MessageSquare, PanelBottomClose, Users } from 'lucide-react';
+import { GripHorizontal, MessageSquare, PanelBottomClose, Users } from 'lucide-react';
 
 import {
+  MAX_BOTTOM_PANEL_HEIGHT,
+  MIN_BOTTOM_PANEL_HEIGHT,
   useDesktopShell,
   type DesktopBottomPanel as DesktopBottomPanelId,
 } from './DesktopShellContext';
@@ -25,15 +34,78 @@ const PANEL_OPTIONS = [
 ] satisfies Array<{ label: string; value: DesktopBottomPanelId }>;
 
 export function DesktopBottomPanel() {
-  const { isDesktopClient, bottomPanel, openBottomPanel, closeBottomPanel } = useDesktopShell();
+  const {
+    bottomPanel,
+    bottomPanelHeight,
+    setBottomPanelHeight,
+    openBottomPanel,
+    closeBottomPanel,
+  } = useDesktopShell();
+  const dragStateRef = useRef<{ startY: number; startHeight: number } | null>(null);
 
-  if (!isDesktopClient || !bottomPanel) return null;
+  if (!bottomPanel) return null;
+
+  const resizeBy = (delta: number) => {
+    setBottomPanelHeight(bottomPanelHeight + delta);
+  };
+
+  const handleResizePointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    dragStateRef.current = {
+      startY: event.clientY,
+      startHeight: bottomPanelHeight,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handleResizePointerMove = (event: PointerEvent<HTMLButtonElement>) => {
+    if (!dragStateRef.current) return;
+    const delta = dragStateRef.current.startY - event.clientY;
+    setBottomPanelHeight(dragStateRef.current.startHeight + delta);
+  };
+
+  const handleResizePointerEnd = (event: PointerEvent<HTMLButtonElement>) => {
+    dragStateRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleResizeKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      resizeBy(event.shiftKey ? 80 : 24);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      resizeBy(event.shiftKey ? -80 : -24);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      setBottomPanelHeight(MIN_BOTTOM_PANEL_HEIGHT);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      setBottomPanelHeight(MAX_BOTTOM_PANEL_HEIGHT);
+    }
+  };
 
   return (
     <section
-      className="desktop-bottom-panel border-t border-border bg-card"
-      aria-label="Desktop bottom panel"
+      className="workbench-bottom-panel border-t border-border bg-card"
+      aria-label="Workbench bottom panel"
+      style={{ '--workbench-bottom-panel-height': `${bottomPanelHeight}px` } as CSSProperties}
     >
+      <button
+        type="button"
+        className="workbench-bottom-panel-resizer desktop-no-drag"
+        aria-label="Resize workbench panel"
+        title="Drag to resize workbench panel"
+        onPointerDown={handleResizePointerDown}
+        onPointerMove={handleResizePointerMove}
+        onPointerUp={handleResizePointerEnd}
+        onPointerCancel={handleResizePointerEnd}
+        onKeyDown={handleResizeKeyDown}
+      >
+        <GripHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
       <Group
         justify="space-between"
         wrap="nowrap"

--- a/web/src/components/layout/DesktopShellContext.tsx
+++ b/web/src/components/layout/DesktopShellContext.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { useMediaQuery } from '@mantine/hooks';
 
 export type DesktopBottomPanel = 'board-chat' | 'squad-chat';
 
@@ -15,8 +16,10 @@ interface DesktopShellContextValue {
   leftRailOpen: boolean;
   rightRailOpen: boolean;
   bottomPanel: DesktopBottomPanel | null;
+  bottomPanelHeight: number;
   setLeftRailOpen: (open: boolean) => void;
   setRightRailOpen: (open: boolean) => void;
+  setBottomPanelHeight: (height: number) => void;
   openBottomPanel: (panel: DesktopBottomPanel) => void;
   closeBottomPanel: () => void;
   toggleBottomPanel: (panel?: DesktopBottomPanel) => void;
@@ -25,14 +28,20 @@ interface DesktopShellContextValue {
 const LEFT_RAIL_STORAGE_KEY = 'veritas.desktop.leftRailOpen';
 const RIGHT_RAIL_STORAGE_KEY = 'veritas.desktop.rightRailOpen';
 const BOTTOM_PANEL_STORAGE_KEY = 'veritas.desktop.bottomPanel';
+const BOTTOM_PANEL_HEIGHT_STORAGE_KEY = 'veritas.workbench.bottomPanelHeight';
+export const DEFAULT_BOTTOM_PANEL_HEIGHT = 340;
+export const MIN_BOTTOM_PANEL_HEIGHT = 220;
+export const MAX_BOTTOM_PANEL_HEIGHT = 640;
 
 const DEFAULT_CONTEXT: DesktopShellContextValue = {
   isDesktopClient: false,
   leftRailOpen: false,
   rightRailOpen: false,
   bottomPanel: null,
+  bottomPanelHeight: DEFAULT_BOTTOM_PANEL_HEIGHT,
   setLeftRailOpen: () => undefined,
   setRightRailOpen: () => undefined,
+  setBottomPanelHeight: () => undefined,
   openBottomPanel: () => undefined,
   closeBottomPanel: () => undefined,
   toggleBottomPanel: () => undefined,
@@ -70,6 +79,30 @@ function readStoredBottomPanel(): DesktopBottomPanel | null {
   }
 }
 
+function clampBottomPanelHeight(height: number): number {
+  const viewportMax =
+    typeof window === 'undefined'
+      ? MAX_BOTTOM_PANEL_HEIGHT
+      : Math.max(MIN_BOTTOM_PANEL_HEIGHT, Math.floor(window.innerHeight * 0.68));
+  return Math.min(
+    Math.min(MAX_BOTTOM_PANEL_HEIGHT, viewportMax),
+    Math.max(MIN_BOTTOM_PANEL_HEIGHT, height)
+  );
+}
+
+function readStoredBottomPanelHeight(): number {
+  if (typeof window === 'undefined') return DEFAULT_BOTTOM_PANEL_HEIGHT;
+
+  try {
+    const value = Number(window.localStorage.getItem(BOTTOM_PANEL_HEIGHT_STORAGE_KEY));
+    return Number.isFinite(value)
+      ? clampBottomPanelHeight(value)
+      : clampBottomPanelHeight(DEFAULT_BOTTOM_PANEL_HEIGHT);
+  } catch {
+    return DEFAULT_BOTTOM_PANEL_HEIGHT;
+  }
+}
+
 function writeStoredValue(key: string, value: string): void {
   try {
     window.localStorage.setItem(key, value);
@@ -80,6 +113,8 @@ function writeStoredValue(key: string, value: string): void {
 
 export function DesktopShellProvider({ children }: { children: ReactNode }) {
   const desktopClient = isDesktopClient();
+  const supportsWorkbenchPanel = useMediaQuery('(min-width: 768px)', false);
+  const canUseBottomPanel = desktopClient || supportsWorkbenchPanel;
   const [leftRailOpen, setLeftRailOpenState] = useState(() =>
     readStoredBoolean(LEFT_RAIL_STORAGE_KEY, true)
   );
@@ -88,6 +123,9 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
   );
   const [bottomPanel, setBottomPanel] = useState<DesktopBottomPanel | null>(() =>
     readStoredBottomPanel()
+  );
+  const [bottomPanelHeight, setBottomPanelHeightState] = useState(() =>
+    readStoredBottomPanelHeight()
   );
 
   const setLeftRailOpen = useCallback(
@@ -106,29 +144,29 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
     [desktopClient]
   );
 
-  const openBottomPanel = useCallback(
-    (panel: DesktopBottomPanel) => {
-      setBottomPanel(panel);
-      if (desktopClient) writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, panel);
-    },
-    [desktopClient]
-  );
+  const setBottomPanelHeight = useCallback((height: number) => {
+    const next = clampBottomPanelHeight(height);
+    setBottomPanelHeightState(next);
+    writeStoredValue(BOTTOM_PANEL_HEIGHT_STORAGE_KEY, String(next));
+  }, []);
+
+  const openBottomPanel = useCallback((panel: DesktopBottomPanel) => {
+    setBottomPanel(panel);
+    writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, panel);
+  }, []);
 
   const closeBottomPanel = useCallback(() => {
     setBottomPanel(null);
-    if (desktopClient) writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, 'closed');
-  }, [desktopClient]);
+    writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, 'closed');
+  }, []);
 
-  const toggleBottomPanel = useCallback(
-    (panel: DesktopBottomPanel = 'board-chat') => {
-      setBottomPanel((current) => {
-        const next = current === panel ? null : panel;
-        if (desktopClient) writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, next ?? 'closed');
-        return next;
-      });
-    },
-    [desktopClient]
-  );
+  const toggleBottomPanel = useCallback((panel: DesktopBottomPanel = 'board-chat') => {
+    setBottomPanel((current) => {
+      const next = current === panel ? null : panel;
+      writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, next ?? 'closed');
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     if (!desktopClient || typeof document === 'undefined') return;
@@ -140,9 +178,11 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
       isDesktopClient: desktopClient,
       leftRailOpen: desktopClient ? leftRailOpen : false,
       rightRailOpen: desktopClient ? rightRailOpen : false,
-      bottomPanel: desktopClient ? bottomPanel : null,
+      bottomPanel: canUseBottomPanel ? bottomPanel : null,
+      bottomPanelHeight,
       setLeftRailOpen,
       setRightRailOpen,
+      setBottomPanelHeight,
       openBottomPanel,
       closeBottomPanel,
       toggleBottomPanel,
@@ -150,10 +190,13 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
     [
       bottomPanel,
       closeBottomPanel,
+      canUseBottomPanel,
       desktopClient,
+      bottomPanelHeight,
       leftRailOpen,
       openBottomPanel,
       rightRailOpen,
+      setBottomPanelHeight,
       setLeftRailOpen,
       setRightRailOpen,
       toggleBottomPanel,

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import {
   Menu,
   Text,
 } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import {
   Plus,
   Settings,
@@ -145,6 +146,7 @@ export function Header() {
   const [chatOpen, setChatOpen] = useState(false);
   const [squadChatOpen, setSquadChatOpen] = useState(false);
   const [loadedPanels, setLoadedPanels] = useState<Set<LazyPanel>>(() => new Set());
+  const supportsWorkbenchPanel = useMediaQuery('(min-width: 768px)', false);
   const { setOpenCreateDialog, setOpenChatPanel } = useKeyboard();
   const { view, setView, navigateToTask } = useView();
   const { data: backlogCount = 0 } = useBacklogCount();
@@ -184,13 +186,13 @@ export function Header() {
   }, [markPanelLoaded]);
 
   const openChatPanel = useCallback(() => {
-    if (isDesktopClient) {
+    if (isDesktopClient || supportsWorkbenchPanel) {
       openBottomPanel('board-chat');
       return;
     }
     markPanelLoaded('chat');
     setChatOpen(true);
-  }, [isDesktopClient, markPanelLoaded, openBottomPanel]);
+  }, [isDesktopClient, markPanelLoaded, openBottomPanel, supportsWorkbenchPanel]);
 
   const openSearchDialog = useCallback(
     (preset?: SearchPreset) => {
@@ -202,13 +204,13 @@ export function Header() {
   );
 
   const openSquadChatPanel = useCallback(() => {
-    if (isDesktopClient) {
+    if (isDesktopClient || supportsWorkbenchPanel) {
       openBottomPanel('squad-chat');
       return;
     }
     markPanelLoaded('squadChat');
     setSquadChatOpen(true);
-  }, [isDesktopClient, markPanelLoaded, openBottomPanel]);
+  }, [isDesktopClient, markPanelLoaded, openBottomPanel, supportsWorkbenchPanel]);
 
   const openSettingsDialog = useCallback(
     (section?: string) => {
@@ -382,38 +384,42 @@ export function Header() {
             aria-label="Board actions"
             className="min-w-0 shrink-0"
           >
-            {isDesktopClient && (
+            {(isDesktopClient || supportsWorkbenchPanel) && (
               <Group gap={4} wrap="nowrap" className="desktop-no-drag">
-                <ActionIcon
-                  variant={leftRailOpen ? 'light' : 'subtle'}
-                  color={leftRailOpen ? 'veritas' : 'gray'}
-                  size={32}
-                  onClick={() => setLeftRailOpen(!leftRailOpen)}
-                  aria-label={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
-                  aria-pressed={leftRailOpen}
-                  title={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
-                >
-                  {leftRailOpen ? (
-                    <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
-                  ) : (
-                    <PanelLeft className="h-4 w-4" aria-hidden="true" />
-                  )}
-                </ActionIcon>
-                <ActionIcon
-                  variant={rightRailOpen ? 'light' : 'subtle'}
-                  color={rightRailOpen ? 'veritas' : 'gray'}
-                  size={32}
-                  onClick={() => setRightRailOpen(!rightRailOpen)}
-                  aria-label={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
-                  aria-pressed={rightRailOpen}
-                  title={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
-                >
-                  {rightRailOpen ? (
-                    <PanelRightClose className="h-4 w-4" aria-hidden="true" />
-                  ) : (
-                    <PanelRight className="h-4 w-4" aria-hidden="true" />
-                  )}
-                </ActionIcon>
+                {isDesktopClient && (
+                  <>
+                    <ActionIcon
+                      variant={leftRailOpen ? 'light' : 'subtle'}
+                      color={leftRailOpen ? 'veritas' : 'gray'}
+                      size={32}
+                      onClick={() => setLeftRailOpen(!leftRailOpen)}
+                      aria-label={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
+                      aria-pressed={leftRailOpen}
+                      title={leftRailOpen ? 'Collapse left sidebar' : 'Expand left sidebar'}
+                    >
+                      {leftRailOpen ? (
+                        <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <PanelLeft className="h-4 w-4" aria-hidden="true" />
+                      )}
+                    </ActionIcon>
+                    <ActionIcon
+                      variant={rightRailOpen ? 'light' : 'subtle'}
+                      color={rightRailOpen ? 'veritas' : 'gray'}
+                      size={32}
+                      onClick={() => setRightRailOpen(!rightRailOpen)}
+                      aria-label={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
+                      aria-pressed={rightRailOpen}
+                      title={rightRailOpen ? 'Collapse right sidebar' : 'Expand right sidebar'}
+                    >
+                      {rightRailOpen ? (
+                        <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <PanelRight className="h-4 w-4" aria-hidden="true" />
+                      )}
+                    </ActionIcon>
+                  </>
+                )}
                 <ActionIcon
                   variant={bottomPanel ? 'light' : 'subtle'}
                   color={bottomPanel ? 'veritas' : 'gray'}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -448,20 +448,29 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
       trapFocus
       returnFocus
       closeButtonProps={{ 'aria-label': 'Close settings' }}
+      classNames={{
+        content: 'settings-dialog-content',
+        body: 'settings-dialog-body',
+      }}
       styles={{
         content: { height: '85vh', overflow: 'hidden' },
         body: { height: '100%', padding: 0 },
+        close: { top: '1rem', right: '1rem' },
       }}
     >
       <ErrorBoundary level="section">
-        <div ref={dialogContentRef} className="flex h-full min-h-0" onKeyDown={handleDialogKeyDown}>
+        <div
+          ref={dialogContentRef}
+          className="settings-dialog flex h-full min-h-0"
+          onKeyDown={handleDialogKeyDown}
+        >
           {/* Sidebar Tabs — hidden on narrow screens, shown as dropdown instead */}
-          <div className="hidden sm:flex flex-col w-48 border-r bg-muted/30 py-4">
+          <div className="hidden min-h-0 w-48 flex-col border-r bg-muted/30 py-4 sm:flex">
             <div className="px-4 pb-3">
               <h2 className="text-sm font-semibold">Settings</h2>
             </div>
             <nav
-              className="flex-1 space-y-0.5 px-2"
+              className="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-2 pr-1"
               role="tablist"
               aria-orientation="vertical"
               onKeyDown={handleKeyDown}
@@ -500,7 +509,7 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
             </nav>
 
             {/* Import/Export/Reset */}
-            <Stack gap={4} className="mt-auto border-t px-2 pt-3">
+            <Stack gap={4} className="mt-auto shrink-0 border-t px-3 pt-3 pb-6">
               <input
                 ref={settingsFileInputRef}
                 type="file"

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -181,13 +181,47 @@ html[data-client='desktop'] .desktop-main-content {
   overflow: auto;
 }
 
-html[data-client='desktop'] .desktop-bottom-panel {
+.workbench-bottom-panel {
   display: flex;
-  min-height: 240px;
-  max-height: 34vh;
-  flex: 0 0 clamp(240px, 30vh, 360px);
+  height: var(--workbench-bottom-panel-height, 340px);
+  min-height: 220px;
+  max-height: min(68vh, 640px);
+  flex: 0 0 var(--workbench-bottom-panel-height, 340px);
   flex-direction: column;
   overflow: hidden;
+}
+
+html:not([data-client='desktop']) .workbench-bottom-panel {
+  position: sticky;
+  bottom: 0;
+  z-index: 35;
+  box-shadow: 0 -12px 32px color-mix(in oklch, var(--foreground) 10%, transparent);
+}
+
+html[data-client='desktop'] .workbench-bottom-panel {
+  min-height: 240px;
+  max-height: min(68vh, 640px);
+  flex: 0 0 var(--workbench-bottom-panel-height, 340px);
+}
+
+.workbench-bottom-panel-resizer {
+  display: flex;
+  height: 10px;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklch, var(--card) 92%, var(--muted));
+  color: var(--muted-foreground);
+  cursor: ns-resize;
+  touch-action: none;
+}
+
+.workbench-bottom-panel-resizer:hover,
+.workbench-bottom-panel-resizer:focus-visible {
+  background: color-mix(in oklch, var(--primary) 12%, var(--card));
+  color: var(--foreground);
 }
 
 html[data-client='desktop'] .desktop-board-with-right-rail {
@@ -202,6 +236,54 @@ html[data-client='desktop'] .desktop-board-with-right-rail {
   html[data-client='desktop'] .desktop-board-with-right-rail {
     grid-template-columns: 1fr;
   }
+}
+
+.settings-dialog-content,
+.settings-dialog {
+  --settings-surface: var(--background);
+  --settings-panel: color-mix(in oklch, var(--muted) 52%, var(--background));
+  --settings-card: var(--card);
+  --settings-muted-card: color-mix(in oklch, var(--muted) 42%, var(--card));
+  --settings-border: var(--border);
+}
+
+.dark .settings-dialog-content,
+.dark .settings-dialog {
+  --settings-surface: oklch(0.17 0.01 286);
+  --settings-panel: oklch(0.205 0.012 286);
+  --settings-card: oklch(0.19 0.012 286);
+  --settings-muted-card: oklch(0.22 0.012 286);
+  --settings-border: oklch(0.31 0.014 286);
+}
+
+.settings-dialog-content {
+  background: var(--settings-surface) !important;
+  border: 1px solid var(--settings-border);
+}
+
+.settings-dialog [class~='bg-card'] {
+  background-color: var(--settings-card) !important;
+}
+
+.settings-dialog [class~='bg-muted/30'],
+.settings-dialog [class~='bg-background/50'] {
+  background-color: var(--settings-panel) !important;
+}
+
+.settings-dialog [class~='border'],
+.settings-dialog [class~='border-r'],
+.settings-dialog [class~='border-t'],
+.settings-dialog [class~='border-b'],
+.settings-dialog [class~='border-dashed'] {
+  border-color: var(--settings-border) !important;
+}
+
+.settings-dialog .mantine-Input-input,
+.settings-dialog .mantine-Select-input,
+.settings-dialog .mantine-Textarea-input,
+.settings-dialog .mantine-NumberInput-input {
+  background: var(--settings-muted-card);
+  border-color: var(--settings-border);
 }
 
 /* Custom scrollbar for dark mode */


### PR DESCRIPTION
## Summary
- keep Settings modal chrome and import/export/reset controls inside the viewport with scrollable tab navigation
- scope Settings dark-mode surfaces so pages match the light-mode structure without black-box panels
- make Board Chat and Squad Chat use a shared resizable workbench bottom panel on desktop-sized web and mac desktop clients

Closes #690.
Closes #691.

## Verification
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/web lint (existing 34 warnings, 0 errors)
- pnpm --filter @veritas-kanban/web build
- Browser smoke against isolated clean-install profile on http://127.0.0.1:3000 with API on 127.0.0.1:3101: setup/login, empty board load, Settings modal light/dark geometry, Agents tab dark surfaces, Board Chat bottom panel resize, Squad Chat switch, console errors = 0

## Notes
- Smoke used a throwaway /tmp data dir with localhost admin bypass so the installed app password and user data were not changed.