### PR TITLE
Add human reply communication adapters

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -651,6 +651,69 @@ POST /api/chat/squad/:messageId/react
 
 Search returns redacted snippets only. Mention notifications link back to the squad message and do not include raw secrets beyond the existing redaction rules.
 
+### Communication Adapters
+
+Bidirectional human reply adapters live under integrations. The first adapter
+contract is provider-neutral with Microsoft Teams posture fields and a local
+ingest API. It stores external thread mappings separately from message content.
+
+```
+GET  /api/integrations/communication/adapters
+PUT  /api/integrations/communication/adapters/:adapterId
+GET  /api/integrations/communication/adapters/:adapterId/health
+POST /api/integrations/communication/adapters/:adapterId/test
+POST /api/integrations/communication/adapters/:adapterId/send
+POST /api/integrations/communication/adapters/:adapterId/replies
+POST /api/integrations/communication/adapters/:adapterId/poll
+POST /api/integrations/communication/adapters/:adapterId/disconnect
+GET  /api/integrations/communication/mappings
+GET  /api/integrations/communication/deliveries
+```
+
+Adapter setup uses `settings:write`. External reply ingestion uses
+`comment:write`; approval-targeted replies also require `workflow:execute`,
+`task:write`, or admin authority. Reply ingestion sanitizes the body, redacts
+secret-like text, dedupes `externalReplyId`, creates a Squad Chat reply through
+the normal chat service, and broadcasts it to connected clients.
+
+**Configure body**:
+
+```json
+{
+  "kind": "msteams",
+  "displayName": "Microsoft Teams",
+  "enabled": true,
+  "deliveryMode": "webhook",
+  "destinationType": "channel",
+  "tenantId": "tenant-id",
+  "teamId": "team-id",
+  "channelId": "channel-id",
+  "webhookUrl": "https://example.com/teams-adapter",
+  "credential": "write-only-token"
+}
+```
+
+Responses never return credentials or raw webhook query strings. Redacted
+posture appears as `webhookUrlConfigured`, `webhookUrlRedacted`, and
+`hasCredential`.
+
+**Reply ingest body**:
+
+```json
+{
+  "externalThreadId": "teams-thread-1",
+  "externalReplyId": "reply-42",
+  "actor": "alice@example.com",
+  "displayName": "Alice",
+  "message": "Looks good. Please ship it.",
+  "target": {
+    "kind": "squad",
+    "squadMessageId": "msg_parent",
+    "taskId": "task-123"
+  }
+}
+```
+
 ### Chat Sessions
 
 ```
@@ -2905,45 +2968,45 @@ Rate limit headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-R
 
 These endpoints follow the same auth/error patterns documented above:
 
-| Mount                            | Purpose                                       |
-| -------------------------------- | --------------------------------------------- |
-| `/api/projects`                  | Project CRUD                                  |
-| `/api/sprints`                   | Sprint management                             |
-| `/api/backlog`                   | Backlog operations                            |
-| `/api/agents`                    | Agent CRUD, routing                           |
-| `/api/agents/register`           | Agent self-registration                       |
-| `/api/agents/permissions`        | Agent permission management                   |
-| `/api/templates`                 | Task templates                                |
-| `/api/task-types`                | Custom task type definitions                  |
-| `/api/activity`                  | Activity feed                                 |
-| `/api/notifications`             | User notifications                            |
-| `/api/broadcasts`                | Broadcast messages                            |
-| `/api/changes`                   | Efficient agent polling (change feed)         |
-| `/api/diff`                      | Task diff comparisons                         |
-| `/api/automation`                | Automation rules                              |
-| `/api/summary`                   | Board summaries                               |
-| `/api/github`                    | GitHub integration                            |
-| `/api/conflicts`                 | Merge conflict detection                      |
-| `/api/watcher-policies`          | Agent continuation guardrail decisions        |
-| `/api/metrics`                   | Prometheus-style metrics                      |
-| `/api/traces`                    | Distributed tracing                           |
-| `/api/cost-prediction`           | Token cost forecasting                        |
-| `/api/error-learning`            | Error pattern learning                        |
-| `/api/reports`                   | Generated reports                             |
-| `/api/deliverables`              | Scheduled deliverables                        |
-| `/api/doc-freshness`             | Documentation freshness tracking              |
-| `/api/docs`                      | Docs endpoint                                 |
-| `/api/shared-resources`          | Shared resource management                    |
-| `/api/status-history`            | Task status history                           |
-| `/api/digest`                    | Digest generation                             |
-| `/api/audit`                     | Audit log                                     |
-| `/api/lessons`                   | Lessons learned                               |
-| `/api/delegation`                | Task delegation                               |
-| `/api/workflows`                 | Workflow engine ([details](API-WORKFLOWS.md)) |
-| `/api/tool-policies`             | Tool access policies                          |
-| `/api/sandbox-policies`          | Agent sandbox policy presets                  |
-| `/api/integrations`              | External integrations                         |
-| `/api/settings/transition-hooks` | Status transition hooks                       |
+| Mount                            | Purpose                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| `/api/projects`                  | Project CRUD                                                             |
+| `/api/sprints`                   | Sprint management                                                        |
+| `/api/backlog`                   | Backlog operations                                                       |
+| `/api/agents`                    | Agent CRUD, routing                                                      |
+| `/api/agents/register`           | Agent self-registration                                                  |
+| `/api/agents/permissions`        | Agent permission management                                              |
+| `/api/templates`                 | Task templates                                                           |
+| `/api/task-types`                | Custom task type definitions                                             |
+| `/api/activity`                  | Activity feed                                                            |
+| `/api/notifications`             | User notifications                                                       |
+| `/api/broadcasts`                | Broadcast messages                                                       |
+| `/api/changes`                   | Efficient agent polling (change feed)                                    |
+| `/api/diff`                      | Task diff comparisons                                                    |
+| `/api/automation`                | Automation rules                                                         |
+| `/api/summary`                   | Board summaries                                                          |
+| `/api/github`                    | GitHub integration                                                       |
+| `/api/conflicts`                 | Merge conflict detection                                                 |
+| `/api/watcher-policies`          | Agent continuation guardrail decisions                                   |
+| `/api/metrics`                   | Prometheus-style metrics                                                 |
+| `/api/traces`                    | Distributed tracing                                                      |
+| `/api/cost-prediction`           | Token cost forecasting                                                   |
+| `/api/error-learning`            | Error pattern learning                                                   |
+| `/api/reports`                   | Generated reports                                                        |
+| `/api/deliverables`              | Scheduled deliverables                                                   |
+| `/api/doc-freshness`             | Documentation freshness tracking                                         |
+| `/api/docs`                      | Docs endpoint                                                            |
+| `/api/shared-resources`          | Shared resource management                                               |
+| `/api/status-history`            | Task status history                                                      |
+| `/api/digest`                    | Digest generation                                                        |
+| `/api/audit`                     | Audit log                                                                |
+| `/api/lessons`                   | Lessons learned                                                          |
+| `/api/delegation`                | Task delegation                                                          |
+| `/api/workflows`                 | Workflow engine ([details](API-WORKFLOWS.md))                            |
+| `/api/tool-policies`             | Tool access policies                                                     |
+| `/api/sandbox-policies`          | Agent sandbox policy presets                                             |
+| `/api/integrations`              | External integrations, outbound delivery audit, and human reply adapters |
+| `/api/settings/transition-hooks` | Status transition hooks                                                  |
 
 | `/api/feedback` | User feedback & sentiment analytics |
 | `/api/decisions` | Decision audit trail |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -456,20 +456,22 @@ Real-time agent-to-agent communication channel for multi-agent collaboration. Sh
 - **Configurable display names** — Agents set custom display names for chat identity
 - **Squad Chat Webhook** — Optional outbound delivery for chat messages; supports generic HTTP and OpenClaw Direct modes
 - **OpenClaw Direct gateway wake** — Optional real-time Squad Chat events pushed to OpenClaw gateway for agent orchestration
+- **Human reply adapters** — Configure Teams reply posture, run health checks and test sends, store external thread mappings, and ingest audited human replies back into the correct Squad Chat thread
 - **Searchable history** — Browse and search past squad chat messages
 
 ### API Endpoints
 
-| Endpoint                            | Method | Description                                   |
-| ----------------------------------- | ------ | --------------------------------------------- |
-| `/api/chat/squad`                   | POST   | Send a squad chat message                     |
-| `/api/chat/squad`                   | GET    | Retrieve squad chat history                   |
-| `/api/chat/squad/search`            | GET    | Search redacted snippets                      |
-| `/api/chat/squad/unread`            | GET    | Get actor-scoped unread state                 |
-| `/api/chat/squad/read`              | POST   | Mark messages read for an actor               |
-| `/api/chat/squad/:messageId/thread` | GET    | Read a compact thread                         |
-| `/api/chat/squad/:messageId/pin`    | POST   | Pin/unpin or mark/unmark a decision           |
-| `/api/chat/squad/:messageId/react`  | POST   | Add a lightweight reaction or acknowledgement |
+| Endpoint                                                      | Method | Description                                    |
+| ------------------------------------------------------------- | ------ | ---------------------------------------------- |
+| `/api/chat/squad`                                             | POST   | Send a squad chat message                      |
+| `/api/chat/squad`                                             | GET    | Retrieve squad chat history                    |
+| `/api/chat/squad/search`                                      | GET    | Search redacted snippets                       |
+| `/api/chat/squad/unread`                                      | GET    | Get actor-scoped unread state                  |
+| `/api/chat/squad/read`                                        | POST   | Mark messages read for an actor                |
+| `/api/chat/squad/:messageId/thread`                           | GET    | Read a compact thread                          |
+| `/api/chat/squad/:messageId/pin`                              | POST   | Pin/unpin or mark/unmark a decision            |
+| `/api/chat/squad/:messageId/react`                            | POST   | Add a lightweight reaction or acknowledgement  |
+| `/api/integrations/communication/adapters/:adapterId/replies` | POST   | Ingest an external human reply into Squad Chat |
 
 ---
 
@@ -1127,6 +1129,7 @@ Notification and broadcast features provide local visibility and optional delive
 - **Per-event toggles** — Enable/disable notification types in Settings → Notifications
 - **Broadcast messages** — Durable system-wide messages at `/api/broadcasts` with `info`, `action-required`, and `urgent` priorities
 - **External delivery boundary** — Local notifications, broadcasts, and Squad Chat can work while external webhook delivery is disabled
+- **Human reply adapter health** — Settings -> Notifications shows Teams reply posture, redacted webhook state, recent delivery audit, test send, and disconnect controls
 
 ### API Endpoints
 

--- a/docs/features/squad-chat.md
+++ b/docs/features/squad-chat.md
@@ -10,14 +10,15 @@ Squad Chat stores and streams messages. It does not wake an external agent proce
 
 ## Terminology
 
-| Term                    | What it means                                                                                                                                    | External delivery?                                                                                  |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| **Squad Chat**          | Local shared chat log at `/api/chat/squad`, backed by daily markdown files and WebSocket updates.                                                | No. It stores and streams messages to VK clients only.                                              |
-| **Squad Chat Webhook**  | Optional outbound delivery triggered by Squad Chat messages. Supports generic HTTP and OpenClaw Direct modes.                                    | Yes, when enabled and configured. HTTP success means VK delivered the event to the configured URL.  |
-| **External wake/reply** | Behavior implemented by an external consumer such as OpenClaw Direct, a custom webhook receiver, or another orchestrator.                        | Yes, but only the external consumer can wake an agent or post a visible reply back into Squad Chat. |
-| **Broadcasts**          | Durable system-wide messages at `/api/broadcasts` for agent polling and operator visibility. Priorities are `info`, `action-required`, `urgent`. | No. Broadcasts are not chat replies and do not wake external agents by themselves.                  |
-| **Notifications**       | Recipient-specific task and system events at `/api/notifications`, including mentions, assignments, subscriptions, and failure alerts.           | Optional. Local records exist even when delivery channels are disabled.                             |
-| **Failure alerts**      | Notification/system-event records created when agent work fails.                                                                                 | Optional. External delivery depends on configured notification channels or webhook consumers.       |
+| Term                    | What it means                                                                                                                                    | External delivery?                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| **Squad Chat**          | Local shared chat log at `/api/chat/squad`, backed by daily markdown files and WebSocket updates.                                                | No. It stores and streams messages to VK clients only.                                                |
+| **Squad Chat Webhook**  | Optional outbound delivery triggered by Squad Chat messages. Supports generic HTTP and OpenClaw Direct modes.                                    | Yes, when enabled and configured. HTTP success means VK delivered the event to the configured URL.    |
+| **Human reply adapter** | Adapter posture, thread mapping, health, and reply ingestion for approved external channels such as Teams.                                       | Yes. External replies are accepted through an authenticated ingest API and become Squad Chat replies. |
+| **External wake/reply** | Behavior implemented by an external consumer such as OpenClaw Direct, a custom webhook receiver, or another orchestrator.                        | Yes, but only the external consumer can wake an agent or post a visible reply back into Squad Chat.   |
+| **Broadcasts**          | Durable system-wide messages at `/api/broadcasts` for agent polling and operator visibility. Priorities are `info`, `action-required`, `urgent`. | No. Broadcasts are not chat replies and do not wake external agents by themselves.                    |
+| **Notifications**       | Recipient-specific task and system events at `/api/notifications`, including mentions, assignments, subscriptions, and failure alerts.           | Optional. Local records exist even when delivery channels are disabled.                               |
+| **Failure alerts**      | Notification/system-event records created when agent work fails.                                                                                 | Optional. External delivery depends on configured notification channels or webhook consumers.         |
 
 ## Features
 
@@ -32,6 +33,7 @@ Squad Chat stores and streams messages. It does not wake an external agent proce
 - **Human participation** — Humans can post messages and interact with agents
 - **Message persistence** — Daily markdown files stored in `.veritas-kanban/chats/squad/`
 - **Webhook integration** — Route messages to external systems (OpenClaw, custom webhooks)
+- **Human reply ingestion** — Map external threads to Squad Chat targets and ingest human replies with attribution, sanitization, idempotency, and audit records
 
 ## API Endpoints
 
@@ -135,6 +137,59 @@ curl -X POST http://localhost:3001/api/chat/squad/msg_decision/react \
 ```
 
 Search operates over redacted message text and returns bounded snippets. Notification payloads for mentions use the same redaction rules and include only message IDs, thread IDs, targets, and safe display text.
