### PR TITLE
Fix desktop release blockmap regeneration

### DIFF
--- a/scripts/finalize-macos-release-assets.mjs
+++ b/scripts/finalize-macos-release-assets.mjs
@@ -96,22 +96,19 @@ async function hashFile(file, algorithm, encoding) {
     .digest(encoding);
 }
 
-function resolveAppBuilderPath() {
+function resolvePackageModule(moduleName, packageName) {
   const resolutionRoots = [
     path.join(rootDir, 'node_modules/.pnpm/node_modules'),
     path.join(desktopDir, 'node_modules/.pnpm/node_modules'),
-    path.join(desktopDir, 'node_modules/electron-builder'),
     desktopDir,
     rootDir,
   ];
 
   for (const resolutionRoot of resolutionRoots) {
     try {
-      const appBuilderBin = requireFromScript.resolve('app-builder-bin', {
+      return requireFromScript.resolve(moduleName, {
         paths: [resolutionRoot],
       });
-
-      return createRequire(appBuilderBin)('app-builder-bin').appBuilderPath;
     } catch {
       // Try the next pnpm resolution root.
     }
@@ -126,18 +123,32 @@ function resolveAppBuilderPath() {
     }
 
     for (const entry of readdirSync(storeRoot)) {
-      if (!entry.startsWith('app-builder-bin@')) {
+      if (!entry.startsWith(`${packageName}@`)) {
         continue;
       }
 
-      const appBuilderBin = path.join(storeRoot, entry, 'node_modules/app-builder-bin/index.js');
-      if (existsSync(appBuilderBin)) {
-        return createRequire(appBuilderBin)('app-builder-bin').appBuilderPath;
+      const modulePath = path.join(storeRoot, entry, 'node_modules', moduleName);
+      if (existsSync(modulePath)) {
+        return modulePath;
       }
     }
   }
 
-  throw new Error('Unable to resolve app-builder-bin for DMG blockmap regeneration');
+  throw new Error(`Unable to resolve ${moduleName} for DMG blockmap regeneration`);
+}
+
+async function writeDmgBlockmap(dmg, dmgBlockmap) {
+  const blockmapModule = resolvePackageModule(
+    'app-builder-lib/out/targets/blockmap/blockmap.js',
+    'app-builder-lib'
+  );
+  const { buildBlockMap } = createRequire(blockmapModule)(blockmapModule);
+
+  if (typeof buildBlockMap !== 'function') {
+    throw new Error('Electron Builder blockmap module did not expose buildBlockMap');
+  }
+
+  await buildBlockMap(dmg, 'gzip', dmgBlockmap);
 }
 
 async function writeLatestMacYml(version, zip, dmg) {
@@ -187,7 +198,7 @@ async function main() {
   run('xcrun', ['stapler', 'validate', dmg]);
   run('spctl', ['-a', '-vvv', '-t', 'open', '--context', 'context:primary-signature', dmg]);
 
-  run(resolveAppBuilderPath(), ['blockmap', '--input', dmg, '--output', dmgBlockmap]);
+  await writeDmgBlockmap(dmg, dmgBlockmap);
   await writeLatestMacYml(version, zip, dmg);
 }
 


### PR DESCRIPTION
## Summary
- Updates `scripts/finalize-macos-release-assets.mjs` to regenerate the stapled DMG blockmap through Electron Builder 26's installed `app-builder-lib` module.
- Removes the obsolete `app-builder-bin` resolver path that failed during the v5.0.1 Desktop Release workflow.

## Context
The v5.0.1 Desktop Release run passed signing, notarization, and stapling, then failed while regenerating the DMG blockmap because `app-builder-bin` is no longer present in the installed Electron Builder dependency graph.

## Verification
- `pnpm exec prettier --write scripts/finalize-macos-release-assets.mjs`
- `node --check scripts/finalize-macos-release-assets.mjs`
- Focused local blockmap smoke: resolved `app-builder-lib/out/targets/blockmap/blockmap.js` from pnpm's layout and generated a non-empty blockmap for a temporary file.
- `pnpm lint:budget`

## Release follow-up
After this merges, manually dispatch `Desktop Release` on `main` with `channel=stable` so the workflow uses this fix while uploading assets to the existing `v5.0.1` release.
