### PR TITLE
Add sandbox policy presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 
 2. **Never trigger agents from uncontrolled inputs.** Don't let inbound emails, webhooks from third parties, or public form submissions automatically spawn agent work. An attacker who can craft an input can control your agent.
 
-3. **Principle of least privilege.** Give agents the minimum permissions they need. Use the `agent` role (not `admin`) for API keys. Restrict file system access. Don't run agents as root.
+3. **Principle of least privilege.** Give agents the minimum permissions they need. Use the `agent` role (not `admin`) for API keys. Restrict file system access with sandbox policy presets. Don't run agents as root.
 
 4. **Review before merge.** Agents can write code — that doesn't mean the code is correct or safe. Always review agent-generated code before merging to production branches. Use the built-in code review workflow.
 
@@ -134,7 +134,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 
 7. **Rotate credentials regularly.** If an agent has access to API keys, tokens, or secrets, rotate them on a schedule. Don't embed real credentials in task descriptions or prompts.
 
-8. **Isolate environments.** Run agents in containers, VMs, or sandboxed environments when possible. Keep agent workspaces separate from sensitive data.
+8. **Isolate environments.** Run agents in containers, VMs, or sandboxed environments when possible. Keep agent workspaces separate from sensitive data, use deny-by-default network presets for untrusted work, and broker credentials instead of exposing broad environment variables.
 
 **The bottom line:** Agentic AI is transformational, but it amplifies both your capabilities and your mistakes. Plan accordingly, start small, and add autonomy gradually as you build confidence in your guardrails.
 
@@ -144,7 +144,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 
 ### 🛡️ Agent Governance
 
-**Policy Engine** — Define what agents can and can't do. Configurable tool/action policies with `allow`, `deny`, and `require-approval` guard rules. Every policy decision is logged. **Decision Audit Trail** — Log agent decisions with confidence scores, supporting evidence, and stated assumptions. Record outcomes afterward to see whether assumptions held. **Behavioral Drift Detection** — Set metric baselines and thresholds; get alerted when an agent's behavior deviates. **User Feedback Loop** — Collect feedback on agent outputs with sentiment tagging and category analytics. **Output Evaluation** — Score agent outputs against weighted criteria profiles (regex, keyword, numeric range, custom expressions).
+**Policy Engine** — Define what agents can and can't do. Configurable tool/action policies with `allow`, `deny`, and `require-approval` guard rules. Every policy decision is logged. **Sandbox Policy Presets** — Assign reusable filesystem, network, environment, and credential rules to agents, workflow agents, or one-off runs; unsupported required controls fail closed before launch with redacted audit traces. **Decision Audit Trail** — Log agent decisions with confidence scores, supporting evidence, and stated assumptions. Record outcomes afterward to see whether assumptions held. **Behavioral Drift Detection** — Set metric baselines and thresholds; get alerted when an agent's behavior deviates. **User Feedback Loop** — Collect feedback on agent outputs with sentiment tagging and category analytics. **Output Evaluation** — Score agent outputs against weighted criteria profiles (regex, keyword, numeric range, custom expressions).
 
 ### 🤖 Agent Orchestration
 
@@ -223,6 +223,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **HermesAgent support** — documents HermesAgent/Hermes Gateway as the active control plane, with Veritas as the GitHub-backed source of truth
 - **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, MCP setup, and default routing for fresh installs
 - **Local LLM provider profiles** — Optional Ollama Local, Ollama Cloud, and LM Studio Local profiles with health metadata and routing support
