### PR TITLE
ci(desktop): validate notarization credential modes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -40,22 +40,64 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
-      - name: Verify signing secrets are configured
+      - name: Verify signing and notarization secrets are configured
+        id: notarization-secrets
         env:
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          missing=0
-          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER; do
+          errors=0
+
+          for name in CSC_LINK CSC_KEY_PASSWORD; do
             if [ -z "${!name}" ]; then
               echo "::error::$name is required for signed/notarized desktop releases"
-              missing=1
+              errors=1
             fi
           done
-          exit "$missing"
+
+          api_key_count=0
+          for name in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER; do
+            if [ -n "${!name}" ]; then
+              api_key_count=$((api_key_count + 1))
+            fi
+          done
+
+          apple_id_count=0
+          for name in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+            if [ -n "${!name}" ]; then
+              apple_id_count=$((apple_id_count + 1))
+            fi
+          done
+
+          if [ "${api_key_count}" -gt 0 ] && [ "${api_key_count}" -lt 3 ]; then
+            echo "::error::App Store Connect API-key notarization requires APPLE_API_KEY_BASE64, APPLE_API_KEY_ID, and APPLE_API_ISSUER together"
+            errors=1
+          fi
+
+          if [ "${apple_id_count}" -gt 0 ] && [ "${apple_id_count}" -lt 3 ]; then
+            echo "::error::Apple ID notarization requires APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID together"
+            errors=1
+          fi
+
+          if [ "${api_key_count}" -eq 3 ] && [ "${apple_id_count}" -eq 3 ]; then
+            echo "::error::Configure exactly one notarization credential set, not both App Store Connect API-key and Apple ID credentials"
+            errors=1
+          elif [ "${api_key_count}" -eq 3 ]; then
+            echo "notarization_mode=api-key" >> "${GITHUB_OUTPUT}"
+          elif [ "${apple_id_count}" -eq 3 ]; then
+            echo "notarization_mode=apple-id" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::error::One complete notarization credential set is required: App Store Connect API key or Apple ID/app-specific password"
+            errors=1
+          fi
+
+          exit "${errors}"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -68,6 +110,7 @@ jobs:
 
       - name: Write App Store Connect API key
         id: notary-key
+        if: steps.notarization-secrets.outputs.notarization_mode == 'api-key'
         env:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
         run: |
