### PR TITLE
Fix v5.2 audit follow-ups

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Veritas Kanban — Task Management Built for AI Agents</title>
-  <meta name="description" content="The open-source kanban board that speaks your agent's language. CLI-first, API-native, built for the age of agentic development. 190+ stars in 72 hours.">
+  <meta name="description" content="The open-source kanban board that speaks your agent's language. CLI-first, API-native, and built for local-first agent operations.">
   <meta name="keywords" content="kanban, AI agents, task management, CLI, MCP, open source, developer tools, agentic development">
   <meta name="author" content="Digital Meld">
 
@@ -1619,7 +1619,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
         <div class="stack-item fade-in fade-in-delay-3">
           <span class="stack-icon">🧪</span>
           <h3>Testing</h3>
-          <p>1,143+ unit tests (Vitest)<br>19 E2E tests (Playwright)<br>CI/CD with GitHub Actions</p>
+          <p>Vitest unit coverage<br>Playwright E2E coverage<br>CI/CD with GitHub Actions</p>
         </div>
       </div>
     </div>
@@ -1660,20 +1660,20 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
     <div class="container">
       <div class="fade-in">
         <span class="section-label">Community</span>
-        <h2 class="section-title">Growing fast.</h2>
+        <h2 class="section-title">Current release line.</h2>
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">190+</div>
-          <div class="proof-stat-label">GitHub stars in 72 hours</div>
+          <div class="proof-stat-number">v5.2</div>
+          <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">
-          <div class="proof-stat-number">1,143</div>
-          <div class="proof-stat-label">Unit tests passing</div>
+          <div class="proof-stat-number">Local</div>
+          <div class="proof-stat-label">Markdown task storage</div>
         </div>
         <div class="proof-stat">
-          <div class="proof-stat-number">4</div>
-          <div class="proof-stat-label">Major releases shipped</div>
+          <div class="proof-stat-number">Agent</div>
+          <div class="proof-stat-label">CLI, MCP, and OpenClaw ready</div>
         </div>
       </div>
       <div class="hero-stars fade-in">

--- a/server/src/__tests__/communication-adapter-service.test.ts
+++ b/server/src/__tests__/communication-adapter-service.test.ts
@@ -154,4 +154,30 @@ describe('CommunicationAdapterService', () => {
     expect(retry.delivery).toMatchObject({ status: 'skipped', squadMessageId: 'msg_reply' });
     expect(chatService.sendSquadMessage).toHaveBeenCalledTimes(1);
   });
+
+  it('blocks inbound replies when the adapter is disabled', async () => {
+    await service.configureAdapter('msteams-default', {
+      enabled: false,
+      deliveryMode: 'manual',
+      channelId: 'channel-1',
+    });
+
+    const result = await service.ingestReply('msteams-default', {
+      externalThreadId: 'teams-thread-1',
+      externalReplyId: 'reply-1',
+      actor: 'alice@example.com',
+      displayName: 'Alice',
+      message: 'Approved',
+      target: { kind: 'squad', squadMessageId: 'msg_root', taskId: 'task-1' },
+    });
+
+    expect(result.delivery).toMatchObject({
+      operation: 'reply-ingest',
+      status: 'blocked',
+      error: 'Adapter disabled',
+    });
+    expect(result.squadMessageId).toBe('');
+    expect(chatService.sendSquadMessage).not.toHaveBeenCalled();
+    expect(await service.listMappings('msteams-default')).toEqual([]);
+  });
 });

--- a/server/src/__tests__/workspace-capability-service.test.ts
+++ b/server/src/__tests__/workspace-capability-service.test.ts
@@ -49,6 +49,10 @@ const trustedManifest: WorkspaceCapabilityManifest = {
   },
 };
 
