### PR TITLE
Implement agent budget enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 
 2. **Never trigger agents from uncontrolled inputs.** Don't let inbound emails, webhooks from third parties, or public form submissions automatically spawn agent work. An attacker who can craft an input can control your agent.
 
-3. **Principle of least privilege.** Give agents the minimum permissions they need. Use the `agent` role (not `admin`) for API keys. Restrict file system access with sandbox policy presets. Don't run agents as root.
+3. **Principle of least privilege.** Give agents the minimum permissions they need. Use the `agent` role (not `admin`) for API keys. Restrict file system access with sandbox policy presets, enforce run budgets before long-running work, and don't run agents as root.
 
 4. **Review before merge.** Agents can write code — that doesn't mean the code is correct or safe. Always review agent-generated code before merging to production branches. Use the built-in code review workflow.
 
@@ -224,6 +224,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, MCP setup, and default routing for fresh installs
 - **Local LLM provider profiles** — Optional Ollama Local, Ollama Cloud, and LM Studio Local profiles with health metadata and routing support
 - **Sandbox policy presets** — Built-in and custom presets for filesystem scope, network egress, environment passthrough, and credential brokering, with Settings dry-runs before agent launch
+- **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run caps for tokens, cost, tool calls, runtime, retries, and fan-out with auditable warn, approval, downgrade, pause, or cancel decisions
 - **Optional OpenClaw support** — Native integration with [OpenClaw](https://github.com/openclaw/openclaw) when you want OpenClaw to execute or wake agents
 - **Squad Chat** — Real-time agent-to-agent communication with WebSocket updates, system lifecycle events, model attribution per message, and configurable display names
 - **@Mention notifications** — @agent-name parsing in comments, thread subscriptions

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -28,6 +28,12 @@ The launch path dry-runs the selected preset before starting Codex CLI, Codex SD
 
 Credential references and environment-style `name=value` values are redacted from dry-run output and governance traces. Prefer brokered credential presets for workflows that need scoped secrets instead of exposing broad environment passthrough.
 
+## Budget Policies
+
+Use **Settings -> Agents** and **Settings -> Data & Storage -> Budget Tracking** to define workspace defaults, agent defaults, workflow budgets, workflow-agent budgets, and per-run overrides. Budgets can cap tokens, provider-reported cost, tool calls, runtime, retries, and workflow fan-out.
+
+Soft thresholds create `budget-policy` governance traces and visible warnings. Hard thresholds can pause for review, require approval, downgrade to a configured model, or cancel the run. Completion packets include the final budget decision, usage, threshold events, related trace IDs, and operator override notes when present.
+
 ## Local And Cloud Profiles
 
 | Profile            | Provider          | Default command                               | Auth / readiness                    |

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2666,7 +2666,7 @@ Update a specific assumption by its zero-based index.
 
 ### Governance Decision Traces (`/api/governance/traces`)
 
-Inspect policy, tool-policy, sandbox-policy, agent-permission, routing, and workflow-gate decisions with evaluated rules, matched rules, remediation, and redacted raw detail.
+Inspect policy, tool-policy, sandbox-policy, budget-policy, agent-permission, routing, and workflow-gate decisions with evaluated rules, matched rules, remediation, and redacted raw detail.
 
 #### List Governance Traces
 
@@ -2676,7 +2676,7 @@ GET /api/governance/traces
 
 Query params: `kind`, `outcome`, `agent`, `taskId`, `actionType`, `startTime`, `endTime`, `limit`.
 
-`kind` values: `policy`, `tool-policy`, `sandbox-policy`, `agent-permission`, `routing`, `workflow-gate`.
+`kind` values: `policy`, `tool-policy`, `sandbox-policy`, `budget-policy`, `agent-permission`, `routing`, `workflow-gate`.
 
 `outcome` values: `allowed`, `warned`, `blocked`, `approval-required`, `routed`, `fallback`, `skipped`.
 

--- a/docs/API-WORKFLOWS.md
+++ b/docs/API-WORKFLOWS.md
@@ -493,6 +493,21 @@ curl -X POST http://localhost:3001/api/workflows/feature-dev/runs \
     clientMode?: "local" | "remote" | "cloud"; // Optional: workflow skill gate mode
     [key: string]: unknown;
   };
+  budget?: {
+    enabled?: boolean;
+    limits?: {
+      totalTokens?: number;
+      costUsd?: number;
+      toolCalls?: number;
+      runtimeSeconds?: number;
+      idleRuntimeSeconds?: number;
+      retries?: number;
+      fanOut?: number;
+    };
+    softThresholdPercent?: number;
+    hardAction?: "pause" | "require-approval" | "downgrade" | "cancel";
+    downgradeModel?: string;
+  };
 }
 ```
 
@@ -501,6 +516,11 @@ cloud execution when a referenced shared skill is missing, unscanned, or blocked
 The run context includes the resulting `skillAudit` summary when execution is
 allowed. Workflows with `pipeline` metadata also include `context.pipeline`,
 which rolls subagent role status and time/token telemetry into the run record.
+
+Run budgets are merged with workspace, workflow, and workflow-agent defaults
+using the strictest positive limit. Soft thresholds write `budget-policy`
+governance traces. Hard thresholds pause/block, require approval, downgrade the
+model route, or cancel according to the effective policy.
 
 **Response**:
 
@@ -1225,6 +1245,36 @@ Sandbox policies are complementary to tool policies:
 
 ---
 
+## Budget Policies
+
+Workflow definitions can set `config.budget` for workflow-wide defaults and
+`agents[].budget` for stricter role-specific caps. Launch callers can also pass
+a stricter `budget` override to `POST /api/workflows/:id/runs`.
+
+Supported budget limits:
+
+- `totalTokens`, `inputTokens`, and `outputTokens`
+- `costUsd`
+- `toolCalls`
+- `runtimeSeconds` and `idleRuntimeSeconds`
+- `retries`
+- `fanOut`
+
+Budget evaluation is policy enforcement, not dashboard-only analytics. Soft
+thresholds create visible warnings and `budget-policy` governance traces. Hard
+thresholds enforce the configured action:
+
+- `pause` or `require-approval` blocks the workflow run for operator review.
+- `downgrade` records a routed decision and applies `downgradeModel` to Codex
+  workflow steps.
+- `cancel` fails the run immediately.
+
+The run record includes `budget.usage`, `budget.thresholdEvents`, `budget.traceIds`,
+and `budget.modelOverride` so run detail, timelines, and completion packets can
+show exactly what happened.
+
+---
+
 ## Task Dependencies
 
 ### GET /api/tasks/:id/dependencies
@@ -1918,6 +1968,7 @@ export interface WorkflowConfig {
   fresh_session_default?: boolean;
   progress_file?: string;
   telemetry_tags?: string[];
+  budget?: AgentBudgetPolicy;
 }
 ```
 
