### PR TITLE
docs: record annotated v5.2.2 tag

### DIFF
--- a/docs/V5-RC-EVIDENCE-PACKET.md
+++ b/docs/V5-RC-EVIDENCE-PACKET.md
@@ -26,7 +26,7 @@ The Homebrew cask update passed its registered-tap gates and merged in #23.
 | Field               | Value                                                                                       |
 | ------------------- | ------------------------------------------------------------------------------------------- |
 | Release version     | 5.2.2                                                                                       |
-| Git tag             | `v5.2.2`                                                                                    |
+| Git tag             | Annotated `v5.2.2`; object `81ce4928e457c91a16a20827ddac1a94fb8f4170`                       |
 | Release commit      | `4b84eccd1bf827c842e93a82afd0240e6855b3df`                                                  |
 | GitHub release      | <https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.2>                           |
 | Desktop Release run | <https://github.com/BradGroux/veritas-kanban/actions/runs/29213420721>                      |
@@ -162,15 +162,14 @@ Open follow-ups:
 
 - #796: retain the non-sensitive external follow-up without exposing private
   advisory content.
-- The published `v5.2.2` ref is lightweight. Converting it to an annotated tag
-  at the same release commit requires an explicit force-update decision.
 
 ### Release Decision
 
 v5.2.2 passes the required source, web, server, CLI, MCP, desktop, signing,
 notarization, artifact, signed-runtime, update, and Homebrew gates. The macOS
-distribution is approved for installation. The remaining tag-object decision
-does not change the release commit or published artifact contents.
+distribution is approved for installation. The annotated tag peels to release
+commit `4b84eccd1bf827c842e93a82afd0240e6855b3df`; converting the tag object did
+not change source contents or published assets.
 
 ## v5.0.0 Retained Release Evidence
 


### PR DESCRIPTION
## Summary

- record the annotated v5.2.2 tag object and unchanged peeled release commit
- remove the completed lightweight-tag follow-up
- confirm source contents and seven published assets were unchanged

## Verification

- `git cat-file -t v5.2.2` -> `tag`
- `git rev-parse v5.2.2^{commit}` -> `4b84eccd1bf827c842e93a82afd0240e6855b3df`
- `pnpm validate:release -- --version 5.2.2 --github --repo BradGroux/veritas-kanban`

Fixes #833.