### PR TITLE
test: align release E2E selectors

### DIFF
--- a/e2e/mantine-qa-gate.spec.ts
+++ b/e2e/mantine-qa-gate.spec.ts
@@ -585,7 +585,7 @@ test.describe('v5 Mantine migration QA gate', () => {
     await page.keyboard.press('Escape');
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 });
 
-    await page.getByRole('button', { name: 'Settings', exact: true }).click();
+    await page.getByRole('button', { name: 'Mobile settings', exact: true }).click();
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 });
     await assertNoHorizontalOverflow(page);
     await assertMobileTouchTargets(page);

--- a/e2e/task-creation.spec.ts
+++ b/e2e/task-creation.spec.ts
@@ -64,7 +64,9 @@ test.describe('Task Creation', () => {
     await expect(dialog).not.toBeVisible({ timeout: 15_000 });
 
     // The new task should appear on the board (in the To Do column)
-    const taskCard = page.locator('text=E2E Created Task');
+    const taskCard = page
+      .getByRole('region', { name: 'To Do' })
+      .getByRole('heading', { name: 'E2E Created Task', exact: true });
     await expect(taskCard).toBeVisible({ timeout: 10_000 });
 
     // Clean up — find the task ID via API and queue for deletion


### PR DESCRIPTION
## Summary

- open compact Settings through the supported `Mobile settings` navigation control
- scope the task-creation assertion to the created task heading inside the To Do region
- remove strict-locator ambiguity introduced by the activity-feed echo

## Verification

- mobile Mantine smoke: 1 passed
- task creation regression: 1 passed
- mobile WebKit responsive/PWA suite after installing pinned WebKit 2311: 4 passed
- Prettier check passed

No production behavior changes.

Fixes #828