### PR TITLE
fix: restore compact navigation and chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevented compact bottom-navigation labels from overlapping, kept the mobile
+  header within 320 px, and restored a fixed, safe-area-aware Board Chat entry
+  point (#811).
 - Kept mobile Settings navigation visible and touch-sized in the dialog content
   flow, and stacked the Product Mode summary and selector at compact widths
   (#810).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -116,6 +116,7 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 - **Dark/light mode** — Ships dark by default with a toggle in Settings → General → Appearance; persists to localStorage; inline script in `index.html` prevents flash of wrong theme on load
 - **Filter bar** — Search tasks by text, filter by project and task type; filters persist in URL query params
 - **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, view toggles, and left/right/bottom panel controls shared by the web and macOS app shells
+- **Mobile shell controls** — Compact navigation uses bounded labels and full accessible names; Board Chat stays fixed above the bottom navigation and device safe area
 - **Resizable Workbench** — Board Chat and Squad Chat live in a collapsible bottom panel that can be resized vertically for longer chat sessions
 - **Bulk operations** — Select multiple tasks to move, archive, or delete in batch; select-all toggle
 - **Keyboard shortcuts** — Navigate tasks (j/k, arrows), open (Enter), close (Esc), create (c), move to column (1-4), help (?)

--- a/web/src/__tests__/activity-chat-mantine.test.tsx
+++ b/web/src/__tests__/activity-chat-mantine.test.tsx
@@ -271,7 +271,9 @@ describe('activity and chat Mantine migration', () => {
     expect(screen.getByText('Ready to help with the board.')).toBeDefined();
     expect(screen.getByText('Squad Chat')).toBeDefined();
     expect(screen.getByText('Code review ready.')).toBeDefined();
-    expect(screen.getByLabelText('Open chat')).toBeDefined();
+    const chatTrigger = screen.getByLabelText('Open chat');
+    expect(chatTrigger.style.position).toBe('fixed');
+    expect(chatTrigger.className).toContain('floating-chat-trigger');
     expect(baseElement.querySelectorAll('.mantine-Drawer-root').length).toBeGreaterThanOrEqual(2);
     expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Select-root')).toBeDefined();
@@ -300,5 +302,16 @@ describe('activity and chat Mantine migration', () => {
     expect(screen.getByLabelText('Close chat panel')).toBeDefined();
     expect(screen.getByLabelText('Close squad chat panel')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Drawer-root')).toBeNull();
+  });
+
+  it('opens the floating Board Chat trigger from the keyboard', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<FloatingChat />);
+
+    const trigger = screen.getByRole('button', { name: 'Open chat' });
+    trigger.focus();
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByRole('dialog', { name: 'Board Chat' })).toBeDefined();
   });
 });

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -232,6 +232,14 @@ describe('layout chrome Mantine migration', () => {
     expect(onOpenIdentitySettings).toHaveBeenCalledOnce();
   });
 
