### PR TITLE
fix: restore keyboard board movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored keyboard drag-and-drop parity on the Kanban board with spatial
+  cross-column movement, empty-column targeting, same-column reordering,
+  accurate screen-reader announcements, mutation rollback, and post-move focus
+  restoration (#812).
 - Kept Electron's runtime API external in Vite 8/Rolldown desktop builds,
   preventing the npm executable-path shim from replacing `app`,
   `BrowserWindow`, `contextBridge`, and related native APIs in emitted main and

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -99,7 +99,7 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 | ![v5 Workbench panel](assets/v5/v5-workbench-panel.png) | ![v5 mobile PWA board](assets/v5/v5-mobile-pwa-board.png) |
 
 - **Kanban columns** — Four default columns for compatibility: To Do, In Progress, Blocked, Done; board columns and the default create status can be customized in Settings -> Board & Display
-- **Drag-and-drop** — Move tasks between configured columns with [@dnd-kit](https://dndkit.com/); reorder within columns; custom collision detection (pointerWithin + rectIntersection fallback) for reliable cross-column moves; tooltips suppressed during drag; local state management for real-time column updates
+- **Drag-and-drop** — Move tasks between configured columns with [@dnd-kit](https://dndkit.com/); reorder within columns; keyboard users press Space to pick up or drop, use spatial arrow-key movement across populated or empty columns, and press Escape to cancel; custom collision detection (pointerWithin + rectIntersection fallback) supports pointer and keyboard moves; tooltips are suppressed during drag; local state provides real-time column updates
 
 - **Task CRUD** — Create, read, update, and delete tasks through the UI or API
 - **Create task dialog** — Quick-create with title, type, priority, project, sprint, and description
@@ -2149,14 +2149,14 @@ Multi-layer testing strategy.
 Working toward WCAG 2.1 AA compliance.
 
 - **ARIA labels** — Applied to interactive elements: buttons, dialogs, form controls, navigation
-- **Keyboard navigation** — Full keyboard support: j/k navigation, Enter to open, Esc to close, number keys for column moves
+- **Keyboard navigation** — Navigate with j/k, open with Enter, move directly with number keys, or press Space on a board card to pick it up and use arrow keys to reorder or cross columns; Escape cancels and restores focus
 - **Keyboard shortcuts dialog** — Discoverable via `?` key with grouped shortcut reference
 - **Focus management** — Focus trapped in dialogs and sheets; restored on close
 - **Screen reader support** — Semantic HTML, ARIA roles, and descriptive labels throughout
 - **Color contrast** — Dark and light mode palettes designed for readability; purple primary (`270° 50% 40%`) buttons with white text in dark mode
 - **Skip navigation** — Keyboard users can navigate efficiently between sections
 - **Sortable list accessibility** — Drag-and-drop lists in settings include keyboard-accessible reordering
-- **Interactive cards** — Task cards, metric cards, and stat cards support keyboard activation (Enter/Space)
+- **Interactive cards** — Enter opens a task card; Space opens it when drag-and-drop is unavailable or starts keyboard drag when board sorting is enabled
 - **Error boundaries** — Crash recovery UI accessible via keyboard
 
 ---

--- a/web/src/__tests__/TaskCard.test.tsx
+++ b/web/src/__tests__/TaskCard.test.tsx
@@ -12,11 +12,13 @@ import type { Task } from '@veritas-kanban/shared';
 
 // ── Mocks ────────────────────────────────────────────────────
 
+const { sortableKeyDown } = vi.hoisted(() => ({ sortableKeyDown: vi.fn() }));
+
 // Mock @dnd-kit/sortable — card uses useSortable
 vi.mock('@dnd-kit/sortable', () => ({
   useSortable: () => ({
     attributes: {},
-    listeners: {},
+    listeners: { onKeyDown: sortableKeyDown },
     setNodeRef: vi.fn(),
     transform: null,
     transition: undefined,
@@ -147,6 +149,7 @@ function renderCard(task: Task, props: Partial<React.ComponentProps<typeof TaskC
 describe('TaskCard', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    sortableKeyDown.mockClear();
   });
 
   afterEach(() => {
@@ -235,14 +238,27 @@ describe('TaskCard', () => {
     expect(onClick).toHaveBeenCalledOnce();
   });
 
-  it('handles Space key press', () => {
+  it('opens with Space when drag and drop is disabled', () => {
     const onClick = vi.fn();
     const task = createMockTask();
-    renderCard(task, { onClick });
+    renderCard(task, { dragEnabled: false, onClick });
 
     const card = screen.getByRole('article');
     fireEvent.keyDown(card, { key: ' ' });
     expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('delegates Space to the keyboard drag sensor when drag and drop is enabled', () => {
+    const onClick = vi.fn();
+    const task = createMockTask();
+    renderCard(task, { dragEnabled: true, onClick });
+
+    const card = screen.getByRole('article');
+    fireEvent.keyDown(card, { key: ' ' });
+
+    expect(sortableKeyDown).toHaveBeenCalledOnce();
+    expect(onClick).not.toHaveBeenCalled();
+    expect(card.getAttribute('data-task-id')).toBe(task.id);
   });
 
   it('applies selected ring when isSelected', () => {

--- a/web/src/__tests__/useBoardDragDrop.test.tsx
+++ b/web/src/__tests__/useBoardDragDrop.test.tsx
@@ -1,0 +1,243 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { KeyboardSensor, PointerSensor } from '@dnd-kit/core';
+import type { DragCancelEvent, DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
+import { describe, expect, it, vi, type Mock } from 'vitest';
+import { DEFAULT_FEATURE_SETTINGS, type Task, type TaskStatus } from '@veritas-kanban/shared';
+import { createBoardKeyboardCoordinates, useBoardDragDrop } from '@/hooks/useBoardDragDrop';
+import { createMockTask } from './test-utils';
+
+const columns = DEFAULT_FEATURE_SETTINGS.board.columns;
+type StatusChange = (taskId: string, status: TaskStatus) => Promise<void>;
+type Reorder = (taskIds: string[]) => Promise<void>;
+type Announce = (message: string) => void;
+
+function dragEvent(activeId: string, overId?: string) {
+  return {
+    active: { id: activeId },
+    over: overId ? { id: overId } : null,
+  };
+}
+
+function renderDragHook({
+  tasks = [
+    createMockTask({ id: 'todo-1', title: 'First task', status: 'todo' }),
+    createMockTask({ id: 'todo-2', title: 'Second task', status: 'todo' }),
+    createMockTask({ id: 'done-1', title: 'Done task', status: 'done' }),
+  ],
+  onStatusChange = vi.fn<StatusChange>().mockResolvedValue(undefined),
+  onReorder = vi.fn<Reorder>().mockResolvedValue(undefined),
+  announce = vi.fn<Announce>(),
+}: {
+  tasks?: Task[];
+  onStatusChange?: Mock<StatusChange>;
+  onReorder?: Mock<Reorder>;
+  announce?: Mock<Announce>;
+} = {}) {
+  const tasksByStatus = Object.fromEntries(
+    columns.map((column) => [column.id, tasks.filter((task) => task.status === column.id)])
+  );
+
+  const hook = renderHook(() =>
+    useBoardDragDrop({
+      tasks,
+      tasksByStatus,
+      columns,
+      onStatusChange,
+      onReorder,
+      announce,
+    })
+  );
+
+  return { ...hook, announce, onReorder, onStatusChange };
+}
+
+describe('useBoardDragDrop keyboard parity', () => {
+  it('targets the next board column even when it has no sortable tasks', () => {
+    const coordinateGetter = createBoardKeyboardCoordinates(['todo', 'done']);
+    const preventDefault = vi.fn();
+    const result = coordinateGetter(
+      { code: 'ArrowRight', preventDefault } as unknown as KeyboardEvent,
+      {
+        active: 'todo-1',
+        currentCoordinates: { x: 20, y: 100 },
+        context: {
+          collisionRect: {
+            left: 20,
+            right: 220,
+            top: 100,
+            bottom: 180,
+            width: 200,
+            height: 80,
+          },
+          droppableRects: new Map([
+            ['todo', { left: 0, right: 240, top: 60, bottom: 700, width: 240, height: 640 }],
+            ['done', { left: 260, right: 500, top: 60, bottom: 700, width: 240, height: 640 }],
+          ]),
+        },
+      } as never
+    );
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(result).toEqual({ x: 280, y: 100 });
+  });
+
+  it('targets an empty column on another visual row', () => {
+    const coordinateGetter = createBoardKeyboardCoordinates(['todo', 'done']);
+    const preventDefault = vi.fn();
+    const result = coordinateGetter(
+      { code: 'ArrowUp', preventDefault } as unknown as KeyboardEvent,
+      {
+        active: 'done-1',
+        currentCoordinates: { x: 20, y: 760 },
+        context: {
+          collisionRect: {
+            left: 20,
+            right: 220,
+            top: 760,
+            bottom: 840,
+            width: 200,
+            height: 80,
+          },
+          droppableRects: new Map([
+            ['todo', { left: 0, right: 240, top: 60, bottom: 700, width: 240, height: 640 }],
+            ['done', { left: 0, right: 240, top: 720, bottom: 1360, width: 240, height: 640 }],
+          ]),
+        },
+      } as never
+    );
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(result).toEqual({ x: 20, y: 60 });
+  });
+
+  it('registers pointer and keyboard sensors and accurate keyboard instructions', () => {
+    const { result } = renderDragHook();
+
+    expect(result.current.sensors.map((descriptor) => descriptor.sensor)).toEqual([
+      PointerSensor,
+      KeyboardSensor,
+    ]);
+    expect(result.current.screenReaderInstructions.draggable).toContain('arrow keys');
+    expect(result.current.screenReaderInstructions.draggable).toContain('Escape');
+    expect(
+      result.current.announcements.onDragOver({
+        active: { id: 'todo-1' },
+        over: { id: 'todo' },
+      } as never)
+    ).toBe('First task is over To Do, position 1 of 2.');
+  });
+
+  it('reorders within a column and announces the committed position', async () => {
+    const { result, onReorder, announce } = renderDragHook();
+
+    act(() => result.current.handleDragStart(dragEvent('todo-2') as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent('todo-2', 'todo-1') as DragOverEvent));
+    await act(async () =>
+      result.current.handleDragEnd(dragEvent('todo-2', 'todo-1') as DragEndEvent)
+    );
+
+    expect(onReorder).toHaveBeenCalledWith(['todo-2', 'todo-1']);
+    expect(announce).toHaveBeenCalledWith('Second task moved to To Do, position 1 of 2');
+  });
+
+  it('moves a task into an empty column and persists its destination order', async () => {
+    const tasks = [
+      createMockTask({ id: 'todo-1', title: 'First task', status: 'todo' }),
+      createMockTask({ id: 'todo-2', title: 'Second task', status: 'todo' }),
+    ];
+    const originalCard = document.createElement('button');
+    originalCard.dataset.taskId = 'todo-1';
+    document.body.append(originalCard);
+    const movedCard = document.createElement('button');
+    movedCard.dataset.taskId = 'todo-1';
+    const onStatusChange = vi.fn<StatusChange>().mockImplementation(async () => {
+      originalCard.remove();
+      document.body.append(movedCard);
+    });
+    const { result, onReorder, announce } = renderDragHook({ tasks, onStatusChange });
+
+    act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent('todo-1', 'done') as DragOverEvent));
+    await act(async () =>
+      result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent)
+    );
+
+    expect(onStatusChange).toHaveBeenCalledWith('todo-1', 'done');
+    expect(onReorder).toHaveBeenCalledWith(['todo-1']);
+    expect(announce).toHaveBeenCalledWith('First task moved to Done, position 1 of 1');
+    await waitFor(() => expect(document.activeElement).toBe(movedCard));
+    movedCard.remove();
+  });
+
+  it('cancels without persisting and restores focus to the active task', async () => {
+    const card = document.createElement('button');
+    card.dataset.taskId = 'todo-1';
+    document.body.append(card);
+    const { result, onReorder, onStatusChange, announce } = renderDragHook();
+
+    act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
+    act(() => result.current.handleDragCancel(dragEvent('todo-1') as DragCancelEvent));
+
+    await waitFor(() => expect(document.activeElement).toBe(card));
+    expect(onStatusChange).not.toHaveBeenCalled();
+    expect(onReorder).not.toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith(
+      'Move canceled. First task returned to To Do, position 1 of 2'
+    );
+    card.remove();
+  });
+
+  it('announces a same-column rollback when reordering fails', async () => {
+    const onReorder = vi.fn<Reorder>().mockRejectedValue(new Error('network failed'));
+    const { result, announce } = renderDragHook({ onReorder });
+
+    act(() => result.current.handleDragStart(dragEvent('todo-2') as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent('todo-2', 'todo-1') as DragOverEvent));
+    await act(async () =>
+      result.current.handleDragEnd(dragEvent('todo-2', 'todo-1') as DragEndEvent)
+    );
+
+    expect(announce).toHaveBeenCalledWith(
+      'Move failed. Second task returned to To Do, position 2 of 2'
+    );
+  });
+
+  it('rolls status back when destination ordering fails', async () => {
+    const onStatusChange = vi.fn<StatusChange>().mockResolvedValue(undefined);
+    const onReorder = vi.fn<Reorder>().mockRejectedValue(new Error('network failed'));
+    const { result, announce } = renderDragHook({ onStatusChange, onReorder });
+
+    act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent('todo-1', 'done') as DragOverEvent));
+    await act(async () =>
+      result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent)
+    );
+
+    expect(onStatusChange.mock.calls).toEqual([
+      ['todo-1', 'done'],
+      ['todo-1', 'todo'],
+    ]);
+    expect(announce).toHaveBeenCalledWith(
+      'Move failed. First task returned to To Do, position 1 of 2'
+    );
+  });
+
+  it('announces a partial failure when automatic status rollback also fails', async () => {
+    const onStatusChange = vi
+      .fn<StatusChange>()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('rollback failed'));
+    const onReorder = vi.fn<Reorder>().mockRejectedValue(new Error('network failed'));
+    const { result, announce } = renderDragHook({ onStatusChange, onReorder });
+
+    act(() => result.current.handleDragStart(dragEvent('todo-1') as unknown as DragStartEvent));
+    act(() => result.current.handleDragOver(dragEvent('todo-1', 'done') as DragOverEvent));
+    await act(async () =>
+      result.current.handleDragEnd(dragEvent('todo-1', 'done') as DragEndEvent)
+    );
+
+    expect(announce).toHaveBeenCalledWith(
+      'Move partially failed. First task may still be in Done because automatic rollback failed; refresh the board before trying again'
+    );
+  });
+});

--- a/web/src/components/board/KanbanBoard.tsx
+++ b/web/src/components/board/KanbanBoard.tsx
@@ -418,21 +418,25 @@ export function KanbanBoard() {
     liveTasksByStatus,
     sensors,
     collisionDetection,
+    announcements,
+    screenReaderInstructions,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
+    handleDragCancel,
   } = useBoardDragDrop({
     tasks: filteredTasks,
     tasksByStatus,
     columns,
-    onStatusChange: (taskId, status) => {
-      if (!canWriteTasks || !isOnline) return;
-      updateTask.mutate({ id: taskId, input: { status } });
+    onStatusChange: async (taskId, status) => {
+      if (!canWriteTasks || !isOnline) throw new Error('Task movement is unavailable');
+      await updateTask.mutateAsync({ id: taskId, input: { status } });
     },
-    onReorder: (taskIds) => {
-      if (!canWriteTasks || !isOnline) return;
-      reorderTasks.mutate(taskIds);
+    onReorder: async (taskIds) => {
+      if (!canWriteTasks || !isOnline) throw new Error('Task movement is unavailable');
+      await reorderTasks.mutateAsync(taskIds);
     },
+    announce,
   });
 
   const handleDetailClose = (open: boolean) => {
@@ -543,9 +547,11 @@ export function KanbanBoard() {
               <DndContext
                 sensors={sensors}
                 collisionDetection={collisionDetection}
+                accessibility={{ announcements, screenReaderInstructions, restoreFocus: false }}
                 onDragStart={handleDragStart}
                 onDragOver={handleDragOver}
                 onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
               >
                 <div
                   className={boardColumnGridClassName}

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -248,7 +248,11 @@ export const TaskCard = memo(function TaskCard({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
+    if (dragEnabled && e.key === ' ') {
+      listeners?.onKeyDown?.(e);
+      return;
+    }
+    if (e.key === 'Enter' || (!dragEnabled && e.key === ' ')) {
       e.preventDefault();
       handleClick();
     }
@@ -337,6 +341,7 @@ export const TaskCard = memo(function TaskCard({
     >
       <div
         ref={setNodeRef}
+        data-task-id={task.id}
         style={style}
         {...(dragEnabled ? listeners : {})}
         {...(dragEnabled ? attributes : {})}

--- a/web/src/hooks/useBoardDragDrop.ts
+++ b/web/src/hooks/useBoardDragDrop.ts
@@ -1,24 +1,30 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import {
+  Announcements,
   CollisionDetection,
+  DragCancelEvent,
   DragEndEvent,
   DragOverEvent,
   DragStartEvent,
+  KeyboardCoordinateGetter,
+  KeyboardSensor,
   PointerSensor,
+  ScreenReaderInstructions,
   pointerWithin,
   rectIntersection,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import { arrayMove } from '@dnd-kit/sortable';
+import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import type { BoardColumnConfig, Task, TaskStatus } from '@veritas-kanban/shared';
 
 interface UseBoardDragDropOptions {
   tasks: Task[];
   tasksByStatus: Record<string, Task[]>;
   columns: BoardColumnConfig[];
-  onStatusChange: (taskId: string, status: TaskStatus) => void;
-  onReorder: (taskIds: string[], onSuccess?: () => void) => void;
+  onStatusChange: (taskId: string, status: TaskStatus) => Promise<void>;
+  onReorder: (taskIds: string[]) => Promise<void>;
+  announce: (message: string) => void;
 }
 
 interface UseBoardDragDropReturn {
@@ -28,9 +34,113 @@ interface UseBoardDragDropReturn {
   liveTasksByStatus: Record<string, Task[]>;
   sensors: ReturnType<typeof useSensors>;
   collisionDetection: CollisionDetection;
+  announcements: Announcements;
+  screenReaderInstructions: ScreenReaderInstructions;
   handleDragStart: (event: DragStartEvent) => void;
   handleDragOver: (event: DragOverEvent) => void;
-  handleDragEnd: (event: DragEndEvent) => void;
+  handleDragEnd: (event: DragEndEvent) => Promise<void>;
+  handleDragCancel: (event: DragCancelEvent) => void;
+}
+
+const screenReaderInstructions: ScreenReaderInstructions = {
+  draggable:
+    'To pick up a task, press Space. While dragging, use the arrow keys to move it within or between columns. Press Space again to drop it, or press Escape to cancel.',
+};
+
+export function createBoardKeyboardCoordinates(columnIds: string[]): KeyboardCoordinateGetter {
+  return (event, args) => {
+    const isHorizontal = event.code === 'ArrowLeft' || event.code === 'ArrowRight';
+    const isVertical = event.code === 'ArrowUp' || event.code === 'ArrowDown';
+    if (!isHorizontal && !isVertical) {
+      return sortableKeyboardCoordinates(event, args);
+    }
+
+    if (isVertical) {
+      const sortable =
+        args.context.over?.data.current?.sortable ?? args.context.active?.data.current?.sortable;
+      const index = typeof sortable?.index === 'number' ? sortable.index : -1;
+      const itemCount = Array.isArray(sortable?.items) ? sortable.items.length : 0;
+      const canSortWithinColumn =
+        (event.code === 'ArrowUp' && index > 0) ||
+        (event.code === 'ArrowDown' && index >= 0 && index < itemCount - 1);
+      if (canSortWithinColumn) return sortableKeyboardCoordinates(event, args);
+    }
+
+    const { collisionRect, droppableRects } = args.context;
+    if (!collisionRect) return sortableKeyboardCoordinates(event, args);
+
+    const columnRects = columnIds
+      .map((id) => ({ id, rect: droppableRects.get(id) }))
+      .filter((entry): entry is { id: string; rect: NonNullable<typeof entry.rect> } =>
+        Boolean(entry.rect)
+      );
+    if (columnRects.length === 0) return sortableKeyboardCoordinates(event, args);
+
+    const collisionCenter = {
+      x: collisionRect.left + collisionRect.width / 2,
+      y: collisionRect.top + collisionRect.height / 2,
+    };
+    let currentIndex = columnRects.findIndex(
+      ({ rect }) =>
+        collisionCenter.x >= rect.left &&
+        collisionCenter.x <= rect.right &&
+        collisionCenter.y >= rect.top &&
+        collisionCenter.y <= rect.bottom
+    );
+    if (currentIndex < 0) {
+      currentIndex = columnRects.reduce((closestIndex, { rect }, index) => {
+        const distance = Math.hypot(
+          rect.left + rect.width / 2 - collisionCenter.x,
+          rect.top + rect.height / 2 - collisionCenter.y
+        );
+        const closestRect = columnRects[closestIndex].rect;
+        const closestDistance = Math.hypot(
+          closestRect.left + closestRect.width / 2 - collisionCenter.x,
+          closestRect.top + closestRect.height / 2 - collisionCenter.y
+        );
+        return distance < closestDistance ? index : closestIndex;
+      }, 0);
+    }
+
+    const currentRect = columnRects[currentIndex].rect;
+    const currentCenter = {
+      x: currentRect.left + currentRect.width / 2,
+      y: currentRect.top + currentRect.height / 2,
+    };
+    const candidates = columnRects.filter(({ rect }, index) => {
+      if (index === currentIndex) return false;
+      const center = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+      if (event.code === 'ArrowLeft') return center.x < currentCenter.x;
+      if (event.code === 'ArrowRight') return center.x > currentCenter.x;
+      if (event.code === 'ArrowUp') return center.y < currentCenter.y;
+      return center.y > currentCenter.y;
+    });
+    const target = candidates.sort((a, b) => {
+      const score = ({ rect }: (typeof candidates)[number]) => {
+        const deltaX = Math.abs(rect.left + rect.width / 2 - currentCenter.x);
+        const deltaY = Math.abs(rect.top + rect.height / 2 - currentCenter.y);
+        return isHorizontal ? deltaX + deltaY * 0.5 : deltaY + deltaX * 0.5;
+      };
+      return score(a) - score(b);
+    })[0]?.rect;
+    if (!target) return undefined;
+
+    event.preventDefault();
+    return {
+      x: isHorizontal
+        ? target.left + Math.max(0, (target.width - collisionRect.width) / 2)
+        : Math.max(
+            target.left,
+            Math.min(args.currentCoordinates.x, target.right - collisionRect.width)
+          ),
+      y: isVertical
+        ? target.top
+        : Math.max(
+            target.top,
+            Math.min(args.currentCoordinates.y, target.bottom - collisionRect.height)
+          ),
+    };
+  };
 }
 
 export function useBoardDragDrop({
@@ -39,22 +149,29 @@ export function useBoardDragDrop({
   columns,
   onStatusChange,
   onReorder,
+  announce,
 }: UseBoardDragDropOptions): UseBoardDragDropReturn {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   // Local copy of tasksByStatus that updates in real-time during drag.
   // null = not dragging, use server state; non-null = mid-drag, use local state
   const [dragState, setDragState] = useState<Record<string, Task[]> | null>(null);
   const activeIdRef = useRef<string | null>(null);
+  const columnIds = useMemo(() => columns.map((column) => column.id), [columns]);
+  const keyboardCoordinateGetter = useMemo(
+    () => createBoardKeyboardCoordinates(columnIds),
+    [columnIds]
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
       },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: keyboardCoordinateGetter,
     })
   );
-
-  const columnIds = columns.map((c) => c.id);
 
   // Custom collision detection: pointerWithin for accuracy, rectIntersection as fallback.
   // When over a column, prefer a task collision for precise positioning; fall back to
@@ -84,6 +201,11 @@ export function useBoardDragDrop({
   // The live state columns should render from — either mid-drag local state or server state
   const liveTasksByStatus = dragState ?? tasksByStatus;
 
+  const taskTitle = useCallback(
+    (taskId: string) => tasks.find((task) => task.id === taskId)?.title ?? taskId,
+    [tasks]
+  );
+
   // Find which column a task belongs to in the given state
   const findColumn = useCallback(
     (taskId: string, state: Record<string, Task[]>): TaskStatus | null => {
@@ -95,6 +217,64 @@ export function useBoardDragDrop({
       return null;
     },
     [columns]
+  );
+
+  const describeTaskPosition = useCallback(
+    (taskId: string, state: Record<string, Task[]>): string | null => {
+      const columnId = findColumn(taskId, state);
+      if (!columnId) return null;
+      const columnTasks = state[columnId] ?? [];
+      const index = columnTasks.findIndex((task) => task.id === taskId);
+      if (index < 0) return null;
+      const columnTitle = columns.find((column) => column.id === columnId)?.title ?? columnId;
+      return `${columnTitle}, position ${index + 1} of ${columnTasks.length}`;
+    },
+    [columns, findColumn]
+  );
+
+  const focusTask = useCallback((taskId: string) => {
+    window.setTimeout(() => {
+      const taskCard = Array.from(document.querySelectorAll<HTMLElement>('[data-task-id]')).find(
+        (element) => element.dataset.taskId === taskId
+      );
+      taskCard?.focus();
+    }, 0);
+  }, []);
+
+  const clearDragState = useCallback(
+    (taskId: string | null) => {
+      setActiveTask(null);
+      setDragState(null);
+      activeIdRef.current = null;
+      if (taskId) focusTask(taskId);
+    },
+    [focusTask]
+  );
+
+  const announcements = useMemo<Announcements>(
+    () => ({
+      onDragStart: ({ active }) =>
+        `Picked up ${taskTitle(String(active.id))}. Use the arrow keys to move, Space to drop, or Escape to cancel.`,
+      onDragOver: ({ active, over }) => {
+        if (!over) return `${taskTitle(String(active.id))} is no longer over a drop target.`;
+        const state = dragState ?? tasksByStatus;
+        const overId = String(over.id);
+        const activeId = String(active.id);
+        if (columnIds.includes(overId as TaskStatus)) {
+          const destination = state[overId] ?? [];
+          const columnTitle = columns.find((column) => column.id === overId)?.title ?? overId;
+          const activeIndex = destination.findIndex((task) => task.id === activeId);
+          const position = activeIndex >= 0 ? activeIndex + 1 : destination.length + 1;
+          const total = activeIndex >= 0 ? destination.length : destination.length + 1;
+          return `${taskTitle(activeId)} is over ${columnTitle}, position ${position} of ${total}.`;
+        }
+        const position = describeTaskPosition(overId, state);
+        return position ? `${taskTitle(activeId)} is over ${position}.` : undefined;
+      },
+      onDragEnd: ({ active }) => `${taskTitle(String(active.id))} was dropped. Saving move.`,
+      onDragCancel: ({ active }) => `${taskTitle(String(active.id))} move canceled.`,
+    }),
+    [columnIds, columns, describeTaskPosition, dragState, taskTitle, tasksByStatus]
   );
 
   const handleDragStart = useCallback(
@@ -179,18 +359,16 @@ export function useBoardDragDrop({
   );
 
   const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
+    async (event: DragEndEvent) => {
       const { active, over } = event;
       const finalState = dragState;
+      const activeId = active.id as string;
+      const originalPosition = describeTaskPosition(activeId, tasksByStatus);
 
-      // Clear drag UI state
-      setActiveTask(null);
-      setDragState(null);
-      activeIdRef.current = null;
+      clearDragState(activeId);
 
       if (!over || !finalState) return;
 
-      const activeId = active.id as string;
       const overId = over.id as string;
 
       // Find where the task ended up in our local drag state
@@ -208,18 +386,71 @@ export function useBoardDragDrop({
 
         if (oldIndex !== newIndex && oldIndex >= 0 && newIndex >= 0) {
           const reordered = arrayMove(origColumnTasks, oldIndex, newIndex);
-          onReorder(reordered.map((t: Task) => t.id));
+          try {
+            await onReorder(reordered.map((t: Task) => t.id));
+            announce(
+              `${taskTitle(activeId)} moved to ${describeTaskPosition(activeId, finalState)}`
+            );
+          } catch {
+            announce(`Move failed. ${taskTitle(activeId)} returned to ${originalPosition}`);
+          }
         }
       } else if (originalColumn !== finalColumn) {
-        // Cross-column: commit the status change and new order
-        onStatusChange(activeId, finalColumn);
+        let statusChanged = false;
+        try {
+          await onStatusChange(activeId, finalColumn);
+          statusChanged = true;
+          const newOrder = (finalState[finalColumn] ?? []).map((t: Task) => t.id);
+          await onReorder(newOrder);
+          announce(`${taskTitle(activeId)} moved to ${describeTaskPosition(activeId, finalState)}`);
+        } catch {
+          if (statusChanged) {
+            try {
+              await onStatusChange(activeId, originalColumn);
+            } catch {
+              const finalColumnTitle =
+                columns.find((column) => column.id === finalColumn)?.title ?? finalColumn;
+              announce(
+                `Move partially failed. ${taskTitle(activeId)} may still be in ${finalColumnTitle} because automatic rollback failed; refresh the board before trying again`
+              );
+              focusTask(activeId);
+              return;
+            }
+          }
+          announce(`Move failed. ${taskTitle(activeId)} returned to ${originalPosition}`);
+        }
+      }
 
-        // Send the new order for the destination column
-        const newOrder = (finalState[finalColumn] ?? []).map((t: Task) => t.id);
-        onReorder(newOrder);
+      // Status changes can remount the card in another column. Restore focus only
+      // after the commit or rollback has updated the task cache.
+      focusTask(activeId);
+    },
+    [
+      announce,
+      clearDragState,
+      columnIds,
+      columns,
+      describeTaskPosition,
+      dragState,
+      findColumn,
+      focusTask,
+      onReorder,
+      onStatusChange,
+      taskTitle,
+      tasksByStatus,
+    ]
+  );
+
+  const handleDragCancel = useCallback(
+    (_event: DragCancelEvent) => {
+      const activeId = activeIdRef.current;
+      const position = activeId ? describeTaskPosition(activeId, tasksByStatus) : null;
+      clearDragState(activeId);
+      if (activeId && position) {
+        announce(`Move canceled. ${taskTitle(activeId)} returned to ${position}`);
       }
     },
-    [columnIds, dragState, findColumn, onReorder, onStatusChange, tasksByStatus]
+    [announce, clearDragState, describeTaskPosition, taskTitle, tasksByStatus]
   );
 
   return {
@@ -228,8 +459,11 @@ export function useBoardDragDrop({
     liveTasksByStatus,
     sensors,
     collisionDetection,
+    announcements,
+    screenReaderInstructions,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
+    handleDragCancel,
   };
 }


### PR DESCRIPTION
## Summary

- register a keyboard sensor for board cards and route Space to dnd-kit instead of opening task details when drag-and-drop is enabled
- add spatial arrow-key targeting across populated, empty, and wrapped board columns while retaining vertical same-column sorting
- provide board-specific screen-reader instructions and start, move, drop, cancel, success, rollback, and partial-failure announcements
- persist keyboard moves through awaited mutations, roll status back when destination ordering fails, and restore focus after cancel, commit, or rollback
- document the board keyboard interaction in the changelog and feature guide

## Verification

- `pnpm --filter @veritas-kanban/web test` (71 files, 396 tests)
- `pnpm --filter @veritas-kanban/web lint` (0 errors, 29 existing warnings)
- `pnpm --filter @veritas-kanban/web build`
- `pnpm typecheck`
- `pnpm lint:budget` (597/600 warnings)
- in-app browser keyboard pass with the live local board:
  - moved across populated columns and into an empty wrapped column
  - reordered two tasks within one column
  - canceled a move and confirmed the original card regained focus
  - committed cross-column moves and a reorder and confirmed the moved card retained focus
  - verified the exposed instructions and live-region text for movement, drop, cancel, and success

Fixes #812