+- **Sandbox policy presets** — Built-in and custom presets for filesystem scope, network egress, environment passthrough, and credential brokering, with Settings dry-runs before agent launch
 - **Optional OpenClaw support** — Native integration with [OpenClaw](https://github.com/openclaw/openclaw) when you want OpenClaw to execute or wake agents
 - **Squad Chat** — Real-time agent-to-agent communication with WebSocket updates, system lifecycle events, model attribution per message, and configurable display names
 - **@Mention notifications** — @agent-name parsing in comments, thread subscriptions
@@ -678,7 +679,7 @@ vk agents:pending
 ### Codex + HermesAgent
 
 - Follow the [Codex Integration SOP](docs/SOP-codex-integration.md) when Codex should implement, review, or delegate Veritas tasks.
-- Use the [Agent Providers guide](docs/AGENT-PROVIDERS.md) when enabling Codex, Ollama, LM Studio, or provider-specific routing in the web app or macOS app.
+- Use the [Agent Providers guide](docs/AGENT-PROVIDERS.md) when enabling Codex, Ollama, LM Studio, provider-specific routing, or sandbox presets in the web app or macOS app.
 - Use the [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) when routing work through the HermesAgent roster, enforcing QA evidence, or creating GitHub-backed task templates.
 - Configure Codex MCP access with the [MCP Server Guide](docs/mcp/README.md#codex) so Codex reads and updates Veritas through typed tools instead of one-off HTTP calls.
 

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -14,6 +14,20 @@ Fresh v5 installs use OpenAI Codex as the default agent:
 
 Existing configs keep the user's chosen default agent. Missing built-in profiles are added during config normalization without overwriting customized commands, arguments, or enabled states.
 
+## Sandbox Policy Presets
+
+Use **Settings -> Agents -> Sandbox Policies** to manage reusable filesystem, network, environment, and credential controls for agent execution. Built-in presets are immutable; custom presets can be created, edited, disabled, or deleted.
+
+Presets can be assigned to:
+
+- An agent profile, as the default guardrail for that provider.
+- A workflow agent, as the guardrail for that workflow role.
+- A one-off agent start request, by passing `sandboxPresetId`.
+
+The launch path dry-runs the selected preset before starting Codex CLI, Codex SDK, or OpenClaw-backed work. Required controls fail closed when the provider cannot support them. Advisory controls continue with warnings and a governance trace. Settings also includes a dry-run panel that shows effective sandbox mode, network access, environment allowlist, unsupported controls, and the trace ID.
+
+Credential references and environment-style `name=value` values are redacted from dry-run output and governance traces. Prefer brokered credential presets for workflows that need scoped secrets instead of exposing broad environment passthrough.
+
 ## Local And Cloud Profiles
 
 | Profile            | Provider          | Default command                               | Auth / readiness                    |
@@ -37,6 +51,12 @@ The provider model is the same in both shells:
 - The macOS app bundles and supervises the local Veritas server. Local providers execute on that Mac.
 - Cloud profiles are still explicit. Routing a local workflow to a cloud provider surfaces a warning during workflow dry-runs.
 - Remote or cloud clients should not route directly to local-only providers unless a trusted local host/supervisor is configured.
+
+Sandbox policy enforcement follows the execution host:
+
+- **Local desktop:** filesystem paths, environment passthrough, credentials, and network controls apply on the user's Mac through the bundled server/provider process.
+- **Remote server:** the same presets apply on the remote Veritas server host. Browser and mobile clients never receive direct local filesystem access.
+- **Cloud-hosted runners:** only provider-reported controls can be treated as enforced. Required controls fail closed when the cloud provider cannot prove support; advisory controls continue with traceable warnings.
 
 ## Routing
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -36,22 +36,23 @@
 23. [Attachments](#attachments)
 24. [Agent Permissions](#agent-permissions)
 25. [Agent Routing](#agent-routing)
-26. [Shared Resources](#shared-resources)
-27. [Skill Capability Profiles](#skill-capability-profiles-apiskillscapabilities)
-28. [Skill Security Scanner](#skill-security-scanner-apiskillssecurity)
-29. [Doc Freshness](#doc-freshness)
-30. [Cost Prediction](#cost-prediction)
-31. [Error Learning](#error-learning)
-32. [Tool Policies](#tool-policies)
-33. [Watcher Continuation Policies](#watcher-continuation-policies)
-34. [Traces](#traces)
-35. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
-36. [Audit](#audit)
-37. [Maintenance Center](#maintenance-center-apiv1maintenance)
-38. [Common Workflows](#common-workflows)
-39. [Versioning & Deprecation](#versioning--deprecation)
-40. [Rate Limits](#rate-limits)
-41. [Additional Endpoint Groups](#additional-endpoint-groups)
+26. [Sandbox Policies](#sandbox-policies)
+27. [Shared Resources](#shared-resources)
+28. [Skill Capability Profiles](#skill-capability-profiles-apiskillscapabilities)
+29. [Skill Security Scanner](#skill-security-scanner-apiskillssecurity)
+30. [Doc Freshness](#doc-freshness)
+31. [Cost Prediction](#cost-prediction)
+32. [Error Learning](#error-learning)
+33. [Tool Policies](#tool-policies)
+34. [Watcher Continuation Policies](#watcher-continuation-policies)
+35. [Traces](#traces)
+36. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
+37. [Audit](#audit)
+38. [Maintenance Center](#maintenance-center-apiv1maintenance)
+39. [Common Workflows](#common-workflows)
+40. [Versioning & Deprecation](#versioning--deprecation)
+41. [Rate Limits](#rate-limits)
+42. [Additional Endpoint Groups](#additional-endpoint-groups)
 
 ---
 
@@ -1422,6 +1423,112 @@ PUT /api/agents/routing
 
 ---
 
+## Sandbox Policies
+
+Reusable filesystem, network, environment, and credential presets for agent
+and workflow launch guardrails.
+
+Mounted at `/api/sandbox-policies`.
+
+| Method   | Path                             | Description                                    | Permissions                 |
+| -------- | -------------------------------- | ---------------------------------------------- | --------------------------- |
+| `GET`    | `/api/sandbox-policies`          | List built-in and custom presets               | `policy:read`               |
+| `GET`    | `/api/sandbox-policies/:id`      | Get one preset                                 | `policy:read`               |
+| `POST`   | `/api/sandbox-policies`          | Create a custom preset                         | `policy:write` + admin role |
+| `PUT`    | `/api/sandbox-policies/:id`      | Update a custom preset                         | `policy:write` + admin role |
+| `DELETE` | `/api/sandbox-policies/:id`      | Delete a custom preset                         | `policy:write` + admin role |
+| `POST`   | `/api/sandbox-policies/validate` | Dry-run a preset against provider capabilities | `policy:read`, `agent:read` |
+
+Built-in presets are immutable. Custom presets live in the shared app config.
+Agent profiles, workflow agents, and one-off agent starts can reference a preset
+with `sandboxPresetId`.
+
+### Create Preset
+
+```
+POST /api/sandbox-policies
+```
+
+**Body**:
+
+```json
+{
+  "id": "repo-contained-no-network",
+  "name": "Repo contained, no network",
+  "enabled": true,
+  "enforcement": "required",
+  "requiredCapabilities": ["filesystem.write"],
+  "filesystem": {
+    "readPaths": ["."],
+    "writePaths": ["."],
+    "deniedPaths": ["~/.ssh", "~/.aws", "~/.config/gh"],
+    "dotfileMasking": true,
+    "localOnlyHandles": true
+  },
+  "network": {
+    "defaultEgress": "deny",
+    "allowedHosts": [],
+    "allowedMethods": [],
+    "allowedPathPrefixes": [],
+    "blockPrivateNetwork": true,
+    "blockMetadataEndpoints": true,
+    "blockLoopback": false
+  },
+  "environment": {
+    "passthrough": ["CODEX_HOME", "OPENAI_API_KEY"],
+    "redactDisplay": true
+  },
+  "credentials": {
+    "mode": "brokered",
+    "brokerRefs": ["openai-api-key"]
+  }
+}
+```
+
+**Response** `201`: Created preset with `createdAt` and `updatedAt`.
+
+### Validate Preset
+
+```
+POST /api/sandbox-policies/validate
+```
+
+**Body**:
+
+```json
+{
+  "presetId": "repo-contained-no-network",
+  "provider": "codex-sdk",
+  "workspacePath": "/workspace/veritas-kanban",
+  "requiredCapabilities": ["filesystem.write"]
+}
+```
+
+**Response** `200`:
+
+```json
+{
+  "decision": "allow",
+  "provider": "codex-sdk",
+  "effective": {
+    "sandboxMode": "workspace-write",
+    "networkAccessEnabled": false,
+    "envPassthrough": ["CODEX_HOME", "OPENAI_API_KEY"],
+    "credentialRefs": ["openai-api-key"]
+  },
+  "unsupportedRules": [],
+  "warnings": [],
+  "traceId": "govtrace_1760000000000_ab12cd"
+}
+```
+
+`decision` is `allow`, `warn`, or `block`. Required unsupported controls block
+launches before execution. Advisory unsupported controls continue with warnings.
+Credential references and environment-style `name=value` values are redacted in
+responses and governance traces.
+
+---
+
 ## Shared Resources
 
 Registry for shared resources (credentials, config files, API keys, docs) that can be mounted to projects.
@@ -2373,6 +2480,7 @@ These endpoints follow the same auth/error patterns documented above:
 | `/api/delegation`                | Task delegation                               |
 | `/api/workflows`                 | Workflow engine ([details](API-WORKFLOWS.md)) |
 | `/api/tool-policies`             | Tool access policies                          |
+| `/api/sandbox-policies`          | Agent sandbox policy presets                  |
 | `/api/integrations`              | External integrations                         |
 | `/api/settings/transition-hooks` | Status transition hooks                       |
 
@@ -2558,7 +2666,7 @@ Update a specific assumption by its zero-based index.
 
 ### Governance Decision Traces (`/api/governance/traces`)
 
-Inspect policy, tool-policy, agent-permission, routing, and workflow-gate decisions with evaluated rules, matched rules, remediation, and redacted raw detail.
+Inspect policy, tool-policy, sandbox-policy, agent-permission, routing, and workflow-gate decisions with evaluated rules, matched rules, remediation, and redacted raw detail.
 
 #### List Governance Traces
 
@@ -2568,7 +2676,7 @@ GET /api/governance/traces
 
 Query params: `kind`, `outcome`, `agent`, `taskId`, `actionType`, `startTime`, `endTime`, `limit`.
 
-`kind` values: `policy`, `tool-policy`, `agent-permission`, `routing`, `workflow-gate`.
+`kind` values: `policy`, `tool-policy`, `sandbox-policy`, `agent-permission`, `routing`, `workflow-gate`.
 
 `outcome` values: `allowed`, `warned`, `blocked`, `approval-required`, `routed`, `fallback`, `skipped`.
 

--- a/docs/API-WORKFLOWS.md
+++ b/docs/API-WORKFLOWS.md
@@ -13,13 +13,14 @@
 3. [Workflow Runs](#workflow-runs)
 4. [Gate Operations](#gate-operations)
 5. [Tool Policies](#tool-policies)
-6. [Task Dependencies](#task-dependencies) (NEW — v3.3)
-7. [Crash-Recovery Checkpointing](#crash-recovery-checkpointing) (NEW — v3.3)
-8. [Observational Memory](#observational-memory) (NEW — v3.3)
-9. [Agent Filter](#agent-filter) (NEW — v3.3)
-10. [WebSocket Events](#websocket-events)
-11. [TypeScript Interfaces](#typescript-interfaces)
-12. [Error Responses](#error-responses)
+6. [Sandbox Policies](#sandbox-policies)
+7. [Task Dependencies](#task-dependencies) (NEW — v3.3)
+8. [Crash-Recovery Checkpointing](#crash-recovery-checkpointing) (NEW — v3.3)
+9. [Observational Memory](#observational-memory) (NEW — v3.3)
+10. [Agent Filter](#agent-filter) (NEW — v3.3)
+11. [WebSocket Events](#websocket-events)
+12. [TypeScript Interfaces](#typescript-interfaces)
+13. [Error Responses](#error-responses)
 
 ---
 
@@ -1203,6 +1204,27 @@ curl -X POST http://localhost:3001/api/tool-policies/planner/validate \
 
 ---
 
+## Sandbox Policies
+
+Workflow agents can set `sandboxPresetId` to select a sandbox policy preset for
+that role. The workflow executor dry-runs the preset against the selected
+provider before launching the step. Required unsupported controls block the
+step before execution and write a `sandbox-policy` governance trace; advisory
+unsupported controls continue with warnings.
+
+Use `/api/sandbox-policies/validate` to preflight a workflow agent's preset in
+the authoring UI or custom automation. Presets can also be assigned visually in
+the workflow authoring panel.
+
+Sandbox policies are complementary to tool policies:
+
+- Tool policies decide which Veritas/OpenClaw tools a workflow role may use.
+- Sandbox policies decide what the underlying provider process may access at
+  launch time: filesystem paths, network egress, environment variables, and
+  credentials.
+
+---
+
 ## Task Dependencies
 
 ### GET /api/tasks/:id/dependencies
@@ -1906,6 +1928,7 @@ export interface WorkflowAgent {
   id: string;
   name: string;
   role: string; // maps to tool policy
+  sandboxPresetId?: string; // maps to a sandbox policy preset
   model?: string; // default model for this agent
   description: string;
   tools?: string[]; // tool restrictions (overrides role policy)

--- a/docs/CODEX-INTEGRATION.md
+++ b/docs/CODEX-INTEGRATION.md
@@ -34,6 +34,12 @@ Recommended default shape:
 codex exec --cwd <task-worktree> --sandbox workspace-write --json <prompt>
 ```
 
+When a Codex agent profile or workflow agent has `sandboxPresetId`, Veritas
+dry-runs the sandbox policy before launching the CLI process. The resulting
+filesystem mode, network posture, and environment passthrough are applied where
+the provider supports them. Required unsupported controls fail closed before
+execution and write a redacted `sandbox-policy` governance trace.
+
 ### Codex SDK Provider
 
 The SDK path supports long-lived local Codex threads, resumable session IDs, and richer follow-up workflows. Veritas starts `@openai/codex-sdk` threads in the task worktree, streams SDK events into attempt logs, emits token telemetry, and persists the SDK `threadId` on the active/completed attempt.
@@ -48,6 +54,11 @@ const thread = codex.startThread({
   networkAccessEnabled: true,
 });
 ```
+
+The SDK provider also honors sandbox policy presets. This is the preferred path
+for deny-by-default network policies because the SDK capability check supports
+network disablement, whereas the CLI path is limited to the controls exposed by
+`codex exec`.
 
 ### Codex Cloud Delegation
 
@@ -114,6 +125,7 @@ Workflow agent steps execute through provider-aware step handling. Codex-backed 
 - step output files
 - retry and failure handling through the workflow runner
 - tool-policy hints in prompt/config where direct enforcement is unavailable
+- per-agent `sandboxPresetId` launch guardrails
 
 Workflow agents can opt into Codex with provider metadata:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -286,6 +286,7 @@ First-class support for autonomous coding agents.
 - **HermesAgent operating support** — v4.3 documents HermesAgent/Hermes Gateway as the active control plane, with Veritas tracking task truth, QA evidence, and GitHub delivery state
 - **OpenAI Codex support** — Local CLI attempts, SDK sessions, GitHub-native Codex Cloud delegation, workflow steps, review actions, Settings health checks, MCP setup, and fresh-install default routing
 - **Local LLM provider profiles** — Ollama Local, Ollama Cloud, and LM Studio Local profiles can be enabled, health-checked, and targeted by routing rules in the web app or macOS app
+- **Sandbox policy presets** — Built-in and custom presets control filesystem scope, network egress, environment passthrough, and credential brokering for agent profiles, workflow agents, and per-run overrides
 - **Platform-agnostic REST API** — Any platform that can make HTTP calls can drive the full agent lifecycle
 - **Agent request tracking** — VK can create and display pending agent requests; a configured external runner/provider must execute the work
 - **Automation tasks** — Separate automation task type with pending/running/complete lifecycle, session key tracking, and sub-agent spawning
@@ -876,6 +877,32 @@ Role-based tool restrictions for least-privilege security.
 
 - Tool filters are resolved before OpenClaw workflow session execution and passed through the provider-adapter boundary.
 - Denied list takes precedence over allowed list
+
+### Sandbox Policies
+
+Reusable launch-time sandbox presets for provider execution guardrails.
+
+**Built-in presets:**
+
+| Preset                       | Enforcement | Use case                                                                        |
+| ---------------------------- | ----------- | ------------------------------------------------------------------------------- |
+| `legacy-permissive`          | advisory    | Preserve existing Codex CLI behavior while surfacing sandbox telemetry          |
+| `codex-repo-contained`       | required    | Default-deny network with repository-scoped filesystem writes                   |
+| `brokered-network-allowlist` | required    | Allowlist egress and brokered credential references for controlled integrations |
+
+**Configuration:**
+
+- Create, edit, enable, disable, and delete custom presets in **Settings -> Agents -> Sandbox Policies**.
+- Assign presets to agent profiles or workflow agents; one-off agent starts can pass `sandboxPresetId` to override the profile default.
+- Presets declare filesystem read/write paths, denied paths, dotfile masking, network default egress, allowed hosts and paths, environment passthrough keys, credential mode, and broker references.
+- Dry-runs compare a preset against provider capabilities before execution and show the effective sandbox mode, network state, environment allowlist, unsupported controls, and governance trace ID.
+
+**Enforcement:**
+
+- Required controls fail closed before agent or workflow launch when the selected provider cannot support them.
+- Advisory controls warn and record trace evidence without blocking the run.
+- Credential references and environment-style `name=value` values are redacted in dry-run output and governance traces.
+- Provider capability checks currently distinguish Codex CLI, Codex SDK, and OpenClaw execution behavior.
 
 ### Session Isolation
 

--- a/docs/SOP-codex-integration.md
+++ b/docs/SOP-codex-integration.md
@@ -65,10 +65,17 @@ export VK_API_KEY="<agent-role-key-if-auth-required>"
 export CODEX_API_KEY="<optional-api-key-for-automation>"
 ```
 
+When the selected agent profile has `sandboxPresetId`, Veritas validates the
+policy before launch and derives the effective Codex sandbox arguments and
+environment passthrough from that preset. Required unsupported controls block
+the attempt before Codex starts; advisory controls continue with warnings and a
+redacted governance trace.
+
 ### Veritas Behavior
 
 1. Resolve the selected agent to a provider: `codex-cli`.
-2. Create an attempt with provider metadata:
+2. Dry-run the selected sandbox policy preset when one is assigned.
+3. Create an attempt with provider metadata:
    ```json
    {
      "agent": "codex",
@@ -77,8 +84,8 @@ export CODEX_API_KEY="<optional-api-key-for-automation>"
      "sandbox": "workspace-write"
    }
    ```
-3. Run Codex in the task worktree.
-4. Parse JSONL events:
+4. Run Codex in the task worktree.
+5. Parse JSONL events:
    - `thread.started`
    - `turn.started`
    - `item.started`
@@ -86,9 +93,9 @@ export CODEX_API_KEY="<optional-api-key-for-automation>"
    - `turn.completed`
    - `turn.failed`
    - `error`
-5. Append human-readable attempt logs.
-6. Preserve final response as the completion summary.
-7. Emit telemetry and token usage when available.
+6. Append human-readable attempt logs.
+7. Preserve final response as the completion summary.
+8. Emit telemetry and token usage when available.
 
 ---
 
@@ -108,6 +115,9 @@ const thread = codex.startThread({
 });
 const result = await thread.run('Implement the Veritas task in the current worktree.');
 ```
+
+Codex SDK starts use the same preset dry-run path as CLI starts. Prefer SDK mode
+for required network disablement because the SDK supports that control directly.
 
 Veritas persists the Codex thread ID in attempt metadata:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -136,6 +136,30 @@ limits are tracked in
 Compatibility errors and debug bundles must redact tokens, cookies, private
 keys, local private paths, raw chat content, and task body text.
 
+## Agent Sandbox Policies
+
+Agent sandbox policy presets live in the shared app config and are managed from
+**Settings -> Agents -> Sandbox Policies** or `/api/sandbox-policies`.
+
+Use them to constrain:
+
+- Filesystem read/write paths, denied paths, dotfile masking, and local-only handles.
+- Network egress defaults, allowlisted hosts and path prefixes, and private network or metadata endpoint blocks.
+- Environment variable passthrough.
+- Credential access mode: none, brokered references, or explicit environment passthrough.
+
+Launch-time validation compares the preset with the selected provider's
+capabilities. Required unsupported controls block the agent or workflow step
+before execution. Advisory unsupported controls continue with warnings. Every
+dry-run and launch-time decision writes a governance trace with raw detail
+redacted; credential references and environment-style `name=value` strings are
+shown as `[redacted]`.
+
+For untrusted or externally sourced work, prefer a required preset with
+repository-scoped writes, default-deny network egress, metadata endpoint
+blocking, and brokered credentials. Keep the legacy permissive preset only for
+existing local Codex CLI workflows that still need broad compatibility.
+
 ## Configuration Reference
 
 ### Environment Variables
@@ -258,7 +282,11 @@ ws.onclose = (event) => {
 
 5. **Monitor access** - The server logs connection attempts with role information
 
-6. **Keep remote mode explicit** - Binding outside loopback, reverse proxying,
+6. **Constrain agent launches** - Assign sandbox policy presets before running
+   untrusted work. Default-deny network egress and broker credentials when a
+   workflow does not need broad host access.
+
+7. **Keep remote mode explicit** - Binding outside loopback, reverse proxying,
    tunneling, or serving mobile/PWA clients requires auth enabled, localhost
    bypass disabled, exact CORS/WebSocket origins, and redacted diagnostics. See
    [ADR 0002](architecture/ADR-0002-v5-remote-server-security-posture.md).

--- a/server/src/__tests__/agent-host-service.test.ts
+++ b/server/src/__tests__/agent-host-service.test.ts
@@ -49,6 +49,12 @@ describe('AgentHostService', () => {
       posture: 'connected',
       workspaceLabels: ['workspace:veritas-kanban'],
     });
+    expect(health.hosts[0].sandboxCapabilities).toEqual([
+      'environment.allowlist',
+      'filesystem.read',
+      'filesystem.write',
+    ]);
+    expect(health.hosts[0].sandboxCapabilities).not.toContain('network.disable');
     expect(JSON.stringify(health.hosts)).not.toContain('/Users/bradgroux');
   });
 
@@ -113,6 +119,34 @@ describe('AgentHostService', () => {
     expect(preview.decision.policy).toBe('manual');
     expect(preview.decision.selectedHostId).toBeUndefined();
     expect(preview.decision.reason).toContain('not compatible');
+  });
+
+  it('marks hosts without sandbox capability signals incompatible when a preset is requested', () => {
+    const service = serviceFor([
+      agent(
+        'custom',
+        { provider: 'custom' },
+        { hostId: 'host-custom', hostName: 'Custom Host', providers: ['custom'] }
+      ),
+    ]);
+
+    const preview = service.preview(
+      {
+        agent: 'custom',
+        provider: 'custom',
+        sandboxPresetId: 'codex-repo-contained',
+      },
+      now
+    );
+
+    expect(preview.decision.selectedHostId).toBeUndefined();
+    expect(preview.decision.excludedHostIds).toContain('host-custom');
+    expect(preview.previews[0].checks.find((check) => check.id === 'sandbox-policy')).toMatchObject(
+      {
+        passed: false,
+        detail: 'Host does not report sandbox capability support for preset codex-repo-contained.',
+      }
+    );
   });
 
   it('disables auto-routing when no host is registered', () => {

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url';
 const {
   mockSpawn,
   mockGetConfig,
+  mockSaveConfig,
   mockGetTask,
   mockUpdateTask,
   mockCheckAgent,
@@ -21,6 +22,7 @@ const {
 } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
   mockGetConfig: vi.fn(),
+  mockSaveConfig: vi.fn(),
   mockGetTask: vi.fn(),
   mockUpdateTask: vi.fn(),
   mockCheckAgent: vi.fn(),
@@ -38,8 +40,9 @@ vi.mock('child_process', () => ({
 
 vi.mock('../services/config-service.js', () => ({
   ConfigService: function () {
-    return { getConfig: mockGetConfig };
+    return { getConfig: mockGetConfig, saveConfig: mockSaveConfig };
   },
+  getConfigService: () => ({ getConfig: mockGetConfig, saveConfig: mockSaveConfig }),
 }));
 
 vi.mock('../services/task-service.js', () => ({

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -13,6 +13,7 @@ import {
   scoringAccess,
   searchAccess,
   settingsAccess,
+  sandboxPolicyAccess,
   taskAccess,
   taskCommentAccess,
   workflowAccess,
@@ -144,6 +145,19 @@ describe('v1 REST permission guard presets', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         details: expect.objectContaining({ required: ['policy:read'] }),
+      })
+    );
+  });
+
+  it('keeps sandbox policy validation read-like while guarding preset mutations', () => {
+    expect(runGuard(sandboxPolicyAccess, mockRequest('POST', '/validate')).next).toHaveBeenCalled();
+
+    const { res, next } = runGuard(sandboxPolicyAccess, mockRequest('POST', '/'));
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['policy:write'] }),
       })
     );
   });

--- a/server/src/__tests__/sandbox-policy-service.test.ts
+++ b/server/src/__tests__/sandbox-policy-service.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { SandboxPolicyPreset } from '@veritas-kanban/shared';
+import { ConfigService } from '../services/config-service.js';
+import {
+  DEFAULT_SANDBOX_PRESET_ID,
+  SandboxPolicyService,
+} from '../services/sandbox-policy-service.js';
+
+function preset(overrides: Partial<SandboxPolicyPreset> = {}): SandboxPolicyPreset {
+  const now = '2026-06-18T00:00:00.000Z';
+  return {
+    id: 'custom-repo-contained',
+    name: 'Custom repo contained',
+    enabled: true,
+    builtIn: false,
+    enforcement: 'required',
+    requiredCapabilities: [],
+    filesystem: {
+      readPaths: ['<workspace>'],
+      writePaths: ['<workspace>'],
+      deniedPaths: [],
+      dotfileMasking: false,
+      localOnlyHandles: true,
+    },
+    network: {
+      defaultEgress: 'deny',
+      allowedHosts: [],
+      allowedMethods: [],
+      allowedPathPrefixes: [],
+      blockPrivateNetwork: true,
+      blockMetadataEndpoints: true,
+      blockLoopback: true,
+    },
+    environment: {
+      passthrough: ['PATH', 'HOME'],
+      redactDisplay: true,
+    },
+    credentials: {
+      mode: 'none',
+      brokerRefs: [],
+    },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('SandboxPolicyService', () => {
+  let testRoot: string;
+  let configService: ConfigService;
+  let service: SandboxPolicyService;
+
+  beforeEach(async () => {
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-sandbox-policy-'));
+    const configDir = path.join(testRoot, '.veritas-kanban');
+    configService = new ConfigService({
+      configDir,
+      configFile: path.join(configDir, 'config.json'),
+      storageType: 'file',
+    });
+    service = new SandboxPolicyService(configService);
+  });
+
+  afterEach(async () => {
+    configService.dispose();
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('seeds built-in presets and persists the default preset id', async () => {
+    const presets = await service.listPresets();
+
+    expect(presets.map((item) => item.id)).toEqual(
+      expect.arrayContaining([
+        DEFAULT_SANDBOX_PRESET_ID,
+        'codex-repo-contained',
+        'brokered-network-allowlist',
+      ])
+    );
+    expect((await configService.getConfig()).defaultSandboxPresetId).toBe(
+      DEFAULT_SANDBOX_PRESET_ID
+    );
+  });
+
+  it('allows repo-contained Codex SDK launches and blocks unsupported Codex CLI launches', async () => {
+    const sdkResult = await service.dryRun({
+      presetId: 'codex-repo-contained',
+      provider: 'codex-sdk',
+    });
+
+    expect(sdkResult.decision).toBe('allow');
+    expect(sdkResult.effective).toMatchObject({
+      sandboxMode: 'workspace-write',
+      networkAccessEnabled: false,
+    });
+
+    const cliResult = await service.dryRun({
+      presetId: 'codex-repo-contained',
+      provider: 'codex-cli',
+    });
+
+    expect(cliResult.decision).toBe('block');
+    expect(cliResult.unsupportedRules.map((rule) => rule.capability)).toContain('network.disable');
+  });
+
+  it('creates, updates, and deletes custom presets without allowing built-in mutation', async () => {
+    const created = await service.createPreset(preset());
+    expect(created.builtIn).toBe(false);
+
+    const updated = await service.updatePreset(created.id, {
+      ...created,
+      name: 'Custom repo contained updated',
+      environment: {
+        ...created.environment,
+        passthrough: ['PATH', 'HOME', 'PATH'],
+      },
+    });
+    expect(updated.name).toBe('Custom repo contained updated');
+    expect(updated.environment.passthrough).toEqual(['HOME', 'PATH']);
+
+    await expect(
+      service.updatePreset('codex-repo-contained', {
+        ...(await service.getPreset('codex-repo-contained'))!,
+        name: 'Edited built in',
+      })
+    ).rejects.toThrow('Built-in sandbox presets cannot be edited');
+    await expect(service.deletePreset('codex-repo-contained')).rejects.toThrow(
+      'Built-in sandbox presets cannot be deleted'
+    );
+
+    await service.deletePreset(created.id);
+    expect(await service.getPreset(created.id)).toBeNull();
+  });
+
+  it('redacts broker reference values from dry-run results and governance trace payloads', async () => {
+    const evaluation = await service.dryRunWithTrace({
+      preset: preset({
+        id: 'brokered-custom',
+        name: 'Brokered custom',
+        network: {
+          defaultEgress: 'deny',
+          allowedHosts: ['api.github.com'],
+          allowedMethods: ['post', 'GET'],
+          allowedPathPrefixes: ['/repos'],
+          blockPrivateNetwork: true,
+          blockMetadataEndpoints: true,
+          blockLoopback: true,
+        },
+        credentials: {
+          mode: 'brokered',
+          brokerRefs: ['github-token=raw-secret'],
+        },
+      }),
+      provider: 'hosted-agent',
+      providerCapabilities: {
+        provider: 'hosted-agent',
+        supported: [
+          'filesystem.read',
+          'filesystem.write',
+          'network.allowlist',
+          'network.block-private',
+          'network.block-metadata',
+          'environment.allowlist',
+          'credential.broker',
+        ],
+      },
+      workspacePath: '/Users/bradgroux/Projects/veritas-kanban',
+    });
+
+    const serialized = JSON.stringify(evaluation);
+    expect(evaluation.result.decision).toBe('allow');
+    expect(evaluation.result.effective.credentialRefs).toEqual(['github-token=[redacted]']);
+    expect(evaluation.trace).toMatchObject({
+      kind: 'sandbox-policy',
+      outcome: 'allowed',
+      subject: {
+        project: '[redacted-local-path]',
+      },
+    });
+    expect(serialized).toContain('github-token=[redacted]');
+    expect(serialized).not.toContain('raw-secret');
+    expect(serialized).not.toContain('/Users/bradgroux');
+  });
+});

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -28,4 +28,13 @@ describe('shared API permission metadata', () => {
         .permissions
     ).toEqual(['workflow:execute']);
   });
+
+  it('separates sandbox policy validation from preset mutations', () => {
+    expect(
+      getApiPermissionRequirement('/api/sandbox-policies/validate', { method: 'POST' }).permissions
+    ).toEqual(['policy:read', 'agent:read']);
+    expect(
+      getApiPermissionRequirement('/api/sandbox-policies', { method: 'POST' }).permissions
+    ).toEqual(['policy:write']);
+  });
 });

--- a/server/src/routes/agent-routing.ts
+++ b/server/src/routes/agent-routing.ts
@@ -66,6 +66,7 @@ const hostPreviewSchema = z.object({
   workspacePath: z.string().max(1000).optional(),
   requiredTools: z.array(z.string().max(80)).max(50).optional(),
   verificationGates: z.array(z.string().max(200)).max(50).optional(),
+  sandboxPresetId: z.string().max(80).optional(),
   manualHostId: z.string().max(120).optional(),
   projectDefaultHostId: z.string().max(120).optional(),
   autoRouting: z.boolean().optional(),

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -40,10 +40,12 @@ router.post(
   asyncHandler(async (req, res) => {
     let agent: AgentType | undefined;
     let overrideReason: string | undefined;
+    let sandboxPresetId: string | undefined;
     try {
-      ({ agent, overrideReason } = startAgentSchema.parse(req.body) as {
+      ({ agent, overrideReason, sandboxPresetId } = startAgentSchema.parse(req.body) as {
         agent?: AgentType;
         overrideReason?: string;
+        sandboxPresetId?: string;
       });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -55,6 +57,7 @@ router.post(
     try {
       status = await clawdbotAgentService.startAgent(req.params.taskId as string, agent, {
         overrideReason,
+        sandboxPresetId,
       });
     } catch (error) {
       if (error instanceof AgentReadinessError) {

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -39,6 +39,7 @@ const agentSchema = z.object({
     ])
     .optional(),
   model: z.string().optional(),
+  sandboxPresetId: z.string().min(1).max(80).optional(),
 });
 
 const setDefaultAgentSchema = z.object({

--- a/server/src/routes/governance-traces.ts
+++ b/server/src/routes/governance-traces.ts
@@ -8,7 +8,14 @@ const router: RouterType = Router();
 
 const traceListQuerySchema = z.object({
   kind: z
-    .enum(['policy', 'tool-policy', 'agent-permission', 'routing', 'workflow-gate'])
+    .enum([
+      'policy',
+      'tool-policy',
+      'sandbox-policy',
+      'agent-permission',
+      'routing',
+      'workflow-gate',
+    ])
     .optional(),
   outcome: z
     .enum(['allowed', 'warned', 'blocked', 'approval-required', 'routed', 'fallback', 'skipped'])

--- a/server/src/routes/sandbox-policies.ts
+++ b/server/src/routes/sandbox-policies.ts
@@ -1,0 +1,88 @@
+import { Router } from 'express';
+import type { SandboxPolicyDryRunRequest, SandboxPolicyPreset } from '@veritas-kanban/shared';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { authorize } from '../middleware/auth.js';
+import { getGovernanceTraceService } from '../services/governance-trace-service.js';
+import { getSandboxPolicyService } from '../services/sandbox-policy-service.js';
+import { validate, type ValidatedRequest } from '../middleware/validate.js';
+import {
+  sandboxPolicyDryRunSchema,
+  sandboxPolicyParamsSchema,
+  sandboxPolicyPresetSchema,
+} from '../schemas/sandbox-policy-schemas.js';
+
+const router = Router();
+const sandboxPolicyService = getSandboxPolicyService();
+
+router.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    const presets = await sandboxPolicyService.listPresets();
+    res.json(presets);
+  })
+);
+
+router.get(
+  '/:id',
+  validate({ params: sandboxPolicyParamsSchema }),
+  asyncHandler(async (req: ValidatedRequest<{ id: string }>, res) => {
+    const { id } = req.validated.params as { id: string };
+    const preset = await sandboxPolicyService.getPreset(id);
+    if (!preset) {
+      res.status(404).json({ error: 'Sandbox preset not found' });
+      return;
+    }
+    res.json(preset);
+  })
+);
+
+router.post(
+  '/',
+  authorize('admin'),
+  validate({ body: sandboxPolicyPresetSchema }),
+  asyncHandler(async (req: ValidatedRequest<unknown, unknown, SandboxPolicyPreset>, res) => {
+    const preset = await sandboxPolicyService.createPreset(
+      req.validated.body as SandboxPolicyPreset
+    );
+    res.status(201).json(preset);
+  })
+);
+
+router.put(
+  '/:id',
+  authorize('admin'),
+  validate({ params: sandboxPolicyParamsSchema, body: sandboxPolicyPresetSchema }),
+  asyncHandler(async (req: ValidatedRequest<{ id: string }, unknown, SandboxPolicyPreset>, res) => {
+    const { id } = req.validated.params as { id: string };
+    const preset = await sandboxPolicyService.updatePreset(
+      id,
+      req.validated.body as SandboxPolicyPreset
+    );
+    res.json(preset);
+  })
+);
+
+router.delete(
+  '/:id',
+  authorize('admin'),
+  validate({ params: sandboxPolicyParamsSchema }),
+  asyncHandler(async (req: ValidatedRequest<{ id: string }>, res) => {
+    const { id } = req.validated.params as { id: string };
+    await sandboxPolicyService.deletePreset(id);
+    res.json({ deleted: id });
+  })
+);
+
+router.post(
+  '/validate',
+  validate({ body: sandboxPolicyDryRunSchema }),
+  asyncHandler(async (req: ValidatedRequest<unknown, unknown, SandboxPolicyDryRunRequest>, res) => {
+    const evaluation = await sandboxPolicyService.dryRunWithTrace(
+      req.validated.body as SandboxPolicyDryRunRequest
+    );
+    const trace = await getGovernanceTraceService().record(evaluation.trace);
+    res.json({ ...evaluation.result, traceId: trace.id });
+  })
+);
+
+export default router;

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -39,6 +39,7 @@ import {
   promptRegistryAccess,
   reportAccess,
   reportRoutesAccess,
+  sandboxPolicyAccess,
   scoringAccess,
   searchAccess,
   settingsAccess,
@@ -129,6 +130,7 @@ import { identityRoutes } from '../identity.js';
 import { skillCapabilityRoutes } from '../skill-capabilities.js';
 import { skillSecurityRoutes } from '../skill-security.js';
 import { watcherPolicyRoutes } from '../watcher-policies.js';
+import sandboxPolicyRoutes from '../sandbox-policies.js';
 
 const v1Router: IRouter = Router();
 
@@ -225,6 +227,7 @@ v1Router.use('/workflows', workflowAccess, workflowRoutes);
 v1Router.use('/watcher-policies', watcherPolicyAccess, watcherPolicyRoutes);
 v1Router.use('/tool-policies', policyAccess, toolPolicyRoutes);
 v1Router.use('/policies', policyAccess, policyRoutes);
+v1Router.use('/sandbox-policies', sandboxPolicyAccess, sandboxPolicyRoutes);
 v1Router.use('/skills/capabilities', skillCapabilityAccess, skillCapabilityRoutes);
 v1Router.use('/skills/security', skillSecurityAccess, skillSecurityRoutes);
 v1Router.use('/integrations', settingsAccess, integrationsRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -42,6 +42,9 @@ export const telemetryAccess = routeAccess('telemetry:read', 'telemetry:write');
 export const policyAccess = routeAccess('policy:read', 'policy:read', [
   { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
 ]);
+export const sandboxPolicyAccess = routeAccess('policy:read', 'policy:write', [
+  { methods: ['POST'], path: /^\/validate\/?$/, permissions: ['policy:read', 'agent:read'] },
+]);
 export const skillCapabilityAccess = routeAccess('policy:read', 'policy:write', [
   {
     methods: ['POST'],

--- a/server/src/schemas/agent-schemas.ts
+++ b/server/src/schemas/agent-schemas.ts
@@ -8,6 +8,7 @@ const AgentTypeSchema = z.string().min(1).max(50);
 export const StartAgentBodySchema = z.object({
   agent: AgentTypeSchema.optional(),
   overrideReason: z.string().trim().min(8).max(1000).optional(),
+  sandboxPresetId: z.string().trim().min(1).max(80).optional(),
 });
 
 export type StartAgentBody = z.infer<typeof StartAgentBodySchema>;

--- a/server/src/schemas/sandbox-policy-schemas.ts
+++ b/server/src/schemas/sandbox-policy-schemas.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+
+const sandboxPresetIdSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-_]*$/, 'Sandbox preset id must be lowercase kebab/snake case');
+
+const pathListSchema = z.array(z.string().min(1).max(1000)).max(100);
+const envKeySchema = z
+  .string()
+  .min(1)
+  .max(120)
+  .regex(/^[A-Z_][A-Z0-9_]*$/i, 'Environment keys must be shell-safe identifiers');
+
+export const sandboxPolicyEnforcementSchema = z.enum(['required', 'advisory']);
+export const sandboxNetworkDefaultSchema = z.enum(['allow', 'deny']);
+export const sandboxCredentialModeSchema = z.enum(['none', 'brokered', 'env-passthrough']);
+
+export const sandboxProviderCapabilityIdSchema = z.enum([
+  'filesystem.read',
+  'filesystem.write',
+  'filesystem.deny-paths',
+  'filesystem.dotfile-masking',
+  'network.disable',
+  'network.allowlist',
+  'network.block-private',
+  'network.block-metadata',
+  'environment.allowlist',
+  'credential.broker',
+]);
+
+export const skillCapabilityIdSchema = z.enum([
+  'filesystem.read',
+  'filesystem.write',
+  'shell.execute',
+  'network.egress',
+  'credential.access',
+  'external.message',
+  'memory.write',
+  'task.mutate',
+  'schedule.persist',
+  'browser.session',
+  'mcp.tool',
+]);
+
+export const sandboxPolicyPresetSchema = z.object({
+  id: sandboxPresetIdSchema,
+  name: z.string().min(1).max(120),
+  description: z.string().max(800).optional(),
+  enabled: z.boolean(),
+  builtIn: z.boolean().optional(),
+  enforcement: sandboxPolicyEnforcementSchema,
+  requiredCapabilities: z.array(skillCapabilityIdSchema).max(50).default([]),
+  filesystem: z.object({
+    readPaths: pathListSchema.default([]),
+    writePaths: pathListSchema.default([]),
+    deniedPaths: pathListSchema.default([]),
+    dotfileMasking: z.boolean(),
+    localOnlyHandles: z.boolean(),
+  }),
+  network: z.object({
+    defaultEgress: sandboxNetworkDefaultSchema,
+    allowedHosts: z.array(z.string().min(1).max(255)).max(100).default([]),
+    allowedMethods: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .max(16)
+          .transform((method) => method.toUpperCase())
+      )
+      .max(20)
+      .default([]),
+    allowedPathPrefixes: pathListSchema.default([]),
+    blockPrivateNetwork: z.boolean(),
+    blockMetadataEndpoints: z.boolean(),
+    blockLoopback: z.boolean(),
+  }),
+  environment: z.object({
+    passthrough: z.array(envKeySchema).max(120).default([]),
+    redactDisplay: z.boolean(),
+  }),
+  credentials: z.object({
+    mode: sandboxCredentialModeSchema,
+    brokerRefs: z.array(z.string().min(1).max(160)).max(50).default([]),
+  }),
+  createdAt: z.string().datetime().optional(),
+  updatedAt: z.string().datetime().optional(),
+});
+
+export const sandboxPolicyParamsSchema = z.object({
+  id: sandboxPresetIdSchema,
+});
+
+export const sandboxProviderCapabilitiesSchema = z.object({
+  provider: z.string().max(80).optional(),
+  supported: z.array(sandboxProviderCapabilityIdSchema).max(50).default([]),
+  advisory: z.array(sandboxProviderCapabilityIdSchema).max(50).optional().default([]),
+});
+
+export const sandboxPolicyDryRunSchema = z.object({
+  presetId: sandboxPresetIdSchema.optional(),
+  preset: sandboxPolicyPresetSchema.optional(),
+  provider: z.string().max(80).optional(),
+  workspacePath: z.string().max(1000).optional(),
+  requiredCapabilities: z.array(skillCapabilityIdSchema).max(50).optional(),
+  providerCapabilities: sandboxProviderCapabilitiesSchema.optional(),
+});
+
+export type SandboxPolicyPresetInput = z.infer<typeof sandboxPolicyPresetSchema>;
+export type SandboxPolicyDryRunInput = z.infer<typeof sandboxPolicyDryRunSchema>;

--- a/server/src/services/agent-host-service.ts
+++ b/server/src/services/agent-host-service.ts
@@ -9,6 +9,7 @@ import type {
   AgentHostPreviewRequest,
   AgentHostRecord,
   AgentHostRoutingDecision,
+  SandboxProviderCapabilityId,
 } from '@veritas-kanban/shared';
 import { getAgentRegistryService, type RegisteredAgent } from './agent-registry-service.js';
 
@@ -29,6 +30,7 @@ interface HostAccumulator {
   supportedProviders: Set<string>;
   supportedModels: Set<string>;
   supportedTools: Set<string>;
+  sandboxCapabilities: Set<SandboxProviderCapabilityId>;
   workspaceLabels: Set<string>;
   workspaceRoots: string[];
   activeSessions: number;
@@ -89,6 +91,17 @@ export class AgentHostService {
 
       if (agent.provider) host.supportedProviders.add(agent.provider);
       for (const item of stringArray(metadata.providers)) host.supportedProviders.add(item);
+      for (const capability of sandboxCapabilityArray(metadata.sandboxCapabilities)) {
+        host.sandboxCapabilities.add(capability);
+      }
+      for (const capability of inferredSandboxCapabilities(agent.provider)) {
+        host.sandboxCapabilities.add(capability);
+      }
+      for (const provider of stringArray(metadata.providers)) {
+        for (const capability of inferredSandboxCapabilities(provider)) {
+          host.sandboxCapabilities.add(capability);
+        }
+      }
 
       if (agent.model) host.supportedModels.add(agent.model);
       for (const item of stringArray(metadata.models)) host.supportedModels.add(item);
@@ -169,6 +182,7 @@ export class AgentHostService {
         'No model requirement supplied.'
       ),
       this.requiredToolsCheck(host, request.requiredTools),
+      this.sandboxPolicyCheck(host, request.sandboxPresetId),
       {
         id: 'verification-gates',
         label: 'Verification gates',
@@ -301,6 +315,30 @@ export class AgentHostService {
     };
   }
 
+  private sandboxPolicyCheck(
+    host: AgentHostRecord,
+    sandboxPresetId: string | undefined
+  ): AgentHostCompatibilityCheck {
+    if (!sandboxPresetId) {
+      return {
+        id: 'sandbox-policy',
+        label: 'Sandbox policy',
+        passed: true,
+        detail: 'No sandbox preset requirement supplied.',
+      };
+    }
+
+    return {
+      id: 'sandbox-policy',
+      label: 'Sandbox policy',
+      passed: host.sandboxCapabilities.length > 0,
+      detail:
+        host.sandboxCapabilities.length > 0
+          ? `Host reports ${host.sandboxCapabilities.length} sandbox capability signal(s) for preset ${sandboxPresetId}.`
+          : `Host does not report sandbox capability support for preset ${sandboxPresetId}.`,
+    };
+  }
+
   private resolveDecision(
     previews: AgentHostCompatibilityPreview[],
     request: AgentHostPreviewRequest
@@ -405,6 +443,7 @@ function getOrCreateHost(
     supportedProviders: new Set(),
     supportedModels: new Set(),
     supportedTools: new Set(),
+    sandboxCapabilities: new Set(),
     workspaceLabels: new Set(),
     workspaceRoots: [],
     activeSessions: 0,
@@ -448,6 +487,9 @@ function finalizeHost(host: HostAccumulator, now: Date): ResolvedAgentHost {
     supportedProviders: uniqueSorted(Array.from(host.supportedProviders)),
     supportedModels: uniqueSorted(Array.from(host.supportedModels)),
     supportedTools: uniqueSorted(Array.from(host.supportedTools)),
+    sandboxCapabilities: uniqueSorted(
+      Array.from(host.sandboxCapabilities)
+    ) as SandboxProviderCapabilityId[],
     workspaceLabels: uniqueSorted(Array.from(host.workspaceLabels)),
     activeSessions: host.activeSessions,
     queueDepth: host.queueDepth,
@@ -507,6 +549,7 @@ function normalizeRequest(request: AgentHostPreviewRequest): AgentHostPreviewReq
     workspacePath: trimOptional(request.workspacePath),
     requiredTools: uniqueSorted(request.requiredTools ?? []),
     verificationGates: uniqueSorted(request.verificationGates ?? []),
+    sandboxPresetId: trimOptional(request.sandboxPresetId),
     manualHostId: trimOptional(request.manualHostId),
     projectDefaultHostId: trimOptional(request.projectDefaultHostId),
     autoRouting: request.autoRouting,
@@ -543,6 +586,38 @@ function trimOptional(value: string | undefined): string | undefined {
 function stringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+const SANDBOX_CAPABILITY_IDS = new Set<SandboxProviderCapabilityId>([
+  'filesystem.read',
+  'filesystem.write',
+  'filesystem.deny-paths',
+  'filesystem.dotfile-masking',
+  'network.disable',
+  'network.allowlist',
+  'network.block-private',
+  'network.block-metadata',
+  'environment.allowlist',
+  'credential.broker',
+]);
+
+function sandboxCapabilityArray(value: unknown): SandboxProviderCapabilityId[] {
+  return stringArray(value).filter((item): item is SandboxProviderCapabilityId =>
+    SANDBOX_CAPABILITY_IDS.has(item as SandboxProviderCapabilityId)
+  );
+}
+
+function inferredSandboxCapabilities(provider: string | undefined): SandboxProviderCapabilityId[] {
+  switch (provider) {
+    case 'codex-cli':
+      return ['filesystem.read', 'filesystem.write', 'environment.allowlist'];
+    case 'codex-sdk':
+      return ['filesystem.read', 'filesystem.write', 'network.disable', 'environment.allowlist'];
+    case 'openclaw':
+      return ['filesystem.read', 'filesystem.write', 'environment.allowlist'];
+    default:
+      return [];
+  }
 }
 
 function numberValue(value: unknown): number | undefined {

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -19,6 +19,8 @@ import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
 import { getTelemetryService } from './telemetry-service.js';
 import { getAgentRoutingService } from './agent-routing-service.js';
+import { getGovernanceTraceService } from './governance-trace-service.js';
+import { getSandboxPolicyService } from './sandbox-policy-service.js';
 import { AgentHealthService, type AgentHealthChecker } from './agent-health-service.js';
 import { getBreaker } from './circuit-registry.js';
 import { activityService } from './activity-service.js';
@@ -41,6 +43,7 @@ import type {
   RunErrorEvent,
   TokenTelemetryEvent,
   TaskReadinessSummary,
+  SandboxPolicyDryRunResult,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError } from '../middleware/error-handler.js';
@@ -71,6 +74,7 @@ export interface AgentProviderStartContext {
   startedAt: string;
   emitter: EventEmitter;
   attempt: TaskAttempt;
+  sandboxPolicy?: SandboxPolicyDryRunResult;
 }
 
 export interface AgentProviderStopContext {
@@ -110,6 +114,7 @@ export interface AgentOutput {
 
 export interface AgentStartOptions {
   overrideReason?: string;
+  sandboxPresetId?: string;
 }
 
 export class AgentReadinessError extends Error {
@@ -207,6 +212,24 @@ export class ClawdbotAgentService {
     const agentConfig = this.resolveAgentConfig(config.agents, agent);
     await this.assertAgentAvailable(agent, agentConfig);
     const provider = this.resolveAgentProvider(agentConfig, agent);
+    const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
+      presetId: options.sandboxPresetId ?? agentConfig?.sandboxPresetId,
+      provider,
+      workspacePath: task.git.worktreePath,
+    });
+    const sandboxTrace = await getGovernanceTraceService().record(sandboxPolicy.trace);
+    if (sandboxPolicy.result.decision === 'block') {
+      throw new ConflictError('Sandbox preset cannot be enforced by the selected provider', {
+        presetId: sandboxPolicy.result.preset.id,
+        provider,
+        traceId: sandboxTrace.id,
+        unsupportedRules: sandboxPolicy.result.unsupportedRules.map((rule) => ({
+          id: rule.id,
+          capability: rule.capability,
+          detail: rule.detail,
+        })),
+      });
+    }
     const readiness = evaluateTaskReadiness(task, { isCodeTask: true, selectedAgent: agent });
     const overrideReason = options.overrideReason?.trim();
 
@@ -307,6 +330,7 @@ export class ClawdbotAgentService {
         startedAt,
         emitter,
         attempt,
+        sandboxPolicy: sandboxPolicy.result,
       });
     } catch (error: any) {
       pendingAgents.delete(taskId);
@@ -567,8 +591,26 @@ export class ClawdbotAgentService {
         id: 'codex-cli',
         label: 'Codex CLI',
         capabilities: { ...commonCapabilities, stop: true, resume: false },
-        start: ({ task, agentConfig, prompt, logPath, attemptId, startedAt, emitter }) => {
-          this.startCodexCli(task, agentConfig, prompt, logPath, attemptId, startedAt, emitter);
+        start: ({
+          task,
+          agentConfig,
+          prompt,
+          logPath,
+          attemptId,
+          startedAt,
+          emitter,
+          sandboxPolicy,
+        }) => {
+          this.startCodexCli(
+            task,
+            agentConfig,
+            prompt,
+            logPath,
+            attemptId,
+            startedAt,
+            emitter,
+            sandboxPolicy
+          );
         },
         stop: ({ pending }) => {
           if (pending.process && !pending.process.killed) pending.process.kill('SIGTERM');
@@ -581,7 +623,16 @@ export class ClawdbotAgentService {
         id: 'codex-sdk',
         label: 'Codex SDK',
         capabilities: { ...commonCapabilities, stop: true, resume: true },
-        start: ({ task, agentConfig, prompt, logPath, attemptId, startedAt, emitter }) => {
+        start: ({
+          task,
+          agentConfig,
+          prompt,
+          logPath,
+          attemptId,
+          startedAt,
+          emitter,
+          sandboxPolicy,
+        }) => {
           const abortController = new AbortController();
           const pending = pendingAgents.get(task.id);
           if (pending) pending.abortController = abortController;
@@ -593,7 +644,8 @@ export class ClawdbotAgentService {
             attemptId,
             startedAt,
             emitter,
-            abortController
+            abortController,
+            sandboxPolicy
           ).catch(async (error: any) => {
             if (!pendingAgents.has(task.id)) return;
             await this.appendLog(
@@ -638,7 +690,8 @@ export class ClawdbotAgentService {
     logPath: string,
     attemptId: string,
     startedAt: string,
-    emitter: EventEmitter
+    emitter: EventEmitter,
+    sandboxPolicy: SandboxPolicyDryRunResult | undefined
   ): void {
     const worktreePath = this.expandPath(task.git?.worktreePath || '');
     if (!worktreePath) {
@@ -646,13 +699,10 @@ export class ClawdbotAgentService {
     }
 
     const command = agentConfig?.command || 'codex';
-    const args = this.buildCodexArgs(agentConfig, prompt, logPath, attemptId);
+    const args = this.buildCodexArgs(agentConfig, prompt, logPath, attemptId, sandboxPolicy);
     const child = spawn(command, args, {
       cwd: worktreePath,
-      env: {
-        ...process.env,
-        VK_API_URL: process.env.VK_API_URL || 'http://localhost:3001',
-      },
+      env: buildSafeCodexEnv(process.env, sandboxPolicy?.effective.envPassthrough),
       shell: false,
     });
 
@@ -775,11 +825,18 @@ export class ClawdbotAgentService {
     agentConfig: AgentConfig | undefined,
     prompt: string,
     logPath: string,
-    attemptId: string
+    attemptId: string,
+    sandboxPolicy?: SandboxPolicyDryRunResult
   ): string[] {
     const configured = agentConfig?.args?.length ? [...agentConfig.args] : ['exec'];
     const args = configured.includes('exec') ? configured : ['exec', ...configured];
-    if (!args.includes('--sandbox')) args.push('--sandbox', 'workspace-write');
+    const sandboxMode = sandboxPolicy?.effective.sandboxMode ?? 'workspace-write';
+    const sandboxIndex = args.indexOf('--sandbox');
+    if (sandboxIndex >= 0) {
+      args[sandboxIndex + 1] = sandboxMode;
+    } else {
+      args.push('--sandbox', sandboxMode);
+    }
     if (!args.includes('--json')) args.push('--json');
     if (!args.includes('--output-last-message')) {
       args.push('--output-last-message', this.getCodexFinalPath(logPath, attemptId));
@@ -800,7 +857,8 @@ export class ClawdbotAgentService {
     attemptId: string,
     startedAt: string,
     emitter: EventEmitter,
-    abortController: AbortController
+    abortController: AbortController,
+    sandboxPolicy: SandboxPolicyDryRunResult | undefined
   ): Promise<void> {
     const worktreePath = this.expandPath(task.git?.worktreePath || '');
     if (!worktreePath) {
@@ -811,15 +869,15 @@ export class ClawdbotAgentService {
     const codex = new Codex({
       codexPathOverride:
         agentConfig?.command && agentConfig.command !== 'codex' ? agentConfig.command : undefined,
-      env: buildSafeCodexEnv(),
+      env: buildSafeCodexEnv(process.env, sandboxPolicy?.effective.envPassthrough),
     });
 
     const thread = codex.startThread({
       workingDirectory: worktreePath,
       skipGitRepoCheck: true,
-      sandboxMode: 'workspace-write',
+      sandboxMode: sandboxPolicy?.effective.sandboxMode ?? 'workspace-write',
       approvalPolicy: 'never',
-      networkAccessEnabled: true,
+      networkAccessEnabled: sandboxPolicy?.effective.networkAccessEnabled ?? true,
       model: agentConfig?.model,
     });
 

--- a/server/src/services/sandbox-policy-service.ts
+++ b/server/src/services/sandbox-policy-service.ts
@@ -1,0 +1,632 @@
+import type {
+  CreateGovernanceTraceInput,
+  SandboxPolicyDryRunRequest,
+  SandboxPolicyDryRunResult,
+  SandboxPolicyPreset,
+  SandboxPolicyRuleEvaluation,
+  SandboxProviderCapabilityId,
+  SandboxProviderCapabilities,
+} from '@veritas-kanban/shared';
+import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { sandboxPolicyPresetSchema } from '../schemas/sandbox-policy-schemas.js';
+import { ConfigService, getConfigService } from './config-service.js';
+
+const BUILT_IN_TIMESTAMP = '2026-06-18T00:00:00.000Z';
+
+export const DEFAULT_SANDBOX_PRESET_ID = 'legacy-permissive';
+
+export const BUILT_IN_SANDBOX_PRESETS: SandboxPolicyPreset[] = [
+  {
+    id: DEFAULT_SANDBOX_PRESET_ID,
+    name: 'Legacy permissive',
+    description:
+      'Preserves existing agent behavior. Use this only for trusted local runs or compatibility.',
+    enabled: true,
+    builtIn: true,
+    enforcement: 'advisory',
+    requiredCapabilities: [],
+    filesystem: {
+      readPaths: ['<workspace>'],
+      writePaths: ['<workspace>'],
+      deniedPaths: [],
+      dotfileMasking: false,
+      localOnlyHandles: false,
+    },
+    network: {
+      defaultEgress: 'allow',
+      allowedHosts: [],
+      allowedMethods: [],
+      allowedPathPrefixes: [],
+      blockPrivateNetwork: false,
+      blockMetadataEndpoints: false,
+      blockLoopback: false,
+    },
+    environment: {
+      passthrough: [
+        'CODEX_API_KEY',
+        'CODEX_HOME',
+        'HOME',
+        'OPENAI_API_KEY',
+        'OPENAI_BASE_URL',
+        'OPENAI_ORG_ID',
+        'OPENAI_ORGANIZATION',
+        'OPENAI_PROJECT',
+        'PATH',
+        'SHELL',
+        'TEMP',
+        'TERM',
+        'TMPDIR',
+        'USER',
+        'VK_API_URL',
+      ],
+      redactDisplay: true,
+    },
+    credentials: {
+      mode: 'env-passthrough',
+      brokerRefs: [],
+    },
+    createdAt: BUILT_IN_TIMESTAMP,
+    updatedAt: BUILT_IN_TIMESTAMP,
+  },
+  {
+    id: 'codex-repo-contained',
+    name: 'Codex repo contained',
+    description:
+      'Repo-scoped read/write access, safe Codex environment passthrough, and no network egress.',
+    enabled: true,
+    builtIn: true,
+    enforcement: 'required',
+    requiredCapabilities: ['filesystem.read', 'filesystem.write', 'network.egress'],
+    filesystem: {
+      readPaths: ['<workspace>'],
+      writePaths: ['<workspace>'],
+      deniedPaths: [],
+      dotfileMasking: false,
+      localOnlyHandles: true,
+    },
+    network: {
+      defaultEgress: 'deny',
+      allowedHosts: [],
+      allowedMethods: [],
+      allowedPathPrefixes: [],
+      blockPrivateNetwork: true,
+      blockMetadataEndpoints: true,
+      blockLoopback: true,
+    },
+    environment: {
+      passthrough: [
+        'CI',
+        'CODEX_API_KEY',
+        'CODEX_HOME',
+        'FORCE_COLOR',
+        'HOME',
+        'LANG',
+        'LC_ALL',
+        'LC_CTYPE',
+        'LOGNAME',
+        'NODE_EXTRA_CA_CERTS',
+        'NO_COLOR',
+        'OPENAI_API_KEY',
+        'OPENAI_BASE_URL',
+        'OPENAI_ORG_ID',
+        'OPENAI_ORGANIZATION',
+        'OPENAI_PROJECT',
+        'PATH',
+        'SHELL',
+        'SSL_CERT_FILE',
+        'TEMP',
+        'TERM',
+        'TMP',
+        'TMPDIR',
+        'USER',
+        'VK_API_URL',
+      ],
+      redactDisplay: true,
+    },
+    credentials: {
+      mode: 'none',
+      brokerRefs: [],
+    },
+    createdAt: BUILT_IN_TIMESTAMP,
+    updatedAt: BUILT_IN_TIMESTAMP,
+  },
+  {
+    id: 'brokered-network-allowlist',
+    name: 'Brokered network allowlist',
+    description:
+      'Strict network allowlist and credential broker references for hosts that can enforce fine-grained egress.',
+    enabled: true,
+    builtIn: true,
+    enforcement: 'required',
+    requiredCapabilities: [
+      'filesystem.read',
+      'filesystem.write',
+      'network.egress',
+      'credential.access',
+    ],
+    filesystem: {
+      readPaths: ['<workspace>'],
+      writePaths: ['<workspace>'],
+      deniedPaths: ['~/.ssh', '~/.aws', '~/.config/gh', '~/.git-credentials'],
+      dotfileMasking: true,
+      localOnlyHandles: true,
+    },
+    network: {
+      defaultEgress: 'deny',
+      allowedHosts: ['api.github.com', 'github.com', 'api.openai.com'],
+      allowedMethods: ['GET', 'POST'],
+      allowedPathPrefixes: ['/'],
+      blockPrivateNetwork: true,
+      blockMetadataEndpoints: true,
+      blockLoopback: true,
+    },
+    environment: {
+      passthrough: ['PATH', 'HOME', 'SHELL', 'USER', 'TMPDIR', 'TEMP', 'TERM', 'VK_API_URL'],
+      redactDisplay: true,
+    },
+    credentials: {
+      mode: 'brokered',
+      brokerRefs: ['github-token', 'openai-api-key'],
+    },
+    createdAt: BUILT_IN_TIMESTAMP,
+    updatedAt: BUILT_IN_TIMESTAMP,
+  },
+];
+
+const PROVIDER_CAPABILITIES: Record<string, SandboxProviderCapabilities> = {
+  'codex-cli': {
+    provider: 'codex-cli',
+    supported: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
+  },
+  'codex-sdk': {
+    provider: 'codex-sdk',
+    supported: ['filesystem.read', 'filesystem.write', 'network.disable', 'environment.allowlist'],
+  },
+  openclaw: {
+    provider: 'openclaw',
+    supported: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
+    advisory: ['network.allowlist', 'credential.broker'],
+  },
+};
+
+export class SandboxPolicyService {
+  constructor(private readonly configService: ConfigService = getConfigService()) {}
+
+  async listPresets(): Promise<SandboxPolicyPreset[]> {
+    const config = await this.configService.getConfig();
+    const presets = this.mergeBuiltIns(config.sandboxPolicyPresets ?? []);
+    if (presetsChanged(config.sandboxPolicyPresets ?? [], presets)) {
+      config.sandboxPolicyPresets = presets;
+      config.defaultSandboxPresetId ??= DEFAULT_SANDBOX_PRESET_ID;
+      await this.configService.saveConfig(config);
+    }
+    return presets;
+  }
+
+  async getPreset(id: string): Promise<SandboxPolicyPreset | null> {
+    const presets = await this.listPresets();
+    return presets.find((preset) => preset.id === id) ?? null;
+  }
+
+  async createPreset(input: SandboxPolicyPreset): Promise<SandboxPolicyPreset> {
+    const config = await this.configService.getConfig();
+    const presets = this.mergeBuiltIns(config.sandboxPolicyPresets ?? []);
+    if (presets.some((preset) => preset.id === input.id)) {
+      throw new ConflictError(`Sandbox preset already exists: ${input.id}`);
+    }
+    const now = new Date().toISOString();
+    const preset = this.normalizePreset({
+      ...input,
+      builtIn: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    config.sandboxPolicyPresets = [...presets, preset];
+    config.defaultSandboxPresetId ??= DEFAULT_SANDBOX_PRESET_ID;
+    await this.configService.saveConfig(config);
+    return preset;
+  }
+
+  async updatePreset(id: string, input: SandboxPolicyPreset): Promise<SandboxPolicyPreset> {
+    if (id !== input.id) {
+      throw new ValidationError('Sandbox preset id in URL must match request body');
+    }
+
+    const config = await this.configService.getConfig();
+    const presets = this.mergeBuiltIns(config.sandboxPolicyPresets ?? []);
+    const index = presets.findIndex((preset) => preset.id === id);
+    if (index === -1) throw new NotFoundError(`Sandbox preset not found: ${id}`);
+    const existing = presets[index];
+    if (existing.builtIn) {
+      throw new ValidationError('Built-in sandbox presets cannot be edited');
+    }
+
+    const preset = this.normalizePreset({
+      ...input,
+      builtIn: false,
+      createdAt: existing.createdAt,
+      updatedAt: new Date().toISOString(),
+    });
+    presets[index] = preset;
+    config.sandboxPolicyPresets = presets;
+    await this.configService.saveConfig(config);
+    return preset;
+  }
+
+  async deletePreset(id: string): Promise<void> {
+    const config = await this.configService.getConfig();
+    const presets = this.mergeBuiltIns(config.sandboxPolicyPresets ?? []);
+    const preset = presets.find((candidate) => candidate.id === id);
+    if (!preset) throw new NotFoundError(`Sandbox preset not found: ${id}`);
+    if (preset.builtIn) throw new ValidationError('Built-in sandbox presets cannot be deleted');
+
+    config.sandboxPolicyPresets = presets.filter((candidate) => candidate.id !== id);
+    if (config.defaultSandboxPresetId === id)
+      config.defaultSandboxPresetId = DEFAULT_SANDBOX_PRESET_ID;
+    await this.configService.saveConfig(config);
+  }
+
+  async dryRun(input: SandboxPolicyDryRunRequest = {}): Promise<SandboxPolicyDryRunResult> {
+    const preset = input.preset
+      ? this.normalizePreset(input.preset)
+      : await this.resolvePreset(input.presetId);
+    if (!preset.enabled) {
+      return this.resultForDisabledPreset(preset, input);
+    }
+
+    const capabilities = input.providerCapabilities ?? this.capabilitiesForProvider(input.provider);
+    const evaluations = this.evaluateRules(preset, capabilities);
+    const unsupportedRules = evaluations.filter((rule) => rule.status === 'unsupported');
+    const advisoryRules = evaluations.filter((rule) => rule.status === 'advisory');
+    const shouldBlock = preset.enforcement === 'required' && unsupportedRules.length > 0;
+    const decision = shouldBlock ? 'block' : advisoryRules.length > 0 ? 'warn' : 'allow';
+    const networkAccessEnabled = preset.network.defaultEgress === 'allow';
+    return {
+      decision,
+      preset: this.redactPresetForResult(preset),
+      provider: input.provider ?? capabilities.provider,
+      effective: {
+        sandboxMode: this.effectiveSandboxMode(preset),
+        networkAccessEnabled,
+        envPassthrough: preset.environment.passthrough.slice().sort(),
+        credentialRefs: redactBrokerRefs(preset.credentials.brokerRefs),
+      },
+      evaluations,
+      unsupportedRules,
+      warnings: [
+        ...advisoryRules.map((rule) => rule.detail),
+        ...(networkAccessEnabled ? ['Network egress remains enabled by this preset.'] : []),
+      ],
+      remediation: shouldBlock
+        ? 'Select a provider or host that reports support for every required sandbox rule, or choose a less restrictive preset.'
+        : undefined,
+    };
+  }
+
+  async dryRunWithTrace(input: SandboxPolicyDryRunRequest = {}): Promise<{
+    result: SandboxPolicyDryRunResult;
+    trace: CreateGovernanceTraceInput;
+  }> {
+    const result = await this.dryRun(input);
+    return {
+      result,
+      trace: this.buildTrace(result, input),
+    };
+  }
+
+  async assertLaunchAllowed(
+    input: SandboxPolicyDryRunRequest = {}
+  ): Promise<SandboxPolicyDryRunResult> {
+    const result = await this.dryRun(input);
+    if (result.decision === 'block') {
+      throw new ConflictError(
+        'Sandbox preset cannot be enforced by the selected provider or host',
+        {
+          presetId: result.preset.id,
+          provider: result.provider,
+          unsupportedRules: result.unsupportedRules.map((rule) => ({
+            id: rule.id,
+            capability: rule.capability,
+            detail: rule.detail,
+          })),
+        }
+      );
+    }
+    return result;
+  }
+
+  capabilitiesForProvider(provider?: string): SandboxProviderCapabilities {
+    const key = (provider || 'codex-cli').toLowerCase();
+    return (
+      PROVIDER_CAPABILITIES[key] ?? {
+        provider,
+        supported: [],
+        advisory: [],
+      }
+    );
+  }
+
+  private async resolvePreset(id?: string): Promise<SandboxPolicyPreset> {
+    const config = await this.configService.getConfig();
+    const presetId = id ?? config.defaultSandboxPresetId ?? DEFAULT_SANDBOX_PRESET_ID;
+    const preset = await this.getPreset(presetId);
+    if (!preset) throw new NotFoundError(`Sandbox preset not found: ${presetId}`);
+    return preset;
+  }
+
+  private mergeBuiltIns(existing: SandboxPolicyPreset[]): SandboxPolicyPreset[] {
+    const byId = new Map<string, SandboxPolicyPreset>();
+    for (const preset of BUILT_IN_SANDBOX_PRESETS)
+      byId.set(preset.id, this.normalizePreset(preset));
+    for (const preset of existing) {
+      if (preset.builtIn) continue;
+      byId.set(preset.id, this.normalizePreset(preset));
+    }
+    return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private normalizePreset(input: SandboxPolicyPreset): SandboxPolicyPreset {
+    const now = new Date().toISOString();
+    const parsed = sandboxPolicyPresetSchema.parse({
+      ...input,
+      createdAt: input.createdAt ?? now,
+      updatedAt: input.updatedAt ?? now,
+    }) as SandboxPolicyPreset;
+    return {
+      ...parsed,
+      filesystem: {
+        ...parsed.filesystem,
+        readPaths: uniqueSorted(parsed.filesystem.readPaths),
+        writePaths: uniqueSorted(parsed.filesystem.writePaths),
+        deniedPaths: uniqueSorted(parsed.filesystem.deniedPaths),
+      },
+      network: {
+        ...parsed.network,
+        allowedHosts: uniqueSorted(parsed.network.allowedHosts.map((host) => host.toLowerCase())),
+        allowedMethods: uniqueSorted(
+          parsed.network.allowedMethods.map((method) => method.toUpperCase())
+        ),
+        allowedPathPrefixes: uniqueSorted(parsed.network.allowedPathPrefixes),
+      },
+      environment: {
+        ...parsed.environment,
+        passthrough: uniqueSorted(parsed.environment.passthrough.map((key) => key.toUpperCase())),
+      },
+      credentials: {
+        ...parsed.credentials,
+        brokerRefs: uniqueSorted(parsed.credentials.brokerRefs),
+      },
+    };
+  }
+
+  private evaluateRules(
+    preset: SandboxPolicyPreset,
+    capabilities: SandboxProviderCapabilities
+  ): SandboxPolicyRuleEvaluation[] {
+    const supported = new Set(capabilities.supported);
+    const advisory = new Set(capabilities.advisory ?? []);
+    const evaluations: SandboxPolicyRuleEvaluation[] = [];
+    const add = (
+      id: string,
+      label: string,
+      capability: SandboxProviderCapabilityId,
+      required: boolean,
+      detail: string,
+      supportedWhen?: boolean
+    ) => {
+      if (!required) return;
+      const status =
+        supportedWhen === true || supported.has(capability)
+          ? 'supported'
+          : advisory.has(capability)
+            ? 'advisory'
+            : 'unsupported';
+      evaluations.push({ id, label, capability, status, detail });
+    };
+
+    add(
+      'filesystem-read',
+      'Filesystem read grants',
+      'filesystem.read',
+      preset.filesystem.readPaths.length > 0,
+      `Read paths: ${preset.filesystem.readPaths.join(', ')}`
+    );
+    add(
+      'filesystem-write',
+      'Filesystem write grants',
+      'filesystem.write',
+      preset.filesystem.writePaths.length > 0,
+      `Write paths: ${preset.filesystem.writePaths.join(', ')}`
+    );
+    add(
+      'filesystem-deny',
+      'Filesystem denied paths',
+      'filesystem.deny-paths',
+      preset.filesystem.deniedPaths.length > 0,
+      `Denied paths: ${preset.filesystem.deniedPaths.join(', ')}`
+    );
+    add(
+      'filesystem-dotfiles',
+      'Dotfile masking',
+      'filesystem.dotfile-masking',
+      preset.filesystem.dotfileMasking,
+      'Dotfile masking must be enforced before launch.'
+    );
+    add(
+      'network-disabled',
+      'Default-deny network',
+      'network.disable',
+      preset.network.defaultEgress === 'deny' && preset.network.allowedHosts.length === 0,
+      'Network egress is disabled.',
+      supported.has('network.disable')
+    );
+    add(
+      'network-allowlist',
+      'Network allowlist',
+      'network.allowlist',
+      preset.network.defaultEgress === 'deny' && preset.network.allowedHosts.length > 0,
+      `Allowed hosts: ${preset.network.allowedHosts.join(', ')}`
+    );
+    add(
+      'network-private',
+      'Private network blocking',
+      'network.block-private',
+      preset.network.blockPrivateNetwork,
+      'Private network ranges must be blocked.',
+      preset.network.defaultEgress === 'deny' && preset.network.allowedHosts.length === 0
+    );
+    add(
+      'network-metadata',
+      'Metadata endpoint blocking',
+      'network.block-metadata',
+      preset.network.blockMetadataEndpoints,
+      'Cloud metadata endpoints must be blocked.',
+      preset.network.defaultEgress === 'deny' && preset.network.allowedHosts.length === 0
+    );
+    add(
+      'environment-allowlist',
+      'Environment allowlist',
+      'environment.allowlist',
+      preset.environment.passthrough.length > 0,
+      `Environment passthrough keys: ${preset.environment.passthrough.length}`
+    );
+    add(
+      'credential-broker',
+      'Credential broker',
+      'credential.broker',
+      preset.credentials.mode === 'brokered',
+      `Broker refs: ${redactBrokerRefs(preset.credentials.brokerRefs).join(', ')}`
+    );
+    return evaluations;
+  }
+
+  private resultForDisabledPreset(
+    preset: SandboxPolicyPreset,
+    input: SandboxPolicyDryRunRequest
+  ): SandboxPolicyDryRunResult {
+    return {
+      decision: preset.enforcement === 'required' ? 'block' : 'warn',
+      preset: this.redactPresetForResult(preset),
+      provider: input.provider,
+      effective: {
+        sandboxMode: 'danger-full-access',
+        networkAccessEnabled: true,
+        envPassthrough: [],
+        credentialRefs: [],
+      },
+      evaluations: [],
+      unsupportedRules: [],
+      warnings: [`Sandbox preset ${preset.id} is disabled.`],
+      remediation: 'Enable the preset or choose another preset before launch.',
+    };
+  }
+
+  private effectiveSandboxMode(
+    preset: SandboxPolicyPreset
+  ): SandboxPolicyDryRunResult['effective']['sandboxMode'] {
+    const hasWrites = preset.filesystem.writePaths.length > 0;
+    const workspaceOnly =
+      preset.filesystem.readPaths.every((entry) => entry === '<workspace>') &&
+      preset.filesystem.writePaths.every((entry) => entry === '<workspace>');
+    if (hasWrites && workspaceOnly) return 'workspace-write';
+    if (!hasWrites && preset.filesystem.readPaths.length > 0) return 'read-only';
+    return 'danger-full-access';
+  }
+
+  private buildTrace(
+    result: SandboxPolicyDryRunResult,
+    input: SandboxPolicyDryRunRequest
+  ): CreateGovernanceTraceInput {
+    const outcome =
+      result.decision === 'block' ? 'blocked' : result.decision === 'warn' ? 'warned' : 'allowed';
+    return {
+      kind: 'sandbox-policy',
+      outcome,
+      title: `Sandbox preset ${result.preset.name}`,
+      summary:
+        result.decision === 'block'
+          ? `Preset ${result.preset.id} cannot be fully enforced.`
+          : `Preset ${result.preset.id} can be used with decision ${result.decision}.`,
+      remediation: result.remediation,
+      subject: {
+        actionType: 'sandbox-policy.validate',
+        project: input.workspacePath ? '[redacted-local-path]' : undefined,
+      },
+      evaluatedRules: result.evaluations.map((rule) => ({
+        id: rule.id,
+        label: rule.label,
+        type: 'sandbox-policy',
+        status:
+          rule.status === 'supported'
+            ? 'matched'
+            : rule.status === 'advisory'
+              ? 'info'
+              : 'not-matched',
+        outcome:
+          rule.status === 'unsupported'
+            ? 'blocked'
+            : rule.status === 'advisory'
+              ? 'warned'
+              : 'allowed',
+        message: rule.detail,
+        details: {
+          capability: rule.capability,
+          status: rule.status,
+        },
+      })),
+      matchedRules: result.evaluations
+        .filter((rule) => rule.status !== 'supported')
+        .map((rule) => ({
+          id: rule.id,
+          label: rule.label,
+          type: 'sandbox-policy',
+          status: rule.status === 'advisory' ? 'info' : 'not-matched',
+          outcome: rule.status === 'advisory' ? 'warned' : 'blocked',
+          message: rule.detail,
+          details: {
+            capability: rule.capability,
+            status: rule.status,
+          },
+        })),
+      raw: {
+        presetId: result.preset.id,
+        provider: result.provider,
+        effective: result.effective,
+        unsupportedRules: result.unsupportedRules.map((rule) => ({
+          id: rule.id,
+          capability: rule.capability,
+          status: rule.status,
+        })),
+      },
+    };
+  }
+
+  private redactPresetForResult(preset: SandboxPolicyPreset): SandboxPolicyPreset {
+    return {
+      ...preset,
+      credentials: {
+        ...preset.credentials,
+        brokerRefs: redactBrokerRefs(preset.credentials.brokerRefs),
+      },
+    };
+  }
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function redactBrokerRefs(refs: string[]): string[] {
+  return uniqueSorted(refs.map((ref) => ref.replace(/=.*/, '=[redacted]')));
+}
+
+function presetsChanged(existing: SandboxPolicyPreset[], merged: SandboxPolicyPreset[]): boolean {
+  return JSON.stringify(existing) !== JSON.stringify(merged);
+}
+
+let singleton: SandboxPolicyService | null = null;
+
+export function getSandboxPolicyService(): SandboxPolicyService {
+  singleton ??= new SandboxPolicyService();
+  return singleton;
+}

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -7,7 +7,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import sanitizeFilename from 'sanitize-filename';
 import yaml from 'yaml';
-import type { AgentHostRoutingDecision } from '@veritas-kanban/shared';
+import type { AgentHostRoutingDecision, SandboxPolicyDryRunResult } from '@veritas-kanban/shared';
 import type {
   WorkflowStep,
   WorkflowRun,
@@ -31,6 +31,7 @@ import {
 } from './openclaw-workflow-adapter.js';
 import { getToolPolicyService } from './tool-policy-service.js';
 import { getAgentHostService } from './agent-host-service.js';
+import { getSandboxPolicyService } from './sandbox-policy-service.js';
 
 const log = createLogger('workflow-step-executor');
 
@@ -99,13 +100,26 @@ export class WorkflowStepExecutor {
 
     // Get tool policy filter for this agent role (#110)
     const toolPolicyFilter = await this.getToolPolicyForAgent(agentDef);
+    const workingDirectory = this.expandPath(this.getWorkflowWorkingDirectory(run));
+    const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
+      presetId: agentDef?.sandboxPresetId,
+      provider: agentDef?.provider,
+      workspacePath: workingDirectory,
+    });
+    const sandboxTrace = await getGovernanceTraceService().record(sandboxPolicy.trace);
+    if (sandboxPolicy.result.decision === 'block') {
+      throw new Error(
+        `Workflow step ${step.id} cannot enforce sandbox preset ${sandboxPolicy.result.preset.id}; trace ${sandboxTrace.id}`
+      );
+    }
     const hostPreview = getAgentHostService().preview({
       agent: step.agent,
       provider: agentDef?.provider,
       model: agentDef?.model,
-      workspacePath: this.expandPath(this.getWorkflowWorkingDirectory(run)),
+      workspacePath: workingDirectory,
       requiredTools: this.routingTools(agentDef, toolPolicyFilter),
       verificationGates: step.acceptance_criteria,
+      sandboxPresetId: sandboxPolicy.result.preset.id,
     });
     this.recordAgentHostRouting(run, step, hostPreview.decision, hostPreview.generatedAt);
 
@@ -132,7 +146,8 @@ export class WorkflowStepExecutor {
         prompt,
         sessionConfig,
         toolPolicyFilter,
-        hostPreview.decision
+        hostPreview.decision,
+        sandboxPolicy.result
       );
     }
 
@@ -408,7 +423,8 @@ export class WorkflowStepExecutor {
     prompt: string,
     sessionConfig: StepSessionConfig,
     toolPolicyFilter: { allowed?: string[]; denied?: string[] },
-    hostRouting: AgentHostRoutingDecision
+    hostRouting: AgentHostRoutingDecision,
+    sandboxPolicy: SandboxPolicyDryRunResult
   ): Promise<StepExecutionResult> {
     this.assertCodexToolPolicySupported(step, agentDef, toolPolicyFilter);
 
@@ -420,7 +436,7 @@ export class WorkflowStepExecutor {
     const workingDirectory = this.expandPath(this.getWorkflowWorkingDirectory(run));
     const codex = new Codex({
       codexPathOverride,
-      env: buildSafeCodexEnv(),
+      env: buildSafeCodexEnv(process.env, sandboxPolicy.effective.envPassthrough),
     });
 
     const sessionKey = step.agent || agentDef?.id || step.id;
@@ -431,17 +447,17 @@ export class WorkflowStepExecutor {
     const thread = existingThreadId
       ? codex.resumeThread(existingThreadId, {
           workingDirectory,
-          sandboxMode: 'workspace-write',
+          sandboxMode: sandboxPolicy.effective.sandboxMode,
           approvalPolicy: 'never',
-          networkAccessEnabled: true,
+          networkAccessEnabled: sandboxPolicy.effective.networkAccessEnabled,
           model: agentDef?.model,
         })
       : codex.startThread({
           workingDirectory,
           skipGitRepoCheck: true,
-          sandboxMode: 'workspace-write',
+          sandboxMode: sandboxPolicy.effective.sandboxMode,
           approvalPolicy: 'never',
-          networkAccessEnabled: true,
+          networkAccessEnabled: sandboxPolicy.effective.networkAccessEnabled,
           model: agentDef?.model,
         });
 

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -118,6 +118,7 @@ export interface WorkflowAgent {
   model?: string; // default model for this agent
   provider?: 'openclaw' | 'codex-cli' | 'codex-sdk' | 'codex-cloud' | string;
   command?: string;
+  sandboxPresetId?: string;
   description: string;
   tools?: string[]; // Phase 2: Tool restrictions (#110)
 }

--- a/server/src/utils/codex-env.ts
+++ b/server/src/utils/codex-env.ts
@@ -35,10 +35,16 @@ export function isSensitiveCodexEnvKey(key: string): boolean {
   return SECRET_ENV_KEY_PATTERN.test(key);
 }
 
-export function buildSafeCodexEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
+export function buildSafeCodexEnv(
+  source: NodeJS.ProcessEnv = process.env,
+  passthroughKeys?: Iterable<string>
+): Record<string, string> {
   const env: Record<string, string> = {};
+  const allowlist = passthroughKeys
+    ? new Set(Array.from(passthroughKeys, (key) => key.toUpperCase()))
+    : CODEX_ENV_ALLOWLIST;
 
-  for (const key of CODEX_ENV_ALLOWLIST) {
+  for (const key of allowlist) {
     const value = source[key];
     if (typeof value === 'string' && !isSensitiveCodexEnvKey(key)) {
       env[key] = value;

--- a/shared/src/types/agent-host.types.ts
+++ b/shared/src/types/agent-host.types.ts
@@ -1,3 +1,5 @@
+import type { SandboxProviderCapabilityId } from './sandbox-policy.types.js';
+
 export type AgentHostPosture =
   | 'connected'
   | 'stale'
@@ -25,6 +27,7 @@ export interface AgentHostRecord {
   supportedProviders: string[];
   supportedModels: string[];
   supportedTools: string[];
+  sandboxCapabilities: SandboxProviderCapabilityId[];
   workspaceLabels: string[];
   activeSessions: number;
   queueDepth: number;
@@ -53,6 +56,7 @@ export type AgentHostCompatibilityCheckId =
   | 'model-supported'
   | 'agent-supported'
   | 'required-tools'
+  | 'sandbox-policy'
   | 'verification-gates';
 
 export interface AgentHostCompatibilityCheck {
@@ -79,6 +83,7 @@ export interface AgentHostPreviewRequest {
   workspacePath?: string;
   requiredTools?: string[];
   verificationGates?: string[];
+  sandboxPresetId?: string;
   manualHostId?: string;
   projectDefaultHostId?: string;
   autoRouting?: boolean;

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -3,6 +3,7 @@
 import type { AgentType, TaskPriority, TaskStatus } from './task.types.js';
 import type { TelemetryConfig } from './telemetry.types.js';
 import type { WatcherContinuationSettings } from './watcher-policy.types.js';
+import type { SandboxPolicyPreset } from './sandbox-policy.types.js';
 
 export interface DevServerConfig {
   command: string; // e.g., "pnpm dev" or "npm run dev"
@@ -25,6 +26,7 @@ export interface AgentConfig {
   enabled: boolean;
   provider?: AgentProvider;
   model?: string;
+  sandboxPresetId?: string;
 }
 
 export type AgentProvider =
@@ -160,6 +162,8 @@ export interface AppConfig {
   telemetry?: TelemetryConfig;
   features?: FeatureSettings;
   coolify?: CoolifyConfig;
+  sandboxPolicyPresets?: SandboxPolicyPreset[];
+  defaultSandboxPresetId?: string;
 }
 
 // ============ Feature Settings Types ============

--- a/shared/src/types/governance-trace.types.ts
+++ b/shared/src/types/governance-trace.types.ts
@@ -1,6 +1,7 @@
 export type GovernanceTraceKind =
   | 'policy'
   | 'tool-policy'
+  | 'sandbox-policy'
   | 'agent-permission'
   | 'routing'
   | 'workflow-gate';

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -29,6 +29,7 @@ export * from './maintenance.types.js';
 export * from './governance-trace.types.js';
 export * from './skill-capability.types.js';
 export * from './skill-security.types.js';
+export * from './sandbox-policy.types.js';
 export * from './watcher-policy.types.js';
 export * from './evidence.types.js';
 export * from './time-breakdown.types.js';

--- a/shared/src/types/sandbox-policy.types.ts
+++ b/shared/src/types/sandbox-policy.types.ts
@@ -1,0 +1,101 @@
+import type { SkillCapabilityId } from './skill-capability.types.js';
+
+export type SandboxPolicyEnforcement = 'required' | 'advisory';
+export type SandboxNetworkDefault = 'allow' | 'deny';
+export type SandboxCredentialMode = 'none' | 'brokered' | 'env-passthrough';
+export type SandboxPolicyDecision = 'allow' | 'warn' | 'block';
+export type SandboxPolicyRuleStatus = 'supported' | 'unsupported' | 'advisory';
+export type SandboxProviderCapabilityId =
+  | 'filesystem.read'
+  | 'filesystem.write'
+  | 'filesystem.deny-paths'
+  | 'filesystem.dotfile-masking'
+  | 'network.disable'
+  | 'network.allowlist'
+  | 'network.block-private'
+  | 'network.block-metadata'
+  | 'environment.allowlist'
+  | 'credential.broker';
+
+export interface SandboxFilesystemRules {
+  readPaths: string[];
+  writePaths: string[];
+  deniedPaths: string[];
+  dotfileMasking: boolean;
+  localOnlyHandles: boolean;
+}
+
+export interface SandboxNetworkRules {
+  defaultEgress: SandboxNetworkDefault;
+  allowedHosts: string[];
+  allowedMethods: string[];
+  allowedPathPrefixes: string[];
+  blockPrivateNetwork: boolean;
+  blockMetadataEndpoints: boolean;
+  blockLoopback: boolean;
+}
+
+export interface SandboxEnvironmentRules {
+  passthrough: string[];
+  redactDisplay: boolean;
+}
+
+export interface SandboxCredentialRules {
+  mode: SandboxCredentialMode;
+  brokerRefs: string[];
+}
+
+export interface SandboxPolicyPreset {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  builtIn?: boolean;
+  enforcement: SandboxPolicyEnforcement;
+  requiredCapabilities: SkillCapabilityId[];
+  filesystem: SandboxFilesystemRules;
+  network: SandboxNetworkRules;
+  environment: SandboxEnvironmentRules;
+  credentials: SandboxCredentialRules;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SandboxProviderCapabilities {
+  provider?: string;
+  supported: SandboxProviderCapabilityId[];
+  advisory?: SandboxProviderCapabilityId[];
+}
+
+export interface SandboxPolicyDryRunRequest {
+  presetId?: string;
+  preset?: SandboxPolicyPreset;
+  provider?: string;
+  workspacePath?: string;
+  requiredCapabilities?: SkillCapabilityId[];
+  providerCapabilities?: SandboxProviderCapabilities;
+}
+
+export interface SandboxPolicyRuleEvaluation {
+  id: string;
+  label: string;
+  capability: SandboxProviderCapabilityId;
+  status: SandboxPolicyRuleStatus;
+  detail: string;
+}
+
+export interface SandboxPolicyDryRunResult {
+  decision: SandboxPolicyDecision;
+  preset: SandboxPolicyPreset;
+  provider?: string;
+  effective: {
+    sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access';
+    networkAccessEnabled: boolean;
+    envPassthrough: string[];
+    credentialRefs: string[];
+  };
+  evaluations: SandboxPolicyRuleEvaluation[];
+  unsupportedRules: SandboxPolicyRuleEvaluation[];
+  warnings: string[];
+  remediation?: string;
+}

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -144,6 +144,7 @@ export interface WorkflowAgent {
   name: string;
   role: string; // maps to toolPolicy
   model?: string; // default model for this agent
+  sandboxPresetId?: string;
   description: string;
   tools?: string[]; // Phase 2: Tool restrictions (#110)
 }

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -274,6 +274,14 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     ],
   },
   {
+    prefix: '/api/sandbox-policies',
+    read: 'policy:read',
+    write: 'policy:write',
+    overrides: [
+      { methods: ['POST'], path: /^\/validate\/?$/, permissions: ['policy:read', 'agent:read'] },
+    ],
+  },
+  {
     prefix: '/api/skills/capabilities',
     read: 'policy:read',
     write: 'policy:write',

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -13,6 +13,7 @@ const agents: AgentConfig[] = [
     enabled: true,
     provider: 'codex-cli',
     model: 'gpt-5',
+    sandboxPresetId: 'codex-repo-contained',
   },
   {
     type: 'claude-code' as AgentType,
@@ -227,6 +228,7 @@ vi.mock('@/hooks/useAgent', () => ({
           supportedProviders: ['codex-cli'],
           supportedModels: ['gpt-5'],
           supportedTools: ['code'],
+          sandboxCapabilities: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
           workspaceLabels: ['workspace:veritas-kanban'],
           activeSessions: 0,
           queueDepth: 0,
@@ -275,6 +277,86 @@ vi.mock('@/hooks/useAgent', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useSandboxPolicies', () => ({
+  useSandboxPolicies: () => ({
+    data: [
+      {
+        id: 'legacy-permissive',
+        name: 'Legacy permissive',
+        enabled: true,
+        builtIn: true,
+        enforcement: 'advisory',
+        requiredCapabilities: [],
+        filesystem: {
+          readPaths: ['<workspace>'],
+          writePaths: ['<workspace>'],
+          deniedPaths: [],
+          dotfileMasking: false,
+          localOnlyHandles: false,
+        },
+        network: {
+          defaultEgress: 'allow',
+          allowedHosts: [],
+          allowedMethods: [],
+          allowedPathPrefixes: [],
+          blockPrivateNetwork: false,
+          blockMetadataEndpoints: false,
+          blockLoopback: false,
+        },
+        environment: {
+          passthrough: ['PATH', 'OPENAI_API_KEY'],
+          redactDisplay: true,
+        },
+        credentials: {
+          mode: 'env-passthrough',
+          brokerRefs: [],
+        },
+        createdAt: '2026-06-18T00:00:00.000Z',
+        updatedAt: '2026-06-18T00:00:00.000Z',
+      },
+      {
+        id: 'codex-repo-contained',
+        name: 'Codex repo contained',
+        enabled: true,
+        builtIn: true,
+        enforcement: 'required',
+        requiredCapabilities: [],
+        filesystem: {
+          readPaths: ['<workspace>'],
+          writePaths: ['<workspace>'],
+          deniedPaths: [],
+          dotfileMasking: false,
+          localOnlyHandles: true,
+        },
+        network: {
+          defaultEgress: 'deny',
+          allowedHosts: [],
+          allowedMethods: [],
+          allowedPathPrefixes: [],
+          blockPrivateNetwork: true,
+          blockMetadataEndpoints: true,
+          blockLoopback: true,
+        },
+        environment: {
+          passthrough: ['PATH', 'OPENAI_API_KEY'],
+          redactDisplay: true,
+        },
+        credentials: {
+          mode: 'none',
+          brokerRefs: [],
+        },
+        createdAt: '2026-06-18T00:00:00.000Z',
+        updatedAt: '2026-06-18T00:00:00.000Z',
+      },
+    ],
+    isLoading: false,
+  }),
+  useCreateSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false }),
+  useValidateSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false, data: undefined }),
+}));
+
 describe('Agents settings Mantine migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -288,14 +370,14 @@ describe('Agents settings Mantine migration', () => {
     const { baseElement } = renderWithProviders(<AgentsTab />);
 
     expect(screen.getByText('Installed Agents')).toBeDefined();
-    expect(screen.getByText('Codex CLI')).toBeDefined();
+    expect(screen.getAllByText('Codex CLI').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('gpt-5')).toBeDefined();
     expect(screen.getByText('Codex Health')).toBeDefined();
     expect(screen.getByText('Context Provider Health')).toBeDefined();
     expect(screen.getByText('Agent Host Health')).toBeDefined();
     expect(screen.getByText('Launch Compatibility')).toBeDefined();
     expect(screen.getAllByText('Local Supervisor').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('OpenClaw')).toBeDefined();
+    expect(screen.getAllByText('OpenClaw').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Risky').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('OpenClaw plugins')).toBeDefined();
     expect(screen.getByText('Exec and elevated posture')).toBeDefined();

--- a/web/src/__tests__/workflow-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/workflow-surfaces-mantine.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@/hooks/useWebSocket', () => ({
   useWebSocket: mocks.useWebSocket,
 }));
 
+vi.mock('@/hooks/useSandboxPolicies', () => ({
+  useSandboxPolicies: () => ({ data: [] }),
+}));
+
 const workflowRun = {
   id: 'run-1',
   workflowId: 'wf-release',

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -1,9 +1,26 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
-import { ActionIcon, Badge, Button, Modal, Select, Switch, Text, TextInput } from '@mantine/core';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Modal,
+  Select,
+  Switch,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
 import { useCodexHealth, useConfig, useProviderHealth, useUpdateAgents } from '@/hooks/useConfig';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { useRoutingConfig, useUpdateRoutingConfig } from '@/hooks/useRouting';
 import { useAgentHostPreview, useAgentHosts } from '@/hooks/useAgent';
+import {
+  useCreateSandboxPolicy,
+  useDeleteSandboxPolicy,
+  useSandboxPolicies,
+  useUpdateSandboxPolicy,
+  useValidateSandboxPolicy,
+} from '@/hooks/useSandboxPolicies';
 import {
   Bot,
   Plus,
@@ -17,6 +34,7 @@ import {
   Loader2,
   RefreshCw,
   ShieldAlert,
+  ShieldCheck,
   Server,
 } from 'lucide-react';
 import type {
@@ -30,6 +48,8 @@ import type {
   AgentType,
   RoutingRule,
   AgentRoutingConfig,
+  SandboxPolicyDryRunResult,
+  SandboxPolicyPreset,
 } from '@veritas-kanban/shared';
 import type {
   CodexHealthStatus,
@@ -55,6 +75,10 @@ const AGENT_PROVIDER_OPTIONS: Array<{ value: AgentProvider | '__none__'; label: 
   { value: 'custom', label: 'Custom' },
 ];
 
+const SANDBOX_PROVIDER_OPTIONS = AGENT_PROVIDER_OPTIONS.filter(
+  (option): option is { value: AgentProvider; label: string } => option.value !== '__none__'
+);
+
 export function AgentsTab() {
   const { data: config, isLoading } = useConfig();
   const {
@@ -67,6 +91,7 @@ export function AgentsTab() {
     isFetching: isProviderHealthFetching,
     refetch: refetchProviderHealth,
   } = useProviderHealth();
+  const { data: sandboxPresets = [], isLoading: isSandboxPoliciesLoading } = useSandboxPolicies();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
   const updateAgents = useUpdateAgents();
@@ -131,6 +156,8 @@ export function AgentsTab() {
         {showAddForm && (
           <AgentForm
             existingTypes={config?.agents.map((a) => a.type) || []}
+            sandboxPresets={sandboxPresets}
+            defaultSandboxPresetId={config?.defaultSandboxPresetId}
             onSubmit={handleAddAgent}
             onCancel={() => setShowAddForm(false)}
           />
@@ -152,6 +179,8 @@ export function AgentsTab() {
                   existingTypes={config.agents
                     .filter((a) => a.type !== agent.type)
                     .map((a) => a.type)}
+                  sandboxPresets={sandboxPresets}
+                  defaultSandboxPresetId={config.defaultSandboxPresetId}
                   onSubmit={(updated) => handleEditAgent(agent.type, updated)}
                   onCancel={() => setEditingAgent(null)}
                 />
@@ -159,6 +188,7 @@ export function AgentsTab() {
                 <AgentItem
                   key={agent.type}
                   agent={agent}
+                  sandboxPresets={sandboxPresets}
                   isDefault={isDefault(agent.type)}
                   onToggle={() => handleToggleAgent(agent.type)}
                   onEdit={() => setEditingAgent(agent.type)}
@@ -183,6 +213,12 @@ export function AgentsTab() {
       />
 
       <AgentHostHealthPanel agents={config?.agents || []} />
+
+      <SandboxPoliciesSection
+        agents={config?.agents || []}
+        presets={sandboxPresets}
+        isLoading={isSandboxPoliciesLoading}
+      />
 
       {/* Agent Behavior */}
       <div className="space-y-4">
@@ -476,9 +512,16 @@ function AgentHostHealthPanel({ agents }: { agents: AgentConfig[] }) {
       agent: selectedAgent || undefined,
       provider: selectedAgentConfig?.provider,
       model: selectedAgentConfig?.model,
+      sandboxPresetId: selectedAgentConfig?.sandboxPresetId,
       manualHostId: selectedHostId === 'auto' ? undefined : selectedHostId,
     }),
-    [selectedAgent, selectedAgentConfig?.provider, selectedAgentConfig?.model, selectedHostId]
+    [
+      selectedAgent,
+      selectedAgentConfig?.provider,
+      selectedAgentConfig?.model,
+      selectedAgentConfig?.sandboxPresetId,
+      selectedHostId,
+    ]
   );
   const { data: preview, isFetching: isPreviewFetching } = useAgentHostPreview(
     previewRequest,
@@ -605,6 +648,11 @@ function AgentHostItem({ host }: { host: AgentHostRecord }) {
             {provider}
           </Badge>
         ))}
+        {host.sandboxCapabilities.slice(0, 3).map((capability) => (
+          <Badge key={capability} size="xs" variant="light" color="teal">
+            {capability}
+          </Badge>
+        ))}
       </div>
 
       {host.workspaceLabels.length > 0 && (
@@ -707,6 +755,526 @@ function AgentHostPreviewPanel({
   );
 }
 
+function SandboxPoliciesSection({
+  agents,
+  presets,
+  isLoading,
+}: {
+  agents: AgentConfig[];
+  presets: SandboxPolicyPreset[];
+  isLoading: boolean;
+}) {
+  const createPreset = useCreateSandboxPolicy();
+  const updatePreset = useUpdateSandboxPolicy();
+  const deletePreset = useDeleteSandboxPolicy();
+  const validatePreset = useValidateSandboxPolicy();
+  const [editingPreset, setEditingPreset] = useState<SandboxPolicyPreset | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [previewPresetId, setPreviewPresetId] = useState<string>('');
+  const [previewProvider, setPreviewProvider] = useState<AgentProvider>('codex-sdk');
+
+  useEffect(() => {
+    if (!previewPresetId && presets.length > 0) {
+      setPreviewPresetId(presets[0].id);
+    }
+  }, [presets, previewPresetId]);
+
+  const assignedByPreset = useMemo(() => {
+    const grouped = new Map<string, AgentConfig[]>();
+    for (const agent of agents) {
+      if (!agent.sandboxPresetId) continue;
+      const current = grouped.get(agent.sandboxPresetId) ?? [];
+      current.push(agent);
+      grouped.set(agent.sandboxPresetId, current);
+    }
+    return grouped;
+  }, [agents]);
+
+  const selectedPreset = presets.find((preset) => preset.id === previewPresetId);
+  const validation = validatePreset.data as
+    | (SandboxPolicyDryRunResult & { traceId?: string })
+    | undefined;
+
+  const handlePreview = () => {
+    if (!selectedPreset) return;
+    validatePreset.mutate({
+      presetId: selectedPreset.id,
+      provider: previewProvider,
+    });
+  };
+
+  const handleSavePreset = (preset: SandboxPolicyPreset) => {
+    if (editingPreset) {
+      updatePreset.mutate(
+        { id: editingPreset.id, preset },
+        {
+          onSuccess: () => setEditingPreset(null),
+        }
+      );
+      return;
+    }
+
+    createPreset.mutate(preset, {
+      onSuccess: () => setShowCreateForm(false),
+    });
+  };
+
+  return (
+    <div className="rounded-md border bg-card p-3 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">Sandbox Policies</h3>
+          <p className="text-xs text-muted-foreground">
+            {isLoading ? 'Loading presets' : `${presets.length} presets configured`}
+          </p>
+        </div>
+        {!showCreateForm && !editingPreset && (
+          <Button
+            variant="outline"
+            size="xs"
+            leftSection={<Plus className="h-4 w-4" />}
+            onClick={() => setShowCreateForm(true)}
+          >
+            Add Preset
+          </Button>
+        )}
+      </div>
+
+      {(showCreateForm || editingPreset) && (
+        <SandboxPresetForm
+          preset={editingPreset ?? undefined}
+          existingIds={presets.map((preset) => preset.id)}
+          onSubmit={handleSavePreset}
+          onCancel={() => {
+            setShowCreateForm(false);
+            setEditingPreset(null);
+          }}
+        />
+      )}
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <div className="space-y-2">
+          {presets.map((preset) => {
+            const assignedAgents = assignedByPreset.get(preset.id) ?? [];
+            return (
+              <div key={preset.id} className="rounded-md border bg-background/60 p-3 space-y-2">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-sm font-medium">{preset.name}</span>
+                      <Badge size="xs" variant="light" color={preset.enabled ? 'green' : 'gray'}>
+                        {preset.enabled ? 'Enabled' : 'Disabled'}
+                      </Badge>
+                      <Badge size="xs" variant="outline" color="gray">
+                        {preset.enforcement}
+                      </Badge>
+                      {preset.builtIn && (
+                        <Badge size="xs" variant="outline" color="teal">
+                          Built-in
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {sandboxPresetSummary(preset)}
+                    </p>
+                  </div>
+                  {!preset.builtIn && (
+                    <div className="flex items-center gap-1">
+                      <ActionIcon
+                        variant="subtle"
+                        size="sm"
+                        aria-label={`Edit ${preset.name}`}
+                        onClick={() => setEditingPreset(preset)}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </ActionIcon>
+                      <ActionIcon
+                        variant="subtle"
+                        size="sm"
+                        aria-label={
+                          preset.enabled ? `Disable ${preset.name}` : `Enable ${preset.name}`
+                        }
+                        onClick={() =>
+                          updatePreset.mutate({
+                            id: preset.id,
+                            preset: { ...preset, enabled: !preset.enabled },
+                          })
+                        }
+                      >
+                        <ShieldAlert className="h-3.5 w-3.5" />
+                      </ActionIcon>
+                      <ActionIcon
+                        variant="subtle"
+                        size="sm"
+                        color="red"
+                        aria-label={`Delete ${preset.name}`}
+                        onClick={() => deletePreset.mutate(preset.id)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </ActionIcon>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap gap-1">
+                  <Badge size="xs" variant="light" color="gray">
+                    {formatSandboxMode(preset)}
+                  </Badge>
+                  <Badge size="xs" variant="light" color="gray">
+                    Network {preset.network.defaultEgress}
+                  </Badge>
+                  <Badge size="xs" variant="light" color="gray">
+                    Env {preset.environment.passthrough.length}
+                  </Badge>
+                  {assignedAgents.length > 0 && (
+                    <Badge size="xs" variant="light" color="violet">
+                      {assignedAgents.length} assigned
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+
+          {!presets.length && (
+            <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+              No sandbox presets configured.
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-md border bg-background/60 p-3 space-y-3">
+          <div>
+            <h4 className="text-sm font-medium">Dry Run</h4>
+            <p className="text-xs text-muted-foreground">
+              Check provider enforcement before launch.
+            </p>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Select
+              label="Preset"
+              size="xs"
+              value={previewPresetId}
+              onChange={(value) => setPreviewPresetId(value || '')}
+              data={presets.map((preset) => ({ value: preset.id, label: preset.name }))}
+              disabled={presets.length === 0}
+            />
+            <Select
+              label="Provider"
+              size="xs"
+              value={previewProvider}
+              onChange={(value) => setPreviewProvider((value as AgentProvider) || 'codex-sdk')}
+              data={SANDBOX_PROVIDER_OPTIONS}
+              allowDeselect={false}
+            />
+          </div>
+          <Button
+            size="xs"
+            variant="light"
+            onClick={handlePreview}
+            disabled={!selectedPreset || validatePreset.isPending}
+          >
+            {validatePreset.isPending ? 'Checking...' : 'Run Dry Check'}
+          </Button>
+
+          {validation && (
+            <div className="space-y-2">
+              <div className="flex flex-wrap gap-2">
+                <Badge color={sandboxDecisionColor(validation.decision)} variant="light">
+                  {validation.decision}
+                </Badge>
+                <Badge variant="outline" color="gray">
+                  {validation.effective.sandboxMode}
+                </Badge>
+                <Badge
+                  variant="outline"
+                  color={validation.effective.networkAccessEnabled ? 'yellow' : 'green'}
+                >
+                  Network {validation.effective.networkAccessEnabled ? 'on' : 'off'}
+                </Badge>
+              </div>
+              {validation.unsupportedRules.length > 0 && (
+                <ul className="space-y-1 text-xs text-muted-foreground">
+                  {validation.unsupportedRules.slice(0, 5).map((rule) => (
+                    <li key={rule.id}>{rule.detail}</li>
+                  ))}
+                </ul>
+              )}
+              {validation.traceId && (
+                <p className="text-xs text-muted-foreground">Trace {validation.traceId}</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SandboxPresetForm({
+  preset,
+  existingIds,
+  onSubmit,
+  onCancel,
+}: {
+  preset?: SandboxPolicyPreset;
+  existingIds: string[];
+  onSubmit: (preset: SandboxPolicyPreset) => void;
+  onCancel: () => void;
+}) {
+  const isEditing = !!preset;
+  const now = new Date().toISOString();
+  const [name, setName] = useState(preset?.name ?? '');
+  const [id, setId] = useState(preset?.id ?? '');
+  const [enabled, setEnabled] = useState(preset?.enabled ?? true);
+  const [enforcement, setEnforcement] = useState<SandboxPolicyPreset['enforcement']>(
+    preset?.enforcement ?? 'required'
+  );
+  const [readPaths, setReadPaths] = useState(
+    joinList(preset?.filesystem.readPaths ?? ['<workspace>'])
+  );
+  const [writePaths, setWritePaths] = useState(
+    joinList(preset?.filesystem.writePaths ?? ['<workspace>'])
+  );
+  const [deniedPaths, setDeniedPaths] = useState(joinList(preset?.filesystem.deniedPaths ?? []));
+  const [networkDefault, setNetworkDefault] = useState<
+    SandboxPolicyPreset['network']['defaultEgress']
+  >(preset?.network.defaultEgress ?? 'deny');
+  const [allowedHosts, setAllowedHosts] = useState(joinList(preset?.network.allowedHosts ?? []));
+  const [environmentKeys, setEnvironmentKeys] = useState(
+    joinList(
+      preset?.environment.passthrough ?? [
+        'PATH',
+        'HOME',
+        'SHELL',
+        'USER',
+        'TMPDIR',
+        'TEMP',
+        'TERM',
+        'VK_API_URL',
+      ]
+    )
+  );
+  const [credentialMode, setCredentialMode] = useState<SandboxPolicyPreset['credentials']['mode']>(
+    preset?.credentials.mode ?? 'none'
+  );
+  const [brokerRefs, setBrokerRefs] = useState(joinList(preset?.credentials.brokerRefs ?? []));
+
+  const effectiveId = isEditing ? preset.id : id || presetIdFromName(name);
+  const duplicate = !isEditing && existingIds.includes(effectiveId);
+  const valid = name.trim() && effectiveId && !duplicate;
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!valid) return;
+
+    onSubmit({
+      id: effectiveId,
+      name: name.trim(),
+      enabled,
+      builtIn: false,
+      enforcement,
+      requiredCapabilities: [],
+      filesystem: {
+        readPaths: splitList(readPaths),
+        writePaths: splitList(writePaths),
+        deniedPaths: splitList(deniedPaths),
+        dotfileMasking: splitList(deniedPaths).length > 0,
+        localOnlyHandles: true,
+      },
+      network: {
+        defaultEgress: networkDefault,
+        allowedHosts: splitList(allowedHosts),
+        allowedMethods: allowedHosts.trim() ? ['GET', 'POST'] : [],
+        allowedPathPrefixes: allowedHosts.trim() ? ['/'] : [],
+        blockPrivateNetwork: networkDefault === 'deny',
+        blockMetadataEndpoints: networkDefault === 'deny',
+        blockLoopback: networkDefault === 'deny',
+      },
+      environment: {
+        passthrough: splitList(environmentKeys).map((key) => key.toUpperCase()),
+        redactDisplay: true,
+      },
+      credentials: {
+        mode: credentialMode,
+        brokerRefs: splitList(brokerRefs),
+      },
+      createdAt: preset?.createdAt ?? now,
+      updatedAt: now,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-md border bg-muted/30 p-3 space-y-3">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <ShieldCheck className="h-4 w-4" />
+        {isEditing ? `Edit ${preset.name}` : 'Add Sandbox Preset'}
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <TextInput
+          label="Name"
+          value={name}
+          onChange={(event) => setName(event.currentTarget.value)}
+        />
+        <TextInput
+          label="ID"
+          value={isEditing ? preset.id : id}
+          onChange={(event) => setId(event.currentTarget.value)}
+          disabled={isEditing}
+          placeholder={name ? presetIdFromName(name) : 'repo-contained'}
+          error={duplicate ? 'Preset ID already exists' : undefined}
+        />
+        <Select
+          label="Enforcement"
+          value={enforcement}
+          onChange={(value) =>
+            setEnforcement((value as SandboxPolicyPreset['enforcement']) ?? 'required')
+          }
+          data={[
+            { value: 'required', label: 'Required' },
+            { value: 'advisory', label: 'Advisory' },
+          ]}
+          allowDeselect={false}
+        />
+        <Select
+          label="Network"
+          value={networkDefault}
+          onChange={(value) =>
+            setNetworkDefault((value as SandboxPolicyPreset['network']['defaultEgress']) ?? 'deny')
+          }
+          data={[
+            { value: 'deny', label: 'Default deny' },
+            { value: 'allow', label: 'Default allow' },
+          ]}
+          allowDeselect={false}
+        />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Textarea
+          label="Read Paths"
+          value={readPaths}
+          onChange={(event) => setReadPaths(event.currentTarget.value)}
+          minRows={2}
+        />
+        <Textarea
+          label="Write Paths"
+          value={writePaths}
+          onChange={(event) => setWritePaths(event.currentTarget.value)}
+          minRows={2}
+        />
+        <Textarea
+          label="Denied Paths"
+          value={deniedPaths}
+          onChange={(event) => setDeniedPaths(event.currentTarget.value)}
+          minRows={2}
+        />
+        <Textarea
+          label="Allowed Hosts"
+          value={allowedHosts}
+          onChange={(event) => setAllowedHosts(event.currentTarget.value)}
+          minRows={2}
+        />
+        <Textarea
+          label="Environment"
+          value={environmentKeys}
+          onChange={(event) => setEnvironmentKeys(event.currentTarget.value)}
+          minRows={2}
+        />
+        <Textarea
+          label="Broker Refs"
+          value={brokerRefs}
+          onChange={(event) => setBrokerRefs(event.currentTarget.value)}
+          minRows={2}
+        />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Select
+          label="Credentials"
+          value={credentialMode}
+          onChange={(value) =>
+            setCredentialMode((value as SandboxPolicyPreset['credentials']['mode']) ?? 'none')
+          }
+          data={[
+            { value: 'none', label: 'None' },
+            { value: 'brokered', label: 'Brokered' },
+            { value: 'env-passthrough', label: 'Environment passthrough' },
+          ]}
+          allowDeselect={false}
+        />
+        <Switch
+          label="Enabled"
+          checked={enabled}
+          onChange={(event) => setEnabled(event.currentTarget.checked)}
+        />
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="subtle"
+          size="xs"
+          leftSection={<X className="h-3.5 w-3.5" />}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          size="xs"
+          leftSection={<Check className="h-3.5 w-3.5" />}
+          disabled={!valid}
+        >
+          Save Preset
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function splitList(value: string): string[] {
+  return value
+    .split(/[\n,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function joinList(values: string[]): string {
+  return values.join('\n');
+}
+
+function presetIdFromName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function sandboxPresetSummary(preset: SandboxPolicyPreset): string {
+  const pieces = [
+    `${preset.filesystem.readPaths.length} read`,
+    `${preset.filesystem.writePaths.length} write`,
+    `${preset.network.allowedHosts.length} hosts`,
+    `${preset.credentials.mode} credentials`,
+  ];
+  return pieces.join(' · ');
+}
+
+function formatSandboxMode(preset: SandboxPolicyPreset): string {
+  if (preset.filesystem.writePaths.length > 0) return 'Workspace write';
+  if (preset.filesystem.readPaths.length > 0) return 'Read only';
+  return 'Full access';
+}
+
+function sandboxDecisionColor(decision: SandboxPolicyDryRunResult['decision']): string {
+  if (decision === 'allow') return 'green';
+  if (decision === 'warn') return 'yellow';
+  return 'red';
+}
+
 function CodexHealthPanel({
   health,
   isFetching,
@@ -783,14 +1351,23 @@ function CodexHealthPanel({
 
 interface AgentItemProps {
   agent: AgentConfig;
+  sandboxPresets: SandboxPolicyPreset[];
   isDefault: boolean;
   onToggle: () => void;
   onEdit: () => void;
   onRemove: () => void;
 }
 
-function AgentItem({ agent, isDefault, onToggle, onEdit, onRemove }: AgentItemProps) {
+function AgentItem({
+  agent,
+  sandboxPresets,
+  isDefault,
+  onToggle,
+  onEdit,
+  onRemove,
+}: AgentItemProps) {
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
+  const sandboxPreset = sandboxPresets.find((preset) => preset.id === agent.sandboxPresetId);
 
   return (
     <>
@@ -827,6 +1404,11 @@ function AgentItem({ agent, isDefault, onToggle, onEdit, onRemove }: AgentItemPr
               {agent.model && (
                 <Badge size="xs" variant="light" color="gray">
                   {agent.model}
+                </Badge>
+              )}
+              {sandboxPreset && (
+                <Badge size="xs" variant="light" color="teal">
+                  {sandboxPreset.name}
                 </Badge>
               )}
             </div>
@@ -898,6 +1480,8 @@ function AgentItem({ agent, isDefault, onToggle, onEdit, onRemove }: AgentItemPr
 interface AgentFormProps {
   agent?: AgentConfig;
   existingTypes: string[];
+  sandboxPresets: SandboxPolicyPreset[];
+  defaultSandboxPresetId?: string;
   onSubmit: (agent: AgentConfig) => void;
   onCancel: () => void;
 }
@@ -1487,7 +2071,14 @@ function RoutingRuleForm({ rule, agents, existingIds, onSubmit, onCancel }: Rout
 
 // ============ Agent Form (add/edit mode) ============
 
-function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps) {
+function AgentForm({
+  agent,
+  existingTypes,
+  sandboxPresets,
+  defaultSandboxPresetId,
+  onSubmit,
+  onCancel,
+}: AgentFormProps) {
   const isEditing = !!agent;
   const [name, setName] = useState(agent?.name || '');
   const [type, setType] = useState(agent?.type || '');
@@ -1495,6 +2086,7 @@ function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps)
   const [argsStr, setArgsStr] = useState(agent?.args.join(' ') || '');
   const [provider, setProvider] = useState<AgentProvider | ''>(agent?.provider || '');
   const [model, setModel] = useState(agent?.model || '');
+  const [sandboxPresetId, setSandboxPresetId] = useState(agent?.sandboxPresetId || '');
 
   const typeSlug =
     type ||
@@ -1519,6 +2111,7 @@ function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps)
       enabled: agent?.enabled ?? true,
       provider: provider || undefined,
       model: model.trim() || undefined,
+      sandboxPresetId: sandboxPresetId || undefined,
     });
   };
 
@@ -1597,6 +2190,23 @@ function AgentForm({ agent, existingTypes, onSubmit, onCancel }: AgentFormProps)
             classNames={{ input: 'font-mono text-sm' }}
           />
         </div>
+
+        <Select
+          id="agent-sandbox-preset"
+          label="Sandbox Preset"
+          value={sandboxPresetId || '__default__'}
+          onChange={(value) => setSandboxPresetId(value === '__default__' ? '' : value || '')}
+          data={[
+            {
+              value: '__default__',
+              label: defaultSandboxPresetId
+                ? `Default (${defaultSandboxPresetId})`
+                : 'Default / legacy',
+            },
+            ...sandboxPresets.map((preset) => ({ value: preset.id, label: preset.name })),
+          ]}
+          allowDeselect={false}
+        />
       </div>
 
       <div className="flex justify-end gap-2">

--- a/web/src/components/workflows/WorkflowAuthoringPanel.tsx
+++ b/web/src/components/workflows/WorkflowAuthoringPanel.tsx
@@ -52,6 +52,7 @@ import {
   type WorkflowRecipeInput,
   type WorkflowRecipeMaterialization,
 } from '@/lib/api/workflows';
+import { useSandboxPolicies } from '@/hooks/useSandboxPolicies';
 
 interface WorkflowAuthoringPanelProps {
   canSaveWorkflow: boolean;
@@ -695,10 +696,15 @@ function WorkflowDefinitionEditor({
   workflow: WorkflowDefinition;
   onChange: (workflow: WorkflowDefinition) => void;
 }) {
+  const { data: sandboxPresets = [] } = useSandboxPolicies();
   const agentOptions = workflow.agents.map((agent) => ({
     value: agent.id,
     label: agent.name || agent.id,
   }));
+  const sandboxPresetOptions = [
+    { value: '__default__', label: 'Default / agent preset' },
+    ...sandboxPresets.map((preset) => ({ value: preset.id, label: preset.name })),
+  ];
   const schedule = workflow.schedule ?? { mode: 'manual', enabled: false };
 
   const update = (patch: Partial<WorkflowDefinition>) => onChange({ ...workflow, ...patch });
@@ -823,6 +829,18 @@ function WorkflowDefinitionEditor({
                   </ActionIcon>
                 </Tooltip>
               </Group>
+              <Select
+                mt="sm"
+                label="Sandbox Preset"
+                value={agent.sandboxPresetId ?? '__default__'}
+                onChange={(value) =>
+                  updateAgent(index, {
+                    sandboxPresetId: value === '__default__' ? undefined : value || undefined,
+                  })
+                }
+                data={sandboxPresetOptions}
+                allowDeselect={false}
+              />
             </div>
           ))}
         </Stack>

--- a/web/src/hooks/useSandboxPolicies.ts
+++ b/web/src/hooks/useSandboxPolicies.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { SandboxPolicyDryRunRequest, SandboxPolicyPreset } from '@veritas-kanban/shared';
+import { sandboxPoliciesApi } from '@/lib/api/sandbox-policies';
+
+export const SANDBOX_POLICIES_QUERY_KEY = ['sandbox-policies'];
+
+export function useSandboxPolicies() {
+  return useQuery({
+    queryKey: SANDBOX_POLICIES_QUERY_KEY,
+    queryFn: sandboxPoliciesApi.list,
+  });
+}
+
+export function useCreateSandboxPolicy() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (preset: SandboxPolicyPreset) => sandboxPoliciesApi.create(preset),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SANDBOX_POLICIES_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+    },
+  });
+}
+
+export function useUpdateSandboxPolicy() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, preset }: { id: string; preset: SandboxPolicyPreset }) =>
+      sandboxPoliciesApi.update(id, preset),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SANDBOX_POLICIES_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+    },
+  });
+}
+
+export function useDeleteSandboxPolicy() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => sandboxPoliciesApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SANDBOX_POLICIES_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+    },
+  });
+}
+
+export function useValidateSandboxPolicy() {
+  return useMutation({
+    mutationFn: (request: SandboxPolicyDryRunRequest) => sandboxPoliciesApi.validate(request),
+  });
+}

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -14,6 +14,7 @@ import { API_BASE, handleResponse } from './helpers';
 export interface StartAgentRequest {
   agent?: AgentType;
   overrideReason?: string;
+  sandboxPresetId?: string;
 }
 
 export const worktreeApi = {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -27,6 +27,7 @@ import { digestApi } from './digest';
 import { scheduledDeliverablesApi } from './deliverables';
 import { evidenceApi } from './evidence';
 import { timeBreakdownsApi } from './time-breakdowns';
+import { sandboxPoliciesApi } from './sandbox-policies';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -65,6 +66,7 @@ export const api = {
   scheduledDeliverables: scheduledDeliverablesApi,
   evidence: evidenceApi,
   timeBreakdowns: timeBreakdownsApi,
+  sandboxPolicies: sandboxPoliciesApi,
 };
 
 export type {

--- a/web/src/lib/api/sandbox-policies.ts
+++ b/web/src/lib/api/sandbox-policies.ts
@@ -1,0 +1,36 @@
+import type {
+  SandboxPolicyDryRunRequest,
+  SandboxPolicyDryRunResult,
+  SandboxPolicyPreset,
+} from '@veritas-kanban/shared';
+import { apiFetch } from './helpers';
+
+export const sandboxPoliciesApi = {
+  list: () => apiFetch<SandboxPolicyPreset[]>('/api/sandbox-policies'),
+
+  create: (preset: SandboxPolicyPreset) =>
+    apiFetch<SandboxPolicyPreset>('/api/sandbox-policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(preset),
+    }),
+
+  update: (id: string, preset: SandboxPolicyPreset) =>
+    apiFetch<SandboxPolicyPreset>(`/api/sandbox-policies/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(preset),
+    }),
+
+  delete: (id: string) =>
+    apiFetch<{ deleted: string }>(`/api/sandbox-policies/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    }),
+
+  validate: (request: SandboxPolicyDryRunRequest) =>
+    apiFetch<SandboxPolicyDryRunResult & { traceId: string }>('/api/sandbox-policies/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    }),
+};


### PR DESCRIPTION
## Description

Adds typed sandbox policy presets for agent execution and wires them through one-off agent starts, workflow agents, provider capability checks, and governance traces.

Includes:
- Built-in sandbox presets for legacy permissive behavior, repo-contained execution, and brokered-network execution.
- Sandbox policy API, validation/dry-run support, v1 permission metadata, and typed config/workflow persistence.
- Fail-closed launch checks for unsupported required sandbox controls with governance trace records.
- Settings UI controls for managing presets and dry-running provider compatibility.
- Workflow authoring support for assigning sandbox presets per agent.
- Documentation updates for API, workflows, security, agent providers, Codex integration, and feature docs.

Fixes #723.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactor

## Testing

**How has this been tested?**

Implemented coverage for sandbox policy validation, provider capability reporting, v1 permission guards, shared API permission metadata, Codex env passthrough, Codex provider sandbox propagation, workflow sandbox enforcement, and the Settings/Workflow UI surfaces.

Also smoke-tested the live dev API for `GET /api/sandbox-policies`, which returned the three built-in presets. Full Settings browser smoke was blocked by mandatory first-run setup in this local environment, and POST dry-run smoke was blocked by read-only localhost auth context; both paths are covered by focused tests.

**Test commands:**

```bash
git diff --check
pnpm --filter @veritas-kanban/shared build
pnpm --filter @veritas-kanban/server typecheck
pnpm --filter @veritas-kanban/web typecheck
pnpm --filter @veritas-kanban/web test -- src/__tests__/settings-agents-mantine.test.tsx src/__tests__/workflow-surfaces-mantine.test.tsx
pnpm --filter @veritas-kanban/web build
VERITAS_DISABLE_WATCHERS=1 pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/sandbox-policy-service.test.ts src/__tests__/agent-host-service.test.ts src/__tests__/routes/v1-permission-guards.test.ts src/__tests__/shared-api-permissions.test.ts src/__tests__/codex-env.test.ts src/__tests__/codex-provider-service.test.ts src/__tests__/workflow-step-executor-codex.test.ts --maxWorkers=1
pnpm --filter @veritas-kanban/server lint
curl -s http://127.0.0.1:3001/api/sandbox-policies
```

Notes:
- `pnpm --filter @veritas-kanban/server lint` exits 0 with existing warnings.
- The focused server Vitest run timed out once while running concurrently with web build/test load, then passed when rerun alone.
- An unrelated `docker-paths` Vitest timeout under parallel load passed when rerun alone.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any breaking changes have been documented in the PR description

## Risk Notes

- Provider-specific network enforcement depends on provider capability reporting. The Codex CLI provider cannot enforce `network.disable`, so required no-network presets block there and are expected to run only on providers that report that capability.