@@ -91,6 +134,9 @@ jobs:
           APPLE_API_KEY: ${{ steps.notary-key.outputs.key_path }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: node ./node_modules/electron-builder/cli.js --mac dmg zip --publish always
 
       - name: Finalize notarized macOS release assets
@@ -98,6 +144,9 @@ jobs:
           APPLE_API_KEY: ${{ steps.notary-key.outputs.key_path }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: node scripts/finalize-macos-release-assets.mjs
 
       - name: Upload macOS release assets

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -83,19 +83,36 @@ brew livecheck bradgroux/tap/veritas-kanban
 
 ## Required Release Secrets
 
-Configure these repository secrets before running `Desktop Release`:
+Configure Developer ID signing secrets before running `Desktop Release`:
 
 - `MACOS_CSC_LINK`: base64 encoded `.p12` Developer ID Application certificate
   or a secure URL accepted by electron-builder `CSC_LINK`.
 - `MACOS_CSC_KEY_PASSWORD`: password for the `.p12` signing identity.
+
+Then configure exactly one complete notarization credential set. The workflow
+fails before packaging if neither set is complete, if either set is partial, or
+if both sets are configured at the same time.
+
+### Preferred: App Store Connect API-key notarization
+
 - `APPLE_API_KEY_BASE64`: base64 encoded App Store Connect API `.p8` key.
 - `APPLE_API_KEY_ID`: App Store Connect API key ID.
 - `APPLE_API_ISSUER`: App Store Connect API issuer UUID.
 
-The workflow maps those secrets to electron-builder's `CSC_LINK`,
-`CSC_KEY_PASSWORD`, `APPLE_API_KEY`, `APPLE_API_KEY_ID`, and
-`APPLE_API_ISSUER` environment variables. The API key is decoded into a
-temporary file during the release job and is not written to the repository.
+The workflow decodes `APPLE_API_KEY_BASE64` into a temporary private-key file
+and maps it to electron-builder/notarytool as `APPLE_API_KEY`. The key file is
+created under the runner temp directory and is not written to the repository.
+
+### Fallback: Apple ID app-specific-password notarization
+
+- `APPLE_ID`: Apple developer account email address.
+- `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for notarization.
+- `APPLE_TEAM_ID`: Apple Developer Team ID.
+
+The workflow maps those values to electron-builder/notarytool only when the API
+key credential set is absent. Do not configure both notarization modes in the
+same repository environment; that is treated as a release-preflight error so CI
+cannot silently use the wrong credential path.
 
 Windows releases need a separate code-signing certificate before the first
 supported Windows artifact is published. Use `WINDOWS_CSC_LINK` and
@@ -152,9 +169,10 @@ policy is tracked in
   `Desktop Artifacts` Windows job and inspect preview artifact names. This is
   not a v5 GA release gate.
 - Run `Desktop Artifacts` and download the uploaded DMG/ZIP/update metadata.
-- Run `Desktop Release` only after Apple signing secrets are configured.
-- Confirm notarization succeeds and the DMG installs without Gatekeeper
-  warnings on a clean Mac.
+- Run `Desktop Release` only after Developer ID signing secrets and exactly one
+  complete notarization credential set are configured.
+- Confirm notarization succeeds with the intended credential mode and the DMG
+  installs without Gatekeeper warnings on a clean Mac.
 - Confirm a first run creates the profile/workspace app data directories.
 - Confirm update check, download, install, failed-download, and rollback paths
   on the selected channel.

--- a/scripts/finalize-macos-release-assets.mjs
+++ b/scripts/finalize-macos-release-assets.mjs
@@ -11,6 +11,20 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const desktopDir = path.join(rootDir, 'desktop');
 const releaseDir = path.join(desktopDir, 'release');
 const requireFromScript = createRequire(import.meta.url);
+const sensitiveArgumentFlags = new Set([
+  '--apple-id',
+  '--issuer',
+  '--key',
+  '--key-id',
+  '--password',
+  '--team-id',
+]);
+
+function sanitizeArgsForError(args) {
+  return args.map((arg, index) =>
+    index > 0 && sensitiveArgumentFlags.has(args[index - 1]) ? '<redacted>' : arg
+  );
+}
 
 function run(command, args) {
   const result = spawnSync(command, args, {
@@ -24,7 +38,9 @@ function run(command, args) {
   }
 
   if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+    throw new Error(
+      `${command} ${sanitizeArgsForError(args).join(' ')} failed with exit code ${result.status}`
+    );
   }
 }
 

--- a/scripts/finalize-macos-release-assets.mjs
+++ b/scripts/finalize-macos-release-assets.mjs
@@ -28,13 +28,46 @@ function run(command, args) {
   }
 }
 
-function requireEnv(name) {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`${name} is required`);
+function getNotarytoolCredentials() {
+  const apiKey = process.env.APPLE_API_KEY;
+  const apiKeyId = process.env.APPLE_API_KEY_ID;
+  const apiIssuer = process.env.APPLE_API_ISSUER;
+  const appleId = process.env.APPLE_ID;
+  const applePassword = process.env.APPLE_APP_SPECIFIC_PASSWORD;
+  const appleTeamId = process.env.APPLE_TEAM_ID;
+
+  const apiKeyValues = [apiKey, apiKeyId, apiIssuer].filter(Boolean).length;
+  const appleIdValues = [appleId, applePassword, appleTeamId].filter(Boolean).length;
+
+  if (apiKeyValues > 0 && apiKeyValues < 3) {
+    throw new Error(
+      'APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER must be provided together for API-key notarization'
+    );
   }
 
-  return value;
+  if (appleIdValues > 0 && appleIdValues < 3) {
+    throw new Error(
+      'APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID must be provided together for Apple ID notarization'
+    );
+  }
+
+  if (apiKeyValues === 3 && appleIdValues === 3) {
+    throw new Error(
+      'Provide exactly one notarization credential set, not both API-key and Apple ID credentials'
+    );
+  }
+
+  if (apiKeyValues === 3) {
+    return ['--key', apiKey, '--key-id', apiKeyId, '--issuer', apiIssuer];
+  }
+
+  if (appleIdValues === 3) {
+    return ['--apple-id', appleId, '--password', applePassword, '--team-id', appleTeamId];
+  }
+
+  throw new Error(
+    'Notarization credentials are required: provide App Store Connect API-key credentials or Apple ID credentials'
+  );
 }
 
 async function assertFile(file) {
@@ -42,7 +75,9 @@ async function assertFile(file) {
 }
 
 async function hashFile(file, algorithm, encoding) {
-  return createHash(algorithm).update(await readFile(file)).digest(encoding);
+  return createHash(algorithm)
+    .update(await readFile(file))
+    .digest(encoding);
 }
 
 function resolveAppBuilderPath() {
@@ -123,21 +158,15 @@ async function main() {
   const dmgBlockmap = `${dmg}.blockmap`;
   const zipBlockmap = `${zip}.blockmap`;
 
-  await Promise.all([assertFile(dmg), assertFile(zip), assertFile(dmgBlockmap), assertFile(zipBlockmap)]);
+  await Promise.all([
+    assertFile(dmg),
+    assertFile(zip),
+    assertFile(dmgBlockmap),
+    assertFile(zipBlockmap),
+  ]);
 
   run('codesign', ['--verify', '--verbose=2', dmg]);
-  run('xcrun', [
-    'notarytool',
-    'submit',
-    dmg,
-    '--key',
-    requireEnv('APPLE_API_KEY'),
-    '--key-id',
-    requireEnv('APPLE_API_KEY_ID'),
-    '--issuer',
-    requireEnv('APPLE_API_ISSUER'),
-    '--wait',
-  ]);
+  run('xcrun', ['notarytool', 'submit', dmg, ...getNotarytoolCredentials(), '--wait']);
   run('xcrun', ['stapler', 'staple', dmg]);
   run('xcrun', ['stapler', 'validate', dmg]);
   run('spctl', ['-a', '-vvv', '-t', 'open', '--context', 'context:primary-signature', dmg]);


### PR DESCRIPTION
## Summary
- Support both App Store Connect API-key and Apple ID notarization credentials in the Desktop Release workflow.
- Reject partial, missing, or mixed notarization credential sets before packaging starts.
- Update final macOS release asset finalization to use either notarytool credential mode.
- Document both supported credential paths and the exact-one-mode rule.

Fixes #661

## Validation
- Local shell guard cases: API-key ok, Apple ID ok, partial API-key fails, mixed modes fail, missing notarization fails, missing signing fails.
- `pnpm exec prettier --check .github/workflows/desktop-release.yml docs/DESKTOP-RELEASE.md scripts/finalize-macos-release-assets.mjs`
- `pnpm --filter @veritas-kanban/desktop typecheck`
- `node --check scripts/finalize-macos-release-assets.mjs`
- `pnpm desktop:package:mac:unsigned`
