### PR TITLE
fix: remove layout-driven dashboard motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserved the selected profile across create and duplicate actions, and
   guarded unsaved drafts when returning to the list, changing tabs, or leaving
   the scoring surface (#813).
+- Replaced broad and layout-property dashboard transitions with instant chart
+  updates, explicit short hover feedback, and accessible immediate section
+  expansion, including intentional reduced-motion behavior (#814).
 - Made SQLite activity ordering deterministic for multiple events written in
   the same millisecond, preserving the newest-first feed contract and stable
   retention trimming (#823).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1830,6 +1830,7 @@ Optimizations spanning server, frontend, and data lifecycle.
 - **Memoized task cards** — Custom `React.memo` comparison function avoids unnecessary re-renders from React Query refetches
 - **Debounced saves** — Task edits debounced to reduce API calls
 - **Loading skeletons** — Board, settings tabs, and dashboard show shimmer placeholders during load
+- **Safe dashboard motion** — Data bars update without animating layout dimensions, dashboard expansion is immediate, and interactive card feedback uses an explicit 150 ms shadow transition with a reduced-motion override
 
 ---
 
@@ -2158,6 +2159,7 @@ Working toward WCAG 2.1 AA compliance.
   blur and use solid materials for reduced-transparency users; increased-contrast
   mode strengthens backdrops, surface boundaries, muted text, and focus rings in
   light and dark themes
+- **Reduced motion** — Dashboard data and expand/collapse state avoid vestibular layout animation; remaining interaction feedback resolves immediately when reduced motion is requested
 - **Screen reader support** — Semantic HTML, ARIA roles, and descriptive labels throughout
 - **Color contrast** — Dark and light mode palettes designed for readability; purple primary (`270° 50% 40%`) buttons with white text in dark mode
 - **Skip navigation** — Keyboard users can navigate efficiently between sections

--- a/docs/testing/v5-performance-load.md
+++ b/docs/testing/v5-performance-load.md
@@ -98,6 +98,31 @@ The profile covers:
 Thresholds keep p95 read/write paths between 250 ms and 750 ms and require
 HTTP errors below 1 percent plus WebSocket connection errors below 5 percent.
 
+## Dashboard Motion Profile
+
+Review date: 2026-07-12
+
+The active Activity, dashboard, timeline, and chart sources are guarded by
+`dashboard-motion-contract.test.tsx`. The contract rejects `transition-all`,
+layout-property transition utilities, and the former 5,000 px max-height
+collapse technique. Chart widths and heights still represent the data, but
+they update immediately instead of scheduling layout work across animation
+frames. Dashboard section expansion also updates immediately and exposes its
+state through `aria-expanded` and `aria-controls`.
+
+A live Activity view with representative status-history rows was inspected in
+the in-app browser after the change:
+
+| Check                                              | Result |
+| -------------------------------------------------- | -----: |
+| `.transition-all` nodes in the active view         |      0 |
+| Active animations after representative render      |      0 |
+| Inline layout-sized nodes with transition duration |    0 s |
+| Active animations with reduced motion emulated     |      0 |
+
+The remaining dashboard card hover response is an explicit 150 ms shadow
+transition and becomes immediate under `prefers-reduced-motion: reduce`.
+
 ## Recommended Limits
 
 - Treat the target dataset above as the supported v5.0 GA local/small-team

--- a/web/src/__tests__/dashboard-motion-contract.test.tsx
+++ b/web/src/__tests__/dashboard-motion-contract.test.tsx
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DashboardSection } from '@/components/dashboard/DashboardSection';
+import { renderWithProviders } from './test-utils';
+
+vi.mock('@/components/dashboard/Dashboard', () => ({
+  Dashboard: () => <div>Dashboard content loaded</div>,
+}));
+
+const motionSources = [
+  'components/activity/ActivityFeed.tsx',
+  'components/dashboard/Dashboard.tsx',
+  'components/dashboard/DashboardPage.tsx',
+  'components/dashboard/DashboardSection.tsx',
+  'components/dashboard/HourlyActivityChart.tsx',
+  'components/dashboard/StatusTimeline.tsx',
+  'components/dashboard/WhereTimeWent.tsx',
+];
+
+const storage = new Map<string, string>();
+const localStorageStub = {
+  clear: () => storage.clear(),
+  getItem: (key: string) => storage.get(key) ?? null,
+  key: (index: number) => [...storage.keys()][index] ?? null,
+  get length() {
+    return storage.size;
+  },
+  removeItem: (key: string) => storage.delete(key),
+  setItem: (key: string, value: string) => storage.set(key, value),
+};
+
+describe('dashboard motion contract', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal('localStorage', localStorageStub);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('avoids broad and layout-property transitions in active dashboard surfaces', () => {
+    for (const file of motionSources) {
+      const source = readFileSync(resolve(process.cwd(), 'src', file), 'utf8');
+
+      expect(source, file).not.toContain('transition-all');
+      expect(source, file).not.toMatch(/transition-\[(?:height|max-height|width)/);
+      expect(source, file).not.toContain('max-h-[5000px]');
+    }
+  });
+
+  it('expands and collapses immediately with explicit accessible state', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DashboardSection />);
+
+    const toggle = screen.getByRole('button', { name: /Dashboard/ });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Dashboard content loaded')).toBeNull();
+
+    await user.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Dashboard content loaded')).toBeDefined();
+
+    await user.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Dashboard content loaded')).toBeNull();
+  });
+});

