### PR TITLE
feat: add evidence-backed provider runtime manifests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,5 +90,13 @@ VERITAS_ADMIN_KEY=
 # PROMETHEUS_METRICS_PUBLIC=false
 
 # ── External Services ────────────────────────────────────────
-# Clawdbot gateway URL (default: http://127.0.0.1:18789)
+# OpenClaw gateway URL (default: http://127.0.0.1:18789) and optional bearer token.
+# OPENCLAW_GATEWAY_URL=http://127.0.0.1:18789
+# OPENCLAW_GATEWAY_TOKEN=
+
+# Optional operator-declared OpenClaw version hint for provider runtime manifests.
+# This does not count as runtime-verified evidence; host registration must verify it.
+# OPENCLAW_GATEWAY_VERSION=
+
+# Legacy gateway URL alias.
 # CLAWDBOT_GATEWAY=http://127.0.0.1:18789

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,14 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   **Currently supported providers:**
   `openclaw` | `codex-cli` | `codex-sdk` | `codex-cloud` | `hermes-cli` |
   `ollama-local` | `ollama-cloud` | `lm-studio-local` | `custom`
+- Executable task adapters are currently `openclaw`, `codex-cli`, `codex-sdk`,
+  and `hermes-cli`. Explicitly configured providers outside that set must fail
+  closed; never route them through an implicit OpenClaw fallback.
+- Probe and persist `provider-runtime-manifest/v1` before mutating attempt state.
+  New runtime controls must use the persisted evidence instead of provider-name
+  checks, and provider version/build changes must invalidate cached conformance.
+  Increment `PROVIDER_RUNTIME_PROBE_REVISION` whenever probe semantics or the
+  built-in adapter capability evidence changes.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added versioned, evidence-backed provider runtime manifests for Codex CLI,
+  Codex SDK, Hermes, and OpenClaw with bounded identity and conformance probes,
+  race-safe version-skew cache invalidation, canonical immutable run snapshots
+  and digests, complete capability posture, and attempt/history/trace/log
+  persistence (#885).
 - Added an admin-governed SQLite journal maintenance workflow with non-mutating
   previews, restart-time exclusive conversion, verified backups, durable stage
   journals, forward-only crash recovery, integrity verification, in-place mode
@@ -17,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added Hermes to normalized provider profiles and Settings selectors, and made
+  explicitly configured providers without an executable task adapter fail
+  closed instead of silently dispatching through OpenClaw (#885).
 - Classified the authoritative SQLite filesystem before database open, limited
   WAL to recognized durable local filesystems, refused known-unsafe and unknown
   storage before creating database sidecars, and exposed redacted filesystem,

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [Setup Paths](docs/SETUP-PATHS.md) — start here for board-only, CLI, MCP, OpenClaw, and self-hosted paths without mixing optional layers into first-run setup.
 - [Getting Started Guide](docs/GETTING-STARTED.md) — zero ➝ agent-ready in 5 minutes, plus sanity checks and prompt registry tips.
 - [MCP Server Guide](docs/mcp/README.md) — optional MCP setup, 36 tools, architecture, tool catalog, security model, and read/write smoke checks.
-- [Agent Providers](docs/AGENT-PROVIDERS.md) — Codex defaults, Ollama local/cloud, LM Studio local, routing, and web vs macOS behavior.
+- [Agent Providers](docs/AGENT-PROVIDERS.md) — evidence-backed runtime manifests, Codex and Hermes execution, optional model profiles, routing, and host behavior.
 - [OpenAI Codex Integration Roadmap](docs/CODEX-INTEGRATION.md) — optional local execution, SDK sessions, cloud delegation, MCP setup, workflows, telemetry, and release QA.
 - [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) — authority model, HermesAgent roster, QA evidence gate, and GitHub-backed task templates.
 - [Codex Integration SOP](docs/SOP-codex-integration.md) & [Codex Workflow Examples](docs/EXAMPLES-codex-workflows.md) — operational playbooks for using Codex as a first-class Veritas agent.

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -9,10 +9,38 @@ Veritas works as a board without any agent runner. When you do enable agents, pr
 Fresh v5 installs use OpenAI Codex as the default agent:
 
 - `codex` is enabled by default and uses `codex exec --sandbox workspace-write --json`.
-- `claude-code`, `amp`, `copilot`, `gemini`, `codex-sdk`, `codex-cloud`, `ollama-local`, `ollama-cloud`, and `lm-studio-local` are available as profiles you can enable or route to.
+- `claude-code`, `amp`, `copilot`, `gemini`, `codex-sdk`, `codex-cloud`, `hermes`, `ollama-local`, `ollama-cloud`, and `lm-studio-local` are available as profiles you can enable or route to.
 - Built-in routing sends code, bug, documentation, and review work to `codex` first, with conservative fallbacks for higher-risk code paths.
 
 Existing configs keep the user's chosen default agent. Missing built-in profiles are added during config normalization without overwriting customized commands, arguments, or enabled states.
+
+## Provider Runtime Manifests
+
+Before a task attempt mutates task state, the selected execution adapter emits a
+`provider-runtime-manifest/v1` snapshot. The snapshot records the adapter and
+protocol version, provider build/version evidence, configured models, probe
+timestamp and diagnostics, and every known runtime or sandbox capability as
+`supported`, `advisory`, `unsupported`, or `unknown`.
+
+Veritas currently has executable task adapters for `codex-cli`, `codex-sdk`,
+`hermes-cli`, and `openclaw`. An explicitly configured Codex Cloud, Ollama, LM
+Studio, or custom profile is not silently sent through OpenClaw; task dispatch
+fails with an actionable `409` until that provider has an execution adapter.
+
+The exact manifest and its `sha256:` digest are stored on the current attempt,
+attempt history, optional run trace, and Markdown run log. Provider identity
+evidence is collected on each launch. CLI/SDK identities come from bounded
+runtime or installed-package probes, and conformance probes are bounded before
+launch. An OpenClaw version supplied through the environment remains degraded
+operator evidence until host registration can verify it. A matching
+version/build can reuse conformance evidence for up to five minutes; a version
+change invalidates it and reruns the probe. Failed probes and unknown versions
+are not positively cached.
+
+Capability states describe behavior that the current adapter actually proves.
+They do not imply that adjacent roadmap work already exists. For example,
+provider-neutral approvals, reattachment, follow-up/fork/steer controls, and MCP
+governance remain unsupported or unknown until their dedicated issues land.
 
 ## Sandbox Policy Presets
 
@@ -193,12 +221,13 @@ install at the operator-level endpoint. You must explicitly allow them:
 
 ### Environment variables
 
-| Variable                         | Default                  | Purpose                       |
-| -------------------------------- | ------------------------ | ----------------------------- |
-| `OPENCLAW_GATEWAY_URL`           | `http://127.0.0.1:18789` | Gateway base URL              |
-| `OPENCLAW_GATEWAY_TOKEN`         | _(none)_                 | Bearer token for the gateway  |
-| `OPENCLAW_GATEWAY_SESSION_KEY`   | `main`                   | Parent session key            |
-| `OPENCLAW_GATEWAY_ALLOW_PRIVATE` | `false`                  | Allow private IP gateway URLs |
+| Variable                         | Default                  | Purpose                                                                                  |
+| -------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
+| `OPENCLAW_GATEWAY_URL`           | `http://127.0.0.1:18789` | Gateway base URL                                                                         |
+| `OPENCLAW_GATEWAY_TOKEN`         | _(none)_                 | Bearer token for the gateway                                                             |
+| `OPENCLAW_GATEWAY_SESSION_KEY`   | `main`                   | Parent session key                                                                       |
+| `OPENCLAW_GATEWAY_ALLOW_PRIVATE` | `false`                  | Allow private IP gateway URLs                                                            |
+| `OPENCLAW_GATEWAY_VERSION`       | _(none)_                 | Operator-declared version hint; the manifest remains degraded until runtime verification |
 
 ### Dispatch flow
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1874,6 +1874,45 @@ In addition to `agent`, `sandboxPresetId`, and `budget`, callers can pass a port
 
 The launch path resolves the package runtime against configured provider profiles, applies package model/sandbox/budget posture, injects package instructions into the run prompt, and records the profile ID and version on the task attempt plus activity audit history.
 
+### Provider Runtime Manifest On Attempts
+
+Every executable task adapter is probed before the attempt mutates task state.
+Task and trace responses can therefore include the immutable
+`providerRuntimeManifest` used at launch:
+
+```json
+{
+  "schemaVersion": "provider-runtime-manifest/v1",
+  "probeRevision": 1,
+  "provider": "codex-cli",
+  "adapter": "codex-cli",
+  "protocolVersion": "codex-exec-json/v1",
+  "providerVersion": "codex-cli 0.144.0",
+  "models": ["gpt-5.5"],
+  "capabilities": [
+    {
+      "id": "run.streaming",
+      "state": "supported",
+      "source": "contract-test",
+      "reason": "Codex JSONL output is streamed into run events."
+    }
+  ],
+  "probe": {
+    "state": "ready",
+    "probedAt": "2026-07-16T01:30:00.000Z",
+    "source": "codex --version",
+    "diagnostics": []
+  },
+  "digest": "sha256:<64 lowercase hex characters>"
+}
+```
+
+The full manifest contains one entry for every known runtime and sandbox
+capability. A provider version/build change invalidates cached conformance
+evidence. Failed probes and unknown versions are not positively cached.
+Explicitly configured providers without a task execution adapter fail with
+`409 Conflict` instead of falling back to OpenClaw.
+
 ---
 
 ## Team Roster Manifests

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -277,7 +277,7 @@ First-class support for autonomous coding agents.
 ![Agent provider settings](assets/v5/v5-agent-providers.png)
 
 - **Agent orchestration** — Start, stop, and monitor AI agents on code tasks from the UI or API
-- **Multi-agent support** — Ships with Codex, Codex SDK, Codex Cloud, Claude Code, Amp, Copilot, Gemini, Ollama Local, Ollama Cloud, LM Studio Local, and Veritas profiles; add completely custom agents via Settings → Agents
+- **Multi-agent support** — Ships with Codex, Codex SDK, Codex Cloud, Hermes Agent, Claude Code, Amp, Copilot, Gemini, Ollama Local, Ollama Cloud, LM Studio Local, and Veritas profiles; add completely custom agents via Settings → Agents
 - **Agent CRUD management** — Full Add/Edit/Remove for agents in Settings → Agents; add agent form with name, type slug (auto-generated), command, and args; inline edit via pencil icon; remove via trash icon with confirmation (blocked for the default agent); `AgentType` accepts any string slug, not just built-in names
 - **Agent request files** — Server writes structured requests to `.veritas-kanban/agent-requests/` for agent pickup
 - **Completion callbacks** — Agents call the completion endpoint with success/failure status and summary
@@ -296,6 +296,7 @@ First-class support for autonomous coding agents.
 - **Team roster routing manifests** — Workspace coordinators can define enabled members, capabilities, routing rules, fallbacks, reviewers, and escalation posture before `/api/agents/route` selects an agent
 - **Workspace capability discovery** — Trusted workspace catalogs expose supported task types, SLA/queue posture, intake requirements, and delegated-work packaging so cross-workspace handoffs are explicit
 - **Agent profile packages** — Reusable YAML/JSON packages bundle role, runtime, model, prompt instructions, tools, permissions, sandbox, budget, workflow, and health metadata for portable task launches
+- **Provider runtime manifests** — Every executable adapter records a versioned, evidence-backed capability snapshot and digest on the attempt, history, trace, and log; provider version skew reruns conformance and unsupported configured providers fail closed instead of falling back to OpenClaw
 - **Sandbox policy presets** — Built-in and custom presets control filesystem scope, network egress, environment passthrough, and credential brokering for agent profiles, workflow agents, and per-run overrides
 - **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run budgets can cap tokens, provider cost, tool calls, runtime, retries, and workflow fan-out with warning, approval, downgrade, pause, or cancel actions
 - **Platform-agnostic REST API** — Any platform that can make HTTP calls can drive the full agent lifecycle
@@ -992,7 +993,7 @@ Reusable launch-time sandbox presets for provider execution guardrails.
 - Required controls fail closed before agent or workflow launch when the selected provider cannot support them.
 - Advisory controls warn and record trace evidence without blocking the run.
 - Credential references and environment-style `name=value` values are redacted in dry-run output and governance traces.
-- Provider capability checks currently distinguish Codex CLI, Codex SDK, and OpenClaw execution behavior.
+- Provider capability checks currently distinguish Codex CLI, Codex SDK, Hermes, and OpenClaw execution behavior.
 
 ### Session Isolation
 

--- a/server/src/__tests__/agent-health-service.test.ts
+++ b/server/src/__tests__/agent-health-service.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfig } from '@veritas-kanban/shared';
+import {
+  AgentHealthService,
+  type AgentHealthCommandRunner,
+} from '../services/agent-health-service.js';
+
+const baseAgent: AgentConfig = {
+  type: 'fixture-agent',
+  name: 'Fixture Agent',
+  command: process.execPath,
+  args: [],
+  enabled: true,
+  provider: 'custom',
+};
+
+const originalHermesApiKey = process.env.HERMES_API_KEY;
+const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv('HERMES_API_KEY', originalHermesApiKey);
+  restoreEnv('ANTHROPIC_API_KEY', originalAnthropicApiKey);
+});
+
+describe('AgentHealthService provider version evidence', () => {
+  it('captures version evidence with a bounded no-shell probe', async () => {
+    const runCommand = vi.fn<AgentHealthCommandRunner>().mockResolvedValue({
+      stdout: 'fixture-provider 1.2.3\n',
+      stderr: '',
+    });
+
+    const result = await new AgentHealthService(runCommand).checkAgent(baseAgent);
+
+    expect(result).toMatchObject({
+      healthy: true,
+      authenticated: null,
+      providerVersion: 'fixture-provider 1.2.3',
+      providerVersionSource: `${process.platform === 'win32' ? 'node.exe' : 'node'} --version`,
+    });
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(runCommand).toHaveBeenCalledWith(process.execPath, ['--version'], {
+      timeout: 5_000,
+      maxBuffer: 8 * 1024,
+      shell: false,
+    });
+  });
+
+  it('keeps version probe failures advisory for providers without version-based auth', async () => {
+    const runCommand = vi
+      .fn<AgentHealthCommandRunner>()
+      .mockRejectedValue(new Error('version command failed'));
+
+    const result = await new AgentHealthService(runCommand).checkAgent(baseAgent);
+
+    expect(result.healthy).toBe(true);
+    expect(result.authenticated).toBeNull();
+    expect(result.providerVersion).toBeUndefined();
+    expect(result.providerVersionSource).toBeUndefined();
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('caps recorded version evidence at 8 KiB even when a runner exceeds its contract', async () => {
+    const runCommand = vi.fn<AgentHealthCommandRunner>().mockResolvedValue({
+      stdout: 'v'.repeat(9 * 1024),
+      stderr: '',
+    });
+
+    const result = await new AgentHealthService(runCommand).checkAgent(baseAgent);
+
+    expect(Buffer.byteLength(result.providerVersion ?? '', 'utf8')).toBe(8 * 1024);
+  });
+
+  it('reuses the version evidence for Hermes authentication instead of probing twice', async () => {
+    process.env.HERMES_API_KEY = 'test-only';
+    delete process.env.ANTHROPIC_API_KEY;
+    const runCommand = vi.fn<AgentHealthCommandRunner>().mockResolvedValue({
+      stdout: 'Hermes Agent 2026.7.7.2\n',
+      stderr: '',
+    });
+    const hermesAgent: AgentConfig = {
+      ...baseAgent,
+      type: 'hermes',
+      name: 'Hermes',
+      provider: 'hermes-cli',
+    };
+
+    const result = await new AgentHealthService(runCommand).checkAgent(hermesAgent);
+
+    expect(result).toMatchObject({
+      healthy: true,
+      authenticated: true,
+      providerVersion: 'Hermes Agent 2026.7.7.2',
+    });
+    expect(runCommand).toHaveBeenCalledOnce();
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -12,6 +12,7 @@ const {
   mockSaveConfig,
   mockGetTask,
   mockUpdateTask,
+  mockPatchTaskAttempt,
   mockCheckAgent,
   mockTelemetryEmit,
   mockLogActivity,
@@ -25,6 +26,7 @@ const {
   mockSaveConfig: vi.fn(),
   mockGetTask: vi.fn(),
   mockUpdateTask: vi.fn(),
+  mockPatchTaskAttempt: vi.fn(),
   mockCheckAgent: vi.fn(),
   mockTelemetryEmit: vi.fn(),
   mockLogActivity: vi.fn(),
@@ -47,7 +49,11 @@ vi.mock('../services/config-service.js', () => ({
 
 vi.mock('../services/task-service.js', () => ({
   TaskService: function () {
-    return { getTask: mockGetTask, updateTask: mockUpdateTask };
+    return {
+      getTask: mockGetTask,
+      updateTask: mockUpdateTask,
+      patchTaskAttempt: mockPatchTaskAttempt,
+    };
   },
 }));
 
@@ -102,6 +108,7 @@ type TestableClawdbotAgentService = ClawdbotAgentService & {
     summary?: string;
     usage?: { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string };
   };
+  recordCodexThread(task: Task, attemptId: string, threadId: string): Promise<void>;
 };
 
 function testableService(tmpDir: string): TestableClawdbotAgentService {
@@ -216,6 +223,11 @@ describe('ClawdbotAgentService Codex providers', () => {
       task = { ...task, ...update } as Task;
       return task;
     });
+    mockPatchTaskAttempt.mockImplementation(async (_id, attemptId, patch) => {
+      if (task.attempt?.id !== attemptId) return null;
+      task = { ...task, attempt: { ...task.attempt, ...patch } } as Task;
+      return task;
+    });
     mockCheckAgent.mockImplementation(async (agent: AgentConfig) => ({
       type: agent.type,
       name: agent.name,
@@ -224,6 +236,8 @@ describe('ClawdbotAgentService Codex providers', () => {
       command: agent.command,
       executableFound: true,
       executablePath: `/usr/local/bin/${agent.command}`,
+      providerVersion: 'codex-cli 0.144.0',
+      providerVersionSource: 'codex --version',
       authenticated: true,
       healthy: true,
       checkedAt: '2026-06-03T00:00:00.000Z',
@@ -291,6 +305,24 @@ describe('ClawdbotAgentService Codex providers', () => {
       await waitFor(() => {
         expect(service.getAgentStatus(task.id)).toBeNull();
       });
+      expect(task.attempt?.providerRuntimeManifest).toMatchObject({
+        schemaVersion: 'provider-runtime-manifest/v1',
+        provider: 'codex-cli',
+        providerVersion: 'codex-cli 0.144.0',
+      });
+      expect(task.attempt?.providerRuntimeManifest?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+      expect(task.attempts).toEqual([
+        expect.objectContaining({
+          id: task.attempt?.id,
+          providerRuntimeManifest: expect.objectContaining({
+            digest: task.attempt?.providerRuntimeManifest?.digest,
+          }),
+        }),
+      ]);
+      const log = await service.getAttemptLog(task.id, task.attempt?.id ?? 'missing');
+      expect(log).toContain(
+        `Provider manifest:** ${task.attempt?.providerRuntimeManifest?.digest}`
+      );
       expect(mockStartStep).toHaveBeenCalledWith(
         expect.any(String),
         'stream',
@@ -522,6 +554,54 @@ describe('ClawdbotAgentService Codex providers', () => {
         reason: 'Stopped by user',
         provider: 'codex-cli',
       })
+    );
+  });
+
+  it('patches a provider thread without dropping the persisted runtime manifest', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+
+    await service.startAgent(task.id, 'codex');
+    const currentAttempt = task.attempt;
+    if (!currentAttempt?.providerRuntimeManifest) {
+      throw new Error('Expected the started attempt to persist a provider runtime manifest');
+    }
+    const attemptId = currentAttempt.id;
+    const manifestDigest = currentAttempt.providerRuntimeManifest.digest;
+    await service.recordCodexThread(task, attemptId, 'thread_fixture_123');
+
+    expect(task.attempt).toMatchObject({
+      id: attemptId,
+      threadId: 'thread_fixture_123',
+      providerRuntimeManifest: { digest: manifestDigest },
+    });
+    await service.stopAgent(task.id);
+  });
+
+  it('preserves the previous attempt when a new provider process fails to start', async () => {
+    const previousAttempt = {
+      id: 'attempt_previous',
+      agent: 'codex',
+      status: 'complete' as const,
+      provider: 'codex-cli',
+    };
+    task = { ...task, attempt: previousAttempt, attempts: [] } as Task;
+    mockGetTask.mockResolvedValue(task);
+    mockSpawn.mockImplementation(() => {
+      throw new Error('fixture spawn failure');
+    });
+    const service = testableService(tmpDir);
+
+    await expect(service.startAgent(task.id, 'codex')).rejects.toThrow(
+      'Failed to start agent via Codex CLI: fixture spawn failure'
+    );
+
+    expect(task.attempts).toEqual(
+      expect.arrayContaining([
+        previousAttempt,
+        expect.objectContaining({ status: 'failed', providerRuntimeManifest: expect.any(Object) }),
+      ])
     );
   });
 

--- a/server/src/__tests__/provider-runtime-adapters.test.ts
+++ b/server/src/__tests__/provider-runtime-adapters.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AgentConfig } from '@veritas-kanban/shared';
+import { ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
+import type { AgentHealthChecker } from '../services/agent-health-service.js';
+
+const originalOpenClawVersion = process.env.OPENCLAW_GATEWAY_VERSION;
+
+afterEach(() => {
+  if (originalOpenClawVersion === undefined) {
+    delete process.env.OPENCLAW_GATEWAY_VERSION;
+  } else {
+    process.env.OPENCLAW_GATEWAY_VERSION = originalOpenClawVersion;
+  }
+});
+
+const health: AgentHealthChecker = {
+  async checkAgent(agent) {
+    return {
+      type: agent.type,
+      name: agent.name,
+      enabled: agent.enabled,
+      configured: true,
+      command: agent.command,
+      executableFound: true,
+      executablePath: `/usr/local/bin/${agent.command}`,
+      providerVersion: `${agent.provider ?? 'openclaw'} 1.0.0`,
+      providerVersionSource: `${agent.command} --version`,
+      authenticated: true,
+      healthy: true,
+      checkedAt: '2026-07-16T00:00:00.000Z',
+    };
+  },
+};
+
+function config(provider: AgentConfig['provider']): AgentConfig {
+  return {
+    type: provider ?? 'fixture',
+    name: provider ?? 'Fixture',
+    command: provider === 'hermes-cli' ? 'hermes' : 'codex',
+    args: [],
+    enabled: true,
+    provider,
+    model: 'fixture-model',
+  };
+}
+
+describe('ClawdbotAgentService provider runtime adapters', () => {
+  it.each([
+    ['codex-cli', 'codex-exec-json/v1', 'supported', 'ready'],
+    ['codex-sdk', 'openai-codex-sdk/v1', 'supported', 'ready'],
+    ['hermes-cli', 'hermes-one-shot/v1', 'supported', 'ready'],
+    ['openclaw', 'openclaw-tools/v1', 'unsupported', 'degraded'],
+  ] as const)(
+    'probes the %s adapter manifest',
+    async (provider, protocolVersion, stopState, probeState) => {
+      process.env.OPENCLAW_GATEWAY_VERSION = 'openclaw 2026.6.11';
+      const manifest = await new ClawdbotAgentService(health).probeProviderRuntime(
+        config(provider)
+      );
+
+      expect(manifest.provider).toBe(provider);
+      expect(manifest.protocolVersion).toBe(protocolVersion);
+      expect(manifest.probe.state).toBe(probeState);
+      expect(manifest.models).toEqual(['fixture-model']);
+      expect(manifest.capabilities.find((item) => item.id === 'run.start')?.state).toBe(
+        'supported'
+      );
+      expect(manifest.capabilities.find((item) => item.id === 'run.stop')?.state).toBe(stopState);
+    }
+  );
+
+  it.each(['codex-cloud', 'ollama-local', 'ollama-cloud', 'lm-studio-local', 'custom'] as const)(
+    'fails closed instead of routing the configured %s provider through OpenClaw',
+    async (provider) => {
+      await expect(
+        new ClawdbotAgentService(health).probeProviderRuntime(config(provider))
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        code: 'CONFLICT',
+        details: expect.objectContaining({ provider }),
+      });
+    }
+  );
+});

--- a/server/src/__tests__/provider-runtime-manifest-service.test.ts
+++ b/server/src/__tests__/provider-runtime-manifest-service.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS,
+  PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION,
+} from '@veritas-kanban/shared';
+import {
+  buildProviderRuntimeCapabilities,
+  ProviderRuntimeManifestService,
+  verifyProviderRuntimeManifestDigest,
+  type ProviderRuntimeProbeRequest,
+} from '../services/provider-runtime-manifest-service.js';
+import { ProviderRuntimeManifestSchema } from '../schemas/provider-runtime-manifest-schemas.js';
+
+function request(version = 'fixture 1.0.0'): ProviderRuntimeProbeRequest {
+  return {
+    provider: 'fixture',
+    adapter: 'fixture-adapter',
+    protocolVersion: 'fixture/v1',
+    command: 'fixture',
+    models: ['model-b', 'model-a', 'model-a'],
+    identity: {
+      providerVersion: version,
+      source: 'fixture --version',
+      verified: true,
+      authenticated: true,
+      executableFingerprint: '/private/fixture',
+      diagnostics: ['Authorization=super-secret-value'],
+    },
+    capabilities: buildProviderRuntimeCapabilities({
+      'run.start': {
+        state: 'supported',
+        reason: 'The fixture launch contract passed.',
+      },
+      'run.stop': {
+        state: 'advisory',
+        reason: 'The fixture exposes a best-effort stop.',
+      },
+      'run.resume': {
+        state: 'unsupported',
+        reason: 'The fixture cannot resume.',
+      },
+    }),
+  };
+}
+
+describe('ProviderRuntimeManifestService', () => {
+  it('builds a complete, validated, immutable, and redacted v1 manifest', async () => {
+    const manifest = await new ProviderRuntimeManifestService().probe(request());
+
+    expect(manifest.schemaVersion).toBe(PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION);
+    expect(manifest.probe.state).toBe('ready');
+    expect(manifest.models).toEqual(['model-a', 'model-b']);
+    expect(manifest.capabilities).toHaveLength(KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS.length);
+    expect(manifest.capabilities.find((item) => item.id === 'run.start')?.state).toBe('supported');
+    expect(manifest.capabilities.find((item) => item.id === 'run.stop')?.state).toBe('advisory');
+    expect(manifest.capabilities.find((item) => item.id === 'run.resume')?.state).toBe(
+      'unsupported'
+    );
+    expect(manifest.probe.diagnostics).toEqual(['Authorization=[REDACTED]']);
+    expect(manifest.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(verifyProviderRuntimeManifestDigest(manifest)).toBe(true);
+    expect(ProviderRuntimeManifestSchema.safeParse(manifest).success).toBe(true);
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.capabilities)).toBe(true);
+    expect(
+      verifyProviderRuntimeManifestDigest({
+        ...structuredClone(manifest),
+        providerVersion: 'tampered',
+      })
+    ).toBe(false);
+    expect(
+      ProviderRuntimeManifestSchema.safeParse({
+        ...structuredClone(manifest),
+        providerVersion: 'tampered',
+      }).success
+    ).toBe(false);
+  });
+
+  it('serves the same version from cache and reruns conformance after version skew', async () => {
+    const conformanceProbe = vi.fn(
+      async (input: ProviderRuntimeProbeRequest) => input.capabilities
+    );
+    const service = new ProviderRuntimeManifestService({ conformanceProbe });
+
+    const first = await service.probe(request('fixture 1.0.0'));
+    const second = await service.probe(request('fixture 1.0.0'));
+    const upgraded = await service.probe(request('fixture 2.0.0'));
+
+    expect(conformanceProbe).toHaveBeenCalledTimes(2);
+    expect(first).not.toBe(second);
+    expect(first.digest).toBe(second.digest);
+    expect(upgraded.digest).not.toBe(first.digest);
+    expect(upgraded.providerVersion).toBe('fixture 2.0.0');
+  });
+
+  it('deduplicates concurrent conformance probes for the same provider identity', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const conformanceProbe = vi.fn(async (input: ProviderRuntimeProbeRequest) => {
+      await gate;
+      return input.capabilities;
+    });
+    const service = new ProviderRuntimeManifestService({ conformanceProbe });
+
+    const first = service.probe(request());
+    const second = service.probe(request());
+    release();
+
+    const [firstManifest, secondManifest] = await Promise.all([first, second]);
+    expect(conformanceProbe).toHaveBeenCalledOnce();
+    expect(firstManifest.digest).toBe(secondManifest.digest);
+  });
+
+  it('expires cached conformance evidence after the bounded TTL', async () => {
+    let now = new Date('2026-07-16T00:00:00.000Z');
+    const conformanceProbe = vi.fn(
+      async (input: ProviderRuntimeProbeRequest) => input.capabilities
+    );
+    const service = new ProviderRuntimeManifestService({
+      cacheTtlMs: 100,
+      now: () => now,
+      conformanceProbe,
+    });
+
+    await service.probe(request());
+    now = new Date('2026-07-16T00:00:00.050Z');
+    await service.probe(request());
+    now = new Date('2026-07-16T00:00:00.101Z');
+    await service.probe(request());
+
+    expect(conformanceProbe).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not positively cache a manifest with an unknown provider version', async () => {
+    const conformanceProbe = vi.fn(
+      async (input: ProviderRuntimeProbeRequest) => input.capabilities
+    );
+    const service = new ProviderRuntimeManifestService({ conformanceProbe });
+    const unknown = request('');
+
+    const first = await service.probe(unknown);
+    const second = await service.probe(unknown);
+
+    expect(first.providerVersion).toBe('unknown');
+    expect(first.probe.state).toBe('degraded');
+    expect(second.probe.state).toBe('degraded');
+    expect(conformanceProbe).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a failed, non-cached manifest when conformance throws', async () => {
+    const conformanceProbe = vi.fn(async () => {
+      throw new Error('probe failed with token=private-value');
+    });
+    const service = new ProviderRuntimeManifestService({ conformanceProbe });
+
+    const first = await service.probe(request());
+    const second = await service.probe(request());
+
+    expect(first.probe.state).toBe('failed');
+    expect(first.probe.diagnostics).toContain('probe failed with token=[REDACTED]');
+    expect(first.capabilities.every((capability) => capability.state === 'unknown')).toBe(true);
+    expect(second.probe.state).toBe('failed');
+    expect(conformanceProbe).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds conformance probes and does not cache timeouts', async () => {
+    const conformanceProbe = vi.fn(() => new Promise<never>(() => undefined));
+    const service = new ProviderRuntimeManifestService({
+      conformanceProbe,
+      conformanceProbeTimeoutMs: 5,
+    });
+
+    const first = await service.probe(request());
+    const second = await service.probe(request());
+
+    expect(first.probe.state).toBe('failed');
+    expect(first.probe.diagnostics).toContain('Provider conformance probe timed out.');
+    expect(second.probe.state).toBe('failed');
+    expect(conformanceProbe).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let a slower stale-version probe replace the latest cache entry', async () => {
+    const releases = new Map<string, () => void>();
+    const conformanceProbe = vi.fn(
+      (input: ProviderRuntimeProbeRequest) =>
+        new Promise<ProviderRuntimeProbeRequest['capabilities']>((resolve) => {
+          releases.set(input.identity.providerVersion ?? 'unknown', () =>
+            resolve(input.capabilities)
+          );
+        })
+    );
+    const service = new ProviderRuntimeManifestService({ conformanceProbe });
+
+    const stale = service.probe(request('fixture 1.0.0'));
+    const latest = service.probe(request('fixture 2.0.0'));
+    releases.get('fixture 2.0.0')?.();
+    await latest;
+    releases.get('fixture 1.0.0')?.();
+    await stale;
+    await service.probe(request('fixture 2.0.0'));
+
+    expect(conformanceProbe).toHaveBeenCalledTimes(2);
+  });
+
+  it('calculates the digest from canonical field order', async () => {
+    const manifest = await new ProviderRuntimeManifestService().probe(request());
+    const reordered = {
+      ...structuredClone(manifest),
+      capabilities: manifest.capabilities.map((capability) => ({
+        reason: capability.reason,
+        source: capability.source,
+        state: capability.state,
+        id: capability.id,
+      })),
+      probe: {
+        diagnostics: [...manifest.probe.diagnostics],
+        source: manifest.probe.source,
+        probedAt: manifest.probe.probedAt,
+        state: manifest.probe.state,
+      },
+    };
+
+    expect(verifyProviderRuntimeManifestDigest(reordered)).toBe(true);
+  });
+
+  it('redacts provider identity output before it enters the immutable snapshot', async () => {
+    const manifest = await new ProviderRuntimeManifestService().probe(
+      request('fixture 1.0.0 token=private-value sk-proj-abcdefghijklmnopqrstuvwxyz')
+    );
+
+    expect(manifest.providerVersion).toBe('fixture 1.0.0 token=[REDACTED] [REDACTED]');
+    expect(JSON.stringify(manifest)).not.toContain('private-value');
+    expect(JSON.stringify(manifest)).not.toContain('sk-proj-');
+  });
+
+  it('rejects duplicate capabilities and unknown top-level fields', async () => {
+    const manifest = await new ProviderRuntimeManifestService().probe(request());
+    const duplicate = {
+      ...structuredClone(manifest),
+      capabilities: [manifest.capabilities[0], manifest.capabilities[0]],
+    };
+    const extra = { ...structuredClone(manifest), unexpected: true };
+
+    expect(ProviderRuntimeManifestSchema.safeParse(duplicate).success).toBe(false);
+    expect(ProviderRuntimeManifestSchema.safeParse(extra).success).toBe(false);
+  });
+});

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -406,6 +406,14 @@ runtime:
           model: 'gpt-5.5',
         },
         {
+          type: 'hermes',
+          name: 'Hermes Agent',
+          command: 'hermes',
+          args: [],
+          enabled: false,
+          provider: 'hermes-cli',
+        },
+        {
           type: 'ollama-local',
           name: 'Ollama Local',
           command: 'ollama',

--- a/server/src/__tests__/settings-service.test.ts
+++ b/server/src/__tests__/settings-service.test.ts
@@ -183,6 +183,7 @@ describe('ConfigService', () => {
       expect(config.agents.length).toBeGreaterThan(0);
       expect(config.agents.some((a) => a.type === 'claude-code')).toBe(true);
       expect(config.agents.some((a) => a.type === 'codex')).toBe(true);
+      expect(config.agents.some((a) => a.type === 'hermes')).toBe(true);
       expect(config.agents.some((a) => a.type === 'ollama-local')).toBe(true);
       expect(config.agents.some((a) => a.type === 'ollama-cloud')).toBe(true);
       expect(config.agents.some((a) => a.type === 'lm-studio-local')).toBe(true);

--- a/server/src/__tests__/task-service-sqlite.test.ts
+++ b/server/src/__tests__/task-service-sqlite.test.ts
@@ -100,6 +100,24 @@ describe('TaskService SQLite mode', () => {
     });
   });
 
+  it('round-trips provider runtime manifests in current and historical attempts', async () => {
+    const task = await service.createTask({ title: 'SQLite manifest-backed attempt' });
+    const manifest = providerRuntimeManifestFixture();
+    const attempt = {
+      id: 'attempt_manifest',
+      agent: 'codex',
+      status: 'complete' as const,
+      provider: 'codex-cli',
+      providerRuntimeManifest: manifest,
+    };
+
+    await service.updateTask(task.id, { attempt, attempts: [attempt] });
+    const reloaded = await service.getTask(task.id);
+
+    expect(reloaded?.attempt?.providerRuntimeManifest).toEqual(manifest);
+    expect(reloaded?.attempts?.[0]?.providerRuntimeManifest?.digest).toBe(manifest.digest);
+  });
+
   it('archives, lists archived tasks, restores, and deletes without task files', async () => {
     const task = await service.createTask({ title: 'Archive SQLite task' });
     const deletedAt = new Date().toISOString();
@@ -153,3 +171,30 @@ describe('TaskService SQLite mode', () => {
     expect(await service.restoreTask(invalid.id)).toBeNull();
   });
 });
+
+function providerRuntimeManifestFixture() {
+  return {
+    schemaVersion: 'provider-runtime-manifest/v1' as const,
+    probeRevision: 1 as const,
+    provider: 'codex-cli',
+    adapter: 'codex-cli',
+    protocolVersion: 'codex-exec-json/v1',
+    providerVersion: 'codex-cli 0.144.0',
+    models: ['gpt-5.5'],
+    capabilities: [
+      {
+        id: 'run.start',
+        state: 'supported' as const,
+        source: 'contract-test' as const,
+        reason: 'Fixture launch support.',
+      },
+    ],
+    probe: {
+      state: 'ready' as const,
+      probedAt: '2026-07-16T00:00:00.000Z',
+      source: 'codex --version',
+      diagnostics: [],
+    },
+    digest: `sha256:${'a'.repeat(64)}`,
+  };
+}

--- a/server/src/__tests__/task-service.test.ts
+++ b/server/src/__tests__/task-service.test.ts
@@ -246,6 +246,28 @@ updated: '2026-01-26T10:00:00.000Z'
   });
 
   describe('Task updates', () => {
+    it('round-trips provider runtime manifests in current and historical attempts', async () => {
+      const task = await service.createTask({ title: 'Manifest-backed attempt' });
+      const manifest = providerRuntimeManifestFixture();
+      const attempt = {
+        id: 'attempt_manifest',
+        agent: 'codex',
+        status: 'complete' as const,
+        provider: 'codex-cli',
+        providerRuntimeManifest: manifest,
+      };
+
+      const updated = await service.updateTask(task.id, { attempt, attempts: [attempt] });
+      const taskFile = (await fs.readdir(tasksDir)).find((file) => file.startsWith(`${task.id}-`));
+      if (!taskFile) throw new Error('Expected the task file to be persisted');
+      const persisted = await fs.readFile(path.join(tasksDir, taskFile), 'utf8');
+
+      expect(updated?.attempt?.providerRuntimeManifest).toEqual(manifest);
+      expect(updated?.attempts?.[0]?.providerRuntimeManifest?.digest).toBe(manifest.digest);
+      expect(persisted).toContain('schemaVersion: provider-runtime-manifest/v1');
+      expect(persisted).toContain(manifest.digest);
+    });
+
     it('should update task fields', async () => {
       const task = await service.createTask({ title: 'Original' });
 
@@ -492,3 +514,30 @@ updated: '2026-01-26T10:00:00.000Z'
     });
   });
 });
+
+function providerRuntimeManifestFixture() {
+  return {
+    schemaVersion: 'provider-runtime-manifest/v1' as const,
+    probeRevision: 1 as const,
+    provider: 'codex-cli',
+    adapter: 'codex-cli',
+    protocolVersion: 'codex-exec-json/v1',
+    providerVersion: 'codex-cli 0.144.0',
+    models: ['gpt-5.5'],
+    capabilities: [
+      {
+        id: 'run.start',
+        state: 'supported' as const,
+        source: 'contract-test' as const,
+        reason: 'Fixture launch support.',
+      },
+    ],
+    probe: {
+      state: 'ready' as const,
+      probedAt: '2026-07-16T00:00:00.000Z',
+      source: 'codex --version',
+      diagnostics: [],
+    },
+    digest: `sha256:${'a'.repeat(64)}`,
+  };
+}

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -49,6 +49,7 @@ const agentSchema = z.object({
       'openclaw',
       'codex-cli',
       'codex-sdk',
+      'hermes-cli',
       'codex-cloud',
       'ollama-local',
       'ollama-cloud',

--- a/server/src/schemas/agent-profile-package-schemas.ts
+++ b/server/src/schemas/agent-profile-package-schemas.ts
@@ -27,6 +27,7 @@ export const AgentProfileRuntimeSchema = z
         'openclaw',
         'codex-cli',
         'codex-sdk',
+        'hermes-cli',
         'codex-cloud',
         'ollama-local',
         'ollama-cloud',

--- a/server/src/schemas/provider-runtime-manifest-schemas.ts
+++ b/server/src/schemas/provider-runtime-manifest-schemas.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+import {
+  KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS,
+  PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION,
+  PROVIDER_RUNTIME_PROBE_REVISION,
+  type ProviderRuntimeManifest,
+} from '@veritas-kanban/shared';
+import { calculateProviderRuntimeManifestDigest } from '../utils/provider-runtime-manifest-digest.js';
+
+const identifierSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(120)
+  .regex(/^[a-zA-Z][a-zA-Z0-9._:/-]*$/, 'Invalid runtime identifier');
+
+const capabilityIdSchema = z
+  .string()
+  .trim()
+  .min(2)
+  .max(80)
+  .regex(/^[a-z][a-z0-9.-]*$/, 'Invalid capability identifier');
+
+export const ProviderRuntimeCapabilityEvidenceSchema = z
+  .object({
+    id: capabilityIdSchema,
+    state: z.enum(['supported', 'advisory', 'unsupported', 'unknown']),
+    source: z.enum(['runtime-probe', 'contract-test', 'host-enforced']),
+    reason: z.string().trim().min(1).max(1000),
+  })
+  .strict();
+
+export const ProviderRuntimeManifestSchema = z
+  .object({
+    schemaVersion: z.literal(PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION),
+    probeRevision: z.number().int().min(1).max(PROVIDER_RUNTIME_PROBE_REVISION),
+    provider: identifierSchema,
+    adapter: identifierSchema,
+    protocolVersion: identifierSchema,
+    providerVersion: z.string().trim().min(1).max(200),
+    providerBuild: z.string().trim().min(1).max(300).optional(),
+    models: z.array(z.string().trim().min(1).max(200)).max(100),
+    capabilities: z.array(ProviderRuntimeCapabilityEvidenceSchema).min(1).max(128),
+    probe: z
+      .object({
+        state: z.enum(['ready', 'degraded', 'failed']),
+        probedAt: z.iso.datetime(),
+        source: z.string().trim().min(1).max(200),
+        diagnostics: z.array(z.string().trim().min(1).max(1000)).max(32),
+      })
+      .strict(),
+    digest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    const seen = new Set<string>();
+    for (const [index, capability] of manifest.capabilities.entries()) {
+      if (seen.has(capability.id)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['capabilities', index, 'id'],
+          message: `Duplicate capability: ${capability.id}`,
+        });
+      }
+      seen.add(capability.id);
+    }
+    for (const capabilityId of KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS) {
+      if (!seen.has(capabilityId)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['capabilities'],
+          message: `Missing known capability: ${capabilityId}`,
+        });
+      }
+    }
+    if (manifest.digest !== calculateProviderRuntimeManifestDigest(manifest)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['digest'],
+        message: 'Provider runtime manifest digest does not match its canonical payload',
+      });
+    }
+  });
+
+export function parseProviderRuntimeManifest(input: unknown): ProviderRuntimeManifest {
+  return ProviderRuntimeManifestSchema.parse(input) as ProviderRuntimeManifest;
+}

--- a/server/src/services/agent-health-service.ts
+++ b/server/src/services/agent-health-service.ts
@@ -6,6 +6,40 @@ import { promisify } from 'util';
 import type { AgentConfig } from '@veritas-kanban/shared';
 
 const execFileAsync = promisify(execFile);
+const PROVIDER_VERSION_TIMEOUT_MS = 5_000;
+const PROVIDER_VERSION_MAX_BUFFER_BYTES = 8 * 1024;
+
+interface CommandOptions {
+  timeout?: number;
+  maxBuffer?: number;
+  shell?: boolean;
+}
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type AgentHealthCommandRunner = (
+  command: string,
+  args: string[],
+  options?: CommandOptions
+) => Promise<CommandResult>;
+
+interface ProviderVersionProbe {
+  attempted: boolean;
+  output?: string;
+  source?: string;
+  error?: string;
+}
+
+const defaultCommandRunner: AgentHealthCommandRunner = async (command, args, options) => {
+  const { stdout, stderr } = await execFileAsync(command, args, {
+    ...options,
+    encoding: 'utf8',
+  });
+  return { stdout: String(stdout), stderr: String(stderr) };
+};
 
 export interface AgentHealthStatus {
   type: string;
@@ -15,6 +49,8 @@ export interface AgentHealthStatus {
   command: string;
   executableFound: boolean;
   executablePath?: string;
+  providerVersion?: string;
+  providerVersionSource?: string;
   authenticated: boolean | null;
   healthy: boolean;
   checkedAt: string;
@@ -26,10 +62,15 @@ export interface AgentHealthChecker {
 }
 
 export class AgentHealthService implements AgentHealthChecker {
+  constructor(private readonly runCommand: AgentHealthCommandRunner = defaultCommandRunner) {}
+
   async checkAgent(agent: AgentConfig): Promise<AgentHealthStatus> {
     const checkedAt = new Date().toISOString();
     const executable = await this.findExecutable(agent.command);
-    const auth = executable.found ? await this.checkAuth(agent) : { authenticated: null };
+    const version = executable.found
+      ? await this.probeProviderVersion(agent.command)
+      : { attempted: false };
+    const auth = executable.found ? await this.checkAuth(agent, version) : { authenticated: null };
     const reason = this.buildReason(agent, executable.found, auth.authenticated, auth.error);
 
     return {
@@ -40,6 +81,8 @@ export class AgentHealthService implements AgentHealthChecker {
       command: agent.command,
       executableFound: executable.found,
       executablePath: executable.path,
+      providerVersion: version.output,
+      providerVersionSource: version.source,
       authenticated: auth.authenticated,
       healthy: agent.enabled && executable.found && auth.authenticated !== false,
       checkedAt,
@@ -60,7 +103,7 @@ export class AgentHealthService implements AgentHealthChecker {
     }
 
     try {
-      const { stdout } = await execFileAsync('which', [command]);
+      const { stdout } = await this.runCommand('which', [command]);
       return { found: true, path: stdout.trim() };
     } catch {
       return { found: false };
@@ -68,7 +111,8 @@ export class AgentHealthService implements AgentHealthChecker {
   }
 
   private async checkAuth(
-    agent: AgentConfig
+    agent: AgentConfig,
+    versionProbe: ProviderVersionProbe
   ): Promise<{ authenticated: boolean | null; error?: string }> {
     const command = path.basename(agent.command);
     const provider = agent.provider ?? '';
@@ -97,12 +141,8 @@ export class AgentHealthService implements AgentHealthChecker {
     if (provider === 'hermes-cli' || command === 'hermes') {
       // Hermes v2026.7.7.2: binary existence + version probe. API key is optional at
       // probe time; the actual run will fail if no key is configured.
-      const versionProbe = await this.runAuthProbe(
-        agent.command,
-        ['--version'],
-        /hermes|version|\d+\.\d+/i
-      );
-      if (!versionProbe.authenticated) return versionProbe;
+      const versionAuth = this.authResultFromVersionProbe(versionProbe, /hermes|version|\d+\.\d+/i);
+      if (!versionAuth.authenticated) return versionAuth;
       // Check for at least one supported API key in the environment
       const hasKey = Boolean(process.env.HERMES_API_KEY || process.env.ANTHROPIC_API_KEY);
       if (!hasKey) {
@@ -127,7 +167,7 @@ export class AgentHealthService implements AgentHealthChecker {
     successPattern: RegExp
   ): Promise<{ authenticated: boolean; error?: string }> {
     try {
-      const { stdout, stderr } = await execFileAsync(command, args);
+      const { stdout, stderr } = await this.runCommand(command, args);
       const output = `${stdout}${stderr}`.trim();
       return {
         authenticated: successPattern.test(output),
@@ -137,6 +177,43 @@ export class AgentHealthService implements AgentHealthChecker {
       const message = error instanceof Error ? error.message : 'Authentication probe failed';
       return { authenticated: false, error: message };
     }
+  }
+
+  private async probeProviderVersion(command: string): Promise<ProviderVersionProbe> {
+    const source = `${path.basename(command)} --version`;
+    try {
+      const { stdout, stderr } = await this.runCommand(command, ['--version'], {
+        timeout: PROVIDER_VERSION_TIMEOUT_MS,
+        maxBuffer: PROVIDER_VERSION_MAX_BUFFER_BYTES,
+        shell: false,
+      });
+      const output = boundUtf8(`${stdout}${stderr}`.trim(), PROVIDER_VERSION_MAX_BUFFER_BYTES);
+      return {
+        attempted: true,
+        output: output || undefined,
+        source: output ? source : undefined,
+        error: output ? undefined : 'Provider version output was empty',
+      };
+    } catch (error) {
+      return {
+        attempted: true,
+        error: error instanceof Error ? error.message : 'Provider version probe failed',
+      };
+    }
+  }
+
+  private authResultFromVersionProbe(
+    probe: ProviderVersionProbe,
+    successPattern: RegExp
+  ): { authenticated: boolean; error?: string } {
+    const output = probe.output ?? '';
+    const authenticated = successPattern.test(output);
+    return {
+      authenticated,
+      error: authenticated
+        ? undefined
+        : probe.error || output || (probe.attempted ? 'Authentication status unknown' : undefined),
+    };
   }
 
   private buildReason(
@@ -152,4 +229,13 @@ export class AgentHealthService implements AgentHealthChecker {
     }
     return undefined;
   }
+}
+
+function boundUtf8(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.byteLength <= maxBytes) return value;
+  return bytes
+    .subarray(0, maxBytes)
+    .toString('utf8')
+    .replace(/\uFFFD$/u, '');
 }

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -22,7 +22,11 @@ import { getAgentRoutingService } from './agent-routing-service.js';
 import { getGovernanceTraceService } from './governance-trace-service.js';
 import { getSandboxPolicyService } from './sandbox-policy-service.js';
 import { getAgentBudgetService } from './agent-budget-service.js';
-import { AgentHealthService, type AgentHealthChecker } from './agent-health-service.js';
+import {
+  AgentHealthService,
+  type AgentHealthChecker,
+  type AgentHealthStatus,
+} from './agent-health-service.js';
 import { activityService } from './activity-service.js';
 import { getTraceService } from './trace-service.js';
 import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
@@ -52,14 +56,20 @@ import type {
   AgentBudgetUsage,
   AgentBudgetDecision,
   AgentProfileLaunchMetadata,
+  ExecutableAgentProvider,
+  ProviderRuntimeManifest,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError } from '../middleware/error-handler.js';
 import type { AgentBudgetThresholdEvent } from '@veritas-kanban/shared';
 import { getAgentProfilePackageService } from './agent-profile-package-service.js';
+import {
+  ProviderRuntimeManifestService,
+  type ProviderRuntimeProbeRequest,
+} from './provider-runtime-manifest-service.js';
+import { getProviderRuntimeAdapterDefinition } from './provider-runtime-adapter-registry.js';
+import { getInstalledPackageVersion } from '../utils/package-version.js';
 const log = createLogger('clawdbot-agent-service');
-
-export type AgentProvider = 'openclaw' | 'codex-cli' | 'codex-sdk' | 'hermes-cli';
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
@@ -90,17 +100,15 @@ export interface AgentProviderStopContext {
   pending: PendingAgent;
 }
 
+export interface AgentProviderProbeContext {
+  agentConfig?: AgentConfig;
+  health: AgentHealthStatus;
+}
+
 export interface AgentProviderAdapter {
-  id: AgentProvider;
+  id: ExecutableAgentProvider;
   label: string;
-  capabilities: {
-    start: true;
-    stop: boolean;
-    status: true;
-    logs: boolean;
-    complete: true;
-    resume: boolean;
-  };
+  probe(context: AgentProviderProbeContext): Promise<ProviderRuntimeManifest>;
   start(context: AgentProviderStartContext): Promise<void> | void;
   stop(context: AgentProviderStopContext): Promise<void> | void;
 }
@@ -154,11 +162,12 @@ interface PendingAgent {
   agent: AgentType;
   startedAt: string;
   emitter: EventEmitter;
-  provider: AgentProvider;
+  provider: ExecutableAgentProvider;
   model?: string;
   budget?: AgentBudgetState;
   budgetStopped?: boolean;
   agentProfile?: AgentProfileLaunchMetadata;
+  providerRuntimeManifest: ProviderRuntimeManifest;
   threadId?: string;
   abortController?: AbortController;
   process?: ChildProcessWithoutNullStreams;
@@ -174,12 +183,17 @@ export class ClawdbotAgentService {
   private configService: ConfigService;
   private taskService: TaskService;
   private agentHealth: AgentHealthChecker;
+  private providerRuntimeManifests: ProviderRuntimeManifestService;
   private logsDir: string;
 
-  constructor(agentHealth?: AgentHealthChecker) {
+  constructor(
+    agentHealth?: AgentHealthChecker,
+    providerRuntimeManifests = new ProviderRuntimeManifestService()
+  ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
     this.agentHealth = agentHealth || new AgentHealthService();
+    this.providerRuntimeManifests = providerRuntimeManifests;
     this.logsDir = getLogsDir();
     this.ensureLogsDir();
   }
@@ -220,16 +234,18 @@ export class ClawdbotAgentService {
       if (pendingAgents.has(task.id)) continue;
 
       try {
+        const failedAttempt: TaskAttempt = {
+          ...task.attempt,
+          status: 'failed',
+          ended: now,
+        };
         await this.taskService.updateTask(task.id, {
           // Only revert task status if it is still 'in-progress' from this run.
           // Tasks in other states (blocked, done, todo, etc.) keep their status;
           // we only fix the orphaned attempt record.
           ...(task.status === 'in-progress' ? { status: 'todo' } : {}),
-          attempt: {
-            ...task.attempt,
-            status: 'failed',
-            ended: now,
-          },
+          attempt: failedAttempt,
+          attempts: upsertAttemptHistory(task.attempts, failedAttempt),
         });
         log.info(
           { taskId: task.id, attemptId: task.attempt.id },
@@ -316,8 +332,9 @@ export class ClawdbotAgentService {
             model: profileLaunch.model ?? agentConfig.model,
           }
         : agentConfig;
-    await this.assertAgentAvailable(agent, profileAgentConfig);
+    const agentHealth = await this.assertAgentAvailable(agent, profileAgentConfig);
     const provider = this.resolveAgentProvider(profileAgentConfig, agent);
+    const adapter = this.resolveProviderAdapter(provider);
     const budgetService = getAgentBudgetService();
     const budgetPolicy = budgetService.resolve({
       workspaceBudget: config.features?.budget?.enabled
@@ -352,6 +369,10 @@ export class ClawdbotAgentService {
       budgetEvaluation.modelOverride && profileAgentConfig
         ? { ...profileAgentConfig, model: budgetEvaluation.modelOverride }
         : profileAgentConfig;
+    const providerRuntimeManifest = await adapter.probe({
+      agentConfig: launchAgentConfig,
+      health: agentHealth,
+    });
     const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
       presetId:
         options.sandboxPresetId ??
@@ -424,6 +445,7 @@ export class ClawdbotAgentService {
       provider,
       model: launchAgentConfig?.model,
       agentProfile: profileLaunch?.metadata,
+      providerRuntimeManifest,
       budget: budgetPolicy
         ? {
             ...budgetService.initialState(budgetPolicy),
@@ -452,7 +474,7 @@ export class ClawdbotAgentService {
 
     // Initialize log file (ensure it stays within logs dir)
     ensureWithinBase(this.logsDir, logPath);
-    await this.initLogFile(logPath, task, agent, taskPrompt);
+    await this.initLogFile(logPath, task, agent, taskPrompt, providerRuntimeManifest);
 
     // Update task with attempt info
     const attempt: TaskAttempt = {
@@ -464,11 +486,13 @@ export class ClawdbotAgentService {
       model: launchAgentConfig?.model,
       budget: pendingAgents.get(taskId)?.budget,
       agentProfile: profileLaunch?.metadata,
+      providerRuntimeManifest,
     };
 
     await this.taskService.updateTask(taskId, {
       status: 'in-progress',
       attempt,
+      attempts: task.attempt ? upsertAttemptHistory(task.attempts, task.attempt) : task.attempts,
     });
 
     if (profileLaunch) {
@@ -500,7 +524,6 @@ export class ClawdbotAgentService {
       project: task.project,
     });
 
-    const adapter = this.resolveProviderAdapter(provider);
     try {
       await adapter.start({
         task,
@@ -523,9 +546,18 @@ export class ClawdbotAgentService {
         model: agentConfig?.model,
       });
       await getTraceService().completeTrace(attemptId, 'error');
+      const failedAttempt: TaskAttempt = {
+        ...attempt,
+        status: 'failed',
+        ended: new Date().toISOString(),
+      };
       await this.taskService.updateTask(taskId, {
         status: 'todo',
-        attempt: { ...attempt, status: 'failed', ended: new Date().toISOString() },
+        attempt: failedAttempt,
+        attempts: upsertAttemptHistory(
+          task.attempt ? upsertAttemptHistory(task.attempts, task.attempt) : task.attempts,
+          failedAttempt
+        ),
       });
       await telemetry.emit<RunErrorEvent>({
         type: 'run.error',
@@ -614,21 +646,26 @@ export class ClawdbotAgentService {
       );
     }
 
-    // Update task
+    const taskBeforeCompletion = await this.taskService.getTask(taskId);
+    const completedAttempt: TaskAttempt = {
+      id: attemptId,
+      agent: pending.agent,
+      status,
+      started: pending.startedAt,
+      ended: endedAt,
+      provider: pending.provider,
+      model: pending.model,
+      threadId: pending.threadId,
+      budget: pending.budget,
+      agentProfile: pending.agentProfile,
+      providerRuntimeManifest: pending.providerRuntimeManifest,
+    };
+
+    // Update task and preserve the exact launch manifest in attempt history.
     await this.taskService.updateTask(taskId, {
       status: result.success ? 'done' : 'in-progress',
-      attempt: {
-        id: attemptId,
-        agent: pending.agent,
-        status,
-        started: pending.startedAt,
-        ended: endedAt,
-        provider: pending.provider,
-        model: pending.model,
-        threadId: pending.threadId,
-        budget: pending.budget,
-        agentProfile: pending.agentProfile,
-      },
+      attempt: completedAttempt,
+      attempts: upsertAttemptHistory(taskBeforeCompletion?.attempts, completedAttempt),
     });
 
     // Append to log
@@ -833,10 +870,19 @@ export class ClawdbotAgentService {
     return agents.find((a) => a.type === agent);
   }
 
+  async probeProviderRuntime(
+    agentConfig: AgentConfig,
+    agent: AgentType = agentConfig.type
+  ): Promise<ProviderRuntimeManifest> {
+    const health = await this.assertAgentAvailable(agent, agentConfig);
+    const provider = this.resolveAgentProvider(agentConfig, agent);
+    return this.resolveProviderAdapter(provider).probe({ agentConfig, health });
+  }
+
   private async assertAgentAvailable(
     agent: AgentType,
     agentConfig: AgentConfig | undefined
-  ): Promise<void> {
+  ): Promise<AgentHealthStatus> {
     if (!agentConfig) {
       throw new ConflictError(`Agent "${agent}" is not configured`, {
         agent,
@@ -863,34 +909,49 @@ export class ClawdbotAgentService {
         }
       );
     }
+    return health;
   }
 
   private resolveAgentProvider(
     agentConfig: AgentConfig | undefined,
     agent: AgentType
-  ): AgentProvider {
-    if (agentConfig?.provider === 'codex-sdk') return 'codex-sdk';
-    if (agentConfig?.provider === 'codex-cli') return 'codex-cli';
-    if (agentConfig?.provider === 'hermes-cli') return 'hermes-cli';
+  ): ExecutableAgentProvider {
+    if (agentConfig?.provider) {
+      if (
+        agentConfig.provider === 'openclaw' ||
+        agentConfig.provider === 'codex-sdk' ||
+        agentConfig.provider === 'codex-cli' ||
+        agentConfig.provider === 'hermes-cli'
+      ) {
+        return agentConfig.provider;
+      }
+      throw new ConflictError(
+        `Provider "${agentConfig.provider}" is configured but has no execution adapter`,
+        {
+          agent,
+          provider: agentConfig.provider,
+          reason: 'No executable provider adapter is registered',
+        }
+      );
+    }
     if (agent === 'codex') return 'codex-cli';
     if (agentConfig?.command === 'codex') return 'codex-cli';
     if (agentConfig?.command === 'hermes') return 'hermes-cli';
     return 'openclaw';
   }
 
-  private resolveProviderAdapter(provider: AgentProvider): AgentProviderAdapter {
-    const commonCapabilities = {
-      start: true as const,
-      status: true as const,
-      logs: true,
-      complete: true as const,
-    };
+  private resolveProviderAdapter(provider: ExecutableAgentProvider): AgentProviderAdapter {
+    const definition = getProviderRuntimeAdapterDefinition(provider);
+    const probe = (context: AgentProviderProbeContext) =>
+      this.providerRuntimeManifests.probe(
+        this.buildProviderRuntimeProbeRequest(provider, context, definition)
+      );
 
     if (provider === 'codex-cli') {
       return {
-        id: 'codex-cli',
-        label: 'Codex CLI',
-        capabilities: { ...commonCapabilities, stop: true, resume: false },
+        id: definition.id,
+        label: definition.label,
+        probe,
         start: ({
           task,
           agentConfig,
@@ -920,9 +981,9 @@ export class ClawdbotAgentService {
 
     if (provider === 'codex-sdk') {
       return {
-        id: 'codex-sdk',
-        label: 'Codex SDK',
-        capabilities: { ...commonCapabilities, stop: true, resume: true },
+        id: definition.id,
+        label: definition.label,
+        probe,
         start: ({
           task,
           agentConfig,
@@ -966,9 +1027,9 @@ export class ClawdbotAgentService {
 
     if (provider === 'hermes-cli') {
       return {
-        id: 'hermes-cli',
-        label: 'Hermes Agent',
-        capabilities: { ...commonCapabilities, stop: true, resume: false },
+        id: definition.id,
+        label: definition.label,
+        probe,
         start: ({
           task,
           agentConfig,
@@ -1010,9 +1071,9 @@ export class ClawdbotAgentService {
     }
 
     return {
-      id: 'openclaw',
-      label: 'OpenClaw',
-      capabilities: { ...commonCapabilities, stop: false, resume: false },
+      id: definition.id,
+      label: definition.label,
+      probe,
       start: async ({ prompt, task, attemptId, agentConfig }) => {
         // Use the HTTP gateway adapter (sessions_spawn) instead of writing a request file.
         // The real spawn acknowledgement surfaces policy denial or gateway
@@ -1054,6 +1115,63 @@ export class ClawdbotAgentService {
           '[ClawdbotAgent] OpenClaw stop requested; sub-session will complete via callback'
         );
       },
+    };
+  }
+
+  private buildProviderRuntimeProbeRequest(
+    provider: ExecutableAgentProvider,
+    context: AgentProviderProbeContext,
+    definition: ReturnType<typeof getProviderRuntimeAdapterDefinition>
+  ): ProviderRuntimeProbeRequest {
+    const sdkVersion =
+      provider === 'codex-sdk' ? getInstalledPackageVersion('@openai/codex-sdk') : undefined;
+    const configuredOpenClawVersion =
+      provider === 'openclaw' ? process.env.OPENCLAW_GATEWAY_VERSION?.trim() : undefined;
+    const providerVersion =
+      sdkVersion ||
+      configuredOpenClawVersion ||
+      (provider === 'openclaw' ? undefined : context.health.providerVersion);
+    const providerBuild =
+      provider === 'codex-sdk' && context.health.providerVersion
+        ? `codex-cli:${context.health.providerVersion}`
+        : undefined;
+    const diagnostics: string[] = [];
+
+    if (!providerVersion) {
+      diagnostics.push(
+        provider === 'openclaw'
+          ? 'OpenClaw runtime version was not registered; set OPENCLAW_GATEWAY_VERSION or register a host manifest.'
+          : 'The provider version command did not return verifiable output.'
+      );
+    }
+
+    return {
+      provider,
+      adapter: definition.id,
+      protocolVersion: definition.protocolVersion,
+      command:
+        provider === 'openclaw'
+          ? process.env.OPENCLAW_GATEWAY_URL ||
+            process.env.CLAWDBOT_GATEWAY ||
+            process.env.CLAWDBOT_GATEWAY_URL ||
+            'openclaw'
+          : context.agentConfig?.command,
+      models: context.agentConfig?.model ? [context.agentConfig.model] : [],
+      identity: {
+        providerVersion,
+        providerBuild,
+        verified: provider === 'openclaw' ? false : Boolean(providerVersion),
+        source:
+          provider === 'codex-sdk'
+            ? 'installed-package:@openai/codex-sdk'
+            : configuredOpenClawVersion
+              ? 'environment:OPENCLAW_GATEWAY_VERSION'
+              : context.health.providerVersionSource || 'agent-health',
+        authenticated: context.health.authenticated,
+        executableFingerprint: context.health.executablePath,
+        diagnostics,
+      },
+      capabilities: definition.capabilities,
     };
   }
 
@@ -1546,7 +1664,7 @@ export class ClawdbotAgentService {
     task: Task,
     attemptId: string,
     agent: string,
-    provider: AgentProvider,
+    provider: ExecutableAgentProvider,
     agentConfig?: AgentConfig
   ): Promise<void> {
     getTraceService().startTrace(
@@ -1588,7 +1706,7 @@ export class ClawdbotAgentService {
     task: Task,
     attemptId: string,
     agentConfig: AgentConfig | undefined,
-    provider: AgentProvider,
+    provider: ExecutableAgentProvider,
     stream: 'stdout' | 'stderr',
     chunk: string
   ): void {
@@ -1610,13 +1728,16 @@ export class ClawdbotAgentService {
   private buildTraceMetadata(
     task: Task,
     attemptId: string,
-    provider: AgentProvider,
+    provider: ExecutableAgentProvider,
     agentConfig?: AgentConfig
   ): AgentRunTraceMetadata {
+    const providerRuntimeManifest = pendingAgents.get(task.id)?.providerRuntimeManifest;
     return {
       clientSource: 'agent-service',
       mode: task.runMode ?? 'agent',
-      capabilitySet: this.traceCapabilitiesForProvider(provider),
+      capabilitySet: providerRuntimeManifest?.capabilities
+        .filter((capability) => capability.state === 'supported')
+        .map((capability) => capability.id),
       workspaceId: 'local',
       runKey: attemptId,
       policyProfile:
@@ -1634,15 +1755,8 @@ export class ClawdbotAgentService {
       branch: task.git?.branch,
       baseBranch: task.git?.baseBranch,
       worktreePath: task.git?.worktreePath,
+      providerRuntimeManifest,
     };
-  }
-
-  private traceCapabilitiesForProvider(provider: AgentProvider): string[] {
-    const base = ['start', 'status', 'logs', 'complete'];
-    if (provider === 'openclaw') return base;
-    if (provider === 'codex-cli') return [...base, 'stop'];
-    if (provider === 'hermes-cli') return [...base, 'stop'];
-    return [...base, 'stop', 'resume'];
   }
 
   private async recordCodexEvent(
@@ -2005,18 +2119,7 @@ export class ClawdbotAgentService {
       pending.threadId = threadId;
     }
 
-    await this.taskService.updateTask(task.id, {
-      status: 'in-progress',
-      attempt: {
-        id: attemptId,
-        agent: pending?.agent || 'codex-sdk',
-        status: 'running',
-        started: pending?.startedAt,
-        provider: pending?.provider || 'codex-sdk',
-        model: pending?.model,
-        threadId,
-      },
-    });
+    await this.taskService.patchTaskAttempt(task.id, attemptId, { threadId });
   }
 
   private extractCodexSummary(event: unknown): string | undefined {
@@ -2249,7 +2352,8 @@ If you encounter errors, call with \`success: false\` and include the error mess
     logPath: string,
     task: Task,
     agent: AgentType,
-    prompt: string
+    prompt: string,
+    providerRuntimeManifest: ProviderRuntimeManifest
   ): Promise<void> {
     const header = `# Agent Log: ${task.title}
 
@@ -2257,6 +2361,15 @@ If you encounter errors, call with \`success: false\` and include the error mess
 **Agent:** ${agent}
 **Started:** ${new Date().toISOString()}
 **Worktree:** ${task.git?.worktreePath}
+**Provider manifest:** ${providerRuntimeManifest.digest}
+
+<details><summary>Provider runtime manifest</summary>
+
+\`\`\`json
+${JSON.stringify(providerRuntimeManifest, null, 2)}
+\`\`\`
+
+</details>
 
 ## Task Prompt
 
@@ -2275,6 +2388,13 @@ ${prompt}
 
 // Export singleton
 export const clawdbotAgentService = new ClawdbotAgentService();
+
+function upsertAttemptHistory(
+  history: TaskAttempt[] | undefined,
+  attempt: TaskAttempt
+): TaskAttempt[] {
+  return [...(history ?? []).filter((candidate) => candidate.id !== attempt.id), attempt];
+}
 
 function mergeThresholdEvents(
   existing: AgentBudgetThresholdEvent[],

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -79,6 +79,14 @@ const DEFAULT_CONFIG: AppConfig = {
       provider: 'codex-cloud',
     },
     {
+      type: 'hermes',
+      name: 'Hermes Agent',
+      command: 'hermes',
+      args: [],
+      enabled: false,
+      provider: 'hermes-cli',
+    },
+    {
       type: 'ollama-local',
       name: 'Ollama Local',
       command: 'ollama',

--- a/server/src/services/provider-runtime-adapter-registry.ts
+++ b/server/src/services/provider-runtime-adapter-registry.ts
@@ -1,0 +1,164 @@
+import type {
+  ExecutableAgentProvider,
+  ProviderRuntimeCapabilityEvidence,
+} from '@veritas-kanban/shared';
+import {
+  buildProviderRuntimeCapabilities,
+  type ProviderRuntimeCapabilityOverrides,
+} from './provider-runtime-manifest-service.js';
+
+export interface ProviderRuntimeAdapterDefinition {
+  id: ExecutableAgentProvider;
+  label: string;
+  protocolVersion: string;
+  capabilities: ProviderRuntimeCapabilityEvidence[];
+}
+
+const COMMON_SUPPORTED: ProviderRuntimeCapabilityOverrides = {
+  'run.start': supported('The adapter has a contract-tested launch path.'),
+  'run.status': supported('Veritas tracks adapter run status.'),
+  'run.logs': supported('Veritas persists adapter run logs.'),
+  'run.complete': supported('The adapter records a terminal run result.'),
+};
+
+const CLI_SANDBOX: ProviderRuntimeCapabilityOverrides = {
+  'filesystem.read': supported('The launch sandbox grants bounded filesystem reads.'),
+  'filesystem.write': supported('The launch sandbox grants bounded workspace writes.'),
+  'environment.allowlist': supported('The adapter receives an allowlisted environment.'),
+};
+
+const NOT_YET_IMPLEMENTED: ProviderRuntimeCapabilityOverrides = {
+  'run.follow-up': unsupported('Provider-neutral follow-up turns are tracked by issue #856.'),
+  'run.steer': unsupported('Provider-neutral steering is tracked by issue #856.'),
+  'run.fork': unsupported('Provider-neutral conversation forks are tracked by issue #856.'),
+  'run.reattach': unsupported('Durable provider reattachment is tracked by issue #853.'),
+  'run.approvals': unsupported('Provider-native approvals are tracked by issue #852.'),
+  'run.elicitation': unsupported('Provider-native elicitation is tracked by issue #852.'),
+};
+
+const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinition> = {
+  'codex-cli': definition('codex-cli', 'Codex CLI', 'codex-exec-json/v1', {
+    ...COMMON_SUPPORTED,
+    ...CLI_SANDBOX,
+    ...NOT_YET_IMPLEMENTED,
+    'run.stop': supported('The adapter terminates the supervised Codex process.'),
+    'run.streaming': supported('Codex JSONL output is streamed into run events.'),
+    'run.structured-events': supported('Codex CLI emits contract-tested JSONL events.'),
+    'run.interrupt': advisory('Process termination is available; semantic interrupt is not.'),
+    'run.resume': unsupported('Codex CLI resume is not wired into task execution.'),
+    'tool.calls': supported('Codex tool events are parsed and recorded.'),
+    'output.structured': advisory(
+      'Structured events are available without output-schema enforcement.'
+    ),
+    'usage.tokens': supported('Codex token usage events are parsed and persisted.'),
+    'artifact.write': supported('Codex file events create task deliverable records.'),
+    'workspace.worktrees': supported('Codex runs with the task worktree as its working directory.'),
+  }),
+  'codex-sdk': definition('codex-sdk', 'Codex SDK', 'openai-codex-sdk/v1', {
+    ...COMMON_SUPPORTED,
+    ...CLI_SANDBOX,
+    ...NOT_YET_IMPLEMENTED,
+    'run.stop': supported('The adapter aborts the active Codex SDK run.'),
+    'run.streaming': supported('Codex SDK thread events are streamed into run events.'),
+    'run.structured-events': supported('Codex SDK emits typed thread events.'),
+    'run.interrupt': advisory('Abort is available; semantic interrupt is not wired.'),
+    'run.resume': advisory(
+      'Thread identity is retained, but task-level resume is not yet exposed.'
+    ),
+    'tool.calls': supported('Codex SDK tool events are parsed and recorded.'),
+    'output.structured': advisory('Typed events are available without output-schema enforcement.'),
+    'usage.tokens': supported('Codex SDK token usage events are parsed and persisted.'),
+    'artifact.write': supported('Codex SDK file events create task deliverable records.'),
+    'workspace.worktrees': supported('Codex SDK runs against the task worktree.'),
+    'network.disable': supported('The SDK sandbox can disable network access.'),
+    'network.block-private': supported('Disabling network access blocks private network ranges.'),
+    'network.block-metadata': supported('Disabling network access blocks metadata endpoints.'),
+  }),
+  'hermes-cli': definition('hermes-cli', 'Hermes Agent', 'hermes-one-shot/v1', {
+    ...COMMON_SUPPORTED,
+    ...CLI_SANDBOX,
+    ...NOT_YET_IMPLEMENTED,
+    'run.stop': supported('The adapter terminates the supervised Hermes process.'),
+    'run.streaming': supported('Hermes stdout and diagnostics are streamed into the run log.'),
+    'run.structured-events': unsupported(
+      'Hermes currently runs through its one-shot text interface.'
+    ),
+    'run.interrupt': advisory('Process termination is available; semantic interrupt is not.'),
+    'run.resume': unsupported('Hermes session resume is not implemented.'),
+    'output.structured': unsupported('The one-shot Hermes interface returns text output.'),
+    'usage.tokens': unsupported('The Hermes adapter does not receive token usage events.'),
+    'artifact.write': unknown('Hermes artifact events have not been verified.'),
+    'workspace.worktrees': supported(
+      'Hermes runs with the task worktree as its working directory.'
+    ),
+    'filesystem.read': advisory(
+      'Hermes starts in the worktree without an enforceable read boundary.'
+    ),
+    'filesystem.write': advisory(
+      'Hermes starts in the worktree without an enforceable write boundary.'
+    ),
+  }),
+  openclaw: definition('openclaw', 'OpenClaw', 'openclaw-tools/v1', {
+    ...COMMON_SUPPORTED,
+    ...NOT_YET_IMPLEMENTED,
+    'run.stop': unsupported('OpenClaw does not expose a task-session stop API.'),
+    'run.streaming': unknown('Task-session streaming has not been conformance tested.'),
+    'run.structured-events': unknown('OpenClaw task event normalization is tracked by issue #850.'),
+    'run.interrupt': unsupported(
+      'OpenClaw does not expose task-session interrupt through this adapter.'
+    ),
+    'run.resume': unsupported('OpenClaw task-session resume is not wired into task execution.'),
+    'tool.calls': advisory(
+      'OpenClaw agents may use tools, but Veritas does not yet enforce the tool set.'
+    ),
+    'output.structured': unknown('Structured output has not been conformance tested.'),
+    'usage.tokens': unknown('Token usage is not returned by the current task adapter.'),
+    'artifact.write': unknown('Artifact events are not returned by the current task adapter.'),
+    'workspace.worktrees': advisory('The worktree is delegated in the prompt, not host-enforced.'),
+    'filesystem.read': advisory('Filesystem scope is delegated to the OpenClaw runtime.'),
+    'filesystem.write': advisory('Workspace write scope is delegated to the OpenClaw runtime.'),
+    'network.allowlist': advisory('OpenClaw network policy is external to this adapter.'),
+    'environment.allowlist': advisory('Environment filtering is external to this adapter.'),
+    'credential.broker': advisory('Credentials are governed by the external OpenClaw runtime.'),
+  }),
+};
+
+export function getProviderRuntimeAdapterDefinition(
+  provider: ExecutableAgentProvider
+): ProviderRuntimeAdapterDefinition {
+  return DEFINITIONS[provider];
+}
+
+function definition(
+  id: ExecutableAgentProvider,
+  label: string,
+  protocolVersion: string,
+  overrides: ProviderRuntimeCapabilityOverrides
+): ProviderRuntimeAdapterDefinition {
+  return {
+    id,
+    label,
+    protocolVersion,
+    capabilities: buildProviderRuntimeCapabilities(overrides),
+  };
+}
+
+function supported(reason: string) {
+  return posture('supported', reason);
+}
+
+function advisory(reason: string) {
+  return posture('advisory', reason);
+}
+
+function unsupported(reason: string) {
+  return posture('unsupported', reason);
+}
+
+function unknown(reason: string) {
+  return posture('unknown', reason);
+}
+
+function posture(state: 'supported' | 'advisory' | 'unsupported' | 'unknown', reason: string) {
+  return { state, reason, source: 'contract-test' as const };
+}

--- a/server/src/services/provider-runtime-manifest-service.ts
+++ b/server/src/services/provider-runtime-manifest-service.ts
@@ -1,0 +1,338 @@
+import { createHash } from 'node:crypto';
+import {
+  KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS,
+  PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION,
+  PROVIDER_RUNTIME_PROBE_REVISION,
+  type KnownProviderRuntimeCapabilityId,
+  type ProviderRuntimeCapabilityEvidence,
+  type ProviderRuntimeCapabilityState,
+  type ProviderRuntimeEvidenceSource,
+  type ProviderRuntimeManifest,
+} from '@veritas-kanban/shared';
+import { parseProviderRuntimeManifest } from '../schemas/provider-runtime-manifest-schemas.js';
+import { calculateProviderRuntimeManifestDigest } from '../utils/provider-runtime-manifest-digest.js';
+
+export {
+  calculateProviderRuntimeManifestDigest,
+  verifyProviderRuntimeManifestDigest,
+} from '../utils/provider-runtime-manifest-digest.js';
+export type { ProviderRuntimeManifestPayload } from '../utils/provider-runtime-manifest-digest.js';
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CONFORMANCE_PROBE_TIMEOUT_MS = 5_000;
+const MAX_DIAGNOSTIC_BYTES = 8 * 1024;
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
+  [/\b(?:sk-|ghp_|github_pat_)[A-Za-z0-9_-]{12,}/gi, '[REDACTED]'],
+  [/\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*([^\s"'`,}]+)/gi, '$1=[REDACTED]'],
+];
+
+export interface ProviderRuntimeIdentityEvidence {
+  providerVersion?: string;
+  providerBuild?: string;
+  source: string;
+  verified?: boolean;
+  authenticated?: boolean | null;
+  executableFingerprint?: string;
+  diagnostics?: string[];
+}
+
+export interface ProviderRuntimeProbeRequest {
+  provider: string;
+  adapter: string;
+  protocolVersion: string;
+  command?: string;
+  models?: string[];
+  identity: ProviderRuntimeIdentityEvidence;
+  capabilities: ProviderRuntimeCapabilityEvidence[];
+}
+
+export interface ProviderRuntimeManifestServiceOptions {
+  cacheTtlMs?: number;
+  conformanceProbeTimeoutMs?: number;
+  now?: () => Date;
+  conformanceProbe?: (
+    request: ProviderRuntimeProbeRequest
+  ) => Promise<ProviderRuntimeCapabilityEvidence[]>;
+}
+
+interface CacheEntry {
+  fullKey: string;
+  cachedAt: number;
+  manifest: ProviderRuntimeManifest;
+}
+
+export interface ProviderRuntimeCapabilityOverride {
+  state: ProviderRuntimeCapabilityState;
+  reason: string;
+  source?: ProviderRuntimeEvidenceSource;
+}
+
+export type ProviderRuntimeCapabilityOverrides = Partial<
+  Record<KnownProviderRuntimeCapabilityId, ProviderRuntimeCapabilityOverride>
+>;
+
+export function buildProviderRuntimeCapabilities(
+  overrides: ProviderRuntimeCapabilityOverrides
+): ProviderRuntimeCapabilityEvidence[] {
+  return KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS.map((id) => {
+    const override = overrides[id];
+    return {
+      id,
+      state: override?.state ?? 'unknown',
+      source: override?.source ?? 'contract-test',
+      reason: override?.reason ?? 'No adapter conformance evidence is available yet.',
+    };
+  });
+}
+
+export class ProviderRuntimeManifestService {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, Promise<ProviderRuntimeManifest>>();
+  private readonly latestFullKeyByScope = new Map<string, string>();
+  private readonly cacheTtlMs: number;
+  private readonly conformanceProbeTimeoutMs: number;
+  private readonly now: () => Date;
+  private cacheGeneration = 0;
+  private readonly conformanceProbe: NonNullable<
+    ProviderRuntimeManifestServiceOptions['conformanceProbe']
+  >;
+
+  constructor(options: ProviderRuntimeManifestServiceOptions = {}) {
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.conformanceProbeTimeoutMs =
+      options.conformanceProbeTimeoutMs ?? DEFAULT_CONFORMANCE_PROBE_TIMEOUT_MS;
+    this.now = options.now ?? (() => new Date());
+    this.conformanceProbe =
+      options.conformanceProbe ?? (async (request) => structuredClone(request.capabilities));
+  }
+
+  async probe(request: ProviderRuntimeProbeRequest): Promise<ProviderRuntimeManifest> {
+    const scopeKey = hashJson({
+      schemaVersion: PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION,
+      probeRevision: PROVIDER_RUNTIME_PROBE_REVISION,
+      provider: request.provider,
+      adapter: request.adapter,
+      protocolVersion: request.protocolVersion,
+      command: request.command ?? '',
+      models: uniqueSorted(request.models ?? []),
+    });
+    const providerVersion = normalizedIdentityValue(request.identity.providerVersion, 200);
+    const providerBuild = normalizedOptionalIdentityValue(request.identity.providerBuild, 300);
+    const fullKey = hashJson({
+      scopeKey,
+      providerVersion,
+      providerBuild,
+      verified: request.identity.verified ?? false,
+      authenticated: request.identity.authenticated ?? null,
+      executableFingerprint: request.identity.executableFingerprint ?? '',
+    });
+    const nowMs = this.now().getTime();
+    const cached = this.cache.get(scopeKey);
+
+    if (
+      providerVersion !== 'unknown' &&
+      cached !== undefined &&
+      cached.fullKey === fullKey &&
+      nowMs - cached.cachedAt < this.cacheTtlMs
+    ) {
+      return immutableClone(cached.manifest);
+    }
+
+    if (cached && cached.fullKey !== fullKey) this.cache.delete(scopeKey);
+
+    const existingProbe = this.inFlight.get(fullKey);
+    if (existingProbe) return immutableClone(await existingProbe);
+
+    const cacheGeneration = this.cacheGeneration;
+    this.latestFullKeyByScope.set(scopeKey, fullKey);
+    const probe = this.buildManifest(request, providerVersion, providerBuild);
+    this.inFlight.set(fullKey, probe);
+
+    try {
+      const manifest = await probe;
+      if (
+        providerVersion !== 'unknown' &&
+        manifest.probe.state !== 'failed' &&
+        this.cacheGeneration === cacheGeneration &&
+        this.latestFullKeyByScope.get(scopeKey) === fullKey
+      ) {
+        this.cache.set(scopeKey, {
+          fullKey,
+          cachedAt: this.now().getTime(),
+          manifest,
+        });
+      }
+      return immutableClone(manifest);
+    } finally {
+      if (this.inFlight.get(fullKey) === probe) this.inFlight.delete(fullKey);
+      if (
+        this.cacheGeneration === cacheGeneration &&
+        this.latestFullKeyByScope.get(scopeKey) === fullKey &&
+        !this.cache.has(scopeKey)
+      ) {
+        this.latestFullKeyByScope.delete(scopeKey);
+      }
+    }
+  }
+
+  clear(): void {
+    this.cacheGeneration += 1;
+    this.cache.clear();
+    this.inFlight.clear();
+    this.latestFullKeyByScope.clear();
+  }
+
+  private async buildManifest(
+    request: ProviderRuntimeProbeRequest,
+    providerVersion: string,
+    providerBuild: string | undefined
+  ): Promise<ProviderRuntimeManifest> {
+    const probedAt = this.now().toISOString();
+    const diagnostics = sanitizeDiagnostics(request.identity.diagnostics ?? []);
+    let capabilities: ProviderRuntimeCapabilityEvidence[];
+    let probeState: ProviderRuntimeManifest['probe']['state'] =
+      providerVersion === 'unknown' || request.identity.verified === false ? 'degraded' : 'ready';
+
+    if (providerVersion === 'unknown') {
+      diagnostics.unshift('Provider version could not be verified; this manifest is not cached.');
+    } else if (request.identity.verified === false) {
+      diagnostics.unshift('Provider version is operator-declared and was not runtime-verified.');
+    }
+
+    try {
+      capabilities = normalizeCapabilities(
+        await withTimeout(
+          this.conformanceProbe(request),
+          this.conformanceProbeTimeoutMs,
+          'Provider conformance probe timed out.'
+        )
+      );
+    } catch (error) {
+      probeState = 'failed';
+      capabilities = normalizeCapabilities(
+        request.capabilities.map((capability) => ({
+          ...capability,
+          state: 'unknown',
+          source: 'runtime-probe',
+          reason: 'The provider conformance probe failed before this capability was verified.',
+        }))
+      );
+      diagnostics.push(
+        sanitizeDiagnostic(
+          error instanceof Error ? error.message : 'Provider conformance probe failed.'
+        )
+      );
+    }
+
+    const payload = {
+      schemaVersion: PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION,
+      probeRevision: PROVIDER_RUNTIME_PROBE_REVISION,
+      provider: request.provider,
+      adapter: request.adapter,
+      protocolVersion: request.protocolVersion,
+      providerVersion,
+      ...(providerBuild ? { providerBuild } : {}),
+      models: uniqueSorted(request.models ?? []),
+      capabilities,
+      probe: {
+        state: probeState,
+        probedAt,
+        source: request.identity.source,
+        diagnostics: sanitizeDiagnostics(diagnostics),
+      },
+    };
+    const manifest = {
+      ...payload,
+      digest: calculateProviderRuntimeManifestDigest(payload),
+    };
+
+    return immutableClone(parseProviderRuntimeManifest(manifest));
+  }
+}
+
+function normalizeCapabilities(
+  capabilities: ProviderRuntimeCapabilityEvidence[]
+): ProviderRuntimeCapabilityEvidence[] {
+  const byId = new Map<string, ProviderRuntimeCapabilityEvidence>();
+  for (const capability of capabilities) {
+    if (byId.has(capability.id)) {
+      throw new Error(`Duplicate provider runtime capability: ${capability.id}`);
+    }
+    byId.set(capability.id, {
+      ...capability,
+      reason: sanitizeDiagnostic(capability.reason),
+    });
+  }
+  return [...byId.values()].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function normalizedIdentityValue(value: string | undefined, maxLength: number): string {
+  return normalizedOptionalIdentityValue(value, maxLength) ?? 'unknown';
+}
+
+function normalizedOptionalIdentityValue(
+  value: string | undefined,
+  maxLength: number
+): string | undefined {
+  const normalized = value ? sanitizeDiagnostic(value).slice(0, maxLength) : undefined;
+  return normalized || undefined;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort((a, b) =>
+    a.localeCompare(b)
+  );
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function sanitizeDiagnostics(values: string[]): string[] {
+  const diagnostics: string[] = [];
+  let bytes = 0;
+  for (const value of values) {
+    const diagnostic = sanitizeDiagnostic(value);
+    if (!diagnostic) continue;
+    const size = Buffer.byteLength(diagnostic, 'utf8');
+    if (bytes + size > MAX_DIAGNOSTIC_BYTES) break;
+    diagnostics.push(diagnostic);
+    bytes += size;
+  }
+  return diagnostics;
+}
+
+function sanitizeDiagnostic(value: string): string {
+  let sanitized = value.trim().replace(/\s+/g, ' ');
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    sanitized = sanitized.replace(pattern, replacement);
+  }
+  return sanitized.slice(0, 1000);
+}
+
+function immutableClone<T>(value: T): T {
+  return deepFreeze(structuredClone(value));
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), Math.max(1, timeoutMs));
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  return value;
+}

--- a/server/src/utils/package-version.ts
+++ b/server/src/utils/package-version.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, parse } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/** Read the installed package's own version without relying on package exports. */
+export function getInstalledPackageVersion(packageName: string): string | undefined {
+  try {
+    let directory = dirname(require.resolve(packageName));
+    const root = parse(directory).root;
+
+    while (directory !== root) {
+      try {
+        const packageJson = JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8')) as {
+          name?: unknown;
+          version?: unknown;
+        };
+        if (packageJson.name === packageName && typeof packageJson.version === 'string') {
+          return packageJson.version;
+        }
+      } catch {
+        // Continue walking until the package root is found.
+      }
+      directory = dirname(directory);
+    }
+  } catch {
+    // The package may be optional or unavailable in a source-only environment.
+  }
+  return undefined;
+}

--- a/server/src/utils/provider-runtime-manifest-digest.ts
+++ b/server/src/utils/provider-runtime-manifest-digest.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+import type { ProviderRuntimeManifest } from '@veritas-kanban/shared';
+
+export type ProviderRuntimeManifestPayload = Omit<ProviderRuntimeManifest, 'digest'>;
+
+export function calculateProviderRuntimeManifestDigest(
+  manifest: ProviderRuntimeManifestPayload
+): string {
+  const payload = {
+    schemaVersion: manifest.schemaVersion,
+    probeRevision: manifest.probeRevision,
+    provider: manifest.provider,
+    adapter: manifest.adapter,
+    protocolVersion: manifest.protocolVersion,
+    providerVersion: manifest.providerVersion,
+    ...(manifest.providerBuild ? { providerBuild: manifest.providerBuild } : {}),
+    models: uniqueSorted(manifest.models),
+    capabilities: [...manifest.capabilities]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((capability) => ({
+        id: capability.id,
+        state: capability.state,
+        source: capability.source,
+        reason: capability.reason,
+      })),
+    probe: {
+      state: manifest.probe.state,
+      probedAt: manifest.probe.probedAt,
+      source: manifest.probe.source,
+      diagnostics: [...manifest.probe.diagnostics],
+    },
+  };
+  return `sha256:${hashJson(payload)}`;
+}
+
+export function verifyProviderRuntimeManifestDigest(manifest: ProviderRuntimeManifest): boolean {
+  return manifest.digest === calculateProviderRuntimeManifestDigest(manifest);
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort((a, b) =>
+    a.localeCompare(b)
+  );
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -48,6 +48,15 @@ export type AgentProvider =
   | 'lm-studio-local'
   | 'custom';
 
+export const EXECUTABLE_AGENT_PROVIDERS = [
+  'openclaw',
+  'codex-cli',
+  'codex-sdk',
+  'hermes-cli',
+] as const satisfies readonly AgentProvider[];
+
+export type ExecutableAgentProvider = (typeof EXECUTABLE_AGENT_PROVIDERS)[number];
+
 // ============ Agent Routing Types ============
 
 /** Criteria for matching a task to a routing rule */

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -26,6 +26,7 @@ export * from './run-session.types.js';
 export * from './evaluation.types.js';
 export * from './policy.types.js';
 export * from './prompt-registry.types.js';
+export * from './provider-runtime.types.js';
 export * from './system-health.types.js';
 export * from './feedback.types.js';
 export * from './workflow.js';

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -1,0 +1,95 @@
+import type { SandboxProviderCapabilityId } from './sandbox-policy.types.js';
+
+export const PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION = 'provider-runtime-manifest/v1' as const;
+
+export const PROVIDER_RUNTIME_PROBE_REVISION = 1 as const;
+
+export const KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS = [
+  'run.start',
+  'run.stop',
+  'run.status',
+  'run.logs',
+  'run.complete',
+  'run.streaming',
+  'run.structured-events',
+  'run.follow-up',
+  'run.steer',
+  'run.interrupt',
+  'run.resume',
+  'run.fork',
+  'run.reattach',
+  'run.approvals',
+  'run.elicitation',
+  'tool.calls',
+  'tool.parallel',
+  'tool.mcp',
+  'output.structured',
+  'usage.tokens',
+  'artifact.write',
+  'workspace.worktrees',
+  'filesystem.read',
+  'filesystem.write',
+  'filesystem.deny-paths',
+  'filesystem.dotfile-masking',
+  'network.disable',
+  'network.allowlist',
+  'network.block-private',
+  'network.block-metadata',
+  'environment.allowlist',
+  'credential.broker',
+] as const;
+
+export type KnownProviderRuntimeCapabilityId =
+  (typeof KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS)[number];
+
+export type ProviderRuntimeCapabilityId =
+  KnownProviderRuntimeCapabilityId | SandboxProviderCapabilityId | (string & {});
+
+export type ProviderRuntimeCapabilityState = 'supported' | 'advisory' | 'unsupported' | 'unknown';
+
+export type ProviderRuntimeEvidenceSource = 'runtime-probe' | 'contract-test' | 'host-enforced';
+
+export type ProviderRuntimeProbeState = 'ready' | 'degraded' | 'failed';
+
+export interface ProviderRuntimeCapabilityEvidence {
+  id: ProviderRuntimeCapabilityId;
+  state: ProviderRuntimeCapabilityState;
+  source: ProviderRuntimeEvidenceSource;
+  reason: string;
+}
+
+export interface ProviderRuntimeProbeEvidence {
+  state: ProviderRuntimeProbeState;
+  probedAt: string;
+  source: string;
+  diagnostics: string[];
+}
+
+/**
+ * Immutable, evidence-backed snapshot of one provider adapter's runtime posture.
+ *
+ * `digest` is a SHA-256 of the canonical manifest payload excluding the digest
+ * itself. Consumers can therefore prove that the snapshot persisted with a run
+ * is the exact posture used for launch decisions.
+ */
+export interface ProviderRuntimeManifest {
+  schemaVersion: typeof PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION;
+  /** Positive revision used to interpret probe evidence within the v1 contract. */
+  probeRevision: number;
+  provider: string;
+  adapter: string;
+  protocolVersion: string;
+  providerVersion: string;
+  providerBuild?: string;
+  models: string[];
+  capabilities: ProviderRuntimeCapabilityEvidence[];
+  probe: ProviderRuntimeProbeEvidence;
+  digest: string;
+}
+
+export function findProviderRuntimeCapability(
+  manifest: ProviderRuntimeManifest,
+  capabilityId: ProviderRuntimeCapabilityId
+): ProviderRuntimeCapabilityEvidence | undefined {
+  return manifest.capabilities.find((capability) => capability.id === capabilityId);
+}

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -61,6 +61,7 @@ export interface TaskAttempt {
   orchestration?: import('./workflow.js').WorkflowPipelineSummary;
   budget?: import('./agent-budget.types.js').AgentBudgetState;
   agentProfile?: import('./agent-profile-package.types.js').AgentProfileLaunchMetadata;
+  providerRuntimeManifest?: import('./provider-runtime.types.js').ProviderRuntimeManifest;
 }
 
 export interface Subtask {
@@ -399,6 +400,7 @@ export interface UpdateTaskInput {
   delegatedWork?: import('./workspace-capability.types.js').TaskDelegatedWorkLink[];
   externalWorkItems?: import('./external-tracker.types.js').ExternalWorkItemLink[];
   attempt?: TaskAttempt;
+  attempts?: TaskAttempt[];
   reviewComments?: ReviewComment[];
   reviewScores?: [number, number, number, number];
   review?: ReviewState;

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -108,14 +108,7 @@ export interface TelemetryConfig {
 
 /** Low-level trace step types captured during an agent attempt. */
 export type AgentRunTraceStepType =
-  | 'init'
-  | 'execute'
-  | 'stream'
-  | 'retry'
-  | 'abort'
-  | 'finalize'
-  | 'complete'
-  | 'error';
+  'init' | 'execute' | 'stream' | 'retry' | 'abort' | 'finalize' | 'complete' | 'error';
 
 /** Additional run context persisted with each trace for replay/audit surfaces. */
 export interface AgentRunTraceMetadata {
@@ -133,6 +126,7 @@ export interface AgentRunTraceMetadata {
   branch?: string;
   baseBranch?: string;
   worktreePath?: string;
+  providerRuntimeManifest?: import('./provider-runtime.types.js').ProviderRuntimeManifest;
 }
 
 /** A single sequenced step inside an agent run trace. */
@@ -161,15 +155,7 @@ export interface AgentRunTrace {
 
 /** Timeline event categories exposed to the task run replay UI. */
 export type AgentRunTimelineEventType =
-  | 'prompt'
-  | 'command'
-  | 'file'
-  | 'policy'
-  | 'approval'
-  | 'error'
-  | 'usage'
-  | 'tool'
-  | 'result';
+  'prompt' | 'command' | 'file' | 'policy' | 'approval' | 'error' | 'usage' | 'tool' | 'result';
 
 export type AgentRunTimelineEventSource = 'live' | 'stored' | 'derived';
 

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -85,6 +85,7 @@ const AGENT_PROVIDER_OPTIONS: Array<{ value: AgentProvider | '__none__'; label: 
   { value: '__none__', label: 'None / legacy' },
   { value: 'codex-cli', label: 'Codex CLI' },
   { value: 'codex-sdk', label: 'Codex SDK' },
+  { value: 'hermes-cli', label: 'Hermes Agent' },
   { value: 'codex-cloud', label: 'Codex Cloud' },
   { value: 'ollama-local', label: 'Ollama Local' },
   { value: 'ollama-cloud', label: 'Ollama Cloud' },
@@ -1170,8 +1171,7 @@ function SandboxPoliciesSection({
 
   const selectedPreset = presets.find((preset) => preset.id === previewPresetId);
   const validation = validatePreset.data as
-    | (SandboxPolicyDryRunResult & { traceId?: string })
-    | undefined;
+    (SandboxPolicyDryRunResult & { traceId?: string }) | undefined;
 
   const handlePreview = () => {
     if (!selectedPreset) return;


### PR DESCRIPTION
## Summary

- add the versioned provider-runtime-manifest/v1 contract, strict server validation, canonical SHA-256 digests, and complete capability posture
- add bounded, cached, race-safe readiness and conformance probes for Codex CLI, Codex SDK, Hermes, and OpenClaw
- persist the exact launch manifest on the current attempt, attempt history, run trace, and Markdown log
- fail closed for configured providers without an executable adapter instead of silently routing through OpenClaw
- add Hermes to normalized configuration and Settings, and update provider/API/feature documentation

## Why

Provider capability truth was split across name-based tables and narrow adapter flags. This establishes the evidence-backed contract and probe/cache foundation required by parent issue #851 before registration, routing, and enforcement consume it.

## Verification

- server: 199 files passed; 2,183 tests passed; 2 skipped
- pnpm typecheck
- pnpm lint:budget: 596 warnings, existing baseline, within 600 budget
- pnpm build
- pnpm smoke:cli-mcp: compatibility checks passed; live read/write checks skipped because VK_API_KEY is not configured
- independent GPT audit findings fixed: digest verification, standard secret redaction, historical probe-revision compatibility, stale-probe cache race, conformance timeout, and failed-start attempt history
- all seven GitHub checks passed

## Review decision

Brad explicitly waived the opposite-model Claude gate on 2026-07-16 and authorized GPT-only review for this backlog execution.

Closes #885
Parent: #851