### PR TITLE
Prepare Veritas Kanban 5.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-06-18
+
+### Added
+
+- Added shared live run sessions with workspace-scoped view, co-drive, and fork
+  permissions. Shared viewers receive live output and run events, editors send
+  attributed messages and mobile-safe approval responses, and forks create
+  linked tasks without mutating parent run state (#721, #731).
+- Added reusable agent profile packages with YAML/JSON validation, import,
+  export, metadata editing, and profile-aware agent launch posture (#720).
+- Added enforceable agent run budgets for token, cost, tool-call, runtime,
+  retry, and fan-out limits with auditable enforcement decisions (#722).
+- Added sandbox policy presets for filesystem, network, environment, and
+  credential access with dry-run validation before launch (#723).
+- Added multi-participant decision review sessions with independent responses,
+  critique rounds, synthesis packets, work-product attachment, and decision
+  audit links (#724).
+
+### Changed
+
+- Bumped the release from `5.0.1` to `5.1.0` across the root, shared, server,
+  web, CLI, MCP, and desktop package manifests.
+- Updated the README version badge, API reference, release notes, permission
+  coverage manifest, and MCP documentation footer for `5.1.0`.
+
+### Fixed
+
+- Fixed Docker source builds by restoring required Dockerfile inputs to the
+  build context (#725).
+
 ## [5.0.1] - 2026-06-12
 
 ### Changed
@@ -1584,7 +1614,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.1...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.1.0...HEAD
+[5.1.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v4.3.2...v5.0.0
 [4.1.0]: https://github.com/BradGroux/veritas-kanban/compare/v4.0.1...v4.1.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.0.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.1.0-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -96,7 +96,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [v5 Visual Tour](docs/V5-VISUAL-TOUR.md) — release-safe dummy screenshots and GIFs for the v5 desktop shell, resizable workbench, agent providers, task work view, Maintenance Center, and mobile/PWA shell.
 - [v5 Upgrade, Install, Remote, And Admin Guide](docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md) — fresh install, v4-to-v5 upgrade, desktop setup, remote/server, mobile/PWA, admin, backup, and diagnostics paths.
 - [v5 Compatibility And Release Policy](docs/V5-COMPATIBILITY-AND-RELEASE-POLICY.md) — supported version combinations, update channels, stale-client behavior, rollback limits, and release validation.
-- [v5 Release Notes](docs/V5-RELEASE-NOTES.md) — breaking changes, migration warnings, published v5.0.x artifacts, and deferred post-GA backlog.
+- [v5 Release Notes](docs/V5-RELEASE-NOTES.md) — breaking changes, migration warnings, published v5.1.0 artifacts, and deferred post-GA backlog.
 - [v5 Desktop Architecture ADR](docs/architecture/ADR-0001-v5-desktop-architecture.md) — shell decision, native/server boundaries, connection modes, lifecycle, packaging, and security model.
 - [Post-GA Desktop Agent Workbench Spec](docs/DESKTOP-AGENT-WORKBENCH.md) — desktop workbench UX, run controls, approvals, evidence, native affordances, and safety coverage.
 - [Post-GA Native Mobile Offline ADR](docs/architecture/ADR-0003-post-ga-native-mobile-offline.md) — native mobile authority model, offline queue semantics, conflict handling, and security review.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -1,13 +1,39 @@
-# v5.0 Release Notes
+# v5 Release Notes
 
-These notes describe the published Veritas Kanban v5.0 stable release line.
+These notes describe the published Veritas Kanban v5 stable release line.
 
 - GitHub release:
-  [Veritas Kanban v5.0.1](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.0.1)
+  [Veritas Kanban v5.1.0](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.1.0)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
-  [Veritas-Kanban-5.0.0-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.0.0/Veritas-Kanban-5.0.0-mac-arm64.zip)
+  [Veritas-Kanban-5.1.0-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.1.0/Veritas-Kanban-5.1.0-mac-arm64.zip)
+
+## v5.1.0 Release
+
+v5.1.0 completes the post-v5.0 agent governance and collaboration release
+train while preserving the v5 storage, desktop, security, and migration
+posture.
+
+- Docker source builds include the required server, web, shared, CLI, MCP, and
+  desktop workspace inputs so self-host validation can build from a clean
+  context.
+- Sandbox policy presets define reusable filesystem, network, environment, and
+  credential boundaries for agent launches, with dry-run validation before run
+  start.
+- Agent budget enforcement adds auditable token, cost, tool-call, runtime,
+  retry, and fan-out guardrails across workspace, agent, workflow, workflow
+  agent, and one-off run scopes.
+- Agent profile packages can be imported, validated, exported, enabled, edited,
+  and used at launch so role/runtime/prompt/tool/sandbox/budget posture can
+  travel as YAML or JSON.
+- Decision review sessions capture independent participant responses, critique
+  rounds, final synthesis packets, work-product attachment, and decision audit
+  links.
+- Shared live run sessions let workspace members create view, co-drive, or fork
+  shares for active task runs. Viewers receive live output and events, editors
+  send attributed messages and mobile-safe approvals, and forks create linked
+  tasks without changing the parent run.
 
 ## v5.0.1 Patch
 
@@ -93,7 +119,13 @@ desktop, security, and migration posture unchanged from v5.0.0.
 
 ## Release Artifacts
 
-The v5.0.0 stable desktop release includes:
+The v5.1.0 stable desktop release publishes signed/notarized macOS ZIP and DMG
+assets plus `latest-mac.yml`, blockmaps, and SHA-256 sidecars under the
+[v5.1.0 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.1.0).
+Use the release-attached `.sha256` files as the checksum source of truth.
+
+The v5.0.0 stable desktop release artifacts are retained here as the v5 baseline
+used by the updater evidence packet:
 
 | Artifact                                                                                                                                                        | SHA-256                                                            |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/docs/VERITAS-5.1-GOAL-PROMPT.md
+++ b/docs/VERITAS-5.1-GOAL-PROMPT.md
@@ -1,0 +1,81 @@
+# Veritas Kanban 5.1 Goal Prompt
+
+```text
+/goal Complete the Veritas Kanban 5.1 release train end to end.
+
+Work from /Users/bradgroux/Projects/veritas-kanban. Start by refreshing live GitHub state, local git state, repo instructions, and release docs. Preserve unrelated local changes.
+
+Current known queue as of 2026-06-18:
+- PR #719: Dependabot production-dependencies group, green and clean.
+- Issue #725: Docker source build is broken because .dockerignore excludes Dockerfile inputs.
+- Issue #723: Sandbox policy presets for filesystem, network, environment, and credential access.
+- Issue #722: Enforceable agent cost and tool-use budgets.
+- Issue #720: Reusable agent profile packages with YAML/JSON import/export and launch.
+- Issue #724: Multi-model decision review sessions with recorded outcomes.
+- Issue #721: Shared live run sessions with view, co-drive, and fork permissions.
+
+Recommended order:
+1. Re-check and merge PR #719 first if still clean.
+2. Fix #725 before feature work because Docker/self-host build is a release blocker.
+3. Implement #723 next because sandbox policy is the security foundation.
+4. Implement #722 next because budgets should flow through policy traces and run control.
+5. Implement #720 next, using sandbox and budget posture in profile validation/launch.
+6. Implement #724 next, reusing profiles, workflow primitives, budgets, telemetry, and work products.
+7. Implement #721 last because live shared sessions touch multi-user, permissions, remote/mobile, WebSocket, artifacts, and active-run safety.
+
+For each issue:
+- Inspect existing schema, services, routes, UI, tests, docs, and nearby patterns before editing.
+- Prefer small vertical slices and focused PRs. Combine only when the code is inseparable.
+- Include tests and docs in the same PR that changes behavior.
+- Close issues through merged PRs with clear "Fixes #..." references.
+- If scope is larger than a sane PR, split into tracked sub-issues, but do not call the parent done until the user-facing capability and acceptance criteria are complete.
+
+Docs must be current before release:
+- README.md
+- CHANGELOG.md
+- docs/FEATURES.md
+- docs/API-REFERENCE.md / API workflow docs where relevant
+- CLI/MCP docs where commands or surfaces change
+- security, policy, workflow, desktop, self-host, and release docs touched by the features
+- v5 release notes/checklist docs should be updated or renamed/extended for 5.1 where appropriate
+
+Release target:
+- Use SemVer package metadata version 5.1.0.
+- Use public release/tag naming v5.1.0, with prose allowed to say 5.1.
+- Bump all workspace package versions together: root, shared, server, web, cli, mcp, desktop.
+- Update README badge and docs/mcp version footer.
+- Update pnpm lockfile consistently using the repo package manager only.
+
+Required verification before final release:
+- pnpm install --frozen-lockfile
+- pnpm typecheck
+- pnpm lint:budget
+- pnpm build
+- pnpm test:unit
+- targeted API/UI/Playwright tests for touched surfaces
+- pnpm desktop:smoke:mac:local
+- pnpm desktop:package:mac:unsigned
+- pnpm validate:release -- --version 5.1.0
+- pnpm validate:release -- --version 5.1.0 --docker-build after #725
+
+Release and distribution:
+- Create and merge the final 5.1 release PR after all issue PRs are merged.
+- Create/publish GitHub release v5.1.0.
+- Run the Desktop Release workflow on main with channel=stable and verify signed/notarized macOS ZIP/DMG assets plus latest-mac.yml.
+- Run pnpm validate:release -- --version 5.1.0 --github after tag/release publication.
+- Update /Users/bradgroux/Projects/homebrew-tap/Casks/veritas-kanban.rb if the signed ZIP changed.
+- Validate the tap from the tap checkout:
+  HOMEBREW_NO_AUTO_UPDATE=1 brew style --cask bradgroux/tap/veritas-kanban
+  brew audit --cask --strict --online bradgroux/tap/veritas-kanban
+  brew install --cask --dry-run bradgroux/tap/veritas-kanban
+  brew livecheck bradgroux/tap/veritas-kanban
+- Create/merge the tap PR if needed.
+
+Final answer must include:
+- PRs/issues completed and merged
+- Release/tag URL
+- Desktop Release workflow run URL
+- Homebrew tap PR/status
+- Verification commands and results
+- Any remaining risk or follow-up
+```

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -802,7 +802,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `5.0.1`      | Matches VK server version   |
+| MCP server package | `5.1.0`      | Matches VK server version   |
 | MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2024-11-05` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -846,4 +846,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-06-12 · VK v5.0.1 · 36 tools / 8 categories_
+_Last updated: 2026-06-18 · VK v5.1.0 · 36 tools / 8 categories_

--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "lastReviewed": "2026-06-18",
-  "notes": "Authority surface manifest for v5.0. The REST route-map entry is backed by shared/src/utils/api-permissions.ts, and CI compares it against server/src/routes/v1/index.ts.",
+  "notes": "Authority surface manifest for v5. The REST route-map entry is backed by shared/src/utils/api-permissions.ts, and CI compares it against server/src/routes/v1/index.ts.",
   "surfaces": [
     {
       "id": "rest:v1-route-map",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump Veritas Kanban workspace packages from 5.0.1 to 5.1.0.
- Update README, CHANGELOG, v5 release notes, MCP docs, and security permission manifest for the 5.1 release line.
- Add the durable 5.1 goal prompt that documents the issue/PR completion order and release checklist.

## Verification
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm lint:budget
- pnpm build
- pnpm test:unit
- pnpm desktop:smoke:mac:local
- pnpm desktop:package:mac:unsigned
- pnpm validate:release -- --version 5.1.0
- pnpm validate:release -- --version 5.1.0 --docker-build
- node scripts/check-permission-coverage.mjs
- git diff --check

## Release notes
- Open issue and PR queues are clean after the 5.1 feature PRs landed.
- The signed/notarized macOS assets still need the Desktop Release workflow after this PR merges and the v5.1.0 release is published.
- The Homebrew tap should be updated after the signed ZIP checksum is available from the published release assets.
