### PR TITLE
Prepare v5.0.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-06-12
+
+### Changed
+
+- Bumped the release from `5.0.0` to `5.0.1` across the root, shared, server,
+  web, CLI, MCP, and desktop package manifests.
+- Updated the README version badge and MCP documentation footer for `5.0.1`.
+
+### Fixed
+
+- Made MCP write tools return concise confirmations instead of echoing full task
+  JSON payloads with complete comment history, reducing token usage for
+  agent-heavy boards (#714, #715). Thanks to @Cob-AI for the report.
+- Stabilized the Mantine task detail Progress tab test under CI load.
+- Fixed the local macOS desktop packaging smoke check to follow the configured
+  app bundle name.
+
 ## [5.0.0] - 2026-06-05
 
 ### Added
@@ -1567,7 +1584,9 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v4.1.0...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.0...v5.0.1
+[5.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v4.3.2...v5.0.0
 [4.1.0]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.1...v4.1.0
 [4.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v3.3.3...v4.0.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.0.1-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -96,7 +96,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [v5 Visual Tour](docs/V5-VISUAL-TOUR.md) — release-safe dummy screenshots and GIFs for the v5 desktop shell, resizable workbench, agent providers, task work view, Maintenance Center, and mobile/PWA shell.
 - [v5 Upgrade, Install, Remote, And Admin Guide](docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md) — fresh install, v4-to-v5 upgrade, desktop setup, remote/server, mobile/PWA, admin, backup, and diagnostics paths.
 - [v5 Compatibility And Release Policy](docs/V5-COMPATIBILITY-AND-RELEASE-POLICY.md) — supported version combinations, update channels, stale-client behavior, rollback limits, and release validation.
-- [v5 Release Notes](docs/V5-RELEASE-NOTES.md) — breaking changes, migration warnings, published v5.0.0 artifacts, and deferred post-GA backlog.
+- [v5 Release Notes](docs/V5-RELEASE-NOTES.md) — breaking changes, migration warnings, published v5.0.x artifacts, and deferred post-GA backlog.
 - [v5 Desktop Architecture ADR](docs/architecture/ADR-0001-v5-desktop-architecture.md) — shell decision, native/server boundaries, connection modes, lifecycle, packaging, and security model.
 - [Post-GA Desktop Agent Workbench Spec](docs/DESKTOP-AGENT-WORKBENCH.md) — desktop workbench UX, run controls, approvals, evidence, native affordances, and safety coverage.
 - [Post-GA Native Mobile Offline ADR](docs/architecture/ADR-0003-post-ga-native-mobile-offline.md) — native mobile authority model, offline queue semantics, conflict handling, and security review.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -1,13 +1,29 @@
 # v5.0 Release Notes
 
-These notes describe the published Veritas Kanban v5.0.0 stable release.
+These notes describe the published Veritas Kanban v5.0 stable release line.
 
 - GitHub release:
-  [Veritas Kanban v5.0.0](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.0.0)
+  [Veritas Kanban v5.0.1](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.0.1)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
   [Veritas-Kanban-5.0.0-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.zip)
+
+## v5.0.1 Patch
+
+v5.0.1 is a small MCP/runtime patch release. It keeps the v5 storage,
+desktop, security, and migration posture unchanged from v5.0.0.
+
+- MCP write tools now return concise confirmations instead of echoing the full
+  task JSON and complete comment history on every mutation.
+- Read tools remain the full-detail paths: `get_task`, `list_tasks`, and
+  `list_comments`.
+- The MCP documentation and response-contract tests cover the concise write
+  behavior.
+- The Mantine task detail Progress tab test was stabilized under CI load while
+  validating the patch.
+- The local macOS desktop packaging smoke check now follows the configured app
+  bundle name.
 
 ## Highlights
 
@@ -77,7 +93,7 @@ These notes describe the published Veritas Kanban v5.0.0 stable release.
 
 ## Release Artifacts
 
-The v5.0.0 stable release includes:
+The v5.0.0 stable desktop release includes:
 
 | Artifact                                                                                                                                                        | SHA-256                                                            |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -802,7 +802,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `4.0.0`      | Matches VK server version   |
+| MCP server package | `5.0.1`      | Matches VK server version   |
 | MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2024-11-05` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -846,4 +846,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-06-05 · VK v5.0.0 · 36 tools / 8 categories_
+_Last updated: 2026-06-12 · VK v5.0.1 · 36 tools / 8 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/scripts/check-desktop-local-packaging-smoke.mjs
+++ b/scripts/check-desktop-local-packaging-smoke.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { constants } from 'node:fs';
-import { access, stat } from 'node:fs/promises';
+import { access, readFile, stat } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,6 +21,11 @@ async function snapshotPath(label, targetPath) {
   await assertExists(label, targetPath);
   const info = await stat(targetPath);
   return { label, targetPath, mtimeMs: info.mtimeMs };
+}
+
+async function getMacAppBundleName() {
+  const packageJson = JSON.parse(await readFile(path.join(desktopDir, 'package.json'), 'utf8'));
+  return `${packageJson.build?.executableName ?? packageJson.build?.productName ?? 'Veritas Kanban'}.app`;
 }
 
 function run(command, args) {
@@ -80,7 +85,7 @@ async function main() {
   await assertExists('Desktop staging web app', path.join(stagingDir, 'web/dist/index.html'));
   await assertExists(
     'Unpacked macOS app',
-    path.join(desktopDir, 'release/mac-arm64/Veritas Kanban.app')
+    path.join(desktopDir, 'release/mac-arm64', await getMacAppBundleName())
   );
 
   console.log(

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps the Veritas Kanban workspace from 5.0.0 to 5.0.1 across root, shared, server, web, CLI, MCP, and desktop manifests.
- Updates the README badge, changelog, MCP docs, and v5 release notes for the v5.0.1 patch.
- Fixes the local macOS desktop packaging smoke check to validate the configured app bundle name.

## Context
This packages the MCP write-response fix from #715 for the issue reported in #714. Thanks to @Cob-AI for the original report.

Closes #716

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --write package.json shared/package.json server/package.json web/package.json cli/package.json mcp/package.json desktop/package.json README.md CHANGELOG.md docs/mcp/README.md docs/V5-RELEASE-NOTES.md`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm test:unit`
- `pnpm desktop:smoke:mac:local`
- `pnpm --filter @veritas-kanban/mcp exec vitest run src/__tests__/write-response-contract.test.ts`
- `pnpm validate:release -- --version 5.0.1`

## Notes
- `pnpm install --frozen-lockfile` confirms the version bump does not require a lockfile update.
- The v5.0.1 source build locally recompiles the MCP and desktop outputs. Signed macOS release assets will be produced by the Desktop Release workflow after the GitHub release is published.
