### PR TITLE
Add Ollama and LM Studio agent providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [Setup Paths](docs/SETUP-PATHS.md) — start here for board-only, CLI, MCP, OpenClaw, and self-hosted paths without mixing optional layers into first-run setup.
 - [Getting Started Guide](docs/GETTING-STARTED.md) — zero ➝ agent-ready in 5 minutes, plus sanity checks and prompt registry tips.
 - [MCP Server Guide](docs/mcp/README.md) — optional MCP setup, 36 tools, architecture, tool catalog, security model, and read/write smoke checks.
+- [Agent Providers](docs/AGENT-PROVIDERS.md) — Codex defaults, Ollama local/cloud, LM Studio local, routing, and web vs macOS behavior.
 - [OpenAI Codex Integration Roadmap](docs/CODEX-INTEGRATION.md) — optional local execution, SDK sessions, cloud delegation, MCP setup, workflows, telemetry, and release QA.
 - [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) — authority model, HermesAgent roster, QA evidence gate, and GitHub-backed task templates.
 - [Codex Integration SOP](docs/SOP-codex-integration.md) & [Codex Workflow Examples](docs/EXAMPLES-codex-workflows.md) — operational playbooks for using Codex as a first-class Veritas agent.
@@ -216,7 +217,8 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **Custom agents** — Add your own agents with any name and command; not limited to built-in types
 - **Platform-agnostic API** — REST endpoints work with any agentic platform
 - **HermesAgent support** — documents HermesAgent/Hermes Gateway as the active control plane, with Veritas as the GitHub-backed source of truth
