### PR TITLE
Make MCP write responses concise

### DIFF
--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -300,6 +300,8 @@ These are set in `server/.env`, not in the MCP client config:
 | `archive_task` | Archive a completed task                | `id`            | —                                                                         |
 | `delete_task`  | Permanently delete a task               | `id`            | —                                                                         |
 
+Task write tools return concise confirmations. Use `get_task`, `list_tasks`, or `list_comments` when an assistant needs the full task or comment payload.
+
 <details>
 <summary><strong>Examples</strong></summary>
 
@@ -329,7 +331,7 @@ These are set in `server/.env`, not in the MCP client config:
 }
 ```
 
-→ Returns `Task created: task_20260302_abc123\n{...task JSON...}`
+→ Returns `Task created: task_20260302_abc123` plus status, priority, and comment count.
 
 **Update task status:**
 
@@ -340,7 +342,7 @@ These are set in `server/.env`, not in the MCP client config:
 }
 ```
 
-→ Partial IDs work — matches the last 6+ characters.
+→ Returns `Task updated: task_20260302_abc123; fields: status; comments: 0`. Partial IDs work — matches the last 6+ characters.
 
 </details>
 
@@ -641,6 +643,7 @@ Full project lifecycle management from MCP — create, organize, and track proje
 ### Comment Management (3 tools) <small>_New in v4.0_</small>
 
 Comment tools for task discussion threads, enabling agents to participate in async review notes.
+Comment write tools return concise confirmations. Use `list_comments` when an assistant needs the full thread.
 
 | Tool             | Description                 | Required Inputs       | Key Options |
 | ---------------- | --------------------------- | --------------------- | ----------- |
@@ -664,6 +667,8 @@ Comment tools for task discussion threads, enabling agents to participate in asy
 }
 ```
 
+→ Returns `Comment added to task task_20260321_abc; comment: comment_xyz789; comments: 3`.
+
 **List comments on a task:**
 
 ```json
