### PR TITLE
Fix Docker source builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,9 +45,6 @@ LICENSE
 coverage
 
 # Development tools
-cli/
-mcp/
-scripts/
 tasks/
 eslint.config.js
 .prettierrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # ---------------------------------------------------------------------------
 FROM node:22-alpine AS deps
 
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 
 WORKDIR /app
 
@@ -27,8 +27,10 @@ COPY server/package.json ./server/
 COPY web/package.json ./web/
 COPY cli/package.json ./cli/
 COPY mcp/package.json ./mcp/
+COPY scripts/ ./scripts/
 
 # Install all dependencies (dev + prod) for building
+ENV HUSKY=0
 RUN pnpm install --frozen-lockfile
 
 # ---------------------------------------------------------------------------
@@ -65,7 +67,7 @@ RUN pnpm --filter @veritas-kanban/server build
 # ---------------------------------------------------------------------------
 FROM node:22-alpine AS production
 
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 
 # Security: run as non-root
 RUN addgroup -g 1001 -S nodejs && \

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 | **Git**             | simple-git, worktree management      | —                                |
 | **Testing**         | Playwright (E2E), Vitest (unit)      | Playwright 1.58, Vitest 4        |
 | **Runtime**         | Node.js                              | 22+                              |
-| **Package Manager** | pnpm                                 | 9+                               |
+| **Package Manager** | pnpm                                 | 11.1.1+                          |
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -226,13 +226,13 @@ If you need to debug inside a container, use `docker exec` to inspect — don't 
 | Requirement | Version |
 | ----------- | ------- |
 | Node.js     | 22.0.0+ |
-| pnpm        | 9.0.0+  |
+| pnpm        | 11.1.1+ |
 
 Install pnpm if not present:
 
 ```bash
 corepack enable
-corepack prepare pnpm@9.15.4 --activate
+corepack prepare pnpm@11.1.1 --activate
 ```
 
 ### Build Steps

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -28,12 +28,12 @@ A working board is not the same as agent-ready or external wake/delivery-ready. 
 
 ## Prerequisites (30 seconds)
 
-| What              | Command            | Notes                                              |
-| ----------------- | ------------------ | -------------------------------------------------- |
-| Node.js           | `node -v`          | Requires **22+**. Install via Volta/nvm if older.  |
-| pnpm              | `pnpm -v`          | Requires **9+**. `npm install -g pnpm` if missing. |
-| Git               | `git --version`    | Any current version works.                         |
-| (Optional) Docker | `docker --version` | Needed only if you prefer containers.              |
+| What              | Command            | Notes                                                                   |
+| ----------------- | ------------------ | ----------------------------------------------------------------------- |
+| Node.js           | `node -v`          | Requires **22+**. Install via Volta/nvm if older.                       |
+| pnpm              | `pnpm -v`          | Requires **11.1.1+**. Prefer `corepack prepare pnpm@11.1.1 --activate`. |
+| Git               | `git --version`    | Any current version works.                                              |
+| (Optional) Docker | `docker --version` | Needed only if you prefer containers.                                   |
 
 That's it. No database, no extra services.
 

--- a/docs/guides/SELF_HOST.md
+++ b/docs/guides/SELF_HOST.md
@@ -33,14 +33,14 @@ This guide walks you through every self-hosting scenario — from running locall
 | Requirement | Version | Install                                                      |
 | ----------- | ------- | ------------------------------------------------------------ |
 | Node.js     | 22.0.0+ | https://nodejs.org or `nvm install 22`                       |
-| pnpm        | 9.0.0+  | `corepack enable && corepack prepare pnpm@9.15.4 --activate` |
+| pnpm        | 11.1.1+ | `corepack enable && corepack prepare pnpm@11.1.1 --activate` |
 | Git         | any     | https://git-scm.com                                          |
 
 Verify:
 
 ```bash
 node --version   # v22.x.x
-pnpm --version   # 9.x.x
+pnpm --version   # 11.x.x
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Fix the source Docker build context so `cli/`, `mcp/`, and `scripts/` are available to the Dockerfile.
- Align Docker's Corepack pnpm activation with the repo-pinned `pnpm@11.1.1`.
- Refresh active setup/self-host docs that still pointed users at pnpm 9.

Fixes #725.

## Root Cause

The root `.dockerignore` excluded `cli/`, `mcp/`, and `scripts/`, but the Dockerfile copies `cli/package.json` and `mcp/package.json` during dependency setup. The dependency stage also let the root `prepare` lifecycle run without `scripts/prepare-husky.mjs` in the image context.

## Verification

- `pnpm validate:release -- --skip-build-output --docker-build`
- `docker run -d --name veritas-725-smoke -p 127.0.0.1:13001:3001 -e VERITAS_ADMIN_KEY=veritas-725-local-smoke-key -e VERITAS_AUTH_LOCALHOST_BYPASS=false -e VERITAS_STORAGE=sqlite veritas-kanban:validate-5.0.1`
- `curl -fsS http://127.0.0.1:13001/health`
- `pnpm validate:release -- --skip-build-output`
- `git diff --check`