+  it('renders an icon-only session target for compact headers', () => {
+    const { container } = renderWithProviders(<UserMenu compact />);
+
+    const sessionMenu = screen.getByRole('button', { name: 'Session menu' });
+    expect(sessionMenu.className).toContain('mantine-ActionIcon-root');
+    expect(container.querySelector('.mantine-Button-root')).toBeNull();
+  });
+
   it('renders WebSocket status with a direct Mantine popover', async () => {
     const user = userEvent.setup();
     const { baseElement } = renderWithProviders(<WebSocketIndicator />);

--- a/web/src/__tests__/mobile-shell.test.tsx
+++ b/web/src/__tests__/mobile-shell.test.tsx
@@ -60,6 +60,14 @@ describe('mobile shell', () => {
 
     expect(screen.getByRole('navigation', { name: 'Mobile navigation' })).toBeDefined();
     expect(screen.getByText('mobile-pwa')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Mobile notifications' }).textContent).toContain(
+      'Alerts'
+    );
+
+    for (const button of screen.getAllByRole('button', { name: /^Mobile / })) {
+      expect(button.className).toContain('min-w-0');
+      expect(button.querySelector('[data-mobile-nav-label]')?.className).toContain('w-full');
+    }
 
     await user.click(screen.getByRole('button', { name: 'Mobile notifications' }));
     expect(await screen.findByText('Open mobile approval')).toBeDefined();

--- a/web/src/components/chat/FloatingChat.tsx
+++ b/web/src/components/chat/FloatingChat.tsx
@@ -54,9 +54,9 @@ export function FloatingChat() {
         size={56}
         radius="xl"
         variant="filled"
+        style={{ position: 'fixed' }}
         className={cn(
-          'fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full shadow-lg',
-          'max-md:bottom-24',
+          'floating-chat-trigger z-40 h-14 w-14 rounded-full shadow-lg',
           'bg-primary hover:bg-primary/90 text-primary-foreground',
           'transition-all duration-200 hover:scale-105',
           open && 'hidden'

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -520,17 +520,19 @@ export function Header() {
                 </ActionIcon>
               </>
             )}
-            <ActionIcon
-              variant="subtle"
-              color="gray"
-              size={32}
-              onClick={() => openSettingsDialog()}
-              disabled={!canOpenSettings}
-              aria-label="Settings"
-              title={canOpenSettings ? 'Settings' : 'Settings permission required'}
-            >
-              <Settings className="h-4 w-4" aria-hidden="true" />
-            </ActionIcon>
+            {!isCompactHeader && (
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                size={32}
+                onClick={() => openSettingsDialog()}
+                disabled={!canOpenSettings}
+                aria-label="Settings"
+                title={canOpenSettings ? 'Settings' : 'Settings permission required'}
+              >
+                <Settings className="h-4 w-4" aria-hidden="true" />
+              </ActionIcon>
+            )}
             {!isCompactHeader && (
               <ActionIcon
                 variant="subtle"
@@ -548,6 +550,7 @@ export function Header() {
               </ActionIcon>
             )}
             <UserMenu
+              compact={isCompactHeader}
               onOpenSecuritySettings={openSecuritySettings}
               onOpenIdentitySettings={openIdentitySettings}
             />

--- a/web/src/components/layout/MobileShell.tsx
+++ b/web/src/components/layout/MobileShell.tsx
@@ -58,6 +58,7 @@ export function MobileShell() {
     },
     {
       label: 'Notifications',
+      compactLabel: 'Alerts',
       active: inboxOpen,
       icon: Bell,
       onClick: () => setInboxOpen(true),
@@ -108,7 +109,7 @@ export function MobileShell() {
                 disabled={item.disabled}
                 onClick={item.onClick}
                 className={[
-                  'flex min-h-12 flex-col items-center justify-center rounded-md px-1 text-[11px] leading-tight text-muted-foreground transition-colors',
+                  'flex min-h-12 min-w-0 flex-col items-center justify-center overflow-hidden rounded-md px-1 text-[11px] leading-tight text-muted-foreground transition-colors',
                   item.active
                     ? 'bg-primary/15 text-primary'
                     : 'hover:bg-muted hover:text-foreground',
@@ -116,7 +117,9 @@ export function MobileShell() {
                 ].join(' ')}
               >
                 <Icon className="mb-0.5 h-4 w-4" aria-hidden="true" />
-                <span className="truncate">{item.label}</span>
+                <span data-mobile-nav-label className="block w-full truncate text-center">
+                  {'compactLabel' in item ? item.compactLabel : item.label}
+                </span>
               </button>
             );
           })}

--- a/web/src/components/layout/UserMenu.tsx
+++ b/web/src/components/layout/UserMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   Badge,
+  ActionIcon,
   Box,
   Button,
   Group,
@@ -15,11 +16,16 @@ import { useAuth } from '@/hooks/useAuth';
 import { useIdentity } from '@/hooks/useIdentity';
 
 interface UserMenuProps {
+  compact?: boolean;
   onOpenSecuritySettings?: () => void;
   onOpenIdentitySettings?: () => void;
 }
 
-export function UserMenu({ onOpenSecuritySettings, onOpenIdentitySettings }: UserMenuProps) {
+export function UserMenu({
+  compact = false,
+  onOpenSecuritySettings,
+  onOpenIdentitySettings,
+}: UserMenuProps) {
   const { status, logout } = useAuth();
   const { activeMembership, activeWorkspace, authContext, profile, canManageMembers } =
     useIdentity();
@@ -100,23 +106,36 @@ export function UserMenu({ onOpenSecuritySettings, onOpenIdentitySettings }: Use
       withinPortal
     >
       <Popover.Target>
-        <Button
-          variant="subtle"
-          color="gray"
-          size="sm"
-          aria-label="Session menu"
-          leftSection={<Lock className="h-4 w-4 text-emerald-500" aria-hidden="true" />}
-          rightSection={
-            <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
-          }
-          title="Session menu"
-          className="min-h-8"
-          onClick={() => setOpen((current) => !current)}
-        >
-          <Text span size="xs" c="dimmed" className="hidden sm:inline">
-            {displayName}
-          </Text>
-        </Button>
+        {compact ? (
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size={32}
+            aria-label="Session menu"
+            title="Session menu"
+            onClick={() => setOpen((current) => !current)}
+          >
+            <Lock className="h-4 w-4 text-emerald-500" aria-hidden="true" />
+          </ActionIcon>
+        ) : (
+          <Button
+            variant="subtle"
+            color="gray"
+            size="sm"
+            aria-label="Session menu"
+            leftSection={<Lock className="h-4 w-4 text-emerald-500" aria-hidden="true" />}
+            rightSection={
+              <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
+            }
+            title="Session menu"
+            className="min-h-8"
+            onClick={() => setOpen((current) => !current)}
+          >
+            <Text span size="xs" c="dimmed" className="hidden sm:inline">
+              {displayName}
+            </Text>
+          </Button>
+        )}
       </Popover.Target>
       <Popover.Dropdown className="w-72 bg-popover p-0 text-popover-foreground">
         <Box className="border-b border-border p-3">

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -128,6 +128,19 @@
   backdrop-filter: blur(2px);
 }
 
+/* Mantine's unlayered ActionIcon position wins over Tailwind utilities. */
+.floating-chat-trigger {
+  right: 1.5rem;
+  bottom: 1.5rem;
+}
+
+@media (max-width: 767px) {
+  .floating-chat-trigger {
+    right: max(1rem, env(safe-area-inset-right));
+    bottom: calc(5.5rem + env(safe-area-inset-bottom));
+  }
+}
+
 @media (prefers-reduced-transparency: reduce) {
   .veritas-overlay {
     background-color: rgb(0 0 0 / 72%) !important;


### PR DESCRIPTION
## Summary
- constrain compact navigation tracks and use the intentional `Alerts` label while preserving the full accessible name
- force the Board Chat trigger to fixed positioning with mobile safe-area clearance
- use an icon-only compact session menu and remove the duplicate compact-header Settings action
- add touch and keyboard regression coverage and update docs

## Verification
- `pnpm --filter @veritas-kanban/web test` (402 tests)
- `pnpm --filter @veritas-kanban/web lint` (0 errors, 29 existing warnings)
- `pnpm --filter @veritas-kanban/web build`
- `pnpm typecheck`
- `pnpm lint:budget` (597/600)
- in-app browser at 320, 375, 390, and 430 px in light and dark themes
- measured zero navigation overlap, zero page overflow, a 292 px compact toolbar, and a fixed 56 px chat target with 27 px navigation clearance
- opened Board Chat at a narrow viewport and verified keyboard activation in component coverage

Fixes #811