### PR TITLE
Bump version to 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   count claims from current-release copy (#763, #764).
 - Bumped the source metadata from `5.2.0` to `5.2.1` across package manifests
   and operator-facing version docs (#765).
+- Stabilized workflow run metadata coverage and file-backed ChatService startup
+  directory setup so release CI does not leak asynchronous test setup errors.
 
 ## [5.2.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.1] - 2026-06-29
+
+### Fixed
+
+- Blocked disabled communication adapters from ingesting inbound human replies
+  into Squad Chat (#760, #764).
+- Made delegated workspace intake recoverable when config persistence fails
+  after target task creation (#761, #764).
+- Verified queue monitor candidate selection already prioritizes runnable work
+  before the bounded candidate cap (#762).
+
+### Changed
+
+- Refreshed the static docs homepage to remove brittle launch-era star and test
+  count claims from current-release copy (#763, #764).
+- Bumped the source metadata from `5.2.0` to `5.2.1` across package manifests
+  and operator-facing version docs (#765).
+
 ## [5.2.0] - 2026-06-26
 
 ### Added
@@ -1652,7 +1670,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.0...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.1...HEAD
+[5.2.1]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.0...v5.2.1
 [5.2.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.0...v5.0.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.2.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.1-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,7 +1,7 @@
 # Veritas Kanban — API Reference
 
-**Version**: 5.2.0
-**Last Updated**: 2026-06-26
+**Version**: 5.2.1
+**Last Updated**: 2026-06-29
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)
 

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -1,6 +1,6 @@
 # Veritas Kanban v5 GA Checklist
 
-v5.0.0 stable is published. The current source line is v5.2.0, including the
+v5.0.0 stable is published. The current source line is v5.2.1, including the
 post-v5.1 backlog train for team rosters, workspace capability discovery,
 queue monitors, recurring work, Squad Chat threading and human replies,
 ceremony gates, reflection promotion, external tracker introspection, and audit

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -2,13 +2,28 @@
 
 These notes describe the Veritas Kanban v5 stable release line.
 
-- Current source version: `v5.2.0`
+- Current source version: `v5.2.1`
 - Latest published GitHub release:
   [Veritas Kanban v5.1.0](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.1.0)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
   [Veritas-Kanban-5.1.0-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.1.0/Veritas-Kanban-5.1.0-mac-arm64.zip)
+
+## v5.2.1 Patch
+
+v5.2.1 records the completed v5.2 audit follow-up pass. It keeps the published
+release/install channel unchanged while updating source metadata and docs.
+
+- Disabled communication adapters now block inbound human reply ingestion
+  before creating Squad Chat messages or thread mappings.
+- Delegated workspace intake now leaves a recoverable pending delegation if
+  persistence fails mid-handoff, and retries can reconcile the target task by
+  delegation ID.
+- The static docs homepage no longer carries brittle launch-era star and exact
+  test-count claims.
+- Queue monitor selection was audited and left unchanged because current sorting
+  already puts runnable candidates ahead of blocked work before the cap.
 
 ## v5.2.0 Release
 

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -24,6 +24,9 @@ release/install channel unchanged while updating source metadata and docs.
   test-count claims.
 - Queue monitor selection was audited and left unchanged because current sorting
   already puts runnable candidates ahead of blocked work before the cap.
+- Release CI was hardened by waiting for workflow-run metadata completion and
+  file-backed ChatService directory initialization before temp workspaces are
+  removed.
 
 ## v5.2.0 Release
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1664,7 +1664,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">v5.2</div>
+          <div class="proof-stat-number">v5.2.1</div>
           <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -802,7 +802,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `5.2.0`      | Matches VK server version   |
+| MCP server package | `5.2.1`      | Matches VK server version   |
 | MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2024-11-05` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -846,4 +846,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-06-26 · VK v5.2.0 · 36 tools / 8 categories_
+_Last updated: 2026-06-29 · VK v5.2.1 · 36 tools / 8 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/server/src/__tests__/workflow-run-service.test.ts
+++ b/server/src/__tests__/workflow-run-service.test.ts
@@ -323,6 +323,7 @@ describe('WorkflowRunService', () => {
   it('lists runs and metadata with filters while skipping invalid or broken entries', async () => {
     const run1 = await service.startRun('wf-1', 'task-1');
     const run2 = await service.startRun('wf-1', 'task-2');
+    await vi.waitFor(async () => expect((await service.getRun(run1.id)).status).toBe('completed'));
     await vi.waitFor(async () => expect((await service.getRun(run2.id)).status).toBe('completed'));
 
     await fs.mkdir(path.join(tmpDir, 'run_9999999999_brokenxx'), { recursive: true });

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -76,6 +76,7 @@ export class ChatService {
   private readonly repository: SqliteChatRepository | null = null;
   private readonly sqliteDatabase: SqliteDatabase | null = null;
   private readonly ownsSqliteDatabase: boolean = false;
+  private directorySetup: Promise<void> = Promise.resolve();
 
   constructor(options: ChatServiceOptions = {}) {
     this.chatsDir = options.chatsDir || DEFAULT_CHATS_DIR;
@@ -93,7 +94,10 @@ export class ChatService {
     }
 
     if (!this.repository) {
-      this.ensureDirectories();
+      this.directorySetup = this.ensureDirectories();
+      this.directorySetup.catch((err) => {
+        log.warn({ err }, 'Failed to initialize chat directories');
+      });
     }
   }
 
@@ -101,6 +105,11 @@ export class ChatService {
     await fs.mkdir(this.chatsDir, { recursive: true });
     await fs.mkdir(this.sessionsDir, { recursive: true });
     await fs.mkdir(this.squadDir, { recursive: true });
+  }
+
+  private async ensureFileStorageReady(): Promise<void> {
+    if (this.repository) return;
+    await this.directorySetup;
   }
 
   /**
@@ -243,6 +252,8 @@ export class ChatService {
       return this.repository.getSession(sessionId);
     }
 
+    await this.ensureFileStorageReady();
+
     if (taskMatch) {
       const taskId = taskMatch[1];
       const filePath = this.getSessionPath(sessionId, taskId);
@@ -277,6 +288,8 @@ export class ChatService {
       return this.repository.getSessionForTask(taskId);
     }
 
+    await this.ensureFileStorageReady();
+
     const filePath = this.getSessionPath(`task_${taskId}`, taskId);
 
     try {
@@ -295,6 +308,8 @@ export class ChatService {
     if (this.repository) {
       return this.repository.listBoardSessions();
     }
+
+    await this.ensureFileStorageReady();
 
     try {
       const files = await fs.readdir(this.sessionsDir);
@@ -350,6 +365,8 @@ export class ChatService {
       return session;
     }
 
+    await this.ensureFileStorageReady();
+
     const filePath = this.getSessionPath(sessionId, input.taskId);
     const content = this.serializeSession(session);
 
@@ -398,6 +415,8 @@ export class ChatService {
       return newMessage;
     }
 
+    await this.ensureFileStorageReady();
+
     const filePath = this.getSessionPath(sessionId, taskId);
 
     await withFileLock(filePath, async () => {
@@ -441,6 +460,8 @@ export class ChatService {
       log.info({ sessionId }, 'Deleted chat session');
       return;
     }
+
+    await this.ensureFileStorageReady();
 
     const filePath = this.getSessionPath(sessionId, taskId);
 
@@ -496,12 +517,14 @@ export class ChatService {
   }
 
   private async readSquadMetadata(): Promise<SquadMetadataFile> {
+    await this.ensureFileStorageReady();
     return this.readSquadMetadataFromPath(this.getSquadMetadataPath());
   }
 
   private async updateSquadMetadata<T>(
     mutator: (metadata: SquadMetadataFile) => T | Promise<T>
   ): Promise<T> {
+    await this.ensureFileStorageReady();
     const filePath = this.getSquadMetadataPath();
     await fs.mkdir(this.squadDir, { recursive: true });
 
@@ -695,6 +718,8 @@ export class ChatService {
     if (this.repository) {
       this.repository.appendSquadMessage(squadMessage);
     } else {
+      await this.ensureFileStorageReady();
+
       // Store as daily markdown file: squad/YYYY-MM-DD.md
       const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
       const filePath = path.join(this.squadDir, `${date}.md`);
@@ -794,6 +819,8 @@ export class ChatService {
         })
       );
     }
+
+    await this.ensureFileStorageReady();
 
     const messages: SquadMessage[] = [];
     const includeSystem = options.includeSystem !== false; // Default to true

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump root and workspace package versions from `5.2.0` to `5.2.1`.
- Add the `5.2.1` changelog and v5 release-note patch entries for the completed audit follow-ups.
- Update README, API, MCP, GA checklist, and static homepage current-version references.

Closes #765.

## Verification

- `pnpm validate:release`
- Package version consistency loop over root, shared, server, web, CLI, MCP, and desktop manifests.
- Headless Chrome render of `docs/index.html` verified the `v5.2.1` current source label.
- `git diff --check`

## Notes

This is source metadata and documentation only. It does not publish a GitHub release, rebuild signed desktop assets, or update Homebrew tap metadata.
