### PR TITLE
feat(tasks): soft-delete tasks into archive

### DIFF
--- a/server/src/__tests__/routes/task-archive-coverage.test.ts
+++ b/server/src/__tests__/routes/task-archive-coverage.test.ts
@@ -10,6 +10,7 @@ const { mockTaskService, mockActivityService } = vi.hoisted(() => ({
     getTask: vi.fn(),
     listTasks: vi.fn(),
     listArchivedTasks: vi.fn(),
+    getArchivedTask: vi.fn(),
     archiveTask: vi.fn(),
     restoreTask: vi.fn(),
     archiveSprint: vi.fn(),
@@ -98,12 +99,26 @@ describe('Task Archive Routes (actual module)', () => {
   });
 
   it('POST /:id/restore should restore a task', async () => {
+    mockTaskService.getArchivedTask.mockResolvedValue({
+      id: 't1',
+      title: 'Task',
+      deletedAt: '2026-01-01T00:00:00.000Z',
+      deletedBy: 'service:test',
+      purgeAfter: '2026-01-31T00:00:00.000Z',
+    });
     mockTaskService.restoreTask.mockResolvedValue({ id: 't1', title: 'Task', status: 'done' });
     const res = await request(app).post('/api/tasks/t1/restore');
     expect(res.status).toBe(200);
+    expect(res.body.restoreMetadata).toMatchObject({
+      deletedAt: '2026-01-01T00:00:00.000Z',
+      deletedBy: 'service:test',
+      purgeAfter: '2026-01-31T00:00:00.000Z',
+      restoredFromDelete: true,
+    });
   });
 
   it('POST /:id/restore should 404 for missing', async () => {
+    mockTaskService.getArchivedTask.mockResolvedValue(null);
     mockTaskService.restoreTask.mockResolvedValue(null);
     const res = await request(app).post('/api/tasks/missing/restore');
     expect(res.status).toBe(404);

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -20,6 +20,7 @@ const {
     createTask: vi.fn(),
     updateTask: vi.fn(),
     deleteTask: vi.fn(),
+    archiveTask: vi.fn(),
     reorderTasks: vi.fn(),
     getIdentityScanSources: vi.fn().mockReturnValue([]),
   },
@@ -398,15 +399,19 @@ describe('Tasks Routes (actual module)', () => {
   describe('DELETE /api/tasks/:id', () => {
     it('should delete a task', async () => {
       mockTaskService.getTask.mockResolvedValue({ id: 't1', title: 'Task' });
-      mockTaskService.deleteTask.mockResolvedValue(true);
+      mockTaskService.archiveTask.mockResolvedValue(true);
 
       const res = await request(app).delete('/api/tasks/t1');
       expect(res.status).toBe(204);
+      expect(mockTaskService.archiveTask).toHaveBeenCalledWith(
+        't1',
+        expect.objectContaining({ deletedBy: 'system:unknown' })
+      );
     });
 
     it('should return 404 for missing task', async () => {
       mockTaskService.getTask.mockResolvedValue(null);
-      mockTaskService.deleteTask.mockResolvedValue(false);
+      mockTaskService.archiveTask.mockResolvedValue(false);
 
       const res = await request(app).delete('/api/tasks/nonexistent');
       expect(res.status).toBe(404);

--- a/server/src/__tests__/routes/tasks.test.ts
+++ b/server/src/__tests__/routes/tasks.test.ts
@@ -25,26 +25,26 @@ describe('Tasks Routes', () => {
     testRoot = path.join(os.tmpdir(), `veritas-test-routes-${uniqueSuffix}`);
     tasksDir = path.join(testRoot, 'active');
     archiveDir = path.join(testRoot, 'archive');
-    
+
     await fs.mkdir(tasksDir, { recursive: true });
     await fs.mkdir(archiveDir, { recursive: true });
-    
+
     // Create TaskService with test directories
     taskService = new TaskService({ tasksDir, archiveDir });
-    
+
     // Create app with mocked routes
     app = express();
     app.use(express.json());
-    
+
     // Create a router that uses our test TaskService
     const router = express.Router();
-    
+
     // GET /api/tasks - List all tasks
     router.get('/', async (_req, res) => {
       const tasks = await taskService.listTasks();
       res.json(tasks);
     });
-    
+
     // POST /api/tasks - Create task
     router.post('/', async (req, res) => {
       try {
@@ -54,7 +54,7 @@ describe('Tasks Routes', () => {
         res.status(400).json({ error: error.message });
       }
     });
-    
+
     // GET /api/tasks/:id - Get single task
     router.get('/:id', async (req, res) => {
       const task = await taskService.getTask(req.params.id);
@@ -63,7 +63,7 @@ describe('Tasks Routes', () => {
       }
       res.json(task);
     });
-    
+
     // PATCH /api/tasks/:id - Update task
     router.patch('/:id', async (req, res) => {
       const task = await taskService.updateTask(req.params.id, req.body);
@@ -72,16 +72,22 @@ describe('Tasks Routes', () => {
       }
       res.json(task);
     });
-    
-    // DELETE /api/tasks/:id - Delete task
+
+    // DELETE /api/tasks/:id - Soft delete task into archive/recycle bin
     router.delete('/:id', async (req, res) => {
-      const success = await taskService.deleteTask(req.params.id);
+      const deletedAt = new Date().toISOString();
+      const purgeAfter = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      const success = await taskService.archiveTask(req.params.id, {
+        deletedAt,
+        deletedBy: 'test-user',
+        purgeAfter,
+      });
       if (!success) {
         return res.status(404).json({ error: 'Task not found' });
       }
       res.status(204).send();
     });
-    
+
     // POST /api/tasks/reorder - Reorder tasks
     router.post('/reorder', async (req, res) => {
       const { orderedIds } = req.body;
@@ -91,7 +97,7 @@ describe('Tasks Routes', () => {
       const updated = await taskService.reorderTasks(orderedIds);
       res.json({ updated: updated.length });
     });
-    
+
     app.use('/api/tasks', router);
     app.use(errorHandler);
   });
@@ -105,7 +111,7 @@ describe('Tasks Routes', () => {
   describe('GET /api/tasks', () => {
     it('should return empty array when no tasks exist', async () => {
       const res = await request(app).get('/api/tasks');
-      
+
       expect(res.status).toBe(200);
       expect(res.body).toEqual([]);
     });
@@ -113,9 +119,9 @@ describe('Tasks Routes', () => {
     it('should return all tasks', async () => {
       await taskService.createTask({ title: 'Task 1' });
       await taskService.createTask({ title: 'Task 2' });
-      
+
       const res = await request(app).get('/api/tasks');
-      
+
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(2);
       expect(res.body.map((t: any) => t.title)).toContain('Task 1');
@@ -125,10 +131,8 @@ describe('Tasks Routes', () => {
 
   describe('POST /api/tasks', () => {
     it('should create a task with minimal fields', async () => {
-      const res = await request(app)
-        .post('/api/tasks')
-        .send({ title: 'New Task' });
-      
+      const res = await request(app).post('/api/tasks').send({ title: 'New Task' });
+
       expect(res.status).toBe(201);
       expect(res.body.title).toBe('New Task');
       expect(res.body.id).toMatch(/^task_/);
@@ -138,17 +142,15 @@ describe('Tasks Routes', () => {
     });
 
     it('should create a task with all fields', async () => {
-      const res = await request(app)
-        .post('/api/tasks')
-        .send({
-          title: 'Full Task',
-          description: 'Detailed description',
-          type: 'research',
-          priority: 'high',
-          project: 'test-project',
-          sprint: 'US-100',
-        });
-      
+      const res = await request(app).post('/api/tasks').send({
+        title: 'Full Task',
+        description: 'Detailed description',
+        type: 'research',
+        priority: 'high',
+        project: 'test-project',
+        sprint: 'US-100',
+      });
+
       expect(res.status).toBe(201);
       expect(res.body.title).toBe('Full Task');
       expect(res.body.description).toBe('Detailed description');
@@ -162,9 +164,9 @@ describe('Tasks Routes', () => {
   describe('GET /api/tasks/:id', () => {
     it('should return a task by id', async () => {
       const task = await taskService.createTask({ title: 'Fetch Me' });
-      
+
       const res = await request(app).get(`/api/tasks/${task.id}`);
-      
+
       expect(res.status).toBe(200);
       expect(res.body.id).toBe(task.id);
       expect(res.body.title).toBe('Fetch Me');
@@ -172,7 +174,7 @@ describe('Tasks Routes', () => {
 
     it('should return 404 for non-existent task', async () => {
       const res = await request(app).get('/api/tasks/nonexistent_id');
-      
+
       expect(res.status).toBe(404);
     });
   });
@@ -180,15 +182,13 @@ describe('Tasks Routes', () => {
   describe('PATCH /api/tasks/:id', () => {
     it('should update task fields', async () => {
       const task = await taskService.createTask({ title: 'Original' });
-      
-      const res = await request(app)
-        .patch(`/api/tasks/${task.id}`)
-        .send({
-          title: 'Updated',
-          status: 'in-progress',
-          priority: 'high',
-        });
-      
+
+      const res = await request(app).patch(`/api/tasks/${task.id}`).send({
+        title: 'Updated',
+        status: 'in-progress',
+        priority: 'high',
+      });
+
       expect(res.status).toBe(200);
       expect(res.body.title).toBe('Updated');
       expect(res.body.status).toBe('in-progress');
@@ -199,7 +199,7 @@ describe('Tasks Routes', () => {
       const res = await request(app)
         .patch('/api/tasks/nonexistent_id')
         .send({ title: 'Will Fail' });
-      
+
       expect(res.status).toBe(404);
     });
 
@@ -209,11 +209,9 @@ describe('Tasks Routes', () => {
         description: 'Original Desc',
         priority: 'low',
       });
-      
-      const res = await request(app)
-        .patch(`/api/tasks/${task.id}`)
-        .send({ priority: 'high' });
-      
+
+      const res = await request(app).patch(`/api/tasks/${task.id}`).send({ priority: 'high' });
+
       expect(res.status).toBe(200);
       expect(res.body.title).toBe('Original Title');
       expect(res.body.description).toBe('Original Desc');
@@ -222,21 +220,27 @@ describe('Tasks Routes', () => {
   });
 
   describe('DELETE /api/tasks/:id', () => {
-    it('should delete a task', async () => {
+    it('should soft delete a task into archive with recovery metadata', async () => {
       const task = await taskService.createTask({ title: 'Delete Me' });
-      
+
       const res = await request(app).delete(`/api/tasks/${task.id}`);
-      
+
       expect(res.status).toBe(204);
-      
-      // Verify task is gone
+
+      // Verify task is gone from active list
       const tasks = await taskService.listTasks();
       expect(tasks).toHaveLength(0);
+
+      // Verify task is in archive with restore metadata
+      const archived = await taskService.getArchivedTask(task.id);
+      expect(archived).not.toBeNull();
+      expect(archived?.deletedAt).toBeTruthy();
+      expect(archived?.purgeAfter).toBeTruthy();
     });
 
     it('should return 404 for non-existent task', async () => {
       const res = await request(app).delete('/api/tasks/nonexistent_id');
-      
+
       expect(res.status).toBe(404);
     });
   });
@@ -246,35 +250,31 @@ describe('Tasks Routes', () => {
       const task1 = await taskService.createTask({ title: 'Task 1' });
       const task2 = await taskService.createTask({ title: 'Task 2' });
       const task3 = await taskService.createTask({ title: 'Task 3' });
-      
+
       const res = await request(app)
         .post('/api/tasks/reorder')
         .send({ orderedIds: [task3.id, task1.id, task2.id] });
-      
+
       expect(res.status).toBe(200);
       expect(res.body.updated).toBe(3);
-      
+
       // Verify positions
       const tasks = await taskService.listTasks();
-      const taskMap = new Map(tasks.map(t => [t.id, t]));
+      const taskMap = new Map(tasks.map((t) => [t.id, t]));
       expect(taskMap.get(task3.id)?.position).toBe(0);
       expect(taskMap.get(task1.id)?.position).toBe(1);
       expect(taskMap.get(task2.id)?.position).toBe(2);
     });
 
     it('should reject empty orderedIds', async () => {
-      const res = await request(app)
-        .post('/api/tasks/reorder')
-        .send({ orderedIds: [] });
-      
+      const res = await request(app).post('/api/tasks/reorder').send({ orderedIds: [] });
+
       expect(res.status).toBe(400);
     });
 
     it('should reject missing orderedIds', async () => {
-      const res = await request(app)
-        .post('/api/tasks/reorder')
-        .send({});
-      
+      const res = await request(app).post('/api/tasks/reorder').send({});
+
       expect(res.status).toBe(400);
     });
   });

--- a/server/src/__tests__/task-service-sqlite.test.ts
+++ b/server/src/__tests__/task-service-sqlite.test.ts
@@ -78,20 +78,54 @@ describe('TaskService SQLite mode', () => {
 
   it('archives, lists archived tasks, restores, and deletes without task files', async () => {
     const task = await service.createTask({ title: 'Archive SQLite task' });
+    const deletedAt = new Date().toISOString();
+    const purgeAfter = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 
-    expect(await service.archiveTask(task.id)).toBe(true);
+    expect(
+      await service.archiveTask(task.id, {
+        deletedAt,
+        deletedBy: 'service:test',
+        purgeAfter,
+      })
+    ).toBe(true);
     expect(await service.getTask(task.id)).toBeNull();
 
     const archived = await service.listArchivedTasks();
     expect(archived.map((archivedTask) => archivedTask.id)).toEqual([task.id]);
+    expect(archived[0]).toMatchObject({ deletedAt, deletedBy: 'service:test', purgeAfter });
 
     const restored = await service.restoreTask(task.id);
     expect(restored?.id).toBe(task.id);
     expect(restored?.status).toBe('done');
+    expect(restored?.deletedAt).toBeUndefined();
+    expect(restored?.deletedBy).toBeUndefined();
+    expect(restored?.purgeAfter).toBeUndefined();
     expect(await service.listArchivedTasks()).toEqual([]);
 
     expect(await service.deleteTask(task.id)).toBe(true);
     expect(await service.getTask(task.id)).toBeNull();
     await expect(fs.readdir(archiveDir)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('enforces expired and invalid restore windows in SQLite mode', async () => {
+    const expired = await service.createTask({ title: 'Expired SQLite restore' });
+    expect(
+      await service.archiveTask(expired.id, {
+        deletedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString(),
+        deletedBy: 'service:test',
+        purgeAfter: new Date(Date.now() - 1000).toISOString(),
+      })
+    ).toBe(true);
+    expect(await service.restoreTask(expired.id)).toBeNull();
+
+    const invalid = await service.createTask({ title: 'Invalid SQLite restore' });
+    expect(
+      await service.archiveTask(invalid.id, {
+        deletedAt: new Date().toISOString(),
+        deletedBy: 'service:test',
+        purgeAfter: 'not-a-date',
+      })
+    ).toBe(true);
+    expect(await service.restoreTask(invalid.id)).toBeNull();
   });
 });

--- a/server/src/__tests__/task-service.test.ts
+++ b/server/src/__tests__/task-service.test.ts
@@ -342,7 +342,13 @@ updated: '2026-01-26T10:00:00.000Z'
     it('should move task to archive', async () => {
       const task = await service.createTask({ title: 'To Archive' });
 
-      const result = await service.archiveTask(task.id);
+      const deletedAt = new Date().toISOString();
+      const purgeAfter = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      const result = await service.archiveTask(task.id, {
+        deletedAt,
+        deletedBy: 'test-user',
+        purgeAfter,
+      });
       expect(result).toBe(true);
 
       // Task should be gone from active
@@ -352,11 +358,29 @@ updated: '2026-01-26T10:00:00.000Z'
       // Task should be in archive
       const archiveFiles = await fs.readdir(archiveDir);
       expect(archiveFiles.some((f) => f.includes('to-archive'))).toBe(true);
+
+      const archivedTask = await service.getArchivedTask(task.id);
+      expect(archivedTask?.deletedAt).toBe(deletedAt);
+      expect(archivedTask?.deletedBy).toBe('test-user');
+      expect(archivedTask?.purgeAfter).toBe(purgeAfter);
     });
 
     it('should return false for non-existent task', async () => {
       const result = await service.archiveTask('nonexistent');
       expect(result).toBe(false);
+    });
+
+    it('should reject restore after purge window has expired', async () => {
+      const task = await service.createTask({ title: 'Expired Restore' });
+      const result = await service.archiveTask(task.id, {
+        deletedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString(),
+        deletedBy: 'test-user',
+        purgeAfter: new Date(Date.now() - 1000).toISOString(),
+      });
+      expect(result).toBe(true);
+
+      const restored = await service.restoreTask(task.id);
+      expect(restored).toBeNull();
     });
 
     it('should cleanup all orphaned files when archiving tasks with title changes', async () => {

--- a/server/src/routes/task-archive.ts
+++ b/server/src/routes/task-archive.ts
@@ -218,7 +218,15 @@ router.post(
       },
     });
 
-    res.json(task);
+    res.json({
+      ...task,
+      restoreMetadata: {
+        deletedAt: archivedTask?.deletedAt,
+        deletedBy: archivedTask?.deletedBy,
+        purgeAfter: archivedTask?.purgeAfter,
+        restoredFromDelete: Boolean(archivedTask?.deletedAt),
+      },
+    });
   })
 );
 

--- a/server/src/routes/task-archive.ts
+++ b/server/src/routes/task-archive.ts
@@ -185,9 +185,10 @@ router.post(
 router.post(
   '/:id/restore',
   asyncHandler(async (req, res) => {
+    const archivedTask = await taskService.getArchivedTask(req.params.id as string);
     const task = await taskService.restoreTask(req.params.id as string);
     if (!task) {
-      throw new NotFoundError('Archived task not found');
+      throw new NotFoundError('Archived task not found or restore window expired');
     }
     broadcastTaskChange('restored', task.id);
 
@@ -199,9 +200,23 @@ router.post(
       {
         from: 'archived',
         status: 'done',
+        restoredFromDelete: Boolean(archivedTask?.deletedAt),
       },
       task.agent
     );
+
+    const authReq = req as AuthenticatedRequest;
+    await auditLog({
+      action: 'task.restore',
+      actor: authReq.auth?.keyName || 'unknown',
+      resource: task.id,
+      details: {
+        title: task.title,
+        deletedAt: archivedTask?.deletedAt,
+        deletedBy: archivedTask?.deletedBy,
+        restoredFromDelete: Boolean(archivedTask?.deletedAt),
+      },
+    });
 
     res.json(task);
   })

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -819,7 +819,16 @@ router.delete(
   '/:id',
   asyncHandler(async (req, res) => {
     const task = await taskService.getTask(req.params.id as string);
-    const success = await taskService.deleteTask(req.params.id as string);
+    const authReqDel = req as AuthenticatedRequest;
+    const actor = authReqDel.auth?.keyName || 'unknown';
+    const deletedAt = new Date().toISOString();
+    const purgeAfter = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    const success = await taskService.archiveTask(req.params.id as string, {
+      deletedAt,
+      deletedBy: actor,
+      purgeAfter,
+    });
     if (!success) {
       throw new NotFoundError('Task not found');
     }
@@ -827,26 +836,24 @@ router.delete(
 
     // Log activity
     if (task) {
-      const authReqDel = req as AuthenticatedRequest;
-      const actor = actorFromRequest(authReqDel);
       await activityService.logActivity(
         'task_deleted',
         task.id,
         task.title,
-        { actor },
+        { actor, deletedAt, deletedBy: actor, purgeAfter, recovery: 'recycle-bin' },
         task.agent,
         actor
       );
     }
 
     // Audit log
-    const authReqDel = req as AuthenticatedRequest;
-    const actor = actorFromRequest(authReqDel);
     await auditLog({
       action: 'task.delete',
       actor,
       resource: req.params.id as string,
-      details: task ? { title: task.title } : undefined,
+      details: task
+        ? { title: task.title, deletedAt, purgeAfter, recovery: 'recycle-bin' }
+        : undefined,
     });
 
     res.status(204).send();

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -820,7 +820,7 @@ router.delete(
   asyncHandler(async (req, res) => {
     const task = await taskService.getTask(req.params.id as string);
     const authReqDel = req as AuthenticatedRequest;
-    const actor = authReqDel.auth?.keyName || 'unknown';
+    const actor = actorFromRequest(authReqDel);
     const deletedAt = new Date().toISOString();
     const purgeAfter = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -617,6 +617,9 @@ export class TaskService {
         dependencies: data.dependencies,
         runMode: data.runMode,
         qaGate: data.qaGate,
+        deletedAt: data.deletedAt,
+        deletedBy: data.deletedBy,
+        purgeAfter: data.purgeAfter,
       };
     } catch (error) {
       log.error({ err: error, filename }, 'Failed to parse task file');
@@ -1228,13 +1231,24 @@ export class TaskService {
     return true;
   }
 
-  async archiveTask(id: string): Promise<boolean> {
+  async archiveTask(
+    id: string,
+    options?: { deletedAt?: string; deletedBy?: string; purgeAfter?: string }
+  ): Promise<boolean> {
     await this.assertTaskIdentityIntegrity('task.archive', id, {
       allowSameLocationTaskIdDuplicates: true,
     });
 
     const task = await this.getTaskWithoutIdentityCheck(id);
     if (!task) return false;
+
+    const archivedTask: Task = {
+      ...task,
+      updated: new Date().toISOString(),
+      deletedAt: options?.deletedAt ?? task.deletedAt,
+      deletedBy: options?.deletedBy ?? task.deletedBy,
+      purgeAfter: options?.purgeAfter ?? task.purgeAfter,
+    };
 
     if (this.sqliteTasks) {
       const sqliteTasks = this.sqliteTasks;
@@ -1243,17 +1257,19 @@ export class TaskService {
 
       await this.telemetry.emit<TaskTelemetryEvent>({
         type: 'task.archived',
-        taskId: task.id,
-        project: task.project,
-        status: task.status,
+        taskId: archivedTask.id,
+        project: archivedTask.project,
+        status: archivedTask.status,
       });
 
-      fireHook('onArchived', task).catch((err) => {
-        log.warn({ taskId: task.id }, 'onArchived hook failed: %s', err);
+      fireHook('onArchived', archivedTask).catch((err) => {
+        log.warn({ taskId: archivedTask.id }, 'onArchived hook failed: %s', err);
       });
 
       return true;
     }
+
+    const archivedContent = this.taskToMarkdown(archivedTask);
 
     // Find ALL files on disk with this task ID (handles orphaned slug variations)
     const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
@@ -1270,6 +1286,7 @@ export class TaskService {
         await withFileLock(sourcePath, async () => {
           this.markWrite();
           await fs.rename(sourcePath, destPath);
+          await fs.writeFile(destPath, archivedContent, 'utf-8');
         });
         log.debug({ taskId: id, filename }, 'Archived task file');
       })
@@ -1291,14 +1308,14 @@ export class TaskService {
     // Emit telemetry event
     await this.telemetry.emit<TaskTelemetryEvent>({
       type: 'task.archived',
-      taskId: task.id,
-      project: task.project,
-      status: task.status,
+      taskId: archivedTask.id,
+      project: archivedTask.project,
+      status: archivedTask.status,
     });
 
     // Fire onArchived hook
-    fireHook('onArchived', task).catch((err) => {
-      log.warn({ taskId: task.id }, 'onArchived hook failed: %s', err);
+    fireHook('onArchived', archivedTask).catch((err) => {
+      log.warn({ taskId: archivedTask.id }, 'onArchived hook failed: %s', err);
     });
 
     return true;
@@ -1362,6 +1379,14 @@ export class TaskService {
     const task = await this.getArchivedTask(id);
     if (!task) return null;
 
+    if (task.purgeAfter && new Date(task.purgeAfter).getTime() < Date.now()) {
+      log.info(
+        { taskId: id, purgeAfter: task.purgeAfter },
+        'Restore window expired for archived task'
+      );
+      return null;
+    }
+
     // Find actual file on disk (slug may differ from current title)
     const actualFilename = await this.findTaskFile(this.archiveDir, id);
     if (!actualFilename) {
@@ -1377,6 +1402,9 @@ export class TaskService {
       ...task,
       status: 'done',
       updated: new Date().toISOString(),
+      deletedAt: undefined,
+      deletedBy: undefined,
+      purgeAfter: undefined,
     };
 
     const content = this.taskToMarkdown(restoredTask);

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -1252,7 +1252,7 @@ export class TaskService {
 
     if (this.sqliteTasks) {
       const sqliteTasks = this.sqliteTasks;
-      const archived = await this.runSqliteMutation(() => sqliteTasks.archive(id));
+      const archived = await this.runSqliteMutation(() => sqliteTasks.archive(id, archivedTask));
       if (!archived) return false;
 
       await this.telemetry.emit<TaskTelemetryEvent>({
@@ -1358,8 +1358,32 @@ export class TaskService {
     return tasks.find((t) => t.id === id) || null;
   }
 
+  private isRestoreWindowExpired(task: Task): boolean {
+    if (!task.purgeAfter) {
+      return false;
+    }
+
+    const purgeAfterTime = new Date(task.purgeAfter).getTime();
+    if (Number.isFinite(purgeAfterTime) && purgeAfterTime >= Date.now()) {
+      return false;
+    }
+
+    log.info(
+      { taskId: task.id, purgeAfter: task.purgeAfter },
+      'Restore window invalid or expired for archived task'
+    );
+    return true;
+  }
+
   async restoreTask(id: string): Promise<Task | null> {
     await this.assertTaskIdentityIntegrity('task.restore', id);
+
+    const task = await this.getArchivedTask(id);
+    if (!task) return null;
+
+    if (this.isRestoreWindowExpired(task)) {
+      return null;
+    }
 
     if (this.sqliteTasks) {
       const sqliteTasks = this.sqliteTasks;
@@ -1374,17 +1398,6 @@ export class TaskService {
       });
 
       return restoredTask;
-    }
-
-    const task = await this.getArchivedTask(id);
-    if (!task) return null;
-
-    if (task.purgeAfter && new Date(task.purgeAfter).getTime() < Date.now()) {
-      log.info(
-        { taskId: id, purgeAfter: task.purgeAfter },
-        'Restore window expired for archived task'
-      );
-      return null;
     }
 
     // Find actual file on disk (slug may differ from current title)

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -136,8 +136,6 @@ export class TaskService {
         options.sqliteDatabase ?? new SqliteDatabase(options.sqliteConnectionOptions);
       this.sqliteDatabase.open();
       this.sqliteTasks = new SqliteTaskRepository(this.sqliteDatabase);
-    } else {
-      this.ensureDirectories();
     }
 
     this.startTaskSyncReconciler();

--- a/server/src/storage/sqlite/task-repository.ts
+++ b/server/src/storage/sqlite/task-repository.ts
@@ -126,13 +126,13 @@ export class SqliteTaskRepository implements TaskRepository {
     return result.changes > 0;
   }
 
-  async archive(id: string): Promise<boolean> {
+  async archive(id: string, archivedTask?: Task): Promise<boolean> {
     const existing = await this.findById(id);
     if (!existing) {
       return false;
     }
 
-    this.save(existing, 'archived', new Date().toISOString());
+    this.save(archivedTask ?? existing, 'archived', new Date().toISOString());
     return true;
   }
 
@@ -146,6 +146,9 @@ export class SqliteTaskRepository implements TaskRepository {
       ...existing,
       status: 'done' as const,
       updated: new Date().toISOString(),
+      deletedAt: undefined,
+      deletedBy: undefined,
+      purgeAfter: undefined,
     };
     this.save(restored, 'active', null);
     return restored;

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -328,6 +328,11 @@ export interface Task {
   // Run mode — controls the review/QA strategy for the task
   runMode?: RunMode | null;
 
+  // Soft-delete / recycle-bin metadata
+  deletedAt?: string; // ISO timestamp when task was soft-deleted/archived via delete
+  deletedBy?: string; // Actor who deleted the task
+  purgeAfter?: string; // ISO timestamp when restore window expires
+
   // QA gate — requires a QA pass before the task can move to Done
   qaGate?: QaGateState | null;
 }
@@ -416,6 +421,9 @@ export interface UpdateTaskInput {
     resumeCount?: number;
   };
   runMode?: RunMode | null;
+  deletedAt?: string;
+  deletedBy?: string;
+  purgeAfter?: string;
   qaGate?: QaGateState | null;
 }
 


### PR DESCRIPTION
## Summary
- Turn task DELETE into a soft-delete/recycle-bin flow by archiving tasks with `deletedAt`, `deletedBy`, and `purgeAfter` metadata.
- Add 30-day restore-window enforcement for delete-originated archived tasks.
- Preserve delete audit/activity metadata with actor and recovery details.
- Show delete/recovery metadata in archive restore responses.
- Persist soft-delete metadata through markdown parse/serialize.

Covers local VK task `task_20260417_KL2f2Y`.

## Validation
- `pnpm vitest run server/src/__tests__/task-service.test.ts server/src/__tests__/routes/tasks.test.ts web/src/__tests__/archive-backlog-mantine.test.tsx`
- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`
