### PR TITLE
fix: stabilize storage service ordering and startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made SQLite activity ordering deterministic for multiple events written in
   the same millisecond, preserving the newest-first feed contract and stable
   retention trimming (#823).
+- Removed untracked asynchronous directory creation from `AttachmentService`
+  construction; attachment and archive paths are now created lazily by the
+  operations that need them (#825).
 - Prevented compact bottom-navigation labels from overlapping, kept the mobile
   header within 320 px, and restored a fixed, safe-area-aware Board Chat entry
   point (#811).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made SQLite activity ordering deterministic for multiple events written in
+  the same millisecond, preserving the newest-first feed contract and stable
+  retention trimming (#823).
 - Prevented compact bottom-navigation labels from overlapping, kept the mobile
   header within 320 px, and restored a fixed, safe-area-aware Board Chat entry
   point (#811).

--- a/server/src/__tests__/activity-service.test.ts
+++ b/server/src/__tests__/activity-service.test.ts
@@ -44,6 +44,7 @@ describe('ActivityService', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     // Clear activities between tests
     await service.clearActivities();
     await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
@@ -78,6 +79,9 @@ describe('ActivityService', () => {
     });
 
     it('should prepend new activities (most recent first)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-07-12T12:00:00.123Z'));
+
       await service.logActivity('task_created', 'task_1', 'First');
       await service.logActivity('task_updated', 'task_2', 'Second');
 

--- a/server/src/__tests__/attachment-service.test.ts
+++ b/server/src/__tests__/attachment-service.test.ts
@@ -18,10 +18,7 @@ describe('AttachmentService', () => {
     testRoot = path.join(os.tmpdir(), `veritas-test-attachments-${uniqueSuffix}`);
     attachmentsDir = path.join(testRoot, 'attachments');
     archiveDir = path.join(testRoot, 'archive-attachments');
-    
-    await fs.mkdir(attachmentsDir, { recursive: true });
-    await fs.mkdir(archiveDir, { recursive: true });
-    
+
     service = new AttachmentService({
       attachmentsDir,
       archiveAttachmentsDir: archiveDir,
@@ -36,6 +33,23 @@ describe('AttachmentService', () => {
   });
 
   describe('File upload', () => {
+    it('creates attachment directories lazily on the first write', async () => {
+      await expect(fs.access(attachmentsDir)).rejects.toThrow();
+      await expect(fs.access(archiveDir)).rejects.toThrow();
+
+      const mockFile = {
+        originalname: 'lazy-create.txt',
+        mimetype: 'text/plain',
+        size: 12,
+        buffer: Buffer.from('Lazy create'),
+      } as Express.Multer.File;
+
+      await service.saveAttachment(testTaskId, mockFile);
+
+      await expect(fs.access(attachmentsDir)).resolves.toBeUndefined();
+      await expect(fs.access(archiveDir)).rejects.toThrow();
+    });
+
     it('should save an attachment and return metadata', async () => {
       const mockFile = {
         originalname: 'test-file.txt',
@@ -97,9 +111,7 @@ describe('AttachmentService', () => {
         buffer: Buffer.from('Test'),
       } as Express.Multer.File;
 
-      await expect(service.saveAttachment(testTaskId, mockFile)).rejects.toThrow(
-        /not allowed/
-      );
+      await expect(service.saveAttachment(testTaskId, mockFile)).rejects.toThrow(/not allowed/);
     });
 
     it('should reject when max files per task is reached', async () => {
@@ -122,9 +134,9 @@ describe('AttachmentService', () => {
         buffer: Buffer.from('Test'),
       } as Express.Multer.File;
 
-      await expect(service.saveAttachment(testTaskId, mockFile, existingAttachments)).rejects.toThrow(
-        /Maximum number of attachments.*already reached/
-      );
+      await expect(
+        service.saveAttachment(testTaskId, mockFile, existingAttachments)
+      ).rejects.toThrow(/Maximum number of attachments.*already reached/);
     });
   });
 
@@ -265,7 +277,7 @@ describe('AttachmentService', () => {
 
       const files = await service.listFiles(testTaskId);
       expect(files).toHaveLength(2);
-      expect(files.every(f => f !== '.extracted')).toBe(true);
+      expect(files.every((f) => f !== '.extracted')).toBe(true);
     });
 
     it('should return empty array for non-existent task', async () => {

--- a/server/src/services/attachment-service.ts
+++ b/server/src/services/attachment-service.ts
@@ -32,12 +32,6 @@ export class AttachmentService {
     this.attachmentsDir = options.attachmentsDir || DEFAULT_ATTACHMENTS_DIR;
     this.archiveAttachmentsDir = options.archiveAttachmentsDir || DEFAULT_ARCHIVE_ATTACHMENTS_DIR;
     this.limits = options.limits || DEFAULT_ATTACHMENT_LIMITS;
-    this.ensureDirectories();
-  }
-
-  private async ensureDirectories(): Promise<void> {
-    await fs.mkdir(this.attachmentsDir, { recursive: true });
-    await fs.mkdir(this.archiveAttachmentsDir, { recursive: true });
   }
 
   private sanitizeFilename(filename: string): string {

--- a/server/src/storage/sqlite/activity-repository.ts
+++ b/server/src/storage/sqlite/activity-repository.ts
@@ -20,7 +20,7 @@ export class SqliteActivityRepository implements ActivityRepository {
           SELECT activity_json
           FROM activity_events
           WHERE workspace_id = 'local'
-          ORDER BY datetime(created_at) DESC, id DESC
+          ORDER BY created_at DESC, rowid DESC
           LIMIT ?
         `
       )
@@ -101,7 +101,7 @@ export class SqliteActivityRepository implements ActivityRepository {
           SELECT id
           FROM activity_events
           WHERE workspace_id = 'local'
-          ORDER BY datetime(created_at) DESC, id DESC
+          ORDER BY created_at DESC, rowid DESC
           LIMIT -1 OFFSET ?
         )
       `


### PR DESCRIPTION
## Summary
- sort SQLite activity events by the full ISO timestamp with insertion-order tie-breaking
- apply the same stable order to activity retention trimming and freeze time in regression coverage
- remove untracked async directory creation from `AttachmentService` construction
- create attachment and archive directories lazily in the operations that need them

## Verification
- activity and attachment tests passed 5 consecutive targeted runs
- `pnpm --filter @veritas-kanban/server test` (2,109 tests, 2 skipped)
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/server lint` (0 errors, existing warnings only)

Fixes #823
Fixes #825