@@ -686,6 +691,8 @@ Comment tools for task discussion threads, enabling agents to participate in asy
   }
 }
 ```
+
+→ Returns `Comment deleted from task task_20260321_abc; comment: cmt_xyz789; comments: 2`.
 
 </details>
 

--- a/mcp/src/__tests__/task-tools.test.ts
+++ b/mcp/src/__tests__/task-tools.test.ts
@@ -21,6 +21,13 @@ function parseToolResponse(result: any): any {
   return JSON.parse(text.substring(start));
 }
 
+function extractCreatedTaskId(result: any): string {
+  const text = result.content[0].text;
+  const match = text.match(/^Task created: ([^\n]+)/);
+  if (!match) throw new Error(`Unable to extract task id from response: ${text}`);
+  return match[1];
+}
+
 describe('Task MCP Tools', () => {
   const testTaskIds: string[] = [];
 
@@ -108,12 +115,13 @@ describe('Task MCP Tools', () => {
         priority: 'low',
         description: 'Integration test task — safe to delete',
       });
-      const task = parseToolResponse(result);
+      taskId = extractCreatedTaskId(result);
+      const getResult = await handleTaskTool('get_task', { id: taskId });
+      const task = parseToolResponse(getResult);
       expect(task.title).toBe('__mcp_test_task');
       expect(task.type).toBe('research');
       expect(task.priority).toBe('low');
       expect(task.id).toBeDefined();
-      taskId = task.id;
       testTaskIds.push(taskId);
     });
 
@@ -130,7 +138,9 @@ describe('Task MCP Tools', () => {
         status: 'in-progress',
         priority: 'high',
       });
-      const task = parseToolResponse(result);
+      expect(result.content[0].text).toContain(`Task updated: ${taskId}`);
+      const getResult = await handleTaskTool('get_task', { id: taskId });
+      const task = parseToolResponse(getResult);
       expect(task.status).toBe('in-progress');
       expect(task.priority).toBe('high');
     });

--- a/mcp/src/__tests__/write-response-contract.test.ts
+++ b/mcp/src/__tests__/write-response-contract.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  findTask: vi.fn(),
+}));
+
+vi.mock('../utils/api.js', () => ({
+  api: mocks.api,
+}));
+
+vi.mock('../utils/find.js', () => ({
+  findTask: mocks.findTask,
+}));
+
+import { handleCommentTool } from '../tools/comments.js';
+import { handleTaskTool } from '../tools/tasks.js';
+
+function task(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task_20260612_abc123',
+    title: 'Token-heavy task',
+    description: 'Full task details should stay out of MCP write confirmations.',
+    type: 'code',
+    status: 'todo',
+    priority: 'medium',
+    created: '2026-06-12T00:00:00.000Z',
+    updated: '2026-06-12T00:00:00.000Z',
+    comments: [],
+    ...overrides,
+  };
+}
+
+describe('MCP write response contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a concise create_task confirmation instead of full task JSON', async () => {
+    mocks.api.mockResolvedValueOnce(
+      task({
+        priority: 'high',
+        comments: [{ id: 'comment_1', text: 'Existing context' }],
+      })
+    );
+
+    const result = await handleTaskTool('create_task', {
+      title: 'Token-heavy task',
+      priority: 'high',
+    });
+
+    const text = result.content[0].text;
+    expect(text).toBe(
+      ['Task created: task_20260612_abc123', 'Status: todo', 'Priority: high', 'Comments: 1'].join(
+        '\n'
+      )
+    );
+    expect(text).not.toContain('{');
+    expect(text).not.toContain('Full task details');
+  });
+
+  it('returns changed fields for update_task without echoing comments', async () => {
+    mocks.findTask.mockResolvedValueOnce(task());
+    mocks.api.mockResolvedValueOnce(
+      task({
+        status: 'in-progress',
+        priority: 'high',
+        comments: [
+          { id: 'comment_1', text: 'First long comment' },
+          { id: 'comment_2', text: 'Second long comment' },
+        ],
+      })
+    );
+
+    const result = await handleTaskTool('update_task', {
+      id: 'abc123',
+      status: 'in-progress',
+      priority: 'high',
+    });
+
+    const text = result.content[0].text;
+    expect(text).toBe('Task updated: task_20260612_abc123; fields: status, priority; comments: 2');
+    expect(text).not.toContain('First long comment');
+    expect(text).not.toContain('{');
+  });
+
+  it('returns the added comment id and count for add_comment', async () => {
+    mocks.api.mockResolvedValueOnce(
+      task({
+        comments: [
+          { id: 'comment_1', text: 'Earlier status' },
+          { id: 'comment_2', text: 'New status' },
+        ],
+      })
+    );
+
+    const result = await handleCommentTool('add_comment', {
+      taskId: 'task_20260612_abc123',
+      text: 'New status',
+      agent: 'agent',
+    });
+
+    const text = result.content[0].text;
+    expect(text).toBe(
+      'Comment added to task task_20260612_abc123; comment: comment_2; comments: 2'
+    );
+    expect(text).not.toContain('Earlier status');
+    expect(text).not.toContain('{');
+  });
+
+  it('returns a concise delete_comment confirmation', async () => {
+    mocks.api.mockResolvedValueOnce(
+      task({
+        comments: [{ id: 'comment_2', text: 'Remaining status' }],
+      })
+    );
+
+    const result = await handleCommentTool('delete_comment', {
+      taskId: 'task_20260612_abc123',
+      commentId: 'comment_1',
+    });
+
+    const text = result.content[0].text;
+    expect(text).toBe(
+      'Comment deleted from task task_20260612_abc123; comment: comment_1; comments: 1'
+    );
+    expect(text).not.toContain('Remaining status');
+    expect(text).not.toContain('{');
+  });
+});

--- a/mcp/src/tools/comments.ts
+++ b/mcp/src/tools/comments.ts
@@ -18,6 +18,10 @@ const DeleteCommentSchema = z.object({
   commentId: z.string().min(1),
 });
 
+function commentCount(task: Pick<Task, 'comments'>): number {
+  return Array.isArray(task.comments) ? task.comments.length : 0;
+}
+
 export const commentTools = [
   {
     name: 'add_comment',
@@ -90,7 +94,7 @@ export async function handleCommentTool(name: string, args: any): Promise<any> {
         content: [
           {
             type: 'text',
-            text: `Comment added to task ${taskId}\n${JSON.stringify(task, null, 2)}`,
+            text: `Comment added to task ${task.id}; comment: ${task.comments?.at(-1)?.id ?? 'unknown'}; comments: ${commentCount(task)}`,
           },
         ],
       };
@@ -123,7 +127,7 @@ export async function handleCommentTool(name: string, args: any): Promise<any> {
         content: [
           {
             type: 'text',
-            text: `Comment ${commentId} deleted from task ${taskId}\n${JSON.stringify(task, null, 2)}`,
+            text: `Comment deleted from task ${task.id}; comment: ${commentId}; comments: ${commentCount(task)}`,
           },
         ],
       };

--- a/mcp/src/tools/tasks.ts
+++ b/mcp/src/tools/tasks.ts
@@ -35,6 +35,18 @@ const TaskIdSchema = z.object({
   id: z.string().min(1),
 });
 
+function commentCount(task: Pick<Task, 'comments'>): number {
+  return Array.isArray(task.comments) ? task.comments.length : 0;
+}
+
+function changedFieldList(updates: Record<string, unknown>): string {
+  const fields = Object.entries(updates)
+    .filter(([, value]) => value !== undefined)
+    .map(([field]) => field);
+
+  return fields.length > 0 ? fields.join(', ') : 'none';
+}
+
 export const taskTools = [
   {
     name: 'list_tasks',
@@ -242,7 +254,12 @@ export async function handleTaskTool(name: string, args: any): Promise<any> {
         content: [
           {
             type: 'text',
-            text: `Task created: ${task.id}\n${JSON.stringify(task, null, 2)}`,
+            text: [
+              `Task created: ${task.id}`,
+              `Status: ${task.status}`,
+              `Priority: ${task.priority}`,
+              `Comments: ${commentCount(task)}`,
+            ].join('\n'),
           },
         ],
       };
@@ -268,7 +285,7 @@ export async function handleTaskTool(name: string, args: any): Promise<any> {
         content: [
           {
             type: 'text',
-            text: `Task updated: ${updated.id}\n${JSON.stringify(updated, null, 2)}`,
+            text: `Task updated: ${updated.id}; fields: ${changedFieldList(updates)}; comments: ${commentCount(updated)}`,
           },
         ],
       };

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -215,8 +215,10 @@ describe('task detail Mantine migration', () => {
 
     expect(mocks.updateField).toHaveBeenCalledWith('title', 'Renamed task');
     await waitFor(() => expect(progressTab.getAttribute('aria-selected')).toBe('true'));
-    expect(await screen.findByText('Progress Notes')).toBeDefined();
-    expect(await screen.findByText('Mantine task detail renders')).toBeDefined();
+    expect(await screen.findByText('Progress Notes', {}, { timeout: 5000 })).toBeDefined();
+    expect(
+      await screen.findByText('Mantine task detail renders', {}, { timeout: 5000 })
+    ).toBeDefined();
     expect(baseElement.querySelector('.mantine-Paper-root')).toBeDefined();
     expect(baseElement.querySelector('[data-slot="textarea"]')).toBeNull();
   });


### PR DESCRIPTION
## Summary
- Make MCP write tools return concise confirmations instead of echoing full task JSON with comment history.
- Keep detailed payloads on read paths such as `get_task`, `list_tasks`, and `list_comments`.
- Update MCP docs and add regression coverage for the response contract.
- Stabilize the Progress tab web test that failed under CI load while verifying this PR.

## Reporter credit
Thanks to @Cob-AI for reporting this in #714 and calling out the context-window impact for agent-heavy boards.

## Verification
- `pnpm --filter @veritas-kanban/mcp exec vitest run src/__tests__/write-response-contract.test.ts`
- `pnpm --filter @veritas-kanban/mcp build`
- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/task-detail-mantine.test.tsx --testTimeout 15000`
- `pnpm --filter @veritas-kanban/web test` (64 files, 326 tests)
- `pnpm lint:budget` (0 errors, 599 warnings, budget 600)

Fixes #714
