### PR TITLE
Add workspace capability discovery and intake

### DIFF
--- a/cli/src/__tests__/api-permissions.test.ts
+++ b/cli/src/__tests__/api-permissions.test.ts
@@ -89,4 +89,31 @@ describe('CLI API permission preflight', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe('http://vk.test/api/auth/context');
   });
+
+  it('requires task write permission for delegated workspace intake', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        role: 'read-only',
+        isLocalhost: false,
+        permissions: ['workspace:read'],
+      })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const api = createGuardedApiClient('http://vk.test', 'reader-key');
+
+    await expect(
+      api('/api/workspace-capabilities/intake', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'blocked' }),
+      })
+    ).rejects.toMatchObject({
+      required: ['task:write'],
+      path: '/api/workspace-capabilities/intake',
+      method: 'POST',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://vk.test/api/auth/context');
+  });
 });

--- a/cli/src/commands/workspaces.ts
+++ b/cli/src/commands/workspaces.ts
@@ -1,0 +1,201 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { api } from '../utils/api.js';
+import type {
+  WorkspaceCapabilityDiscoveryResult,
+  WorkspaceCapabilityFormat,
+  WorkspaceCapabilityRegistrationResult,
+  WorkspaceCapabilityValidationResult,
+  WorkspaceDelegatedWorkIntakeResult,
+} from '@veritas-kanban/shared';
+
+function inferFormat(filePath: string): WorkspaceCapabilityFormat {
+  return path.extname(filePath).toLowerCase() === '.json' ? 'json' : 'yaml';
+}
+
+function contextField(
+  value: string,
+  previous: Record<string, string> = {}
+): Record<string, string> {
+  const index = value.indexOf('=');
+  if (index === -1) {
+    throw new Error('Context fields must use key=value format');
+  }
+  return {
+    ...previous,
+    [value.slice(0, index).trim()]: value.slice(index + 1).trim(),
+  };
+}
+
+export function registerWorkspaceCommands(program: Command): void {
+  const workspaces = program
+    .command('workspaces')
+    .alias('workspace')
+    .description('Workspace capability discovery and delegated intake');
+
+  workspaces
+    .command('discover')
+    .description('List local and trusted workspace capability manifests')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const result = await api<WorkspaceCapabilityDiscoveryResult>(
+          '/api/workspace-capabilities/discover'
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        if (result.local) {
+          console.log(chalk.bold(`\nLocal: ${result.local.name}`));
+          console.log(chalk.dim(`  ${result.local.workspaceId}`));
+          for (const capability of result.local.capabilities) {
+            console.log(`  - ${capability.id}: ${capability.name}`);
+          }
+        }
+
+        console.log(chalk.bold(`\nTrusted Workspaces (${result.trusted.length})`));
+        if (result.trusted.length === 0) {
+          console.log(chalk.dim('  No trusted workspace manifests registered.'));
+        }
+        for (const workspace of result.trusted) {
+          console.log(`  ${chalk.cyan(workspace.workspaceId)} ${workspace.name}`);
+          for (const capability of workspace.capabilities) {
+            console.log(
+              `    - ${capability.id}: ${capability.acceptedTaskTypes.join(', ') || 'any'}`
+            );
+          }
+        }
+        console.log();
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  workspaces
+    .command('validate <file>')
+    .description('Validate a workspace capability manifest YAML or JSON file')
+    .option('--json', 'Output as JSON')
+    .action(async (file, options) => {
+      try {
+        const content = readFileSync(file, 'utf-8');
+        const result = await api<WorkspaceCapabilityValidationResult>(
+          '/api/workspace-capabilities/manifest/validate',
+          {
+            method: 'POST',
+            body: JSON.stringify({ content, format: inferFormat(file), source: file }),
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        if (result.valid) {
+          console.log(chalk.green(`Valid workspace manifest: ${result.manifest?.workspaceId}`));
+          return;
+        }
+        console.log(chalk.red('Invalid workspace manifest'));
+        for (const issue of result.issues) {
+          console.log(chalk.dim(`  ${issue.path}: ${issue.message}`));
+        }
+        process.exitCode = 1;
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  workspaces
+    .command('trust <file>')
+    .description('Register a trusted peer workspace manifest')
+    .option('--json', 'Output as JSON')
+    .action(async (file, options) => {
+      try {
+        const content = readFileSync(file, 'utf-8');
+        const result = await api<WorkspaceCapabilityRegistrationResult>(
+          '/api/workspace-capabilities/trusted',
+          {
+            method: 'POST',
+            body: JSON.stringify({ content, format: inferFormat(file), source: file }),
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(
+          chalk.green(
+            `${result.created ? 'Registered' : 'Updated'} trusted workspace: ${result.manifest.name}`
+          )
+        );
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  workspaces
+    .command('intake')
+    .description('Create delegated work intake in this workspace')
+    .requiredOption('--source-workspace <id>', 'Source workspace ID')
+    .requiredOption('--capability <id>', 'Target capability ID')
+    .requiredOption('--title <title>', 'Delegated work title')
+    .requiredOption('--context <text>', 'Delegated work context')
+    .option('--source-name <name>', 'Source workspace display name')
+    .option('--source-task <id>', 'Originating task ID')
+    .option('--source-task-url <url>', 'Originating task URL')
+    .option('--repository <repo>', 'Source repository')
+    .option('--issue-url <url>', 'Source issue URL')
+    .option('--type <type>', 'Task type')
+    .option('--project <project>', 'Target project')
+    .option('--priority <priority>', 'Target priority')
+    .option('--label <label...>', 'Delegation labels')
+    .option('--context-field <key=value>', 'Required context field', contextField, {})
+    .option('--requested-by <actor>', 'Requester actor')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const result = await api<WorkspaceDelegatedWorkIntakeResult>(
+          '/api/workspace-capabilities/intake',
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              source: {
+                workspaceId: options.sourceWorkspace,
+                workspaceName: options.sourceName,
+                taskId: options.sourceTask,
+                taskUrl: options.sourceTaskUrl,
+                repository: options.repository,
+                issueUrl: options.issueUrl,
+              },
+              capabilityId: options.capability,
+              title: options.title,
+              context: options.context,
+              contextFields: options.contextField,
+              labels: options.label,
+              priority: options.priority,
+              project: options.project,
+              type: options.type,
+              requestedBy: options.requestedBy,
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(chalk.green(`Created delegated task: ${result.taskId}`));
+        console.log(chalk.dim(`Delegation: ${result.record.id}`));
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,7 @@ import { registerSprintCommands } from './commands/sprints.js';
 import { registerDoctorCommand } from './commands/doctor.js';
 import { registerSnapshotCommand } from './commands/snapshot.js';
 import { registerPromptCommands } from './commands/prompts.js';
+import { registerWorkspaceCommands } from './commands/workspaces.js';
 
 const program = new Command();
 const packageJson = JSON.parse(
@@ -49,5 +50,6 @@ registerSprintCommands(program);
 registerDoctorCommand(program);
 registerSnapshotCommand(program);
 registerPromptCommands(program);
+registerWorkspaceCommands(program);
 
 program.parse();

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1608,6 +1608,97 @@ Invalid rosters never route agent launches.
 
 ---
 
+## Workspace Capability Discovery
+
+Workspace capability manifests let a board publish what work it accepts and
+register trusted peer manifests for delegated intake. Manifest data is stored in
+app config as `workspaceCapability`, `trustedWorkspaceCapabilities`, and
+`workspaceDelegations`.
+
+Mounted at `/api/workspace-capabilities`.
+
+| Method   | Path                                                  | Description                                      | Permissions      |
+| -------- | ----------------------------------------------------- | ------------------------------------------------ | ---------------- |
+| `GET`    | `/api/workspace-capabilities/manifest`                | Return the local published manifest or `null`    | `workspace:read` |
+| `PUT`    | `/api/workspace-capabilities/manifest`                | Replace the local published manifest             | `settings:write` |
+| `POST`   | `/api/workspace-capabilities/manifest/validate`       | Validate a manifest object or YAML/JSON content  | `workspace:read` |
+| `POST`   | `/api/workspace-capabilities/manifest/import`         | Import and store the local manifest              | `settings:write` |
+| `GET`    | `/api/workspace-capabilities/manifest/export`         | Export the local manifest as YAML or JSON        | `workspace:read` |
+| `GET`    | `/api/workspace-capabilities/trusted`                 | List trusted peer manifests                      | `workspace:read` |
+| `POST`   | `/api/workspace-capabilities/trusted`                 | Register or replace a trusted peer manifest      | `settings:write` |
+| `DELETE` | `/api/workspace-capabilities/trusted/:workspaceId`    | Remove a trusted peer manifest                   | `settings:write` |
+| `GET`    | `/api/workspace-capabilities/discover`                | Return local plus trusted manifests for browsing | `workspace:read` |
+| `POST`   | `/api/workspace-capabilities/intake`                  | Create delegated task intake from a trusted peer | `task:write`     |
+| `GET`    | `/api/workspace-capabilities/delegations`             | List stored delegation records                   | `task:read`      |
+| `POST`   | `/api/workspace-capabilities/delegations/:id/refresh` | Refresh latest target state                      | `task:write`     |
+
+### Manifest Shape
+
+```json
+{
+  "id": "local-board",
+  "schemaVersion": "workspace-capability/v1",
+  "workspaceId": "local",
+  "name": "Local Board",
+  "enabled": true,
+  "boardUrl": "https://veritas.example",
+  "capabilities": [
+    {
+      "id": "docs",
+      "name": "Documentation",
+      "acceptedTaskTypes": ["docs"],
+      "defaultLabels": ["docs"],
+      "defaultProject": "handbook",
+      "defaultPriority": "medium",
+      "requiredContextFields": ["acceptance"],
+      "intakeTargets": ["task"]
+    }
+  ]
+}
+```
+
+Validation rejects duplicate capability IDs and secret-like manifest fields such
+as `token`, `password`, `apiKey`, or `privateKey`. Discovery responses redact
+manifest import source metadata.
+
+### Delegated Intake
+
+```json
+{
+  "source": {
+    "workspaceId": "source",
+    "workspaceName": "Source Board",
+    "taskId": "task_20260626_source",
+    "taskUrl": "https://source.example/tasks/task_20260626_source"
+  },
+  "capabilityId": "docs",
+  "title": "Write operator handoff docs",
+  "context": "Document the delegated queue handoff.",
+  "contextFields": {
+    "acceptance": "Includes handoff and rollback steps"
+  },
+  "type": "docs",
+  "labels": ["handoff"],
+  "requestedBy": "user:brad"
+}
+```
+
+Intake fails closed unless the source workspace is trusted by the local manifest
+or registered as a trusted peer manifest. Successful task intake stores a
+delegation record and, when the source task exists locally, appends a
+`delegatedWork` status link to that originating task.
+
+CLI support is available under `vk workspaces`:
+
+```bash
+vk workspaces discover
+vk workspaces validate ./workspace-capability.yaml
+vk workspaces trust ./peer-workspace.yaml
+vk workspaces intake --source-workspace source --capability docs --title "Write docs" --context "Document handoff" --context-field acceptance="Includes rollback steps"
+```
+
+---
+
 ## Agent Profile Packages
 
 Reusable YAML/JSON packages for agent role, runtime, prompt, tools, permissions, policy posture, workflow entrypoint, and health metadata.

--- a/server/src/__tests__/routes/workspace-capabilities.test.ts
+++ b/server/src/__tests__/routes/workspace-capabilities.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import type { AppConfig, Task, WorkspaceCapabilityManifest } from '@veritas-kanban/shared';
+import { workspaceCapabilityRoutes } from '../../routes/workspace-capabilities';
+import { errorHandler } from '../../middleware/error-handler';
+
+const { mockConfigService, mockTaskService } = vi.hoisted(() => ({
+  mockConfigService: {
+    getConfig: vi.fn(),
+    saveConfig: vi.fn(),
+  },
+  mockTaskService: {
+    createTask: vi.fn(),
+    getTask: vi.fn(),
+    updateTask: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/config-service.js', () => ({
+  ConfigService: function () {
+    return mockConfigService;
+  },
+  getConfigService: () => mockConfigService,
+}));
+
+vi.mock('../../services/task-service.js', () => ({
+  getTaskService: () => mockTaskService,
+}));
+
+const localManifest: WorkspaceCapabilityManifest = {
+  id: 'local-board',
+  schemaVersion: 'workspace-capability/v1',
+  workspaceId: 'local',
+  name: 'Local Board',
+  enabled: true,
+  capabilities: [
+    {
+      id: 'docs',
+      name: 'Documentation',
+      acceptedTaskTypes: ['docs'],
+      requiredContextFields: ['acceptance'],
+      intakeTargets: ['task'],
+    },
+  ],
+};
+
+const trustedManifest: WorkspaceCapabilityManifest = {
+  id: 'source-board',
+  schemaVersion: 'workspace-capability/v1',
+  workspaceId: 'source',
+  name: 'Source Board',
+  enabled: true,
+  capabilities: [
+    {
+      id: 'ops',
+      name: 'Ops',
+      acceptedTaskTypes: ['feature'],
+      intakeTargets: ['task'],
+    },
+  ],
+};
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/workspace-capabilities', workspaceCapabilityRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('workspace capability routes', () => {
+  let app: express.Express;
+  let config: AppConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = createApp();
+    config = {
+      repos: [],
+      agents: [],
+      defaultAgent: 'codex',
+      workspaceCapability: localManifest,
+      trustedWorkspaceCapabilities: [trustedManifest],
+    };
+    mockConfigService.getConfig.mockImplementation(async () => config);
+    mockConfigService.saveConfig.mockImplementation(async (next: AppConfig) => {
+      Object.assign(config, next);
+    });
+    mockTaskService.getTask.mockResolvedValue(null);
+    mockTaskService.updateTask.mockResolvedValue(null);
+    mockTaskService.createTask.mockImplementation(
+      async (input) =>
+        ({
+          id: 'task_20260626_target',
+          title: input.title,
+          description: input.description,
+          type: input.type,
+          status: 'todo',
+          priority: input.priority,
+          created: '2026-06-26T00:00:00.000Z',
+          updated: '2026-06-26T00:00:00.000Z',
+        }) satisfies Task
+    );
+  });
+
+  it('validates manifests and reports field paths', async () => {
+    const res = await request(app)
+      .post('/api/workspace-capabilities/manifest/validate')
+      .send({
+        manifest: {
+          ...localManifest,
+          capabilities: [
+            { ...localManifest.capabilities[0] },
+            { ...localManifest.capabilities[0] },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.issues.map((issue: { message: string }) => issue.message)).toContain(
+      'Duplicate capability ID: docs'
+    );
+  });
+
+  it('registers trusted manifests and exposes redacted discovery', async () => {
+    config.trustedWorkspaceCapabilities = [];
+
+    const register = await request(app)
+      .post('/api/workspace-capabilities/trusted')
+      .send({
+        manifest: {
+          ...trustedManifest,
+          metadata: { source: '/tmp/source.yaml' },
+        },
+      });
+
+    expect(register.status).toBe(201);
+    expect(register.body.manifest.metadata.source).toBeUndefined();
+
+    const discover = await request(app).get('/api/workspace-capabilities/discover');
+    expect(discover.status).toBe(200);
+    expect(discover.body.trusted[0].workspaceId).toBe('source');
+    expect(discover.body.trusted[0].metadata.source).toBeUndefined();
+  });
+
+  it('creates delegated task intake for trusted sources', async () => {
+    const res = await request(app)
+      .post('/api/workspace-capabilities/intake')
+      .send({
+        source: { workspaceId: 'source', workspaceName: 'Source Board' },
+        capabilityId: 'docs',
+        title: 'Write docs',
+        context: 'Document the handoff.',
+        contextFields: { acceptance: 'Includes handoff and rollback steps' },
+        type: 'docs',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.taskId).toBe('task_20260626_target');
+    expect(mockTaskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Write docs',
+        type: 'docs',
+      })
+    );
+    expect(config.workspaceDelegations?.[0]).toMatchObject({
+      source: { workspaceId: 'source' },
+      target: { taskId: 'task_20260626_target' },
+    });
+  });
+
+  it('rejects untrusted delegated intake', async () => {
+    const res = await request(app)
+      .post('/api/workspace-capabilities/intake')
+      .send({
+        source: { workspaceId: 'unknown' },
+        capabilityId: 'docs',
+        title: 'Write docs',
+        context: 'Document the handoff.',
+        contextFields: { acceptance: 'Includes handoff and rollback steps' },
+        type: 'docs',
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('Workspace is not trusted');
+  });
+});

--- a/server/src/__tests__/workspace-capability-service.test.ts
+++ b/server/src/__tests__/workspace-capability-service.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  AppConfig,
+  Task,
+  WorkspaceCapabilityManifest,
+  WorkspaceDelegatedWorkIntakeInput,
+} from '@veritas-kanban/shared';
+import { WorkspaceCapabilityService } from '../services/workspace-capability-service';
+
+const localManifest: WorkspaceCapabilityManifest = {
+  id: 'local-board',
+  schemaVersion: 'workspace-capability/v1',
+  workspaceId: 'local',
+  name: 'Local Board',
+  enabled: true,
+  defaultLabels: ['delegated'],
+  capabilities: [
+    {
+      id: 'docs',
+      name: 'Documentation',
+      acceptedTaskTypes: ['docs'],
+      defaultLabels: ['docs'],
+      defaultProject: 'handbook',
+      defaultPriority: 'medium',
+      requiredContextFields: ['acceptance'],
+      intakeTargets: ['task'],
+    },
+  ],
+};
+
+const trustedManifest: WorkspaceCapabilityManifest = {
+  id: 'source-board',
+  schemaVersion: 'workspace-capability/v1',
+  workspaceId: 'source',
+  name: 'Source Board',
+  enabled: true,
+  capabilities: [
+    {
+      id: 'ops',
+      name: 'Ops',
+      acceptedTaskTypes: ['feature'],
+      intakeTargets: ['task'],
+    },
+  ],
+  metadata: {
+    source: '/tmp/source.yaml',
+    importedAt: '2026-06-26T00:00:00.000Z',
+    updatedAt: '2026-06-26T00:00:00.000Z',
+  },
+};
+
+function serviceWithConfig(config: AppConfig, sourceTask?: Task) {
+  const createdTasks: Task[] = [];
+  const updateTask = vi.fn(async (_id: string, input: Partial<Task>) => ({
+    ...(sourceTask as Task),
+    ...input,
+  }));
+  const service = new WorkspaceCapabilityService(
+    {
+      getConfig: async () => config,
+      saveConfig: async (next: AppConfig) => {
+        Object.assign(config, next);
+      },
+    } as never,
+    {
+      createTask: async (input) => {
+        const task = {
+          id: 'task_20260626_target',
+          title: input.title,
+          description: input.description ?? '',
+          type: input.type ?? 'code',
+          status: input.status ?? 'todo',
+          priority: input.priority ?? 'medium',
+          project: input.project,
+          created: '2026-06-26T00:00:00.000Z',
+          updated: '2026-06-26T00:00:00.000Z',
+          revision: 1,
+        } satisfies Task;
+        createdTasks.push(task);
+        return task;
+      },
+      getTask: async (id) => (sourceTask?.id === id ? sourceTask : null),
+      updateTask,
+    } as never
+  );
+  return { service, createdTasks, updateTask };
+}
+
+function intakeInput(overrides: Partial<WorkspaceDelegatedWorkIntakeInput> = {}) {
+  return {
+    source: {
+      workspaceId: 'source',
+      workspaceName: 'Source Board',
+      taskId: 'task_20260626_source',
+      taskUrl: 'https://source.example/tasks/task_20260626_source',
+    },
+    capabilityId: 'docs',
+    title: 'Write operator docs',
+    context: 'Document the queue handoff flow.',
+    contextFields: { acceptance: 'Docs include handoff and rollback steps' },
+    type: 'docs',
+    labels: ['urgent-docs'],
+    requestedBy: 'user:brad',
+    ...overrides,
+  } satisfies WorkspaceDelegatedWorkIntakeInput;
+}
+
+describe('WorkspaceCapabilityService', () => {
+  it('validates duplicate capabilities and rejects sensitive manifest fields', () => {
+    const { service } = serviceWithConfig({ repos: [], agents: [], defaultAgent: 'codex' });
+
+    const duplicate = service.validateManifest({
+      ...localManifest,
+      capabilities: [localManifest.capabilities[0], localManifest.capabilities[0]],
+    });
+
+    expect(duplicate.valid).toBe(false);
+    expect(duplicate.issues.map((issue) => issue.message)).toContain(
+      'Duplicate capability ID: docs'
+    );
+
+    const sensitive = service.validateManifest({
+      ...localManifest,
+      apiToken: 'should-not-be-present',
+    });
+    expect(sensitive.valid).toBe(false);
+    expect(sensitive.issues.some((issue) => issue.message.includes('Sensitive field'))).toBe(true);
+  });
+
+  it('registers trusted manifests and redacts import source during discovery', async () => {
+    const config: AppConfig = {
+      repos: [],
+      agents: [],
+      defaultAgent: 'codex',
+      workspaceCapability: localManifest,
+    };
+    const { service } = serviceWithConfig(config);
+
+    const result = await service.registerTrustedManifest({ manifest: trustedManifest });
+    expect(result.created).toBe(true);
+    expect(config.trustedWorkspaceCapabilities?.[0].metadata?.source).toBe('/tmp/source.yaml');
+
+    const discovery = await service.discover();
+    expect(discovery.trusted[0].workspaceId).toBe('source');
+    expect(discovery.trusted[0].metadata?.source).toBeUndefined();
+  });
+
+  it('fails closed for untrusted sources and missing required context', async () => {
+    const config: AppConfig = {
+      repos: [],
+      agents: [],
+      defaultAgent: 'codex',
+      workspaceCapability: localManifest,
+    };
+    const { service } = serviceWithConfig(config);
+
+    await expect(service.intake(intakeInput())).rejects.toThrow(
+      'Workspace is not trusted for delegated intake: source'
+    );
+
+    config.trustedWorkspaceCapabilities = [trustedManifest];
+    await expect(service.intake(intakeInput({ contextFields: {} }))).rejects.toThrow(
+      'Missing required delegation context: acceptance'
+    );
+  });
+
+  it('creates a target task, stores a delegation record, and updates a local source task link', async () => {
+    const sourceTask: Task = {
+      id: 'task_20260626_source',
+      title: 'Source task',
+      description: '',
+      type: 'feature',
+      status: 'todo',
+      priority: 'medium',
+      created: '2026-06-26T00:00:00.000Z',
+      updated: '2026-06-26T00:00:00.000Z',
+    };
+    const config: AppConfig = {
+      repos: [],
+      agents: [],
+      defaultAgent: 'codex',
+      workspaceCapability: localManifest,
+      trustedWorkspaceCapabilities: [trustedManifest],
+    };
+    const { service, createdTasks, updateTask } = serviceWithConfig(config, sourceTask);
+
+    const result = await service.intake(intakeInput());
+
+    expect(createdTasks[0]).toMatchObject({
+      title: 'Write operator docs',
+      type: 'docs',
+      priority: 'medium',
+      project: 'handbook',
+    });
+    expect(createdTasks[0].description).toContain('## Delegated Intake');
+    expect(result.record.labels).toEqual(['delegated', 'docs', 'urgent-docs']);
+    expect(config.workspaceDelegations).toHaveLength(1);
+    expect(updateTask).toHaveBeenCalledWith(
+      sourceTask.id,
+      expect.objectContaining({
+        delegatedWork: [
+          expect.objectContaining({
+            targetWorkspaceId: 'local',
+            targetId: 'task_20260626_target',
+            latestState: 'todo',
+          }),
+        ],
+      })
+    );
+  });
+});

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -52,6 +52,7 @@ import {
   watcherPolicyAccess,
   workflowAccess,
   workProductAccess,
+  workspaceCapabilityAccess,
   workspaceAccess,
 } from './permissions.js';
 
@@ -132,6 +133,7 @@ import { skillSecurityRoutes } from '../skill-security.js';
 import { watcherPolicyRoutes } from '../watcher-policies.js';
 import sandboxPolicyRoutes from '../sandbox-policies.js';
 import { runSessionRoutes } from '../run-sessions.js';
+import { workspaceCapabilityRoutes } from '../workspace-capabilities.js';
 
 const v1Router: IRouter = Router();
 
@@ -235,6 +237,7 @@ v1Router.use('/integrations', settingsAccess, integrationsRoutes);
 v1Router.use('/transcripts', transcriptAccess, transcriptRoutes);
 v1Router.use('/scoring', scoringAccess, scoringRoutes);
 v1Router.use('/system/health', workspaceAccess, systemHealthRouter);
+v1Router.use('/workspace-capabilities', workspaceCapabilityAccess, workspaceCapabilityRoutes);
 v1Router.use('/decisions', taskAccess, decisionRoutes);
 v1Router.use('/run-sessions', taskAccess, runSessionRoutes);
 v1Router.use('/governance/traces', policyAccess, governanceTraceRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -61,6 +61,12 @@ export const backupAccess = routeAccess('backup:read', 'backup:write', [
 ]);
 export const previewAccess = routeAccess('task:read', 'admin:manage');
 export const workspaceAccess = routeAccess('workspace:read', 'admin:manage');
+export const workspaceCapabilityAccess = routeAccess('workspace:read', 'settings:write', [
+  { methods: ['POST'], path: /^\/manifest\/validate\/?$/, permissions: 'workspace:read' },
+  { methods: ['POST'], path: /^\/intake\/?$/, permissions: 'task:write' },
+  { methods: ['GET'], path: /^\/delegations(?:\/.*)?$/, permissions: 'task:read' },
+  { methods: ['POST'], path: /^\/delegations\/[^/]+\/refresh\/?$/, permissions: 'task:write' },
+]);
 export const notificationAccess = routeAccess('agent:read', 'comment:write');
 export const broadcastAccess = routeAccess('task:read', 'comment:write');
 export const activityAccess = routeAccess('telemetry:read', 'admin:manage');

--- a/server/src/routes/workspace-capabilities.ts
+++ b/server/src/routes/workspace-capabilities.ts
@@ -1,0 +1,118 @@
+import { Router, type Router as RouterType } from 'express';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { BadRequestError, NotFoundError } from '../middleware/error-handler.js';
+import { WorkspaceCapabilityService } from '../services/workspace-capability-service.js';
+import {
+  WorkspaceCapabilityFormatSchema,
+  WorkspaceCapabilityImportBodySchema,
+  WorkspaceCapabilityIntakeBodySchema,
+  WorkspaceCapabilityManifestSchema,
+  WorkspaceCapabilityValidateBodySchema,
+} from '../schemas/workspace-capability-schemas.js';
+
+const router: RouterType = Router();
+const workspaceCapabilityService = new WorkspaceCapabilityService();
+
+router.get(
+  '/manifest',
+  asyncHandler(async (_req, res) => {
+    res.json(await workspaceCapabilityService.getLocalManifest());
+  })
+);
+
+router.put(
+  '/manifest',
+  asyncHandler(async (req, res) => {
+    const manifest = WorkspaceCapabilityManifestSchema.parse(req.body);
+    res.json(await workspaceCapabilityService.saveLocalManifest(manifest));
+  })
+);
+
+router.post(
+  '/manifest/validate',
+  asyncHandler(async (req, res) => {
+    const input = WorkspaceCapabilityValidateBodySchema.parse(req.body);
+    res.json(workspaceCapabilityService.validateInput(input));
+  })
+);
+
+router.post(
+  '/manifest/import',
+  asyncHandler(async (req, res) => {
+    const input = WorkspaceCapabilityImportBodySchema.parse(req.body);
+    res.status(201).json(await workspaceCapabilityService.importLocalManifest(input));
+  })
+);
+
+router.get(
+  '/manifest/export',
+  asyncHandler(async (req, res) => {
+    const format =
+      WorkspaceCapabilityFormatSchema.parse(req.query.format) ??
+      (req.query.format === 'json' ? 'json' : 'yaml');
+    res.json(await workspaceCapabilityService.exportLocalManifest(format));
+  })
+);
+
+router.get(
+  '/trusted',
+  asyncHandler(async (_req, res) => {
+    res.json(await workspaceCapabilityService.listTrustedManifests());
+  })
+);
+
+router.post(
+  '/trusted',
+  asyncHandler(async (req, res) => {
+    const input = WorkspaceCapabilityImportBodySchema.parse(req.body);
+    const result = await workspaceCapabilityService.registerTrustedManifest(input);
+    res.status(result.created ? 201 : 200).json(result);
+  })
+);
+
+router.delete(
+  '/trusted/:workspaceId',
+  asyncHandler(async (req, res) => {
+    const removed = await workspaceCapabilityService.removeTrustedManifest(
+      req.params.workspaceId as string
+    );
+    if (!removed) throw new NotFoundError(`Trusted workspace not found: ${req.params.workspaceId}`);
+    res.status(204).send();
+  })
+);
+
+router.get(
+  '/discover',
+  asyncHandler(async (_req, res) => {
+    res.json(await workspaceCapabilityService.discover());
+  })
+);
+
+router.post(
+  '/intake',
+  asyncHandler(async (req, res) => {
+    const input = WorkspaceCapabilityIntakeBodySchema.parse(req.body);
+    try {
+      res.status(201).json(await workspaceCapabilityService.intake(input));
+    } catch (error) {
+      if (error instanceof BadRequestError || error instanceof NotFoundError) throw error;
+      throw error;
+    }
+  })
+);
+
+router.get(
+  '/delegations',
+  asyncHandler(async (_req, res) => {
+    res.json(await workspaceCapabilityService.listDelegations());
+  })
+);
+
+router.post(
+  '/delegations/:id/refresh',
+  asyncHandler(async (req, res) => {
+    res.json(await workspaceCapabilityService.refreshDelegation(req.params.id as string));
+  })
+);
+
+export { router as workspaceCapabilityRoutes };

--- a/server/src/schemas/workspace-capability-schemas.ts
+++ b/server/src/schemas/workspace-capability-schemas.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+
+const SlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-_]*$/, 'ID must start with a lowercase letter or number');
+
+const WorkspaceIdSchema = z.string().trim().min(1).max(120);
+const LabelListSchema = z.array(z.string().trim().min(1).max(80)).max(50).default([]);
+const ContextFieldListSchema = z.array(z.string().trim().min(1).max(80)).max(25).default([]);
+const TaskTypeListSchema = z.array(z.string().trim().min(1).max(80)).max(50).default([]);
+const OptionalUrlSchema = z.string().trim().url().max(500).optional();
+
+const SECRET_KEY_PATTERN = /(?:secret|token|password|api[-_]?key|private[-_]?key)/i;
+
+function rejectSensitiveKeys(value: unknown, ctx: z.RefinementCtx, path: (string | number)[] = []) {
+  if (!value || typeof value !== 'object') return;
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => rejectSensitiveKeys(entry, ctx, [...path, index]));
+    return;
+  }
+
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    const nextPath = [...path, key];
+    if (SECRET_KEY_PATTERN.test(key)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: nextPath,
+        message: `Sensitive field is not allowed in capability manifests: ${key}`,
+      });
+    }
+    rejectSensitiveKeys(nested, ctx, nextPath);
+  }
+}
+
+export const WorkspaceCapabilityFormatSchema = z.enum(['json', 'yaml']).optional();
+
+export const WorkspaceCapabilityDescriptorSchema = z
+  .object({
+    id: SlugSchema,
+    name: z.string().trim().min(1).max(160),
+    description: z.string().trim().max(2000).optional(),
+    acceptedTaskTypes: TaskTypeListSchema,
+    defaultLabels: LabelListSchema.optional(),
+    defaultProject: z.string().trim().min(1).max(160).optional(),
+    defaultPriority: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+    defaultTaskType: z.string().trim().min(1).max(80).optional(),
+    triageOwner: z.string().trim().min(1).max(120).optional(),
+    requiredContextFields: ContextFieldListSchema.optional(),
+    intakeTargets: z
+      .array(z.enum(['task', 'github-issue']))
+      .max(2)
+      .default(['task']),
+  })
+  .strict();
+
+export const WorkspaceCapabilityManifestSchema = z
+  .object({
+    id: SlugSchema,
+    schemaVersion: z.literal('workspace-capability/v1').default('workspace-capability/v1'),
+    workspaceId: WorkspaceIdSchema,
+    name: z.string().trim().min(1).max(160),
+    description: z.string().trim().max(2000).optional(),
+    boardUrl: OptionalUrlSchema,
+    repositoryUrl: OptionalUrlSchema,
+    safeContact: z
+      .object({
+        label: z.string().trim().min(1).max(120).optional(),
+        url: OptionalUrlSchema,
+        email: z.string().trim().email().max(200).optional(),
+      })
+      .strict()
+      .optional(),
+    enabled: z.boolean().default(true),
+    capabilities: z.array(WorkspaceCapabilityDescriptorSchema).min(1).max(100),
+    defaultLabels: LabelListSchema.optional(),
+    defaultProject: z.string().trim().min(1).max(160).optional(),
+    defaultPriority: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+    triageOwner: z.string().trim().min(1).max(120).optional(),
+    trustedSourceWorkspaceIds: z.array(WorkspaceIdSchema).max(100).optional(),
+    metadata: z
+      .object({
+        source: z.string().trim().min(1).max(500).optional(),
+        importedAt: z.string().datetime().optional(),
+        updatedAt: z.string().datetime().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    rejectSensitiveKeys(manifest, ctx);
+
+    const capabilityIds = new Set<string>();
+    manifest.capabilities.forEach((capability, index) => {
+      if (capabilityIds.has(capability.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['capabilities', index, 'id'],
+          message: `Duplicate capability ID: ${capability.id}`,
+        });
+      }
+      capabilityIds.add(capability.id);
+    });
+  });
+
+export const WorkspaceCapabilityImportBodySchema = z
+  .object({
+    content: z.string().min(1).max(200_000).optional(),
+    format: WorkspaceCapabilityFormatSchema,
+    source: z.string().trim().min(1).max(500).optional(),
+    manifest: z.unknown().optional(),
+  })
+  .strict()
+  .refine((value) => value.manifest || value.content, {
+    message: 'Provide manifest or content',
+  });
+
+export const WorkspaceCapabilityValidateBodySchema = WorkspaceCapabilityImportBodySchema;
+
+export const WorkspaceCapabilityIntakeBodySchema = z
+  .object({
+    source: z
+      .object({
+        workspaceId: WorkspaceIdSchema,
+        workspaceName: z.string().trim().min(1).max(160).optional(),
+        taskId: z.string().trim().min(1).max(120).optional(),
+        taskUrl: OptionalUrlSchema,
+        repository: z.string().trim().min(1).max(200).optional(),
+        issueUrl: OptionalUrlSchema,
+      })
+      .strict(),
+    capabilityId: SlugSchema,
+    title: z.string().trim().min(1).max(200),
+    context: z.string().trim().min(1).max(20_000),
+    contextFields: z
+      .record(z.string().trim().min(1).max(80), z.string().trim().max(2000))
+      .optional(),
+    labels: LabelListSchema.optional(),
+    priority: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+    project: z.string().trim().min(1).max(160).optional(),
+    type: z.string().trim().min(1).max(80).optional(),
+    requestedBy: z.string().trim().min(1).max(160).optional(),
+    backlinkUrl: OptionalUrlSchema,
+    createAs: z.enum(['task', 'github-issue']).default('task'),
+  })
+  .strict();

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -590,6 +590,7 @@ export class TaskService {
         updated: data.updated || new Date().toISOString(),
         git: data.git,
         github: data.github,
+        delegatedWork: data.delegatedWork,
         attempt: data.attempt,
         attempts: data.attempts,
         reviewComments,

--- a/server/src/services/workspace-capability-service.ts
+++ b/server/src/services/workspace-capability-service.ts
@@ -1,0 +1,443 @@
+import yaml from 'yaml';
+import { nanoid } from 'nanoid';
+import type {
+  AppConfig,
+  CreateTaskInput,
+  Task,
+  WorkspaceCapabilityDiscoveryResult,
+  WorkspaceCapabilityExportResult,
+  WorkspaceCapabilityFormat,
+  WorkspaceCapabilityManifest,
+  WorkspaceCapabilityRegistrationResult,
+  WorkspaceCapabilityValidationResult,
+  WorkspaceDelegatedWorkIntakeInput,
+  WorkspaceDelegatedWorkIntakeResult,
+  WorkspaceDelegationRecord,
+} from '@veritas-kanban/shared';
+import { getConfigService, type ConfigService } from './config-service.js';
+import { getTaskService, type TaskService } from './task-service.js';
+import { WorkspaceCapabilityManifestSchema } from '../schemas/workspace-capability-schemas.js';
+import { BadRequestError, ForbiddenError, NotFoundError } from '../middleware/error-handler.js';
+
+const SECRET_KEY_PATTERN = /(?:secret|token|password|api[-_]?key|private[-_]?key)/i;
+
+interface ImportManifestInput {
+  content?: string;
+  format?: WorkspaceCapabilityFormat;
+  source?: string;
+  manifest?: unknown;
+}
+
+type WorkspaceCapabilityConfigStore = Pick<ConfigService, 'getConfig' | 'saveConfig'>;
+type WorkspaceCapabilityTaskStore = Pick<TaskService, 'createTask' | 'getTask' | 'updateTask'>;
+
+export class WorkspaceCapabilityService {
+  constructor(
+    private readonly configService: WorkspaceCapabilityConfigStore = getConfigService(),
+    private readonly taskService: WorkspaceCapabilityTaskStore = getTaskService()
+  ) {}
+
+  async getLocalManifest(): Promise<WorkspaceCapabilityManifest | null> {
+    const config = await this.configService.getConfig();
+    return config.workspaceCapability ?? null;
+  }
+
+  async saveLocalManifest(
+    manifest: WorkspaceCapabilityManifest
+  ): Promise<WorkspaceCapabilityManifest> {
+    const parsed = this.requireValidManifest(manifest);
+    const config = await this.configService.getConfig();
+    const next = this.stampManifest(parsed, parsed.metadata?.source);
+    config.workspaceCapability = next;
+    await this.configService.saveConfig(config);
+    return next;
+  }
+
+  async importLocalManifest(input: ImportManifestInput): Promise<WorkspaceCapabilityManifest> {
+    const manifest = this.requireValidManifest(this.readManifestInput(input));
+    return this.saveLocalManifest(
+      this.stampManifest(manifest, input.source ?? manifest.metadata?.source)
+    );
+  }
+
+  async exportLocalManifest(
+    format: WorkspaceCapabilityFormat
+  ): Promise<WorkspaceCapabilityExportResult> {
+    const manifest = await this.getLocalManifest();
+    if (!manifest) throw new BadRequestError('Workspace capability manifest is not configured');
+    return {
+      id: manifest.id,
+      format,
+      content: this.stringifyManifest(manifest, format),
+    };
+  }
+
+  async listTrustedManifests(): Promise<WorkspaceCapabilityManifest[]> {
+    const config = await this.configService.getConfig();
+    return (config.trustedWorkspaceCapabilities ?? []).map((manifest) =>
+      this.redactManifest(manifest)
+    );
+  }
+
+  async registerTrustedManifest(
+    input: ImportManifestInput
+  ): Promise<WorkspaceCapabilityRegistrationResult> {
+    const manifest = this.stampManifest(
+      this.requireValidManifest(this.readManifestInput(input)),
+      input.source
+    );
+    const config = await this.configService.getConfig();
+    const existing = config.trustedWorkspaceCapabilities ?? [];
+    const created = !existing.some((candidate) => candidate.workspaceId === manifest.workspaceId);
+    config.trustedWorkspaceCapabilities = [
+      ...existing.filter((candidate) => candidate.workspaceId !== manifest.workspaceId),
+      manifest,
+    ].sort((a, b) => a.name.localeCompare(b.name));
+    await this.configService.saveConfig(config);
+    return { manifest: this.redactManifest(manifest), created };
+  }
+
+  async removeTrustedManifest(workspaceId: string): Promise<boolean> {
+    const config = await this.configService.getConfig();
+    const existing = config.trustedWorkspaceCapabilities ?? [];
+    const next = existing.filter((candidate) => candidate.workspaceId !== workspaceId);
+    if (next.length === existing.length) return false;
+    config.trustedWorkspaceCapabilities = next;
+    await this.configService.saveConfig(config);
+    return true;
+  }
+
+  async discover(): Promise<WorkspaceCapabilityDiscoveryResult> {
+    const config = await this.configService.getConfig();
+    return {
+      local: config.workspaceCapability ? this.redactManifest(config.workspaceCapability) : null,
+      trusted: (config.trustedWorkspaceCapabilities ?? []).map((manifest) =>
+        this.redactManifest(manifest)
+      ),
+    };
+  }
+
+  validateManifest(manifest: unknown): WorkspaceCapabilityValidationResult {
+    const sensitiveIssues = this.findSensitiveFieldIssues(manifest);
+    const parsed = WorkspaceCapabilityManifestSchema.safeParse(manifest);
+    if (!parsed.success) {
+      return {
+        valid: false,
+        issues: [
+          ...sensitiveIssues,
+          ...parsed.error.issues.map((issue) => ({
+            path: issue.path.length ? `$.${issue.path.join('.')}` : '$',
+            message: issue.message,
+          })),
+        ],
+      };
+    }
+    if (sensitiveIssues.length > 0) {
+      return { valid: false, issues: sensitiveIssues };
+    }
+    return { valid: true, manifest: parsed.data as WorkspaceCapabilityManifest, issues: [] };
+  }
+
+  validateInput(input: ImportManifestInput): WorkspaceCapabilityValidationResult {
+    try {
+      return this.validateManifest(this.readManifestInput(input));
+    } catch (error) {
+      return {
+        valid: false,
+        issues: [{ path: '$', message: error instanceof Error ? error.message : String(error) }],
+      };
+    }
+  }
+
+  async listDelegations(): Promise<WorkspaceDelegationRecord[]> {
+    const config = await this.configService.getConfig();
+    return config.workspaceDelegations ?? [];
+  }
+
+  async intake(
+    input: WorkspaceDelegatedWorkIntakeInput
+  ): Promise<WorkspaceDelegatedWorkIntakeResult> {
+    const config = await this.configService.getConfig();
+    const local = config.workspaceCapability;
+    if (!local?.enabled) {
+      throw new BadRequestError('Workspace capability manifest is not configured or enabled');
+    }
+
+    this.assertTrustedSource(config, input.source.workspaceId, local);
+    const capability = local.capabilities.find((candidate) => candidate.id === input.capabilityId);
+    if (!capability) {
+      throw new BadRequestError(
+        `Capability is not published by this workspace: ${input.capabilityId}`
+      );
+    }
+    if (!(capability.intakeTargets ?? ['task']).includes(input.createAs ?? 'task')) {
+      throw new BadRequestError(`Capability does not accept ${input.createAs ?? 'task'} intake`);
+    }
+    if ((input.createAs ?? 'task') === 'github-issue') {
+      throw new BadRequestError('GitHub issue intake is not configured; use createAs=task');
+    }
+
+    const taskType =
+      input.type ?? capability.defaultTaskType ?? capability.acceptedTaskTypes[0] ?? 'code';
+    if (
+      capability.acceptedTaskTypes.length > 0 &&
+      !capability.acceptedTaskTypes.includes(taskType)
+    ) {
+      throw new BadRequestError(
+        `Capability ${capability.id} does not accept task type: ${taskType}`
+      );
+    }
+    this.assertRequiredContext(input, capability.requiredContextFields ?? []);
+
+    const labels = [
+      ...(local.defaultLabels ?? []),
+      ...(capability.defaultLabels ?? []),
+      ...(input.labels ?? []),
+    ].filter((label, index, list) => list.indexOf(label) === index);
+    const task = await this.taskService.createTask({
+      title: input.title,
+      description: this.buildDelegatedTaskDescription(input, labels),
+      type: taskType,
+      priority: input.priority ?? capability.defaultPriority ?? local.defaultPriority ?? 'medium',
+      project: input.project ?? capability.defaultProject ?? local.defaultProject,
+      createdBy: input.requestedBy ?? `workspace:${input.source.workspaceId}`,
+      updatedBy: input.requestedBy ?? `workspace:${input.source.workspaceId}`,
+    } satisfies CreateTaskInput);
+
+    const now = new Date().toISOString();
+    const record: WorkspaceDelegationRecord = {
+      id: this.generateDelegationId(),
+      capabilityId: capability.id,
+      title: input.title,
+      status: 'created',
+      latestState: task.status,
+      labels,
+      source: input.source,
+      target: {
+        type: 'task',
+        workspaceId: local.workspaceId,
+        workspaceName: local.name,
+        taskId: task.id,
+        url: input.backlinkUrl ?? `/tasks/${task.id}`,
+      },
+      requestedBy: input.requestedBy,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.saveDelegationRecord(config, record);
+    await this.attachDelegationToSourceTask(input.source.taskId, record);
+    return { record, taskId: task.id, taskUrl: record.target.url };
+  }
+
+  async refreshDelegation(id: string): Promise<WorkspaceDelegationRecord> {
+    const config = await this.configService.getConfig();
+    const existing = (config.workspaceDelegations ?? []).find((record) => record.id === id);
+    if (!existing) throw new NotFoundError(`Workspace delegation not found: ${id}`);
+
+    let next = { ...existing, updatedAt: new Date().toISOString() };
+    if (existing.target.type === 'task' && existing.target.taskId) {
+      const task = await this.taskService.getTask(existing.target.taskId);
+      next = task
+        ? {
+            ...next,
+            latestState: task.status,
+            status: task.status === 'done' ? 'closed' : 'linked',
+          }
+        : { ...next, status: 'blocked', latestState: 'target task missing' };
+    }
+
+    await this.saveDelegationRecord(config, next);
+    await this.attachDelegationToSourceTask(next.source.taskId, next);
+    return next;
+  }
+
+  private requireValidManifest(manifest: unknown): WorkspaceCapabilityManifest {
+    const validation = this.validateManifest(manifest);
+    if (!validation.valid || !validation.manifest) {
+      const firstIssue = validation.issues[0];
+      throw new BadRequestError(
+        firstIssue
+          ? `${firstIssue.path}: ${firstIssue.message}`
+          : 'Invalid workspace capability manifest'
+      );
+    }
+    return validation.manifest;
+  }
+
+  private readManifestInput(input: ImportManifestInput): unknown {
+    if (input.manifest) return input.manifest;
+    if (!input.content) throw new BadRequestError('Manifest content is required');
+    if (input.format === 'json') return JSON.parse(input.content);
+    if (input.format === 'yaml') return yaml.parse(input.content);
+    try {
+      return JSON.parse(input.content);
+    } catch {
+      return yaml.parse(input.content);
+    }
+  }
+
+  private stringifyManifest(
+    manifest: WorkspaceCapabilityManifest,
+    format: WorkspaceCapabilityFormat
+  ): string {
+    return format === 'json' ? `${JSON.stringify(manifest, null, 2)}\n` : yaml.stringify(manifest);
+  }
+
+  private stampManifest(
+    manifest: WorkspaceCapabilityManifest,
+    source?: string
+  ): WorkspaceCapabilityManifest {
+    const now = new Date().toISOString();
+    return {
+      ...manifest,
+      metadata: {
+        ...manifest.metadata,
+        source: source ?? manifest.metadata?.source,
+        importedAt: manifest.metadata?.importedAt ?? now,
+        updatedAt: now,
+      },
+    };
+  }
+
+  private redactManifest(manifest: WorkspaceCapabilityManifest): WorkspaceCapabilityManifest {
+    const { metadata, ...rest } = manifest;
+    return {
+      ...rest,
+      metadata: metadata
+        ? {
+            importedAt: metadata.importedAt,
+            updatedAt: metadata.updatedAt,
+          }
+        : undefined,
+    };
+  }
+
+  private assertTrustedSource(
+    config: AppConfig,
+    sourceWorkspaceId: string,
+    local: WorkspaceCapabilityManifest
+  ): void {
+    if (sourceWorkspaceId === local.workspaceId) return;
+    if (local.trustedSourceWorkspaceIds?.includes(sourceWorkspaceId)) return;
+    const trustedManifest = (config.trustedWorkspaceCapabilities ?? []).find(
+      (manifest) => manifest.workspaceId === sourceWorkspaceId && manifest.enabled
+    );
+    if (!trustedManifest) {
+      throw new ForbiddenError(
+        `Workspace is not trusted for delegated intake: ${sourceWorkspaceId}`
+      );
+    }
+  }
+
+  private assertRequiredContext(
+    input: WorkspaceDelegatedWorkIntakeInput,
+    requiredFields: string[]
+  ): void {
+    const fields = input.contextFields ?? {};
+    const missing = requiredFields.filter((field) => !fields[field]?.trim());
+    if (missing.length > 0) {
+      throw new BadRequestError(`Missing required delegation context: ${missing.join(', ')}`);
+    }
+  }
+
+  private buildDelegatedTaskDescription(
+    input: WorkspaceDelegatedWorkIntakeInput,
+    labels: string[]
+  ): string {
+    const contextFields = Object.entries(input.contextFields ?? {})
+      .map(([key, value]) => `- ${key}: ${value}`)
+      .join('\n');
+    const lines = [
+      input.context.trim(),
+      '',
+      '## Delegated Intake',
+      `- Source workspace: ${input.source.workspaceName ?? input.source.workspaceId}`,
+      input.source.taskId ? `- Source task: ${input.source.taskId}` : undefined,
+      input.source.taskUrl ? `- Source task URL: ${input.source.taskUrl}` : undefined,
+      input.source.repository ? `- Source repository: ${input.source.repository}` : undefined,
+      input.source.issueUrl ? `- Source issue: ${input.source.issueUrl}` : undefined,
+      labels.length > 0 ? `- Labels: ${labels.join(', ')}` : undefined,
+      input.requestedBy ? `- Requested by: ${input.requestedBy}` : undefined,
+      contextFields ? `\n### Required Context\n${contextFields}` : undefined,
+    ];
+    return lines.filter(Boolean).join('\n');
+  }
+
+  private async saveDelegationRecord(
+    config: AppConfig,
+    record: WorkspaceDelegationRecord
+  ): Promise<void> {
+    config.workspaceDelegations = [
+      record,
+      ...(config.workspaceDelegations ?? []).filter((candidate) => candidate.id !== record.id),
+    ].slice(0, 500);
+    await this.configService.saveConfig(config);
+  }
+
+  private async attachDelegationToSourceTask(
+    sourceTaskId: string | undefined,
+    record: WorkspaceDelegationRecord
+  ): Promise<void> {
+    if (!sourceTaskId) return;
+    const sourceTask: Task | null = await this.taskService.getTask(sourceTaskId);
+    if (!sourceTask) return;
+
+    await this.taskService.updateTask(sourceTask.id, {
+      delegatedWork: [
+        {
+          id: record.id,
+          sourceWorkspaceId: record.source.workspaceId,
+          targetWorkspaceId: record.target.workspaceId,
+          targetType: record.target.type,
+          capabilityId: record.capabilityId,
+          targetId: record.target.taskId ?? record.target.issueNumber?.toString(),
+          targetUrl: record.target.url,
+          status: record.status,
+          latestState: record.latestState,
+          requestedAt: record.createdAt,
+          updatedAt: record.updatedAt,
+        },
+        ...(sourceTask.delegatedWork ?? []).filter((link) => link.id !== record.id),
+      ],
+    });
+  }
+
+  private generateDelegationId(): string {
+    return `delegation_${new Date().toISOString().slice(0, 10).replace(/-/g, '')}_${nanoid(6)}`;
+  }
+
+  private findSensitiveFieldIssues(
+    value: unknown,
+    path: (string | number)[] = []
+  ): WorkspaceCapabilityValidationResult['issues'] {
+    if (!value || typeof value !== 'object') return [];
+    if (Array.isArray(value)) {
+      return value.flatMap((entry, index) =>
+        this.findSensitiveFieldIssues(entry, [...path, index])
+      );
+    }
+
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, nested]) => {
+      const nextPath = [...path, key];
+      const issue = SECRET_KEY_PATTERN.test(key)
+        ? [
+            {
+              path: nextPath.length ? `$.${nextPath.join('.')}` : '$',
+              message: `Sensitive field is not allowed in capability manifests: ${key}`,
+            },
+          ]
+        : [];
+      return [...issue, ...this.findSensitiveFieldIssues(nested, nextPath)];
+    });
+  }
+}
+
+let workspaceCapabilityService: WorkspaceCapabilityService | null = null;
+
+export function getWorkspaceCapabilityService(): WorkspaceCapabilityService {
+  if (!workspaceCapabilityService) {
+    workspaceCapabilityService = new WorkspaceCapabilityService();
+  }
+  return workspaceCapabilityService;
+}

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -7,6 +7,10 @@ import type { SandboxPolicyPreset } from './sandbox-policy.types.js';
 import type { AgentBudgetPolicy } from './agent-budget.types.js';
 import type { AgentProfilePackage } from './agent-profile-package.types.js';
 import type { TeamRosterManifest } from './team-roster.types.js';
+import type {
+  WorkspaceCapabilityManifest,
+  WorkspaceDelegationRecord,
+} from './workspace-capability.types.js';
 
 export interface DevServerConfig {
   command: string; // e.g., "pnpm dev" or "npm run dev"
@@ -170,6 +174,9 @@ export interface AppConfig {
   defaultSandboxPresetId?: string;
   agentProfiles?: AgentProfilePackage[];
   teamRoster?: TeamRosterManifest;
+  workspaceCapability?: WorkspaceCapabilityManifest;
+  trustedWorkspaceCapabilities?: WorkspaceCapabilityManifest[];
+  workspaceDelegations?: WorkspaceDelegationRecord[];
 }
 
 // ============ Feature Settings Types ============

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -34,6 +34,7 @@ export * from './sandbox-policy.types.js';
 export * from './agent-budget.types.js';
 export * from './agent-profile-package.types.js';
 export * from './team-roster.types.js';
+export * from './workspace-capability.types.js';
 export * from './watcher-policy.types.js';
 export * from './evidence.types.js';
 export * from './time-breakdown.types.js';

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -239,6 +239,9 @@ export interface Task {
   // GitHub Issue cross-reference
   github?: TaskGitHub;
 
+  // Cross-workspace delegation status links
+  delegatedWork?: import('./workspace-capability.types.js').TaskDelegatedWorkLink[];
+
   // Current attempt
   attempt?: TaskAttempt;
 
@@ -389,6 +392,7 @@ export interface UpdateTaskInput {
   agents?: AgentType[];
   git?: Partial<TaskGit>;
   github?: TaskGitHub;
+  delegatedWork?: import('./workspace-capability.types.js').TaskDelegatedWorkLink[];
   attempt?: TaskAttempt;
   reviewComments?: ReviewComment[];
   reviewScores?: [number, number, number, number];

--- a/shared/src/types/workspace-capability.types.ts
+++ b/shared/src/types/workspace-capability.types.ts
@@ -1,0 +1,144 @@
+import type { TaskPriority, TaskStatus, TaskType } from './task.types.js';
+
+export type WorkspaceCapabilityFormat = 'json' | 'yaml';
+export type WorkspaceDelegationTargetType = 'task' | 'github-issue';
+export type WorkspaceDelegationStatus = 'created' | 'linked' | 'blocked' | 'closed';
+
+export interface WorkspaceCapabilityDescriptor {
+  id: string;
+  name: string;
+  description?: string;
+  acceptedTaskTypes: TaskType[];
+  defaultLabels?: string[];
+  defaultProject?: string;
+  defaultPriority?: TaskPriority;
+  defaultTaskType?: TaskType;
+  triageOwner?: string;
+  requiredContextFields?: string[];
+  intakeTargets?: WorkspaceDelegationTargetType[];
+}
+
+export interface WorkspaceCapabilityContact {
+  label?: string;
+  url?: string;
+  email?: string;
+}
+
+export interface WorkspaceCapabilityManifestMetadata {
+  source?: string;
+  importedAt?: string;
+  updatedAt?: string;
+}
+
+export interface WorkspaceCapabilityManifest {
+  id: string;
+  schemaVersion: 'workspace-capability/v1';
+  workspaceId: string;
+  name: string;
+  description?: string;
+  boardUrl?: string;
+  repositoryUrl?: string;
+  safeContact?: WorkspaceCapabilityContact;
+  enabled: boolean;
+  capabilities: WorkspaceCapabilityDescriptor[];
+  defaultLabels?: string[];
+  defaultProject?: string;
+  defaultPriority?: TaskPriority;
+  triageOwner?: string;
+  trustedSourceWorkspaceIds?: string[];
+  metadata?: WorkspaceCapabilityManifestMetadata;
+}
+
+export interface WorkspaceCapabilityValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface WorkspaceCapabilityValidationResult {
+  valid: boolean;
+  manifest?: WorkspaceCapabilityManifest;
+  issues: WorkspaceCapabilityValidationIssue[];
+}
+
+export interface WorkspaceCapabilityExportResult {
+  id: string;
+  format: WorkspaceCapabilityFormat;
+  content: string;
+}
+
+export interface WorkspaceCapabilityRegistrationResult {
+  manifest: WorkspaceCapabilityManifest;
+  created: boolean;
+}
+
+export interface WorkspaceCapabilityDiscoveryResult {
+  local: WorkspaceCapabilityManifest | null;
+  trusted: WorkspaceCapabilityManifest[];
+}
+
+export interface WorkspaceDelegationSource {
+  workspaceId: string;
+  workspaceName?: string;
+  taskId?: string;
+  taskUrl?: string;
+  repository?: string;
+  issueUrl?: string;
+}
+
+export interface WorkspaceDelegatedWorkTarget {
+  type: WorkspaceDelegationTargetType;
+  workspaceId: string;
+  workspaceName?: string;
+  taskId?: string;
+  issueNumber?: number;
+  url?: string;
+}
+
+export interface TaskDelegatedWorkLink {
+  id: string;
+  sourceWorkspaceId: string;
+  targetWorkspaceId: string;
+  targetType: WorkspaceDelegationTargetType;
+  capabilityId: string;
+  targetId?: string;
+  targetUrl?: string;
+  status: WorkspaceDelegationStatus;
+  latestState?: TaskStatus | string;
+  requestedAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceDelegationRecord {
+  id: string;
+  capabilityId: string;
+  title: string;
+  status: WorkspaceDelegationStatus;
+  latestState?: TaskStatus | string;
+  labels: string[];
+  source: WorkspaceDelegationSource;
+  target: WorkspaceDelegatedWorkTarget;
+  requestedBy?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceDelegatedWorkIntakeInput {
+  source: WorkspaceDelegationSource;
+  capabilityId: string;
+  title: string;
+  context: string;
+  contextFields?: Record<string, string>;
+  labels?: string[];
+  priority?: TaskPriority;
+  project?: string;
+  type?: TaskType;
+  requestedBy?: string;
+  backlinkUrl?: string;
+  createAs?: WorkspaceDelegationTargetType;
+}
+
+export interface WorkspaceDelegatedWorkIntakeResult {
+  record: WorkspaceDelegationRecord;
+  taskId?: string;
+  taskUrl?: string;
+}

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -314,6 +314,17 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     overrides: [{ methods: ['POST'], path: /^\/evaluate\/?$/, permissions: 'report:read' }],
   },
   { prefix: '/api/system/health', read: 'workspace:read', write: 'admin:manage' },
+  {
+    prefix: '/api/workspace-capabilities',
+    read: 'workspace:read',
+    write: 'settings:write',
+    overrides: [
+      { methods: ['POST'], path: /^\/manifest\/validate\/?$/, permissions: 'workspace:read' },
+      { methods: ['POST'], path: /^\/intake\/?$/, permissions: 'task:write' },
+      { methods: ['GET'], path: /^\/delegations(?:\/.*)?$/, permissions: 'task:read' },
+      { methods: ['POST'], path: /^\/delegations\/[^/]+\/refresh\/?$/, permissions: 'task:write' },
+    ],
+  },
   { prefix: '/api/decisions', read: 'task:read', write: 'task:write' },
   { prefix: '/api/run-sessions', read: 'task:read', write: 'task:write' },
   { prefix: '/api/governance/traces', read: 'policy:read' },

--- a/web/src/__tests__/workspace-capabilities-tab.test.tsx
+++ b/web/src/__tests__/workspace-capabilities-tab.test.tsx
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { WorkspaceCapabilitiesTab } from '@/components/settings/tabs/WorkspaceCapabilitiesTab';
+import { renderWithProviders } from './test-utils';
+
+const mocks = vi.hoisted(() => ({
+  refetchDiscovery: vi.fn(),
+  mutateIntake: vi.fn(),
+  discovery: {
+    local: {
+      id: 'local-board',
+      schemaVersion: 'workspace-capability/v1',
+      workspaceId: 'local',
+      name: 'Local Board',
+      enabled: true,
+      capabilities: [
+        {
+          id: 'docs',
+          name: 'Documentation',
+          acceptedTaskTypes: ['docs'],
+          defaultPriority: 'medium',
+          defaultProject: 'handbook',
+          requiredContextFields: ['acceptance'],
+          intakeTargets: ['task'],
+        },
+      ],
+    },
+    trusted: [
+      {
+        id: 'source-board',
+        schemaVersion: 'workspace-capability/v1',
+        workspaceId: 'source',
+        name: 'Source Board',
+        enabled: true,
+        capabilities: [
+          {
+            id: 'ops',
+            name: 'Ops',
+            acceptedTaskTypes: ['feature'],
+            intakeTargets: ['task'],
+          },
+        ],
+      },
+    ],
+  },
+}));
+
+vi.mock('@/hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    hasPermission: (permission: string) => ['workspace:read', 'task:write'].includes(permission),
+  }),
+}));
+
+vi.mock('@/hooks/useWorkspaceCapabilities', () => ({
+  useWorkspaceCapabilityDiscovery: () => ({
+    data: mocks.discovery,
+    isLoading: false,
+    refetch: mocks.refetchDiscovery,
+  }),
+  useWorkspaceDelegations: () => ({
+    data: [],
+    isLoading: false,
+  }),
+  useWorkspaceDelegatedIntake: () => ({
+    mutateAsync: mocks.mutateIntake,
+    isPending: false,
+  }),
+}));
+
+describe('WorkspaceCapabilitiesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mutateIntake.mockResolvedValue({
+      taskId: 'task_20260626_target',
+      record: { id: 'delegation_20260626_abc123' },
+    });
+  });
+
+  it('renders discovery data and submits delegated intake with required context', async () => {
+    renderWithProviders(<WorkspaceCapabilitiesTab />);
+
+    expect(screen.getByText('Local Board')).toBeTruthy();
+    expect(screen.getAllByText('Source Board')[0]).toBeTruthy();
+    expect(screen.getAllByText('Documentation')[0]).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Write handoff docs' },
+    });
+    fireEvent.change(screen.getByLabelText('Context'), {
+      target: { value: 'Document the delegated workflow.' },
+    });
+    fireEvent.change(screen.getByLabelText('acceptance'), {
+      target: { value: 'Includes handoff and rollback steps' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Intake' }));
+
+    await waitFor(() => {
+      expect(mocks.mutateIntake).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: { workspaceId: 'source', workspaceName: 'Source Board' },
+          capabilityId: 'docs',
+          title: 'Write handoff docs',
+          context: 'Document the delegated workflow.',
+          contextFields: { acceptance: 'Includes handoff and rollback steps' },
+          type: 'docs',
+          project: 'handbook',
+          priority: 'medium',
+        })
+      );
+    });
+  });
+});

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -22,6 +22,7 @@ import {
   BookOpen,
   UserCog,
   Wrench,
+  Network,
 } from 'lucide-react';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import type { ClientAuthPermission } from '@veritas-kanban/shared';
@@ -68,6 +69,9 @@ const LazyMultiUserTab = lazy(() =>
 const LazyMaintenanceTab = lazy(() =>
   import('./tabs/MaintenanceTab').then((m) => ({ default: m.MaintenanceTab }))
 );
+const LazyWorkspaceCapabilitiesTab = lazy(() =>
+  import('./tabs/WorkspaceCapabilitiesTab').then((m) => ({ default: m.WorkspaceCapabilitiesTab }))
+);
 
 // ============ Tab Skeleton ============
 
@@ -100,6 +104,7 @@ type TabId =
   | 'shared-resources'
   | 'doc-freshness'
   | 'multi-user'
+  | 'workspace-capabilities'
   | 'maintenance'
   | 'manage';
 
@@ -119,6 +124,12 @@ const TABS: TabDef[] = [
   { id: 'notifications', label: 'Notifications', icon: Bell },
   { id: 'security', label: 'Security', icon: Shield, requiredPermission: 'settings:read' },
   { id: 'multi-user', label: 'Multi-user', icon: UserCog, requiredPermission: 'workspace:read' },
+  {
+    id: 'workspace-capabilities',
+    label: 'Workspaces',
+    icon: Network,
+    requiredPermission: 'workspace:read',
+  },
   { id: 'maintenance', label: 'Maintenance', icon: Wrench, requiredPermission: 'backup:read' },
   { id: 'delegation', label: 'Delegation', icon: Plane, requiredPermission: 'agent:read' },
   { id: 'tool-policies', label: 'Tool Policies', icon: Lock, requiredPermission: 'policy:read' },
@@ -396,6 +407,11 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
         {activeTab === 'multi-user' && (
           <SettingsErrorBoundary tabName="Multi-user">
             <LazyMultiUserTab />
+          </SettingsErrorBoundary>
+        )}
+        {activeTab === 'workspace-capabilities' && (
+          <SettingsErrorBoundary tabName="Workspaces">
+            <LazyWorkspaceCapabilitiesTab />
           </SettingsErrorBoundary>
         )}
         {activeTab === 'delegation' && (

--- a/web/src/components/settings/tabs/WorkspaceCapabilitiesTab.tsx
+++ b/web/src/components/settings/tabs/WorkspaceCapabilitiesTab.tsx
@@ -1,0 +1,418 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  Select,
+  SimpleGrid,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { Network, RefreshCw, SendHorizonal } from 'lucide-react';
+import type { TaskPriority } from '@veritas-kanban/shared';
+import { useIdentity } from '@/hooks/useIdentity';
+import { useToast } from '@/hooks/useToast';
+import {
+  useWorkspaceCapabilityDiscovery,
+  useWorkspaceDelegatedIntake,
+  useWorkspaceDelegations,
+} from '@/hooks/useWorkspaceCapabilities';
+
+const EMPTY_CAPABILITIES: NonNullable<
+  NonNullable<ReturnType<typeof useWorkspaceCapabilityDiscovery>['data']>['local']
+>['capabilities'] = [];
+const EMPTY_WORKSPACES: NonNullable<
+  ReturnType<typeof useWorkspaceCapabilityDiscovery>['data']
+>['trusted'] = [];
+const EMPTY_CONTEXT_FIELDS: string[] = [];
+
+const PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'critical', label: 'Critical' },
+];
+
+export function WorkspaceCapabilitiesTab() {
+  const { hasPermission } = useIdentity();
+  const { toast } = useToast();
+  const discoveryQuery = useWorkspaceCapabilityDiscovery();
+  const delegationsQuery = useWorkspaceDelegations();
+  const intake = useWorkspaceDelegatedIntake();
+  const discovery = discoveryQuery.data;
+  const localCapabilities = discovery?.local?.capabilities ?? EMPTY_CAPABILITIES;
+  const trusted = discovery?.trusted ?? EMPTY_WORKSPACES;
+  const canCreateDelegatedTask = hasPermission('task:write');
+
+  const [sourceWorkspaceId, setSourceWorkspaceId] = useState<string | null>(null);
+  const [capabilityId, setCapabilityId] = useState<string | null>(null);
+  const [title, setTitle] = useState('');
+  const [context, setContext] = useState('');
+  const [type, setType] = useState<string | null>(null);
+  const [priority, setPriority] = useState<TaskPriority | null>(null);
+  const [project, setProject] = useState('');
+  const [contextFields, setContextFields] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!sourceWorkspaceId && trusted[0]) setSourceWorkspaceId(trusted[0].workspaceId);
+  }, [sourceWorkspaceId, trusted]);
+
+  useEffect(() => {
+    if (!capabilityId && localCapabilities[0]) setCapabilityId(localCapabilities[0].id);
+  }, [capabilityId, localCapabilities]);
+
+  const selectedCapability = useMemo(
+    () => localCapabilities.find((capability) => capability.id === capabilityId) ?? null,
+    [capabilityId, localCapabilities]
+  );
+  const selectedSource = useMemo(
+    () => trusted.find((workspace) => workspace.workspaceId === sourceWorkspaceId) ?? null,
+    [sourceWorkspaceId, trusted]
+  );
+  const taskTypeOptions = useMemo(
+    () =>
+      (selectedCapability?.acceptedTaskTypes ?? []).map((taskType) => ({
+        value: taskType,
+        label: taskType,
+      })),
+    [selectedCapability]
+  );
+  const requiredFields = selectedCapability?.requiredContextFields ?? EMPTY_CONTEXT_FIELDS;
+
+  useEffect(() => {
+    setType(
+      selectedCapability?.defaultTaskType ?? selectedCapability?.acceptedTaskTypes[0] ?? null
+    );
+    setPriority(
+      selectedCapability?.defaultPriority ?? discovery?.local?.defaultPriority ?? 'medium'
+    );
+    setProject(selectedCapability?.defaultProject ?? discovery?.local?.defaultProject ?? '');
+    setContextFields((existing) =>
+      Object.fromEntries(requiredFields.map((field) => [field, existing[field] ?? '']))
+    );
+  }, [
+    discovery?.local?.defaultPriority,
+    discovery?.local?.defaultProject,
+    requiredFields,
+    selectedCapability,
+  ]);
+
+  const canSubmit =
+    canCreateDelegatedTask &&
+    Boolean(selectedSource) &&
+    Boolean(selectedCapability) &&
+    title.trim().length > 0 &&
+    context.trim().length > 0 &&
+    requiredFields.every((field) => contextFields[field]?.trim());
+
+  const handleSubmit = async () => {
+    if (!selectedSource || !selectedCapability || !canSubmit) return;
+    try {
+      const result = await intake.mutateAsync({
+        source: {
+          workspaceId: selectedSource.workspaceId,
+          workspaceName: selectedSource.name,
+        },
+        capabilityId: selectedCapability.id,
+        title: title.trim(),
+        context: context.trim(),
+        contextFields,
+        priority: priority ?? undefined,
+        project: project.trim() || undefined,
+        type: type ?? undefined,
+      });
+      toast({
+        title: 'Delegated task created',
+        description: result.taskId ?? result.record.id,
+      });
+      setTitle('');
+      setContext('');
+    } catch (error) {
+      toast({
+        title: 'Delegated intake failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (discoveryQuery.isLoading) {
+    return (
+      <Group gap="sm" className="text-muted-foreground">
+        <Loader size="xs" />
+        <Text size="sm">Loading workspace capabilities...</Text>
+      </Group>
+    );
+  }
+
+  return (
+    <Stack gap="lg">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
+          <Network className="h-4 w-4 text-muted-foreground" />
+          <Text size="sm" fw={600}>
+            Workspace Capabilities
+          </Text>
+        </Group>
+        <Button
+          size="xs"
+          variant="subtle"
+          color="gray"
+          onClick={() => discoveryQuery.refetch()}
+          leftSection={<RefreshCw className="h-3.5 w-3.5" />}
+        >
+          Refresh
+        </Button>
+      </Group>
+
+      {!discovery?.local && (
+        <Alert color="yellow" variant="light">
+          No local workspace capability manifest is configured.
+        </Alert>
+      )}
+
+      {discovery?.local && (
+        <Paper className="border bg-card p-4" radius="md">
+          <Stack gap="sm">
+            <Group justify="space-between" align="flex-start">
+              <Stack gap={2}>
+                <Text size="sm" fw={600}>
+                  {discovery.local.name}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  {discovery.local.workspaceId}
+                </Text>
+              </Stack>
+              <Badge color={discovery.local.enabled ? 'green' : 'gray'} variant="light">
+                {discovery.local.enabled ? 'Enabled' : 'Disabled'}
+              </Badge>
+            </Group>
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+              {discovery.local.capabilities.map((capability) => (
+                <CapabilityCard key={capability.id} capability={capability} />
+              ))}
+            </SimpleGrid>
+          </Stack>
+        </Paper>
+      )}
+
+      <Stack gap="sm">
+        <Text size="sm" fw={600}>
+          Trusted Workspaces
+        </Text>
+        {trusted.length === 0 ? (
+          <Paper className="border border-dashed p-4 text-center" radius="md">
+            <Text size="sm" c="dimmed">
+              No trusted workspace manifests registered.
+            </Text>
+          </Paper>
+        ) : (
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+            {trusted.map((workspace) => (
+              <Paper key={workspace.workspaceId} className="border bg-card p-4" radius="md">
+                <Stack gap="xs">
+                  <Group justify="space-between" align="flex-start">
+                    <Stack gap={2}>
+                      <Text size="sm" fw={600}>
+                        {workspace.name}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {workspace.workspaceId}
+                      </Text>
+                    </Stack>
+                    <Badge color={workspace.enabled ? 'green' : 'gray'} variant="light">
+                      {workspace.enabled ? 'Trusted' : 'Disabled'}
+                    </Badge>
+                  </Group>
+                  {workspace.capabilities.map((capability) => (
+                    <CapabilityCard key={capability.id} capability={capability} compact />
+                  ))}
+                </Stack>
+              </Paper>
+            ))}
+          </SimpleGrid>
+        )}
+      </Stack>
+
+      <Paper className="border bg-card p-4" radius="md">
+        <Stack gap="md">
+          <Group gap="xs">
+            <SendHorizonal className="h-4 w-4 text-muted-foreground" />
+            <Text size="sm" fw={600}>
+              Delegated Intake
+            </Text>
+          </Group>
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+            <Select
+              label="Source workspace"
+              value={sourceWorkspaceId}
+              onChange={setSourceWorkspaceId}
+              data={trusted.map((workspace) => ({
+                value: workspace.workspaceId,
+                label: workspace.name,
+              }))}
+              disabled={trusted.length === 0}
+            />
+            <Select
+              label="Capability"
+              value={capabilityId}
+              onChange={setCapabilityId}
+              data={localCapabilities.map((capability) => ({
+                value: capability.id,
+                label: capability.name,
+              }))}
+              disabled={localCapabilities.length === 0}
+            />
+            <TextInput
+              label="Title"
+              value={title}
+              onChange={(event) => setTitle(event.currentTarget.value)}
+            />
+            <Select
+              label="Priority"
+              value={priority}
+              onChange={(value) => setPriority((value as TaskPriority | null) ?? null)}
+              data={PRIORITY_OPTIONS}
+              allowDeselect={false}
+            />
+            <Select
+              label="Type"
+              value={type}
+              onChange={setType}
+              data={taskTypeOptions}
+              disabled={taskTypeOptions.length === 0}
+            />
+            <TextInput
+              label="Project"
+              value={project}
+              onChange={(event) => setProject(event.currentTarget.value)}
+            />
+          </SimpleGrid>
+          <Textarea
+            label="Context"
+            value={context}
+            onChange={(event) => setContext(event.currentTarget.value)}
+            minRows={4}
+          />
+          {requiredFields.length > 0 && (
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing="sm">
+              {requiredFields.map((field) => (
+                <TextInput
+                  key={field}
+                  label={field}
+                  value={contextFields[field] ?? ''}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setContextFields((existing) => ({
+                      ...existing,
+                      [field]: value,
+                    }));
+                  }}
+                />
+              ))}
+            </SimpleGrid>
+          )}
+          <Group justify="flex-end">
+            <Button
+              onClick={handleSubmit}
+              disabled={!canSubmit || intake.isPending}
+              leftSection={<SendHorizonal className="h-4 w-4" />}
+            >
+              Create Intake
+            </Button>
+          </Group>
+        </Stack>
+      </Paper>
+
+      <Stack gap="sm">
+        <Text size="sm" fw={600}>
+          Recent Delegations
+        </Text>
+        {delegationsQuery.isLoading ? (
+          <Text size="sm" c="dimmed">
+            Loading delegations...
+          </Text>
+        ) : (delegationsQuery.data ?? []).length === 0 ? (
+          <Paper className="border border-dashed p-4 text-center" radius="md">
+            <Text size="sm" c="dimmed">
+              No delegated work recorded.
+            </Text>
+          </Paper>
+        ) : (
+          <Stack gap="xs">
+            {(delegationsQuery.data ?? []).slice(0, 5).map((record) => (
+              <Paper key={record.id} className="border bg-card p-3" radius="md">
+                <Group justify="space-between" align="flex-start" wrap="nowrap">
+                  <Stack gap={2} className="min-w-0">
+                    <Text size="sm" fw={500} className="truncate">
+                      {record.title}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {record.source.workspaceId}
+                      {' -> '}
+                      {record.target.workspaceId}
+                    </Text>
+                  </Stack>
+                  <Badge variant="light" color={record.status === 'blocked' ? 'red' : 'blue'}>
+                    {record.latestState ?? record.status}
+                  </Badge>
+                </Group>
+              </Paper>
+            ))}
+          </Stack>
+        )}
+      </Stack>
+    </Stack>
+  );
+}
+
+function CapabilityCard({
+  capability,
+  compact = false,
+}: {
+  capability: {
+    id: string;
+    name: string;
+    acceptedTaskTypes: string[];
+    requiredContextFields?: string[];
+    intakeTargets?: string[];
+  };
+  compact?: boolean;
+}) {
+  return (
+    <Paper
+      className={compact ? 'border bg-background/40 p-3' : 'border bg-background/40 p-4'}
+      radius="md"
+    >
+      <Stack gap={6}>
+        <Group gap="xs" justify="space-between" align="center">
+          <Text size="sm" fw={600}>
+            {capability.name}
+          </Text>
+          <Badge variant="light" color="gray">
+            {capability.id}
+          </Badge>
+        </Group>
+        <Group gap={6}>
+          {(capability.acceptedTaskTypes.length > 0 ? capability.acceptedTaskTypes : ['any']).map(
+            (taskType) => (
+              <Badge key={taskType} size="sm" variant="outline">
+                {taskType}
+              </Badge>
+            )
+          )}
+        </Group>
+        {capability.requiredContextFields && capability.requiredContextFields.length > 0 && (
+          <Text size="xs" c="dimmed">
+            Required: {capability.requiredContextFields.join(', ')}
+          </Text>
+        )}
+      </Stack>
+    </Paper>
+  );
+}

--- a/web/src/components/task/detail/TaskDetailsTab.tsx
+++ b/web/src/components/task/detail/TaskDetailsTab.tsx
@@ -14,8 +14,9 @@ import { BlockedReasonSection } from '../BlockedReasonSection';
 import { LessonsLearnedSection } from '../LessonsLearnedSection';
 import { useDeleteTask, useArchiveTask } from '@/hooks/useTasks';
 import { useFeatureSettings } from '@/hooks/useFeatureSettings';
-import { Trash2, Archive, Calendar, Clock, RotateCcw } from 'lucide-react';
+import { Trash2, Archive, Calendar, Clock, RotateCcw, ExternalLink } from 'lucide-react';
 import type { Task, BlockedReason } from '@veritas-kanban/shared';
+import { isExternalTargetHref, normalizeSafeHref } from '@veritas-kanban/shared';
 
 interface TaskDetailsTabProps {
   task: Task;
@@ -101,6 +102,21 @@ export function TaskDetailsTab({
 
       {/* Metadata Section */}
       <TaskMetadataSection task={task} onUpdate={onUpdate} readOnly={readOnly} />
+
+      {task.delegatedWork && task.delegatedWork.length > 0 && (
+        <Box className="border-t pt-4">
+          <Stack gap="sm">
+            <Text size="sm" c="dimmed" fw={500}>
+              Delegated Work
+            </Text>
+            <Stack gap="xs">
+              {task.delegatedWork.map((link) => (
+                <DelegatedWorkLink key={link.id} link={link} />
+              ))}
+            </Stack>
+          </Stack>
+        </Box>
+      )}
 
       {/* Blocked Reason (shown when status is blocked) */}
       {task.status === 'blocked' && (
@@ -274,5 +290,44 @@ export function TaskDetailsTab({
         </Stack>
       </Modal>
     </Stack>
+  );
+}
+
+function DelegatedWorkLink({ link }: { link: NonNullable<Task['delegatedWork']>[number] }) {
+  const href = normalizeSafeHref(link.targetUrl);
+  const external = isExternalTargetHref(href);
+  return (
+    <Paper className="border bg-card p-3" radius="md">
+      <Group justify="space-between" gap="sm" wrap="nowrap">
+        <Stack gap={2} className="min-w-0">
+          <Group gap="xs">
+            <Badge variant="light" color={link.status === 'blocked' ? 'red' : 'blue'}>
+              {link.latestState ?? link.status}
+            </Badge>
+            <Text size="xs" c="dimmed">
+              {link.capabilityId}
+            </Text>
+          </Group>
+          <Text size="xs" c="dimmed" className="truncate">
+            {link.sourceWorkspaceId}
+            {' -> '}
+            {link.targetWorkspaceId}
+          </Text>
+        </Stack>
+        {href && (
+          <Button
+            component="a"
+            href={href}
+            target={external ? '_blank' : undefined}
+            rel={external ? 'noreferrer' : undefined}
+            variant="subtle"
+            size="xs"
+            leftSection={<ExternalLink className="h-3.5 w-3.5" />}
+          >
+            Open
+          </Button>
+        )}
+      </Group>
+    </Paper>
   );
 }

--- a/web/src/hooks/useWorkspaceCapabilities.ts
+++ b/web/src/hooks/useWorkspaceCapabilities.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type {
+  WorkspaceCapabilityFormat,
+  WorkspaceCapabilityManifest,
+  WorkspaceDelegatedWorkIntakeInput,
+} from '@veritas-kanban/shared';
+
+const DISCOVERY_KEY = ['workspace-capabilities', 'discover'] as const;
+const DELEGATIONS_KEY = ['workspace-capabilities', 'delegations'] as const;
+
+export function useWorkspaceCapabilityDiscovery() {
+  return useQuery({
+    queryKey: DISCOVERY_KEY,
+    queryFn: api.workspaceCapabilities.discover,
+  });
+}
+
+export function useWorkspaceDelegations() {
+  return useQuery({
+    queryKey: DELEGATIONS_KEY,
+    queryFn: api.workspaceCapabilities.listDelegations,
+  });
+}
+
+export function useRegisterTrustedWorkspaceCapability() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      manifest?: unknown;
+      content?: string;
+      format?: WorkspaceCapabilityFormat;
+      source?: string;
+    }) => api.workspaceCapabilities.registerTrusted(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: DISCOVERY_KEY });
+    },
+  });
+}
+
+export function useSaveWorkspaceCapabilityManifest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (manifest: WorkspaceCapabilityManifest) =>
+      api.workspaceCapabilities.saveManifest(manifest),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: DISCOVERY_KEY });
+    },
+  });
+}
+
+export function useWorkspaceDelegatedIntake() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: WorkspaceDelegatedWorkIntakeInput) =>
+      api.workspaceCapabilities.intake(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: DELEGATIONS_KEY });
+    },
+  });
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -29,6 +29,7 @@ import { evidenceApi } from './evidence';
 import { timeBreakdownsApi } from './time-breakdowns';
 import { sandboxPoliciesApi } from './sandbox-policies';
 import { runSessionsApi } from './run-sessions';
