### PR TITLE
Add decision review sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, MCP setup, and default routing for fresh installs
 - **Local LLM provider profiles** — Optional Ollama Local, Ollama Cloud, and LM Studio Local profiles with health metadata and routing support
 - **Agent profile packages** — Portable YAML/JSON packages that bundle role, runtime, prompt, tools, permissions, sandbox, budget, workflow, and health metadata for reusable launches
+- **Decision review sessions** — Multi-participant decision reviews with independent responses, critique rounds, final synthesis packets, work-product attachment, and decision audit links
 - **Sandbox policy presets** — Built-in and custom presets for filesystem scope, network egress, environment passthrough, and credential brokering, with Settings dry-runs before agent launch
 - **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run caps for tokens, cost, tool calls, runtime, retries, and fan-out with auditable warn, approval, downgrade, pause, or cancel decisions
 - **Optional OpenClaw support** — Native integration with [OpenClaw](https://github.com/openclaw/openclaw) when you want OpenClaw to execute or wake agents

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2644,7 +2644,7 @@ Log agent decisions with assumptions and record outcomes.
 GET /api/decisions
 ```
 
-Query params: `agent`, `taskId`, `minConfidence` (0–1), `maxConfidence` (0–1), `since`, `until`, `limit`, `offset`.
+Query params: `agent`, `taskId`, `minConfidence` (0–100), `maxConfidence` (0–100), `minRisk` (0–100), `maxRisk` (0–100), `startTime`, `endTime`.
 
 **Response:** Array of decision objects.
 
@@ -2707,6 +2707,35 @@ Update a specific assumption by its zero-based index.
 ```
 
 **Response:** Updated decision object with the assumption patched.
+
+#### Decision Review Sessions
+
+Task-launched review sessions capture independent participant responses, ordered critique rounds, and a final packet linked to a versioned work product plus a decision audit record.
+
+| Method | Path                                   | Description                                           |
+| ------ | -------------------------------------- | ----------------------------------------------------- |
+| `GET`  | `/api/decisions/reviews?taskId=<id>`   | List decision review sessions                         |
+| `POST` | `/api/decisions/reviews`               | Start a review session with at least two participants |
+| `GET`  | `/api/decisions/reviews/:id`           | Get a review session                                  |
+| `POST` | `/api/decisions/reviews/:id/responses` | Record an independent initial response                |
+| `POST` | `/api/decisions/reviews/:id/critiques` | Record a participant critique round                   |
+| `POST` | `/api/decisions/reviews/:id/finalize`  | Create the final packet, work product, and decision   |
+| `POST` | `/api/decisions/reviews/:id/cancel`    | Cancel a review session                               |
+| `GET`  | `/api/decisions/reviews/:id/export`    | Export the session packet as Markdown                 |
+
+```json
+{
+  "taskId": "task_20260618_abc",
+  "title": "Release readiness approach",
+  "prompt": "Should we cut v5.1 after the remaining PRs merge?",
+  "context": "Open issues require docs, packaging, and tap validation.",
+  "rounds": 1,
+  "participants": [
+    { "id": "architect", "label": "Architect", "model": "gpt-5" },
+    { "id": "qa-reviewer", "label": "QA Reviewer", "profileId": "qa-reviewer" }
+  ]
+}
+```
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2000,7 +2000,8 @@ Log structured decision records for every significant agent choice. Each decisio
 
 **Key capabilities:**
 
-- Structured records: decision text, confidence (0–1), evidence array, assumptions array
+- Structured records: decision text, confidence (0–100), risk score (0–100), evidence context, assumptions array
+- Multi-model decision review sessions: task-launched sessions capture independent participant responses, critique rounds, final synthesis packets, versioned work products, and linked decision records
 - Outcome recording: what happened, whether assumptions held, a retrospective rating
 - Full-text search and filtering by agent, task, confidence range, and date range
 - Queryable from MCP for agent self-review
@@ -2008,12 +2009,16 @@ Log structured decision records for every significant agent choice. Each decisio
 
 **API endpoints:**
 
-| Method  | Path                                  | Description                                            |
-| ------- | ------------------------------------- | ------------------------------------------------------ |
-| `GET`   | `/api/decisions`                      | List decisions (filterable by agent, task, confidence) |
-| `POST`  | `/api/decisions`                      | Log a new decision                                     |
-| `GET`   | `/api/decisions/:id`                  | Get a single decision                                  |
-| `PATCH` | `/api/decisions/:id/assumptions/:idx` | Update an assumption by index                          |
+| Method  | Path                                   | Description                                            |
+| ------- | -------------------------------------- | ------------------------------------------------------ |
+| `GET`   | `/api/decisions`                       | List decisions (filterable by agent, task, confidence) |
+| `POST`  | `/api/decisions`                       | Log a new decision                                     |
+| `GET`   | `/api/decisions/:id`                   | Get a single decision                                  |
+| `PATCH` | `/api/decisions/:id/assumptions/:idx`  | Update an assumption by index                          |
+| `POST`  | `/api/decisions/reviews`               | Start a decision review session                        |
+| `POST`  | `/api/decisions/reviews/:id/responses` | Record an independent participant response             |
+| `POST`  | `/api/decisions/reviews/:id/critiques` | Record a critique-round response                       |
+| `POST`  | `/api/decisions/reviews/:id/finalize`  | Create the final packet, work product, and decision    |
 
 **Related:** `server/src/routes/decisions.ts` · `shared/src/types/decision.types.ts` · `docs/SOP-decision-audit-trail.md`
 

--- a/server/src/__tests__/decision-review-service.test.ts
+++ b/server/src/__tests__/decision-review-service.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { DecisionReviewService } from '../services/decision-review-service.js';
+import type { DecisionService } from '../services/decision-service.js';
+import type { WorkProductService } from '../services/work-product-service.js';
+
+describe('DecisionReviewService', () => {
+  let tmpDir: string;
+  let service: DecisionReviewService;
+  const decisionService = {
+    create: vi.fn(),
+  };
+  const workProductService = {
+    create: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'decision-review-service-'));
+    decisionService.create.mockResolvedValue({ id: 'decision_review_audit' });
+    workProductService.create.mockResolvedValue({ id: 'wp_decision_review' });
+    service = new DecisionReviewService({
+      filePath: path.join(tmpDir, 'decision-review-sessions.json'),
+      decisionService: decisionService as unknown as DecisionService,
+      workProductService: workProductService as unknown as WorkProductService,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function createSession() {
+    return service.create({
+      taskId: 'task-724',
+      title: 'Choose release approach',
+      prompt: 'Should we cut 5.1 after the remaining PRs?',
+      context: 'Open issues require docs and packaging work.',
+      rounds: 1,
+      participants: [
+        { id: 'architect', label: 'Architect', agentId: 'codex', model: 'gpt-5' },
+        { id: 'reviewer', label: 'Reviewer', profileId: 'qa-reviewer' },
+      ],
+    });
+  }
+
+  it('creates and lists review sessions newest first', async () => {
+    const session = await createSession();
+
+    expect(session.status).toBe('collecting');
+    expect(session.participants).toHaveLength(2);
+    expect(await service.list({ taskId: 'task-724' })).toHaveLength(1);
+    expect(await service.get(session.id)).toMatchObject({ id: session.id });
+  });
+
+  it('requires every initial response before critique rounds start', async () => {
+    const session = await createSession();
+
+    await service.recordInitialResponse(session.id, {
+      participantId: 'architect',
+      response: 'Ship only after packaging proof.',
+    });
+
+    await expect(
+      service.recordCritique(session.id, {
+        participantId: 'architect',
+        round: 1,
+        response: 'The reviewer has not responded yet.',
+      })
+    ).rejects.toThrow(/All initial responses/);
+
+    const ready = await service.recordInitialResponse(session.id, {
+      participantId: 'reviewer',
+      response: 'Require a release checklist and artifact evidence.',
+    });
+    expect(ready.status).toBe('critiquing');
+  });
+
+  it('finalizes with a work product and linked decision record after all critiques', async () => {
+    const session = await createSession();
+
+    await service.recordInitialResponse(session.id, {
+      participantId: 'architect',
+      response: 'Use a single release branch after issue PRs merge.',
+    });
+    await service.recordInitialResponse(session.id, {
+      participantId: 'reviewer',
+      response: 'Hold until docs and tap validation are complete.',
+    });
+    await service.recordCritique(session.id, {
+      participantId: 'architect',
+      round: 1,
+      response: 'Reviewer is right to require tap validation.',
+      critiquesParticipantIds: ['reviewer'],
+    });
+    await service.recordCritique(session.id, {
+      participantId: 'reviewer',
+      round: 1,
+      response: 'Architect should spell out release rollback.',
+      critiquesParticipantIds: ['architect'],
+    });
+
+    const finalized = await service.finalize(session.id, {
+      recommendation: 'Cut 5.1 only after all issue PRs merge and artifacts validate.',
+      assumptions: ['CI remains green'],
+      risks: ['Packaging metadata can drift'],
+      validationPlan: ['Run release validation'],
+      followUpTasks: ['Update Homebrew tap if checksum changes'],
+      confidenceLevel: 82,
+      riskScore: 44,
+    });
+
+    expect(finalized.status).toBe('synthesized');
+    expect(finalized.finalPacket?.workProductId).toBe('wp_decision_review');
+    expect(finalized.finalPacket?.decisionId).toBe('decision_review_audit');
+    expect(workProductService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'report',
+        taskId: 'task-724',
+        metadata: expect.objectContaining({ packetType: 'decision_review' }),
+      })
+    );
+    expect(decisionService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputAction: 'Cut 5.1 only after all issue PRs merge and artifacts validate.',
+        confidenceLevel: 82,
+        riskScore: 44,
+      })
+    );
+    expect(service.exportMarkdown(finalized)).toContain(
+      '# Decision Review: Choose release approach'
+    );
+  });
+});

--- a/server/src/__tests__/routes/decisions.test.ts
+++ b/server/src/__tests__/routes/decisions.test.ts
@@ -11,8 +11,23 @@ const mockDecisionService = vi.hoisted(() => ({
   updateAssumption: vi.fn(),
 }));
 
+const mockDecisionReviewService = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(),
+  get: vi.fn(),
+  recordInitialResponse: vi.fn(),
+  recordCritique: vi.fn(),
+  finalize: vi.fn(),
+  cancel: vi.fn(),
+  exportMarkdown: vi.fn(),
+}));
+
 vi.mock('../../services/decision-service.js', () => ({
   getDecisionService: () => mockDecisionService,
+}));
+
+vi.mock('../../services/decision-review-service.js', () => ({
+  getDecisionReviewService: () => mockDecisionReviewService,
 }));
 
 import { decisionRoutes } from '../../routes/decisions.js';
