### PR TITLE
fix: make mobile settings responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kept mobile Settings navigation visible and touch-sized in the dialog content
+  flow, and stacked the Product Mode summary and selector at compact widths
+  (#810).
 - Made dialog, sheet, alert, and Task Detail overlays honor reduced-transparency
   and increased-contrast preferences, strengthened modal focus boundaries, and
   dismissed task-card tooltips when opening Task Detail (#815).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1838,7 +1838,7 @@ The click-through tutorial roadmap lives in [Click-through Tutorials Roadmap](CL
 
 ## Settings & Customization
 
-Modular settings system with 8 focused tabs.
+Modular settings system with focused, permission-aware sections.
 
 ![v5 Maintenance Center settings surface](assets/v5/v5-maintenance-center.png)
 
@@ -1861,6 +1861,7 @@ Modular settings system with 8 focused tabs.
 - **Import/Export** — Backup all settings to JSON; restore with validation
 - **Reset to defaults** — Per-section reset with confirmation
 - **Managed list manager** — Reusable sortable list component with drag-and-drop reordering (used for projects, sprints, task types)
+- **Compact layout** — Mobile section navigation stays in the dialog content flow, controls use touch-sized targets, and dense General settings stack instead of compressing explanatory copy
 
 ---
 

--- a/web/src/__tests__/settings-dialog-mantine.test.tsx
+++ b/web/src/__tests__/settings-dialog-mantine.test.tsx
@@ -98,6 +98,7 @@ vi.mock('@/components/settings/tabs/MultiUserTab', () => ({
 describe('SettingsDialog Mantine shell', () => {
   beforeEach(() => {
     mocks.hasPermission.mockReturnValue(true);
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
   });
 
   afterEach(() => {
@@ -123,5 +124,25 @@ describe('SettingsDialog Mantine shell', () => {
 
     expect(await screen.findByText('Board settings loaded')).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Board' }).getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('keeps compact section navigation in the mobile header flow', async () => {
+    renderWithProviders(<SettingsDialog open onOpenChange={vi.fn()} />);
+
+    const selector = screen.getByRole('combobox', { name: 'Select settings section' });
+    const mobileHeader = selector.closest('[data-settings-mobile-header]');
+
+    expect(mobileHeader).not.toBeNull();
+    expect(mobileHeader?.className).toContain('sm:hidden');
+    expect(mobileHeader?.className).not.toContain('absolute');
+    expect(selector.closest('.mantine-Select-root')?.className).toContain('w-full');
+
+    fireEvent.click(selector);
+    fireEvent.click(await screen.findByRole('option', { name: 'Board' }));
+
+    expect(await screen.findByText('Board settings loaded')).toBeDefined();
+    expect(screen.getByRole('tabpanel', { name: 'Board' }).className).toContain(
+      'focus-visible:outline-2'
+    );
   });
 });

--- a/web/src/__tests__/settings-general-mantine.test.tsx
+++ b/web/src/__tests__/settings-general-mantine.test.tsx
@@ -91,6 +91,14 @@ describe('General settings Mantine migration', () => {
     expect(container.querySelector('.mantine-Button-root')).toBeDefined();
     expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
 
+    const productModeLayout = screen.getByTestId('product-mode-layout');
+    expect(productModeLayout.className).toContain('flex-col');
+    expect(productModeLayout.className).toContain('sm:flex-row');
+    expect(
+      screen.getByRole('combobox', { name: 'Product Mode' }).closest('.mantine-Select-root')
+        ?.className
+    ).toContain('w-full');
+
     fireEvent.click(screen.getByRole('switch', { name: 'Toggle dark mode' }));
 
     expect(mocks.setTheme).toHaveBeenCalledWith('light');

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -641,32 +641,28 @@ export function SettingsDialog({ open, onOpenChange, defaultTab }: SettingsDialo
             </Stack>
           </div>
 
-          {/* Mobile Tab Selector */}
-          <div className="sm:hidden absolute top-3 right-12">
-            <Select
-              value={activeTab}
-              onChange={(value) => {
-                if (value) setActiveTab(value as TabId);
-              }}
-              data={mobileTabOptions}
-              aria-label="Select settings section"
-              size="sm"
-              checkIconPosition="right"
-              className="w-40"
-              styles={{ input: { minHeight: '2rem' } }}
-            />
-          </div>
-
           {/* Content */}
           <div className="flex-1 flex flex-col min-w-0 min-h-0">
-            <div className="px-6 py-4 border-b sm:hidden">
+            <div data-settings-mobile-header className="shrink-0 border-b px-4 py-3 sm:hidden">
               <h2 className="text-lg font-semibold">Settings</h2>
+              <Select
+                value={activeTab}
+                onChange={(value) => {
+                  if (value) setActiveTab(value as TabId);
+                }}
+                data={mobileTabOptions}
+                aria-label="Select settings section"
+                size="sm"
+                checkIconPosition="right"
+                className="mt-3 w-full"
+                styles={{ input: { minHeight: '2.75rem' } }}
+              />
             </div>
             <ScrollArea className="flex-1 min-h-0">
               <div
                 id="settings-tab-content"
                 ref={contentAreaRef}
-                className="px-6 py-4"
+                className="px-4 py-4 focus-visible:outline-2 focus-visible:outline-primary focus-visible:-outline-offset-2 sm:px-6"
                 role="tabpanel"
                 tabIndex={-1}
                 aria-labelledby={`tab-${activeTab}`}

--- a/web/src/components/settings/tabs/GeneralTab.tsx
+++ b/web/src/components/settings/tabs/GeneralTab.tsx
@@ -90,7 +90,10 @@ export function GeneralTab() {
       <div className="space-y-3">
         <h3 className="text-sm font-medium">Product Mode</h3>
         <div className="rounded-md border p-4 bg-card space-y-4">
-          <Group justify="space-between" align="flex-start" gap="md">
+          <div
+            data-testid="product-mode-layout"
+            className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
+          >
             <div className="min-w-0 flex-1 space-y-1">
               <Group gap={8}>
                 <Badge variant="light" color={selectedProductMode === 'advanced' ? 'gray' : 'cyan'}>
@@ -109,7 +112,7 @@ export function GeneralTab() {
               value={selectedProductMode}
               data={PRODUCT_MODE_OPTIONS}
               allowDeselect={false}
-              maw={260}
+              className="w-full shrink-0 sm:w-[260px]"
               onChange={(value) => {
                 if (!value) return;
                 debouncedUpdate({
@@ -120,7 +123,7 @@ export function GeneralTab() {
                 });
               }}
             />
-          </Group>
+          </div>
 
           <SimpleGrid cols={{ base: 1, md: 3 }} spacing="sm">
             <ModeDetail label="Surfaces" items={activeProductMode.visibleSurfaces} />


### PR DESCRIPTION
## Summary
- move compact Settings navigation into the modal content flow with a full-width 44 px selector
- stack Product Mode copy and controls below the small breakpoint
- preserve one dialog scroll region and add a visible focus boundary after section changes
- add regression coverage and update operator-facing docs

## Verification
- `pnpm --filter @veritas-kanban/web test` (400 tests)
- `pnpm --filter @veritas-kanban/web lint` (0 errors, 29 existing warnings)
- `pnpm --filter @veritas-kanban/web build`
- `pnpm typecheck`
- `pnpm lint:budget` (597/600)
- in-app browser at 320, 390, 430, 768, and 1280 px in light and dark themes
- exercised every Settings section, keyboard selection, focus visibility, touch target geometry, and dialog overflow

## Note
- At 320 px, the dialog itself has no horizontal overflow. The background top toolbar still widens the page by 62 px; that separate mobile-shell defect is tracked by #811.

Fixes #810