-- **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, and MCP setup
+- **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, MCP setup, and default routing for fresh installs
+- **Local LLM provider profiles** — Optional Ollama Local, Ollama Cloud, and LM Studio Local profiles with health metadata and routing support
 - **Optional OpenClaw support** — Native integration with [OpenClaw](https://github.com/openclaw/openclaw) when you want OpenClaw to execute or wake agents
 - **Squad Chat** — Real-time agent-to-agent communication with WebSocket updates, system lifecycle events, model attribution per message, and configurable display names
 - **@Mention notifications** — @agent-name parsing in comments, thread subscriptions
@@ -612,6 +614,7 @@ VK also documents the Codex and Hermes operating model:
 - **HermesAgent/Hermes Gateway is the active control plane** for the named Hermes roster and execution routing.
 - **Mission Control is display/control only** in the cutover model, while GitHub Issues, PRs, review comments, and CI remain the durable delivery record.
 - **OpenAI Codex can be a first-class agent** through local CLI runs, SDK sessions, Codex Cloud delegation, workflow steps, review actions, and MCP access.
+- **Ollama and LM Studio profiles are first-class routing targets** for local/server-hosted model workflows, with Ollama Cloud available when cloud execution is intentional.
 
 ### How It Works
 
@@ -671,6 +674,7 @@ vk agents:pending
 ### Codex + HermesAgent
 
 - Follow the [Codex Integration SOP](docs/SOP-codex-integration.md) when Codex should implement, review, or delegate Veritas tasks.
+- Use the [Agent Providers guide](docs/AGENT-PROVIDERS.md) when enabling Codex, Ollama, LM Studio, or provider-specific routing in the web app or macOS app.
 - Use the [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) when routing work through the HermesAgent roster, enforcing QA evidence, or creating GitHub-backed task templates.
 - Configure Codex MCP access with the [MCP Server Guide](docs/mcp/README.md#codex) so Codex reads and updates Veritas through typed tools instead of one-off HTTP calls.
 

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -1,0 +1,48 @@
+# Agent Providers
+
+Veritas works as a board without any agent runner. When you do enable agents, provider profiles are configured in **Settings -> Agents** and are stored in the same app config for the web app and the macOS desktop app.
+
+## Defaults
+
+Fresh v5 installs use OpenAI Codex as the default agent:
+
+- `codex` is enabled by default and uses `codex exec --sandbox workspace-write --json`.
+- `claude-code`, `amp`, `copilot`, `gemini`, `codex-sdk`, `codex-cloud`, `ollama-local`, `ollama-cloud`, and `lm-studio-local` are available as profiles you can enable or route to.
+- Built-in routing sends code, bug, documentation, and review work to `codex` first, with conservative fallbacks for higher-risk code paths.
+
+Existing configs keep the user's chosen default agent. Missing built-in profiles are added during config normalization without overwriting customized commands, arguments, or enabled states.
+
+## Local And Cloud Profiles
+
+| Profile            | Provider          | Default command                               | Auth / readiness                    |
+| ------------------ | ----------------- | --------------------------------------------- | ----------------------------------- |
+| OpenAI Codex       | `codex-cli`       | `codex exec --sandbox workspace-write --json` | `codex login status`                |
+| OpenAI Codex SDK   | `codex-sdk`       | `codex`                                       | SDK import plus Codex login         |
+| OpenAI Codex Cloud | `codex-cloud`     | `gh`                                          | `gh auth status`                    |
+| Ollama Local       | `ollama-local`    | `ollama run llama3.2`                         | `ollama list`                       |
+| Ollama Cloud       | `ollama-cloud`    | `ollama run gpt-oss:120b-cloud`               | `ollama signin` or `OLLAMA_API_KEY` |
+| LM Studio Local    | `lm-studio-local` | `lms server status`                           | `lms server status --json --quiet`  |
+
+Ollama local API access does not require authentication on `localhost:11434`; cloud models require either `ollama signin` from the local install or an `OLLAMA_API_KEY`. See the official Ollama authentication docs: <https://docs.ollama.com/api/authentication>.
+
+LM Studio local serving is controlled by the `lms` CLI. `lms server start` starts the local API server, and `lms server status --json --quiet` returns machine-readable readiness. See the official LM Studio CLI docs: <https://lmstudio.ai/docs/cli/serve/server-status>.
+
+## Web App Vs macOS App
+
+The provider model is the same in both shells:
+
+- The web app talks to the Veritas server. Local providers execute on the server host, not on the browser machine.
+- The macOS app bundles and supervises the local Veritas server. Local providers execute on that Mac.
+- Cloud profiles are still explicit. Routing a local workflow to a cloud provider surfaces a warning during workflow dry-runs.
+- Remote or cloud clients should not route directly to local-only providers unless a trusted local host/supervisor is configured.
+
+## Routing
+
+Use **Settings -> Agents -> Agent Routing** to change defaults. A route can match task type, priority, project, or subtask count, then choose an agent, model override, and fallback.
+
+Recommended starting point:
+
+1. Keep `codex` as the default for general software work.
+2. Enable `ollama-local` or `lm-studio-local` for local model experiments where privacy and offline operation matter more than model capability.
+3. Enable `ollama-cloud` only when the workflow is allowed to leave local execution.
+4. Use explicit routing rules for local LLM profiles instead of making them global defaults on teams with mixed operating systems.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -278,7 +278,8 @@ First-class support for autonomous coding agents.
 - **Send message to agent** — Send text messages to running agents
 - **Optional OpenClaw support** — Built-in integration with [OpenClaw](https://github.com/openclaw/openclaw) (formerly Clawdbot/Moltbot) via gateway URL when you want OpenClaw to execute or wake agents
 - **HermesAgent operating support** — v4.3 documents HermesAgent/Hermes Gateway as the active control plane, with Veritas tracking task truth, QA evidence, and GitHub delivery state
-- **OpenAI Codex support** — Local CLI attempts, SDK sessions, GitHub-native Codex Cloud delegation, workflow steps, review actions, Settings health checks, and MCP setup
+- **OpenAI Codex support** — Local CLI attempts, SDK sessions, GitHub-native Codex Cloud delegation, workflow steps, review actions, Settings health checks, MCP setup, and fresh-install default routing
+- **Local LLM provider profiles** — Ollama Local, Ollama Cloud, and LM Studio Local profiles can be enabled, health-checked, and targeted by routing rules in the web app or macOS app
 - **Platform-agnostic REST API** — Any platform that can make HTTP calls can drive the full agent lifecycle
 - **Agent request tracking** — VK can create and display pending agent requests; a configured external runner/provider must execute the work
 - **Automation tasks** — Separate automation task type with pending/running/complete lifecycle, session key tracking, and sub-agent spawning
@@ -293,7 +294,8 @@ v4.3 adds first-class OpenAI Codex support: local `codex exec` attempts, SDK-bac
 Implemented:
 
 - **Codex CLI provider** — Runs `codex exec --json` in the task worktree, maps JSONL/stdout/stderr into Veritas attempt logs, records final summaries, and emits run/token telemetry when available.
-- **Codex agent defaults** — Adds a disabled-by-default OpenAI Codex agent profile with `codex exec --sandbox workspace-write --json`.
+- **Codex agent defaults** — Fresh installs enable the OpenAI Codex CLI profile by default with `codex exec --sandbox workspace-write --json`; existing configs keep their selected default agent.
+- **Ollama and LM Studio profiles** — Adds disabled-by-default Ollama Local, Ollama Cloud, and LM Studio Local profiles with provider metadata and health probes.
 - **Codex SDK provider** — Uses `@openai/codex-sdk` to start durable local Codex threads, stream SDK events into attempt logs, persist `threadId` on attempts, and emit token telemetry from completed turns.
 - **Codex Cloud delegation** — Creates scoped `@codex` GitHub issue/PR prompts, records cloud attempt metadata, and links the GitHub artifact back to the Veritas task.
 - **Workflow Codex steps** — Executes workflow-engine agent steps through Codex SDK streaming, writes step outputs, and stores Codex thread IDs in workflow session context.

--- a/server/src/__tests__/agent-routing-service.test.ts
+++ b/server/src/__tests__/agent-routing-service.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AgentRoutingService } from '../services/agent-routing-service';
-import type { AgentConfig, AgentRoutingConfig, AppConfig } from '@veritas-kanban/shared';
+import {
+  DEFAULT_ROUTING_CONFIG,
+  type AgentConfig,
+  type AgentRoutingConfig,
+  type AppConfig,
+} from '@veritas-kanban/shared';
 import type { AgentHealthStatus } from '../services/agent-health-service';
 
 // Mock ConfigService
@@ -126,6 +131,29 @@ describe('AgentRoutingService', () => {
   });
 
   describe('resolveAgent', () => {
+    it('routes default built-in rules to Codex first', async () => {
+      const config: AppConfig = {
+        ...structuredClone(BASE_CONFIG),
+        agents: [
+          { type: 'codex', name: 'OpenAI Codex', command: 'codex', args: [], enabled: true },
+          { type: 'claude-code', name: 'Claude Code', command: 'claude', args: [], enabled: false },
+          { type: 'amp', name: 'Amp', command: 'amp', args: [], enabled: false },
+        ],
+        defaultAgent: 'codex',
+        agentRouting: structuredClone(DEFAULT_ROUTING_CONFIG),
+      };
+      mockGetConfig.mockResolvedValue(config);
+
+      const result = await service.resolveAgent({
+        type: 'code',
+        priority: 'high',
+      });
+
+      expect(result.agent).toBe('codex');
+      expect(result.fallback).toBe('claude-code');
+      expect(result.rule).toBe('code-high');
+    });
+
     it('matches high-priority code task to first rule', async () => {
       const result = await service.resolveAgent({
         type: 'code',

--- a/server/src/__tests__/config-service-extended.test.ts
+++ b/server/src/__tests__/config-service-extended.test.ts
@@ -48,7 +48,7 @@ describe('ConfigService', () => {
             name: 'OpenAI Codex',
             command: 'codex',
             provider: 'codex-cli',
-            enabled: false,
+            enabled: true,
           }),
           expect.objectContaining({
             type: 'codex-sdk',
@@ -64,8 +64,30 @@ describe('ConfigService', () => {
             provider: 'codex-cloud',
             enabled: false,
           }),
+          expect.objectContaining({
+            type: 'ollama-local',
+            name: 'Ollama Local',
+            command: 'ollama',
+            provider: 'ollama-local',
+            enabled: false,
+          }),
+          expect.objectContaining({
+            type: 'ollama-cloud',
+            name: 'Ollama Cloud',
+            command: 'ollama',
+            provider: 'ollama-cloud',
+            enabled: false,
+          }),
+          expect.objectContaining({
+            type: 'lm-studio-local',
+            name: 'LM Studio Local',
+            command: 'lms',
+            provider: 'lm-studio-local',
+            enabled: false,
+          }),
         ])
       );
+      expect(config.defaultAgent).toBe('codex');
     });
 
     it('should create config file with defaults when missing', async () => {
@@ -127,6 +149,21 @@ describe('ConfigService', () => {
             type: 'codex-cloud',
             command: 'gh',
             provider: 'codex-cloud',
+          }),
+          expect.objectContaining({
+            type: 'ollama-local',
+            command: 'ollama',
+            provider: 'ollama-local',
+          }),
+          expect.objectContaining({
+            type: 'ollama-cloud',
+            command: 'ollama',
+            provider: 'ollama-cloud',
+          }),
+          expect.objectContaining({
+            type: 'lm-studio-local',
+            command: 'lms',
+            provider: 'lm-studio-local',
           }),
         ])
       );

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -211,6 +211,32 @@ describe('Config Routes (actual module)', () => {
           provider: 'codex-cloud',
           model: 'gpt-5.5',
         },
+        {
+          type: 'ollama-local',
+          name: 'Ollama Local',
+          command: 'ollama',
+          args: ['run', 'llama3.2'],
+          enabled: true,
+          provider: 'ollama-local',
+          model: 'llama3.2',
+        },
+        {
+          type: 'ollama-cloud',
+          name: 'Ollama Cloud',
+          command: 'ollama',
+          args: ['run', 'gpt-oss:120b-cloud'],
+          enabled: true,
+          provider: 'ollama-cloud',
+          model: 'gpt-oss:120b-cloud',
+        },
+        {
+          type: 'lm-studio-local',
+          name: 'LM Studio Local',
+          command: 'lms',
+          args: ['server', 'status'],
+          enabled: true,
+          provider: 'lm-studio-local',
+        },
       ];
       mockConfigService.updateAgents.mockResolvedValue({ agents });
       const res = await request(app).put('/api/config/agents').send(agents);

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -678,7 +678,18 @@ describe('Config Schemas', () => {
     });
 
     it('should accept all valid agent types', () => {
-      const agents = ['claude-code', 'amp', 'copilot', 'gemini'];
+      const agents = [
+        'claude-code',
+        'amp',
+        'copilot',
+        'gemini',
+        'codex',
+        'codex-sdk',
+        'codex-cloud',
+        'ollama-local',
+        'ollama-cloud',
+        'lm-studio-local',
+      ];
       for (const agent of agents) {
         expect(SetDefaultAgentBodySchema.parse({ agent }).agent).toBe(agent);
       }

--- a/server/src/__tests__/settings-service.test.ts
+++ b/server/src/__tests__/settings-service.test.ts
@@ -17,9 +17,9 @@ describe('ConfigService', () => {
     testRoot = path.join(os.tmpdir(), `veritas-test-config-${uniqueSuffix}`);
     configDir = path.join(testRoot, '.veritas-kanban');
     configFile = path.join(configDir, 'config.json');
-    
+
     await fs.mkdir(configDir, { recursive: true });
-    
+
     service = new ConfigService({
       configDir,
       configFile,
@@ -37,7 +37,7 @@ describe('ConfigService', () => {
   describe('Feature Settings', () => {
     it('should return defaults when no config exists', async () => {
       const features = await service.getFeatureSettings();
-      
+
       expect(features).toEqual(DEFAULT_FEATURE_SETTINGS);
       expect(features.board).toBeDefined();
       expect(features.tasks).toBeDefined();
@@ -46,10 +46,13 @@ describe('ConfigService', () => {
 
     it('should create config file with defaults on first access', async () => {
       await service.getConfig();
-      
-      const exists = await fs.access(configFile).then(() => true).catch(() => false);
+
+      const exists = await fs
+        .access(configFile)
+        .then(() => true)
+        .catch(() => false);
       expect(exists).toBe(true);
-      
+
       const content = await fs.readFile(configFile, 'utf-8');
       const parsed = JSON.parse(content);
       expect(parsed.features).toEqual(DEFAULT_FEATURE_SETTINGS);
@@ -58,19 +61,21 @@ describe('ConfigService', () => {
     it('should perform deep merge on PATCH', async () => {
       // First get config to create defaults
       await service.getConfig();
-      
+
       // Patch a nested value
       const updated = await service.updateFeatureSettings({
         board: {
           showDashboard: false,
         },
       });
-      
+
       // Should preserve other board settings
       expect(updated.board.showDashboard).toBe(false);
-      expect(updated.board.showArchiveSuggestions).toBe(DEFAULT_FEATURE_SETTINGS.board.showArchiveSuggestions);
+      expect(updated.board.showArchiveSuggestions).toBe(
+        DEFAULT_FEATURE_SETTINGS.board.showArchiveSuggestions
+      );
       expect(updated.board.cardDensity).toBe(DEFAULT_FEATURE_SETTINGS.board.cardDensity);
-      
+
       // Should preserve other top-level features
       expect(updated.tasks).toEqual(DEFAULT_FEATURE_SETTINGS.tasks);
       expect(updated.agents).toEqual(DEFAULT_FEATURE_SETTINGS.agents);
@@ -87,32 +92,34 @@ describe('ConfigService', () => {
           },
         },
       };
-      
+
       await fs.writeFile(configFile, JSON.stringify(partialConfig, null, 2));
-      
+
       // Force reload
       const config = await service.getConfig();
-      
+
       // Should merge with defaults
       expect(config.features.board.showDashboard).toBe(false);
-      expect(config.features.board.showArchiveSuggestions).toBe(DEFAULT_FEATURE_SETTINGS.board.showArchiveSuggestions);
+      expect(config.features.board.showArchiveSuggestions).toBe(
+        DEFAULT_FEATURE_SETTINGS.board.showArchiveSuggestions
+      );
       expect(config.features.board.cardDensity).toBe(DEFAULT_FEATURE_SETTINGS.board.cardDensity);
       expect(config.features.tasks).toEqual(DEFAULT_FEATURE_SETTINGS.tasks);
     });
 
     it('should handle multiple sequential patches', async () => {
       await service.getConfig();
-      
+
       // First patch
       await service.updateFeatureSettings({
         board: { showDashboard: false },
       });
-      
+
       // Second patch
       const updated = await service.updateFeatureSettings({
         tasks: { enableTimeTracking: false },
       });
-      
+
       // Both patches should be preserved
       expect(updated.board.showDashboard).toBe(false);
       expect(updated.tasks.enableTimeTracking).toBe(false);
@@ -120,17 +127,19 @@ describe('ConfigService', () => {
 
     it('should handle deeply nested patch objects', async () => {
       await service.getConfig();
-      
+
       const updated = await service.updateFeatureSettings({
         agents: {
           timeoutMinutes: 60,
           autoCommitOnComplete: true,
         },
       });
-      
+
       expect(updated.agents.timeoutMinutes).toBe(60);
       expect(updated.agents.autoCommitOnComplete).toBe(true);
-      expect(updated.agents.autoCleanupWorktrees).toBe(DEFAULT_FEATURE_SETTINGS.agents.autoCleanupWorktrees);
+      expect(updated.agents.autoCleanupWorktrees).toBe(
+        DEFAULT_FEATURE_SETTINGS.agents.autoCleanupWorktrees
+      );
       expect(updated.agents.enablePreview).toBe(DEFAULT_FEATURE_SETTINGS.agents.enablePreview);
     });
 
@@ -139,13 +148,13 @@ describe('ConfigService', () => {
       await service.updateFeatureSettings({
         board: { cardDensity: 'compact' },
       });
-      
+
       // Create new instance pointing to same config
       const newService = new ConfigService({
         configDir,
         configFile,
       });
-      
+
       const features = await newService.getFeatureSettings();
       expect(features.board.cardDensity).toBe('compact');
     });
@@ -155,26 +164,70 @@ describe('ConfigService', () => {
     it('should handle missing config directory gracefully', async () => {
       // Delete the config directory
       await fs.rm(configDir, { recursive: true, force: true });
-      
+
       // Should recreate on access
       const config = await service.getConfig();
       expect(config).toBeDefined();
-      
-      const exists = await fs.access(configDir).then(() => true).catch(() => false);
+
+      const exists = await fs
+        .access(configDir)
+        .then(() => true)
+        .catch(() => false);
       expect(exists).toBe(true);
     });
 
     it('should include default agents in new config', async () => {
       const config = await service.getConfig();
-      
+
       expect(config.agents).toBeDefined();
       expect(config.agents.length).toBeGreaterThan(0);
-      expect(config.agents.some(a => a.type === 'claude-code')).toBe(true);
+      expect(config.agents.some((a) => a.type === 'claude-code')).toBe(true);
+      expect(config.agents.some((a) => a.type === 'codex')).toBe(true);
+      expect(config.agents.some((a) => a.type === 'ollama-local')).toBe(true);
+      expect(config.agents.some((a) => a.type === 'ollama-cloud')).toBe(true);
+      expect(config.agents.some((a) => a.type === 'lm-studio-local')).toBe(true);
     });
 
     it('should set default agent', async () => {
       const config = await service.getConfig();
-      expect(config.defaultAgent).toBe('claude-code');
+      expect(config.defaultAgent).toBe('codex');
+    });
+
+    it('should use VERITAS_DATA_DIR for implicit file-backed config', async () => {
+      service.dispose();
+      const previousDataDir = process.env.DATA_DIR;
+      const previousVeritasDataDir = process.env.VERITAS_DATA_DIR;
+      const envRoot = path.join(testRoot, 'runtime-root');
+
+      delete process.env.DATA_DIR;
+      process.env.VERITAS_DATA_DIR = envRoot;
+
+      const envService = new ConfigService();
+      service = envService;
+
+      try {
+        const config = await envService.getConfig();
+        const envConfigFile = path.join(envRoot, '.veritas-kanban', 'config.json');
+        const raw = JSON.parse(await fs.readFile(envConfigFile, 'utf-8'));
+
+        expect(config.defaultAgent).toBe('codex');
+        expect(raw.defaultAgent).toBe('codex');
+        expect(raw.agents.find((agent: { type: string }) => agent.type === 'codex')?.enabled).toBe(
+          true
+        );
+      } finally {
+        if (previousDataDir === undefined) {
+          delete process.env.DATA_DIR;
+        } else {
+          process.env.DATA_DIR = previousDataDir;
+        }
+
+        if (previousVeritasDataDir === undefined) {
+          delete process.env.VERITAS_DATA_DIR;
+        } else {
+          process.env.VERITAS_DATA_DIR = previousVeritasDataDir;
+        }
+      }
     });
   });
 
@@ -182,20 +235,16 @@ describe('ConfigService', () => {
     it('should throw on corrupted config file', async () => {
       // Write invalid JSON
       await fs.writeFile(configFile, '{ invalid json }');
-      
+
       await expect(service.getConfig()).rejects.toThrow();
     });
 
     it('should handle concurrent reads', async () => {
       // Multiple simultaneous reads
-      const promises = [
-        service.getConfig(),
-        service.getConfig(),
-        service.getConfig(),
-      ];
-      
+      const promises = [service.getConfig(), service.getConfig(), service.getConfig()];
+
       const results = await Promise.all(promises);
-      
+
       // All should return the same config
       expect(results[0]).toEqual(results[1]);
       expect(results[1]).toEqual(results[2]);
@@ -206,7 +255,7 @@ describe('ConfigService', () => {
     it('should return cached config within TTL', async () => {
       // First read populates cache
       const config1 = await service.getConfig();
-      
+
       // Modify file on disk behind the service's back
       const raw = JSON.parse(await fs.readFile(configFile, 'utf-8'));
       raw.defaultAgent = 'amp';
@@ -214,7 +263,7 @@ describe('ConfigService', () => {
       // simulating a read within the TTL window
       (service as any).lastWriteTime = Date.now();
       await fs.writeFile(configFile, JSON.stringify(raw, null, 2));
-      
+
       // Should still return the cached version (TTL hasn't expired)
       const config2 = await service.getConfig();
       expect(config2.defaultAgent).toBe(config1.defaultAgent);
@@ -222,7 +271,7 @@ describe('ConfigService', () => {
 
     it('should re-read from disk after invalidateCache()', async () => {
       const config1 = await service.getConfig();
-      expect(config1.defaultAgent).toBe('claude-code');
+      expect(config1.defaultAgent).toBe('codex');
 
       // Modify file on disk
       const raw = JSON.parse(await fs.readFile(configFile, 'utf-8'));

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -182,7 +182,7 @@ router.post(
 
     // Use provided attemptId or current attempt
     const resolvedAttemptId = attemptId || task.attempt?.id || 'unknown';
-    const resolvedAgent = agent || task.attempt?.agent || 'claude-code';
+    const resolvedAgent = agent || task.attempt?.agent || 'codex';
 
     // Emit telemetry event
     const telemetry = getTelemetryService();

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -26,7 +26,18 @@ const agentSchema = z.object({
   command: z.string().min(1),
   args: z.array(z.string()),
   enabled: z.boolean(),
-  provider: z.enum(['openclaw', 'codex-cli', 'codex-sdk', 'codex-cloud', 'custom']).optional(),
+  provider: z
+    .enum([
+      'openclaw',
+      'codex-cli',
+      'codex-sdk',
+      'codex-cloud',
+      'ollama-local',
+      'ollama-cloud',
+      'lm-studio-local',
+      'custom',
+    ])
+    .optional(),
   model: z.string().optional(),
 });
 

--- a/server/src/services/agent-health-service.ts
+++ b/server/src/services/agent-health-service.ts
@@ -77,6 +77,23 @@ export class AgentHealthService implements AgentHealthChecker {
       return this.runAuthProbe(agent.command, ['auth', 'status'], /logged in/i);
     }
 
+    if (provider === 'ollama-local') {
+      return this.runAuthProbe(agent.command, ['list'], /name|model/i);
+    }
+
+    if (provider === 'ollama-cloud') {
+      if (process.env.OLLAMA_API_KEY) return { authenticated: true };
+      return { authenticated: null };
+    }
+
+    if (provider === 'lm-studio-local') {
+      return this.runAuthProbe(
+        agent.command,
+        ['server', 'status', '--json', '--quiet'],
+        /"running"\s*:\s*true|server is running/i
+      );
+    }
+
     if (provider.startsWith('codex') || command === 'codex') {
       return this.runAuthProbe(agent.command, ['login', 'status'], /logged in/i);
     }

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -13,6 +13,7 @@ import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import { withFileLock } from './file-lock.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteSettingsRepository } from '../storage/sqlite/settings-repository.js';
+import { getRuntimeDir } from '../utils/paths.js';
 
 /** How long cached config stays valid before re-reading from disk */
 const CACHE_TTL_MS = 60_000; // 60 seconds
@@ -20,10 +21,7 @@ const CACHE_TTL_MS = 60_000; // 60 seconds
 /** Ignore file-watcher events within this window after our own writes */
 const WRITE_DEBOUNCE_MS = 200;
 
-// Default paths - resolve to project root
-const PROJECT_ROOT = path.resolve(process.cwd(), '..');
-const CONFIG_DIR = path.join(PROJECT_ROOT, '.veritas-kanban');
-const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
+const CONFIG_FILENAME = 'config.json';
 
 const DEFAULT_CONFIG: AppConfig = {
   repos: [],
@@ -33,14 +31,14 @@ const DEFAULT_CONFIG: AppConfig = {
       name: 'Claude Code',
       command: 'claude',
       args: ['--dangerously-skip-permissions'],
-      enabled: true,
+      enabled: false,
     },
     {
       type: 'amp',
       name: 'Amp',
       command: 'amp',
       args: ['--dangerously-allow-all'],
-      enabled: true,
+      enabled: false,
     },
     {
       type: 'copilot',
@@ -61,7 +59,7 @@ const DEFAULT_CONFIG: AppConfig = {
       name: 'OpenAI Codex',
       command: 'codex',
       args: ['exec', '--sandbox', 'workspace-write', '--json'],
-      enabled: false,
+      enabled: true,
       provider: 'codex-cli',
     },
     {
@@ -80,8 +78,34 @@ const DEFAULT_CONFIG: AppConfig = {
       enabled: false,
       provider: 'codex-cloud',
     },
+    {
+      type: 'ollama-local',
+      name: 'Ollama Local',
+      command: 'ollama',
+      args: ['run', 'llama3.2'],
+      enabled: false,
+      provider: 'ollama-local',
+      model: 'llama3.2',
+    },
+    {
+      type: 'ollama-cloud',
+      name: 'Ollama Cloud',
+      command: 'ollama',
+      args: ['run', 'gpt-oss:120b-cloud'],
+      enabled: false,
+      provider: 'ollama-cloud',
+      model: 'gpt-oss:120b-cloud',
+    },
+    {
+      type: 'lm-studio-local',
+      name: 'LM Studio Local',
+      command: 'lms',
+      args: ['server', 'status'],
+      enabled: false,
+      provider: 'lm-studio-local',
+    },
   ],
-  defaultAgent: 'claude-code',
+  defaultAgent: 'codex',
 };
 
 export function createDefaultConfig(): AppConfig {
@@ -193,8 +217,8 @@ export class ConfigService {
   private ownsSqliteDatabase = false;
 
   constructor(options: ConfigServiceOptions = {}) {
-    this.configDir = options.configDir || CONFIG_DIR;
-    this.configFile = options.configFile || CONFIG_FILE;
+    this.configDir = options.configDir || getRuntimeDir();
+    this.configFile = options.configFile || path.join(this.configDir, CONFIG_FILENAME);
     const storageType =
       options.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 

--- a/server/src/services/workflow-authoring-service.ts
+++ b/server/src/services/workflow-authoring-service.ts
@@ -1607,7 +1607,10 @@ export class WorkflowAuthoringService {
       const command = agent.command ?? '';
       if (
         (clientMode === 'remote' || clientMode === 'cloud') &&
-        (provider === 'codex-cli' || command.includes('codex'))
+        (provider === 'codex-cli' ||
+          provider === 'ollama-local' ||
+          provider === 'lm-studio-local' ||
+          command.includes('codex'))
       ) {
         messages.push(
           message(
@@ -1619,13 +1622,13 @@ export class WorkflowAuthoringService {
           )
         );
       }
-      if (clientMode === 'local' && provider === 'codex-cloud') {
+      if (clientMode === 'local' && (provider === 'codex-cloud' || provider === 'ollama-cloud')) {
         messages.push(
           message(
             'info',
             'client',
             `agents[${index}].provider`,
-            `Agent ${agent.id} targets Codex Cloud.`,
+            `Agent ${agent.id} targets a cloud provider.`,
             'Confirm this workflow is intended to leave local execution.'
           )
         );

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -23,9 +23,19 @@ export interface AgentConfig {
   command: string;
   args: string[];
   enabled: boolean;
-  provider?: 'openclaw' | 'codex-cli' | 'codex-sdk' | 'codex-cloud' | 'custom';
+  provider?: AgentProvider;
   model?: string;
 }
+
+export type AgentProvider =
+  | 'openclaw'
+  | 'codex-cli'
+  | 'codex-sdk'
+  | 'codex-cloud'
+  | 'ollama-local'
+  | 'ollama-cloud'
+  | 'lm-studio-local'
+  | 'custom';
 
 // ============ Agent Routing Types ============
 
@@ -74,50 +84,44 @@ export const DEFAULT_ROUTING_CONFIG: AgentRoutingConfig = {
   rules: [
     {
       id: 'code-high',
-      name: 'High-priority code → Claude Code (Opus)',
+      name: 'High-priority code → OpenAI Codex',
       match: { type: 'code', priority: 'high' },
-      agent: 'claude-code',
-      model: 'opus',
-      fallback: 'amp',
+      agent: 'codex',
+      fallback: 'claude-code',
       enabled: true,
     },
     {
       id: 'code-default',
-      name: 'Code tasks → Claude Code (Sonnet)',
+      name: 'Code tasks → OpenAI Codex',
       match: { type: 'code' },
-      agent: 'claude-code',
-      model: 'sonnet',
-      fallback: 'copilot',
-      enabled: true,
-    },
-    {
-      id: 'bug-high',
-      name: 'High-priority bugs → Claude Code (Opus)',
-      match: { type: 'bug', priority: 'high' },
-      agent: 'claude-code',
-      model: 'opus',
+      agent: 'codex',
       fallback: 'amp',
       enabled: true,
     },
     {
+      id: 'bug-high',
+      name: 'High-priority bugs → OpenAI Codex',
+      match: { type: 'bug', priority: 'high' },
+      agent: 'codex',
+      fallback: 'claude-code',
+      enabled: true,
+    },
+    {
       id: 'docs',
-      name: 'Documentation → Claude Code (Haiku)',
+      name: 'Documentation → OpenAI Codex',
       match: { type: 'docs' },
-      agent: 'claude-code',
-      model: 'haiku',
+      agent: 'codex',
       enabled: true,
     },
     {
       id: 'review',
-      name: 'Code review → Claude Code (Opus)',
+      name: 'Code review → OpenAI Codex',
       match: { type: 'review' },
-      agent: 'claude-code',
-      model: 'opus',
+      agent: 'codex',
       enabled: true,
     },
   ],
-  defaultAgent: 'claude-code',
-  defaultModel: 'sonnet',
+  defaultAgent: 'codex',
   fallbackOnFailure: true,
   maxRetries: 1,
 };

--- a/shared/src/types/task.types.d.ts
+++ b/shared/src/types/task.types.d.ts
@@ -11,7 +11,18 @@ export interface QaGateState {
   passedBy?: string;
 }
 /** Built-in agent types. Custom agents use any string slug. */
-export type BuiltInAgentType = 'claude-code' | 'amp' | 'copilot' | 'gemini' | 'veritas';
+export type BuiltInAgentType =
+  | 'claude-code'
+  | 'amp'
+  | 'copilot'
+  | 'gemini'
+  | 'codex'
+  | 'codex-sdk'
+  | 'codex-cloud'
+  | 'ollama-local'
+  | 'ollama-cloud'
+  | 'lm-studio-local'
+  | 'veritas';
 export type AgentType = BuiltInAgentType | (string & {});
 export type AttemptStatus = 'pending' | 'running' | 'complete' | 'failed';
 export type BlockedCategory = 'waiting-on-feedback' | 'technical-snag' | 'prerequisite' | 'other';

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -22,7 +22,11 @@ export type BuiltInAgentType =
   | 'copilot'
   | 'gemini'
   | 'codex'
+  | 'codex-sdk'
   | 'codex-cloud'
+  | 'ollama-local'
+  | 'ollama-cloud'
+  | 'lm-studio-local'
   | 'veritas';
 export type AgentType = BuiltInAgentType | (string & {});
 export type AttemptStatus = 'pending' | 'running' | 'complete' | 'failed';

--- a/web/src/__tests__/api-helpers.test.ts
+++ b/web/src/__tests__/api-helpers.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { API_BASE, apiFetch, handleResponse } from '@/lib/api/helpers';
+import { normalizeApiBase } from '@/lib/config';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -130,5 +131,14 @@ describe('handleResponse', () => {
 
     expect(fetch).toHaveBeenNthCalledWith(1, `${API_BASE}/tasks`, expect.any(Object));
     expect(fetch).toHaveBeenNthCalledWith(2, `${API_BASE}/metrics`, expect.any(Object));
+  });
+
+  it('normalizes a pure API origin to the /api base path', () => {
+    expect(normalizeApiBase('http://127.0.0.1:3101')).toBe('http://127.0.0.1:3101/api');
+    expect(normalizeApiBase('https://example.com/')).toBe('https://example.com/api');
+    expect(normalizeApiBase('/kanban/api')).toBe('/kanban/api');
+    expect(normalizeApiBase('https://example.com/custom-api')).toBe(
+      'https://example.com/custom-api'
+    );
   });
 });

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -12,6 +12,7 @@ const agents: AgentConfig[] = [
     args: ['exec'],
     enabled: true,
     provider: 'codex-cli',
+    model: 'gpt-5',
   },
   {
     type: 'claude-code' as AgentType,
@@ -287,6 +288,8 @@ describe('Agents settings Mantine migration', () => {
     const { baseElement } = renderWithProviders(<AgentsTab />);
 
     expect(screen.getByText('Installed Agents')).toBeDefined();
+    expect(screen.getByText('Codex CLI')).toBeDefined();
+    expect(screen.getByText('gpt-5')).toBeDefined();
     expect(screen.getByText('Codex Health')).toBeDefined();
     expect(screen.getByText('Context Provider Health')).toBeDefined();
     expect(screen.getByText('Agent Host Health')).toBeDefined();
@@ -348,6 +351,9 @@ describe('Agents settings Mantine migration', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Arguments' }), {
       target: { value: 'run --fast' },
     });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Model' }), {
+      target: { value: 'gemini-2.5-pro' },
+    });
     expect(baseElement.querySelectorAll('.mantine-TextInput-root').length).toBeGreaterThanOrEqual(
       5
     );
@@ -362,6 +368,7 @@ describe('Agents settings Mantine migration', () => {
         command: 'gemini',
         args: ['run', '--fast'],
         enabled: true,
+        model: 'gemini-2.5-pro',
       }),
     ]);
   });

--- a/web/src/__tests__/useWebSocket.test.ts
+++ b/web/src/__tests__/useWebSocket.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
-import { useWebSocket } from '@/hooks/useWebSocket';
+import { resolveDefaultWsUrl, useWebSocket } from '@/hooks/useWebSocket';
 import { createMockWebSocket } from './test-utils';
 
 // ── Setup ────────────────────────────────────────────────────
@@ -35,6 +35,29 @@ afterEach(() => {
 // ── Tests ────────────────────────────────────────────────────
 
 describe('useWebSocket', () => {
+  it('resolves same-origin WebSocket URLs from the current host and base path', () => {
+    expect(
+      resolveDefaultWsUrl('/api', { protocol: 'http:', host: 'localhost:5173' }, '/kanban/')
+    ).toBe('ws://localhost:5173/kanban/ws');
+  });
+
+  it('resolves WebSocket URLs from an absolute API base', () => {
+    expect(
+      resolveDefaultWsUrl(
+        'http://127.0.0.1:3101/api',
+        { protocol: 'http:', host: 'localhost:5173' },
+        '/'
+      )
+    ).toBe('ws://127.0.0.1:3101/ws');
+    expect(
+      resolveDefaultWsUrl(
+        'https://example.com/kanban/api',
+        { protocol: 'http:', host: 'localhost:5173' },
+        '/'
+      )
+    ).toBe('wss://example.com/kanban/ws');
+  });
+
   it('starts disconnected when autoConnect is false', () => {
     const { result } = renderHook(() => useWebSocket({ autoConnect: false }));
     expect(result.current.connectionState).toBe('disconnected');

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -26,6 +26,7 @@ import type {
   AgentHostPosture,
   AgentHostPreviewRequest,
   AgentHostRecord,
+  AgentProvider,
   AgentType,
   RoutingRule,
   AgentRoutingConfig,
@@ -41,6 +42,18 @@ import { cn } from '@/lib/utils';
 import { ToggleRow, NumberRow, SectionHeader, SaveIndicator } from '../shared';
 
 type AgentFeatureSettings = typeof DEFAULT_FEATURE_SETTINGS.agents;
+
+const AGENT_PROVIDER_OPTIONS: Array<{ value: AgentProvider | '__none__'; label: string }> = [
+  { value: '__none__', label: 'None / legacy' },
+  { value: 'codex-cli', label: 'Codex CLI' },
+  { value: 'codex-sdk', label: 'Codex SDK' },
+  { value: 'codex-cloud', label: 'Codex Cloud' },
+  { value: 'ollama-local', label: 'Ollama Local' },
+  { value: 'ollama-cloud', label: 'Ollama Cloud' },
+  { value: 'lm-studio-local', label: 'LM Studio Local' },
+  { value: 'openclaw', label: 'OpenClaw' },
+  { value: 'custom', label: 'Custom' },
+];
 
 export function AgentsTab() {
   const { data: config, isLoading } = useConfig();
@@ -262,6 +275,13 @@ function formatProviderState(value: string): string {
     .split('-')
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function formatAgentProvider(provider: AgentProvider): string {
+  return (
+    AGENT_PROVIDER_OPTIONS.find((option) => option.value === provider)?.label ??
+    formatProviderState(provider)
+  );
 }
 
 function ProviderHealthPanel({
@@ -798,6 +818,18 @@ function AgentItem({ agent, isDefault, onToggle, onEdit, onRemove }: AgentItemPr
             <code className="text-xs text-muted-foreground">
               {agent.command} {agent.args.join(' ')}
             </code>
+            <div className="mt-1 flex flex-wrap gap-1">
+              {agent.provider && (
+                <Badge size="xs" variant="outline" color="gray">
+                  {formatAgentProvider(agent.provider)}
+                </Badge>
+              )}
+              {agent.model && (
+                <Badge size="xs" variant="light" color="gray">
+                  {agent.model}
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -1461,6 +1493,8 @@ function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps)
   const [type, setType] = useState(agent?.type || '');
   const [command, setCommand] = useState(agent?.command || '');
   const [argsStr, setArgsStr] = useState(agent?.args.join(' ') || '');
+  const [provider, setProvider] = useState<AgentProvider | ''>(agent?.provider || '');
+  const [model, setModel] = useState(agent?.model || '');
 
   const typeSlug =
     type ||
@@ -1483,8 +1517,8 @@ function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps)
         .split(/\s+/)
         .filter((a) => a),
       enabled: agent?.enabled ?? true,
-      provider: agent?.provider,
-      model: agent?.model,
+      provider: provider || undefined,
+      model: model.trim() || undefined,
     });
   };
 
@@ -1538,6 +1572,28 @@ function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps)
             value={argsStr}
             onChange={(e) => setArgsStr(e.target.value)}
             placeholder="e.g., --flag -p"
+            classNames={{ input: 'font-mono text-sm' }}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Select
+            id="agent-provider"
+            label="Provider"
+            value={provider || '__none__'}
+            onChange={(value) =>
+              setProvider(!value || value === '__none__' ? '' : (value as AgentProvider))
+            }
+            data={AGENT_PROVIDER_OPTIONS}
+            allowDeselect={false}
+          />
+          <TextInput
+            id="agent-model"
+            label="Model"
+            description="Optional"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder="e.g., llama3.2"
             classNames={{ input: 'font-mono text-sm' }}
           />
         </div>

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { API_BASE } from '@/lib/config';
 
 // ============================================
 // WebSocket Connection States
@@ -60,11 +61,26 @@ const KEEPALIVE_TIMEOUT_MS = 45_000;
 /** Default maximum number of reconnect attempts before giving up. */
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 20;
 
-function getDefaultWsUrl(): string {
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+export function resolveDefaultWsUrl(
+  apiBase = API_BASE,
+  location: Pick<Location, 'protocol' | 'host'> = window.location,
+  basePath = import.meta.env.BASE_URL || '/'
+): string {
+  if (/^https?:\/\//i.test(apiBase)) {
+    const apiUrl = new URL(apiBase);
+    const protocol = apiUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+    const apiPath = apiUrl.pathname.replace(/\/$/, '').replace(/\/api$/, '');
+    return `${protocol}//${apiUrl.host}${apiPath}/ws`;
+  }
+
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
   // Include base path for sub-path deployments (e.g., /kanban/ws)
-  const basePath = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-  return `${protocol}//${window.location.host}${basePath}/ws`;
+  const normalizedBasePath = basePath.replace(/\/$/, '');
+  return `${protocol}//${location.host}${normalizedBasePath}/ws`;
+}
+
+function getDefaultWsUrl(): string {
+  return resolveDefaultWsUrl();
 }
 
 /**

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -6,4 +6,13 @@
  * so all fetch calls hit the correct prefix automatically.
  */
 const basePath = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-export const API_BASE = import.meta.env.VITE_API_URL || `${basePath}/api`;
+
+export function normalizeApiBase(rawBase: string): string {
+  const trimmed = rawBase.replace(/\/$/, '');
+  if (/^https?:\/\/[^/]+$/i.test(trimmed)) {
+    return `${trimmed}/api`;
+  }
+  return trimmed;
+}
+
+export const API_BASE = normalizeApiBase(import.meta.env.VITE_API_URL || `${basePath}/api`);


### PR DESCRIPTION
## Summary
- Add Ollama Local, Ollama Cloud, and LM Studio Local as built-in agent providers with health probes and settings UI support.
- Make the built-in CLI agent the fresh-install default while preserving existing user configs.
- Route fresh code, bug, documentation, and review work through the default CLI profile, and fix API/WebSocket base resolution for external web shells.
- Document provider behavior for web and macOS app users.

Closes #692

## Verification
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/config-service-extended.test.ts src/__tests__/settings-service.test.ts src/__tests__/routes/config-coverage.test.ts src/__tests__/schemas.test.ts src/__tests__/agent-routing-service.test.ts
- pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/api-helpers.test.ts src/__tests__/useWebSocket.test.ts src/__tests__/settings-agents-mantine.test.tsx --testTimeout 15000
- pnpm build
- Fresh web smoke on a new VERITAS_DATA_DIR: first-run setup, login, empty board, Settings > Agents provider list, WebSocket connected, zero console errors before shutdown
- Built-output SQLite default smoke: default agent enabled and new providers present

## Risk
- Existing configs intentionally keep their current default agent and enabled states; the new default applies only to newly-created configs.