### PR TITLE
chore: prepare Veritas Kanban 5.2.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 > read this file first. Harness-specific supplements (e.g. `CLAUDE.md`) extend, never duplicate
 > or contradict, these rules.
 >
-> **Version:** 5.2.1  
+> **Version:** 5.2.2
 > **Freshness policy:** update within two working days of any toolchain or architecture change.
 > Stale fields (package manager, Node version, provider list, test commands) are caught by
 > `pnpm check:pnpm-settings` and the smoke-test CI job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.2] - 2026-07-12
+
+### Added
+
+- Added append-only JSONL activity storage with recovery and compatibility
+  coverage for durable event history (#782, #808).
+
 ### Changed
 
+- Added canonical repository guidance for Codex, OpenClaw, and Hermes and
+  documented validated provider behavior (#803).
+- Routed web API requests through the shared authenticated client and retired
+  the deprecated polling hook (#802).
 - Updated the Codex SDK integration to `0.144.1` and pinned patched transitive
   development-tool dependencies (#792, #795).
 - Added `provider` and `command` fields to `WorkflowAgent` in
@@ -19,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened file-storage mutation ordering, rollback behavior, and integrity
+  recovery across concurrent writes (#804).
+- Fixed runtime lifecycle leaks, async registry persistence, attempt
+  reconciliation, and cross-platform path helpers (#774, #779, #781, #783,
+  #801).
+- Normalized security artifact paths before matching so mixed-case paths cannot
+  bypass expected classification (#807).
 - Reworked Scoring Profiles into a compact list/detail flow at phone widths,
   preserved the selected profile across create and duplicate actions, and
   guarded unsaved drafts when returning to the list, changing tabs, or leaving

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.2.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.2-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,6 +1,6 @@
 # Veritas Kanban — API Reference
 
-**Version**: 5.2.1
+**Version**: 5.2.2
 **Last Updated**: 2026-06-29
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -1,9 +1,8 @@
 # Veritas Kanban v5 GA Checklist
 
-v5.0.0 stable is published. The current source line is v5.2.1, including the
-post-v5.1 backlog train for team rosters, workspace capability discovery,
-queue monitors, recurring work, Squad Chat threading and human replies,
-ceremony gates, reflection promotion, external tracker introspection, and audit
+v5.0.0 stable is published. The current source line is v5.2.2, including the
+post-v5.1 backlog train plus the July 2026 desktop, responsive UI,
+accessibility, motion, workflow-correctness, and storage-integrity audit
 follow-ups. This checklist remains the operator reference for release-gate
 review, follow-up evidence debt, and future v5 patch candidates. The GitHub
 release and release issues remain the source of scheduling truth.

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -2,13 +2,68 @@
 
 These notes describe the Veritas Kanban v5 stable release line.
 
-- Current source version: `v5.2.1`
+- Current source version: `v5.2.2`
 - Latest published GitHub release:
-  [Veritas Kanban v5.2.1](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.1)
+  [Veritas Kanban v5.2.2](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.2)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
-  [Veritas-Kanban-5.2.1-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.2.1/Veritas-Kanban-5.2.1-mac-arm64.zip)
+  [Veritas-Kanban-5.2.2-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.2.2/Veritas-Kanban-5.2.2-mac-arm64.zip)
+
+## v5.2.2 Patch
+
+v5.2.2 is the July 2026 reliability and interface-audit patch. It restores a
+launchable macOS build, closes the web and desktop Apple-design audit backlog,
+and hardens workflow and storage behavior without changing the supported v5
+data model or requiring an operator migration.
+
+### Desktop and release reliability
+
+- Electron runtime APIs remain external in Vite/Rolldown output, preventing the
+  Electron npm installer shim from replacing the native main and preload APIs.
+- Desktop builds now inspect emitted artifacts and fail before packaging if the
+  installer shim or missing Electron runtime bindings reappear.
+- The patched native app was exercised through fresh setup, readiness and
+  Keychain status, native menus, keyboard onboarding, window chrome, and local
+  notification wiring before release.
+- Signed/notarized macOS DMG and ZIP assets, update metadata, blockmaps, and
+  SHA-256 sidecars replace the broken v5.2.1 desktop artifact set.
+
+### Interface, accessibility, and motion
+
+- Keyboard users can move and reorder Kanban cards across populated and empty
+  columns with announcements, rollback, and focus restoration.
+- Compact Settings, bottom navigation, Board Chat, and Scoring Profiles now use
+  deliberate phone layouts with reachable, touch-sized actions at 320-430 px.
+- Scoring Profiles preserves selection across create and duplicate flows and
+  protects unsaved edits when navigating away.
+- Overlays honor reduced-transparency and increased-contrast preferences, and
+  stale task-card tooltips are dismissed before Task Detail opens.
+- Dashboard charts and sections no longer animate layout properties or rely on
+  broad `transition-all` behavior; reduced-motion updates are immediate.
+
+### Workflow and storage correctness
+
+- Human-gate blocks, bounded cross-step reroutes, workflow HTTP errors, shared
+  contracts, and canonical `depends_on` enforcement now follow the documented
+  workflow state model.
+- File-backed mutations have stronger ordering, rollback, recovery, and
+  lifecycle cleanup across concurrent operations.
+- Activity history gains append-only JSONL durability, deterministic
+  same-millisecond ordering, and stable retention trimming.
+- Attachment directories are created lazily by the operations that need them,
+  removing an asynchronous startup/teardown race.
+- Security artifact matching normalizes path case before classification.
+
+### Compatibility and upgrade notes
+
+- No v5 schema migration is required for v5.2.1 installations.
+- Server, web, CLI, MCP, shared, and desktop package versions move together to
+  5.2.2.
+- Linux and Windows desktop outputs remain unsigned preview artifacts; macOS
+  Apple Silicon remains the supported signed desktop target.
+- Operators using the v5.2.1 macOS app should replace it with v5.2.2 rather
+  than relying on the broken v5.2.1 application bundle to self-update.
 
 ## v5.2.1 Patch
 
@@ -161,10 +216,14 @@ desktop, security, and migration posture unchanged from v5.0.0.
 
 ## Release Artifacts
 
-The v5.2.1 stable desktop release publishes signed/notarized macOS ZIP and DMG
+The v5.2.2 stable desktop release publishes signed/notarized macOS ZIP and DMG
 assets plus `latest-mac.yml`, blockmaps, and SHA-256 sidecars under the
-[v5.2.1 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.1).
+[v5.2.2 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.2).
 Use the release-attached `.sha256` files as the checksum source of truth.
+
+The v5.2.1 desktop assets remain available for provenance, but the application
+bundle is not a supported rollback target because its emitted Electron main
+process contains the installer shim fixed in v5.2.2.
 
 The v5.2.0 desktop assets remain available under the
 [v5.2.0 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.0).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1664,7 +1664,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">v5.2.1</div>
+          <div class="proof-stat-number">v5.2.2</div>
           <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -802,7 +802,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `5.2.1`      | Matches VK server version   |
+| MCP server package | `5.2.2`      | Matches VK server version   |
 | MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2024-11-05` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -846,4 +846,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-06-29 · VK v5.2.1 · 36 tools / 8 categories_
+_Last updated: 2026-07-12 · VK v5.2.2 · 36 tools / 8 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump root, shared, server, web, CLI, MCP, and desktop packages from 5.2.1 to 5.2.2
- publish the dated 5.2.2 changelog and detailed release notes for desktop, UI/accessibility, workflow, storage, compatibility, and upgrade behavior
- update operator-facing version references across the repository and release checklist

## Verification

- `pnpm test:unit`
  - desktop: 57 passed
  - server: 2,107 passed, 2 skipped
  - web: 405 passed
- `pnpm lint` (0 errors, 597 existing warnings)
- `pnpm typecheck`
- `pnpm build`
- `pnpm qa:mantine`
- `pnpm lint:budget` (597/600)
- `pnpm smoke:cli-mcp` (metadata/build checks passed; live write smoke skipped because no VK_API_KEY was supplied)
- `pnpm validate:release -- --version 5.2.2`
- `pnpm desktop:smoke:mac:local`
- `pnpm desktop:package:mac:unsigned`
  - generated `Veritas-Kanban-5.2.2-mac-arm64.dmg`
  - generated `Veritas-Kanban-5.2.2-mac-arm64.zip`
  - generated update metadata and blockmaps

## Release follow-through

After merge, publish `v5.2.2`, wait for the signed/notarized Desktop Release workflow, verify signatures/checksums and installed launch, then update the Homebrew cask.

Tracks #809