### PR TITLE
Add team roster routing manifests

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1522,6 +1522,10 @@ Accepts either a task ID or ad-hoc metadata:
 }
 ```
 
+When an enabled team roster exists, `/api/agents/route` evaluates the roster
+before legacy routing rules. Roster-selected responses use a `team-roster:`
+rule prefix.
+
 ### Get/Update Routing Configuration
 
 ```
@@ -1565,6 +1569,42 @@ In addition to `agent`, `sandboxPresetId`, and `budget`, callers can pass a port
 ```
 
 The launch path resolves the package runtime against configured provider profiles, applies package model/sandbox/budget posture, injects package instructions into the run prompt, and records the profile ID and version on the task attempt plus activity audit history.
+
+---
+
+## Team Roster Manifests
+
+Team rosters define the workspace coordinator, enabled agent members, roles,
+capabilities, routing rules, fallbacks, and reviewers. The manifest is stored in
+app config as `teamRoster`.
+
+Mounted at `/api/config/team-roster`.
+
+| Method | Path                                         | Description                                   | Permissions      |
+| ------ | -------------------------------------------- | --------------------------------------------- | ---------------- |
+| `GET`  | `/api/config/team-roster`                    | Return the stored roster or `null`            | `settings:read`  |
+| `PUT`  | `/api/config/team-roster`                    | Replace the roster manifest                   | `settings:write` |
+| `POST` | `/api/config/team-roster/validate`           | Validate a roster object or YAML/JSON content | `settings:read`  |
+| `POST` | `/api/config/team-roster/import`             | Import and store YAML/JSON roster content     | `settings:write` |
+| `GET`  | `/api/config/team-roster/export?format=yaml` | Export the stored roster as YAML or JSON      | `settings:read`  |
+| `POST` | `/api/config/team-roster/preview-route`      | Preview the selected member for task metadata | `settings:read`  |
+
+### Preview Route
+
+```json
+{
+  "type": "docs",
+  "priority": "medium",
+  "project": "docs",
+  "path": "docs/API-REFERENCE.md",
+  "capabilities": ["docs"],
+  "subtaskCount": 2
+}
+```
+
+Preview responses include the matched member, fallback member when used,
+reviewer members, selected agent/profile, reason, and validation issues.
+Invalid rosters never route agent launches.
 
 ---
 

--- a/server/src/__tests__/agent-routing-service.test.ts
+++ b/server/src/__tests__/agent-routing-service.test.ts
@@ -192,6 +192,48 @@ describe('AgentRoutingService', () => {
       expect(result.trace.matchedRules?.map((rule) => rule.id)).toEqual(['routing:code-high']);
     });
 
+    it('uses the enabled team roster before legacy routing rules', async () => {
+      mockGetConfig.mockResolvedValue({
+        ...structuredClone(BASE_CONFIG),
+        teamRoster: {
+          id: 'core-team',
+          schemaVersion: 'team-roster/v1',
+          workspaceId: 'local',
+          name: 'Core Team',
+          enabled: true,
+          members: [
+            {
+              id: 'ops-lead',
+              displayName: 'Ops Lead',
+              role: 'Coordinates high-risk work',
+              agent: 'amp',
+              status: 'enabled',
+              capabilities: ['ops'],
+              defaultTaskTypes: ['code'],
+            },
+          ],
+          routingRules: [
+            {
+              id: 'high-code',
+              name: 'High-priority code owner',
+              enabled: true,
+              match: { type: 'code', priority: 'high' },
+              memberId: 'ops-lead',
+            },
+          ],
+        },
+      });
+
+      const result = await service.resolveAgentWithTrace({
+        type: 'code',
+        priority: 'high',
+      });
+
+      expect(result.result.agent).toBe('amp');
+      expect(result.result.rule).toBe('team-roster:high-code');
+      expect(result.trace.matchedRules?.[0]?.id).toBe('team-roster:high-code');
+    });
+
     it('matches medium-priority code task to second rule', async () => {
       const result = await service.resolveAgent({
         type: 'code',

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -166,6 +166,104 @@ runtime:
     });
   });
 
+  describe('team roster manifests', () => {
+    const teamRoster = {
+      id: 'core-team',
+      schemaVersion: 'team-roster/v1',
+      workspaceId: 'local',
+      name: 'Core Team',
+      enabled: true,
+      coordinatorMemberId: 'ops-lead',
+      members: [
+        {
+          id: 'ops-lead',
+          displayName: 'Ops Lead',
+          role: 'Coordinates queue work',
+          agent: 'codex',
+          status: 'enabled',
+          capabilities: ['ops', 'triage'],
+          defaultTaskTypes: ['feature'],
+        },
+        {
+          id: 'docs-reviewer',
+          displayName: 'Docs Reviewer',
+          role: 'Reviews docs',
+          agent: 'amp',
+          status: 'enabled',
+          capabilities: ['docs', 'review'],
+          defaultTaskTypes: ['docs'],
+        },
+      ],
+      routingRules: [
+        {
+          id: 'docs',
+          name: 'Docs work',
+          enabled: true,
+          match: { type: 'docs' },
+          memberId: 'docs-reviewer',
+          reviewerMemberIds: ['ops-lead'],
+        },
+      ],
+    };
+
+    it('validates and imports roster manifests', async () => {
+      const invalid = await request(app)
+        .post('/api/config/team-roster/validate')
+        .send({
+          roster: {
+            ...teamRoster,
+            routingRules: [{ ...teamRoster.routingRules[0], memberId: 'missing' }],
+          },
+        });
+
+      expect(invalid.status).toBe(200);
+      expect(invalid.body.valid).toBe(false);
+      expect(invalid.body.issues.map((issue: { message: string }) => issue.message)).toContain(
+        'Unknown member ID: missing'
+      );
+
+      mockConfigService.getConfig.mockResolvedValue({
+        repos: [],
+        agents: [],
+        teamRoster: undefined,
+      });
+      mockConfigService.saveConfig.mockResolvedValue(undefined);
+
+      const imported = await request(app)
+        .post('/api/config/team-roster/import')
+        .send({ content: JSON.stringify(teamRoster), format: 'json', source: 'test' });
+
+      expect(imported.status).toBe(201);
+      expect(imported.body.id).toBe('core-team');
+      expect(mockConfigService.saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teamRoster: expect.objectContaining({ id: 'core-team' }),
+        })
+      );
+    });
+
+    it('exports and previews roster routes', async () => {
+      mockConfigService.getConfig.mockResolvedValue({
+        repos: [],
+        agents: [],
+        teamRoster,
+      });
+
+      const exported = await request(app).get('/api/config/team-roster/export?format=json');
+      expect(exported.status).toBe(200);
+      expect(exported.body.content).toContain('"core-team"');
+
+      const preview = await request(app)
+        .post('/api/config/team-roster/preview-route')
+        .send({ type: 'docs' });
+      expect(preview.status).toBe(200);
+      expect(preview.body.member.id).toBe('docs-reviewer');
+      expect(preview.body.reviewerMembers.map((member: { id: string }) => member.id)).toEqual([
+        'ops-lead',
+      ]);
+    });
+  });
+
   describe('POST /api/config/repos', () => {
     it('should add a repo', async () => {
       mockConfigService.addRepo.mockResolvedValue({

--- a/server/src/__tests__/team-roster-service.test.ts
+++ b/server/src/__tests__/team-roster-service.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { AppConfig, TeamRosterManifest } from '@veritas-kanban/shared';
+import { TeamRosterService } from '../services/team-roster-service';
+
+const roster: TeamRosterManifest = {
+  id: 'core-team',
+  schemaVersion: 'team-roster/v1',
+  workspaceId: 'local',
+  name: 'Core Team',
+  enabled: true,
+  coordinatorMemberId: 'ops-lead',
+  members: [
+    {
+      id: 'ops-lead',
+      displayName: 'Ops Lead',
+      role: 'Coordinates queue work',
+      agent: 'codex',
+      status: 'enabled',
+      capabilities: ['ops', 'triage'],
+      defaultTaskTypes: ['feature'],
+    },
+    {
+      id: 'docs-reviewer',
+      displayName: 'Docs Reviewer',
+      role: 'Reviews docs',
+      agent: 'amp',
+      status: 'enabled',
+      capabilities: ['docs', 'review'],
+      defaultTaskTypes: ['docs'],
+    },
+  ],
+  routingRules: [
+    {
+      id: 'docs',
+      name: 'Docs work',
+      enabled: true,
+      match: { type: 'docs' },
+      memberId: 'docs-reviewer',
+      reviewerMemberIds: ['ops-lead'],
+    },
+  ],
+};
+
+function serviceWithConfig(config: AppConfig) {
+  return new TeamRosterService({
+    getConfig: async () => config,
+    saveConfig: async (next: AppConfig) => {
+      Object.assign(config, next);
+    },
+  } as never);
+}
+
+describe('TeamRosterService', () => {
+  it('validates duplicate and missing member references', () => {
+    const service = serviceWithConfig({ repos: [], agents: [], defaultAgent: 'codex' });
+
+    const result = service.validateRoster({
+      ...roster,
+      members: [roster.members[0], { ...roster.members[0] }],
+      routingRules: [{ ...roster.routingRules[0], memberId: 'missing' }],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain('Duplicate member ID: ops-lead');
+    expect(result.issues.map((issue) => issue.message)).toContain('Unknown member ID: missing');
+  });
+
+  it('imports, exports, and previews roster routing', async () => {
+    const config: AppConfig = { repos: [], agents: [], defaultAgent: 'codex' };
+    const service = serviceWithConfig(config);
+
+    const imported = await service.importRoster({
+      content: JSON.stringify(roster),
+      format: 'json',
+      source: 'test',
+    });
+    expect(imported.metadata?.source).toBe('test');
+    expect(config.teamRoster?.id).toBe('core-team');
+
+    const exported = await service.exportRoster('yaml');
+    expect(exported.content).toContain('Core Team');
+
+    const preview = await service.previewRoute({ type: 'docs' });
+    expect(preview.matched).toBe(true);
+    expect(preview.member?.id).toBe('docs-reviewer');
+    expect(preview.reviewerMembers.map((member) => member.id)).toEqual(['ops-lead']);
+  });
+
+  it('falls back to the coordinator when no rule matches', async () => {
+    const service = serviceWithConfig({
+      repos: [],
+      agents: [],
+      defaultAgent: 'codex',
+      teamRoster: roster,
+    });
+
+    const preview = await service.previewRoute({ type: 'bug' });
+
+    expect(preview.matched).toBe(true);
+    expect(preview.member?.id).toBe('ops-lead');
+    expect(preview.reason).toContain('coordinator');
+  });
+});

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -7,16 +7,25 @@ import { ValidationError, BadRequestError } from '../middleware/error-handler.js
 import { authorize } from '../middleware/auth.js';
 import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
 import { AgentProfilePackageService } from '../services/agent-profile-package-service.js';
+import { TeamRosterService } from '../services/team-roster-service.js';
 import {
   AgentProfileImportBodySchema,
   AgentProfileUpdateBodySchema,
   AgentProfileValidateBodySchema,
   AgentProfilePackageFormatSchema,
 } from '../schemas/agent-profile-package-schemas.js';
+import {
+  TeamRosterFormatSchema,
+  TeamRosterImportBodySchema,
+  TeamRosterManifestSchema,
+  TeamRosterRoutePreviewBodySchema,
+  TeamRosterValidateBodySchema,
+} from '../schemas/team-roster-schemas.js';
 
 const router: RouterType = Router();
 const configService = new ConfigService();
 const agentProfilePackageService = new AgentProfilePackageService(configService);
+const teamRosterService = new TeamRosterService(configService);
 
 // Validation schemas
 const repoSchema = z.object({
@@ -75,6 +84,84 @@ router.get(
   asyncHandler(async (_req, res) => {
     const config = await configService.getConfig();
     res.json(config.repos);
+  })
+);
+
+// GET /api/config/team-roster - Get workspace team roster manifest
+router.get(
+  '/team-roster',
+  asyncHandler(async (_req, res) => {
+    res.json(await teamRosterService.getRoster());
+  })
+);
+
+// POST /api/config/team-roster/validate - Validate roster YAML/JSON or object
+router.post(
+  '/team-roster/validate',
+  asyncHandler(async (req, res) => {
+    const input = TeamRosterValidateBodySchema.parse(req.body);
+    res.json(
+      input.roster
+        ? teamRosterService.validateRoster(input.roster)
+        : teamRosterService.validateContent({
+            content: input.content as string,
+            format: input.format,
+          })
+    );
+  })
+);
+
+// POST /api/config/team-roster/import - Import or replace roster YAML/JSON
+router.post(
+  '/team-roster/import',
+  authorize('admin'),
+  asyncHandler(async (req, res) => {
+    const input = TeamRosterImportBodySchema.parse(req.body);
+    try {
+      res.status(201).json(await teamRosterService.importRoster(input));
+    } catch (error) {
+      throw new BadRequestError(error instanceof Error ? error.message : 'Invalid team roster');
+    }
+  })
+);
+
+// PUT /api/config/team-roster - Replace team roster manifest
+router.put(
+  '/team-roster',
+  authorize('admin'),
+  asyncHandler(async (req, res) => {
+    const roster = TeamRosterManifestSchema.parse(req.body);
+    try {
+      res.json(await teamRosterService.saveRoster(roster));
+    } catch (error) {
+      throw new BadRequestError(error instanceof Error ? error.message : 'Invalid team roster');
+    }
+  })
+);
+
+// GET /api/config/team-roster/export - Export roster as YAML or JSON
+router.get(
+  '/team-roster/export',
+  asyncHandler(async (req, res) => {
+    const format =
+      TeamRosterFormatSchema.parse(req.query.format) ??
+      (req.query.format === 'json' ? 'json' : 'yaml');
+    try {
+      res.json(await teamRosterService.exportRoster(format));
+    } catch (error) {
+      throw new BadRequestError(
+        error instanceof Error ? error.message : 'Failed to export team roster'
+      );
+    }
+  })
+);
+
+// POST /api/config/team-roster/preview-route - Preview roster route for task metadata
+router.post(
+  '/team-roster/preview-route',
+  asyncHandler(async (req, res) => {
+    const input = TeamRosterRoutePreviewBodySchema.parse(req.body);
+    res.json(await teamRosterService.previewRoute(input));
   })
 );
 

--- a/server/src/schemas/team-roster-schemas.ts
+++ b/server/src/schemas/team-roster-schemas.ts
@@ -1,0 +1,195 @@
+import { z } from 'zod';
+
+const SlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-_]*$/, 'ID must start with a lowercase letter or number');
+
+const AgentTypeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(50)
+  .regex(/^[a-z0-9-]+$/, 'Agent type must be lowercase alphanumeric with dashes');
+
+const StringListSchema = z.array(z.string().trim().min(1).max(160)).max(80).default([]);
+
+const MatchValueSchema = z.union([
+  z.string().trim().min(1).max(160),
+  z.array(z.string().trim().min(1).max(160)).max(50),
+]);
+
+export const TeamRosterFormatSchema = z.enum(['json', 'yaml']).optional();
+
+export const TeamRosterMemberSchema = z
+  .object({
+    id: SlugSchema,
+    displayName: z.string().trim().min(1).max(120),
+    role: z.string().trim().min(1).max(160),
+    agent: AgentTypeSchema,
+    profileId: SlugSchema.optional(),
+    status: z.enum(['enabled', 'disabled']).default('enabled'),
+    capabilities: StringListSchema,
+    defaultTaskTypes: StringListSchema.optional(),
+    ownedPaths: z.array(z.string().trim().min(1).max(500)).max(100).optional(),
+    projects: z.array(z.string().trim().min(1).max(160)).max(50).optional(),
+    fallbackMemberId: SlugSchema.optional(),
+    reviewerMemberIds: z.array(SlugSchema).max(25).optional(),
+  })
+  .strict();
+
+export const TeamRosterRouteMatchSchema = z
+  .object({
+    type: MatchValueSchema.optional(),
+    priority: z
+      .union([
+        z.enum(['critical', 'high', 'medium', 'low']),
+        z.array(z.enum(['critical', 'high', 'medium', 'low'])).max(4),
+      ])
+      .optional(),
+    project: MatchValueSchema.optional(),
+    path: MatchValueSchema.optional(),
+    capability: MatchValueSchema.optional(),
+    minSubtasks: z.number().int().nonnegative().max(500).optional(),
+  })
+  .strict();
+
+export const TeamRosterRouteRuleSchema = z
+  .object({
+    id: SlugSchema,
+    name: z.string().trim().min(1).max(200),
+    enabled: z.boolean().default(true),
+    match: TeamRosterRouteMatchSchema,
+    memberId: SlugSchema,
+    fallbackMemberId: SlugSchema.optional(),
+    reviewerMemberIds: z.array(SlugSchema).max(25).optional(),
+    risk: z.enum(['normal', 'review', 'security', 'human']).optional(),
+  })
+  .strict();
+
+export const TeamRosterManifestSchema = z
+  .object({
+    id: SlugSchema,
+    schemaVersion: z.literal('team-roster/v1').default('team-roster/v1'),
+    workspaceId: z.string().trim().min(1).max(120),
+    name: z.string().trim().min(1).max(160),
+    description: z.string().trim().max(2000).optional(),
+    enabled: z.boolean().default(true),
+    coordinatorMemberId: SlugSchema.optional(),
+    members: z.array(TeamRosterMemberSchema).min(1).max(100),
+    routingRules: z.array(TeamRosterRouteRuleSchema).max(200).default([]),
+    metadata: z
+      .object({
+        source: z.string().trim().min(1).max(500).optional(),
+        importedAt: z.string().datetime().optional(),
+        updatedAt: z.string().datetime().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((roster, ctx) => {
+    const memberIds = new Set<string>();
+    roster.members.forEach((member, index) => {
+      if (memberIds.has(member.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['members', index, 'id'],
+          message: `Duplicate member ID: ${member.id}`,
+        });
+      }
+      memberIds.add(member.id);
+    });
+
+    const ruleIds = new Set<string>();
+    roster.routingRules.forEach((rule, index) => {
+      if (ruleIds.has(rule.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['routingRules', index, 'id'],
+          message: `Duplicate routing rule ID: ${rule.id}`,
+        });
+      }
+      ruleIds.add(rule.id);
+      for (const [field, id] of [
+        ['memberId', rule.memberId],
+        ['fallbackMemberId', rule.fallbackMemberId],
+      ] as const) {
+        if (id && !memberIds.has(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['routingRules', index, field],
+            message: `Unknown member ID: ${id}`,
+          });
+        }
+      }
+      rule.reviewerMemberIds?.forEach((id, reviewerIndex) => {
+        if (!memberIds.has(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['routingRules', index, 'reviewerMemberIds', reviewerIndex],
+            message: `Unknown reviewer member ID: ${id}`,
+          });
+        }
+      });
+    });
+
+    roster.members.forEach((member, index) => {
+      if (member.fallbackMemberId && !memberIds.has(member.fallbackMemberId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['members', index, 'fallbackMemberId'],
+          message: `Unknown fallback member ID: ${member.fallbackMemberId}`,
+        });
+      }
+      member.reviewerMemberIds?.forEach((id, reviewerIndex) => {
+        if (!memberIds.has(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['members', index, 'reviewerMemberIds', reviewerIndex],
+            message: `Unknown reviewer member ID: ${id}`,
+          });
+        }
+      });
+    });
+
+    if (roster.coordinatorMemberId && !memberIds.has(roster.coordinatorMemberId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['coordinatorMemberId'],
+        message: `Unknown coordinator member ID: ${roster.coordinatorMemberId}`,
+      });
+    }
+  });
+
+export const TeamRosterImportBodySchema = z
+  .object({
+    content: z.string().min(1).max(200_000),
+    format: TeamRosterFormatSchema,
+    source: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict();
+
+export const TeamRosterValidateBodySchema = z
+  .object({
+    roster: z.unknown().optional(),
+    content: z.string().min(1).max(200_000).optional(),
+    format: TeamRosterFormatSchema,
+  })
+  .strict()
+  .refine((value) => value.roster || value.content, {
+    message: 'Provide roster or content',
+  });
+
+export const TeamRosterRoutePreviewBodySchema = z
+  .object({
+    type: z.string().trim().min(1).max(160).optional(),
+    priority: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+    project: z.string().trim().min(1).max(160).optional(),
+    path: z.string().trim().min(1).max(500).optional(),
+    capabilities: z.array(z.string().trim().min(1).max(160)).max(25).optional(),
+    subtaskCount: z.number().int().nonnegative().max(500).optional(),
+  })
+  .strict();

--- a/server/src/services/agent-routing-service.ts
+++ b/server/src/services/agent-routing-service.ts
@@ -28,6 +28,7 @@ import {
   type AgentHealthChecker,
   type AgentHealthStatus,
 } from './agent-health-service.js';
+import { TeamRosterService } from './team-roster-service.js';
 
 const log = createLogger('agent-routing');
 
@@ -47,10 +48,12 @@ interface AgentAvailability {
 export class AgentRoutingService {
   private configService: ConfigService;
   private agentHealth: AgentHealthChecker;
+  private teamRoster: TeamRosterService;
 
   constructor(configService?: ConfigService, agentHealth?: AgentHealthChecker) {
     this.configService = configService || new ConfigService();
     this.agentHealth = agentHealth || new AgentHealthService();
+    this.teamRoster = new TeamRosterService(this.configService);
   }
 
   /**
@@ -71,6 +74,71 @@ export class AgentRoutingService {
     const routing: AgentRoutingConfig = config.agentRouting || DEFAULT_ROUTING_CONFIG;
     const evaluatedRules: GovernanceTraceRule[] = [];
     const steps: GovernanceTraceStep[] = [];
+    const rosterPreview = this.teamRoster.resolveRoute(
+      {
+        type: task.type,
+        priority: task.priority,
+        project: task.project,
+        subtaskCount: task.subtasks?.length,
+      },
+      config.teamRoster
+    );
+
+    if (rosterPreview.matched && rosterPreview.agent) {
+      const availability = await this.getAgentAvailability(config.agents, rosterPreview.agent);
+      const ruleId = rosterPreview.ruleId ?? rosterPreview.member?.id ?? 'default';
+      const traceRule: GovernanceTraceRule = {
+        id: `team-roster:${ruleId}`,
+        label: rosterPreview.ruleId ? `Team roster rule ${rosterPreview.ruleId}` : 'Team roster',
+        type: 'routing',
+        status: availability.available ? 'matched' : 'skipped',
+        outcome: availability.available ? 'routed' : 'skipped',
+        message: availability.available
+          ? rosterPreview.reason
+          : `Roster selected ${rosterPreview.agent}, but it is unavailable: ${availability.reason}.`,
+        details: {
+          memberId: rosterPreview.member?.id,
+          profileId: rosterPreview.profileId,
+          reviewerMemberIds: rosterPreview.reviewerMembers.map((member) => member.id),
+        },
+      };
+      evaluatedRules.push(traceRule);
+      steps.push({
+        id: `team-roster:${ruleId}`,
+        label: 'Team roster',
+        status: availability.available ? 'matched' : 'skipped',
+        message: traceRule.message,
+      });
+
+      if (availability.available) {
+        const profile = config.agentProfiles?.find(
+          (candidate) => candidate.id === rosterPreview.profileId
+        );
+        const result: RoutingResult = {
+          agent: rosterPreview.agent,
+          model: profile?.runtime.model ?? availability.agentConfig?.model,
+          rule: traceRule.id,
+          reason: rosterPreview.reason,
+        };
+        return {
+          result,
+          trace: this.buildRoutingTrace(task, context, result, {
+            outcome: 'routed',
+            evaluatedRules,
+            matchedRules: [traceRule],
+            steps,
+            routing,
+          }),
+        };
+      }
+    } else if (rosterPreview.issues.length) {
+      steps.push({
+        id: 'team-roster-invalid',
+        label: 'Team roster',
+        status: 'skipped',
+        message: `Team roster skipped: ${rosterPreview.issues[0]?.message}`,
+      });
+    }
 
     // If routing is disabled, return the global default
     if (!routing.enabled) {

--- a/server/src/services/team-roster-service.ts
+++ b/server/src/services/team-roster-service.ts
@@ -1,0 +1,322 @@
+import yaml from 'yaml';
+import type {
+  AgentType,
+  TeamRosterExportResult,
+  TeamRosterFormat,
+  TeamRosterManifest,
+  TeamRosterMember,
+  TeamRosterRouteMatch,
+  TeamRosterRoutePreview,
+  TeamRosterRoutePreviewInput,
+  TeamRosterValidationResult,
+} from '@veritas-kanban/shared';
+import { getConfigService, type ConfigService } from './config-service.js';
+import { TeamRosterManifestSchema } from '../schemas/team-roster-schemas.js';
+
+interface ImportRosterInput {
+  content: string;
+  format?: TeamRosterFormat;
+  source?: string;
+}
+
+export class TeamRosterService {
+  constructor(private readonly configService: ConfigService = getConfigService()) {}
+
+  async getRoster(): Promise<TeamRosterManifest | null> {
+    const config = await this.configService.getConfig();
+    return config.teamRoster ?? null;
+  }
+
+  validateContent(input: ImportRosterInput): TeamRosterValidationResult {
+    try {
+      return this.validateUnknown(this.parseContent(input.content, input.format));
+    } catch (error) {
+      return {
+        valid: false,
+        issues: [{ path: '$', message: error instanceof Error ? error.message : String(error) }],
+      };
+    }
+  }
+
+  validateRoster(roster: unknown): TeamRosterValidationResult {
+    return this.validateUnknown(roster);
+  }
+
+  async saveRoster(roster: TeamRosterManifest): Promise<TeamRosterManifest> {
+    const parsed = this.validateUnknown(roster);
+    if (!parsed.valid || !parsed.roster) {
+      const firstIssue = parsed.issues[0];
+      throw new Error(firstIssue ? `${firstIssue.path}: ${firstIssue.message}` : 'Invalid roster');
+    }
+
+    const config = await this.configService.getConfig();
+    const now = new Date().toISOString();
+    const next: TeamRosterManifest = {
+      ...parsed.roster,
+      metadata: {
+        ...parsed.roster.metadata,
+        updatedAt: now,
+      },
+    };
+    config.teamRoster = next;
+    await this.configService.saveConfig(config);
+    return next;
+  }
+
+  async importRoster(input: ImportRosterInput): Promise<TeamRosterManifest> {
+    const validation = this.validateContent(input);
+    if (!validation.valid || !validation.roster) {
+      const firstIssue = validation.issues[0];
+      throw new Error(firstIssue ? `${firstIssue.path}: ${firstIssue.message}` : 'Invalid roster');
+    }
+
+    const now = new Date().toISOString();
+    return this.saveRoster({
+      ...validation.roster,
+      metadata: {
+        ...validation.roster.metadata,
+        source: input.source ?? validation.roster.metadata?.source,
+        importedAt: validation.roster.metadata?.importedAt ?? now,
+        updatedAt: now,
+      },
+    });
+  }
+
+  async exportRoster(format: TeamRosterFormat): Promise<TeamRosterExportResult> {
+    const roster = await this.getRoster();
+    if (!roster) {
+      throw new Error('Team roster is not configured');
+    }
+    const content =
+      format === 'json' ? `${JSON.stringify(roster, null, 2)}\n` : yaml.stringify(roster);
+    return { id: roster.id, format, content };
+  }
+
+  async previewRoute(input: TeamRosterRoutePreviewInput): Promise<TeamRosterRoutePreview> {
+    const roster = await this.getRoster();
+    return this.resolveRoute(input, roster);
+  }
+
+  resolveRoute(
+    input: TeamRosterRoutePreviewInput,
+    roster: TeamRosterManifest | null | undefined
+  ): TeamRosterRoutePreview {
+    if (!roster || !roster.enabled) {
+      return {
+        matched: false,
+        reason: 'No enabled team roster is configured',
+        reviewerMembers: [],
+        issues: [],
+      };
+    }
+
+    const validation = this.validateUnknown(roster);
+    if (!validation.valid || !validation.roster) {
+      return {
+        matched: false,
+        reason: 'Team roster is invalid',
+        reviewerMembers: [],
+        issues: validation.issues,
+      };
+    }
+
+    const validRoster = validation.roster;
+    for (const rule of validRoster.routingRules) {
+      if (!rule.enabled || !this.matches(input, rule.match)) continue;
+      const selected = this.pickMember(validRoster, rule.memberId, rule.fallbackMemberId);
+      if (!selected.member) {
+        return {
+          matched: false,
+          ruleId: rule.id,
+          reason: selected.reason,
+          reviewerMembers: [],
+          issues: [{ path: `$.routingRules.${rule.id}.memberId`, message: selected.reason }],
+        };
+      }
+      return this.toPreview(
+        validRoster,
+        selected.member,
+        `Matched roster rule: ${rule.name}`,
+        rule.id,
+        rule.reviewerMemberIds ?? selected.member.reviewerMemberIds,
+        selected.fallbackMember
+      );
+    }
+
+    const byCapability = input.capabilities?.find((capability) =>
+      validRoster.members.some(
+        (member) =>
+          member.status === 'enabled' &&
+          member.capabilities.includes(capability) &&
+          this.memberScopeMatches(member, input)
+      )
+    );
+    if (byCapability) {
+      const member = validRoster.members.find(
+        (candidate) =>
+          candidate.status === 'enabled' &&
+          candidate.capabilities.includes(byCapability) &&
+          this.memberScopeMatches(candidate, input)
+      );
+      if (member) {
+        return this.toPreview(validRoster, member, `Matched member capability: ${byCapability}`);
+      }
+    }
+
+    const byTaskType = validRoster.members.find(
+      (member) =>
+        member.status === 'enabled' &&
+        input.type &&
+        member.defaultTaskTypes?.includes(input.type) &&
+        this.memberScopeMatches(member, input)
+    );
+    if (byTaskType) {
+      return this.toPreview(validRoster, byTaskType, `Matched member task type: ${input.type}`);
+    }
+
+    const coordinator = validRoster.coordinatorMemberId
+      ? this.pickMember(validRoster, validRoster.coordinatorMemberId).member
+      : null;
+    if (coordinator) {
+      return this.toPreview(validRoster, coordinator, 'No roster rule matched; using coordinator');
+    }
+
+    return {
+      matched: false,
+      reason: 'No enabled roster member matched the task',
+      reviewerMembers: [],
+      issues: [],
+    };
+  }
+
+  private validateUnknown(value: unknown): TeamRosterValidationResult {
+    const parsed = TeamRosterManifestSchema.safeParse(value);
+    if (!parsed.success) {
+      return {
+        valid: false,
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.length ? `$.${issue.path.join('.')}` : '$',
+          message: issue.message,
+        })),
+      };
+    }
+
+    return { valid: true, roster: parsed.data as TeamRosterManifest, issues: [] };
+  }
+
+  private parseContent(content: string, format?: TeamRosterFormat): unknown {
+    if (format === 'json') return JSON.parse(content);
+    if (format === 'yaml') return yaml.parse(content);
+    try {
+      return JSON.parse(content);
+    } catch {
+      return yaml.parse(content);
+    }
+  }
+
+  private matches(input: TeamRosterRoutePreviewInput, match: TeamRosterRouteMatch): boolean {
+    if (match.type !== undefined && !this.matchesValue(input.type, match.type)) return false;
+    if (match.priority !== undefined && !this.matchesValue(input.priority, match.priority)) {
+      return false;
+    }
+    if (match.project !== undefined && !this.matchesValue(input.project, match.project)) {
+      return false;
+    }
+    if (match.path !== undefined && !this.matchesPath(input.path, match.path)) return false;
+    if (
+      match.capability !== undefined &&
+      !this.matchesAny(input.capabilities ?? [], match.capability)
+    ) {
+      return false;
+    }
+    if (match.minSubtasks !== undefined && (input.subtaskCount ?? 0) < match.minSubtasks) {
+      return false;
+    }
+    return true;
+  }
+
+  private matchesValue(actual: string | undefined, expected: string | string[]): boolean {
+    if (!actual) return false;
+    return Array.isArray(expected) ? expected.includes(actual) : actual === expected;
+  }
+
+  private matchesAny(actual: string[], expected: string | string[]): boolean {
+    const values = Array.isArray(expected) ? expected : [expected];
+    return values.some((value) => actual.includes(value));
+  }
+
+  private matchesPath(actual: string | undefined, expected: string | string[]): boolean {
+    if (!actual) return false;
+    const values = Array.isArray(expected) ? expected : [expected];
+    return values.some((value) => actual === value || actual.startsWith(`${value}/`));
+  }
+
+  private memberScopeMatches(
+    member: TeamRosterMember,
+    input: TeamRosterRoutePreviewInput
+  ): boolean {
+    if (member.projects?.length && (!input.project || !member.projects.includes(input.project))) {
+      return false;
+    }
+    if (member.ownedPaths?.length && !this.matchesPath(input.path, member.ownedPaths)) {
+      return false;
+    }
+    return true;
+  }
+
+  private pickMember(
+    roster: TeamRosterManifest,
+    memberId: string,
+    fallbackMemberId?: string
+  ): { member?: TeamRosterMember; fallbackMember?: TeamRosterMember; reason: string } {
+    const member = roster.members.find((candidate) => candidate.id === memberId);
+    if (member?.status === 'enabled') return { member, reason: 'Selected roster member' };
+
+    const fallbackId = fallbackMemberId ?? member?.fallbackMemberId;
+    const fallbackMember = fallbackId
+      ? roster.members.find((candidate) => candidate.id === fallbackId)
+      : undefined;
+    if (fallbackMember?.status === 'enabled') {
+      return {
+        member: fallbackMember,
+        fallbackMember,
+        reason: `Primary roster member is unavailable; using fallback ${fallbackMember.id}`,
+      };
+    }
+
+    return { reason: `Roster member is not enabled: ${memberId}` };
+  }
+
+  private toPreview(
+    roster: TeamRosterManifest,
+    member: TeamRosterMember,
+    reason: string,
+    ruleId?: string,
+    reviewerIds: string[] = [],
+    fallbackMember?: TeamRosterMember
+  ): TeamRosterRoutePreview {
+    const reviewerMembers = reviewerIds
+      .map((id) => roster.members.find((candidate) => candidate.id === id))
+      .filter((candidate): candidate is TeamRosterMember => Boolean(candidate));
+    return {
+      matched: true,
+      ruleId,
+      reason,
+      member,
+      fallbackMember,
+      reviewerMembers,
+      agent: member.agent as AgentType,
+      profileId: member.profileId,
+      issues: [],
+    };
+  }
+}
+
+let teamRosterService: TeamRosterService | null = null;
+
+export function getTeamRosterService(): TeamRosterService {
+  if (!teamRosterService) {
+    teamRosterService = new TeamRosterService();
+  }
+  return teamRosterService;
+}

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -6,6 +6,7 @@ import type { WatcherContinuationSettings } from './watcher-policy.types.js';
 import type { SandboxPolicyPreset } from './sandbox-policy.types.js';
 import type { AgentBudgetPolicy } from './agent-budget.types.js';
 import type { AgentProfilePackage } from './agent-profile-package.types.js';
+import type { TeamRosterManifest } from './team-roster.types.js';
 
 export interface DevServerConfig {
   command: string; // e.g., "pnpm dev" or "npm run dev"
@@ -168,6 +169,7 @@ export interface AppConfig {
   sandboxPolicyPresets?: SandboxPolicyPreset[];
   defaultSandboxPresetId?: string;
   agentProfiles?: AgentProfilePackage[];
+  teamRoster?: TeamRosterManifest;
 }
 
 // ============ Feature Settings Types ============

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -33,6 +33,7 @@ export * from './skill-security.types.js';
 export * from './sandbox-policy.types.js';
 export * from './agent-budget.types.js';
 export * from './agent-profile-package.types.js';
+export * from './team-roster.types.js';
 export * from './watcher-policy.types.js';
 export * from './evidence.types.js';
 export * from './time-breakdown.types.js';

--- a/shared/src/types/team-roster.types.ts
+++ b/shared/src/types/team-roster.types.ts
@@ -1,0 +1,96 @@
+import type { AgentType, TaskPriority, TaskType } from './task.types.js';
+
+export type TeamRosterFormat = 'json' | 'yaml';
+export type TeamRosterMemberStatus = 'enabled' | 'disabled';
+
+export interface TeamRosterMember {
+  id: string;
+  displayName: string;
+  role: string;
+  agent: AgentType;
+  profileId?: string;
+  status: TeamRosterMemberStatus;
+  capabilities: string[];
+  defaultTaskTypes?: TaskType[];
+  ownedPaths?: string[];
+  projects?: string[];
+  fallbackMemberId?: string;
+  reviewerMemberIds?: string[];
+}
+
+export interface TeamRosterRouteMatch {
+  type?: TaskType | TaskType[];
+  priority?: TaskPriority | TaskPriority[];
+  project?: string | string[];
+  path?: string | string[];
+  capability?: string | string[];
+  minSubtasks?: number;
+}
+
+export interface TeamRosterRouteRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  match: TeamRosterRouteMatch;
+  memberId: string;
+  fallbackMemberId?: string;
+  reviewerMemberIds?: string[];
+  risk?: 'normal' | 'review' | 'security' | 'human';
+}
+
+export interface TeamRosterManifestMetadata {
+  source?: string;
+  importedAt?: string;
+  updatedAt?: string;
+}
+
+export interface TeamRosterManifest {
+  id: string;
+  schemaVersion: 'team-roster/v1';
+  workspaceId: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  coordinatorMemberId?: string;
+  members: TeamRosterMember[];
+  routingRules: TeamRosterRouteRule[];
+  metadata?: TeamRosterManifestMetadata;
+}
+
+export interface TeamRosterValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface TeamRosterValidationResult {
+  valid: boolean;
+  roster?: TeamRosterManifest;
+  issues: TeamRosterValidationIssue[];
+}
+
+export interface TeamRosterExportResult {
+  id: string;
+  format: TeamRosterFormat;
+  content: string;
+}
+
+export interface TeamRosterRoutePreviewInput {
+  type?: TaskType;
+  priority?: TaskPriority;
+  project?: string;
+  path?: string;
+  capabilities?: string[];
+  subtaskCount?: number;
+}
+
+export interface TeamRosterRoutePreview {
+  matched: boolean;
+  ruleId?: string;
+  reason: string;
+  member?: TeamRosterMember;
+  fallbackMember?: TeamRosterMember;
+  reviewerMembers: TeamRosterMember[];
+  agent?: AgentType;
+  profileId?: string;
+  issues: TeamRosterValidationIssue[];
+}


### PR DESCRIPTION
## Summary
- Add config-backed team roster manifest types, validation, import/export, and route preview APIs.
- Evaluate enabled team rosters before legacy agent routing rules and record roster-selected governance trace rules.
- Document the roster API surface and add service/route/routing regression coverage.

Closes #734.

## Verification
- pnpm vitest run server/src/__tests__/team-roster-service.test.ts server/src/__tests__/agent-routing-service.test.ts server/src/__tests__/routes/config-coverage.test.ts
- pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/server typecheck
- pnpm build

## Risk
- No roster configured preserves existing routing behavior.
- UI editing for the roster is intentionally left for a later pass; the first surface is API/import/export/preview.