@@ -22,6 +37,7 @@ describe('Decision Routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDecisionReviewService.exportMarkdown.mockReturnValue('# Decision Review');
     app = express();
     app.use(express.json());
     app.use('/api/decisions', decisionRoutes);
@@ -120,5 +136,89 @@ describe('Decision Routes', () => {
     });
 
     expect(response.status).toBe(400);
+  });
+
+  it('POST /api/decisions/reviews creates a decision review session', async () => {
+    mockDecisionReviewService.create.mockResolvedValue({
+      id: 'decision_review_1',
+      taskId: 'task_123',
+      status: 'collecting',
+    });
+
+    const response = await request(app)
+      .post('/api/decisions/reviews')
+      .send({
+        taskId: 'task_123',
+        title: 'Review launch approach',
+        prompt: 'Which launch path should we choose?',
+        context: 'Two options are available.',
+        participants: [
+          { id: 'architect', label: 'Architect' },
+          { id: 'reviewer', label: 'Reviewer' },
+        ],
+      });
+
+    expect(response.status).toBe(201);
+    expect(mockDecisionReviewService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task_123',
+        participants: expect.arrayContaining([
+          expect.objectContaining({ id: 'architect' }),
+          expect.objectContaining({ id: 'reviewer' }),
+        ]),
+      })
+    );
+  });
+
+  it('records responses, critiques, and finalizes review sessions before decision id routes', async () => {
+    mockDecisionReviewService.recordInitialResponse.mockResolvedValue({ id: 'decision_review_1' });
+    mockDecisionReviewService.recordCritique.mockResolvedValue({ id: 'decision_review_1' });
+    mockDecisionReviewService.finalize.mockResolvedValue({
+      id: 'decision_review_1',
+      status: 'synthesized',
+      finalPacket: { decisionId: 'decision_1', workProductId: 'wp_1' },
+    });
+
+    const response = await request(app)
+      .post('/api/decisions/reviews/decision_review_1/responses')
+      .send({ participantId: 'architect', response: 'Use staged rollout.' });
+    const critique = await request(app)
+      .post('/api/decisions/reviews/decision_review_1/critiques')
+      .send({ participantId: 'reviewer', round: 1, response: 'Call out rollback risk.' });
+    const finalize = await request(app)
+      .post('/api/decisions/reviews/decision_review_1/finalize')
+      .send({
+        recommendation: 'Use staged rollout.',
+        assumptions: ['Traffic is moderate'],
+        risks: ['Rollback gap'],
+        validationPlan: ['Run smoke tests'],
+        followUpTasks: ['Write rollout issue'],
+      });
+
+    expect(response.status).toBe(200);
+    expect(critique.status).toBe(200);
+    expect(finalize.status).toBe(200);
+    expect(mockDecisionReviewService.recordInitialResponse).toHaveBeenCalledWith(
+      'decision_review_1',
+      expect.objectContaining({ participantId: 'architect' })
+    );
+    expect(mockDecisionReviewService.recordCritique).toHaveBeenCalledWith(
+      'decision_review_1',
+      expect.objectContaining({ round: 1 })
+    );
+    expect(mockDecisionReviewService.finalize).toHaveBeenCalledWith(
+      'decision_review_1',
+      expect.objectContaining({ recommendation: 'Use staged rollout.' })
+    );
+  });
+
+  it('GET /api/decisions/reviews/:id/export returns markdown', async () => {
+    mockDecisionReviewService.get.mockResolvedValue({ id: 'decision_review_1' });
+
+    const response = await request(app).get('/api/decisions/reviews/decision_review_1/export');
+
+    expect(response.status).toBe(200);
+    expect(response.header['content-type']).toContain('text/markdown');
+    expect(response.text).toBe('# Decision Review');
   });
 });

--- a/server/src/routes/decisions.ts
+++ b/server/src/routes/decisions.ts
@@ -3,21 +3,147 @@ import { asyncHandler } from '../middleware/async-handler.js';
 import { validate, type ValidatedRequest } from '../middleware/validate.js';
 import { NotFoundError } from '../middleware/error-handler.js';
 import { getDecisionService } from '../services/decision-service.js';
+import { getDecisionReviewService } from '../services/decision-review-service.js';
 import {
   assumptionParamsSchema,
   createDecisionSchema,
+  createDecisionReviewSessionSchema,
   decisionIdParamsSchema,
   decisionListQuerySchema,
+  decisionReviewListQuerySchema,
+  decisionReviewSessionParamsSchema,
+  finalizeDecisionReviewSessionSchema,
+  recordDecisionReviewCritiqueSchema,
+  recordDecisionReviewTurnSchema,
   updateAssumptionSchema,
   type AssumptionParams,
   type CreateDecisionSchema,
+  type CreateDecisionReviewSessionSchema,
   type DecisionIdParams,
   type DecisionListQuerySchema,
+  type DecisionReviewListQuerySchema,
+  type DecisionReviewSessionParams,
+  type FinalizeDecisionReviewSessionSchema,
+  type RecordDecisionReviewCritiqueSchema,
+  type RecordDecisionReviewTurnSchema,
   type UpdateAssumptionSchema,
 } from '../schemas/decision-schemas.js';
 
 const router: IRouter = Router();
 const decisionService = getDecisionService();
