### PR TITLE
Add reusable agent profile packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **HermesAgent support** — documents HermesAgent/Hermes Gateway as the active control plane, with Veritas as the GitHub-backed source of truth
 - **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, MCP setup, and default routing for fresh installs
 - **Local LLM provider profiles** — Optional Ollama Local, Ollama Cloud, and LM Studio Local profiles with health metadata and routing support
+- **Agent profile packages** — Portable YAML/JSON packages that bundle role, runtime, prompt, tools, permissions, sandbox, budget, workflow, and health metadata for reusable launches
 - **Sandbox policy presets** — Built-in and custom presets for filesystem scope, network egress, environment passthrough, and credential brokering, with Settings dry-runs before agent launch
 - **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run caps for tokens, cost, tool calls, runtime, retries, and fan-out with auditable warn, approval, downgrade, pause, or cancel decisions
 - **Optional OpenClaw support** — Native integration with [OpenClaw](https://github.com/openclaw/openclaw) when you want OpenClaw to execute or wake agents
@@ -594,6 +595,10 @@ vk github mappings               # List issue↔task mappings
 vk agents:pending                # List pending agent requests
 vk agents:status <id>            # Check if agent running
 vk agents:complete <id> -s       # Mark agent complete
+vk profiles list                 # List reusable agent profile packages
+vk profiles validate ./agent.yml # Validate a package before import
+vk profiles import ./agent.yml   # Import or replace a package
+vk start <task> --profile <id>   # Launch a task with a profile package
 ```
 
 ### Utilities

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -1,7 +1,20 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import { api } from '../utils/api.js';
 import { findTask } from '../utils/find.js';
+import type {
+  AgentProfileExportResult,
+  AgentProfilePackageFormat,
+  AgentProfilePackageSummary,
+  AgentProfileValidationResult,
+} from '@veritas-kanban/shared';
+
+function inferProfileFormat(filePath: string): AgentProfilePackageFormat {
+  const extension = path.extname(filePath).toLowerCase();
+  return extension === '.json' ? 'json' : 'yaml';
+}
 
 export function registerAgentCommands(program: Command): void {
   // Start agent on task
@@ -13,6 +26,7 @@ export function registerAgentCommands(program: Command): void {
       'Agent to use (claude-code, amp, copilot, gemini)',
       'claude-code'
     )
+    .option('-p, --profile <profileId>', 'Agent profile package to launch')
     .option('--json', 'Output as JSON')
     .action(async (id, options) => {
       try {
@@ -35,15 +49,137 @@ export function registerAgentCommands(program: Command): void {
 
         const result = await api<{ attemptId: string }>(`/api/agents/${task.id}/start`, {
           method: 'POST',
-          body: JSON.stringify({ agent: options.agent }),
+          body: JSON.stringify({
+            agent: options.profile ? undefined : options.agent,
+            profileId: options.profile,
+          }),
         });
 
         if (options.json) {
           console.log(JSON.stringify(result, null, 2));
         } else {
-          console.log(chalk.green(`✓ Agent started: ${options.agent}`));
+          console.log(chalk.green(`✓ Agent started: ${options.profile || options.agent}`));
           console.log(chalk.dim(`Attempt ID: ${result.attemptId}`));
           console.log(chalk.dim(`Working in: ${task.git.worktreePath}`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  const profiles = program
+    .command('profiles')
+    .description('Manage reusable agent profile packages');
+
+  profiles
+    .command('list')
+    .description('List imported agent profile packages')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const rows = await api<AgentProfilePackageSummary[]>('/api/config/agent-profiles');
+        if (options.json) {
+          console.log(JSON.stringify(rows, null, 2));
+          return;
+        }
+        if (rows.length === 0) {
+          console.log(chalk.dim('No agent profile packages installed'));
+          return;
+        }
+        for (const profile of rows) {
+          console.log(
+            `${profile.enabled ? chalk.green('●') : chalk.gray('○')} ${chalk.bold(profile.id)} ${chalk.dim(profile.version)}`
+          );
+          console.log(`  ${profile.displayName} — ${profile.role}`);
+          console.log(
+            `  agent=${profile.runtime.agent}${profile.runtime.model ? ` model=${profile.runtime.model}` : ''}`
+          );
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  profiles
+    .command('validate <file>')
+    .description('Validate an agent profile package YAML or JSON file')
+    .option('--json', 'Output as JSON')
+    .action(async (file, options) => {
+      try {
+        const content = readFileSync(file, 'utf-8');
+        const result = await api<AgentProfileValidationResult>(
+          '/api/config/agent-profiles/validate',
+          {
+            method: 'POST',
+            body: JSON.stringify({ content, format: inferProfileFormat(file), source: file }),
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        if (result.valid) {
+          console.log(chalk.green(`✓ Valid profile package: ${result.profile?.id}`));
+        } else {
+          console.log(chalk.red('Invalid profile package'));
+          for (const issue of result.issues) {
+            console.log(chalk.dim(`  ${issue.path}: ${issue.message}`));
+          }
+          process.exitCode = 1;
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  profiles
+    .command('import <file>')
+    .description('Import or replace an agent profile package')
+    .option('--json', 'Output as JSON')
+    .action(async (file, options) => {
+      try {
+        const content = readFileSync(file, 'utf-8');
+        const result = await api<{
+          profile: { id: string; displayName: string; version: string };
+          created: boolean;
+        }>('/api/config/agent-profiles/import', {
+          method: 'POST',
+          body: JSON.stringify({ content, format: inferProfileFormat(file), source: file }),
+        });
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(
+          chalk.green(
+            `✓ ${result.created ? 'Imported' : 'Updated'} ${result.profile.displayName} (${result.profile.id}@${result.profile.version})`
+          )
+        );
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  profiles
+    .command('export <profileId>')
+    .description('Export an agent profile package')
+    .option('-f, --format <format>', 'yaml or json', 'yaml')
+    .option('-o, --output <file>', 'Write export to a file')
+    .action(async (profileId, options) => {
+      try {
+        const format = options.format === 'json' ? 'json' : 'yaml';
+        const result = await api<AgentProfileExportResult>(
+          `/api/config/agent-profiles/${encodeURIComponent(profileId)}/export?format=${format}`
+        );
+        if (options.output) {
+          writeFileSync(options.output, result.content, 'utf-8');
+          console.log(chalk.green(`✓ Exported ${profileId} to ${options.output}`));
+        } else {
+          process.stdout.write(result.content);
         }
       } catch (err) {
         console.error(chalk.red(`Error: ${(err as Error).message}`));

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -28,6 +28,35 @@ The launch path dry-runs the selected preset before starting Codex CLI, Codex SD
 
 Credential references and environment-style `name=value` values are redacted from dry-run output and governance traces. Prefer brokered credential presets for workflows that need scoped secrets instead of exposing broad environment passthrough.
 
+## Agent Profile Packages
+
+Use **Settings -> Agents -> Agent Profile Packages** or `vk profiles` to import reusable YAML/JSON packages that sit above provider profiles. Provider profiles still own low-level command, args, and availability. Profile packages add portable launch metadata:
+
+```yaml
+id: docs-reviewer
+schemaVersion: agent-profile-package/v1
+version: 1.0.0
+displayName: Documentation Reviewer
+role: Reviews documentation changes for accuracy and release readiness
+enabled: true
+capabilities: [docs-review, release-notes]
+defaultTaskTypes: [docs]
+runtime:
+  agent: codex
+  provider: codex-cli
+  model: gpt-5.1
+instructions:
+  prompt: Check docs against shipped behavior and call out stale roadmap language.
+tools:
+  allowed: [shell, git]
+permissions:
+  level: specialist
+policy:
+  sandboxPresetId: workspace-write-default
+```
+
+Profile launches pass `profileId` to `/api/agents/:taskId/start`. Veritas resolves the package runtime against the configured provider profile, applies the package model, sandbox preset, and budget policy, injects package instructions into the run prompt, and records the profile ID/version in the task attempt plus an `agent_event` activity entry.
+
 ## Budget Policies
 
 Use **Settings -> Agents** and **Settings -> Data & Storage -> Budget Tracking** to define workspace defaults, agent defaults, workflow budgets, workflow-agent budgets, and per-run overrides. Budgets can cap tokens, provider-reported cost, tool calls, runtime, retries, and workflow fan-out.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1421,6 +1421,52 @@ PUT /api/agents/routing
 }
 ```
 
+### Start Agent With Profile Package
+
+```
+POST /api/agents/:taskId/start
+```
+
+In addition to `agent`, `sandboxPresetId`, and `budget`, callers can pass a portable profile package ID:
+
+```json
+{
+  "profileId": "docs-reviewer"
+}
+```
+
+The launch path resolves the package runtime against configured provider profiles, applies package model/sandbox/budget posture, injects package instructions into the run prompt, and records the profile ID and version on the task attempt plus activity audit history.
+
+---
+
+## Agent Profile Packages
+
+Reusable YAML/JSON packages for agent role, runtime, prompt, tools, permissions, policy posture, workflow entrypoint, and health metadata.
+
+Mounted at `/api/config/agent-profiles`.
+
+| Method   | Path                                                | Description                                       | Permissions      |
+| -------- | --------------------------------------------------- | ------------------------------------------------- | ---------------- |
+| `GET`    | `/api/config/agent-profiles`                        | List imported profile package summaries           | `settings:read`  |
+| `POST`   | `/api/config/agent-profiles/validate`               | Validate YAML/JSON content with field-path errors | `settings:read`  |
+| `POST`   | `/api/config/agent-profiles/import`                 | Import or replace a profile package               | `settings:write` |
+| `GET`    | `/api/config/agent-profiles/:id`                    | Get one stored profile package                    | `settings:read`  |
+| `GET`    | `/api/config/agent-profiles/:id/export?format=yaml` | Export a package as YAML or JSON                  | `settings:read`  |
+| `PATCH`  | `/api/config/agent-profiles/:id`                    | Edit metadata and enablement                      | `settings:write` |
+| `DELETE` | `/api/config/agent-profiles/:id`                    | Remove a package                                  | `settings:write` |
+
+### Import Package
+
+```json
+{
+  "format": "yaml",
+  "source": "settings",
+  "content": "id: docs-reviewer\nschemaVersion: agent-profile-package/v1\nversion: 1.0.0\n..."
+}
+```
+
+Invalid packages return `valid: false` from `/validate` with issues like `$.runtime.agent: Required`. Import rejects invalid packages and never installs third-party binaries, tools, credentials, or MCP servers.
+
 ---
 
 ## Sandbox Policies

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -286,6 +286,7 @@ First-class support for autonomous coding agents.
 - **HermesAgent operating support** — v4.3 documents HermesAgent/Hermes Gateway as the active control plane, with Veritas tracking task truth, QA evidence, and GitHub delivery state
 - **OpenAI Codex support** — Local CLI attempts, SDK sessions, GitHub-native Codex Cloud delegation, workflow steps, review actions, Settings health checks, MCP setup, and fresh-install default routing
 - **Local LLM provider profiles** — Ollama Local, Ollama Cloud, and LM Studio Local profiles can be enabled, health-checked, and targeted by routing rules in the web app or macOS app
+- **Agent profile packages** — Reusable YAML/JSON packages bundle role, runtime, model, prompt instructions, tools, permissions, sandbox, budget, workflow, and health metadata for portable task launches
 - **Sandbox policy presets** — Built-in and custom presets control filesystem scope, network egress, environment passthrough, and credential brokering for agent profiles, workflow agents, and per-run overrides
 - **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run budgets can cap tokens, provider cost, tool calls, runtime, retries, and workflow fan-out with warning, approval, downgrade, pause, or cancel actions
 - **Platform-agnostic REST API** — Any platform that can make HTTP calls can drive the full agent lifecycle

--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -604,6 +604,46 @@
       "denialReason": "Stopping an agent requires task read and task write access."
     },
     {
+      "id": "cli:agents:profiles",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Profile package command discovery requires settings read access."
+    },
+    {
+      "id": "cli:agents:list",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Listing agent profile packages requires settings read access."
+    },
+    {
+      "id": "cli:agents:validate",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Validating an agent profile package uses settings-scoped profile schema access."
+    },
+    {
+      "id": "cli:agents:import",
+      "kind": "cli",
+      "classification": "authenticated-write",
+      "permissions": ["settings:write"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Importing an agent profile package modifies workspace settings."
+    },
+    {
+      "id": "cli:agents:export",
+      "kind": "cli",
+      "classification": "authenticated-read",
+      "permissions": ["settings:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Exporting an agent profile package requires settings read access."
+    },
+    {
       "id": "cli:agents:agents:pending",
       "kind": "cli",
       "classification": "agent-scoped",

--- a/server/src/__tests__/agent-profile-package-service.test.ts
+++ b/server/src/__tests__/agent-profile-package-service.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { ConfigService } from '../services/config-service.js';
+import { AgentProfilePackageService } from '../services/agent-profile-package-service.js';
+
+const PROFILE_YAML = `id: release-reviewer
+schemaVersion: agent-profile-package/v1
+version: 1.0.0
+displayName: Release Reviewer
+role: Reviews release tasks before publication
+enabled: true
+capabilities:
+  - release
+  - qa
+defaultTaskTypes:
+  - review
+runtime:
+  agent: codex
+  provider: codex-cli
+  model: gpt-5.1
+instructions:
+  prompt: Verify release notes against shipped behavior.
+tools:
+  allowed:
+    - shell
+    - git
+permissions:
+  level: specialist
+policy:
+  sandboxPresetId: workspace-write-default
+  budget:
+    enabled: true
+    scope: run
+    limits:
+      totalTokens: 50000
+    hardAction: require-approval
+`;
+
+describe('AgentProfilePackageService', () => {
+  let tmpDir: string;
+  let configService: ConfigService;
+  let service: AgentProfilePackageService;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-agent-profiles-'));
+    configService = new ConfigService({
+      configDir: tmpDir,
+      configFile: path.join(tmpDir, 'config.json'),
+    });
+    service = new AgentProfilePackageService(configService);
+  });
+
+  afterEach(async () => {
+    configService.dispose();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('validates YAML packages with actionable field paths', () => {
+    const valid = service.validateContent({ content: PROFILE_YAML, format: 'yaml' });
+    expect(valid.valid).toBe(true);
+    expect(valid.profile).toMatchObject({
+      id: 'release-reviewer',
+      runtime: { agent: 'codex', model: 'gpt-5.1' },
+      policy: { sandboxPresetId: 'workspace-write-default' },
+    });
+
+    const invalid = service.validateContent({
+      content: 'displayName: Missing Runtime',
+      format: 'yaml',
+    });
+    expect(invalid.valid).toBe(false);
+    expect(invalid.issues.map((issue) => issue.path)).toContain('$.id');
+    expect(invalid.issues.map((issue) => issue.path)).toContain('$.runtime');
+  });
+
+  it('imports, exports, and reimports without losing package metadata', async () => {
+    const imported = await service.importProfile({
+      content: PROFILE_YAML,
+      format: 'yaml',
+      source: 'test-fixture',
+    });
+    expect(imported.created).toBe(true);
+    expect(imported.profile.metadata).toMatchObject({ source: 'test-fixture' });
+
+    const exported = await service.exportProfile('release-reviewer', 'json');
+    const reimported = await service.importProfile({ content: exported.content, format: 'json' });
+
+    expect(reimported.created).toBe(false);
+    expect(reimported.profile).toMatchObject({
+      id: 'release-reviewer',
+      version: '1.0.0',
+      displayName: 'Release Reviewer',
+      runtime: { agent: 'codex', provider: 'codex-cli', model: 'gpt-5.1' },
+      tools: { allowed: ['shell', 'git'] },
+      permissions: { level: 'specialist' },
+      policy: { sandboxPresetId: 'workspace-write-default' },
+    });
+  });
+
+  it('updates enablement and resolves launch posture from existing provider settings', async () => {
+    await service.importProfile({ content: PROFILE_YAML, format: 'yaml' });
+
+    const updated = await service.updateProfile('release-reviewer', {
+      enabled: false,
+      displayName: 'Release QA Reviewer',
+    });
+    expect(updated.enabled).toBe(false);
+    await expect(service.resolveLaunch('release-reviewer')).rejects.toThrow(/disabled/);
+
+    await service.updateProfile('release-reviewer', { enabled: true });
+    const launch = await service.resolveLaunch('release-reviewer');
+
+    expect(launch).toMatchObject({
+      agent: 'codex',
+      model: 'gpt-5.1',
+      sandboxPresetId: 'workspace-write-default',
+      metadata: {
+        id: 'release-reviewer',
+        displayName: 'Release QA Reviewer',
+        version: '1.0.0',
+        agent: 'codex',
+        provider: 'codex-cli',
+        model: 'gpt-5.1',
+      },
+    });
+    expect(launch.budget?.limits?.totalTokens).toBe(50000);
+    expect(launch.instructions).toContain('Verify release notes');
+  });
+});

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -15,6 +15,7 @@ const { mockConfigService } = vi.hoisted(() => ({
     getRepoBranches: vi.fn(),
     updateAgents: vi.fn(),
     setDefaultAgent: vi.fn(),
+    saveConfig: vi.fn(),
   },
 }));
 
@@ -67,6 +68,101 @@ describe('Config Routes (actual module)', () => {
       mockConfigService.getConfig.mockRejectedValue(new Error('fail'));
       const res = await request(app).get('/api/config/repos');
       expect(res.status).toBe(500);
+    });
+  });
+
+  describe('agent profile packages', () => {
+    const profileYaml = `id: qa-reviewer
+schemaVersion: agent-profile-package/v1
+version: 1.0.0
+displayName: QA Reviewer
+role: Reviews QA evidence
+enabled: true
+capabilities:
+  - qa
+defaultTaskTypes:
+  - review
+runtime:
+  agent: codex
+`;
+
+    it('validates package content with field paths', async () => {
+      const res = await request(app)
+        .post('/api/config/agent-profiles/validate')
+        .send({ content: 'displayName: Broken', format: 'yaml' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.valid).toBe(false);
+      expect(res.body.issues.map((issue: { path: string }) => issue.path)).toContain('$.id');
+    });
+
+    it('imports and lists profile packages', async () => {
+      mockConfigService.getConfig.mockResolvedValue({
+        repos: [],
+        agents: [],
+        agentProfiles: [],
+      });
+      mockConfigService.saveConfig.mockResolvedValue(undefined);
+
+      const imported = await request(app)
+        .post('/api/config/agent-profiles/import')
+        .send({ content: profileYaml, format: 'yaml', source: 'test' });
+
+      expect(imported.status).toBe(201);
+      expect(imported.body.profile.id).toBe('qa-reviewer');
+      expect(mockConfigService.saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentProfiles: [expect.objectContaining({ id: 'qa-reviewer' })],
+        })
+      );
+
+      mockConfigService.getConfig.mockResolvedValue({
+        repos: [],
+        agents: [],
+        agentProfiles: [imported.body.profile],
+      });
+      const listed = await request(app).get('/api/config/agent-profiles');
+      expect(listed.status).toBe(200);
+      expect(listed.body).toHaveLength(1);
+      expect(listed.body[0]).toMatchObject({ id: 'qa-reviewer', displayName: 'QA Reviewer' });
+    });
+
+    it('updates and exports profile packages', async () => {
+      const profile = {
+        id: 'qa-reviewer',
+        schemaVersion: 'agent-profile-package/v1',
+        version: '1.0.0',
+        displayName: 'QA Reviewer',
+        role: 'Reviews QA evidence',
+        enabled: true,
+        capabilities: ['qa'],
+        defaultTaskTypes: ['review'],
+        runtime: { agent: 'codex' },
+      };
+      mockConfigService.getConfig.mockResolvedValue({
+        repos: [],
+        agents: [],
+        agentProfiles: [profile],
+      });
+      mockConfigService.saveConfig.mockResolvedValue(undefined);
+
+      const updated = await request(app)
+        .patch('/api/config/agent-profiles/qa-reviewer')
+        .send({ enabled: false, displayName: 'QA Gate Reviewer' });
+
+      expect(updated.status).toBe(200);
+      expect(updated.body).toMatchObject({ enabled: false, displayName: 'QA Gate Reviewer' });
+
+      mockConfigService.getConfig.mockResolvedValue({
+        repos: [],
+        agents: [],
+        agentProfiles: [updated.body],
+      });
+      const exported = await request(app).get('/api/config/agent-profiles/qa-reviewer/export');
+
+      expect(exported.status).toBe(200);
+      expect(exported.body.format).toBe('yaml');
+      expect(exported.body.content).toContain('QA Gate Reviewer');
     });
   });
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -16,6 +16,7 @@ const AgentTypeSchema = z.string().min(1).max(50);
 
 const startAgentSchema = z.object({
   agent: AgentTypeSchema.optional(),
+  profileId: AgentTypeSchema.optional(),
   overrideReason: z.string().trim().min(8).max(1000).optional(),
   sandboxPresetId: z.string().trim().min(1).max(80).optional(),
   budget: AgentBudgetPolicySchema.optional(),
@@ -43,12 +44,16 @@ router.post(
   requireLocalAgentCapability,
   asyncHandler(async (req, res) => {
     let agent: AgentType | undefined;
+    let profileId: string | undefined;
     let overrideReason: string | undefined;
     let sandboxPresetId: string | undefined;
     let budget: z.infer<typeof AgentBudgetPolicySchema> | undefined;
     try {
-      ({ agent, overrideReason, sandboxPresetId, budget } = startAgentSchema.parse(req.body) as {
+      ({ agent, profileId, overrideReason, sandboxPresetId, budget } = startAgentSchema.parse(
+        req.body
+      ) as {
         agent?: AgentType;
+        profileId?: string;
         overrideReason?: string;
         sandboxPresetId?: string;
         budget?: z.infer<typeof AgentBudgetPolicySchema>;
@@ -62,6 +67,7 @@ router.post(
     let status;
     try {
       status = await clawdbotAgentService.startAgent(req.params.taskId as string, agent, {
+        profileId,
         overrideReason,
         sandboxPresetId,
         budget,

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -6,9 +6,17 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError, BadRequestError } from '../middleware/error-handler.js';
 import { authorize } from '../middleware/auth.js';
 import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
+import { AgentProfilePackageService } from '../services/agent-profile-package-service.js';
+import {
+  AgentProfileImportBodySchema,
+  AgentProfileUpdateBodySchema,
+  AgentProfileValidateBodySchema,
+  AgentProfilePackageFormatSchema,
+} from '../schemas/agent-profile-package-schemas.js';
 
 const router: RouterType = Router();
 const configService = new ConfigService();
+const agentProfilePackageService = new AgentProfilePackageService(configService);
 
 // Validation schemas
 const repoSchema = z.object({
@@ -67,6 +75,99 @@ router.get(
   asyncHandler(async (_req, res) => {
     const config = await configService.getConfig();
     res.json(config.repos);
+  })
+);
+
+// GET /api/config/agent-profiles - List reusable agent profile packages
+router.get(
+  '/agent-profiles',
+  asyncHandler(async (_req, res) => {
+    res.json(await agentProfilePackageService.listProfiles());
+  })
+);
+
+// POST /api/config/agent-profiles/validate - Validate profile package YAML/JSON
+router.post(
+  '/agent-profiles/validate',
+  asyncHandler(async (req, res) => {
+    const input = AgentProfileValidateBodySchema.parse(req.body);
+    res.json(agentProfilePackageService.validateContent(input));
+  })
+);
+
+// POST /api/config/agent-profiles/import - Import or replace a profile package
+router.post(
+  '/agent-profiles/import',
+  authorize('admin'),
+  asyncHandler(async (req, res) => {
+    const input = AgentProfileImportBodySchema.parse(req.body);
+    try {
+      const result = await agentProfilePackageService.importProfile(input);
+      res.status(result.created ? 201 : 200).json(result);
+    } catch (error) {
+      throw new BadRequestError(error instanceof Error ? error.message : 'Invalid profile package');
+    }
+  })
+);
+
+// GET /api/config/agent-profiles/:id - Get a profile package
+router.get(
+  '/agent-profiles/:id',
+  asyncHandler(async (req, res) => {
+    const profile = await agentProfilePackageService.getProfile(req.params.id as string);
+    if (!profile) {
+      throw new BadRequestError(`Agent profile package not found: ${req.params.id}`);
+    }
+    res.json(profile);
+  })
+);
+
+// GET /api/config/agent-profiles/:id/export - Export a profile as YAML or JSON
+router.get(
+  '/agent-profiles/:id/export',
+  asyncHandler(async (req, res) => {
+    const format =
+      AgentProfilePackageFormatSchema.parse(req.query.format) ??
+      (req.query.format === 'json' ? 'json' : 'yaml');
+    try {
+      res.json(await agentProfilePackageService.exportProfile(req.params.id as string, format));
+    } catch (error) {
+      throw new BadRequestError(
+        error instanceof Error ? error.message : 'Failed to export profile package'
+      );
+    }
+  })
+);
+
+// PATCH /api/config/agent-profiles/:id - Edit profile metadata and enablement
+router.patch(
+  '/agent-profiles/:id',
+  authorize('admin'),
+  asyncHandler(async (req, res) => {
+    const patch = AgentProfileUpdateBodySchema.parse(req.body);
+    try {
+      res.json(await agentProfilePackageService.updateProfile(req.params.id as string, patch));
+    } catch (error) {
+      throw new BadRequestError(
+        error instanceof Error ? error.message : 'Failed to update profile package'
+      );
+    }
+  })
+);
+
+// DELETE /api/config/agent-profiles/:id - Remove a profile package
+router.delete(
+  '/agent-profiles/:id',
+  authorize('admin'),
+  asyncHandler(async (req, res) => {
+    try {
+      await agentProfilePackageService.deleteProfile(req.params.id as string);
+      res.status(204).send();
+    } catch (error) {
+      throw new BadRequestError(
+        error instanceof Error ? error.message : 'Failed to delete profile package'
+      );
+    }
   })
 );
 

--- a/server/src/schemas/agent-profile-package-schemas.ts
+++ b/server/src/schemas/agent-profile-package-schemas.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod';
+import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
+
+const AgentTypeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(50)
+  .regex(/^[a-z0-9-]+$/, 'Agent type must be lowercase alphanumeric with dashes');
+
+const SlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-_]*$/, 'ID must start with a lowercase letter or number');
+
+const StringListSchema = z.array(z.string().trim().min(1).max(160)).max(50).default([]);
+
+export const AgentProfilePackageFormatSchema = z.enum(['json', 'yaml']).optional();
+
+export const AgentProfileRuntimeSchema = z
+  .object({
+    agent: AgentTypeSchema,
+    provider: z
+      .enum([
+        'openclaw',
+        'codex-cli',
+        'codex-sdk',
+        'codex-cloud',
+        'ollama-local',
+        'ollama-cloud',
+        'lm-studio-local',
+        'custom',
+      ])
+      .optional(),
+    model: z.string().trim().min(1).max(120).optional(),
+    fallbackAgent: AgentTypeSchema.optional(),
+  })
+  .strict();
+
+export const AgentProfileInstructionsSchema = z
+  .object({
+    prompt: z.string().trim().max(10_000).optional(),
+    promptFile: z.string().trim().min(1).max(500).optional(),
+    files: z.array(z.string().trim().min(1).max(500)).max(25).default([]).optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentProfileToolsSchema = z
+  .object({
+    allowed: StringListSchema.optional(),
+    mcpServers: StringListSchema.optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentProfilePermissionsSchema = z
+  .object({
+    level: z.enum(['intern', 'specialist', 'lead']).optional(),
+    required: StringListSchema.optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentProfilePolicyBundleSchema = z
+  .object({
+    sandboxPresetId: z.string().trim().min(1).max(80).optional(),
+    budget: AgentBudgetPolicySchema.optional(),
+    toolPolicyIds: StringListSchema.optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentProfileWorkflowEntrypointSchema = z
+  .object({
+    id: z.string().trim().min(1).max(100).optional(),
+    entrypoint: z.string().trim().min(1).max(120).optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentProfileHealthCheckSchema = z
+  .object({
+    id: SlugSchema,
+    label: z.string().trim().min(1).max(160),
+    command: z.string().trim().min(1).max(500).optional(),
+    required: z.boolean().optional(),
+  })
+  .strict();
+
+export const AgentProfileHealthSchema = z
+  .object({
+    checks: z.array(AgentProfileHealthCheckSchema).max(20).default([]).optional(),
+    readiness: StringListSchema.optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentProfilePackageMetadataSchema = z
+  .object({
+    source: z.string().trim().min(1).max(500).optional(),
+    importedAt: z.string().datetime().optional(),
+    updatedAt: z.string().datetime().optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentProfilePackageSchema = z
+  .object({
+    id: SlugSchema,
+    schemaVersion: z.literal('agent-profile-package/v1').default('agent-profile-package/v1'),
+    version: z.string().trim().min(1).max(40),
+    displayName: z.string().trim().min(1).max(120),
+    role: z.string().trim().min(1).max(160),
+    description: z.string().trim().max(2000).optional(),
+    enabled: z.boolean().default(true),
+    capabilities: StringListSchema,
+    defaultTaskTypes: StringListSchema,
+    runtime: AgentProfileRuntimeSchema,
+    instructions: AgentProfileInstructionsSchema,
+    tools: AgentProfileToolsSchema,
+    permissions: AgentProfilePermissionsSchema,
+    policy: AgentProfilePolicyBundleSchema,
+    workflow: AgentProfileWorkflowEntrypointSchema,
+    health: AgentProfileHealthSchema,
+    metadata: AgentProfilePackageMetadataSchema,
+  })
+  .strict();
+
+export const AgentProfileImportBodySchema = z
+  .object({
+    content: z.string().min(1).max(200_000),
+    format: AgentProfilePackageFormatSchema,
+    source: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict();
+
+export const AgentProfileValidateBodySchema = AgentProfileImportBodySchema;
+
+export const AgentProfileUpdateBodySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    displayName: z.string().trim().min(1).max(120).optional(),
+    role: z.string().trim().min(1).max(160).optional(),
+    description: z.string().trim().max(2000).optional(),
+    capabilities: StringListSchema.optional(),
+    defaultTaskTypes: StringListSchema.optional(),
+  })
+  .strict();
+
+export const AgentProfileLaunchBodySchema = z
+  .object({
+    profileId: SlugSchema.optional(),
+  })
+  .strict();

--- a/server/src/schemas/agent-schemas.ts
+++ b/server/src/schemas/agent-schemas.ts
@@ -8,6 +8,7 @@ const AgentTypeSchema = z.string().min(1).max(50);
  */
 export const StartAgentBodySchema = z.object({
   agent: AgentTypeSchema.optional(),
+  profileId: AgentTypeSchema.optional(),
   overrideReason: z.string().trim().min(8).max(1000).optional(),
   sandboxPresetId: z.string().trim().min(1).max(80).optional(),
   budget: AgentBudgetPolicySchema.optional(),

--- a/server/src/services/agent-profile-package-service.ts
+++ b/server/src/services/agent-profile-package-service.ts
@@ -1,0 +1,257 @@
+import yaml from 'yaml';
+import type {
+  AgentProfileExportResult,
+  AgentProfileLaunchMetadata,
+  AgentProfilePackage,
+  AgentProfilePackageFormat,
+  AgentProfilePackageSummary,
+  AgentProfileResolvedLaunch,
+  AgentProfileValidationResult,
+} from '@veritas-kanban/shared';
+import { getConfigService, type ConfigService } from './config-service.js';
+import { AgentProfilePackageSchema } from '../schemas/agent-profile-package-schemas.js';
+
+interface ImportProfileInput {
+  content: string;
+  format?: AgentProfilePackageFormat;
+  source?: string;
+}
+
+interface UpdateProfileInput {
+  enabled?: boolean;
+  displayName?: string;
+  role?: string;
+  description?: string;
+  capabilities?: string[];
+  defaultTaskTypes?: string[];
+}
+
+export class AgentProfilePackageService {
+  constructor(private readonly configService: ConfigService = getConfigService()) {}
+
+  async listProfiles(): Promise<AgentProfilePackageSummary[]> {
+    const config = await this.configService.getConfig();
+    return (config.agentProfiles ?? []).map((profile) => this.toSummary(profile));
+  }
+
+  async getProfile(id: string): Promise<AgentProfilePackage | null> {
+    const config = await this.configService.getConfig();
+    return (config.agentProfiles ?? []).find((profile) => profile.id === id) ?? null;
+  }
+
+  validateContent(input: ImportProfileInput): AgentProfileValidationResult {
+    try {
+      return this.validateUnknown(this.parseContent(input.content, input.format));
+    } catch (error) {
+      return {
+        valid: false,
+        issues: [{ path: '$', message: error instanceof Error ? error.message : String(error) }],
+      };
+    }
+  }
+
+  async importProfile(
+    input: ImportProfileInput
+  ): Promise<{ profile: AgentProfilePackage; created: boolean }> {
+    const validation = this.validateContent(input);
+    if (!validation.valid || !validation.profile) {
+      const firstIssue = validation.issues[0];
+      throw new Error(
+        firstIssue ? `${firstIssue.path}: ${firstIssue.message}` : 'Invalid profile package'
+      );
+    }
+
+    const now = new Date().toISOString();
+    const profile: AgentProfilePackage = {
+      ...validation.profile,
+      metadata: {
+        ...validation.profile.metadata,
+        source: input.source ?? validation.profile.metadata?.source,
+        importedAt: validation.profile.metadata?.importedAt ?? now,
+        updatedAt: now,
+      },
+    };
+
+    const config = await this.configService.getConfig();
+    const profiles = config.agentProfiles ?? [];
+    const index = profiles.findIndex((candidate) => candidate.id === profile.id);
+    const created = index === -1;
+    config.agentProfiles = created
+      ? [...profiles, profile]
+      : profiles.map((candidate) => (candidate.id === profile.id ? profile : candidate));
+    await this.configService.saveConfig(config);
+
+    return { profile, created };
+  }
+
+  async updateProfile(id: string, patch: UpdateProfileInput): Promise<AgentProfilePackage> {
+    const config = await this.configService.getConfig();
+    const profiles = config.agentProfiles ?? [];
+    const existing = profiles.find((profile) => profile.id === id);
+    if (!existing) {
+      throw new Error(`Agent profile package not found: ${id}`);
+    }
+
+    const next = AgentProfilePackageSchema.parse({
+      ...existing,
+      ...patch,
+      metadata: {
+        ...existing.metadata,
+        updatedAt: new Date().toISOString(),
+      },
+    }) as AgentProfilePackage;
+
+    config.agentProfiles = profiles.map((profile) => (profile.id === id ? next : profile));
+    await this.configService.saveConfig(config);
+    return next;
+  }
+
+  async deleteProfile(id: string): Promise<void> {
+    const config = await this.configService.getConfig();
+    const profiles = config.agentProfiles ?? [];
+    const next = profiles.filter((profile) => profile.id !== id);
+    if (next.length === profiles.length) {
+      throw new Error(`Agent profile package not found: ${id}`);
+    }
+    config.agentProfiles = next;
+    await this.configService.saveConfig(config);
+  }
+
+  async exportProfile(
+    id: string,
+    format: AgentProfilePackageFormat
+  ): Promise<AgentProfileExportResult> {
+    const profile = await this.getProfile(id);
+    if (!profile) {
+      throw new Error(`Agent profile package not found: ${id}`);
+    }
+    const content =
+      format === 'json' ? `${JSON.stringify(profile, null, 2)}\n` : yaml.stringify(profile);
+    return { id, format, content };
+  }
+
+  async resolveLaunch(profileId: string): Promise<AgentProfileResolvedLaunch> {
+    const config = await this.configService.getConfig();
+    const profile = (config.agentProfiles ?? []).find((candidate) => candidate.id === profileId);
+    if (!profile) {
+      throw new Error(`Agent profile package not found: ${profileId}`);
+    }
+    if (!profile.enabled) {
+      throw new Error(`Agent profile package is disabled: ${profileId}`);
+    }
+
+    const agentConfig = config.agents.find((agent) => agent.type === profile.runtime.agent);
+    const metadata: AgentProfileLaunchMetadata = {
+      id: profile.id,
+      displayName: profile.displayName,
+      version: profile.version,
+      role: profile.role,
+      capabilities: profile.capabilities,
+      defaultTaskTypes: profile.defaultTaskTypes,
+      agent: profile.runtime.agent,
+      provider: profile.runtime.provider ?? agentConfig?.provider,
+      model: profile.runtime.model ?? agentConfig?.model,
+      sandboxPresetId: profile.policy?.sandboxPresetId ?? agentConfig?.sandboxPresetId,
+      workflowId: profile.workflow?.id,
+    };
+
+    return {
+      profile,
+      agentConfig,
+      agent: profile.runtime.agent,
+      model: profile.runtime.model,
+      sandboxPresetId: profile.policy?.sandboxPresetId ?? agentConfig?.sandboxPresetId,
+      budget: profile.policy?.budget ?? agentConfig?.budget,
+      instructions: this.buildInstructions(profile),
+      metadata,
+    };
+  }
+
+  private validateUnknown(value: unknown): AgentProfileValidationResult {
+    const parsed = AgentProfilePackageSchema.safeParse(value);
+    if (!parsed.success) {
+      return {
+        valid: false,
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.length ? `$.${issue.path.join('.')}` : '$',
+          message: issue.message,
+        })),
+      };
+    }
+
+    return {
+      valid: true,
+      profile: parsed.data as AgentProfilePackage,
+      issues: [],
+    };
+  }
+
+  private parseContent(content: string, format?: AgentProfilePackageFormat): unknown {
+    if (format === 'json') return JSON.parse(content);
+    if (format === 'yaml') return yaml.parse(content);
+
+    try {
+      return JSON.parse(content);
+    } catch {
+      return yaml.parse(content);
+    }
+  }
+
+  private buildInstructions(profile: AgentProfilePackage): string | undefined {
+    const lines: string[] = [];
+    lines.push(`## Agent Profile Package`);
+    lines.push('');
+    lines.push(`- Profile: ${profile.displayName} (${profile.id}@${profile.version})`);
+    lines.push(`- Role: ${profile.role}`);
+    if (profile.capabilities.length) {
+      lines.push(`- Capabilities: ${profile.capabilities.join(', ')}`);
+    }
+    if (profile.defaultTaskTypes.length) {
+      lines.push(`- Default task types: ${profile.defaultTaskTypes.join(', ')}`);
+    }
+    if (profile.tools?.allowed?.length) {
+      lines.push(`- Allowed tools: ${profile.tools.allowed.join(', ')}`);
+    }
+    if (profile.permissions?.level) {
+      lines.push(`- Permission level: ${profile.permissions.level}`);
+    }
+    if (profile.instructions?.promptFile) {
+      lines.push(`- Prompt file: ${profile.instructions.promptFile}`);
+    }
+    if (profile.instructions?.files?.length) {
+      lines.push(`- Instruction files: ${profile.instructions.files.join(', ')}`);
+    }
+    if (profile.instructions?.prompt) {
+      lines.push('');
+      lines.push(profile.instructions.prompt);
+    }
+
+    return lines.length > 2 ? lines.join('\n') : undefined;
+  }
+
+  private toSummary(profile: AgentProfilePackage): AgentProfilePackageSummary {
+    return {
+      id: profile.id,
+      version: profile.version,
+      displayName: profile.displayName,
+      role: profile.role,
+      description: profile.description,
+      enabled: profile.enabled,
+      capabilities: profile.capabilities,
+      defaultTaskTypes: profile.defaultTaskTypes,
+      runtime: profile.runtime,
+      policy: profile.policy,
+      workflow: profile.workflow,
+      metadata: profile.metadata,
+    };
+  }
+}
+
+let agentProfilePackageService: AgentProfilePackageService | null = null;
+
+export function getAgentProfilePackageService(): AgentProfilePackageService {
+  if (!agentProfilePackageService) {
+    agentProfilePackageService = new AgentProfilePackageService();
+  }
+  return agentProfilePackageService;
+}

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -49,10 +49,12 @@ import type {
   AgentBudgetState,
   AgentBudgetUsage,
   AgentBudgetDecision,
+  AgentProfileLaunchMetadata,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError } from '../middleware/error-handler.js';
 import type { AgentBudgetThresholdEvent } from '@veritas-kanban/shared';
+import { getAgentProfilePackageService } from './agent-profile-package-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const PROJECT_ROOT = path.resolve(process.cwd(), '..');
@@ -119,6 +121,7 @@ export interface AgentOutput {
 }
 
 export interface AgentStartOptions {
+  profileId?: string;
   overrideReason?: string;
   sandboxPresetId?: string;
   budget?: AgentBudgetPolicy;
@@ -145,6 +148,7 @@ interface PendingAgent {
   model?: string;
   budget?: AgentBudgetState;
   budgetStopped?: boolean;
+  agentProfile?: AgentProfileLaunchMetadata;
   threadId?: string;
   abortController?: AbortController;
   process?: ChildProcessWithoutNullStreams;
@@ -203,14 +207,21 @@ export class ClawdbotAgentService {
 
     // Get agent config — use routing engine when agent is "auto" or not specified
     const config = await this.configService.getConfig();
+    const profileLaunch = options.profileId
+      ? await getAgentProfilePackageService().resolveLaunch(options.profileId)
+      : undefined;
     let agent: AgentType;
-    let routingReason: string | undefined;
 
-    if (!agentType || agentType === 'auto') {
+    if (profileLaunch) {
+      agent = profileLaunch.agent;
+      log.info(
+        `[ClawdbotAgent] Profile ${profileLaunch.profile.id}@${profileLaunch.profile.version} selected ${agent} for task ${taskId}`
+      );
+    } else if (!agentType || agentType === 'auto') {
       const routing = getAgentRoutingService();
       const result = await routing.resolveAgent(task);
       agent = result.agent;
-      routingReason = result.reason;
+      const routingReason = result.reason;
       log.info(
         `[ClawdbotAgent] Routing resolved agent for task ${taskId}: ${agent} (${routingReason})`
       );
@@ -218,16 +229,24 @@ export class ClawdbotAgentService {
       agent = agentType;
     }
 
-    const agentConfig = this.resolveAgentConfig(config.agents, agent);
-    await this.assertAgentAvailable(agent, agentConfig);
-    const provider = this.resolveAgentProvider(agentConfig, agent);
+    const agentConfig = profileLaunch?.agentConfig ?? this.resolveAgentConfig(config.agents, agent);
+    const profileAgentConfig =
+      profileLaunch && agentConfig
+        ? {
+            ...agentConfig,
+            provider: profileLaunch.profile.runtime.provider ?? agentConfig.provider,
+            model: profileLaunch.model ?? agentConfig.model,
+          }
+        : agentConfig;
+    await this.assertAgentAvailable(agent, profileAgentConfig);
+    const provider = this.resolveAgentProvider(profileAgentConfig, agent);
     const budgetService = getAgentBudgetService();
     const budgetPolicy = budgetService.resolve({
       workspaceBudget: config.features?.budget?.enabled
         ? config.features.budget.defaultRunBudget
         : undefined,
-      agentBudget: agentConfig?.budget,
-      runBudget: options.budget,
+      agentBudget: profileAgentConfig?.budget,
+      runBudget: options.budget ?? profileLaunch?.budget,
     });
     const budgetEvaluation = budgetService.evaluate(
       budgetPolicy,
@@ -252,11 +271,14 @@ export class ClawdbotAgentService {
       });
     }
     const launchAgentConfig =
-      budgetEvaluation.modelOverride && agentConfig
-        ? { ...agentConfig, model: budgetEvaluation.modelOverride }
-        : agentConfig;
+      budgetEvaluation.modelOverride && profileAgentConfig
+        ? { ...profileAgentConfig, model: budgetEvaluation.modelOverride }
+        : profileAgentConfig;
     const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
-      presetId: options.sandboxPresetId ?? launchAgentConfig?.sandboxPresetId,
+      presetId:
+        options.sandboxPresetId ??
+        profileLaunch?.sandboxPresetId ??
+        launchAgentConfig?.sandboxPresetId,
       provider,
       workspacePath: task.git.worktreePath,
     });
@@ -323,6 +345,7 @@ export class ClawdbotAgentService {
       emitter,
       provider,
       model: launchAgentConfig?.model,
+      agentProfile: profileLaunch?.metadata,
       budget: budgetPolicy
         ? {
             ...budgetService.initialState(budgetPolicy),
@@ -342,7 +365,12 @@ export class ClawdbotAgentService {
 
     // Build the task prompt for Clawdbot
     const worktreePath = this.expandPath(task.git.worktreePath);
-    const taskPrompt = this.buildTaskPrompt(task, worktreePath, attemptId);
+    const taskPrompt = this.buildTaskPrompt(
+      task,
+      worktreePath,
+      attemptId,
+      profileLaunch?.instructions
+    );
 
     // Initialize log file (ensure it stays within logs dir)
     ensureWithinBase(this.logsDir, logPath);
@@ -357,12 +385,32 @@ export class ClawdbotAgentService {
       provider,
       model: launchAgentConfig?.model,
       budget: pendingAgents.get(taskId)?.budget,
+      agentProfile: profileLaunch?.metadata,
     };
 
     await this.taskService.updateTask(taskId, {
       status: 'in-progress',
       attempt,
     });
+
+    if (profileLaunch) {
+      await activityService.logActivity(
+        'agent_event',
+        taskId,
+        task.title,
+        {
+          event: 'profile_launch',
+          profile: profileLaunch.metadata,
+          effectivePolicy: {
+            sandboxPresetId: options.sandboxPresetId ?? profileLaunch.sandboxPresetId,
+            budgetEnabled: pendingAgents.get(taskId)?.budget?.enabled ?? false,
+            model: launchAgentConfig?.model,
+            provider,
+          },
+        },
+        agent
+      );
+    }
 
     const telemetry = getTelemetryService();
     await telemetry.emit<RunStartedEvent>({
@@ -501,6 +549,7 @@ export class ClawdbotAgentService {
         model: pending.model,
         threadId: pending.threadId,
         budget: pending.budget,
+        agentProfile: pending.agentProfile,
       },
     });
 
@@ -1815,7 +1864,12 @@ export class ClawdbotAgentService {
       .map((f) => f.replace(`${taskId}_`, '').replace('.md', ''));
   }
 
-  private buildTaskPrompt(task: Task, worktreePath: string, attemptId: string): string {
+  private buildTaskPrompt(
+    task: Task,
+    worktreePath: string,
+    attemptId: string,
+    profileInstructions?: string
+  ): string {
     // Build checkpoint context if available
     let checkpointSection = '';
     if (task.checkpoint) {
@@ -1848,6 +1902,8 @@ ${checkpointSection}
 ## Task: ${task.title}
 
 ${task.description || 'No description provided.'}
+
+${profileInstructions ? `${profileInstructions}\n` : ''}
 
 ## Instructions
 

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -106,6 +106,7 @@ const DEFAULT_CONFIG: AppConfig = {
     },
   ],
   defaultAgent: 'codex',
+  agentProfiles: [],
 };
 
 export function createDefaultConfig(): AppConfig {
@@ -119,6 +120,7 @@ export function normalizeAppConfig(config: AppConfig): AppConfig {
   const normalized = cloneJson(config);
   normalized.features = deepMergeDefaults(normalized.features || {}, DEFAULT_FEATURE_SETTINGS);
   normalized.agents = mergeDefaultAgents(normalized.agents || []);
+  normalized.agentProfiles = normalized.agentProfiles || [];
   return normalized;
 }
 

--- a/shared/src/types/agent-profile-package.types.ts
+++ b/shared/src/types/agent-profile-package.types.ts
@@ -1,0 +1,136 @@
+import type { AgentBudgetPolicy } from './agent-budget.types.js';
+import type { AgentProvider, AgentConfig } from './config.types.js';
+import type { AgentType, TaskType } from './task.types.js';
+
+export type AgentProfilePackageFormat = 'json' | 'yaml';
+
+export type AgentProfilePermissionLevel = 'intern' | 'specialist' | 'lead';
+
+export interface AgentProfileRuntime {
+  agent: AgentType;
+  provider?: AgentProvider;
+  model?: string;
+  fallbackAgent?: AgentType;
+}
+
+export interface AgentProfileInstructions {
+  prompt?: string;
+  promptFile?: string;
+  files?: string[];
+}
+
+export interface AgentProfileTools {
+  allowed?: string[];
+  mcpServers?: string[];
+}
+
+export interface AgentProfilePermissions {
+  level?: AgentProfilePermissionLevel;
+  required?: string[];
+}
+
+export interface AgentProfilePolicyBundle {
+  sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
+  toolPolicyIds?: string[];
+}
+
+export interface AgentProfileWorkflowEntrypoint {
+  id?: string;
+  entrypoint?: string;
+}
+
+export interface AgentProfileHealthCheck {
+  id: string;
+  label: string;
+  command?: string;
+  required?: boolean;
+}
+
+export interface AgentProfileHealth {
+  checks?: AgentProfileHealthCheck[];
+  readiness?: string[];
+}
+
+export interface AgentProfilePackageMetadata {
+  source?: string;
+  importedAt?: string;
+  updatedAt?: string;
+}
+
+export interface AgentProfilePackage {
+  id: string;
+  schemaVersion: 'agent-profile-package/v1';
+  version: string;
+  displayName: string;
+  role: string;
+  description?: string;
+  enabled: boolean;
+  capabilities: string[];
+  defaultTaskTypes: TaskType[];
+  runtime: AgentProfileRuntime;
+  instructions?: AgentProfileInstructions;
+  tools?: AgentProfileTools;
+  permissions?: AgentProfilePermissions;
+  policy?: AgentProfilePolicyBundle;
+  workflow?: AgentProfileWorkflowEntrypoint;
+  health?: AgentProfileHealth;
+  metadata?: AgentProfilePackageMetadata;
+}
+
+export interface AgentProfilePackageSummary {
+  id: string;
+  version: string;
+  displayName: string;
+  role: string;
+  description?: string;
+  enabled: boolean;
+  capabilities: string[];
+  defaultTaskTypes: TaskType[];
+  runtime: AgentProfileRuntime;
+  policy?: AgentProfilePolicyBundle;
+  workflow?: AgentProfileWorkflowEntrypoint;
+  metadata?: AgentProfilePackageMetadata;
+}
+
+export interface AgentProfileValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface AgentProfileValidationResult {
+  valid: boolean;
+  profile?: AgentProfilePackage;
+  issues: AgentProfileValidationIssue[];
+}
+
+export interface AgentProfileExportResult {
+  id: string;
+  format: AgentProfilePackageFormat;
+  content: string;
+}
+
+export interface AgentProfileLaunchMetadata {
+  id: string;
+  displayName: string;
+  version: string;
+  role: string;
+  capabilities: string[];
+  defaultTaskTypes: TaskType[];
+  agent: AgentType;
+  provider?: AgentProvider;
+  model?: string;
+  sandboxPresetId?: string;
+  workflowId?: string;
+}
+
+export interface AgentProfileResolvedLaunch {
+  profile: AgentProfilePackage;
+  agentConfig?: AgentConfig;
+  agent: AgentType;
+  model?: string;
+  sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
+  instructions?: string;
+  metadata: AgentProfileLaunchMetadata;
+}

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -5,6 +5,7 @@ import type { TelemetryConfig } from './telemetry.types.js';
 import type { WatcherContinuationSettings } from './watcher-policy.types.js';
 import type { SandboxPolicyPreset } from './sandbox-policy.types.js';
 import type { AgentBudgetPolicy } from './agent-budget.types.js';
+import type { AgentProfilePackage } from './agent-profile-package.types.js';
 
 export interface DevServerConfig {
   command: string; // e.g., "pnpm dev" or "npm run dev"
@@ -166,6 +167,7 @@ export interface AppConfig {
   coolify?: CoolifyConfig;
   sandboxPolicyPresets?: SandboxPolicyPreset[];
   defaultSandboxPresetId?: string;
+  agentProfiles?: AgentProfilePackage[];
 }
 
 // ============ Feature Settings Types ============

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -31,6 +31,7 @@ export * from './skill-capability.types.js';
 export * from './skill-security.types.js';
 export * from './sandbox-policy.types.js';
 export * from './agent-budget.types.js';
+export * from './agent-profile-package.types.js';
 export * from './watcher-policy.types.js';
 export * from './evidence.types.js';
 export * from './time-breakdown.types.js';

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -59,6 +59,7 @@ export interface TaskAttempt {
   cloudTarget?: string;
   orchestration?: import('./workflow.js').WorkflowPipelineSummary;
   budget?: import('./agent-budget.types.js').AgentBudgetState;
+  agentProfile?: import('./agent-profile-package.types.js').AgentProfileLaunchMetadata;
 }
 
 export interface Subtask {

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -156,6 +156,11 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     write: 'settings:write',
     overrides: [
       { methods: ['POST'], path: /^\/repos\/validate\/?$/, permissions: 'settings:read' },
+      {
+        methods: ['POST'],
+        path: /^\/agent-profiles\/validate\/?$/,
+        permissions: 'settings:read',
+      },
     ],
   },
   { prefix: '/api/changes', read: 'task:read' },

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { AgentsTab } from '@/components/settings/tabs/AgentsTab';
 import { renderWithProviders } from './test-utils';
 import type { AgentConfig, AgentRoutingConfig, AgentType } from '@veritas-kanban/shared';
@@ -51,6 +51,12 @@ const mocks = vi.hoisted(() => ({
   refetchHostHealth: vi.fn(),
   updateAgents: vi.fn(),
   updateRouting: vi.fn(),
+  updateProfile: vi.fn(),
+  importProfile: vi.fn(),
+  validateProfile: vi.fn(),
+  exportProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+  startAgent: vi.fn(),
 }));
 
 vi.mock('@/hooks/useConfig', () => ({
@@ -172,6 +178,53 @@ vi.mock('@/hooks/useConfig', () => ({
   useUpdateAgents: () => ({
     mutate: mocks.updateAgents,
   }),
+  useAgentProfiles: () => ({
+    data: [
+      {
+        id: 'qa-reviewer',
+        version: '1.0.0',
+        displayName: 'QA Reviewer',
+        role: 'Reviews QA evidence',
+        enabled: true,
+        capabilities: ['qa'],
+        defaultTaskTypes: ['review'],
+        runtime: { agent: 'codex', provider: 'codex-cli', model: 'gpt-5' },
+        policy: { sandboxPresetId: 'codex-repo-contained' },
+      },
+    ],
+    isLoading: false,
+  }),
+  useValidateAgentProfile: () => ({
+    mutateAsync: mocks.validateProfile.mockResolvedValue({
+      valid: true,
+      profile: { id: 'qa-reviewer', displayName: 'QA Reviewer' },
+      issues: [],
+    }),
+    isPending: false,
+  }),
+  useImportAgentProfile: () => ({
+    mutateAsync: mocks.importProfile.mockResolvedValue({
+      created: true,
+      profile: { id: 'qa-reviewer', displayName: 'QA Reviewer', version: '1.0.0' },
+    }),
+    isPending: false,
+  }),
+  useUpdateAgentProfile: () => ({
+    mutate: mocks.updateProfile,
+    isPending: false,
+  }),
+  useDeleteAgentProfile: () => ({
+    mutate: mocks.deleteProfile,
+    isPending: false,
+  }),
+  useExportAgentProfile: () => ({
+    mutateAsync: mocks.exportProfile.mockResolvedValue({
+      id: 'qa-reviewer',
+      format: 'yaml',
+      content: 'id: qa-reviewer\n',
+    }),
+    isPending: false,
+  }),
 }));
 
 vi.mock('@/hooks/useFeatureSettings', () => ({
@@ -275,6 +328,10 @@ vi.mock('@/hooks/useAgent', () => ({
     },
     isFetching: false,
   }),
+  useStartAgent: () => ({
+    mutate: mocks.startAgent,
+    isPending: false,
+  }),
 }));
 
 vi.mock('@/hooks/useSandboxPolicies', () => ({
@@ -371,10 +428,12 @@ describe('Agents settings Mantine migration', () => {
 
     expect(screen.getByText('Installed Agents')).toBeDefined();
     expect(screen.getAllByText('Codex CLI').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('gpt-5')).toBeDefined();
+    expect(screen.getAllByText('gpt-5').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Codex Health')).toBeDefined();
     expect(screen.getByText('Context Provider Health')).toBeDefined();
     expect(screen.getByText('Agent Host Health')).toBeDefined();
+    expect(screen.getByText('Agent Profile Packages')).toBeDefined();
+    expect(screen.getByText('QA Reviewer')).toBeDefined();
     expect(screen.getByText('Launch Compatibility')).toBeDefined();
     expect(screen.getAllByText('Local Supervisor').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('OpenClaw').length).toBeGreaterThanOrEqual(1);
@@ -486,5 +545,27 @@ describe('Agents settings Mantine migration', () => {
         ],
       })
     );
+  });
+
+  it('imports profile packages and launches a profile from a task id', async () => {
+    renderWithProviders(<AgentsTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => {
+      expect(mocks.importProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ format: 'yaml', source: 'settings' })
+      );
+    });
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Launch Task' }), {
+      target: { value: 'task_123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Launch' }));
+
+    expect(mocks.startAgent).toHaveBeenCalledWith({
+      taskId: 'task_123',
+      profileId: 'qa-reviewer',
+    });
   });
 });

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -11,10 +11,21 @@ import {
   Textarea,
   TextInput,
 } from '@mantine/core';
-import { useCodexHealth, useConfig, useProviderHealth, useUpdateAgents } from '@/hooks/useConfig';
+import {
+  useAgentProfiles,
+  useCodexHealth,
+  useConfig,
+  useDeleteAgentProfile,
+  useExportAgentProfile,
+  useImportAgentProfile,
+  useProviderHealth,
+  useUpdateAgentProfile,
+  useUpdateAgents,
+  useValidateAgentProfile,
+} from '@/hooks/useConfig';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { useRoutingConfig, useUpdateRoutingConfig } from '@/hooks/useRouting';
-import { useAgentHostPreview, useAgentHosts } from '@/hooks/useAgent';
+import { useAgentHostPreview, useAgentHosts, useStartAgent } from '@/hooks/useAgent';
 import {
   useCreateSandboxPolicy,
   useDeleteSandboxPolicy,
@@ -37,6 +48,9 @@ import {
   ShieldAlert,
   ShieldCheck,
   Server,
+  Upload,
+  Download,
+  Rocket,
 } from 'lucide-react';
 import type {
   AgentConfig,
@@ -50,6 +64,8 @@ import type {
   RoutingRule,
   AgentRoutingConfig,
   AgentBudgetLimits,
+  AgentProfilePackageFormat,
+  AgentProfilePackageSummary,
   SandboxPolicyDryRunResult,
   SandboxPolicyPreset,
 } from '@veritas-kanban/shared';
@@ -93,6 +109,7 @@ export function AgentsTab() {
     isFetching: isProviderHealthFetching,
     refetch: refetchProviderHealth,
   } = useProviderHealth();
+  const { data: agentProfiles = [], isLoading: isAgentProfilesLoading } = useAgentProfiles();
   const { data: sandboxPresets = [], isLoading: isSandboxPoliciesLoading } = useSandboxPolicies();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
@@ -201,6 +218,12 @@ export function AgentsTab() {
           </div>
         )}
       </div>
+
+      <AgentProfilePackagesSection
+        profiles={agentProfiles}
+        agents={config?.agents || []}
+        isLoading={isAgentProfilesLoading}
+      />
 
       <CodexHealthPanel
         health={codexHealth}
@@ -331,6 +354,348 @@ function cleanBudgetLimits(limits: AgentBudgetLimits): AgentBudgetLimits {
     }
   }
   return clean;
+}
+
+function splitCsv(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+const SAMPLE_PROFILE_PACKAGE = `id: docs-reviewer
+schemaVersion: agent-profile-package/v1
+version: 1.0.0
+displayName: Documentation Reviewer
+role: Reviews documentation changes for accuracy and release readiness
+enabled: true
+capabilities:
+  - docs-review
+  - release-notes
+defaultTaskTypes:
+  - docs
+runtime:
+  agent: codex
+  provider: codex-cli
+  model: gpt-5.1
+instructions:
+  prompt: Check docs against shipped behavior and call out stale roadmap language.
+tools:
+  allowed:
+    - shell
+    - git
+permissions:
+  level: specialist
+policy:
+  sandboxPresetId: workspace-write-default
+`;
+
+function AgentProfilePackagesSection({
+  profiles,
+  agents,
+  isLoading,
+}: {
+  profiles: AgentProfilePackageSummary[];
+  agents: AgentConfig[];
+  isLoading: boolean;
+}) {
+  const [format, setFormat] = useState<AgentProfilePackageFormat>('yaml');
+  const [content, setContent] = useState(SAMPLE_PROFILE_PACKAGE);
+  const [validationMessage, setValidationMessage] = useState<string>('');
+  const [exportContent, setExportContent] = useState<string>('');
+  const validateProfile = useValidateAgentProfile();
+  const importProfile = useImportAgentProfile();
+  const exportProfile = useExportAgentProfile();
+
+  const handleValidate = async () => {
+    const result = await validateProfile.mutateAsync({ content, format });
+    setValidationMessage(
+      result.valid
+        ? `Valid: ${result.profile?.displayName ?? result.profile?.id}`
+        : result.issues.map((issue) => `${issue.path}: ${issue.message}`).join('\n')
+    );
+  };
+
+  const handleImport = async () => {
+    const result = await importProfile.mutateAsync({ content, format, source: 'settings' });
+    setValidationMessage(
+      `${result.created ? 'Imported' : 'Updated'}: ${result.profile.displayName} ${result.profile.version}`
+    );
+  };
+
+  const handleExport = async (id: string, selectedFormat: AgentProfilePackageFormat) => {
+    const result = await exportProfile.mutateAsync({ id, format: selectedFormat });
+    setFormat(result.format);
+    setExportContent(result.content);
+  };
+
+  return (
+    <div className="rounded-md border bg-card p-3 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">Agent Profile Packages</h3>
+          <p className="text-xs text-muted-foreground">
+            {profiles.length} package{profiles.length === 1 ? '' : 's'} installed
+          </p>
+        </div>
+        <Badge variant="light" color="gray">
+          YAML / JSON
+        </Badge>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)]">
+        <div className="space-y-2">
+          {isLoading ? (
+            <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+              Loading packages...
+            </div>
+          ) : profiles.length === 0 ? (
+            <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+              No profile packages installed.
+            </div>
+          ) : (
+            profiles.map((profile) => (
+              <AgentProfileCard
+                key={profile.id}
+                profile={profile}
+                agents={agents}
+                onExport={handleExport}
+              />
+            ))
+          )}
+        </div>
+
+        <div className="rounded-md border bg-background/60 p-3 space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <Text size="sm" fw={500}>
+              Import Package
+            </Text>
+            <Select
+              size="xs"
+              className="w-28"
+              value={format}
+              onChange={(value) => setFormat((value as AgentProfilePackageFormat) || 'yaml')}
+              data={[
+                { value: 'yaml', label: 'YAML' },
+                { value: 'json', label: 'JSON' },
+              ]}
+              allowDeselect={false}
+            />
+          </div>
+          <Textarea
+            value={content}
+            onChange={(event) => setContent(event.currentTarget.value)}
+            minRows={12}
+            spellCheck={false}
+          />
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={handleValidate}
+              loading={validateProfile.isPending}
+            >
+              Validate
+            </Button>
+            <Button
+              size="xs"
+              leftSection={<Upload className="h-4 w-4" />}
+              onClick={handleImport}
+              loading={importProfile.isPending}
+            >
+              Import
+            </Button>
+          </div>
+          {validationMessage && (
+            <pre className="max-h-36 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-2 text-xs">
+              {validationMessage}
+            </pre>
+          )}
+          {exportContent && (
+            <Textarea
+              label="Last Export"
+              value={exportContent}
+              onChange={(event) => setExportContent(event.currentTarget.value)}
+              minRows={8}
+              spellCheck={false}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentProfileCard({
+  profile,
+  agents,
+  onExport,
+}: {
+  profile: AgentProfilePackageSummary;
+  agents: AgentConfig[];
+  onExport: (id: string, format: AgentProfilePackageFormat) => void;
+}) {
+  const updateProfile = useUpdateAgentProfile();
+  const deleteProfile = useDeleteAgentProfile();
+  const startAgent = useStartAgent();
+  const [displayName, setDisplayName] = useState(profile.displayName);
+  const [role, setRole] = useState(profile.role);
+  const [description, setDescription] = useState(profile.description ?? '');
+  const [capabilities, setCapabilities] = useState(profile.capabilities.join(', '));
+  const [defaultTaskTypes, setDefaultTaskTypes] = useState(profile.defaultTaskTypes.join(', '));
+  const [launchTaskId, setLaunchTaskId] = useState('');
+  const runtimeAgent = agents.find((agent) => agent.type === profile.runtime.agent);
+
+  useEffect(() => {
+    setDisplayName(profile.displayName);
+    setRole(profile.role);
+    setDescription(profile.description ?? '');
+    setCapabilities(profile.capabilities.join(', '));
+    setDefaultTaskTypes(profile.defaultTaskTypes.join(', '));
+  }, [profile]);
+
+  const saveMetadata = () => {
+    updateProfile.mutate({
+      id: profile.id,
+      patch: {
+        displayName,
+        role,
+        description,
+        capabilities: splitCsv(capabilities),
+        defaultTaskTypes: splitCsv(defaultTaskTypes),
+      },
+    });
+  };
+
+  const launch = () => {
+    if (!launchTaskId.trim()) return;
+    startAgent.mutate({ taskId: launchTaskId.trim(), profileId: profile.id });
+  };
+
+  return (
+    <div className="rounded-md border bg-background/70 p-3 space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Bot className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">{profile.displayName}</span>
+            <Badge size="xs" variant="light" color={profile.enabled ? 'green' : 'gray'}>
+              {profile.enabled ? 'Enabled' : 'Disabled'}
+            </Badge>
+            <Badge size="xs" variant="outline">
+              {profile.id}@{profile.version}
+            </Badge>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">{profile.role}</p>
+        </div>
+        <Switch
+          checked={profile.enabled}
+          onChange={(event) =>
+            updateProfile.mutate({
+              id: profile.id,
+              patch: { enabled: event.currentTarget.checked },
+            })
+          }
+          aria-label={`Toggle ${profile.displayName}`}
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Badge size="xs" variant={runtimeAgent?.enabled ? 'light' : 'outline'} color="gray">
+          {profile.runtime.agent}
+        </Badge>
+        {profile.runtime.provider && (
+          <Badge size="xs" variant="outline" color="gray">
+            {profile.runtime.provider}
+          </Badge>
+        )}
+        {profile.runtime.model && (
+          <Badge size="xs" variant="outline" color="blue">
+            {profile.runtime.model}
+          </Badge>
+        )}
+        {profile.policy?.sandboxPresetId && (
+          <Badge size="xs" variant="light" color="teal">
+            {profile.policy.sandboxPresetId}
+          </Badge>
+        )}
+        {profile.policy?.budget?.enabled && (
+          <Badge size="xs" variant="light" color="orange">
+            Budget
+          </Badge>
+        )}
+      </div>
+
+      <div className="grid gap-2 md:grid-cols-2">
+        <TextInput
+          label="Name"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.currentTarget.value)}
+        />
+        <TextInput label="Role" value={role} onChange={(e) => setRole(e.currentTarget.value)} />
+        <TextInput
+          label="Capabilities"
+          value={capabilities}
+          onChange={(e) => setCapabilities(e.currentTarget.value)}
+        />
+        <TextInput
+          label="Task Types"
+          value={defaultTaskTypes}
+          onChange={(e) => setDefaultTaskTypes(e.currentTarget.value)}
+        />
+      </div>
+      <Textarea
+        label="Description"
+        value={description}
+        onChange={(e) => setDescription(e.currentTarget.value)}
+        minRows={2}
+      />
+
+      <div className="flex flex-wrap items-end gap-2">
+        <Button
+          size="xs"
+          variant="outline"
+          onClick={saveMetadata}
+          loading={updateProfile.isPending}
+        >
+          Save Metadata
+        </Button>
+        <Button
+          size="xs"
+          variant="outline"
+          leftSection={<Download className="h-4 w-4" />}
+          onClick={() => onExport(profile.id, 'yaml')}
+        >
+          Export YAML
+        </Button>
+        <Button
+          size="xs"
+          variant="subtle"
+          color="red"
+          onClick={() => deleteProfile.mutate(profile.id)}
+          loading={deleteProfile.isPending}
+        >
+          Remove
+        </Button>
+        <TextInput
+          size="xs"
+          label="Launch Task"
+          value={launchTaskId}
+          onChange={(event) => setLaunchTaskId(event.currentTarget.value)}
+          placeholder="task id"
+        />
+        <Button
+          size="xs"
+          leftSection={<Rocket className="h-4 w-4" />}
+          onClick={launch}
+          loading={startAgent.isPending}
+          disabled={!profile.enabled || !launchTaskId.trim()}
+        >
+          Launch
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 function ProviderHealthPanel({

--- a/web/src/hooks/useAgent.ts
+++ b/web/src/hooks/useAgent.ts
@@ -4,6 +4,7 @@ import { api, AgentOutput } from '@/lib/api';
 import { apiFetch, API_BASE } from '@/lib/api/helpers';
 import { useWebSocket, type WebSocketMessage } from './useWebSocket';
 import type {
+  AgentBudgetPolicy,
   AgentHealthClassificationResponse,
   AgentHostPreviewRequest,
   AgentType,
@@ -12,7 +13,10 @@ import type {
 export interface StartAgentInput {
   taskId: string;
   agent?: AgentType;
+  profileId?: string;
   overrideReason?: string;
+  sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
 }
 
 export interface AgentApprovalRequest {
@@ -47,8 +51,15 @@ export function useStartAgent() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ taskId, agent, overrideReason }: StartAgentInput) =>
-      api.agent.start(taskId, { agent, overrideReason }),
+    mutationFn: ({
+      taskId,
+      agent,
+      profileId,
+      overrideReason,
+      sandboxPresetId,
+      budget,
+    }: StartAgentInput) =>
+      api.agent.start(taskId, { agent, profileId, overrideReason, sandboxPresetId, budget }),
     onSuccess: (_, { taskId }) => {
       queryClient.invalidateQueries({ queryKey: ['agent', 'status', taskId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import type { RepoConfig, AgentConfig, AgentType } from '@veritas-kanban/shared';
+import type { AgentProfilePackage, AgentProfilePackageFormat } from '@veritas-kanban/shared';
 
 export function useConfig() {
   return useQuery({
@@ -99,5 +100,74 @@ export function useSetDefaultAgent() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['config'] });
     },
+  });
+}
+
+export function useAgentProfiles() {
+  return useQuery({
+    queryKey: ['config', 'agent-profiles'],
+    queryFn: api.config.agentProfiles.list,
+  });
+}
+
+export function useValidateAgentProfile() {
+  return useMutation({
+    mutationFn: (input: { content: string; format?: AgentProfilePackageFormat; source?: string }) =>
+      api.config.agentProfiles.validate(input),
+  });
+}
+
+export function useImportAgentProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: { content: string; format?: AgentProfilePackageFormat; source?: string }) =>
+      api.config.agentProfiles.import(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+      queryClient.invalidateQueries({ queryKey: ['config', 'agent-profiles'] });
+    },
+  });
+}
+
+export function useUpdateAgentProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      patch,
+    }: {
+      id: string;
+      patch: Partial<
+        Pick<
+          AgentProfilePackage,
+          'enabled' | 'displayName' | 'role' | 'description' | 'capabilities' | 'defaultTaskTypes'
+        >
+      >;
+    }) => api.config.agentProfiles.update(id, patch),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+      queryClient.invalidateQueries({ queryKey: ['config', 'agent-profiles'] });
+    },
+  });
+}
+
+export function useDeleteAgentProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => api.config.agentProfiles.remove(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+      queryClient.invalidateQueries({ queryKey: ['config', 'agent-profiles'] });
+    },
+  });
+}
+
+export function useExportAgentProfile() {
+  return useMutation({
+    mutationFn: ({ id, format }: { id: string; format?: AgentProfilePackageFormat }) =>
+      api.config.agentProfiles.export(id, format),
   });
 }

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -14,6 +14,7 @@ import { API_BASE, handleResponse } from './helpers';
 
 export interface StartAgentRequest {
   agent?: AgentType;
+  profileId?: string;
   overrideReason?: string;
   sandboxPresetId?: string;
   budget?: AgentBudgetPolicy;

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -7,6 +7,11 @@ import type {
   AgentConfig,
   AgentType,
   FeatureSettings,
+  AgentProfileExportResult,
+  AgentProfilePackage,
+  AgentProfilePackageFormat,
+  AgentProfilePackageSummary,
+  AgentProfileValidationResult,
 } from '@veritas-kanban/shared';
 import { API_BASE, handleResponse } from './helpers';
 
@@ -196,6 +201,77 @@ export const configApi = {
         body: JSON.stringify({ agent }),
       });
       return handleResponse<AppConfig>(response);
+    },
+  },
+
+  agentProfiles: {
+    list: async (): Promise<AgentProfilePackageSummary[]> => {
+      const response = await fetch(`${API_BASE}/config/agent-profiles`);
+      return handleResponse<AgentProfilePackageSummary[]>(response);
+    },
+
+    validate: async (input: {
+      content: string;
+      format?: AgentProfilePackageFormat;
+      source?: string;
+    }): Promise<AgentProfileValidationResult> => {
+      const response = await fetch(`${API_BASE}/config/agent-profiles/validate`, {
+        credentials: 'include',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      return handleResponse<AgentProfileValidationResult>(response);
+    },
+
+    import: async (input: {
+      content: string;
+      format?: AgentProfilePackageFormat;
+      source?: string;
+    }): Promise<{ profile: AgentProfilePackage; created: boolean }> => {
+      const response = await fetch(`${API_BASE}/config/agent-profiles/import`, {
+        credentials: 'include',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      return handleResponse<{ profile: AgentProfilePackage; created: boolean }>(response);
+    },
+
+    export: async (
+      id: string,
+      format: AgentProfilePackageFormat = 'yaml'
+    ): Promise<AgentProfileExportResult> => {
+      const response = await fetch(
+        `${API_BASE}/config/agent-profiles/${encodeURIComponent(id)}/export?format=${format}`
+      );
+      return handleResponse<AgentProfileExportResult>(response);
+    },
+
+    update: async (
+      id: string,
+      patch: Partial<
+        Pick<
+          AgentProfilePackage,
+          'enabled' | 'displayName' | 'role' | 'description' | 'capabilities' | 'defaultTaskTypes'
+        >
+      >
+    ): Promise<AgentProfilePackage> => {
+      const response = await fetch(`${API_BASE}/config/agent-profiles/${encodeURIComponent(id)}`, {
+        credentials: 'include',
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      return handleResponse<AgentProfilePackage>(response);
+    },
+
+    remove: async (id: string): Promise<void> => {
+      const response = await fetch(`${API_BASE}/config/agent-profiles/${encodeURIComponent(id)}`, {
+        credentials: 'include',
+        method: 'DELETE',
+      });
+      return handleResponse<void>(response);
     },
   },
 };


### PR DESCRIPTION
## Summary
- Add reusable YAML/JSON agent profile packages with schema validation, import/export, list, enable/disable, and metadata updates.
- Wire profile launches through `/api/agents/:taskId/start` so runs inherit runtime, model, prompt instructions, sandbox, and budget posture.
- Surface profile package management in Settings and add CLI `vk profiles` commands.
- Document profile package usage in README, provider docs, API reference, and feature docs.

## Verification
- `VERITAS_DISABLE_WATCHERS=1 pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/agent-profile-package-service.test.ts src/__tests__/routes/config-coverage.test.ts --maxWorkers=1`
- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/settings-agents-mantine.test.tsx --maxWorkers=1`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/cli typecheck`
- `pnpm --filter @veritas-kanban/server lint`
- `pnpm --filter @veritas-kanban/web lint`
- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm --filter @veritas-kanban/web build`
- `pnpm --filter @veritas-kanban/cli build`
- `git diff --check`

## Notes
- Server and web lint pass with the repository's existing warning backlog.

Closes #720
