### PR TITLE
fix: harden file storage integrity and mutation ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Isolated QMD result normalization coverage from unrelated persistent search
   collections and restored test environment state only after temporary search
   roots are removed, eliminating the intermittent teardown race (#793).
+- File-backed task mutations (create, update, archive, restore) now use an
+  atomic write-then-rename strategy so a mid-write crash or I/O error cannot
+  leave the task file empty or partially written; the previous valid file
+  remains intact until the replacement is durable (#776).
+- Revision validation is now enforced inside the file-lock / SQLite mutation
+  — not just at the route layer — eliminating the TOCTOU window where two
+  concurrent requests with the same `expectedRevision` could both succeed and
+  the later write silently overwrite the earlier one (#777).
+- Concurrent requests for the same task now always serialize through the lock
+  because the lock key is the task's _current_ filepath (stable per task ID)
+  rather than the tentative new filepath, which differed when titles changed
+  (#777).
+
+### Performance
+
+- Activity-service `countActivities` no longer triggers a second full file
+  parse and filter pass; the filtered result set is shared with `getActivities`
+  in one read (#782).
+- Activity file writes are now atomic (write-temp / rename), and corrupt files
+  are backed up before recovery rather than silently overwritten (#782).
+- Task-identity diagnostics are cached after the first scan and invalidated
+  only on task mutations or external file changes, eliminating the O(N)
+  full-filesystem scan on every `GET /api/tasks` and backlog-list request
+  (#784).
 
 ## [5.2.1] - 2026-06-29
 

--- a/server/src/__tests__/activity-service-perf.test.ts
+++ b/server/src/__tests__/activity-service-perf.test.ts
@@ -2,7 +2,7 @@
  * Tests for activity service performance improvements (#782)
  *
  * Verifies that:
- * - getActivities and countActivities share a single parse/filter pass (no double scan).
+ * - A paginated file-backed request uses a single parse/filter pass.
  * - Writes are atomic (no partial JSON visible to readers).
  * - A corrupt activity file is backed up before a reset — not silently overwritten.
  */
@@ -49,25 +49,25 @@ describe('ActivityService – performance & integrity (#782)', () => {
   });
 
   describe('single-scan pagination (#782)', () => {
-    it('getActivities and countActivities share one parse — loadAll called once per request', async () => {
+    it('reads and parses the activity file once for a paginated result', async () => {
       await service.logActivity('task_created', 'task_1', 'Alpha');
       await service.logActivity('task_updated', 'task_2', 'Beta', {}, 'codex');
 
-      // Spy on readFile to count disk reads
-      const readFileSpy = vi.spyOn(fs, 'readFile');
+      const loadAllSpy = vi.spyOn(
+        service as unknown as { loadAll(): Promise<unknown[]> },
+        'loadAll'
+      );
 
-      const [items, count] = await Promise.all([
-        service.getActivities(10),
-        service.countActivities(),
-      ]);
+      const { items, total } = await service.getActivitiesPage(10);
 
       expect(items).toHaveLength(2);
-      expect(count).toBe(2);
+      expect(total).toBe(2);
+      expect(loadAllSpy).toHaveBeenCalledTimes(1);
 
-      readFileSpy.mockRestore();
+      loadAllSpy.mockRestore();
     });
 
-    it('countActivities applies filters without a second full scan', async () => {
+    it('countActivities applies filters', async () => {
       await service.logActivity('task_created', 'task_1', 'Alpha', {}, 'codex');
       await service.logActivity('task_updated', 'task_2', 'Beta', {}, 'tars');
       await service.logActivity('task_created', 'task_3', 'Gamma', {}, 'codex');
@@ -81,7 +81,7 @@ describe('ActivityService – performance & integrity (#782)', () => {
       expect(totalCount).toBe(3);
     });
 
-    it('getActivities with filters + countActivities with same filters agree on totals', async () => {
+    it('returns filtered page items and total from one result', async () => {
       for (let i = 0; i < 10; i++) {
         await service.logActivity(
           'task_created',
@@ -93,10 +93,9 @@ describe('ActivityService – performance & integrity (#782)', () => {
       }
 
       const filters = { agent: 'codex' };
-      const page = await service.getActivities(3, filters, 0);
-      const total = await service.countActivities(filters);
+      const { items, total } = await service.getActivitiesPage(3, filters, 0);
 
-      expect(page).toHaveLength(3);
+      expect(items).toHaveLength(3);
       expect(total).toBe(5); // 5 even indices: 0,2,4,6,8
     });
   });

--- a/server/src/__tests__/activity-service-perf.test.ts
+++ b/server/src/__tests__/activity-service-perf.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for activity service performance improvements (#782)
+ *
+ * Verifies that:
+ * - getActivities and countActivities share a single parse/filter pass (no double scan).
+ * - Writes are atomic (no partial JSON visible to readers).
+ * - A corrupt activity file is backed up before a reset — not silently overwritten.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+
+const tmpRoot = vi.hoisted(() => {
+  const tmpdir = process.env.TMPDIR || process.env.TEMP || '/tmp';
+  return tmpdir + '/veritas-activity-perf-test-' + Math.random().toString(36).substring(7);
+});
+
+vi.mock('fs', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    existsSync: (p: string) => {
+      if (p.includes('.veritas-kanban')) {
+        const redirected = p.replace(/.*\.veritas-kanban/, path.join(tmpRoot, '.veritas-kanban'));
+        return (original.existsSync as (p: string) => boolean)(redirected);
+      }
+      return (original.existsSync as (p: string) => boolean)(p);
+    },
+  };
+});
+
+import { ActivityService } from '../services/activity-service.js';
+
+describe('ActivityService – performance & integrity (#782)', () => {
+  let service: ActivityService;
+  let activityDir: string;
+  let activityFile: string;
+
+  beforeEach(async () => {
+    activityDir = path.join(tmpRoot, '.veritas-kanban');
+    await fs.mkdir(activityDir, { recursive: true });
+    service = new ActivityService();
+    activityFile = path.join(activityDir, 'activity.json');
+    (service as unknown as { activityFile: string }).activityFile = activityFile;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  describe('single-scan pagination (#782)', () => {
+    it('getActivities and countActivities share one parse — loadAll called once per request', async () => {
+      await service.logActivity('task_created', 'task_1', 'Alpha');
+      await service.logActivity('task_updated', 'task_2', 'Beta', {}, 'codex');
+
+      // Spy on readFile to count disk reads
+      const readFileSpy = vi.spyOn(fs, 'readFile');
+
+      const [items, count] = await Promise.all([
+        service.getActivities(10),
+        service.countActivities(),
+      ]);
+
+      expect(items).toHaveLength(2);
+      expect(count).toBe(2);
+
+      readFileSpy.mockRestore();
+    });
+
+    it('countActivities applies filters without a second full scan', async () => {
+      await service.logActivity('task_created', 'task_1', 'Alpha', {}, 'codex');
+      await service.logActivity('task_updated', 'task_2', 'Beta', {}, 'tars');
+      await service.logActivity('task_created', 'task_3', 'Gamma', {}, 'codex');
+
+      const codexCount = await service.countActivities({ agent: 'codex' });
+      const tarsCount = await service.countActivities({ agent: 'tars' });
+      const totalCount = await service.countActivities();
+
+      expect(codexCount).toBe(2);
+      expect(tarsCount).toBe(1);
+      expect(totalCount).toBe(3);
+    });
+
+    it('getActivities with filters + countActivities with same filters agree on totals', async () => {
+      for (let i = 0; i < 10; i++) {
+        await service.logActivity(
+          'task_created',
+          `task_${i}`,
+          `Task ${i}`,
+          {},
+          i % 2 === 0 ? 'codex' : 'tars'
+        );
+      }
+
+      const filters = { agent: 'codex' };
+      const page = await service.getActivities(3, filters, 0);
+      const total = await service.countActivities(filters);
+
+      expect(page).toHaveLength(3);
+      expect(total).toBe(5); // 5 even indices: 0,2,4,6,8
+    });
+  });
+
+  describe('atomic writes (#782)', () => {
+    it('persisted activity file is valid JSON after concurrent writes', async () => {
+      await Promise.all([
+        service.logActivity('task_created', 'task_a', 'A'),
+        service.logActivity('task_updated', 'task_b', 'B'),
+        service.logActivity('task_created', 'task_c', 'C'),
+      ]);
+
+      const raw = await fs.readFile(activityFile, 'utf-8');
+      expect(() => JSON.parse(raw)).not.toThrow();
+      const parsed = JSON.parse(raw) as unknown[];
+      expect(parsed.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('corrupt file handling (#782)', () => {
+    it('backs up a corrupt activity file before resetting to empty', async () => {
+      // Write corrupt JSON
+      await fs.writeFile(activityFile, '{not-valid-json', 'utf-8');
+
+      // logActivity should succeed and reset gracefully
+      await expect(
+        service.logActivity('task_created', 'task_1', 'After Corruption')
+      ).resolves.toBeDefined();
+
+      // A .corrupt.* backup file should exist
+      const files = await fs.readdir(activityDir);
+      const backupFiles = files.filter((f) => f.includes('.corrupt.'));
+      expect(backupFiles.length).toBeGreaterThan(0);
+
+      // The activity file should now contain valid JSON with our new entry
+      const raw = await fs.readFile(activityFile, 'utf-8');
+      expect(() => JSON.parse(raw)).not.toThrow();
+      const activities = JSON.parse(raw) as { taskTitle: string }[];
+      expect(activities[0].taskTitle).toBe('After Corruption');
+    });
+  });
+});

--- a/server/src/__tests__/atomic-write.test.ts
+++ b/server/src/__tests__/atomic-write.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for atomicWriteFile (#776)
+ *
+ * Verifies that:
+ * - A successful write is visible atomically (no partial state).
+ * - No temp files leak after a successful write.
+ * - A failed rename does not silently corrupt (no stray .tmp.* files remain).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { atomicWriteFile } from '../storage/fs-helpers.js';
+
+describe('atomicWriteFile', () => {
+  let testDir: string;
+
+  afterEach(async () => {
+    if (testDir) {
+      await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('writes content atomically — final content matches what was written', async () => {
+    const suffix = Math.random().toString(36).substring(7);
+    testDir = path.join(os.tmpdir(), `vk-atomic-test-${suffix}`);
+    await fs.mkdir(testDir, { recursive: true });
+
+    const destPath = path.join(testDir, 'task.md');
+    const original = '# original content';
+    const updated = '# updated content';
+
+    await atomicWriteFile(destPath, original);
+    expect(await fs.readFile(destPath, 'utf-8')).toBe(original);
+
+    await atomicWriteFile(destPath, updated);
+    expect(await fs.readFile(destPath, 'utf-8')).toBe(updated);
+  });
+
+  it('leaves no stray temp files after a successful write', async () => {
+    const suffix = Math.random().toString(36).substring(7);
+    testDir = path.join(os.tmpdir(), `vk-atomic-noleak-${suffix}`);
+    await fs.mkdir(testDir, { recursive: true });
+
+    const destPath = path.join(testDir, 'task.md');
+    await atomicWriteFile(destPath, '# content');
+
+    const files = await fs.readdir(testDir);
+    const tmpFiles = files.filter((f) => f.includes('.tmp.'));
+    expect(tmpFiles).toHaveLength(0);
+  });
+
+  it('cleans up the temp file and rejects when rename fails (dest is a directory)', async () => {
+    const suffix = Math.random().toString(36).substring(7);
+    testDir = path.join(os.tmpdir(), `vk-atomic-fail-${suffix}`);
+    await fs.mkdir(testDir, { recursive: true });
+
+    // Point dest at an existing non-empty directory — rename will fail with EISDIR/ENOTDIR
+    const blockingDir = path.join(testDir, 'blocker');
+    const blockingFile = path.join(blockingDir, 'sentinel');
+    await fs.mkdir(blockingDir, { recursive: true });
+    await fs.writeFile(blockingFile, 'sentinel');
+
+    // Attempt to atomically write to the blocking directory path
+    await expect(atomicWriteFile(blockingDir, '# would overwrite dir')).rejects.toThrow();
+
+    // No stray .tmp.* files should remain in the parent dir
+    const files = await fs.readdir(testDir);
+    const tmpFiles = files.filter((f) => f.includes('.tmp.'));
+    expect(tmpFiles).toHaveLength(0);
+
+    // The blocking directory must still be intact — nothing was destroyed
+    await expect(fs.readFile(blockingFile, 'utf-8')).resolves.toBe('sentinel');
+  });
+
+  it('preserves the original file when a second write fails', async () => {
+    const suffix = Math.random().toString(36).substring(7);
+    testDir = path.join(os.tmpdir(), `vk-atomic-preserve-${suffix}`);
+    await fs.mkdir(testDir, { recursive: true });
+
+    const destPath = path.join(testDir, 'task.md');
+    const originalContent = '# safe original';
+
+    // First write succeeds
+    await atomicWriteFile(destPath, originalContent);
+
+    // Second write: write the temp, then try to rename fails because we make
+    // dest a directory via a sibling .tmp directory trickery — instead just
+    // verify the first write survived after success path works correctly.
+    const current = await fs.readFile(destPath, 'utf-8');
+    expect(current).toBe(originalContent);
+  });
+});

--- a/server/src/__tests__/atomic-write.test.ts
+++ b/server/src/__tests__/atomic-write.test.ts
@@ -7,7 +7,7 @@
  * - A failed rename does not silently corrupt (no stray .tmp.* files remain).
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import fs from 'fs/promises';
+import { promises as fs } from 'node:fs';
 import path from 'path';
 import os from 'os';
 import { atomicWriteFile } from '../storage/fs-helpers.js';
@@ -50,7 +50,7 @@ describe('atomicWriteFile', () => {
     expect(tmpFiles).toHaveLength(0);
   });
 
-  it('cleans up the temp file and rejects when rename fails (dest is a directory)', async () => {
+  it('preserves an existing destination and cleans up when replacement rename fails', async () => {
     const suffix = Math.random().toString(36).substring(7);
     testDir = path.join(os.tmpdir(), `vk-atomic-fail-${suffix}`);
     await fs.mkdir(testDir, { recursive: true });
@@ -71,23 +71,5 @@ describe('atomicWriteFile', () => {
 
     // The blocking directory must still be intact — nothing was destroyed
     await expect(fs.readFile(blockingFile, 'utf-8')).resolves.toBe('sentinel');
-  });
-
-  it('preserves the original file when a second write fails', async () => {
-    const suffix = Math.random().toString(36).substring(7);
-    testDir = path.join(os.tmpdir(), `vk-atomic-preserve-${suffix}`);
-    await fs.mkdir(testDir, { recursive: true });
-
-    const destPath = path.join(testDir, 'task.md');
-    const originalContent = '# safe original';
-
-    // First write succeeds
-    await atomicWriteFile(destPath, originalContent);
-
-    // Second write: write the temp, then try to rename fails because we make
-    // dest a directory via a sibling .tmp directory trickery — instead just
-    // verify the first write survived after success path works correctly.
-    const current = await fs.readFile(destPath, 'utf-8');
-    expect(current).toBe(originalContent);
   });
 });

--- a/server/src/__tests__/docker-paths.test.ts
+++ b/server/src/__tests__/docker-paths.test.ts
@@ -9,6 +9,7 @@ const createFsPromisesMock = vi.hoisted(() => () => {
     readFile: vi.fn().mockResolvedValue(''),
     writeFile: vi.fn().mockResolvedValue(undefined),
     readdir: vi.fn().mockResolvedValue([]),
+    rename: vi.fn().mockResolvedValue(undefined),
     unlink: vi.fn().mockResolvedValue(undefined),
     rm: vi.fn().mockResolvedValue(undefined),
     stat: vi.fn().mockResolvedValue({ isDirectory: () => true, size: 0 }),

--- a/server/src/__tests__/jwt-rotation.test.ts
+++ b/server/src/__tests__/jwt-rotation.test.ts
@@ -11,6 +11,7 @@ vi.mock('node:fs/promises', () => {
   const readFile = vi.fn().mockResolvedValue('');
   const writeFile = vi.fn().mockResolvedValue(undefined);
   const readdir = vi.fn().mockResolvedValue([]);
+  const rename = vi.fn().mockResolvedValue(undefined);
   const unlink = vi.fn().mockResolvedValue(undefined);
   const rm = vi.fn().mockResolvedValue(undefined);
   return {
@@ -19,9 +20,10 @@ vi.mock('node:fs/promises', () => {
     readFile,
     writeFile,
     readdir,
+    rename,
     unlink,
     rm,
-    default: { access, mkdir, readFile, writeFile, readdir, unlink, rm },
+    default: { access, mkdir, readFile, writeFile, readdir, rename, unlink, rm },
   };
 });
 

--- a/server/src/__tests__/routes/misc-routes-coverage.test.ts
+++ b/server/src/__tests__/routes/misc-routes-coverage.test.ts
@@ -24,6 +24,7 @@ const {
 } = vi.hoisted(() => ({
   mockActivityService: {
     getActivities: vi.fn(),
+    getActivitiesPage: vi.fn(),
     clearActivities: vi.fn(),
     logActivity: vi.fn().mockResolvedValue(undefined),
   },
@@ -176,6 +177,19 @@ describe('Activity Routes', () => {
     const res = await request(app).get('/api/activity?limit=10');
     expect(res.status).toBe(200);
     expect(mockActivityService.getActivities).toHaveBeenCalledWith(10, undefined);
+  });
+
+  it('GET / should obtain a paginated response in one service call', async () => {
+    mockActivityService.getActivitiesPage.mockResolvedValue({
+      items: [{ id: 'a1' }],
+      total: 3,
+    });
+
+    const res = await request(app).get('/api/activity?page=2&limit=1&agent=codex');
+
+    expect(res.status).toBe(200);
+    expect(mockActivityService.getActivitiesPage).toHaveBeenCalledWith(1, { agent: 'codex' }, 1);
+    expect(mockActivityService.getActivities).not.toHaveBeenCalled();
   });
 
   it('DELETE / should clear activities', async () => {

--- a/server/src/__tests__/task-identity-diagnostics-cache.test.ts
+++ b/server/src/__tests__/task-identity-diagnostics-cache.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for task identity diagnostics caching (#784)
+ *
+ * Verifies that:
+ * - Repeated calls to getTaskIdentityDiagnostics return a cached result (no disk re-scan).
+ * - The cache is invalidated after mutations (create, update, archive, restore).
+ * - External file changes (watcher) also invalidate the cache.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { TaskService } from '../services/task-service.js';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+import * as taskIdentityDiagnostics from '../services/task-identity-diagnostics.js';
+
+describe('TaskService – identity diagnostics cache (#784)', () => {
+  let service: TaskService;
+  let testRoot: string;
+  let tasksDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    const suffix = Math.random().toString(36).substring(7);
+    testRoot = path.join(os.tmpdir(), `vk-diag-cache-test-${suffix}`);
+    tasksDir = path.join(testRoot, 'active');
+    archiveDir = path.join(testRoot, 'archive');
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.mkdir(archiveDir, { recursive: true });
+
+    service = new TaskService({
+      tasksDir,
+      archiveDir,
+      configService: { getFeatureSettings: async () => DEFAULT_FEATURE_SETTINGS },
+    });
+  });
+
+  afterEach(async () => {
+    service.dispose();
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+    vi.restoreAllMocks();
+  });
+
+  it('returns cached result on repeated calls without mutations', async () => {
+    await service.createTask({ title: 'Task A', type: 'code', priority: 'medium' });
+
+    const scanSpy = vi.spyOn(taskIdentityDiagnostics, 'scanTaskIdentityDiagnostics');
+
+    // First call — populates cache
+    const first = await service.getTaskIdentityDiagnostics();
+    // Second call — should hit cache, not re-scan
+    const second = await service.getTaskIdentityDiagnostics();
+    const third = await service.getTaskIdentityDiagnostics();
+
+    expect(first).toBe(second); // same object reference (cached)
+    expect(second).toBe(third);
+    // scanTaskIdentityDiagnostics should have been called exactly once
+    expect(scanSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates cache after createTask', async () => {
+    const scanSpy = vi.spyOn(taskIdentityDiagnostics, 'scanTaskIdentityDiagnostics');
+
+    await service.getTaskIdentityDiagnostics(); // warm cache
+    const callsBefore = scanSpy.mock.calls.length;
+
+    await service.createTask({ title: 'New Task', type: 'code', priority: 'low' });
+
+    await service.getTaskIdentityDiagnostics(); // should re-scan
+    expect(scanSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('invalidates cache after updateTask', async () => {
+    const task = await service.createTask({
+      title: 'Update Target',
+      type: 'code',
+      priority: 'medium',
+    });
+    const scanSpy = vi.spyOn(taskIdentityDiagnostics, 'scanTaskIdentityDiagnostics');
+
+    await service.getTaskIdentityDiagnostics(); // warm cache
+    const callsBefore = scanSpy.mock.calls.length;
+
+    await service.updateTask(task.id, { title: 'Updated Title' });
+
+    await service.getTaskIdentityDiagnostics(); // should re-scan
+    expect(scanSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('invalidates cache after archiveTask', async () => {
+    const task = await service.createTask({
+      title: 'Archive Target',
+      type: 'code',
+      priority: 'low',
+    });
+    const scanSpy = vi.spyOn(taskIdentityDiagnostics, 'scanTaskIdentityDiagnostics');
+
+    await service.getTaskIdentityDiagnostics();
+    const callsBefore = scanSpy.mock.calls.length;
+
+    await service.archiveTask(task.id);
+
+    await service.getTaskIdentityDiagnostics();
+    expect(scanSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('getTaskIdentityDiagnostics with extra sources skips cache and scans fresh', async () => {
+    await service.createTask({ title: 'Task X', type: 'code', priority: 'medium' });
+
+    const scanSpy = vi.spyOn(taskIdentityDiagnostics, 'scanTaskIdentityDiagnostics');
+
+    // Warm cache
+    await service.getTaskIdentityDiagnostics();
+    const callsAfterWarm = scanSpy.mock.calls.length;
+
+    // Extra sources bypass cache
+    const extraDir = path.join(testRoot, 'extra');
+    await fs.mkdir(extraDir, { recursive: true });
+    await service.getTaskIdentityDiagnostics([{ location: 'backlog', dir: extraDir }]);
+
+    // Must have called scan again
+    expect(scanSpy.mock.calls.length).toBeGreaterThan(callsAfterWarm);
+  });
+});

--- a/server/src/__tests__/task-revision-atomicity.test.ts
+++ b/server/src/__tests__/task-revision-atomicity.test.ts
@@ -117,4 +117,72 @@ describe('updateTask – revision atomicity (#777)', () => {
       })
     ).rejects.toThrow(/has changed since it was loaded/);
   });
+
+  it('serializes same-task updates across slug changes without leaving stale files', async () => {
+    const task = await service.createTask({
+      title: 'Slug Queue Root',
+      type: 'code',
+      priority: 'medium',
+    });
+
+    await Promise.all([
+      service.updateTask(task.id, { title: 'Slug Queue First' }),
+      service.updateTask(task.id, { title: 'Slug Queue Final' }),
+      service.updateTask(task.id, { status: 'in-progress' }),
+    ]);
+
+    const finalTask = await service.getTask(task.id);
+    expect(finalTask?.title).toBe('Slug Queue Final');
+    expect(finalTask?.status).toBe('in-progress');
+
+    const taskFiles = (await fs.readdir(tasksDir)).filter((name) => name.startsWith(`${task.id}-`));
+    expect(taskFiles).toHaveLength(1);
+    expect(taskFiles[0]).toContain('slug-queue-final');
+  });
+
+  it('does not let an older finisher clear a newer queued waiter', async () => {
+    const serviceAny = service as unknown as {
+      withTaskMutex: (id: string, fn: () => Promise<void>) => Promise<void>;
+    };
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    const first = serviceAny.withTaskMutex('task_waiter_cleanup', async () => {
+      order.push('start-1');
+      await firstGate;
+      order.push('end-1');
+    });
+    const second = serviceAny.withTaskMutex('task_waiter_cleanup', async () => {
+      order.push('start-2');
+      await secondGate;
+      order.push('end-2');
+    });
+
+    releaseFirst();
+
+    for (let i = 0; i < 50 && !order.includes('start-2'); i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(order).toContain('start-2');
+
+    const third = serviceAny.withTaskMutex('task_waiter_cleanup', async () => {
+      order.push('start-3');
+      order.push('end-3');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(order).not.toContain('start-3');
+
+    releaseSecond();
+    await Promise.all([first, second, third]);
+
+    expect(order).toEqual(['start-1', 'end-1', 'start-2', 'end-2', 'start-3', 'end-3']);
+  });
 });

--- a/server/src/__tests__/task-revision-atomicity.test.ts
+++ b/server/src/__tests__/task-revision-atomicity.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for atomic revision validation in updateTask (#777)
+ *
+ * Verifies that:
+ * - Two concurrent requests with the same revision produce one success and one conflict.
+ * - Revision comparison happens inside the mutation lock (not just at route level).
+ * - Non-conflicting updates with no revision precondition succeed normally.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { TaskService } from '../services/task-service.js';
+import { DEFAULT_FEATURE_SETTINGS } from '@veritas-kanban/shared';
+
+describe('updateTask – revision atomicity (#777)', () => {
+  let service: TaskService;
+  let testRoot: string;
+  let tasksDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    const suffix = Math.random().toString(36).substring(7);
+    testRoot = path.join(os.tmpdir(), `vk-revision-test-${suffix}`);
+    tasksDir = path.join(testRoot, 'active');
+    archiveDir = path.join(testRoot, 'archive');
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.mkdir(archiveDir, { recursive: true });
+
+    service = new TaskService({
+      tasksDir,
+      archiveDir,
+      configService: { getFeatureSettings: async () => DEFAULT_FEATURE_SETTINGS },
+    });
+  });
+
+  afterEach(async () => {
+    service.dispose();
+    await fs.rm(testRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('concurrent updates with the same revision: one succeeds, one throws ConflictError', async () => {
+    const task = await service.createTask({
+      title: 'Concurrent Update Target',
+      type: 'code',
+      priority: 'medium',
+    });
+
+    const initialRevision = task.revision ?? 1;
+
+    // Launch two concurrent updates both supplying the same expectedRevision
+    const [result1, result2] = await Promise.allSettled([
+      service.updateTask(task.id, {
+        title: 'Update from A',
+        expectedRevision: initialRevision,
+      }),
+      service.updateTask(task.id, {
+        title: 'Update from B',
+        expectedRevision: initialRevision,
+      }),
+    ]);
+
+    const succeeded = [result1, result2].filter((r) => r.status === 'fulfilled');
+    const failed = [result1, result2].filter((r) => r.status === 'rejected');
+
+    // Exactly one must succeed
+    expect(succeeded).toHaveLength(1);
+    // Exactly one must fail with a conflict
+    expect(failed).toHaveLength(1);
+    const rejection = failed[0] as PromiseRejectedResult;
+    expect(rejection.reason?.message).toMatch(/has changed since it was loaded/);
+  });
+
+  it('update without expectedRevision always succeeds (no precondition)', async () => {
+    const task = await service.createTask({
+      title: 'Unconditional Update Target',
+      type: 'code',
+      priority: 'low',
+    });
+
+    // No expectedRevision — should succeed regardless of concurrent writes
+    const updated = await service.updateTask(task.id, { title: 'Renamed' });
+    expect(updated?.title).toBe('Renamed');
+  });
+
+  it('update with correct revision succeeds and increments revision', async () => {
+    const task = await service.createTask({
+      title: 'Versioned Task',
+      type: 'code',
+      priority: 'high',
+    });
+
+    const updated = await service.updateTask(task.id, {
+      title: 'Versioned Task v2',
+      expectedRevision: task.revision ?? 1,
+    });
+
+    expect(updated?.title).toBe('Versioned Task v2');
+    expect(updated?.revision).toBe((task.revision ?? 1) + 1);
+  });
+
+  it('update with stale revision rejects even when not concurrent', async () => {
+    const task = await service.createTask({
+      title: 'Stale Revision Target',
+      type: 'code',
+      priority: 'medium',
+    });
+
+    // First update moves the revision forward
+    await service.updateTask(task.id, { title: 'First Update' });
+
+    // Second update uses the original (now stale) revision
+    await expect(
+      service.updateTask(task.id, {
+        title: 'Should Conflict',
+        expectedRevision: task.revision ?? 1,
+      })
+    ).rejects.toThrow(/has changed since it was loaded/);
+  });
+});

--- a/server/src/__tests__/task-revision-atomicity.test.ts
+++ b/server/src/__tests__/task-revision-atomicity.test.ts
@@ -185,4 +185,87 @@ describe('updateTask – revision atomicity (#777)', () => {
 
     expect(order).toEqual(['start-1', 'end-1', 'start-2', 'end-2', 'start-3', 'end-3']);
   });
+
+  it.each(['deleteTask', 'archiveTask'] as const)(
+    'serializes %s behind an existing task mutation',
+    async (method) => {
+      const task = await service.createTask({
+        title: `Queued ${method}`,
+        type: 'code',
+        priority: 'medium',
+      });
+      const serviceAny = service as unknown as {
+        withTaskMutex: (id: string, fn: () => Promise<void>) => Promise<void>;
+      };
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const blocker = serviceAny.withTaskMutex(task.id, () => gate);
+      let settled = false;
+
+      const mutation = service[method](task.id).finally(() => {
+        settled = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(settled).toBe(false);
+
+      release();
+      await blocker;
+      await expect(mutation).resolves.toBe(true);
+    }
+  );
+
+  it('serializes restoreTask behind an existing task mutation', async () => {
+    const task = await service.createTask({
+      title: 'Queued restore',
+      type: 'code',
+      priority: 'medium',
+    });
+    await service.archiveTask(task.id);
+
+    const serviceAny = service as unknown as {
+      withTaskMutex: (id: string, fn: () => Promise<void>) => Promise<void>;
+    };
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const blocker = serviceAny.withTaskMutex(task.id, () => gate);
+    let settled = false;
+
+    const mutation = service.restoreTask(task.id).finally(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+
+    release();
+    await blocker;
+    await expect(mutation).resolves.toMatchObject({ id: task.id, status: 'done' });
+  });
+
+  it('preserves call order when archive and restore queue for the same task', async () => {
+    const task = await service.createTask({
+      title: 'Archive then restore',
+      type: 'code',
+      priority: 'medium',
+    });
+    const serviceAny = service as unknown as {
+      withTaskMutex: (id: string, fn: () => Promise<void>) => Promise<void>;
+    };
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const blocker = serviceAny.withTaskMutex(task.id, () => gate);
+
+    const archive = service.archiveTask(task.id);
+    const restore = service.restoreTask(task.id);
+    release();
+    await blocker;
+
+    await expect(archive).resolves.toBe(true);
+    await expect(restore).resolves.toMatchObject({ id: task.id, status: 'done' });
+  });
 });

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -43,14 +43,13 @@ router.get(
 
     // If pagination is requested, use the sendPaginated helper
     if (page > 0) {
-      const total = await activityService.countActivities(hasFilters ? filters : undefined);
       const offset = (page - 1) * limit;
-      const paged = await activityService.getActivities(
+      const { items, total } = await activityService.getActivitiesPage(
         limit,
         hasFilters ? filters : undefined,
         offset
       );
-      sendPaginated(res, paged, { page, limit, total });
+      sendPaginated(res, items, { page, limit, total });
     } else {
       const activities = await activityService.getActivities(
         limit,

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
-import { fileExists } from '../storage/fs-helpers.js';
+import { fileExists, atomicWriteFile } from '../storage/fs-helpers.js';
 import { join } from 'path';
 import { createLogger } from '../lib/logger.js';
 import { withFileLock } from './file-lock.js';
@@ -112,14 +112,13 @@ export class ActivityService {
     }
   }
 
-  async getActivities(
-    limit: number = 50,
-    filters?: ActivityFilters,
-    offset: number = 0
-  ): Promise<Activity[]> {
+  /**
+   * Load and filter activities in a single pass. Shared by getActivities and countActivities
+   * to avoid reading + parsing the file twice per paginated request.
+   */
+  private async loadAllFiltered(filters?: ActivityFilters): Promise<Activity[]> {
     let activities = await this.loadAll();
 
-    // Apply filters
     if (filters) {
       if (filters.agent) {
         const agentLower = filters.agent.toLowerCase();
@@ -141,16 +140,37 @@ export class ActivityService {
       }
     }
 
+    return activities;
+  }
+
+  async getActivities(
+    limit: number = 50,
+    filters?: ActivityFilters,
+    offset: number = 0
+  ): Promise<Activity[]> {
+    const activities = await this.loadAllFiltered(filters);
     return activities.slice(offset, offset + limit);
   }
 
   /**
    * Return total count of activities matching the given filters (for pagination).
+   * Shares a single parse+filter pass with getActivities — no double scan.
    */
   async countActivities(filters?: ActivityFilters): Promise<number> {
-    // Re-use getActivities with a high limit to count — simpler than duplicating filter logic
-    const all = await this.getActivities(this.MAX_ACTIVITIES, filters);
-    return all.length;
+    if (this.repository) {
+      // SQLite: delegate to repository if it has a count method; otherwise fall back
+      const repo = this.repository as ActivityRepository & {
+        countActivities?: (filters?: ActivityFilters) => Promise<number>;
+      };
+      if (typeof repo.countActivities === 'function') {
+        return repo.countActivities(filters);
+      }
+      // No native count — load all with filters applied via getActivities
+      const all = await this.getActivities(this.MAX_ACTIVITIES, filters);
+      return all.length;
+    }
+    const filtered = await this.loadAllFiltered(filters);
+    return filtered.length;
   }
 
   /**
@@ -210,7 +230,15 @@ export class ActivityService {
           const content = await readFile(this.activityFile, 'utf-8');
           activities = JSON.parse(content);
         } catch (err) {
-          log.warn({ err }, 'Corrupted activity file — resetting to empty list');
+          // Back up the corrupt file before resetting so the data is recoverable.
+          const backupPath = `${this.activityFile}.corrupt.${Date.now()}`;
+          await readFile(this.activityFile, 'utf-8')
+            .then((raw) => writeFile(backupPath, raw, 'utf-8'))
+            .catch(() => {});
+          log.warn(
+            { err, backupPath },
+            'Corrupted activity file — backed up and resetting to empty list'
+          );
           activities = [];
         }
       }
@@ -224,7 +252,7 @@ export class ActivityService {
         );
       }
 
-      await writeFile(this.activityFile, JSON.stringify(activities, null, 2), 'utf-8');
+      await atomicWriteFile(this.activityFile, JSON.stringify(activities, null, 2), 'utf-8');
     });
 
     return activity;
@@ -237,7 +265,7 @@ export class ActivityService {
     }
 
     await this.ensureDir();
-    await writeFile(this.activityFile, '[]', 'utf-8');
+    await atomicWriteFile(this.activityFile, '[]', 'utf-8');
   }
 
   dispose(): void {

--- a/server/src/services/activity-service.ts
+++ b/server/src/services/activity-service.ts
@@ -56,6 +56,11 @@ export interface ActivityFilters {
   until?: string;
 }
 
+export interface ActivityPage {
+  items: Activity[];
+  total: number;
+}
+
 export interface ActivityServiceOptions {
   activityFile?: string;
   storageType?: 'file' | 'sqlite';
@@ -112,10 +117,7 @@ export class ActivityService {
     }
   }
 
-  /**
-   * Load and filter activities in a single pass. Shared by getActivities and countActivities
-   * to avoid reading + parsing the file twice per paginated request.
-   */
+  /** Load and filter activities in a single pass. */
   private async loadAllFiltered(filters?: ActivityFilters): Promise<Activity[]> {
     let activities = await this.loadAll();
 
@@ -152,10 +154,7 @@ export class ActivityService {
     return activities.slice(offset, offset + limit);
   }
 
-  /**
-   * Return total count of activities matching the given filters (for pagination).
-   * Shares a single parse+filter pass with getActivities — no double scan.
-   */
+  /** Return total count of activities matching the given filters. */
   async countActivities(filters?: ActivityFilters): Promise<number> {
     if (this.repository) {
       // SQLite: delegate to repository if it has a count method; otherwise fall back
@@ -171,6 +170,26 @@ export class ActivityService {
     }
     const filtered = await this.loadAllFiltered(filters);
     return filtered.length;
+  }
+
+  async getActivitiesPage(
+    limit: number,
+    filters?: ActivityFilters,
+    offset: number = 0
+  ): Promise<ActivityPage> {
+    if (this.repository) {
+      const [items, total] = await Promise.all([
+        this.getActivities(limit, filters, offset),
+        this.countActivities(filters),
+      ]);
+      return { items, total };
+    }
+
+    const filtered = await this.loadAllFiltered(filters);
+    return {
+      items: filtered.slice(offset, offset + limit),
+      total: filtered.length,
+    };
   }
 
   /**

--- a/server/src/services/backlog-service.ts
+++ b/server/src/services/backlog-service.ts
@@ -14,7 +14,6 @@ import type { TaskTelemetryEvent } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { NotFoundError } from '../middleware/error-handler.js';
 import {
-  scanTaskIdentityDiagnostics,
   type TaskIdentityDiagnostics,
   type TaskIdentityScanSource,
 } from './task-identity-diagnostics.js';
@@ -51,10 +50,10 @@ export class BacklogService {
   }
 
   async getTaskIdentityDiagnostics(): Promise<TaskIdentityDiagnostics> {
-    return scanTaskIdentityDiagnostics([
-      ...this.taskService.getIdentityScanSources(),
-      ...this.getIdentityScanSources(),
-    ]);
+    // Delegate to taskService which owns the diagnostics cache (#784).
+    // Passing backlog sources as extras causes a fresh uncached scan, which is
+    // correct because backlog mutations also call invalidateIdentityDiagnosticsCache.
+    return this.taskService.getTaskIdentityDiagnostics(this.getIdentityScanSources());
   }
 
   private async assertTaskIdentityIntegrity(
@@ -66,6 +65,11 @@ export class BacklogService {
       destinationPath,
       extraSources: this.getIdentityScanSources(),
     });
+  }
+
+  /** Invalidate the shared identity diagnostics cache after backlog mutations (#784). */
+  private invalidateIdentityCache(): void {
+    this.taskService.invalidateIdentityDiagnosticsCache();
   }
 
   /**
@@ -163,6 +167,7 @@ export class BacklogService {
     await this.assertTaskIdentityIntegrity('backlog.create', task.id);
 
     const created = await this.backlogRepo.create(task);
+    this.invalidateIdentityCache();
 
     // Log activity
     await activityService.logActivity(
@@ -198,6 +203,7 @@ export class BacklogService {
     }
 
     const updated = await this.backlogRepo.update(id, updates);
+    this.invalidateIdentityCache();
 
     // Log activity if title changed
     if (updates.title && updates.title !== task.title) {
@@ -229,6 +235,7 @@ export class BacklogService {
     const deleted = await this.backlogRepo.delete(id);
 
     if (deleted) {
+      this.invalidateIdentityCache();
       // Log activity
       await activityService.logActivity(
         'task_deleted',
@@ -275,6 +282,7 @@ export class BacklogService {
     await this.backlogRepo.moveToActive(id, activeTasksDir);
 
     // Invalidate task service cache and reload to pick up the new task
+    this.invalidateIdentityCache();
     await this.taskService['initCache'](); // Force cache reload
 
     // Log activity
@@ -318,6 +326,7 @@ export class BacklogService {
 
     // Invalidate task from active cache
     this.taskService['cacheInvalidate'](id); // Access private method
+    this.invalidateIdentityCache();
 
     // Log activity
     await activityService.logActivity(

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -895,6 +895,13 @@ export class TaskService {
   }
 
   async updateTask(id: string, input: UpdateTaskInput): Promise<Task | null> {
+    if (this.sqliteTasks) {
+      return this.updateTaskMutation(id, input);
+    }
+    return this.withTaskMutex(id, () => this.updateTaskMutation(id, input));
+  }
+
+  private async updateTaskMutation(id: string, input: UpdateTaskInput): Promise<Task | null> {
     await this.assertTaskIdentityIntegrity('task.update', id);
 
     // Initial read to check existence and compute the lock filepath.
@@ -928,392 +935,385 @@ export class TaskService {
       }
 
       // File lock provides cross-process protection.
-      // withTaskMutex (below) provides in-process serialization by task ID.
+      // updateTask provides in-process serialization by task ID.
       await withFileLock(lockPath, callback);
     };
 
-    await this.withTaskMutex(id, () =>
-      runMutation(async () => {
-        // Re-read from cache inside the lock to get the latest state.
-        // This prevents concurrent writes (e.g., debounced field save vs.
-        // timer start) from overwriting each other's changes.
-        const freshTask = this.sqliteTasks
-          ? ((await this.sqliteTasks.findById(id)) ?? task)
-          : (this.cacheGet(id) ?? task);
+    await runMutation(async () => {
+      // Re-read from cache inside the lock to get the latest state.
+      // This prevents concurrent writes (e.g., debounced field save vs.
+      // timer start) from overwriting each other's changes.
+      const freshTask = this.sqliteTasks
+        ? ((await this.sqliteTasks.findById(id)) ?? task)
+        : (this.cacheGet(id) ?? task);
 
-        // Revision check inside the lock — prevents a TOCTOU race where two
-        // concurrent requests with the same valid revision both pass the
-        // pre-lock route check, serialize here, and both succeed.
-        if (_expectedRevision !== undefined) {
-          const currentRevision = normalizedTaskRevision(freshTask);
-          if (_expectedRevision !== currentRevision) {
-            throw new ConflictError(
-              `task ${id} has changed since it was loaded. Reload and retry with the latest revision.`,
-              {
-                resourceType: 'task',
-                resourceId: id,
-                expectedRevision: _expectedRevision,
-                currentRevision,
-                current: freshTask,
-              }
-            );
-          }
-        }
-
-        const previousStatus = freshTask.status;
-        const statusChanged = input.status !== undefined && input.status !== previousStatus;
-        let settings: Awaited<ReturnType<ConfigService['getFeatureSettings']>> | null = null;
-
-        if (statusChanged) {
-          settings = await this.configService.getFeatureSettings();
-          const columns = normalizeBoardColumns(settings.board?.columns);
-          this.assertConfiguredStatus(input.status as TaskStatus, {
-            columns,
-            defaultStatus: normalizeBoardDefaultStatus(settings.board?.defaultStatus, columns),
-            activeStatusIds: new Set(columns.map((column) => column.id)),
-          });
-        }
-
-        // Validate transition hooks (quality gates) before allowing status change
-        if (statusChanged && input.status && settings) {
-          // Check requireDeliverableForDone setting
-          if (input.status === 'done') {
-            if (settings.tasks.requireDeliverableForDone) {
-              const deliverables = input.deliverables ?? freshTask.deliverables ?? [];
-              if (deliverables.length === 0) {
-                throw new ValidationError(
-                  'Cannot complete task without at least one deliverable (required by settings)',
-                  [
-                    {
-                      code: 'DELIVERABLE_REQUIRED',
-                      message: 'Task requires at least one deliverable to be marked as done',
-                      path: ['status'],
-                    },
-                  ]
-                );
-              }
+      // Revision check inside the lock — prevents a TOCTOU race where two
+      // concurrent requests with the same valid revision both pass the
+      // pre-lock route check, serialize here, and both succeed.
+      if (_expectedRevision !== undefined) {
+        const currentRevision = normalizedTaskRevision(freshTask);
+        if (_expectedRevision !== currentRevision) {
+          throw new ConflictError(
+            `task ${id} has changed since it was loaded. Reload and retry with the latest revision.`,
+            {
+              resourceType: 'task',
+              resourceId: id,
+              expectedRevision: _expectedRevision,
+              currentRevision,
+              current: freshTask,
             }
+          );
+        }
+      }
 
-            // Enforcement: 4x10 Review Gate (only if enforcement settings are explicitly configured)
-            // Only applies to code-related task types
-            if (
-              settings.enforcement?.reviewGate === true &&
-              CODE_TASK_TYPES.includes(freshTask.type?.toLowerCase())
-            ) {
-              const scores = input.reviewScores ?? freshTask.reviewScores ?? [];
-              const allPerfect = scores.length === 4 && scores.every((s: number) => s === 10);
-              if (!allPerfect) {
-                const scoresDisplay =
-                  scores.length === 4
+      const previousStatus = freshTask.status;
+      const statusChanged = input.status !== undefined && input.status !== previousStatus;
+      let settings: Awaited<ReturnType<ConfigService['getFeatureSettings']>> | null = null;
+
+      if (statusChanged) {
+        settings = await this.configService.getFeatureSettings();
+        const columns = normalizeBoardColumns(settings.board?.columns);
+        this.assertConfiguredStatus(input.status as TaskStatus, {
+          columns,
+          defaultStatus: normalizeBoardDefaultStatus(settings.board?.defaultStatus, columns),
+          activeStatusIds: new Set(columns.map((column) => column.id)),
+        });
+      }
+
+      // Validate transition hooks (quality gates) before allowing status change
+      if (statusChanged && input.status && settings) {
+        // Check requireDeliverableForDone setting
+        if (input.status === 'done') {
+          if (settings.tasks.requireDeliverableForDone) {
+            const deliverables = input.deliverables ?? freshTask.deliverables ?? [];
+            if (deliverables.length === 0) {
+              throw new ValidationError(
+                'Cannot complete task without at least one deliverable (required by settings)',
+                [
+                  {
+                    code: 'DELIVERABLE_REQUIRED',
+                    message: 'Task requires at least one deliverable to be marked as done',
+                    path: ['status'],
+                  },
+                ]
+              );
+            }
+          }
+
+          // Enforcement: 4x10 Review Gate (only if enforcement settings are explicitly configured)
+          // Only applies to code-related task types
+          if (
+            settings.enforcement?.reviewGate === true &&
+            CODE_TASK_TYPES.includes(freshTask.type?.toLowerCase())
+          ) {
+            const scores = input.reviewScores ?? freshTask.reviewScores ?? [];
+            const allPerfect = scores.length === 4 && scores.every((s: number) => s === 10);
+            if (!allPerfect) {
+              const scoresDisplay =
+                scores.length === 4
+                  ? scores.join('/')
+                  : scores.length > 0
                     ? scores.join('/')
-                    : scores.length > 0
-                      ? scores.join('/')
-                      : 'none';
-                const detailMessage =
-                  scores.length === 4
-                    ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay}`
-                    : scores.length > 0
-                      ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay} (incomplete)`
-                      : `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. No review scores set yet.`;
+                    : 'none';
+              const detailMessage =
+                scores.length === 4
+                  ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay}`
+                  : scores.length > 0
+                    ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay} (incomplete)`
+                    : `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. No review scores set yet.`;
 
-                throw new ValidationError(detailMessage, [
-                  {
-                    code: 'REVIEW_GATE',
-                    message: detailMessage,
-                    path: ['reviewScores'],
-                  },
-                ]);
-              }
-            }
-
-            // Enforcement: Closing Comments Required (only if enforcement settings are explicitly configured)
-            if (settings.enforcement?.closingComments === true) {
-              const comments = input.reviewComments ?? freshTask.reviewComments ?? [];
-              const hasClosingComment =
-                comments.length > 0 &&
-                comments.some((c: { content: string }) => c.content && c.content.length >= 20);
-              if (!hasClosingComment) {
-                const commentCount = comments.length;
-                const detailMessage =
-                  commentCount === 0
-                    ? 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. No comments added yet.'
-                    : 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. Current comments are too short.';
-
-                throw new ValidationError(detailMessage, [
-                  {
-                    code: 'CLOSING_COMMENTS_REQUIRED',
-                    message: detailMessage,
-                    path: ['reviewComments'],
-                  },
-                ]);
-              }
-            }
-          }
-
-          // Create a preview of the task with proposed changes for validation
-          const previewTask: Task = {
-            ...freshTask,
-            ...restInput,
-            blockedReason:
-              blockedReasonUpdate === null
-                ? undefined
-                : (blockedReasonUpdate ?? freshTask.blockedReason),
-          };
-
-          if (input.status === 'done' && settings.enforcement) {
-            const ceremonyEvaluation = await this.ceremonyService.evaluateTaskCompletion(
-              previewTask,
-              settings.enforcement
-            );
-            if (!ceremonyEvaluation.allowed) {
-              const detailMessage = `Ceremony Enforcement: ${ceremonyEvaluation.blockedReasons.join(
-                ' '
-              )}`;
               throw new ValidationError(detailMessage, [
                 {
-                  code: 'CEREMONY_REQUIRED',
+                  code: 'REVIEW_GATE',
                   message: detailMessage,
-                  path: ['status'],
-                  details: ceremonyEvaluation.pending.map((requirement) => ({
-                    id: requirement.id,
-                    kind: requirement.kind,
-                    title: requirement.title,
-                    reason: requirement.reason,
-                    requiredArtifacts: requirement.requiredArtifacts,
-                    dueAt: requirement.dueAt,
-                  })),
+                  path: ['reviewScores'],
                 },
               ]);
             }
           }
 
-          const validation = await validateTransition(previewTask, previousStatus, input.status);
-          if (!validation.allowed) {
-            throw new ValidationError(
-              validation.errorMessage || 'Transition blocked by quality gates',
-              validation.failedGates.map(
-                (g: { gate: { type: string; name: string }; message?: string }) => ({
-                  code: g.gate.type,
-                  message: g.message || g.gate.name,
-                  path: ['status'],
-                })
-              )
-            );
+          // Enforcement: Closing Comments Required (only if enforcement settings are explicitly configured)
+          if (settings.enforcement?.closingComments === true) {
+            const comments = input.reviewComments ?? freshTask.reviewComments ?? [];
+            const hasClosingComment =
+              comments.length > 0 &&
+              comments.some((c: { content: string }) => c.content && c.content.length >= 20);
+            if (!hasClosingComment) {
+              const commentCount = comments.length;
+              const detailMessage =
+                commentCount === 0
+                  ? 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. No comments added yet.'
+                  : 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. Current comments are too short.';
+
+              throw new ValidationError(detailMessage, [
+                {
+                  code: 'CLOSING_COMMENTS_REQUIRED',
+                  message: detailMessage,
+                  path: ['reviewComments'],
+                },
+              ]);
+            }
           }
         }
 
-        // Handle checkpoint resumption: increment resumeCount if transitioning to in-progress with checkpoint
-        const hasCheckpointInput = Object.prototype.hasOwnProperty.call(input, 'checkpoint');
-        let checkpointUpdate = input.checkpoint;
-        let clearCheckpoint = hasCheckpointInput && input.checkpoint === undefined;
-        if (
-          !hasCheckpointInput &&
-          freshTask.checkpoint &&
-          input.status === 'in-progress' &&
-          previousStatus !== 'in-progress'
-        ) {
-          // Task is being resumed — increment resumeCount
-          checkpointUpdate = {
-            ...freshTask.checkpoint,
-            resumeCount: (freshTask.checkpoint.resumeCount || 0) + 1,
-          };
-        }
+        // Create a preview of the task with proposed changes for validation
+        const previewTask: Task = {
+          ...freshTask,
+          ...restInput,
+          blockedReason:
+            blockedReasonUpdate === null
+              ? undefined
+              : (blockedReasonUpdate ?? freshTask.blockedReason),
+        };
 
-        // Clear checkpoint when task completes successfully
-        if (input.status === 'done' && freshTask.checkpoint) {
-          clearCheckpoint = true;
-        }
-
-        // Validate agent ref against registry if being changed (#157)
-        if (restInput.agent !== undefined && restInput.agent !== freshTask.agent) {
-          const registry = getAgentRegistryService();
-          const validation = registry.validateAgentRef(restInput.agent);
-          if (!validation.valid) {
-            throw new ValidationError(validation.reason || 'Invalid agent ref', [
+        if (input.status === 'done' && settings.enforcement) {
+          const ceremonyEvaluation = await this.ceremonyService.evaluateTaskCompletion(
+            previewTask,
+            settings.enforcement
+          );
+          if (!ceremonyEvaluation.allowed) {
+            const detailMessage = `Ceremony Enforcement: ${ceremonyEvaluation.blockedReasons.join(
+              ' '
+            )}`;
+            throw new ValidationError(detailMessage, [
               {
-                code: 'INVALID_AGENT_REF',
-                message: validation.reason || 'Invalid agent ref',
-                path: ['agent'],
+                code: 'CEREMONY_REQUIRED',
+                message: detailMessage,
+                path: ['status'],
+                details: ceremonyEvaluation.pending.map((requirement) => ({
+                  id: requirement.id,
+                  kind: requirement.kind,
+                  title: requirement.title,
+                  reason: requirement.reason,
+                  requiredArtifacts: requirement.requiredArtifacts,
+                  dueAt: requirement.dueAt,
+                })),
               },
             ]);
           }
         }
 
-        updatedTask = {
-          ...freshTask,
-          ...restInput,
-          git: gitUpdate ? ({ ...freshTask.git, ...gitUpdate } as Task['git']) : freshTask.git,
-          github: githubUpdate ?? freshTask.github,
-          // Handle blockedReason: null means clear, undefined means keep existing
-          blockedReason:
-            blockedReasonUpdate === null
-              ? undefined
-              : (blockedReasonUpdate ?? freshTask.blockedReason),
-          // Apply checkpoint update (resume count or clear)
-          checkpoint: clearCheckpoint
+        const validation = await validateTransition(previewTask, previousStatus, input.status);
+        if (!validation.allowed) {
+          throw new ValidationError(
+            validation.errorMessage || 'Transition blocked by quality gates',
+            validation.failedGates.map(
+              (g: { gate: { type: string; name: string }; message?: string }) => ({
+                code: g.gate.type,
+                message: g.message || g.gate.name,
+                path: ['status'],
+              })
+            )
+          );
+        }
+      }
+
+      // Handle checkpoint resumption: increment resumeCount if transitioning to in-progress with checkpoint
+      const hasCheckpointInput = Object.prototype.hasOwnProperty.call(input, 'checkpoint');
+      let checkpointUpdate = input.checkpoint;
+      let clearCheckpoint = hasCheckpointInput && input.checkpoint === undefined;
+      if (
+        !hasCheckpointInput &&
+        freshTask.checkpoint &&
+        input.status === 'in-progress' &&
+        previousStatus !== 'in-progress'
+      ) {
+        // Task is being resumed — increment resumeCount
+        checkpointUpdate = {
+          ...freshTask.checkpoint,
+          resumeCount: (freshTask.checkpoint.resumeCount || 0) + 1,
+        };
+      }
+
+      // Clear checkpoint when task completes successfully
+      if (input.status === 'done' && freshTask.checkpoint) {
+        clearCheckpoint = true;
+      }
+
+      // Validate agent ref against registry if being changed (#157)
+      if (restInput.agent !== undefined && restInput.agent !== freshTask.agent) {
+        const registry = getAgentRegistryService();
+        const validation = registry.validateAgentRef(restInput.agent);
+        if (!validation.valid) {
+          throw new ValidationError(validation.reason || 'Invalid agent ref', [
+            {
+              code: 'INVALID_AGENT_REF',
+              message: validation.reason || 'Invalid agent ref',
+              path: ['agent'],
+            },
+          ]);
+        }
+      }
+
+      updatedTask = {
+        ...freshTask,
+        ...restInput,
+        git: gitUpdate ? ({ ...freshTask.git, ...gitUpdate } as Task['git']) : freshTask.git,
+        github: githubUpdate ?? freshTask.github,
+        // Handle blockedReason: null means clear, undefined means keep existing
+        blockedReason:
+          blockedReasonUpdate === null
             ? undefined
-            : checkpointUpdate !== undefined
-              ? checkpointUpdate
-              : freshTask.checkpoint,
-          revision: normalizedTaskRevision(freshTask) + 1,
-          updated: new Date().toISOString(),
+            : (blockedReasonUpdate ?? freshTask.blockedReason),
+        // Apply checkpoint update (resume count or clear)
+        checkpoint: clearCheckpoint
+          ? undefined
+          : checkpointUpdate !== undefined
+            ? checkpointUpdate
+            : freshTask.checkpoint,
+        revision: normalizedTaskRevision(freshTask) + 1,
+        updated: new Date().toISOString(),
+      };
+
+      if (this.sqliteTasks) {
+        await this.sqliteTasks.replaceActive(updatedTask);
+      } else {
+        // Compute destination filepath inside the lock from the fresh task state.
+        // The new filename may differ from lockPath when the title changed.
+        const freshOldFilename = this.taskToFilename(freshTask);
+        const newFilename = this.taskToFilename(updatedTask);
+        const filepath = path.join(this.tasksDir, newFilename);
+
+        await this.assertTaskIdentityIntegrity('task.update', id, {
+          candidates: [this.taskIdentityCandidate(updatedTask, 'active', filepath)],
+          destinationPath: this.diagnosticPath(filepath),
+          excludeTaskIds: [id],
+        });
+
+        const content = this.taskToMarkdown(updatedTask);
+        this.markWrite();
+
+        // Write new content atomically first; only then remove the old slug file.
+        // This ensures the task is never unrecoverable: if the write fails,
+        // the old file is still present under its original name.
+        await atomicWriteFile(filepath, content, 'utf-8');
+
+        if (freshOldFilename !== newFilename) {
+          // Remove the old slug only after the replacement file is installed.
+          await fs.unlink(path.join(this.tasksDir, freshOldFilename)).catch((err) => {
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+            throw err;
+          });
+        }
+
+        // Write-through: update cache immediately (inside lock for consistency)
+        this.cache.set(updatedTask.id, updatedTask);
+      }
+
+      // Emit telemetry event if status changed
+      if (statusChanged) {
+        this.syncAgentRegistryForStatusTransition(updatedTask);
+
+        await this.telemetry.emit<TaskTelemetryEvent>({
+          type: 'task.status_changed',
+          taskId: updatedTask.id,
+          project: updatedTask.project,
+          status: updatedTask.status,
+          previousStatus,
+        });
+
+        // Fire lifecycle hook if applicable
+        const hookEvent = getHookEventForStatusChange(previousStatus, updatedTask.status);
+        if (hookEvent) {
+          fireHook(hookEvent, updatedTask, previousStatus).catch((err) => {
+            log.warn({ taskId: updatedTask.id, hookEvent }, 'Hook execution failed: %s', err);
+          });
+        }
+
+        // Enforcement: Auto-telemetry emission (run.started/run.completed)
+        const autoTelemetry = settings?.enforcement?.autoTelemetry === true;
+
+        if (autoTelemetry) {
+          const agent = updatedTask.agent || 'veritas';
+          if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
+            // Emit run.started
+            this.telemetry
+              .emit<RunStartedEvent>({
+                type: 'run.started',
+                taskId: updatedTask.id,
+                agent,
+              })
+              .catch((err) => {
+                log.warn({ taskId: updatedTask.id }, 'Auto run.started emission failed: %s', err);
+              });
+          } else if (updatedTask.status === 'done' && previousStatus !== 'done') {
+            // Emit run.completed
+            const durationMs = updatedTask.timeTracking?.totalSeconds
+              ? updatedTask.timeTracking.totalSeconds * 1000
+              : 0;
+            this.telemetry
+              .emit<RunCompletedEvent>({
+                type: 'run.completed',
+                taskId: updatedTask.id,
+                agent,
+                success: true,
+                durationMs,
+              })
+              .catch((err) => {
+                log.warn({ taskId: updatedTask.id }, 'Auto run.completed emission failed: %s', err);
+              });
+          }
+        }
+
+        // Enforcement: Auto time tracking start/stop (only if enforcement is configured)
+        const autoTimeTracking = settings?.enforcement?.autoTimeTracking === true;
+        if (autoTimeTracking) {
+          if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
+            // Auto-start timer
+            if (!updatedTask.timeTracking?.isRunning) {
+              this.startTimer(updatedTask.id).catch((err) => {
+                log.warn({ taskId: updatedTask.id }, 'Auto timer start failed: %s', err);
+              });
+            }
+          } else if (
+            (updatedTask.status === 'done' || updatedTask.status === 'blocked') &&
+            previousStatus !== 'done' &&
+            previousStatus !== 'blocked'
+          ) {
+            // Auto-stop timer
+            if (updatedTask.timeTracking?.isRunning) {
+              this.stopTimer(updatedTask.id).catch((err) => {
+                log.warn({ taskId: updatedTask.id }, 'Auto timer stop failed: %s', err);
+              });
+            }
+          }
+        }
+
+        // Execute post-transition actions (quality gates)
+        const actionCallbacks: TransitionActionCallbacks = {
+          onAutoStartTimer: async (t) => {
+            // Start time tracking if not already active
+            if (!t.timeTracking?.isRunning) {
+              await this.startTimer(t.id);
+            }
+          },
+          onAutoStopTimer: async (t) => {
+            // Stop time tracking if currently running
+            if (t.timeTracking?.isRunning) {
+              await this.stopTimer(t.id);
+            }
+          },
+          onLogActivity: async (t, from, to) => {
+            log.info({ taskId: t.id, from, to }, 'Transition action: logged activity');
+          },
+          onPromptLessonsLearned: async (t) => {
+            // Flag task for lessons learned capture (could set a field or emit event)
+            log.info({ taskId: t.id }, 'Transition action: prompt lessons learned');
+          },
         };
 
-        if (this.sqliteTasks) {
-          await this.sqliteTasks.replaceActive(updatedTask);
-        } else {
-          // Compute destination filepath inside the lock from the fresh task state.
-          // The new filename may differ from lockPath when the title changed.
-          const freshOldFilename = this.taskToFilename(freshTask);
-          const newFilename = this.taskToFilename(updatedTask);
-          const filepath = path.join(this.tasksDir, newFilename);
+        executePostTransitionActions(
+          updatedTask,
+          previousStatus,
+          updatedTask.status,
+          actionCallbacks
+        ).catch((err) => {
+          log.warn({ taskId: updatedTask.id }, 'Post-transition actions failed: %s', err);
+        });
 
-          await this.assertTaskIdentityIntegrity('task.update', id, {
-            candidates: [this.taskIdentityCandidate(updatedTask, 'active', filepath)],
-            destinationPath: this.diagnosticPath(filepath),
-            excludeTaskIds: [id],
-          });
-
-          const content = this.taskToMarkdown(updatedTask);
-          this.markWrite();
-
-          // Write new content atomically first; only then remove the old slug file.
-          // This ensures the task is never unrecoverable: if the write fails,
-          // the old file is still present under its original name.
-          await atomicWriteFile(filepath, content, 'utf-8');
-
-          if (freshOldFilename !== newFilename) {
-            // Remove old slug file now that new file is durably installed.
-            await fs.unlink(path.join(this.tasksDir, freshOldFilename)).catch((err) => {
-              if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
-              throw err;
-            });
-          }
-
-          // Write-through: update cache immediately (inside lock for consistency)
-          this.cache.set(updatedTask.id, updatedTask);
-        }
-
-        // Emit telemetry event if status changed
-        if (statusChanged) {
-          this.syncAgentRegistryForStatusTransition(updatedTask);
-
-          await this.telemetry.emit<TaskTelemetryEvent>({
-            type: 'task.status_changed',
-            taskId: updatedTask.id,
-            project: updatedTask.project,
-            status: updatedTask.status,
-            previousStatus,
-          });
-
-          // Fire lifecycle hook if applicable
-          const hookEvent = getHookEventForStatusChange(previousStatus, updatedTask.status);
-          if (hookEvent) {
-            fireHook(hookEvent, updatedTask, previousStatus).catch((err) => {
-              log.warn({ taskId: updatedTask.id, hookEvent }, 'Hook execution failed: %s', err);
-            });
-          }
-
-          // Enforcement: Auto-telemetry emission (run.started/run.completed)
-          const autoTelemetry = settings?.enforcement?.autoTelemetry === true;
-
-          if (autoTelemetry) {
-            const agent = updatedTask.agent || 'veritas';
-            if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
-              // Emit run.started
-              this.telemetry
-                .emit<RunStartedEvent>({
-                  type: 'run.started',
-                  taskId: updatedTask.id,
-                  agent,
-                })
-                .catch((err) => {
-                  log.warn({ taskId: updatedTask.id }, 'Auto run.started emission failed: %s', err);
-                });
-            } else if (updatedTask.status === 'done' && previousStatus !== 'done') {
-              // Emit run.completed
-              const durationMs = updatedTask.timeTracking?.totalSeconds
-                ? updatedTask.timeTracking.totalSeconds * 1000
-                : 0;
-              this.telemetry
-                .emit<RunCompletedEvent>({
-                  type: 'run.completed',
-                  taskId: updatedTask.id,
-                  agent,
-                  success: true,
-                  durationMs,
-                })
-                .catch((err) => {
-                  log.warn(
-                    { taskId: updatedTask.id },
-                    'Auto run.completed emission failed: %s',
-                    err
-                  );
-                });
-            }
-          }
-
-          // Enforcement: Auto time tracking start/stop (only if enforcement is configured)
-          const autoTimeTracking = settings?.enforcement?.autoTimeTracking === true;
-          if (autoTimeTracking) {
-            if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
-              // Auto-start timer
-              if (!updatedTask.timeTracking?.isRunning) {
-                this.startTimer(updatedTask.id).catch((err) => {
-                  log.warn({ taskId: updatedTask.id }, 'Auto timer start failed: %s', err);
-                });
-              }
-            } else if (
-              (updatedTask.status === 'done' || updatedTask.status === 'blocked') &&
-              previousStatus !== 'done' &&
-              previousStatus !== 'blocked'
-            ) {
-              // Auto-stop timer
-              if (updatedTask.timeTracking?.isRunning) {
-                this.stopTimer(updatedTask.id).catch((err) => {
-                  log.warn({ taskId: updatedTask.id }, 'Auto timer stop failed: %s', err);
-                });
-              }
-            }
-          }
-
-          // Execute post-transition actions (quality gates)
-          const actionCallbacks: TransitionActionCallbacks = {
-            onAutoStartTimer: async (t) => {
-              // Start time tracking if not already active
-              if (!t.timeTracking?.isRunning) {
-                await this.startTimer(t.id);
-              }
-            },
-            onAutoStopTimer: async (t) => {
-              // Stop time tracking if currently running
-              if (t.timeTracking?.isRunning) {
-                await this.stopTimer(t.id);
-              }
-            },
-            onLogActivity: async (t, from, to) => {
-              log.info({ taskId: t.id, from, to }, 'Transition action: logged activity');
-            },
-            onPromptLessonsLearned: async (t) => {
-              // Flag task for lessons learned capture (could set a field or emit event)
-              log.info({ taskId: t.id }, 'Transition action: prompt lessons learned');
-            },
-          };
-
-          executePostTransitionActions(
-            updatedTask,
-            previousStatus,
-            updatedTask.status,
-            actionCallbacks
-          ).catch((err) => {
-            log.warn({ taskId: updatedTask.id }, 'Post-transition actions failed: %s', err);
-          });
-
-          shouldGenerateCompletionPacket =
-            updatedTask.status === 'done' && previousStatus !== 'done';
-        }
-      })
-    );
+        shouldGenerateCompletionPacket = updatedTask.status === 'done' && previousStatus !== 'done';
+      }
+    });
 
     if (shouldGenerateCompletionPacket) {
       try {
@@ -1327,68 +1327,73 @@ export class TaskService {
   }
 
   async deleteTask(id: string): Promise<boolean> {
-    await this.assertTaskIdentityIntegrity('task.delete', id, {
-      allowSameLocationTaskIdDuplicates: true,
-    });
-
-    const task = await this.getTaskWithoutIdentityCheck(id);
-    if (!task) return false;
-
     if (this.sqliteTasks) {
+      await this.assertTaskIdentityIntegrity('task.delete', id, {
+        allowSameLocationTaskIdDuplicates: true,
+      });
+      const task = await this.getTaskWithoutIdentityCheck(id);
+      if (!task) return false;
+
       const sqliteTasks = this.sqliteTasks;
       return this.runSqliteMutation(() => sqliteTasks.deleteActive(id));
     }
 
-    // Find ALL files on disk with this task ID (handles orphaned slug variations)
-    const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
-    if (allFilenames.length === 0) {
-      log.warn({ taskId: id }, 'No task files found on disk for deletion');
-      return false;
-    }
+    return this.withTaskMutex(id, async () => {
+      await this.assertTaskIdentityIntegrity('task.delete', id, {
+        allowSameLocationTaskIdDuplicates: true,
+      });
+      const task = await this.getTaskWithoutIdentityCheck(id);
+      if (!task) return false;
 
-    // Delete ALL matching files (cleanup orphaned files from title changes)
-    await Promise.all(
-      allFilenames.map(async (filename) => {
-        const filepath = path.join(this.tasksDir, filename);
-        await withFileLock(filepath, async () => {
-          this.markWrite();
-          await fs.unlink(filepath);
-        });
-        log.debug({ taskId: id, filename }, 'Deleted task file');
-      })
-    );
+      // Find ALL files on disk with this task ID (handles orphaned slug variations)
+      const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
+      if (allFilenames.length === 0) {
+        log.warn({ taskId: id }, 'No task files found on disk for deletion');
+        return false;
+      }
 
-    // Remove from cache
-    this.cacheInvalidate(id);
+      // Delete ALL matching files (cleanup orphaned files from title changes)
+      await Promise.all(
+        allFilenames.map(async (filename) => {
+          const filepath = path.join(this.tasksDir, filename);
+          await withFileLock(filepath, async () => {
+            this.markWrite();
+            await fs.unlink(filepath);
+          });
+          log.debug({ taskId: id, filename }, 'Deleted task file');
+        })
+      );
 
-    // Delete attachments
-    const { getAttachmentService } = await import('./attachment-service.js');
-    const attachmentService = getAttachmentService();
-    await attachmentService.deleteAllAttachments(id);
+      // Remove from cache
+      this.cacheInvalidate(id);
 
-    return true;
+      // Delete attachments
+      const { getAttachmentService } = await import('./attachment-service.js');
+      const attachmentService = getAttachmentService();
+      await attachmentService.deleteAllAttachments(id);
+
+      return true;
+    });
   }
 
   async archiveTask(
     id: string,
     options?: { deletedAt?: string; deletedBy?: string; purgeAfter?: string }
   ): Promise<boolean> {
-    await this.assertTaskIdentityIntegrity('task.archive', id, {
-      allowSameLocationTaskIdDuplicates: true,
-    });
-
-    const task = await this.getTaskWithoutIdentityCheck(id);
-    if (!task) return false;
-
-    const archivedTask: Task = {
-      ...task,
-      updated: new Date().toISOString(),
-      deletedAt: options?.deletedAt ?? task.deletedAt,
-      deletedBy: options?.deletedBy ?? task.deletedBy,
-      purgeAfter: options?.purgeAfter ?? task.purgeAfter,
-    };
-
     if (this.sqliteTasks) {
+      await this.assertTaskIdentityIntegrity('task.archive', id, {
+        allowSameLocationTaskIdDuplicates: true,
+      });
+      const task = await this.getTaskWithoutIdentityCheck(id);
+      if (!task) return false;
+
+      const archivedTask: Task = {
+        ...task,
+        updated: new Date().toISOString(),
+        deletedAt: options?.deletedAt ?? task.deletedAt,
+        deletedBy: options?.deletedBy ?? task.deletedBy,
+        purgeAfter: options?.purgeAfter ?? task.purgeAfter,
+      };
       const sqliteTasks = this.sqliteTasks;
       const archived = await this.runSqliteMutation(() => sqliteTasks.archive(id, archivedTask));
       if (!archived) return false;
@@ -1407,59 +1412,72 @@ export class TaskService {
       return true;
     }
 
-    const archivedContent = this.taskToMarkdown(archivedTask);
+    return this.withTaskMutex(id, async () => {
+      await this.assertTaskIdentityIntegrity('task.archive', id, {
+        allowSameLocationTaskIdDuplicates: true,
+      });
+      const freshTask = await this.getTaskWithoutIdentityCheck(id);
+      if (!freshTask) return false;
 
-    // Find ALL files on disk with this task ID (handles orphaned slug variations)
-    const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
-    if (allFilenames.length === 0) {
-      log.warn({ taskId: id }, 'No task files found on disk for archiving');
-      return false;
-    }
+      const freshArchivedTask: Task = {
+        ...freshTask,
+        updated: new Date().toISOString(),
+        deletedAt: options?.deletedAt ?? freshTask.deletedAt,
+        deletedBy: options?.deletedBy ?? freshTask.deletedBy,
+        purgeAfter: options?.purgeAfter ?? freshTask.purgeAfter,
+      };
+      const archivedContent = this.taskToMarkdown(freshArchivedTask);
 
-    // Archive ALL matching files (cleanup orphaned files from title changes)
-    await Promise.all(
-      allFilenames.map(async (filename) => {
-        const sourcePath = path.join(this.tasksDir, filename);
-        const destPath = path.join(this.archiveDir, filename);
-        await withFileLock(sourcePath, async () => {
-          this.markWrite();
-          // Write updated content atomically to archive destination first so
-          // the source file remains intact until the new file is durable.
-          await atomicWriteFile(destPath, archivedContent, 'utf-8');
-          // Source is now safe to remove — archive copy is confirmed present.
-          await fs.unlink(sourcePath);
-        });
-        log.debug({ taskId: id, filename }, 'Archived task file');
-      })
-    );
+      // Find ALL files on disk with this task ID (handles orphaned slug variations)
+      const allFilenames = await this.findAllTaskFiles(this.tasksDir, id);
+      if (allFilenames.length === 0) {
+        log.warn({ taskId: id }, 'No task files found on disk for archiving');
+        return false;
+      }
 
-    // Remove from active cache (archived tasks are not cached)
-    this.cacheInvalidate(id);
+      // Archive ALL matching files (cleanup orphaned files from title changes)
+      await Promise.all(
+        allFilenames.map(async (filename) => {
+          const sourcePath = path.join(this.tasksDir, filename);
+          const destPath = path.join(this.archiveDir, filename);
+          await withFileLock(sourcePath, async () => {
+            this.markWrite();
+            // Install the archive copy before removing the active source.
+            await atomicWriteFile(destPath, archivedContent, 'utf-8');
+            await fs.unlink(sourcePath);
+          });
+          log.debug({ taskId: id, filename }, 'Archived task file');
+        })
+      );
 
-    // Move attachments to archive
-    const { getAttachmentService } = await import('./attachment-service.js');
-    const attachmentService = getAttachmentService();
-    await attachmentService.archiveAttachments(id);
+      // Remove from active cache (archived tasks are not cached)
+      this.cacheInvalidate(id);
 
-    // Delete progress file (cleanup when archived)
-    const { getProgressService } = await import('./progress-service.js');
-    const progressService = getProgressService();
-    await progressService.deleteProgress(id);
+      // Move attachments to archive
+      const { getAttachmentService } = await import('./attachment-service.js');
+      const attachmentService = getAttachmentService();
+      await attachmentService.archiveAttachments(id);
 
-    // Emit telemetry event
-    await this.telemetry.emit<TaskTelemetryEvent>({
-      type: 'task.archived',
-      taskId: archivedTask.id,
-      project: archivedTask.project,
-      status: archivedTask.status,
+      // Delete progress file (cleanup when archived)
+      const { getProgressService } = await import('./progress-service.js');
+      const progressService = getProgressService();
+      await progressService.deleteProgress(id);
+
+      // Emit telemetry event
+      await this.telemetry.emit<TaskTelemetryEvent>({
+        type: 'task.archived',
+        taskId: freshArchivedTask.id,
+        project: freshArchivedTask.project,
+        status: freshArchivedTask.status,
+      });
+
+      // Fire onArchived hook
+      fireHook('onArchived', freshArchivedTask).catch((err) => {
+        log.warn({ taskId: freshArchivedTask.id }, 'onArchived hook failed: %s', err);
+      });
+
+      return true;
     });
-
-    // Fire onArchived hook
-    fireHook('onArchived', archivedTask).catch((err) => {
-      log.warn({ taskId: archivedTask.id }, 'onArchived hook failed: %s', err);
-    });
-
-    return true;
   }
 
   async listArchivedTasks(): Promise<Task[]> {
@@ -1517,16 +1535,11 @@ export class TaskService {
   }
 
   async restoreTask(id: string): Promise<Task | null> {
-    await this.assertTaskIdentityIntegrity('task.restore', id);
-
-    const task = await this.getArchivedTask(id);
-    if (!task) return null;
-
-    if (this.isRestoreWindowExpired(task)) {
-      return null;
-    }
-
     if (this.sqliteTasks) {
+      await this.assertTaskIdentityIntegrity('task.restore', id);
+      const task = await this.getArchivedTask(id);
+      if (!task || this.isRestoreWindowExpired(task)) return null;
+
       const sqliteTasks = this.sqliteTasks;
       const restoredTask = await this.runSqliteMutation(() => sqliteTasks.restore(id));
       if (!restoredTask) return null;
@@ -1541,54 +1554,58 @@ export class TaskService {
       return restoredTask;
     }
 
-    // Find actual file on disk (slug may differ from current title)
-    const actualFilename = await this.findTaskFile(this.archiveDir, id);
-    if (!actualFilename) {
-      log.warn({ taskId: id }, 'Archived task file not found on disk for restoration');
-      return null;
-    }
+    return this.withTaskMutex(id, async () => {
+      await this.assertTaskIdentityIntegrity('task.restore', id);
+      const freshTask = await this.getArchivedTask(id);
+      if (!freshTask || this.isRestoreWindowExpired(freshTask)) return null;
 
-    const sourcePath = path.join(this.archiveDir, actualFilename);
-    const destPath = path.join(this.tasksDir, actualFilename);
+      // Find actual file on disk (slug may differ from current title)
+      const actualFilename = await this.findTaskFile(this.archiveDir, id);
+      if (!actualFilename) {
+        log.warn({ taskId: id }, 'Archived task file not found on disk for restoration');
+        return null;
+      }
 
-    // Update status to done
-    const restoredTask: Task = {
-      ...task,
-      status: 'done',
-      updated: new Date().toISOString(),
-      deletedAt: undefined,
-      deletedBy: undefined,
-      purgeAfter: undefined,
-    };
+      const sourcePath = path.join(this.archiveDir, actualFilename);
+      const destPath = path.join(this.tasksDir, actualFilename);
 
-    const content = this.taskToMarkdown(restoredTask);
+      // Update status to done
+      const restoredTask: Task = {
+        ...freshTask,
+        status: 'done',
+        updated: new Date().toISOString(),
+        deletedAt: undefined,
+        deletedBy: undefined,
+        purgeAfter: undefined,
+      };
 
-    await withFileLock(destPath, async () => {
-      // Write updated content atomically to active destination first so the
-      // archive copy remains intact until the new file is durable.
-      this.markWrite();
-      await atomicWriteFile(destPath, content, 'utf-8');
-      // Archive copy confirmed safe to remove now.
-      await fs.unlink(sourcePath);
+      const content = this.taskToMarkdown(restoredTask);
+
+      await withFileLock(destPath, async () => {
+        // Install the active copy before removing the archive source.
+        this.markWrite();
+        await atomicWriteFile(destPath, content, 'utf-8');
+        await fs.unlink(sourcePath);
+      });
+
+      // Restore attachments from archive
+      const { getAttachmentService } = await import('./attachment-service.js');
+      const attachmentService = getAttachmentService();
+      await attachmentService.restoreAttachments(id);
+
+      // Write-through: add restored task to active cache
+      this.cache.set(restoredTask.id, restoredTask);
+
+      // Emit telemetry event
+      await this.telemetry.emit<TaskTelemetryEvent>({
+        type: 'task.restored',
+        taskId: restoredTask.id,
+        project: restoredTask.project,
+        status: restoredTask.status,
+      });
+
+      return restoredTask;
     });
-
-    // Restore attachments from archive
-    const { getAttachmentService } = await import('./attachment-service.js');
-    const attachmentService = getAttachmentService();
-    await attachmentService.restoreAttachments(id);
-
-    // Write-through: add restored task to active cache
-    this.cache.set(restoredTask.id, restoredTask);
-
-    // Emit telemetry event
-    await this.telemetry.emit<TaskTelemetryEvent>({
-      type: 'task.restored',
-      taskId: restoredTask.id,
-      project: restoredTask.project,
-      status: restoredTask.status,
-    });
-
-    return restoredTask;
   }
 
   /**

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -68,6 +68,12 @@ function isValidTaskId(id: string): boolean {
   return TASK_ID_REGEX.test(id);
 }
 
+function normalizedTaskRevision(task: Pick<Task, 'revision'>): number {
+  return typeof task.revision === 'number' && Number.isInteger(task.revision) && task.revision >= 0
+    ? task.revision
+    : 1;
+}
+
 interface BoardStatusConfig {
   columns: BoardColumnConfig[];
   defaultStatus: TaskStatus;
@@ -123,6 +129,11 @@ export class TaskService {
   private cacheStats = { hits: 0, misses: 0 };
   private taskSyncReconcileInterval: ReturnType<typeof setInterval> | null = null;
   private reconcileRunning = false;
+
+  // ============ Per-Task Mutex ============
+  // Keyed on task ID — not filepath — so all in-process mutations for the
+  // same task serialize even when the slug/filename changes between writes.
+  private taskMutexes = new Map<string, Promise<void>>();
 
   // ============ Identity Diagnostics Cache ============
   // Cached to avoid a full filesystem scan on every list request (#784).
@@ -273,6 +284,31 @@ export class TaskService {
     return run;
   }
 
+  /**
+   * Serialize all in-process mutations for the given task ID.
+   *
+   * Uses the task ID as the queue key (not a filepath) so concurrent updates
+   * to the same task always serialize regardless of title / slug changes.
+   * The file lock inside still provides cross-process protection.
+   */
+  private withTaskMutex<T>(id: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.taskMutexes.get(id) ?? Promise.resolve();
+    let release!: () => void;
+    const myTurn = new Promise<void>((r) => {
+      release = r;
+    });
+    this.taskMutexes.set(id, myTurn);
+
+    return previous
+      .then(() => fn())
+      .finally(() => {
+        release();
+        if (this.taskMutexes.get(id) === myTurn) {
+          this.taskMutexes.delete(id);
+        }
+      });
+  }
+
   /** Get a task from the cache */
   private cacheGet(id: string): Task | undefined {
     const task = this.cache.get(id);
@@ -333,6 +369,7 @@ export class TaskService {
     this.sqliteDatabase?.close();
     this.sqliteDatabase = null;
     this.sqliteTasks = null;
+    this.taskMutexes.clear();
     this.cache.clear();
     this.cacheInitialized = false;
     this.cacheLoading = null;
@@ -648,6 +685,10 @@ export class TaskService {
         deletedAt: data.deletedAt,
         deletedBy: data.deletedBy,
         purgeAfter: data.purgeAfter,
+        revision:
+          typeof data.revision === 'number' && Number.isInteger(data.revision) && data.revision >= 0
+            ? data.revision
+            : undefined,
       };
     } catch (error) {
       log.error({ err: error, filename }, 'Failed to parse task file');
@@ -872,8 +913,9 @@ export class TaskService {
     } = input;
 
     // Compute the current file path for locking. We lock on the CURRENT filepath
-    // (stable for this task ID) so all concurrent updates for the same task
-    // serialize through the same lock regardless of title changes.
+    // so the file lock provides cross-process protection. Additionally, we wrap
+    // the entire mutation in withTaskMutex (keyed on task ID) to ensure all
+    // in-process updates for the same task serialize even when the slug changes.
     const oldFilename = this.taskToFilename(task);
     const lockPath = path.join(this.tasksDir, oldFilename);
 
@@ -885,384 +927,393 @@ export class TaskService {
         return;
       }
 
+      // File lock provides cross-process protection.
+      // withTaskMutex (below) provides in-process serialization by task ID.
       await withFileLock(lockPath, callback);
     };
 
-    await runMutation(async () => {
-      // Re-read from cache inside the lock to get the latest state.
-      // This prevents concurrent writes (e.g., debounced field save vs.
-      // timer start) from overwriting each other's changes.
-      const freshTask = this.sqliteTasks
-        ? ((await this.sqliteTasks.findById(id)) ?? task)
-        : (this.cacheGet(id) ?? task);
+    await this.withTaskMutex(id, () =>
+      runMutation(async () => {
+        // Re-read from cache inside the lock to get the latest state.
+        // This prevents concurrent writes (e.g., debounced field save vs.
+        // timer start) from overwriting each other's changes.
+        const freshTask = this.sqliteTasks
+          ? ((await this.sqliteTasks.findById(id)) ?? task)
+          : (this.cacheGet(id) ?? task);
 
-      // Revision check inside the lock — prevents a TOCTOU race where two
-      // concurrent requests with the same valid revision both pass the
-      // pre-lock route check, serialize here, and both succeed.
-      if (_expectedRevision !== undefined) {
-        const currentRevision =
-          typeof freshTask.revision === 'number' && freshTask.revision >= 0
-            ? freshTask.revision
-            : 1;
-        if (_expectedRevision !== currentRevision) {
-          throw new ConflictError(
-            `task ${id} has changed since it was loaded. Reload and retry with the latest revision.`,
-            {
-              resourceType: 'task',
-              resourceId: id,
-              expectedRevision: _expectedRevision,
-              currentRevision,
-              current: freshTask,
-            }
-          );
-        }
-      }
-
-      const previousStatus = freshTask.status;
-      const statusChanged = input.status !== undefined && input.status !== previousStatus;
-      let settings: Awaited<ReturnType<ConfigService['getFeatureSettings']>> | null = null;
-
-      if (statusChanged) {
-        settings = await this.configService.getFeatureSettings();
-        const columns = normalizeBoardColumns(settings.board?.columns);
-        this.assertConfiguredStatus(input.status as TaskStatus, {
-          columns,
-          defaultStatus: normalizeBoardDefaultStatus(settings.board?.defaultStatus, columns),
-          activeStatusIds: new Set(columns.map((column) => column.id)),
-        });
-      }
-
-      // Validate transition hooks (quality gates) before allowing status change
-      if (statusChanged && input.status && settings) {
-        // Check requireDeliverableForDone setting
-        if (input.status === 'done') {
-          if (settings.tasks.requireDeliverableForDone) {
-            const deliverables = input.deliverables ?? freshTask.deliverables ?? [];
-            if (deliverables.length === 0) {
-              throw new ValidationError(
-                'Cannot complete task without at least one deliverable (required by settings)',
-                [
-                  {
-                    code: 'DELIVERABLE_REQUIRED',
-                    message: 'Task requires at least one deliverable to be marked as done',
-                    path: ['status'],
-                  },
-                ]
-              );
-            }
-          }
-
-          // Enforcement: 4x10 Review Gate (only if enforcement settings are explicitly configured)
-          // Only applies to code-related task types
-          if (
-            settings.enforcement?.reviewGate === true &&
-            CODE_TASK_TYPES.includes(freshTask.type?.toLowerCase())
-          ) {
-            const scores = input.reviewScores ?? freshTask.reviewScores ?? [];
-            const allPerfect = scores.length === 4 && scores.every((s: number) => s === 10);
-            if (!allPerfect) {
-              const scoresDisplay =
-                scores.length === 4
-                  ? scores.join('/')
-                  : scores.length > 0
-                    ? scores.join('/')
-                    : 'none';
-              const detailMessage =
-                scores.length === 4
-                  ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay}`
-                  : scores.length > 0
-                    ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay} (incomplete)`
-                    : `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. No review scores set yet.`;
-
-              throw new ValidationError(detailMessage, [
-                {
-                  code: 'REVIEW_GATE',
-                  message: detailMessage,
-                  path: ['reviewScores'],
-                },
-              ]);
-            }
-          }
-
-          // Enforcement: Closing Comments Required (only if enforcement settings are explicitly configured)
-          if (settings.enforcement?.closingComments === true) {
-            const comments = input.reviewComments ?? freshTask.reviewComments ?? [];
-            const hasClosingComment =
-              comments.length > 0 &&
-              comments.some((c: { content: string }) => c.content && c.content.length >= 20);
-            if (!hasClosingComment) {
-              const commentCount = comments.length;
-              const detailMessage =
-                commentCount === 0
-                  ? 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. No comments added yet.'
-                  : 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. Current comments are too short.';
-
-              throw new ValidationError(detailMessage, [
-                {
-                  code: 'CLOSING_COMMENTS_REQUIRED',
-                  message: detailMessage,
-                  path: ['reviewComments'],
-                },
-              ]);
-            }
-          }
-        }
-
-        // Create a preview of the task with proposed changes for validation
-        const previewTask: Task = {
-          ...freshTask,
-          ...restInput,
-          blockedReason:
-            blockedReasonUpdate === null
-              ? undefined
-              : (blockedReasonUpdate ?? freshTask.blockedReason),
-        };
-
-        if (input.status === 'done' && settings.enforcement) {
-          const ceremonyEvaluation = await this.ceremonyService.evaluateTaskCompletion(
-            previewTask,
-            settings.enforcement
-          );
-          if (!ceremonyEvaluation.allowed) {
-            const detailMessage = `Ceremony Enforcement: ${ceremonyEvaluation.blockedReasons.join(
-              ' '
-            )}`;
-            throw new ValidationError(detailMessage, [
+        // Revision check inside the lock — prevents a TOCTOU race where two
+        // concurrent requests with the same valid revision both pass the
+        // pre-lock route check, serialize here, and both succeed.
+        if (_expectedRevision !== undefined) {
+          const currentRevision = normalizedTaskRevision(freshTask);
+          if (_expectedRevision !== currentRevision) {
+            throw new ConflictError(
+              `task ${id} has changed since it was loaded. Reload and retry with the latest revision.`,
               {
-                code: 'CEREMONY_REQUIRED',
-                message: detailMessage,
-                path: ['status'],
-                details: ceremonyEvaluation.pending.map((requirement) => ({
-                  id: requirement.id,
-                  kind: requirement.kind,
-                  title: requirement.title,
-                  reason: requirement.reason,
-                  requiredArtifacts: requirement.requiredArtifacts,
-                  dueAt: requirement.dueAt,
-                })),
+                resourceType: 'task',
+                resourceId: id,
+                expectedRevision: _expectedRevision,
+                currentRevision,
+                current: freshTask,
+              }
+            );
+          }
+        }
+
+        const previousStatus = freshTask.status;
+        const statusChanged = input.status !== undefined && input.status !== previousStatus;
+        let settings: Awaited<ReturnType<ConfigService['getFeatureSettings']>> | null = null;
+
+        if (statusChanged) {
+          settings = await this.configService.getFeatureSettings();
+          const columns = normalizeBoardColumns(settings.board?.columns);
+          this.assertConfiguredStatus(input.status as TaskStatus, {
+            columns,
+            defaultStatus: normalizeBoardDefaultStatus(settings.board?.defaultStatus, columns),
+            activeStatusIds: new Set(columns.map((column) => column.id)),
+          });
+        }
+
+        // Validate transition hooks (quality gates) before allowing status change
+        if (statusChanged && input.status && settings) {
+          // Check requireDeliverableForDone setting
+          if (input.status === 'done') {
+            if (settings.tasks.requireDeliverableForDone) {
+              const deliverables = input.deliverables ?? freshTask.deliverables ?? [];
+              if (deliverables.length === 0) {
+                throw new ValidationError(
+                  'Cannot complete task without at least one deliverable (required by settings)',
+                  [
+                    {
+                      code: 'DELIVERABLE_REQUIRED',
+                      message: 'Task requires at least one deliverable to be marked as done',
+                      path: ['status'],
+                    },
+                  ]
+                );
+              }
+            }
+
+            // Enforcement: 4x10 Review Gate (only if enforcement settings are explicitly configured)
+            // Only applies to code-related task types
+            if (
+              settings.enforcement?.reviewGate === true &&
+              CODE_TASK_TYPES.includes(freshTask.type?.toLowerCase())
+            ) {
+              const scores = input.reviewScores ?? freshTask.reviewScores ?? [];
+              const allPerfect = scores.length === 4 && scores.every((s: number) => s === 10);
+              if (!allPerfect) {
+                const scoresDisplay =
+                  scores.length === 4
+                    ? scores.join('/')
+                    : scores.length > 0
+                      ? scores.join('/')
+                      : 'none';
+                const detailMessage =
+                  scores.length === 4
+                    ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay}`
+                    : scores.length > 0
+                      ? `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. Current scores: ${scoresDisplay} (incomplete)`
+                      : `Review Gate: This ${freshTask.type} task requires all four review scores to be 10/10/10/10 before completion. No review scores set yet.`;
+
+                throw new ValidationError(detailMessage, [
+                  {
+                    code: 'REVIEW_GATE',
+                    message: detailMessage,
+                    path: ['reviewScores'],
+                  },
+                ]);
+              }
+            }
+
+            // Enforcement: Closing Comments Required (only if enforcement settings are explicitly configured)
+            if (settings.enforcement?.closingComments === true) {
+              const comments = input.reviewComments ?? freshTask.reviewComments ?? [];
+              const hasClosingComment =
+                comments.length > 0 &&
+                comments.some((c: { content: string }) => c.content && c.content.length >= 20);
+              if (!hasClosingComment) {
+                const commentCount = comments.length;
+                const detailMessage =
+                  commentCount === 0
+                    ? 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. No comments added yet.'
+                    : 'Closing Comments: At least one review comment with a deliverable summary (≥20 characters) is required before marking this task as done. Current comments are too short.';
+
+                throw new ValidationError(detailMessage, [
+                  {
+                    code: 'CLOSING_COMMENTS_REQUIRED',
+                    message: detailMessage,
+                    path: ['reviewComments'],
+                  },
+                ]);
+              }
+            }
+          }
+
+          // Create a preview of the task with proposed changes for validation
+          const previewTask: Task = {
+            ...freshTask,
+            ...restInput,
+            blockedReason:
+              blockedReasonUpdate === null
+                ? undefined
+                : (blockedReasonUpdate ?? freshTask.blockedReason),
+          };
+
+          if (input.status === 'done' && settings.enforcement) {
+            const ceremonyEvaluation = await this.ceremonyService.evaluateTaskCompletion(
+              previewTask,
+              settings.enforcement
+            );
+            if (!ceremonyEvaluation.allowed) {
+              const detailMessage = `Ceremony Enforcement: ${ceremonyEvaluation.blockedReasons.join(
+                ' '
+              )}`;
+              throw new ValidationError(detailMessage, [
+                {
+                  code: 'CEREMONY_REQUIRED',
+                  message: detailMessage,
+                  path: ['status'],
+                  details: ceremonyEvaluation.pending.map((requirement) => ({
+                    id: requirement.id,
+                    kind: requirement.kind,
+                    title: requirement.title,
+                    reason: requirement.reason,
+                    requiredArtifacts: requirement.requiredArtifacts,
+                    dueAt: requirement.dueAt,
+                  })),
+                },
+              ]);
+            }
+          }
+
+          const validation = await validateTransition(previewTask, previousStatus, input.status);
+          if (!validation.allowed) {
+            throw new ValidationError(
+              validation.errorMessage || 'Transition blocked by quality gates',
+              validation.failedGates.map(
+                (g: { gate: { type: string; name: string }; message?: string }) => ({
+                  code: g.gate.type,
+                  message: g.message || g.gate.name,
+                  path: ['status'],
+                })
+              )
+            );
+          }
+        }
+
+        // Handle checkpoint resumption: increment resumeCount if transitioning to in-progress with checkpoint
+        const hasCheckpointInput = Object.prototype.hasOwnProperty.call(input, 'checkpoint');
+        let checkpointUpdate = input.checkpoint;
+        let clearCheckpoint = hasCheckpointInput && input.checkpoint === undefined;
+        if (
+          !hasCheckpointInput &&
+          freshTask.checkpoint &&
+          input.status === 'in-progress' &&
+          previousStatus !== 'in-progress'
+        ) {
+          // Task is being resumed — increment resumeCount
+          checkpointUpdate = {
+            ...freshTask.checkpoint,
+            resumeCount: (freshTask.checkpoint.resumeCount || 0) + 1,
+          };
+        }
+
+        // Clear checkpoint when task completes successfully
+        if (input.status === 'done' && freshTask.checkpoint) {
+          clearCheckpoint = true;
+        }
+
+        // Validate agent ref against registry if being changed (#157)
+        if (restInput.agent !== undefined && restInput.agent !== freshTask.agent) {
+          const registry = getAgentRegistryService();
+          const validation = registry.validateAgentRef(restInput.agent);
+          if (!validation.valid) {
+            throw new ValidationError(validation.reason || 'Invalid agent ref', [
+              {
+                code: 'INVALID_AGENT_REF',
+                message: validation.reason || 'Invalid agent ref',
+                path: ['agent'],
               },
             ]);
           }
         }
 
-        const validation = await validateTransition(previewTask, previousStatus, input.status);
-        if (!validation.allowed) {
-          throw new ValidationError(
-            validation.errorMessage || 'Transition blocked by quality gates',
-            validation.failedGates.map(
-              (g: { gate: { type: string; name: string }; message?: string }) => ({
-                code: g.gate.type,
-                message: g.message || g.gate.name,
-                path: ['status'],
-              })
-            )
-          );
-        }
-      }
-
-      // Handle checkpoint resumption: increment resumeCount if transitioning to in-progress with checkpoint
-      const hasCheckpointInput = Object.prototype.hasOwnProperty.call(input, 'checkpoint');
-      let checkpointUpdate = input.checkpoint;
-      let clearCheckpoint = hasCheckpointInput && input.checkpoint === undefined;
-      if (
-        !hasCheckpointInput &&
-        freshTask.checkpoint &&
-        input.status === 'in-progress' &&
-        previousStatus !== 'in-progress'
-      ) {
-        // Task is being resumed — increment resumeCount
-        checkpointUpdate = {
-          ...freshTask.checkpoint,
-          resumeCount: (freshTask.checkpoint.resumeCount || 0) + 1,
-        };
-      }
-
-      // Clear checkpoint when task completes successfully
-      if (input.status === 'done' && freshTask.checkpoint) {
-        clearCheckpoint = true;
-      }
-
-      // Validate agent ref against registry if being changed (#157)
-      if (restInput.agent !== undefined && restInput.agent !== freshTask.agent) {
-        const registry = getAgentRegistryService();
-        const validation = registry.validateAgentRef(restInput.agent);
-        if (!validation.valid) {
-          throw new ValidationError(validation.reason || 'Invalid agent ref', [
-            {
-              code: 'INVALID_AGENT_REF',
-              message: validation.reason || 'Invalid agent ref',
-              path: ['agent'],
-            },
-          ]);
-        }
-      }
-
-      updatedTask = {
-        ...freshTask,
-        ...restInput,
-        git: gitUpdate ? ({ ...freshTask.git, ...gitUpdate } as Task['git']) : freshTask.git,
-        github: githubUpdate ?? freshTask.github,
-        // Handle blockedReason: null means clear, undefined means keep existing
-        blockedReason:
-          blockedReasonUpdate === null
+        updatedTask = {
+          ...freshTask,
+          ...restInput,
+          git: gitUpdate ? ({ ...freshTask.git, ...gitUpdate } as Task['git']) : freshTask.git,
+          github: githubUpdate ?? freshTask.github,
+          // Handle blockedReason: null means clear, undefined means keep existing
+          blockedReason:
+            blockedReasonUpdate === null
+              ? undefined
+              : (blockedReasonUpdate ?? freshTask.blockedReason),
+          // Apply checkpoint update (resume count or clear)
+          checkpoint: clearCheckpoint
             ? undefined
-            : (blockedReasonUpdate ?? freshTask.blockedReason),
-        // Apply checkpoint update (resume count or clear)
-        checkpoint: clearCheckpoint
-          ? undefined
-          : checkpointUpdate !== undefined
-            ? checkpointUpdate
-            : freshTask.checkpoint,
-        revision: (typeof freshTask.revision === 'number' ? freshTask.revision : 1) + 1,
-        updated: new Date().toISOString(),
-      };
-
-      if (this.sqliteTasks) {
-        await this.sqliteTasks.replaceActive(updatedTask);
-      } else {
-        // Compute destination filepath inside the lock from the fresh task state.
-        // The new filename may differ from lockPath when the title changed.
-        const freshOldFilename = this.taskToFilename(freshTask);
-        const newFilename = this.taskToFilename(updatedTask);
-        const filepath = path.join(this.tasksDir, newFilename);
-
-        await this.assertTaskIdentityIntegrity('task.update', id, {
-          candidates: [this.taskIdentityCandidate(updatedTask, 'active', filepath)],
-          destinationPath: this.diagnosticPath(filepath),
-          excludeTaskIds: [id],
-        });
-
-        const content = this.taskToMarkdown(updatedTask);
-        this.markWrite();
-
-        // Write new content atomically first; only then remove the old slug file.
-        // This ensures the task is never unrecoverable: if the write fails,
-        // the old file is still present under its original name.
-        await atomicWriteFile(filepath, content, 'utf-8');
-
-        if (freshOldFilename !== newFilename) {
-          // Remove old slug file now that new file is durably installed.
-          await fs.unlink(path.join(this.tasksDir, freshOldFilename)).catch(() => {});
-        }
-
-        // Write-through: update cache immediately (inside lock for consistency)
-        this.cache.set(updatedTask.id, updatedTask);
-      }
-
-      // Emit telemetry event if status changed
-      if (statusChanged) {
-        this.syncAgentRegistryForStatusTransition(updatedTask);
-
-        await this.telemetry.emit<TaskTelemetryEvent>({
-          type: 'task.status_changed',
-          taskId: updatedTask.id,
-          project: updatedTask.project,
-          status: updatedTask.status,
-          previousStatus,
-        });
-
-        // Fire lifecycle hook if applicable
-        const hookEvent = getHookEventForStatusChange(previousStatus, updatedTask.status);
-        if (hookEvent) {
-          fireHook(hookEvent, updatedTask, previousStatus).catch((err) => {
-            log.warn({ taskId: updatedTask.id, hookEvent }, 'Hook execution failed: %s', err);
-          });
-        }
-
-        // Enforcement: Auto-telemetry emission (run.started/run.completed)
-        const autoTelemetry = settings?.enforcement?.autoTelemetry === true;
-
-        if (autoTelemetry) {
-          const agent = updatedTask.agent || 'veritas';
-          if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
-            // Emit run.started
-            this.telemetry
-              .emit<RunStartedEvent>({
-                type: 'run.started',
-                taskId: updatedTask.id,
-                agent,
-              })
-              .catch((err) => {
-                log.warn({ taskId: updatedTask.id }, 'Auto run.started emission failed: %s', err);
-              });
-          } else if (updatedTask.status === 'done' && previousStatus !== 'done') {
-            // Emit run.completed
-            const durationMs = updatedTask.timeTracking?.totalSeconds
-              ? updatedTask.timeTracking.totalSeconds * 1000
-              : 0;
-            this.telemetry
-              .emit<RunCompletedEvent>({
-                type: 'run.completed',
-                taskId: updatedTask.id,
-                agent,
-                success: true,
-                durationMs,
-              })
-              .catch((err) => {
-                log.warn({ taskId: updatedTask.id }, 'Auto run.completed emission failed: %s', err);
-              });
-          }
-        }
-
-        // Enforcement: Auto time tracking start/stop (only if enforcement is configured)
-        const autoTimeTracking = settings?.enforcement?.autoTimeTracking === true;
-        if (autoTimeTracking) {
-          if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
-            // Auto-start timer
-            if (!updatedTask.timeTracking?.isRunning) {
-              this.startTimer(updatedTask.id).catch((err) => {
-                log.warn({ taskId: updatedTask.id }, 'Auto timer start failed: %s', err);
-              });
-            }
-          } else if (
-            (updatedTask.status === 'done' || updatedTask.status === 'blocked') &&
-            previousStatus !== 'done' &&
-            previousStatus !== 'blocked'
-          ) {
-            // Auto-stop timer
-            if (updatedTask.timeTracking?.isRunning) {
-              this.stopTimer(updatedTask.id).catch((err) => {
-                log.warn({ taskId: updatedTask.id }, 'Auto timer stop failed: %s', err);
-              });
-            }
-          }
-        }
-
-        // Execute post-transition actions (quality gates)
-        const actionCallbacks: TransitionActionCallbacks = {
-          onAutoStartTimer: async (t) => {
-            // Start time tracking if not already active
-            if (!t.timeTracking?.isRunning) {
-              await this.startTimer(t.id);
-            }
-          },
-          onAutoStopTimer: async (t) => {
-            // Stop time tracking if currently running
-            if (t.timeTracking?.isRunning) {
-              await this.stopTimer(t.id);
-            }
-          },
-          onLogActivity: async (t, from, to) => {
-            log.info({ taskId: t.id, from, to }, 'Transition action: logged activity');
-          },
-          onPromptLessonsLearned: async (t) => {
-            // Flag task for lessons learned capture (could set a field or emit event)
-            log.info({ taskId: t.id }, 'Transition action: prompt lessons learned');
-          },
+            : checkpointUpdate !== undefined
+              ? checkpointUpdate
+              : freshTask.checkpoint,
+          revision: normalizedTaskRevision(freshTask) + 1,
+          updated: new Date().toISOString(),
         };
 
-        executePostTransitionActions(
-          updatedTask,
-          previousStatus,
-          updatedTask.status,
-          actionCallbacks
-        ).catch((err) => {
-          log.warn({ taskId: updatedTask.id }, 'Post-transition actions failed: %s', err);
-        });
+        if (this.sqliteTasks) {
+          await this.sqliteTasks.replaceActive(updatedTask);
+        } else {
+          // Compute destination filepath inside the lock from the fresh task state.
+          // The new filename may differ from lockPath when the title changed.
+          const freshOldFilename = this.taskToFilename(freshTask);
+          const newFilename = this.taskToFilename(updatedTask);
+          const filepath = path.join(this.tasksDir, newFilename);
 
-        shouldGenerateCompletionPacket = updatedTask.status === 'done' && previousStatus !== 'done';
-      }
-    });
+          await this.assertTaskIdentityIntegrity('task.update', id, {
+            candidates: [this.taskIdentityCandidate(updatedTask, 'active', filepath)],
+            destinationPath: this.diagnosticPath(filepath),
+            excludeTaskIds: [id],
+          });
+
+          const content = this.taskToMarkdown(updatedTask);
+          this.markWrite();
+
+          // Write new content atomically first; only then remove the old slug file.
+          // This ensures the task is never unrecoverable: if the write fails,
+          // the old file is still present under its original name.
+          await atomicWriteFile(filepath, content, 'utf-8');
+
+          if (freshOldFilename !== newFilename) {
+            // Remove old slug file now that new file is durably installed.
+            await fs.unlink(path.join(this.tasksDir, freshOldFilename)).catch((err) => {
+              if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+              throw err;
+            });
+          }
+
+          // Write-through: update cache immediately (inside lock for consistency)
+          this.cache.set(updatedTask.id, updatedTask);
+        }
+
+        // Emit telemetry event if status changed
+        if (statusChanged) {
+          this.syncAgentRegistryForStatusTransition(updatedTask);
+
+          await this.telemetry.emit<TaskTelemetryEvent>({
+            type: 'task.status_changed',
+            taskId: updatedTask.id,
+            project: updatedTask.project,
+            status: updatedTask.status,
+            previousStatus,
+          });
+
+          // Fire lifecycle hook if applicable
+          const hookEvent = getHookEventForStatusChange(previousStatus, updatedTask.status);
+          if (hookEvent) {
+            fireHook(hookEvent, updatedTask, previousStatus).catch((err) => {
+              log.warn({ taskId: updatedTask.id, hookEvent }, 'Hook execution failed: %s', err);
+            });
+          }
+
+          // Enforcement: Auto-telemetry emission (run.started/run.completed)
+          const autoTelemetry = settings?.enforcement?.autoTelemetry === true;
+
+          if (autoTelemetry) {
+            const agent = updatedTask.agent || 'veritas';
+            if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
+              // Emit run.started
+              this.telemetry
+                .emit<RunStartedEvent>({
+                  type: 'run.started',
+                  taskId: updatedTask.id,
+                  agent,
+                })
+                .catch((err) => {
+                  log.warn({ taskId: updatedTask.id }, 'Auto run.started emission failed: %s', err);
+                });
+            } else if (updatedTask.status === 'done' && previousStatus !== 'done') {
+              // Emit run.completed
+              const durationMs = updatedTask.timeTracking?.totalSeconds
+                ? updatedTask.timeTracking.totalSeconds * 1000
+                : 0;
+              this.telemetry
+                .emit<RunCompletedEvent>({
+                  type: 'run.completed',
+                  taskId: updatedTask.id,
+                  agent,
+                  success: true,
+                  durationMs,
+                })
+                .catch((err) => {
+                  log.warn(
+                    { taskId: updatedTask.id },
+                    'Auto run.completed emission failed: %s',
+                    err
+                  );
+                });
+            }
+          }
+
+          // Enforcement: Auto time tracking start/stop (only if enforcement is configured)
+          const autoTimeTracking = settings?.enforcement?.autoTimeTracking === true;
+          if (autoTimeTracking) {
+            if (updatedTask.status === 'in-progress' && previousStatus !== 'in-progress') {
+              // Auto-start timer
+              if (!updatedTask.timeTracking?.isRunning) {
+                this.startTimer(updatedTask.id).catch((err) => {
+                  log.warn({ taskId: updatedTask.id }, 'Auto timer start failed: %s', err);
+                });
+              }
+            } else if (
+              (updatedTask.status === 'done' || updatedTask.status === 'blocked') &&
+              previousStatus !== 'done' &&
+              previousStatus !== 'blocked'
+            ) {
+              // Auto-stop timer
+              if (updatedTask.timeTracking?.isRunning) {
+                this.stopTimer(updatedTask.id).catch((err) => {
+                  log.warn({ taskId: updatedTask.id }, 'Auto timer stop failed: %s', err);
+                });
+              }
+            }
+          }
+
+          // Execute post-transition actions (quality gates)
+          const actionCallbacks: TransitionActionCallbacks = {
+            onAutoStartTimer: async (t) => {
+              // Start time tracking if not already active
+              if (!t.timeTracking?.isRunning) {
+                await this.startTimer(t.id);
+              }
+            },
+            onAutoStopTimer: async (t) => {
+              // Stop time tracking if currently running
+              if (t.timeTracking?.isRunning) {
+                await this.stopTimer(t.id);
+              }
+            },
+            onLogActivity: async (t, from, to) => {
+              log.info({ taskId: t.id, from, to }, 'Transition action: logged activity');
+            },
+            onPromptLessonsLearned: async (t) => {
+              // Flag task for lessons learned capture (could set a field or emit event)
+              log.info({ taskId: t.id }, 'Transition action: prompt lessons learned');
+            },
+          };
+
+          executePostTransitionActions(
+            updatedTask,
+            previousStatus,
+            updatedTask.status,
+            actionCallbacks
+          ).catch((err) => {
+            log.warn({ taskId: updatedTask.id }, 'Post-transition actions failed: %s', err);
+          });
+
+          shouldGenerateCompletionPacket =
+            updatedTask.status === 'done' && previousStatus !== 'done';
+        }
+      })
+    );
 
     if (shouldGenerateCompletionPacket) {
       try {
@@ -1376,7 +1427,7 @@ export class TaskService {
           // the source file remains intact until the new file is durable.
           await atomicWriteFile(destPath, archivedContent, 'utf-8');
           // Source is now safe to remove — archive copy is confirmed present.
-          await fs.unlink(sourcePath).catch(() => {});
+          await fs.unlink(sourcePath);
         });
         log.debug({ taskId: id, filename }, 'Archived task file');
       })
@@ -1518,7 +1569,7 @@ export class TaskService {
       this.markWrite();
       await atomicWriteFile(destPath, content, 'utf-8');
       // Archive copy confirmed safe to remove now.
-      await fs.unlink(sourcePath).catch(() => {});
+      await fs.unlink(sourcePath);
     });
 
     // Restore attachments from archive

--- a/server/src/services/task-service.ts
+++ b/server/src/services/task-service.ts
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { watch, batchedMap, type FSWatcher } from '../storage/fs-helpers.js';
+import { watch, batchedMap, atomicWriteFile, type FSWatcher } from '../storage/fs-helpers.js';
 import path from 'path';
 import matter from '../utils/frontmatter.js';
 import { nanoid } from 'nanoid';
@@ -124,6 +124,11 @@ export class TaskService {
   private taskSyncReconcileInterval: ReturnType<typeof setInterval> | null = null;
   private reconcileRunning = false;
 
+  // ============ Identity Diagnostics Cache ============
+  // Cached to avoid a full filesystem scan on every list request (#784).
+  // Invalidated by any mutation (markWrite path) and by external file changes.
+  private identityDiagnosticsCache: TaskIdentityDiagnostics | null = null;
+
   constructor(options: TaskServiceOptions = {}) {
     this.tasksDir = options.tasksDir || DEFAULT_TASKS_DIR;
     this.archiveDir = options.archiveDir || DEFAULT_ARCHIVE_DIR;
@@ -223,6 +228,8 @@ export class TaskService {
   /** Reload a single file from disk into the cache */
   private async reloadFile(filename: string): Promise<void> {
     const filepath = path.join(this.tasksDir, filename);
+    // External file change also invalidates diagnostics cache (#784)
+    this.identityDiagnosticsCache = null;
     try {
       const content = await fs.readFile(filepath, 'utf-8');
       const task = this.parseTaskFile(content, filename);
@@ -288,6 +295,8 @@ export class TaskService {
   /** Record that we are about to write — suppresses watcher for WRITE_DEBOUNCE_MS */
   private markWrite(): void {
     this.lastWriteTime = Date.now();
+    // Invalidate diagnostics cache on any mutation (#784)
+    this.identityDiagnosticsCache = null;
   }
 
   /** Start watching tasksDir for external file changes */
@@ -415,7 +424,22 @@ export class TaskService {
   async getTaskIdentityDiagnostics(
     extraSources: TaskIdentityScanSource[] = []
   ): Promise<TaskIdentityDiagnostics> {
+    // Use cached result when no extra sources are requested (#784).
+    // The cache is invalidated by markWrite() and by external file changes.
+    if (extraSources.length === 0) {
+      if (!this.identityDiagnosticsCache) {
+        this.identityDiagnosticsCache = await scanTaskIdentityDiagnostics(
+          this.getIdentityScanSources()
+        );
+      }
+      return this.identityDiagnosticsCache;
+    }
     return scanTaskIdentityDiagnostics([...this.getIdentityScanSources(), ...extraSources]);
+  }
+
+  /** Invalidate the identity diagnostics cache (e.g. when backlog tasks change). */
+  invalidateIdentityDiagnosticsCache(): void {
+    this.identityDiagnosticsCache = null;
   }
 
   async assertTaskIdentityIntegrity(
@@ -806,7 +830,7 @@ export class TaskService {
 
       await withFileLock(filepath, async () => {
         this.markWrite();
-        await fs.writeFile(filepath, content, 'utf-8');
+        await atomicWriteFile(filepath, content, 'utf-8');
       });
 
       // Write-through: update cache immediately
@@ -847,12 +871,11 @@ export class TaskService {
       ...restInput
     } = input;
 
-    // Compute filenames for locking. We use the tentative updated task
-    // to determine the new filename (title may have changed).
+    // Compute the current file path for locking. We lock on the CURRENT filepath
+    // (stable for this task ID) so all concurrent updates for the same task
+    // serialize through the same lock regardless of title changes.
     const oldFilename = this.taskToFilename(task);
-    const tentativeTask: Task = { ...task, ...restInput };
-    const newFilename = this.taskToFilename(tentativeTask);
-    const filepath = path.join(this.tasksDir, newFilename);
+    const lockPath = path.join(this.tasksDir, oldFilename);
 
     let updatedTask!: Task;
     let shouldGenerateCompletionPacket = false;
@@ -862,7 +885,7 @@ export class TaskService {
         return;
       }
 
-      await withFileLock(filepath, callback);
+      await withFileLock(lockPath, callback);
     };
 
     await runMutation(async () => {
@@ -872,6 +895,28 @@ export class TaskService {
       const freshTask = this.sqliteTasks
         ? ((await this.sqliteTasks.findById(id)) ?? task)
         : (this.cacheGet(id) ?? task);
+
+      // Revision check inside the lock — prevents a TOCTOU race where two
+      // concurrent requests with the same valid revision both pass the
+      // pre-lock route check, serialize here, and both succeed.
+      if (_expectedRevision !== undefined) {
+        const currentRevision =
+          typeof freshTask.revision === 'number' && freshTask.revision >= 0
+            ? freshTask.revision
+            : 1;
+        if (_expectedRevision !== currentRevision) {
+          throw new ConflictError(
+            `task ${id} has changed since it was loaded. Reload and retry with the latest revision.`,
+            {
+              resourceType: 'task',
+              resourceId: id,
+              expectedRevision: _expectedRevision,
+              currentRevision,
+              current: freshTask,
+            }
+          );
+        }
+      }
 
       const previousStatus = freshTask.status;
       const statusChanged = input.status !== undefined && input.status !== previousStatus;
@@ -1075,6 +1120,12 @@ export class TaskService {
       if (this.sqliteTasks) {
         await this.sqliteTasks.replaceActive(updatedTask);
       } else {
+        // Compute destination filepath inside the lock from the fresh task state.
+        // The new filename may differ from lockPath when the title changed.
+        const freshOldFilename = this.taskToFilename(freshTask);
+        const newFilename = this.taskToFilename(updatedTask);
+        const filepath = path.join(this.tasksDir, newFilename);
+
         await this.assertTaskIdentityIntegrity('task.update', id, {
           candidates: [this.taskIdentityCandidate(updatedTask, 'active', filepath)],
           destinationPath: this.diagnosticPath(filepath),
@@ -1084,11 +1135,15 @@ export class TaskService {
         const content = this.taskToMarkdown(updatedTask);
         this.markWrite();
 
-        if (oldFilename !== newFilename) {
-          // Intentionally silent: old file may already be gone after rename
-          await fs.unlink(path.join(this.tasksDir, oldFilename)).catch(() => {});
+        // Write new content atomically first; only then remove the old slug file.
+        // This ensures the task is never unrecoverable: if the write fails,
+        // the old file is still present under its original name.
+        await atomicWriteFile(filepath, content, 'utf-8');
+
+        if (freshOldFilename !== newFilename) {
+          // Remove old slug file now that new file is durably installed.
+          await fs.unlink(path.join(this.tasksDir, freshOldFilename)).catch(() => {});
         }
-        await fs.writeFile(filepath, content, 'utf-8');
 
         // Write-through: update cache immediately (inside lock for consistency)
         this.cache.set(updatedTask.id, updatedTask);
@@ -1317,8 +1372,11 @@ export class TaskService {
         const destPath = path.join(this.archiveDir, filename);
         await withFileLock(sourcePath, async () => {
           this.markWrite();
-          await fs.rename(sourcePath, destPath);
-          await fs.writeFile(destPath, archivedContent, 'utf-8');
+          // Write updated content atomically to archive destination first so
+          // the source file remains intact until the new file is durable.
+          await atomicWriteFile(destPath, archivedContent, 'utf-8');
+          // Source is now safe to remove — archive copy is confirmed present.
+          await fs.unlink(sourcePath).catch(() => {});
         });
         log.debug({ taskId: id, filename }, 'Archived task file');
       })
@@ -1455,10 +1513,12 @@ export class TaskService {
     const content = this.taskToMarkdown(restoredTask);
 
     await withFileLock(destPath, async () => {
-      // Move back to active and set status to done
-      await fs.rename(sourcePath, destPath);
+      // Write updated content atomically to active destination first so the
+      // archive copy remains intact until the new file is durable.
       this.markWrite();
-      await fs.writeFile(destPath, content, 'utf-8');
+      await atomicWriteFile(destPath, content, 'utf-8');
+      // Archive copy confirmed safe to remove now.
+      await fs.unlink(sourcePath).catch(() => {});
     });
 
     // Restore attachments from archive

--- a/server/src/storage/fs-helpers.ts
+++ b/server/src/storage/fs-helpers.ts
@@ -77,13 +77,14 @@ export const unlink = unlinkAsync;
 export const writeFile = writeFileAsync;
 
 /**
- * Crash-safe atomic file write.
+ * Atomic file replacement.
  *
  * Writes `content` to a randomly-named sibling temp file on the same
- * filesystem as `destPath`, then renames it over `destPath`.  Because
- * `rename(2)` is atomic on POSIX (same-device) systems, readers either see
- * the old file or the new file — never a partial write.  The temp file is
- * cleaned up on failure so it does not accumulate.
+ * filesystem as `destPath`, then renames it over `destPath`. On filesystems
+ * where same-device replacement rename is atomic, readers either see the old
+ * file or the new file — never a partial write. This does not claim crash
+ * durability because the file and parent directory are not explicitly synced.
+ * The temp file is cleaned up on failure so it does not accumulate.
  *
  * Encoding defaults to `'utf-8'` to match the old `writeFile` call sites.
  */

--- a/server/src/storage/fs-helpers.ts
+++ b/server/src/storage/fs-helpers.ts
@@ -17,10 +17,12 @@ import {
   mkdir as mkdirAsync,
   readFile as readFileAsync,
   readdir as readdirAsync,
+  rename as renameAsync,
   rm as rmAsync,
   unlink as unlinkAsync,
   writeFile as writeFileAsync,
 } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
 // Synchronous helpers (used by security config, agent status persistence)
@@ -69,9 +71,39 @@ export const createWriteStream = fs.createWriteStream;
 export const mkdir = mkdirAsync;
 export const readFile = readFileAsync;
 export const readdir = readdirAsync;
+export const rename = renameAsync;
 export const rm = rmAsync;
 export const unlink = unlinkAsync;
 export const writeFile = writeFileAsync;
+
+/**
+ * Crash-safe atomic file write.
+ *
+ * Writes `content` to a randomly-named sibling temp file on the same
+ * filesystem as `destPath`, then renames it over `destPath`.  Because
+ * `rename(2)` is atomic on POSIX (same-device) systems, readers either see
+ * the old file or the new file — never a partial write.  The temp file is
+ * cleaned up on failure so it does not accumulate.
+ *
+ * Encoding defaults to `'utf-8'` to match the old `writeFile` call sites.
+ */
+export async function atomicWriteFile(
+  destPath: string,
+  content: string | Buffer,
+  encoding: BufferEncoding = 'utf-8'
+): Promise<void> {
+  const suffix = randomBytes(6).toString('hex');
+  const tmpPath = `${destPath}.tmp.${suffix}`;
+
+  try {
+    await writeFileAsync(tmpPath, content, encoding);
+    await renameAsync(tmpPath, destPath);
+  } catch (err) {
+    // Best-effort cleanup; ignore errors — the original file is untouched.
+    await unlinkAsync(tmpPath).catch(() => {});
+    throw err;
+  }
+}
 
 /**
  * Async file-existence check.


### PR DESCRIPTION
## Summary
- replace task and activity files through sibling temporary files and atomic rename
- serialize file-backed task mutations by immutable task ID before asynchronous lookup
- preserve revision checks, slug-change ordering, and SQLite mutation behavior
- cache duplicate task-identity diagnostics
- return file-backed activity pages and totals from one load/filter pass
- back up malformed activity data before recovery

## Verification
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing 600-warning budget)
- `pnpm build`
- `pnpm audit --prod --audit-level=high`
- focused storage/route regressions: 49 passed
- Claude cross-model review: no production defects

## Remaining work
#782 remains open: this PR removes duplicate pagination reads and adds atomic/recoverable writes, but file-mode activity appends still rewrite the bounded JSON history. Append-oriented persistence requires a separate compatibility migration.

Closes #776

Closes #777

Closes #784

Refs #782