### PR TITLE
fix: respect overlay display preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made dialog, sheet, alert, and Task Detail overlays honor reduced-transparency
+  and increased-contrast preferences, strengthened modal focus boundaries, and
+  dismissed task-card tooltips when opening Task Detail (#815).
 - Restored keyboard drag-and-drop parity on the Kanban board with spatial
   cross-column movement, empty-column targeting, same-column reordering,
   accurate screen-reader announcements, mutation rollback, and post-move focus

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2152,6 +2152,10 @@ Working toward WCAG 2.1 AA compliance.
 - **Keyboard navigation** — Navigate with j/k, open with Enter, move directly with number keys, or press Space on a board card to pick it up and use arrow keys to reorder or cross columns; Escape cancels and restores focus
 - **Keyboard shortcuts dialog** — Discoverable via `?` key with grouped shortcut reference
 - **Focus management** — Focus trapped in dialogs and sheets; restored on close
+- **Display preferences** — Dialog, sheet, alert, and Task Detail overlays remove
+  blur and use solid materials for reduced-transparency users; increased-contrast
+  mode strengthens backdrops, surface boundaries, muted text, and focus rings in
+  light and dark themes
 - **Screen reader support** — Semantic HTML, ARIA roles, and descriptive labels throughout
 - **Color contrast** — Dark and light mode palettes designed for readability; purple primary (`270° 50% 40%`) buttons with white text in dark mode
 - **Skip navigation** — Keyboard users can navigate efficiently between sections

--- a/web/src/__tests__/TaskCard.test.tsx
+++ b/web/src/__tests__/TaskCard.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TaskCard } from '@/components/task/TaskCard';
 import { createMockTask } from './test-utils';