+const decisionReviewService = getDecisionReviewService();
+
+router.get(
+  '/reviews',
+  validate({ query: decisionReviewListQuerySchema }),
+  asyncHandler(async (req: ValidatedRequest<unknown, DecisionReviewListQuerySchema>, res) => {
+    const query = req.validated.query as DecisionReviewListQuerySchema | undefined;
+    res.json(await decisionReviewService.list(query));
+  })
+);
+
+router.post(
+  '/reviews',
+  validate({ body: createDecisionReviewSessionSchema }),
+  asyncHandler(
+    async (req: ValidatedRequest<unknown, unknown, CreateDecisionReviewSessionSchema>, res) => {
+      const body = req.validated.body as CreateDecisionReviewSessionSchema;
+      const session = await decisionReviewService.create(body);
+      res.status(201).json(session);
+    }
+  )
+);
+
+router.get(
+  '/reviews/:sessionId',
+  validate({ params: decisionReviewSessionParamsSchema }),
+  asyncHandler(async (req: ValidatedRequest<DecisionReviewSessionParams>, res) => {
+    const params = req.validated.params as DecisionReviewSessionParams;
+    const session = await decisionReviewService.get(params.sessionId);
+    if (!session) {
+      throw new NotFoundError('Decision review session not found');
+    }
+    res.json(session);
+  })
+);
+
+router.get(
+  '/reviews/:sessionId/export',
+  validate({ params: decisionReviewSessionParamsSchema }),
+  asyncHandler(async (req: ValidatedRequest<DecisionReviewSessionParams>, res) => {
+    const params = req.validated.params as DecisionReviewSessionParams;
+    const session = await decisionReviewService.get(params.sessionId);
+    if (!session) {
+      throw new NotFoundError('Decision review session not found');
+    }
+    res.type('text/markdown').send(decisionReviewService.exportMarkdown(session));
+  })
+);
+
+router.post(
+  '/reviews/:sessionId/responses',
+  validate({ params: decisionReviewSessionParamsSchema, body: recordDecisionReviewTurnSchema }),
+  asyncHandler(
+    async (
+      req: ValidatedRequest<DecisionReviewSessionParams, unknown, RecordDecisionReviewTurnSchema>,
+      res
+    ) => {
+      const params = req.validated.params as DecisionReviewSessionParams;
+      const body = req.validated.body as RecordDecisionReviewTurnSchema;
+      res.json(await decisionReviewService.recordInitialResponse(params.sessionId, body));
+    }
+  )
+);
+
+router.post(
+  '/reviews/:sessionId/critiques',
+  validate({ params: decisionReviewSessionParamsSchema, body: recordDecisionReviewCritiqueSchema }),
+  asyncHandler(
+    async (
+      req: ValidatedRequest<
+        DecisionReviewSessionParams,
+        unknown,
+        RecordDecisionReviewCritiqueSchema
+      >,
+      res
+    ) => {
+      const params = req.validated.params as DecisionReviewSessionParams;
+      const body = req.validated.body as RecordDecisionReviewCritiqueSchema;
+      res.json(await decisionReviewService.recordCritique(params.sessionId, body));
+    }
+  )
+);
+
+router.post(
+  '/reviews/:sessionId/finalize',
+  validate({
+    params: decisionReviewSessionParamsSchema,
+    body: finalizeDecisionReviewSessionSchema,
+  }),
+  asyncHandler(
+    async (
+      req: ValidatedRequest<
+        DecisionReviewSessionParams,
+        unknown,
+        FinalizeDecisionReviewSessionSchema
+      >,
+      res
+    ) => {
+      const params = req.validated.params as DecisionReviewSessionParams;
+      const body = req.validated.body as FinalizeDecisionReviewSessionSchema;
+      res.json(await decisionReviewService.finalize(params.sessionId, body));
+    }
+  )
+);
+
+router.post(
+  '/reviews/:sessionId/cancel',
+  validate({ params: decisionReviewSessionParamsSchema }),
+  asyncHandler(async (req: ValidatedRequest<DecisionReviewSessionParams>, res) => {
+    const params = req.validated.params as DecisionReviewSessionParams;
+    res.json(await decisionReviewService.cancel(params.sessionId));
+  })
+);
 
 router.post(
   '/',

--- a/server/src/schemas/decision-schemas.ts
+++ b/server/src/schemas/decision-schemas.ts
@@ -55,8 +55,86 @@ export const updateAssumptionSchema = z.object({
   note: z.string().trim().min(1).max(500).optional(),
 });
 
+const DecisionReviewSessionIdSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid decision review session id format');
+
+const StringListSchema = z.array(z.string().trim().min(1).max(5000)).max(100).default([]);
+
+export const decisionReviewParticipantSchema = z.object({
+  id: z.string().trim().min(1).max(120),
+  label: z.string().trim().min(1).max(200),
+  agentId: z.string().trim().min(1).max(120).optional(),
+  profileId: z.string().trim().min(1).max(120).optional(),
+  provider: z.string().trim().min(1).max(120).optional(),
+  model: z.string().trim().min(1).max(120).optional(),
+  role: z.string().trim().min(1).max(200).optional(),
+});
+
+export const createDecisionReviewSessionSchema = z.object({
+  taskId: nonEmptyString,
+  title: z.string().trim().min(1).max(240),
+  prompt: z.string().trim().min(1).max(100_000),
+  context: z.string().trim().min(1).max(250_000),
+  sourceType: z
+    .enum(['task', 'work-product', 'workflow-gate', 'adr', 'command-center'])
+    .default('task'),
+  sourceId: z.string().trim().min(1).max(200).optional(),
+  templateId: z.string().trim().min(1).max(120).optional(),
+  contextLimit: z.number().int().min(1_000).max(500_000).optional(),
+  rounds: z.number().int().min(1).max(5).default(1),
+  participants: z.array(decisionReviewParticipantSchema).min(2).max(12),
+});
+
+export const decisionReviewListQuerySchema = z.object({
+  taskId: z.string().min(1).max(200).optional(),
+  status: z.enum(['collecting', 'critiquing', 'synthesized', 'canceled']).optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+});
+
+export const decisionReviewSessionParamsSchema = z.object({
+  sessionId: DecisionReviewSessionIdSchema,
+});
+
+export const recordDecisionReviewTurnSchema = z.object({
+  participantId: z.string().trim().min(1).max(120),
+  prompt: z.string().trim().min(1).max(100_000).optional(),
+  response: z.string().trim().min(1).max(250_000),
+  provider: z.string().trim().min(1).max(120).optional(),
+  model: z.string().trim().min(1).max(120).optional(),
+  agentId: z.string().trim().min(1).max(120).optional(),
+  profileId: z.string().trim().min(1).max(120).optional(),
+});
+
+export const recordDecisionReviewCritiqueSchema = recordDecisionReviewTurnSchema.extend({
+  round: z.number().int().min(1).max(5),
+  critiquesParticipantIds: z.array(z.string().trim().min(1).max(120)).max(12).optional(),
+});
+
+export const finalizeDecisionReviewSessionSchema = z.object({
+  recommendation: z.string().trim().min(1).max(100_000),
+  dissentingViews: StringListSchema,
+  assumptions: StringListSchema,
+  risks: StringListSchema,
+  validationPlan: StringListSchema,
+  followUpTasks: StringListSchema,
+  confidenceLevel: z.number().int().min(0).max(100).default(70),
+  riskScore: z.number().int().min(0).max(100).default(50),
+  summary: z.string().trim().min(1).max(100_000).optional(),
+  attachWorkProduct: z.boolean().default(true),
+});
+
 export type CreateDecisionSchema = z.infer<typeof createDecisionSchema>;
 export type DecisionListQuerySchema = z.infer<typeof decisionListQuerySchema>;
 export type DecisionIdParams = z.infer<typeof decisionIdParamsSchema>;
 export type AssumptionParams = z.infer<typeof assumptionParamsSchema>;
 export type UpdateAssumptionSchema = z.infer<typeof updateAssumptionSchema>;
+export type CreateDecisionReviewSessionSchema = z.infer<typeof createDecisionReviewSessionSchema>;
+export type DecisionReviewListQuerySchema = z.infer<typeof decisionReviewListQuerySchema>;
+export type DecisionReviewSessionParams = z.infer<typeof decisionReviewSessionParamsSchema>;
+export type RecordDecisionReviewTurnSchema = z.infer<typeof recordDecisionReviewTurnSchema>;
+export type RecordDecisionReviewCritiqueSchema = z.infer<typeof recordDecisionReviewCritiqueSchema>;
+export type FinalizeDecisionReviewSessionSchema = z.infer<
+  typeof finalizeDecisionReviewSessionSchema
+>;

--- a/server/src/services/decision-review-service.ts
+++ b/server/src/services/decision-review-service.ts
@@ -1,0 +1,501 @@
+import path from 'node:path';
+import { nanoid } from 'nanoid';
+import type {
+  CreateDecisionReviewSessionInput,
+  DecisionReviewFinalPacket,
+  DecisionReviewListFilters,
+  DecisionReviewParticipant,
+  DecisionReviewSession,
+  DecisionReviewTurn,
+  FinalizeDecisionReviewSessionInput,
+  RecordDecisionReviewCritiqueInput,
+  RecordDecisionReviewTurnInput,
+  WorkProductRender,
+} from '@veritas-kanban/shared';
+import { BadRequestError, NotFoundError } from '../middleware/error-handler.js';
+import { fileExists, mkdir, readFile, writeFile } from '../storage/fs-helpers.js';
+import { getDataDir } from '../utils/paths.js';
+import { DecisionService, getDecisionService } from './decision-service.js';
+import { WorkProductService, getWorkProductService } from './work-product-service.js';
+
+interface DecisionReviewFileState {
+  sessions: DecisionReviewSession[];
+}
+
+export interface DecisionReviewServiceOptions {
+  filePath?: string;
+  decisionService?: DecisionService;
+  workProductService?: WorkProductService;
+}
+
+export class DecisionReviewService {
+  private readonly filePath: string;
+  private loaded = false;
+  private state: DecisionReviewFileState = { sessions: [] };
+
+  constructor(private readonly options: DecisionReviewServiceOptions = {}) {
+    this.filePath =
+      options.filePath ?? path.join(getDataDir(), 'storage', 'decision-review-sessions.json');
+  }
+
+  async create(input: CreateDecisionReviewSessionInput): Promise<DecisionReviewSession> {
+    const now = new Date().toISOString();
+    const participants = this.normalizeParticipants(input.participants);
+    const session: DecisionReviewSession = {
+      id: `decision_review_${Date.now()}_${nanoid(6)}`,
+      taskId: input.taskId,
+      title: input.title,
+      prompt: input.prompt,
+      context: input.context,
+      sourceType: input.sourceType ?? 'task',
+      sourceId: input.sourceId,
+      templateId: input.templateId,
+      contextLimit: input.contextLimit,
+      rounds: input.rounds ?? 1,
+      participants,
+      status: 'collecting',
+      initialResponses: [],
+      critiqueRounds: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.ensureLoaded();
+    this.state.sessions.push(session);
+    await this.saveState();
+    return session;
+  }
+
+  async list(filters: DecisionReviewListFilters = {}): Promise<DecisionReviewSession[]> {
+    await this.ensureLoaded();
+    const limit = Math.min(Math.max(filters.limit ?? 100, 1), 200);
+    return this.state.sessions
+      .filter((session) => {
+        if (filters.taskId && session.taskId !== filters.taskId) return false;
+        if (filters.status && session.status !== filters.status) return false;
+        return true;
+      })
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.id.localeCompare(b.id))
+      .slice(0, limit);
+  }
+
+  async get(id: string): Promise<DecisionReviewSession | null> {
+    await this.ensureLoaded();
+    return this.state.sessions.find((session) => session.id === id) ?? null;
+  }
+
+  async recordInitialResponse(
+    sessionId: string,
+    input: RecordDecisionReviewTurnInput
+  ): Promise<DecisionReviewSession> {
+    const session = await this.requireMutableSession(sessionId);
+    if (session.initialResponses.some((turn) => turn.participantId === input.participantId)) {
+      throw new BadRequestError(`Initial response already recorded for ${input.participantId}`);
+    }
+
+    const participant = this.requireParticipant(session, input.participantId);
+    session.initialResponses.push(
+      this.createTurn(session, participant, 'initial', 0, input, undefined)
+    );
+    session.status =
+      session.initialResponses.length === session.participants.length ? 'critiquing' : 'collecting';
+    session.updatedAt = new Date().toISOString();
+    await this.saveState();
+    return session;
+  }
+
+  async recordCritique(
+    sessionId: string,
+    input: RecordDecisionReviewCritiqueInput
+  ): Promise<DecisionReviewSession> {
+    const session = await this.requireMutableSession(sessionId);
+    if (session.initialResponses.length < session.participants.length) {
+      throw new BadRequestError('All initial responses must be recorded before critique rounds');
+    }
+    if (input.round > session.rounds) {
+      throw new BadRequestError(`Round ${input.round} exceeds configured rounds ${session.rounds}`);
+    }
+    const participant = this.requireParticipant(session, input.participantId);
+    const critiquesParticipantIds = input.critiquesParticipantIds?.length
+      ? input.critiquesParticipantIds
+      : session.participants
+          .map((candidate) => candidate.id)
+          .filter((participantId) => participantId !== input.participantId);
+    for (const participantId of critiquesParticipantIds) {
+      this.requireParticipant(session, participantId);
+    }
+    if (
+      session.critiqueRounds.some(
+        (turn) => turn.round === input.round && turn.participantId === input.participantId
+      )
+    ) {
+      throw new BadRequestError(
+        `Critique already recorded for ${input.participantId} in round ${input.round}`
+      );
+    }
+
+    session.critiqueRounds.push(
+      this.createTurn(session, participant, 'critique', input.round, input, critiquesParticipantIds)
+    );
+    session.status = 'critiquing';
+    session.updatedAt = new Date().toISOString();
+    await this.saveState();
+    return session;
+  }
+
+  async finalize(
+    sessionId: string,
+    input: FinalizeDecisionReviewSessionInput
+  ): Promise<DecisionReviewSession> {
+    const session = await this.requireMutableSession(sessionId);
+    this.assertReadyForFinalization(session);
+
+    const now = new Date().toISOString();
+    const finalPacket: DecisionReviewFinalPacket = {
+      recommendation: input.recommendation,
+      dissentingViews: input.dissentingViews ?? [],
+      assumptions: input.assumptions ?? [],
+      risks: input.risks ?? [],
+      validationPlan: input.validationPlan ?? [],
+      followUpTasks: input.followUpTasks ?? [],
+      confidenceLevel: input.confidenceLevel ?? 70,
+      riskScore: input.riskScore ?? 50,
+      summary: input.summary,
+      createdAt: now,
+    };
+
+    if (input.attachWorkProduct !== false) {
+      const workProduct = await this.workProductService().create({
+        kind: 'report',
+        title: `Decision Review: ${session.title}`,
+        render: this.buildFinalWorkProductRender(session, finalPacket),
+        taskId: session.taskId,
+        agent: 'decision-review',
+        redaction: {
+          level: 'standard',
+          containsSensitiveContent: false,
+          sensitiveFields: ['tokens', 'secrets', 'local paths'],
+          exportDefault: 'redacted',
+        },
+        sourceLinks: [
+          {
+            label: 'Task',
+            href: `veritas://task/${encodeURIComponent(session.taskId)}?tab=review`,
+            type: 'task',
+          },
+        ],
+        metadata: {
+          packetType: 'decision_review',
+          decisionReviewSessionId: session.id,
+          sourceType: session.sourceType,
+          sourceId: session.sourceId ?? null,
+          participantCount: session.participants.length,
+          critiqueRounds: session.rounds,
+        },
+        changeSummary: 'Generated decision review packet',
+      });
+      finalPacket.workProductId = workProduct.id;
+    }
+
+    const decision = await this.decisionService().create({
+      inputContext: `${session.prompt}\n\n${session.context}`,
+      outputAction: finalPacket.recommendation,
+      assumptions: finalPacket.assumptions,
+      confidenceLevel: finalPacket.confidenceLevel,
+      riskScore: finalPacket.riskScore,
+      agentId: 'decision-review',
+      taskId: session.taskId,
+      timestamp: now,
+    });
+    finalPacket.decisionId = decision.id;
+
+    session.finalPacket = finalPacket;
+    session.status = 'synthesized';
+    session.updatedAt = now;
+    await this.saveState();
+    return session;
+  }
+
+  async cancel(sessionId: string): Promise<DecisionReviewSession> {
+    const session = await this.requireMutableSession(sessionId);
+    const now = new Date().toISOString();
+    session.status = 'canceled';
+    session.updatedAt = now;
+    session.canceledAt = now;
+    await this.saveState();
+    return session;
+  }
+
+  exportMarkdown(session: DecisionReviewSession): string {
+    const lines = [
+      `# Decision Review: ${session.title}`,
+      '',
+      `Status: ${session.status}`,
+      `Task: ${session.taskId}`,
+      `Source: ${session.sourceType}${session.sourceId ? ` ${session.sourceId}` : ''}`,
+      `Rounds: ${session.rounds}`,
+      '',
+      '## Prompt',
+      '',
+      session.prompt,
+      '',
+      '## Context',
+      '',
+      session.context,
+      '',
+      '## Participants',
+      '',
+      this.markdownList(
+        session.participants.map((participant) => this.participantLine(participant))
+      ),
+      '',
+      '## Initial Responses',
+      '',
+      ...session.initialResponses.flatMap((turn) => this.turnSection(session, turn)),
+      '## Critique Rounds',
+      '',
+      ...session.critiqueRounds.flatMap((turn) => this.turnSection(session, turn)),
+    ];
+
+    if (session.finalPacket) {
+      lines.push(...this.finalPacketSections(session.finalPacket));
+    }
+
+    return `${lines.join('\n')}\n`;
+  }
+
+  private async requireMutableSession(sessionId: string): Promise<DecisionReviewSession> {
+    const session = await this.get(sessionId);
+    if (!session) {
+      throw new NotFoundError('Decision review session not found');
+    }
+    if (session.status === 'synthesized' || session.status === 'canceled') {
+      throw new BadRequestError(`Decision review session is ${session.status}`);
+    }
+    return session;
+  }
+
+  private requireParticipant(
+    session: DecisionReviewSession,
+    participantId: string
+  ): DecisionReviewParticipant {
+    const participant = session.participants.find((candidate) => candidate.id === participantId);
+    if (!participant) {
+      throw new BadRequestError(`Unknown participant: ${participantId}`);
+    }
+    return participant;
+  }
+
+  private createTurn(
+    session: DecisionReviewSession,
+    participant: DecisionReviewParticipant,
+    phase: DecisionReviewTurn['phase'],
+    round: number,
+    input: RecordDecisionReviewTurnInput,
+    critiquesParticipantIds: string[] | undefined
+  ): DecisionReviewTurn {
+    return {
+      id: `${phase}_${Date.now()}_${nanoid(6)}`,
+      participantId: participant.id,
+      phase,
+      round,
+      prompt: input.prompt ?? this.defaultTurnPrompt(session, phase, round),
+      response: input.response,
+      critiquesParticipantIds,
+      agentId: input.agentId ?? participant.agentId,
+      profileId: input.profileId ?? participant.profileId,
+      provider: input.provider ?? participant.provider,
+      model: input.model ?? participant.model,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  private assertReadyForFinalization(session: DecisionReviewSession): void {
+    if (session.initialResponses.length < session.participants.length) {
+      throw new BadRequestError('All initial responses must be recorded before final synthesis');
+    }
+
+    for (let round = 1; round <= session.rounds; round += 1) {
+      const roundParticipants = new Set(
+        session.critiqueRounds
+          .filter((turn) => turn.round === round)
+          .map((turn) => turn.participantId)
+      );
+      for (const participant of session.participants) {
+        if (!roundParticipants.has(participant.id)) {
+          throw new BadRequestError(
+            `Critique round ${round} is missing participant ${participant.id}`
+          );
+        }
+      }
+    }
+  }
+
+  private buildFinalWorkProductRender(
+    session: DecisionReviewSession,
+    packet: DecisionReviewFinalPacket
+  ): WorkProductRender {
+    return {
+      schemaVersion: 1,
+      kind: 'report',
+      summary: packet.summary ?? packet.recommendation,
+      sections: [
+        { heading: 'Recommendation', body: packet.recommendation },
+        { heading: 'Dissenting Views', body: this.optionalList(packet.dissentingViews) },
+        { heading: 'Assumptions', body: this.optionalList(packet.assumptions) },
+        { heading: 'Risks', body: this.optionalList(packet.risks) },
+        { heading: 'Validation Plan', body: this.optionalList(packet.validationPlan) },
+        { heading: 'Follow-up Tasks', body: this.optionalList(packet.followUpTasks) },
+        {
+          heading: 'Participants',
+          body: this.markdownList(
+            session.participants.map((participant) => this.participantLine(participant))
+          ),
+        },
+        {
+          heading: 'Initial Responses',
+          body: session.initialResponses
+            .map((turn) => this.turnMarkdown(session, turn))
+            .join('\n\n'),
+        },
+        {
+          heading: 'Critique Rounds',
+          body: session.critiqueRounds.map((turn) => this.turnMarkdown(session, turn)).join('\n\n'),
+        },
+      ],
+    };
+  }
+
+  private normalizeParticipants(
+    participants: DecisionReviewParticipant[]
+  ): DecisionReviewParticipant[] {
+    const seen = new Set<string>();
+    return participants.map((participant) => {
+      if (seen.has(participant.id)) {
+        throw new BadRequestError(`Duplicate participant id: ${participant.id}`);
+      }
+      seen.add(participant.id);
+      return participant;
+    });
+  }
+
+  private defaultTurnPrompt(
+    session: DecisionReviewSession,
+    phase: DecisionReviewTurn['phase'],
+    round: number
+  ): string {
+    if (phase === 'initial') {
+      return `Give an independent recommendation for: ${session.prompt}`;
+    }
+    return `Critique round ${round}: challenge weak assumptions, missing risks, and tradeoffs.`;
+  }
+
+  private participantLine(participant: DecisionReviewParticipant): string {
+    const metadata = [
+      participant.agentId ? `agent ${participant.agentId}` : null,
+      participant.profileId ? `profile ${participant.profileId}` : null,
+      participant.provider ? `provider ${participant.provider}` : null,
+      participant.model ? `model ${participant.model}` : null,
+      participant.role ? `role ${participant.role}` : null,
+    ].filter((value): value is string => Boolean(value));
+    return `${participant.label}${metadata.length > 0 ? ` (${metadata.join(', ')})` : ''}`;
+  }
+
+  private turnSection(session: DecisionReviewSession, turn: DecisionReviewTurn): string[] {
+    return [this.turnMarkdown(session, turn), ''];
+  }
+
+  private turnMarkdown(session: DecisionReviewSession, turn: DecisionReviewTurn): string {
+    const participant =
+      session.participants.find((candidate) => candidate.id === turn.participantId)?.label ??
+      turn.participantId;
+    const target =
+      turn.critiquesParticipantIds && turn.critiquesParticipantIds.length > 0
+        ? ` Critiques: ${turn.critiquesParticipantIds.join(', ')}.`
+        : '';
+    return [
+      `### ${participant} ${turn.phase}${turn.round > 0 ? ` round ${turn.round}` : ''}`,
+      '',
+      `Prompt: ${turn.prompt}${target}`,
+      '',
+      turn.response,
+    ].join('\n');
+  }
+
+  private finalPacketSections(packet: DecisionReviewFinalPacket): string[] {
+    return [
+      '## Final Packet',
+      '',
+      `Confidence: ${packet.confidenceLevel}`,
+      `Risk: ${packet.riskScore}`,
+      packet.workProductId ? `Work product: ${packet.workProductId}` : null,
+      packet.decisionId ? `Decision: ${packet.decisionId}` : null,
+      '',
+      '### Recommendation',
+      '',
+      packet.recommendation,
+      '',
+      '### Dissenting Views',
+      '',
+      this.optionalList(packet.dissentingViews),
+      '',
+      '### Assumptions',
+      '',
+      this.optionalList(packet.assumptions),
+      '',
+      '### Risks',
+      '',
+      this.optionalList(packet.risks),
+      '',
+      '### Validation Plan',
+      '',
+      this.optionalList(packet.validationPlan),
+      '',
+      '### Follow-up Tasks',
+      '',
+      this.optionalList(packet.followUpTasks),
+    ].filter((line): line is string => line !== null);
+  }
+
+  private optionalList(items: string[]): string {
+    return items.length > 0 ? this.markdownList(items) : 'None recorded.';
+  }
+
+  private markdownList(items: string[]): string {
+    return items.map((item) => `- ${item}`).join('\n');
+  }
+
+  private decisionService(): DecisionService {
+    return this.options.decisionService ?? getDecisionService();
+  }
+
+  private workProductService(): WorkProductService {
+    return this.options.workProductService ?? getWorkProductService();
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    if (!(await fileExists(this.filePath))) {
+      this.state = { sessions: [] };
+      this.loaded = true;
+      return;
+    }
+    const raw = await readFile(this.filePath, 'utf8');
+    this.state = JSON.parse(raw) as DecisionReviewFileState;
+    this.loaded = true;
+  }
+
+  private async saveState(): Promise<void> {
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, JSON.stringify(this.state, null, 2), 'utf8');
+  }
+}
+
+let instance: DecisionReviewService | null = null;
+
+export function getDecisionReviewService(): DecisionReviewService {
+  if (!instance) {
+    instance = new DecisionReviewService();
+  }
+  return instance;
+}

--- a/shared/src/types/decision.types.ts
+++ b/shared/src/types/decision.types.ts
@@ -51,3 +51,122 @@ export interface DecisionWithChain {
   decision: DecisionRecord;
   chain: DecisionRecord[];
 }
+
+export type DecisionReviewSourceType =
+  | 'task'
+  | 'work-product'
+  | 'workflow-gate'
+  | 'adr'
+  | 'command-center';
+
+export type DecisionReviewStatus = 'collecting' | 'critiquing' | 'synthesized' | 'canceled';
+
+export type DecisionReviewTurnPhase = 'initial' | 'critique';
+
+export interface DecisionReviewParticipant {
+  id: string;
+  label: string;
+  agentId?: string;
+  profileId?: string;
+  provider?: string;
+  model?: string;
+  role?: string;
+}
+
+export interface DecisionReviewTurn {
+  id: string;
+  participantId: string;
+  phase: DecisionReviewTurnPhase;
+  round: number;
+  prompt: string;
+  response: string;
+  critiquesParticipantIds?: string[];
+  agentId?: string;
+  profileId?: string;
+  provider?: string;
+  model?: string;
+  createdAt: string;
+}
+
+export interface DecisionReviewFinalPacket {
+  recommendation: string;
+  dissentingViews: string[];
+  assumptions: string[];
+  risks: string[];
+  validationPlan: string[];
+  followUpTasks: string[];
+  confidenceLevel: number;
+  riskScore: number;
+  summary?: string;
+  workProductId?: string;
+  decisionId?: string;
+  createdAt?: string;
+}
+
+export interface DecisionReviewSession {
+  id: string;
+  taskId: string;
+  title: string;
+  prompt: string;
+  context: string;
+  sourceType: DecisionReviewSourceType;
+  sourceId?: string;
+  templateId?: string;
+  contextLimit?: number;
+  rounds: number;
+  participants: DecisionReviewParticipant[];
+  status: DecisionReviewStatus;
+  initialResponses: DecisionReviewTurn[];
+  critiqueRounds: DecisionReviewTurn[];
+  finalPacket?: DecisionReviewFinalPacket;
+  createdAt: string;
+  updatedAt: string;
+  canceledAt?: string;
+}
+
+export interface CreateDecisionReviewSessionInput {
+  taskId: string;
+  title: string;
+  prompt: string;
+  context: string;
+  sourceType?: DecisionReviewSourceType;
+  sourceId?: string;
+  templateId?: string;
+  contextLimit?: number;
+  rounds?: number;
+  participants: DecisionReviewParticipant[];
+}
+
+export interface DecisionReviewListFilters {
+  taskId?: string;
+  status?: DecisionReviewStatus;
+  limit?: number;
+}
+
+export interface RecordDecisionReviewTurnInput {
+  participantId: string;
+  prompt?: string;
+  response: string;
+  provider?: string;
+  model?: string;
+  agentId?: string;
+  profileId?: string;
+}
+
+export interface RecordDecisionReviewCritiqueInput extends RecordDecisionReviewTurnInput {
+  round: number;
+  critiquesParticipantIds?: string[];
+}
+
+export interface FinalizeDecisionReviewSessionInput {
+  recommendation: string;
+  dissentingViews?: string[];
+  assumptions?: string[];
+  risks?: string[];
+  validationPlan?: string[];
+  followUpTasks?: string[];
+  confidenceLevel?: number;
+  riskScore?: number;
+  summary?: string;
+  attachWorkProduct?: boolean;
+}

--- a/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-review-preview-mantine.test.tsx
@@ -19,6 +19,13 @@ const mocks = vi.hoisted(() => ({
   resolveConflictMutateAsync: vi.fn(),
   abortConflictMutateAsync: vi.fn(),
   continueConflictMutateAsync: vi.fn(),
+  createDecisionReviewMutateAsync: vi.fn(),
+  recordDecisionReviewResponseMutateAsync: vi.fn(),
+  recordDecisionReviewCritiqueMutateAsync: vi.fn(),
+  finalizeDecisionReviewMutateAsync: vi.fn(),
+  cancelDecisionReviewMutate: vi.fn(),
+  exportDecisionReviewMutateAsync: vi.fn(),
+  useDecisionReviews: vi.fn(),
 }));
 
 vi.mock('@/hooks/useWorktree', () => ({
@@ -59,6 +66,38 @@ vi.mock('@/hooks/useConflicts', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useConfig', () => ({
+  useAgentProfiles: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@/hooks/useDecisionReviews', () => ({
+  useDecisionReviews: mocks.useDecisionReviews,
+  useCreateDecisionReview: () => ({
+    mutateAsync: mocks.createDecisionReviewMutateAsync,
+    isPending: false,
+  }),
+  useRecordDecisionReviewResponse: () => ({
+    mutateAsync: mocks.recordDecisionReviewResponseMutateAsync,
+    isPending: false,
+  }),
+  useRecordDecisionReviewCritique: () => ({
+    mutateAsync: mocks.recordDecisionReviewCritiqueMutateAsync,
+    isPending: false,
+  }),
+  useFinalizeDecisionReview: () => ({
+    mutateAsync: mocks.finalizeDecisionReviewMutateAsync,
+    isPending: false,
+  }),
+  useCancelDecisionReview: () => ({
+    mutate: mocks.cancelDecisionReviewMutate,
+    isPending: false,
+  }),
+  useExportDecisionReview: () => ({
+    mutateAsync: mocks.exportDecisionReviewMutateAsync,
+    isPending: false,
+  }),
+}));
+
 describe('task detail review and preview Mantine migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,6 +109,45 @@ describe('task detail review and preview Mantine migration', () => {
     mocks.resolveConflictMutateAsync.mockResolvedValue({ success: true });
     mocks.abortConflictMutateAsync.mockResolvedValue({ success: true });
     mocks.continueConflictMutateAsync.mockResolvedValue({ success: true });
+    mocks.useDecisionReviews.mockReturnValue({ data: [], isLoading: false });
+    mocks.createDecisionReviewMutateAsync.mockResolvedValue({
+      id: 'decision_review_new',
+      taskId: 'task-review',
+      title: 'Decision Review: Review task',
+      prompt: 'Review task',
+      context: 'Review task',
+      sourceType: 'task',
+      rounds: 1,
+      participants: [
+        { id: 'architect', label: 'Architect' },
+        { id: 'reviewer', label: 'Reviewer' },
+      ],
+      status: 'collecting',
+      initialResponses: [],
+      critiqueRounds: [],
+      createdAt: '2026-06-01T09:00:00Z',
+      updatedAt: '2026-06-01T09:00:00Z',
+    });
+    mocks.recordDecisionReviewResponseMutateAsync.mockResolvedValue({ id: 'decision_review_new' });
+    mocks.recordDecisionReviewCritiqueMutateAsync.mockResolvedValue({ id: 'decision_review_new' });
+    mocks.finalizeDecisionReviewMutateAsync.mockResolvedValue({
+      id: 'decision_review_new',
+      taskId: 'task-review',
+      status: 'synthesized',
+      finalPacket: {
+        recommendation: 'Use staged rollout',
+        dissentingViews: [],
+        assumptions: [],
+        risks: [],
+        validationPlan: [],
+        followUpTasks: [],
+        confidenceLevel: 80,
+        riskScore: 35,
+        workProductId: 'wp_decision_review',
+        decisionId: 'decision_review_audit',
+      },
+    });
+    mocks.exportDecisionReviewMutateAsync.mockResolvedValue('# Decision Review');
     mocks.usePreviewStatus.mockReturnValue({
       data: { status: 'stopped' },
       isLoading: false,
@@ -170,6 +248,140 @@ describe('task detail review and preview Mantine migration', () => {
       onSuccess: expect.any(Function),
     });
     expect(onMergeComplete).toHaveBeenCalled();
+  });
+
+  it('starts and records a task decision review session from the review tab', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-review',
+      title: 'Review task',
+      description: 'Choose the release path',
+      git: {
+        repo: 'veritas',
+        branch: 'feature/review',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-review',
+      },
+    });
+
+    renderWithProviders(<ReviewPanel task={task} onReview={vi.fn()} />);
+
+    expect(await screen.findByText('Decision Review Sessions')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Start Decision Review' }));
+
+    await waitFor(() =>
+      expect(mocks.createDecisionReviewMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'task-review',
+          participants: expect.arrayContaining([
+            expect.objectContaining({ id: 'architect' }),
+            expect.objectContaining({ id: 'reviewer' }),
+          ]),
+        })
+      )
+    );
+  });
+
+  it('finalizes a completed decision review session into a packet', async () => {
+    const user = userEvent.setup();
+    mocks.useDecisionReviews.mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          id: 'decision_review_ready',
+          taskId: 'task-review',
+          title: 'Release approach',
+          prompt: 'Choose release approach',
+          context: 'All issue PRs are queued.',
+          sourceType: 'task',
+          sourceId: 'task-review',
+          rounds: 1,
+          participants: [
+            { id: 'architect', label: 'Architect' },
+            { id: 'reviewer', label: 'Reviewer' },
+          ],
+          status: 'critiquing',
+          initialResponses: [
+            {
+              id: 'turn_1',
+              participantId: 'architect',
+              phase: 'initial',
+              round: 0,
+              prompt: 'p',
+              response: 'Release after CI passes.',
+              createdAt: '2026-06-01T09:00:00Z',
+            },
+            {
+              id: 'turn_2',
+              participantId: 'reviewer',
+              phase: 'initial',
+              round: 0,
+              prompt: 'p',
+              response: 'Require docs and artifacts.',
+              createdAt: '2026-06-01T09:01:00Z',
+            },
+          ],
+          critiqueRounds: [
+            {
+              id: 'turn_3',
+              participantId: 'architect',
+              phase: 'critique',
+              round: 1,
+              prompt: 'p',
+              response: 'Docs are a valid blocker.',
+              createdAt: '2026-06-01T09:02:00Z',
+            },
+            {
+              id: 'turn_4',
+              participantId: 'reviewer',
+              phase: 'critique',
+              round: 1,
+              prompt: 'p',
+              response: 'CI alone is not enough.',
+              createdAt: '2026-06-01T09:03:00Z',
+            },
+          ],
+          createdAt: '2026-06-01T09:00:00Z',
+          updatedAt: '2026-06-01T09:03:00Z',
+        },
+      ],
+    });
+    const task = createMockTask({
+      id: 'task-review',
+      title: 'Review task',
+      description: 'Choose the release path',
+      git: {
+        repo: 'veritas',
+        branch: 'feature/review',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-review',
+      },
+    });
+
+    renderWithProviders(<ReviewPanel task={task} onReview={vi.fn()} />);
+
+    fireEvent.change(await screen.findByLabelText('Recommendation'), {
+      target: { value: 'Use staged release after docs and artifacts pass.' },
+    });
+    fireEvent.change(screen.getByLabelText('Assumptions'), {
+      target: { value: 'CI remains green' },
+    });
+    fireEvent.change(screen.getByLabelText('Risks'), {
+      target: { value: 'Tap metadata can drift' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Finalize Packet' }));
+
+    await waitFor(() =>
+      expect(mocks.finalizeDecisionReviewMutateAsync).toHaveBeenCalledWith({
+        id: 'decision_review_ready',
+        input: expect.objectContaining({
+          recommendation: 'Use staged release after docs and artifacts pass.',
+          assumptions: ['CI remains green'],
+          risks: ['Tap metadata can drift'],
+          attachWorkProduct: true,
+        }),
+      })
+    );
   });
 
   it('renders inline review comments through direct Mantine textarea, button, and action icon', async () => {

--- a/web/src/components/task/DecisionReviewSessionsSection.tsx
+++ b/web/src/components/task/DecisionReviewSessionsSection.tsx
@@ -1,0 +1,619 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  SimpleGrid,
+  Stack,
+  Text,
+  TextInput,
+  Textarea,
+} from '@mantine/core';
+import { BrainCircuit, CheckCircle, FileText, MessageSquare, XCircle } from 'lucide-react';
+import type { DecisionReviewSession, Task } from '@veritas-kanban/shared';
+import { useAgentProfiles } from '@/hooks/useConfig';
+import {
+  useCancelDecisionReview,
+  useCreateDecisionReview,
+  useDecisionReviews,
+  useExportDecisionReview,
+  useFinalizeDecisionReview,
+  useRecordDecisionReviewCritique,
+  useRecordDecisionReviewResponse,
+} from '@/hooks/useDecisionReviews';
+
+interface DecisionReviewSessionsSectionProps {
+  task: Task;
+}
+
+function normalizeParticipantId(value: string, fallback: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || fallback
+  );
+}
+
+function linesToList(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function sessionComplete(session: DecisionReviewSession): boolean {
+  if (session.initialResponses.length < session.participants.length) return false;
+  for (let round = 1; round <= session.rounds; round += 1) {
+    const participants = new Set(
+      session.critiqueRounds
+        .filter((turn) => turn.round === round)
+        .map((turn) => turn.participantId)
+    );
+    if (session.participants.some((participant) => !participants.has(participant.id))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function statusColor(status: DecisionReviewSession['status']): string {
+  if (status === 'synthesized') return 'green';
+  if (status === 'canceled') return 'gray';
+  if (status === 'critiquing') return 'yellow';
+  return 'blue';
+}
+
+export function DecisionReviewSessionsSection({ task }: DecisionReviewSessionsSectionProps) {
+  const { data: sessions = [], isLoading } = useDecisionReviews({ taskId: task.id, limit: 20 });
+  const { data: profiles = [] } = useAgentProfiles();
+  const createSession = useCreateDecisionReview();
+  const recordResponse = useRecordDecisionReviewResponse();
+  const recordCritique = useRecordDecisionReviewCritique();
+  const finalizeSession = useFinalizeDecisionReview();
+  const cancelSession = useCancelDecisionReview();
+  const exportSession = useExportDecisionReview();
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [title, setTitle] = useState(`Decision Review: ${task.title}`);
+  const [prompt, setPrompt] = useState(task.description || task.title);
+  const [context, setContext] = useState(task.description || task.title);
+  const [rounds, setRounds] = useState(1);
+  const [participantsText, setParticipantsText] = useState('');
+  const [responseDrafts, setResponseDrafts] = useState<Record<string, string>>({});
+  const [critiqueDrafts, setCritiqueDrafts] = useState<Record<string, string>>({});
+  const [exportedMarkdown, setExportedMarkdown] = useState('');
+  const [recommendation, setRecommendation] = useState('');
+  const [dissentingViews, setDissentingViews] = useState('');
+  const [assumptions, setAssumptions] = useState('');
+  const [risks, setRisks] = useState('');
+  const [validationPlan, setValidationPlan] = useState('');
+  const [followUpTasks, setFollowUpTasks] = useState('');
+  const [confidenceLevel, setConfidenceLevel] = useState(70);
+  const [riskScore, setRiskScore] = useState(50);
+
+  const profileById = useMemo(
+    () => new Map(profiles.map((profile) => [profile.id, profile])),
+    [profiles]
+  );
+
+  useEffect(() => {
+    if (participantsText.trim()) return;
+    const enabledProfiles = profiles.filter((profile) => profile.enabled).slice(0, 2);
+    if (enabledProfiles.length >= 2) {
+      setParticipantsText(
+        enabledProfiles.map((profile) => `${profile.id}|${profile.displayName}`).join('\n')
+      );
+    } else {
+      setParticipantsText('architect|Architect\nreviewer|Reviewer');
+    }
+  }, [participantsText, profiles]);
+
+  useEffect(() => {
+    if (!selectedId && sessions.length > 0) {
+      setSelectedId(sessions[0].id);
+    }
+  }, [selectedId, sessions]);
+
+  const selectedSession = sessions.find((session) => session.id === selectedId) ?? sessions[0];
+
+  const parsedParticipants = useMemo(
+    () =>
+      linesToList(participantsText).map((line, index) => {
+        const [rawId, rawLabel] = line.split('|').map((part) => part.trim());
+        const id = normalizeParticipantId(rawId, `participant-${index + 1}`);
+        const profile = profileById.get(id);
+        return {
+          id,
+          label: rawLabel || profile?.displayName || id,
+          profileId: profile?.id,
+          agentId: profile?.runtime.agent,
+          provider: profile?.runtime.provider,
+          model: profile?.runtime.model,
+          role: profile?.role,
+        };
+      }),
+    [participantsText, profileById]
+  );
+
+  const createDisabled =
+    parsedParticipants.length < 2 || !title.trim() || !prompt.trim() || !context.trim();
+
+  const handleCreate = async () => {
+    const session = await createSession.mutateAsync({
+      taskId: task.id,
+      title: title.trim(),
+      prompt: prompt.trim(),
+      context: context.trim(),
+      sourceType: 'task',
+      sourceId: task.id,
+      rounds,
+      participants: parsedParticipants,
+    });
+    setSelectedId(session.id);
+    setExportedMarkdown('');
+  };
+
+  const updateResponseDraft = (participantId: string, value: string) => {
+    setResponseDrafts((current) => ({ ...current, [participantId]: value }));
+  };
+
+  const updateCritiqueDraft = (key: string, value: string) => {
+    setCritiqueDrafts((current) => ({ ...current, [key]: value }));
+  };
+
+  const handleFinalize = async (session: DecisionReviewSession) => {
+    const updated = await finalizeSession.mutateAsync({
+      id: session.id,
+      input: {
+        recommendation,
+        dissentingViews: linesToList(dissentingViews),
+        assumptions: linesToList(assumptions),
+        risks: linesToList(risks),
+        validationPlan: linesToList(validationPlan),
+        followUpTasks: linesToList(followUpTasks),
+        confidenceLevel,
+        riskScore,
+        attachWorkProduct: true,
+      },
+    });
+    setSelectedId(updated.id);
+  };
+
+  return (
+    <Paper className="p-3" radius="md" withBorder>
+      <Stack gap="md">
+        <Group justify="space-between" gap="xs">
+          <Group gap="xs">
+            <BrainCircuit className="h-4 w-4" />
+            <Text fw={600}>Decision Review Sessions</Text>
+          </Group>
+          <Badge variant="light" tt="none">
+            {sessions.length}
+          </Badge>
+        </Group>
+
+        <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+          <TextInput
+            label="Title"
+            value={title}
+            onChange={(event) => setTitle(event.currentTarget.value)}
+          />
+          <NumberInput
+            label="Critique rounds"
+            min={1}
+            max={5}
+            value={rounds}
+            onChange={(value) => setRounds(typeof value === 'number' ? value : 1)}
+          />
+        </SimpleGrid>
+        <Textarea
+          label="Decision prompt"
+          minRows={2}
+          value={prompt}
+          onChange={(event) => setPrompt(event.currentTarget.value)}
+        />
+        <Textarea
+          label="Context packet"
+          minRows={3}
+          value={context}
+          onChange={(event) => setContext(event.currentTarget.value)}
+        />
+        <Textarea
+          label="Participants"
+          minRows={2}
+          value={participantsText}
+          onChange={(event) => setParticipantsText(event.currentTarget.value)}
+        />
+        <Button
+          onClick={handleCreate}
+          disabled={createDisabled || createSession.isPending}
+          leftSection={<MessageSquare className="h-4 w-4" />}
+        >
+          Start Decision Review
+        </Button>
+
+        {isLoading ? (
+          <Text size="sm" c="dimmed">
+            Loading decision reviews...
+          </Text>
+        ) : sessions.length > 0 ? (
+          <Select
+            label="Session"
+            value={selectedSession?.id ?? null}
+            onChange={setSelectedId}
+            data={sessions.map((session) => ({
+              value: session.id,
+              label: `${session.title} (${session.status})`,
+            }))}
+            allowDeselect={false}
+          />
+        ) : null}
+
+        {selectedSession && (
+          <DecisionReviewSessionDetail
+            session={selectedSession}
+            responseDrafts={responseDrafts}
+            critiqueDrafts={critiqueDrafts}
+            exportedMarkdown={exportedMarkdown}
+            recommendation={recommendation}
+            dissentingViews={dissentingViews}
+            assumptions={assumptions}
+            risks={risks}
+            validationPlan={validationPlan}
+            followUpTasks={followUpTasks}
+            confidenceLevel={confidenceLevel}
+            riskScore={riskScore}
+            onResponseDraft={updateResponseDraft}
+            onCritiqueDraft={updateCritiqueDraft}
+            onRecommendation={setRecommendation}
+            onDissentingViews={setDissentingViews}
+            onAssumptions={setAssumptions}
+            onRisks={setRisks}
+            onValidationPlan={setValidationPlan}
+            onFollowUpTasks={setFollowUpTasks}
+            onConfidenceLevel={setConfidenceLevel}
+            onRiskScore={setRiskScore}
+            onRecordResponse={(participantId, response) =>
+              recordResponse.mutateAsync({
+                id: selectedSession.id,
+                input: { participantId, response },
+              })
+            }
+            onRecordCritique={(participantId, round, response) =>
+              recordCritique.mutateAsync({
+                id: selectedSession.id,
+                input: { participantId, round, response },
+              })
+            }
+            onFinalize={() => handleFinalize(selectedSession)}
+            onCancel={() => cancelSession.mutate(selectedSession.id)}
+            onExport={async () => {
+              const markdown = await exportSession.mutateAsync(selectedSession.id);
+              setExportedMarkdown(markdown);
+            }}
+            busy={
+              recordResponse.isPending ||
+              recordCritique.isPending ||
+              finalizeSession.isPending ||
+              cancelSession.isPending ||
+              exportSession.isPending
+            }
+          />
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+interface DetailProps {
+  session: DecisionReviewSession;
+  responseDrafts: Record<string, string>;
+  critiqueDrafts: Record<string, string>;
+  exportedMarkdown: string;
+  recommendation: string;
+  dissentingViews: string;
+  assumptions: string;
+  risks: string;
+  validationPlan: string;
+  followUpTasks: string;
+  confidenceLevel: number;
+  riskScore: number;
+  onResponseDraft: (participantId: string, value: string) => void;
+  onCritiqueDraft: (key: string, value: string) => void;
+  onRecommendation: (value: string) => void;
+  onDissentingViews: (value: string) => void;
+  onAssumptions: (value: string) => void;
+  onRisks: (value: string) => void;
+  onValidationPlan: (value: string) => void;
+  onFollowUpTasks: (value: string) => void;
+  onConfidenceLevel: (value: number) => void;
+  onRiskScore: (value: number) => void;
+  onRecordResponse: (participantId: string, response: string) => Promise<unknown>;
+  onRecordCritique: (participantId: string, round: number, response: string) => Promise<unknown>;
+  onFinalize: () => Promise<void>;
+  onCancel: () => void;
+  onExport: () => Promise<void>;
+  busy: boolean;
+}
+
+function DecisionReviewSessionDetail({
+  session,
+  responseDrafts,
+  critiqueDrafts,
+  exportedMarkdown,
+  recommendation,
+  dissentingViews,
+  assumptions,
+  risks,
+  validationPlan,
+  followUpTasks,
+  confidenceLevel,
+  riskScore,
+  onResponseDraft,
+  onCritiqueDraft,
+  onRecommendation,
+  onDissentingViews,
+  onAssumptions,
+  onRisks,
+  onValidationPlan,
+  onFollowUpTasks,
+  onConfidenceLevel,
+  onRiskScore,
+  onRecordResponse,
+  onRecordCritique,
+  onFinalize,
+  onCancel,
+  onExport,
+  busy,
+}: DetailProps) {
+  const initialComplete = session.initialResponses.length >= session.participants.length;
+  const readyForFinal = sessionComplete(session);
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" gap="xs">
+        <Stack gap={2}>
+          <Text fw={600}>{session.title}</Text>
+          <Text size="xs" c="dimmed">
+            {session.participants.length} participants · {session.rounds} round
+            {session.rounds === 1 ? '' : 's'}
+          </Text>
+        </Stack>
+        <Badge color={statusColor(session.status)} variant="light" tt="none">
+          {session.status}
+        </Badge>
+      </Group>
+
+      <Stack gap="xs">
+        <Text size="sm" fw={500}>
+          Initial Responses
+        </Text>
+        {session.participants.map((participant) => {
+          const turn = session.initialResponses.find(
+            (candidate) => candidate.participantId === participant.id
+          );
+          const draft = responseDrafts[participant.id] ?? '';
+          return (
+            <Paper key={participant.id} className="p-3" radius="md" withBorder>
+              <Stack gap="xs">
+                <Group justify="space-between" gap="xs">
+                  <Text size="sm" fw={500}>
+                    {participant.label}
+                  </Text>
+                  {turn ? (
+                    <Badge
+                      color="green"
+                      variant="light"
+                      leftSection={<CheckCircle className="h-3 w-3" />}
+                    >
+                      Recorded
+                    </Badge>
+                  ) : (
+                    <Badge color="blue" variant="light">
+                      Pending
+                    </Badge>
+                  )}
+                </Group>
+                {turn ? (
+                  <Text size="sm" className="whitespace-pre-wrap">
+                    {turn.response}
+                  </Text>
+                ) : (
+                  <>
+                    <Textarea
+                      label={`${participant.label} response`}
+                      minRows={3}
+                      value={draft}
+                      onChange={(event) =>
+                        onResponseDraft(participant.id, event.currentTarget.value)
+                      }
+                    />
+                    <Button
+                      size="xs"
+                      disabled={!draft.trim() || busy}
+                      onClick={() => onRecordResponse(participant.id, draft.trim())}
+                    >
+                      Save Response
+                    </Button>
+                  </>
+                )}
+              </Stack>
+            </Paper>
+          );
+        })}
+      </Stack>
+
+      {initialComplete && session.status !== 'synthesized' && (
+        <Stack gap="xs">
+          <Text size="sm" fw={500}>
+            Critique Rounds
+          </Text>
+          {Array.from({ length: session.rounds }, (_, index) => index + 1).map((round) => (
+            <Paper key={round} className="p-3" radius="md" withBorder>
+              <Stack gap="xs">
+                <Text size="sm" fw={500}>
+                  Round {round}
+                </Text>
+                {session.participants.map((participant) => {
+                  const key = `${round}:${participant.id}`;
+                  const turn = session.critiqueRounds.find(
+                    (candidate) =>
+                      candidate.round === round && candidate.participantId === participant.id
+                  );
+                  const draft = critiqueDrafts[key] ?? '';
+                  return (
+                    <Stack key={key} gap="xs">
+                      <Group justify="space-between" gap="xs">
+                        <Text size="sm">{participant.label}</Text>
+                        {turn && (
+                          <Badge color="green" variant="light">
+                            Recorded
+                          </Badge>
+                        )}
+                      </Group>
+                      {turn ? (
+                        <Text size="sm" className="whitespace-pre-wrap">
+                          {turn.response}
+                        </Text>
+                      ) : (
+                        <>
+                          <Textarea
+                            label={`${participant.label} critique round ${round}`}
+                            minRows={2}
+                            value={draft}
+                            onChange={(event) => onCritiqueDraft(key, event.currentTarget.value)}
+                          />
+                          <Button
+                            size="xs"
+                            disabled={!draft.trim() || busy}
+                            onClick={() => onRecordCritique(participant.id, round, draft.trim())}
+                          >
+                            Save Critique
+                          </Button>
+                        </>
+                      )}
+                    </Stack>
+                  );
+                })}
+              </Stack>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+
+      {session.status === 'synthesized' && session.finalPacket ? (
+        <Paper className="bg-muted/40 p-3" radius="md" withBorder>
+          <Stack gap="xs">
+            <Text size="sm" fw={500}>
+              Final Packet
+            </Text>
+            <Text size="sm" className="whitespace-pre-wrap">
+              {session.finalPacket.recommendation}
+            </Text>
+            <Group gap="xs">
+              {session.finalPacket.workProductId && (
+                <Badge variant="light" leftSection={<FileText className="h-3 w-3" />}>
+                  {session.finalPacket.workProductId}
+                </Badge>
+              )}
+              {session.finalPacket.decisionId && (
+                <Badge variant="light">{session.finalPacket.decisionId}</Badge>
+              )}
+            </Group>
+            <Button size="xs" variant="outline" onClick={onExport} disabled={busy}>
+              Export Packet
+            </Button>
+            {exportedMarkdown && (
+              <Textarea label="Exported markdown" minRows={5} value={exportedMarkdown} readOnly />
+            )}
+          </Stack>
+        </Paper>
+      ) : readyForFinal ? (
+        <Paper className="p-3" radius="md" withBorder>
+          <Stack gap="xs">
+            <Text size="sm" fw={500}>
+              Final Synthesis
+            </Text>
+            <Textarea
+              label="Recommendation"
+              minRows={3}
+              value={recommendation}
+              onChange={(event) => onRecommendation(event.currentTarget.value)}
+            />
+            <Textarea
+              label="Dissenting views"
+              minRows={2}
+              value={dissentingViews}
+              onChange={(event) => onDissentingViews(event.currentTarget.value)}
+            />
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+              <Textarea
+                label="Assumptions"
+                minRows={2}
+                value={assumptions}
+                onChange={(event) => onAssumptions(event.currentTarget.value)}
+              />
+              <Textarea
+                label="Risks"
+                minRows={2}
+                value={risks}
+                onChange={(event) => onRisks(event.currentTarget.value)}
+              />
+            </SimpleGrid>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+              <Textarea
+                label="Validation plan"
+                minRows={2}
+                value={validationPlan}
+                onChange={(event) => onValidationPlan(event.currentTarget.value)}
+              />
+              <Textarea
+                label="Follow-up tasks"
+                minRows={2}
+                value={followUpTasks}
+                onChange={(event) => onFollowUpTasks(event.currentTarget.value)}
+              />
+            </SimpleGrid>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+              <NumberInput
+                label="Confidence"
+                min={0}
+                max={100}
+                value={confidenceLevel}
+                onChange={(value) => onConfidenceLevel(typeof value === 'number' ? value : 70)}
+              />
+              <NumberInput
+                label="Risk"
+                min={0}
+                max={100}
+                value={riskScore}
+                onChange={(value) => onRiskScore(typeof value === 'number' ? value : 50)}
+              />
+            </SimpleGrid>
+            <Button disabled={!recommendation.trim() || busy} onClick={onFinalize}>
+              Finalize Packet
+            </Button>
+          </Stack>
+        </Paper>
+      ) : null}
+
+      {session.status !== 'synthesized' && session.status !== 'canceled' && (
+        <Button
+          variant="subtle"
+          color="red"
+          size="xs"
+          onClick={onCancel}
+          disabled={busy}
+          leftSection={<XCircle className="h-4 w-4" />}
+        >
+          Cancel Session
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/web/src/components/task/ReviewPanel.tsx
+++ b/web/src/components/task/ReviewPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { CheckCircle, XCircle, RefreshCcw, MessageSquare, GitMerge, Loader2 } from 'lucide-react';
 import { useMergeWorktree } from '@/hooks/useWorktree';
 import type { Task, ReviewDecision, ReviewState } from '@veritas-kanban/shared';
+import { DecisionReviewSessionsSection } from './DecisionReviewSessionsSection';
 
 interface ReviewPanelProps {
   task: Task;
@@ -74,18 +75,16 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
     setPendingDecision(null);
   };
 
-  if (!hasWorktree) {
-    return (
-      <Text ta="center" c="dimmed" className="py-8">
-        Start a worktree to enable code review
-      </Text>
-    );
-  }
-
   return (
     <Stack gap="md">
+      {!hasWorktree && (
+        <Text ta="center" c="dimmed" className="py-4">
+          Start a worktree to enable code review
+        </Text>
+      )}
+
       {/* Current review status */}
-      {currentReview?.decision && (
+      {hasWorktree && currentReview?.decision && (
         <Paper className="p-3" radius="md" withBorder>
           <Group gap="sm" wrap="nowrap">
             <ThemeIcon color={decisionStyles[currentReview.decision].color} variant="light">
@@ -108,7 +107,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
         </Paper>
       )}
 
-      {currentReview?.summary && (
+      {hasWorktree && currentReview?.summary && (
         <Paper className="bg-muted/50 p-3" radius="md" withBorder>
           <Text size="sm" className="whitespace-pre-wrap">
             {currentReview.summary}
@@ -136,7 +135,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
       )}
 
       {/* Comment summary */}
-      {comments.length > 0 && (
+      {hasWorktree && comments.length > 0 && (
         <Group gap="xs">
           <MessageSquare className="h-4 w-4" />
           <Text size="sm" c="dimmed">
@@ -146,7 +145,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
       )}
 
       {/* Summary input for changes-requested/rejected */}
-      {showSummary && pendingDecision && (
+      {hasWorktree && showSummary && pendingDecision && (
         <Paper className="bg-muted/50 p-3" radius="md" withBorder>
           <Stack gap="xs">
             <Textarea
@@ -182,7 +181,7 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
       )}
 
       {/* Action buttons */}
-      {!currentReview?.decision && !showSummary && (
+      {hasWorktree && !currentReview?.decision && !showSummary && (
         <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="xs">
           <Button
             onClick={() => handleDecision('approved')}
@@ -207,6 +206,8 @@ export function ReviewPanel({ task, onReview, onMergeComplete }: ReviewPanelProp
           </Button>
         </SimpleGrid>
       )}
+
+      <DecisionReviewSessionsSection task={task} />
 
       <Modal
         opened={mergeDialogOpen}

--- a/web/src/hooks/useDecisionReviews.ts
+++ b/web/src/hooks/useDecisionReviews.ts
@@ -1,0 +1,87 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type {
+  CreateDecisionReviewSessionInput,
+  DecisionReviewListFilters,
+  DecisionReviewSession,
+  FinalizeDecisionReviewSessionInput,
+  RecordDecisionReviewCritiqueInput,
+  RecordDecisionReviewTurnInput,
+} from '@veritas-kanban/shared';
+
+export function useDecisionReviews(filters: DecisionReviewListFilters) {
+  return useQuery({
+    queryKey: ['decision-reviews', filters],
+    queryFn: () => api.decisions.reviews.list(filters),
+  });
+}
+
+export function useDecisionReview(id: string | null) {
+  return useQuery({
+    queryKey: ['decision-reviews', id],
+    queryFn: () => {
+      if (!id) throw new Error('Decision review id is required');
+      return api.decisions.reviews.get(id);
+    },
+    enabled: Boolean(id),
+  });
+}
+
+function updateReviewCaches(
+  queryClient: ReturnType<typeof useQueryClient>,
+  session: DecisionReviewSession
+) {
+  queryClient.invalidateQueries({ queryKey: ['decision-reviews'] });
+  queryClient.invalidateQueries({ queryKey: ['decisions'] });
+  queryClient.invalidateQueries({ queryKey: ['tasks', session.taskId, 'work-products'] });
+  queryClient.setQueryData(['decision-reviews', session.id], session);
+}
+
+export function useCreateDecisionReview() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateDecisionReviewSessionInput) => api.decisions.reviews.create(input),
+    onSuccess: (session) => updateReviewCaches(queryClient, session),
+  });
+}
+
+export function useRecordDecisionReviewResponse() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: RecordDecisionReviewTurnInput }) =>
+      api.decisions.reviews.recordResponse(id, input),
+    onSuccess: (session) => updateReviewCaches(queryClient, session),
+  });
+}
+
+export function useRecordDecisionReviewCritique() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: RecordDecisionReviewCritiqueInput }) =>
+      api.decisions.reviews.recordCritique(id, input),
+    onSuccess: (session) => updateReviewCaches(queryClient, session),
+  });
+}
+
+export function useFinalizeDecisionReview() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: FinalizeDecisionReviewSessionInput }) =>
+      api.decisions.reviews.finalize(id, input),
+    onSuccess: (session) => updateReviewCaches(queryClient, session),
+  });
+}
+
+export function useCancelDecisionReview() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.decisions.reviews.cancel(id),
+    onSuccess: (session) => updateReviewCaches(queryClient, session),
+  });
+}
+
+export function useExportDecisionReview() {
+  return useMutation({
+    mutationFn: (id: string) => api.decisions.reviews.export(id),
+  });
+}

--- a/web/src/lib/api/decisions.ts
+++ b/web/src/lib/api/decisions.ts
@@ -1,8 +1,14 @@
 import type {
   CreateDecisionInput,
+  CreateDecisionReviewSessionInput,
   DecisionListFilters,
   DecisionRecord,
+  DecisionReviewListFilters,
+  DecisionReviewSession,
   DecisionWithChain,
+  FinalizeDecisionReviewSessionInput,
+  RecordDecisionReviewCritiqueInput,
+  RecordDecisionReviewTurnInput,
   UpdateDecisionAssumptionInput,
 } from '@veritas-kanban/shared';
 import { API_BASE, handleResponse } from './helpers';
@@ -64,5 +70,112 @@ export const decisionsApi = {
       }
     );
     return handleResponse<DecisionRecord>(response);
+  },
+
+  reviews: {
+    list: async (filters: DecisionReviewListFilters = {}): Promise<DecisionReviewSession[]> => {
+      const params = new URLSearchParams();
+      if (filters.taskId) params.set('taskId', filters.taskId);
+      if (filters.status) params.set('status', filters.status);
+      if (filters.limit !== undefined) params.set('limit', String(filters.limit));
+      const query = params.toString();
+      const response = await fetch(`${API_BASE}/decisions/reviews${query ? `?${query}` : ''}`, {
+        credentials: 'include',
+      });
+      return handleResponse<DecisionReviewSession[]>(response);
+    },
+
+    get: async (id: string): Promise<DecisionReviewSession> => {
+      const response = await fetch(`${API_BASE}/decisions/reviews/${encodeURIComponent(id)}`, {
+        credentials: 'include',
+      });
+      return handleResponse<DecisionReviewSession>(response);
+    },
+
+    create: async (input: CreateDecisionReviewSessionInput): Promise<DecisionReviewSession> => {
+      const response = await fetch(`${API_BASE}/decisions/reviews`, {
+        credentials: 'include',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      return handleResponse<DecisionReviewSession>(response);
+    },
+
+    recordResponse: async (
+      id: string,
+      input: RecordDecisionReviewTurnInput
+    ): Promise<DecisionReviewSession> => {
+      const response = await fetch(
+        `${API_BASE}/decisions/reviews/${encodeURIComponent(id)}/responses`,
+        {
+          credentials: 'include',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        }
+      );
+      return handleResponse<DecisionReviewSession>(response);
+    },
+
+    recordCritique: async (
+      id: string,
+      input: RecordDecisionReviewCritiqueInput
+    ): Promise<DecisionReviewSession> => {
+      const response = await fetch(
+        `${API_BASE}/decisions/reviews/${encodeURIComponent(id)}/critiques`,
+        {
+          credentials: 'include',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        }
+      );
+      return handleResponse<DecisionReviewSession>(response);
+    },
+
+    finalize: async (
+      id: string,
+      input: FinalizeDecisionReviewSessionInput
+    ): Promise<DecisionReviewSession> => {
+      const response = await fetch(
+        `${API_BASE}/decisions/reviews/${encodeURIComponent(id)}/finalize`,
+        {
+          credentials: 'include',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        }
+      );
+      return handleResponse<DecisionReviewSession>(response);
+    },
+
+    cancel: async (id: string): Promise<DecisionReviewSession> => {
+      const response = await fetch(
+        `${API_BASE}/decisions/reviews/${encodeURIComponent(id)}/cancel`,
+        {
+          credentials: 'include',
+          method: 'POST',
+        }
+      );
+      return handleResponse<DecisionReviewSession>(response);
+    },
+
+    export: async (id: string): Promise<string> => {
+      const response = await fetch(
+        `${API_BASE}/decisions/reviews/${encodeURIComponent(id)}/export`,
+        {
+          credentials: 'include',
+        }
+      );
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        if (body && typeof body === 'object' && 'message' in body) {
+          throw new Error(String((body as { message: unknown }).message));
+        }
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.text();
+    },
   },
 };

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -194,6 +194,7 @@ export type {
 
 export type {
   DecisionRecord,
+  DecisionReviewSession,
   DecisionWithChain,
   DecisionListFilters,
 } from '@veritas-kanban/shared';


### PR DESCRIPTION
## Summary
- adds task-linked decision review sessions with independent participant responses, ordered critique rounds, cancellation, markdown export, and synthesized final packets
- attaches final packets as work products and creates linked decision audit records
- exposes API routes, web hooks, Review tab UI, shared types, and documentation for the review session workflow

## Verification
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- VERITAS_DISABLE_WATCHERS=1 pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/decision-review-service.test.ts src/__tests__/routes/decisions.test.ts --maxWorkers=1
- VERITAS_DISABLE_WATCHERS=1 pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/routes/codex-review.test.ts src/__tests__/codex-review-service.test.ts --maxWorkers=1
- pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/task-detail-review-preview-mantine.test.tsx --maxWorkers=1
- node scripts/check-permission-coverage.mjs
- pnpm --filter @veritas-kanban/server lint
- pnpm --filter @veritas-kanban/web lint
- pnpm lint:budget
- pnpm --filter @veritas-kanban/server build
- pnpm --filter @veritas-kanban/web build
- git diff --check

Closes #724