+
+### Human Reply Adapter
+
+The communication adapter contract lets a trusted external channel map human
+replies back into Veritas without storing secrets in chat content.
+
+```bash
+# Configure Teams adapter posture
+curl -X PUT http://localhost:3001/api/integrations/communication/adapters/msteams-default \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: YOUR_KEY" \
+  -d '{
+    "kind": "msteams",
+    "displayName": "Microsoft Teams",
+    "enabled": true,
+    "deliveryMode": "webhook",
+    "destinationType": "channel",
+    "teamId": "team-id",
+    "channelId": "channel-id",
+    "webhookUrl": "https://example.com/teams-adapter",
+    "credential": "write-only-token"
+  }'
+
+# Send or queue an external thread mapping
+curl -X POST http://localhost:3001/api/integrations/communication/adapters/msteams-default/send \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: YOUR_KEY" \
+  -d '{
+    "target": { "kind": "squad", "squadMessageId": "msg_parent", "taskId": "task-123" },
+    "message": "Please review this in Teams.",
+    "actor": "veritas"
+  }'
+
+# Ingest an external human reply
+curl -X POST http://localhost:3001/api/integrations/communication/adapters/msteams-default/replies \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: YOUR_KEY" \
+  -d '{
+    "externalThreadId": "teams-thread-1",
+    "externalReplyId": "reply-42",
+    "actor": "alice@example.com",
+    "displayName": "Alice",
+    "message": "Looks good. Please ship it.",
+    "target": { "kind": "squad", "squadMessageId": "msg_parent", "taskId": "task-123" }
+  }'
+```
+
+Setup and health operations require settings permissions. Reply ingestion
+requires comment-write permission, and approval-targeted replies require the
+same approval-capable authority as in-app approvals. Inbound reply bodies are
+HTML-stripped, secret-redacted, size-limited, and deduped by external reply ID.
+Adapter responses expose only redacted connection posture such as
+`webhookUrlConfigured`, `webhookUrlRedacted`, and `hasCredential`.
 
 ## System Message Events
 