--- a/web/src/components/activity/ActivityFeed.tsx
+++ b/web/src/components/activity/ActivityFeed.tsx
@@ -106,19 +106,10 @@ function DailySummaryPanel() {
       {/* Progress bar */}
       {total > 0 && (
         <div className="h-3 rounded-full overflow-hidden flex bg-muted">
-          <div
-            className="bg-green-500 transition-all"
-            style={{ width: `${(summary.activeMs / total) * 100}%` }}
-          />
-          <div
-            className="bg-gray-400 transition-all"
-            style={{ width: `${(summary.idleMs / total) * 100}%` }}
-          />
+          <div className="bg-green-500" style={{ width: `${(summary.activeMs / total) * 100}%` }} />
+          <div className="bg-gray-400" style={{ width: `${(summary.idleMs / total) * 100}%` }} />
           {summary.errorMs > 0 && (
-            <div
-              className="bg-red-500 transition-all"
-              style={{ width: `${(summary.errorMs / total) * 100}%` }}
-            />
+            <div className="bg-red-500" style={{ width: `${(summary.errorMs / total) * 100}%` }} />
           )}
         </div>
       )}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -81,7 +81,8 @@ function StatCard({ title, children, onClick, clickable }: StatCardProps) {
     <div
       className={cn(
         'rounded-lg border bg-card p-4',
-        clickable && 'cursor-pointer hover:ring-2 hover:ring-ring transition-all'
+        clickable &&
+          'cursor-pointer transition-shadow duration-150 hover:ring-2 hover:ring-ring motion-reduce:transition-none'
       )}
       onClick={onClick}
       role={clickable ? 'button' : undefined}
@@ -441,7 +442,7 @@ export function Dashboard({ onTaskClick }: DashboardProps = {}) {
                         </span>
                         <div className="flex-1 h-4 bg-muted rounded-sm overflow-hidden">
                           <div
-                            className="h-full bg-green-500 rounded-sm transition-all"
+                            className="h-full rounded-sm bg-green-500"
                             style={{ width: `${Math.min(100, d.utilizationPercent)}%` }}
                           />
                         </div>

--- a/web/src/components/dashboard/DashboardPage.tsx
+++ b/web/src/components/dashboard/DashboardPage.tsx
@@ -72,7 +72,8 @@ function StatCard({ title, children, onClick, clickable }: StatCardProps) {
     <div
       className={cn(
         'rounded-lg bg-card',
-        clickable && 'cursor-pointer hover:ring-2 hover:ring-ring transition-all'
+        clickable &&
+          'cursor-pointer transition-shadow duration-150 hover:ring-2 hover:ring-ring motion-reduce:transition-none'
       )}
       onClick={onClick}
       role={clickable ? 'button' : undefined}
@@ -321,7 +322,7 @@ export function DashboardPage() {
             <span className="text-muted-foreground w-20 shrink-0 text-xs">{d.date.slice(5)}</span>
             <div className="flex-1 h-4 bg-muted rounded-sm overflow-hidden">
               <div
-                className="h-full bg-green-500 rounded-sm transition-all"
+                className="h-full rounded-sm bg-green-500"
                 style={{ width: `${Math.min(100, d.utilizationPercent)}%` }}
               />
             </div>

--- a/web/src/components/dashboard/DashboardSection.tsx
+++ b/web/src/components/dashboard/DashboardSection.tsx
@@ -45,7 +45,10 @@ export function DashboardSection() {
     <div className="mt-6 border-t pt-4">
       {/* Collapsible Header */}
       <button
+        type="button"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-controls="dashboard-section-content"
         className={cn(
           'w-full flex items-center gap-2 px-3 py-2 rounded-lg',
           'hover:bg-muted/50 transition-colors',
@@ -63,12 +66,7 @@ export function DashboardSection() {
       </button>
 
       {/* Dashboard Content */}
-      <div
-        className={cn(
-          'transition-all duration-300 ease-in-out',
-          expanded ? 'max-h-[5000px] opacity-100 mt-4' : 'max-h-0 opacity-0 overflow-hidden'
-        )}
-      >
+      <div id="dashboard-section-content" hidden={!expanded} className={cn(expanded && 'mt-4')}>
         {expanded && <Dashboard />}
       </div>
     </div>

--- a/web/src/components/dashboard/HourlyActivityChart.tsx
+++ b/web/src/components/dashboard/HourlyActivityChart.tsx
@@ -42,7 +42,16 @@ export function HourlyActivityChart({ period }: HourlyActivityChartProps) {
       hour,
       count,
       height: (count / max) * 100,
-      label: hour % 6 === 0 ? (hour === 0 ? '12a' : hour < 12 ? `${hour}a` : hour === 12 ? '12p' : `${hour - 12}p`) : '',
+      label:
+        hour % 6 === 0
+          ? hour === 0
+            ? '12a'
+            : hour < 12
+              ? `${hour}a`
+              : hour === 12
+                ? '12p'
+                : `${hour - 12}p`
+          : '',
     }));
   }, [entries]);
 
@@ -57,14 +66,19 @@ export function HourlyActivityChart({ period }: HourlyActivityChartProps) {
       </h3>
 
       <div className="flex items-end gap-[2px] h-[80px]">
-        <span className="text-[8px] text-muted-foreground/40 self-start -mr-1 rotate-0 w-6 text-right leading-tight">Events</span>
+        <span className="text-[8px] text-muted-foreground/40 self-start -mr-1 rotate-0 w-6 text-right leading-tight">
+          Events
+        </span>
         {hourlyBars.map((bar) => (
           <div key={bar.hour} className="flex-1 flex flex-col items-center justify-end h-full">
             <div
-              className="w-full rounded-t-sm transition-all duration-300 min-h-[2px]"
+              className="min-h-[2px] w-full rounded-t-sm"
               style={{
                 height: `${Math.max(bar.height, 3)}%`,
-                backgroundColor: bar.count > 0 ? `rgba(139, 92, 246, ${0.3 + (bar.height / 100) * 0.7})` : 'rgba(139, 92, 246, 0.08)',
+                backgroundColor:
+                  bar.count > 0
+                    ? `rgba(139, 92, 246, ${0.3 + (bar.height / 100) * 0.7})`
+                    : 'rgba(139, 92, 246, 0.08)',
               }}
               title={`${bar.hour}:00 — ${bar.count} events`}
             />
@@ -74,9 +88,11 @@ export function HourlyActivityChart({ period }: HourlyActivityChartProps) {
 
       {/* X-axis labels */}
       <div className="flex justify-between text-[9px] text-muted-foreground/50 mt-1 ml-6 px-0.5">
-        {hourlyBars.filter((b) => b.label).map((bar) => (
-          <span key={bar.hour}>{bar.label}</span>
-        ))}
+        {hourlyBars
+          .filter((b) => b.label)
+          .map((bar) => (
+            <span key={bar.hour}>{bar.label}</span>
+          ))}
       </div>
     </div>
   );

--- a/web/src/components/dashboard/StatusTimeline.tsx
+++ b/web/src/components/dashboard/StatusTimeline.tsx
@@ -31,7 +31,7 @@ function TimelineBar({ summary }: { summary: DailySummary }) {
     <Group className="h-8 overflow-hidden rounded-md" gap={0} wrap="nowrap">
       {activePercent > 0 && (
         <div
-          className="bg-green-500 flex items-center justify-center text-xs text-white font-medium transition-all"
+          className="flex items-center justify-center bg-green-500 text-xs font-medium text-white"
           style={{ width: `${activePercent}%` }}
           title={`Active: ${formatDurationMs(summary.activeMs)}`}
         >
@@ -40,7 +40,7 @@ function TimelineBar({ summary }: { summary: DailySummary }) {
       )}
       {idlePercent > 0 && (
         <div
-          className="bg-gray-400 flex items-center justify-center text-xs text-white font-medium transition-all"
+          className="flex items-center justify-center bg-gray-400 text-xs font-medium text-white"
           style={{ width: `${idlePercent}%` }}
           title={`Idle: ${formatDurationMs(summary.idleMs)}`}
         >
@@ -49,7 +49,7 @@ function TimelineBar({ summary }: { summary: DailySummary }) {
       )}
       {errorPercent > 0 && (
         <div
-          className="bg-red-500 flex items-center justify-center text-xs text-white font-medium transition-all"
+          className="flex items-center justify-center bg-red-500 text-xs font-medium text-white"
           style={{ width: `${errorPercent}%` }}
           title={`Error: ${formatDurationMs(summary.errorMs)}`}
         >

--- a/web/src/components/dashboard/WhereTimeWent.tsx
+++ b/web/src/components/dashboard/WhereTimeWent.tsx
@@ -97,7 +97,7 @@ export function WhereTimeWent({ period }: WhereTimeWentProps) {
                 </div>
                 <div className="h-2 rounded-full bg-muted/30 overflow-hidden">
                   <div
-                    className="h-full rounded-full transition-all duration-500"
+                    className="h-full rounded-full"
                     style={{
                       width: `${item.percentage}%`,
                       backgroundColor: color,


### PR DESCRIPTION
## Summary
- remove `transition-all` and layout-property animation from active dashboard, activity, timeline, and chart surfaces
- make dashboard expansion immediate with explicit `aria-expanded` and `aria-controls` state
- keep interactive card feedback to an explicit 150 ms shadow transition with a reduced-motion override
- add a durable motion contract and record live profiling evidence

## Verification
- `pnpm --filter @veritas-kanban/web test` (404 tests)
- `pnpm --filter @veritas-kanban/web lint` (0 errors, 29 existing warnings)
- `pnpm --filter @veritas-kanban/web build`
- `pnpm typecheck`
- `pnpm qa:mantine`
- `pnpm lint:budget` (597/600)
- in-app Activity profile with representative rows: zero `transition-all` nodes, zero active animations, and 0 s transitions on layout-sized elements
- reduced-motion emulation: zero active animations

Fixes #814