+function cloneConfig(config: AppConfig): AppConfig {
+  return JSON.parse(JSON.stringify(config)) as AppConfig;
+}
+
 function serviceWithConfig(config: AppConfig, sourceTask?: Task) {
   const createdTasks: Task[] = [];
   const updateTask = vi.fn(async (_id: string, input: Partial<Task>) => ({
@@ -79,8 +83,10 @@ function serviceWithConfig(config: AppConfig, sourceTask?: Task) {
         createdTasks.push(task);
         return task;
       },
-      getTask: async (id) => (sourceTask?.id === id ? sourceTask : null),
+      getTask: async (id) =>
+        sourceTask?.id === id ? sourceTask : (createdTasks.find((task) => task.id === id) ?? null),
       updateTask,
+      listTasks: async () => [sourceTask, ...createdTasks].filter(Boolean) as Task[],
     } as never
   );
   return { service, createdTasks, updateTask };
@@ -193,6 +199,7 @@ describe('WorkspaceCapabilityService', () => {
       project: 'handbook',
     });
     expect(createdTasks[0].description).toContain('## Delegated Intake');
+    expect(createdTasks[0].description).toContain(`- Delegation ID: ${result.record.id}`);
     expect(result.record.labels).toEqual(['delegated', 'docs', 'urgent-docs']);
     expect(config.workspaceDelegations).toHaveLength(1);
     expect(updateTask).toHaveBeenCalledWith(
@@ -205,6 +212,88 @@ describe('WorkspaceCapabilityService', () => {
             latestState: 'todo',
           }),
         ],
+      })
+    );
+  });
+
+  it('recovers the target task when final delegation persistence fails', async () => {
+    const sourceTask: Task = {
+      id: 'task_20260626_source',
+      title: 'Source task',
+      description: '',
+      type: 'feature',
+      status: 'todo',
+      priority: 'medium',
+      created: '2026-06-26T00:00:00.000Z',
+      updated: '2026-06-26T00:00:00.000Z',
+    };
+    let persisted = cloneConfig({
+      repos: [],
+      agents: [],
+      defaultAgent: 'codex',
+      workspaceCapability: localManifest,
+      trustedWorkspaceCapabilities: [trustedManifest],
+    });
+    const createdTasks: Task[] = [];
+    const updateTask = vi.fn(async (_id: string, input: Partial<Task>) => ({
+      ...sourceTask,
+      ...input,
+    }));
+    let saveCount = 0;
+    const service = new WorkspaceCapabilityService(
+      {
+        getConfig: async () => cloneConfig(persisted),
+        saveConfig: async (next: AppConfig) => {
+          saveCount += 1;
+          if (saveCount === 2) throw new Error('config write failed');
+          persisted = cloneConfig(next);
+        },
+      } as never,
+      {
+        createTask: async (input) => {
+          const task = {
+            id: `task_20260626_target_${createdTasks.length + 1}`,
+            title: input.title,
+            description: input.description ?? '',
+            type: input.type ?? 'code',
+            status: input.status ?? 'todo',
+            priority: input.priority ?? 'medium',
+            project: input.project,
+            created: '2026-06-26T00:00:00.000Z',
+            updated: '2026-06-26T00:00:00.000Z',
+            revision: 1,
+          } satisfies Task;
+          createdTasks.push(task);
+          return task;
+        },
+        getTask: async (id) =>
+          sourceTask.id === id ? sourceTask : (createdTasks.find((task) => task.id === id) ?? null),
+        updateTask,
+        listTasks: async () => [sourceTask, ...createdTasks],
+      } as never
+    );
+
+    await expect(service.intake(intakeInput())).rejects.toThrow('config write failed');
+
+    const pending = persisted.workspaceDelegations?.[0];
+    expect(createdTasks).toHaveLength(1);
+    expect(pending?.status).toBe('blocked');
+    expect(pending?.target.taskId).toBeUndefined();
+    expect(createdTasks[0].description).toContain(`- Delegation ID: ${pending?.id}`);
+
+    const result = await service.intake(intakeInput());
+
+    expect(createdTasks).toHaveLength(1);
+    expect(result.record).toMatchObject({
+      id: pending?.id,
+      status: 'created',
+      target: { taskId: createdTasks[0].id },
+    });
+    expect(persisted.workspaceDelegations?.[0].target.taskId).toBe(createdTasks[0].id);
+    expect(updateTask).toHaveBeenCalledWith(
+      sourceTask.id,
+      expect.objectContaining({
+        delegatedWork: [expect.objectContaining({ targetId: createdTasks[0].id })],
       })
     );
   });

