### PR TITLE
Allow current agent attempt payloads

### DIFF
--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -254,6 +254,68 @@ describe('Tasks Routes (actual module)', () => {
       expect(res.status).toBe(200);
     });
 
+    it('should accept current and custom attempt agent slugs', async () => {
+      const oldTask = { id: 't1', title: 'Old', status: 'todo', created: '2025-01-01' };
+      mockTaskService.getTask.mockResolvedValue(oldTask);
+      mockTaskService.updateTask.mockImplementation(async (_id, input) => ({
+        ...oldTask,
+        ...input,
+      }));
+
+      for (const agent of ['codex', 'ollama-local', 'lm-studio-local', 'custom-router']) {
+        const res = await request(app)
+          .patch('/api/tasks/t1')
+          .send({
+            attempt: {
+              id: `attempt_${agent.replaceAll('-', '_')}`,
+              agent,
+              status: 'running',
+              provider: agent,
+              model: agent === 'ollama-local' ? 'llama3.2' : undefined,
+              threadId: 'thread_docs_refresh',
+              cloudTarget: agent === 'custom-router' ? 'local-lab' : undefined,
+            },
+          });
+
+        expect(res.status).toBe(200);
+        expect(res.body.attempt.agent).toBe(agent);
+      }
+
+      expect(mockTaskService.updateTask).toHaveBeenCalledWith(
+        't1',
+        expect.objectContaining({
+          attempt: expect.objectContaining({
+            agent: 'ollama-local',
+            provider: 'ollama-local',
+            model: 'llama3.2',
+            threadId: 'thread_docs_refresh',
+          }),
+        })
+      );
+    });
+
+    it('should still reject invalid attempt status', async () => {
+      mockTaskService.getTask.mockResolvedValue({
+        id: 't1',
+        title: 'Old',
+        status: 'todo',
+        created: '2025-01-01',
+      });
+
+      const res = await request(app)
+        .patch('/api/tasks/t1')
+        .send({
+          attempt: {
+            id: 'attempt_bad',
+            agent: 'codex',
+            status: 'stuck',
+          },
+        });
+
+      expect(res.status).toBe(400);
+      expect(mockTaskService.updateTask).not.toHaveBeenCalled();
+    });
+
     it('should return 404 for missing task on getTask', async () => {
       mockTaskService.getTask.mockResolvedValue(null);
       const res = await request(app).patch('/api/tasks/nonexistent').send({ title: 'Updated' });

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -79,10 +79,16 @@ const gitSchema = z
 const attemptSchema = z
   .object({
     id: z.string(),
-    agent: z.enum(['claude-code', 'amp', 'copilot', 'gemini', 'veritas']),
+    agent: z.string().min(1).max(80),
     status: z.enum(['pending', 'running', 'complete', 'failed']),
     started: z.string().optional(),
     ended: z.string().optional(),
+    provider: z.string().max(80).optional(),
+    model: z.string().max(160).optional(),
+    threadId: z.string().max(240).optional(),
+    cloudUrl: z.string().max(500).optional(),
+    cloudTarget: z.string().max(240).optional(),
+    orchestration: z.unknown().optional(),
   })
   .optional();
 


### PR DESCRIPTION
## Summary
- accept current and custom task attempt agent slugs instead of the stale fixed list
- preserve attempt provider/model/thread/cloud metadata in task updates
- add regression coverage for current providers and invalid attempt statuses

## Verification
- pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/routes/tasks-coverage.test.ts
- pnpm --filter @veritas-kanban/server typecheck

Closes #698