--- a/server/src/__tests__/communication-adapter-service.test.ts
+++ b/server/src/__tests__/communication-adapter-service.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import type { ChatService } from '../services/chat-service.js';
+import type { OutboundIntegrationService } from '../services/outbound-integration-service.js';
+import { CommunicationAdapterService } from '../services/communication-adapter-service.js';
+
+describe('CommunicationAdapterService', () => {
+  let tmpDir: string;
+  let audit: ReturnType<typeof vi.fn>;
+  let chatService: Pick<ChatService, 'sendSquadMessage' | 'getSquadMessages'>;
+  let outboundIntegrations: Pick<OutboundIntegrationService, 'deliver'>;
+  let service: CommunicationAdapterService;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'communication-adapter-'));
+    audit = vi.fn().mockResolvedValue(undefined);
+    chatService = {
+      sendSquadMessage: vi.fn(),
+      getSquadMessages: vi.fn(),
+    } as unknown as Pick<ChatService, 'sendSquadMessage' | 'getSquadMessages'>;
+    outboundIntegrations = {
+      deliver: vi.fn().mockResolvedValue({ ok: true, status: 'success', attemptId: 'out_1' }),
+    } as unknown as Pick<OutboundIntegrationService, 'deliver'>;
+    service = new CommunicationAdapterService({
+      storageDir: tmpDir,
+      persist: true,
+      chatService: chatService as ChatService,
+      outboundIntegrations: outboundIntegrations as OutboundIntegrationService,
+      audit,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('stores adapter posture without returning credentials or sensitive URL parts', async () => {
+    const adapter = await service.configureAdapter('msteams-default', {
+      displayName: 'Ops Teams',
+      enabled: true,
+      deliveryMode: 'webhook',
+      destinationType: 'channel',
+      tenantId: 'tenant-1',
+      teamId: 'team-1',
+      channelId: 'channel-1',
+      webhookUrl: 'https://example.com/hooks/teams?token=query-secret',
+      credential: 'raw-access-token',
+    });
+
+    expect(adapter).toMatchObject({
+      id: 'msteams-default',
+      displayName: 'Ops Teams',
+      enabled: true,
+      webhookUrl: 'https://example.com/hooks/teams',
+      webhookUrlConfigured: true,
+      webhookUrlRedacted: true,
+      hasCredential: true,
+    });
+    expect(JSON.stringify(adapter)).not.toContain('query-secret');
+    expect(JSON.stringify(adapter)).not.toContain('raw-access-token');
+
+    const health = await service.checkHealth('msteams-default');
+    expect(health).toMatchObject({
+      status: 'ok',
+      configured: true,
+      canSend: true,
+      canReceiveReplies: true,
+    });
+  });
+
+  it('sends through webhook delivery and records an external thread mapping', async () => {
+    await service.configureAdapter('msteams-default', {
+      enabled: true,
+      deliveryMode: 'webhook',
+      webhookUrl: 'https://example.com/hooks/teams?token=query-secret',
+    });
+
+    const result = await service.send('msteams-default', {
+      target: { kind: 'squad', squadMessageId: 'msg_root' },
+      message: 'Need a human reply',
+      actor: 'veritas',
+    });
+
+    expect(result.delivery).toMatchObject({
+      operation: 'send',
+      status: 'success',
+      externalThreadId: 'msteams-default:squad:msg_root',
+    });
+    expect(result.mapping).toMatchObject({
+      externalThreadId: 'msteams-default:squad:msg_root',
+      target: { kind: 'squad', squadMessageId: 'msg_root' },
+    });
+    expect(outboundIntegrations.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'communication-adapter-webhook',
+        url: 'https://example.com/hooks/teams?token=query-secret',
+      }),
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+    expect(JSON.stringify(result)).not.toContain('query-secret');
+  });
+
+  it('ingests external replies as sanitized Squad Chat replies and dedupes retry IDs', async () => {
+    await service.configureAdapter('msteams-default', {
+      enabled: true,
+      deliveryMode: 'manual',
+      channelId: 'channel-1',
+    });
+    const squadReply = {
+      id: 'msg_reply',
+      agent: 'alice@example.com',
+      displayName: 'Alice',
+      message: 'Approved Bearer [REDACTED]',
+      timestamp: '2026-06-26T18:00:00.000Z',
+    };
+    vi.mocked(chatService.sendSquadMessage).mockResolvedValue(squadReply);
+    vi.mocked(chatService.getSquadMessages).mockResolvedValue([squadReply]);
+
+    const first = await service.ingestReply('msteams-default', {
+      externalThreadId: 'teams-thread-1',
+      externalReplyId: 'reply-1',
+      actor: 'alice@example.com',
+      displayName: 'Alice',
+      message: '<b>Approved</b> Bearer abcdefghijklmnopqrstuvwxyz1234567890',
+      target: { kind: 'squad', squadMessageId: 'msg_root', taskId: 'task-1' },
+    });
+
+    expect(first.delivery.status).toBe('success');
+    expect(chatService.sendSquadMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'alice@example.com',
+        message: 'Approved Bearer [REDACTED]',
+        replyToId: 'msg_root',
+        taskId: 'task-1',
+        tags: ['external-reply', 'adapter:msteams', 'target:squad'],
+      }),
+      'Alice'
+    );
+
+    const retry = await service.ingestReply('msteams-default', {
+      externalThreadId: 'teams-thread-1',
+      externalReplyId: 'reply-1',
+      actor: 'alice@example.com',
+      displayName: 'Alice',
+      message: 'duplicate',
+      target: { kind: 'squad', squadMessageId: 'msg_root', taskId: 'task-1' },
+    });
+
+    expect(retry.delivery).toMatchObject({ status: 'skipped', squadMessageId: 'msg_reply' });
+    expect(chatService.sendSquadMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/__tests__/routes/integrations.test.ts
+++ b/server/src/__tests__/routes/integrations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import express from 'express';
+import express, { type NextFunction, type Request, type Response } from 'express';
 import request from 'supertest';
 
 const { mockLookup } = vi.hoisted(() => ({
@@ -8,6 +8,22 @@ const { mockLookup } = vi.hoisted(() => ({
 
 const { mockSafeFetch } = vi.hoisted(() => ({
   mockSafeFetch: vi.fn(),
+}));
+
+const { mockCommunicationAdapters, mockBroadcastSquadMessage } = vi.hoisted(() => ({
+  mockCommunicationAdapters: {
+    listAdapters: vi.fn(),
+    getAdapter: vi.fn(),
+    configureAdapter: vi.fn(),
+    checkHealth: vi.fn(),
+    send: vi.fn(),
+    ingestReply: vi.fn(),
+    pollReplies: vi.fn(),
+    disconnectAdapter: vi.fn(),
+    listMappings: vi.fn(),
+    listDeliveries: vi.fn(),
+  },
+  mockBroadcastSquadMessage: vi.fn(),
 }));
 
 vi.mock('node:dns/promises', () => ({
@@ -34,8 +50,26 @@ vi.mock('../../services/config-service.js', () => ({
   },
 }));
 
+vi.mock('../../services/communication-adapter-service.js', () => ({
+  DEFAULT_ADAPTER_ID: 'msteams-default',
+  getCommunicationAdapterService: () => mockCommunicationAdapters,
+}));
+
+vi.mock('../../services/broadcast-service.js', () => ({
+  broadcastSquadMessage: mockBroadcastSquadMessage,
+}));
+
 import { integrationsRoutes } from '../../routes/integrations.js';
 import { getOutboundIntegrationService } from '../../services/outbound-integration-service.js';
+
+interface TestAuthRequest extends Request {
+  auth?: { role: string; permissions: string[] };
+}
+
+interface TestError extends Error {
+  statusCode?: number;
+  code?: string;
+}
 
 describe('integrations routes', () => {
   let app: express.Express;
@@ -49,8 +83,102 @@ describe('integrations routes', () => {
       status: 200,
       text: vi.fn().mockResolvedValue(''),
     } as unknown as Response);
+    mockCommunicationAdapters.listAdapters.mockResolvedValue([]);
+    mockCommunicationAdapters.getAdapter.mockResolvedValue({
+      id: 'msteams-default',
+      kind: 'msteams',
+      displayName: 'Microsoft Teams',
+      enabled: true,
+    });
+    mockCommunicationAdapters.configureAdapter.mockResolvedValue({
+      id: 'msteams-default',
+      kind: 'msteams',
+      displayName: 'Microsoft Teams',
+      enabled: true,
+      webhookUrl: 'https://example.com/hooks/teams',
+      webhookUrlConfigured: true,
+      webhookUrlRedacted: true,
+      hasCredential: true,
+    });
+    mockCommunicationAdapters.checkHealth.mockResolvedValue({
+      adapterId: 'msteams-default',
+      status: 'ok',
+      configured: true,
+      canSend: true,
+      canReceiveReplies: true,
+      checkedAt: '2026-06-26T18:00:00.000Z',
+      detail: 'ok',
+    });
+    mockCommunicationAdapters.send.mockResolvedValue({
+      delivery: {
+        id: 'comm_1',
+        adapterId: 'msteams-default',
+        operation: 'send',
+        status: 'queued',
+        createdAt: '2026-06-26T18:00:00.000Z',
+      },
+      mapping: {
+        id: 'map_1',
+        adapterId: 'msteams-default',
+        externalThreadId: 'thread-1',
+        target: { kind: 'notification' },
+        createdAt: '2026-06-26T18:00:00.000Z',
+        updatedAt: '2026-06-26T18:00:00.000Z',
+      },
+    });
+    mockCommunicationAdapters.ingestReply.mockResolvedValue({
+      delivery: {
+        id: 'comm_2',
+        adapterId: 'msteams-default',
+        operation: 'reply-ingest',
+        status: 'success',
+        createdAt: '2026-06-26T18:01:00.000Z',
+      },
+      mapping: {
+        id: 'map_1',
+        adapterId: 'msteams-default',
+        externalThreadId: 'thread-1',
+        target: { kind: 'squad', squadMessageId: 'msg_root' },
+        createdAt: '2026-06-26T18:00:00.000Z',
+        updatedAt: '2026-06-26T18:01:00.000Z',
+      },
+      squadMessageId: 'msg_reply',
+      squadMessage: {
+        id: 'msg_reply',
+        agent: 'alice',
+        message: 'reply',
+        timestamp: '2026-06-26T18:01:00.000Z',
+      },
+    });
+    mockCommunicationAdapters.pollReplies.mockResolvedValue({
+      delivery: {
+        id: 'comm_3',
+        adapterId: 'msteams-default',
+        operation: 'poll',
+        status: 'skipped',
+        createdAt: '2026-06-26T18:02:00.000Z',
+      },
+      replies: [],
+    });
+    mockCommunicationAdapters.disconnectAdapter.mockResolvedValue({
+      id: 'msteams-default',
+      kind: 'msteams',
+      displayName: 'Microsoft Teams',
+      enabled: false,
+      hasCredential: false,
+    });
+    mockCommunicationAdapters.listMappings.mockResolvedValue([]);
+    mockCommunicationAdapters.listDeliveries.mockResolvedValue([]);
     app = express();
+    app.use(express.json());
+    app.use((req: TestAuthRequest, _res: Response, next: NextFunction) => {
+      req.auth = { role: 'read-only', permissions: ['settings:read'] };
+      next();
+    });
     app.use('/api/integrations', integrationsRoutes);
+    app.use((err: TestError, _req: Request, res: Response, _next: NextFunction) => {
+      res.status(err.statusCode || 500).json({ code: err.code || 'ERROR', message: err.message });
+    });
   });
 
   afterEach(() => {
@@ -167,5 +295,66 @@ describe('integrations routes', () => {
     const responsePayload = JSON.stringify({ endpoint, attempt });
     expect(responsePayload).not.toContain('query-secret');
     expect(responsePayload).not.toContain('raw-token-value');
+  });
+
+  it('configures communication adapters without exposing secrets', async () => {
+    const res = await request(app)
+      .put('/api/integrations/communication/adapters/msteams-default')
+      .send({
+        displayName: 'Microsoft Teams',
+        enabled: true,
+        deliveryMode: 'webhook',
+        webhookUrl: 'https://example.com/hooks/teams?token=query-secret',
+        credential: 'raw-secret',
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockCommunicationAdapters.configureAdapter).toHaveBeenCalledWith(
+      'msteams-default',
+      expect.objectContaining({ credential: 'raw-secret' })
+    );
+    expect(JSON.stringify(res.body)).not.toContain('query-secret');
+    expect(JSON.stringify(res.body)).not.toContain('raw-secret');
+    expect(res.body).toMatchObject({
+      webhookUrl: 'https://example.com/hooks/teams',
+      webhookUrlConfigured: true,
+      webhookUrlRedacted: true,
+      hasCredential: true,
+    });
+  });
+
+  it('ingests communication replies and broadcasts the resulting squad message', async () => {
+    const res = await request(app)
+      .post('/api/integrations/communication/adapters/msteams-default/replies')
+      .send({
+        externalThreadId: 'thread-1',
+        externalReplyId: 'reply-1',
+        actor: 'alice',
+        message: 'Looks good',
+        target: { kind: 'squad', squadMessageId: 'msg_root' },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockCommunicationAdapters.ingestReply).toHaveBeenCalledWith(
+      'msteams-default',
+      expect.objectContaining({ externalReplyId: 'reply-1' })
+    );
+    expect(mockBroadcastSquadMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg_reply' })
+    );
+  });
+
+  it('rejects approval replies without approval-capable permissions', async () => {
+    const res = await request(app)
+      .post('/api/integrations/communication/adapters/msteams-default/replies')
+      .send({
+        externalThreadId: 'thread-1',
+        actor: 'alice',
+        message: 'approve',
+        target: { kind: 'approval', approvalId: 'approval-1' },
+      });
+
+    expect(res.status).toBe(403);
+    expect(mockCommunicationAdapters.ingestReply).not.toHaveBeenCalled();
   });
 });

--- a/server/src/routes/integrations.ts
+++ b/server/src/routes/integrations.ts
@@ -7,17 +7,26 @@
 import { Router } from 'express';
 import { lookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
+import { z } from 'zod';
 import { ConfigService } from '../services/config-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
-import { createLogger } from '../lib/logger.js';
+import { ForbiddenError, NotFoundError } from '../middleware/error-handler.js';
+import { hasPermission, type AuthenticatedRequest } from '../middleware/auth.js';
 import type { CoolifyServiceConfig, CoolifyServicesConfig } from '@veritas-kanban/shared';
+import { broadcastSquadMessage } from '../services/broadcast-service.js';
+import {
+  DEFAULT_ADAPTER_ID,
+  getCommunicationAdapterService,
+} from '../services/communication-adapter-service.js';
 import { getOutboundIntegrationService } from '../services/outbound-integration-service.js';
 import { safeFetch } from '../utils/url-validation.js';
+import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('integrations');
 const router = Router();
 const configService = new ConfigService();
 const outboundIntegrations = getOutboundIntegrationService();
+const communicationAdapters = getCommunicationAdapterService();
 
 const SERVICE_NAMES = ['supabase', 'openpanel', 'n8n', 'plane', 'appsmith'] as const;
 type ServiceName = (typeof SERVICE_NAMES)[number];
@@ -32,6 +41,76 @@ interface ServiceStatus {
 }
 
 const BLOCKED_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+const replyTargetSchema = z.object({
+  kind: z.enum(['squad', 'task', 'run', 'approval', 'notification']),
+  squadMessageId: z.string().optional(),
+  taskId: z.string().optional(),
+  runId: z.string().optional(),
+  approvalId: z.string().optional(),
+  notificationId: z.string().optional(),
+});
+
+const adapterConfigSchema = z.object({
+  kind: z.enum(['msteams']).optional(),
+  displayName: z.string().optional(),
+  enabled: z.boolean().optional(),
+  deliveryMode: z.enum(['manual', 'webhook']).optional(),
+  destinationType: z.enum(['channel', 'direct']).optional(),
+  tenantId: z.string().optional(),
+  teamId: z.string().optional(),
+  channelId: z.string().optional(),
+  chatId: z.string().optional(),
+  webhookUrl: z.string().optional(),
+  credential: z.string().optional(),
+});
+
+const sendSchema = z.object({
+  target: replyTargetSchema,
+  message: z.string().min(1),
+  actor: z.string().optional(),
+  externalThreadId: z.string().optional(),
+  externalUrl: z.string().optional(),
+});
+
+const replyIngestSchema = z.object({
+  externalThreadId: z.string().min(1),
+  externalReplyId: z.string().optional(),
+  actor: z.string().min(1),
+  displayName: z.string().optional(),
+  message: z.string().min(1),
+  target: replyTargetSchema.optional(),
+  externalUrl: z.string().optional(),
+});
+
+function adapterIdParam(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value : DEFAULT_ADAPTER_ID;
+}
+
+async function ensureAdapterExists(adapterId: string): Promise<void> {
+  const adapter = await communicationAdapters.getAdapter(adapterId);
+  if (!adapter) {
+    throw new NotFoundError(`Communication adapter ${adapterId} not found`);
+  }
+}
+
+function enforceApprovalReplyPermission(
+  req: AuthenticatedRequest,
+  target?: { kind: string }
+): void {
+  if (target?.kind !== 'approval') return;
+  if (
+    hasPermission(req.auth, 'workflow:execute') ||
+    hasPermission(req.auth, 'task:write') ||
+    hasPermission(req.auth, 'admin:manage')
+  ) {
+    return;
+  }
+
+  throw new ForbiddenError('Approval replies require approval-capable permissions', {
+    required: ['workflow:execute', 'task:write'],
+  });
+}
 
 function isPrivateIpv4(hostname: string): boolean {
   const parts = hostname.split('.').map((p) => Number(p));
@@ -175,6 +254,121 @@ router.get(
     const rawLimit = typeof req.query.limit === 'string' ? Number(req.query.limit) : 100;
     const limit = Number.isFinite(rawLimit) ? rawLimit : 100;
     res.json(await outboundIntegrations.listDeliveries(limit));
+  })
+);
+
+// GET /api/integrations/communication/adapters
+router.get(
+  '/communication/adapters',
+  asyncHandler(async (_req, res) => {
+    res.json(await communicationAdapters.listAdapters());
+  })
+);
+
+// PUT /api/integrations/communication/adapters/:adapterId
+router.put(
+  '/communication/adapters/:adapterId',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    const input = adapterConfigSchema.parse(req.body);
+    res.json(await communicationAdapters.configureAdapter(adapterId, input));
+  })
+);
+
+// GET /api/integrations/communication/adapters/:adapterId/health
+router.get(
+  '/communication/adapters/:adapterId/health',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    res.json(await communicationAdapters.checkHealth(adapterId));
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/test
+router.post(
+  '/communication/adapters/:adapterId/test',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    const message =
+      typeof req.body?.message === 'string' && req.body.message.trim()
+        ? req.body.message
+        : 'Veritas communication adapter test';
+    const result = await communicationAdapters.send(adapterId, {
+      target: { kind: 'notification', notificationId: 'adapter-test' },
+      message,
+      actor: 'system',
+    });
+    res.json(result);
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/send
+router.post(
+  '/communication/adapters/:adapterId/send',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    const input = sendSchema.parse(req.body);
+    const result = await communicationAdapters.send(adapterId, input);
+    res.status(result.delivery.status === 'blocked' ? 409 : 202).json(result);
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/replies
+router.post(
+  '/communication/adapters/:adapterId/replies',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    const input = replyIngestSchema.parse(req.body);
+    enforceApprovalReplyPermission(req as AuthenticatedRequest, input.target);
+    const result = await communicationAdapters.ingestReply(adapterId, input);
+    if (result.squadMessage) {
+      broadcastSquadMessage(result.squadMessage);
+    }
+    res.status(result.delivery.status === 'success' ? 201 : 400).json(result);
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/poll
+router.post(
+  '/communication/adapters/:adapterId/poll',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    res.json(await communicationAdapters.pollReplies(adapterId));
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/disconnect
+router.post(
+  '/communication/adapters/:adapterId/disconnect',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    res.json(await communicationAdapters.disconnectAdapter(adapterId));
+  })
+);
+
+// GET /api/integrations/communication/mappings?adapterId=msteams-default
+router.get(
+  '/communication/mappings',
+  asyncHandler(async (req, res) => {
+    const adapterId = typeof req.query.adapterId === 'string' ? req.query.adapterId : undefined;
+    res.json(await communicationAdapters.listMappings(adapterId));
+  })
+);
+
+// GET /api/integrations/communication/deliveries?adapterId=msteams-default&limit=100
+router.get(
+  '/communication/deliveries',
+  asyncHandler(async (req, res) => {
+    const rawLimit = typeof req.query.limit === 'string' ? Number(req.query.limit) : 100;
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 100;
+    const adapterId = typeof req.query.adapterId === 'string' ? req.query.adapterId : undefined;
+    res.json(await communicationAdapters.listDeliveries(limit, adapterId));
   })
 );
 

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -31,6 +31,7 @@ import {
   delegationAccess,
   diffAccess,
   feedbackAccess,
+  integrationsAccess,
   notificationAccess,
   policyAccess,
   queueMonitorAccess,
@@ -239,7 +240,7 @@ v1Router.use('/policies', policyAccess, policyRoutes);
 v1Router.use('/sandbox-policies', sandboxPolicyAccess, sandboxPolicyRoutes);
 v1Router.use('/skills/capabilities', skillCapabilityAccess, skillCapabilityRoutes);
 v1Router.use('/skills/security', skillSecurityAccess, skillSecurityRoutes);
-v1Router.use('/integrations', settingsAccess, integrationsRoutes);
+v1Router.use('/integrations', integrationsAccess, integrationsRoutes);
 v1Router.use('/transcripts', transcriptAccess, transcriptRoutes);
 v1Router.use('/scoring', scoringAccess, scoringRoutes);
 v1Router.use('/system/health', workspaceAccess, systemHealthRouter);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -75,6 +75,13 @@ export const statusHistoryAccess = routeAccess('telemetry:read', 'admin:manage')
 export const delegationAccess = routeAccess('agent:read', 'admin:manage');
 export const transcriptAccess = routeAccess('workspace:read', 'workflow:execute');
 export const feedbackAccess = routeAccess('report:read', 'comment:write');
+export const integrationsAccess = routeAccess('settings:read', 'settings:write', [
+  {
+    methods: ['POST'],
+    path: /^\/communication\/adapters\/[^/]+\/replies\/?$/,
+    permissions: 'comment:write',
+  },
+]);
 
 export const configAccess = routeAccess('settings:read', 'settings:write', [
   { methods: ['POST'], path: /^\/repos\/validate\/?$/, permissions: 'settings:read' },

--- a/server/src/services/communication-adapter-service.ts
+++ b/server/src/services/communication-adapter-service.ts
@@ -1,0 +1,674 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { nanoid } from 'nanoid';
+import type {
+  CommunicationAdapterHealth,
+  CommunicationAdapterInput,
+  CommunicationAdapterRecord,
+  CommunicationDeliveryAudit,
+  CommunicationDeliveryOperation,
+  CommunicationDeliveryStatus,
+  CommunicationReplyIngestInput,
+  CommunicationReplyIngestResult,
+  CommunicationReplyTarget,
+  CommunicationSendInput,
+  CommunicationSendResult,
+  CommunicationThreadMapping,
+  SquadMessage,
+} from '@veritas-kanban/shared';
+import { auditLog, type AuditEvent } from './audit-service.js';
+import { getChatService, type ChatService } from './chat-service.js';
+import {
+  getOutboundIntegrationService,
+  type OutboundIntegrationService,
+} from './outbound-integration-service.js';
+import { withFileLock } from './file-lock.js';
+import { redactString } from '../lib/redact.js';
+import { ensureWithinBase, sanitizeCommentText, validatePathSegment } from '../utils/sanitize.js';
+import { getRuntimeDir } from '../utils/paths.js';
+
+const DEFAULT_ADAPTER_ID = 'msteams-default';
+const MAX_DELIVERIES = 500;
+const MAX_MESSAGE_LENGTH = 4000;
+
+interface InternalCommunicationAdapterRecord extends CommunicationAdapterRecord {
+  webhookUrlRaw?: string;
+}
+
+interface CommunicationAdapterState {
+  version: 1;
+  adapters: Record<string, InternalCommunicationAdapterRecord>;
+  mappings: Record<string, CommunicationThreadMapping>;
+  replyIds: Record<string, string>;
+  deliveries: CommunicationDeliveryAudit[];
+  updatedAt: string;
+}
+
+export interface CommunicationAdapterServiceOptions {
+  storageDir?: string;
+  persist?: boolean;
+  chatService?: ChatService;
+  outboundIntegrations?: OutboundIntegrationService;
+  audit?: (event: AuditEvent) => Promise<void>;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function trimOrUndefined(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function sanitizeUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return '[invalid-url]';
+  }
+}
+
+function sanitizeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return redactString(message).slice(0, 500);
+}
+
+function normalizeTarget(target: CommunicationReplyTarget): CommunicationReplyTarget {
+  return {
+    kind: target.kind,
+    squadMessageId: trimOrUndefined(target.squadMessageId),
+    taskId: trimOrUndefined(target.taskId),
+    runId: trimOrUndefined(target.runId),
+    approvalId: trimOrUndefined(target.approvalId),
+    notificationId: trimOrUndefined(target.notificationId),
+  };
+}
+
+function targetKey(target: CommunicationReplyTarget): string {
+  return [
+    target.kind,
+    target.squadMessageId,
+    target.taskId,
+    target.runId,
+    target.approvalId,
+    target.notificationId,
+  ]
+    .filter(Boolean)
+    .join(':');
+}
+
+function stripUnsafeControlCharacters(value: string): string {
+  return Array.from(value)
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127);
+    })
+    .join('');
+}
+
+function cleanInboundMessage(message: string): string {
+  return stripUnsafeControlCharacters(sanitizeCommentText(redactString(message)))
+    .trim()
+    .slice(0, MAX_MESSAGE_LENGTH);
+}
+
+export class CommunicationAdapterService {
+  private readonly storageDir: string;
+  private readonly persist: boolean;
+  private readonly chatService: ChatService;
+  private readonly outboundIntegrations: OutboundIntegrationService;
+  private readonly audit: (event: AuditEvent) => Promise<void>;
+  private loaded = false;
+  private state: CommunicationAdapterState = this.emptyState();
+
+  constructor(options: CommunicationAdapterServiceOptions = {}) {
+    this.storageDir = options.storageDir || path.join(getRuntimeDir(), 'communication-adapters');
+    this.persist = options.persist ?? process.env.VITEST !== 'true';
+    this.chatService = options.chatService || getChatService();
+    this.outboundIntegrations = options.outboundIntegrations || getOutboundIntegrationService();
+    this.audit = options.audit || auditLog;
+  }
+
+  async listAdapters(): Promise<CommunicationAdapterRecord[]> {
+    await this.ensureLoaded();
+    return Object.values(this.state.adapters)
+      .map((adapter) => this.publicAdapter(adapter))
+      .sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  async getAdapter(adapterId: string): Promise<CommunicationAdapterRecord | null> {
+    await this.ensureLoaded();
+    const adapter = this.state.adapters[adapterId];
+    return adapter ? this.publicAdapter(adapter) : null;
+  }
+
+  async configureAdapter(
+    adapterId: string,
+    input: CommunicationAdapterInput
+  ): Promise<CommunicationAdapterRecord> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+
+    const timestamp = nowIso();
+    const existing = this.state.adapters[adapterId];
+    const rawWebhook =
+      input.webhookUrl !== undefined ? trimOrUndefined(input.webhookUrl) : existing?.webhookUrlRaw;
+    const adapter: InternalCommunicationAdapterRecord = {
+      id: adapterId,
+      kind: input.kind ?? existing?.kind ?? 'msteams',
+      displayName: trimOrUndefined(input.displayName) ?? existing?.displayName ?? 'Microsoft Teams',
+      enabled: input.enabled ?? existing?.enabled ?? true,
+      deliveryMode: input.deliveryMode ?? existing?.deliveryMode ?? 'manual',
+      replyMode: 'ingest-api',
+      destinationType: input.destinationType ?? existing?.destinationType ?? 'channel',
+      tenantId: trimOrUndefined(input.tenantId) ?? existing?.tenantId,
+      teamId: trimOrUndefined(input.teamId) ?? existing?.teamId,
+      channelId: trimOrUndefined(input.channelId) ?? existing?.channelId,
+      chatId: trimOrUndefined(input.chatId) ?? existing?.chatId,
+      webhookUrl: sanitizeUrl(rawWebhook),
+      webhookUrlRaw: rawWebhook,
+      webhookUrlConfigured: Boolean(rawWebhook),
+      webhookUrlRedacted: Boolean(rawWebhook),
+      hasCredential: Boolean(input.credential?.trim()) || existing?.hasCredential || false,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+      lastHealth: existing?.lastHealth,
+    };
+
+    this.state.adapters[adapterId] = adapter;
+    const delivery = this.recordDelivery({
+      adapterId,
+      operation: 'configure',
+      status: 'success',
+    });
+    await this.saveState();
+    await this.auditAdapter('communication_adapter.configured', adapter, delivery);
+    return this.publicAdapter(adapter);
+  }
+
+  async disconnectAdapter(adapterId: string): Promise<CommunicationAdapterRecord> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    const timestamp = nowIso();
+    const disconnected: InternalCommunicationAdapterRecord = {
+      ...adapter,
+      enabled: false,
+      webhookUrl: undefined,
+      webhookUrlRaw: undefined,
+      webhookUrlConfigured: false,
+      webhookUrlRedacted: false,
+      hasCredential: false,
+      updatedAt: timestamp,
+    };
+    this.state.adapters[adapterId] = disconnected;
+    const delivery = this.recordDelivery({
+      adapterId,
+      operation: 'disconnect',
+      status: 'success',
+    });
+    await this.saveState();
+    await this.auditAdapter('communication_adapter.disconnected', disconnected, delivery);
+    return this.publicAdapter(disconnected);
+  }
+
+  async checkHealth(adapterId: string): Promise<CommunicationAdapterHealth> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    const configured = this.hasDestination(adapter);
+    const health: CommunicationAdapterHealth = {
+      adapterId,
+      status: !adapter.enabled ? 'disabled' : configured ? 'ok' : 'warning',
+      configured,
+      canSend: adapter.enabled && configured,
+      canReceiveReplies: adapter.enabled && configured && adapter.replyMode === 'ingest-api',
+      checkedAt: nowIso(),
+      detail: !adapter.enabled
+        ? 'Adapter is disabled.'
+        : configured
+          ? 'Adapter can send through the configured delivery path and receive replies through the ingest API.'
+          : 'Configure a Teams destination or webhook before sending messages.',
+    };
+
+    adapter.lastHealth = health;
+    adapter.updatedAt = health.checkedAt;
+    this.recordDelivery({
+      adapterId,
+      operation: 'health',
+      status: health.status === 'ok' ? 'success' : 'skipped',
+    });
+    await this.saveState();
+    return health;
+  }
+
+  async send(adapterId: string, input: CommunicationSendInput): Promise<CommunicationSendResult> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    const target = normalizeTarget(input.target);
+    const externalThreadId =
+      trimOrUndefined(input.externalThreadId) ?? this.buildExternalThreadId(adapterId, target);
+    const mapping = this.upsertMapping({
+      adapterId,
+      externalThreadId,
+      externalUrl: trimOrUndefined(input.externalUrl),
+      target,
+      createdBy: trimOrUndefined(input.actor),
+    });
+
+    if (!adapter.enabled || !this.hasDestination(adapter)) {
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'send',
+        status: 'blocked',
+        target,
+        externalThreadId,
+        error: !adapter.enabled ? 'Adapter disabled' : 'Adapter destination missing',
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping };
+    }
+
+    const delivery = await this.deliverOutbound(adapter, input, mapping);
+    await this.saveState();
+    await this.auditDelivery(delivery);
+    return { delivery, mapping };
+  }
+
+  async ingestReply(
+    adapterId: string,
+    input: CommunicationReplyIngestInput
+  ): Promise<CommunicationReplyIngestResult> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    const externalThreadId = trimOrUndefined(input.externalThreadId);
+    if (!externalThreadId) {
+      throw new Error('externalThreadId is required');
+    }
+
+    const existing = this.findMapping(adapterId, externalThreadId);
+    const target = normalizeTarget(input.target ?? existing?.target ?? { kind: 'squad' });
+    const mapping = this.upsertMapping({
+      adapterId,
+      externalThreadId,
+      externalUrl: trimOrUndefined(input.externalUrl) ?? existing?.externalUrl,
+      target,
+      createdBy: trimOrUndefined(input.actor),
+    });
+    const replyKey = input.externalReplyId
+      ? `${adapterId}:${input.externalThreadId}:${input.externalReplyId}`
+      : undefined;
+    const existingReplyMessageId = replyKey ? this.state.replyIds[replyKey] : undefined;
+    if (existingReplyMessageId) {
+      const squadMessage = await this.findSquadMessage(existingReplyMessageId);
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'reply-ingest',
+        status: 'skipped',
+        target,
+        externalThreadId,
+        actor: input.actor,
+        squadMessageId: existingReplyMessageId,
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return {
+        delivery,
+        mapping,
+        squadMessageId: existingReplyMessageId,
+        squadMessage,
+      };
+    }
+
+    const cleanedMessage = cleanInboundMessage(input.message);
+    if (!cleanedMessage) {
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'reply-ingest',
+        status: 'blocked',
+        target,
+        externalThreadId,
+        actor: input.actor,
+        error: 'Reply message is empty after sanitization',
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping, squadMessageId: '' };
+    }
+
+    const squadMessage = await this.chatService.sendSquadMessage(
+      {
+        agent: input.actor,
+        message: cleanedMessage,
+        replyToId: target.squadMessageId,
+        taskId: target.taskId,
+        runId: target.runId,
+        decision: target.kind === 'approval' ? true : undefined,
+        tags: ['external-reply', `adapter:${adapter.kind}`, `target:${target.kind}`],
+      },
+      input.displayName
+    );
+
+    if (replyKey) {
+      this.state.replyIds[replyKey] = squadMessage.id;
+    }
+
+    const delivery = this.recordDelivery({
+      adapterId,
+      operation: 'reply-ingest',
+      status: 'success',
+      target,
+      externalThreadId,
+      actor: input.actor,
+      squadMessageId: squadMessage.id,
+    });
+
+    await this.saveState();
+    await this.auditDelivery(delivery);
+    return { delivery, mapping, squadMessageId: squadMessage.id, squadMessage };
+  }
+
+  async pollReplies(
+    adapterId: string
+  ): Promise<{ delivery: CommunicationDeliveryAudit; replies: [] }> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    this.requireAdapter(adapterId);
+    const delivery = this.recordDelivery({
+      adapterId,
+      operation: 'poll',
+      status: 'skipped',
+      error: 'Reply polling is adapter-defined; this adapter uses the ingest API.',
+    });
+    await this.saveState();
+    await this.auditDelivery(delivery);
+    return { delivery, replies: [] };
+  }
+
+  async listMappings(adapterId?: string): Promise<CommunicationThreadMapping[]> {
+    await this.ensureLoaded();
+    return Object.values(this.state.mappings)
+      .filter((mapping) => !adapterId || mapping.adapterId === adapterId)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  async listDeliveries(limit = 100, adapterId?: string): Promise<CommunicationDeliveryAudit[]> {
+    await this.ensureLoaded();
+    const safeLimit = Math.max(1, Math.min(Math.floor(limit), MAX_DELIVERIES));
+    return this.state.deliveries
+      .filter((delivery) => !adapterId || delivery.adapterId === adapterId)
+      .slice(-safeLimit)
+      .reverse();
+  }
+
+  private async deliverOutbound(
+    adapter: InternalCommunicationAdapterRecord,
+    input: CommunicationSendInput,
+    mapping: CommunicationThreadMapping
+  ): Promise<CommunicationDeliveryAudit> {
+    const target = normalizeTarget(input.target);
+    if (adapter.deliveryMode !== 'webhook' || !adapter.webhookUrlRaw) {
+      return this.recordDelivery({
+        adapterId: adapter.id,
+        operation: 'send',
+        status: 'queued',
+        target,
+        externalThreadId: mapping.externalThreadId,
+      });
+    }
+
+    const outbound = await this.outboundIntegrations.deliver(
+      {
+        id: `communication.${adapter.id}`,
+        type: 'communication-adapter-webhook',
+        displayName: adapter.displayName,
+        url: adapter.webhookUrlRaw,
+        enabled: adapter.enabled,
+        owner: { source: 'runtime', resourceId: `communication.${adapter.id}` },
+      },
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          adapterId: adapter.id,
+          kind: adapter.kind,
+          target,
+          message: input.message,
+          externalThreadId: mapping.externalThreadId,
+          externalUrl: mapping.externalUrl,
+          actor: input.actor ?? 'veritas',
+        }),
+        responseBodyLimit: 1024,
+      }
+    );
+
+    return this.recordDelivery({
+      adapterId: adapter.id,
+      operation: 'send',
+      status: outbound.ok ? 'success' : outbound.status === 'blocked' ? 'blocked' : 'failed',
+      target,
+      externalThreadId: mapping.externalThreadId,
+      error: outbound.error,
+    });
+  }
+
+  private buildExternalThreadId(adapterId: string, target: CommunicationReplyTarget): string {
+    const key = targetKey(target);
+    if (key) return `${adapterId}:${key}`;
+    return `${adapterId}:thread:${nanoid(8)}`;
+  }
+
+  private findMapping(
+    adapterId: string,
+    externalThreadId: string
+  ): CommunicationThreadMapping | undefined {
+    return Object.values(this.state.mappings).find(
+      (mapping) => mapping.adapterId === adapterId && mapping.externalThreadId === externalThreadId
+    );
+  }
+
+  private upsertMapping(input: {
+    adapterId: string;
+    externalThreadId: string;
+    externalUrl?: string;
+    target: CommunicationReplyTarget;
+    createdBy?: string;
+  }): CommunicationThreadMapping {
+    const existing = this.findMapping(input.adapterId, input.externalThreadId);
+    const timestamp = nowIso();
+    const mapping: CommunicationThreadMapping = {
+      id: existing?.id ?? `map_${nanoid(10)}`,
+      adapterId: input.adapterId,
+      externalThreadId: input.externalThreadId,
+      externalUrl: sanitizeUrl(input.externalUrl),
+      target: input.target,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+      createdBy: existing?.createdBy ?? input.createdBy,
+    };
+    this.state.mappings[mapping.id] = mapping;
+    return mapping;
+  }
+
+  private recordDelivery(input: {
+    adapterId: string;
+    operation: CommunicationDeliveryOperation;
+    status: CommunicationDeliveryStatus;
+    target?: CommunicationReplyTarget;
+    externalThreadId?: string;
+    squadMessageId?: string;
+    actor?: string;
+    error?: string;
+  }): CommunicationDeliveryAudit {
+    const delivery: CommunicationDeliveryAudit = {
+      id: `comm_${nanoid(10)}`,
+      adapterId: input.adapterId,
+      operation: input.operation,
+      status: input.status,
+      target: input.target,
+      externalThreadId: input.externalThreadId,
+      squadMessageId: input.squadMessageId,
+      actor: input.actor,
+      error: input.error ? sanitizeError(input.error) : undefined,
+      createdAt: nowIso(),
+    };
+    this.state.deliveries.push(delivery);
+    if (this.state.deliveries.length > MAX_DELIVERIES) {
+      this.state.deliveries = this.state.deliveries.slice(-MAX_DELIVERIES);
+    }
+    return delivery;
+  }
+
+  private hasDestination(adapter: InternalCommunicationAdapterRecord): boolean {
+    if (adapter.deliveryMode === 'webhook') {
+      return Boolean(adapter.webhookUrlRaw);
+    }
+    if (adapter.destinationType === 'direct') {
+      return Boolean(adapter.chatId);
+    }
+    return Boolean(adapter.channelId || adapter.teamId);
+  }
+
+  private requireAdapter(adapterId: string): InternalCommunicationAdapterRecord {
+    const adapter = this.state.adapters[adapterId];
+    if (!adapter) {
+      throw new Error(`Communication adapter ${adapterId} not found`);
+    }
+    return adapter;
+  }
+
+  private publicAdapter(adapter: InternalCommunicationAdapterRecord): CommunicationAdapterRecord {
+    const { webhookUrlRaw: _webhookUrlRaw, ...publicRecord } = adapter;
+    return {
+      ...publicRecord,
+      webhookUrl: adapter.webhookUrlRaw ? sanitizeUrl(adapter.webhookUrlRaw) : undefined,
+      webhookUrlConfigured: Boolean(adapter.webhookUrlRaw),
+      webhookUrlRedacted: Boolean(adapter.webhookUrlRaw),
+      hasCredential: Boolean(adapter.hasCredential),
+    };
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    if (!this.persist) {
+      this.loaded = true;
+      return;
+    }
+
+    await fs.mkdir(this.storageDir, { recursive: true });
+    try {
+      const raw = await fs.readFile(this.statePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<CommunicationAdapterState>;
+      this.state = {
+        version: 1,
+        adapters:
+          parsed.adapters && typeof parsed.adapters === 'object'
+            ? (parsed.adapters as Record<string, InternalCommunicationAdapterRecord>)
+            : {},
+        mappings:
+          parsed.mappings && typeof parsed.mappings === 'object'
+            ? (parsed.mappings as Record<string, CommunicationThreadMapping>)
+            : {},
+        replyIds:
+          parsed.replyIds && typeof parsed.replyIds === 'object'
+            ? (parsed.replyIds as Record<string, string>)
+            : {},
+        deliveries: Array.isArray(parsed.deliveries)
+          ? (parsed.deliveries as CommunicationDeliveryAudit[]).slice(-MAX_DELIVERIES)
+          : [],
+        updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : nowIso(),
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      this.state = this.emptyState();
+    }
+    this.loaded = true;
+  }
+
+  private async saveState(): Promise<void> {
+    this.state.updatedAt = nowIso();
+    if (!this.persist) return;
+    await fs.mkdir(this.storageDir, { recursive: true });
+    await withFileLock(this.statePath, async () => {
+      await fs.writeFile(this.statePath, JSON.stringify(this.state, null, 2), 'utf-8');
+    });
+  }
+
+  private get statePath(): string {
+    const filePath = path.join(this.storageDir, 'state.json');
+    ensureWithinBase(this.storageDir, filePath);
+    return filePath;
+  }
+
+  private emptyState(): CommunicationAdapterState {
+    return {
+      version: 1,
+      adapters: {},
+      mappings: {},
+      replyIds: {},
+      deliveries: [],
+      updatedAt: nowIso(),
+    };
+  }
+
+  private async findSquadMessage(messageId: string): Promise<SquadMessage | undefined> {
+    const messages = await this.chatService.getSquadMessages({ includeSystem: true, limit: 500 });
+    return messages.find((message) => message.id === messageId);
+  }
+
+  private async auditAdapter(
+    action: string,
+    adapter: InternalCommunicationAdapterRecord,
+    delivery: CommunicationDeliveryAudit
+  ): Promise<void> {
+    await this.audit({
+      action,
+      actor: 'system',
+      resource: adapter.id,
+      details: {
+        adapter: this.publicAdapter(adapter),
+        delivery,
+      },
+    });
+  }
+
+  private async auditDelivery(delivery: CommunicationDeliveryAudit): Promise<void> {
+    await this.audit({
+      action: `communication_adapter.${delivery.operation}`,
+      actor: delivery.actor ?? 'system',
+      resource: delivery.adapterId,
+      details: {
+        status: delivery.status,
+        target: delivery.target,
+        externalThreadId: delivery.externalThreadId,
+        squadMessageId: delivery.squadMessageId,
+        error: delivery.error,
+      },
+    });
+  }
+}
+
+let communicationAdapterService: CommunicationAdapterService | null = null;
+
+export function getCommunicationAdapterService(): CommunicationAdapterService {
+  if (!communicationAdapterService) {
+    communicationAdapterService = new CommunicationAdapterService();
+  }
+  return communicationAdapterService;
+}
+
+export function resetCommunicationAdapterServiceForTests(): void {
+  communicationAdapterService = null;
+}
+
+export { DEFAULT_ADAPTER_ID };

--- a/server/src/services/outbound-integration-service.ts
+++ b/server/src/services/outbound-integration-service.ts
@@ -18,7 +18,8 @@ export type OutboundEndpointType =
   | 'squad-webhook'
   | 'openclaw-wake'
   | 'openclaw-gateway'
-  | 'failure-alert-webhook';
+  | 'failure-alert-webhook'
+  | 'communication-adapter-webhook';
 
 export type OutboundDeliveryStatus = 'success' | 'failed' | 'blocked' | 'timeout' | 'skipped';
 

--- a/shared/src/types/communication-adapter.types.ts
+++ b/shared/src/types/communication-adapter.types.ts
@@ -1,0 +1,131 @@
+import type { SquadMessage } from './chat.types.js';
+
+export type CommunicationAdapterKind = 'msteams';
+
+export type CommunicationAdapterDeliveryMode = 'manual' | 'webhook';
+
+export type CommunicationAdapterDestinationType = 'channel' | 'direct';
+
+export type CommunicationAdapterHealthStatus = 'ok' | 'warning' | 'disabled' | 'error';
+
+export type CommunicationAdapterReplyMode = 'ingest-api';
+
+export type CommunicationReplyTargetKind = 'squad' | 'task' | 'run' | 'approval' | 'notification';
+
+export interface CommunicationReplyTarget {
+  kind: CommunicationReplyTargetKind;
+  squadMessageId?: string;
+  taskId?: string;
+  runId?: string;
+  approvalId?: string;
+  notificationId?: string;
+}
+
+export interface CommunicationAdapterRecord {
+  id: string;
+  kind: CommunicationAdapterKind;
+  displayName: string;
+  enabled: boolean;
+  deliveryMode: CommunicationAdapterDeliveryMode;
+  replyMode: CommunicationAdapterReplyMode;
+  destinationType: CommunicationAdapterDestinationType;
+  tenantId?: string;
+  teamId?: string;
+  channelId?: string;
+  chatId?: string;
+  webhookUrl?: string;
+  webhookUrlConfigured?: boolean;
+  webhookUrlRedacted?: boolean;
+  hasCredential: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastHealth?: CommunicationAdapterHealth;
+}
+
+export interface CommunicationAdapterInput {
+  kind?: CommunicationAdapterKind;
+  displayName?: string;
+  enabled?: boolean;
+  deliveryMode?: CommunicationAdapterDeliveryMode;
+  destinationType?: CommunicationAdapterDestinationType;
+  tenantId?: string;
+  teamId?: string;
+  channelId?: string;
+  chatId?: string;
+  webhookUrl?: string;
+  credential?: string;
+}
+
+export interface CommunicationAdapterHealth {
+  adapterId: string;
+  status: CommunicationAdapterHealthStatus;
+  configured: boolean;
+  canSend: boolean;
+  canReceiveReplies: boolean;
+  checkedAt: string;
+  detail: string;
+}
+
+export interface CommunicationThreadMapping {
+  id: string;
+  adapterId: string;
+  externalThreadId: string;
+  externalUrl?: string;
+  target: CommunicationReplyTarget;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+}
+
+export type CommunicationDeliveryOperation =
+  | 'configure'
+  | 'health'
+  | 'send'
+  | 'reply-ingest'
+  | 'poll'
+  | 'disconnect';
+
+export type CommunicationDeliveryStatus = 'success' | 'queued' | 'failed' | 'blocked' | 'skipped';
+
+export interface CommunicationDeliveryAudit {
+  id: string;
+  adapterId: string;
+  operation: CommunicationDeliveryOperation;
+  status: CommunicationDeliveryStatus;
+  target?: CommunicationReplyTarget;
+  externalThreadId?: string;
+  squadMessageId?: string;
+  actor?: string;
+  error?: string;
+  createdAt: string;
+}
+
+export interface CommunicationSendInput {
+  target: CommunicationReplyTarget;
+  message: string;
+  actor?: string;
+  externalThreadId?: string;
+  externalUrl?: string;
+}
+
+export interface CommunicationSendResult {
+  delivery: CommunicationDeliveryAudit;
+  mapping: CommunicationThreadMapping;
+}
+
+export interface CommunicationReplyIngestInput {
+  externalThreadId: string;
+  externalReplyId?: string;
+  actor: string;
+  displayName?: string;
+  message: string;
+  target?: CommunicationReplyTarget;
+  externalUrl?: string;
+}
+
+export interface CommunicationReplyIngestResult {
+  delivery: CommunicationDeliveryAudit;
+  mapping: CommunicationThreadMapping;
+  squadMessageId: string;
+  squadMessage?: SquadMessage;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -7,6 +7,7 @@ export * from './template.types.js';
 export * from './websocket.types.js';
 export * from './managed-list.types.js';
 export * from './chat.types.js';
+export * from './communication-adapter.types.js';
 export * from './transition-hooks.types.js';
 export * from './delegation.types.js';
 export * from './changes.types.js';

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -325,7 +325,18 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     write: 'admin:manage',
     overrides: [{ methods: ['POST'], path: /^\/scan\/?$/, permissions: 'admin:manage' }],
   },
-  { prefix: '/api/integrations', read: 'settings:read', write: 'settings:write' },
+  {
+    prefix: '/api/integrations',
+    read: 'settings:read',
+    write: 'settings:write',
+    overrides: [
+      {
+        methods: ['POST'],
+        path: /^\/communication\/adapters\/[^/]+\/replies\/?$/,
+        permissions: 'comment:write',
+      },
+    ],
+  },
   { prefix: '/api/transcripts', read: 'workspace:read', write: 'workflow:execute' },
   {
     prefix: '/api/scoring',

--- a/web/src/__tests__/settings-tabs-mantine-controls.test.tsx
+++ b/web/src/__tests__/settings-tabs-mantine-controls.test.tsx
@@ -67,6 +67,93 @@ const mocks = vi.hoisted(() => ({
       completedAt: '2026-06-04T08:00:02.000Z',
     },
   ]),
+  communicationAdapters: vi.fn(async () => [
+    {
+      id: 'msteams-default',
+      kind: 'msteams',
+      displayName: 'Microsoft Teams',
+      enabled: true,
+      deliveryMode: 'manual',
+      replyMode: 'ingest-api',
+      destinationType: 'channel',
+      teamId: 'team-1',
+      channelId: 'channel-1',
+      hasCredential: false,
+      createdAt: '2026-06-04T08:00:00.000Z',
+      updatedAt: '2026-06-04T08:00:00.000Z',
+      lastHealth: {
+        adapterId: 'msteams-default',
+        status: 'ok',
+        configured: true,
+        canSend: true,
+        canReceiveReplies: true,
+        checkedAt: '2026-06-04T08:00:00.000Z',
+        detail:
+          'Adapter can send through the configured delivery path and receive replies through the ingest API.',
+      },
+    },
+  ]),
+  communicationHealth: vi.fn(async () => ({
+    adapterId: 'msteams-default',
+    status: 'ok',
+    configured: true,
+    canSend: true,
+    canReceiveReplies: true,
+    checkedAt: '2026-06-04T08:00:00.000Z',
+    detail:
+      'Adapter can send through the configured delivery path and receive replies through the ingest API.',
+  })),
+  communicationDeliveries: vi.fn(async () => [
+    {
+      id: 'comm_1',
+      adapterId: 'msteams-default',
+      operation: 'send',
+      status: 'queued',
+      target: { kind: 'notification' },
+      createdAt: '2026-06-04T08:00:00.000Z',
+    },
+  ]),
+  configureCommunicationAdapter: vi.fn(async () => ({
+    id: 'msteams-default',
+    kind: 'msteams',
+    displayName: 'Microsoft Teams',
+    enabled: true,
+    deliveryMode: 'manual',
+    replyMode: 'ingest-api',
+    destinationType: 'channel',
+    hasCredential: false,
+    createdAt: '2026-06-04T08:00:00.000Z',
+    updatedAt: '2026-06-04T08:00:00.000Z',
+  })),
+  testCommunicationAdapter: vi.fn(async () => ({
+    delivery: {
+      id: 'comm_test',
+      adapterId: 'msteams-default',
+      operation: 'send',
+      status: 'queued',
+      createdAt: '2026-06-04T08:00:00.000Z',
+    },
+    mapping: {
+      id: 'map_1',
+      adapterId: 'msteams-default',
+      externalThreadId: 'msteams-default:notification:adapter-test',
+      target: { kind: 'notification', notificationId: 'adapter-test' },
+      createdAt: '2026-06-04T08:00:00.000Z',
+      updatedAt: '2026-06-04T08:00:00.000Z',
+    },
+  })),
+  disconnectCommunicationAdapter: vi.fn(async () => ({
+    id: 'msteams-default',
+    kind: 'msteams',
+    displayName: 'Microsoft Teams',
+    enabled: false,
+    deliveryMode: 'manual',
+    replyMode: 'ingest-api',
+    destinationType: 'channel',
+    hasCredential: false,
+    createdAt: '2026-06-04T08:00:00.000Z',
+    updatedAt: '2026-06-04T08:00:00.000Z',
+  })),
   settings: {
     board: {},
     tasks: {},
@@ -114,6 +201,12 @@ vi.mock('@/lib/api', () => ({
     integrations: {
       outboundEndpoints: mocks.outboundEndpoints,
       outboundDeliveries: mocks.outboundDeliveries,
+      communicationAdapters: mocks.communicationAdapters,
+      communicationHealth: mocks.communicationHealth,
+      communicationDeliveries: mocks.communicationDeliveries,
+      configureCommunicationAdapter: mocks.configureCommunicationAdapter,
+      testCommunicationAdapter: mocks.testCommunicationAdapter,
+      disconnectCommunicationAdapter: mocks.disconnectCommunicationAdapter,
     },
   },
 }));
@@ -180,6 +273,7 @@ describe('Settings tab Mantine controls', () => {
 
     expect(await screen.findByText('Communication Health')).toBeDefined();
     expect(screen.getByText('Local Squad Chat')).toBeDefined();
+    expect(screen.getByText('Human Reply Adapter')).toBeDefined();
     expect(screen.getAllByText('Squad Chat Webhook').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText(/Visually verified: not recorded in VK/).length).toBeGreaterThan(0);
     expect(screen.getByText('X-VK-Signature')).toBeDefined();

--- a/web/src/components/settings/tabs/NotificationsTab.tsx
+++ b/web/src/components/settings/tabs/NotificationsTab.tsx
@@ -1,21 +1,33 @@
 import {
   Badge,
+  Button,
   Code,
   Group,
   Paper,
+  PasswordInput,
   Select,
   SimpleGrid,
   Stack,
   Text,
   TextInput,
 } from '@mantine/core';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useFeatureSettings, useDebouncedFeatureUpdate } from '@/hooks/useFeatureSettings';
 import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
 import { SettingRow, ToggleRow, SectionHeader, SaveIndicator } from '../shared';
-import { api, type OutboundDeliveryAttempt, type OutboundEndpointRecord } from '@/lib/api';
+import {
+  api,
+  type CommunicationAdapterInput,
+  type CommunicationAdapterRecord,
+  type CommunicationDeliveryAudit,
+  type OutboundDeliveryAttempt,
+  type OutboundEndpointRecord,
+} from '@/lib/api';
 
 type CommunicationState = 'ok' | 'warn' | 'off' | 'unknown';
+
+const DEFAULT_COMMUNICATION_ADAPTER_ID = 'msteams-default';
 
 const STATE_COLORS: Record<CommunicationState, string> = {
   ok: 'green',
@@ -100,14 +112,139 @@ function endpointLabel(endpoint?: OutboundEndpointRecord): string {
   return endpoint.enabled ? 'endpoint enabled' : 'endpoint disabled';
 }
 
+function adapterHealthState(adapter?: CommunicationAdapterRecord): CommunicationState {
+  if (!adapter || !adapter.enabled) return 'off';
+  if (adapter.lastHealth?.status === 'error') return 'warn';
+  if (adapter.lastHealth?.status === 'warning') return 'warn';
+  return 'ok';
+}
+
+function formatCommunicationDelivery(delivery?: CommunicationDeliveryAudit): string {
+  if (!delivery) return 'not recorded';
+  const target = delivery.target?.kind ? ` ${delivery.target.kind}` : '';
+  return `${delivery.operation}${target}: ${delivery.status} at ${new Date(delivery.createdAt).toLocaleString()}`;
+}
+
+interface AdapterFormState {
+  displayName: string;
+  enabled: boolean;
+  deliveryMode: 'manual' | 'webhook';
+  destinationType: 'channel' | 'direct';
+  tenantId: string;
+  teamId: string;
+  channelId: string;
+  chatId: string;
+  webhookUrl: string;
+  credential: string;
+}
+
+function adapterToForm(adapter?: CommunicationAdapterRecord): AdapterFormState {
+  return {
+    displayName: adapter?.displayName ?? 'Microsoft Teams',
+    enabled: adapter?.enabled ?? false,
+    deliveryMode: adapter?.deliveryMode ?? 'manual',
+    destinationType: adapter?.destinationType ?? 'channel',
+    tenantId: adapter?.tenantId ?? '',
+    teamId: adapter?.teamId ?? '',
+    channelId: adapter?.channelId ?? '',
+    chatId: adapter?.chatId ?? '',
+    webhookUrl: adapter?.webhookUrlRedacted ? '' : (adapter?.webhookUrl ?? ''),
+    credential: '',
+  };
+}
+
+function formToInput(form: AdapterFormState): CommunicationAdapterInput {
+  return {
+    kind: 'msteams',
+    displayName: form.displayName,
+    enabled: form.enabled,
+    deliveryMode: form.deliveryMode,
+    destinationType: form.destinationType,
+    tenantId: form.tenantId || undefined,
+    teamId: form.teamId || undefined,
+    channelId: form.channelId || undefined,
+    chatId: form.chatId || undefined,
+    webhookUrl: form.webhookUrl || undefined,
+    credential: form.credential || undefined,
+  };
+}
+
 export function NotificationsTab() {
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
+  const queryClient = useQueryClient();
   const { data: outboundEndpoints = [] } = useQuery({
     queryKey: ['integrations', 'outbound', 'endpoints'],
     queryFn: api.integrations.outboundEndpoints,
     staleTime: 30_000,
     retry: false,
+  });
+  const { data: communicationAdapters = [] } = useQuery({
+    queryKey: ['integrations', 'communication', 'adapters'],
+    queryFn: api.integrations.communicationAdapters,
+    staleTime: 30_000,
+    retry: false,
+  });
+  const communicationAdapter = communicationAdapters.find(
+    (adapter) => adapter.id === DEFAULT_COMMUNICATION_ADAPTER_ID
+  );
+  const { data: communicationDeliveries = [] } = useQuery({
+    queryKey: ['integrations', 'communication', 'deliveries', DEFAULT_COMMUNICATION_ADAPTER_ID, 10],
+    queryFn: () => api.integrations.communicationDeliveries(10, DEFAULT_COMMUNICATION_ADAPTER_ID),
+    staleTime: 30_000,
+    retry: false,
+  });
+  const { data: communicationHealth } = useQuery({
+    queryKey: ['integrations', 'communication', 'health', DEFAULT_COMMUNICATION_ADAPTER_ID],
+    queryFn: () => api.integrations.communicationHealth(DEFAULT_COMMUNICATION_ADAPTER_ID),
+    enabled: Boolean(communicationAdapter),
+    staleTime: 30_000,
+    retry: false,
+  });
+  const [adapterForm, setAdapterForm] = useState<AdapterFormState>(() =>
+    adapterToForm(communicationAdapter)
+  );
+  const [adapterDirty, setAdapterDirty] = useState(false);
+
+  useEffect(() => {
+    if (adapterDirty) return;
+    setAdapterForm(adapterToForm(communicationAdapter));
+  }, [adapterDirty, communicationAdapter]);
+
+  const invalidateCommunication = () => {
+    void queryClient.invalidateQueries({ queryKey: ['integrations', 'communication'] });
+    void queryClient.invalidateQueries({ queryKey: ['integrations', 'outbound'] });
+  };
+
+  const saveAdapter = useMutation({
+    mutationFn: () =>
+      api.integrations.configureCommunicationAdapter(
+        DEFAULT_COMMUNICATION_ADAPTER_ID,
+        formToInput(adapterForm)
+      ),
+    onSuccess: () => {
+      setAdapterDirty(false);
+      setAdapterForm((current) => ({ ...current, credential: '' }));
+      invalidateCommunication();
+    },
+  });
+
+  const testAdapter = useMutation({
+    mutationFn: () =>
+      api.integrations.testCommunicationAdapter(
+        DEFAULT_COMMUNICATION_ADAPTER_ID,
+        'Veritas communication adapter test'
+      ),
+    onSuccess: invalidateCommunication,
+  });
+
+  const disconnectAdapter = useMutation({
+    mutationFn: () =>
+      api.integrations.disconnectCommunicationAdapter(DEFAULT_COMMUNICATION_ADAPTER_ID),
+    onSuccess: () => {
+      setAdapterDirty(false);
+      invalidateCommunication();
+    },
   });
   const { data: outboundDeliveries = [] } = useQuery({
     queryKey: ['integrations', 'outbound', 'deliveries', 25],
@@ -116,11 +253,11 @@ export function NotificationsTab() {
     retry: false,
   });
 
-  const updateNotifications = (key: string, value: any) => {
+  const updateNotifications = (key: string, value: unknown) => {
     debouncedUpdate({ notifications: { [key]: value } });
   };
 
-  const updateSquadWebhook = (key: string, value: any) => {
+  const updateSquadWebhook = (key: string, value: unknown) => {
     debouncedUpdate({ squadWebhook: { [key]: value } });
   };
 
@@ -154,6 +291,16 @@ export function NotificationsTab() {
   const squadDelivery = findDelivery(outboundDeliveries, squadEndpointId);
   const notificationEndpoint = findEndpoint(outboundEndpoints, 'notifications.failureAlert');
   const failureDelivery = findDelivery(outboundDeliveries, 'notifications.failureAlert');
+  const latestCommunicationDelivery = communicationDeliveries[0];
+  const effectiveCommunicationHealth = communicationHealth ?? communicationAdapter?.lastHealth;
+
+  const updateAdapterForm = <K extends keyof AdapterFormState>(
+    key: K,
+    value: AdapterFormState[K]
+  ) => {
+    setAdapterDirty(true);
+    setAdapterForm((current) => ({ ...current, [key]: value }));
+  };
 
   return (
     <div className="space-y-4">
@@ -204,17 +351,18 @@ export function NotificationsTab() {
           />
           <HealthCard
             title="Inbound Wake / Replies"
-            state={
-              webhookMode === 'openclaw' && squadWebhookEnabled && squadDestinationConfigured
-                ? 'ok'
-                : 'off'
-            }
+            state={adapterHealthState(communicationAdapter)}
             label={
-              webhookMode === 'openclaw' && squadWebhookEnabled && squadDestinationConfigured
-                ? 'OpenClaw configured'
-                : 'Not configured'
+              !communicationAdapter?.enabled
+                ? 'Disabled'
+                : effectiveCommunicationHealth?.status === 'ok'
+                  ? 'Configured'
+                  : 'Needs check'
             }
-            detail="Generic webhooks are outbound only. OpenClaw Direct can wake a gateway; replies still require the external orchestrator."
+            detail={
+              effectiveCommunicationHealth?.detail ??
+              'Configure a bidirectional adapter to map external replies back into Squad Chat threads.'
+            }
           />
           <Paper withBorder radius="md" p="sm">
             <Stack gap={4}>
@@ -237,6 +385,178 @@ export function NotificationsTab() {
             </Stack>
           </Paper>
         </SimpleGrid>
+      </div>
+
+      <div className="border-t my-6" />
+
+      <div className="space-y-4">
+        <SectionHeader title="Human Reply Adapter" />
+        <p className="text-sm text-muted-foreground -mt-2">
+          Route approved external replies back into Squad Chat threads with attribution and audit
+        </p>
+        <Paper withBorder radius="md" p="sm">
+          <Stack gap="sm">
+            <Group justify="space-between" gap="sm">
+              <div>
+                <Text size="sm" fw={600}>
+                  Microsoft Teams
+                </Text>
+                <Text size="xs" c="dimmed">
+                  {communicationAdapter?.webhookUrlConfigured
+                    ? `Webhook: ${redactDestination(communicationAdapter.webhookUrl)}`
+                    : adapterForm.deliveryMode === 'webhook'
+                      ? 'Webhook delivery needs a URL'
+                      : 'Manual delivery stores thread mappings for reply ingestion'}
+                </Text>
+              </div>
+              <Badge
+                color={STATE_COLORS[adapterHealthState(communicationAdapter)]}
+                variant="light"
+                tt="none"
+              >
+                {communicationAdapter?.enabled
+                  ? (communicationAdapter.lastHealth?.status ?? 'configured')
+                  : 'disabled'}
+              </Badge>
+            </Group>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+              <TextInput
+                label="Display name"
+                value={adapterForm.displayName}
+                onChange={(event) => updateAdapterForm('displayName', event.target.value)}
+                size="xs"
+              />
+              <Select
+                label="Delivery"
+                value={adapterForm.deliveryMode}
+                onChange={(value) =>
+                  value &&
+                  updateAdapterForm('deliveryMode', value as AdapterFormState['deliveryMode'])
+                }
+                data={[
+                  { value: 'manual', label: 'Manual thread mapping' },
+                  { value: 'webhook', label: 'Webhook send' },
+                ]}
+                allowDeselect={false}
+                size="xs"
+              />
+              <Select
+                label="Destination"
+                value={adapterForm.destinationType}
+                onChange={(value) =>
+                  value &&
+                  updateAdapterForm('destinationType', value as AdapterFormState['destinationType'])
+                }
+                data={[
+                  { value: 'channel', label: 'Channel' },
+                  { value: 'direct', label: 'Direct chat' },
+                ]}
+                allowDeselect={false}
+                size="xs"
+              />
+              <TextInput
+                label="Tenant ID"
+                value={adapterForm.tenantId}
+                onChange={(event) => updateAdapterForm('tenantId', event.target.value)}
+                size="xs"
+              />
+              {adapterForm.destinationType === 'channel' ? (
+                <>
+                  <TextInput
+                    label="Team ID"
+                    value={adapterForm.teamId}
+                    onChange={(event) => updateAdapterForm('teamId', event.target.value)}
+                    size="xs"
+                  />
+                  <TextInput
+                    label="Channel ID"
+                    value={adapterForm.channelId}
+                    onChange={(event) => updateAdapterForm('channelId', event.target.value)}
+                    size="xs"
+                  />
+                </>
+              ) : (
+                <TextInput
+                  label="Chat ID"
+                  value={adapterForm.chatId}
+                  onChange={(event) => updateAdapterForm('chatId', event.target.value)}
+                  size="xs"
+                />
+              )}
+              {adapterForm.deliveryMode === 'webhook' && (
+                <TextInput
+                  label="Webhook URL"
+                  value={adapterForm.webhookUrl}
+                  onChange={(event) => updateAdapterForm('webhookUrl', event.target.value)}
+                  placeholder={
+                    communicationAdapter?.webhookUrlConfigured
+                      ? 'Saved URL is redacted; enter a new URL to replace it'
+                      : 'https://example.com/teams-adapter'
+                  }
+                  type="url"
+                  size="xs"
+                />
+              )}
+              <PasswordInput
+                label="Credential"
+                value={adapterForm.credential}
+                onChange={(event) => updateAdapterForm('credential', event.target.value)}
+                placeholder={
+                  communicationAdapter?.hasCredential
+                    ? 'Saved credential is write-only'
+                    : 'Optional adapter token'
+                }
+                size="xs"
+              />
+            </SimpleGrid>
+            <ToggleRow
+              label="Enable Adapter"
+              description="Allow outbound sends and inbound reply ingestion for this adapter"
+              checked={adapterForm.enabled}
+              onCheckedChange={(value) => updateAdapterForm('enabled', value)}
+            />
+            <Group justify="space-between" gap="sm">
+              <Text size="xs" c="dimmed">
+                Last adapter event: {formatCommunicationDelivery(latestCommunicationDelivery)}
+              </Text>
+              <Group gap="xs">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="light"
+                  color="gray"
+                  onClick={() => testAdapter.mutate()}
+                  disabled={!communicationAdapter || testAdapter.isPending || saveAdapter.isPending}
+                >
+                  Test Send
+                </Button>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="light"
+                  color="red"
+                  onClick={() => disconnectAdapter.mutate()}
+                  disabled={!communicationAdapter || disconnectAdapter.isPending}
+                >
+                  Disconnect
+                </Button>
+                <Button
+                  type="button"
+                  size="xs"
+                  onClick={() => saveAdapter.mutate()}
+                  disabled={saveAdapter.isPending}
+                >
+                  Save Adapter
+                </Button>
+              </Group>
+            </Group>
+            {(saveAdapter.error || testAdapter.error || disconnectAdapter.error) && (
+              <Text size="xs" c="red">
+                {(saveAdapter.error || testAdapter.error || disconnectAdapter.error)?.message}
+              </Text>
+            )}
+          </Stack>
+        </Paper>
       </div>
 
       <div className="border-t my-6" />

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -91,6 +91,17 @@ export type { WorkProductExportFormat, WorkProductExportOptions } from './work-p
 export type { TraceStatus } from './traces';
 export type { SqlitePortabilityReport } from './maintenance';
 export type {
+  CommunicationAdapterHealth,
+  CommunicationAdapterInput,
+  CommunicationAdapterRecord,
+  CommunicationDeliveryAudit,
+  CommunicationReplyIngestInput,
+  CommunicationReplyIngestResult,
+  CommunicationSendInput,
+  CommunicationSendResult,
+  CommunicationThreadMapping,
+} from '@veritas-kanban/shared';
+export type {
   OutboundDeliveryAttempt,
   OutboundDeliveryStatus,
   OutboundEndpointRecord,

--- a/web/src/lib/api/integrations.ts
+++ b/web/src/lib/api/integrations.ts
@@ -1,4 +1,15 @@
 import { API_BASE, handleResponse } from './helpers';
+import type {
+  CommunicationAdapterHealth,
+  CommunicationAdapterInput,
+  CommunicationAdapterRecord,
+  CommunicationDeliveryAudit,
+  CommunicationReplyIngestInput,
+  CommunicationReplyIngestResult,
+  CommunicationSendInput,
+  CommunicationSendResult,
+  CommunicationThreadMapping,
+} from '@veritas-kanban/shared';
 
 export type OutboundEndpointType =
   | 'broadcast-webhook'
@@ -8,7 +19,8 @@ export type OutboundEndpointType =
   | 'squad-webhook'
   | 'openclaw-wake'
   | 'openclaw-gateway'
-  | 'failure-alert-webhook';
+  | 'failure-alert-webhook'
+  | 'communication-adapter-webhook';
 
 export type OutboundDeliveryStatus = 'success' | 'failed' | 'blocked' | 'timeout' | 'skipped';
 
@@ -61,5 +73,120 @@ export const integrationsApi = {
       credentials: 'include',
     });
     return handleResponse<OutboundDeliveryAttempt[]>(response);
+  },
+
+  communicationAdapters: async (): Promise<CommunicationAdapterRecord[]> => {
+    const response = await fetch(`${API_BASE}/integrations/communication/adapters`, {
+      credentials: 'include',
+    });
+    return handleResponse<CommunicationAdapterRecord[]>(response);
+  },
+
+  configureCommunicationAdapter: async (
+    adapterId: string,
+    input: CommunicationAdapterInput
+  ): Promise<CommunicationAdapterRecord> => {
+    const response = await fetch(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(input),
+      }
+    );
+    return handleResponse<CommunicationAdapterRecord>(response);
+  },
+
+  communicationHealth: async (adapterId: string): Promise<CommunicationAdapterHealth> => {
+    const response = await fetch(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/health`,
+      {
+        credentials: 'include',
+      }
+    );
+    return handleResponse<CommunicationAdapterHealth>(response);
+  },
+
+  testCommunicationAdapter: async (
+    adapterId: string,
+    message?: string
+  ): Promise<CommunicationSendResult> => {
+    const response = await fetch(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/test`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ message }),
+      }
+    );
+    return handleResponse<CommunicationSendResult>(response);
+  },
+
+  sendCommunicationMessage: async (
+    adapterId: string,
+    input: CommunicationSendInput
+  ): Promise<CommunicationSendResult> => {
+    const response = await fetch(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/send`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(input),
+      }
+    );
+    return handleResponse<CommunicationSendResult>(response);
+  },
+
+  ingestCommunicationReply: async (
+    adapterId: string,
+    input: CommunicationReplyIngestInput
+  ): Promise<CommunicationReplyIngestResult> => {
+    const response = await fetch(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/replies`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(input),
+      }
+    );
+    return handleResponse<CommunicationReplyIngestResult>(response);
+  },
+
+  disconnectCommunicationAdapter: async (
+    adapterId: string
+  ): Promise<CommunicationAdapterRecord> => {
+    const response = await fetch(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/disconnect`,
+      {
+        method: 'POST',
+        credentials: 'include',
+      }
+    );
+    return handleResponse<CommunicationAdapterRecord>(response);
+  },
+
+  communicationMappings: async (adapterId?: string): Promise<CommunicationThreadMapping[]> => {
+    const params = new URLSearchParams();
+    if (adapterId) params.set('adapterId', adapterId);
+    const response = await fetch(`${API_BASE}/integrations/communication/mappings?${params}`, {
+      credentials: 'include',
+    });
+    return handleResponse<CommunicationThreadMapping[]>(response);
+  },
+
+  communicationDeliveries: async (
+    limit = 25,
+    adapterId?: string
+  ): Promise<CommunicationDeliveryAudit[]> => {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (adapterId) params.set('adapterId', adapterId);
+    const response = await fetch(`${API_BASE}/integrations/communication/deliveries?${params}`, {
+      credentials: 'include',
+    });
+    return handleResponse<CommunicationDeliveryAudit[]>(response);
   },
 };


### PR DESCRIPTION
## Summary
- add a provider-neutral communication adapter contract with Microsoft Teams posture fields, redacted connection state, thread mappings, health, test-send, poll, disconnect, and bounded delivery audit records
- add authenticated reply ingestion that sanitizes and redacts inbound text, dedupes external reply IDs, writes through Squad Chat, broadcasts live updates, and requires approval-capable permissions for approval-targeted replies
- expose adapter setup and health in Settings -> Notifications, add web API bindings, permission metadata, and docs for the adapter workflow

## Verification
- pnpm exec eslint shared/src/types/communication-adapter.types.ts shared/src/types/index.ts shared/src/utils/api-permissions.ts server/src/services/communication-adapter-service.ts server/src/services/outbound-integration-service.ts server/src/routes/integrations.ts server/src/routes/v1/permissions.ts server/src/routes/v1/index.ts server/src/__tests__/communication-adapter-service.test.ts server/src/__tests__/routes/integrations.test.ts web/src/lib/api/integrations.ts web/src/lib/api/index.ts web/src/components/settings/tabs/NotificationsTab.tsx web/src/__tests__/settings-tabs-mantine-controls.test.tsx
- pnpm --filter @veritas-kanban/shared build
- pnpm --filter @veritas-kanban/server typecheck
- pnpm --filter @veritas-kanban/web typecheck
- pnpm vitest run server/src/__tests__/communication-adapter-service.test.ts server/src/__tests__/routes/integrations.test.ts server/src/__tests__/shared-api-permissions.test.ts web/src/__tests__/settings-tabs-mantine-controls.test.tsx --reporter=verbose
- pnpm build

## Notes
- This is the safe first slice: adapter contract, local/mock-style Teams posture, webhook/manual delivery, and authenticated ingest. It does not implement production Teams OAuth or Graph polling.

Closes #739