### PR TITLE
Document v5.2 latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 
 ### 🤖 Agent Orchestration
 
-Spawn autonomous coding agents on tasks when you choose to connect an agent runner. Track them in real-time with the multi-agent dashboard — status indicators, expandable agent cards, model attribution. Shared live run sessions let workspace members observe an active task run, co-drive with attributed messages, or fork a clean follow-up task without taking over the parent run. Squad Chat gives agents a shared local communication channel with system lifecycle events (spawned, completed, failed). Assign multiple agents per task, set permission levels (Intern/Specialist/Lead), and let them coordinate.
+Spawn autonomous coding agents on tasks when you choose to connect an agent runner. Track them in real-time with the multi-agent dashboard — status indicators, expandable agent cards, model attribution. Team roster manifests and workspace capability discovery route work to the right agent or trusted workspace before a run starts. Shared live run sessions let workspace members observe an active task run, co-drive with attributed messages, or fork a clean follow-up task without taking over the parent run. Squad Chat gives agents a shared local communication channel with system lifecycle events (spawned, completed, failed). Assign multiple agents per task, set permission levels (Intern/Specialist/Lead), and let them coordinate.
 
 ![Agent orchestration board](docs/assets/v5/v5-board-overview.png)
 
@@ -223,6 +223,8 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **HermesAgent support** — documents HermesAgent/Hermes Gateway as the active control plane, with Veritas as the GitHub-backed source of truth
 - **OpenAI Codex support** — Local CLI runs, SDK-backed sessions, Codex Cloud delegation, workflow steps, review actions, health checks, MCP setup, and default routing for fresh installs
 - **Local LLM provider profiles** — Optional Ollama Local, Ollama Cloud, and LM Studio Local profiles with health metadata and routing support
+- **Team roster routing** — Workspace coordinator/member manifests route tasks by capabilities, reviewers, fallbacks, and escalation posture
+- **Workspace capability discovery** — Trusted workspace capability catalogs let Veritas package delegated work intake before handing work across workspace boundaries
 - **Agent profile packages** — Portable YAML/JSON packages that bundle role, runtime, prompt, tools, permissions, sandbox, budget, workflow, and health metadata for reusable launches
 - **Decision review sessions** — Multi-participant decision reviews with independent responses, critique rounds, final synthesis packets, work-product attachment, and decision audit links
 - **Shared live run sessions** — Create workspace-scoped view, co-drive, or fork links for active task runs; viewers receive live output and events, editors send attributed messages and mobile-safe approval responses, and forks create linked tasks without mutating the parent run
@@ -331,16 +333,16 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 
 ## 🛠️ Tech Stack
 
