### PR TITLE
chore: prepare Veritas Kanban 5.2.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 > read this file first. Harness-specific supplements (e.g. `CLAUDE.md`) extend, never duplicate
 > or contradict, these rules.
 >
-> **Version:** 5.2.2
+> **Version:** 5.2.3
 > **Freshness policy:** update within two working days of any toolchain or architecture change.
 > Stale fields (package manager, Node version, provider list, test commands) are caught by
 > `pnpm check:pnpm-settings` and the smoke-test CI job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.3] - 2026-07-13
+
+### Changed
+
+- Enforced the tracked runtime security artifact guard in pre-commit and CI
+  security gates, with documented rotation and private-evidence handling
+  requirements (#836).
+
+### Fixed
+
+- Rebuilt the desktop login actions as a stable vertical Mantine stack with a
+  full-width primary action, centered recovery action, consistent spacing, and
+  regression coverage for the packaged layout (#839).
+
 ## [5.2.2] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.2.2-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.3-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,7 +1,7 @@
 # Veritas Kanban — API Reference
 
-**Version**: 5.2.2
-**Last Updated**: 2026-06-29
+**Version**: 5.2.3
+**Last Updated**: 2026-07-13
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)
 

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -1,11 +1,11 @@
 # Veritas Kanban v5 GA Checklist
 
-v5.0.0 stable is published. The current source line is v5.2.2, including the
-post-v5.1 backlog train plus the July 2026 desktop, responsive UI,
-accessibility, motion, workflow-correctness, and storage-integrity audit
-follow-ups. This checklist remains the operator reference for release-gate
-review, follow-up evidence debt, and future v5 patch candidates. The GitHub
-release and release issues remain the source of scheduling truth.
+v5.0.0 stable is published. The current source line is v5.2.3, including the
+post-v5.1 backlog train, the July 2026 desktop and responsive UI audit, the
+runtime security artifact gate, and the packaged login-layout correction. This
+checklist remains the operator reference for release-gate review, follow-up
+evidence debt, and future v5 patch candidates. The GitHub release and release
+issues remain the source of scheduling truth.
 
 For future candidates, use
 [v5 Release Candidate Evidence Packet](V5-RC-EVIDENCE-PACKET.md) as the single

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -2,13 +2,44 @@
 
 These notes describe the Veritas Kanban v5 stable release line.
 
-- Current source version: `v5.2.2`
+- Current source version: `v5.2.3`
 - Latest published GitHub release:
-  [Veritas Kanban v5.2.2](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.2)
+  [Veritas Kanban v5.2.3](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.3)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
-  [Veritas-Kanban-5.2.2-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.2.2/Veritas-Kanban-5.2.2-mac-arm64.zip)
+  [Veritas-Kanban-5.2.3-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.2.3/Veritas-Kanban-5.2.3-mac-arm64.zip)
+
+## v5.2.3 Patch
+
+v5.2.3 publishes the signed desktop follow-through for the login-layout fix
+that landed after v5.2.2, and promotes the runtime security artifact guard into
+the standard local and CI gates.
+
+### Desktop login polish
+
+- Login and password-recovery actions now render in an explicit vertical
+  Mantine stack instead of collapsing to intrinsic-width inline buttons.
+- The primary login action fills the 384 px form column at a 42 px control
+  height; the recovery action is centered beneath it with a full-width hit
+  target and subordinate visual treatment.
+- The packaged Electron layout is covered by a regression test that asserts
+  both actions use Mantine's native block behavior.
+
+### Security gate
+
+- The existing runtime security artifact guard is now a stable package command
+  enforced by pre-commit and the CI security job.
+- Security-response guidance now covers rotation, history remediation, and
+  private evidence handling without changing runtime data or credentials.
+
+### Compatibility and upgrade notes
+
+- No schema or configuration migration is required from v5.2.2.
+- Server, web, CLI, MCP, shared, and desktop package versions move together to
+  5.2.3.
+- macOS Apple Silicon remains the supported signed desktop target. Linux and
+  Windows artifacts remain unsigned previews.
 
 ## v5.2.2 Patch
 
@@ -217,10 +248,12 @@ Manual installation is also supported from the stable GitHub release ZIP.
 ## Release Artifacts
 
 The
-[v5.2.2 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.2)
+[v5.2.3 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.3)
 publishes signed/notarized macOS ZIP and DMG assets, `latest-mac.yml`,
 blockmaps, and SHA-256 sidecars. Use the release-attached `.sha256` files as the
 checksum source of truth.
+
+The v5.2.2 desktop assets remain available for provenance and rollback.
 
 The v5.2.1 desktop assets remain available for provenance, but the application
 bundle is not a supported rollback target because its emitted Electron main

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -32,8 +32,8 @@ candidate, belongs in the reusable
    ```
 
    Manual install is also supported from the
-   [stable GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.2)
-   by downloading `Veritas-Kanban-5.2.2-mac-arm64.zip`, unzipping it, and
+   [stable GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.3)
+   by downloading `Veritas-Kanban-5.2.3-mac-arm64.zip`, unzipping it, and
    moving `Veritas Kanban.app` into `/Applications`.
 
 2. Launch normally. A stable release should not show a Gatekeeper warning.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1664,7 +1664,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">v5.2.2</div>
+          <div class="proof-stat-number">v5.2.3</div>
           <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -802,7 +802,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `5.2.2`      | Matches VK server version   |
+| MCP server package | `5.2.3`      | Matches VK server version   |
 | MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2024-11-05` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -846,4 +846,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-07-12 · VK v5.2.2 · 36 tools / 8 categories_
+_Last updated: 2026-07-13 · VK v5.2.3 · 36 tools / 8 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- align all workspace package versions on 5.2.3
- document the packaged desktop login-layout fix and runtime security gate
- update stable release links, badges, and operator guidance for v5.2.3

Tracks #840

## Verification

- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `pnpm qa:mantine`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- desktop: 57 tests passed
- server: 2,107 passed, 2 skipped
- web: 405 tests passed
- `pnpm desktop:smoke:mac:local`
- `pnpm desktop:package:mac:unsigned`
- `pnpm validate:release -- --version 5.2.3 --docker-build`

## Release note

The v5.2.3 links become live when the release is published after merge. The signed and notarized macOS assets, Homebrew cask update, and local install verification remain tracked in #840. Cross-model review is not required for GPT 5.6 per maintainer direction.