@@ -1929,6 +1980,7 @@ export interface WorkflowAgent {
   name: string;
   role: string; // maps to tool policy
   sandboxPresetId?: string; // maps to a sandbox policy preset
+  budget?: AgentBudgetPolicy; // stricter workflow-agent budget
   model?: string; // default model for this agent
   description: string;
   tools?: string[]; // tool restrictions (overrides role policy)
@@ -2053,6 +2105,7 @@ export interface WorkflowRun {
   status: WorkflowRunStatus;
   currentStep?: string; // current step ID
   context: Record<string, unknown>; // shared context across steps
+  budget?: AgentBudgetState; // effective budget, usage, threshold events, traces
   startedAt: string;
   completedAt?: string;
   lastCheckpoint?: string; // last state persistence timestamp

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -287,6 +287,7 @@ First-class support for autonomous coding agents.
 - **OpenAI Codex support** — Local CLI attempts, SDK sessions, GitHub-native Codex Cloud delegation, workflow steps, review actions, Settings health checks, MCP setup, and fresh-install default routing
 - **Local LLM provider profiles** — Ollama Local, Ollama Cloud, and LM Studio Local profiles can be enabled, health-checked, and targeted by routing rules in the web app or macOS app
 - **Sandbox policy presets** — Built-in and custom presets control filesystem scope, network egress, environment passthrough, and credential brokering for agent profiles, workflow agents, and per-run overrides
+- **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run budgets can cap tokens, provider cost, tool calls, runtime, retries, and workflow fan-out with warning, approval, downgrade, pause, or cancel actions
 - **Platform-agnostic REST API** — Any platform that can make HTTP calls can drive the full agent lifecycle
 - **Agent request tracking** — VK can create and display pending agent requests; a configured external runner/provider must execute the work
 - **Automation tasks** — Separate automation task type with pending/running/complete lifecycle, session key tracking, and sub-agent spawning
@@ -1325,6 +1326,7 @@ New endpoints for advanced metrics and visualization (v1.6):
 - **Blocked task breakdown** — Blocked task counts by category (feedback, technical snag, prerequisite, other)
 - **Sprint velocity** — Track task completion rate over time
 - **Cost budget tracking** — Token usage and cost metrics with budget cards
+- **Run budget policy traces** — Budget threshold decisions are recorded as `budget-policy` governance traces and appear in workflow run detail, task timelines, work products, and completion packets
 - **Agent comparison** — Side-by-side performance metrics across different AI agents (uses `apiFetch()` to properly unwrap the API envelope)
 - **Drill-down panels** — Click any metric card to drill into tasks, errors, tokens, or duration details; focus rings use `ring-inset` to prevent clipping
   - **Tasks drill-down** — List of tasks matching the selected metric; clicking a task opens its detail panel (with API fallback for deleted tasks via `open-task` event)

--- a/docs/security.md
+++ b/docs/security.md
@@ -155,6 +155,13 @@ dry-run and launch-time decision writes a governance trace with raw detail
 redacted; credential references and environment-style `name=value` strings are
 shown as `[redacted]`.
 
+Agent budget policies are enforced through the same governance path. Workspace,
+agent, workflow, workflow-agent, and per-run budgets can cap tokens,
+provider-reported cost, tool-call counts, runtime, retry count, and workflow
+fan-out. Soft thresholds write `budget-policy` warning traces. Hard thresholds
+pause or block for approval, downgrade to a configured model route, or cancel
+the run with recorded trace and completion-packet evidence.
+
 For untrusted or externally sourced work, prefer a required preset with
 repository-scoped writes, default-deny network egress, metadata endpoint
 blocking, and brokered credentials. Keep the legacy permissive preset only for
@@ -282,9 +289,10 @@ ws.onclose = (event) => {
 
 5. **Monitor access** - The server logs connection attempts with role information
 
-6. **Constrain agent launches** - Assign sandbox policy presets before running
-   untrusted work. Default-deny network egress and broker credentials when a
-   workflow does not need broad host access.
+6. **Constrain agent launches** - Assign sandbox policy presets and run budgets
+   before running untrusted or expensive work. Default-deny network egress,
+   broker credentials, and cap token, spend, tool-call, runtime, retry, and
+   fan-out exposure when a workflow does not need broad access.
 
 7. **Keep remote mode explicit** - Binding outside loopback, reverse proxying,
    tunneling, or serving mobile/PWA clients requires auth enabled, localhost

--- a/server/src/__tests__/agent-budget-service.test.ts
+++ b/server/src/__tests__/agent-budget-service.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { AgentBudgetService } from '../services/agent-budget-service.js';
+
+describe('AgentBudgetService', () => {
+  it('merges workspace, agent, workflow, and run budgets using the strictest limits', () => {
+    const service = new AgentBudgetService();
+
+    const policy = service.resolve({
+      workspaceBudget: {
+        enabled: true,
+        scope: 'workspace',
+        limits: { totalTokens: 100_000, costUsd: 25, retries: 5 },
+        softThresholdPercent: 80,
+        hardAction: 'require-approval',
+      },
+      agentBudget: {
+        enabled: true,
+        scope: 'agent',
+        limits: { totalTokens: 80_000, toolCalls: 40 },
+        hardAction: 'pause',
+      },
+      workflowBudget: {
+        enabled: true,
+        scope: 'workflow',
+        limits: { retries: 2, fanOut: 6 },
+      },
+      runBudget: {
+        enabled: true,
+        scope: 'run',
+        limits: { totalTokens: 50_000, fanOut: 4 },
+        softThresholdPercent: 70,
+      },
+    });
+
+    expect(policy?.limits).toMatchObject({
+      totalTokens: 50_000,
+      costUsd: 25,
+      toolCalls: 40,
+      retries: 2,
+      fanOut: 4,
+    });
+    expect(policy?.softThresholdPercent).toBe(70);
+    expect(policy?.hardAction).toBe('require-approval');
+  });
+
+  it('warns on soft thresholds and records a budget governance trace', () => {
+    const service = new AgentBudgetService();
+    const policy = service.resolve({
+      workspaceBudget: {
+        enabled: true,
+        limits: { totalTokens: 1000 },
+        softThresholdPercent: 75,
+        hardAction: 'require-approval',
+      },
+    });
+
+    const evaluation = service.evaluate(policy, { totalTokens: 800 }, { taskId: 'task-1' });
+
+    expect(evaluation.decision).toBe('warn');
+    expect(evaluation.thresholdEvents).toHaveLength(1);
+    expect(evaluation.thresholdEvents[0]).toMatchObject({
+      metric: 'totalTokens',
+      threshold: 'soft',
+      action: 'warn',
+    });
+    expect(evaluation.trace).toMatchObject({
+      kind: 'budget-policy',
+      outcome: 'warned',
+      subject: { taskId: 'task-1', actionType: 'budget.evaluate' },
+    });
+  });
+
+  it('ignores disabled policies when resolving effective limits', () => {
+    const service = new AgentBudgetService();
+
+    const policy = service.resolve({
+      workspaceBudget: {
+        enabled: true,
+        scope: 'workspace',
+        limits: { totalTokens: 10_000 },
+      },
+      agentBudget: {
+        enabled: false,
+        scope: 'agent',
+        limits: { totalTokens: 100, costUsd: 1 },
+        hardAction: 'cancel',
+      },
+    });
+
+    expect(policy?.limits).toMatchObject({ totalTokens: 10_000 });
+    expect(policy?.limits?.costUsd).toBeUndefined();
+    expect(policy?.hardAction).toBe('require-approval');
+  });
+
+  it('requires operator action when a hard threshold is reached', () => {
+    const service = new AgentBudgetService();
+    const policy = service.resolve({
+      workspaceBudget: {
+        enabled: true,
+        limits: { toolCalls: 3 },
+        hardAction: 'cancel',
+      },
+    });
+
+    const evaluation = service.evaluate(policy, { toolCalls: 3 }, { runId: 'run-1' });
+
+    expect(evaluation.decision).toBe('cancel');
+    expect(evaluation.trace).toMatchObject({
+      kind: 'budget-policy',
+      outcome: 'blocked',
+      subject: { runId: 'run-1' },
+    });
+  });
+
+  it('returns model overrides for explicit downgrade policies', () => {
+    const service = new AgentBudgetService();
+    const policy = service.resolve({
+      workspaceBudget: {
+        enabled: true,
+        limits: { costUsd: 2 },
+        hardAction: 'downgrade',
+        downgradeModel: 'gpt-4.1-mini',
+      },
+    });
+
+    const evaluation = service.evaluate(policy, { costUsd: 2.5 });
+
+    expect(evaluation.decision).toBe('downgrade');
+    expect(evaluation.modelOverride).toBe('gpt-4.1-mini');
+    expect(evaluation.trace?.outcome).toBe('routed');
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -7,6 +7,7 @@ import type { AgentType, TokenTelemetryEvent } from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { requireLocalAgentCapability } from '../middleware/local-agent-capability.js';
+import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
 
 const router: RouterType = Router();
 
@@ -16,6 +17,8 @@ const AgentTypeSchema = z.string().min(1).max(50);
 const startAgentSchema = z.object({
   agent: AgentTypeSchema.optional(),
   overrideReason: z.string().trim().min(8).max(1000).optional(),
+  sandboxPresetId: z.string().trim().min(1).max(80).optional(),
+  budget: AgentBudgetPolicySchema.optional(),
 });
 
 const completeAgentSchema = z.object({
@@ -29,6 +32,7 @@ const reportTokensSchema = z.object({
   inputTokens: z.number({ message: 'inputTokens is required' }).int().nonnegative(),
   outputTokens: z.number({ message: 'outputTokens is required' }).int().nonnegative(),
   totalTokens: z.number().int().nonnegative().optional(),
+  cost: z.number().nonnegative().optional(),
   model: z.string().optional(),
   agent: AgentTypeSchema.optional(),
 });
@@ -41,11 +45,13 @@ router.post(
     let agent: AgentType | undefined;
     let overrideReason: string | undefined;
     let sandboxPresetId: string | undefined;
+    let budget: z.infer<typeof AgentBudgetPolicySchema> | undefined;
     try {
-      ({ agent, overrideReason, sandboxPresetId } = startAgentSchema.parse(req.body) as {
+      ({ agent, overrideReason, sandboxPresetId, budget } = startAgentSchema.parse(req.body) as {
         agent?: AgentType;
         overrideReason?: string;
         sandboxPresetId?: string;
+        budget?: z.infer<typeof AgentBudgetPolicySchema>;
       });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -58,6 +64,7 @@ router.post(
       status = await clawdbotAgentService.startAgent(req.params.taskId as string, agent, {
         overrideReason,
         sandboxPresetId,
+        budget,
       });
     } catch (error) {
       if (error instanceof AgentReadinessError) {
@@ -156,6 +163,7 @@ router.post(
     let inputTokens: number;
     let outputTokens: number;
     let totalTokens: number | undefined;
+    let cost: number | undefined;
     let model: string | undefined;
     let agent: AgentType | undefined;
     try {
@@ -164,6 +172,7 @@ router.post(
       inputTokens = parsed.inputTokens;
       outputTokens = parsed.outputTokens;
       totalTokens = parsed.totalTokens;
+      cost = parsed.cost;
       model = parsed.model;
       agent = parsed.agent as AgentType | undefined;
     } catch (error) {
@@ -198,7 +207,15 @@ router.post(
       inputTokens,
       outputTokens,
       totalTokens: totalTokens ?? inputTokens + outputTokens,
+      cost,
       model,
+    });
+
+    await clawdbotAgentService.recordBudgetUsage(taskId, {
+      inputTokens,
+      outputTokens,
+      totalTokens: totalTokens ?? inputTokens + outputTokens,
+      costUsd: cost,
     });
 
     res.status(201).json({

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -5,6 +5,7 @@ import type { RepoConfig, AgentConfig, AgentType } from '@veritas-kanban/shared'
 import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError, BadRequestError } from '../middleware/error-handler.js';
 import { authorize } from '../middleware/auth.js';
+import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
 
 const router: RouterType = Router();
 const configService = new ConfigService();
@@ -40,6 +41,7 @@ const agentSchema = z.object({
     .optional(),
   model: z.string().optional(),
   sandboxPresetId: z.string().min(1).max(80).optional(),
+  budget: AgentBudgetPolicySchema.optional(),
 });
 
 const setDefaultAgentSchema = z.object({

--- a/server/src/routes/governance-traces.ts
+++ b/server/src/routes/governance-traces.ts
@@ -12,6 +12,7 @@ const traceListQuerySchema = z.object({
       'policy',
       'tool-policy',
       'sandbox-policy',
+      'budget-policy',
       'agent-permission',
       'routing',
       'workflow-gate',

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -16,6 +16,7 @@ import { NotFoundError, ValidationError, BadRequestError } from '../middleware/e
 import { checkWorkflowPermission, assertWorkflowPermission } from '../middleware/workflow-auth.js';
 import { diffWorkflows } from '../utils/workflow-diff.js';
 import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../utils/concurrency.js';
+import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
 
 const router = Router();
 const workflowService = getWorkflowService();
@@ -42,6 +43,7 @@ function getRequestPermissions(req: AuthenticatedRequest): string[] | undefined 
 const startRunSchema = z.object({
   taskId: z.string().optional(),
   context: z.record(z.string(), z.unknown()).optional(),
+  budget: AgentBudgetPolicySchema.optional(),
 });
 
 const resumeRunSchema = z.object({
@@ -429,7 +431,7 @@ router.post(
     await assertWorkflowPermission(workflowId, userId, 'execute');
 
     // Validate input
-    const { taskId, context } = startRunSchema.parse(req.body);
+    const { taskId, context, budget } = startRunSchema.parse(req.body);
     const workflow = await workflowService.loadWorkflow(workflowId);
     if (!workflow) {
       throw new NotFoundError(`Workflow ${workflowId} not found`);
@@ -460,10 +462,15 @@ router.post(
     }
 
     // Start run
-    const run = await workflowRunService.startRun(workflowId, taskId, {
-      ...context,
-      skillAudit: dryRun.skillAudit,
-    });
+    const run = await workflowRunService.startRun(
+      workflowId,
+      taskId,
+      {
+        ...context,
+        skillAudit: dryRun.skillAudit,
+      },
+      budget
+    );
 
     // Audit log
     await workflowService.auditChange({

--- a/server/src/schemas/agent-budget-schemas.ts
+++ b/server/src/schemas/agent-budget-schemas.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const AgentBudgetLimitsSchema = z
+  .object({
+    inputTokens: z.number().int().min(0).optional(),
+    outputTokens: z.number().int().min(0).optional(),
+    totalTokens: z.number().int().min(0).optional(),
+    costUsd: z.number().min(0).optional(),
+    toolCalls: z.number().int().min(0).optional(),
+    runtimeSeconds: z.number().int().min(0).optional(),
+    idleRuntimeSeconds: z.number().int().min(0).optional(),
+    retries: z.number().int().min(0).optional(),
+    fanOut: z.number().int().min(0).optional(),
+  })
+  .strict();
+
+export const AgentBudgetPolicySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    name: z.string().trim().min(1).max(120).optional(),
+    scope: z.enum(['workspace', 'agent', 'workflow', 'workflow-agent', 'run']).optional(),
+    limits: AgentBudgetLimitsSchema.optional(),
+    softThresholdPercent: z.number().min(1).max(99).optional(),
+    hardAction: z.enum(['pause', 'require-approval', 'downgrade', 'cancel']).optional(),
+    downgradeModel: z.string().trim().min(1).max(120).optional(),
+    notes: z.string().trim().max(1000).optional(),
+  })
+  .strict();
+
+export type AgentBudgetPolicyInput = z.infer<typeof AgentBudgetPolicySchema>;

--- a/server/src/schemas/agent-schemas.ts
+++ b/server/src/schemas/agent-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
 
 const AgentTypeSchema = z.string().min(1).max(50);
 
@@ -9,6 +10,7 @@ export const StartAgentBodySchema = z.object({
   agent: AgentTypeSchema.optional(),
   overrideReason: z.string().trim().min(8).max(1000).optional(),
   sandboxPresetId: z.string().trim().min(1).max(80).optional(),
+  budget: AgentBudgetPolicySchema.optional(),
 });
 
 export type StartAgentBody = z.infer<typeof StartAgentBodySchema>;
@@ -32,6 +34,7 @@ export const ReportTokensBodySchema = z.object({
   inputTokens: z.number({ message: 'inputTokens is required' }).int().nonnegative(),
   outputTokens: z.number({ message: 'outputTokens is required' }).int().nonnegative(),
   totalTokens: z.number().int().nonnegative().optional(),
+  cost: z.number().nonnegative().optional(),
   model: z.string().optional(),
   agent: AgentTypeSchema.optional(),
 });

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
 import { BOARD_COLUMN_ID_PATTERN } from '@veritas-kanban/shared';
 
 // Dangerous keys check
@@ -205,6 +206,7 @@ const BudgetSettingsSchema = z
     monthlyTokenLimit: z.number().int().min(0).optional(),
     monthlyCostLimit: z.number().min(0).optional(),
     warningThreshold: z.number().min(0).max(100).optional(),
+    defaultRunBudget: AgentBudgetPolicySchema.optional(),
   })
   .strict()
   .optional();

--- a/server/src/services/agent-budget-service.ts
+++ b/server/src/services/agent-budget-service.ts
@@ -1,0 +1,327 @@
+import type {
+  AgentBudgetAction,
+  AgentBudgetDecision,
+  AgentBudgetEvaluation,
+  AgentBudgetLimits,
+  AgentBudgetMetric,
+  AgentBudgetPolicy,
+  AgentBudgetResolutionInput,
+  AgentBudgetState,
+  AgentBudgetThresholdEvent,
+  AgentBudgetUsage,
+  CreateGovernanceTraceInput,
+  GovernanceTraceOutcome,
+} from '@veritas-kanban/shared';
+import { ZERO_AGENT_BUDGET_USAGE } from '@veritas-kanban/shared';
+import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
+
+const METRICS: AgentBudgetMetric[] = [
+  'inputTokens',
+  'outputTokens',
+  'totalTokens',
+  'costUsd',
+  'toolCalls',
+  'runtimeSeconds',
+  'idleRuntimeSeconds',
+  'retries',
+  'fanOut',
+];
+
+const ACTION_RANK: Record<Exclude<AgentBudgetAction, 'warn'>, number> = {
+  downgrade: 1,
+  pause: 2,
+  'require-approval': 3,
+  cancel: 4,
+};
+
+export class AgentBudgetService {
+  resolve(input: AgentBudgetResolutionInput): AgentBudgetPolicy | undefined {
+    const policies = [
+      input.workspaceBudget,
+      input.agentBudget,
+      input.workflowBudget,
+      input.workflowAgentBudget,
+      input.runBudget,
+    ]
+      .filter((policy): policy is AgentBudgetPolicy => Boolean(policy))
+      .map((policy) => this.normalizePolicy(policy))
+      .filter((policy) => policy.enabled !== false);
+
+    if (policies.length === 0) return undefined;
+
+    const limits: AgentBudgetLimits = {};
+    for (const policy of policies) {
+      for (const metric of METRICS) {
+        const limit = policy.limits?.[metric];
+        if (!isPositiveLimit(limit)) continue;
+        const current = limits[metric];
+        limits[metric] = current === undefined ? limit : Math.min(current, limit);
+      }
+    }
+
+    const softThresholdPercent = Math.min(
+      ...policies
+        .map((policy) => policy.softThresholdPercent)
+        .filter((value): value is number => typeof value === 'number' && value > 0)
+    );
+    const hardAction = policies.reduce<Exclude<AgentBudgetAction, 'warn'> | undefined>(
+      (current, policy) => stricterAction(current, policy.hardAction),
+      undefined
+    );
+    const downgradeModel = [...policies]
+      .reverse()
+      .find((policy) => policy.downgradeModel)?.downgradeModel;
+    const name = [...policies].reverse().find((policy) => policy.name)?.name;
+
+    if (Object.keys(limits).length === 0) {
+      return undefined;
+    }
+
+    return {
+      enabled: true,
+      name: name ?? 'Effective agent run budget',
+      scope: 'run',
+      limits,
+      softThresholdPercent: Number.isFinite(softThresholdPercent) ? softThresholdPercent : 80,
+      hardAction: hardAction ?? 'require-approval',
+      downgradeModel,
+      notes: [...policies].reverse().find((policy) => policy.notes)?.notes,
+    };
+  }
+
+  evaluate(
+    policy: AgentBudgetPolicy | undefined,
+    usage: Partial<AgentBudgetUsage>,
+    subject: CreateGovernanceTraceInput['subject'] = {}
+  ): AgentBudgetEvaluation {
+    const normalizedUsage = normalizeUsage(usage);
+    if (!policy || policy.enabled === false || !policy.limits) {
+      return {
+        decision: 'allow',
+        usage: normalizedUsage,
+        thresholdEvents: [],
+      };
+    }
+
+    const normalizedPolicy = this.normalizePolicy(policy);
+    const thresholdEvents = this.evaluateThresholds(normalizedPolicy, normalizedUsage);
+    const hardEvents = thresholdEvents.filter((event) => event.threshold === 'hard');
+    const softEvents = thresholdEvents.filter((event) => event.threshold === 'soft');
+    const hardAction = normalizedPolicy.hardAction ?? 'require-approval';
+    const decision: AgentBudgetDecision =
+      hardEvents.length > 0 ? hardAction : softEvents.length > 0 ? 'warn' : 'allow';
+    const modelOverride =
+      decision === 'downgrade' && normalizedPolicy.downgradeModel
+        ? normalizedPolicy.downgradeModel
+        : undefined;
+
+    return {
+      decision,
+      usage: normalizedUsage,
+      effectiveBudget: normalizedPolicy,
+      thresholdEvents,
+      modelOverride,
+      trace:
+        thresholdEvents.length > 0
+          ? this.buildTrace(normalizedPolicy, normalizedUsage, thresholdEvents, decision, subject)
+          : undefined,
+    };
+  }
+
+  initialState(policy: AgentBudgetPolicy | undefined): AgentBudgetState {
+    return {
+      enabled: Boolean(
+        policy?.enabled !== false && policy?.limits && Object.keys(policy.limits).length
+      ),
+      policy,
+      usage: { ...ZERO_AGENT_BUDGET_USAGE },
+      decision: 'allow',
+      thresholdEvents: [],
+      traceIds: [],
+    };
+  }
+
+  mergeUsage(
+    current: AgentBudgetUsage | undefined,
+    delta: Partial<AgentBudgetUsage>
+  ): AgentBudgetUsage {
+    const base = current ?? ZERO_AGENT_BUDGET_USAGE;
+    return {
+      inputTokens: Math.max(0, base.inputTokens + (delta.inputTokens ?? 0)),
+      outputTokens: Math.max(0, base.outputTokens + (delta.outputTokens ?? 0)),
+      totalTokens: Math.max(0, base.totalTokens + (delta.totalTokens ?? 0)),
+      costUsd: Math.max(0, base.costUsd + (delta.costUsd ?? 0)),
+      toolCalls: Math.max(0, base.toolCalls + (delta.toolCalls ?? 0)),
+      runtimeSeconds: Math.max(base.runtimeSeconds, delta.runtimeSeconds ?? 0),
+      idleRuntimeSeconds: Math.max(base.idleRuntimeSeconds, delta.idleRuntimeSeconds ?? 0),
+      retries: Math.max(base.retries, delta.retries ?? 0),
+      fanOut: Math.max(base.fanOut, delta.fanOut ?? 0),
+    };
+  }
+
+  private normalizePolicy(policy: AgentBudgetPolicy): AgentBudgetPolicy {
+    return AgentBudgetPolicySchema.parse(policy) as AgentBudgetPolicy;
+  }
+
+  private evaluateThresholds(
+    policy: AgentBudgetPolicy,
+    usage: AgentBudgetUsage
+  ): AgentBudgetThresholdEvent[] {
+    const limits = policy.limits ?? {};
+    const softPercent = policy.softThresholdPercent ?? 80;
+    const hardAction = policy.hardAction ?? 'require-approval';
+    const events: AgentBudgetThresholdEvent[] = [];
+
+    for (const metric of METRICS) {
+      const limit = limits[metric];
+      if (!isPositiveLimit(limit)) continue;
+      const used = usage[metric];
+      const percent = limit === 0 ? 0 : (used / limit) * 100;
+      if (used >= limit) {
+        events.push({
+          metric,
+          limit,
+          used,
+          percent,
+          threshold: 'hard',
+          action: hardAction,
+          message: `${metric} used ${formatMetricValue(metric, used)} of ${formatMetricValue(
+            metric,
+            limit
+          )}.`,
+        });
+      } else if (percent >= softPercent) {
+        events.push({
+          metric,
+          limit,
+          used,
+          percent,
+          threshold: 'soft',
+          action: 'warn',
+          message: `${metric} is at ${Math.round(percent)}% of budget.`,
+        });
+      }
+    }
+
+    return events;
+  }
+
+  private buildTrace(
+    policy: AgentBudgetPolicy,
+    usage: AgentBudgetUsage,
+    thresholdEvents: AgentBudgetThresholdEvent[],
+    decision: AgentBudgetDecision,
+    subject: CreateGovernanceTraceInput['subject']
+  ): CreateGovernanceTraceInput {
+    const outcome = outcomeForDecision(decision);
+    const hardEvents = thresholdEvents.filter((event) => event.threshold === 'hard');
+    const title = `Budget policy ${policy.name ?? 'run budget'}`;
+    return {
+      kind: 'budget-policy',
+      outcome,
+      title,
+      summary:
+        hardEvents.length > 0
+          ? `Hard budget threshold reached for ${hardEvents.map((event) => event.metric).join(', ')}.`
+          : `Soft budget threshold reached for ${thresholdEvents
+              .map((event) => event.metric)
+              .join(', ')}.`,
+      remediation: remediationForDecision(decision),
+      subject: {
+        ...subject,
+        actionType: subject?.actionType ?? 'budget.evaluate',
+      },
+      evaluatedRules: thresholdEvents.map((event) => ({
+        id: `budget:${event.metric}:${event.threshold}`,
+        label: `${event.metric} ${event.threshold} threshold`,
+        type: 'budget-policy',
+        status: event.threshold === 'hard' ? 'matched' : 'info',
+        outcome: event.threshold === 'hard' ? outcomeForDecision(event.action) : 'warned',
+        message: event.message,
+        details: {
+          metric: event.metric,
+          limit: event.limit,
+          used: event.used,
+          percent: event.percent,
+          action: event.action,
+        },
+      })),
+      matchedRules: thresholdEvents.map((event) => ({
+        id: `budget:${event.metric}:${event.threshold}`,
+        label: `${event.metric} ${event.threshold} threshold`,
+        type: 'budget-policy',
+        status: event.threshold === 'hard' ? 'matched' : 'info',
+        outcome: event.threshold === 'hard' ? outcomeForDecision(event.action) : 'warned',
+        message: event.message,
+      })),
+      raw: {
+        policy: {
+          name: policy.name,
+          scope: policy.scope,
+          limits: policy.limits,
+          softThresholdPercent: policy.softThresholdPercent,
+          hardAction: policy.hardAction,
+          downgradeModel: policy.downgradeModel,
+        },
+        usage,
+        thresholdEvents,
+        decision,
+      },
+    };
+  }
+}
+
+export const agentBudgetService = new AgentBudgetService();
+
+export function getAgentBudgetService(): AgentBudgetService {
+  return agentBudgetService;
+}
+
+function normalizeUsage(usage: Partial<AgentBudgetUsage>): AgentBudgetUsage {
+  return {
+    ...ZERO_AGENT_BUDGET_USAGE,
+    ...usage,
+    totalTokens: usage.totalTokens ?? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),
+  };
+}
+
+function isPositiveLimit(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function stricterAction(
+  current: Exclude<AgentBudgetAction, 'warn'> | undefined,
+  next: Exclude<AgentBudgetAction, 'warn'> | undefined
+): Exclude<AgentBudgetAction, 'warn'> | undefined {
+  if (!next) return current;
+  if (!current) return next;
+  return ACTION_RANK[next] > ACTION_RANK[current] ? next : current;
+}
+
+function outcomeForDecision(
+  decision: AgentBudgetDecision | AgentBudgetAction
+): GovernanceTraceOutcome {
+  if (decision === 'allow') return 'allowed';
+  if (decision === 'warn') return 'warned';
+  if (decision === 'require-approval' || decision === 'pause') return 'approval-required';
+  if (decision === 'downgrade') return 'routed';
+  return 'blocked';
+}
+
+function remediationForDecision(decision: AgentBudgetDecision): string | undefined {
+  if (decision === 'warn') return 'Review budget posture before allowing the run to continue.';
+  if (decision === 'pause')
+    return 'Pause the run and resume after operator review or a stricter budget override.';
+  if (decision === 'require-approval')
+    return 'Request operator approval or lower the run scope before continuing.';
+  if (decision === 'downgrade')
+    return 'Run with the configured lower-cost model route and keep the trace visible.';
+  if (decision === 'cancel') return 'Cancel the run or restart with a stricter scope.';
+  return undefined;
+}
+
+function formatMetricValue(metric: AgentBudgetMetric, value: number): string {
+  if (metric === 'costUsd') return `$${value.toFixed(value < 1 ? 4 : 2)}`;
+  if (metric.endsWith('Seconds')) return `${value}s`;
+  return value.toLocaleString();
+}

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -21,6 +21,7 @@ import { getTelemetryService } from './telemetry-service.js';
 import { getAgentRoutingService } from './agent-routing-service.js';
 import { getGovernanceTraceService } from './governance-trace-service.js';
 import { getSandboxPolicyService } from './sandbox-policy-service.js';
+import { getAgentBudgetService } from './agent-budget-service.js';
 import { AgentHealthService, type AgentHealthChecker } from './agent-health-service.js';
 import { getBreaker } from './circuit-registry.js';
 import { activityService } from './activity-service.js';
@@ -44,9 +45,14 @@ import type {
   TokenTelemetryEvent,
   TaskReadinessSummary,
   SandboxPolicyDryRunResult,
+  AgentBudgetPolicy,
+  AgentBudgetState,
+  AgentBudgetUsage,
+  AgentBudgetDecision,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError } from '../middleware/error-handler.js';
+import type { AgentBudgetThresholdEvent } from '@veritas-kanban/shared';
 const log = createLogger('clawdbot-agent-service');
 
 const PROJECT_ROOT = path.resolve(process.cwd(), '..');
@@ -115,6 +121,7 @@ export interface AgentOutput {
 export interface AgentStartOptions {
   overrideReason?: string;
   sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
 }
 
 export class AgentReadinessError extends Error {
@@ -136,6 +143,8 @@ interface PendingAgent {
   emitter: EventEmitter;
   provider: AgentProvider;
   model?: string;
+  budget?: AgentBudgetState;
+  budgetStopped?: boolean;
   threadId?: string;
   abortController?: AbortController;
   process?: ChildProcessWithoutNullStreams;
@@ -212,8 +221,42 @@ export class ClawdbotAgentService {
     const agentConfig = this.resolveAgentConfig(config.agents, agent);
     await this.assertAgentAvailable(agent, agentConfig);
     const provider = this.resolveAgentProvider(agentConfig, agent);
+    const budgetService = getAgentBudgetService();
+    const budgetPolicy = budgetService.resolve({
+      workspaceBudget: config.features?.budget?.enabled
+        ? config.features.budget.defaultRunBudget
+        : undefined,
+      agentBudget: agentConfig?.budget,
+      runBudget: options.budget,
+    });
+    const budgetEvaluation = budgetService.evaluate(
+      budgetPolicy,
+      { fanOut: 1 },
+      {
+        taskId,
+        agentId: agent,
+        actionType: 'agent.start',
+        project: task.project,
+      }
+    );
+    const budgetTraceIds: string[] = [];
+    if (budgetEvaluation.trace) {
+      const trace = await getGovernanceTraceService().record(budgetEvaluation.trace);
+      budgetTraceIds.push(trace.id);
+    }
+    if (this.isBlockingBudgetDecision(budgetEvaluation.decision)) {
+      throw new ConflictError('Agent run budget requires operator action before launch', {
+        decision: budgetEvaluation.decision,
+        thresholdEvents: budgetEvaluation.thresholdEvents,
+        traceId: budgetTraceIds[0],
+      });
+    }
+    const launchAgentConfig =
+      budgetEvaluation.modelOverride && agentConfig
+        ? { ...agentConfig, model: budgetEvaluation.modelOverride }
+        : agentConfig;
     const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
-      presetId: options.sandboxPresetId ?? agentConfig?.sandboxPresetId,
+      presetId: options.sandboxPresetId ?? launchAgentConfig?.sandboxPresetId,
       provider,
       workspacePath: task.git.worktreePath,
     });
@@ -279,7 +322,18 @@ export class ClawdbotAgentService {
       startedAt,
       emitter,
       provider,
-      model: agentConfig?.model,
+      model: launchAgentConfig?.model,
+      budget: budgetPolicy
+        ? {
+            ...budgetService.initialState(budgetPolicy),
+            usage: budgetEvaluation.usage,
+            decision: budgetEvaluation.decision,
+            thresholdEvents: budgetEvaluation.thresholdEvents,
+            traceIds: budgetTraceIds,
+            modelOverride: budgetEvaluation.modelOverride,
+            overrideReason: options.overrideReason,
+          }
+        : undefined,
     });
 
     // Validate path segments for log file
@@ -301,7 +355,8 @@ export class ClawdbotAgentService {
       status: 'running',
       started: startedAt,
       provider,
-      model: agentConfig?.model,
+      model: launchAgentConfig?.model,
+      budget: pendingAgents.get(taskId)?.budget,
     };
 
     await this.taskService.updateTask(taskId, {
@@ -315,7 +370,7 @@ export class ClawdbotAgentService {
       taskId,
       attemptId,
       agent,
-      model: agentConfig?.model,
+      model: launchAgentConfig?.model,
       project: task.project,
     });
 
@@ -323,7 +378,7 @@ export class ClawdbotAgentService {
     try {
       await adapter.start({
         task,
-        agentConfig,
+        agentConfig: launchAgentConfig,
         prompt: taskPrompt,
         logPath,
         attemptId,
@@ -424,6 +479,14 @@ export class ClawdbotAgentService {
     const endedAt = new Date().toISOString();
     const status: AttemptStatus = result.success ? 'complete' : 'failed';
     const durationMs = new Date(endedAt).getTime() - new Date(pending.startedAt).getTime();
+    if (pending.budget?.enabled) {
+      await this.evaluatePendingBudget(
+        taskId,
+        { runtimeSeconds: Math.ceil(durationMs / 1000) },
+        'agent.complete',
+        false
+      );
+    }
 
     // Update task
     await this.taskService.updateTask(taskId, {
@@ -437,6 +500,7 @@ export class ClawdbotAgentService {
         provider: pending.provider,
         model: pending.model,
         threadId: pending.threadId,
+        budget: pending.budget,
       },
     });
 
@@ -528,6 +592,66 @@ export class ClawdbotAgentService {
     await this.completeAgent(taskId, {
       success: false,
       error: 'Stopped by user',
+    });
+  }
+
+  async recordBudgetUsage(taskId: string, delta: Partial<AgentBudgetUsage>): Promise<void> {
+    await this.evaluatePendingBudget(taskId, delta, 'agent.usage', true);
+  }
+
+  private isBlockingBudgetDecision(decision: AgentBudgetDecision): boolean {
+    return decision === 'pause' || decision === 'require-approval' || decision === 'cancel';
+  }
+
+  private async evaluatePendingBudget(
+    taskId: string,
+    delta: Partial<AgentBudgetUsage>,
+    actionType: string,
+    enforce: boolean
+  ): Promise<void> {
+    const pending = pendingAgents.get(taskId);
+    if (!pending?.budget?.enabled || !pending.budget.policy) return;
+
+    const task = await this.taskService.getTask(taskId);
+    const budgetService = getAgentBudgetService();
+    pending.budget.usage = budgetService.mergeUsage(pending.budget.usage, delta);
+    const evaluation = budgetService.evaluate(pending.budget.policy, pending.budget.usage, {
+      taskId,
+      agentId: pending.agent,
+      actionType,
+      project: task?.project,
+    });
+
+    pending.budget.decision = evaluation.decision;
+    pending.budget.modelOverride ??= evaluation.modelOverride;
+    pending.budget.thresholdEvents = mergeThresholdEvents(
+      pending.budget.thresholdEvents,
+      evaluation.thresholdEvents
+    );
+
+    if (evaluation.trace) {
+      const trace = await getGovernanceTraceService().record(evaluation.trace);
+      pending.budget.traceIds = [...new Set([...pending.budget.traceIds, trace.id])];
+    }
+
+    if (!enforce || pending.budgetStopped || !this.isBlockingBudgetDecision(evaluation.decision)) {
+      return;
+    }
+
+    pending.budgetStopped = true;
+    const logPath = path.join(this.logsDir, `${taskId}_${pending.attemptId}.md`);
+    await this.appendLog(
+      logPath,
+      `\n## Budget Enforcement\n\nDecision: ${evaluation.decision}\n\n${evaluation.thresholdEvents
+        .map((event) => `- ${event.message}`)
+        .join('\n')}\n`
+    );
+    await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
+    await this.completeAgent(taskId, {
+      success: false,
+      error: `Budget ${evaluation.decision}: ${evaluation.thresholdEvents
+        .map((event) => event.message)
+        .join(' ')}`,
     });
   }
 
@@ -727,7 +851,13 @@ export class ClawdbotAgentService {
     let stderrBuffer = '';
     let finalSummary = '';
     let tokenUsage:
-      | { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string }
+      | {
+          inputTokens: number;
+          outputTokens: number;
+          totalTokens?: number;
+          cost?: number;
+          model?: string;
+        }
       | undefined;
 
     child.stdout.setEncoding('utf-8');
@@ -791,8 +921,20 @@ export class ClawdbotAgentService {
             inputTokens: tokenUsage.inputTokens,
             outputTokens: tokenUsage.outputTokens,
             totalTokens: tokenUsage.totalTokens,
+            cost: tokenUsage.cost,
             model: tokenUsage.model || agentConfig?.model,
           });
+          await this.evaluatePendingBudget(
+            task.id,
+            {
+              inputTokens: tokenUsage.inputTokens,
+              outputTokens: tokenUsage.outputTokens,
+              totalTokens: tokenUsage.totalTokens,
+              costUsd: tokenUsage.cost,
+            },
+            'agent.tokens',
+            false
+          );
         }
 
         await this.appendLog(
@@ -897,7 +1039,13 @@ export class ClawdbotAgentService {
     let finalSummary = '';
     let failureMessage = '';
     let tokenUsage:
-      | { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string }
+      | {
+          inputTokens: number;
+          outputTokens: number;
+          totalTokens?: number;
+          cost?: number;
+          model?: string;
+        }
       | undefined;
 
     for await (const event of streamed.events) {
@@ -926,8 +1074,20 @@ export class ClawdbotAgentService {
         inputTokens: tokenUsage.inputTokens,
         outputTokens: tokenUsage.outputTokens,
         totalTokens: tokenUsage.totalTokens,
+        cost: tokenUsage.cost,
         model: tokenUsage.model || agentConfig?.model,
       });
+      await this.evaluatePendingBudget(
+        task.id,
+        {
+          inputTokens: tokenUsage.inputTokens,
+          outputTokens: tokenUsage.outputTokens,
+          totalTokens: tokenUsage.totalTokens,
+          costUsd: tokenUsage.cost,
+        },
+        'agent.tokens',
+        false
+      );
     }
 
     await this.appendLog(
@@ -951,7 +1111,13 @@ export class ClawdbotAgentService {
     agentConfig?: AgentConfig
   ): {
     summary?: string;
-    usage?: { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string };
+    usage?: {
+      inputTokens: number;
+      outputTokens: number;
+      totalTokens?: number;
+      cost?: number;
+      model?: string;
+    };
   } {
     const trimmed = line.trim();
     if (!trimmed) return {};
@@ -973,7 +1139,13 @@ export class ClawdbotAgentService {
     agentConfig?: AgentConfig
   ): {
     summary?: string;
-    usage?: { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string };
+    usage?: {
+      inputTokens: number;
+      outputTokens: number;
+      totalTokens?: number;
+      cost?: number;
+      model?: string;
+    };
   } {
     const record = event as Record<string, unknown>;
     const type = String(record.type || record.event || 'codex.event');
@@ -984,7 +1156,18 @@ export class ClawdbotAgentService {
       `\n### ${type}\n\n${summary ? `${summary}\n\n` : ''}<details><summary>Raw event</summary>\n\n\`\`\`json\n${JSON.stringify(record, null, 2)}\n\`\`\`\n\n</details>\n`
     );
     if (task && attemptId) {
-      void this.recordCodexEvent(task, attemptId, agentConfig, type, record, summary);
+      void this.recordCodexEvent(task, attemptId, agentConfig, type, record, summary).catch(
+        (error) => {
+          log.warn(
+            {
+              error: error instanceof Error ? error.message : String(error),
+              taskId: task.id,
+              attemptId,
+            },
+            'Failed to record Codex event'
+          );
+        }
+      );
     }
     return { summary, usage };
   }
@@ -1139,6 +1322,10 @@ export class ClawdbotAgentService {
         },
         agent
       );
+    }
+
+    if (tool) {
+      await this.evaluatePendingBudget(task.id, { toolCalls: 1 }, 'agent.tool', true);
     }
 
     if (files.length > 0) {
@@ -1489,10 +1676,14 @@ export class ClawdbotAgentService {
     return visit(event);
   }
 
-  private extractCodexUsage(
-    event: unknown
-  ):
-    | { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string }
+  private extractCodexUsage(event: unknown):
+    | {
+        inputTokens: number;
+        outputTokens: number;
+        totalTokens?: number;
+        cost?: number;
+        model?: string;
+      }
     | undefined {
     const seen = new Set<unknown>();
     const visit = (value: unknown): Record<string, unknown> | undefined => {
@@ -1526,10 +1717,12 @@ export class ClawdbotAgentService {
       usage.completion_tokens ??
       usage.completionTokens) as number;
     const total = usage.total_tokens ?? usage.totalTokens;
+    const cost = usage.cost ?? usage.cost_usd ?? usage.costUsd;
     return {
       inputTokens: input,
       outputTokens: output,
       totalTokens: typeof total === 'number' ? total : input + output,
+      cost: typeof cost === 'number' ? cost : undefined,
       model: typeof usage.model === 'string' ? usage.model : undefined,
     };
   }
@@ -1702,3 +1895,14 @@ ${prompt}
 
 // Export singleton
 export const clawdbotAgentService = new ClawdbotAgentService();
+
+function mergeThresholdEvents(
+  existing: AgentBudgetThresholdEvent[],
+  next: AgentBudgetThresholdEvent[]
+): AgentBudgetThresholdEvent[] {
+  const byKey = new Map<string, AgentBudgetThresholdEvent>();
+  for (const event of [...existing, ...next]) {
+    byKey.set(`${event.metric}:${event.threshold}:${event.action}`, event);
+  }
+  return Array.from(byKey.values());
+}

--- a/server/src/services/work-product-service.ts
+++ b/server/src/services/work-product-service.ts
@@ -478,6 +478,8 @@ export class WorkProductService {
       orchestrationRoles: task.attempt?.orchestration?.totals.roles ?? 0,
       orchestrationBlocked: task.attempt?.orchestration?.totals.blocked ?? 0,
       orchestrationFailed: task.attempt?.orchestration?.totals.failed ?? 0,
+      budgetDecision: task.attempt?.budget?.decision ?? null,
+      budgetTraceCount: task.attempt?.budget?.traceIds.length ?? 0,
     };
   }
 
@@ -652,8 +654,35 @@ export class WorkProductService {
       task.costPrediction
         ? `Predicted cost: ${this.formatCost(task.costPrediction.estimatedCost)} (${task.costPrediction.confidence} confidence)`
         : 'Predicted cost: Not recorded.',
+      ...this.budgetLines(task),
     ];
     return this.packetText(lines.join('\n'));
+  }
+
+  private budgetLines(task: Task): string[] {
+    const budget = task.attempt?.budget;
+    if (!budget?.enabled) return ['Run budget: Not enforced.'];
+    const usage = budget.usage;
+    const limits = budget.policy?.limits ?? {};
+    const used = [
+      `tokens ${usage.totalTokens.toLocaleString()}${limits.totalTokens ? `/${limits.totalTokens.toLocaleString()}` : ''}`,
+      `cost ${this.formatCost(usage.costUsd)}${limits.costUsd ? `/${this.formatCost(limits.costUsd)}` : ''}`,
+      `tools ${usage.toolCalls.toLocaleString()}${limits.toolCalls ? `/${limits.toolCalls.toLocaleString()}` : ''}`,
+      `runtime ${this.formatDurationSeconds(usage.runtimeSeconds)}${limits.runtimeSeconds ? `/${this.formatDurationSeconds(limits.runtimeSeconds)}` : ''}`,
+      `retries ${usage.retries.toLocaleString()}${limits.retries ? `/${limits.retries.toLocaleString()}` : ''}`,
+      `fan-out ${usage.fanOut.toLocaleString()}${limits.fanOut ? `/${limits.fanOut.toLocaleString()}` : ''}`,
+    ].join(', ');
+    const thresholdEvents =
+      budget.thresholdEvents.length > 0
+        ? budget.thresholdEvents.map((event) => event.message).join(' ')
+        : 'No threshold events.';
+    const traces =
+      budget.traceIds.length > 0 ? ` Budget traces: ${budget.traceIds.join(', ')}.` : '';
+    const override = budget.overrideReason ? ` Override: ${budget.overrideReason}.` : '';
+    return [
+      `Run budget: ${budget.decision}. Used ${used}.`,
+      `Budget thresholds: ${thresholdEvents}.${traces}${override}`,
+    ];
   }
 
   private deliverablesSection(task: Task): string {

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -8,6 +8,11 @@ import path from 'path';
 import { nanoid } from 'nanoid';
 import {
   buildWorkflowPipelineSummary,
+  ZERO_AGENT_BUDGET_USAGE,
+  type AgentBudgetDecision,
+  type AgentBudgetPolicy,
+  type AgentBudgetThresholdEvent,
+  type AgentBudgetUsage,
   type WorkflowPipelineRoleStatusPatch,
   type WorkflowSubagentRunStatus,
   type WorkflowSubagentTelemetry,
@@ -21,6 +26,9 @@ import { broadcastWorkflowStatus } from './broadcast-service.js';
 import { getTaskService } from './task-service.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteWorkflowRunRepository } from '../storage/sqlite/workflow-repositories.js';
+import { getConfigService } from './config-service.js';
+import { getAgentBudgetService } from './agent-budget-service.js';
+import { getGovernanceTraceService } from './governance-trace-service.js';
 
 const log = createLogger('workflow-run');
 
@@ -189,6 +197,86 @@ export class WorkflowRunService {
     return 'pending';
   }
 
+  private isBlockingBudgetDecision(decision: AgentBudgetDecision): boolean {
+    return decision === 'pause' || decision === 'require-approval' || decision === 'cancel';
+  }
+
+  private async evaluateRunBudget(
+    run: WorkflowRun,
+    workflow: WorkflowDefinition,
+    step: WorkflowStep,
+    actionType: string,
+    enforce: boolean,
+    delta: Partial<AgentBudgetUsage> = {}
+  ): Promise<boolean> {
+    if (!run.budget?.enabled) return false;
+
+    const agentDef = step.agent
+      ? workflow.agents.find((candidate) => candidate.id === step.agent)
+      : undefined;
+    const activeAgentBudget =
+      agentDef?.budget?.enabled &&
+      agentDef.budget.limits &&
+      Object.keys(agentDef.budget.limits).length > 0
+        ? agentDef.budget
+        : undefined;
+    const budgetService = getAgentBudgetService();
+    const effectivePolicy =
+      budgetService.resolve({
+        workflowBudget: run.budget.policy,
+        workflowAgentBudget: activeAgentBudget,
+      }) ?? run.budget.policy;
+    if (!effectivePolicy) return false;
+    const runtimeSeconds = Math.ceil((Date.now() - new Date(run.startedAt).getTime()) / 1000);
+    const retries = run.steps.reduce((sum, stepRun) => sum + stepRun.retries, 0);
+    const fanOut = Math.max(run.budget.usage.fanOut, step.parallel?.steps.length ?? 1);
+    run.budget.usage = budgetService.mergeUsage(run.budget.usage, {
+      ...delta,
+      runtimeSeconds,
+      retries,
+      fanOut,
+    });
+
+    const evaluation = budgetService.evaluate(effectivePolicy, run.budget.usage, {
+      workflowId: run.workflowId,
+      runId: run.id,
+      taskId: run.taskId,
+      stepId: step.id,
+      agentId: step.agent,
+      actionType,
+    });
+    if (!activeAgentBudget) {
+      run.budget.policy = effectivePolicy;
+    }
+    run.budget.decision = evaluation.decision;
+    run.budget.modelOverride ??= evaluation.modelOverride;
+    run.budget.thresholdEvents = mergeBudgetThresholdEvents(
+      run.budget.thresholdEvents,
+      evaluation.thresholdEvents
+    );
+
+    if (evaluation.trace) {
+      const trace = await getGovernanceTraceService().record(evaluation.trace);
+      run.budget.traceIds = [...new Set([...run.budget.traceIds, trace.id])];
+    }
+
+    if (!enforce || !this.isBlockingBudgetDecision(evaluation.decision)) {
+      return false;
+    }
+
+    const detail = evaluation.thresholdEvents.map((event) => event.message).join(' ');
+    if (evaluation.decision === 'cancel') {
+      run.status = 'failed';
+      run.error = `Budget cancel: ${detail}`;
+      run.completedAt = new Date().toISOString();
+    } else {
+      run.status = 'blocked';
+      run.error = `Budget ${evaluation.decision}: ${detail}`;
+    }
+    this.syncPipelineSummary(run, workflow);
+    return true;
+  }
+
   private mergeStepTelemetry(telemetry: WorkflowSubagentTelemetry, stepRun: StepRun): void {
     if (stepRun.startedAt) {
       telemetry.startedAt =
@@ -210,7 +298,8 @@ export class WorkflowRunService {
   async startRun(
     workflowId: string,
     taskId?: string,
-    initialContext?: Record<string, unknown>
+    initialContext?: Record<string, unknown>,
+    runBudget?: AgentBudgetPolicy
   ): Promise<WorkflowRun> {
     // Check concurrency limit
     if (activeRunCount >= MAX_CONCURRENT_RUNS) {
@@ -228,6 +317,39 @@ export class WorkflowRunService {
     const taskService = getTaskService();
     const task = taskId ? await taskService.getTask(taskId) : null;
     const safeInitialContext = this.validateExternalContext(initialContext, 'Initial context');
+    const config = await getConfigService().getConfig();
+    const budgetService = getAgentBudgetService();
+    const budgetPolicy = budgetService.resolve({
+      workspaceBudget: config.features?.budget?.enabled
+        ? config.features.budget.defaultRunBudget
+        : undefined,
+      workflowBudget: workflow.config?.budget,
+      runBudget,
+    });
+    const hasWorkflowAgentBudget = workflow.agents.some(
+      (agent) =>
+        agent.budget?.enabled && agent.budget.limits && Object.keys(agent.budget.limits).length > 0
+    );
+    const budgetEvaluation = budgetService.evaluate(
+      budgetPolicy,
+      { fanOut: 1 },
+      {
+        workflowId: workflow.id,
+        taskId,
+        actionType: 'workflow.start',
+        project: task?.project,
+      }
+    );
+    const budgetTraceIds: string[] = [];
+    if (budgetEvaluation.trace) {
+      const trace = await getGovernanceTraceService().record(budgetEvaluation.trace);
+      budgetTraceIds.push(trace.id);
+    }
+    if (this.isBlockingBudgetDecision(budgetEvaluation.decision)) {
+      throw new ValidationError(
+        `Workflow run budget requires operator action before launch: ${budgetEvaluation.decision}`
+      );
+    }
 
     const runId = `run_${Date.now()}_${nanoid(8)}`;
     const now = new Date().toISOString();
@@ -264,6 +386,24 @@ export class WorkflowRunService {
         // Phase 2: Session tracking for reuse mode (#111)
         _sessions: {},
       },
+      budget: budgetPolicy
+        ? {
+            ...budgetService.initialState(budgetPolicy),
+            usage: budgetEvaluation.usage,
+            decision: budgetEvaluation.decision,
+            thresholdEvents: budgetEvaluation.thresholdEvents,
+            traceIds: budgetTraceIds,
+            modelOverride: budgetEvaluation.modelOverride,
+          }
+        : hasWorkflowAgentBudget
+          ? {
+              enabled: true,
+              usage: { ...ZERO_AGENT_BUDGET_USAGE },
+              decision: 'allow',
+              thresholdEvents: [],
+              traceIds: [],
+            }
+          : undefined,
       startedAt: now,
       steps: workflow.steps.map((step) => ({
         stepId: step.id,
@@ -302,6 +442,11 @@ export class WorkflowRunService {
       while (stepQueue.length > 0) {
         const stepId = stepQueue.shift()!;
         const step = workflow.steps.find((s) => s.id === stepId)!;
+        if (await this.evaluateRunBudget(run, workflow, step, 'workflow.step.start', true)) {
+          await this.saveRun(run);
+          broadcastWorkflowStatus(run);
+          return;
+        }
 
         // Skip if step already completed/skipped (defensive when retry_step rebuilds queue)
         const existingStepRun = run.steps.find((s) => s.stepId === step.id)!;
@@ -322,6 +467,21 @@ export class WorkflowRunService {
 
         try {
           const result = await this.stepExecutor.executeStep(step, run);
+          if (result.budgetUsage) {
+            const budgetBlocked = await this.evaluateRunBudget(
+              run,
+              workflow,
+              step,
+              'workflow.step.usage',
+              true,
+              result.budgetUsage
+            );
+            if (budgetBlocked) {
+              await this.saveRun(run);
+              broadcastWorkflowStatus(run);
+              return;
+            }
+          }
 
           stepRun.status = 'completed';
           stepRun.completedAt = new Date().toISOString();
@@ -353,7 +513,7 @@ export class WorkflowRunService {
             throw err;
           }
 
-          if (run.status === 'blocked') {
+          if ((run.status as WorkflowRun['status']) === 'blocked') {
             log.info({ runId: run.id, stepId: step.id }, 'Workflow run blocked — awaiting resume');
             return;
           }
@@ -910,4 +1070,15 @@ export function getWorkflowRunService(): WorkflowRunService {
     workflowRunServiceInstance = new WorkflowRunService();
   }
   return workflowRunServiceInstance;
+}
+
+function mergeBudgetThresholdEvents(
+  existing: AgentBudgetThresholdEvent[],
+  next: AgentBudgetThresholdEvent[]
+): AgentBudgetThresholdEvent[] {
+  const byKey = new Map<string, AgentBudgetThresholdEvent>();
+  for (const event of [...existing, ...next]) {
+    byKey.set(`${event.metric}:${event.threshold}:${event.action}`, event);
+  }
+  return Array.from(byKey.values());
 }

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -81,7 +81,10 @@ export class WorkflowStepExecutor {
       throw new Error(`Agent step ${step.id} missing agent`);
     }
 
-    const agentDef = this.getAgentDefinition(run, step.agent);
+    let agentDef = this.getAgentDefinition(run, step.agent);
+    if (agentDef && run.budget?.modelOverride) {
+      agentDef = { ...agentDef, model: run.budget.modelOverride };
+    }
     const workflowConfig = run.context.workflow as
       | { config?: { fresh_session_default?: boolean } }
       | undefined;
@@ -466,9 +469,20 @@ export class WorkflowStepExecutor {
     let threadId = existingThreadId || '';
     let finalResponse = '';
     let failureMessage = '';
+    let toolCalls = 0;
+    let tokenUsage:
+      | {
+          inputTokens: number;
+          outputTokens: number;
+          totalTokens?: number;
+          cost?: number;
+        }
+      | undefined;
 
     for await (const event of streamed.events) {
       events.push(event);
+      if (this.isCodexToolEvent(event)) toolCalls++;
+      tokenUsage = this.extractCodexBudgetUsage(event) ?? tokenUsage;
       if (event.type === 'thread.started') {
         threadId = event.thread_id;
         run.context._sessions = {
@@ -527,7 +541,76 @@ export class WorkflowStepExecutor {
     return {
       output: parsed,
       outputPath,
+      budgetUsage: {
+        inputTokens: tokenUsage?.inputTokens,
+        outputTokens: tokenUsage?.outputTokens,
+        totalTokens: tokenUsage?.totalTokens,
+        costUsd: tokenUsage?.cost,
+        toolCalls,
+      },
     };
+  }
+
+  private extractCodexBudgetUsage(event: unknown):
+    | {
+        inputTokens: number;
+        outputTokens: number;
+        totalTokens?: number;
+        cost?: number;
+      }
+    | undefined {
+    const seen = new Set<unknown>();
+    const visit = (value: unknown): Record<string, unknown> | undefined => {
+      if (!value || typeof value !== 'object') return undefined;
+      if (seen.has(value)) return undefined;
+      seen.add(value);
+      const record = value as Record<string, unknown>;
+      const input =
+        record.input_tokens ?? record.inputTokens ?? record.prompt_tokens ?? record.promptTokens;
+      const output =
+        record.output_tokens ??
+        record.outputTokens ??
+        record.completion_tokens ??
+        record.completionTokens;
+      if (typeof input === 'number' && typeof output === 'number') return record;
+      for (const child of Object.values(record)) {
+        const result = visit(child);
+        if (result) return result;
+      }
+      return undefined;
+    };
+
+    const usage = visit(event);
+    if (!usage) return undefined;
+    const input = (usage.input_tokens ??
+      usage.inputTokens ??
+      usage.prompt_tokens ??
+      usage.promptTokens) as number;
+    const output = (usage.output_tokens ??
+      usage.outputTokens ??
+      usage.completion_tokens ??
+      usage.completionTokens) as number;
+    const total = usage.total_tokens ?? usage.totalTokens;
+    const cost = usage.cost ?? usage.cost_usd ?? usage.costUsd;
+    return {
+      inputTokens: input,
+      outputTokens: output,
+      totalTokens: typeof total === 'number' ? total : input + output,
+      cost: typeof cost === 'number' ? cost : undefined,
+    };
+  }
+
+  private isCodexToolEvent(event: unknown): boolean {
+    if (!event || typeof event !== 'object') return false;
+    const record = event as Record<string, unknown>;
+    const type = String(record.type || record.event || '').toLowerCase();
+    if (type.includes('tool')) return true;
+    const item = record.item;
+    if (item && typeof item === 'object') {
+      const itemType = String((item as Record<string, unknown>).type || '').toLowerCase();
+      return itemType.includes('tool') || itemType.includes('function_call');
+    }
+    return false;
   }
 
   private assertCodexToolPolicySupported(

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -31,6 +31,7 @@ export interface WorkflowConfig {
   fresh_session_default?: boolean;
   progress_file?: string;
   telemetry_tags?: string[];
+  budget?: import('@veritas-kanban/shared').AgentBudgetPolicy;
 }
 
 export type WorkflowPipelineMode = 'single-agent' | 'orchestrated';
@@ -119,6 +120,7 @@ export interface WorkflowAgent {
   provider?: 'openclaw' | 'codex-cli' | 'codex-sdk' | 'codex-cloud' | string;
   command?: string;
   sandboxPresetId?: string;
+  budget?: import('@veritas-kanban/shared').AgentBudgetPolicy;
   description: string;
   tools?: string[]; // Phase 2: Tool restrictions (#110)
 }
@@ -210,6 +212,7 @@ export interface WorkflowRun {
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps
+  budget?: import('@veritas-kanban/shared').AgentBudgetState;
   startedAt: string;
   completedAt?: string;
   lastCheckpoint?: string; // Phase 2: Last state persistence timestamp (#113)
@@ -262,6 +265,7 @@ export interface StepSessionConfig {
 export interface StepExecutionResult {
   output: unknown; // Parsed output (for context passing)
   outputPath: string; // Path to output file
+  budgetUsage?: Partial<import('@veritas-kanban/shared').AgentBudgetUsage>;
 }
 
 // ==================== RBAC & Audit Types ====================

--- a/shared/src/types/agent-budget.types.ts
+++ b/shared/src/types/agent-budget.types.ts
@@ -1,0 +1,103 @@
+import type { CreateGovernanceTraceInput } from './governance-trace.types.js';
+
+export type AgentBudgetAction = 'warn' | 'pause' | 'require-approval' | 'downgrade' | 'cancel';
+
+export type AgentBudgetDecision = 'allow' | AgentBudgetAction;
+
+export type AgentBudgetScope = 'workspace' | 'agent' | 'workflow' | 'workflow-agent' | 'run';
+
+export type AgentBudgetMetric =
+  | 'inputTokens'
+  | 'outputTokens'
+  | 'totalTokens'
+  | 'costUsd'
+  | 'toolCalls'
+  | 'runtimeSeconds'
+  | 'idleRuntimeSeconds'
+  | 'retries'
+  | 'fanOut';
+
+export interface AgentBudgetLimits {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  costUsd?: number;
+  toolCalls?: number;
+  runtimeSeconds?: number;
+  idleRuntimeSeconds?: number;
+  retries?: number;
+  fanOut?: number;
+}
+
+export interface AgentBudgetPolicy {
+  enabled?: boolean;
+  name?: string;
+  scope?: AgentBudgetScope;
+  limits?: AgentBudgetLimits;
+  softThresholdPercent?: number;
+  hardAction?: Exclude<AgentBudgetAction, 'warn'>;
+  downgradeModel?: string;
+  notes?: string;
+}
+
+export interface AgentBudgetUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  toolCalls: number;
+  runtimeSeconds: number;
+  idleRuntimeSeconds: number;
+  retries: number;
+  fanOut: number;
+}
+
+export interface AgentBudgetThresholdEvent {
+  metric: AgentBudgetMetric;
+  limit: number;
+  used: number;
+  percent: number;
+  threshold: 'soft' | 'hard';
+  action: AgentBudgetAction;
+  message: string;
+}
+
+export interface AgentBudgetEvaluation {
+  decision: AgentBudgetDecision;
+  usage: AgentBudgetUsage;
+  effectiveBudget?: AgentBudgetPolicy;
+  thresholdEvents: AgentBudgetThresholdEvent[];
+  modelOverride?: string;
+  trace?: CreateGovernanceTraceInput;
+}
+
+export interface AgentBudgetState {
+  enabled: boolean;
+  policy?: AgentBudgetPolicy;
+  usage: AgentBudgetUsage;
+  decision: AgentBudgetDecision;
+  thresholdEvents: AgentBudgetThresholdEvent[];
+  traceIds: string[];
+  overrideReason?: string;
+  modelOverride?: string;
+}
+
+export interface AgentBudgetResolutionInput {
+  workspaceBudget?: AgentBudgetPolicy;
+  agentBudget?: AgentBudgetPolicy;
+  workflowBudget?: AgentBudgetPolicy;
+  workflowAgentBudget?: AgentBudgetPolicy;
+  runBudget?: AgentBudgetPolicy;
+}
+
+export const ZERO_AGENT_BUDGET_USAGE: AgentBudgetUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+  costUsd: 0,
+  toolCalls: 0,
+  runtimeSeconds: 0,
+  idleRuntimeSeconds: 0,
+  retries: 0,
+  fanOut: 0,
+};

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -4,6 +4,7 @@ import type { AgentType, TaskPriority, TaskStatus } from './task.types.js';
 import type { TelemetryConfig } from './telemetry.types.js';
 import type { WatcherContinuationSettings } from './watcher-policy.types.js';
 import type { SandboxPolicyPreset } from './sandbox-policy.types.js';
+import type { AgentBudgetPolicy } from './agent-budget.types.js';
 
 export interface DevServerConfig {
   command: string; // e.g., "pnpm dev" or "npm run dev"
@@ -27,6 +28,7 @@ export interface AgentConfig {
   provider?: AgentProvider;
   model?: string;
   sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
 }
 
 export type AgentProvider =
@@ -304,6 +306,7 @@ export interface BudgetSettings {
   monthlyTokenLimit: number; // Monthly token budget (0 = no limit)
   monthlyCostLimit: number; // Monthly cost budget in dollars (0 = no limit)
   warningThreshold: number; // Percentage threshold for warning (0-100, default 80)
+  defaultRunBudget?: AgentBudgetPolicy;
 }
 
 /** Structural enforcement toggles (all on by default). */
@@ -503,6 +506,14 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     monthlyTokenLimit: 0, // 0 = no limit
     monthlyCostLimit: 0, // 0 = no limit (dollars)
     warningThreshold: 80, // Warn at 80% of budget
+    defaultRunBudget: {
+      enabled: false,
+      name: 'Workspace default run budget',
+      scope: 'workspace',
+      limits: {},
+      softThresholdPercent: 80,
+      hardAction: 'require-approval',
+    },
   },
   enforcement: {
     squadChat: false,

--- a/shared/src/types/governance-trace.types.ts
+++ b/shared/src/types/governance-trace.types.ts
@@ -2,6 +2,7 @@ export type GovernanceTraceKind =
   | 'policy'
   | 'tool-policy'
   | 'sandbox-policy'
+  | 'budget-policy'
   | 'agent-permission'
   | 'routing'
   | 'workflow-gate';

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -30,6 +30,7 @@ export * from './governance-trace.types.js';
 export * from './skill-capability.types.js';
 export * from './skill-security.types.js';
 export * from './sandbox-policy.types.js';
+export * from './agent-budget.types.js';
 export * from './watcher-policy.types.js';
 export * from './evidence.types.js';
 export * from './time-breakdown.types.js';

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -58,6 +58,7 @@ export interface TaskAttempt {
   cloudUrl?: string;
   cloudTarget?: string;
   orchestration?: import('./workflow.js').WorkflowPipelineSummary;
+  budget?: import('./agent-budget.types.js').AgentBudgetState;
 }
 
 export interface Subtask {

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -29,6 +29,7 @@ export interface WorkflowConfig {
   fresh_session_default?: boolean;
   progress_file?: string;
   telemetry_tags?: string[];
+  budget?: import('./agent-budget.types.js').AgentBudgetPolicy;
 }
 
 export type WorkflowPipelineMode = 'single-agent' | 'orchestrated';
@@ -145,6 +146,7 @@ export interface WorkflowAgent {
   role: string; // maps to toolPolicy
   model?: string; // default model for this agent
   sandboxPresetId?: string;
+  budget?: import('./agent-budget.types.js').AgentBudgetPolicy;
   description: string;
   tools?: string[]; // Phase 2: Tool restrictions (#110)
 }
@@ -236,6 +238,7 @@ export interface WorkflowRun {
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps
+  budget?: import('./agent-budget.types.js').AgentBudgetState;
   startedAt: string;
   completedAt?: string;
   lastCheckpoint?: string; // Phase 2: Last state persistence timestamp (#113)
@@ -288,6 +291,7 @@ export interface StepSessionConfig {
 export interface StepExecutionResult {
   output: unknown; // Parsed output (for context passing)
   outputPath: string; // Path to output file
+  budgetUsage?: Partial<import('./agent-budget.types.js').AgentBudgetUsage>;
 }
 
 // ==================== RBAC & Audit Types ====================

--- a/web/src/components/decisions/DecisionExplorer.tsx
+++ b/web/src/components/decisions/DecisionExplorer.tsx
@@ -26,6 +26,7 @@ const traceKindOptions: Array<{ value: 'all' | GovernanceTraceKind; label: strin
   { value: 'all', label: 'All trace types' },
   { value: 'policy', label: 'Policies' },
   { value: 'tool-policy', label: 'Tool policies' },
+  { value: 'budget-policy', label: 'Budget policies' },
   { value: 'agent-permission', label: 'Agent permissions' },
   { value: 'routing', label: 'Routing' },
   { value: 'workflow-gate', label: 'Workflow gates' },

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -4,6 +4,7 @@ import {
   Badge,
   Button,
   Modal,
+  NumberInput,
   Select,
   Switch,
   Text,
@@ -48,6 +49,7 @@ import type {
   AgentType,
   RoutingRule,
   AgentRoutingConfig,
+  AgentBudgetLimits,
   SandboxPolicyDryRunResult,
   SandboxPolicyPreset,
 } from '@veritas-kanban/shared';
@@ -318,6 +320,17 @@ function formatAgentProvider(provider: AgentProvider): string {
     AGENT_PROVIDER_OPTIONS.find((option) => option.value === provider)?.label ??
     formatProviderState(provider)
   );
+}
+
+function cleanBudgetLimits(limits: AgentBudgetLimits): AgentBudgetLimits {
+  const clean: AgentBudgetLimits = {};
+  for (const key of ['totalTokens', 'costUsd', 'toolCalls', 'runtimeSeconds'] as const) {
+    const value = limits[key];
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      clean[key] = value;
+    }
+  }
+  return clean;
 }
 
 function ProviderHealthPanel({
@@ -1411,6 +1424,11 @@ function AgentItem({
                   {sandboxPreset.name}
                 </Badge>
               )}
+              {agent.budget?.enabled && (
+                <Badge size="xs" variant="light" color="orange">
+                  Budget
+                </Badge>
+              )}
             </div>
           </div>
         </div>
@@ -2087,6 +2105,8 @@ function AgentForm({
   const [provider, setProvider] = useState<AgentProvider | ''>(agent?.provider || '');
   const [model, setModel] = useState(agent?.model || '');
   const [sandboxPresetId, setSandboxPresetId] = useState(agent?.sandboxPresetId || '');
+  const [budgetEnabled, setBudgetEnabled] = useState(agent?.budget?.enabled ?? false);
+  const [budgetLimits, setBudgetLimits] = useState<AgentBudgetLimits>(agent?.budget?.limits ?? {});
 
   const typeSlug =
     type ||
@@ -2112,7 +2132,26 @@ function AgentForm({
       provider: provider || undefined,
       model: model.trim() || undefined,
       sandboxPresetId: sandboxPresetId || undefined,
+      budget: budgetEnabled
+        ? {
+            enabled: true,
+            scope: 'agent',
+            name: `${name.trim()} run budget`,
+            limits: cleanBudgetLimits(budgetLimits),
+            softThresholdPercent: agent?.budget?.softThresholdPercent ?? 80,
+            hardAction: agent?.budget?.hardAction ?? 'require-approval',
+            downgradeModel: agent?.budget?.downgradeModel,
+          }
+        : undefined,
     });
+  };
+
+  const updateBudgetLimit = (key: keyof AgentBudgetLimits, value: number | string) => {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    setBudgetLimits((current) => ({
+      ...current,
+      [key]: Number.isFinite(numeric) ? Math.max(0, numeric) : 0,
+    }));
   };
 
   return (
@@ -2207,6 +2246,49 @@ function AgentForm({
           ]}
           allowDeselect={false}
         />
+
+        <div className="rounded-md border bg-background/70 p-3 space-y-3">
+          <Switch
+            label="Agent Budget Defaults"
+            description="Apply stricter caps when this agent launches runs"
+            checked={budgetEnabled}
+            onChange={(event) => setBudgetEnabled(event.currentTarget.checked)}
+          />
+          {budgetEnabled && (
+            <div className="grid grid-cols-2 gap-3">
+              <NumberInput
+                label="Token Limit"
+                value={budgetLimits.totalTokens ?? 0}
+                onChange={(value) => updateBudgetLimit('totalTokens', value)}
+                min={0}
+                hideControls
+                thousandSeparator=","
+              />
+              <NumberInput
+                label="Cost Limit"
+                value={budgetLimits.costUsd ?? 0}
+                onChange={(value) => updateBudgetLimit('costUsd', value)}
+                min={0}
+                hideControls
+                prefix="$"
+              />
+              <NumberInput
+                label="Tool Calls"
+                value={budgetLimits.toolCalls ?? 0}
+                onChange={(value) => updateBudgetLimit('toolCalls', value)}
+                min={0}
+                hideControls
+              />
+              <NumberInput
+                label="Runtime Seconds"
+                value={budgetLimits.runtimeSeconds ?? 0}
+                onChange={(value) => updateBudgetLimit('runtimeSeconds', value)}
+                min={0}
+                hideControls
+              />
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="flex justify-end gap-2">

--- a/web/src/components/settings/tabs/DataTab.tsx
+++ b/web/src/components/settings/tabs/DataTab.tsx
@@ -1,21 +1,39 @@
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
-import { ToggleRow, NumberRow, SectionHeader, SaveIndicator } from '../shared';
+import { Select, TextInput } from '@mantine/core';
+import { ToggleRow, NumberRow, SectionHeader, SaveIndicator, SettingRow } from '../shared';
 
 export function DataTab() {
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
 
-  const updateTelemetry = (key: string, value: any) => {
+  const updateTelemetry = (key: string, value: unknown) => {
     debouncedUpdate({ telemetry: { [key]: value } });
   };
 
-  const updateArchive = (key: string, value: any) => {
+  const updateArchive = (key: string, value: unknown) => {
     debouncedUpdate({ archive: { [key]: value } });
   };
 
-  const updateBudget = (key: string, value: any) => {
+  const updateBudget = (key: string, value: unknown) => {
     debouncedUpdate({ budget: { [key]: value } });
+  };
+  const defaultRunBudget =
+    settings.budget?.defaultRunBudget ?? DEFAULT_FEATURE_SETTINGS.budget.defaultRunBudget;
+  const defaultRunLimits = defaultRunBudget?.limits ?? {};
+  const updateDefaultRunBudget = (patch: Record<string, unknown>) => {
+    updateBudget('defaultRunBudget', {
+      ...defaultRunBudget,
+      ...patch,
+    });
+  };
+  const updateDefaultRunLimit = (key: string, value: number) => {
+    updateDefaultRunBudget({
+      limits: {
+        ...defaultRunLimits,
+        [key]: value,
+      },
+    });
   };
 
   const resetData = () => {
@@ -135,6 +153,123 @@ export function DataTab() {
                 hideSpinners
                 maxLength={2}
               />
+              <ToggleRow
+                label="Default Run Budget"
+                description="Enforce workspace defaults on agent and workflow runs"
+                checked={defaultRunBudget?.enabled ?? false}
+                onCheckedChange={(v) =>
+                  updateDefaultRunBudget({
+                    enabled: v,
+                    scope: 'workspace',
+                    name: defaultRunBudget?.name ?? 'Workspace default run budget',
+                  })
+                }
+              />
+              {(defaultRunBudget?.enabled ?? false) && (
+                <>
+                  <NumberRow
+                    label="Run Token Limit"
+                    description="Maximum total tokens per run (0 = no limit)"
+                    value={defaultRunLimits.totalTokens ?? 0}
+                    onChange={(v) => updateDefaultRunLimit('totalTokens', v)}
+                    min={0}
+                    max={9_999_999_999}
+                    unit="tokens"
+                    hideSpinners
+                    maxLength={10}
+                  />
+                  <NumberRow
+                    label="Run Cost Limit"
+                    description="Maximum provider-reported spend per run (0 = no limit)"
+                    value={defaultRunLimits.costUsd ?? 0}
+                    onChange={(v) => updateDefaultRunLimit('costUsd', v)}
+                    min={0}
+                    max={1_000_000}
+                    unit="USD"
+                    hideSpinners
+                    maxLength={8}
+                  />
+                  <NumberRow
+                    label="Tool Call Limit"
+                    description="Maximum counted tool calls per run (0 = no limit)"
+                    value={defaultRunLimits.toolCalls ?? 0}
+                    onChange={(v) => updateDefaultRunLimit('toolCalls', v)}
+                    min={0}
+                    max={100_000}
+                    unit="calls"
+                    hideSpinners
+                    maxLength={6}
+                  />
+                  <NumberRow
+                    label="Runtime Limit"
+                    description="Maximum wall-clock runtime per run (0 = no limit)"
+                    value={defaultRunLimits.runtimeSeconds ?? 0}
+                    onChange={(v) => updateDefaultRunLimit('runtimeSeconds', v)}
+                    min={0}
+                    max={604_800}
+                    unit="sec"
+                    hideSpinners
+                    maxLength={6}
+                  />
+                  <NumberRow
+                    label="Retry Limit"
+                    description="Maximum workflow retry count per run (0 = no limit)"
+                    value={defaultRunLimits.retries ?? 0}
+                    onChange={(v) => updateDefaultRunLimit('retries', v)}
+                    min={0}
+                    max={100}
+                    unit="retries"
+                    hideSpinners
+                    maxLength={3}
+                  />
+                  <NumberRow
+                    label="Fan-out Limit"
+                    description="Maximum parallel branch width per workflow run (0 = no limit)"
+                    value={defaultRunLimits.fanOut ?? 0}
+                    onChange={(v) => updateDefaultRunLimit('fanOut', v)}
+                    min={0}
+                    max={100}
+                    unit="branches"
+                    hideSpinners
+                    maxLength={3}
+                  />
+                  <SettingRow
+                    label="Hard Threshold Action"
+                    description="Action when a run reaches a hard budget limit"
+                  >
+                    <Select
+                      aria-label="Hard Threshold Action"
+                      className="w-48"
+                      data={[
+                        { value: 'require-approval', label: 'Require approval' },
+                        { value: 'pause', label: 'Pause' },
+                        { value: 'downgrade', label: 'Downgrade model' },
+                        { value: 'cancel', label: 'Cancel' },
+                      ]}
+                      value={defaultRunBudget?.hardAction ?? 'require-approval'}
+                      onChange={(value) =>
+                        updateDefaultRunBudget({ hardAction: value ?? 'require-approval' })
+                      }
+                    />
+                  </SettingRow>
+                  {defaultRunBudget?.hardAction === 'downgrade' && (
+                    <SettingRow
+                      label="Downgrade Model"
+                      description="Model route to use after a hard threshold downgrade"
+                    >
+                      <TextInput
+                        aria-label="Downgrade Model"
+                        className="w-48"
+                        value={defaultRunBudget?.downgradeModel ?? ''}
+                        onChange={(event) =>
+                          updateDefaultRunBudget({ downgradeModel: event.currentTarget.value })
+                        }
+                        placeholder="gpt-4.1-mini"
+                      />
+                    </SettingRow>
+                  )}
+                </>
+              )}
             </>
           )}
         </div>

--- a/web/src/components/task/AgentRunTimelinePanel.tsx
+++ b/web/src/components/task/AgentRunTimelinePanel.tsx
@@ -623,6 +623,22 @@ export function buildAgentRunTimelineEvents({
         link: { label: 'Agent logs', href: '#agent', target: 'agent' },
       });
     }
+    if (currentAttempt.budget?.enabled) {
+      events.push({
+        id: `budget-${currentAttempt.id}`,
+        sequence: nextSequence++,
+        type: currentAttempt.budget.decision === 'allow' ? 'usage' : 'policy',
+        source: 'derived',
+        timestamp: currentAttempt.ended || currentAttempt.started || task.updated,
+        title: `Budget ${currentAttempt.budget.decision}`,
+        detail:
+          currentAttempt.budget.thresholdEvents.length > 0
+            ? currentAttempt.budget.thresholdEvents.map((event) => event.message).join(' ')
+            : 'No budget threshold events recorded',
+        metadata: currentAttempt.budget as unknown as Record<string, unknown>,
+        link: { label: 'Agent logs', href: '#agent', target: 'agent' },
+      });
+    }
   }
 
   if (task.git?.worktreePath) {

--- a/web/src/components/workflows/WorkflowAuthoringPanel.tsx
+++ b/web/src/components/workflows/WorkflowAuthoringPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import type {
   WorkflowAgent,
+  AgentBudgetLimits,
   WorkflowDefinition,
   WorkflowOutputTarget,
   WorkflowPipelineSummary,
@@ -706,14 +707,74 @@ function WorkflowDefinitionEditor({
     ...sandboxPresets.map((preset) => ({ value: preset.id, label: preset.name })),
   ];
   const schedule = workflow.schedule ?? { mode: 'manual', enabled: false };
+  const workflowBudget = workflow.config?.budget;
 
   const update = (patch: Partial<WorkflowDefinition>) => onChange({ ...workflow, ...patch });
+
+  const updateWorkflowBudget = (
+    patch: NonNullable<NonNullable<WorkflowDefinition['config']>['budget']>
+  ) => {
+    update({
+      config: {
+        ...(workflow.config ?? {}),
+        budget: {
+          ...(workflow.config?.budget ?? {}),
+          ...patch,
+          scope: 'workflow',
+          name: workflow.config?.budget?.name ?? `${workflow.name || workflow.id} workflow budget`,
+        },
+      },
+    });
+  };
+
+  const updateWorkflowBudgetLimit = (key: keyof AgentBudgetLimits, value: number | string) => {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    updateWorkflowBudget({
+      enabled: true,
+      limits: {
+        ...(workflow.config?.budget?.limits ?? {}),
+        [key]: Number.isFinite(numeric) ? Math.max(0, numeric) : 0,
+      },
+      softThresholdPercent: workflow.config?.budget?.softThresholdPercent ?? 80,
+      hardAction: workflow.config?.budget?.hardAction ?? 'require-approval',
+    });
+  };
 
   const updateAgent = (index: number, patch: Partial<WorkflowAgent>) => {
     update({
       agents: workflow.agents.map((agent, candidateIndex) =>
         candidateIndex === index ? { ...agent, ...patch } : agent
       ),
+    });
+  };
+
+  const updateAgentBudget = (index: number, patch: NonNullable<WorkflowAgent['budget']>) => {
+    const current = workflow.agents[index];
+    updateAgent(index, {
+      budget: {
+        ...(current.budget ?? {}),
+        ...patch,
+        scope: 'workflow-agent',
+        name: current.budget?.name ?? `${current.name || current.id} workflow budget`,
+      },
+    });
+  };
+
+  const updateAgentBudgetLimit = (
+    index: number,
+    key: keyof AgentBudgetLimits,
+    value: number | string
+  ) => {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    const current = workflow.agents[index];
+    updateAgentBudget(index, {
+      enabled: true,
+      limits: {
+        ...(current.budget?.limits ?? {}),
+        [key]: Number.isFinite(numeric) ? Math.max(0, numeric) : 0,
+      },
+      softThresholdPercent: current.budget?.softThresholdPercent ?? 80,
+      hardAction: current.budget?.hardAction ?? 'require-approval',
     });
   };
 
@@ -752,6 +813,55 @@ function WorkflowDefinitionEditor({
             onChange={(event) => update({ description: event.currentTarget.value })}
             minRows={2}
           />
+          <div className="rounded-md border bg-background/70 p-3">
+            <Switch
+              label="Workflow Budget"
+              description="Apply default caps to every run of this workflow"
+              checked={workflowBudget?.enabled ?? false}
+              onChange={(event) =>
+                updateWorkflowBudget({
+                  enabled: event.currentTarget.checked,
+                  limits: workflowBudget?.limits ?? {},
+                  softThresholdPercent: workflowBudget?.softThresholdPercent ?? 80,
+                  hardAction: workflowBudget?.hardAction ?? 'require-approval',
+                })
+              }
+            />
+            {workflowBudget?.enabled && (
+              <SimpleGrid cols={{ base: 1, md: 4 }} spacing="sm" mt="sm">
+                <NumberInput
+                  label="Tokens"
+                  value={workflowBudget?.limits?.totalTokens ?? 0}
+                  onChange={(value) => updateWorkflowBudgetLimit('totalTokens', value)}
+                  min={0}
+                  hideControls
+                  thousandSeparator=","
+                />
+                <NumberInput
+                  label="Cost"
+                  value={workflowBudget?.limits?.costUsd ?? 0}
+                  onChange={(value) => updateWorkflowBudgetLimit('costUsd', value)}
+                  min={0}
+                  hideControls
+                  prefix="$"
+                />
+                <NumberInput
+                  label="Retries"
+                  value={workflowBudget?.limits?.retries ?? 0}
+                  onChange={(value) => updateWorkflowBudgetLimit('retries', value)}
+                  min={0}
+                  hideControls
+                />
+                <NumberInput
+                  label="Fan-out"
+                  value={workflowBudget?.limits?.fanOut ?? 0}
+                  onChange={(value) => updateWorkflowBudgetLimit('fanOut', value)}
+                  min={0}
+                  hideControls
+                />
+              </SimpleGrid>
+            )}
+          </div>
         </Stack>
       </Paper>
 
@@ -841,6 +951,55 @@ function WorkflowDefinitionEditor({
                 data={sandboxPresetOptions}
                 allowDeselect={false}
               />
+              <div className="mt-3 rounded-md border bg-background/70 p-3">
+                <Switch
+                  label="Workflow Agent Budget"
+                  description="Apply stricter caps when this workflow agent runs"
+                  checked={agent.budget?.enabled ?? false}
+                  onChange={(event) =>
+                    updateAgentBudget(index, {
+                      enabled: event.currentTarget.checked,
+                      limits: agent.budget?.limits ?? {},
+                      softThresholdPercent: agent.budget?.softThresholdPercent ?? 80,
+                      hardAction: agent.budget?.hardAction ?? 'require-approval',
+                    })
+                  }
+                />
+                {agent.budget?.enabled && (
+                  <SimpleGrid cols={{ base: 1, md: 4 }} spacing="sm" mt="sm">
+                    <NumberInput
+                      label="Tokens"
+                      value={agent.budget?.limits?.totalTokens ?? 0}
+                      onChange={(value) => updateAgentBudgetLimit(index, 'totalTokens', value)}
+                      min={0}
+                      hideControls
+                      thousandSeparator=","
+                    />
+                    <NumberInput
+                      label="Cost"
+                      value={agent.budget?.limits?.costUsd ?? 0}
+                      onChange={(value) => updateAgentBudgetLimit(index, 'costUsd', value)}
+                      min={0}
+                      hideControls
+                      prefix="$"
+                    />
+                    <NumberInput
+                      label="Tool Calls"
+                      value={agent.budget?.limits?.toolCalls ?? 0}
+                      onChange={(value) => updateAgentBudgetLimit(index, 'toolCalls', value)}
+                      min={0}
+                      hideControls
+                    />
+                    <NumberInput
+                      label="Runtime Sec"
+                      value={agent.budget?.limits?.runtimeSeconds ?? 0}
+                      onChange={(value) => updateAgentBudgetLimit(index, 'runtimeSeconds', value)}
+                      min={0}
+                      hideControls
+                    />
+                  </SimpleGrid>
+                )}
+              </div>
             </div>
           ))}
         </Stack>

--- a/web/src/components/workflows/WorkflowRunView.tsx
+++ b/web/src/components/workflows/WorkflowRunView.tsx
@@ -13,6 +13,8 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   buildWorkflowPipelineSummary,
   type WorkflowDefinition as SharedWorkflowDefinition,
+  type AgentBudgetState,
+  type AgentBudgetMetric,
   type WorkflowPipelineSummary,
   type WorkflowSubagentRunStatus,
 } from '@veritas-kanban/shared';
@@ -79,6 +81,7 @@ interface WorkflowRun {
   startedAt: string;
   completedAt?: string;
   context?: Record<string, unknown>;
+  budget?: AgentBudgetState;
   error?: string;
   steps: StepRun[];
 }
@@ -142,6 +145,20 @@ function formatPipelineDuration(seconds?: number): string {
   const minutes = Math.floor(seconds / 60);
   const remainder = seconds % 60;
   return `${minutes}m ${remainder}s`;
+}
+
+function formatBudgetMetric(metric: AgentBudgetMetric, value: number): string {
+  if (metric === 'costUsd') return `$${value.toFixed(value < 1 ? 4 : 2)}`;
+  if (metric.endsWith('Seconds')) return `${value}s`;
+  return Math.round(value).toLocaleString();
+}
+
+function budgetDecisionColor(decision: AgentBudgetState['decision']): string {
+  if (decision === 'allow') return 'green';
+  if (decision === 'warn') return 'yellow';
+  if (decision === 'downgrade') return 'blue';
+  if (decision === 'pause' || decision === 'require-approval') return 'orange';
+  return 'red';
 }
 
 export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
@@ -441,6 +458,8 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
         </Stack>
       </Paper>
 
+      {run.budget?.enabled && <WorkflowBudgetCard budget={run.budget} />}
+
       {pipelineSummary && <WorkflowPipelineCard pipeline={pipelineSummary} />}
 
       {/* Step Timeline */}
@@ -467,6 +486,85 @@ export function WorkflowRunView({ runId, onBack }: WorkflowRunViewProps) {
         })}
       </Stack>
     </Stack>
+  );
+}
+
+function WorkflowBudgetCard({ budget }: { budget: AgentBudgetState }) {
+  const usage = budget.usage;
+  const limits = budget.policy?.limits ?? {};
+  const metrics = (
+    [
+      'totalTokens',
+      'costUsd',
+      'toolCalls',
+      'runtimeSeconds',
+      'idleRuntimeSeconds',
+      'retries',
+      'fanOut',
+    ] as AgentBudgetMetric[]
+  ).filter((metric) => limits[metric] !== undefined || usage[metric] > 0);
+
+  return (
+    <Paper className="p-6" radius="md" withBorder>
+      <Stack gap="md">
+        <Group justify="space-between" align="flex-start">
+          <div className="space-y-1">
+            <Group gap="xs">
+              <ThemeIcon variant="light" color={budgetDecisionColor(budget.decision)}>
+                <AlertCircle className="h-4 w-4" />
+              </ThemeIcon>
+              <Title order={2} className="text-lg">
+                Budget Posture
+              </Title>
+            </Group>
+            <Text size="sm" c="dimmed">
+              {budget.policy?.name ?? 'Run budget'} · hard action{' '}
+              {budget.policy?.hardAction ?? 'require-approval'}
+            </Text>
+          </div>
+          <Group gap="xs">
+            <Badge color={budgetDecisionColor(budget.decision)} variant="light">
+              {budget.decision}
+            </Badge>
+            {budget.modelOverride && (
+              <Badge color="blue" variant="outline">
+                model {budget.modelOverride}
+              </Badge>
+            )}
+          </Group>
+        </Group>
+
+        {metrics.length > 0 && (
+          <Group gap="xs">
+            {metrics.map((metric) => {
+              const limit = limits[metric];
+              return (
+                <Badge key={metric} variant="outline" color="gray">
+                  {metric}: {formatBudgetMetric(metric, usage[metric])}
+                  {typeof limit === 'number' ? ` / ${formatBudgetMetric(metric, limit)}` : ''}
+                </Badge>
+              );
+            })}
+          </Group>
+        )}
+
+        {budget.thresholdEvents.length > 0 && (
+          <Stack gap={4}>
+            {budget.thresholdEvents.map((event) => (
+              <Text key={`${event.metric}-${event.threshold}-${event.action}`} size="sm">
+                {event.threshold} {event.metric}: {event.message} Action: {event.action}.
+              </Text>
+            ))}
+          </Stack>
+        )}
+
+        {budget.traceIds.length > 0 && (
+          <Text size="xs" c="dimmed">
+            Trace IDs: {budget.traceIds.join(', ')}
+          </Text>
+        )}
+      </Stack>
+    </Paper>
   );
 }
 

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -8,6 +8,7 @@ import type {
   AgentType,
   AgentRoutingConfig,
   RoutingResult,
+  AgentBudgetPolicy,
 } from '@veritas-kanban/shared';
 import { API_BASE, handleResponse } from './helpers';
 
@@ -15,6 +16,7 @@ export interface StartAgentRequest {
   agent?: AgentType;
   overrideReason?: string;
   sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
 }
 
 export const worktreeApi = {

--- a/web/src/lib/api/workflows.ts
+++ b/web/src/lib/api/workflows.ts
@@ -6,6 +6,7 @@ import type {
   WorkflowSchedule,
   WorkflowStep,
   WorkflowSkillAuditSummary,
+  AgentBudgetPolicy,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -147,13 +148,16 @@ export const workflowsApi = {
       body: JSON.stringify(workflow),
     }),
 
-  startRun: async (workflowId: string): Promise<WorkflowRunStartResponse> => {
+  startRun: async (
+    workflowId: string,
+    options: { budget?: AgentBudgetPolicy; context?: Record<string, unknown> } = {}
+  ): Promise<WorkflowRunStartResponse> => {
     const response = await apiFetch<WorkflowRunStartResponse | { data: WorkflowRunStartResponse }>(
       `${API_BASE}/workflows/${encodeURIComponent(workflowId)}/runs`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify(options),
       }
     );
     return unwrapData(response);


### PR DESCRIPTION
Closes #722

## Summary
- Add shared budget policy types, server validation, and an AgentBudgetService that resolves workspace, agent, workflow, workflow-agent, and per-run limits.
- Enforce budget decisions across agent starts, token reports, tool events, workflow steps, model downgrades, governance traces, work products, and completion state.
- Add Settings, agent profile, workflow authoring, workflow run, timeline, and decision explorer UI surfaces for budget posture.
- Update API, provider, feature, README, and security docs for budget policies.

## Verification
- VERITAS_DISABLE_WATCHERS=1 pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/agent-budget-service.test.ts --maxWorkers=1
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/web build
- pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/settings-agents-mantine.test.tsx src/__tests__/workflow-surfaces-mantine.test.tsx --maxWorkers=1
- pnpm --filter @veritas-kanban/server lint (0 errors; existing warnings remain)
- pnpm --filter @veritas-kanban/web lint (0 errors; existing warnings remain)

## Risk
- Provider cost accounting depends on provider-reported usage fields; runs still enforce token/tool/runtime limits when cost is not reported.