+import { workspaceCapabilitiesApi } from './workspace-capabilities';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -69,6 +70,7 @@ export const api = {
   timeBreakdowns: timeBreakdownsApi,
   sandboxPolicies: sandboxPoliciesApi,
   runSessions: runSessionsApi,
+  workspaceCapabilities: workspaceCapabilitiesApi,
 };
 
 export type {

--- a/web/src/lib/api/workspace-capabilities.ts
+++ b/web/src/lib/api/workspace-capabilities.ts
@@ -1,0 +1,72 @@
+import type {
+  WorkspaceCapabilityDiscoveryResult,
+  WorkspaceCapabilityExportResult,
+  WorkspaceCapabilityFormat,
+  WorkspaceCapabilityManifest,
+  WorkspaceCapabilityRegistrationResult,
+  WorkspaceCapabilityValidationResult,
+  WorkspaceDelegatedWorkIntakeInput,
+  WorkspaceDelegatedWorkIntakeResult,
+  WorkspaceDelegationRecord,
+} from '@veritas-kanban/shared';
+import { apiFetch } from './helpers';
+
+export const workspaceCapabilitiesApi = {
+  getManifest: () =>
+    apiFetch<WorkspaceCapabilityManifest | null>('/api/workspace-capabilities/manifest'),
+
+  saveManifest: (manifest: WorkspaceCapabilityManifest) =>
+    apiFetch<WorkspaceCapabilityManifest>('/api/workspace-capabilities/manifest', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(manifest),
+    }),
+
+  validateManifest: (input: {
+    manifest?: unknown;
+    content?: string;
+    format?: WorkspaceCapabilityFormat;
+    source?: string;
+  }) =>
+    apiFetch<WorkspaceCapabilityValidationResult>('/api/workspace-capabilities/manifest/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  registerTrusted: (input: {
+    manifest?: unknown;
+    content?: string;
+    format?: WorkspaceCapabilityFormat;
+    source?: string;
+  }) =>
+    apiFetch<WorkspaceCapabilityRegistrationResult>('/api/workspace-capabilities/trusted', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  exportManifest: (format: WorkspaceCapabilityFormat = 'yaml') =>
+    apiFetch<WorkspaceCapabilityExportResult>(
+      `/api/workspace-capabilities/manifest/export?format=${format}`
+    ),
+
+  discover: () =>
+    apiFetch<WorkspaceCapabilityDiscoveryResult>('/api/workspace-capabilities/discover'),
+
+  intake: (input: WorkspaceDelegatedWorkIntakeInput) =>
+    apiFetch<WorkspaceDelegatedWorkIntakeResult>('/api/workspace-capabilities/intake', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+
+  listDelegations: () =>
+    apiFetch<WorkspaceDelegationRecord[]>('/api/workspace-capabilities/delegations'),
+
+  refreshDelegation: (id: string) =>
+    apiFetch<WorkspaceDelegationRecord>(
+      `/api/workspace-capabilities/delegations/${encodeURIComponent(id)}/refresh`,
+      { method: 'POST' }
+    ),
+};


### PR DESCRIPTION
## Summary
- Add workspace capability manifests, trusted peer registration, discovery, delegated intake, and delegation refresh APIs.
- Add task-level delegated work links so originating tasks can show target status when intake references a local source task.
- Add `vk workspaces` CLI commands and a Settings > Workspaces panel for discovery and delegated task intake.
- Document the manifest/intake contract and permission model.

Closes #735.

## Verification
- pnpm vitest run server/src/__tests__/workspace-capability-service.test.ts server/src/__tests__/routes/workspace-capabilities.test.ts cli/src/__tests__/api-permissions.test.ts --reporter=verbose
- pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/workspace-capabilities-tab.test.tsx --reporter=verbose --testTimeout=15000
- pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/server typecheck && pnpm --filter @veritas-kanban/cli typecheck && pnpm --filter @veritas-kanban/web typecheck
- pnpm build
- pnpm exec eslint <touched files> && git diff --check

## Risk
- GitHub issue intake is modeled as a target type but intentionally fails closed until a GitHub issue adapter is configured; task intake is the supported path in this PR.