### PR TITLE
Bump version to 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-06-26
+
+### Added
+
+- Added workspace team roster manifests and capability routing rules for
+  capability-aware delegation (#734).
+- Added cross-workspace capability discovery and delegated work intake (#735).
+- Added policy-gated queue intake monitoring for GitHub issues and agent runs
+  (#736).
+- Added a unified recurring work scheduler for monitors, workflows, and digests
+  (#737).
+- Added Squad Chat threads, unread state, mentions, and search (#738).
+- Added bidirectional human reply adapters for Squad Chat and notifications
+  (#739).
+- Added ceremony enforcement for design reviews and failure retrospectives
+  (#740).
+- Added reflection-to-memory promotion for agent corrections and lessons (#741).
+- Added external tracker schema introspection for configurable work items
+  (#742).
+
+### Changed
+
+- Bumped the release from `5.1.0` to `5.2.0` across the root, shared, server,
+  web, CLI, MCP, and desktop package manifests.
+- Updated the README version badge, API reference, v5 release notes, and MCP
+  documentation footer for `5.2.0`.
+
+### Fixed
+
+- Fixed CLI/MCP compatibility smoke checks so missing `VK_API_KEY` records
+  explicit skip results after local package/build validation instead of failing
+  unrelated release gates (#753).
+- Removed vulnerable frontmatter dependencies from the server by using the
+  existing YAML parser and preserving malformed-prompt fallback behavior
+  (#754).
+- Upgraded DOMPurify and kept the Mantine QA gate below the initial bundle
+  budget by deferring drag/drop code outside the first page load (#754, #755).
+
 ## [5.1.0] - 2026-06-18
 
 ### Added
@@ -1614,7 +1652,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.1.0...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.0...HEAD
+[5.2.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v4.3.2...v5.0.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.1.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.0-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -96,7 +96,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [v5 Visual Tour](docs/V5-VISUAL-TOUR.md) — release-safe dummy screenshots and GIFs for the v5 desktop shell, resizable workbench, agent providers, task work view, Maintenance Center, and mobile/PWA shell.
 - [v5 Upgrade, Install, Remote, And Admin Guide](docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md) — fresh install, v4-to-v5 upgrade, desktop setup, remote/server, mobile/PWA, admin, backup, and diagnostics paths.
 - [v5 Compatibility And Release Policy](docs/V5-COMPATIBILITY-AND-RELEASE-POLICY.md) — supported version combinations, update channels, stale-client behavior, rollback limits, and release validation.
-- [v5 Release Notes](docs/V5-RELEASE-NOTES.md) — breaking changes, migration warnings, published v5.1.0 artifacts, and deferred post-GA backlog.
+- [v5 Release Notes](docs/V5-RELEASE-NOTES.md) — current source release notes, breaking changes, migration warnings, published v5 artifacts, and deferred post-GA backlog.
 - [v5 Desktop Architecture ADR](docs/architecture/ADR-0001-v5-desktop-architecture.md) — shell decision, native/server boundaries, connection modes, lifecycle, packaging, and security model.
 - [Post-GA Desktop Agent Workbench Spec](docs/DESKTOP-AGENT-WORKBENCH.md) — desktop workbench UX, run controls, approvals, evidence, native affordances, and safety coverage.
 - [Post-GA Native Mobile Offline ADR](docs/architecture/ADR-0003-post-ga-native-mobile-offline.md) — native mobile authority model, offline queue semantics, conflict handling, and security review.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,6 +1,6 @@
 # Veritas Kanban — API Reference
 
-**Version**: 5.1.0
+**Version**: 5.2.0
 **Last Updated**: 2026-06-26
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -1,13 +1,37 @@
 # v5 Release Notes
 
-These notes describe the published Veritas Kanban v5 stable release line.
+These notes describe the Veritas Kanban v5 stable release line.
 
-- GitHub release:
+- Current source version: `v5.2.0`
+- Latest published GitHub release:
   [Veritas Kanban v5.1.0](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.1.0)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
   [Veritas-Kanban-5.1.0-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.1.0/Veritas-Kanban-5.1.0-mac-arm64.zip)
+
+## v5.2.0 Release
+
+v5.2.0 closes the post-v5.1 backlog train and the follow-up audit issues found
+after that work landed. It keeps the v5 storage, desktop, security, and
+migration posture unchanged from v5.1.0.
+
+- Team roster manifests, capability routing, cross-workspace capability
+  discovery, and delegated intake make work handoffs explicit before agents
+  accept tasks.
+- Queue intake monitoring and the recurring scheduler unify GitHub issue
+  watches, agent-run monitors, workflows, digests, and follow-up loops.
+- Squad Chat now has durable threads, unread state, mentions, search, and
+  bidirectional human reply adapters for chat and notification channels.
+- Ceremony enforcement adds design-review and failure-retrospective gates for
+  the workflows that should not proceed without recorded review evidence.
+- Reflection memory promotion turns agent corrections and lessons into a
+  reviewable memory queue instead of losing useful run context in chat history.
+- External tracker schema introspection lets configurable work item mappings
+  inspect tracker field shape before sync.
+- Release audit follow-ups removed the vulnerable frontmatter dependency path,
+  upgraded DOMPurify, made CLI/MCP smoke checks skip cleanly without
+  `VK_API_KEY`, and kept initial Mantine bundle size under the QA budget.
 
 ## v5.1.0 Release
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -802,7 +802,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `5.1.0`      | Matches VK server version   |
+| MCP server package | `5.2.0`      | Matches VK server version   |
 | MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2024-11-05` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -846,4 +846,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-06-18 · VK v5.1.0 · 36 tools / 8 categories_
+_Last updated: 2026-06-26 · VK v5.2.0 · 36 tools / 8 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump root, shared, server, web, CLI, MCP, and desktop package versions to 5.2.0
- document the completed #734-#742 backlog train and #753-#755 audit follow-ups in the changelog and v5 release notes
- update the README badge, API reference, and MCP docs for the 5.2.0 source version

## Verification
- pnpm build
- pnpm validate:release -- --version 5.2.0
- pnpm smoke:cli-mcp -- --expected-version 5.2.0
- pnpm qa:mantine
- pnpm lint:budget
- pnpm audit --prod
- pnpm check:pnpm-settings
- git diff --check

## Notes
- The v5 release notes mark 5.2.0 as the current source version while keeping published desktop artifact links on the latest published v5.1.0 release until v5.2.0 artifacts are cut.