### PR TITLE
Prepare Veritas Kanban 5.2.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 > read this file first. Harness-specific supplements (e.g. `CLAUDE.md`) extend, never duplicate
 > or contradict, these rules.
 >
-> **Version:** 5.2.3
+> **Version:** 5.2.4
 > **Freshness policy:** update within two working days of any toolchain or architecture change.
 > Stale fields (package manager, Node version, provider list, test commands) are caught by
 > `pnpm check:pnpm-settings` and the smoke-test CI job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.4] - 2026-07-13
+
+### Fixed
+
+- Restored the native macOS Edit menu so Cut, Copy, Paste, Select All, and
+  their standard keyboard shortcuts work in desktop text and password fields
+  (#842).
+- Rebuilt the password-recovery actions as one full-width vertical stack with
+  consistent spacing, and added password-manager autocomplete metadata to the
+  login and recovery password fields (#842).
+
 ## [5.2.3] - 2026-07-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.2.3-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.4-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,6 +1,6 @@
 # Veritas Kanban — API Reference
 
-**Version**: 5.2.3
+**Version**: 5.2.4
 **Last Updated**: 2026-07-13
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -1,11 +1,11 @@
 # Veritas Kanban v5 GA Checklist
 
-v5.0.0 stable is published. The current source line is v5.2.3, including the
+v5.0.0 stable is published. The current source line is v5.2.4, including the
 post-v5.1 backlog train, the July 2026 desktop and responsive UI audit, the
-runtime security artifact gate, and the packaged login-layout correction. This
-checklist remains the operator reference for release-gate review, follow-up
-evidence debt, and future v5 patch candidates. The GitHub release and release
-issues remain the source of scheduling truth.
+runtime security artifact gate, and the macOS recovery-screen input and layout
+corrections. This checklist remains the operator reference for release-gate
+review, follow-up evidence debt, and future v5 patch candidates. The GitHub
+release and release issues remain the source of scheduling truth.
 
 For future candidates, use
 [v5 Release Candidate Evidence Packet](V5-RC-EVIDENCE-PACKET.md) as the single

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -2,13 +2,43 @@
 
 These notes describe the Veritas Kanban v5 stable release line.
 
-- Current source version: `v5.2.3`
+- Current source version: `v5.2.4`
 - Latest published GitHub release:
-  [Veritas Kanban v5.2.3](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.3)
+  [Veritas Kanban v5.2.4](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
-  [Veritas-Kanban-5.2.3-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.2.3/Veritas-Kanban-5.2.3-mac-arm64.zip)
+  [Veritas-Kanban-5.2.4-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.2.4/Veritas-Kanban-5.2.4-mac-arm64.zip)
+
+## v5.2.4 Patch
+
+v5.2.4 restores native macOS editing behavior in the signed desktop app and
+corrects the password-recovery action layout.
+
+### Native macOS editing
+
+- The desktop menu now includes Electron's standard Edit role, restoring
+  Command-V and the normal Cut, Copy, Paste, Select All, Undo, and Redo menu
+  actions for text and password fields.
+- Packaged-app verification covers native Command-V in the recovery key, new
+  password, and password confirmation fields.
+
+### Password recovery layout
+
+- Recovery inputs and actions now share one 384 px column with the primary and
+  secondary actions stacked vertically at full width.
+- Login and recovery password fields expose the correct autocomplete metadata
+  for password-manager integration.
+- Regression coverage protects both the native Edit menu and the recovery form
+  structure.
+
+### Compatibility and upgrade notes
+
+- No schema or configuration migration is required from v5.2.3.
+- Server, web, CLI, MCP, shared, and desktop package versions move together to
+  5.2.4.
+- macOS Apple Silicon remains the supported signed desktop target. Linux and
+  Windows artifacts remain unsigned previews.
 
 ## v5.2.3 Patch
 
@@ -248,12 +278,13 @@ Manual installation is also supported from the stable GitHub release ZIP.
 ## Release Artifacts
 
 The
-[v5.2.3 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.3)
+[v5.2.4 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
 publishes signed/notarized macOS ZIP and DMG assets, `latest-mac.yml`,
 blockmaps, and SHA-256 sidecars. Use the release-attached `.sha256` files as the
 checksum source of truth.
 
-The v5.2.2 desktop assets remain available for provenance and rollback.
+The v5.2.3 and v5.2.2 desktop assets remain available for provenance and
+rollback.
 
 The v5.2.1 desktop assets remain available for provenance, but the application
 bundle is not a supported rollback target because its emitted Electron main

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -32,8 +32,8 @@ candidate, belongs in the reusable
    ```
 
    Manual install is also supported from the
-   [stable GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.3)
-   by downloading `Veritas-Kanban-5.2.3-mac-arm64.zip`, unzipping it, and
+   [stable GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
+   by downloading `Veritas-Kanban-5.2.4-mac-arm64.zip`, unzipping it, and
    moving `Veritas Kanban.app` into `/Applications`.
 
 2. Launch normally. A stable release should not show a Gatekeeper warning.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1664,7 +1664,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">v5.2.3</div>
+          <div class="proof-stat-number">v5.2.4</div>
           <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -802,7 +802,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `5.2.3`      | Matches VK server version   |
+| MCP server package | `5.2.4`      | Matches VK server version   |
 | MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2024-11-05` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -846,4 +846,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-07-13 · VK v5.2.3 · 36 tools / 8 categories_
+_Last updated: 2026-07-13 · VK v5.2.4 · 36 tools / 8 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- align every workspace package version on 5.2.4
- document the native macOS Edit menu fix, recovery action alignment, and password-manager metadata
- update stable release links, badges, and operator guidance for v5.2.4

Tracks #844

## Verification
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `pnpm qa:mantine`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- desktop: 58 tests passed
- server: 2,107 passed, 2 skipped
- web: 405 tests passed
- `pnpm desktop:smoke:mac:local`
- `pnpm desktop:package:mac:unsigned`
- `pnpm validate:release -- --version 5.2.4 --docker-build`

## Release note
The v5.2.4 links become live when the release is published after merge. The signed and notarized macOS assets, Homebrew cask update, and local install verification remain tracked in #844. Cross-model review is not required for GPT 5.6 per maintainer direction.
