### PR TITLE
fix: classify SQLite filesystem posture before startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ tasks/attachments/
 tasks/archive-attachments/
 storage/
 server/storage/
+!server/src/storage/
+!server/src/storage/**
 .veritas-kanban/*
 !.veritas-kanban/.gitkeep
 .veritas-desktop-dev/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Classified the authoritative SQLite filesystem before database open, limited
+  WAL to recognized durable local filesystems, refused known-unsafe and unknown
+  storage before creating database sidecars, and exposed redacted filesystem,
+  journal, and integrity posture through deep health and Maintenance diagnostics
+  (#881).
+
 ### Fixed
 
 - Kept mobile notifications above the safe-area-aware bottom navigation so

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -979,6 +979,26 @@ Three-tier health check system for container orchestration.
 }
 ```
 
+Authenticated deep-health responses include an optional top-level `sqlite`
+object after SQLite initializes successfully. The same redacted
+`sqlite-storage/v1` contract is returned by the Maintenance summary:
+
+| Field                               | Meaning                                                                                |
+| ----------------------------------- | -------------------------------------------------------------------------------------- |
+| `schemaVersion`                     | Always `sqlite-storage/v1`                                                             |
+| `databaseLocation`                  | `memory`, `configured`, or `runtime-default`; never a raw path                         |
+| `platform`                          | Runtime platform used for classification                                               |
+| `filesystemType`                    | Normalized filesystem type or conservative sentinel                                    |
+| `filesystemPosture`                 | `supported-local`, `known-unsafe`, `unknown`, or `not-applicable`                      |
+| `detectionSource` / `reasonCode`    | Redacted evidence and decision reason                                                  |
+| `journalMode`                       | `wal`, `memory`, `refused`, or `unknown`                                               |
+| `decisionSource` / `overrideSource` | Automatic/memory decision and override provenance (`null` in this release)             |
+| `lastIntegrityCheck`                | Optional timestamp, `ok`/`failed` status, and bounded result from `PRAGMA quick_check` |
+
+Raw database paths, mount points, and mount sources are intentionally omitted.
+Unsafe or unknown startup posture cannot be queried through health because the
+server refuses to bind; use the redacted startup/supervisor log instead.
+
 ---
 
 ## WebSocket
@@ -4134,7 +4154,8 @@ GET /api/v1/maintenance/summary
 Returns health checks, storage categories, lifecycle policy metadata, work
 product maintenance preview data, safe cleanup preview items, and allowlisted
 log sources with redacted local paths. Cleanup is preview-only; the endpoint
-does not delete data.
+does not delete data. When SQLite is active, the response also includes the
+optional `sqlite` posture object documented under [Health](#health).
 
 #### Redacted Log Tail
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -137,6 +137,15 @@ mkdir -p ./data
 chown 1001:1001 ./data
 ```
 
+When `VERITAS_STORAGE=sqlite`, the bind mount must resolve to durable local
+storage on the Docker host. Do not place the authoritative database on NFS,
+SMB/CIFS, FUSE, WebDAV, a NAS mount, a synchronized cloud folder, or an
+ephemeral container overlay. Detected unsafe or unverified filesystem posture
+refuses startup before SQLite opens the file. Cloud-sync folders may still look
+like ordinary local storage to the operating system, so the operator must keep
+them out of the authoritative path. See
+[SQLite Filesystem Safety Posture](SQLITE-SCHEMA.md#filesystem-safety-posture).
+
 ---
 
 ## NODE_ENV & Docker
@@ -548,6 +557,8 @@ All variables are set in `server/.env` (or passed as environment variables in Do
 | -------------------------- | -------------------------------------------- | -------------------------------------------------------------------------- |
 | `VERITAS_DATA_DIR`         | `.veritas-kanban` (relative to project root) | Directory for config, logs, and internal data                              |
 | `DATA_DIR`                 | `/app/data` (Docker only)                    | Mapped data directory inside the Docker container                          |
+| `VERITAS_STORAGE`          | `file`                                       | Selects `file` or `sqlite` storage                                         |
+| `VERITAS_SQLITE_PATH`      | Runtime `veritas.db`                         | SQLite database override; must resolve to verified durable local storage   |
 | `TELEMETRY_RETENTION_DAYS` | `30`                                         | Days to keep telemetry event files before deletion                         |
 | `TELEMETRY_COMPRESS_DAYS`  | `7`                                          | Days after which NDJSON telemetry files are gzip-compressed (0 = disabled) |
 
@@ -641,15 +652,20 @@ tar czf veritas-tasks-$(date +%Y%m%d).tar.gz tasks/
 
 #### Docker
 
+For a live SQLite deployment, create a completed SQLite export from Settings ->
+Maintenance or `POST /api/v1/maintenance/sqlite/export`, then copy the completed
+bundle to remote backup storage. A raw filesystem archive is safe only after the
+Veritas container is stopped; copying a live database without its coordinated
+WAL state can produce an incomplete backup.
+
 ```bash
-# Backup the named volume
+# Stop before making a raw named-volume archive
+docker compose down
 docker run --rm \
   -v kanban-data:/data \
   -v $(pwd):/backup \
   alpine tar czf /backup/veritas-backup-$(date +%Y%m%d).tar.gz -C /data .
-
-# Or copy from the running container
-docker cp veritas-kanban:/app/data ./backup-data
+docker compose up -d
 ```
 
 ### Restore
@@ -780,6 +796,13 @@ Remote clients and desktop onboarding should also validate:
 - `GET /health/ready` for storage, memory, and disk readiness.
 - `GET /api/auth/status` for setup/auth/session state.
 - `/ws` upgrade from the same origin used by the web app.
+
+When SQLite is active, authenticated admin calls to `/health/deep` and
+`/api/health/deep` include redacted filesystem posture, journal mode, and
+integrity evidence. If the filesystem is unsafe or unverified, the server
+refuses startup before binding the HTTP port; inspect container or desktop
+supervisor logs for the reason and move `VERITAS_SQLITE_PATH` to supported local
+storage.
 
 The Docker image includes a built-in health check:
 

--- a/docs/MAINTENANCE-CENTER.md
+++ b/docs/MAINTENANCE-CENTER.md
@@ -17,6 +17,9 @@ in Settings -> Maintenance and is backed by `/api/v1/maintenance`.
   safe to paste into support handoffs by default.
 - SQLite export/import actions that report bundle path, database path, table
   counts, warnings, and failure messages.
+- Redacted authoritative SQLite filesystem type/posture, detection and decision
+  source, effective journal mode, override source, and last one-time integrity
+  check when SQLite storage is active.
 - Admin-only skill security scans through
   `/api/v1/maintenance/skill-security/scan`, with redacted JSON and Markdown
   reports persisted for audit review.
@@ -31,6 +34,9 @@ in Settings -> Maintenance and is backed by `/api/v1/maintenance`.
   lifecycle policy metadata, and work-product preview metadata.
 - Maintenance summaries and log-tail responses redact local log paths before
   returning data to the UI.
+- SQLite posture diagnostics omit the database path, mount point, and mount
+  source. Known-unsafe or unknown filesystems refuse startup before Maintenance
+  becomes reachable.
 - Debug bundles exclude raw tokens, token hashes, cookies, private keys, raw
   prompts, raw chat content, and generated sensitive text.
 - Local home, project, storage, runtime, and log paths are redacted in bundle

--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -23,9 +23,46 @@ The default v5 database file is:
 ```
 
 The existing `DATA_DIR` and `VERITAS_DATA_DIR` rules remain authoritative. When
-either environment variable is set, the database lives on that configured volume.
-Fresh v5 installs use SQLite by default. Upgraded v4 projects keep their original
+either environment variable is set, the default database path follows that
+configured local volume. SQLite is selected with `VERITAS_STORAGE=sqlite`; file
+storage remains the runtime default. Upgraded v4 projects keep their original
 files as a migration backup until the migration is verified.
+
+### Filesystem Safety Posture
+
+The authoritative database must live on durable local storage. Before
+`DatabaseSync` opens the database or can create `-wal`/`-shm` sidecars, startup
+classifies the database parent filesystem and records a redacted
+`sqlite-storage/v1` decision. WAL is enabled only when the current platform
+provides affirmative supported-local evidence:
+
+- Linux: `btrfs`, `ext2`, `ext3`, `ext4`, `f2fs`, `jfs`, `xfs`, or `zfs` from
+  `/proc/self/mountinfo`.
+- macOS: `apfs` or `hfs` from `/sbin/mount`, and only when the mount also reports
+  the `local` flag.
+- Windows: a volume/access-path probe accepts only fixed NTFS or ReFS volumes.
+  UNC/mapped remote and RAM-disk volumes are unsafe; removable, unsupported, or
+  unresolved volumes remain unknown and refuse startup.
+- Other platforms: local paths are currently unverified and refuse startup.
+
+NFS, SMB/CIFS, FUSE, WebDAV, distributed/remote filesystems, volatile
+`ramfs`/`tmpfs`, unrecognized filesystems (including container `overlay`), probe
+failures, and database-file symlinks fail closed. The startup error explains the
+locking/shared-memory corruption risk and remediation without exposing the raw
+database path, mount point, or mount source. Existing rollback-journal databases
+also refuse automatic conversion; use the governed offline maintenance workflow
+when it becomes available rather than changing journal mode during startup.
+
+Do not share one SQLite file between Veritas servers, relocate it into a synced
+cloud folder, or create independent per-host authoritative copies. Cloud-sync
+folders can still report an ordinary local filesystem and therefore cannot be
+detected reliably; they remain unsupported even when the classifier sees APFS,
+ext4, NTFS, or another accepted local type. Keep the live database local, create
+a completed export/backup, and then copy that artifact to remote or NAS storage.
+
+After successful startup, admin deep-health and Maintenance diagnostics expose
+the redacted filesystem type/posture, detection reason/source, effective journal
+mode, decision/override source, and last one-time `PRAGMA quick_check` result.
 
 ## Global Column Conventions
 

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -52,6 +52,13 @@ Desktop data lives under:
 ~/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/
 ```
 
+Keep the workspace `data/` directory on the normal local Application Support
+filesystem. Do not relocate or symlink the authoritative SQLite database into a
+NAS, NFS, SMB, FUSE, iCloud, Dropbox, OneDrive, or other synchronized/remote
+folder. The desktop supervisor refuses unsafe or unverified storage before the
+local server binds. Use Maintenance to create a completed export/backup, then
+copy that artifact to remote storage.
+
 Desktop secrets use the native safe-storage/keychain path documented in the
 desktop architecture and release docs. Do not copy raw keychain payloads between
 machines.
@@ -157,11 +164,18 @@ Use Settings -> Maintenance for:
 - redacted log tails
 - redacted debug bundles
 - SQLite export/import reporting
+- redacted SQLite filesystem posture, effective journal mode, decision source,
+  and last integrity check
 - cleanup previews
 - skill security scans
 
 For backup/import API details, see the SQLite portability and Maintenance
-Center sections in `docs/API-REFERENCE.md`.
+Center sections in `docs/API-REFERENCE.md`. Diagnostics omit the raw database
+path, mount point, and mount source. Windows accepts only fixed NTFS/ReFS
+volumes; remote, RAM-disk, removable, unsupported, and unresolved volumes fail
+closed. Other unvalidated platforms refuse local SQLite startup rather than
+assuming filesystem safety. macOS remains the GA desktop target for this
+release.
 
 ## Assistant-Safe Setup Prompts
 

--- a/docs/guides/SELF_HOST.md
+++ b/docs/guides/SELF_HOST.md
@@ -470,6 +470,15 @@ The `DATA_DIR=/app/data` volume holds all persistent data:
 
 **Without a named volume, data is lost on every `docker compose down`.** Always use a volume or bind mount.
 
+For `VERITAS_STORAGE=sqlite`, persistence is not enough: the authoritative
+database must resolve to a verified durable local filesystem. Detected NFS,
+SMB/CIFS, FUSE, WebDAV, NAS, volatile filesystems, container overlay, unknown
+probes, and database-file symlinks refuse startup. Synchronized cloud folders
+remain unsupported but may look local to the operating system, so keep them out
+of the authoritative path. Copy only completed Maintenance exports/backups to
+remote storage.
+See [SQLite Filesystem Safety Posture](../SQLITE-SCHEMA.md#filesystem-safety-posture).
+
 ---
 
 ## Security

--- a/server/src/__tests__/maintenance-service.test.ts
+++ b/server/src/__tests__/maintenance-service.test.ts
@@ -4,6 +4,10 @@ import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { MaintenanceService } from '../services/maintenance-service.js';
 import { resetWorkProductServiceForTests } from '../services/work-product-service.js';
+import {
+  resetSqliteStorageDiagnosticsForTests,
+  SqliteDatabase,
+} from '../storage/sqlite/database.js';
 
 const seededSensitiveValues = [
   'vk_seededNegativeFixture1234567890',
@@ -20,9 +24,11 @@ const seededSensitiveValues = [
 describe('MaintenanceService', () => {
   let root: string;
   let originalDataDir: string | undefined;
+  let originalSqlitePath: string | undefined;
 
   beforeEach(async () => {
     originalDataDir = process.env.DATA_DIR;
+    originalSqlitePath = process.env.VERITAS_SQLITE_PATH;
     root = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-maintenance-'));
     process.env.DATA_DIR = root;
     resetWorkProductServiceForTests();
@@ -53,6 +59,12 @@ describe('MaintenanceService', () => {
     } else {
       process.env.DATA_DIR = originalDataDir;
     }
+    if (originalSqlitePath === undefined) {
+      delete process.env.VERITAS_SQLITE_PATH;
+    } else {
+      process.env.VERITAS_SQLITE_PATH = originalSqlitePath;
+    }
+    resetSqliteStorageDiagnosticsForTests();
     resetWorkProductServiceForTests();
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -82,6 +94,39 @@ describe('MaintenanceService', () => {
         'lifecycle-policy',
       ])
     );
+  });
+
+  it('includes redacted SQLite posture in support diagnostics', async () => {
+    const databasePath = path.join(root, '.veritas-kanban', 'support-diagnostics.db');
+    process.env.VERITAS_SQLITE_PATH = databasePath;
+    const database = new SqliteDatabase({
+      databasePath,
+      applyMigrations: false,
+      filesystemClassifier: () => ({
+        platform: 'linux',
+        filesystemType: 'ext4',
+        posture: 'supported-local',
+        detectionSource: 'maintenance-test',
+        reasonCode: 'supported-local-filesystem',
+      }),
+    });
+    database.open();
+
+    try {
+      const summary = await new MaintenanceService().buildSummary();
+
+      expect(summary.sqlite).toMatchObject({
+        databaseLocation: 'configured',
+        filesystemType: 'ext4',
+        filesystemPosture: 'supported-local',
+        journalMode: 'wal',
+        detectionSource: 'maintenance-test',
+        decisionSource: 'automatic',
+      });
+      expect(JSON.stringify(summary.sqlite)).not.toContain(databasePath);
+    } finally {
+      database.close();
+    }
   });
 
   it('tails allowlisted logs with secrets and local paths redacted', async () => {

--- a/server/src/__tests__/routes/health.test.ts
+++ b/server/src/__tests__/routes/health.test.ts
@@ -6,7 +6,7 @@
  *   /health/ready — Readiness probe
  *   /health/deep  — Full diagnostics (admin only)
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import fs from 'fs/promises';
@@ -14,11 +14,16 @@ import path from 'path';
 import os from 'os';
 import { healthRouter } from '../../routes/health.js';
 import { errorHandler } from '../../middleware/error-handler.js';
+import {
+  resetSqliteStorageDiagnosticsForTests,
+  SqliteDatabase,
+} from '../../storage/sqlite/database.js';
 
 describe('Health Routes', () => {
   let app: express.Express;
   let testDataDir: string;
   let originalDataDir: string | undefined;
+  let originalSqlitePath: string | undefined;
 
   beforeEach(async () => {
     // Create a temp data directory for testing
@@ -31,6 +36,7 @@ describe('Health Routes', () => {
 
     // Set DATA_DIR env var
     originalDataDir = process.env.DATA_DIR;
+    originalSqlitePath = process.env.VERITAS_SQLITE_PATH;
     process.env.DATA_DIR = testDataDir;
 
     // Create test app
@@ -47,6 +53,12 @@ describe('Health Routes', () => {
     } else {
       delete process.env.DATA_DIR;
     }
+    if (originalSqlitePath !== undefined) {
+      process.env.VERITAS_SQLITE_PATH = originalSqlitePath;
+    } else {
+      delete process.env.VERITAS_SQLITE_PATH;
+    }
+    resetSqliteStorageDiagnosticsForTests();
 
     // Clean up test directory
     try {
@@ -140,6 +152,20 @@ describe('Health Routes', () => {
       process.env.VERITAS_ADMIN_KEY = adminKey;
       process.env.VERITAS_AUTH_ENABLED = 'true';
       process.env.NODE_ENV = 'development';
+      const databasePath = path.join(testDataDir, 'health-diagnostics.db');
+      process.env.VERITAS_SQLITE_PATH = databasePath;
+      const database = new SqliteDatabase({
+        databasePath,
+        applyMigrations: false,
+        filesystemClassifier: () => ({
+          platform: 'darwin',
+          filesystemType: 'apfs',
+          posture: 'supported-local',
+          detectionSource: 'health-test',
+          reasonCode: 'supported-local-filesystem',
+        }),
+      });
+      database.open();
 
       try {
         const res = await request(app).get('/health/deep').set('X-API-Key', adminKey);
@@ -160,8 +186,18 @@ describe('Health Routes', () => {
         expect(res.body.dataDirectory).toBeDefined();
         expect(res.body.dataDirectory.path).toBe(testDataDir);
         expect(res.body.dataDirectory.sizeBytes).toBeTypeOf('number');
+        expect(res.body.sqlite).toMatchObject({
+          databaseLocation: 'configured',
+          filesystemType: 'apfs',
+          filesystemPosture: 'supported-local',
+          journalMode: 'wal',
+          detectionSource: 'health-test',
+          decisionSource: 'automatic',
+        });
+        expect(JSON.stringify(res.body.sqlite)).not.toContain(databasePath);
         expect(res.body.timestamp).toBeDefined();
       } finally {
+        database.close();
         // Restore
         if (origAdminKey !== undefined) process.env.VERITAS_ADMIN_KEY = origAdminKey;
         else delete process.env.VERITAS_ADMIN_KEY;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -75,6 +75,7 @@ import {
   type WebSocketEventChannel,
 } from './services/websocket-permissions.js';
 import { closeWebSocketSafely } from './utils/websocket-close.js';
+import { startAfterInitialization } from './utils/startup-gate.js';
 
 const log = createLogger('server');
 
@@ -521,65 +522,60 @@ app.use(errorHandler);
 let configService: ConfigService | null = null;
 let storageInitialized = false;
 
-// Initialize services on startup
-(async () => {
+// Initialize services before binding the HTTP port. Storage safety failures must
+// prevent the process from briefly accepting requests against partial state.
+async function initializeServices(): Promise<void> {
+  // 1. Backup + integrity checks on the data directory
+  const dataDir = process.env.VERITAS_DATA_DIR || path.join(process.cwd(), '..', '.veritas-kanban');
+  let backupPath = '';
   try {
-    // 1. Backup + integrity checks on the data directory
-    const dataDir =
-      process.env.VERITAS_DATA_DIR || path.join(process.cwd(), '..', '.veritas-kanban');
-    let backupPath = '';
-    try {
-      backupPath = await createBackup(dataDir);
-    } catch (backupErr) {
-      log.warn({ err: backupErr }, 'Startup backup failed — continuing without backup');
-    }
-
-    const integrityReport = await runIntegrityChecks(dataDir);
-    log.info(
-      {
-        backup: backupPath || '(skipped)',
-        filesChecked: integrityReport.filesChecked,
-        issues: integrityReport.issuesFound,
-        recovered: integrityReport.recoveredCount,
-      },
-      `Startup: backup ${backupPath ? 'created' : 'skipped'}, integrity: ${integrityReport.filesChecked} files checked, ${integrityReport.issuesFound} issues found`
-    );
-
-    // 2. Run data migrations (idempotent)
-    await runStartupMigrations();
-
-    // 3. Initialize telemetry service and sync with feature settings
-    configService = new ConfigService();
-    // Wire the singleton into the agent-status route so delegation-violation
-    // requests never allocate a per-request ConfigService (issue #779).
-    // This must happen after configService is assigned (the IIFE is async so
-    // initAgentStatus at module eval time receives null).
-    setAgentStatusConfigService(configService);
-    const featureSettings = await configService.getFeatureSettings();
-    syncSettingsToServices(featureSettings);
-    await getTelemetryService().init();
-    await getPolicyService().waitForInit();
-
-    const storageType = getStorageTypeFromEnv();
-    if (storageType === 'sqlite') {
-      await initStorage('sqlite');
-      storageInitialized = true;
-      log.info('SQLite storage initialized');
-    }
-
-    // 4. Reconcile any agent attempts that were left in `running` state from
-    //    a previous server crash/restart (issue #781).
-    try {
-      await agentService.reconcileRunningAttempts();
-    } catch (reconcileErr) {
-      // Non-fatal: log and continue — the server can still serve requests.
-      log.warn({ err: reconcileErr }, 'Startup: agent attempt reconciliation failed');
-    }
-  } catch (err) {
-    log.fatal({ err }, 'Failed to initialize services — server cannot start safely');
-    process.exit(1);
+    backupPath = await createBackup(dataDir);
+  } catch (backupErr) {
+    log.warn({ err: backupErr }, 'Startup backup failed — continuing without backup');
   }
-})();
+
+  const integrityReport = await runIntegrityChecks(dataDir);
+  log.info(
+    {
+      backup: backupPath || '(skipped)',
+      filesChecked: integrityReport.filesChecked,
+      issues: integrityReport.issuesFound,
+      recovered: integrityReport.recoveredCount,
+    },
+    `Startup: backup ${backupPath ? 'created' : 'skipped'}, integrity: ${integrityReport.filesChecked} files checked, ${integrityReport.issuesFound} issues found`
+  );
+
+  // 2. Run data migrations (idempotent)
+  await runStartupMigrations();
+
+  // 3. Initialize telemetry service and sync with feature settings
+  configService = new ConfigService();
+  // Wire the singleton into the agent-status route so delegation-violation
+  // requests never allocate a per-request ConfigService (issue #779).
+  // This must happen after configService is assigned (the IIFE is async so
+  // initAgentStatus at module eval time receives null).
+  setAgentStatusConfigService(configService);
+  const featureSettings = await configService.getFeatureSettings();
+  syncSettingsToServices(featureSettings);
+  await getTelemetryService().init();
+  await getPolicyService().waitForInit();
+
+  const storageType = getStorageTypeFromEnv();
+  if (storageType === 'sqlite') {
+    await initStorage('sqlite');
+    storageInitialized = true;
+    log.info('SQLite storage initialized');
+  }
+
+  // 4. Reconcile any agent attempts that were left in `running` state from
+  //    a previous server crash/restart (issue #781).
+  try {
+    await agentService.reconcileRunningAttempts();
+  } catch (reconcileErr) {
+    // Non-fatal: log and continue — the server can still serve requests.
+    log.warn({ err: reconcileErr }, 'Startup: agent attempt reconciliation failed');
+  }
+}
 
 // Create HTTP server
 const server = createServer(app);
@@ -754,8 +750,7 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
   let currentEmitter: import('events').EventEmitter | null = null;
   let currentOutputHandler: ((output: AgentOutput) => void) | null = null;
   let currentCompleteHandler:
-    | ((result: { code: number; signal: string | null; status: string }) => void)
-    | null = null;
+    ((result: { code: number; signal: string | null; status: string }) => void) | null = null;
   let currentErrorHandler: ((error: Error) => void) | null = null;
 
   const cleanupEmitterListeners = () => {
@@ -1153,69 +1148,75 @@ async function gracefulShutdown(signal: string) {
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
-// Start server
-server.listen(Number(PORT), HOST, () => {
-  const authStatus = getAuthStatus();
-  const localhostInfo = authStatus.localhostBypass
-    ? `, localhost bypass [${authStatus.localhostRole}]`
-    : '';
-  const authLine = authStatus.enabled
-    ? `Auth: ON (${authStatus.configuredKeys} keys${localhostInfo})`
-    : 'Auth: OFF (dev mode)';
-  const corsLine = `CORS: ${ALLOWED_ORIGINS.length} origins`;
+function startServer(): void {
+  server.listen(Number(PORT), HOST, () => {
+    const authStatus = getAuthStatus();
+    const localhostInfo = authStatus.localhostBypass
+      ? `, localhost bypass [${authStatus.localhostRole}]`
+      : '';
+    const authLine = authStatus.enabled
+      ? `Auth: ON (${authStatus.configuredKeys} keys${localhostInfo})`
+      : 'Auth: OFF (dev mode)';
+    const corsLine = `CORS: ${ALLOWED_ORIGINS.length} origins`;
 
-  log.info(
-    {
-      port: PORT,
-      host: HOST || 'default',
-      api: `http://${HOST || 'localhost'}:${PORT}`,
-      ws: `ws://${HOST || 'localhost'}:${PORT}/ws`,
-      auth: authLine,
-      cors: corsLine,
-      helmet: true,
-      compression: true,
-      rateLimit: `${process.env.RATE_LIMIT_MAX || 300} req/min (localhost exempt)`,
-      bodyLimit: '1MB',
-    },
-    'Veritas Kanban Server started'
-  );
+    log.info(
+      {
+        port: PORT,
+        host: HOST || 'default',
+        api: `http://${HOST || 'localhost'}:${PORT}`,
+        ws: `ws://${HOST || 'localhost'}:${PORT}/ws`,
+        auth: authLine,
+        cors: corsLine,
+        helmet: true,
+        compression: true,
+        rateLimit: `${process.env.RATE_LIMIT_MAX || 300} req/min (localhost exempt)`,
+        bodyLimit: '1MB',
+      },
+      'Veritas Kanban Server started'
+    );
 
-  // Security warnings for localhost bypass
-  if (authStatus.localhostBypass) {
-    if (authStatus.localhostRole === 'admin') {
-      log.warn(
-        { localhostRole: 'admin' },
-        'Localhost bypass is active with ADMIN role — any local process has full access without authentication'
-      );
-    } else {
-      log.info(
-        { localhostRole: authStatus.localhostRole },
-        'Localhost bypass active — local connections can read data without authentication'
-      );
+    // Security warnings for localhost bypass
+    if (authStatus.localhostBypass) {
+      if (authStatus.localhostRole === 'admin') {
+        log.warn(
+          { localhostRole: 'admin' },
+          'Localhost bypass is active with ADMIN role — any local process has full access without authentication'
+        );
+      } else {
+        log.info(
+          { localhostRole: authStatus.localhostRole },
+          'Localhost bypass active — local connections can read data without authentication'
+        );
+      }
     }
-  }
 
-  // Security warnings for weak admin keys
-  const keyWarnings = checkAdminKeyStrength();
-  for (const warning of keyWarnings) {
-    if (warning.level === 'critical') {
-      log.warn({ security: 'admin-key' }, `⚠️  SECURITY: ${warning.message}`);
-    } else {
-      log.warn({ security: 'admin-key' }, warning.message);
+    // Security warnings for weak admin keys
+    const keyWarnings = checkAdminKeyStrength();
+    for (const warning of keyWarnings) {
+      if (warning.level === 'critical') {
+        log.warn({ security: 'admin-key' }, `⚠️  SECURITY: ${warning.message}`);
+      } else {
+        log.warn({ security: 'admin-key' }, warning.message);
+      }
     }
-  }
 
-  // Security warnings for JWT secret configuration
-  const jwtWarnings = checkJwtSecretConfig();
-  for (const warning of jwtWarnings) {
-    if (warning.level === 'critical') {
-      log.warn({ security: 'jwt-secret' }, `⚠️  SECURITY: ${warning.message}`);
-    } else if (warning.level === 'warning') {
-      log.warn({ security: 'jwt-secret' }, warning.message);
-    } else {
-      log.info({ security: 'jwt-secret' }, warning.message);
+    // Security warnings for JWT secret configuration
+    const jwtWarnings = checkJwtSecretConfig();
+    for (const warning of jwtWarnings) {
+      if (warning.level === 'critical') {
+        log.warn({ security: 'jwt-secret' }, `⚠️  SECURITY: ${warning.message}`);
+      } else if (warning.level === 'warning') {
+        log.warn({ security: 'jwt-secret' }, warning.message);
+      } else {
+        log.info({ security: 'jwt-secret' }, warning.message);
+      }
     }
-  }
 
-  startScheduledDeliverablesRunner();
+    startScheduledDeliverablesRunner();
+  });
+}
+
+void startAfterInitialization(initializeServices, startServer).catch((err) => {
+  log.fatal({ err }, 'Failed to initialize services — server cannot start safely');
+  process.exit(1);
 });

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import { createLogger } from '../lib/logger.js';
 import { authenticate, authorize } from '../middleware/auth.js';
 import { getAllStatus as getCircuitBreakerStatus } from '../services/circuit-registry.js';
+import { getSqliteStorageDiagnostics } from '../storage/sqlite/database.js';
 import type { WebSocketServer } from 'ws';
 
 const log = createLogger('health');
@@ -275,6 +276,7 @@ async function buildDeepHealthPayload() {
     },
     wsConnections,
     circuitBreakers,
+    sqlite: getSqliteStorageDiagnostics(),
     node: {
       version: process.version,
       platform: process.platform,

--- a/server/src/services/maintenance-service.ts
+++ b/server/src/services/maintenance-service.ts
@@ -25,6 +25,7 @@ import {
   getWorktreesDir,
 } from '../utils/paths.js';
 import { redactString } from '../lib/redact.js';
+import { getSqliteStorageDiagnostics } from '../storage/sqlite/database.js';
 
 interface DirectoryStats {
   bytes: number;
@@ -62,6 +63,7 @@ const MAINTENANCE_CONTENT_REDACTIONS: [RegExp, string][] = [
 export class MaintenanceService {
   async buildSummary(): Promise<MaintenanceSummary> {
     const generatedAt = new Date().toISOString();
+    const sqlite = getSqliteStorageDiagnostics();
     const workProducts = await getWorkProductService().maintenancePreview();
     const [
       storageRoot,
@@ -182,6 +184,7 @@ export class MaintenanceService {
       generatedAt,
       mode: process.env.VERITAS_REMOTE_MODE === 'true' ? 'remote' : 'local',
       storageMode: process.env.VERITAS_STORAGE ?? 'file',
+      ...(sqlite ? { sqlite } : {}),
       health: await this.buildHealthChecks(generatedAt),
       storage: {
         totalBytes: storageRoot.bytes,
@@ -322,6 +325,8 @@ export class MaintenanceService {
       .catch(() => null);
     const agentState = this.signalState(systemHealth?.signals.agents.status);
     const operationsState = this.signalState(systemHealth?.signals.operations.status);
+    const sqlite = getSqliteStorageDiagnostics();
+    const sqliteEnabled = process.env.VERITAS_STORAGE === 'sqlite';
 
     return [
       {
@@ -384,6 +389,26 @@ export class MaintenanceService {
         detail: 'Data lifecycle policy is loaded for cleanup previews.',
         checkedAt,
       },
+      ...(sqliteEnabled
+        ? [
+            {
+              id: 'sqlite-posture',
+              label: 'SQLite storage posture',
+              state:
+                sqlite?.filesystemPosture === 'supported-local' &&
+                sqlite.journalMode === 'wal' &&
+                sqlite.lastIntegrityCheck?.status === 'ok'
+                  ? ('ok' as const)
+                  : sqlite
+                    ? ('fail' as const)
+                    : ('unknown' as const),
+              detail: sqlite
+                ? `${sqlite.filesystemType} is ${sqlite.filesystemPosture}; journal mode is ${sqlite.journalMode}; last quick check is ${sqlite.lastIntegrityCheck?.status ?? 'unavailable'}.`
+                : 'SQLite filesystem posture is unavailable.',
+              checkedAt,
+            },
+          ]
+        : []),
     ];
   }
 

--- a/server/src/storage/sqlite/database.test.ts
+++ b/server/src/storage/sqlite/database.test.ts
@@ -1,0 +1,193 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getSqliteStorageDiagnostics,
+  resetSqliteStorageDiagnosticsForTests,
+  SqliteDatabase,
+  SqliteFilesystemSafetyError,
+  SqliteJournalModeMaintenanceError,
+} from './database.js';
+import type { SqliteFilesystemDecision } from './filesystem-posture.js';
+
+const roots: string[] = [];
+
+function tempDatabasePath(name = 'veritas-test.db'): string {
+  const root = mkdtempSync(join(tmpdir(), 'veritas-sqlite-posture-'));
+  roots.push(root);
+  return join(root, name);
+}
+
+function filesystemDecision(
+  posture: SqliteFilesystemDecision['posture'],
+  filesystemType = posture === 'supported-local' ? 'apfs' : 'nfs'
+): SqliteFilesystemDecision {
+  return {
+    platform: 'darwin',
+    filesystemType,
+    posture,
+    detectionSource: 'test-fixture',
+    reasonCode: `${posture}-fixture`,
+  };
+}
+
+afterEach(() => {
+  resetSqliteStorageDiagnosticsForTests();
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('SqliteDatabase filesystem and journal posture', () => {
+  it.each([filesystemDecision('known-unsafe', 'nfs'), filesystemDecision('unknown', 'mysteryfs')])(
+    'refuses $posture posture before creating the database',
+    (decision) => {
+      const databasePath = tempDatabasePath();
+      const database = new SqliteDatabase({
+        databasePath,
+        filesystemClassifier: () => decision,
+      });
+
+      expect(() => database.open()).toThrow(SqliteFilesystemSafetyError);
+      expect(existsSync(databasePath)).toBe(false);
+      expect(existsSync(`${databasePath}-wal`)).toBe(false);
+      expect(existsSync(`${databasePath}-shm`)).toBe(false);
+      expect(getSqliteStorageDiagnostics(databasePath)).toMatchObject({
+        filesystemPosture: decision.posture,
+        filesystemType: decision.filesystemType,
+        journalMode: 'refused',
+      });
+    }
+  );
+
+  it('refuses a database-file symlink before classification or SQLite open', () => {
+    const targetPath = tempDatabasePath('remote-target.db');
+    const databasePath = tempDatabasePath('configured-link.db');
+    symlinkSync(targetPath, databasePath);
+    const classifier = vi.fn(() => filesystemDecision('supported-local'));
+    const database = new SqliteDatabase({ databasePath, filesystemClassifier: classifier });
+
+    expect(() => database.open()).toThrow(SqliteFilesystemSafetyError);
+    expect(classifier).not.toHaveBeenCalled();
+    expect(existsSync(targetPath)).toBe(false);
+    expect(existsSync(`${targetPath}-wal`)).toBe(false);
+    expect(existsSync(`${targetPath}-shm`)).toBe(false);
+    expect(getSqliteStorageDiagnostics(databasePath)).toMatchObject({
+      filesystemPosture: 'unknown',
+      filesystemType: 'symlink',
+      detectionSource: 'database-path',
+      reasonCode: 'database-file-symlink',
+      journalMode: 'refused',
+    });
+  });
+
+  it('creates a new database in WAL mode and records a quick check', () => {
+    const databasePath = tempDatabasePath();
+    const database = new SqliteDatabase({
+      databasePath,
+      applyMigrations: false,
+      filesystemClassifier: () => filesystemDecision('supported-local'),
+    });
+
+    const connection = database.open();
+    expect(
+      (connection.prepare('PRAGMA journal_mode;').get() as { journal_mode: string }).journal_mode
+    ).toBe('wal');
+    expect(getSqliteStorageDiagnostics(databasePath)).toMatchObject({
+      filesystemPosture: 'supported-local',
+      journalMode: 'wal',
+      overrideSource: null,
+      lastIntegrityCheck: { status: 'ok', result: 'ok' },
+    });
+    database.close();
+  });
+
+  it('bypasses filesystem classification for memory databases', () => {
+    const classifier = vi.fn(() => filesystemDecision('known-unsafe'));
+    const database = new SqliteDatabase({
+      databasePath: ':memory:',
+      applyMigrations: false,
+      filesystemClassifier: classifier,
+    });
+
+    database.open();
+    expect(classifier).not.toHaveBeenCalled();
+    expect(getSqliteStorageDiagnostics(':memory:')).toMatchObject({
+      filesystemPosture: 'not-applicable',
+      journalMode: 'memory',
+    });
+    database.close();
+  });
+
+  it('refuses to convert an existing rollback-journal database during startup', () => {
+    const databasePath = tempDatabasePath();
+    const raw = new DatabaseSync(databasePath);
+    raw.exec('CREATE TABLE sample (id TEXT PRIMARY KEY);');
+    raw.close();
+
+    expect(readFileSync(databasePath)[18]).toBe(1);
+    const database = new SqliteDatabase({
+      databasePath,
+      applyMigrations: false,
+      filesystemClassifier: () => filesystemDecision('supported-local'),
+    });
+    expect(() => database.open()).toThrow(SqliteJournalModeMaintenanceError);
+  });
+
+  it('opens an existing WAL database without changing its journal posture', () => {
+    const databasePath = tempDatabasePath();
+    const raw = new DatabaseSync(databasePath);
+    raw.exec('PRAGMA journal_mode = WAL; CREATE TABLE sample (id TEXT PRIMARY KEY);');
+    raw.close();
+
+    expect(readFileSync(databasePath)[18]).toBe(2);
+    const database = new SqliteDatabase({
+      databasePath,
+      applyMigrations: false,
+      filesystemClassifier: () => filesystemDecision('supported-local'),
+    });
+    const connection = database.open();
+    expect(
+      connection.prepare('SELECT name FROM sqlite_master WHERE name = ?').get('sample')
+    ).toEqual({ name: 'sample' });
+    database.close();
+  });
+
+  it('refuses unrecognized existing files instead of opening or converting them', () => {
+    const databasePath = tempDatabasePath('private-token-name.db');
+    writeFileSync(databasePath, 'not sqlite');
+    const database = new SqliteDatabase({
+      databasePath,
+      applyMigrations: false,
+      filesystemClassifier: () => filesystemDecision('supported-local'),
+    });
+
+    try {
+      database.open();
+      expect.fail('Expected unrecognized SQLite file refusal');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SqliteJournalModeMaintenanceError);
+      expect((error as Error).message).not.toContain(databasePath);
+      expect((error as Error).message).not.toContain('private-token-name.db');
+    }
+  });
+
+  it('does not expose the database path in filesystem safety errors', () => {
+    const databasePath = tempDatabasePath('secret-customer-name.db');
+    const database = new SqliteDatabase({
+      databasePath,
+      filesystemClassifier: () => filesystemDecision('known-unsafe', 'nfs'),
+    });
+
+    try {
+      database.open();
+      expect.fail('Expected unsafe filesystem refusal');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SqliteFilesystemSafetyError);
+      expect((error as Error).message).not.toContain(databasePath);
+      expect((error as Error).message).not.toContain('secret-customer-name.db');
+    }
+  });
+});

--- a/server/src/storage/sqlite/database.ts
+++ b/server/src/storage/sqlite/database.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'crypto';
-import { mkdirSync } from 'fs';
+import { closeSync, existsSync, lstatSync, mkdirSync, openSync, readSync, statSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { DatabaseSync } from 'node:sqlite';
+import type { SqliteStorageDiagnostics } from '@veritas-kanban/shared';
 import { getRuntimeDir } from '../../utils/paths.js';
 import { SQLITE_BASE_MIGRATIONS, sortedMigrations, type SqliteMigration } from './migrations.js';
+import { detectSqliteFilesystem, type SqliteFilesystemDecision } from './filesystem-posture.js';
 
 export const DEFAULT_SQLITE_FILENAME = 'veritas.db';
 
@@ -11,6 +13,7 @@ export interface SqliteConnectionOptions {
   databasePath?: string;
   migrations?: readonly SqliteMigration[];
   applyMigrations?: boolean;
+  filesystemClassifier?: (directoryPath: string) => SqliteFilesystemDecision;
 }
 
 interface AppliedMigrationRow {
@@ -21,6 +24,31 @@ interface AppliedMigrationRow {
 
 interface UserVersionRow {
   user_version: number;
+}
+
+interface JournalModeRow {
+  journal_mode?: string;
+}
+
+type ExistingSqliteJournalPosture = 'new' | 'wal' | 'rollback' | 'unrecognized';
+
+const SQLITE_HEADER = 'SQLite format 3\u0000';
+const sqliteDiagnostics = new Map<string, SqliteStorageDiagnostics>();
+
+function cloneDiagnostics(
+  diagnostics: SqliteStorageDiagnostics | undefined
+): SqliteStorageDiagnostics | undefined {
+  return diagnostics ? structuredClone(diagnostics) : undefined;
+}
+
+export function getSqliteStorageDiagnostics(
+  databasePath?: string
+): SqliteStorageDiagnostics | undefined {
+  return cloneDiagnostics(sqliteDiagnostics.get(resolveSqliteDatabasePath(databasePath)));
+}
+
+export function resetSqliteStorageDiagnosticsForTests(): void {
+  sqliteDiagnostics.clear();
 }
 
 export class UnsupportedSqliteSchemaError extends Error {
@@ -42,6 +70,32 @@ export class UnsupportedSqliteSchemaError extends Error {
     this.appliedVersion = input.appliedVersion;
     this.maxSupportedVersion = input.maxSupportedVersion;
     this.migrationName = input.migrationName;
+  }
+}
+
+export class SqliteFilesystemSafetyError extends Error {
+  readonly code = 'SQLITE_FILESYSTEM_UNSAFE';
+  readonly diagnostics: SqliteStorageDiagnostics;
+
+  constructor(diagnostics: SqliteStorageDiagnostics) {
+    const posture =
+      diagnostics.filesystemPosture === 'known-unsafe' ? 'known unsafe' : 'unverified';
+    super(
+      `Refusing to open the authoritative SQLite database on ${posture} filesystem type "${diagnostics.filesystemType}" because WAL locking and shared-memory safety cannot be established without risking corruption. Move VERITAS_SQLITE_PATH to local durable storage and use governed backup/export for remote storage.`
+    );
+    this.name = 'SqliteFilesystemSafetyError';
+    this.diagnostics = structuredClone(diagnostics);
+  }
+}
+
+export class SqliteJournalModeMaintenanceError extends Error {
+  readonly code = 'SQLITE_JOURNAL_MODE_MAINTENANCE_REQUIRED';
+
+  constructor(posture: ExistingSqliteJournalPosture) {
+    super(
+      `Refusing to change journal mode automatically for the authoritative SQLite database (${posture}). Use the governed offline journal-mode maintenance workflow before startup.`
+    );
+    this.name = 'SqliteJournalModeMaintenanceError';
   }
 }
 
@@ -69,11 +123,20 @@ export class SqliteDatabase {
   private db: DatabaseSync | null = null;
   private readonly migrations: readonly SqliteMigration[];
   private readonly applyMigrations: boolean;
+  private readonly filesystemClassifier: (directoryPath: string) => SqliteFilesystemDecision;
+  private readonly databaseLocation: SqliteStorageDiagnostics['databaseLocation'];
 
   constructor(options: SqliteConnectionOptions = {}) {
     this.databasePath = resolveSqliteDatabasePath(options.databasePath);
     this.migrations = options.migrations ?? SQLITE_BASE_MIGRATIONS;
     this.applyMigrations = options.applyMigrations ?? true;
+    this.filesystemClassifier = options.filesystemClassifier ?? detectSqliteFilesystem;
+    this.databaseLocation =
+      this.databasePath === ':memory:'
+        ? 'memory'
+        : options.databasePath || process.env.VERITAS_SQLITE_PATH
+          ? 'configured'
+          : 'runtime-default';
   }
 
   open(): DatabaseSync {
@@ -81,18 +144,74 @@ export class SqliteDatabase {
       return this.db;
     }
 
-    if (!this.isMemoryDatabase()) {
-      mkdirSync(dirname(this.databasePath), { recursive: true });
+    let existingJournalPosture: ExistingSqliteJournalPosture = 'new';
+
+    if (this.isMemoryDatabase()) {
+      sqliteDiagnostics.set(this.databasePath, {
+        schemaVersion: 'sqlite-storage/v1',
+        databaseLocation: 'memory',
+        platform: process.platform,
+        filesystemType: 'memory',
+        filesystemPosture: 'not-applicable',
+        detectionSource: 'memory',
+        reasonCode: 'memory-database',
+        journalMode: 'memory',
+        decisionSource: 'memory',
+        overrideSource: null,
+      });
+    } else {
+      const databaseDirectory = dirname(this.databasePath);
+      mkdirSync(databaseDirectory, { recursive: true });
+      const filesystem =
+        inspectDatabaseFilePath(this.databasePath) ?? this.filesystemClassifier(databaseDirectory);
+      const priorIntegrity = sqliteDiagnostics.get(this.databasePath)?.lastIntegrityCheck;
+      const diagnostics: SqliteStorageDiagnostics = {
+        schemaVersion: 'sqlite-storage/v1',
+        databaseLocation: this.databaseLocation,
+        platform: filesystem.platform,
+        filesystemType: filesystem.filesystemType,
+        filesystemPosture: filesystem.posture,
+        detectionSource: filesystem.detectionSource,
+        reasonCode: filesystem.reasonCode,
+        journalMode: filesystem.posture === 'supported-local' ? 'unknown' : 'refused',
+        decisionSource: 'automatic',
+        overrideSource: null,
+        lastIntegrityCheck: priorIntegrity,
+      };
+      sqliteDiagnostics.set(this.databasePath, diagnostics);
+
+      if (filesystem.posture !== 'supported-local') {
+        throw new SqliteFilesystemSafetyError(diagnostics);
+      }
+
+      existingJournalPosture = inspectExistingSqliteJournalPosture(this.databasePath);
+      if (existingJournalPosture === 'rollback' || existingJournalPosture === 'unrecognized') {
+        throw new SqliteJournalModeMaintenanceError(existingJournalPosture);
+      }
     }
 
-    this.db = new DatabaseSync(this.databasePath);
-    this.applyPragmas();
+    try {
+      this.db = new DatabaseSync(this.databasePath);
+      this.applyPragmas(existingJournalPosture);
+    } catch (error) {
+      this.closeAfterStartupFailure();
+      throw error;
+    }
 
+    // Preserve the established migration-failure contract: callers may inspect
+    // the still-open connection to verify that the migration transaction rolled
+    // back cleanly before deciding whether to close or retry.
     if (this.applyMigrations) {
       this.runMigrations();
     }
 
-    return this.db;
+    try {
+      this.verifyIntegrityOnce();
+      return this.db;
+    } catch (error) {
+      this.closeAfterStartupFailure();
+      throw error;
+    }
   }
 
   getConnection(): DatabaseSync {
@@ -151,14 +270,66 @@ export class SqliteDatabase {
     this.db = null;
   }
 
-  private applyPragmas(): void {
+  private applyPragmas(existingJournalPosture: ExistingSqliteJournalPosture): void {
     const db = this.getConnection();
     db.exec('PRAGMA foreign_keys = ON;');
     db.exec('PRAGMA busy_timeout = 5000;');
 
     if (!this.isMemoryDatabase()) {
-      db.exec('PRAGMA journal_mode = WAL;');
+      const row =
+        existingJournalPosture === 'new'
+          ? (db.prepare('PRAGMA journal_mode = WAL;').get() as JournalModeRow | undefined)
+          : (db.prepare('PRAGMA journal_mode;').get() as JournalModeRow | undefined);
+      const journalMode = row?.journal_mode?.toLowerCase();
+      if (journalMode !== 'wal') {
+        throw new Error(
+          `SQLite refused required WAL journal mode (reported ${journalMode ?? 'unknown'})`
+        );
+      }
+
+      const diagnostics = sqliteDiagnostics.get(this.databasePath);
+      if (diagnostics) {
+        sqliteDiagnostics.set(this.databasePath, { ...diagnostics, journalMode: 'wal' });
+      }
     }
+  }
+
+  private verifyIntegrityOnce(): void {
+    if (this.isMemoryDatabase()) return;
+
+    const diagnostics = sqliteDiagnostics.get(this.databasePath);
+    if (diagnostics?.lastIntegrityCheck?.status === 'ok') return;
+
+    const checkedAt = new Date().toISOString();
+    const rows = this.getConnection().prepare('PRAGMA quick_check;').all() as Array<
+      Record<string, unknown>
+    >;
+    const messages = rows
+      .flatMap((row) => Object.values(row))
+      .map(String)
+      .filter(Boolean);
+    const ok = messages.length === 1 && messages[0].toLowerCase() === 'ok';
+    const result = (messages.join('; ') || 'no result').slice(0, 240);
+
+    if (diagnostics) {
+      sqliteDiagnostics.set(this.databasePath, {
+        ...diagnostics,
+        lastIntegrityCheck: { checkedAt, status: ok ? 'ok' : 'failed', result },
+      });
+    }
+
+    if (!ok) {
+      throw new Error(`SQLite quick_check failed: ${result}`);
+    }
+  }
+
+  private closeAfterStartupFailure(): void {
+    try {
+      this.db?.close();
+    } catch {
+      // Preserve the actionable startup error.
+    }
+    this.db = null;
   }
 
   private ensureSchemaMigrationsTable(): void {
@@ -191,8 +362,7 @@ export class SqliteDatabase {
 
   private assertSupportedUserVersion(maxSupportedVersion: number): void {
     const row = this.getConnection().prepare('PRAGMA user_version;').get() as unknown as
-      | UserVersionRow
-      | undefined;
+      UserVersionRow | undefined;
     const rawUserVersion = row?.user_version;
     const userVersion =
       typeof rawUserVersion === 'number' && Number.isInteger(rawUserVersion) ? rawUserVersion : 0;
@@ -266,5 +436,50 @@ export class SqliteDatabase {
 
   private isMemoryDatabase(): boolean {
     return this.databasePath === ':memory:';
+  }
+}
+
+function inspectExistingSqliteJournalPosture(databasePath: string): ExistingSqliteJournalPosture {
+  if (!existsSync(databasePath) || statSync(databasePath).size === 0) {
+    return 'new';
+  }
+
+  const header = Buffer.alloc(20);
+  const file = openSync(databasePath, 'r');
+  try {
+    const bytesRead = readSync(file, header, 0, header.length, 0);
+    if (bytesRead < header.length || header.subarray(0, 16).toString('utf8') !== SQLITE_HEADER) {
+      return 'unrecognized';
+    }
+
+    const writeVersion = header[18];
+    const readVersion = header[19];
+    if (writeVersion === 2 && readVersion === 2) return 'wal';
+    if (writeVersion === 1 && readVersion === 1) return 'rollback';
+    return 'unrecognized';
+  } finally {
+    closeSync(file);
+  }
+}
+
+function inspectDatabaseFilePath(databasePath: string): SqliteFilesystemDecision | undefined {
+  try {
+    if (!lstatSync(databasePath).isSymbolicLink()) return undefined;
+    return {
+      platform: process.platform,
+      filesystemType: 'symlink',
+      posture: 'unknown',
+      detectionSource: 'database-path',
+      reasonCode: 'database-file-symlink',
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    return {
+      platform: process.platform,
+      filesystemType: 'unknown',
+      posture: 'unknown',
+      detectionSource: 'database-path',
+      reasonCode: 'database-path-inspection-failed',
+    };
   }
 }

--- a/server/src/storage/sqlite/filesystem-posture.test.ts
+++ b/server/src/storage/sqlite/filesystem-posture.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  classifyFilesystemType,
+  decodeMountPath,
+  detectSqliteFilesystem,
+  parseDarwinMountOutput,
+  parseLinuxMountInfo,
+  parseWindowsVolumeProbe,
+} from './filesystem-posture.js';
+
+describe('SQLite filesystem posture', () => {
+  it('classifies supported local and known unsafe filesystem types', () => {
+    expect(classifyFilesystemType('linux', 'ext4').posture).toBe('supported-local');
+    expect(classifyFilesystemType('darwin', 'apfs').posture).toBe('supported-local');
+    expect(classifyFilesystemType('linux', 'nfs4').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('linux', 'cifs').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('linux', 'fuse.sshfs').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('linux', 'fuseblk').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('linux', 'fuse-overlayfs').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('darwin', 'macfuse').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('linux', '9p').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('linux', 'tmpfs')).toEqual({
+      posture: 'known-unsafe',
+      reasonCode: 'volatile-filesystem',
+    });
+    expect(classifyFilesystemType('linux', 'ramfs').posture).toBe('known-unsafe');
+    expect(classifyFilesystemType('linux', 'overlay').posture).toBe('unknown');
+    expect(classifyFilesystemType('darwin', 'mysteryfs').posture).toBe('unknown');
+  });
+
+  it('selects the longest matching Linux mount and decodes escaped paths', () => {
+    const mountInfo = [
+      '36 25 0:32 / / rw,relatime - overlay overlay rw',
+      '41 36 0:40 / /mnt/team\\040share rw,relatime - nfs4 server:/share rw',
+    ].join('\n');
+
+    expect(decodeMountPath('/mnt/team\\040share')).toBe('/mnt/team share');
+    expect(parseLinuxMountInfo(mountInfo, '/mnt/team share/project')).toEqual({
+      mountPoint: '/mnt/team share',
+      filesystemType: 'nfs4',
+    });
+    expect(parseLinuxMountInfo(mountInfo, '/workspace/project')).toEqual({
+      mountPoint: '/',
+      filesystemType: 'overlay',
+    });
+  });
+
+  it('classifies Linux mount table evidence and fails unknown on probe errors', () => {
+    const supported = detectSqliteFilesystem('/data', {
+      platform: 'linux',
+      realpath: (value) => value,
+      readTextFile: () => '36 25 0:32 / / rw,relatime - ext4 /dev/sda1 rw',
+    });
+    expect(supported).toMatchObject({
+      posture: 'supported-local',
+      filesystemType: 'ext4',
+      detectionSource: 'linux-mountinfo',
+    });
+
+    const failed = detectSqliteFilesystem('/data', {
+      platform: 'linux',
+      realpath: (value) => value,
+      readTextFile: () => {
+        throw new Error('unavailable');
+      },
+    });
+    expect(failed).toMatchObject({
+      posture: 'unknown',
+      reasonCode: 'filesystem-probe-failed',
+    });
+  });
+
+  it('selects the longest matching macOS mount and detects remote filesystems', () => {
+    const mounts = [
+      '/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)',
+      'server:/share on /Volumes/Team (nfs, nodev, nosuid)',
+      '//server/share on /Volumes/SMB (smbfs, nodev, nosuid)',
+      'macfuse on /Volumes/Fuse (fusefs, nodev)',
+    ].join('\n');
+
+    expect(parseDarwinMountOutput(mounts, '/Volumes/Team/project')).toMatchObject({
+      mountPoint: '/Volumes/Team',
+      filesystemType: 'nfs',
+      local: false,
+    });
+    expect(parseDarwinMountOutput(mounts, '/Users/test')).toMatchObject({
+      mountPoint: '/',
+      filesystemType: 'apfs',
+      local: true,
+    });
+
+    for (const targetPath of ['/Volumes/Team/project', '/Volumes/SMB/db', '/Volumes/Fuse/db']) {
+      expect(
+        detectSqliteFilesystem(targetPath, {
+          platform: 'darwin',
+          realpath: (value) => value,
+          runCommand: () => mounts,
+        }).posture
+      ).toBe('known-unsafe');
+    }
+  });
+
+  it('accepts only fixed NTFS/ReFS Windows volumes and selects folder mount points', () => {
+    const volumes = JSON.stringify([
+      { accessPath: 'C:\\', driveType: 'Fixed', filesystemType: 'NTFS' },
+      { accessPath: 'C:\\data\\mounted\\', driveType: 'Fixed', filesystemType: 'ReFS' },
+      { accessPath: 'R:\\', driveType: 'Remote', filesystemType: 'NTFS' },
+      { accessPath: 'M:\\', driveType: 'Removable', filesystemType: 'exFAT' },
+      { accessPath: 'T:\\', driveType: 'RAMDisk', filesystemType: 'NTFS' },
+    ]);
+
+    expect(parseWindowsVolumeProbe(volumes, 'C:\\data\\mounted\\project')).toMatchObject({
+      accessPath: 'C:\\data\\mounted\\',
+      filesystemType: 'refs',
+    });
+
+    const fixed = detectSqliteFilesystem('C:\\data', {
+      platform: 'win32',
+      realpath: (value) => value,
+      runCommand: () => volumes,
+    });
+    expect(fixed).toMatchObject({
+      posture: 'supported-local',
+      filesystemType: 'ntfs',
+      detectionSource: 'windows-volume-probe',
+      reasonCode: 'supported-local-filesystem',
+    });
+
+    expect(
+      detectSqliteFilesystem('C:\\data\\mounted\\project', {
+        platform: 'win32',
+        realpath: (value) => value,
+        runCommand: () => volumes,
+      })
+    ).toMatchObject({ posture: 'supported-local', filesystemType: 'refs' });
+
+    expect(
+      detectSqliteFilesystem('M:\\data', {
+        platform: 'win32',
+        realpath: (value) => value,
+        runCommand: () => volumes,
+      }).posture
+    ).toBe('unknown');
+    expect(
+      detectSqliteFilesystem('T:\\data', {
+        platform: 'win32',
+        realpath: (value) => value,
+        runCommand: () => volumes,
+      })
+    ).toMatchObject({ posture: 'known-unsafe', reasonCode: 'volatile-filesystem' });
+  });
+
+  it('rejects Windows network paths and fails closed when volume evidence is unavailable', () => {
+    const runCommand = vi.fn(() => {
+      throw new Error('Network paths should not invoke the volume probe');
+    });
+
+    const remote = detectSqliteFilesystem('\\\\server\\share\\data', {
+      platform: 'win32',
+      realpath: (value) => value,
+      runCommand,
+    });
+    expect(remote).toMatchObject({
+      posture: 'known-unsafe',
+      reasonCode: 'windows-network-path',
+    });
+
+    const extendedRemote = detectSqliteFilesystem('\\\\?\\UNC\\server\\share\\data', {
+      platform: 'win32',
+      realpath: (value) => value,
+      runCommand,
+    });
+    expect(extendedRemote.posture).toBe('known-unsafe');
+    expect(runCommand).not.toHaveBeenCalled();
+
+    const extendedLocal = detectSqliteFilesystem('\\\\?\\C:\\data', {
+      platform: 'win32',
+      realpath: (value) => value,
+      runCommand: () =>
+        JSON.stringify({ accessPath: 'C:\\', driveType: 'Fixed', filesystemType: 'NTFS' }),
+    });
+    expect(extendedLocal).toMatchObject({
+      posture: 'supported-local',
+      filesystemType: 'ntfs',
+    });
+
+    expect(
+      detectSqliteFilesystem('C:\\data', {
+        platform: 'win32',
+        realpath: (value) => value,
+        runCommand: () => 'not-json',
+      })
+    ).toMatchObject({
+      posture: 'unknown',
+      reasonCode: 'filesystem-probe-failed',
+    });
+  });
+
+  it('requires the macOS local mount signal for APFS and HFS', () => {
+    const withoutLocal = '/dev/disk3s1 on /Volumes/Data (apfs, journaled)';
+    const withLocal = '/dev/disk3s1 on /Volumes/Data (apfs, local, journaled)';
+
+    expect(
+      detectSqliteFilesystem('/Volumes/Data/project', {
+        platform: 'darwin',
+        realpath: (value) => value,
+        runCommand: () => withoutLocal,
+      })
+    ).toMatchObject({ posture: 'unknown', reasonCode: 'darwin-local-signal-missing' });
+    expect(
+      detectSqliteFilesystem('/Volumes/Data/project', {
+        platform: 'darwin',
+        realpath: (value) => value,
+        runCommand: () => withLocal,
+      }).posture
+    ).toBe('supported-local');
+  });
+
+  it('returns explicit unknown posture for unsupported platforms and realpath failures', () => {
+    expect(
+      detectSqliteFilesystem('/data', {
+        platform: 'aix',
+        realpath: (value) => value,
+      })
+    ).toMatchObject({ posture: 'unknown', reasonCode: 'unsupported-platform' });
+
+    expect(
+      detectSqliteFilesystem('/data', {
+        platform: 'linux',
+        realpath: () => {
+          throw new Error('no path');
+        },
+      })
+    ).toMatchObject({ posture: 'unknown', reasonCode: 'filesystem-realpath-failed' });
+  });
+});

--- a/server/src/storage/sqlite/filesystem-posture.ts
+++ b/server/src/storage/sqlite/filesystem-posture.ts
@@ -1,0 +1,399 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+import type { SqliteFilesystemPosture } from '@veritas-kanban/shared';
+
+export interface SqliteFilesystemDecision {
+  platform: string;
+  filesystemType: string;
+  posture: Exclude<SqliteFilesystemPosture, 'not-applicable'>;
+  detectionSource: string;
+  reasonCode: string;
+}
+
+interface MountedFilesystem {
+  mountPoint: string;
+  filesystemType: string;
+  local?: boolean;
+}
+
+export interface WindowsVolume {
+  accessPath: string;
+  driveType: string;
+  filesystemType: string;
+}
+
+export interface SqliteFilesystemDetectionDependencies {
+  platform?: NodeJS.Platform;
+  realpath?: (targetPath: string) => string;
+  readTextFile?: (targetPath: string) => string;
+  runCommand?: (command: string, args: string[]) => string;
+}
+
+const LINUX_SUPPORTED_LOCAL = new Set([
+  'btrfs',
+  'ext2',
+  'ext3',
+  'ext4',
+  'f2fs',
+  'jfs',
+  'xfs',
+  'zfs',
+]);
+
+const DARWIN_SUPPORTED_LOCAL = new Set(['apfs', 'hfs']);
+const KNOWN_VOLATILE = new Set(['ramfs', 'tmpfs']);
+const WINDOWS_SUPPORTED_LOCAL = new Set(['ntfs', 'refs']);
+
+const WINDOWS_VOLUME_PROBE = String.raw`
+$records = @()
+Get-Partition -ErrorAction SilentlyContinue | ForEach-Object {
+  $volume = $_ | Get-Volume -ErrorAction SilentlyContinue
+  if ($null -ne $volume) {
+    foreach ($accessPath in $_.AccessPaths) {
+      $records += [pscustomobject]@{
+        accessPath = $accessPath
+        driveType = [string]$volume.DriveType
+        filesystemType = [string]$volume.FileSystem
+      }
+    }
+  }
+}
+Get-CimInstance Win32_LogicalDisk -ErrorAction SilentlyContinue | ForEach-Object {
+  $driveType = switch ($_.DriveType) {
+    2 { 'Removable' }
+    3 { 'Fixed' }
+    4 { 'Remote' }
+    6 { 'RAMDisk' }
+    default { 'Unknown' }
+  }
+  $records += [pscustomobject]@{
+    accessPath = "$($_.DeviceID)\"
+    driveType = $driveType
+    filesystemType = [string]$_.FileSystem
+  }
+}
+$records | ConvertTo-Json -Compress
+`;
+
+const KNOWN_UNSAFE = new Set([
+  '9p',
+  'afs',
+  'afpfs',
+  'ceph',
+  'cifs',
+  'coda',
+  'davfs',
+  'drvfs',
+  'glusterfs',
+  'gpfs',
+  'lustre',
+  'nfs',
+  'nfs4',
+  'osxfuse',
+  'remote',
+  'smb2',
+  'smb3',
+  'smbfs',
+  'virtiofs',
+  'webdav',
+]);
+
+function normalizeFilesystemType(filesystemType: string): string {
+  return filesystemType.trim().toLowerCase() || 'unknown';
+}
+
+export function classifyFilesystemType(
+  platform: string,
+  filesystemType: string
+): Pick<SqliteFilesystemDecision, 'posture' | 'reasonCode'> {
+  const normalized = normalizeFilesystemType(filesystemType);
+
+  if (
+    normalized === 'fuse' ||
+    normalized === 'fuseblk' ||
+    normalized === 'fusefs' ||
+    normalized === 'macfuse' ||
+    normalized.startsWith('fuse.') ||
+    normalized.startsWith('fuse-')
+  ) {
+    return { posture: 'known-unsafe', reasonCode: 'fuse-filesystem' };
+  }
+
+  if (KNOWN_VOLATILE.has(normalized)) {
+    return { posture: 'known-unsafe', reasonCode: 'volatile-filesystem' };
+  }
+
+  if (KNOWN_UNSAFE.has(normalized)) {
+    return { posture: 'known-unsafe', reasonCode: 'known-remote-filesystem' };
+  }
+
+  const supported =
+    (platform === 'linux' && LINUX_SUPPORTED_LOCAL.has(normalized)) ||
+    (platform === 'darwin' && DARWIN_SUPPORTED_LOCAL.has(normalized));
+
+  if (supported) {
+    return { posture: 'supported-local', reasonCode: 'supported-local-filesystem' };
+  }
+
+  return { posture: 'unknown', reasonCode: 'unrecognized-filesystem' };
+}
+
+export function decodeMountPath(value: string): string {
+  const replacements: Record<string, string> = {
+    '011': '\t',
+    '012': '\n',
+    '040': ' ',
+    '134': '\\',
+  };
+
+  return value.replace(/\\(011|012|040|134)/g, (_match, code: string) => replacements[code]);
+}
+
+function normalizeMountPoint(mountPoint: string): string {
+  const normalized = path.normalize(mountPoint);
+  return normalized === path.parse(normalized).root
+    ? normalized
+    : normalized.replace(/[\\/]+$/, '');
+}
+
+function isWithinMount(targetPath: string, mountPoint: string): boolean {
+  const target = path.normalize(targetPath);
+  const mount = normalizeMountPoint(mountPoint);
+  const root = path.parse(mount).root;
+
+  if (mount === root) {
+    return target.startsWith(root);
+  }
+
+  return target === mount || target.startsWith(`${mount}${path.sep}`);
+}
+
+function selectMountedFilesystem(
+  entries: MountedFilesystem[],
+  targetPath: string
+): MountedFilesystem | undefined {
+  return entries
+    .filter((entry) => isWithinMount(targetPath, entry.mountPoint))
+    .sort((a, b) => b.mountPoint.length - a.mountPoint.length)[0];
+}
+
+export function parseLinuxMountInfo(
+  content: string,
+  targetPath: string
+): MountedFilesystem | undefined {
+  const entries = content
+    .split(/\r?\n/)
+    .map((line): MountedFilesystem | undefined => {
+      const fields = line.trim().split(' ');
+      const separator = fields.indexOf('-');
+      if (separator < 6 || fields.length <= separator + 1) return undefined;
+
+      return {
+        mountPoint: decodeMountPath(fields[4]),
+        filesystemType: normalizeFilesystemType(fields[separator + 1]),
+      };
+    })
+    .filter((entry): entry is MountedFilesystem => Boolean(entry));
+
+  return selectMountedFilesystem(entries, targetPath);
+}
+
+export function parseDarwinMountOutput(
+  content: string,
+  targetPath: string
+): MountedFilesystem | undefined {
+  const entries = content
+    .split(/\r?\n/)
+    .map((line): MountedFilesystem | undefined => {
+      const match = line.match(/^.+ on (.+) \(([^,\s)]+)(?:,(.*))?\)$/);
+      if (!match) return undefined;
+      return {
+        mountPoint: decodeMountPath(match[1]),
+        filesystemType: normalizeFilesystemType(match[2]),
+        local: (match[3] ?? '')
+          .split(',')
+          .map((option) => option.trim().toLowerCase())
+          .includes('local'),
+      };
+    })
+    .filter((entry): entry is MountedFilesystem => Boolean(entry));
+
+  return selectMountedFilesystem(entries, targetPath);
+}
+
+function normalizeWindowsAccessPath(accessPath: string): string {
+  const normalized = path.win32.normalize(accessPath.trim());
+  return normalized.endsWith('\\') ? normalized : `${normalized}\\`;
+}
+
+function normalizeWindowsTargetPath(targetPath: string): string {
+  return path.win32.normalize(targetPath.replace(/^\\\\\?\\(?=[a-z]:\\)/i, ''));
+}
+
+function isWithinWindowsAccessPath(targetPath: string, accessPath: string): boolean {
+  const target = normalizeWindowsTargetPath(targetPath).toLowerCase();
+  const mount = normalizeWindowsAccessPath(accessPath).toLowerCase();
+  const mountWithoutSlash = mount.slice(0, -1);
+  return target === mountWithoutSlash || target.startsWith(mount);
+}
+
+export function parseWindowsVolumeProbe(
+  output: string,
+  targetPath: string
+): WindowsVolume | undefined {
+  const parsed = JSON.parse(output) as unknown;
+  const rows = Array.isArray(parsed) ? parsed : [parsed];
+  const volumes = rows
+    .map((row): WindowsVolume | undefined => {
+      if (!row || typeof row !== 'object') return undefined;
+      const record = row as Record<string, unknown>;
+      if (typeof record.accessPath !== 'string' || record.accessPath.trim().length === 0) {
+        return undefined;
+      }
+      return {
+        accessPath: normalizeWindowsAccessPath(record.accessPath),
+        driveType: String(record.driveType ?? 'unknown')
+          .trim()
+          .toLowerCase(),
+        filesystemType: normalizeFilesystemType(String(record.filesystemType ?? 'unknown')),
+      };
+    })
+    .filter((volume): volume is WindowsVolume => Boolean(volume));
+
+  return volumes
+    .filter((volume) => isWithinWindowsAccessPath(targetPath, volume.accessPath))
+    .sort((a, b) => b.accessPath.length - a.accessPath.length)[0];
+}
+
+function classifyWindowsVolume(volume: WindowsVolume): SqliteFilesystemDecision {
+  if (volume.driveType === 'remote') {
+    return {
+      platform: 'win32',
+      filesystemType: volume.filesystemType,
+      posture: 'known-unsafe',
+      detectionSource: 'windows-volume-probe',
+      reasonCode: 'known-remote-filesystem',
+    };
+  }
+
+  if (volume.driveType === 'ramdisk' || volume.driveType === 'ram-disk') {
+    return {
+      platform: 'win32',
+      filesystemType: volume.filesystemType,
+      posture: 'known-unsafe',
+      detectionSource: 'windows-volume-probe',
+      reasonCode: 'volatile-filesystem',
+    };
+  }
+
+  const supported =
+    volume.driveType === 'fixed' && WINDOWS_SUPPORTED_LOCAL.has(volume.filesystemType);
+  return {
+    platform: 'win32',
+    filesystemType: volume.filesystemType,
+    posture: supported ? 'supported-local' : 'unknown',
+    detectionSource: 'windows-volume-probe',
+    reasonCode: supported ? 'supported-local-filesystem' : 'windows-volume-unvalidated',
+  };
+}
+
+function decision(
+  platform: string,
+  filesystemType: string,
+  detectionSource: string,
+  reasonCode?: string
+): SqliteFilesystemDecision {
+  const normalizedType = normalizeFilesystemType(filesystemType);
+  const classification = classifyFilesystemType(platform, normalizedType);
+  return {
+    platform,
+    filesystemType: normalizedType,
+    posture: classification.posture,
+    detectionSource,
+    reasonCode: reasonCode ?? classification.reasonCode,
+  };
+}
+
+function unknownDecision(
+  platform: string,
+  detectionSource: string,
+  reasonCode: string
+): SqliteFilesystemDecision {
+  return {
+    platform,
+    filesystemType: 'unknown',
+    posture: 'unknown',
+    detectionSource,
+    reasonCode,
+  };
+}
+
+export function detectSqliteFilesystem(
+  directoryPath: string,
+  dependencies?: SqliteFilesystemDetectionDependencies
+): SqliteFilesystemDecision {
+  const platform = dependencies?.platform ?? process.platform;
+  const realpath =
+    dependencies?.realpath ?? ((targetPath: string) => realpathSync.native(targetPath));
+  const readTextFile =
+    dependencies?.readTextFile ?? ((targetPath: string) => readFileSync(targetPath, 'utf8'));
+  const runCommand =
+    dependencies?.runCommand ??
+    ((command: string, args: string[]) => execFileSync(command, args, { encoding: 'utf8' }));
+
+  let canonicalPath: string;
+  try {
+    canonicalPath = realpath(directoryPath);
+  } catch {
+    return unknownDecision(platform, 'realpath', 'filesystem-realpath-failed');
+  }
+
+  let result: SqliteFilesystemDecision;
+  try {
+    if (platform === 'linux') {
+      const mounted = parseLinuxMountInfo(readTextFile('/proc/self/mountinfo'), canonicalPath);
+      result = mounted
+        ? decision(platform, mounted.filesystemType, 'linux-mountinfo')
+        : unknownDecision(platform, 'linux-mountinfo', 'mount-not-found');
+    } else if (platform === 'darwin') {
+      const mounted = parseDarwinMountOutput(runCommand('/sbin/mount', []), canonicalPath);
+      if (!mounted) {
+        result = unknownDecision(platform, 'darwin-mount-table', 'mount-not-found');
+      } else if (DARWIN_SUPPORTED_LOCAL.has(mounted.filesystemType) && mounted.local !== true) {
+        result = {
+          platform,
+          filesystemType: mounted.filesystemType,
+          posture: 'unknown',
+          detectionSource: 'darwin-mount-table',
+          reasonCode: 'darwin-local-signal-missing',
+        };
+      } else {
+        result = decision(platform, mounted.filesystemType, 'darwin-mount-table');
+      }
+    } else if (platform === 'win32') {
+      if (/^\\\\\?\\UNC\\/i.test(canonicalPath) || /^\\\\(?!\?\\)/.test(canonicalPath)) {
+        result = decision(platform, 'remote', 'windows-path', 'windows-network-path');
+      } else {
+        const volume = parseWindowsVolumeProbe(
+          runCommand('powershell.exe', [
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            WINDOWS_VOLUME_PROBE,
+          ]),
+          canonicalPath
+        );
+        result = volume
+          ? classifyWindowsVolume(volume)
+          : unknownDecision(platform, 'windows-volume-probe', 'windows-volume-unresolved');
+      }
+    } else {
+      result = unknownDecision(platform, 'platform', 'unsupported-platform');
+    }
+  } catch {
+    result = unknownDecision(platform, `${platform}-filesystem-probe`, 'filesystem-probe-failed');
+  }
+
+  return result;
+}

--- a/server/src/utils/startup-gate.test.ts
+++ b/server/src/utils/startup-gate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { startAfterInitialization } from './startup-gate.js';
+
+describe('startAfterInitialization', () => {
+  it('starts only after initialization resolves', async () => {
+    const order: string[] = [];
+    const initialize = vi.fn(async () => {
+      order.push('initialize');
+    });
+    const start = vi.fn(() => {
+      order.push('start');
+    });
+
+    await startAfterInitialization(initialize, start);
+
+    expect(order).toEqual(['initialize', 'start']);
+  });
+
+  it('does not start when initialization fails', async () => {
+    const failure = new Error('unsafe storage posture');
+    const start = vi.fn();
+
+    await expect(
+      startAfterInitialization(async () => {
+        throw failure;
+      }, start)
+    ).rejects.toBe(failure);
+    expect(start).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/utils/startup-gate.ts
+++ b/server/src/utils/startup-gate.ts
@@ -1,0 +1,11 @@
+/**
+ * Keep the network listener behind successful service initialization.
+ * A rejected initializer must never expose a partially initialized server.
+ */
+export async function startAfterInitialization(
+  initialize: () => Promise<void>,
+  start: () => void
+): Promise<void> {
+  await initialize();
+  start();
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -31,6 +31,7 @@ export * from './feedback.types.js';
 export * from './workflow.js';
 export * from './work-product.types.js';
 export * from './maintenance.types.js';
+export * from './sqlite-storage.types.js';
 export * from './governance-trace.types.js';
 export * from './skill-capability.types.js';
 export * from './skill-security.types.js';

--- a/shared/src/types/maintenance.types.ts
+++ b/shared/src/types/maintenance.types.ts
@@ -1,4 +1,5 @@
 import type { WorkProductMaintenancePreview } from './work-product.types.js';
+import type { SqliteStorageDiagnostics } from './sqlite-storage.types.js';
 
 export type DataLifecycleClassId =
   | 'workspaceIdentity'
@@ -77,6 +78,7 @@ export interface MaintenanceSummary {
   generatedAt: string;
   mode: 'local' | 'remote';
   storageMode: string;
+  sqlite?: SqliteStorageDiagnostics;
   health: MaintenanceHealthCheck[];
   storage: {
     totalBytes: number;

--- a/shared/src/types/sqlite-storage.types.ts
+++ b/shared/src/types/sqlite-storage.types.ts
@@ -1,0 +1,28 @@
+export type SqliteFilesystemPosture =
+  'supported-local' | 'known-unsafe' | 'unknown' | 'not-applicable';
+
+export type SqliteJournalModePosture = 'wal' | 'memory' | 'refused' | 'unknown';
+
+export interface SqliteIntegrityCheckPosture {
+  checkedAt: string;
+  status: 'ok' | 'failed';
+  result: string;
+}
+
+/**
+ * Redacted runtime evidence for the authoritative SQLite database.
+ * Raw database paths, mount points, and mount sources are intentionally omitted.
+ */
+export interface SqliteStorageDiagnostics {
+  schemaVersion: 'sqlite-storage/v1';
+  databaseLocation: 'memory' | 'configured' | 'runtime-default';
+  platform: string;
+  filesystemType: string;
+  filesystemPosture: SqliteFilesystemPosture;
+  detectionSource: string;
+  reasonCode: string;
+  journalMode: SqliteJournalModePosture;
+  decisionSource: 'automatic' | 'memory';
+  overrideSource: null;
+  lastIntegrityCheck?: SqliteIntegrityCheckPosture;
+}


### PR DESCRIPTION
## Summary

- classify the authoritative SQLite parent filesystem before database open and enable WAL only on proven durable local storage
- fail closed for remote, volatile, unknown, probe-failure, and database-file-symlink posture without creating database/WAL/SHM files
- gate the HTTP listener behind successful service initialization and expose redacted `sqlite-storage/v1` posture through deep health and Maintenance diagnostics
- document supported Linux, macOS, and Windows posture, safe backup/export behavior, deployment constraints, and operator remediation

## Compatibility and risk

- Existing rollback-journal databases are not converted during startup; the governed conversion and override workflow remains in #882.
- Windows accepts fixed NTFS/ReFS access paths from the PowerShell volume probe. Missing or restricted probe support fails closed as unknown.
- Cloud-synchronized folders remain unsupported even when the operating system reports an otherwise supported local filesystem.

## Verification

- `pnpm --dir server test` — 192 files, 2,127 passed, 2 skipped
- `pnpm typecheck`
- `pnpm lint` — 0 errors; existing warning baseline only
- `pnpm build`
- `pnpm smoke:cli-mcp` — build checks passed; live write smoke skipped without `VK_API_KEY`
- `pnpm check:pnpm-settings`
- Native macOS process smoke — APFS classified supported-local, SQLite opened in WAL, deep health returned redacted posture and successful quick check, graceful shutdown passed
- Cross-model review — xAI Grok 4.3: APPROVE, no blocking findings

Fixes #881
Parent: #877

[author: gpt-5-codex][reviewed-by: xai/grok-4.3]