--- a/server/src/services/communication-adapter-service.ts
+++ b/server/src/services/communication-adapter-service.ts
@@ -298,6 +298,35 @@ export class CommunicationAdapterService {
 
     const existing = this.findMapping(adapterId, externalThreadId);
     const target = normalizeTarget(input.target ?? existing?.target ?? { kind: 'squad' });
+    if (!adapter.enabled) {
+      const timestamp = nowIso();
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'reply-ingest',
+        status: 'blocked',
+        target,
+        externalThreadId,
+        actor: input.actor,
+        error: 'Adapter disabled',
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return {
+        delivery,
+        mapping: existing ?? {
+          id: `map_${nanoid(10)}`,
+          adapterId,
+          externalThreadId,
+          externalUrl: sanitizeUrl(input.externalUrl),
+          target,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          createdBy: trimOrUndefined(input.actor),
+        },
+        squadMessageId: '',
+      };
+    }
+
     const mapping = this.upsertMapping({
       adapterId,
       externalThreadId,
@@ -306,7 +335,7 @@ export class CommunicationAdapterService {
       createdBy: trimOrUndefined(input.actor),
     });
     const replyKey = input.externalReplyId
-      ? `${adapterId}:${input.externalThreadId}:${input.externalReplyId}`
+      ? `${adapterId}:${externalThreadId}:${input.externalReplyId}`
       : undefined;
     const existingReplyMessageId = replyKey ? this.state.replyIds[replyKey] : undefined;
     if (existingReplyMessageId) {

--- a/server/src/services/workspace-capability-service.ts
+++ b/server/src/services/workspace-capability-service.ts
@@ -29,7 +29,10 @@ interface ImportManifestInput {
 }
 
 type WorkspaceCapabilityConfigStore = Pick<ConfigService, 'getConfig' | 'saveConfig'>;
-type WorkspaceCapabilityTaskStore = Pick<TaskService, 'createTask' | 'getTask' | 'updateTask'>;
+type WorkspaceCapabilityTaskStore = Pick<
+  TaskService,
+  'createTask' | 'getTask' | 'updateTask' | 'listTasks'
+>;
 
 export class WorkspaceCapabilityService {
   constructor(
@@ -194,9 +197,56 @@ export class WorkspaceCapabilityService {
       ...(capability.defaultLabels ?? []),
       ...(input.labels ?? []),
     ].filter((label, index, list) => list.indexOf(label) === index);
+
+    const existing = this.findMatchingDelegation(config, input, capability.id, local.workspaceId);
+    if (existing?.target.taskId) {
+      const existingTask = await this.taskService.getTask(existing.target.taskId);
+      if (existingTask) {
+        await this.attachDelegationToSourceTask(input.source.taskId, existing);
+        return { record: existing, taskId: existingTask.id, taskUrl: existing.target.url };
+      }
+    }
+
+    if (existing && !existing.target.taskId) {
+      const recoveredTask = await this.findTaskForDelegation(existing.id);
+      if (recoveredTask) {
+        const recovered = this.finalizeDelegationRecord(
+          existing,
+          input,
+          local,
+          labels,
+          recoveredTask
+        );
+        await this.saveDelegationRecord(config, recovered);
+        await this.attachDelegationToSourceTask(input.source.taskId, recovered);
+        return { record: recovered, taskId: recoveredTask.id, taskUrl: recovered.target.url };
+      }
+    }
+
+    const now = new Date().toISOString();
+    const pendingRecord: WorkspaceDelegationRecord = {
+      id: existing?.id ?? this.generateDelegationId(),
+      capabilityId: capability.id,
+      title: input.title,
+      status: 'blocked',
+      latestState: 'pending-intake',
+      labels,
+      source: input.source,
+      target: {
+        type: 'task',
+        workspaceId: local.workspaceId,
+        workspaceName: local.name,
+        url: input.backlinkUrl,
+      },
+      requestedBy: input.requestedBy,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    await this.saveDelegationRecord(config, pendingRecord);
+
     const task = await this.taskService.createTask({
       title: input.title,
-      description: this.buildDelegatedTaskDescription(input, labels),
+      description: this.buildDelegatedTaskDescription(input, labels, pendingRecord.id),
       type: taskType,
       priority: input.priority ?? capability.defaultPriority ?? local.defaultPriority ?? 'medium',
       project: input.project ?? capability.defaultProject ?? local.defaultProject,
@@ -204,26 +254,7 @@ export class WorkspaceCapabilityService {
       updatedBy: input.requestedBy ?? `workspace:${input.source.workspaceId}`,
     } satisfies CreateTaskInput);
 
-    const now = new Date().toISOString();
-    const record: WorkspaceDelegationRecord = {
-      id: this.generateDelegationId(),
-      capabilityId: capability.id,
-      title: input.title,
-      status: 'created',
-      latestState: task.status,
-      labels,
-      source: input.source,
-      target: {
-        type: 'task',
-        workspaceId: local.workspaceId,
-        workspaceName: local.name,
-        taskId: task.id,
-        url: input.backlinkUrl ?? `/tasks/${task.id}`,
-      },
-      requestedBy: input.requestedBy,
-      createdAt: now,
-      updatedAt: now,
-    };
+    const record = this.finalizeDelegationRecord(pendingRecord, input, local, labels, task);
 
     await this.saveDelegationRecord(config, record);
     await this.attachDelegationToSourceTask(input.source.taskId, record);
@@ -343,7 +374,8 @@ export class WorkspaceCapabilityService {
 
   private buildDelegatedTaskDescription(
     input: WorkspaceDelegatedWorkIntakeInput,
-    labels: string[]
+    labels: string[],
+    delegationId?: string
   ): string {
     const contextFields = Object.entries(input.contextFields ?? {})
       .map(([key, value]) => `- ${key}: ${value}`)
@@ -357,11 +389,67 @@ export class WorkspaceCapabilityService {
       input.source.taskUrl ? `- Source task URL: ${input.source.taskUrl}` : undefined,
       input.source.repository ? `- Source repository: ${input.source.repository}` : undefined,
       input.source.issueUrl ? `- Source issue: ${input.source.issueUrl}` : undefined,
+      delegationId ? `- Delegation ID: ${delegationId}` : undefined,
       labels.length > 0 ? `- Labels: ${labels.join(', ')}` : undefined,
       input.requestedBy ? `- Requested by: ${input.requestedBy}` : undefined,
       contextFields ? `\n### Required Context\n${contextFields}` : undefined,
     ];
     return lines.filter(Boolean).join('\n');
+  }
+
+  private findMatchingDelegation(
+    config: AppConfig,
+    input: WorkspaceDelegatedWorkIntakeInput,
+    capabilityId: string,
+    targetWorkspaceId: string
+  ): WorkspaceDelegationRecord | undefined {
+    return (config.workspaceDelegations ?? []).find((record) => {
+      if (record.capabilityId !== capabilityId || record.target.workspaceId !== targetWorkspaceId) {
+        return false;
+      }
+      if (record.source.workspaceId !== input.source.workspaceId || record.title !== input.title) {
+        return false;
+      }
+      if (record.source.taskId || input.source.taskId)
+        return record.source.taskId === input.source.taskId;
+      if (record.source.issueUrl || input.source.issueUrl) {
+        return record.source.issueUrl === input.source.issueUrl;
+      }
+      return true;
+    });
+  }
+
+  private async findTaskForDelegation(delegationId: string): Promise<Task | null> {
+    const tasks = await this.taskService.listTasks();
+    return (
+      tasks.find((task) => task.description.includes(`Delegation ID: ${delegationId}`)) ?? null
+    );
+  }
+
+  private finalizeDelegationRecord(
+    base: WorkspaceDelegationRecord,
+    input: WorkspaceDelegatedWorkIntakeInput,
+    local: WorkspaceCapabilityManifest,
+    labels: string[],
+    task: Task
+  ): WorkspaceDelegationRecord {
+    return {
+      ...base,
+      title: input.title,
+      status: 'created',
+      latestState: task.status,
+      labels,
+      source: input.source,
+      target: {
+        type: 'task',
+        workspaceId: local.workspaceId,
+        workspaceName: local.name,
+        taskId: task.id,
+        url: input.backlinkUrl ?? `/tasks/${task.id}`,
+      },
+      requestedBy: input.requestedBy,
+      updatedAt: new Date().toISOString(),
+    };
   }
 
   private async saveDelegationRecord(


### PR DESCRIPTION
## Summary

- Block disabled communication adapters from ingesting inbound human replies, without creating Squad Chat messages or thread mappings.
- Make workspace delegated intake recoverable by saving a pending delegation before task creation and reconciling retries by delegation id.
- Refresh the static docs homepage copy to remove brittle launch-era/test-count claims.

Closes #760.
Closes #761.
Closes #763.

## Verification

- `pnpm --filter @veritas-kanban/server test -- src/__tests__/communication-adapter-service.test.ts src/__tests__/workspace-capability-service.test.ts src/__tests__/queue-intake-monitor-service.test.ts` passed; this ran the full server Vitest suite: 178 files, 1986 tests.
- `pnpm exec vitest run src/__tests__/workspace-capability-service.test.ts` from `server/` passed: 1 file, 5 tests.
- `pnpm --filter @veritas-kanban/server typecheck`
- `git diff --check`
- `rg -n "190\\+|1,143|72 hours" docs/index.html` returned no matches.
- Headless Chrome render of `docs/index.html` verified the updated release-line, v5.2, coverage, and OpenClaw-ready homepage text.

## Risk

- Delegated intake now writes config once before creating the task and once after. This is intentional so a mid-handoff failure leaves a visible pending delegation instead of an orphaned task.
