### PR TITLE
fix: enforce runtime security artifact guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Reject tracked runtime security configuration
+        run: pnpm check:security-artifacts
+
       - name: Audit production dependencies (blocks on high/critical)
         run: pnpm audit --prod --audit-level=high
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+pnpm check:security-artifacts
 npx lint-staged

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,32 @@ Instead, email us at:
 
 We will work with you to understand the issue and coordinate disclosure.
 
+## Repository Secret Hygiene
+
+Runtime authentication state must never be committed. In particular, any
+`.veritas-kanban/security.json` file may contain password and recovery-key
+hashes for an enabled installation. The repository ignores these files and
+enforces the rule locally and in CI:
+
+```bash
+pnpm check:security-artifacts
+```
+
+Deleting a sensitive file in a later commit does not remove it from Git
+history. If authentication material is ever tracked, treat it as exposed:
+
+1. Determine whether it belongs to a real installation.
+2. Rotate or invalidate the affected password, recovery key, sessions, and
+   related credentials before relying on repository cleanup.
+3. Review reachable history, forks, and clones and make an explicit decision
+   about coordinated history rewriting versus retaining the invalidated blob.
+4. Record sensitive evidence in a private security advisory, not a public
+   issue, commit message, test fixture, or log.
+
+GitHub secret scanning and push protection should remain enabled for the
+repository. The tracked-file guard complements those services because generic
+password and recovery-key hashes may not match provider-specific signatures.
+
 ## Scope
 
 This policy applies to:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:report": "node scripts/lint-warning-budget.mjs --all-rules",
     "lint:fix": "eslint . --fix",
     "check:pnpm-settings": "node scripts/check-pnpm-settings.mjs",
+    "check:security-artifacts": "node scripts/check-security-artifacts.mjs",
     "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",
     "test": "vitest run",
     "test:unit": "pnpm -r --workspace-concurrency=1 test",


### PR DESCRIPTION
## Summary
- expose the tracked runtime-security-artifact guard as a stable package command
- run the guard in pre-commit and the CI security job
- document rotation, history-remediation, and private evidence handling requirements

Fixes #835
Related to #796.

## Verification
- `pnpm check:security-artifacts`
- `pnpm --filter @veritas-kanban/server test -- src/__tests__/security-artifacts-guard.test.ts` (full server suite: 2,107 passed, 2 skipped)
- `pnpm lint:budget`
- `pnpm typecheck`
- `pnpm exec prettier --check package.json .github/workflows/ci.yml SECURITY.md`
- `git diff --check`

## Risk
Low. This wires an existing tested guard into local and CI gates and adds security-response documentation; it does not change runtime behavior.