-| Layer               | Technology                           | Version                          |
-| ------------------- | ------------------------------------ | -------------------------------- |
-| **Frontend**        | React, Vite, Tailwind CSS, Shadcn UI | React 19, Vite 7.3, Tailwind 4.2 |
-| **Backend**         | Express, WebSocket                   | Express 5.2                      |
-| **Language**        | TypeScript (strict mode)             | 6.0                              |
-| **Storage**         | Markdown files with YAML frontmatter | yaml + local frontmatter helper  |
-| **Git**             | simple-git, worktree management      | —                                |
-| **Testing**         | Playwright (E2E), Vitest (unit)      | Playwright 1.58, Vitest 4        |
-| **Runtime**         | Node.js                              | 22+                              |
-| **Package Manager** | pnpm                                 | 11.1.1+                          |
+| Layer               | Technology                            | Version                                     |
+| ------------------- | ------------------------------------- | ------------------------------------------- |
+| **Frontend**        | React, Vite, Tailwind CSS, Mantine UI | React 19, Vite 8, Tailwind 4.3, Mantine 9.3 |
+| **Backend**         | Express, WebSocket                    | Express 5.2                                 |
+| **Language**        | TypeScript (strict mode)              | 6.0                                         |
+| **Storage**         | Markdown files with YAML frontmatter  | yaml + local frontmatter helper             |
+| **Git**             | simple-git, worktree management       | —                                           |
+| **Testing**         | Playwright (E2E), Vitest (unit)       | Playwright 1.61, Vitest 4.1                 |
+| **Runtime**         | Node.js                               | 22+                                         |
+| **Package Manager** | pnpm                                  | 11.1.1+                                     |
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -27,6 +27,7 @@ For current v5 screenshots and GIFs, see the
 ### AI Agents
 
 - [Agent Integration](#agent-integration)
+- [Team Roster & Capability Routing](#team-roster--capability-routing)
 - [OpenAI Codex Integration](#openai-codex-integration-v5)
 - [Veritas Cutover & Hermes Support](#veritas-cutover--hermes-support)
 - [Multi-Agent System](#multi-agent-system)
@@ -290,6 +291,8 @@ First-class support for autonomous coding agents.
 - **HermesAgent operating support** — v4.3 documents HermesAgent/Hermes Gateway as the active control plane, with Veritas tracking task truth, QA evidence, and GitHub delivery state
 - **OpenAI Codex support** — Local CLI attempts, SDK sessions, GitHub-native Codex Cloud delegation, workflow steps, review actions, Settings health checks, MCP setup, and fresh-install default routing
 - **Local LLM provider profiles** — Ollama Local, Ollama Cloud, and LM Studio Local profiles can be enabled, health-checked, and targeted by routing rules in the web app or macOS app
+- **Team roster routing manifests** — Workspace coordinators can define enabled members, capabilities, routing rules, fallbacks, reviewers, and escalation posture before `/api/agents/route` selects an agent
+- **Workspace capability discovery** — Trusted workspace catalogs expose supported task types, SLA/queue posture, intake requirements, and delegated-work packaging so cross-workspace handoffs are explicit
 - **Agent profile packages** — Reusable YAML/JSON packages bundle role, runtime, model, prompt instructions, tools, permissions, sandbox, budget, workflow, and health metadata for portable task launches
 - **Sandbox policy presets** — Built-in and custom presets control filesystem scope, network egress, environment passthrough, and credential brokering for agent profiles, workflow agents, and per-run overrides
 - **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run budgets can cap tokens, provider cost, tool calls, runtime, retries, and workflow fan-out with warning, approval, downgrade, pause, or cancel actions
@@ -322,6 +325,20 @@ Documentation:
 - [OpenAI Codex Integration Roadmap](CODEX-INTEGRATION.md)
 - [SOP: OpenAI Codex Integration](SOP-codex-integration.md)
 - [Codex Workflow Examples](EXAMPLES-codex-workflows.md)
+
+---
+
+## Team Roster & Capability Routing
+
+Workspace-level routing metadata for agent teams and delegated work intake. Added in v5.2.
+
+- **Roster manifests** — Store the coordinator, enabled members, roles, capabilities, routing rules, fallbacks, escalation posture, and review requirements as `teamRoster` app config.
+- **Routing priority** — `/api/agents/route` evaluates enabled rosters before legacy routing rules and labels roster-selected responses with a `team-roster:` rule prefix.
+- **Capability catalogs** — `workspaceCapability` and `trustedWorkspaceCapabilities` describe what a workspace can accept, which evidence it requires, queue/SLA posture, and how delegated work should be packaged.
+- **Delegated intake packets** — Veritas can prepare a bounded handoff from task metadata and capability rules instead of sending raw task context across workspace boundaries.
+- **Settings surfaces** — Settings exposes team roster routing and shared workspace capabilities without requiring hand-edited JSON.
+
+See [API Reference: Team Roster Manifests](API-REFERENCE.md#team-roster-manifests) and [Workspace Capability Discovery](API-REFERENCE.md#workspace-capability-discovery).
 
 ---
 

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -1,8 +1,12 @@
 # Veritas Kanban v5 GA Checklist
 
-v5.0.0 stable is published. This checklist remains the operator reference for
-release-gate review, follow-up evidence debt, and future v5 patch candidates.
-The GitHub release and release issues remain the source of scheduling truth.
+v5.0.0 stable is published. The current source line is v5.2.0, including the
+post-v5.1 backlog train for team rosters, workspace capability discovery,
+queue monitors, recurring work, Squad Chat threading and human replies,
+ceremony gates, reflection promotion, external tracker introspection, and audit
+follow-ups. This checklist remains the operator reference for release-gate
+review, follow-up evidence debt, and future v5 patch candidates. The GitHub
+release and release issues remain the source of scheduling truth.
 
 For future candidates, use
 [v5 Release Candidate Evidence Packet](V5-RC-EVIDENCE-PACKET.md) as the single


### PR DESCRIPTION
## Summary
- refresh README agent orchestration and tech-stack docs for the v5.2 source line
- add team roster and workspace capability routing to the feature reference
- mark the v5 GA checklist as covering the current v5.2 backlog/audit state

## Verification
- git diff --check
- pnpm exec prettier --check README.md docs/FEATURES.md docs/V5-GA-CHECKLIST.md
- pnpm validate:release -- --version 5.2.0 --skip-build-output

Fixes #758