@@ -199,6 +199,23 @@ describe('TaskCard', () => {
 
     const card = screen.getByRole('article');
     fireEvent.click(card);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('dismisses its tooltip when activated and keeps it suppressed until pointer exit', async () => {
+    const onClick = vi.fn();
+    const task = createMockTask({ title: 'Open task details' });
+    const { baseElement } = renderCard(task, { onClick });
+    const card = screen.getByRole('article');
+
+    fireEvent.mouseEnter(card);
+    await waitFor(() => expect(baseElement.querySelector('[role="tooltip"]')).not.toBeNull(), {
+      timeout: 1000,
+    });
+
+    fireEvent.click(card);
+
+    await waitFor(() => expect(baseElement.querySelector('[role="tooltip"]')).toBeNull());
     expect(onClick).toHaveBeenCalledOnce();
   });
 

--- a/web/src/__tests__/mantine-ui-primitives.test.tsx
+++ b/web/src/__tests__/mantine-ui-primitives.test.tsx
@@ -1,4 +1,8 @@
+/// <reference types="node" />
+
 import * as React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { notifications } from '@mantine/notifications';
@@ -52,6 +56,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Toaster } from '@/components/ui/toaster';
 import { toast } from '@/hooks/useToast';
+
+const globalStyles = readFileSync(resolve(process.cwd(), 'src/globals.css'), 'utf8');
 
 const originalScrollIntoView = Element.prototype.scrollIntoView;
 
@@ -256,6 +262,14 @@ describe('Mantine-backed shared UI primitives', () => {
     expect(screen.getByTestId('scroll-area').getAttribute('data-slot')).toBe('scroll-area');
   });
 
+  it('defines reduced-transparency and increased-contrast overlay materials', () => {
+    expect(globalStyles).toContain('@media (prefers-reduced-transparency: reduce)');
+    expect(globalStyles).toContain('@media (prefers-contrast: more)');
+    expect(globalStyles).toContain('.veritas-overlay');
+    expect(globalStyles).toContain('.veritas-overlay-surface');
+    expect(globalStyles).toContain('backdrop-filter: none !important');
+  });
+
   it('applies legacy text field classes to the native input slot', () => {
     renderWithProviders(
       <div>
@@ -364,7 +378,7 @@ describe('Mantine-backed shared UI primitives', () => {
   });
 
   it('opens and closes Mantine-backed dialogs through the legacy API', async () => {
-    renderWithProviders(<DialogProbe />);
+    const { baseElement } = renderWithProviders(<DialogProbe />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
 
@@ -380,6 +394,10 @@ describe('Mantine-backed shared UI primitives', () => {
         description.textContent
       );
       expect(screen.getByTestId('dialog-state').textContent).toBe('true');
+      expect(baseElement.querySelector('.mantine-Modal-overlay')?.className).toContain(
+        'veritas-overlay'
+      );
+      expect(dialog.className).toContain('veritas-overlay-surface');
     });
 
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
@@ -390,7 +408,7 @@ describe('Mantine-backed shared UI primitives', () => {
   });
 
   it('opens and closes Mantine-backed sheets through the legacy API', async () => {
-    renderWithProviders(<SheetProbe />);
+    const { baseElement } = renderWithProviders(<SheetProbe />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Open sheet' }));
 
@@ -407,6 +425,10 @@ describe('Mantine-backed shared UI primitives', () => {
         description.textContent
       );
       expect(screen.getByTestId('sheet-state').textContent).toBe('true');
+      expect(baseElement.querySelector('.mantine-Drawer-overlay')?.className).toContain(
+        'veritas-overlay'
+      );
+      expect(dialog.className).toContain('veritas-overlay-surface');
     });
 
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
@@ -417,7 +439,7 @@ describe('Mantine-backed shared UI primitives', () => {
   });
 
   it('opens and closes Mantine-backed alert dialogs through the legacy API', async () => {
-    renderWithProviders(<AlertDialogProbe />);
+    const { baseElement } = renderWithProviders(<AlertDialogProbe />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Open alert' }));
 
@@ -433,6 +455,10 @@ describe('Mantine-backed shared UI primitives', () => {
         description.textContent
       );
       expect(screen.getByTestId('alert-state').textContent).toBe('true');
+      expect(baseElement.querySelector('.mantine-Modal-overlay')?.className).toContain(
+        'veritas-overlay'
+      );
+      expect(dialog.className).toContain('veritas-overlay-surface');
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -191,6 +191,10 @@ describe('task detail Mantine migration', () => {
     expect(screen.queryByRole('tab', { name: 'Timeline' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Chat' })).toBeDefined();
     expect(container.querySelector('.mantine-Drawer-content')).toBeDefined();
+    expect(container.querySelector('.mantine-Drawer-overlay')?.className).toContain(
+      'veritas-overlay'
+    );
+    expect(screen.getByTestId('task-detail-panel').className).toContain('veritas-overlay-surface');
     expect(container.querySelector('.mantine-Tabs-root')).toBeDefined();
     expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(container.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(5);

--- a/web/src/components/task/TaskCard.tsx
+++ b/web/src/components/task/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { Select, Tooltip } from '@mantine/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -216,6 +216,7 @@ export const TaskCard = memo(function TaskCard({
     disabled: !dragEnabled,
   });
   const { isSelecting, toggleSelect, isSelected: isBulkSelected } = useBulkActions();
+  const [tooltipDismissed, setTooltipDismissed] = useState(false);
   const isChecked = isBulkSelected(task.id);
   const { settings: featureSettings } = useFeatureSettings();
   const boardSettings = featureSettings.board;
@@ -240,6 +241,7 @@ export const TaskCard = memo(function TaskCard({
 
   const handleClick = () => {
     if (isCurrentlyDragging || isDragging) return;
+    setTooltipDismissed(true);
     if (isSelecting) {
       toggleSelect(task.id);
       return;
@@ -321,7 +323,7 @@ export const TaskCard = memo(function TaskCard({
   const readinessAria = readinessSummary ? `, Readiness: ${readinessSummary.percent}%` : '';
 
   // Suppress the outer card tooltip entirely during any drag operation
-  const suppressCardTooltip = isDragActive || isDragging || isCurrentlyDragging;
+  const suppressCardTooltip = isDragActive || isDragging || isCurrentlyDragging || tooltipDismissed;
 
   return (
     <Tooltip
@@ -347,6 +349,7 @@ export const TaskCard = memo(function TaskCard({
         {...(dragEnabled ? attributes : {})}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
+        onMouseLeave={() => setTooltipDismissed(false)}
         role="article"
         tabIndex={0}
         aria-label={`Task: ${task.title}, Priority: ${task.priority}${readinessAria}${isBlocked ? ', Blocked' : ''}${isAgentRunning ? ', Agent running' : ''}`}

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -196,11 +196,11 @@ export function TaskDetailPanel({
         size="auto"
         trapFocus
       >
-        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
+        <Drawer.Overlay className="veritas-overlay fixed inset-0 z-50" />
         <Drawer.Content
           aria-label={`Task details: ${localTask.title}`}
           data-testid="task-detail-panel"
-          className="flex h-full max-h-[100dvh] w-[min(100vw,700px)] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:max-w-[700px]"
+          className="veritas-overlay-surface flex h-full max-h-[100dvh] w-[min(100vw,700px)] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:max-w-[700px]"
         >
           <Drawer.Body className="contents">
             <Stack gap={0} className="h-full overflow-hidden">

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -73,8 +73,7 @@ function cloneButtonChild(
   if (React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
     const childOnClick = child.props.onClick as
-      | ((event: React.MouseEvent<HTMLElement>) => void)
-      | undefined;
+      ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
 
     return React.cloneElement(child, {
       ...props,
@@ -117,10 +116,7 @@ function AlertDialogOverlay({ className, ...props }: React.ComponentProps<'div'>
   return (
     <div
       data-slot="alert-dialog-overlay"
-      className={cn(
-        'fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs',
-        className
-      )}
+      className={cn('veritas-overlay fixed inset-0 z-50', className)}
       {...props}
     />
   );
@@ -151,12 +147,12 @@ function AlertDialogContent({
       size="auto"
       trapFocus
     >
-      <Modal.Overlay className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
+      <Modal.Overlay className="veritas-overlay fixed inset-0 z-50" />
       <Modal.Content
         data-size={size}
         data-slot="alert-dialog-content"
         className={cn(
-          'group/alert-dialog-content grid w-full gap-4 rounded-xl bg-background p-4 ring-1 ring-foreground/10 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm',
+          'veritas-overlay-surface group/alert-dialog-content grid w-full gap-4 rounded-xl bg-background p-4 ring-1 ring-foreground/10 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm',
           className
         )}
         {...props}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -74,8 +74,7 @@ function cloneButtonChild(
   if (React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
     const childOnClick = child.props.onClick as
-      | ((event: React.MouseEvent<HTMLElement>) => void)
-      | undefined;
+      ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
 
     return React.cloneElement(child, {
       ...props,
@@ -138,10 +137,7 @@ function DialogOverlay({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-overlay"
-      className={cn(
-        'fixed inset-0 isolate z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs',
-        className
-      )}
+      className={cn('veritas-overlay fixed inset-0 isolate z-50', className)}
       {...props}
     />
   );
@@ -171,11 +167,11 @@ function DialogContent({
       size="auto"
       trapFocus
     >
-      <Modal.Overlay className="fixed inset-0 isolate z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
+      <Modal.Overlay className="veritas-overlay fixed inset-0 isolate z-50" />
       <Modal.Content
         data-slot="dialog-content"
         className={cn(
-          'grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 outline-none sm:max-w-sm',
+          'veritas-overlay-surface grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 outline-none sm:max-w-sm',
           className
         )}
         {...props}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -76,8 +76,7 @@ function cloneButtonChild(
   if (React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
     const childOnClick = child.props.onClick as
-      | ((event: React.MouseEvent<HTMLElement>) => void)
-      | undefined;
+      ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
 
     return React.cloneElement(child, {
       ...props,
@@ -157,12 +156,12 @@ function SheetContent({
       size="auto"
       trapFocus
     >
-      <Drawer.Overlay className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs" />
+      <Drawer.Overlay className="veritas-overlay fixed inset-0 z-50" />
       <Drawer.Content
         data-side={side}
         data-slot="sheet-content"
         className={cn(
-          'flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm',
+          'veritas-overlay-surface flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm',
           className
         )}
         {...props}

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -121,6 +121,50 @@
   }
 }
 
+/* Shared modal material for browser and macOS accessibility preferences. */
+.veritas-overlay {
+  background-color: rgb(0 0 0 / 10%) !important;
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .veritas-overlay {
+    background-color: rgb(0 0 0 / 72%) !important;
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
+  }
+
+  .veritas-overlay-surface {
+    background-color: var(--background) !important;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .veritas-overlay {
+    background-color: rgb(0 0 0 / 84%) !important;
+  }
+
+  .veritas-overlay-surface {
+    background-color: var(--background) !important;
+    outline: 2px solid var(--foreground);
+    outline-offset: -2px;
+    box-shadow:
+      0 0 0 1px var(--background),
+      0 24px 80px rgb(0 0 0 / 60%);
+  }
+
+  .veritas-overlay-surface .text-muted-foreground {
+    color: color-mix(in oklch, var(--foreground) 82%, var(--background)) !important;
+  }
+
+  .veritas-overlay-surface :focus-visible {
+    outline-color: var(--foreground) !important;
+    outline-width: 3px !important;
+    box-shadow: 0 0 0 2px var(--background) !important;
+  }
+}
+
 html[data-client='desktop'],
 html[data-client='desktop'] body,
 html[data-client='desktop'] #root {


### PR DESCRIPTION
## Summary

- centralize dialog, sheet, alert, and Task Detail backdrops on shared overlay and surface material classes
- remove backdrop blur and use a solid modal treatment when reduced transparency is requested
- strengthen backdrop opacity, surface boundaries, muted text, and focus rings when increased contrast is requested
- keep combined preference modes coherent in dark and light themes
- dismiss a task-card tooltip immediately when the card opens Task Detail
- document the display-preference behavior in the changelog and feature guide

## Verification

- `pnpm --filter @veritas-kanban/web test` (71 files, 399 tests)
- `pnpm --filter @veritas-kanban/web lint` (0 errors, 29 existing warnings)
- `pnpm --filter @veritas-kanban/web build`
- `pnpm typecheck`
- `pnpm lint:budget` (597/600 warnings)
- in-app browser computed-style matrix:
  - default: 2 px backdrop blur and 10% backdrop
  - reduced transparency: no blur and 72% solid backdrop
  - increased contrast: 84% backdrop, 2 px surface outline, stronger muted text, and 3 px focus outline
  - combined preferences: solid treatment and high-contrast boundary in dark and light themes
  - Task Detail activation: triggering tooltip count falls to zero before the drawer is inspected

Fixes #815
