### PR TITLE
Add policy-gated queue intake monitors

### DIFF
--- a/cli/src/__tests__/api-permissions.test.ts
+++ b/cli/src/__tests__/api-permissions.test.ts
@@ -142,4 +142,30 @@ describe('CLI API permission preflight', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe('http://vk.test/api/auth/context');
   });
+
+  it('requires workflow execute permission for queue monitor run actions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        role: 'read-only',
+        isLocalhost: false,
+        permissions: ['workflow:read'],
+      })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const api = createGuardedApiClient('http://vk.test', 'reader-key');
+
+    await expect(
+      api('/api/queue-monitors/veritas-backlog/run', {
+        method: 'POST',
+      })
+    ).rejects.toMatchObject({
+      required: ['workflow:execute'],
+      path: '/api/queue-monitors/veritas-backlog/run',
+      method: 'POST',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://vk.test/api/auth/context');
+  });
 });

--- a/cli/src/commands/queue-monitors.ts
+++ b/cli/src/commands/queue-monitors.ts
@@ -1,0 +1,176 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { api } from '../utils/api.js';
+import type {
+  QueueMonitorExplainResult,
+  QueueMonitorHealthResult,
+  QueueMonitorListResponse,
+  QueueMonitorRunResult,
+  QueueMonitorSnapshot,
+} from '@veritas-kanban/shared';
+
+export function registerQueueMonitorCommands(program: Command): void {
+  const monitors = program
+    .command('queue-monitors')
+    .alias('queue-monitor')
+    .alias('queues')
+    .description('Inspect and run policy-gated GitHub queue intake monitors');
+
+  monitors
+    .command('list')
+    .alias('status')
+    .description('List configured queue intake monitors')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const result = await api<QueueMonitorListResponse>('/api/queue-monitors');
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        printSummary(result);
+        for (const monitor of result.monitors) printMonitor(monitor);
+      } catch (err) {
+        printError(err);
+      }
+    });
+
+  monitors
+    .command('run <monitorId>')
+    .description('Run a queue intake monitor once')
+    .option('--json', 'Output as JSON')
+    .action(async (monitorId, options) => runAction(monitorId, 'run', options.json));
+
+  monitors
+    .command('pause <monitorId>')
+    .description('Pause a queue intake monitor')
+    .option('--json', 'Output as JSON')
+    .action(async (monitorId, options) => runAction(monitorId, 'pause', options.json));
+
+  monitors
+    .command('resume <monitorId>')
+    .description('Resume a queue intake monitor')
+    .option('--json', 'Output as JSON')
+    .action(async (monitorId, options) => runAction(monitorId, 'resume', options.json));
+
+  monitors
+    .command('health <monitorId>')
+    .description('Show queue monitor health')
+    .option('--json', 'Output as JSON')
+    .action(async (monitorId, options) => {
+      try {
+        const result = await api<QueueMonitorHealthResult>(
+          `/api/queue-monitors/${encodeURIComponent(monitorId)}/health`
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        printMonitor(result.monitor);
+        if (result.actionItem) {
+          console.log(chalk.yellow(`Action item: ${result.actionItem.summary}`));
+          console.log(chalk.dim(result.actionItem.remediation));
+        }
+      } catch (err) {
+        printError(err);
+      }
+    });
+
+  monitors
+    .command('explain <monitorId>')
+    .description('Build a fresh candidate packet and explain the selected action')
+    .option('--json', 'Output as JSON')
+    .action(async (monitorId, options) => {
+      try {
+        const result = await api<QueueMonitorExplainResult>(
+          `/api/queue-monitors/${encodeURIComponent(monitorId)}/explain`
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        printMonitor(result.monitor);
+        console.log(chalk.bold('\nSelected'));
+        if (result.packet.selected) {
+          console.log(
+            `${result.packet.selected.repo}#${result.packet.selected.number} ${result.packet.selected.title}`
+          );
+        } else {
+          console.log(chalk.dim('No candidate selected.'));
+        }
+        console.log(chalk.bold('\nAction'));
+        console.log(`${result.action.action}: ${result.action.summary}`);
+        for (const check of result.action.gateChecks) {
+          const color =
+            check.status === 'pass'
+              ? chalk.green
+              : check.status === 'warn'
+                ? chalk.yellow
+                : chalk.red;
+          console.log(`  ${color(check.status)} ${check.name}: ${check.summary}`);
+        }
+      } catch (err) {
+        printError(err);
+      }
+    });
+}
+
+async function runAction(
+  monitorId: string,
+  action: 'run' | 'pause' | 'resume',
+  json: boolean
+): Promise<void> {
+  try {
+    const result = await api<QueueMonitorRunResult>(
+      `/api/queue-monitors/${encodeURIComponent(monitorId)}/${action}`,
+      { method: 'POST' }
+    );
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(chalk.green(`${action}: ${result.event.summary}`));
+    if (result.packet.selected) {
+      console.log(
+        chalk.dim(
+          `Selected ${result.packet.selected.repo}#${result.packet.selected.number} ${result.packet.selected.title}`
+        )
+      );
+    }
+    if (result.action.skippedReasons.length > 0) {
+      console.log(chalk.yellow(`Skipped: ${result.action.skippedReasons.length}`));
+    }
+  } catch (err) {
+    printError(err);
+  }
+}
+
+function printSummary(result: QueueMonitorListResponse): void {
+  console.log(chalk.bold('\nQueue Intake Monitors'));
+  console.log(
+    chalk.dim(
+      `total=${result.summary.total} enabled=${result.summary.enabled} due=${result.summary.due} failed=${result.summary.failed} blocked=${result.summary.blocked}`
+    )
+  );
+  console.log();
+}
+
+function printMonitor(monitor: QueueMonitorSnapshot): void {
+  const health =
+    monitor.health === 'healthy'
+      ? chalk.green(monitor.health)
+      : monitor.health === 'blocked'
+        ? chalk.red(monitor.health)
+        : chalk.yellow(monitor.health);
+  console.log(`${chalk.bold(monitor.id)} ${health}`);
+  console.log(`  ${monitor.name}`);
+  console.log(
+    `  repo=${monitor.source.repo} mode=${monitor.mode} next=${monitor.nextRunAt ?? 'not set'}`
+  );
+  if (monitor.lastSummary) console.log(chalk.dim(`  last=${monitor.lastSummary}`));
+}
+
+function printError(err: unknown): never {
+  console.error(chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`));
+  process.exit(1);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -21,6 +21,7 @@ import { registerSnapshotCommand } from './commands/snapshot.js';
 import { registerPromptCommands } from './commands/prompts.js';
 import { registerWorkspaceCommands } from './commands/workspaces.js';
 import { registerSchedulerCommands } from './commands/scheduler.js';
+import { registerQueueMonitorCommands } from './commands/queue-monitors.js';
 
 const program = new Command();
 const packageJson = JSON.parse(
@@ -53,5 +54,6 @@ registerSnapshotCommand(program);
 registerPromptCommands(program);
 registerWorkspaceCommands(program);
 registerSchedulerCommands(program);
+registerQueueMonitorCommands(program);
 
 program.parse();

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -34,27 +34,28 @@
 21. [Task Subtasks](#task-subtasks)
 22. [Task Deliverables](#task-deliverables)
 23. [Recurring Work Scheduler](#recurring-work-scheduler)
-24. [Task Archive](#task-archive)
-25. [Attachments](#attachments)
-26. [Agent Permissions](#agent-permissions)
-27. [Agent Routing](#agent-routing)
-28. [Sandbox Policies](#sandbox-policies)
-29. [Shared Resources](#shared-resources)
-30. [Skill Capability Profiles](#skill-capability-profiles-apiskillscapabilities)
-31. [Skill Security Scanner](#skill-security-scanner-apiskillssecurity)
-32. [Doc Freshness](#doc-freshness)
-33. [Cost Prediction](#cost-prediction)
-34. [Error Learning](#error-learning)
-35. [Tool Policies](#tool-policies)
-36. [Watcher Continuation Policies](#watcher-continuation-policies)
-37. [Traces](#traces)
-38. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
-39. [Audit](#audit)
-40. [Maintenance Center](#maintenance-center-apiv1maintenance)
-41. [Common Workflows](#common-workflows)
-42. [Versioning & Deprecation](#versioning--deprecation)
-43. [Rate Limits](#rate-limits)
-44. [Additional Endpoint Groups](#additional-endpoint-groups)
+24. [Queue Intake Monitors](#queue-intake-monitors)
+25. [Task Archive](#task-archive)
+26. [Attachments](#attachments)
+27. [Agent Permissions](#agent-permissions)
+28. [Agent Routing](#agent-routing)
+29. [Sandbox Policies](#sandbox-policies)
+30. [Shared Resources](#shared-resources)
+31. [Skill Capability Profiles](#skill-capability-profiles-apiskillscapabilities)
+32. [Skill Security Scanner](#skill-security-scanner-apiskillssecurity)
+33. [Doc Freshness](#doc-freshness)
+34. [Cost Prediction](#cost-prediction)
+35. [Error Learning](#error-learning)
+36. [Tool Policies](#tool-policies)
+37. [Watcher Continuation Policies](#watcher-continuation-policies)
+38. [Traces](#traces)
+39. [Governance Decision Traces](#governance-decision-traces-apigovernancetraces)
+40. [Audit](#audit)
+41. [Maintenance Center](#maintenance-center-apiv1maintenance)
+42. [Common Workflows](#common-workflows)
+43. [Versioning & Deprecation](#versioning--deprecation)
+44. [Rate Limits](#rate-limits)
+45. [Additional Endpoint Groups](#additional-endpoint-groups)
 
 ---
 
@@ -1290,6 +1291,7 @@ Item IDs use the source prefix:
 
 - `scheduled-deliverable:<deliverableId>`
 - `workflow:<workflowId>`
+- `queue-monitor:<monitorId>`
 
 ### Run Item Now
 
@@ -1330,6 +1332,47 @@ POST /api/scheduler/due/run
 ```
 
 Runs all due standard schedules and refuses overlapping due-run passes.
+
+---
+
+## Queue Intake Monitors
+
+Scan bounded GitHub issue and PR queues, build candidate packets, and gate assign/execute actions through policy, budget, sandbox, auth, and workflow preflight checks.
+
+Mounted at `/api/queue-monitors`.
+
+| Method | Path                              | Description                                                |
+| ------ | --------------------------------- | ---------------------------------------------------------- |
+| `GET`  | `/api/queue-monitors`             | List monitors, health, candidate packet state, and events  |
+| `GET`  | `/api/queue-monitors/:id`         | Read one monitor                                           |
+| `PUT`  | `/api/queue-monitors/:id`         | Update mode, runner, labels, caps, workflow, and guardrail |
+| `GET`  | `/api/queue-monitors/:id/health`  | Read health and visible action item state                  |
+| `GET`  | `/api/queue-monitors/:id/explain` | Build a fresh packet and planned action without mutation   |
+| `POST` | `/api/queue-monitors/:id/run`     | Run one monitor now                                        |
+| `POST` | `/api/queue-monitors/:id/pause`   | Pause one monitor                                          |
+| `POST` | `/api/queue-monitors/:id/resume`  | Resume one monitor                                         |
+
+### Monitor Modes
+
+- `dry-run` records the selected candidate and skipped reasons without assigning or starting work.
+- `assign-only` can assign the selected GitHub issue/PR only after watcher policy, budget, sandbox, and stop-condition checks pass.
+- `draft-plan` records a local plan intent without GitHub mutation or workflow launch.
+- `execute` can start `workflowId` only after watcher policy, budget, sandbox, workflow dry-run, auth, and stop-condition checks pass.
+
+`runner: "local"` is executable in this version. `runner: "github-actions"` is persisted for monitor definitions but launch is blocked until a workflow-dispatch adapter is configured.
+
+### Candidate Packet
+
+Each run stores a bounded packet with:
+
+- `candidates`: issue/PR records with labels, assignees, CI state, score, reasons, and blockers
+- `selected`: first unblocked candidate after deterministic scoring
+- `skipped`: candidate IDs and skipped-work reasons
+- `checks`: GitHub scan, watcher policy, sandbox, budget, and workflow gate checks
+
+Repeated `failed` or `blocked` runs increment `failureStreak`. When the monitor reaches `stopConditions.maxFailureStreak`, health becomes `blocked` and `actionItem` explains what must be fixed before resuming.
+
+Queue monitor events are included in the operations digest when they fall inside the selected digest window.
 
 ---
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -20,6 +20,8 @@ Comprehensive guide to the `vk` command-line tool for Veritas Kanban.
   - [Project Management](#project-management)
   - [Agent Commands](#agent-commands)
   - [Automation Commands](#automation-commands)
+  - [Scheduler Commands](#scheduler-commands)
+  - [Queue Monitor Commands](#queue-monitor-commands)
   - [GitHub Sync](#github-sync)
   - [Utilities](#utilities)
 - [Workflow Commands Deep Dive](#workflow-commands-deep-dive)
@@ -465,6 +467,40 @@ Manage automation tasks.
 | `vk automation:running`       | `ar`  | List running automation tasks      |
 | `vk automation:start <id>`    | `as`  | Start an automation task           |
 | `vk automation:complete <id>` | `ac`  | Mark automation complete or failed |
+
+---
+
+### Scheduler Commands
+
+Inspect and control recurring work from the terminal.
+
+| Command                      | Description                                      |
+| ---------------------------- | ------------------------------------------------ |
+| `vk scheduler list`          | List recurring scheduler items and recent events |
+| `vk scheduler run-due`       | Run all due scheduler items                      |
+| `vk scheduler run <id>`      | Run one scheduler item now                       |
+| `vk scheduler pause <id>`    | Pause one scheduler item                         |
+| `vk scheduler resume <id>`   | Resume one scheduler item                        |
+| `vk scheduler validate <id>` | Validate one scheduler item                      |
+
+Item IDs include a source prefix: `scheduled-deliverable:<id>`, `workflow:<id>`, or `queue-monitor:<id>`.
+
+---
+
+### Queue Monitor Commands
+
+Inspect and run policy-gated GitHub queue intake monitors.
+
+| Command                          | Description                                     |
+| -------------------------------- | ----------------------------------------------- |
+| `vk queue-monitors list`         | List queue monitors, health, and recent events  |
+| `vk queue-monitors run <id>`     | Run one monitor now                             |
+| `vk queue-monitors explain <id>` | Build a fresh candidate packet without mutation |
+| `vk queue-monitors health <id>`  | Show monitor health and action item state       |
+| `vk queue-monitors pause <id>`   | Pause one monitor                               |
+| `vk queue-monitors resume <id>`  | Resume one monitor                              |
+
+Every queue monitor command supports `--json`. `run` requires `workflow:execute`; list, health, and explain require `workflow:read`.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -47,6 +47,7 @@ For current v5 screenshots and GIFs, see the
 - [Broadcast Notifications](#broadcast-notifications)
 - [Task Deliverables](#task-deliverables)
 - [Recurring Work Scheduler](#recurring-work-scheduler)
+- [Queue Intake Monitors](#queue-intake-monitors)
 - [Efficient Polling](#efficient-polling)
 - [Approval Delegation](#approval-delegation)
 - [Lifecycle Hooks](#task-lifecycle-hooks)
@@ -1158,12 +1159,12 @@ First-class deliverable objects attached to tasks with type and status tracking.
 
 ## Recurring Work Scheduler
 
-Unified operator surface for scheduled deliverables and scheduled workflow definitions.
+Unified operator surface for scheduled deliverables, scheduled workflow definitions, and queue intake monitors.
 
 - **Single scheduler dashboard** — Settings exposes all recurring work with health, retry, next run, last run, and recent events
 - **Manual controls** — Run, pause, resume, and validate individual scheduler items
 - **Due runner** — `POST /api/scheduler/due/run` and `vk scheduler run-due` execute due items while refusing overlapping passes
-- **Existing service adapters** — Deliverables execute through the scheduled deliverables runner; workflows start through the workflow run service
+- **Existing service adapters** — Deliverables execute through the scheduled deliverables runner; workflows start through the workflow run service; queue monitors scan through the GitHub adapter
 - **Operations telemetry** — Scheduler events emit bounded run telemetry with `agent=scheduler` for operations digest visibility
 - **Custom cron guardrail** — Cron schedules are visible and manually runnable, but automatic custom-cron due execution is deferred until a cron adapter is configured
 
@@ -1180,6 +1181,33 @@ Unified operator surface for scheduled deliverables and scheduled workflow defin
 | `/api/scheduler/items/:id/resume`   | POST   | Resume one scheduler item       |
 | `/api/scheduler/items/:id/validate` | POST   | Validate one scheduler item     |
 | `/api/scheduler/due/run`            | POST   | Run due scheduler items         |
+
+---
+
+## Queue Intake Monitors
+
+Policy-gated monitors that scan GitHub issue and PR queues, build bounded candidate packets, and decide the next safe action.
+
+- **GitHub queue packets** — Monitor definitions specify repo, labels, issue/PR inclusion, interval, candidate cap, runner, mode, budget, sandbox preset, and stop conditions
+- **Deterministic selection** — Candidates are scored by priority, assignment state, issue/PR readiness, and CI state; blocked labels, draft PRs, and failed checks become skipped-work reasons
+- **Fail-closed execution** — Dry-run is the default. Assign-only and execute modes require watcher policy, budget, sandbox, auth, stop-condition, and workflow validation gates to pass
+- **Visible circuit state** — Repeated failures trip the monitor health state and expose an action item instead of retrying indefinitely
+- **Shared operations surfaces** — Queue monitors appear in Settings -> Queues, in the recurring scheduler, in `vk queue-monitors`, and in operations digest output
+
+→ [Full guide](features/queue-intake-monitor.md) — monitor model, API, CLI, execution gates, and digest behavior
+
+### API Endpoints
+
+| Endpoint                          | Method | Description                         |
+| --------------------------------- | ------ | ----------------------------------- |
+| `/api/queue-monitors`             | GET    | List monitors, health, and events   |
+| `/api/queue-monitors/:id`         | GET    | Read one monitor                    |
+| `/api/queue-monitors/:id`         | PUT    | Update monitor mode and filters     |
+| `/api/queue-monitors/:id/health`  | GET    | Read health and action item state   |
+| `/api/queue-monitors/:id/explain` | GET    | Build a fresh packet without mutate |
+| `/api/queue-monitors/:id/run`     | POST   | Run one monitor now                 |
+| `/api/queue-monitors/:id/pause`   | POST   | Pause one monitor                   |
+| `/api/queue-monitors/:id/resume`  | POST   | Resume one monitor                  |
 
 ---
 
@@ -1487,6 +1515,28 @@ Added in v3.3.2.
 | `vk automation:running`       | `ar`  | List running automation tasks      |
 | `vk automation:start <id>`    | `as`  | Start an automation task           |
 | `vk automation:complete <id>` | `ac`  | Mark automation complete or failed |
+
+### Scheduler Commands
+
+| Command                      | Description                    |
+| ---------------------------- | ------------------------------ |
+| `vk scheduler list`          | List recurring scheduler items |
+| `vk scheduler run-due`       | Run all due recurring work     |
+| `vk scheduler run <id>`      | Run one scheduler item now     |
+| `vk scheduler pause <id>`    | Pause one scheduler item       |
+| `vk scheduler resume <id>`   | Resume one scheduler item      |
+| `vk scheduler validate <id>` | Validate one scheduler item    |
+
+### Queue Monitor Commands
+
+| Command                          | Description                                     |
+| -------------------------------- | ----------------------------------------------- |
+| `vk queue-monitors list`         | List queue intake monitors                      |
+| `vk queue-monitors run <id>`     | Run one monitor now                             |
+| `vk queue-monitors explain <id>` | Build a fresh candidate packet without mutation |
+| `vk queue-monitors health <id>`  | Show monitor health and action item state       |
+| `vk queue-monitors pause <id>`   | Pause one monitor                               |
+| `vk queue-monitors resume <id>`  | Resume one monitor                              |
 
 ### GitHub Sync Commands
 

--- a/docs/features/queue-intake-monitor.md
+++ b/docs/features/queue-intake-monitor.md
@@ -1,0 +1,97 @@
+# Queue Intake Monitor
+
+Queue intake monitors scan bounded GitHub issue and pull request queues, build an inspectable candidate packet, and decide the next safe action under Veritas policy gates.
+
+The first adapter is GitHub-backed. Monitor state is stored in `.veritas-kanban/queue-monitors.json`, and the default monitor scans open high-priority items in `BradGroux/veritas-kanban` in `dry-run` mode.
+
+## Operator Surfaces
+
+- Settings -> Queues shows monitor health, next scan, last packet, selected work, skipped reasons, and visible action items.
+- Settings -> Scheduler includes queue monitors as `queue-monitor:<id>` recurring work items.
+- `vk queue-monitors` provides list, run, explain, health, pause, and resume commands.
+- `/api/queue-monitors` exposes the same state for local and remote clients.
+- Operations digest output includes queue monitor events and skipped-work counts inside the digest window.
+
+## Candidate Packets
+
+A run fetches a bounded set of GitHub issues and PRs from the configured repo and labels. The packet records:
+
+- candidates with repo, number, title, URL, labels, assignees, author, timestamps, CI state, blockers, score, and score reasons
+- selected candidate, if any unblocked candidate remains
+- skipped candidates with explicit reasons
+- gate checks for GitHub scan, watcher policy, sandbox, budget, and workflow preflight
+
+Selection is deterministic. Priority labels, unassigned issues, passing PR checks, and age increase score. Blocked labels, draft PRs, and failed PR checks become skipped reasons by default.
+
+## Modes
+
+| Mode          | Behavior                                                                                            |
+| ------------- | --------------------------------------------------------------------------------------------------- |
+| `dry-run`     | Records the selected candidate and skipped reasons without mutating GitHub or starting workflows.   |
+| `draft-plan`  | Records a local plan intent without mutation.                                                       |
+| `assign-only` | Assigns the selected GitHub issue/PR only after policy, budget, sandbox, and stop checks pass.      |
+| `execute`     | Starts `workflowId` only after every policy, budget, sandbox, workflow, auth, and stop gate passes. |
+
+Execute mode fails closed when `workflowId` is missing, the workflow cannot dry-run, policy requires approval, budget blocks launch, sandbox enforcement blocks, GitHub auth fails, runner dispatch is unavailable, or stop conditions are tripped.
+
+`runner: "local"` is the executable runner in this version. `runner: "github-actions"` is part of the persisted monitor model, but launch is blocked until a workflow-dispatch adapter is configured.
+
+## Circuit State
+
+Each failed or blocked run increments `failureStreak`. When it reaches `stopConditions.maxFailureStreak`, the monitor health becomes `blocked` and an `actionItem` is exposed with remediation. The scheduler will not run blocked monitors until an operator fixes the condition and resumes or updates the monitor.
+
+## CLI
+
+```bash
+vk queue-monitors list
+vk queue-monitors explain veritas-backlog-high-priority
+vk queue-monitors run veritas-backlog-high-priority
+vk queue-monitors health veritas-backlog-high-priority
+vk queue-monitors pause veritas-backlog-high-priority
+vk queue-monitors resume veritas-backlog-high-priority
+```
+
+Use `--json` on any command for scripts.
+
+## API
+
+Mounted at `/api/queue-monitors`.
+
+| Method | Path                              | Description                                               |
+| ------ | --------------------------------- | --------------------------------------------------------- |
+| `GET`  | `/api/queue-monitors`             | List monitors, health, candidate packet state, and events |
+| `GET`  | `/api/queue-monitors/:id`         | Read one monitor                                          |
+| `PUT`  | `/api/queue-monitors/:id`         | Update monitor mode, runner, filters, and guardrails      |
+| `GET`  | `/api/queue-monitors/:id/health`  | Read health and action item state                         |
+| `GET`  | `/api/queue-monitors/:id/explain` | Build a fresh packet and planned action without mutation  |
+| `POST` | `/api/queue-monitors/:id/run`     | Run one monitor now                                       |
+| `POST` | `/api/queue-monitors/:id/pause`   | Pause one monitor                                         |
+| `POST` | `/api/queue-monitors/:id/resume`  | Resume one monitor                                        |
+
+### Update Example
+
+```json
+{
+  "mode": "execute",
+  "workflowId": "queue-intake-workflow",
+  "sandboxPresetId": "codex-repo-contained",
+  "repo": "BradGroux/veritas-kanban",
+  "state": "open",
+  "labels": ["priority: high"],
+  "maxCandidates": 20,
+  "stopConditions": {
+    "maxFailureStreak": 3,
+    "skipBlockedLabels": ["blocked", "needs-info"],
+    "skipDraftPullRequests": true,
+    "skipFailedChecks": true
+  }
+}
+```
+
+## Permissions
+
+- `GET /api/queue-monitors`, `GET /:id/health`, and `GET /:id/explain` require `workflow:read`.
+- `PUT /api/queue-monitors/:id`, pause, and resume require `workflow:write`.
+- `POST /api/queue-monitors/:id/run` requires `workflow:execute`.
+
+CLI permission preflight checks `/api/auth/context` before sending mutating requests.

--- a/docs/features/recurring-work-scheduler.md
+++ b/docs/features/recurring-work-scheduler.md
@@ -7,6 +7,7 @@ It currently surfaces:
 - scheduled deliverables, including operations digest deliverables
 - workflow definitions with enabled non-manual schedules
 - workflow scheduled-snapshot outputs
+- queue intake monitors
 
 ## Operator Controls
 
@@ -20,9 +21,11 @@ Each scheduler item exposes:
 - recent scheduler events
 - manual run, pause, resume, and validate actions
 
+Queue monitors appear as `queue-monitor:<monitorId>` items. They use the monitor interval and execute through the queue monitor service, so Run Due can scan GitHub queues without bypassing monitor policy gates.
+
 ## Execution Model
 
-Scheduled deliverables run through the existing scheduled deliverables runner. Workflow schedules run through the existing workflow run service and create a normal workflow run record.
+Scheduled deliverables run through the existing scheduled deliverables runner. Workflow schedules run through the existing workflow run service and create a normal workflow run record. Queue monitors run through the policy-gated queue monitor service and record their own candidate packet before the scheduler records the recurring event.
 
 The due-runner refuses overlapping scheduler passes and refuses overlapping item runs in the same server process. Failed scheduler runs record retry state with exponential backoff up to the configured retry limit. Scheduler executions also emit bounded run telemetry with `agent=scheduler` and `project=operations`, so operations digests can include scheduler activity.
 
@@ -36,6 +39,7 @@ Custom cron schedules are visible, manually runnable, and validated for a cron e
 vk scheduler list
 vk scheduler run-due
 vk scheduler run "scheduled-deliverable:del_ops"
+vk scheduler run "queue-monitor:veritas-backlog-high-priority"
 vk scheduler pause "workflow:weekly-snapshot"
 vk scheduler resume "workflow:weekly-snapshot"
 vk scheduler validate "workflow:weekly-snapshot"

--- a/server/src/__tests__/digest-service.test.ts
+++ b/server/src/__tests__/digest-service.test.ts
@@ -8,6 +8,14 @@ import type { RunTelemetryEvent, Task, TokenTelemetryEvent } from '@veritas-kanb
 import { DigestService, type DailyDigest } from '../services/digest-service.js';
 
 const mockPendingApprovals = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const mockQueueMonitorList = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    generatedAt: '2026-06-04T12:00:00.000Z',
+    summary: { total: 0, enabled: 0, paused: 0, blocked: 0, failed: 0, due: 0 },
+    monitors: [],
+    recentEvents: [],
+  })
+);
 
 // Mock dependencies
 vi.mock('../services/metrics/index.js', () => ({
@@ -39,6 +47,12 @@ vi.mock('../services/task-service.js', () => ({
 vi.mock('../services/agent-permission-service.js', () => ({
   getAgentPermissionService: () => ({
     getPendingApprovals: mockPendingApprovals,
+  }),
+}));
+
+vi.mock('../services/queue-intake-monitor-service.js', () => ({
+  getQueueIntakeMonitorService: () => ({
+    list: mockQueueMonitorList,
   }),
 }));
 
@@ -98,6 +112,12 @@ describe('DigestService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPendingApprovals.mockResolvedValue([]);
+    mockQueueMonitorList.mockResolvedValue({
+      generatedAt: '2026-06-04T12:00:00.000Z',
+      summary: { total: 0, enabled: 0, paused: 0, blocked: 0, failed: 0, due: 0 },
+      monitors: [],
+      recentEvents: [],
+    });
     service = new DigestService();
   });
 
@@ -235,6 +255,58 @@ describe('DigestService', () => {
         action: 'push_branch',
       });
       expect(digest.totals.openApprovals).toBe(1);
+    });
+
+    it('includes queue monitor activity and skipped reasons', async () => {
+      const serviceOverrides = service as unknown as {
+        telemetry: { getEvents: ReturnType<typeof vi.fn> };
+        taskService: { listTasks: ReturnType<typeof vi.fn> };
+      };
+      serviceOverrides.telemetry = { getEvents: vi.fn().mockResolvedValue([]) };
+      serviceOverrides.taskService = { listTasks: vi.fn().mockResolvedValue([]) };
+      mockQueueMonitorList.mockResolvedValue({
+        generatedAt: '2026-06-04T12:00:00.000Z',
+        summary: { total: 1, enabled: 1, paused: 0, blocked: 0, failed: 0, due: 0 },
+        monitors: [
+          {
+            id: 'veritas-backlog',
+            source: { repo: 'veritas-kanban' },
+          },
+        ],
+        recentEvents: [
+          {
+            id: 'qm_evt_1',
+            monitorId: 'veritas-backlog',
+            type: 'manual-run',
+            status: 'success',
+            action: 'dry-run',
+            summary: 'Dry run selected BradGroux/veritas-kanban#736.',
+            createdAt: '2026-06-04T11:30:00.000Z',
+            skippedReasons: ['Blocked item: needs-info'],
+          },
+        ],
+      });
+
+      const digest = await service.generateOperationsDigest({
+        from: '2026-06-04T00:00:00.000Z',
+        to: '2026-06-04T12:00:00.000Z',
+        project: 'operations',
+      });
+      const markdown = service.formatOperationsDigestMarkdown(digest);
+
+      expect(digest.hasActivity).toBe(true);
+      expect(digest.groups[0]).toMatchObject({
+        project: 'operations',
+        repo: 'veritas-kanban',
+      });
+      expect(digest.groups[0].queueMonitors[0]).toMatchObject({
+        id: 'qm_evt_1',
+        status: 'success',
+        action: 'dry-run',
+        skippedReasons: ['Blocked item: needs-info'],
+      });
+      expect(markdown.markdown).toContain('Queue monitors:');
+      expect(markdown.markdown).toContain('skipped 1');
     });
 
     it('filters deterministic operations by repository and cwd', async () => {

--- a/server/src/__tests__/queue-intake-monitor-service.test.ts
+++ b/server/src/__tests__/queue-intake-monitor-service.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { QueueIntakeMonitorService } from '../services/queue-intake-monitor-service.js';
+
+describe('QueueIntakeMonitorService', () => {
+  let testRoot: string;
+  let githubExec: ReturnType<typeof vi.fn>;
+  let watcherPolicyService: { evaluateContinuation: ReturnType<typeof vi.fn> };
+  let sandboxPolicyService: { dryRun: ReturnType<typeof vi.fn> };
+  let budgetService: { resolve: ReturnType<typeof vi.fn>; evaluate: ReturnType<typeof vi.fn> };
+  let governanceTraceService: { record: ReturnType<typeof vi.fn> };
+  let workflowService: { loadWorkflow: ReturnType<typeof vi.fn> };
+  let workflowRunService: { startRun: ReturnType<typeof vi.fn> };
+  let workflowAuthoringService: { dryRun: ReturnType<typeof vi.fn> };
+  let telemetryService: { emit: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-queue-monitor-'));
+    githubExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'issue') return JSON.stringify(defaultIssues());
+      if (args[0] === 'pr') return JSON.stringify(defaultPullRequests());
+      return '';
+    });
+    watcherPolicyService = {
+      evaluateContinuation: vi.fn(async () => ({
+        decision: 'allow',
+        mode: 'auto',
+        riskLevel: 'low',
+        riskClasses: [],
+        reasons: ['Allowed in test policy.'],
+        evidence: [],
+        caps: { maxContinuations: 5, spendCapUsd: 0 },
+        auditLogged: true,
+        evaluatedAt: '2026-06-26T12:00:00.000Z',
+      })),
+    };
+    sandboxPolicyService = {
+      dryRun: vi.fn(async () => ({
+        decision: 'allow',
+        preset: { id: 'legacy-permissive', name: 'Legacy permissive' },
+        provider: 'codex-cli',
+        effective: {
+          sandboxMode: 'workspace-write',
+          networkAccessEnabled: true,
+          envPassthrough: [],
+          credentialRefs: [],
+        },
+        evaluations: [],
+        unsupportedRules: [],
+        warnings: [],
+      })),
+    };
+    budgetService = {
+      resolve: vi.fn(() => undefined),
+      evaluate: vi.fn(() => ({
+        decision: 'allow',
+        usage: {},
+        thresholdEvents: [],
+      })),
+    };
+    governanceTraceService = { record: vi.fn(async (trace) => ({ id: 'trace_1', ...trace })) };
+    workflowService = { loadWorkflow: vi.fn(async () => workflowDefinition()) };
+    workflowRunService = {
+      startRun: vi.fn(async () => ({ id: 'run_queue_1' })),
+    };
+    workflowAuthoringService = {
+      dryRun: vi.fn(async () => ({ messages: [], status: 'ready', canRun: true, checks: [] })),
+    };
+    telemetryService = { emit: vi.fn(async (event) => event) };
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('builds a bounded dry-run candidate packet and records skipped reasons', async () => {
+    const service = queueService();
+
+    const result = await service.runOnce(
+      'veritas-backlog-high-priority',
+      'manual-run',
+      new Date('2026-06-26T12:00:00.000Z')
+    );
+
+    expect(result.packet.candidates).toHaveLength(4);
+    expect(result.packet.selected?.id).toBe('BradGroux/veritas-kanban#736');
+    expect(result.packet.skipped).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          candidateId: 'BradGroux/veritas-kanban#900',
+          reasons: ['Blocked by label: blocked'],
+        }),
+        expect.objectContaining({
+          candidateId: 'BradGroux/veritas-kanban#902',
+          reasons: ['Draft pull request.'],
+        }),
+      ])
+    );
+    expect(result.action).toMatchObject({
+      action: 'dry-run',
+      status: 'success',
+      selectedCandidateId: 'BradGroux/veritas-kanban#736',
+    });
+    expect(telemetryService.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'run.completed',
+        taskId: 'queue-monitor:veritas-backlog-high-priority',
+        agent: 'queue-intake-monitor',
+        project: 'operations',
+      })
+    );
+
+    const reloaded = queueService();
+    const monitor = await reloaded.getMonitor('veritas-backlog-high-priority');
+    expect(monitor.lastPacket?.selected?.number).toBe(736);
+  });
+
+  it('blocks execute mode until workflow launch gates pass and opens a visible action item', async () => {
+    const service = queueService();
+    await service.updateMonitor('veritas-backlog-high-priority', { mode: 'execute' });
+
+    await service.runOnce('veritas-backlog-high-priority');
+    await service.runOnce('veritas-backlog-high-priority');
+    const result = await service.runOnce('veritas-backlog-high-priority');
+
+    expect(result.action).toMatchObject({
+      action: 'blocked',
+      status: 'blocked',
+      summary: 'Execute mode requires a workflowId before launching work.',
+    });
+    const health = await service.health('veritas-backlog-high-priority');
+    expect(health.monitor.health).toBe('blocked');
+    expect(health.actionItem?.summary).toBe(
+      'Execute mode requires a workflowId before launching work.'
+    );
+    expect(workflowRunService.startRun).not.toHaveBeenCalled();
+  });
+
+  it('starts a workflow when execute gates pass', async () => {
+    const service = queueService();
+    await service.updateMonitor('veritas-backlog-high-priority', {
+      mode: 'execute',
+      workflowId: 'queue-intake-workflow',
+    });
+
+    const result = await service.runOnce(
+      'veritas-backlog-high-priority',
+      'manual-run',
+      new Date('2026-06-26T12:00:00.000Z')
+    );
+
+    expect(result.action).toMatchObject({
+      action: 'start-workflow',
+      status: 'started',
+      sourceRunId: 'run_queue_1',
+    });
+    expect(workflowRunService.startRun).toHaveBeenCalledWith(
+      'queue-intake-workflow',
+      undefined,
+      expect.objectContaining({
+        queueMonitor: expect.objectContaining({
+          monitorId: 'veritas-backlog-high-priority',
+          candidate: expect.objectContaining({
+            number: 736,
+            url: 'https://github.com/BradGroux/veritas-kanban/issues/736',
+          }),
+        }),
+      }),
+      undefined
+    );
+  });
+
+  function queueService(): QueueIntakeMonitorService {
+    return new QueueIntakeMonitorService({
+      storeFile: path.join(testRoot, 'queue-monitors.json'),
+      githubExec,
+      watcherPolicyService: watcherPolicyService as never,
+      sandboxPolicyService: sandboxPolicyService as never,
+      budgetService: budgetService as never,
+      governanceTraceService: governanceTraceService as never,
+      workflowService: workflowService as never,
+      workflowRunService: workflowRunService as never,
+      workflowAuthoringService: workflowAuthoringService as never,
+      telemetryService: telemetryService as never,
+    });
+  }
+});
+
+function defaultIssues() {
+  return [
+    {
+      number: 736,
+      title: 'Add policy-gated queue intake monitor',
+      state: 'OPEN',
+      labels: [{ name: 'priority: high' }, { name: 'workflow-engine' }],
+      assignees: [],
+      author: { login: 'BradGroux' },
+      createdAt: '2026-06-20T12:00:00.000Z',
+      updatedAt: '2026-06-21T12:00:00.000Z',
+      url: 'https://github.com/BradGroux/veritas-kanban/issues/736',
+      comments: 2,
+    },
+    {
+      number: 900,
+      title: 'Blocked backlog item',
+      state: 'OPEN',
+      labels: [{ name: 'priority: high' }, { name: 'blocked' }],
+      assignees: [],
+      author: { login: 'BradGroux' },
+      createdAt: '2026-06-20T12:00:00.000Z',
+      updatedAt: '2026-06-22T12:00:00.000Z',
+      url: 'https://github.com/BradGroux/veritas-kanban/issues/900',
+      comments: 1,
+    },
+  ];
+}
+
+function defaultPullRequests() {
+  return [
+    {
+      number: 901,
+      title: 'Ready pull request',
+      state: 'OPEN',
+      labels: [{ name: 'priority: high' }],
+      assignees: [{ login: 'BradGroux' }],
+      author: { login: 'BradGroux' },
+      createdAt: '2026-06-20T12:00:00.000Z',
+      updatedAt: '2026-06-25T12:00:00.000Z',
+      url: 'https://github.com/BradGroux/veritas-kanban/pull/901',
+      isDraft: false,
+      reviewDecision: 'APPROVED',
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+    },
+    {
+      number: 902,
+      title: 'Draft pull request',
+      state: 'OPEN',
+      labels: [{ name: 'priority: high' }],
+      assignees: [],
+      author: { login: 'BradGroux' },
+      createdAt: '2026-06-20T12:00:00.000Z',
+      updatedAt: '2026-06-26T12:00:00.000Z',
+      url: 'https://github.com/BradGroux/veritas-kanban/pull/902',
+      isDraft: true,
+      reviewDecision: '',
+      statusCheckRollup: [],
+    },
+  ];
+}
+
+function workflowDefinition() {
+  return {
+    id: 'queue-intake-workflow',
+    name: 'Queue Intake Workflow',
+    version: 1,
+    description: 'Handle selected queue item.',
+    agents: [
+      {
+        id: 'coordinator',
+        name: 'Coordinator',
+        role: 'general',
+        description: 'Coordinates queue work.',
+      },
+    ],
+    steps: [
+      {
+        id: 'plan',
+        name: 'Plan',
+        type: 'agent',
+        agent: 'coordinator',
+        input: 'Plan selected work.',
+      },
+    ],
+  };
+}

--- a/server/src/__tests__/scheduler-service.test.ts
+++ b/server/src/__tests__/scheduler-service.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import type { WorkflowDefinition } from '@veritas-kanban/shared';
+import type { QueueMonitorSnapshot, WorkflowDefinition } from '@veritas-kanban/shared';
 import { SchedulerService } from '../services/scheduler-service.js';
 import {
   ScheduledDeliverablesService,
@@ -134,19 +134,126 @@ describe('SchedulerService', () => {
     );
   });
 
+  it('exposes due queue monitors through scheduler run-due', async () => {
+    const monitor = queueMonitorSnapshot({
+      nextRunAt: '2026-06-05T08:59:00.000Z',
+    });
+    const queueMonitorService = {
+      list: vi.fn(async () => ({
+        generatedAt: '2026-06-05T09:00:00.000Z',
+        summary: { total: 1, enabled: 1, paused: 0, blocked: 0, failed: 0, due: 1 },
+        monitors: [monitor],
+        recentEvents: [],
+      })),
+      updateMonitor: vi.fn(),
+      runOnce: vi.fn(async () => ({
+        monitor: {
+          ...monitor,
+          lastScanAt: '2026-06-05T09:00:00.000Z',
+          nextRunAt: '2026-06-05T09:30:00.000Z',
+        },
+        packet: monitor.lastPacket,
+        action: monitor.lastAction,
+        event: {
+          id: 'qm_evt_1',
+          monitorId: monitor.id,
+          type: 'due-run',
+          status: 'success',
+          action: 'dry-run',
+          summary: 'Dry run selected BradGroux/veritas-kanban#736.',
+          createdAt: '2026-06-05T09:00:00.000Z',
+          skippedReasons: [],
+        },
+      })),
+    };
+    const service = new SchedulerService({
+      stateFile: path.join(testRoot, 'scheduler-state.json'),
+      deliverablesService,
+      workflowService,
+      queueMonitorService: queueMonitorService as never,
+      telemetryService: telemetry as never,
+    });
+
+    const list = await service.list(new Date('2026-06-05T09:00:00.000Z'));
+    expect(list.items.map((item) => item.id)).toContain('queue-monitor:veritas-backlog');
+
+    const result = await service.runDue(new Date('2026-06-05T09:00:00.000Z'));
+    expect(result.executed).toBe(1);
+    expect(queueMonitorService.runOnce).toHaveBeenCalledWith(
+      'veritas-backlog',
+      'due-run',
+      new Date('2026-06-05T09:00:00.000Z')
+    );
+  });
+
   function schedulerService(): SchedulerService {
     return new SchedulerService({
       stateFile: path.join(testRoot, 'scheduler-state.json'),
       deliverablesService,
       workflowService,
+      queueMonitorService: emptyQueueMonitorService() as never,
       telemetryService: telemetry as never,
     });
   }
 });
 
+function emptyQueueMonitorService() {
+  return {
+    list: vi.fn(async () => ({
+      generatedAt: '2026-06-05T09:00:00.000Z',
+      summary: { total: 0, enabled: 0, paused: 0, blocked: 0, failed: 0, due: 0 },
+      monitors: [],
+      recentEvents: [],
+    })),
+    updateMonitor: vi.fn(),
+    runOnce: vi.fn(),
+  };
+}
+
 async function seedDeliverables(root: string, deliverables: Deliverable[]): Promise<void> {
   await fs.writeFile(path.join(root, 'scheduled-deliverables.json'), JSON.stringify(deliverables));
   await fs.writeFile(path.join(root, 'deliverable-runs.json'), '[]');
+}
+
+function queueMonitorSnapshot(overrides: Partial<QueueMonitorSnapshot> = {}): QueueMonitorSnapshot {
+  return {
+    id: 'veritas-backlog',
+    name: 'Veritas backlog',
+    description: 'Scan backlog.',
+    enabled: true,
+    source: {
+      kind: 'github',
+      repo: 'BradGroux/veritas-kanban',
+      state: 'open',
+      labels: ['priority: high'],
+      includeIssues: true,
+      includePullRequests: true,
+    },
+    mode: 'dry-run',
+    runner: 'local',
+    intervalMinutes: 30,
+    maxCandidates: 20,
+    stopConditions: {
+      maxFailureStreak: 3,
+      skipBlockedLabels: ['blocked'],
+      skipDraftPullRequests: true,
+      skipFailedChecks: true,
+    },
+    tags: ['backlog'],
+    createdAt: '2026-06-01T09:00:00.000Z',
+    updatedAt: '2026-06-01T09:00:00.000Z',
+    health: 'healthy',
+    healthSummary: 'Ready',
+    failureStreak: 0,
+    nextRunAt: '2026-06-05T08:59:00.000Z',
+    actions: {
+      canRun: true,
+      canPause: true,
+      canResume: false,
+      canExplain: true,
+    },
+    ...overrides,
+  };
 }
 
 function scheduledDeliverable(overrides: Partial<Deliverable> = {}): Deliverable {

--- a/server/src/routes/queue-monitors.ts
+++ b/server/src/routes/queue-monitors.ts
@@ -1,0 +1,107 @@
+import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { ValidationError } from '../middleware/error-handler.js';
+import { getQueueIntakeMonitorService } from '../services/queue-intake-monitor-service.js';
+
+const router: RouterType = Router();
+
+const updateMonitorSchema = z.object({
+  enabled: z.boolean().optional(),
+  mode: z.enum(['dry-run', 'assign-only', 'draft-plan', 'execute']).optional(),
+  runner: z.enum(['local', 'github-actions']).optional(),
+  intervalMinutes: z
+    .number()
+    .int()
+    .min(1)
+    .max(24 * 60)
+    .optional(),
+  maxCandidates: z.number().int().min(1).max(100).optional(),
+  workflowId: z.string().min(1).nullable().optional(),
+  assignee: z.string().min(1).nullable().optional(),
+  sandboxPresetId: z.string().min(1).nullable().optional(),
+  budget: z.record(z.string(), z.unknown()).nullable().optional(),
+  repo: z.string().min(1).optional(),
+  state: z.enum(['open', 'closed', 'all']).optional(),
+  labels: z.array(z.string().min(1)).optional(),
+  includeIssues: z.boolean().optional(),
+  includePullRequests: z.boolean().optional(),
+  stopConditions: z
+    .object({
+      maxCandidates: z.number().int().min(1).max(100).optional(),
+      maxFailureStreak: z.number().int().min(1).max(20).optional(),
+      skipBlockedLabels: z.array(z.string().min(1)).optional(),
+      skipDraftPullRequests: z.boolean().optional(),
+      skipFailedChecks: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+router.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    res.json(await getQueueIntakeMonitorService().list());
+  })
+);
+
+router.get(
+  '/:monitorId',
+  asyncHandler(async (req, res) => {
+    res.json(await getQueueIntakeMonitorService().getMonitor(String(req.params.monitorId)));
+  })
+);
+
+router.put(
+  '/:monitorId',
+  asyncHandler(async (req, res) => {
+    let input;
+    try {
+      input = updateMonitorSchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+    res.json(
+      await getQueueIntakeMonitorService().updateMonitor(String(req.params.monitorId), input)
+    );
+  })
+);
+
+router.get(
+  '/:monitorId/health',
+  asyncHandler(async (req, res) => {
+    res.json(await getQueueIntakeMonitorService().health(String(req.params.monitorId)));
+  })
+);
+
+router.get(
+  '/:monitorId/explain',
+  asyncHandler(async (req, res) => {
+    res.json(await getQueueIntakeMonitorService().explain(String(req.params.monitorId)));
+  })
+);
+
+router.post(
+  '/:monitorId/run',
+  asyncHandler(async (req, res) => {
+    res.json(await getQueueIntakeMonitorService().runOnce(String(req.params.monitorId)));
+  })
+);
+
+router.post(
+  '/:monitorId/pause',
+  asyncHandler(async (req, res) => {
+    res.json(await getQueueIntakeMonitorService().pause(String(req.params.monitorId)));
+  })
+);
+
+router.post(
+  '/:monitorId/resume',
+  asyncHandler(async (req, res) => {
+    res.json(await getQueueIntakeMonitorService().resume(String(req.params.monitorId)));
+  })
+);
+
+export { router as queueMonitorRoutes };

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -33,6 +33,7 @@ import {
   feedbackAccess,
   notificationAccess,
   policyAccess,
+  queueMonitorAccess,
   skillCapabilityAccess,
   skillSecurityAccess,
   previewAccess,
@@ -136,6 +137,7 @@ import sandboxPolicyRoutes from '../sandbox-policies.js';
 import { runSessionRoutes } from '../run-sessions.js';
 import { workspaceCapabilityRoutes } from '../workspace-capabilities.js';
 import { schedulerRoutes } from '../scheduler.js';
+import { queueMonitorRoutes } from '../queue-monitors.js';
 
 const v1Router: IRouter = Router();
 
@@ -230,6 +232,7 @@ v1Router.use('/lessons', taskReadAccess, lessonsRoutes);
 v1Router.use('/delegation', delegationAccess, delegationRoutes);
 v1Router.use('/workflows', workflowAccess, workflowRoutes);
 v1Router.use('/scheduler', schedulerAccess, schedulerRoutes);
+v1Router.use('/queue-monitors', queueMonitorAccess, queueMonitorRoutes);
 v1Router.use('/watcher-policies', watcherPolicyAccess, watcherPolicyRoutes);
 v1Router.use('/tool-policies', policyAccess, toolPolicyRoutes);
 v1Router.use('/policies', policyAccess, policyRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -101,6 +101,12 @@ export const schedulerAccess = routeAccess('workflow:read', 'workflow:write', [
   { methods: ['POST'], path: /^\/due\/run\/?$/, permissions: 'workflow:execute' },
 ]);
 
+export const queueMonitorAccess = routeAccess('workflow:read', 'workflow:write', [
+  { methods: ['POST'], path: /^\/[^/]+\/run\/?$/, permissions: 'workflow:execute' },
+  { methods: ['GET', 'POST'], path: /^\/[^/]+\/explain\/?$/, permissions: 'workflow:read' },
+  { methods: ['GET'], path: /^\/[^/]+\/health\/?$/, permissions: 'workflow:read' },
+]);
+
 export const watcherPolicyAccess = routeAccess('policy:read', 'policy:write', [
   { methods: ['POST'], path: /^\/evaluate\/?$/, permissions: ['policy:read', 'agent:read'] },
 ]);

--- a/server/src/services/digest-service.ts
+++ b/server/src/services/digest-service.ts
@@ -2,7 +2,9 @@ import { getMetricsService, type MetricsService } from './metrics/index.js';
 import { getTelemetryService, type TelemetryService } from './telemetry-service.js';
 import { TaskService } from './task-service.js';
 import { getAgentPermissionService, type ApprovalRequest } from './agent-permission-service.js';
+import { getQueueIntakeMonitorService } from './queue-intake-monitor-service.js';
 import type {
+  QueueMonitorEvent,
   RunTelemetryEvent,
   Task,
   TaskTelemetryEvent,
@@ -96,6 +98,12 @@ export interface AgentOperationsApproval extends AgentOperationsSourceLink {
   details?: string;
 }
 
+export interface AgentOperationsQueueMonitorActivity extends AgentOperationsSourceLink {
+  status: QueueMonitorEvent['status'];
+  action: QueueMonitorEvent['action'];
+  skippedReasons: string[];
+}
+
 export interface AgentOperationsDigestGroup {
   key: string;
   project: string;
@@ -126,6 +134,7 @@ export interface AgentOperationsDigestGroup {
   topPlanCompletions: AgentOperationsSourceLink[];
   notableFailures: AgentOperationsFailure[];
   openApprovals: AgentOperationsApproval[];
+  queueMonitors: AgentOperationsQueueMonitorActivity[];
 }
 
 export interface AgentOperationsDigest {
@@ -156,6 +165,7 @@ export interface DigestMarkdownMessage {
 const DEFAULT_OPERATIONS_WINDOW_HOURS = 24;
 const MAX_OPERATIONS_WINDOW_HOURS = 24 * 30;
 const STUCK_TASK_MS = 2 * 60 * 60 * 1000;
+const MONITOR_PROJECT = 'operations';
 
 /**
  * Service for generating daily digest summaries
@@ -281,7 +291,7 @@ export class DigestService {
   ): Promise<AgentOperationsDigest> {
     const filters = normalizeOperationsOptions(options);
     const period = resolveOperationsPeriod(filters);
-    const [tasks, events, approvals] = await Promise.all([
+    const [tasks, events, approvals, queueMonitorList] = await Promise.all([
       this.taskService.listTasks(),
       this.telemetry.getEvents({
         since: period.start,
@@ -291,9 +301,11 @@ export class DigestService {
         limit: 10000,
       }),
       getAgentPermissionService().getPendingApprovals(),
+      getQueueIntakeMonitorService().list(new Date(period.end)),
     ]);
 
     const taskById = new Map(tasks.map((task) => [task.id, task]));
+    const monitorById = new Map(queueMonitorList.monitors.map((monitor) => [monitor.id, monitor]));
     const groups = new Map<string, AgentOperationsDigestGroup>();
     const signalTimesByGroup = new Map<string, number[]>();
 
@@ -321,6 +333,7 @@ export class DigestService {
         topPlanCompletions: [],
         notableFailures: [],
         openApprovals: [],
+        queueMonitors: [],
       };
       groups.set(key, group);
       signalTimesByGroup.set(key, []);
@@ -431,12 +444,27 @@ export class DigestService {
       recordSignal(group, approval.createdAt);
     }
 
+    for (const event of queueMonitorList.recentEvents) {
+      if (!inPeriod(event.createdAt, period.start, period.end)) continue;
+      const monitor = monitorById.get(event.monitorId);
+      const context = {
+        project: MONITOR_PROJECT,
+        repo: monitor?.source.repo ?? 'unknown',
+      };
+      if (!matchesOperationsFilters(context, filters)) continue;
+      const group = getGroup(context.project, context.repo);
+      const monitorLink = queueMonitorSourceLink(event);
+      pushUnique(group.queueMonitors, monitorLink);
+      recordSignal(group, event.createdAt);
+    }
+
     for (const group of groups.values()) {
       const signals = signalTimesByGroup.get(group.key) ?? [];
       group.totals.wallTimeMs = observedWallTime(signals);
       group.topPlanCompletions = group.topPlanCompletions.slice(0, 5);
       group.notableFailures = group.notableFailures.slice(0, 5);
       group.openApprovals = group.openApprovals.slice(0, 10);
+      group.queueMonitors = group.queueMonitors.slice(0, 10);
     }
 
     const sortedGroups = Array.from(groups.values())
@@ -509,6 +537,14 @@ export class DigestService {
         lines.push('- Open approvals:');
         for (const approval of group.openApprovals) {
           lines.push(`  - ${approval.agent}: ${approval.action} (${approval.id})`);
+        }
+      }
+      if (group.queueMonitors.length > 0) {
+        lines.push('- Queue monitors:');
+        for (const monitor of group.queueMonitors) {
+          const skipped =
+            monitor.skippedReasons.length > 0 ? `; skipped ${monitor.skippedReasons.length}` : '';
+          lines.push(`  - ${monitor.label}: ${monitor.status}/${monitor.action}${skipped}`);
         }
       }
       lines.push('');
@@ -686,6 +722,7 @@ function groupHasActivity(group: AgentOperationsDigestGroup): boolean {
   return (
     groupActivityRank(group) > 0 ||
     group.openApprovals.length > 0 ||
+    group.queueMonitors.length > 0 ||
     group.sourceLinks.tokenEvents.length > 0
   );
 }
@@ -831,6 +868,18 @@ function approvalSourceLink(approval: ApprovalRequest): AgentOperationsApproval 
     agent: approval.agentId,
     action: approval.action,
     details: approval.details,
+  };
+}
+
+function queueMonitorSourceLink(event: QueueMonitorEvent): AgentOperationsQueueMonitorActivity {
+  return {
+    kind: 'telemetry',
+    id: event.id,
+    label: `${event.monitorId}: ${event.summary}`,
+    timestamp: event.createdAt,
+    status: event.status,
+    action: event.action,
+    skippedReasons: event.skippedReasons,
   };
 }
 

--- a/server/src/services/queue-intake-monitor-service.ts
+++ b/server/src/services/queue-intake-monitor-service.ts
@@ -1,0 +1,1359 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { nanoid } from 'nanoid';
+import type {
+  QueueMonitorAction,
+  QueueMonitorActionRecord,
+  QueueMonitorCandidate,
+  QueueMonitorCandidatePacket,
+  QueueMonitorDefinition,
+  QueueMonitorEvent,
+  QueueMonitorEventType,
+  QueueMonitorExplainResult,
+  QueueMonitorGateCheck,
+  QueueMonitorHealthResult,
+  QueueMonitorListResponse,
+  QueueMonitorRunResult,
+  QueueMonitorRunStatus,
+  QueueMonitorRunTrigger,
+  QueueMonitorSnapshot,
+  QueueMonitorState,
+  QueueMonitorUpdateInput,
+  RunTelemetryEvent,
+  WatcherContinuationEvaluationResult,
+} from '@veritas-kanban/shared';
+import { createLogger } from '../lib/logger.js';
+import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { getAgentBudgetService, type AgentBudgetService } from './agent-budget-service.js';
+import { getBreaker } from './circuit-registry.js';
+import {
+  getGovernanceTraceService,
+  type GovernanceTraceService,
+} from './governance-trace-service.js';
+import {
+  DEFAULT_SANDBOX_PRESET_ID,
+  getSandboxPolicyService,
+  type SandboxPolicyService,
+} from './sandbox-policy-service.js';
+import { getTelemetryService, type TelemetryService } from './telemetry-service.js';
+import { WatcherPolicyService } from './watcher-policy-service.js';
+import {
+  getWorkflowAuthoringService,
+  type WorkflowAuthoringService,
+} from './workflow-authoring-service.js';
+import { getWorkflowRunService, type WorkflowRunService } from './workflow-run-service.js';
+import { getWorkflowService, type WorkflowService } from './workflow-service.js';
+
+const execFileAsync = promisify(execFile);
+const log = createLogger('queue-intake-monitor');
+
+const STORE_VERSION = 1;
+const MAX_EVENTS = 200;
+const DEFAULT_MAX_CANDIDATES = 20;
+const DEFAULT_INTERVAL_MINUTES = 30;
+const DEFAULT_FAILURE_THRESHOLD = 3;
+const MONITOR_AGENT = 'queue-intake-monitor';
+const MONITOR_PROJECT = 'operations';
+const DEFAULT_CREATED_AT = '2026-06-26T00:00:00.000Z';
+const DEFAULT_BLOCKED_LABELS = ['blocked', 'status: blocked', 'needs-info', 'on hold'];
+
+interface QueueMonitorStore {
+  version: typeof STORE_VERSION;
+  monitors: QueueMonitorDefinition[];
+  state: Record<string, QueueMonitorState>;
+  events: QueueMonitorEvent[];
+}
+
+export interface QueueIntakeMonitorServiceOptions {
+  storeFile?: string;
+  githubExec?: (args: string[]) => Promise<string>;
+  watcherPolicyService?: WatcherPolicyService;
+  sandboxPolicyService?: SandboxPolicyService;
+  budgetService?: AgentBudgetService;
+  governanceTraceService?: GovernanceTraceService;
+  workflowService?: WorkflowService;
+  workflowRunService?: WorkflowRunService;
+  workflowAuthoringService?: WorkflowAuthoringService;
+  telemetryService?: TelemetryService;
+}
+
+interface GhUser {
+  login?: string;
+}
+
+interface GhLabel {
+  name: string;
+}
+
+interface GhIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels?: GhLabel[];
+  assignees?: GhUser[];
+  author?: GhUser | null;
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+  comments?: number;
+}
+
+interface GhPullRequest extends GhIssue {
+  isDraft?: boolean;
+  reviewDecision?: string;
+  statusCheckRollup?: Array<{
+    conclusion?: string;
+    status?: string;
+    state?: string;
+  }>;
+}
+
+interface GateContext {
+  checks: QueueMonitorGateCheck[];
+  policy?: WatcherContinuationEvaluationResult;
+  sandbox?: QueueMonitorActionRecord['sandbox'];
+  budgetDecision?: string;
+}
+
+export class QueueIntakeMonitorService {
+  private readonly storeFile: string;
+  private readonly githubExec: (args: string[]) => Promise<string>;
+  private readonly watcherPolicyService: WatcherPolicyService;
+  private readonly sandboxPolicyService: SandboxPolicyService;
+  private readonly budgetService: AgentBudgetService;
+  private readonly governanceTraceService: GovernanceTraceService;
+  private readonly workflowService: WorkflowService;
+  private readonly workflowRunService: WorkflowRunService;
+  private readonly workflowAuthoringService: WorkflowAuthoringService;
+  private readonly telemetryService: TelemetryService;
+  private store: QueueMonitorStore | null = null;
+  private readonly runningMonitors = new Set<string>();
+
+  constructor(options: QueueIntakeMonitorServiceOptions = {}) {
+    this.storeFile = options.storeFile ?? path.join(getRuntimeDir(), 'queue-monitors.json');
+    this.githubExec = options.githubExec ?? defaultGhExec;
+    this.watcherPolicyService = options.watcherPolicyService ?? new WatcherPolicyService();
+    this.sandboxPolicyService = options.sandboxPolicyService ?? getSandboxPolicyService();
+    this.budgetService = options.budgetService ?? getAgentBudgetService();
+    this.governanceTraceService = options.governanceTraceService ?? getGovernanceTraceService();
+    this.workflowService = options.workflowService ?? getWorkflowService();
+    this.workflowRunService = options.workflowRunService ?? getWorkflowRunService();
+    this.workflowAuthoringService =
+      options.workflowAuthoringService ?? getWorkflowAuthoringService();
+    this.telemetryService = options.telemetryService ?? getTelemetryService();
+  }
+
+  async list(now = new Date()): Promise<QueueMonitorListResponse> {
+    await this.ensureLoaded();
+    const monitors = this.currentStore()
+      .monitors.map((monitor) => this.snapshot(monitor, now))
+      .sort((a, b) => {
+        const aNext = a.nextRunAt ? Date.parse(a.nextRunAt) : Number.POSITIVE_INFINITY;
+        const bNext = b.nextRunAt ? Date.parse(b.nextRunAt) : Number.POSITIVE_INFINITY;
+        if (aNext !== bNext) return aNext - bNext;
+        return a.name.localeCompare(b.name);
+      });
+    const cutoff = now.getTime();
+    const summary = monitors.reduce(
+      (acc, monitor) => {
+        acc.total++;
+        if (monitor.enabled) acc.enabled++;
+        if (!monitor.enabled) acc.paused++;
+        if (monitor.health === 'blocked') acc.blocked++;
+        if (monitor.lastStatus === 'failed' || monitor.lastStatus === 'blocked') acc.failed++;
+        if (isMonitorDue(monitor, cutoff)) acc.due++;
+        return acc;
+      },
+      { total: 0, enabled: 0, paused: 0, blocked: 0, failed: 0, due: 0 }
+    );
+
+    return {
+      generatedAt: now.toISOString(),
+      summary,
+      monitors,
+      recentEvents: this.currentStore().events.slice(-20).reverse(),
+    };
+  }
+
+  async getMonitor(monitorId: string, now = new Date()): Promise<QueueMonitorSnapshot> {
+    await this.ensureLoaded();
+    const monitor = this.findDefinition(monitorId);
+    return this.snapshot(monitor, now);
+  }
+
+  async health(monitorId: string, now = new Date()): Promise<QueueMonitorHealthResult> {
+    const monitor = await this.getMonitor(monitorId, now);
+    return {
+      monitor,
+      actionItem: monitor.actionItem,
+    };
+  }
+
+  async explain(monitorId: string, now = new Date()): Promise<QueueMonitorExplainResult> {
+    await this.ensureLoaded();
+    const definition = this.findDefinition(monitorId);
+    const packet = await this.buildPacket(definition, now);
+    const action = await this.planAction(definition, packet, 'explain', now, { mutate: false });
+    return {
+      monitor: this.snapshot(definition, now),
+      packet,
+      action,
+    };
+  }
+
+  async updateMonitor(
+    monitorId: string,
+    patch: QueueMonitorUpdateInput,
+    now = new Date()
+  ): Promise<QueueMonitorSnapshot> {
+    await this.ensureLoaded();
+    const store = this.currentStore();
+    const index = store.monitors.findIndex((monitor) => monitor.id === monitorId);
+    if (index === -1) throw new NotFoundError(`Queue monitor not found: ${monitorId}`);
+    const current = store.monitors[index];
+    const updated: QueueMonitorDefinition = {
+      ...current,
+      enabled: patch.enabled ?? current.enabled,
+      mode: patch.mode ?? current.mode,
+      runner: patch.runner ?? current.runner,
+      intervalMinutes: clampInt(patch.intervalMinutes ?? current.intervalMinutes, 1, 24 * 60),
+      maxCandidates: clampInt(patch.maxCandidates ?? current.maxCandidates, 1, 100),
+      workflowId: nullableString(patch.workflowId, current.workflowId),
+      assignee: nullableString(patch.assignee, current.assignee),
+      sandboxPresetId: nullableString(patch.sandboxPresetId, current.sandboxPresetId),
+      budget: patch.budget === null ? undefined : (patch.budget ?? current.budget),
+      source: {
+        ...current.source,
+        repo: patch.repo?.trim() || current.source.repo,
+        state: patch.state ?? current.source.state,
+        labels: Array.isArray(patch.labels) ? normalizeLabels(patch.labels) : current.source.labels,
+        includeIssues: patch.includeIssues ?? current.source.includeIssues,
+        includePullRequests: patch.includePullRequests ?? current.source.includePullRequests,
+      },
+      stopConditions: {
+        ...current.stopConditions,
+        ...(patch.stopConditions ?? {}),
+      },
+      updatedAt: now.toISOString(),
+    };
+    store.monitors[index] = normalizeDefinition(updated);
+    if (patch.enabled === true) {
+      store.state[monitorId] = {
+        ...this.stateFor(monitorId),
+        failureStreak: 0,
+        lastError: undefined,
+        actionItem: undefined,
+        nextRunAt: now.toISOString(),
+      };
+    }
+    await this.saveStore();
+    return this.snapshot(store.monitors[index], now);
+  }
+
+  async pause(monitorId: string, now = new Date()): Promise<QueueMonitorRunResult> {
+    await this.ensureLoaded();
+    const monitor = await this.updateMonitor(monitorId, { enabled: false }, now);
+    const packet = emptyPacket(monitor, now);
+    const action = actionRecord({
+      action: 'none',
+      status: 'success',
+      summary: 'Queue monitor paused.',
+      packet,
+      checks: [],
+      now,
+    });
+    const event = await this.recordEvent(monitor, 'pause', action, packet, now);
+    return { monitor: await this.getMonitor(monitorId, now), packet, action, event };
+  }
+
+  async resume(monitorId: string, now = new Date()): Promise<QueueMonitorRunResult> {
+    await this.ensureLoaded();
+    const monitor = await this.updateMonitor(monitorId, { enabled: true }, now);
+    const packet = emptyPacket(monitor, now);
+    const action = actionRecord({
+      action: 'none',
+      status: 'success',
+      summary: 'Queue monitor resumed.',
+      packet,
+      checks: [],
+      now,
+    });
+    const event = await this.recordEvent(monitor, 'resume', action, packet, now);
+    return { monitor: await this.getMonitor(monitorId, now), packet, action, event };
+  }
+
+  async runOnce(
+    monitorId: string,
+    trigger: QueueMonitorRunTrigger = 'manual-run',
+    now = new Date()
+  ): Promise<QueueMonitorRunResult> {
+    await this.ensureLoaded();
+    const definition = this.findDefinition(monitorId);
+    const initialSnapshot = this.snapshot(definition, now);
+    if (!definition.enabled) {
+      const packet = emptyPacket(initialSnapshot, now);
+      const action = actionRecord({
+        action: 'none',
+        status: 'skipped',
+        summary: 'Queue monitor is paused.',
+        packet,
+        checks: [],
+        now,
+      });
+      const event = await this.recordEvent(initialSnapshot, trigger, action, packet, now);
+      return { monitor: await this.getMonitor(monitorId, now), packet, action, event };
+    }
+
+    if (initialSnapshot.health === 'blocked') {
+      const packet = initialSnapshot.lastPacket ?? emptyPacket(initialSnapshot, now);
+      const action = actionRecord({
+        action: 'blocked',
+        status: 'blocked',
+        summary: initialSnapshot.healthSummary,
+        packet,
+        checks: [
+          {
+            name: 'circuit-breaker',
+            status: 'block',
+            summary: initialSnapshot.healthSummary,
+          },
+        ],
+        now,
+      });
+      const event = await this.recordEvent(initialSnapshot, 'circuit-open', action, packet, now);
+      return { monitor: await this.getMonitor(monitorId, now), packet, action, event };
+    }
+
+    if (this.runningMonitors.has(monitorId)) {
+      const packet = initialSnapshot.lastPacket ?? emptyPacket(initialSnapshot, now);
+      const action = actionRecord({
+        action: 'none',
+        status: 'skipped',
+        summary: 'Queue monitor is already running.',
+        packet,
+        checks: [],
+        now,
+      });
+      const event = await this.recordEvent(initialSnapshot, trigger, action, packet, now);
+      return { monitor: await this.getMonitor(monitorId, now), packet, action, event };
+    }
+
+    this.runningMonitors.add(monitorId);
+    const startedAt = Date.now();
+    try {
+      const packet = await this.buildPacket(definition, now);
+      const action = await this.planAction(definition, packet, trigger, now, { mutate: true });
+      const event = await this.recordEvent(
+        this.snapshot(definition, now),
+        trigger,
+        action,
+        packet,
+        now,
+        Date.now() - startedAt
+      );
+      return { monitor: await this.getMonitor(monitorId, now), packet, action, event };
+    } catch (error) {
+      const packet = initialSnapshot.lastPacket ?? emptyPacket(initialSnapshot, now);
+      const action = actionRecord({
+        action: 'blocked',
+        status: 'failed',
+        summary: 'Queue monitor scan failed.',
+        error: errorMessage(error),
+        packet,
+        checks: [
+          {
+            name: 'github-scan',
+            status: 'block',
+            summary: errorMessage(error),
+          },
+        ],
+        now,
+      });
+      const event = await this.recordEvent(
+        this.snapshot(definition, now),
+        trigger,
+        action,
+        packet,
+        now,
+        Date.now() - startedAt
+      );
+      return { monitor: await this.getMonitor(monitorId, now), packet, action, event };
+    } finally {
+      this.runningMonitors.delete(monitorId);
+    }
+  }
+
+  async dueMonitors(now = new Date()): Promise<QueueMonitorSnapshot[]> {
+    const list = await this.list(now);
+    return list.monitors.filter((monitor) => isMonitorDue(monitor, now.getTime()));
+  }
+
+  recentEvents(limit = 20): QueueMonitorEvent[] {
+    const store = this.store;
+    if (!store) return [];
+    return store.events.slice(-limit).reverse();
+  }
+
+  private async buildPacket(
+    definition: QueueMonitorDefinition,
+    now: Date
+  ): Promise<QueueMonitorCandidatePacket> {
+    const rawCandidates = await this.fetchGitHubCandidates(definition);
+    const maxCandidates = clampInt(definition.maxCandidates, 1, 100);
+    const candidates = rawCandidates
+      .map((candidate) => scoreCandidate(candidate, definition))
+      .sort(compareCandidates)
+      .slice(0, maxCandidates);
+    const skipped = candidates
+      .filter((candidate) => candidate.blockers.length > 0)
+      .map((candidate) => ({
+        candidateId: candidate.id,
+        title: candidate.title,
+        reasons: candidate.blockers,
+      }));
+    const selected = candidates.find((candidate) => candidate.blockers.length === 0);
+    return {
+      id: `qmp_${nanoid(10)}`,
+      monitorId: definition.id,
+      generatedAt: now.toISOString(),
+      repo: definition.source.repo,
+      filters: {
+        labels: definition.source.labels,
+        state: definition.source.state,
+        includeIssues: definition.source.includeIssues,
+        includePullRequests: definition.source.includePullRequests,
+        limit: maxCandidates,
+      },
+      candidates,
+      selected,
+      skipped,
+      truncated: rawCandidates.length > maxCandidates,
+      checks: [
+        {
+          name: 'github-scan',
+          status: 'pass',
+          summary: `Fetched ${rawCandidates.length} GitHub records from ${definition.source.repo}.`,
+        },
+      ],
+    };
+  }
+
+  private async planAction(
+    definition: QueueMonitorDefinition,
+    packet: QueueMonitorCandidatePacket,
+    trigger: QueueMonitorRunTrigger,
+    now: Date,
+    options: { mutate: boolean }
+  ): Promise<QueueMonitorActionRecord> {
+    const selected = packet.selected;
+    if (!selected) {
+      return actionRecord({
+        action: 'none',
+        status: 'skipped',
+        summary:
+          packet.candidates.length === 0
+            ? 'No GitHub queue candidates matched the monitor filters.'
+            : 'No candidate passed monitor blocker checks.',
+        packet,
+        checks: packet.checks,
+        now,
+      });
+    }
+
+    if (definition.mode === 'dry-run') {
+      return actionRecord({
+        action: 'dry-run',
+        status: 'success',
+        summary: `Dry run selected ${candidateLabel(selected)}.`,
+        selectedCandidateId: selected.id,
+        packet,
+        checks: packet.checks,
+        now,
+      });
+    }
+
+    if (definition.mode === 'draft-plan') {
+      return actionRecord({
+        action: 'draft-plan',
+        status: 'success',
+        summary: `Draft plan ready for ${candidateLabel(selected)}.`,
+        selectedCandidateId: selected.id,
+        packet,
+        checks: [
+          ...packet.checks,
+          {
+            name: 'mutation',
+            status: 'pass',
+            summary:
+              'Draft-plan mode records intent without mutating GitHub or starting workflows.',
+          },
+        ],
+        now,
+      });
+    }
+
+    const gate = await this.evaluateGates(definition, packet, trigger);
+    const blocker = gate.checks.find((check) => check.status === 'block');
+    if (blocker) {
+      return actionRecord({
+        action: 'blocked',
+        status: 'blocked',
+        summary: blocker.summary,
+        selectedCandidateId: selected.id,
+        packet,
+        checks: gate.checks,
+        policy: gate.policy,
+        sandbox: gate.sandbox,
+        budgetDecision: gate.budgetDecision,
+        now,
+      });
+    }
+
+    if (!options.mutate || trigger === 'explain') {
+      return actionRecord({
+        action: definition.mode === 'assign-only' ? 'assign' : 'start-workflow',
+        status: 'success',
+        summary: `Policy gates passed for ${candidateLabel(selected)}.`,
+        selectedCandidateId: selected.id,
+        packet,
+        checks: gate.checks,
+        policy: gate.policy,
+        sandbox: gate.sandbox,
+        budgetDecision: gate.budgetDecision,
+        now,
+      });
+    }
+
+    if (definition.mode === 'assign-only') {
+      if (!definition.assignee) {
+        return actionRecord({
+          action: 'blocked',
+          status: 'blocked',
+          summary: 'Assign-only mode requires an assignee.',
+          selectedCandidateId: selected.id,
+          packet,
+          checks: [
+            ...gate.checks,
+            { name: 'assignee', status: 'block', summary: 'Assign-only mode requires assignee.' },
+          ],
+          policy: gate.policy,
+          sandbox: gate.sandbox,
+          budgetDecision: gate.budgetDecision,
+          now,
+        });
+      }
+      await this.githubExec([
+        'issue',
+        'edit',
+        String(selected.number),
+        '--repo',
+        selected.repo,
+        '--add-assignee',
+        definition.assignee,
+      ]);
+      return actionRecord({
+        action: 'assign',
+        status: 'success',
+        summary: `Assigned ${candidateLabel(selected)} to ${definition.assignee}.`,
+        selectedCandidateId: selected.id,
+        packet,
+        checks: gate.checks,
+        policy: gate.policy,
+        sandbox: gate.sandbox,
+        budgetDecision: gate.budgetDecision,
+        now,
+      });
+    }
+
+    const run = await this.startWorkflow(definition, packet, selected, trigger, now);
+    return actionRecord({
+      action: 'start-workflow',
+      status: 'started',
+      summary: `Started workflow ${run.id} for ${candidateLabel(selected)}.`,
+      selectedCandidateId: selected.id,
+      sourceRunId: run.id,
+      packet,
+      checks: gate.checks,
+      policy: gate.policy,
+      sandbox: gate.sandbox,
+      budgetDecision: gate.budgetDecision,
+      now,
+    });
+  }
+
+  private async evaluateGates(
+    definition: QueueMonitorDefinition,
+    packet: QueueMonitorCandidatePacket,
+    trigger: QueueMonitorRunTrigger
+  ): Promise<GateContext> {
+    const selected = packet.selected;
+    const checks: QueueMonitorGateCheck[] = [...packet.checks];
+    if (!selected) return { checks };
+
+    checks.push({
+      name: 'runner',
+      status: definition.runner === 'local' ? 'pass' : 'block',
+      summary:
+        definition.runner === 'local'
+          ? 'Local runner is available.'
+          : 'GitHub Actions runner mode requires a dispatch adapter before launch.',
+    });
+
+    const policy = await this.watcherPolicyService.evaluateContinuation(
+      {
+        runId: `queue-monitor:${definition.id}`,
+        project: MONITOR_PROJECT,
+        agent: MONITOR_AGENT,
+        prompt: monitorDispatchPrompt(definition, selected),
+        continuationCount: this.stateFor(definition.id).failureStreak,
+        metadata: {
+          monitorId: definition.id,
+          trigger,
+          candidate: {
+            kind: selected.kind,
+            repo: selected.repo,
+            number: selected.number,
+            url: selected.url,
+          },
+        },
+      },
+      { actor: MONITOR_AGENT }
+    );
+    checks.push({
+      name: 'watcher-policy',
+      status:
+        policy.decision === 'block'
+          ? 'block'
+          : policy.decision === 'require_approval'
+            ? 'block'
+            : 'pass',
+      summary:
+        policy.decision === 'allow'
+          ? 'Watcher policy allowed the action.'
+          : `Watcher policy returned ${policy.decision}.`,
+      evidence: policy.reasons,
+    });
+
+    let sandbox: QueueMonitorActionRecord['sandbox'];
+    const sandboxResult = await this.sandboxPolicyService.dryRun({
+      presetId: definition.sandboxPresetId ?? DEFAULT_SANDBOX_PRESET_ID,
+      provider: 'codex-cli',
+    });
+    sandbox = {
+      presetId: sandboxResult.preset.id,
+      decision: sandboxResult.decision,
+      provider: sandboxResult.provider,
+      warnings: sandboxResult.warnings,
+      remediation: sandboxResult.remediation,
+    };
+    checks.push({
+      name: 'sandbox',
+      status: sandboxResult.decision === 'block' ? 'block' : 'pass',
+      summary:
+        sandboxResult.decision === 'block'
+          ? `Sandbox preset ${sandboxResult.preset.id} cannot be enforced.`
+          : `Sandbox preset ${sandboxResult.preset.id} is usable.`,
+      evidence: sandboxResult.warnings,
+    });
+
+    const budgetDecision = await this.evaluateBudget(definition, selected);
+    checks.push({
+      name: 'budget',
+      status: isBlockingBudgetDecision(budgetDecision) ? 'block' : 'pass',
+      summary: `Budget decision: ${budgetDecision}.`,
+    });
+
+    if (definition.mode === 'execute') {
+      if (!definition.workflowId) {
+        checks.push({
+          name: 'workflow',
+          status: 'block',
+          summary: 'Execute mode requires a workflowId before launching work.',
+        });
+      } else {
+        const workflow = await this.workflowService.loadWorkflow(definition.workflowId);
+        if (!workflow) {
+          checks.push({
+            name: 'workflow',
+            status: 'block',
+            summary: `Workflow not found: ${definition.workflowId}.`,
+          });
+        } else {
+          const dryRun = await this.workflowAuthoringService.dryRun({
+            workflow,
+            context: {
+              clientMode: 'local',
+            },
+          });
+          const blocker = dryRun.messages.find((message) => message.severity === 'error');
+          checks.push({
+            name: 'workflow',
+            status: blocker ? 'block' : 'pass',
+            summary: blocker?.message ?? `Workflow ${workflow.id} passed dry-run validation.`,
+          });
+        }
+      }
+    }
+
+    return { checks, policy, sandbox, budgetDecision };
+  }
+
+  private async evaluateBudget(
+    definition: QueueMonitorDefinition,
+    selected: QueueMonitorCandidate
+  ): Promise<string> {
+    const policy = this.budgetService.resolve({ runBudget: definition.budget });
+    const evaluation = this.budgetService.evaluate(
+      policy,
+      { fanOut: 1 },
+      {
+        actionType: 'queue-monitor.run',
+        project: MONITOR_PROJECT,
+        workflowId: definition.workflowId,
+        taskId: selected.id,
+      }
+    );
+    if (evaluation.trace) {
+      await this.governanceTraceService.record(evaluation.trace);
+    }
+    return evaluation.decision;
+  }
+
+  private async startWorkflow(
+    definition: QueueMonitorDefinition,
+    packet: QueueMonitorCandidatePacket,
+    selected: QueueMonitorCandidate,
+    trigger: QueueMonitorRunTrigger,
+    now: Date
+  ) {
+    if (!definition.workflowId) {
+      throw new ValidationError('Execute mode requires workflowId');
+    }
+    return this.workflowRunService.startRun(
+      definition.workflowId,
+      undefined,
+      {
+        queueMonitor: {
+          monitorId: definition.id,
+          packetId: packet.id,
+          trigger,
+          selectedAt: now.toISOString(),
+          candidate: {
+            id: selected.id,
+            kind: selected.kind,
+            repo: selected.repo,
+            number: selected.number,
+            title: selected.title,
+            url: selected.url,
+            labels: selected.labels,
+            ciState: selected.ciState,
+          },
+        },
+      },
+      definition.budget
+    );
+  }
+
+  private async fetchGitHubCandidates(
+    definition: QueueMonitorDefinition
+  ): Promise<QueueMonitorCandidate[]> {
+    const limit = clampInt(definition.maxCandidates * 2, 1, 100);
+    const candidates: QueueMonitorCandidate[] = [];
+    if (definition.source.includeIssues) {
+      const issues = await this.ghJson<GhIssue[]>(issueListArgs(definition, limit));
+      candidates.push(...issues.map((issue) => issueCandidate(definition.source.repo, issue)));
+    }
+    if (definition.source.includePullRequests) {
+      const prs = await this.ghJson<GhPullRequest[]>(prListArgs(definition, limit));
+      candidates.push(...prs.map((pr) => prCandidate(definition.source.repo, pr)));
+    }
+    return candidates;
+  }
+
+  private async ghJson<T>(args: string[]): Promise<T> {
+    const stdout = await this.githubExec(args);
+    return JSON.parse(stdout || '[]') as T;
+  }
+
+  private async recordEvent(
+    monitor: QueueMonitorSnapshot,
+    type: QueueMonitorEventType,
+    action: QueueMonitorActionRecord,
+    packet: QueueMonitorCandidatePacket,
+    now: Date,
+    durationMs?: number
+  ): Promise<QueueMonitorEvent> {
+    await this.ensureLoaded();
+    const store = this.currentStore();
+    const state = this.stateFor(monitor.id);
+    const failure = action.status === 'failed' || action.status === 'blocked';
+    const failureStreak = failure ? state.failureStreak + 1 : 0;
+    const actionItem =
+      failureStreak >= failureThreshold(monitor)
+        ? {
+            id: `qmai_${nanoid(8)}`,
+            title: `Queue monitor blocked: ${monitor.name}`,
+            severity: 'blocker' as const,
+            summary: action.summary,
+            remediation:
+              'Review GitHub auth, policy settings, budget, sandbox, workflow configuration, or candidate blockers before resuming this monitor.',
+            createdAt: now.toISOString(),
+          }
+        : failure
+          ? state.actionItem
+          : undefined;
+
+    store.state[monitor.id] = {
+      ...state,
+      lastScanAt:
+        type === 'manual-run' || type === 'due-run' || type === 'explain'
+          ? now.toISOString()
+          : state.lastScanAt,
+      lastActionAt: now.toISOString(),
+      nextRunAt: nextRunAt(monitor, now),
+      failureStreak,
+      lastStatus: action.status,
+      lastSummary: action.summary,
+      lastError: action.error,
+      lastPacket: packet,
+      lastAction: action,
+      actionItem,
+    };
+
+    const event: QueueMonitorEvent = {
+      id: `qm_evt_${nanoid(10)}`,
+      monitorId: monitor.id,
+      type,
+      status: action.status,
+      action: action.action,
+      summary: action.summary,
+      createdAt: now.toISOString(),
+      durationMs,
+      error: action.error,
+      selectedCandidateId: action.selectedCandidateId,
+      sourceRunId: action.sourceRunId,
+      skippedReasons: action.skippedReasons,
+    };
+    store.events.push(event);
+    store.events = store.events.slice(-MAX_EVENTS);
+    await this.saveStore();
+    await this.emitTelemetry(monitor.id, event);
+    log.info(
+      { monitorId: monitor.id, eventId: event.id, status: event.status, action: event.action },
+      'Queue monitor event recorded'
+    );
+    return event;
+  }
+
+  private async emitTelemetry(monitorId: string, event: QueueMonitorEvent): Promise<void> {
+    const base = {
+      taskId: `queue-monitor:${monitorId}`,
+      project: MONITOR_PROJECT,
+      agent: MONITOR_AGENT,
+      attemptId: event.id,
+      durationMs: event.durationMs,
+      error: event.error,
+    };
+    if (event.status === 'failed' || event.status === 'blocked') {
+      await this.telemetryService.emit<RunTelemetryEvent>({
+        ...base,
+        type: 'run.error',
+        error: event.error ?? event.summary,
+      });
+      return;
+    }
+    await this.telemetryService.emit<RunTelemetryEvent>({
+      ...base,
+      type: 'run.completed',
+      success: event.status !== 'skipped',
+    });
+  }
+
+  private snapshot(definition: QueueMonitorDefinition, now: Date): QueueMonitorSnapshot {
+    const state = this.stateFor(definition.id);
+    const next = state.nextRunAt ?? (definition.enabled ? now.toISOString() : undefined);
+    const base: QueueMonitorSnapshot = {
+      ...definition,
+      health: 'healthy',
+      healthSummary: 'Ready',
+      lastScanAt: state.lastScanAt,
+      lastActionAt: state.lastActionAt,
+      nextRunAt: next,
+      failureStreak: state.failureStreak,
+      lastStatus: state.lastStatus,
+      lastSummary: state.lastSummary,
+      lastError: state.lastError,
+      lastPacket: state.lastPacket,
+      lastAction: state.lastAction,
+      actionItem: state.actionItem,
+      actions: {
+        canRun: true,
+        canPause: definition.enabled,
+        canResume: !definition.enabled,
+        canExplain: true,
+      },
+    };
+
+    if (!definition.enabled) {
+      return { ...base, health: 'paused', healthSummary: 'Paused' };
+    }
+    if (state.failureStreak >= failureThreshold(definition)) {
+      return {
+        ...base,
+        health: 'blocked',
+        healthSummary: state.actionItem?.summary ?? 'Failure threshold reached.',
+      };
+    }
+    if (state.failureStreak > 0) {
+      return {
+        ...base,
+        health: 'warning',
+        healthSummary: `${state.failureStreak} consecutive failure${state.failureStreak === 1 ? '' : 's'}.`,
+      };
+    }
+    if (definition.mode === 'execute' && !definition.workflowId) {
+      return {
+        ...base,
+        health: 'warning',
+        healthSummary: 'Execute mode needs workflowId before launch.',
+      };
+    }
+    return base;
+  }
+
+  private findDefinition(monitorId: string): QueueMonitorDefinition {
+    const monitor = this.currentStore().monitors.find((candidate) => candidate.id === monitorId);
+    if (!monitor) throw new NotFoundError(`Queue monitor not found: ${monitorId}`);
+    return monitor;
+  }
+
+  private stateFor(monitorId: string): QueueMonitorState {
+    const store = this.currentStore();
+    store.state[monitorId] ??= { failureStreak: 0 };
+    return store.state[monitorId];
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.store) return;
+    try {
+      const raw = await fs.readFile(this.storeFile, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<QueueMonitorStore>;
+      this.store = normalizeStore(parsed);
+    } catch {
+      this.store = defaultStore();
+    }
+  }
+
+  private currentStore(): QueueMonitorStore {
+    if (!this.store) throw new Error('Queue monitor store has not been loaded');
+    return this.store;
+  }
+
+  private async saveStore(): Promise<void> {
+    await fs.mkdir(path.dirname(this.storeFile), { recursive: true });
+    await fs.writeFile(this.storeFile, JSON.stringify(this.store, null, 2), 'utf-8');
+  }
+}
+
+async function defaultGhExec(args: string[]): Promise<string> {
+  const ghBreaker = getBreaker('github');
+  const { stdout } = await ghBreaker.execute(() => execFileAsync('gh', args));
+  return stdout.trim();
+}
+
+function defaultStore(): QueueMonitorStore {
+  return {
+    version: STORE_VERSION,
+    monitors: [defaultBacklogMonitor()],
+    state: {},
+    events: [],
+  };
+}
+
+function defaultBacklogMonitor(): QueueMonitorDefinition {
+  return {
+    id: 'veritas-backlog-high-priority',
+    name: 'Veritas high-priority backlog',
+    description: 'Scan open high-priority Veritas issues and PRs for the next policy-safe action.',
+    enabled: true,
+    source: {
+      kind: 'github',
+      repo: 'BradGroux/veritas-kanban',
+      state: 'open',
+      labels: ['priority: high'],
+      includeIssues: true,
+      includePullRequests: true,
+    },
+    mode: 'dry-run',
+    runner: 'local',
+    intervalMinutes: DEFAULT_INTERVAL_MINUTES,
+    maxCandidates: DEFAULT_MAX_CANDIDATES,
+    sandboxPresetId: DEFAULT_SANDBOX_PRESET_ID,
+    stopConditions: {
+      maxFailureStreak: DEFAULT_FAILURE_THRESHOLD,
+      skipBlockedLabels: DEFAULT_BLOCKED_LABELS,
+      skipDraftPullRequests: true,
+      skipFailedChecks: true,
+    },
+    tags: ['github', 'backlog', 'operations'],
+    createdAt: DEFAULT_CREATED_AT,
+    updatedAt: DEFAULT_CREATED_AT,
+  };
+}
+
+function normalizeStore(input: Partial<QueueMonitorStore>): QueueMonitorStore {
+  const monitors = Array.isArray(input.monitors) ? input.monitors : [defaultBacklogMonitor()];
+  return {
+    version: STORE_VERSION,
+    monitors: monitors.map(normalizeDefinition),
+    state: input.state ?? {},
+    events: Array.isArray(input.events) ? input.events.slice(-MAX_EVENTS) : [],
+  };
+}
+
+function normalizeDefinition(input: QueueMonitorDefinition): QueueMonitorDefinition {
+  const fallback = defaultBacklogMonitor();
+  return {
+    ...fallback,
+    ...input,
+    source: {
+      ...fallback.source,
+      ...input.source,
+      labels: normalizeLabels(input.source?.labels ?? fallback.source.labels),
+      includeIssues: input.source?.includeIssues ?? true,
+      includePullRequests: input.source?.includePullRequests ?? true,
+    },
+    intervalMinutes: clampInt(input.intervalMinutes, 1, 24 * 60),
+    maxCandidates: clampInt(input.maxCandidates, 1, 100),
+    stopConditions: {
+      ...fallback.stopConditions,
+      ...(input.stopConditions ?? {}),
+    },
+    tags: Array.isArray(input.tags) ? input.tags : [],
+  };
+}
+
+function issueListArgs(definition: QueueMonitorDefinition, limit: number): string[] {
+  const args = [
+    'issue',
+    'list',
+    '--repo',
+    definition.source.repo,
+    '--state',
+    definition.source.state,
+    '--limit',
+    String(limit),
+    '--json',
+    'number,title,state,labels,assignees,author,createdAt,updatedAt,url,comments',
+  ];
+  addLabelArgs(args, definition.source.labels);
+  return args;
+}
+
+function prListArgs(definition: QueueMonitorDefinition, limit: number): string[] {
+  const args = [
+    'pr',
+    'list',
+    '--repo',
+    definition.source.repo,
+    '--state',
+    definition.source.state,
+    '--limit',
+    String(limit),
+    '--json',
+    'number,title,state,labels,assignees,author,createdAt,updatedAt,url,isDraft,reviewDecision,statusCheckRollup',
+  ];
+  addLabelArgs(args, definition.source.labels);
+  return args;
+}
+
+function addLabelArgs(args: string[], labels: string[]): void {
+  for (const label of labels) {
+    args.push('--label', label);
+  }
+}
+
+function issueCandidate(repo: string, issue: GhIssue): QueueMonitorCandidate {
+  return {
+    id: `${repo}#${issue.number}`,
+    kind: 'issue',
+    repo,
+    number: issue.number,
+    title: issue.title,
+    url: issue.url,
+    state: issue.state,
+    labels: labelNames(issue.labels),
+    assignees: userLogins(issue.assignees),
+    author: issue.author?.login,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    comments: issue.comments,
+    ciState: 'unknown',
+    blockers: [],
+    score: 0,
+    reasons: [],
+  };
+}
+
+function prCandidate(repo: string, pr: GhPullRequest): QueueMonitorCandidate {
+  return {
+    id: `${repo}#${pr.number}`,
+    kind: 'pull-request',
+    repo,
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    state: pr.state,
+    labels: labelNames(pr.labels),
+    assignees: userLogins(pr.assignees),
+    author: pr.author?.login,
+    createdAt: pr.createdAt,
+    updatedAt: pr.updatedAt,
+    isDraft: Boolean(pr.isDraft),
+    reviewDecision: pr.reviewDecision,
+    ciState: statusCheckState(pr.statusCheckRollup),
+    blockers: [],
+    score: 0,
+    reasons: [],
+  };
+}
+
+function scoreCandidate(
+  candidate: QueueMonitorCandidate,
+  definition: QueueMonitorDefinition
+): QueueMonitorCandidate {
+  const labels = candidate.labels.map((label) => label.toLowerCase());
+  const blockers: string[] = [];
+  const blockedLabels = definition.stopConditions.skipBlockedLabels ?? DEFAULT_BLOCKED_LABELS;
+  for (const blocked of blockedLabels) {
+    if (labels.includes(blocked.toLowerCase())) {
+      blockers.push(`Blocked by label: ${blocked}`);
+    }
+  }
+  if (candidate.kind === 'pull-request' && definition.stopConditions.skipDraftPullRequests) {
+    if (candidate.isDraft) blockers.push('Draft pull request.');
+  }
+  if (
+    candidate.kind === 'pull-request' &&
+    definition.stopConditions.skipFailedChecks &&
+    candidate.ciState === 'failing'
+  ) {
+    blockers.push('Pull request has failing CI.');
+  }
+
+  const reasons: string[] = [];
+  let score = 0;
+  if (labels.includes('priority: high')) {
+    score += 100;
+    reasons.push('high priority');
+  } else if (labels.includes('priority: medium')) {
+    score += 50;
+    reasons.push('medium priority');
+  } else if (labels.includes('priority: low')) {
+    score += 10;
+    reasons.push('low priority');
+  }
+  if (candidate.assignees.length === 0) {
+    score += 15;
+    reasons.push('unassigned');
+  }
+  if (candidate.kind === 'issue') {
+    score += 10;
+    reasons.push('issue intake');
+  }
+  if (candidate.kind === 'pull-request' && candidate.ciState === 'passing') {
+    score += 20;
+    reasons.push('passing checks');
+  }
+  if (candidate.kind === 'pull-request' && candidate.ciState === 'pending') {
+    score -= 10;
+    reasons.push('pending checks');
+  }
+  const ageDays = Math.max(0, (Date.now() - Date.parse(candidate.updatedAt)) / 86_400_000);
+  score += Math.min(20, Math.floor(ageDays));
+
+  return {
+    ...candidate,
+    blockers,
+    score,
+    reasons,
+  };
+}
+
+function compareCandidates(a: QueueMonitorCandidate, b: QueueMonitorCandidate): number {
+  if (a.blockers.length !== b.blockers.length) return a.blockers.length - b.blockers.length;
+  if (a.score !== b.score) return b.score - a.score;
+  const updatedDelta = Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
+  if (updatedDelta !== 0) return updatedDelta;
+  return a.id.localeCompare(b.id);
+}
+
+function statusCheckState(
+  checks?: GhPullRequest['statusCheckRollup']
+): QueueMonitorCandidate['ciState'] {
+  if (!checks || checks.length === 0) return 'unknown';
+  if (
+    checks.some((check) =>
+      ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED'].includes(
+        (check.conclusion ?? '').toUpperCase()
+      )
+    )
+  ) {
+    return 'failing';
+  }
+  if (
+    checks.some((check) => {
+      const status = (check.status ?? check.state ?? '').toUpperCase();
+      const conclusion = (check.conclusion ?? '').toUpperCase();
+      return status !== 'COMPLETED' && conclusion !== 'SUCCESS';
+    })
+  ) {
+    return 'pending';
+  }
+  return 'passing';
+}
+
+function actionRecord(params: {
+  action: QueueMonitorAction;
+  status: QueueMonitorRunStatus;
+  summary: string;
+  packet: QueueMonitorCandidatePacket;
+  checks: QueueMonitorGateCheck[];
+  now: Date;
+  selectedCandidateId?: string;
+  sourceRunId?: string;
+  error?: string;
+  policy?: WatcherContinuationEvaluationResult;
+  sandbox?: QueueMonitorActionRecord['sandbox'];
+  budgetDecision?: string;
+}): QueueMonitorActionRecord {
+  return {
+    action: params.action,
+    status: params.status,
+    summary: params.summary,
+    selectedCandidateId: params.selectedCandidateId,
+    sourceRunId: params.sourceRunId,
+    error: params.error,
+    skippedReasons: params.packet.skipped.flatMap((item) =>
+      item.reasons.map((reason) => `${item.title}: ${reason}`)
+    ),
+    policy: params.policy,
+    sandbox: params.sandbox,
+    budgetDecision: params.budgetDecision,
+    gateChecks: params.checks,
+    recordedAt: params.now.toISOString(),
+  };
+}
+
+function emptyPacket(
+  monitor: Pick<QueueMonitorDefinition, 'id' | 'source' | 'maxCandidates'>,
+  now: Date
+): QueueMonitorCandidatePacket {
+  return {
+    id: `qmp_${nanoid(10)}`,
+    monitorId: monitor.id,
+    generatedAt: now.toISOString(),
+    repo: monitor.source.repo,
+    filters: {
+      labels: monitor.source.labels,
+      state: monitor.source.state,
+      includeIssues: monitor.source.includeIssues,
+      includePullRequests: monitor.source.includePullRequests,
+      limit: monitor.maxCandidates,
+    },
+    candidates: [],
+    skipped: [],
+    truncated: false,
+    checks: [],
+  };
+}
+
+function monitorDispatchPrompt(
+  definition: QueueMonitorDefinition,
+  selected: QueueMonitorCandidate
+): string {
+  return JSON.stringify({
+    mode: definition.mode,
+    runner: definition.runner,
+    monitorId: definition.id,
+    action: definition.mode === 'execute' ? 'start-workflow' : 'assign',
+    repo: selected.repo,
+    candidate: {
+      kind: selected.kind,
+      number: selected.number,
+      title: selected.title,
+      url: selected.url,
+      labels: selected.labels,
+    },
+  });
+}
+
+function candidateLabel(candidate: QueueMonitorCandidate): string {
+  return `${candidate.repo}#${candidate.number} ${candidate.title}`;
+}
+
+function labelNames(labels?: GhLabel[]): string[] {
+  return (labels ?? [])
+    .map((label) => label.name)
+    .filter(Boolean)
+    .sort();
+}
+
+function userLogins(users?: GhUser[]): string[] {
+  return (users ?? []).map((user) => user.login).filter((login): login is string => Boolean(login));
+}
+
+function normalizeLabels(labels: string[]): string[] {
+  return [...new Set(labels.map((label) => label.trim()).filter(Boolean))].sort();
+}
+
+function nullableString(value: string | null | undefined, fallback?: string): string | undefined {
+  if (value === null) return undefined;
+  if (typeof value === 'string') return value.trim() || undefined;
+  return fallback;
+}
+
+function clampInt(value: unknown, min: number, max: number): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return min;
+  return Math.min(max, Math.max(min, Math.round(parsed)));
+}
+
+function failureThreshold(monitor: Pick<QueueMonitorDefinition, 'stopConditions'>): number {
+  return clampInt(monitor.stopConditions.maxFailureStreak ?? DEFAULT_FAILURE_THRESHOLD, 1, 20);
+}
+
+function nextRunAt(
+  monitor: Pick<QueueMonitorDefinition, 'enabled' | 'intervalMinutes'>,
+  now: Date
+): string | undefined {
+  if (!monitor.enabled) return undefined;
+  return new Date(now.getTime() + monitor.intervalMinutes * 60_000).toISOString();
+}
+
+function isMonitorDue(monitor: QueueMonitorSnapshot, cutoff: number): boolean {
+  if (!monitor.enabled || monitor.health === 'blocked' || monitor.health === 'paused') return false;
+  if (!monitor.nextRunAt) return false;
+  const next = Date.parse(monitor.nextRunAt);
+  return Number.isFinite(next) && next <= cutoff;
+}
+
+function isBlockingBudgetDecision(decision: string): boolean {
+  return decision === 'pause' || decision === 'require-approval' || decision === 'cancel';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+let queueIntakeMonitorServiceInstance: QueueIntakeMonitorService | null = null;
+
+export function getQueueIntakeMonitorService(): QueueIntakeMonitorService {
+  if (!queueIntakeMonitorServiceInstance) {
+    queueIntakeMonitorServiceInstance = new QueueIntakeMonitorService();
+  }
+  return queueIntakeMonitorServiceInstance;
+}

--- a/server/src/services/scheduler-service.ts
+++ b/server/src/services/scheduler-service.ts
@@ -12,6 +12,7 @@ import type {
   SchedulerRunStatus,
   SchedulerValidationIssue,
   SchedulerValidationResult,
+  QueueMonitorSnapshot,
   WorkflowDefinition,
   WorkflowSchedule,
   WorkflowScheduleMode,
@@ -34,6 +35,10 @@ import {
 } from './workflow-authoring-service.js';
 import { getWorkflowRunService, type WorkflowRunService } from './workflow-run-service.js';
 import { getWorkflowService, type WorkflowService } from './workflow-service.js';
+import {
+  getQueueIntakeMonitorService,
+  type QueueIntakeMonitorService,
+} from './queue-intake-monitor-service.js';
 
 const log = createLogger('scheduler');
 const STATE_VERSION = 1;
@@ -66,6 +71,7 @@ interface SchedulerServiceOptions {
   workflowService?: WorkflowService;
   workflowRunService?: WorkflowRunService;
   workflowAuthoringService?: WorkflowAuthoringService;
+  queueMonitorService?: QueueIntakeMonitorService;
   telemetryService?: TelemetryService;
 }
 
@@ -75,6 +81,7 @@ export class SchedulerService {
   private readonly workflowService: WorkflowService;
   private readonly workflowRunService: WorkflowRunService;
   private readonly workflowAuthoringService: WorkflowAuthoringService;
+  private readonly queueMonitorService: QueueIntakeMonitorService;
   private readonly telemetryService: TelemetryService;
   private state: SchedulerStateFile | null = null;
   private runningDue = false;
@@ -87,6 +94,7 @@ export class SchedulerService {
     this.workflowRunService = options.workflowRunService ?? getWorkflowRunService();
     this.workflowAuthoringService =
       options.workflowAuthoringService ?? getWorkflowAuthoringService();
+    this.queueMonitorService = options.queueMonitorService ?? getQueueIntakeMonitorService();
     this.telemetryService = options.telemetryService ?? getTelemetryService();
   }
 
@@ -152,6 +160,8 @@ export class SchedulerService {
 
     if (item.kind === 'scheduled-deliverable') {
       await this.deliverablesService.update(item.sourceId, { enabled: false });
+    } else if (item.kind === 'queue-monitor') {
+      await this.queueMonitorService.updateMonitor(item.sourceId, { enabled: false }, now);
     } else {
       await this.updateWorkflowSchedule(item.sourceId, { enabled: false });
     }
@@ -181,6 +191,8 @@ export class SchedulerService {
 
     if (item.kind === 'scheduled-deliverable') {
       await this.deliverablesService.update(item.sourceId, { enabled: true });
+    } else if (item.kind === 'queue-monitor') {
+      await this.queueMonitorService.updateMonitor(item.sourceId, { enabled: true }, now);
     } else {
       await this.updateWorkflowSchedule(item.sourceId, { enabled: true });
     }
@@ -239,7 +251,9 @@ export class SchedulerService {
       const result =
         item.kind === 'scheduled-deliverable'
           ? await this.runDeliverable(item, trigger, now, startedAt)
-          : await this.runWorkflow(item, trigger, now, startedAt);
+          : item.kind === 'queue-monitor'
+            ? await this.runQueueMonitor(item, trigger, now, startedAt)
+            : await this.runWorkflow(item, trigger, now, startedAt);
       await this.saveState();
       return result;
     } finally {
@@ -375,6 +389,27 @@ export class SchedulerService {
     return { item: await this.getItem(item.id, now), event };
   }
 
+  private async runQueueMonitor(
+    item: SchedulerItem,
+    trigger: Extract<SchedulerEventType, 'manual-run' | 'due-run'>,
+    now: Date,
+    startedAt: number
+  ): Promise<SchedulerRunResult> {
+    const result = await this.queueMonitorService.runOnce(item.sourceId, trigger, now);
+    const event = await this.recordEvent({
+      item,
+      type: trigger,
+      status: queueMonitorStatus(result.event.status),
+      summary: result.event.summary,
+      error: result.event.error,
+      sourceRunId: result.event.sourceRunId,
+      durationMs: Date.now() - startedAt,
+      now,
+      nextRunAt: result.monitor.nextRunAt,
+    });
+    return { item: await this.getItem(item.id, now), event };
+  }
+
   private async updateWorkflowSchedule(
     workflowId: string,
     update: Partial<Pick<WorkflowSchedule, 'enabled'>>
@@ -391,9 +426,10 @@ export class SchedulerService {
 
   private async buildItems(now: Date): Promise<SchedulerItem[]> {
     await this.ensureLoaded();
-    const [deliverables, workflows] = await Promise.all([
+    const [deliverables, workflows, queueMonitors] = await Promise.all([
       this.deliverablesService.list(),
       this.workflowService.listWorkflows(),
+      this.queueMonitorService.list(now),
     ]);
 
     const items = [
@@ -401,6 +437,7 @@ export class SchedulerService {
       ...workflows
         .filter((workflow) => shouldExposeWorkflow(workflow))
         .map((workflow) => this.workflowItem(workflow, now)),
+      ...queueMonitors.monitors.map((monitor) => this.queueMonitorItem(monitor)),
     ];
 
     return items.sort((a, b) => {
@@ -478,6 +515,36 @@ export class SchedulerService {
     });
   }
 
+  private queueMonitorItem(monitor: QueueMonitorSnapshot): SchedulerItem {
+    const id = itemId('queue-monitor', monitor.id);
+    const state = this.currentState().items[id] ?? {};
+    return this.decorateItem({
+      id,
+      kind: 'queue-monitor',
+      provider: 'local-server',
+      sourceId: monitor.id,
+      name: monitor.name,
+      description: monitor.description,
+      enabled: monitor.enabled,
+      trigger: {
+        mode: 'custom',
+        description: `Every ${monitor.intervalMinutes} minute${monitor.intervalMinutes === 1 ? '' : 's'}`,
+        customDueRunnerSupported: true,
+      },
+      tags: monitor.tags,
+      nextRunAt: monitor.nextRunAt,
+      lastRunAt: monitor.lastScanAt,
+      lastStatus: state.lastStatus ?? queueMonitorStatus(monitor.lastStatus),
+      lastSummary: state.lastSummary ?? monitor.lastSummary,
+      lastError: state.lastError ?? monitor.lastError,
+      sourceRunId: state.sourceRunId ?? monitor.lastAction?.sourceRunId,
+      health: monitor.health,
+      healthSummary: monitor.healthSummary,
+      retry: retryState(state),
+      actions: baseActions(monitor.enabled),
+    });
+  }
+
   private decorateItem(item: SchedulerItem): SchedulerItem {
     const issues = this.validateItem(item);
     const retryBlocked =
@@ -488,6 +555,9 @@ export class SchedulerService {
     if (!item.enabled) {
       return { ...item, health: 'paused', healthSummary: 'Paused' };
     }
+    if (item.health === 'blocked') {
+      return { ...item, health: 'blocked', healthSummary: item.healthSummary };
+    }
     if (retryBlocked || error) {
       return {
         ...item,
@@ -496,6 +566,9 @@ export class SchedulerService {
           ? 'Retry limit reached; run manually or resume to reset.'
           : (error?.message ?? 'Blocked'),
       };
+    }
+    if (item.health === 'warning') {
+      return { ...item, health: 'warning', healthSummary: item.healthSummary };
     }
     if (warning) {
       return { ...item, health: 'warning', healthSummary: warning.message };
@@ -513,7 +586,12 @@ export class SchedulerService {
         remediation: 'Name the scheduled deliverable or workflow.',
       });
     }
-    if (item.enabled && item.trigger.mode === 'custom' && !item.trigger.cronExpr) {
+    if (
+      item.enabled &&
+      item.kind !== 'queue-monitor' &&
+      item.trigger.mode === 'custom' &&
+      !item.trigger.cronExpr
+    ) {
       issues.push({
         severity: 'error',
         path: 'trigger.cronExpr',
@@ -521,7 +599,7 @@ export class SchedulerService {
         remediation: 'Add cronExpr or switch to a standard interval schedule.',
       });
     }
-    if (item.enabled && !item.trigger.customDueRunnerSupported) {
+    if (item.enabled && item.kind !== 'queue-monitor' && !item.trigger.customDueRunnerSupported) {
       issues.push({
         severity: 'warning',
         path: 'trigger.mode',
@@ -752,6 +830,14 @@ function deliverableRunnerStatus(result: {
   if (result.failed > 0) return 'failed';
   if (result.executed > 0) return 'success';
   if (result.skipped > 0) return 'skipped';
+  return 'skipped';
+}
+
+function queueMonitorStatus(status: QueueMonitorSnapshot['lastStatus']): SchedulerRunStatus {
+  if (status === 'failed' || status === 'blocked') return 'failed';
+  if (status === 'skipped') return 'skipped';
+  if (status === 'started') return 'started';
+  if (status === 'success') return 'success';
   return 'skipped';
 }
 

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -36,6 +36,7 @@ export * from './agent-profile-package.types.js';
 export * from './team-roster.types.js';
 export * from './workspace-capability.types.js';
 export * from './scheduler.types.js';
+export * from './queue-monitor.types.js';
 export * from './watcher-policy.types.js';
 export * from './evidence.types.js';
 export * from './time-breakdown.types.js';

--- a/shared/src/types/queue-monitor.types.ts
+++ b/shared/src/types/queue-monitor.types.ts
@@ -1,0 +1,246 @@
+import type { AgentBudgetPolicy } from './agent-budget.types.js';
+import type { SandboxPolicyDryRunResult } from './sandbox-policy.types.js';
+import type { WatcherContinuationEvaluationResult } from './watcher-policy.types.js';
+
+export type QueueMonitorMode = 'dry-run' | 'assign-only' | 'draft-plan' | 'execute';
+export type QueueMonitorRunnerMode = 'local' | 'github-actions';
+export type QueueMonitorSourceKind = 'github';
+export type QueueMonitorCandidateKind = 'issue' | 'pull-request';
+export type QueueMonitorHealth = 'healthy' | 'warning' | 'paused' | 'blocked';
+export type QueueMonitorRunTrigger = 'manual-run' | 'due-run' | 'explain';
+export type QueueMonitorEventType =
+  | QueueMonitorRunTrigger
+  | 'scan'
+  | 'pause'
+  | 'resume'
+  | 'circuit-open';
+export type QueueMonitorRunStatus = 'success' | 'failed' | 'skipped' | 'started' | 'blocked';
+export type QueueMonitorAction =
+  | 'none'
+  | 'dry-run'
+  | 'assign'
+  | 'draft-plan'
+  | 'start-workflow'
+  | 'blocked'
+  | 'escalate';
+
+export interface QueueMonitorGitHubSource {
+  kind: 'github';
+  repo: string;
+  state: 'open' | 'closed' | 'all';
+  labels: string[];
+  includeIssues: boolean;
+  includePullRequests: boolean;
+}
+
+export interface QueueMonitorStopConditions {
+  maxCandidates?: number;
+  maxFailureStreak?: number;
+  skipBlockedLabels?: string[];
+  skipDraftPullRequests?: boolean;
+  skipFailedChecks?: boolean;
+}
+
+export interface QueueMonitorDefinition {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  source: QueueMonitorGitHubSource;
+  mode: QueueMonitorMode;
+  runner: QueueMonitorRunnerMode;
+  intervalMinutes: number;
+  maxCandidates: number;
+  workflowId?: string;
+  assignee?: string;
+  sandboxPresetId?: string;
+  budget?: AgentBudgetPolicy;
+  stopConditions: QueueMonitorStopConditions;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface QueueMonitorActionItem {
+  id: string;
+  title: string;
+  severity: 'warning' | 'blocker';
+  summary: string;
+  remediation: string;
+  createdAt: string;
+}
+
+export interface QueueMonitorState {
+  lastScanAt?: string;
+  lastActionAt?: string;
+  nextRunAt?: string;
+  failureStreak: number;
+  lastStatus?: QueueMonitorRunStatus;
+  lastSummary?: string;
+  lastError?: string;
+  lastPacket?: QueueMonitorCandidatePacket;
+  lastAction?: QueueMonitorActionRecord;
+  actionItem?: QueueMonitorActionItem;
+}
+
+export interface QueueMonitorGateCheck {
+  name: string;
+  status: 'pass' | 'warn' | 'block';
+  summary: string;
+  evidence?: string[];
+}
+
+export interface QueueMonitorCandidate {
+  id: string;
+  kind: QueueMonitorCandidateKind;
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  labels: string[];
+  assignees: string[];
+  author?: string;
+  createdAt: string;
+  updatedAt: string;
+  comments?: number;
+  isDraft?: boolean;
+  reviewDecision?: string;
+  ciState?: 'passing' | 'failing' | 'pending' | 'unknown';
+  blockers: string[];
+  score: number;
+  reasons: string[];
+}
+
+export interface QueueMonitorSkippedCandidate {
+  candidateId: string;
+  title: string;
+  reasons: string[];
+}
+
+export interface QueueMonitorCandidatePacket {
+  id: string;
+  monitorId: string;
+  generatedAt: string;
+  repo: string;
+  filters: {
+    labels: string[];
+    state: string;
+    includeIssues: boolean;
+    includePullRequests: boolean;
+    limit: number;
+  };
+  candidates: QueueMonitorCandidate[];
+  selected?: QueueMonitorCandidate;
+  skipped: QueueMonitorSkippedCandidate[];
+  truncated: boolean;
+  checks: QueueMonitorGateCheck[];
+}
+
+export interface QueueMonitorActionRecord {
+  action: QueueMonitorAction;
+  status: QueueMonitorRunStatus;
+  summary: string;
+  error?: string;
+  selectedCandidateId?: string;
+  sourceRunId?: string;
+  skippedReasons: string[];
+  policy?: WatcherContinuationEvaluationResult;
+  sandbox?: Pick<
+    SandboxPolicyDryRunResult,
+    'decision' | 'provider' | 'warnings' | 'remediation'
+  > & {
+    presetId: string;
+  };
+  budgetDecision?: string;
+  gateChecks: QueueMonitorGateCheck[];
+  recordedAt: string;
+}
+
+export interface QueueMonitorSnapshot extends QueueMonitorDefinition {
+  health: QueueMonitorHealth;
+  healthSummary: string;
+  lastScanAt?: string;
+  lastActionAt?: string;
+  nextRunAt?: string;
+  failureStreak: number;
+  lastStatus?: QueueMonitorRunStatus;
+  lastSummary?: string;
+  lastError?: string;
+  lastPacket?: QueueMonitorCandidatePacket;
+  lastAction?: QueueMonitorActionRecord;
+  actionItem?: QueueMonitorActionItem;
+  actions: {
+    canRun: boolean;
+    canPause: boolean;
+    canResume: boolean;
+    canExplain: boolean;
+  };
+}
+
+export interface QueueMonitorEvent {
+  id: string;
+  monitorId: string;
+  type: QueueMonitorEventType;
+  status: QueueMonitorRunStatus;
+  action: QueueMonitorAction;
+  summary: string;
+  createdAt: string;
+  durationMs?: number;
+  error?: string;
+  selectedCandidateId?: string;
+  sourceRunId?: string;
+  skippedReasons: string[];
+}
+
+export interface QueueMonitorSummary {
+  total: number;
+  enabled: number;
+  paused: number;
+  blocked: number;
+  failed: number;
+  due: number;
+}
+
+export interface QueueMonitorListResponse {
+  generatedAt: string;
+  summary: QueueMonitorSummary;
+  monitors: QueueMonitorSnapshot[];
+  recentEvents: QueueMonitorEvent[];
+}
+
+export interface QueueMonitorRunResult {
+  monitor: QueueMonitorSnapshot;
+  packet: QueueMonitorCandidatePacket;
+  action: QueueMonitorActionRecord;
+  event: QueueMonitorEvent;
+}
+
+export interface QueueMonitorExplainResult {
+  monitor: QueueMonitorSnapshot;
+  packet: QueueMonitorCandidatePacket;
+  action: QueueMonitorActionRecord;
+}
+
+export interface QueueMonitorHealthResult {
+  monitor: QueueMonitorSnapshot;
+  actionItem?: QueueMonitorActionItem;
+}
+
+export interface QueueMonitorUpdateInput {
+  enabled?: boolean;
+  mode?: QueueMonitorMode;
+  runner?: QueueMonitorRunnerMode;
+  intervalMinutes?: number;
+  maxCandidates?: number;
+  workflowId?: string | null;
+  assignee?: string | null;
+  sandboxPresetId?: string | null;
+  budget?: AgentBudgetPolicy | null;
+  repo?: string;
+  state?: QueueMonitorGitHubSource['state'];
+  labels?: string[];
+  includeIssues?: boolean;
+  includePullRequests?: boolean;
+  stopConditions?: Partial<QueueMonitorStopConditions>;
+}

--- a/shared/src/types/scheduler.types.ts
+++ b/shared/src/types/scheduler.types.ts
@@ -1,7 +1,7 @@
 import type { WorkflowScheduleMode } from './workflow.js';
 
 export type SchedulerDeliverableSchedule = 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'custom';
-export type SchedulerItemKind = 'scheduled-deliverable' | 'workflow';
+export type SchedulerItemKind = 'scheduled-deliverable' | 'workflow' | 'queue-monitor';
 export type SchedulerItemProvider = 'local-server';
 export type SchedulerHealth = 'healthy' | 'warning' | 'paused' | 'blocked';
 export type SchedulerRunStatus = 'success' | 'failed' | 'skipped' | 'started';

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -268,6 +268,16 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     ],
   },
   {
+    prefix: '/api/queue-monitors',
+    read: 'workflow:read',
+    write: 'workflow:write',
+    overrides: [
+      { methods: ['POST'], path: /^\/[^/]+\/run\/?$/, permissions: 'workflow:execute' },
+      { methods: ['GET', 'POST'], path: /^\/[^/]+\/explain\/?$/, permissions: 'workflow:read' },
+      { methods: ['GET'], path: /^\/[^/]+\/health\/?$/, permissions: 'workflow:read' },
+    ],
+  },
+  {
     prefix: '/api/watcher-policies',
     read: 'policy:read',
     write: 'policy:write',

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -7,6 +7,7 @@ import {
   Settings2,
   Layout,
   ListTodo,
+  ListChecks,
   Cpu,
   Database,
   Bell,
@@ -76,6 +77,9 @@ const LazyWorkspaceCapabilitiesTab = lazy(() =>
 const LazySchedulerTab = lazy(() =>
   import('./tabs/SchedulerTab').then((m) => ({ default: m.SchedulerTab }))
 );
+const LazyQueueMonitorsTab = lazy(() =>
+  import('./tabs/QueueMonitorsTab').then((m) => ({ default: m.QueueMonitorsTab }))
+);
 
 // ============ Tab Skeleton ============
 
@@ -110,6 +114,7 @@ type TabId =
   | 'multi-user'
   | 'workspace-capabilities'
   | 'scheduler'
+  | 'queue-monitors'
   | 'maintenance'
   | 'manage';
 
@@ -139,6 +144,12 @@ const TABS: TabDef[] = [
     id: 'scheduler',
     label: 'Scheduler',
     icon: CalendarClock,
+    requiredPermission: 'workflow:read',
+  },
+  {
+    id: 'queue-monitors',
+    label: 'Queues',
+    icon: ListChecks,
     requiredPermission: 'workflow:read',
   },
   { id: 'maintenance', label: 'Maintenance', icon: Wrench, requiredPermission: 'backup:read' },
@@ -428,6 +439,11 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
         {activeTab === 'scheduler' && (
           <SettingsErrorBoundary tabName="Scheduler">
             <LazySchedulerTab />
+          </SettingsErrorBoundary>
+        )}
+        {activeTab === 'queue-monitors' && (
+          <SettingsErrorBoundary tabName="Queues">
+            <LazyQueueMonitorsTab />
           </SettingsErrorBoundary>
         )}
         {activeTab === 'delegation' && (

--- a/web/src/components/settings/tabs/QueueMonitorsTab.tsx
+++ b/web/src/components/settings/tabs/QueueMonitorsTab.tsx
@@ -1,0 +1,353 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ListChecks,
+  Pause,
+  Play,
+  RefreshCw,
+  RotateCw,
+  Search,
+} from 'lucide-react';
+import type {
+  QueueMonitorCandidatePacket,
+  QueueMonitorEvent,
+  QueueMonitorSnapshot,
+} from '@veritas-kanban/shared';
+import { useIdentity } from '@/hooks/useIdentity';
+import {
+  useQueueMonitorExplain,
+  useQueueMonitorPause,
+  useQueueMonitorResume,
+  useQueueMonitorRun,
+  useQueueMonitors,
+} from '@/hooks/useQueueMonitors';
+import { useToast } from '@/hooks/useToast';
+
+const EMPTY_MONITORS: QueueMonitorSnapshot[] = [];
+const EMPTY_EVENTS: QueueMonitorEvent[] = [];
+
+export function QueueMonitorsTab() {
+  const { hasPermission } = useIdentity();
+  const { toast } = useToast();
+  const monitorsQuery = useQueueMonitors();
+  const run = useQueueMonitorRun();
+  const pause = useQueueMonitorPause();
+  const resume = useQueueMonitorResume();
+  const explain = useQueueMonitorExplain();
+  const [packet, setPacket] = useState<QueueMonitorCandidatePacket | null>(null);
+  const canExecute = hasPermission('workflow:execute');
+  const canWrite = hasPermission('workflow:write');
+  const monitors = monitorsQuery.data?.monitors ?? EMPTY_MONITORS;
+  const events = monitorsQuery.data?.recentEvents ?? EMPTY_EVENTS;
+
+  const mutate = async (action: () => Promise<unknown>, successTitle: string) => {
+    try {
+      await action();
+      toast({ title: successTitle });
+    } catch (error) {
+      toast({
+        title: 'Queue monitor action failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const explainMonitor = async (monitorId: string) => {
+    await mutate(async () => {
+      const result = await explain.mutateAsync(monitorId);
+      setPacket(result.packet);
+    }, 'Queue packet refreshed');
+  };
+
+  if (monitorsQuery.isLoading) {
+    return (
+      <Group gap="sm" className="text-muted-foreground">
+        <Loader size="xs" />
+        <Text size="sm">Loading queue monitors...</Text>
+      </Group>
+    );
+  }
+
+  return (
+    <Stack gap="lg">
+      <Group justify="space-between" align="center">
+        <Group gap="xs">
+          <ListChecks className="h-4 w-4 text-muted-foreground" />
+          <Text size="sm" fw={600}>
+            Queue Intake Monitors
+          </Text>
+        </Group>
+        <Tooltip label="Refresh queue monitors">
+          <Button
+            size="xs"
+            variant="subtle"
+            color="gray"
+            leftSection={<RefreshCw className="h-3.5 w-3.5" />}
+            onClick={() => monitorsQuery.refetch()}
+          >
+            Refresh
+          </Button>
+        </Tooltip>
+      </Group>
+
+      {monitorsQuery.data && (
+        <SimpleGrid cols={{ base: 2, md: 5 }} spacing="sm">
+          <SummaryStat label="Total" value={monitorsQuery.data.summary.total} />
+          <SummaryStat label="Enabled" value={monitorsQuery.data.summary.enabled} />
+          <SummaryStat label="Due" value={monitorsQuery.data.summary.due} />
+          <SummaryStat label="Failed" value={monitorsQuery.data.summary.failed} />
+          <SummaryStat label="Blocked" value={monitorsQuery.data.summary.blocked} />
+        </SimpleGrid>
+      )}
+
+      <Stack gap="sm">
+        {monitors.length === 0 ? (
+          <Paper className="border border-dashed p-4 text-center" radius="md">
+            <Text size="sm" c="dimmed">
+              No queue monitors are configured.
+            </Text>
+          </Paper>
+        ) : (
+          monitors.map((monitor) => (
+            <Paper key={monitor.id} className="border bg-card p-4" radius="md">
+              <Stack gap="sm">
+                <Group justify="space-between" align="flex-start">
+                  <Stack gap={2}>
+                    <Group gap="xs">
+                      <Text size="sm" fw={600}>
+                        {monitor.name}
+                      </Text>
+                      <Badge size="xs" color="blue" variant="light">
+                        {monitor.mode}
+                      </Badge>
+                      <HealthBadge monitor={monitor} />
+                    </Group>
+                    <Text size="xs" c="dimmed" lineClamp={2}>
+                      {monitor.source.repo} · {monitor.source.labels.join(', ') || 'all labels'}
+                    </Text>
+                  </Stack>
+                  <Group gap="xs">
+                    <Button
+                      size="xs"
+                      variant="subtle"
+                      color="gray"
+                      disabled={explain.isPending || !monitor.actions.canExplain}
+                      leftSection={<Search className="h-3.5 w-3.5" />}
+                      onClick={() => explainMonitor(monitor.id)}
+                    >
+                      Explain
+                    </Button>
+                    <Button
+                      size="xs"
+                      variant="light"
+                      color="gray"
+                      disabled={!canExecute || run.isPending || !monitor.actions.canRun}
+                      leftSection={<Play className="h-3.5 w-3.5" />}
+                      onClick={() =>
+                        mutate(() => run.mutateAsync(monitor.id), 'Queue monitor run recorded')
+                      }
+                    >
+                      Run
+                    </Button>
+                    {monitor.enabled ? (
+                      <Button
+                        size="xs"
+                        variant="subtle"
+                        color="gray"
+                        disabled={!canWrite || pause.isPending || !monitor.actions.canPause}
+                        leftSection={<Pause className="h-3.5 w-3.5" />}
+                        onClick={() =>
+                          mutate(() => pause.mutateAsync(monitor.id), 'Queue monitor paused')
+                        }
+                      >
+                        Pause
+                      </Button>
+                    ) : (
+                      <Button
+                        size="xs"
+                        variant="subtle"
+                        color="gray"
+                        disabled={!canWrite || resume.isPending || !monitor.actions.canResume}
+                        leftSection={<RotateCw className="h-3.5 w-3.5" />}
+                        onClick={() =>
+                          mutate(() => resume.mutateAsync(monitor.id), 'Queue monitor resumed')
+                        }
+                      >
+                        Resume
+                      </Button>
+                    )}
+                  </Group>
+                </Group>
+
+                <SimpleGrid cols={{ base: 1, md: 4 }} spacing="xs">
+                  <Meta label="Next" value={formatDate(monitor.nextRunAt)} />
+                  <Meta label="Last scan" value={formatDate(monitor.lastScanAt)} />
+                  <Meta
+                    label="Candidates"
+                    value={String(monitor.lastPacket?.candidates.length ?? 0)}
+                  />
+                  <Meta label="Failures" value={String(monitor.failureStreak)} />
+                </SimpleGrid>
+
+                {monitor.actionItem && (
+                  <Alert
+                    color="yellow"
+                    variant="light"
+                    icon={<AlertTriangle className="h-4 w-4" />}
+                  >
+                    <Text size="xs" fw={600}>
+                      {monitor.actionItem.summary}
+                    </Text>
+                    <Text size="xs">{monitor.actionItem.remediation}</Text>
+                  </Alert>
+                )}
+
+                {monitor.lastSummary && (
+                  <Text size="xs" c={monitor.lastStatus === 'failed' ? 'red' : 'dimmed'}>
+                    {monitor.lastSummary}
+                  </Text>
+                )}
+              </Stack>
+            </Paper>
+          ))
+        )}
+      </Stack>
+
+      {packet && (
+        <Paper className="border bg-card p-4" radius="md">
+          <Stack gap="sm">
+            <Group gap="xs">
+              <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
+              <Text size="sm" fw={600}>
+                Latest Candidate Packet
+              </Text>
+              <Badge size="xs" variant="light">
+                {packet.candidates.length} candidates
+              </Badge>
+            </Group>
+            {packet.selected ? (
+              <Stack gap={2}>
+                <Text size="sm" fw={600}>
+                  {packet.selected.repo}#{packet.selected.number} {packet.selected.title}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  score {packet.selected.score} ·{' '}
+                  {packet.selected.reasons.join(', ') || 'no score reasons'}
+                </Text>
+              </Stack>
+            ) : (
+              <Text size="sm" c="dimmed">
+                No candidate selected.
+              </Text>
+            )}
+            {packet.skipped.length > 0 && (
+              <Stack gap={4}>
+                <Text size="xs" fw={600}>
+                  Skipped
+                </Text>
+                {packet.skipped.slice(0, 5).map((item) => (
+                  <Text key={item.candidateId} size="xs" c="dimmed">
+                    {item.title}: {item.reasons.join(', ')}
+                  </Text>
+                ))}
+              </Stack>
+            )}
+          </Stack>
+        </Paper>
+      )}
+
+      {events.length > 0 && (
+        <Stack gap="sm">
+          <Text size="sm" fw={600}>
+            Recent Events
+          </Text>
+          <Stack gap="xs">
+            {events.slice(0, 6).map((event) => (
+              <Group key={event.id} justify="space-between" className="rounded border px-3 py-2">
+                <Stack gap={0}>
+                  <Text size="xs" fw={600}>
+                    {event.summary}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {event.monitorId} · {formatDate(event.createdAt)}
+                  </Text>
+                </Stack>
+                <Badge size="xs" color={statusColor(event.status)} variant="light">
+                  {event.status}
+                </Badge>
+              </Group>
+            ))}
+          </Stack>
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: number }) {
+  return (
+    <Paper className="border bg-card p-3" radius="md">
+      <Text size="xs" c="dimmed">
+        {label}
+      </Text>
+      <Text size="lg" fw={700}>
+        {value}
+      </Text>
+    </Paper>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <Stack gap={0}>
+      <Text size="xs" c="dimmed">
+        {label}
+      </Text>
+      <Text size="xs" fw={600}>
+        {value}
+      </Text>
+    </Stack>
+  );
+}
+
+function HealthBadge({ monitor }: { monitor: QueueMonitorSnapshot }) {
+  return (
+    <Badge size="xs" color={healthColor(monitor.health)} variant="light">
+      {monitor.health}
+    </Badge>
+  );
+}
+
+function healthColor(health: QueueMonitorSnapshot['health']): string {
+  if (health === 'healthy') return 'green';
+  if (health === 'blocked') return 'red';
+  if (health === 'paused') return 'gray';
+  return 'yellow';
+}
+
+function statusColor(status: QueueMonitorEvent['status']): string {
+  if (status === 'success' || status === 'started') return 'green';
+  if (status === 'blocked' || status === 'failed') return 'red';
+  return 'gray';
+}
+
+function formatDate(value?: string): string {
+  if (!value) return 'not set';
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return 'invalid';
+  return date.toLocaleString();
+}

--- a/web/src/components/settings/tabs/SchedulerTab.tsx
+++ b/web/src/components/settings/tabs/SchedulerTab.tsx
@@ -126,10 +126,20 @@ export function SchedulerTab() {
                       </Text>
                       <Badge
                         size="xs"
-                        color={item.kind === 'workflow' ? 'blue' : 'grape'}
+                        color={
+                          item.kind === 'workflow'
+                            ? 'blue'
+                            : item.kind === 'queue-monitor'
+                              ? 'teal'
+                              : 'grape'
+                        }
                         variant="light"
                       >
-                        {item.kind === 'workflow' ? 'Workflow' : 'Deliverable'}
+                        {item.kind === 'workflow'
+                          ? 'Workflow'
+                          : item.kind === 'queue-monitor'
+                            ? 'Queue'
+                            : 'Deliverable'}
                       </Badge>
                       <HealthBadge item={item} />
                     </Group>

--- a/web/src/hooks/useQueueMonitors.ts
+++ b/web/src/hooks/useQueueMonitors.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type { QueueMonitorUpdateInput } from '@veritas-kanban/shared';
+
+export const QUEUE_MONITORS_KEY = ['queue-monitors'] as const;
+
+export function useQueueMonitors() {
+  return useQuery({
+    queryKey: QUEUE_MONITORS_KEY,
+    queryFn: api.queueMonitors.list,
+  });
+}
+
+export function useQueueMonitorRun() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (monitorId: string) => api.queueMonitors.run(monitorId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUEUE_MONITORS_KEY }),
+  });
+}
+
+export function useQueueMonitorPause() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (monitorId: string) => api.queueMonitors.pause(monitorId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUEUE_MONITORS_KEY }),
+  });
+}
+
+export function useQueueMonitorResume() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (monitorId: string) => api.queueMonitors.resume(monitorId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUEUE_MONITORS_KEY }),
+  });
+}
+
+export function useQueueMonitorExplain() {
+  return useMutation({
+    mutationFn: (monitorId: string) => api.queueMonitors.explain(monitorId),
+  });
+}
+
+export function useQueueMonitorUpdate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ monitorId, input }: { monitorId: string; input: QueueMonitorUpdateInput }) =>
+      api.queueMonitors.update(monitorId, input),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUEUE_MONITORS_KEY }),
+  });
+}

--- a/web/src/lib/api/digest.ts
+++ b/web/src/lib/api/digest.ts
@@ -28,6 +28,12 @@ export interface AgentOperationsApproval extends AgentOperationsSourceLink {
   details?: string;
 }
 
+export interface AgentOperationsQueueMonitorActivity extends AgentOperationsSourceLink {
+  status: 'success' | 'failed' | 'skipped' | 'started' | 'blocked';
+  action: 'none' | 'dry-run' | 'assign' | 'draft-plan' | 'start-workflow' | 'blocked' | 'escalate';
+  skippedReasons: string[];
+}
+
 export interface AgentOperationsDigestGroup {
   key: string;
   project: string;
@@ -58,6 +64,7 @@ export interface AgentOperationsDigestGroup {
   topPlanCompletions: AgentOperationsSourceLink[];
   notableFailures: AgentOperationsFailure[];
   openApprovals: AgentOperationsApproval[];
+  queueMonitors?: AgentOperationsQueueMonitorActivity[];
 }
 
 export interface AgentOperationsDigest {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -31,6 +31,7 @@ import { sandboxPoliciesApi } from './sandbox-policies';
 import { runSessionsApi } from './run-sessions';
 import { workspaceCapabilitiesApi } from './workspace-capabilities';
 import { schedulerApi } from './scheduler';
+import { queueMonitorsApi } from './queue-monitors';
 
 // Assemble the full API object (matches original structure exactly)
 export const api = {
@@ -73,6 +74,7 @@ export const api = {
   runSessions: runSessionsApi,
   workspaceCapabilities: workspaceCapabilitiesApi,
   scheduler: schedulerApi,
+  queueMonitors: queueMonitorsApi,
 };
 
 export type {
@@ -100,6 +102,7 @@ export type {
   AgentOperationsDigestFilters,
   AgentOperationsDigestGroup,
   AgentOperationsFailure,
+  AgentOperationsQueueMonitorActivity,
   AgentOperationsMarkdown,
   AgentOperationsSourceLink,
 } from './digest';

--- a/web/src/lib/api/queue-monitors.ts
+++ b/web/src/lib/api/queue-monitors.ts
@@ -1,0 +1,47 @@
+import type {
+  QueueMonitorExplainResult,
+  QueueMonitorHealthResult,
+  QueueMonitorListResponse,
+  QueueMonitorRunResult,
+  QueueMonitorSnapshot,
+  QueueMonitorUpdateInput,
+} from '@veritas-kanban/shared';
+import { API_BASE, apiFetch } from './helpers';
+
+function monitorPath(monitorId: string, action?: string): string {
+  const encoded = encodeURIComponent(monitorId);
+  return `${API_BASE}/queue-monitors/${encoded}${action ? `/${action}` : ''}`;
+}
+
+export const queueMonitorsApi = {
+  list: () => apiFetch<QueueMonitorListResponse>(`${API_BASE}/queue-monitors`),
+
+  get: (monitorId: string) => apiFetch<QueueMonitorSnapshot>(monitorPath(monitorId)),
+
+  update: (monitorId: string, input: QueueMonitorUpdateInput) =>
+    apiFetch<QueueMonitorSnapshot>(monitorPath(monitorId), {
+      method: 'PUT',
+      body: JSON.stringify(input),
+    }),
+
+  health: (monitorId: string) =>
+    apiFetch<QueueMonitorHealthResult>(monitorPath(monitorId, 'health')),
+
+  explain: (monitorId: string) =>
+    apiFetch<QueueMonitorExplainResult>(monitorPath(monitorId, 'explain')),
+
+  run: (monitorId: string) =>
+    apiFetch<QueueMonitorRunResult>(monitorPath(monitorId, 'run'), {
+      method: 'POST',
+    }),
+
+  pause: (monitorId: string) =>
+    apiFetch<QueueMonitorRunResult>(monitorPath(monitorId, 'pause'), {
+      method: 'POST',
+    }),
+
+  resume: (monitorId: string) =>
+    apiFetch<QueueMonitorRunResult>(monitorPath(monitorId, 'resume'), {
+      method: 'POST',
+    }),
+};


### PR DESCRIPTION
## Summary
- Add GitHub-backed queue intake monitor definitions, state, candidate packets, failure action items, and policy/budget/sandbox/workflow execution gates.
- Expose monitor APIs, CLI commands, Settings -> Queues dashboard, scheduler integration, and operations digest monitor activity.
- Document queue monitor behavior, endpoints, CLI usage, runner limits, and scheduler source kind.

Closes #736

## Verification
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/cli typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm vitest run server/src/__tests__/queue-intake-monitor-service.test.ts server/src/__tests__/scheduler-service.test.ts server/src/__tests__/digest-service.test.ts cli/src/__tests__/api-permissions.test.ts --reporter=verbose
- pnpm exec eslint shared/src/types/queue-monitor.types.ts shared/src/types/index.ts shared/src/types/scheduler.types.ts shared/src/utils/api-permissions.ts server/src/services/queue-intake-monitor-service.ts server/src/services/scheduler-service.ts server/src/services/digest-service.ts server/src/routes/queue-monitors.ts server/src/routes/v1/index.ts server/src/routes/v1/permissions.ts server/src/__tests__/queue-intake-monitor-service.test.ts server/src/__tests__/scheduler-service.test.ts server/src/__tests__/digest-service.test.ts cli/src/commands/queue-monitors.ts cli/src/index.ts cli/src/__tests__/api-permissions.test.ts web/src/lib/api/queue-monitors.ts web/src/lib/api/index.ts web/src/lib/api/digest.ts web/src/hooks/useQueueMonitors.ts web/src/components/settings/tabs/QueueMonitorsTab.tsx web/src/components/settings/SettingsDialog.tsx web/src/components/settings/tabs/SchedulerTab.tsx
- git diff --check
- pnpm build

## Notes
- `dry-run` is the default monitor mode.
- `runner: "github-actions"` is modeled but blocked until a dispatch adapter is configured; `runner: "local"` is executable now.
