### PR TITLE
feat: enforce runtime manifests across run controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provider discovery, manifest-authoritative host posture, and provider-neutral
   required-capability routing with structured evidence for every attempted
   primary, fallback, or rejected candidate (#886).
+- Added one provider-runtime control evaluator for launch requirements and
+  status, logs, completion, stop, steer, resume, reattach, tool, MCP, structured
+  output, token-usage, and artifact controls. Agent status now returns concrete
+  capability-derived availability, reasons, and remediation, and REST, CLI, and
+  MCP starts can declare additional required capabilities. Completion callbacks,
+  token budgets, and shared co-drive controls are attempt-bound; provider-native
+  approvals fail closed; OpenClaw task and workflow evidence are separated; and
+  workflow requirements account for standard MCP names and metric-specific
+  budgets (#887).
 - Added an admin-governed SQLite journal maintenance workflow with non-mutating
   previews, restart-time exclusive conversion, verified backups, durable stage
   journals, forward-only crash recovery, integrity verification, in-place mode
@@ -36,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   heartbeat liveness, and invalidate when provider identity changes. Unresolved
   sandbox presets fail closed instead of borrowing aggregate host signals
   (#886).
+- Made active agent and workflow controls consume the exact persisted launch
+  manifest, reject invalid or mismatched snapshots, and fail closed before
+  unsupported work. Sandbox dry-runs now resolve live registered manifest
+  digests server-side, workflow manifests persist before provider execution,
+  and task, Work view, and shared co-drive controls expose accessible disabled
+  reasons when a runtime cannot stop or steer (#887).
 - Classified the authoritative SQLite filesystem before database open, limited
   WAL to recognized durable local filesystems, refused known-unsafe and unknown
   storage before creating database sidecars, and exposed redacted filesystem,
@@ -44,6 +59,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Serialized agent launch and terminalization ownership per task and attempt so
+  concurrent starts, stop requests, provider exits, and callbacks cannot launch
+  or finalize the same run twice (#887).
+- Restored packaged desktop agent controls after password login by granting the
+  verified loopback owner session the narrow `local-agent:run` capability while
+  keeping production localhost bypass disabled (#887).
+- Made packaged desktop port selection detect listeners on both IPv4 and IPv6
+  loopback and kept dev server/web fallback ports distinct, preventing Electron
+  from attaching to an unrelated local server or colliding with itself.
 - Kept mobile notifications above the safe-area-aware bottom navigation so
   long-lived toasts cannot intercept touch input after Task Detail closes
   (#869).

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ vk github mappings               # List issue↔task mappings
 ```bash
 vk agents:pending                # List pending agent requests
 vk agents:status <id>            # Check if agent running
-vk agents:complete <id> -s       # Mark agent complete
+vk agents:complete <id> -s --attempt-id <id> --manifest-digest <sha256:...>
 vk profiles list                 # List reusable agent profile packages
 vk profiles validate ./agent.yml # Validate a package before import
 vk profiles import ./agent.yml   # Import or replace a package

--- a/cli/src/__tests__/agents-runtime-capabilities.test.ts
+++ b/cli/src/__tests__/agents-runtime-capabilities.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+
+const { mockApi, mockFindTask } = vi.hoisted(() => ({
+  mockApi: vi.fn(),
+  mockFindTask: vi.fn(),
+}));
+
+vi.mock('../utils/api.js', () => ({ api: mockApi }));
+vi.mock('../utils/find.js', () => ({ findTask: mockFindTask }));
+
+import { registerAgentCommands } from '../commands/agents.js';
+
+describe('vk agent runtime capability controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindTask.mockResolvedValue({
+      id: 'task_1',
+      type: 'code',
+      git: { worktreePath: '/tmp/task_1' },
+    });
+    mockApi.mockImplementation(async (url: string) =>
+      url.endsWith('/status')
+        ? { running: true, attemptId: 'attempt_1' }
+        : { attemptId: 'attempt_1' }
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  it('forwards required runtime capabilities to the launch API', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+
+    await program.parseAsync(
+      [
+        'start',
+        'task_1',
+        '--agent',
+        'codex',
+        '--require-capability',
+        'tool.mcp',
+        'output.structured',
+        '--json',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
+      method: 'POST',
+      body: JSON.stringify({
+        agent: 'codex',
+        profileId: undefined,
+        requiredRuntimeCapabilities: ['tool.mcp', 'output.structured'],
+      }),
+    });
+  });
+
+  it('surfaces authoritative fail-closed stop errors from the API', async () => {
+    mockApi
+      .mockResolvedValueOnce({ running: true, attemptId: 'attempt_1' })
+      .mockRejectedValueOnce(
+        new Error('Provider runtime does not support stop run: run.stop is unsupported.')
+      );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      _code?: number | string | null
+    ) => {
+      throw new Error('process.exit called');
+    }) as typeof process.exit);
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+
+    try {
+      await expect(program.parseAsync(['stop', 'task_1'], { from: 'user' })).rejects.toThrow(
+        'process.exit called'
+      );
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('run.stop is unsupported'));
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('binds stop requests to the attempt returned by status', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+
+    await program.parseAsync(['stop', 'task_1', '--json'], { from: 'user' });
+
+    expect(mockApi).toHaveBeenNthCalledWith(1, '/api/agents/task_1/status');
+    expect(mockApi).toHaveBeenNthCalledWith(2, '/api/agents/task_1/stop', {
+      method: 'POST',
+      body: JSON.stringify({ attemptId: 'attempt_1' }),
+    });
+  });
+
+  it('forwards attempt and manifest provenance when completing a run', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+    const digest = `sha256:${'a'.repeat(64)}`;
+
+    await program.parseAsync(
+      [
+        'agents:complete',
+        'task_1',
+        '--attempt-id',
+        'attempt_1',
+        '--manifest-digest',
+        digest,
+        '--summary',
+        'Done',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        attemptId: 'attempt_1',
+        providerRuntimeManifestDigest: digest,
+        success: true,
+        summary: 'Done',
+        error: undefined,
+      }),
+    });
+  });
+});

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -27,6 +27,10 @@ export function registerAgentCommands(program: Command): void {
       'claude-code'
     )
     .option('-p, --profile <profileId>', 'Agent profile package to launch')
+    .option(
+      '--require-capability <capabilities...>',
+      'Require provider runtime capabilities before launch'
+    )
     .option('--json', 'Output as JSON')
     .action(async (id, options) => {
       try {
@@ -52,6 +56,7 @@ export function registerAgentCommands(program: Command): void {
           body: JSON.stringify({
             agent: options.profile ? undefined : options.agent,
             profileId: options.profile,
+            requiredRuntimeCapabilities: options.requireCapability,
           }),
         });
 
@@ -201,7 +206,16 @@ export function registerAgentCommands(program: Command): void {
           process.exit(1);
         }
 
-        await api(`/api/agents/${task.id}/stop`, { method: 'POST' });
+        const status = await api<{ running: boolean; attemptId?: string }>(
+          `/api/agents/${task.id}/status`
+        );
+        if (!status.running || !status.attemptId) {
+          throw new Error('No active agent attempt is available to stop');
+        }
+        await api(`/api/agents/${task.id}/stop`, {
+          method: 'POST',
+          body: JSON.stringify({ attemptId: status.attemptId }),
+        });
 
         if (options.json) {
           console.log(JSON.stringify({ stopped: true }));
@@ -278,10 +292,17 @@ export function registerAgentCommands(program: Command): void {
     .option('-f, --failed', 'Mark as failed')
     .option('-m, --summary <text>', 'Summary of what was done')
     .option('-e, --error <text>', 'Error message (if failed)')
+    .requiredOption('--attempt-id <id>', 'Attempt ID that produced this completion')
+    .requiredOption(
+      '--manifest-digest <digest>',
+      'Provider runtime manifest digest bound to the attempt'
+    )
     .action(async (taskId, options) => {
       try {
         const success = !options.failed;
         const body = {
+          attemptId: options.attemptId,
+          providerRuntimeManifestDigest: options.manifestDigest,
           success,
           summary: options.summary,
           error: options.error,

--- a/desktop/src/main/__tests__/ports.test.ts
+++ b/desktop/src/main/__tests__/ports.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import net from 'node:net';
 
 import { findAvailablePort, isPortAvailable } from '../ports.js';
@@ -19,6 +19,104 @@ describe('port selection', () => {
       expect(port).toBeGreaterThan(47632);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('keeps separately selected desktop fallback ports distinct', async () => {
+    const busyServer = net.createServer();
+    await new Promise<void>((resolve) => busyServer.listen(47633, '127.0.0.1', resolve));
+
+    try {
+      const serverPort = await findAvailablePort(47633, '127.0.0.1', 3);
+      const webPort = await findAvailablePort(47633, '127.0.0.1', 3, new Set([serverPort]));
+
+      expect(serverPort).toBeGreaterThan(47633);
+      expect(webPort).toBeGreaterThan(47633);
+      expect(webPort).not.toBe(serverPort);
+    } finally {
+      await new Promise<void>((resolve) => busyServer.close(() => resolve()));
+    }
+  });
+
+  it('falls forward when the preferred port is busy on an IPv6 wildcard', async () => {
+    const server = net.createServer();
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(47634, '::', resolve);
+      });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'EAFNOSUPPORT' || code === 'EADDRNOTAVAIL') {
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      expect(await isPortAvailable(47634)).toBe(false);
+      const port = await findAvailablePort(47634, '127.0.0.1', 3);
+      expect(port).toBeGreaterThan(47634);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('rejects IPv6-busy and excluded ephemeral fallback candidates', async () => {
+    const ipv6Server = net.createServer();
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        ipv6Server.once('error', reject);
+        ipv6Server.listen(0, '::1', resolve);
+      });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'EAFNOSUPPORT' || code === 'EADDRNOTAVAIL') {
+        return;
+      }
+      throw error;
+    }
+
+    const ipv6Address = ipv6Server.address();
+    if (!ipv6Address || typeof ipv6Address === 'string') {
+      throw new Error('Unable to resolve IPv6 test listener port');
+    }
+
+    const excludedServer = net.createServer();
+    await new Promise<void>((resolve) => excludedServer.listen(0, '127.0.0.1', resolve));
+    const excludedAddress = excludedServer.address();
+    if (!excludedAddress || typeof excludedAddress === 'string') {
+      throw new Error('Unable to resolve excluded test listener port');
+    }
+    await new Promise<void>((resolve) => excludedServer.close(() => resolve()));
+
+    const originalListen = net.Server.prototype.listen;
+    const forcedPorts = [ipv6Address.port, excludedAddress.port];
+    const listenSpy = vi.spyOn(net.Server.prototype, 'listen').mockImplementation(function (
+      this: net.Server,
+      ...args: unknown[]
+    ) {
+      if (args[0] === 0 && args[1] === '127.0.0.1' && forcedPorts.length > 0) {
+        return Reflect.apply(originalListen, this, [
+          forcedPorts.shift(),
+          '127.0.0.1',
+        ]) as net.Server;
+      }
+      return Reflect.apply(originalListen, this, args) as net.Server;
+    });
+
+    try {
+      const port = await findAvailablePort(47635, '127.0.0.1', 0, new Set([excludedAddress.port]));
+
+      expect(forcedPorts).toHaveLength(0);
+      expect(port).not.toBe(ipv6Address.port);
+      expect(port).not.toBe(excludedAddress.port);
+      expect(await isPortAvailable(port)).toBe(true);
+    } finally {
+      listenSpy.mockRestore();
+      await new Promise<void>((resolve) => ipv6Server.close(() => resolve()));
     }
   });
 });

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -215,7 +215,12 @@ async function boot(): Promise<void> {
   const serverPort = await findAvailablePort(
     Number(process.env.VERITAS_DESKTOP_SERVER_PORT || 3001)
   );
-  const webPort = await findAvailablePort(Number(process.env.VERITAS_DESKTOP_WEB_PORT || 3000));
+  const webPort = await findAvailablePort(
+    Number(process.env.VERITAS_DESKTOP_WEB_PORT || 3000),
+    '127.0.0.1',
+    50,
+    new Set([serverPort])
+  );
 
   mainWindow = createMainWindow(await readDesktopWindowState(paths));
   await mainWindow.loadURL(statusPageUrl('Starting Veritas Kanban', 'Preparing the local app.'));

--- a/desktop/src/main/ports.ts
+++ b/desktop/src/main/ports.ts
@@ -1,10 +1,39 @@
 import net from 'node:net';
 
-export async function isPortAvailable(port: number, host = '127.0.0.1'): Promise<boolean> {
+async function isPortAcceptingConnections(port: number, host: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const socket = net.createConnection({ port, host });
+    const finish = (accepting: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(accepting);
+    };
+
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+    socket.setTimeout(250, () => finish(false));
+  });
+}
+
+async function isPortAvailableOnHost(port: number, host: string): Promise<boolean> {
+  // macOS can allow a specific-address bind beside an existing IPv6 wildcard
+  // listener. Probe for an accepting server before trusting the bind check.
+  if (await isPortAcceptingConnections(port, host)) {
+    return false;
+  }
+
   return new Promise((resolve) => {
     const server = net.createServer();
 
-    server.once('error', () => resolve(false));
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      if (host === '::1' && (error.code === 'EAFNOSUPPORT' || error.code === 'EADDRNOTAVAIL')) {
+        resolve(true);
+        return;
+      }
+      resolve(false);
+    });
     server.once('listening', () => {
       server.close(() => resolve(true));
     });
@@ -12,31 +41,79 @@ export async function isPortAvailable(port: number, host = '127.0.0.1'): Promise
   });
 }
 
+async function isPortAvailableOnComplementaryHost(port: number, host: string): Promise<boolean> {
+  return host === '127.0.0.1' ? isPortAvailableOnHost(port, '::1') : true;
+}
+
+export async function isPortAvailable(port: number, host = '127.0.0.1'): Promise<boolean> {
+  if (!(await isPortAvailableOnHost(port, host))) {
+    return false;
+  }
+
+  // Chromium can reach an IPv6 wildcard listener even when the renderer URL
+  // names 127.0.0.1. Reject the candidate if either loopback family is busy so
+  // the desktop app cannot attach to an unrelated local Veritas/dev server.
+  return isPortAvailableOnComplementaryHost(port, host);
+}
+
 export async function findAvailablePort(
   preferredPort: number,
   host = '127.0.0.1',
-  maxAttempts = 50
+  maxAttempts = 50,
+  excludedPorts: ReadonlySet<number> = new Set()
 ): Promise<number> {
   for (let offset = 0; offset < maxAttempts; offset += 1) {
     const candidate = preferredPort + offset;
+    if (excludedPorts.has(candidate)) {
+      continue;
+    }
     if (await isPortAvailable(candidate, host)) {
       return candidate;
     }
   }
 
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once('error', reject);
-    server.once('listening', () => {
-      const address = server.address();
-      server.close(() => {
-        if (typeof address === 'object' && address) {
-          resolve(address.port);
-          return;
-        }
-        reject(new Error('Unable to allocate an ephemeral port'));
+  const reservations: net.Server[] = [];
+  try {
+    // Keep rejected reservations open so the OS cannot hand the same
+    // ephemeral candidate back to a later attempt. The extra attempts cover
+    // candidates rejected by the complementary-family collision probe.
+    const fallbackAttempts = excludedPorts.size + 50;
+    for (let attempt = 0; attempt < fallbackAttempts; attempt += 1) {
+      const reservation = net.createServer();
+      const port = await new Promise<number>((resolve, reject) => {
+        reservation.once('error', reject);
+        reservation.once('listening', () => {
+          const address = reservation.address();
+          if (typeof address === 'object' && address) {
+            resolve(address.port);
+            return;
+          }
+          reject(new Error('Unable to allocate an ephemeral port'));
+        });
+        reservation.listen(0, host);
       });
-    });
-    server.listen(0, host);
-  });
+      reservations.push(reservation);
+
+      if (excludedPorts.has(port)) {
+        continue;
+      }
+
+      // The live reservation proves the requested family is available. Probe
+      // the other loopback family with the same connect + bind checks used by
+      // isPortAvailable before releasing the candidate.
+      if (!(await isPortAvailableOnComplementaryHost(port, host))) {
+        continue;
+      }
+
+      return port;
+    }
+  } finally {
+    await Promise.all(
+      reservations.map(
+        (reservation) => new Promise<void>((resolve) => reservation.close(() => resolve()))
+      )
+    );
+  }
+
+  throw new Error('Unable to allocate an unexcluded ephemeral port');
 }

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -42,6 +42,21 @@ They do not imply that adjacent roadmap work already exists. For example,
 provider-neutral approvals, reattachment, follow-up/fork/steer controls, and MCP
 governance remain unsupported or unknown until their dedicated issues land.
 
+One evaluator maps those capabilities to launch and run controls. Agent starts
+always require `run.start`, `run.status`, `run.logs`, `run.complete`, and
+`workspace.worktrees`; callers can add `requiredRuntimeCapabilities`. Profile
+tools, MCP servers, token/cost/tool budgets, workflow sessions, structured
+output, and saved artifacts add their own requirements before provider work
+starts. `supported` and `advisory` evidence qualify; `unsupported`, `unknown`,
+missing, failed-probe, invalid-digest, or mismatched active/persisted evidence
+fails closed with concrete remediation.
+
+The task status API returns a `controls` set derived from the persisted launch
+snapshot. Stop, message/steer, completion, token reporting, logs, tool events,
+and artifact ingestion compare the active and persisted manifest digests before
+acting. Task Detail, Work view, and shared co-drive messaging disable actions
+that the manifest does not support and show the evaluator's reason.
+
 Agents and supervisors can register the same validated manifest with
 `POST /api/agents/register` and refresh it through the heartbeat endpoint. Host
 provider, model, `tool.*`, and sandbox posture is derived only from those
@@ -55,15 +70,28 @@ Self-registration requires an authenticated agent key/token whose identity
 matches the registry agent ID; operators with `agent:write` can register on an
 agent's behalf. Unknown request fields and unredacted secret-like evidence are
 rejected. Only registrations with a current five-minute heartbeat qualify for
-routing. Probe-evidence age enforcement is completed by #887; until then,
-operators must refresh the manifest whenever provider identity or evidence
-changes.
+routing. Provider version/build changes invalidate the readiness cache and
+force a new conformance probe; active controls continue to use the immutable
+snapshot persisted for that attempt.
 
-Host previews fail closed on a bare `sandboxPresetId` until #887 resolves each
-preset control through the same manifest evaluator. For a capability-only
-preview during this intermediate contract, omit the preset ID and provide the
-required filesystem, network, environment, and credential capability IDs
-directly.
+Sandbox launch checks resolve every preset rule through the same manifest.
+Settings dry-runs send the digest of the newest matching manifest registered by
+a live host; the server resolves that digest rather than trusting a
+caller-supplied capability object. A missing, expired, unknown, or
+provider-mismatched digest fails closed. Required presets block on unsupported
+rules, while advisory presets record warnings and governance evidence.
+
+Workflow agent steps currently execute through the `codex-sdk` and `openclaw`
+workflow adapters. A workflow configured with `codex-cli`, `hermes-cli`, or
+another provider is rejected before probing or launch instead of validating one
+runtime and executing another. The workflow run persists the manifest and
+derived controls before provider execution, then gates resume/reattach, tools,
+MCP, structured output, token usage, and saved output artifacts from that same
+snapshot. Capability evidence is surface-specific: OpenClaw task manifests do
+not claim workflow-only follow-up, reattach, or output-artifact behavior, while
+workflow manifests use the `openclaw-workflow-session/v1` protocol evidence.
+Token telemetry is required only when the effective step budget includes token
+or cost limits; runtime-, retry-, or fan-out-only budgets do not require it.
 
 ## Sandbox Policy Presets
 
@@ -254,11 +282,15 @@ install at the operator-level endpoint. You must explicitly allow them:
 
 ### Dispatch flow
 
-1. Veritas calls `sessions_spawn` with the full task prompt (including the
-   callback URL: `http://localhost:3001/api/agents/<taskId>/complete`).
+1. Veritas calls `sessions_spawn` with the full task prompt, including the
+   callback URL and required `attemptId` plus `providerRuntimeManifestDigest`
+   completion provenance.
 2. A policy or connection failure rolls the task attempt back to `todo` with an error message.
 3. OpenClaw returns a `childSessionKey` which Veritas stores in the attempt record.
 4. The OpenClaw sub-session runs autonomously and calls the Veritas callback URL when done.
+
+Late or replayed callbacks are rejected when either provenance value differs
+from the active attempt.
 
 ### Limitations
 

--- a/docs/AGENTS-TEMPLATE.md
+++ b/docs/AGENTS-TEMPLATE.md
@@ -113,8 +113,9 @@ When picking up a task:
 
 1. Send heartbeat with `status: "busy"` and `currentTaskId`
 2. Use existing task APIs: `POST /api/agents/:taskId/start`
-3. Report tokens: `POST /api/agents/:taskId/tokens`
-4. Complete: `POST /api/agents/:taskId/complete`
+3. Report tokens: `POST /api/agents/:taskId/tokens` with the active `attemptId`
+4. Complete: `POST /api/agents/:taskId/complete` with the active `attemptId` and
+   `providerRuntimeManifestDigest` returned by the start/status response
 5. Send heartbeat with `status: "idle"` and clear task
 
 ## OpenAI Codex Notes

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -94,6 +94,11 @@ endpoints still accept the compatibility roles above, but new v5 route work
 should declare the specific permission it requires, such as `task:read`,
 `task:write`, `workflow:execute`, or `admin:manage`.
 
+Production keeps unauthenticated localhost bypass disabled. A password session
+that passes the local-owner loopback `Host`/`Origin`/`Referer` checks receives
+only the explicit `local-agent:run` client capability needed by packaged desktop
+agent controls. Remote password-session cookies remain invalid.
+
 Password sessions are intentionally local-owner only for v5 GA. Remote,
 server-mode, PWA, CLI, MCP, and multi-user clients must use device sessions or
 scoped API tokens; those credentials are revalidated against workspace
@@ -1554,6 +1559,11 @@ Mounted at `/api/queue-monitors`.
 
 `runner: "local"` is executable in this version. `runner: "github-actions"` is persisted for monitor definitions but launch is blocked until a workflow-dispatch adapter is configured.
 
+Local queue sandbox preflight probes the configured Codex runtime and evaluates
+the preset against that exact manifest. If no valid manifest can be resolved,
+capability-dependent presets fail closed instead of using provider-name
+assumptions.
+
 ### Candidate Packet
 
 Each run stores a bounded packet with:
@@ -1904,21 +1914,89 @@ PUT /api/agents/routing
 }
 ```
 
-### Start Agent With Profile Package
+### Start Agent And Require Runtime Capabilities
 
 ```
 POST /api/agents/:taskId/start
 ```
 
-In addition to `agent`, `sandboxPresetId`, and `budget`, callers can pass a portable profile package ID:
+Callers can select an agent or portable profile package and require additional
+runtime capabilities:
 
 ```json
 {
-  "profileId": "docs-reviewer"
+  "profileId": "docs-reviewer",
+  "sandboxPresetId": "codex-repo-contained",
+  "requiredRuntimeCapabilities": ["tool.mcp", "output.structured"]
 }
 ```
 
-The launch path resolves the package runtime against configured provider profiles, applies package model/sandbox/budget posture, injects package instructions into the run prompt, and records the profile ID and version on the task attempt plus activity audit history.
+The launch path resolves the package runtime against configured provider
+profiles, applies package model/sandbox/budget posture, injects package
+instructions, and records the profile ID and version. Baseline launch
+capabilities plus caller, profile, sandbox, and budget requirements must be
+`supported` or `advisory` in one valid manifest before attempt state is
+mutated. Failure returns `409 Conflict` with `requiredCapabilities`, reasons,
+manifest identity, and remediation.
+
+`GET /api/agents/:taskId/status` returns the active manifest and its derived
+controls:
+
+```json
+{
+  "running": true,
+  "attemptId": "attempt_123",
+  "provider": "codex-cli",
+  "providerRuntimeManifest": { "digest": "sha256:..." },
+  "controls": {
+    "manifestDigest": "sha256:...",
+    "probeState": "ready",
+    "controls": [
+      {
+        "action": "stop",
+        "label": "Stop run",
+        "capabilityId": "run.stop",
+        "state": "supported",
+        "available": true,
+        "advisory": false,
+        "reason": "The adapter terminates the supervised provider process."
+      }
+    ]
+  }
+}
+```
+
+Stop, message, completion, token-reporting, and attempt-log endpoints re-check
+the persisted snapshot. Invalid or active/persisted digest mismatches return
+`409 Conflict`; unsupported capability states return the same structured
+control evidence.
+
+Stop and message requests must carry the `attemptId` returned by status so a
+delayed control cannot affect a replacement run:
+
+```json
+{ "attemptId": "attempt_123" }
+```
+
+`POST /api/agents/:taskId/message` adds the attributed `message` (and optional
+`actor`) to that body. `POST /api/agents/:taskId/tokens` also requires the exact
+`attemptId`; the server never falls back to the task's current attempt.
+
+Completion callbacks must identify the exact run that produced them:
+
+```json
+{
+  "attemptId": "attempt_123",
+  "providerRuntimeManifestDigest": "sha256:<64 lowercase hex characters>",
+  "success": true,
+  "summary": "Implemented and verified the requested change"
+}
+```
+
+`POST /api/agents/:taskId/complete` rejects callbacks whose attempt or manifest
+digest does not match the active run. Token reports likewise bind telemetry and
+budget mutation to their required `attemptId`, so a late event from a prior
+attempt cannot charge or stop a replacement run.
 
 ### Provider Runtime Manifest On Attempts
 
@@ -1929,7 +2007,7 @@ Task and trace responses can therefore include the immutable
 ```json
 {
   "schemaVersion": "provider-runtime-manifest/v1",
-  "probeRevision": 1,
+  "probeRevision": 3,
   "provider": "codex-cli",
   "adapter": "codex-cli",
   "protocolVersion": "codex-exec-json/v1",
@@ -1994,15 +2072,11 @@ execution adapter is still required before launch.
 
 Only live registrations with a heartbeat no older than five minutes contribute
 runtime evidence. `requiredTools` values using `tool.*` are evaluated through
-the same single-manifest path; legacy named tools cannot qualify a host. Probe
-timestamp freshness and action-level enforcement are completed by #887, so
-agents must refresh evidence when their provider runtime changes. A bare
-`sandboxPresetId` does not qualify a host in this intermediate contract because
-the preset's individual controls have not yet been resolved into manifest
-requirements. For a capability-only preview, omit the preset ID and supply the
-relevant filesystem, network, environment, and credential IDs in
-`requiredRuntimeCapabilities`; #887 wires actual preset resolution into the
-same evaluator.
+the same single-manifest path; legacy named tools cannot qualify a host.
+Launch-time sandbox preset rules and active run controls use the exact manifest
+persisted on the attempt. Provider events, status, logs, completion, stop,
+steer, token usage, and artifacts reject missing, invalid, failed-probe, or
+active/persisted digest-mismatched snapshots.
 
 ---
 
@@ -2239,10 +2313,16 @@ POST /api/sandbox-policies/validate
 {
   "presetId": "repo-contained-no-network",
   "provider": "codex-sdk",
+  "providerRuntimeManifestDigest": "sha256:<64 lowercase hex characters>",
   "workspacePath": "/workspace/veritas-kanban",
   "requiredCapabilities": ["filesystem.write"]
 }
 ```
+
+The digest must belong to a manifest currently registered by a live agent host
+and must match `provider`. The API rejects caller-supplied manifest objects,
+unknown or expired digests, and provider mismatches. Internal launch checks use
+the immutable manifest already selected and persisted for the attempt.
 
 **Response** `200`:
 

--- a/docs/API-WORKFLOWS.md
+++ b/docs/API-WORKFLOWS.md
@@ -1233,8 +1233,10 @@ step before execution and write a `sandbox-policy` governance trace; advisory
 unsupported controls continue with warnings.
 
 Use `/api/sandbox-policies/validate` to preflight a workflow agent's preset in
-the authoring UI or custom automation. Presets can also be assigned visually in
-the workflow authoring panel.
+the authoring UI or custom automation. Public preflights must include a
+`providerRuntimeManifestDigest` currently registered by a connected agent host;
+the API rejects stale, disconnected, unknown, or provider-mismatched manifests.
+Presets can also be assigned visually in the workflow authoring panel.
 
 Sandbox policies are complementary to tool policies:
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -441,14 +441,34 @@ vk project create "rubicon" --color "#7c3aed" --description "Main product"
 
 Manage AI agents on code tasks.
 
-| Command                      | Description                                         |
-| ---------------------------- | --------------------------------------------------- |
-| `vk start <id>`              | Start an agent on a code task (`--agent` to choose) |
-| `vk stop <id>`               | Stop a running agent                                |
-| `vk agents:pending`          | List pending agent requests                         |
-| `vk agents:status <id>`      | Check agent running status                          |
-| `vk agents:complete <id> -s` | Mark agent complete (success)                       |
-| `vk agents:complete <id> -f` | Mark agent complete (failure)                       |
+| Command                                                                       | Description                                               |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `vk start <id>`                                                               | Start an agent; optionally require runtime capabilities   |
+| `vk stop <id>`                                                                | Stop a run only when its persisted manifest supports stop |
+| `vk agents:pending`                                                           | List pending agent requests                               |
+| `vk agents:status <id>`                                                       | Check agent running status                                |
+| `vk agents:complete <id> -s --attempt-id <id> --manifest-digest <sha256:...>` | Mark the matching agent attempt complete (success)        |
+| `vk agents:complete <id> -f --attempt-id <id> --manifest-digest <sha256:...>` | Mark the matching agent attempt complete (failure)        |
+
+Require one or more capabilities before launch:
+
+```bash
+vk start TASK-001 --agent codex \
+  --require-capability tool.mcp output.structured \
+  --json
+```
+
+`--require-capability <capabilities...>` is additive to the baseline launch,
+profile, sandbox, and budget requirements. The server returns a structured
+conflict and the CLI exits non-zero when any capability is unsupported,
+unknown, missing, or backed by an invalid/failed manifest.
+
+Use `vk agents:status TASK-001 --json` to inspect the persisted manifest and
+capability-derived `controls` set. `vk stop` does not infer support from the
+agent name. It resolves the current `attemptId` from status and includes it in
+the stop request, so a replacement run fails a delayed stop closed. The CLI
+preserves the server's reason when `run.stop` is unavailable or the active and
+persisted manifest digests do not match.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1614,13 +1614,14 @@ Added in v3.3.2.
 
 ### Agent Commands
 
-| Command                   | Description                                              |
-| ------------------------- | -------------------------------------------------------- |
-| `vk start <id>`           | Start an agent on a code task (`--agent` to choose)      |
-| `vk stop <id>`            | Stop a running agent                                     |
-| `vk agents:pending`       | List pending agent requests                              |
-| `vk agents:status <id>`   | Check agent running status                               |
-| `vk agents:complete <id>` | Mark agent complete (`-s` for success, `-f` for failure) |
+| Command                                                                       | Description                                         |
+| ----------------------------------------------------------------------------- | --------------------------------------------------- |
+| `vk start <id>`                                                               | Start an agent on a code task (`--agent` to choose) |
+| `vk stop <id>`                                                                | Stop a running agent                                |
+| `vk agents:pending`                                                           | List pending agent requests                         |
+| `vk agents:status <id>`                                                       | Check agent running status                          |
+| `vk agents:complete <id> -s --attempt-id <id> --manifest-digest <sha256:...>` | Mark the matching agent attempt complete (success)  |
+| `vk agents:complete <id> -f --attempt-id <id> --manifest-digest <sha256:...>` | Mark the matching agent attempt complete (failure)  |
 
 ### Automation Commands
 

--- a/docs/architecture/ADR-0001-v5-desktop-architecture.md
+++ b/docs/architecture/ADR-0001-v5-desktop-architecture.md
@@ -263,10 +263,14 @@ and must not be inferred from client-provided labels.
 ### Port Conflicts
 
 The desktop shell must not require users to diagnose port conflicts manually. If
-the preferred port is unavailable, main process records the conflict in desktop
-logs, chooses another loopback port, and passes the actual origin to the renderer
-through the bridge. The UI may show the selected local origin in diagnostics, but
-the happy path should proceed without a terminal.
+the preferred port is unavailable on either IPv4 or IPv6 loopback, the main
+process records the conflict in desktop logs, chooses another loopback port, and
+passes the actual origin to the renderer through the bridge. The dual-stack
+probe must reject an accepting wildcard listener even when the operating system
+would allow a second address-specific bind on the same port. The UI may show the
+selected local origin in diagnostics, but the happy path should proceed without
+a terminal. In development mode, the web fallback scan excludes the server port
+selected earlier in startup so the two managed processes remain distinct.
 
 ### Restart
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -356,10 +356,10 @@ Task write tools return concise confirmations. Use `get_task`, `list_tasks`, or 
 
 ### Agent Control (2 tools)
 
-| Tool          | Description                    | Required Inputs | Key Options                                         |
-| ------------- | ------------------------------ | --------------- | --------------------------------------------------- |
-| `start_agent` | Start a coding agent on a task | `id`            | `agent` (`claude-code`, `amp`, `copilot`, `gemini`) |
-| `stop_agent`  | Stop a running agent           | `id`            | —                                                   |
+| Tool          | Description                    | Required Inputs | Key Options                                                           |
+| ------------- | ------------------------------ | --------------- | --------------------------------------------------------------------- |
+| `start_agent` | Start a coding agent on a task | `id`            | `agent`; `requiredRuntimeCapabilities`                                |
+| `stop_agent`  | Stop a running agent           | `id`            | Resolves status and binds the stop to that exact attempt and manifest |
 
 > **Constraints:** Only works on tasks with `type: "code"` that already have a git worktree attached.
 
@@ -371,11 +371,19 @@ Task write tools return concise confirmations. Use `get_task`, `list_tasks`, or 
 ```json
 {
   "name": "start_agent",
-  "arguments": { "id": "abc123", "agent": "claude-code" }
+  "arguments": {
+    "id": "abc123",
+    "agent": "claude-code",
+    "requiredRuntimeCapabilities": ["tool.mcp", "output.structured"]
+  }
 }
 ```
 
 → Returns attempt ID and worktree path.
+
+The required capability list is forwarded unchanged to the authoritative
+launch API. Unsupported, unknown, missing, failed-probe, or invalid manifest
+evidence fails closed before provider work starts.
 
 **Stop a running agent:**
 
@@ -385,6 +393,10 @@ Task write tools return concise confirmations. Use `get_task`, `list_tasks`, or 
   "arguments": { "id": "abc123" }
 }
 ```
+
+The tool reads the active `attemptId` from status immediately before sending
+the stop. If the run is replaced between those calls, the server returns a
+conflict instead of stopping the replacement.
 
 </details>
 
@@ -755,14 +767,16 @@ All tool errors return:
 
 ### Common Errors
 
-| Error                                 | Cause                                        | Fix                                                                      |
-| ------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------ |
-| `Task not found: abc123`              | ID doesn't match any task                    | Check the ID — partial match needs ≥ 6 characters                        |
-| `Can only start agents on code tasks` | Tried `start_agent` on a non-code task       | Change task type to `code` first                                         |
-| `Task needs a worktree first`         | `start_agent` on a task without git worktree | Create a worktree via the VK UI or API before starting an agent          |
-| `fetch failed` / `ECONNREFUSED`       | VK server not running                        | Start the server: `pnpm dev`                                             |
-| `401 Unauthorized`                    | Invalid or missing API key                   | Check `VK_API_KEY` in MCP config and `VERITAS_API_KEYS` in server `.env` |
-| `Unknown tool: <name>`                | Typo in tool name                            | Check the [Tool Catalog](#tool-catalog) for exact names                  |
+| Error                                 | Cause                                             | Fix                                                                        |
+| ------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
+| `Task not found: abc123`              | ID doesn't match any task                         | Check the ID — partial match needs ≥ 6 characters                          |
+| `Can only start agents on code tasks` | Tried `start_agent` on a non-code task            | Change task type to `code` first                                           |
+| `Task needs a worktree first`         | `start_agent` on a task without git worktree      | Create a worktree via the VK UI or API before starting an agent            |
+| `Provider runtime does not support…`  | Required launch or stop capability is unavailable | Select a capable provider or refresh its validated manifest                |
+| `Provider runtime manifest is stale…` | Active and persisted run snapshots do not match   | Terminate through the host supervisor, reconcile the attempt, and relaunch |
+| `fetch failed` / `ECONNREFUSED`       | VK server not running                             | Start the server: `pnpm dev`                                               |
+| `401 Unauthorized`                    | Invalid or missing API key                        | Check `VK_API_KEY` in MCP config and `VERITAS_API_KEYS` in server `.env`   |
+| `Unknown tool: <name>`                | Typo in tool name                                 | Check the [Tool Catalog](#tool-catalog) for exact names                    |
 
 ### Debugging
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -114,9 +114,12 @@ checks. Legacy role guards remain supported while route coverage is migrated.
 
 Browser password sessions are local-owner only in v5 GA. The server accepts the
 session cookie only on loopback requests with loopback `Host`/`Origin`/`Referer`
-metadata. Remote, server, PWA, and multi-user clients must authenticate with a
-trusted device session or scoped API token so active workspace membership, role,
-revocation, and downgraded scopes are revalidated.
+metadata. A verified loopback owner session receives the narrow
+`local-agent:run` capability so the packaged desktop can start and control local
+agents; this does not enable unauthenticated localhost bypass, which remains
+disabled in production. Remote, server, PWA, and multi-user clients must
+authenticate with a trusted device session or scoped API token so active
+workspace membership, role, revocation, and downgraded scopes are revalidated.
 
 The v5 authority surface is tracked in
 [`docs/security/permission-coverage.json`](security/permission-coverage.json).
@@ -136,6 +139,32 @@ limits are tracked in
 Compatibility errors and debug bundles must redact tokens, cookies, private
 keys, local private paths, raw chat content, and task body text.
 
+## Provider Runtime Capability Enforcement
+
+Provider runtime manifests are authorization evidence, not display metadata.
+The server validates their complete capability inventory, canonical SHA-256
+digest, probe state, and secret redaction before use. Launch requirements and
+run controls qualify only with `supported` or `advisory` evidence;
+`unsupported`, `unknown`, missing, failed-probe, malformed, or invalid-digest
+evidence fails closed.
+
+The selected manifest is persisted on the attempt before provider execution.
+Status, logs, completion, stop, message/steer, token reporting, tool events, and
+artifact ingestion compare the active snapshot with the persisted digest before
+acting. A mismatch stops provider event ingestion and requires the operator to
+terminate the detached provider through its host supervisor, reconcile attempt
+state, and launch a fresh run. Veritas does not offer a UI force-stop that
+bypasses runtime evidence.
+
+Public sandbox dry-runs accept a live registered manifest digest, not a
+caller-supplied manifest body. The server resolves the digest from current host
+registrations and rejects unknown, expired, or provider-mismatched evidence.
+Human Veritas approval gates remain separate from provider-native
+`run.approvals`; one does not imply the other. Shared co-drive links are pinned
+to their source attempt. Message and approval actions require that exact attempt
+to remain active and require current `run.steer` or `run.approvals` evidence, so
+an old link cannot control a replacement run on the same task.
+
 ## Agent Sandbox Policies
 
 Agent sandbox policy presets live in the shared app config and are managed from
@@ -148,12 +177,12 @@ Use them to constrain:
 - Environment variable passthrough.
 - Credential access mode: none, brokered references, or explicit environment passthrough.
 
-Launch-time validation compares the preset with the selected provider's
-capabilities. Required unsupported controls block the agent or workflow step
-before execution. Advisory unsupported controls continue with warnings. Every
-dry-run and launch-time decision writes a governance trace with raw detail
-redacted; credential references and environment-style `name=value` strings are
-shown as `[redacted]`.
+Launch-time validation resolves every preset rule from the persisted provider
+runtime manifest. Required unsupported controls block the agent or workflow
+step before execution. Advisory unsupported controls continue with warnings.
+Every dry-run and launch-time decision writes a governance trace with raw
+detail redacted; credential references and environment-style `name=value`
+strings are shown as `[redacted]`.
 
 Agent budget policies are enforced through the same governance path. Workspace,
 agent, workflow, workflow-agent, and per-run budgets can cap tokens,

--- a/mcp/src/__tests__/agent-tools.test.ts
+++ b/mcp/src/__tests__/agent-tools.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockApi, mockFindTask } = vi.hoisted(() => ({
+  mockApi: vi.fn(),
+  mockFindTask: vi.fn(),
+}));
+
+vi.mock('../utils/api.js', () => ({ api: mockApi }));
+vi.mock('../utils/find.js', () => ({ findTask: mockFindTask }));
+
+import { agentTools, handleAgentTool } from '../tools/agents.js';
+
+describe('MCP agent runtime capability controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindTask.mockResolvedValue({
+      id: 'task_1',
+      type: 'code',
+      git: { worktreePath: '/tmp/task_1' },
+    });
+    mockApi.mockImplementation(async (url: string) =>
+      url.endsWith('/status')
+        ? { running: true, attemptId: 'attempt_1' }
+        : { attemptId: 'attempt_1' }
+    );
+  });
+
+  it('publishes required runtime capabilities in the start tool schema', () => {
+    const start = agentTools.find((tool) => tool.name === 'start_agent');
+    expect(start?.inputSchema.properties.requiredRuntimeCapabilities).toMatchObject({
+      type: 'array',
+    });
+  });
+
+  it('forwards required capabilities to the authoritative launch API', async () => {
+    await handleAgentTool('start_agent', {
+      id: 'task_1',
+      agent: 'claude-code',
+      requiredRuntimeCapabilities: ['tool.mcp', 'output.structured'],
+    });
+
+    expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
+      method: 'POST',
+      body: JSON.stringify({
+        agent: 'claude-code',
+        requiredRuntimeCapabilities: ['tool.mcp', 'output.structured'],
+      }),
+    });
+  });
+
+  it('preserves fail-closed stop errors from the API', async () => {
+    mockApi
+      .mockResolvedValueOnce({ running: true, attemptId: 'attempt_1' })
+      .mockRejectedValueOnce(
+        new Error(
+          'Provider runtime does not support stop run: run.stop is unsupported. Select a capable provider.'
+        )
+      );
+
+    await expect(handleAgentTool('stop_agent', { id: 'task_1' })).rejects.toThrow(
+      'run.stop is unsupported'
+    );
+  });
+
+  it('binds stop requests to the attempt returned by status', async () => {
+    await handleAgentTool('stop_agent', { id: 'task_1' });
+
+    expect(mockApi).toHaveBeenNthCalledWith(1, '/api/agents/task_1/status');
+    expect(mockApi).toHaveBeenNthCalledWith(2, '/api/agents/task_1/stop', {
+      method: 'POST',
+      body: JSON.stringify({ attemptId: 'attempt_1' }),
+    });
+  });
+});

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -5,6 +5,15 @@ import { findTask } from '../utils/find.js';
 const StartAgentSchema = z.object({
   id: z.string().min(1),
   agent: z.enum(['claude-code', 'amp', 'copilot', 'gemini', 'veritas']).default('claude-code'),
+  requiredRuntimeCapabilities: z
+    .array(
+      z
+        .string()
+        .regex(/^[a-z][a-z0-9.-]*$/)
+        .max(80)
+    )
+    .max(64)
+    .optional(),
 });
 
 const TaskIdSchema = z.object({
@@ -26,6 +35,11 @@ export const agentTools = [
           type: 'string',
           enum: ['claude-code', 'amp', 'copilot', 'gemini'],
           description: 'Agent to use (default: claude-code)',
+        },
+        requiredRuntimeCapabilities: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Provider runtime capabilities that must be evidenced before launch',
         },
       },
       required: ['id'],
@@ -50,7 +64,7 @@ export const agentTools = [
 export async function handleAgentTool(name: string, args: any): Promise<any> {
   switch (name) {
     case 'start_agent': {
-      const { id, agent } = StartAgentSchema.parse(args);
+      const { id, agent, requiredRuntimeCapabilities } = StartAgentSchema.parse(args);
       const task = await findTask(id);
 
       if (!task) {
@@ -76,7 +90,7 @@ export async function handleAgentTool(name: string, args: any): Promise<any> {
 
       const result = await api<{ attemptId: string }>(`/api/agents/${task.id}/start`, {
         method: 'POST',
-        body: JSON.stringify({ agent }),
+        body: JSON.stringify({ agent, requiredRuntimeCapabilities }),
       });
 
       return {
@@ -100,7 +114,20 @@ export async function handleAgentTool(name: string, args: any): Promise<any> {
         };
       }
 
-      await api(`/api/agents/${task.id}/stop`, { method: 'POST' });
+      const status = await api<{ running: boolean; attemptId?: string }>(
+        `/api/agents/${task.id}/status`
+      );
+      if (!status.running || !status.attemptId) {
+        return {
+          content: [{ type: 'text', text: 'No active agent attempt is available to stop' }],
+          isError: true,
+        };
+      }
+
+      await api(`/api/agents/${task.id}/stop`, {
+        method: 'POST',
+        body: JSON.stringify({ attemptId: status.attemptId }),
+      });
 
       return {
         content: [{ type: 'text', text: 'Agent stopped' }],

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -15,11 +15,14 @@ const {
   mockPatchTaskAttempt,
   mockCheckAgent,
   mockTelemetryEmit,
+  mockGovernanceRecord,
   mockLogActivity,
   mockStartTrace,
   mockStartStep,
   mockEndStep,
   mockCompleteTrace,
+  mockSdkStartThread,
+  mockSdkRunStreamed,
 } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
   mockGetConfig: vi.fn(),
@@ -29,15 +32,24 @@ const {
   mockPatchTaskAttempt: vi.fn(),
   mockCheckAgent: vi.fn(),
   mockTelemetryEmit: vi.fn(),
+  mockGovernanceRecord: vi.fn(),
   mockLogActivity: vi.fn(),
   mockStartTrace: vi.fn(),
   mockStartStep: vi.fn(),
   mockEndStep: vi.fn(),
   mockCompleteTrace: vi.fn(),
+  mockSdkStartThread: vi.fn(),
+  mockSdkRunStreamed: vi.fn(),
 }));
 
 vi.mock('child_process', () => ({
   spawn: mockSpawn,
+}));
+
+vi.mock('@openai/codex-sdk', () => ({
+  Codex: class {
+    startThread = mockSdkStartThread;
+  },
 }));
 
 vi.mock('../services/config-service.js', () => ({
@@ -59,6 +71,10 @@ vi.mock('../services/task-service.js', () => ({
 
 vi.mock('../services/telemetry-service.js', () => ({
   getTelemetryService: () => ({ emit: mockTelemetryEmit, getConfig: () => ({ traces: true }) }),
+}));
+
+vi.mock('../services/governance-trace-service.js', () => ({
+  getGovernanceTraceService: () => ({ record: mockGovernanceRecord }),
 }));
 
 vi.mock('../services/activity-service.js', () => ({
@@ -93,6 +109,7 @@ vi.mock('../services/circuit-registry.js', () => ({
 import { AgentReadinessError, ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
 import type { AgentConfig, Task } from '@veritas-kanban/shared';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
 
@@ -104,10 +121,10 @@ type TestableClawdbotAgentService = ClawdbotAgentService & {
     task?: Task,
     attemptId?: string,
     agentConfig?: Partial<AgentConfig>
-  ): {
+  ): Promise<{
     summary?: string;
     usage?: { inputTokens: number; outputTokens: number; totalTokens?: number; model?: string };
-  };
+  }>;
   recordCodexThread(task: Task, attemptId: string, threadId: string): Promise<void>;
 };
 
@@ -164,12 +181,12 @@ function createControllableChild() {
   return child;
 }
 
-async function waitFor(assertion: () => void): Promise<void> {
+async function waitFor(assertion: () => void | Promise<void>): Promise<void> {
   const started = Date.now();
   let lastError: unknown;
   while (Date.now() - started < 10_000) {
     try {
-      assertion();
+      await assertion();
       return;
     } catch (error) {
       lastError = error;
@@ -218,7 +235,7 @@ describe('ClawdbotAgentService Codex providers', () => {
       ],
     } as Task;
 
-    mockGetTask.mockResolvedValue(task);
+    mockGetTask.mockImplementation(async () => task);
     mockUpdateTask.mockImplementation(async (_id, update) => {
       task = { ...task, ...update } as Task;
       return task;
@@ -255,6 +272,8 @@ describe('ClawdbotAgentService Codex providers', () => {
         },
       ],
     });
+    mockSdkStartThread.mockReturnValue({ runStreamed: mockSdkRunStreamed });
+    mockGovernanceRecord.mockResolvedValue({ id: 'governance_trace_fixture' });
   });
 
   afterEach(async () => {
@@ -302,8 +321,8 @@ describe('ClawdbotAgentService Codex providers', () => {
           'codex'
         );
       });
-      await waitFor(() => {
-        expect(service.getAgentStatus(task.id)).toBeNull();
+      await waitFor(async () => {
+        expect(await service.getAgentStatus(task.id)).toBeNull();
       });
       expect(task.attempt?.providerRuntimeManifest).toMatchObject({
         schemaVersion: 'provider-runtime-manifest/v1',
@@ -319,6 +338,15 @@ describe('ClawdbotAgentService Codex providers', () => {
           }),
         }),
       ]);
+      expect(task.deliverables).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: 'server/src/services/example.ts',
+            type: 'code',
+            agent: 'codex',
+          }),
+        ])
+      );
       const log = await service.getAttemptLog(task.id, task.attempt?.id ?? 'missing');
       expect(log).toContain(
         `Provider manifest:** ${task.attempt?.providerRuntimeManifest?.digest}`
@@ -367,60 +395,46 @@ describe('ClawdbotAgentService Codex providers', () => {
     }
   );
 
-  it('maps Codex file events to task deliverables linked to the attempt', async () => {
+  it('does not trust Codex file events without a persisted runtime snapshot', async () => {
     const service = testableService(tmpDir);
     const logPath = path.join(tmpDir, 'codex.md');
     await fs.writeFile(logPath, '# log\n');
 
-    service.handleCodexEvent(
-      {
-        type: 'item.completed',
-        item: {
-          type: 'file_change',
-          file_path: 'server/src/services/codex-provider.ts',
+    await expect(
+      service.handleCodexEvent(
+        {
+          type: 'item.completed',
+          item: {
+            type: 'file_change',
+            file_path: 'server/src/services/codex-provider.ts',
+          },
         },
-      },
-      logPath,
-      task,
-      'attempt_fixture',
-      { type: 'codex', provider: 'codex-cli' }
-    );
+        logPath,
+        task,
+        'attempt_fixture',
+        { type: 'codex', provider: 'codex-cli' }
+      )
+    ).rejects.toThrow('provider event does not match the active attempt');
 
-    await waitFor(() => {
-      expect(mockUpdateTask).toHaveBeenCalledWith(
-        task.id,
-        expect.objectContaining({
-          deliverables: [
-            expect.objectContaining({
-              path: 'server/src/services/codex-provider.ts',
-              type: 'code',
-              agent: 'codex',
-              description: expect.stringContaining('attempt_fixture'),
-            }),
-          ],
-        })
-      );
-    });
-
-    expect(mockStartStep).toHaveBeenCalledWith(
-      'attempt_fixture',
-      'execute',
-      expect.objectContaining({
-        eventType: 'item.completed',
-        tool: 'file_change',
-        files: ['server/src/services/codex-provider.ts'],
-      })
-    );
-    expect(mockLogActivity).toHaveBeenCalledWith(
-      'deliverable_added',
+    expect(mockUpdateTask).not.toHaveBeenCalledWith(
       task.id,
-      task.title,
-      expect.objectContaining({ attemptId: 'attempt_fixture', deliverableCount: 1 }),
-      'codex'
+      expect.objectContaining({ deliverables: expect.any(Array) })
+    );
+    expect(mockStartStep).not.toHaveBeenCalledWith(
+      'attempt_fixture',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      'deliverable_added',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything()
     );
   });
 
-  it('accepts every Codex SDK 0.144 event contract consumed by the stream adapter', () => {
+  it('accepts every Codex SDK 0.144 event contract consumed by the stream adapter', async () => {
     const service = testableService(tmpDir);
     const logPath = path.join(tmpDir, 'codex.md');
     const events = [
@@ -451,7 +465,9 @@ describe('ClawdbotAgentService Codex providers', () => {
       { type: 'error', message: 'fixture stream error' },
     ] satisfies ThreadEvent[];
 
-    const parsed = events.map((event) => service.handleCodexEvent(event, logPath));
+    const parsed = await Promise.all(
+      events.map((event) => service.handleCodexEvent(event, logPath))
+    );
 
     expect(parsed[2]?.usage).toEqual({
       inputTokens: 10,
@@ -465,8 +481,13 @@ describe('ClawdbotAgentService Codex providers', () => {
     const service = testableService(tmpDir);
     const logPath = path.join(tmpDir, 'codex.md');
     await fs.writeFile(logPath, '# log\n');
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    await service.startAgent(task.id, 'codex');
+    const attemptId = task.attempt?.id;
+    if (!attemptId) throw new Error('Expected active attempt');
 
-    service.handleCodexEvent(
+    await service.handleCodexEvent(
       {
         type: 'response.output_text.delta',
         delta: 'partial output OPENAI_API_KEY=sk-supersecret123456',
@@ -474,10 +495,10 @@ describe('ClawdbotAgentService Codex providers', () => {
       },
       logPath,
       task,
-      'attempt_fixture',
+      attemptId,
       { type: 'codex', provider: 'codex-cli', model: 'gpt-5.5' }
     );
-    service.handleCodexEvent(
+    await service.handleCodexEvent(
       {
         type: 'turn.retrying',
         message: 'Retrying after rate limit',
@@ -486,12 +507,12 @@ describe('ClawdbotAgentService Codex providers', () => {
       },
       logPath,
       task,
-      'attempt_fixture',
+      attemptId,
       { type: 'codex', provider: 'codex-cli', model: 'gpt-5.5' }
     );
 
     expect(mockStartStep).toHaveBeenCalledWith(
-      'attempt_fixture',
+      attemptId,
       'stream',
       expect.objectContaining({
         eventType: 'response.output_text.delta',
@@ -500,7 +521,7 @@ describe('ClawdbotAgentService Codex providers', () => {
       })
     );
     expect(mockStartStep).toHaveBeenCalledWith(
-      'attempt_fixture',
+      attemptId,
       'retry',
       expect.objectContaining({
         eventType: 'turn.retrying',
@@ -509,6 +530,451 @@ describe('ClawdbotAgentService Codex providers', () => {
         retryDelayMs: 1250,
       })
     );
+    await service.stopAgent(task.id, attemptId);
+  });
+
+  it('fails status and provider event ingestion when the persisted snapshot changes', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+
+    await service.startAgent(task.id, 'codex');
+    const activeAttempt = task.attempt;
+    const attemptId = activeAttempt?.id;
+    if (!activeAttempt || !attemptId) throw new Error('Expected active attempt');
+    const originalManifest = activeAttempt.providerRuntimeManifest;
+    if (!originalManifest) throw new Error('Expected persisted runtime manifest');
+    task = {
+      ...task,
+      attempt: {
+        ...activeAttempt,
+        providerRuntimeManifest: providerRuntimeManifestFixture({ provider: 'codex-cli' }),
+      },
+    } as Task;
+
+    await expect(service.getAgentStatus(task.id)).rejects.toThrow('digest mismatch');
+
+    child.stdout.write(
+      `${JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'stale' } })}\n`
+    );
+    await waitFor(() => expect(child.kill).toHaveBeenCalledWith('SIGTERM'));
+    expect(mockStartStep).not.toHaveBeenCalledWith(
+      attemptId,
+      expect.anything(),
+      expect.objectContaining({ eventType: 'item.completed' })
+    );
+    task = {
+      ...task,
+      attempt: { ...activeAttempt, providerRuntimeManifest: originalManifest },
+    } as Task;
+    await service.stopAgent(task.id, attemptId);
+  });
+
+  it('aborts and removes a Codex SDK run when stale evidence also blocks finalization', async () => {
+    let releaseEvents: (() => void) | undefined;
+    const eventGate = new Promise<void>((resolve) => {
+      releaseEvents = resolve;
+    });
+    let sdkSignal: AbortSignal | undefined;
+    mockSdkRunStreamed.mockImplementation(
+      async (_prompt: string, options: { signal?: AbortSignal }) => {
+        sdkSignal = options.signal;
+        return {
+          events: {
+            async *[Symbol.asyncIterator]() {
+              await eventGate;
+              yield {
+                type: 'item.completed',
+                item: { type: 'agent_message', text: 'stale SDK event' },
+              };
+            },
+          },
+        };
+      }
+    );
+    mockGetConfig.mockResolvedValue({
+      agents: [
+        {
+          type: 'codex-sdk',
+          name: 'OpenAI Codex SDK',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          provider: 'codex-sdk',
+          model: 'gpt-5.5',
+        },
+      ],
+    });
+    const service = testableService(tmpDir);
+
+    await service.startAgent(task.id, 'codex-sdk');
+    await waitFor(() => expect(mockSdkRunStreamed).toHaveBeenCalled());
+    const activeAttempt = task.attempt;
+    if (!activeAttempt?.providerRuntimeManifest) throw new Error('Expected SDK runtime manifest');
+    task = {
+      ...task,
+      attempt: {
+        ...activeAttempt,
+        providerRuntimeManifest: providerRuntimeManifestFixture({ provider: 'codex-sdk' }),
+      },
+    } as Task;
+
+    releaseEvents?.();
+
+    await waitFor(async () => expect(await service.getAgentStatus(task.id)).toBeNull());
+    expect(sdkSignal?.aborted).toBe(true);
+  });
+
+  it('does not let a stopped SDK rejection remove its replacement run', async () => {
+    let releaseFirst: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+    let firstRejected = false;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    let invocation = 0;
+    mockSdkRunStreamed.mockImplementation(async () => {
+      invocation += 1;
+      const currentInvocation = invocation;
+      return {
+        events: {
+          async *[Symbol.asyncIterator]() {
+            if (currentInvocation === 1) {
+              await firstGate;
+              firstRejected = true;
+              throw new Error('stopped run rejected late');
+            }
+            await secondGate;
+            yield { type: 'thread.started', thread_id: 'replacement-thread' };
+          },
+        },
+      };
+    });
+    mockGetConfig.mockResolvedValue({
+      agents: [
+        {
+          type: 'codex-sdk',
+          name: 'OpenAI Codex SDK',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          provider: 'codex-sdk',
+          model: 'gpt-5.5',
+        },
+      ],
+    });
+    const service = testableService(tmpDir);
+
+    const first = await service.startAgent(task.id, 'codex-sdk');
+    await waitFor(() => expect(mockSdkRunStreamed).toHaveBeenCalledTimes(1));
+    await service.stopAgent(task.id, first.attemptId);
+    const replacement = await service.startAgent(task.id, 'codex-sdk');
+    expect(replacement.attemptId).not.toBe(first.attemptId);
+    await waitFor(() => expect(mockSdkRunStreamed).toHaveBeenCalledTimes(2));
+
+    releaseFirst?.();
+    await waitFor(() => expect(firstRejected).toBe(true));
+    await Promise.resolve();
+
+    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
+      attemptId: replacement.attemptId,
+      status: 'running',
+    });
+    await service.stopAgent(task.id, replacement.attemptId);
+    releaseSecond?.();
+  });
+
+  it('serializes concurrent starts before asynchronous launch checks complete', async () => {
+    let releaseConfig: (() => void) | undefined;
+    const configGate = new Promise<void>((resolve) => {
+      releaseConfig = resolve;
+    });
+    const config = {
+      agents: [
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: ['exec', '--json'],
+          enabled: true,
+          provider: 'codex-cli',
+          model: 'gpt-5.5',
+        },
+      ],
+    };
+    mockGetConfig
+      .mockImplementationOnce(async () => {
+        await configGate;
+        return config;
+      })
+      .mockResolvedValue(config);
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+
+    const firstStart = service.startAgent(task.id, 'codex');
+    await waitFor(() => expect(mockGetConfig).toHaveBeenCalledTimes(1));
+
+    await expect(service.startAgent(task.id, 'codex')).rejects.toThrow(
+      'An agent is already running or starting for this task'
+    );
+
+    releaseConfig?.();
+    const first = await firstStart;
+    expect(first.status).toBe('running');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    await service.stopAgent(task.id, first.attemptId);
+  });
+
+  it('coalesces concurrent completion claims for the same active attempt', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    const provenance = {
+      attemptId: active.attemptId,
+      providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
+    };
+
+    const naturalCompletion = service.completeAgent(
+      task.id,
+      { success: true, summary: 'natural completion won' },
+      provenance
+    );
+    const competingStopCompletion = service.completeAgent(
+      task.id,
+      { success: false, error: 'competing stop completion' },
+      provenance
+    );
+
+    await Promise.all([naturalCompletion, competingStopCompletion]);
+
+    expect(task.attempt).toMatchObject({
+      id: active.attemptId,
+      status: 'complete',
+    });
+    expect(
+      mockUpdateTask.mock.calls.filter(
+        ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+      )
+    ).toHaveLength(1);
+    expect(
+      mockTelemetryEmit.mock.calls.filter(([event]) => event.type === 'run.completed')
+    ).toHaveLength(1);
+    expect(mockLogActivity.mock.calls.filter(([type]) => type === 'agent_completed')).toHaveLength(
+      1
+    );
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('coalesces concurrent stops with the provider close terminalizer', async () => {
+    const child = createControllableChild();
+    child.kill.mockImplementation(() => {
+      child.killed = true;
+      child.emit('close', 143, 'SIGTERM');
+      return true;
+    });
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+
+    const firstStop = service.stopAgent(task.id, active.attemptId);
+    const concurrentStop = service.stopAgent(task.id, active.attemptId);
+    await Promise.all([firstStop, concurrentStop]);
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(
+      mockStartStep.mock.calls.filter(
+        ([attemptId, stepType]) => attemptId === active.attemptId && stepType === 'abort'
+      )
+    ).toHaveLength(1);
+    expect(
+      mockUpdateTask.mock.calls.filter(
+        ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+      )
+    ).toHaveLength(1);
+    expect(
+      mockTelemetryEmit.mock.calls.filter(([event]) => event.type === 'run.completed')
+    ).toHaveLength(1);
+    const log = await fs.readFile(path.join(tmpDir, `${task.id}_${active.attemptId}.md`), 'utf-8');
+    expect(log).not.toContain('## Codex Exit');
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('retries only the authoritative commit after a persistence failure', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    mockUpdateTask.mockRejectedValueOnce(new Error('persistence unavailable'));
+
+    await expect(service.stopAgent(task.id, active.attemptId)).rejects.toThrow(
+      'persistence unavailable'
+    );
+    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
+      attemptId: active.attemptId,
+      status: 'running',
+    });
+
+    await service.stopAgent(task.id, active.attemptId);
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(
+      mockStartStep.mock.calls.filter(
+        ([attemptId, stepType]) => attemptId === active.attemptId && stepType === 'abort'
+      )
+    ).toHaveLength(1);
+    expect(
+      mockUpdateTask.mock.calls.filter(
+        ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+      )
+    ).toHaveLength(2);
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('does not enforce a budget evaluation that outlives its active run', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex', {
+      budget: {
+        enabled: true,
+        limits: { runtimeSeconds: 10_000 },
+        hardAction: 'cancel',
+      },
+    });
+    let releaseBudgetLookup: (() => void) | undefined;
+    const budgetLookupGate = new Promise<void>((resolve) => {
+      releaseBudgetLookup = resolve;
+    });
+    mockGetTask.mockClear();
+    mockGetTask
+      .mockImplementationOnce(async () => {
+        await budgetLookupGate;
+        return task;
+      })
+      .mockImplementation(async () => task);
+
+    const staleBudgetEvaluation = service.recordBudgetUsage(task.id, active.attemptId, {
+      runtimeSeconds: 20_000,
+    });
+    await waitFor(() => expect(mockGetTask).toHaveBeenCalledTimes(1));
+    await service.stopAgent(task.id, active.attemptId);
+    releaseBudgetLookup?.();
+
+    await expect(staleBudgetEvaluation).rejects.toMatchObject({ statusCode: 409 });
+    const log = await fs.readFile(path.join(tmpDir, `${task.id}_${active.attemptId}.md`), 'utf-8');
+    expect(log).not.toContain('## Budget Enforcement');
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reapply budget usage when governance trace persistence retries', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex', {
+      budget: {
+        enabled: true,
+        limits: { toolCalls: 2 },
+        hardAction: 'cancel',
+      },
+    });
+    mockGovernanceRecord.mockRejectedValueOnce(new Error('governance trace unavailable'));
+
+    await expect(
+      service.recordBudgetUsage(task.id, active.attemptId, { toolCalls: 2 })
+    ).rejects.toThrow('governance trace unavailable');
+    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
+      attemptId: active.attemptId,
+      status: 'running',
+    });
+
+    await service.recordBudgetUsage(task.id, active.attemptId, { toolCalls: 2 });
+
+    expect(task.attempt?.budget?.usage.toolCalls).toBe(2);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('does not replay a committed completion when post-commit telemetry fails', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    const provenance = {
+      attemptId: active.attemptId,
+      providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
+    };
+    mockTelemetryEmit.mockRejectedValueOnce(new Error('telemetry unavailable'));
+
+    await expect(
+      service.completeAgent(
+        task.id,
+        { success: true, summary: 'committed before telemetry' },
+        provenance
+      )
+    ).resolves.toBeUndefined();
+
+    expect(task.attempt).toMatchObject({ id: active.attemptId, status: 'complete' });
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+    await expect(
+      service.completeAgent(task.id, { success: true, summary: 'must not replay' }, provenance)
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(
+      mockUpdateTask.mock.calls.filter(
+        ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+      )
+    ).toHaveLength(1);
+    expect(mockCompleteTrace).toHaveBeenCalledWith(active.attemptId, 'completed');
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      'agent_completed',
+      task.id,
+      task.title,
+      expect.objectContaining({ attemptId: active.attemptId, success: true }),
+      'codex'
+    );
+  });
+
+  it('rejects stale completion and budget provenance after a replacement starts', async () => {
+    const firstChild = createControllableChild();
+    const replacementChild = createControllableChild();
+    mockSpawn.mockReturnValueOnce(firstChild).mockReturnValueOnce(replacementChild);
+    const service = testableService(tmpDir);
+
+    const first = await service.startAgent(task.id, 'codex');
+    await service.stopAgent(task.id, first.attemptId);
+    const replacement = await service.startAgent(task.id, 'codex');
+
+    await expect(service.stopAgent(task.id, first.attemptId)).rejects.toMatchObject({
+      statusCode: 409,
+    });
+    await expect(
+      service.sendMessage(task.id, 'late steering command', {
+        expectedAttemptId: first.attemptId,
+      })
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await expect(
+      service.completeAgent(
+        task.id,
+        { success: true, summary: 'late completion' },
+        {
+          attemptId: first.attemptId,
+          providerRuntimeManifestDigest: first.providerRuntimeManifest.digest,
+        }
+      )
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await expect(
+      service.recordBudgetUsage(task.id, first.attemptId, { totalTokens: 99 })
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
+      attemptId: replacement.attemptId,
+      status: 'running',
+    });
+
+    await service.stopAgent(task.id, replacement.attemptId);
   });
 
   it('blocks explicit dispatch when the selected agent is unhealthy', async () => {
@@ -542,8 +1008,8 @@ describe('ClawdbotAgentService Codex providers', () => {
     mockSpawn.mockReturnValue(child);
     const service = testableService(tmpDir);
 
-    await service.startAgent(task.id, 'codex');
-    await service.stopAgent(task.id);
+    const active = await service.startAgent(task.id, 'codex');
+    await service.stopAgent(task.id, active.attemptId);
 
     expect(child.kill).toHaveBeenCalledWith('SIGTERM');
     expect(mockStartStep).toHaveBeenCalledWith(
@@ -576,7 +1042,7 @@ describe('ClawdbotAgentService Codex providers', () => {
       threadId: 'thread_fixture_123',
       providerRuntimeManifest: { digest: manifestDigest },
     });
-    await service.stopAgent(task.id);
+    await service.stopAgent(task.id, attemptId);
   });
 
   it('preserves the previous attempt when a new provider process fails to start', async () => {
@@ -587,7 +1053,7 @@ describe('ClawdbotAgentService Codex providers', () => {
       provider: 'codex-cli',
     };
     task = { ...task, attempt: previousAttempt, attempts: [] } as Task;
-    mockGetTask.mockResolvedValue(task);
+    mockGetTask.mockImplementation(async () => task);
     mockSpawn.mockImplementation(() => {
       throw new Error('fixture spawn failure');
     });
@@ -613,7 +1079,7 @@ describe('ClawdbotAgentService Codex providers', () => {
       subtasks: [],
       verificationSteps: [],
     } as Task;
-    mockGetTask.mockResolvedValue(task);
+    mockGetTask.mockImplementation(async () => task);
 
     const service = testableService(tmpDir);
 
@@ -647,8 +1113,8 @@ describe('ClawdbotAgentService Codex providers', () => {
         expect.objectContaining({ status: 'done' })
       );
     });
-    await waitFor(() => {
-      expect(service.getAgentStatus(task.id)).toBeNull();
+    await waitFor(async () => {
+      expect(await service.getAgentStatus(task.id)).toBeNull();
     });
   });
 });

--- a/server/src/__tests__/hermes-provider.test.ts
+++ b/server/src/__tests__/hermes-provider.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildSafeHermesEnv, isSensitiveHermesEnvKey } from '../utils/hermes-env.js';
 import { AgentHealthService } from '../services/agent-health-service.js';
-import { SandboxPolicyService } from '../services/sandbox-policy-service.js';
+import { getProviderRuntimeAdapterDefinition } from '../services/provider-runtime-adapter-registry.js';
 import type { AgentConfig } from '@veritas-kanban/shared';
 
 // ── buildSafeHermesEnv ────────────────────────────────────────────────────────
@@ -136,13 +136,23 @@ describe('AgentHealthService hermes-cli auth probe', () => {
   });
 });
 
-describe('SandboxPolicyService hermes-cli capabilities', () => {
-  it('reports the same local capability set as codex-cli', () => {
-    const service = new SandboxPolicyService();
-    expect(service.capabilitiesForProvider('hermes-cli')).toMatchObject({
-      provider: 'hermes-cli',
-      supported: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
-    });
+describe('Hermes provider runtime sandbox capabilities', () => {
+  it('reports the same evidence-backed local capability set as codex-cli', () => {
+    const supported = (provider: 'hermes-cli' | 'codex-cli') =>
+      getProviderRuntimeAdapterDefinition(provider)
+        .capabilities.filter((capability) => capability.state === 'supported')
+        .map((capability) => capability.id);
+    expect(supported('hermes-cli')).toContain('environment.allowlist');
+    const hermes = getProviderRuntimeAdapterDefinition('hermes-cli').capabilities;
+    expect(hermes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'filesystem.read', state: 'advisory' }),
+        expect.objectContaining({ id: 'filesystem.write', state: 'advisory' }),
+      ])
+    );
+    expect(supported('codex-cli')).toEqual(
+      expect.arrayContaining(['filesystem.read', 'filesystem.write', 'environment.allowlist'])
+    );
   });
 });
 

--- a/server/src/__tests__/middleware/auth.test.ts
+++ b/server/src/__tests__/middleware/auth.test.ts
@@ -495,6 +495,7 @@ describe('Auth Middleware', () => {
       expect(req.auth?.role).toBe('admin');
       expect(req.auth?.authMethod).toBe('session');
       expect(req.auth?.isLocalhost).toBe(false);
+      expect(req.auth?.capabilities).toEqual(['local-agent:run']);
     });
 
     it('should reject JWT cookie from remote hosts because password sessions are local-owner only', () => {
@@ -1133,6 +1134,7 @@ describe('Auth Middleware', () => {
       expect(result.role).toBe('admin');
       expect(result.authMethod).toBe('session');
       expect(result.isLocalhost).toBe(false);
+      expect(result.capabilities).toEqual(['local-agent:run']);
     });
 
     it('should reject WebSocket JWT cookie from remote hosts', () => {

--- a/server/src/__tests__/provider-runtime-adapters.test.ts
+++ b/server/src/__tests__/provider-runtime-adapters.test.ts
@@ -81,4 +81,32 @@ describe('ClawdbotAgentService provider runtime adapters', () => {
       });
     }
   );
+
+  it('separates OpenClaw task evidence from workflow-only controls and artifacts', async () => {
+    process.env.OPENCLAW_GATEWAY_VERSION = 'openclaw 2026.6.11';
+    const service = new ClawdbotAgentService(health);
+
+    const taskManifest = await service.probeProviderRuntime(config('openclaw'));
+    const workflowManifest = await service.probeProviderRuntime(
+      config('openclaw'),
+      'openclaw',
+      'workflow'
+    );
+
+    expect(taskManifest.protocolVersion).toBe('openclaw-tools/v1');
+    expect(
+      taskManifest.capabilities.find((capability) => capability.id === 'run.follow-up')?.state
+    ).toBe('unsupported');
+    expect(
+      taskManifest.capabilities.find((capability) => capability.id === 'artifact.write')?.state
+    ).toBe('unknown');
+    expect(workflowManifest.protocolVersion).toBe('openclaw-workflow-session/v1');
+    expect(
+      workflowManifest.capabilities.find((capability) => capability.id === 'run.follow-up')?.state
+    ).toBe('supported');
+    expect(
+      workflowManifest.capabilities.find((capability) => capability.id === 'artifact.write')?.state
+    ).toBe('supported');
+    expect(workflowManifest.digest).not.toBe(taskManifest.digest);
+  });
 });

--- a/server/src/__tests__/provider-runtime-control-service.test.ts
+++ b/server/src/__tests__/provider-runtime-control-service.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertProviderRuntimeCapabilities,
+  assertProviderRuntimeControl,
+  assertProviderRuntimeManifestSnapshot,
+  providerRuntimeControl,
+  providerRuntimeControls,
+  sandboxCapabilitiesFromManifest,
+} from '../services/provider-runtime-control-service.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+
+describe('provider runtime control enforcement', () => {
+  it.each([
+    ['supported', true, false],
+    ['advisory', true, true],
+    ['unsupported', false, false],
+    ['unknown', false, false],
+  ] as const)('maps %s evidence into one authoritative control', (state, available, advisory) => {
+    const manifest = providerRuntimeManifestFixture({
+      capabilityStates: { 'run.stop': state },
+    });
+
+    expect(providerRuntimeControl(manifest, 'stop')).toMatchObject({
+      capabilityId: 'run.stop',
+      state,
+      available,
+      advisory,
+      reason: `Fixture reports run.stop as ${state}.`,
+    });
+  });
+
+  it('fails closed for missing, failed, and invalid persisted manifests', () => {
+    const failed = providerRuntimeManifestFixture({
+      probeState: 'failed',
+      capabilityStates: { 'run.stop': 'supported' },
+    });
+    const invalid = { ...providerRuntimeManifestFixture(), digest: 'sha256:'.padEnd(71, '0') };
+
+    expect(providerRuntimeControl(undefined, 'stop').available).toBe(false);
+    expect(providerRuntimeControl(failed, 'stop')).toMatchObject({
+      available: false,
+      reason: 'The manifest readiness probe failed.',
+    });
+    expect(providerRuntimeControl(invalid, 'stop')).toMatchObject({
+      available: false,
+      state: 'unknown',
+      reason: expect.stringContaining('failed schema or digest validation'),
+    });
+    expect(() => assertProviderRuntimeControl(invalid, 'stop')).toThrow('stale or invalid');
+  });
+
+  it('rejects stale active and persisted snapshot digests', () => {
+    const manifest = providerRuntimeManifestFixture();
+
+    expect(() =>
+      assertProviderRuntimeManifestSnapshot(manifest, 'sha256:'.padEnd(71, 'f'))
+    ).toThrow('digest mismatch');
+  });
+
+  it('enforces arbitrary launch requirements without cross-capability inference', () => {
+    const manifest = providerRuntimeManifestFixture({
+      capabilityStates: {
+        'run.start': 'supported',
+        'tool.mcp': 'unsupported',
+      },
+    });
+
+    expect(() =>
+      assertProviderRuntimeCapabilities(manifest, ['run.start', 'tool.mcp'], 'test launch')
+    ).toThrow('tool.mcp');
+  });
+
+  it('returns capability-derived controls and sandbox posture from the same snapshot', () => {
+    const manifest = providerRuntimeManifestFixture({
+      capabilityStates: {
+        'run.stop': 'supported',
+        'filesystem.read': 'supported',
+        'network.allowlist': 'advisory',
+        'network.disable': 'unsupported',
+      },
+    });
+
+    expect(providerRuntimeControls(manifest)).toMatchObject({
+      manifestDigest: manifest.digest,
+      provider: manifest.provider,
+      controls: expect.arrayContaining([
+        expect.objectContaining({ action: 'stop', available: true }),
+      ]),
+    });
+    expect(sandboxCapabilitiesFromManifest(manifest)).toEqual({
+      provider: manifest.provider,
+      supported: expect.arrayContaining(['filesystem.read']),
+      advisory: ['network.allowlist'],
+    });
+  });
+});

--- a/server/src/__tests__/queue-intake-monitor-service.test.ts
+++ b/server/src/__tests__/queue-intake-monitor-service.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { QueueIntakeMonitorService } from '../services/queue-intake-monitor-service.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 
 describe('QueueIntakeMonitorService', () => {
   let testRoot: string;
@@ -15,6 +16,7 @@ describe('QueueIntakeMonitorService', () => {
   let workflowRunService: { startRun: ReturnType<typeof vi.fn> };
   let workflowAuthoringService: { dryRun: ReturnType<typeof vi.fn> };
   let telemetryService: { emit: ReturnType<typeof vi.fn> };
+  let runtimeManifestResolver: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     testRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-queue-monitor-'));
@@ -69,6 +71,7 @@ describe('QueueIntakeMonitorService', () => {
       dryRun: vi.fn(async () => ({ messages: [], status: 'ready', canRun: true, checks: [] })),
     };
     telemetryService = { emit: vi.fn(async (event) => event) };
+    runtimeManifestResolver = vi.fn(async () => providerRuntimeManifestFixture());
   });
 
   afterEach(async () => {
@@ -170,6 +173,44 @@ describe('QueueIntakeMonitorService', () => {
       }),
       undefined
     );
+    expect(sandboxPolicyService.dryRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'codex-cli',
+        providerRuntimeManifest: expect.objectContaining({
+          digest: expect.stringMatching(/^sha256:/),
+        }),
+      })
+    );
+  });
+
+  it('fails queue dispatch closed when runtime manifest resolution fails', async () => {
+    runtimeManifestResolver.mockResolvedValue(undefined);
+    const service = queueService();
+    await service.updateMonitor('veritas-backlog-high-priority', {
+      mode: 'execute',
+      workflowId: 'queue-intake-workflow',
+    });
+
+    const result = await service.runOnce('veritas-backlog-high-priority');
+
+    expect(result.action).toMatchObject({
+      action: 'blocked',
+      status: 'blocked',
+      sandbox: {
+        decision: 'block',
+        provider: 'codex-cli',
+      },
+    });
+    expect(result.action.gateChecks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'sandbox',
+          status: 'block',
+        }),
+      ])
+    );
+    expect(sandboxPolicyService.dryRun).not.toHaveBeenCalled();
+    expect(workflowRunService.startRun).not.toHaveBeenCalled();
   });
 
   function queueService(): QueueIntakeMonitorService {
@@ -184,6 +225,7 @@ describe('QueueIntakeMonitorService', () => {
       workflowRunService: workflowRunService as never,
       workflowAuthoringService: workflowAuthoringService as never,
       telemetryService: telemetryService as never,
+      runtimeManifestResolver,
     });
   }
 });

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -4,9 +4,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthContext, AuthenticatedRequest } from '../../middleware/auth.js';
 import { errorHandler } from '../../middleware/error-handler.js';
 
-const { mockStartAgent, mockStopAgent } = vi.hoisted(() => ({
+const {
+  mockStartAgent,
+  mockStopAgent,
+  mockSendMessage,
+  mockCompleteAgent,
+  mockGetAgentStatus,
+  mockAssertActiveRunControl,
+  mockRecordBudgetUsage,
+  mockGetTask,
+  mockTelemetryEmit,
+} = vi.hoisted(() => ({
   mockStartAgent: vi.fn(),
   mockStopAgent: vi.fn(),
+  mockSendMessage: vi.fn(),
+  mockCompleteAgent: vi.fn(),
+  mockGetAgentStatus: vi.fn(),
+  mockAssertActiveRunControl: vi.fn(),
+  mockRecordBudgetUsage: vi.fn(),
+  mockGetTask: vi.fn(),
+  mockTelemetryEmit: vi.fn(),
 }));
 
 vi.mock('../../services/clawdbot-agent-service.js', () => ({
@@ -16,12 +33,24 @@ vi.mock('../../services/clawdbot-agent-service.js', () => ({
   clawdbotAgentService: {
     startAgent: mockStartAgent,
     stopAgent: mockStopAgent,
-    completeAgent: vi.fn(),
-    getAgentStatus: vi.fn(),
+    sendMessage: mockSendMessage,
+    completeAgent: mockCompleteAgent,
+    getAgentStatus: mockGetAgentStatus,
+    assertRunControl: vi.fn(),
+    assertActiveRunControl: mockAssertActiveRunControl,
+    recordBudgetUsage: mockRecordBudgetUsage,
     listPendingRequests: vi.fn(),
     listAttempts: vi.fn(),
     getAttemptLog: vi.fn(),
   },
+}));
+
+vi.mock('../../services/task-service.js', () => ({
+  getTaskService: () => ({ getTask: mockGetTask }),
+}));
+
+vi.mock('../../services/telemetry-service.js', () => ({
+  getTelemetryService: () => ({ emit: mockTelemetryEmit }),
 }));
 
 import { agentRoutes } from '../../routes/agents.js';
@@ -55,6 +84,17 @@ describe('agent local capability enforcement', () => {
     vi.clearAllMocks();
     mockStartAgent.mockResolvedValue({ taskId: 'task_1', agent: 'codex', status: 'running' });
     mockStopAgent.mockResolvedValue(undefined);
+    mockSendMessage.mockResolvedValue({ delivered: true, note: 'delivered' });
+    mockCompleteAgent.mockResolvedValue(undefined);
+    mockGetAgentStatus.mockReturnValue(null);
+    mockAssertActiveRunControl.mockResolvedValue(undefined);
+    mockRecordBudgetUsage.mockResolvedValue(undefined);
+    mockGetTask.mockResolvedValue({
+      id: 'task_1',
+      project: 'veritas',
+      attempt: { id: 'attempt_1', agent: 'codex' },
+    });
+    mockTelemetryEmit.mockImplementation(async (event) => ({ id: 'event_1', ...event }));
   });
 
   it('rejects remote sessions without a local-agent capability before starting agents', async () => {
@@ -78,7 +118,65 @@ describe('agent local capability enforcement', () => {
       .send({ agent: 'codex' });
 
     expect(response.status).toBe(201);
-    expect(mockStartAgent).toHaveBeenCalledWith('task_1', 'codex', { overrideReason: undefined });
+    expect(mockStartAgent).toHaveBeenCalledWith('task_1', 'codex', {
+      profileId: undefined,
+      overrideReason: undefined,
+      sandboxPresetId: undefined,
+      budget: undefined,
+      requiredRuntimeCapabilities: undefined,
+    });
+  });
+
+  it('validates and forwards required runtime capabilities', async () => {
+    const app = createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }));
+    const response = await request(app)
+      .post('/api/agents/task_1/start')
+      .send({ agent: 'codex', requiredRuntimeCapabilities: ['tool.mcp'] });
+
+    expect(response.status).toBe(201);
+    expect(mockStartAgent).toHaveBeenCalledWith(
+      'task_1',
+      'codex',
+      expect.objectContaining({ requiredRuntimeCapabilities: ['tool.mcp'] })
+    );
+
+    const invalid = await request(app)
+      .post('/api/agents/task_1/start')
+      .send({ agent: 'codex', requiredRuntimeCapabilities: ['INVALID CAPABILITY'] });
+    expect(invalid.status).toBe(400);
+  });
+
+  it('returns capability-derived controls with agent status', async () => {
+    mockGetAgentStatus.mockReturnValue({
+      taskId: 'task_1',
+      attemptId: 'attempt_1',
+      agent: 'codex',
+      status: 'running',
+      providerRuntimeManifest: { digest: 'sha256:fixture' },
+      controls: {
+        manifestDigest: 'sha256:fixture',
+        controls: [
+          {
+            action: 'stop',
+            capabilityId: 'run.stop',
+            state: 'unsupported',
+            available: false,
+            advisory: false,
+            reason: 'Provider cannot stop this run.',
+          },
+        ],
+      },
+    });
+
+    const response = await request(createApp(auth())).get('/api/agents/task_1/status');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      running: true,
+      controls: {
+        controls: [expect.objectContaining({ action: 'stop', available: false })],
+      },
+    });
   });
 
   it('allows explicitly authorized remote sessions to stop agents', async () => {
@@ -86,10 +184,80 @@ describe('agent local capability enforcement', () => {
       createApp(auth({ capabilities: ['desktop:remote', 'agent:run:local'] }))
     )
       .post('/api/agents/task_1/stop')
-      .send();
+      .send({ attemptId: 'attempt_1' });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ stopped: true });
-    expect(mockStopAgent).toHaveBeenCalledWith('task_1');
+    expect(mockStopAgent).toHaveBeenCalledWith('task_1', 'attempt_1');
+  });
+
+  it('requires active attempt provenance for stop and message controls', async () => {
+    const app = createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }));
+
+    const missingStop = await request(app).post('/api/agents/task_1/stop').send({});
+    const missingMessage = await request(app)
+      .post('/api/agents/task_1/message')
+      .send({ message: 'continue' });
+    expect(missingStop.status).toBe(400);
+    expect(missingMessage.status).toBe(400);
+    expect(mockStopAgent).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+
+    const message = await request(app).post('/api/agents/task_1/message').send({
+      attemptId: 'attempt_1',
+      message: 'continue',
+    });
+    expect(message.status).toBe(200);
+    expect(mockSendMessage).toHaveBeenCalledWith('task_1', 'continue', {
+      actor: 'agent',
+      source: 'agent-route',
+      expectedAttemptId: 'attempt_1',
+    });
+  });
+
+  it('requires and forwards completion attempt provenance', async () => {
+    const app = createApp(auth());
+    const digest = `sha256:${'a'.repeat(64)}`;
+
+    const missing = await request(app).post('/api/agents/task_1/complete').send({ success: true });
+    expect(missing.status).toBe(400);
+
+    const response = await request(app).post('/api/agents/task_1/complete').send({
+      attemptId: 'attempt_1',
+      providerRuntimeManifestDigest: digest,
+      success: true,
+      summary: 'Done',
+    });
+    expect(response.status).toBe(200);
+    expect(mockCompleteAgent).toHaveBeenCalledWith(
+      'task_1',
+      { success: true, summary: 'Done', error: undefined },
+      { attemptId: 'attempt_1', providerRuntimeManifestDigest: digest }
+    );
+  });
+
+  it('binds token budget mutation to the resolved active attempt', async () => {
+    const app = createApp(auth());
+    const missing = await request(app).post('/api/agents/task_1/tokens').send({
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    expect(missing.status).toBe(400);
+    expect(mockRecordBudgetUsage).not.toHaveBeenCalled();
+
+    const response = await request(app).post('/api/agents/task_1/tokens').send({
+      attemptId: 'attempt_1',
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockAssertActiveRunControl).toHaveBeenCalledWith('task_1', 'token-usage', 'attempt_1');
+    expect(mockRecordBudgetUsage).toHaveBeenCalledWith('task_1', 'attempt_1', {
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      costUsd: undefined,
+    });
   });
 });

--- a/server/src/__tests__/routes/sandbox-policies-runtime-manifest.test.ts
+++ b/server/src/__tests__/routes/sandbox-policies-runtime-manifest.test.ts
@@ -1,0 +1,139 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { errorHandler } from '../../middleware/error-handler.js';
+import { providerRuntimeManifestFixture } from '../fixtures/provider-runtime-manifest.js';
+
+const { mockDryRunWithTrace, mockGetHostHealth, mockRecordTrace } = vi.hoisted(() => ({
+  mockDryRunWithTrace: vi.fn(),
+  mockGetHostHealth: vi.fn(),
+  mockRecordTrace: vi.fn(),
+}));
+
+vi.mock('../../services/sandbox-policy-service.js', () => ({
+  getSandboxPolicyService: () => ({
+    dryRunWithTrace: mockDryRunWithTrace,
+    listPresets: vi.fn(),
+    getPreset: vi.fn(),
+    createPreset: vi.fn(),
+    updatePreset: vi.fn(),
+    deletePreset: vi.fn(),
+  }),
+}));
+
+vi.mock('../../services/agent-host-service.js', () => ({
+  getAgentHostService: () => ({ getHealth: mockGetHostHealth }),
+}));
+
+vi.mock('../../services/governance-trace-service.js', () => ({
+  getGovernanceTraceService: () => ({ record: mockRecordTrace }),
+}));
+
+import sandboxPolicyRoutes from '../../routes/sandbox-policies.js';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/sandbox-policies', sandboxPolicyRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('sandbox policy runtime manifest provenance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDryRunWithTrace.mockResolvedValue({
+      result: { decision: 'allow' },
+      trace: { kind: 'sandbox-policy' },
+    });
+    mockRecordTrace.mockResolvedValue({ id: 'govtrace_fixture' });
+  });
+
+  it('resolves public dry-runs from a live registered manifest digest', async () => {
+    const manifest = providerRuntimeManifestFixture({ provider: 'codex-sdk' });
+    mockGetHostHealth.mockReturnValue({
+      hosts: [{ posture: 'connected', providerRuntimeManifests: [manifest] }],
+    });
+
+    const response = await request(createApp()).post('/api/sandbox-policies/validate').send({
+      presetId: 'codex-repo-contained',
+      provider: 'codex-sdk',
+      providerRuntimeManifestDigest: manifest.digest,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockDryRunWithTrace).toHaveBeenCalledWith({
+      presetId: 'codex-repo-contained',
+      provider: 'codex-sdk',
+      providerRuntimeManifestDigest: manifest.digest,
+      providerRuntimeManifest: manifest,
+    });
+  });
+
+  it('rejects unknown digests and caller-supplied manifest bodies', async () => {
+    mockGetHostHealth.mockReturnValue({ hosts: [] });
+    const unknown = await request(createApp())
+      .post('/api/sandbox-policies/validate')
+      .send({
+        presetId: 'codex-repo-contained',
+        provider: 'codex-sdk',
+        providerRuntimeManifestDigest: `sha256:${'f'.repeat(64)}`,
+      });
+    expect(unknown.status).toBe(409);
+
+    const forged = await request(createApp())
+      .post('/api/sandbox-policies/validate')
+      .send({
+        presetId: 'codex-repo-contained',
+        provider: 'codex-sdk',
+        providerRuntimeManifest: providerRuntimeManifestFixture({ provider: 'codex-sdk' }),
+      });
+    expect(forged.status).toBe(400);
+    expect(mockDryRunWithTrace).not.toHaveBeenCalled();
+  });
+
+  it.each(['stale', 'disconnected'] as const)(
+    'rejects manifests from %s hosts',
+    async (posture) => {
+      const manifest = providerRuntimeManifestFixture({ provider: 'codex-sdk' });
+      mockGetHostHealth.mockReturnValue({
+        hosts: [{ posture, providerRuntimeManifests: [manifest] }],
+      });
+
+      const response = await request(createApp()).post('/api/sandbox-policies/validate').send({
+        presetId: 'codex-repo-contained',
+        provider: 'codex-sdk',
+        providerRuntimeManifestDigest: manifest.digest,
+      });
+      expect(response.status).toBe(409);
+    }
+  );
+
+  it('rejects missing digests', async () => {
+    const manifest = providerRuntimeManifestFixture({ provider: 'codex-sdk' });
+    mockGetHostHealth.mockReturnValue({
+      hosts: [{ posture: 'connected', providerRuntimeManifests: [manifest] }],
+    });
+
+    const missing = await request(createApp()).post('/api/sandbox-policies/validate').send({
+      presetId: 'codex-repo-contained',
+      provider: 'codex-sdk',
+    });
+    expect(missing.status).toBe(400);
+  });
+
+  it('rejects provider mismatches', async () => {
+    const manifest = providerRuntimeManifestFixture({ provider: 'codex-sdk' });
+    mockGetHostHealth.mockReturnValue({
+      hosts: [{ posture: 'connected', providerRuntimeManifests: [manifest] }],
+    });
+
+    const response = await request(createApp()).post('/api/sandbox-policies/validate').send({
+      presetId: 'codex-repo-contained',
+      provider: 'openclaw',
+      providerRuntimeManifestDigest: manifest.digest,
+    });
+    expect(response.status).toBe(409);
+    expect(mockDryRunWithTrace).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/run-session-share-service.test.ts
+++ b/server/src/__tests__/run-session-share-service.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import type { Task } from '@veritas-kanban/shared';
 import { RunSessionShareService } from '../services/run-session-share-service.js';
 import type { TaskService } from '../services/task-service.js';
-import { ForbiddenError } from '../middleware/error-handler.js';
+import { ConflictError, ForbiddenError } from '../middleware/error-handler.js';
 
 const mockTask: Task = {
   id: 'task-721',
@@ -55,6 +55,7 @@ describe('RunSessionShareService', () => {
     getAgentStatus: ReturnType<typeof vi.fn>;
     getAttemptLog: ReturnType<typeof vi.fn>;
     sendMessage: ReturnType<typeof vi.fn>;
+    assertActiveRunControl: ReturnType<typeof vi.fn>;
   };
   let service: RunSessionShareService;
 
@@ -90,6 +91,7 @@ describe('RunSessionShareService', () => {
         .fn()
         .mockResolvedValue('running in /Users/bradgroux/Projects/veritas-kanban\nready'),
       sendMessage: vi.fn().mockResolvedValue({ delivered: true }),
+      assertActiveRunControl: vi.fn().mockResolvedValue(undefined),
     };
     service = new RunSessionShareService({
       filePath: path.join(tmpDir, 'run-session-shares.json'),
@@ -150,7 +152,16 @@ describe('RunSessionShareService', () => {
     expect(agentService.sendMessage).toHaveBeenCalledWith(
       mockTask.id,
       'Run the focused test gate',
-      expect.objectContaining({ actor: 'Pair Editor', source: `run-session:${share.id}` })
+      expect.objectContaining({
+        actor: 'Pair Editor',
+        source: `run-session:${share.id}`,
+        expectedAttemptId: 'attempt-721',
+      })
+    );
+    expect(agentService.assertActiveRunControl).toHaveBeenCalledWith(
+      mockTask.id,
+      'message',
+      'attempt-721'
     );
 
     await service.revoke(share.id, owner, 'Rotated reviewer access');
@@ -195,6 +206,11 @@ describe('RunSessionShareService', () => {
       actionClass: 'human-review',
       approvalResponse: 'approved',
     });
+    expect(agentService.assertActiveRunControl).toHaveBeenCalledWith(
+      mockTask.id,
+      'approvals',
+      'attempt-721'
+    );
 
     await expect(
       service.respondToApproval(
@@ -203,6 +219,18 @@ describe('RunSessionShareService', () => {
         mobileActor
       )
     ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('blocks stale shared controls from targeting a replacement attempt', async () => {
+    const share = await service.create({ taskId: mockTask.id, permission: 'edit' }, owner);
+    agentService.assertActiveRunControl.mockRejectedValueOnce(
+      new ConflictError('Run control does not match the active attempt')
+    );
+
+    await expect(
+      service.sendMessage(share.id, { message: 'Do not steer the replacement' }, owner)
+    ).rejects.toBeInstanceOf(ConflictError);
+    expect(agentService.sendMessage).not.toHaveBeenCalled();
   });
 
   it('forks into a new task without inheriting local handles or mutating parent state', async () => {

--- a/server/src/__tests__/sandbox-policy-service.test.ts
+++ b/server/src/__tests__/sandbox-policy-service.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SANDBOX_PRESET_ID,
   SandboxPolicyService,
 } from '../services/sandbox-policy-service.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 
 function preset(overrides: Partial<SandboxPolicyPreset> = {}): SandboxPolicyPreset {
   const now = '2026-06-18T00:00:00.000Z';
@@ -84,10 +85,20 @@ describe('SandboxPolicyService', () => {
     );
   });
 
-  it('allows repo-contained Codex SDK launches and blocks unsupported Codex CLI launches', async () => {
+  it('uses manifest evidence instead of provider names for sandbox enforcement', async () => {
+    const sdkManifest = providerRuntimeManifestFixture({
+      provider: 'codex-sdk',
+      capabilityStates: {
+        'filesystem.read': 'supported',
+        'filesystem.write': 'supported',
+        'network.disable': 'supported',
+        'environment.allowlist': 'supported',
+      },
+    });
     const sdkResult = await service.dryRun({
       presetId: 'codex-repo-contained',
       provider: 'codex-sdk',
+      providerRuntimeManifest: sdkManifest,
     });
 
     expect(sdkResult.decision).toBe('allow');
@@ -99,10 +110,40 @@ describe('SandboxPolicyService', () => {
     const cliResult = await service.dryRun({
       presetId: 'codex-repo-contained',
       provider: 'codex-cli',
+      providerRuntimeManifest: providerRuntimeManifestFixture({
+        provider: 'codex-cli',
+        capabilityStates: {
+          'filesystem.read': 'supported',
+          'filesystem.write': 'supported',
+          'environment.allowlist': 'supported',
+        },
+      }),
     });
 
     expect(cliResult.decision).toBe('block');
     expect(cliResult.unsupportedRules.map((rule) => rule.capability)).toContain('network.disable');
+  });
+
+  it('fails closed when only a provider name is supplied', async () => {
+    const result = await service.dryRun({
+      presetId: 'codex-repo-contained',
+      provider: 'codex-sdk',
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.unsupportedRules.length).toBeGreaterThan(0);
+  });
+
+  it('warns instead of silently allowing unsupported advisory controls', async () => {
+    const result = await service.dryRun({
+      preset: preset({ enforcement: 'advisory' }),
+      provider: 'codex-sdk',
+    });
+
+    expect(result.decision).toBe('warn');
+    expect(result.warnings).toEqual(
+      expect.arrayContaining(result.unsupportedRules.map((rule) => rule.detail))
+    );
   });
 
   it('creates, updates, and deletes custom presets without allowing built-in mutation', async () => {
@@ -154,18 +195,18 @@ describe('SandboxPolicyService', () => {
         },
       }),
       provider: 'hosted-agent',
-      providerCapabilities: {
+      providerRuntimeManifest: providerRuntimeManifestFixture({
         provider: 'hosted-agent',
-        supported: [
-          'filesystem.read',
-          'filesystem.write',
-          'network.allowlist',
-          'network.block-private',
-          'network.block-metadata',
-          'environment.allowlist',
-          'credential.broker',
-        ],
-      },
+        capabilityStates: {
+          'filesystem.read': 'supported',
+          'filesystem.write': 'supported',
+          'network.allowlist': 'supported',
+          'network.block-private': 'supported',
+          'network.block-metadata': 'supported',
+          'environment.allowlist': 'supported',
+          'credential.broker': 'supported',
+        },
+      }),
       workspacePath: '/Users/bradgroux/Projects/veritas-kanban',
     });
 

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -774,6 +774,7 @@ describe('Agent Schemas', () => {
   describe('ReportTokensBodySchema', () => {
     it('should accept valid token report', () => {
       const result = ReportTokensBodySchema.parse({
+        attemptId: 'attempt_1',
         inputTokens: 1000,
         outputTokens: 500,
         model: 'claude-opus',
@@ -783,21 +784,39 @@ describe('Agent Schemas', () => {
       expect(result.outputTokens).toBe(500);
     });
 
-    it('should accept minimal token report', () => {
-      const result = ReportTokensBodySchema.parse({ inputTokens: 100, outputTokens: 50 });
+    it('should accept minimal token report with attempt provenance', () => {
+      const result = ReportTokensBodySchema.parse({
+        attemptId: 'attempt_1',
+        inputTokens: 100,
+        outputTokens: 50,
+      });
       expect(result.inputTokens).toBe(100);
     });
 
+    it('should reject missing attempt provenance', () => {
+      expect(() => ReportTokensBodySchema.parse({ inputTokens: 100, outputTokens: 50 })).toThrow();
+    });
+
     it('should reject missing inputTokens', () => {
-      expect(() => ReportTokensBodySchema.parse({ outputTokens: 50 })).toThrow();
+      expect(() =>
+        ReportTokensBodySchema.parse({ attemptId: 'attempt_1', outputTokens: 50 })
+      ).toThrow();
     });
 
     it('should reject missing outputTokens', () => {
-      expect(() => ReportTokensBodySchema.parse({ inputTokens: 100 })).toThrow();
+      expect(() =>
+        ReportTokensBodySchema.parse({ attemptId: 'attempt_1', inputTokens: 100 })
+      ).toThrow();
     });
 
     it('should reject negative tokens', () => {
-      expect(() => ReportTokensBodySchema.parse({ inputTokens: -1, outputTokens: 50 })).toThrow();
+      expect(() =>
+        ReportTokensBodySchema.parse({
+          attemptId: 'attempt_1',
+          inputTokens: -1,
+          outputTokens: 50,
+        })
+      ).toThrow();
     });
   });
 });

--- a/server/src/__tests__/workflow-step-executor-codex.test.ts
+++ b/server/src/__tests__/workflow-step-executor-codex.test.ts
@@ -35,6 +35,32 @@ vi.mock('../services/governance-trace-service.js', () => ({
 
 import { WorkflowStepExecutor } from '../services/workflow-step-executor.js';
 import type { WorkflowRun, WorkflowStep } from '../types/workflow.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+
+const runtimeManifestResolver = vi.fn();
+
+function codexRuntimeManifest(capabilityStates = {}) {
+  return providerRuntimeManifestFixture({
+    provider: 'codex-sdk',
+    capabilityStates: {
+      'run.start': 'supported',
+      'run.status': 'supported',
+      'run.logs': 'supported',
+      'run.complete': 'supported',
+      'run.resume': 'advisory',
+      'tool.calls': 'supported',
+      'output.structured': 'supported',
+      'usage.tokens': 'supported',
+      'artifact.write': 'supported',
+      'workspace.worktrees': 'supported',
+      'filesystem.read': 'supported',
+      'filesystem.write': 'supported',
+      'network.disable': 'supported',
+      'environment.allowlist': 'supported',
+      ...capabilityStates,
+    },
+  });
+}
 
 async function* codexEvents() {
   yield { type: 'thread.started', thread_id: 'thread_test_123' };
@@ -83,6 +109,7 @@ describe('WorkflowStepExecutor Codex integration', () => {
     mockResumeThread.mockReturnValue({ runStreamed: mockRunStreamed });
     mockRecordGovernanceTrace.mockResolvedValue({ id: 'govtrace_1' });
     mockGetToolFilterForRole.mockResolvedValue({});
+    runtimeManifestResolver.mockResolvedValue(codexRuntimeManifest());
   });
 
   afterEach(async () => {
@@ -90,7 +117,8 @@ describe('WorkflowStepExecutor Codex integration', () => {
   });
 
   it('executes Codex workflow agent steps and records the thread session', async () => {
-    const executor = new WorkflowStepExecutor(tmpDir);
+    const persistRun = vi.fn().mockResolvedValue(undefined);
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver, persistRun });
     const step: WorkflowStep = {
       id: 'implement',
       name: 'Implement',
@@ -142,6 +170,178 @@ describe('WorkflowStepExecutor Codex integration', () => {
     expect(run.context._sessions).toMatchObject({ codex: 'thread_test_123' });
     expect(result.output).toContain('Implemented workflow Codex step.');
     expect(result.outputPath).toContain('implement.md');
+    expect(result.providerRuntimeManifest?.digest).toBe(
+      run.steps[0].providerRuntimeManifest?.digest
+    );
+    expect(persistRun).toHaveBeenCalledWith(run);
+    expect(persistRun.mock.invocationCallOrder[0]).toBeLessThan(
+      mockStartThread.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('rejects providers that have no workflow execution adapter before probing or launch', async () => {
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
+    const step: WorkflowStep = {
+      id: 'hermes-step',
+      type: 'agent',
+      agent: 'hermes',
+      input: 'Run Hermes',
+    };
+    const run = {
+      id: 'run_1234567890_hermes',
+      workflowId: 'wf-hermes',
+      workflowVersion: 1,
+      status: 'running',
+      context: {
+        task: { id: 'task_1', title: 'Hermes', git: { worktreePath: tmpDir } },
+        workflow: {
+          agents: [
+            {
+              id: 'hermes',
+              name: 'Hermes',
+              role: 'implementer',
+              provider: 'hermes-cli',
+              description: 'Hermes workflow agent',
+            },
+          ],
+        },
+      },
+      startedAt: new Date().toISOString(),
+      steps: [{ stepId: 'hermes-step', status: 'running', retries: 0 }],
+    } as WorkflowRun;
+
+    await expect(executor.executeStep(step, run)).rejects.toThrow(
+      'hermes-cli, which has no workflow execution adapter'
+    );
+    expect(runtimeManifestResolver).not.toHaveBeenCalled();
+    expect(mockStartThread).not.toHaveBeenCalled();
+  });
+
+  it('requires artifact evidence because every agent step persists an output artifact', async () => {
+    runtimeManifestResolver.mockResolvedValueOnce(
+      codexRuntimeManifest({ 'artifact.write': 'unsupported' })
+    );
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
+    const step: WorkflowStep = {
+      id: 'artifact-step',
+      type: 'agent',
+      agent: 'codex',
+      input: 'Produce output',
+    };
+    const run = {
+      id: 'run_1234567890_artifact',
+      workflowId: 'wf-artifact',
+      workflowVersion: 1,
+      status: 'running',
+      context: {
+        task: { id: 'task_1', title: 'Artifact', git: { worktreePath: tmpDir } },
+      },
+      startedAt: new Date().toISOString(),
+      steps: [{ stepId: 'artifact-step', status: 'running', retries: 0 }],
+    } as WorkflowRun;
+
+    await expect(executor.executeStep(step, run)).rejects.toThrow('artifact.write');
+    expect(mockStartThread).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on tool, MCP, structured-output, usage, and artifact requirements', async () => {
+    runtimeManifestResolver.mockResolvedValueOnce(
+      codexRuntimeManifest({
+        'tool.mcp': 'unknown',
+        'output.structured': 'unsupported',
+        'usage.tokens': 'unknown',
+        'artifact.write': 'unsupported',
+      })
+    );
+    mockGetToolFilterForRole.mockResolvedValue({ allowed: ['mcp__github__search'] });
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
+    const step: WorkflowStep = {
+      id: 'governed',
+      name: 'Governed',
+      type: 'agent',
+      agent: 'codex',
+      input: 'Run governed work',
+      output: { file: 'governed.json', schema: 'result/v1' },
+    };
+    const run = {
+      id: 'run_1234567890_governed',
+      workflowId: 'wf-codex',
+      workflowVersion: 1,
+      status: 'running',
+      context: {
+        task: { id: 'task_1', title: 'Governed', git: { worktreePath: tmpDir } },
+        workflow: {
+          agents: [
+            {
+              id: 'codex',
+              name: 'Codex',
+              role: 'implementer',
+              provider: 'codex-sdk',
+              description: 'Codex implementer',
+              tools: ['mcp__github__search'],
+            },
+          ],
+        },
+      },
+      budget: { enabled: true, policy: { limits: { totalTokens: 100 } } },
+      startedAt: new Date().toISOString(),
+      steps: [{ stepId: 'governed', status: 'running', retries: 0 }],
+    } as unknown as WorkflowRun;
+
+    await expect(executor.executeStep(step, run)).rejects.toMatchObject({
+      statusCode: 409,
+      details: {
+        requiredCapabilities: expect.arrayContaining([
+          'tool.calls',
+          'tool.mcp',
+          'output.structured',
+          'usage.tokens',
+          'artifact.write',
+        ]),
+      },
+    });
+    expect(mockStartThread).not.toHaveBeenCalled();
+  });
+
+  it('requires resume evidence before reusing a persisted Codex thread', async () => {
+    runtimeManifestResolver.mockResolvedValueOnce(
+      codexRuntimeManifest({ 'run.resume': 'unsupported' })
+    );
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
+    const step: WorkflowStep = {
+      id: 'resume',
+      name: 'Resume',
+      type: 'agent',
+      agent: 'codex',
+      input: 'Continue',
+      session: { mode: 'reuse', context: 'minimal', cleanup: 'keep', timeout: 60 },
+    };
+    const run = {
+      id: 'run_1234567890_resume',
+      workflowId: 'wf-codex',
+      workflowVersion: 1,
+      status: 'running',
+      context: {
+        task: { id: 'task_1', title: 'Resume', git: { worktreePath: tmpDir } },
+        workflow: {
+          agents: [
+            {
+              id: 'codex',
+              name: 'Codex',
+              role: 'implementer',
+              provider: 'codex-sdk',
+              description: 'Codex implementer',
+            },
+          ],
+        },
+        _sessions: { codex: 'thread_existing' },
+      },
+      startedAt: new Date().toISOString(),
+      steps: [{ stepId: 'resume', status: 'running', retries: 0 }],
+    } as WorkflowRun;
+
+    await expect(executor.executeStep(step, run)).rejects.toThrow('run.resume');
+    expect(mockResumeThread).not.toHaveBeenCalled();
   });
 
   it('passes only a minimal environment to Codex workflow sessions', async () => {
@@ -159,7 +359,7 @@ describe('WorkflowStepExecutor Codex integration', () => {
     process.env.VK_API_URL = 'http://127.0.0.1:3001';
 
     try {
-      const executor = new WorkflowStepExecutor(tmpDir);
+      const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
       const step: WorkflowStep = {
         id: 'implement',
         name: 'Implement',
@@ -227,7 +427,7 @@ describe('WorkflowStepExecutor Codex integration', () => {
     delete process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES;
 
     try {
-      const executor = new WorkflowStepExecutor(tmpDir);
+      const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
       const step: WorkflowStep = {
         id: 'implement',
         name: 'Implement',
@@ -283,7 +483,7 @@ describe('WorkflowStepExecutor Codex integration', () => {
     delete process.env.VERITAS_ALLOW_UNSAFE_CODEX_COMMAND_OVERRIDES;
 
     try {
-      const executor = new WorkflowStepExecutor(tmpDir);
+      const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
       const step: WorkflowStep = {
         id: 'implement',
         name: 'Implement',
@@ -338,7 +538,7 @@ describe('WorkflowStepExecutor Codex integration', () => {
       denied: ['Write', 'exec'],
     });
 
-    const executor = new WorkflowStepExecutor(tmpDir);
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
     const step: WorkflowStep = {
       id: 'plan',
       name: 'Plan',
@@ -384,7 +584,7 @@ describe('WorkflowStepExecutor Codex integration', () => {
   });
 
   it('records governance traces for workflow gate decisions', async () => {
-    const executor = new WorkflowStepExecutor(tmpDir);
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver });
     const step: WorkflowStep = {
       id: 'approval-gate',
       name: 'Approval Gate',

--- a/server/src/__tests__/workflow-step-executor-openclaw.test.ts
+++ b/server/src/__tests__/workflow-step-executor-openclaw.test.ts
@@ -29,6 +29,10 @@ vi.mock('../services/governance-trace-service.js', () => ({
 
 import { WorkflowStepExecutor } from '../services/workflow-step-executor.js';
 import type { WorkflowRun, WorkflowStep } from '../types/workflow.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+import { getProviderRuntimeAdapterDefinition } from '../services/provider-runtime-adapter-registry.js';
+
+const runtimeManifestResolver = vi.fn();
 
 type MockOpenClawAdapter = OpenClawWorkflowAdapter & {
   spawn: ReturnType<
@@ -115,6 +119,15 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
       allowed: ['Read', 'sessions_spawn', 'sessions_send'],
       denied: ['Write'],
     });
+    const openClawDefinition = getProviderRuntimeAdapterDefinition('openclaw', 'workflow');
+    runtimeManifestResolver.mockResolvedValue(
+      providerRuntimeManifestFixture({
+        provider: 'openclaw',
+        capabilityStates: Object.fromEntries(
+          openClawDefinition.capabilities.map((capability) => [capability.id, capability.state])
+        ),
+      })
+    );
   });
 
   afterEach(async () => {
@@ -134,7 +147,10 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
       output: 'STATUS: done\nOUTPUT: Completed via OpenClaw',
     });
 
-    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
     const step = createStep();
     const run = createRun();
 
@@ -184,6 +200,122 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
     expect(output).not.toContain('Implement OpenClaw adapter');
   });
 
+  it('does not require token telemetry for runtime-only workflow budgets', async () => {
+    adapter.spawn.mockResolvedValue({
+      sessionKey: 'oc_session_runtime_budget',
+      runId: 'oc_run_runtime_budget',
+      status: 'completed',
+      output: 'STATUS: done\nOUTPUT: Runtime budget completed',
+    });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
+    const run = createRun({
+      budget: {
+        enabled: true,
+        policy: { enabled: true, limits: { runtimeSeconds: 300 } },
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          costUsd: 0,
+          toolCalls: 0,
+          runtimeSeconds: 0,
+          idleRuntimeSeconds: 0,
+          retries: 0,
+          fanOut: 0,
+        },
+        decision: 'allow',
+        thresholdEvents: [],
+        traceIds: [],
+      },
+    });
+
+    await expect(executor.executeStep(createStep(), run)).resolves.toMatchObject({
+      output: expect.stringContaining('Runtime budget completed'),
+    });
+    expect(adapter.spawn).toHaveBeenCalled();
+  });
+
+  it('dispatches by the explicit provider instead of a Codex-like agent id', async () => {
+    adapter.spawn.mockResolvedValue({
+      sessionKey: 'oc_session_codex_name',
+      runId: 'oc_run_codex_name',
+      status: 'completed',
+      output: 'STATUS: done\nOUTPUT: Executed by OpenClaw',
+    });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
+    const step = createStep({ agent: 'codex' });
+    const run = createRun({
+      context: {
+        task: { id: 'task_1', title: 'Explicit provider dispatch' },
+        workflow: {
+          agents: [
+            {
+              id: 'codex',
+              name: 'Codex-named OpenClaw agent',
+              role: 'developer',
+              provider: 'openclaw',
+              description: 'Explicit provider wins over the agent id.',
+            },
+          ],
+        },
+        _sessions: {},
+      },
+    });
+
+    await executor.executeStep(step, run);
+
+    expect(adapter.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'codex', agentName: 'Codex-named OpenClaw agent' })
+    );
+  });
+
+  it('uses OpenClaw reattach requirements for an explicitly OpenClaw Codex-like agent', async () => {
+    adapter.send.mockResolvedValue({
+      sessionKey: 'oc_existing',
+      runId: 'oc_run_existing',
+      status: 'completed',
+      output: 'STATUS: done\nOUTPUT: Continued through OpenClaw',
+    });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
+    const step = createStep({
+      agent: 'codex',
+      session: { mode: 'reuse', context: 'minimal', cleanup: 'keep', timeout: 60 },
+    });
+    const run = createRun({
+      context: {
+        task: { id: 'task_1', title: 'Explicit provider reuse' },
+        workflow: {
+          agents: [
+            {
+              id: 'codex',
+              name: 'Codex-named OpenClaw agent',
+              role: 'developer',
+              provider: 'openclaw',
+              description: 'Explicit provider controls reuse requirements.',
+            },
+          ],
+        },
+        _sessions: { codex: 'oc_existing' },
+      },
+    });
+
+    await executor.executeStep(step, run);
+
+    expect(adapter.send).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'codex', sessionKey: 'oc_existing' })
+    );
+    expect(adapter.spawn).not.toHaveBeenCalled();
+  });
+
   it('reuses an existing OpenClaw session when requested', async () => {
     adapter.send.mockResolvedValue({
       sessionKey: 'oc_existing_1',
@@ -192,7 +324,10 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
       output: 'STATUS: done\nOUTPUT: Reused existing session',
     });
 
-    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
     const step = createStep({
       session: {
         mode: 'reuse',
@@ -237,7 +372,10 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
       )
     );
 
-    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
     const step = createStep({
       input: 'Implement {{task.title}} token=sk-test-secret-value-123456',
     });
@@ -280,7 +418,10 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
       error: 'Timed out waiting for completion',
     });
 
-    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
 
     await expect(executor.executeStep(createStep(), createRun())).rejects.toThrow(
       'OpenClaw session oc_session_timeout timed out'
@@ -303,7 +444,10 @@ describe('WorkflowStepExecutor OpenClaw integration', () => {
       output: 'STATUS: done\nOUTPUT: Kept for debugging',
     });
 
-    const executor = new WorkflowStepExecutor(tmpDir, { openClawAdapter: adapter });
+    const executor = new WorkflowStepExecutor(tmpDir, {
+      openClawAdapter: adapter,
+      runtimeManifestResolver,
+    });
     const step = createStep({
       session: {
         mode: 'fresh',

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -147,6 +147,23 @@ function buildAuthContext(input: {
   };
 }
 
+function buildLocalOwnerPasswordSessionContext(
+  isLocalhost: boolean
+): NonNullable<AuthenticatedRequest['auth']> {
+  return {
+    ...buildAuthContext({
+      role: 'admin',
+      keyName: 'session',
+      isLocalhost,
+      authMethod: 'session',
+    }),
+    // Production deliberately keeps isLocalhost=false so loopback never enables
+    // passwordless bypass. A verified local-owner password session still needs
+    // the narrow capability required by the packaged desktop agent controls.
+    capabilities: ['local-agent:run'],
+  };
+}
+
 function permissionListFor(auth: Pick<AuthContext, 'role' | 'permissions'>): AuthPermission[] {
   return auth.permissions ?? permissionsForRole(auth.role);
 }
@@ -521,12 +538,7 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
       if (!isLocalOwnerPasswordSessionRequest(req, isLocalhost)) {
         blockedPasswordSession = true;
       } else {
-        req.auth = buildAuthContext({
-          role: 'admin',
-          keyName: 'session',
-          isLocalhost,
-          authMethod: 'session',
-        });
+        req.auth = buildLocalOwnerPasswordSessionContext(isLocalhost);
         return next();
       }
     }
@@ -818,12 +830,7 @@ export function authenticateWebSocket(req: IncomingMessage): WebSocketAuthResult
         } else {
           return {
             authenticated: true,
-            ...buildAuthContext({
-              role: 'admin',
-              keyName: 'session',
-              isLocalhost,
-              authMethod: 'session',
-            }),
+            ...buildLocalOwnerPasswordSessionContext(isLocalhost),
           };
         }
       }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3,12 +3,17 @@ import { z } from 'zod';
 import { AgentReadinessError, clawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import { getTelemetryService } from '../services/telemetry-service.js';
 import { getTaskService } from '../services/task-service.js';
-import type { AgentType, TokenTelemetryEvent } from '@veritas-kanban/shared';
+import type {
+  AgentType,
+  ProviderRuntimeCapabilityId,
+  TokenTelemetryEvent,
+} from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { requireLocalAgentCapability } from '../middleware/local-agent-capability.js';
 import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { ProviderRuntimeCapabilityIdSchema } from '../schemas/provider-runtime-manifest-schemas.js';
 
 const router: RouterType = Router();
 
@@ -21,21 +26,29 @@ const startAgentSchema = z.object({
   overrideReason: z.string().trim().min(8).max(1000).optional(),
   sandboxPresetId: z.string().trim().min(1).max(80).optional(),
   budget: AgentBudgetPolicySchema.optional(),
+  requiredRuntimeCapabilities: z.array(ProviderRuntimeCapabilityIdSchema).max(64).optional(),
 });
 
 const completeAgentSchema = z.object({
+  attemptId: z.string().trim().min(1).max(120),
+  providerRuntimeManifestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
   success: z.boolean(),
   summary: z.string().optional(),
   error: z.string().optional(),
 });
 
 const sendAgentMessageSchema = z.object({
+  attemptId: z.string().trim().min(1).max(120),
   message: z.string().trim().min(1).max(4000),
   actor: z.string().trim().min(1).max(120).optional(),
 });
 
+const runControlSchema = z.object({
+  attemptId: z.string().trim().min(1).max(120),
+});
+
 const reportTokensSchema = z.object({
-  attemptId: z.string().optional(),
+  attemptId: z.string().trim().min(1).max(120),
   inputTokens: z.number({ message: 'inputTokens is required' }).int().nonnegative(),
   outputTokens: z.number({ message: 'outputTokens is required' }).int().nonnegative(),
   totalTokens: z.number().int().nonnegative().optional(),
@@ -54,16 +67,17 @@ router.post(
     let overrideReason: string | undefined;
     let sandboxPresetId: string | undefined;
     let budget: z.infer<typeof AgentBudgetPolicySchema> | undefined;
+    let requiredRuntimeCapabilities: ProviderRuntimeCapabilityId[] | undefined;
     try {
-      ({ agent, profileId, overrideReason, sandboxPresetId, budget } = startAgentSchema.parse(
-        req.body
-      ) as {
-        agent?: AgentType;
-        profileId?: string;
-        overrideReason?: string;
-        sandboxPresetId?: string;
-        budget?: z.infer<typeof AgentBudgetPolicySchema>;
-      });
+      ({ agent, profileId, overrideReason, sandboxPresetId, budget, requiredRuntimeCapabilities } =
+        startAgentSchema.parse(req.body) as {
+          agent?: AgentType;
+          profileId?: string;
+          overrideReason?: string;
+          sandboxPresetId?: string;
+          budget?: z.infer<typeof AgentBudgetPolicySchema>;
+          requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
+        });
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new ValidationError('Validation failed', error.issues);
@@ -77,6 +91,7 @@ router.post(
         overrideReason,
         sandboxPresetId,
         budget,
+        requiredRuntimeCapabilities,
       });
     } catch (error) {
       if (error instanceof AgentReadinessError) {
@@ -94,11 +109,14 @@ router.post(
 router.post(
   '/:taskId/complete',
   asyncHandler(async (req, res) => {
+    let attemptId: string;
+    let providerRuntimeManifestDigest: string;
     let success: boolean;
     let summary: string | undefined;
     let error: string | undefined;
     try {
-      ({ success, summary, error } = completeAgentSchema.parse(req.body));
+      ({ attemptId, providerRuntimeManifestDigest, success, summary, error } =
+        completeAgentSchema.parse(req.body));
     } catch (err) {
       if (err instanceof z.ZodError) {
         throw new ValidationError('Validation failed', err.issues);
@@ -106,11 +124,15 @@ router.post(
       throw err;
     }
 
-    await clawdbotAgentService.completeAgent(req.params.taskId as string, {
-      success,
-      summary,
-      error,
-    });
+    await clawdbotAgentService.completeAgent(
+      req.params.taskId as string,
+      {
+        success,
+        summary,
+        error,
+      },
+      { attemptId, providerRuntimeManifestDigest }
+    );
     res.json({ received: true });
   })
 );
@@ -120,7 +142,16 @@ router.post(
   '/:taskId/stop',
   requireLocalAgentCapability,
   asyncHandler(async (req, res) => {
-    await clawdbotAgentService.stopAgent(req.params.taskId as string);
+    let attemptId: string;
+    try {
+      ({ attemptId } = runControlSchema.parse(req.body));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+    await clawdbotAgentService.stopAgent(req.params.taskId as string, attemptId);
     res.json({ stopped: true });
   })
 );
@@ -130,10 +161,12 @@ router.post(
   '/:taskId/message',
   asyncHandler(async (req, res) => {
     let message: string;
+    let attemptId: string;
     let actorOverride: string | undefined;
     try {
       const parsed = sendAgentMessageSchema.parse(req.body);
       message = parsed.message;
+      attemptId = parsed.attemptId;
       actorOverride = parsed.actor;
     } catch (err) {
       if (err instanceof z.ZodError) {
@@ -154,6 +187,7 @@ router.post(
     const delivery = await clawdbotAgentService.sendMessage(req.params.taskId as string, message, {
       actor,
       source: 'agent-route',
+      expectedAttemptId: attemptId,
     });
     res.json(delivery);
   })
@@ -163,7 +197,7 @@ router.post(
 router.get(
   '/:taskId/status',
   asyncHandler(async (req, res) => {
-    const status = clawdbotAgentService.getAgentStatus(req.params.taskId as string);
+    const status = await clawdbotAgentService.getAgentStatus(req.params.taskId as string);
     if (!status) {
       return res.json({ running: false });
     }
@@ -205,7 +239,7 @@ router.get(
 router.post(
   '/:taskId/tokens',
   asyncHandler(async (req, res) => {
-    let attemptId: string | undefined;
+    let attemptId: string;
     let inputTokens: number;
     let outputTokens: number;
     let totalTokens: number | undefined;
@@ -238,16 +272,22 @@ router.post(
       throw new NotFoundError('Task not found');
     }
 
-    // Use provided attemptId or current attempt
-    const resolvedAttemptId = attemptId || task.attempt?.id || 'unknown';
+    await clawdbotAgentService.assertActiveRunControl(taskId, 'token-usage', attemptId);
     const resolvedAgent = agent || task.attempt?.agent || 'codex';
+
+    await clawdbotAgentService.recordBudgetUsage(taskId, attemptId, {
+      inputTokens,
+      outputTokens,
+      totalTokens: totalTokens ?? inputTokens + outputTokens,
+      costUsd: cost,
+    });
 
     // Emit telemetry event
     const telemetry = getTelemetryService();
     const event = await telemetry.emit<TokenTelemetryEvent>({
       type: 'run.tokens',
       taskId,
-      attemptId: resolvedAttemptId,
+      attemptId,
       agent: resolvedAgent,
       project: task.project,
       inputTokens,
@@ -255,13 +295,6 @@ router.post(
       totalTokens: totalTokens ?? inputTokens + outputTokens,
       cost,
       model,
-    });
-
-    await clawdbotAgentService.recordBudgetUsage(taskId, {
-      inputTokens,
-      outputTokens,
-      totalTokens: totalTokens ?? inputTokens + outputTokens,
-      costUsd: cost,
     });
 
     res.status(201).json({

--- a/server/src/routes/sandbox-policies.ts
+++ b/server/src/routes/sandbox-policies.ts
@@ -3,7 +3,9 @@ import type { SandboxPolicyDryRunRequest, SandboxPolicyPreset } from '@veritas-k
 import { asyncHandler } from '../middleware/async-handler.js';
 import { authorize } from '../middleware/auth.js';
 import { getGovernanceTraceService } from '../services/governance-trace-service.js';
+import { getAgentHostService } from '../services/agent-host-service.js';
 import { getSandboxPolicyService } from '../services/sandbox-policy-service.js';
+import { ConflictError } from '../middleware/error-handler.js';
 import { validate, type ValidatedRequest } from '../middleware/validate.js';
 import {
   sandboxPolicyDryRunSchema,
@@ -77,9 +79,41 @@ router.post(
   '/validate',
   validate({ body: sandboxPolicyDryRunSchema }),
   asyncHandler(async (req: ValidatedRequest<unknown, unknown, SandboxPolicyDryRunRequest>, res) => {
-    const evaluation = await sandboxPolicyService.dryRunWithTrace(
-      req.validated.body as SandboxPolicyDryRunRequest
-    );
+    const request = req.validated.body as SandboxPolicyDryRunRequest;
+    const manifest = request.providerRuntimeManifestDigest
+      ? getAgentHostService()
+          .getHealth()
+          .hosts.filter((host) => host.posture === 'connected')
+          .flatMap((host) => host.providerRuntimeManifests)
+          .find((candidate) => candidate.digest === request.providerRuntimeManifestDigest)
+      : undefined;
+    if (request.providerRuntimeManifestDigest && !manifest) {
+      throw new ConflictError(
+        'The requested provider runtime manifest is not registered on a live agent host',
+        {
+          manifestDigest: request.providerRuntimeManifestDigest,
+          remediation:
+            'Refresh provider readiness and host registration, then run the check again.',
+        }
+      );
+    }
+    if (
+      manifest &&
+      request.provider &&
+      manifest.provider.toLowerCase() !== request.provider.toLowerCase() &&
+      manifest.adapter.toLowerCase() !== request.provider.toLowerCase()
+    ) {
+      throw new ConflictError('The requested provider does not match the registered manifest', {
+        provider: request.provider,
+        manifestProvider: manifest.provider,
+        manifestAdapter: manifest.adapter,
+        manifestDigest: manifest.digest,
+      });
+    }
+    const evaluation = await sandboxPolicyService.dryRunWithTrace({
+      ...request,
+      providerRuntimeManifest: manifest,
+    });
     const trace = await getGovernanceTraceService().record(evaluation.trace);
     res.json({ ...evaluation.result, traceId: trace.id });
   })

--- a/server/src/schemas/agent-schemas.ts
+++ b/server/src/schemas/agent-schemas.ts
@@ -31,7 +31,7 @@ export type CompleteAgentBody = z.infer<typeof CompleteAgentBodySchema>;
  * POST /api/agents/:taskId/tokens - Report token usage
  */
 export const ReportTokensBodySchema = z.object({
-  attemptId: z.string().optional(),
+  attemptId: z.string().trim().min(1).max(120),
   inputTokens: z.number({ message: 'inputTokens is required' }).int().nonnegative(),
   outputTokens: z.number({ message: 'outputTokens is required' }).int().nonnegative(),
   totalTokens: z.number().int().nonnegative().optional(),

--- a/server/src/schemas/provider-runtime-manifest-schemas.ts
+++ b/server/src/schemas/provider-runtime-manifest-schemas.ts
@@ -15,7 +15,7 @@ const identifierSchema = z
   .max(120)
   .regex(/^[a-zA-Z][a-zA-Z0-9._:/-]*$/, 'Invalid runtime identifier');
 
-const capabilityIdSchema = z
+export const ProviderRuntimeCapabilityIdSchema = z
   .string()
   .trim()
   .min(2)
@@ -24,7 +24,7 @@ const capabilityIdSchema = z
 
 export const ProviderRuntimeCapabilityEvidenceSchema = z
   .object({
-    id: capabilityIdSchema,
+    id: ProviderRuntimeCapabilityIdSchema,
     state: z.enum(['supported', 'advisory', 'unsupported', 'unknown']),
     source: z.enum(['runtime-probe', 'contract-test', 'host-enforced']),
     reason: z.string().trim().min(1).max(1000),

--- a/server/src/schemas/sandbox-policy-schemas.ts
+++ b/server/src/schemas/sandbox-policy-schemas.ts
@@ -17,19 +17,6 @@ export const sandboxPolicyEnforcementSchema = z.enum(['required', 'advisory']);
 export const sandboxNetworkDefaultSchema = z.enum(['allow', 'deny']);
 export const sandboxCredentialModeSchema = z.enum(['none', 'brokered', 'env-passthrough']);
 
-export const sandboxProviderCapabilityIdSchema = z.enum([
-  'filesystem.read',
-  'filesystem.write',
-  'filesystem.deny-paths',
-  'filesystem.dotfile-masking',
-  'network.disable',
-  'network.allowlist',
-  'network.block-private',
-  'network.block-metadata',
-  'environment.allowlist',
-  'credential.broker',
-]);
-
 export const skillCapabilityIdSchema = z.enum([
   'filesystem.read',
   'filesystem.write',
@@ -93,20 +80,16 @@ export const sandboxPolicyParamsSchema = z.object({
   id: sandboxPresetIdSchema,
 });
 
-export const sandboxProviderCapabilitiesSchema = z.object({
-  provider: z.string().max(80).optional(),
-  supported: z.array(sandboxProviderCapabilityIdSchema).max(50).default([]),
-  advisory: z.array(sandboxProviderCapabilityIdSchema).max(50).optional().default([]),
-});
-
-export const sandboxPolicyDryRunSchema = z.object({
-  presetId: sandboxPresetIdSchema.optional(),
-  preset: sandboxPolicyPresetSchema.optional(),
-  provider: z.string().max(80).optional(),
-  workspacePath: z.string().max(1000).optional(),
-  requiredCapabilities: z.array(skillCapabilityIdSchema).max(50).optional(),
-  providerCapabilities: sandboxProviderCapabilitiesSchema.optional(),
-});
+export const sandboxPolicyDryRunSchema = z
+  .object({
+    presetId: sandboxPresetIdSchema.optional(),
+    preset: sandboxPolicyPresetSchema.optional(),
+    provider: z.string().max(80).optional(),
+    workspacePath: z.string().max(1000).optional(),
+    requiredCapabilities: z.array(skillCapabilityIdSchema).max(50).optional(),
+    providerRuntimeManifestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  })
+  .strict();
 
 export type SandboxPolicyPresetInput = z.infer<typeof sandboxPolicyPresetSchema>;
 export type SandboxPolicyDryRunInput = z.infer<typeof sandboxPolicyDryRunSchema>;

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -55,8 +55,12 @@ import type {
   AgentBudgetState,
   AgentBudgetUsage,
   AgentBudgetDecision,
+  AgentBudgetEvaluation,
   AgentProfileLaunchMetadata,
   ExecutableAgentProvider,
+  ProviderRuntimeCapabilityId,
+  ProviderRuntimeControlAction,
+  ProviderRuntimeControlSet,
   ProviderRuntimeManifest,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
@@ -67,8 +71,18 @@ import {
   ProviderRuntimeManifestService,
   type ProviderRuntimeProbeRequest,
 } from './provider-runtime-manifest-service.js';
-import { getProviderRuntimeAdapterDefinition } from './provider-runtime-adapter-registry.js';
+import {
+  getProviderRuntimeAdapterDefinition,
+  type ProviderRuntimeSurface,
+} from './provider-runtime-adapter-registry.js';
 import { getInstalledPackageVersion } from '../utils/package-version.js';
+import {
+  assertProviderRuntimeCapabilities,
+  assertProviderRuntimeControl,
+  assertProviderRuntimeManifestSnapshot,
+  BASELINE_LAUNCH_CAPABILITIES,
+  providerRuntimeControls,
+} from './provider-runtime-control-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -120,6 +134,10 @@ export interface AgentStatus {
   status: AttemptStatus;
   startedAt?: string;
   endedAt?: string;
+  provider?: ExecutableAgentProvider;
+  model?: string;
+  providerRuntimeManifest: ProviderRuntimeManifest;
+  controls: ProviderRuntimeControlSet;
 }
 
 export interface AgentOutput {
@@ -133,11 +151,18 @@ export interface AgentStartOptions {
   overrideReason?: string;
   sandboxPresetId?: string;
   budget?: AgentBudgetPolicy;
+  requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
 }
 
 export interface AgentMessageOptions {
   actor?: string;
   source?: string;
+  expectedAttemptId: string;
+}
+
+export interface AgentCompletionProvenance {
+  attemptId: string;
+  providerRuntimeManifestDigest: string;
 }
 
 export interface AgentMessageDelivery {
@@ -175,9 +200,34 @@ interface PendingAgent {
   openclawSessionKey?: string;
   /** Hermes session identity captured from process output (hermes-cli provider only) */
   hermesSessionId?: string;
+  /**
+   * The first terminal result prepared for this run. Keep it across a failed
+   * authoritative task update so retries only repeat persistence, never
+   * provider-stop, abort-trace, or budget-enforcement side effects.
+   */
+  preparedFinalizationResult?: AgentTerminalResult;
+  completionTiming?: {
+    endedAt: string;
+    durationMs: number;
+  };
+  completionBudgetEvaluated?: boolean;
+  preparedCompletion?: {
+    status: AttemptStatus;
+    taskBeforeCompletion?: Task;
+    completedAttempt: TaskAttempt;
+  };
+}
+
+interface AgentTerminalResult {
+  success: boolean;
+  summary?: string;
+  error?: string;
 }
 
 const pendingAgents = new Map<string, PendingAgent>();
+const startingAgents = new Set<string>();
+const finalizingAgents = new Map<PendingAgent, Promise<void>>();
+const budgetEvaluations = new Map<PendingAgent, Promise<void>>();
 
 export class ClawdbotAgentService {
   private configService: ConfigService;
@@ -280,6 +330,23 @@ export class ClawdbotAgentService {
     agentType?: AgentType,
     options: AgentStartOptions = {}
   ): Promise<AgentStatus> {
+    if (startingAgents.has(taskId) || pendingAgents.has(taskId)) {
+      throw new ConflictError('An agent is already running or starting for this task');
+    }
+
+    startingAgents.add(taskId);
+    try {
+      return await this.startReservedAgent(taskId, agentType, options);
+    } finally {
+      startingAgents.delete(taskId);
+    }
+  }
+
+  private async startReservedAgent(
+    taskId: string,
+    agentType?: AgentType,
+    options: AgentStartOptions = {}
+  ): Promise<AgentStatus> {
     // Get task
     const task = await this.taskService.getTask(taskId);
     if (!task) {
@@ -296,7 +363,7 @@ export class ClawdbotAgentService {
 
     // Check if agent already running for this task
     if (pendingAgents.has(taskId)) {
-      throw new Error('An agent is already running for this task');
+      throw new ConflictError('An agent is already running for this task');
     }
 
     // Get agent config — use routing engine when agent is "auto" or not specified
@@ -373,6 +440,32 @@ export class ClawdbotAgentService {
       agentConfig: launchAgentConfig,
       health: agentHealth,
     });
+    const launchRuntimeCapabilities = new Set<ProviderRuntimeCapabilityId>([
+      ...BASELINE_LAUNCH_CAPABILITIES,
+      ...(options.requiredRuntimeCapabilities ?? []),
+    ]);
+    if ((profileLaunch?.profile.tools?.allowed?.length ?? 0) > 0) {
+      launchRuntimeCapabilities.add('tool.calls');
+    }
+    if ((profileLaunch?.profile.tools?.mcpServers?.length ?? 0) > 0) {
+      launchRuntimeCapabilities.add('tool.calls');
+      launchRuntimeCapabilities.add('tool.mcp');
+    }
+    const budgetLimits = budgetPolicy?.enabled ? budgetPolicy.limits : undefined;
+    if (
+      budgetLimits?.inputTokens !== undefined ||
+      budgetLimits?.outputTokens !== undefined ||
+      budgetLimits?.totalTokens !== undefined ||
+      budgetLimits?.costUsd !== undefined
+    ) {
+      launchRuntimeCapabilities.add('usage.tokens');
+    }
+    if (budgetLimits?.toolCalls !== undefined) launchRuntimeCapabilities.add('tool.calls');
+    assertProviderRuntimeCapabilities(
+      providerRuntimeManifest,
+      [...launchRuntimeCapabilities],
+      'agent launch'
+    );
     const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
       presetId:
         options.sandboxPresetId ??
@@ -380,6 +473,7 @@ export class ClawdbotAgentService {
         launchAgentConfig?.sandboxPresetId,
       provider,
       workspacePath: task.git.worktreePath,
+      providerRuntimeManifest,
     });
     const sandboxTrace = await getGovernanceTraceService().record(sandboxPolicy.trace);
     if (sandboxPolicy.result.decision === 'block') {
@@ -469,6 +563,7 @@ export class ClawdbotAgentService {
       task,
       worktreePath,
       attemptId,
+      providerRuntimeManifest.digest,
       profileLaunch?.instructions
     );
 
@@ -579,6 +674,10 @@ export class ClawdbotAgentService {
       agent,
       status: 'running',
       startedAt,
+      provider,
+      model: launchAgentConfig?.model,
+      providerRuntimeManifest,
+      controls: providerRuntimeControls(providerRuntimeManifest),
     };
   }
 
@@ -625,41 +724,120 @@ export class ClawdbotAgentService {
    */
   async completeAgent(
     taskId: string,
-    result: { success: boolean; summary?: string; error?: string }
+    result: AgentTerminalResult,
+    provenance: AgentCompletionProvenance
   ): Promise<void> {
     const pending = pendingAgents.get(taskId);
-    if (!pending) {
-      log.warn(`[ClawdbotAgent] Received completion for unknown task ${taskId}`);
+    if (
+      !pending ||
+      pending.attemptId !== provenance.attemptId ||
+      pending.providerRuntimeManifest.digest !== provenance.providerRuntimeManifestDigest
+    ) {
+      throw new ConflictError('Provider completion does not match the active run', {
+        activeAttemptId: pending?.attemptId,
+        completionAttemptId: provenance.attemptId,
+        activeManifestDigest: pending?.providerRuntimeManifest.digest,
+        completionManifestDigest: provenance.providerRuntimeManifestDigest,
+        remediation:
+          'Discard the stale callback and retry only from the provider process bound to the active attempt manifest.',
+      });
+    }
+
+    await this.finalizePendingAgent(taskId, pending, async () => result);
+  }
+
+  private async finalizePendingAgent(
+    taskId: string,
+    pending: PendingAgent,
+    prepareResult: () => Promise<AgentTerminalResult>
+  ): Promise<void> {
+    if (pendingAgents.get(taskId) !== pending) {
+      throw new ConflictError('Provider finalization does not match the active run', {
+        activeAttemptId: pendingAgents.get(taskId)?.attemptId,
+        finalizationAttemptId: pending.attemptId,
+      });
+    }
+
+    const inFlight = finalizingAgents.get(pending);
+    if (inFlight) {
+      await inFlight;
       return;
     }
 
+    // Defer preparation to the next microtask so the ownership claim is
+    // registered before a synchronous provider stop can emit `close`.
+    const finalization = Promise.resolve().then(async () => {
+      const result = pending.preparedFinalizationResult ?? (await prepareResult());
+      pending.preparedFinalizationResult = result;
+      await this.completePendingAgent(taskId, result, pending);
+    });
+    finalizingAgents.set(pending, finalization);
+    try {
+      await finalization;
+    } finally {
+      if (finalizingAgents.get(pending) === finalization) {
+        finalizingAgents.delete(pending);
+      }
+    }
+  }
+
+  private async completePendingAgent(
+    taskId: string,
+    result: AgentTerminalResult,
+    pending: PendingAgent
+  ): Promise<void> {
+    await this.assertPendingRunControl(taskId, pending, 'complete');
+
     const { attemptId, emitter } = pending;
-    const endedAt = new Date().toISOString();
     const status: AttemptStatus = result.success ? 'complete' : 'failed';
-    const durationMs = new Date(endedAt).getTime() - new Date(pending.startedAt).getTime();
-    if (pending.budget?.enabled) {
-      await this.evaluatePendingBudget(
-        taskId,
-        { runtimeSeconds: Math.ceil(durationMs / 1000) },
-        'agent.complete',
-        false
-      );
+    const timing =
+      pending.completionTiming ??
+      (pending.completionTiming = (() => {
+        const endedAt = new Date().toISOString();
+        return {
+          endedAt,
+          durationMs: new Date(endedAt).getTime() - new Date(pending.startedAt).getTime(),
+        };
+      })());
+    if (pending.budget?.enabled && !pending.completionBudgetEvaluated) {
+      // Terminal ownership wins over an older usage report. Waiting behind that
+      // report can deadlock when it is itself waiting for this finalization.
+      if (!budgetEvaluations.has(pending)) {
+        await this.evaluatePendingBudget(
+          taskId,
+          attemptId,
+          { runtimeSeconds: Math.ceil(timing.durationMs / 1000) },
+          'agent.complete',
+          false
+        );
+      }
+      pending.completionBudgetEvaluated = true;
     }
 
-    const taskBeforeCompletion = await this.taskService.getTask(taskId);
-    const completedAttempt: TaskAttempt = {
-      id: attemptId,
-      agent: pending.agent,
-      status,
-      started: pending.startedAt,
-      ended: endedAt,
-      provider: pending.provider,
-      model: pending.model,
-      threadId: pending.threadId,
-      budget: pending.budget,
-      agentProfile: pending.agentProfile,
-      providerRuntimeManifest: pending.providerRuntimeManifest,
-    };
+    const preparedCompletion =
+      pending.preparedCompletion ??
+      (await (async () => {
+        const taskBeforeCompletion = (await this.taskService.getTask(taskId)) ?? undefined;
+        const completedAttempt: TaskAttempt = {
+          id: attemptId,
+          agent: pending.agent,
+          status,
+          started: pending.startedAt,
+          ended: timing.endedAt,
+          provider: pending.provider,
+          model: pending.model,
+          threadId: pending.threadId,
+          budget: pending.budget,
+          agentProfile: pending.agentProfile,
+          providerRuntimeManifest: pending.providerRuntimeManifest,
+        };
+        return (pending.preparedCompletion = {
+          status,
+          taskBeforeCompletion,
+          completedAttempt,
+        });
+      })());
+    const { taskBeforeCompletion, completedAttempt } = preparedCompletion;
 
     // Update task and preserve the exact launch manifest in attempt history.
     await this.taskService.updateTask(taskId, {
@@ -667,62 +845,92 @@ export class ClawdbotAgentService {
       attempt: completedAttempt,
       attempts: upsertAttemptHistory(taskBeforeCompletion?.attempts, completedAttempt),
     });
+    if (pendingAgents.get(taskId) === pending) {
+      pendingAgents.delete(taskId);
+    }
 
-    // Append to log
     const logPath = path.join(this.logsDir, `${taskId}_${attemptId}.md`);
     const summary = result.summary || result.error || 'No summary provided';
-    await fs.appendFile(logPath, `\n\n---\n\n## Result\n\n**Status:** ${status}\n\n${summary}\n`);
-
-    // Emit completion
-    emitter.emit('complete', { status, summary });
-
-    const task = await this.taskService.getTask(taskId);
+    const { durationMs } = timing;
     const completionStepType = result.success ? 'complete' : 'error';
-    this.recordTraceStep(attemptId, completionStepType, {
-      eventType: result.success ? 'run.completed' : 'run.failed',
-      summary: this.redactTraceText(summary),
-      success: result.success,
-      status,
-      error: result.error ? this.redactTraceText(result.error) : undefined,
-      durationMs,
-      agent: pending.agent,
-      provider: pending.provider,
-      model: pending.model,
-    });
-    await getTelemetryService().emit<RunCompletedEvent>({
-      type: 'run.completed',
-      taskId,
-      attemptId,
-      agent: pending.agent,
-      project: task?.project,
-      durationMs,
-      success: result.success,
-      error: result.error,
-    });
-    await getTraceService().completeTrace(attemptId, result.success ? 'completed' : 'failed');
-    await activityService.logActivity(
-      'agent_completed',
-      taskId,
-      task?.title || taskId,
-      {
-        attemptId,
-        provider: pending.provider,
-        model: pending.model,
-        success: result.success,
-        summary,
-      },
-      pending.agent
-    );
-
-    // Clean up
-    pendingAgents.delete(taskId);
-
-    // Remove request file
     const requestFile = path.join(getRuntimeDir(), 'agent-requests', `${taskId}.json`);
-    try {
-      await fs.unlink(requestFile);
-    } catch {
-      // Ignore if already deleted
+    const postCommitEffects: Array<[string, () => void | Promise<void>]> = [
+      [
+        'append result log',
+        () =>
+          fs.appendFile(logPath, `\n\n---\n\n## Result\n\n**Status:** ${status}\n\n${summary}\n`),
+      ],
+      ['emit completion event', () => emitter.emit('complete', { status, summary })],
+      [
+        'record terminal trace step',
+        () =>
+          this.recordTraceStep(attemptId, completionStepType, {
+            eventType: result.success ? 'run.completed' : 'run.failed',
+            summary: this.redactTraceText(summary),
+            success: result.success,
+            status,
+            error: result.error ? this.redactTraceText(result.error) : undefined,
+            durationMs,
+            agent: pending.agent,
+            provider: pending.provider,
+            model: pending.model,
+          }),
+      ],
+      [
+        'emit completion telemetry',
+        () =>
+          getTelemetryService().emit<RunCompletedEvent>({
+            type: 'run.completed',
+            taskId,
+            attemptId,
+            agent: pending.agent,
+            project: taskBeforeCompletion?.project,
+            durationMs,
+            success: result.success,
+            error: result.error,
+          }),
+      ],
+      [
+        'complete trace',
+        () => getTraceService().completeTrace(attemptId, result.success ? 'completed' : 'failed'),
+      ],
+      [
+        'record completion activity',
+        () =>
+          activityService.logActivity(
+            'agent_completed',
+            taskId,
+            taskBeforeCompletion?.title || taskId,
+            {
+              attemptId,
+              provider: pending.provider,
+              model: pending.model,
+              success: result.success,
+              summary,
+            },
+            pending.agent
+          ),
+      ],
+      [
+        'remove request file',
+        async () => {
+          try {
+            await fs.unlink(requestFile);
+          } catch {
+            // Ignore if already deleted.
+          }
+        },
+      ],
+    ];
+    for (const [effect, run] of postCommitEffects) {
+      try {
+        await run();
+      } catch (error) {
+        log.error(
+          { err: error, taskId, attemptId, effect },
+          '[ClawdbotAgent] Post-commit completion effect failed'
+        );
+      }
     }
 
     log.info(`[ClawdbotAgent] Task ${taskId} completed with status: ${status}`);
@@ -731,38 +939,44 @@ export class ClawdbotAgentService {
   /**
    * Stop a running agent
    */
-  async stopAgent(taskId: string): Promise<void> {
+  async stopAgent(taskId: string, expectedAttemptId: string): Promise<void> {
     const pending = pendingAgents.get(taskId);
-    if (!pending) {
-      throw new Error('No agent running for this task');
+    if (!pending || pending.attemptId !== expectedAttemptId) {
+      throw new ConflictError('Stop request does not match the active run', {
+        activeAttemptId: pending?.attemptId,
+        requestedAttemptId: expectedAttemptId,
+      });
     }
 
-    await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
-    this.recordTraceStep(pending.attemptId, 'abort', {
-      eventType: 'run.aborted',
-      summary: 'Stopped by user',
-      reason: 'Stopped by user',
-      agent: pending.agent,
-      provider: pending.provider,
-      model: pending.model,
-    });
-
-    // Mark as failed/stopped
-    await this.completeAgent(taskId, {
-      success: false,
-      error: 'Stopped by user',
+    await this.finalizePendingAgent(taskId, pending, async () => {
+      await this.assertPendingRunControl(taskId, pending, 'stop');
+      await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
+      this.recordTraceStep(pending.attemptId, 'abort', {
+        eventType: 'run.aborted',
+        summary: 'Stopped by user',
+        reason: 'Stopped by user',
+        agent: pending.agent,
+        provider: pending.provider,
+        model: pending.model,
+      });
+      return {
+        success: false,
+        error: 'Stopped by user',
+      };
     });
   }
 
   async sendMessage(
     taskId: string,
     message: string,
-    options: AgentMessageOptions = {}
+    options: AgentMessageOptions
   ): Promise<AgentMessageDelivery> {
     const pending = pendingAgents.get(taskId);
     if (!pending) {
       throw new Error('No agent running for this task');
     }
+
+    await this.assertActiveRunControl(taskId, 'message', options.expectedAttemptId);
 
     const content = message.trim();
     if (!content) {
@@ -806,63 +1020,118 @@ export class ClawdbotAgentService {
     };
   }
 
-  async recordBudgetUsage(taskId: string, delta: Partial<AgentBudgetUsage>): Promise<void> {
-    await this.evaluatePendingBudget(taskId, delta, 'agent.usage', true);
+  async recordBudgetUsage(
+    taskId: string,
+    attemptId: string,
+    delta: Partial<AgentBudgetUsage>
+  ): Promise<void> {
+    await this.evaluatePendingBudget(taskId, attemptId, delta, 'agent.usage', true);
   }
 
   private isBlockingBudgetDecision(decision: AgentBudgetDecision): boolean {
     return decision === 'pause' || decision === 'require-approval' || decision === 'cancel';
   }
 
+  private async serializeBudgetEvaluation<T>(
+    pending: PendingAgent,
+    evaluate: () => Promise<T>
+  ): Promise<T> {
+    const previous = budgetEvaluations.get(pending) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(evaluate);
+    const tail = current.then(
+      () => undefined,
+      () => undefined
+    );
+    budgetEvaluations.set(pending, tail);
+    try {
+      return await current;
+    } finally {
+      if (budgetEvaluations.get(pending) === tail) {
+        budgetEvaluations.delete(pending);
+      }
+    }
+  }
+
   private async evaluatePendingBudget(
     taskId: string,
+    attemptId: string,
     delta: Partial<AgentBudgetUsage>,
     actionType: string,
     enforce: boolean
   ): Promise<void> {
     const pending = pendingAgents.get(taskId);
+    if (!pending || pending.attemptId !== attemptId) {
+      throw new ConflictError('Budget usage does not match the active run', {
+        activeAttemptId: pending?.attemptId,
+        usageAttemptId: attemptId,
+      });
+    }
     if (!pending?.budget?.enabled || !pending.budget.policy) return;
 
-    const task = await this.taskService.getTask(taskId);
-    const budgetService = getAgentBudgetService();
-    pending.budget.usage = budgetService.mergeUsage(pending.budget.usage, delta);
-    const evaluation = budgetService.evaluate(pending.budget.policy, pending.budget.usage, {
-      taskId,
-      agentId: pending.agent,
-      actionType,
-      project: task?.project,
-    });
+    const evaluation = await this.serializeBudgetEvaluation(
+      pending,
+      async (): Promise<AgentBudgetEvaluation> => {
+        const task = await this.taskService.getTask(taskId);
+        if (pendingAgents.get(taskId) !== pending || !pending.budget?.policy) {
+          throw new ConflictError('Budget usage does not match the active run', {
+            activeAttemptId: pendingAgents.get(taskId)?.attemptId,
+            usageAttemptId: attemptId,
+          });
+        }
+        const budgetService = getAgentBudgetService();
+        const usage = budgetService.mergeUsage(pending.budget.usage, delta);
+        const nextEvaluation = budgetService.evaluate(pending.budget.policy, usage, {
+          taskId,
+          agentId: pending.agent,
+          actionType,
+          project: task?.project,
+        });
 
-    pending.budget.decision = evaluation.decision;
-    pending.budget.modelOverride ??= evaluation.modelOverride;
-    pending.budget.thresholdEvents = mergeThresholdEvents(
-      pending.budget.thresholdEvents,
-      evaluation.thresholdEvents
+        let traceId: string | undefined;
+        if (nextEvaluation.trace) {
+          traceId = (await getGovernanceTraceService().record(nextEvaluation.trace)).id;
+        }
+        if (pendingAgents.get(taskId) !== pending || !pending.budget) {
+          throw new ConflictError('Budget usage does not match the active run', {
+            activeAttemptId: pendingAgents.get(taskId)?.attemptId,
+            usageAttemptId: attemptId,
+          });
+        }
+
+        pending.budget.usage = usage;
+        pending.budget.decision = nextEvaluation.decision;
+        pending.budget.modelOverride ??= nextEvaluation.modelOverride;
+        pending.budget.thresholdEvents = mergeThresholdEvents(
+          pending.budget.thresholdEvents,
+          nextEvaluation.thresholdEvents
+        );
+        if (traceId) {
+          pending.budget.traceIds = [...new Set([...pending.budget.traceIds, traceId])];
+        }
+        return nextEvaluation;
+      }
     );
-
-    if (evaluation.trace) {
-      const trace = await getGovernanceTraceService().record(evaluation.trace);
-      pending.budget.traceIds = [...new Set([...pending.budget.traceIds, trace.id])];
-    }
 
     if (!enforce || pending.budgetStopped || !this.isBlockingBudgetDecision(evaluation.decision)) {
       return;
     }
 
     pending.budgetStopped = true;
-    const logPath = path.join(this.logsDir, `${taskId}_${pending.attemptId}.md`);
-    await this.appendLog(
-      logPath,
-      `\n## Budget Enforcement\n\nDecision: ${evaluation.decision}\n\n${evaluation.thresholdEvents
-        .map((event) => `- ${event.message}`)
-        .join('\n')}\n`
-    );
-    await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
-    await this.completeAgent(taskId, {
-      success: false,
-      error: `Budget ${evaluation.decision}: ${evaluation.thresholdEvents
-        .map((event) => event.message)
-        .join(' ')}`,
+    await this.finalizePendingAgent(taskId, pending, async () => {
+      const logPath = path.join(this.logsDir, `${taskId}_${pending.attemptId}.md`);
+      await this.appendLog(
+        logPath,
+        `\n## Budget Enforcement\n\nDecision: ${evaluation.decision}\n\n${evaluation.thresholdEvents
+          .map((event) => `- ${event.message}`)
+          .join('\n')}\n`
+      );
+      await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
+      return {
+        success: false,
+        error: `Budget ${evaluation.decision}: ${evaluation.thresholdEvents
+          .map((event) => event.message)
+          .join(' ')}`,
+      };
     });
   }
 
@@ -872,11 +1141,12 @@ export class ClawdbotAgentService {
 
   async probeProviderRuntime(
     agentConfig: AgentConfig,
-    agent: AgentType = agentConfig.type
+    agent: AgentType = agentConfig.type,
+    surface: ProviderRuntimeSurface = 'task'
   ): Promise<ProviderRuntimeManifest> {
     const health = await this.assertAgentAvailable(agent, agentConfig);
     const provider = this.resolveAgentProvider(agentConfig, agent);
-    return this.resolveProviderAdapter(provider).probe({ agentConfig, health });
+    return this.resolveProviderAdapter(provider, surface).probe({ agentConfig, health });
   }
 
   private async assertAgentAvailable(
@@ -940,8 +1210,11 @@ export class ClawdbotAgentService {
     return 'openclaw';
   }
 
-  private resolveProviderAdapter(provider: ExecutableAgentProvider): AgentProviderAdapter {
-    const definition = getProviderRuntimeAdapterDefinition(provider);
+  private resolveProviderAdapter(
+    provider: ExecutableAgentProvider,
+    surface: ProviderRuntimeSurface = 'task'
+  ): AgentProviderAdapter {
+    const definition = getProviderRuntimeAdapterDefinition(provider, surface);
     const probe = (context: AgentProviderProbeContext) =>
       this.providerRuntimeManifests.probe(
         this.buildProviderRuntimeProbeRequest(provider, context, definition)
@@ -1007,16 +1280,37 @@ export class ClawdbotAgentService {
             emitter,
             abortController,
             sandboxPolicy
-          ).catch(async (error: any) => {
-            if (!pendingAgents.has(task.id)) return;
-            await this.appendLog(
-              logPath,
-              `\n## Codex SDK Error\n\n${error.message || 'Codex SDK attempt failed'}\n`
-            );
-            await this.completeAgent(task.id, {
-              success: false,
-              error: error.message || 'Codex SDK attempt failed',
-            });
+          ).catch(async (error: unknown) => {
+            const current = pendingAgents.get(task.id);
+            if (!current || current.attemptId !== attemptId) return;
+            abortController.abort();
+            const message = error instanceof Error ? error.message : 'Codex SDK attempt failed';
+            try {
+              await this.appendLog(logPath, `\n## Codex SDK Error\n\n${message}\n`);
+            } catch (logError) {
+              log.error({ err: logError, taskId: task.id }, 'Failed to append Codex SDK error');
+            }
+            try {
+              await this.completeAgent(
+                task.id,
+                { success: false, error: message },
+                {
+                  attemptId,
+                  providerRuntimeManifestDigest: current.providerRuntimeManifest.digest,
+                }
+              );
+            } catch (finalizationError) {
+              if (pendingAgents.get(task.id)?.attemptId === attemptId) {
+                pendingAgents.delete(task.id);
+              }
+              if (emitter.listenerCount('error') > 0) {
+                emitter.emit('error', finalizationError);
+              }
+              log.error(
+                { err: finalizationError, taskId: task.id, attemptId },
+                'Codex SDK failure could not update stale persisted attempt state'
+              );
+            }
           });
         },
         stop: ({ pending }) => {
@@ -1265,7 +1559,10 @@ export class ClawdbotAgentService {
     });
 
     child.on('close', (code, signal) => {
-      void (async () => {
+      if (!pending || pendingAgents.get(task.id) !== pending || pending.attemptId !== attemptId) {
+        return;
+      }
+      void this.finalizePendingAgent(task.id, pending, async () => {
         const finalOutput = stdoutBuffer.trim() || stderrBuffer.trim();
         const success = code === 0;
 
@@ -1284,12 +1581,13 @@ export class ClawdbotAgentService {
           model: agentConfig?.model,
         });
 
-        await this.completeAgent(task.id, {
+        return {
           success,
           summary: finalOutput || (success ? 'Hermes completed.' : undefined),
           error: success ? undefined : finalOutput || `Hermes exited with code ${code}`,
-        });
-      })().catch((error) => {
+        };
+      }).catch((error) => {
+        if (pendingAgents.get(task.id) !== pending) return;
         log.error({ err: error, taskId: task.id }, 'Failed to finalize Hermes attempt');
       });
     });
@@ -1347,25 +1645,51 @@ export class ClawdbotAgentService {
           model?: string;
         }
       | undefined;
+    let eventProcessing = Promise.resolve();
+    let eventProcessingError: Error | undefined;
+    const enqueueEventProcessing = (work: () => Promise<void>) => {
+      eventProcessing = eventProcessing.then(async () => {
+        if (eventProcessingError) return;
+        try {
+          await work();
+        } catch (error) {
+          eventProcessingError =
+            error instanceof Error ? error : new Error('Provider event ingestion failed closed.');
+          child.kill('SIGTERM');
+        }
+      });
+    };
 
     child.stdout.setEncoding('utf-8');
     child.stdout.on('data', (chunk: string) => {
-      this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stdout', chunk);
-      stdoutBuffer += chunk;
-      const lines = stdoutBuffer.split(/\r?\n/);
-      stdoutBuffer = lines.pop() || '';
-      for (const line of lines) {
-        const parsed = this.handleCodexJsonLine(line, logPath, task, attemptId, agentConfig);
-        if (parsed.summary) finalSummary = parsed.summary;
-        if (parsed.usage) tokenUsage = parsed.usage;
-      }
+      enqueueEventProcessing(async () => {
+        await this.assertPendingManifestSnapshotForAttempt(task.id, attemptId);
+        this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stdout', chunk);
+        stdoutBuffer += chunk;
+        const lines = stdoutBuffer.split(/\r?\n/);
+        stdoutBuffer = lines.pop() || '';
+        for (const line of lines) {
+          const parsed = await this.handleCodexJsonLine(
+            line,
+            logPath,
+            task,
+            attemptId,
+            agentConfig
+          );
+          if (parsed.summary) finalSummary = parsed.summary;
+          if (parsed.usage) tokenUsage = parsed.usage;
+        }
+      });
     });
 
     child.stderr.setEncoding('utf-8');
     child.stderr.on('data', (chunk: string) => {
-      stderrBuffer += chunk;
-      this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stderr', chunk);
-      void this.appendLog(logPath, `\n### stderr\n\n\`\`\`\n${chunk.trimEnd()}\n\`\`\`\n`);
+      enqueueEventProcessing(async () => {
+        await this.assertPendingManifestSnapshotForAttempt(task.id, attemptId);
+        stderrBuffer += chunk;
+        this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stderr', chunk);
+        await this.appendLog(logPath, `\n### stderr\n\n\`\`\`\n${chunk.trimEnd()}\n\`\`\`\n`);
+      });
     });
 
     child.on('error', (error) => {
@@ -1381,9 +1705,13 @@ export class ClawdbotAgentService {
     });
 
     child.on('close', (code, signal) => {
-      void (async () => {
-        if (stdoutBuffer.trim()) {
-          const parsed = this.handleCodexJsonLine(
+      if (!pending || pendingAgents.get(task.id) !== pending || pending.attemptId !== attemptId) {
+        return;
+      }
+      void this.finalizePendingAgent(task.id, pending, async () => {
+        await eventProcessing;
+        if (stdoutBuffer.trim() && !eventProcessingError) {
+          const parsed = await this.handleCodexJsonLine(
             stdoutBuffer,
             logPath,
             task,
@@ -1396,10 +1724,13 @@ export class ClawdbotAgentService {
 
         const finalPath = this.getCodexFinalPath(logPath, attemptId);
         finalSummary ||= await this.readOptionalFile(finalPath);
+        finalSummary ||= eventProcessingError?.message || '';
         finalSummary ||=
           code === 0 ? 'Codex completed without a final summary.' : stderrBuffer.trim();
+        const succeeded = code === 0 && !eventProcessingError;
 
-        if (tokenUsage) {
+        if (tokenUsage && !eventProcessingError) {
+          await this.assertRunControl(task.id, 'token-usage', attemptId);
           await getTelemetryService().emit<TokenTelemetryEvent>({
             type: 'run.tokens',
             taskId: task.id,
@@ -1414,6 +1745,7 @@ export class ClawdbotAgentService {
           });
           await this.evaluatePendingBudget(
             task.id,
+            attemptId,
             {
               inputTokens: tokenUsage.inputTokens,
               outputTokens: tokenUsage.outputTokens,
@@ -1433,19 +1765,20 @@ export class ClawdbotAgentService {
           eventType: 'run.finalizing',
           exitCode: code,
           signal,
-          success: code === 0,
+          success: succeeded,
           durationMs: Date.now() - new Date(startedAt).getTime(),
           provider: 'codex-cli',
           agent: agentConfig?.type || 'codex',
           model: agentConfig?.model,
         });
 
-        await this.completeAgent(task.id, {
-          success: code === 0,
+        return {
+          success: succeeded,
           summary: finalSummary,
-          error: code === 0 ? undefined : finalSummary || `Codex exited with code ${code}`,
-        });
-      })().catch((error) => {
+          error: succeeded ? undefined : finalSummary || `Codex exited with code ${code}`,
+        };
+      }).catch((error) => {
+        if (pendingAgents.get(task.id) !== pending) return;
         log.error({ err: error, taskId: task.id }, 'Failed to finalize Codex attempt');
       });
     });
@@ -1537,7 +1870,7 @@ export class ClawdbotAgentService {
       | undefined;
 
     for await (const event of streamed.events) {
-      const parsed = this.handleCodexEvent(event, logPath, task, attemptId, agentConfig);
+      const parsed = await this.handleCodexEvent(event, logPath, task, attemptId, agentConfig);
       if (parsed.summary) finalSummary = parsed.summary;
       if (parsed.usage) tokenUsage = parsed.usage;
 
@@ -1553,6 +1886,7 @@ export class ClawdbotAgentService {
     }
 
     if (tokenUsage) {
+      await this.assertRunControl(task.id, 'token-usage', attemptId);
       await getTelemetryService().emit<TokenTelemetryEvent>({
         type: 'run.tokens',
         taskId: task.id,
@@ -1567,6 +1901,7 @@ export class ClawdbotAgentService {
       });
       await this.evaluatePendingBudget(
         task.id,
+        attemptId,
         {
           inputTokens: tokenUsage.inputTokens,
           outputTokens: tokenUsage.outputTokens,
@@ -1583,21 +1918,29 @@ export class ClawdbotAgentService {
       `\n## Codex SDK Complete\n\n**Duration:** ${Date.now() - new Date(startedAt).getTime()}ms\n`
     );
 
-    await this.completeAgent(task.id, {
-      success: !failureMessage,
-      summary: finalSummary || failureMessage || 'Codex SDK completed without a final summary.',
-      error: failureMessage || undefined,
-    });
+    await this.completeAgent(
+      task.id,
+      {
+        success: !failureMessage,
+        summary: finalSummary || failureMessage || 'Codex SDK completed without a final summary.',
+        error: failureMessage || undefined,
+      },
+      {
+        attemptId,
+        providerRuntimeManifestDigest:
+          pendingAgents.get(task.id)?.providerRuntimeManifest.digest ?? '',
+      }
+    );
     emitter.emit('sdk.complete', { taskId: task.id, attemptId });
   }
 
-  private handleCodexJsonLine(
+  private async handleCodexJsonLine(
     line: string,
     logPath: string,
     task?: Task,
     attemptId?: string,
     agentConfig?: AgentConfig
-  ): {
+  ): Promise<{
     summary?: string;
     usage?: {
       inputTokens: number;
@@ -1606,26 +1949,27 @@ export class ClawdbotAgentService {
       cost?: number;
       model?: string;
     };
-  } {
+  }> {
     const trimmed = line.trim();
     if (!trimmed) return {};
 
+    let event: Record<string, unknown>;
     try {
-      const event = JSON.parse(trimmed) as Record<string, unknown>;
-      return this.handleCodexEvent(event, logPath, task, attemptId, agentConfig);
+      event = JSON.parse(trimmed) as Record<string, unknown>;
     } catch {
-      void this.appendLog(logPath, `\n### stdout\n\n\`\`\`\n${trimmed}\n\`\`\`\n`);
+      await this.appendLog(logPath, `\n### stdout\n\n\`\`\`\n${trimmed}\n\`\`\`\n`);
       return { summary: trimmed };
     }
+    return this.handleCodexEvent(event, logPath, task, attemptId, agentConfig);
   }
 
-  private handleCodexEvent(
+  private async handleCodexEvent(
     event: ThreadEvent | Record<string, unknown>,
     logPath: string,
     task?: Task,
     attemptId?: string,
     agentConfig?: AgentConfig
-  ): {
+  ): Promise<{
     summary?: string;
     usage?: {
       inputTokens: number;
@@ -1634,28 +1978,26 @@ export class ClawdbotAgentService {
       cost?: number;
       model?: string;
     };
-  } {
+  }> {
+    if (task && attemptId) {
+      await this.assertPendingManifestSnapshotForAttempt(task.id, attemptId);
+    }
     const record = event as Record<string, unknown>;
     const type = String(record.type || record.event || 'codex.event');
     const summary = this.extractCodexSummary(record);
     const usage = this.extractCodexUsage(record);
-    void this.appendLog(
+    if (usage && task) {
+      assertProviderRuntimeControl(
+        pendingAgents.get(task.id)?.providerRuntimeManifest,
+        'token-usage'
+      );
+    }
+    await this.appendLog(
       logPath,
       `\n### ${type}\n\n${summary ? `${summary}\n\n` : ''}<details><summary>Raw event</summary>\n\n\`\`\`json\n${JSON.stringify(record, null, 2)}\n\`\`\`\n\n</details>\n`
     );
     if (task && attemptId) {
-      void this.recordCodexEvent(task, attemptId, agentConfig, type, record, summary).catch(
-        (error) => {
-          log.warn(
-            {
-              error: error instanceof Error ? error.message : String(error),
-              taskId: task.id,
-              attemptId,
-            },
-            'Failed to record Codex event'
-          );
-        }
-      );
+      await this.recordCodexEvent(task, attemptId, agentConfig, type, record, summary);
     }
     return { summary, usage };
   }
@@ -1812,10 +2154,12 @@ export class ClawdbotAgentService {
     }
 
     if (tool) {
-      await this.evaluatePendingBudget(task.id, { toolCalls: 1 }, 'agent.tool', true);
+      await this.assertRunControl(task.id, 'tool-calls', attemptId);
+      await this.evaluatePendingBudget(task.id, attemptId, { toolCalls: 1 }, 'agent.tool', true);
     }
 
     if (files.length > 0) {
+      await this.assertRunControl(task.id, 'artifacts', attemptId);
       await this.attachCodexDeliverables(task, attemptId, agent, files);
     }
   }
@@ -2057,6 +2401,7 @@ export class ClawdbotAgentService {
     agent: string,
     files: string[]
   ): Promise<void> {
+    await this.assertRunControl(task.id, 'artifacts', attemptId);
     const freshTask = await this.taskService.getTask(task.id);
     if (!freshTask) return;
 
@@ -2088,6 +2433,7 @@ export class ClawdbotAgentService {
 
     if (additions.length === 0) return;
 
+    await this.assertRunControl(task.id, 'artifacts', attemptId);
     await this.taskService.updateTask(task.id, {
       deliverables: [...existing, ...additions],
     });
@@ -2219,11 +2565,12 @@ export class ClawdbotAgentService {
   /**
    * Get agent status
    */
-  getAgentStatus(taskId: string): AgentStatus | null {
+  async getAgentStatus(taskId: string): Promise<AgentStatus | null> {
     const pending = pendingAgents.get(taskId);
     if (!pending) {
       return null;
     }
+    await this.assertPendingRunControl(taskId, pending, 'status');
 
     return {
       taskId,
@@ -2231,7 +2578,112 @@ export class ClawdbotAgentService {
       agent: pending.agent,
       status: 'running',
       startedAt: pending.startedAt,
+      provider: pending.provider,
+      model: pending.model,
+      providerRuntimeManifest: pending.providerRuntimeManifest,
+      controls: providerRuntimeControls(pending.providerRuntimeManifest),
     };
+  }
+
+  async assertRunControl(
+    taskId: string,
+    action: ProviderRuntimeControlAction,
+    attemptId?: string
+  ): Promise<void> {
+    const pending = pendingAgents.get(taskId);
+    if (pending && (!attemptId || attemptId === pending.attemptId)) {
+      await this.assertPendingRunControl(taskId, pending, action);
+      return;
+    }
+
+    const task = await this.taskService.getTask(taskId);
+    const attempts = [task?.attempt, ...(task?.attempts ?? [])].filter(
+      (attempt): attempt is TaskAttempt => Boolean(attempt)
+    );
+    const attempt = attemptId
+      ? attempts.find((candidate) => candidate.id === attemptId)
+      : task?.attempt;
+    assertProviderRuntimeControl(attempt?.providerRuntimeManifest, action);
+  }
+
+  async assertActiveRunControl(
+    taskId: string,
+    action: ProviderRuntimeControlAction,
+    attemptId: string,
+    expectedManifestDigest?: string
+  ): Promise<void> {
+    const pending = pendingAgents.get(taskId);
+    if (
+      !pending ||
+      pending.attemptId !== attemptId ||
+      (expectedManifestDigest && pending.providerRuntimeManifest.digest !== expectedManifestDigest)
+    ) {
+      throw new ConflictError('Run control does not match the active attempt', {
+        action,
+        activeAttemptId: pending?.attemptId,
+        requestedAttemptId: attemptId,
+        activeManifestDigest: pending?.providerRuntimeManifest.digest,
+        expectedManifestDigest,
+      });
+    }
+    await this.assertPendingRunControl(taskId, pending, action);
+  }
+
+  private async assertPendingRunControl(
+    taskId: string,
+    pending: PendingAgent,
+    action: ProviderRuntimeControlAction
+  ): Promise<void> {
+    await this.assertPendingManifestSnapshot(taskId, pending, action);
+    assertProviderRuntimeControl(pending.providerRuntimeManifest, action);
+  }
+
+  private async assertPendingManifestSnapshotForAttempt(
+    taskId: string,
+    attemptId: string
+  ): Promise<void> {
+    const pending = pendingAgents.get(taskId);
+    if (!pending || pending.attemptId !== attemptId) {
+      throw new ConflictError(
+        'Provider runtime manifest is stale or invalid: provider event does not match the active attempt',
+        {
+          activeAttemptId: pending?.attemptId,
+          eventAttemptId: attemptId,
+          remediation:
+            'Terminate the detached provider through its host supervisor, reconcile persisted attempt state, and launch again.',
+        }
+      );
+    }
+    await this.assertPendingManifestSnapshot(taskId, pending, 'status');
+  }
+
+  private async assertPendingManifestSnapshot(
+    taskId: string,
+    pending: PendingAgent,
+    action: ProviderRuntimeControlAction
+  ): Promise<void> {
+    const task = await this.taskService.getTask(taskId);
+    const persistedAttempt = task?.attempt;
+    if (!persistedAttempt || persistedAttempt.id !== pending.attemptId) {
+      throw new ConflictError(
+        'Provider runtime manifest is stale or invalid: active attempt does not match persisted state',
+        {
+          action,
+          activeAttemptId: pending.attemptId,
+          persistedAttemptId: persistedAttempt?.id,
+          remediation:
+            'Terminate the detached provider through its host supervisor, reconcile persisted attempt state, and launch again.',
+        }
+      );
+    }
+    assertProviderRuntimeManifestSnapshot(
+      persistedAttempt.providerRuntimeManifest,
+      pending.providerRuntimeManifest.digest
+    );
+    assertProviderRuntimeManifestSnapshot(
+      pending.providerRuntimeManifest,
+      persistedAttempt.providerRuntimeManifest?.digest
+    );
   }
 
   /**
@@ -2273,6 +2725,7 @@ export class ClawdbotAgentService {
   }
 
   async getAttemptLog(taskId: string, attemptId: string): Promise<string> {
+    await this.assertRunControl(taskId, 'logs', attemptId);
     validatePathSegment(taskId);
     validatePathSegment(attemptId);
     const logPath = path.join(this.logsDir, `${taskId}_${attemptId}.md`);
@@ -2295,6 +2748,7 @@ export class ClawdbotAgentService {
     task: Task,
     worktreePath: string,
     attemptId: string,
+    providerRuntimeManifestDigest: string,
     profileInstructions?: string
   ): string {
     // Build checkpoint context if available
@@ -2341,7 +2795,7 @@ ${profileInstructions ? `${profileInstructions}\n` : ''}
    \`\`\`bash
    curl -X POST http://localhost:3001/api/agents/${task.id}/complete \\
      -H "Content-Type: application/json" \\
-     -d '{"success": true, "summary": "Brief description of what was done"}'
+     -d '{"attemptId": "${attemptId}", "providerRuntimeManifestDigest": "${providerRuntimeManifestDigest}", "success": true, "summary": "Brief description of what was done"}'
    \`\`\`
 
 If you encounter errors, call with \`success: false\` and include the error message.

--- a/server/src/services/provider-runtime-adapter-registry.ts
+++ b/server/src/services/provider-runtime-adapter-registry.ts
@@ -14,6 +14,8 @@ export interface ProviderRuntimeAdapterDefinition {
   capabilities: ProviderRuntimeCapabilityEvidence[];
 }
 
+export type ProviderRuntimeSurface = 'task' | 'workflow';
+
 const COMMON_SUPPORTED: ProviderRuntimeCapabilityOverrides = {
   'run.start': supported('The adapter has a contract-tested launch path.'),
   'run.status': supported('Veritas tracks adapter run status.'),
@@ -113,7 +115,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     ),
     'output.structured': unknown('Structured output has not been conformance tested.'),
     'usage.tokens': unknown('Token usage is not returned by the current task adapter.'),
-    'artifact.write': unknown('Artifact events are not returned by the current task adapter.'),
+    'artifact.write': unknown('OpenClaw task-session artifact persistence is not implemented.'),
     'workspace.worktrees': advisory('The worktree is delegated in the prompt, not host-enforced.'),
     'filesystem.read': advisory('Filesystem scope is delegated to the OpenClaw runtime.'),
     'filesystem.write': advisory('Workspace write scope is delegated to the OpenClaw runtime.'),
@@ -124,9 +126,33 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
 };
 
 export function getProviderRuntimeAdapterDefinition(
-  provider: ExecutableAgentProvider
+  provider: ExecutableAgentProvider,
+  surface: ProviderRuntimeSurface = 'task'
 ): ProviderRuntimeAdapterDefinition {
-  return DEFINITIONS[provider];
+  const base = DEFINITIONS[provider];
+  if (provider !== 'openclaw' || surface !== 'workflow') return base;
+
+  const overrides: ProviderRuntimeCapabilityOverrides = {
+    'run.follow-up': supported(
+      'The workflow adapter sends follow-up prompts to an existing OpenClaw session.'
+    ),
+    'run.reattach': advisory(
+      'The workflow adapter reuses a persisted session key, subject to external session retention.'
+    ),
+    'artifact.write': {
+      state: 'supported',
+      source: 'host-enforced',
+      reason: 'Veritas persists the adapter final response as a workflow output artifact.',
+    },
+  };
+  return {
+    ...base,
+    protocolVersion: 'openclaw-workflow-session/v1',
+    capabilities: base.capabilities.map((capability) => {
+      const override = overrides[capability.id as keyof ProviderRuntimeCapabilityOverrides];
+      return override ? { ...capability, ...override } : capability;
+    }),
+  };
 }
 
 function definition(

--- a/server/src/services/provider-runtime-control-service.ts
+++ b/server/src/services/provider-runtime-control-service.ts
@@ -1,0 +1,267 @@
+import type {
+  ProviderRuntimeCapabilityId,
+  ProviderRuntimeControlAction,
+  ProviderRuntimeControlAssessment,
+  ProviderRuntimeControlSet,
+  ProviderRuntimeManifest,
+  SandboxProviderCapabilities,
+  SandboxProviderCapabilityId,
+} from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import { ProviderRuntimeManifestSchema } from '../schemas/provider-runtime-manifest-schemas.js';
+import { selectProviderRuntimeManifest } from './provider-runtime-capability-service.js';
+
+interface RuntimeControlDefinition {
+  action: ProviderRuntimeControlAction;
+  label: string;
+  capabilityId: ProviderRuntimeCapabilityId;
+}
+
+const CONTROL_DEFINITIONS: RuntimeControlDefinition[] = [
+  { action: 'start', label: 'Start run', capabilityId: 'run.start' },
+  { action: 'status', label: 'Read run status', capabilityId: 'run.status' },
+  { action: 'logs', label: 'Read run logs', capabilityId: 'run.logs' },
+  { action: 'complete', label: 'Complete run', capabilityId: 'run.complete' },
+  { action: 'stop', label: 'Stop run', capabilityId: 'run.stop' },
+  { action: 'interrupt', label: 'Interrupt run', capabilityId: 'run.interrupt' },
+  { action: 'message', label: 'Steer run', capabilityId: 'run.steer' },
+  { action: 'resume', label: 'Resume run', capabilityId: 'run.resume' },
+  { action: 'reattach', label: 'Reattach run', capabilityId: 'run.reattach' },
+  { action: 'approvals', label: 'Provider approvals', capabilityId: 'run.approvals' },
+  { action: 'tool-calls', label: 'Tool calls', capabilityId: 'tool.calls' },
+  { action: 'mcp', label: 'MCP tools', capabilityId: 'tool.mcp' },
+  { action: 'structured-output', label: 'Structured output', capabilityId: 'output.structured' },
+  { action: 'token-usage', label: 'Token usage', capabilityId: 'usage.tokens' },
+  { action: 'artifacts', label: 'Artifact writes', capabilityId: 'artifact.write' },
+];
+
+export const BASELINE_LAUNCH_CAPABILITIES: ProviderRuntimeCapabilityId[] = [
+  'run.start',
+  'run.status',
+  'run.logs',
+  'run.complete',
+  'workspace.worktrees',
+];
+
+const SANDBOX_CAPABILITY_IDS = new Set<SandboxProviderCapabilityId>([
+  'filesystem.read',
+  'filesystem.write',
+  'filesystem.deny-paths',
+  'filesystem.dotfile-masking',
+  'network.disable',
+  'network.allowlist',
+  'network.block-private',
+  'network.block-metadata',
+  'environment.allowlist',
+  'credential.broker',
+]);
+
+export function providerRuntimeControls(
+  manifest: ProviderRuntimeManifest | undefined
+): ProviderRuntimeControlSet {
+  const validation = validateManifest(manifest);
+  if (validation.reason) {
+    return {
+      manifestDigest: manifest?.digest,
+      provider: manifest?.provider,
+      providerVersion: manifest?.providerVersion,
+      probeState: manifest?.probe.state,
+      controls: CONTROL_DEFINITIONS.map((definition) => ({
+        ...definition,
+        state: 'unknown',
+        available: false,
+        advisory: false,
+        reason: validation.reason as string,
+        remediation:
+          'Re-probe the provider and persist a valid manifest snapshot before using run controls.',
+      })),
+    };
+  }
+  const validatedManifest = validation.manifest;
+  return {
+    manifestDigest: validatedManifest?.digest,
+    provider: validatedManifest?.provider,
+    providerVersion: validatedManifest?.providerVersion,
+    probeState: validatedManifest?.probe.state,
+    controls: CONTROL_DEFINITIONS.map((definition) => assessControl(validatedManifest, definition)),
+  };
+}
+
+export function providerRuntimeControl(
+  manifest: ProviderRuntimeManifest | undefined,
+  action: ProviderRuntimeControlAction
+): ProviderRuntimeControlAssessment {
+  const validation = validateManifest(manifest);
+  if (validation.reason) {
+    const definition = CONTROL_DEFINITIONS.find((candidate) => candidate.action === action);
+    if (!definition) throw new Error(`Unknown provider runtime control action: ${action}`);
+    return {
+      ...definition,
+      state: 'unknown',
+      available: false,
+      advisory: false,
+      reason: validation.reason,
+      remediation:
+        'Re-probe the provider and persist a valid manifest snapshot before using run controls.',
+    };
+  }
+  const definition = CONTROL_DEFINITIONS.find((candidate) => candidate.action === action);
+  if (!definition) {
+    throw new Error(`Unknown provider runtime control action: ${action}`);
+  }
+  return assessControl(validation.manifest, definition);
+}
+
+export function assertProviderRuntimeManifestSnapshot(
+  manifest: ProviderRuntimeManifest | undefined,
+  expectedDigest?: string
+): asserts manifest is ProviderRuntimeManifest {
+  const validation = validateManifest(manifest);
+  if (validation.reason) {
+    throw new ConflictError(`Provider runtime manifest is stale or invalid: ${validation.reason}`, {
+      manifestDigest: manifest?.digest,
+      expectedDigest,
+      reasons: [validation.reason],
+      remediation:
+        'Re-probe the provider and persist a valid manifest snapshot before using run controls.',
+    });
+  }
+  if (expectedDigest && validation.manifest?.digest !== expectedDigest) {
+    throw new ConflictError('Provider runtime manifest is stale or invalid: digest mismatch', {
+      manifestDigest: validation.manifest?.digest,
+      expectedDigest,
+      reasons: ['The active and persisted provider runtime manifest digests do not match.'],
+      remediation:
+        'Terminate the detached provider through its host supervisor, reconcile persisted attempt state, and launch again with one manifest snapshot.',
+    });
+  }
+}
+
+export function assertProviderRuntimeCapabilities(
+  manifest: ProviderRuntimeManifest | undefined,
+  requiredCapabilities: ProviderRuntimeCapabilityId[],
+  action: string
+): void {
+  if (manifest) assertProviderRuntimeManifestSnapshot(manifest);
+  const selection = selectProviderRuntimeManifest({
+    manifests: manifest ? [manifest] : [],
+    requiredCapabilities,
+  });
+  if (selection.compatible) return;
+
+  const reasons = selection.candidates.flatMap((candidate) => candidate.reasons);
+  const resolvedReasons = reasons.length > 0 ? reasons : [selection.reason];
+  const remediation = remediationForManifest(manifest);
+  throw new ConflictError(
+    `Provider runtime does not support ${action}: ${resolvedReasons[0]} ${remediation}`,
+    {
+      action,
+      manifestDigest: manifest?.digest,
+      provider: manifest?.provider,
+      providerVersion: manifest?.providerVersion,
+      probeState: manifest?.probe.state,
+      requiredCapabilities: selection.requiredCapabilities,
+      reasons: resolvedReasons,
+      remediation,
+    }
+  );
+}
+
+export function assertProviderRuntimeControl(
+  manifest: ProviderRuntimeManifest | undefined,
+  action: ProviderRuntimeControlAction
+): void {
+  if (manifest) assertProviderRuntimeManifestSnapshot(manifest);
+  const control = providerRuntimeControl(manifest, action);
+  if (control.available) return;
+  throw new ConflictError(
+    `Provider runtime does not support ${control.label.toLowerCase()}: ${control.reason} ${control.remediation}`,
+    {
+      action,
+      manifestDigest: manifest?.digest,
+      provider: manifest?.provider,
+      providerVersion: manifest?.providerVersion,
+      probeState: manifest?.probe.state,
+      requiredCapabilities: [control.capabilityId],
+      reasons: [control.reason],
+      remediation: control.remediation,
+    }
+  );
+}
+
+export function sandboxCapabilitiesFromManifest(
+  manifest: ProviderRuntimeManifest | undefined
+): SandboxProviderCapabilities {
+  const validation = validateManifest(manifest);
+  const validatedManifest = validation.manifest;
+  const supported: SandboxProviderCapabilityId[] = [];
+  const advisory: SandboxProviderCapabilityId[] = [];
+  for (const capability of validatedManifest?.capabilities ?? []) {
+    if (!isSandboxCapability(capability.id)) continue;
+    if (capability.state === 'supported') supported.push(capability.id);
+    if (capability.state === 'advisory') advisory.push(capability.id);
+  }
+  return {
+    provider: validatedManifest?.provider ?? manifest?.provider,
+    supported: uniqueSorted(supported),
+    advisory: uniqueSorted(advisory),
+  };
+}
+
+function validateManifest(manifest: ProviderRuntimeManifest | undefined): {
+  manifest?: ProviderRuntimeManifest;
+  reason?: string;
+} {
+  if (!manifest) return { reason: 'No persisted provider runtime manifest is available.' };
+  const parsed = ProviderRuntimeManifestSchema.safeParse(manifest);
+  if (!parsed.success) {
+    return {
+      reason: 'The persisted provider runtime manifest failed schema or digest validation.',
+    };
+  }
+  return { manifest: parsed.data as ProviderRuntimeManifest };
+}
+
+function assessControl(
+  manifest: ProviderRuntimeManifest | undefined,
+  definition: RuntimeControlDefinition
+): ProviderRuntimeControlAssessment {
+  const selection = selectProviderRuntimeManifest({
+    manifests: manifest ? [manifest] : [],
+    requiredCapabilities: [definition.capabilityId],
+  });
+  const candidate = selection.candidates[0];
+  const capability = candidate?.capabilities[0];
+  const reason =
+    candidate?.probeState === 'failed'
+      ? (candidate.reasons[0] ?? selection.reason)
+      : (capability?.reason ?? candidate?.reasons[0] ?? selection.reason);
+  return {
+    ...definition,
+    state: capability?.state ?? 'unknown',
+    available: selection.compatible,
+    advisory: selection.selectedManifest?.advisory ?? false,
+    reason,
+    remediation: selection.compatible ? undefined : remediationForManifest(manifest),
+  };
+}
+
+function remediationForManifest(manifest: ProviderRuntimeManifest | undefined): string {
+  if (!manifest) {
+    return 'Select a provider with a validated runtime manifest and run its readiness probe again.';
+  }
+  if (manifest.probe.state === 'failed') {
+    return 'Resolve the provider readiness probe failure and launch again with fresh manifest evidence.';
+  }
+  return 'Select a provider whose fresh manifest reports this capability as supported or advisory.';
+}
+
+function isSandboxCapability(
+  capabilityId: ProviderRuntimeCapabilityId
+): capabilityId is SandboxProviderCapabilityId {
+  return SANDBOX_CAPABILITY_IDS.has(capabilityId as SandboxProviderCapabilityId);
+}
+
+function uniqueSorted<T extends string>(values: T[]): T[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}

--- a/server/src/services/queue-intake-monitor-service.ts
+++ b/server/src/services/queue-intake-monitor-service.ts
@@ -21,6 +21,7 @@ import type {
   QueueMonitorSnapshot,
   QueueMonitorState,
   QueueMonitorUpdateInput,
+  ProviderRuntimeManifest,
   RunTelemetryEvent,
   WatcherContinuationEvaluationResult,
 } from '@veritas-kanban/shared';
@@ -78,6 +79,7 @@ export interface QueueIntakeMonitorServiceOptions {
   workflowRunService?: WorkflowRunService;
   workflowAuthoringService?: WorkflowAuthoringService;
   telemetryService?: TelemetryService;
+  runtimeManifestResolver?: () => Promise<ProviderRuntimeManifest | undefined>;
 }
 
 interface GhUser {
@@ -129,6 +131,7 @@ export class QueueIntakeMonitorService {
   private readonly workflowRunService: WorkflowRunService;
   private readonly workflowAuthoringService: WorkflowAuthoringService;
   private readonly telemetryService: TelemetryService;
+  private readonly runtimeManifestResolver: () => Promise<ProviderRuntimeManifest | undefined>;
   private store: QueueMonitorStore | null = null;
   private readonly runningMonitors = new Set<string>();
 
@@ -144,6 +147,8 @@ export class QueueIntakeMonitorService {
     this.workflowAuthoringService =
       options.workflowAuthoringService ?? getWorkflowAuthoringService();
     this.telemetryService = options.telemetryService ?? getTelemetryService();
+    this.runtimeManifestResolver =
+      options.runtimeManifestResolver ?? defaultQueueRuntimeManifestResolver;
   }
 
   async list(now = new Date()): Promise<QueueMonitorListResponse> {
@@ -638,26 +643,47 @@ export class QueueIntakeMonitorService {
     });
 
     let sandbox: QueueMonitorActionRecord['sandbox'];
-    const sandboxResult = await this.sandboxPolicyService.dryRun({
-      presetId: definition.sandboxPresetId ?? DEFAULT_SANDBOX_PRESET_ID,
-      provider: 'codex-cli',
-    });
-    sandbox = {
-      presetId: sandboxResult.preset.id,
-      decision: sandboxResult.decision,
-      provider: sandboxResult.provider,
-      warnings: sandboxResult.warnings,
-      remediation: sandboxResult.remediation,
-    };
-    checks.push({
-      name: 'sandbox',
-      status: sandboxResult.decision === 'block' ? 'block' : 'pass',
-      summary:
-        sandboxResult.decision === 'block'
-          ? `Sandbox preset ${sandboxResult.preset.id} cannot be enforced.`
-          : `Sandbox preset ${sandboxResult.preset.id} is usable.`,
-      evidence: sandboxResult.warnings,
-    });
+    const providerRuntimeManifest = await this.runtimeManifestResolver();
+    const sandboxPresetId = definition.sandboxPresetId ?? DEFAULT_SANDBOX_PRESET_ID;
+    if (!providerRuntimeManifest) {
+      const warning = 'A validated provider runtime manifest is required before queue dispatch.';
+      sandbox = {
+        presetId: sandboxPresetId,
+        decision: 'block',
+        provider: 'codex-cli',
+        warnings: [warning],
+        remediation:
+          'Enable and authenticate a supported provider, then rerun the runtime manifest probe.',
+      };
+      checks.push({
+        name: 'sandbox',
+        status: 'block',
+        summary: `Sandbox preset ${sandboxPresetId} cannot be evaluated without a validated runtime manifest.`,
+        evidence: [warning],
+      });
+    } else {
+      const sandboxResult = await this.sandboxPolicyService.dryRun({
+        presetId: sandboxPresetId,
+        provider: providerRuntimeManifest.provider,
+        providerRuntimeManifest,
+      });
+      sandbox = {
+        presetId: sandboxResult.preset.id,
+        decision: sandboxResult.decision,
+        provider: sandboxResult.provider,
+        warnings: sandboxResult.warnings,
+        remediation: sandboxResult.remediation,
+      };
+      checks.push({
+        name: 'sandbox',
+        status: sandboxResult.decision === 'block' ? 'block' : 'pass',
+        summary:
+          sandboxResult.decision === 'block'
+            ? `Sandbox preset ${sandboxResult.preset.id} cannot be enforced.`
+            : `Sandbox preset ${sandboxResult.preset.id} is usable.`,
+        evidence: sandboxResult.warnings,
+      });
+    }
 
     const budgetDecision = await this.evaluateBudget(definition, selected);
     checks.push({
@@ -1347,6 +1373,27 @@ function isBlockingBudgetDecision(decision: string): boolean {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+async function defaultQueueRuntimeManifestResolver(): Promise<ProviderRuntimeManifest | undefined> {
+  try {
+    const [{ getConfigService }, { clawdbotAgentService }] = await Promise.all([
+      import('./config-service.js'),
+      import('./clawdbot-agent-service.js'),
+    ]);
+    const config = await getConfigService().getConfig();
+    const agent = config.agents.find(
+      (candidate) => candidate.provider === 'codex-cli' || candidate.type === 'codex'
+    );
+    if (!agent) return undefined;
+    return await clawdbotAgentService.probeProviderRuntime(agent, agent.type, 'task');
+  } catch (error) {
+    log.warn(
+      { err: error },
+      'Queue monitor could not resolve a validated Codex runtime manifest for sandbox preflight'
+    );
+    return undefined;
+  }
 }
 
 let queueIntakeMonitorServiceInstance: QueueIntakeMonitorService | null = null;

--- a/server/src/services/run-session-share-service.ts
+++ b/server/src/services/run-session-share-service.ts
@@ -84,7 +84,7 @@ export class RunSessionShareService {
       actorLabel: input.actorLabel,
       stablePath: `/runs/shared/${id}`,
       mobileSafeApprovalClasses: this.normalizeApprovalClasses(input.mobileSafeApprovalClasses),
-      snapshot: this.snapshotTask(task),
+      snapshot: await this.snapshotTask(task),
       forkedTaskIds: [],
     };
 
@@ -209,9 +209,11 @@ export class RunSessionShareService {
     actor: RunSessionActor
   ): Promise<RunSessionEvent> {
     const share = await this.get(id, { actor, permission: 'edit' });
+    await this.agentService.assertActiveRunControl(share.taskId, 'message', share.sourceId);
     const delivery = await this.agentService.sendMessage(share.taskId, input.message, {
       actor: actor.label || actor.id,
       source: `run-session:${share.id}`,
+      expectedAttemptId: share.sourceId,
     });
     const event = this.createEvent(share, 'message.sent', actor, {
       delivered: delivery.delivered,
@@ -232,6 +234,7 @@ export class RunSessionShareService {
     actor: RunSessionActor
   ): Promise<RunSessionEvent> {
     const share = await this.get(id, { actor, permission: 'edit' });
+    await this.agentService.assertActiveRunControl(share.taskId, 'approvals', share.sourceId);
     const mobileClient = actor.clientMode === 'mobile-pwa';
     if (mobileClient && !share.mobileSafeApprovalClasses.includes(input.actionClass)) {
       throw new ForbiddenError('Approval class is not mobile-safe for this share', {
@@ -326,8 +329,8 @@ export class RunSessionShareService {
     return task;
   }
 
-  private snapshotTask(task: Task): RunSessionSnapshot {
-    const status = this.agentService.getAgentStatus(task.id);
+  private async snapshotTask(task: Task): Promise<RunSessionSnapshot> {
+    const status = await this.agentService.getAgentStatus(task.id);
     return {
       running: Boolean(status),
       taskTitle: task.title,

--- a/server/src/services/sandbox-policy-service.ts
+++ b/server/src/services/sandbox-policy-service.ts
@@ -1,6 +1,6 @@
 import type {
   CreateGovernanceTraceInput,
-  SandboxPolicyDryRunRequest,
+  SandboxPolicyEvaluationInput,
   SandboxPolicyDryRunResult,
   SandboxPolicyPreset,
   SandboxPolicyRuleEvaluation,
@@ -10,6 +10,7 @@ import type {
 import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { sandboxPolicyPresetSchema } from '../schemas/sandbox-policy-schemas.js';
 import { ConfigService, getConfigService } from './config-service.js';
+import { sandboxCapabilitiesFromManifest } from './provider-runtime-control-service.js';
 
 const BUILT_IN_TIMESTAMP = '2026-06-18T00:00:00.000Z';
 
@@ -179,26 +180,6 @@ export const BUILT_IN_SANDBOX_PRESETS: SandboxPolicyPreset[] = [
   },
 ];
 
-const PROVIDER_CAPABILITIES: Record<string, SandboxProviderCapabilities> = {
-  'codex-cli': {
-    provider: 'codex-cli',
-    supported: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
-  },
-  'hermes-cli': {
-    provider: 'hermes-cli',
-    supported: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
-  },
-  'codex-sdk': {
-    provider: 'codex-sdk',
-    supported: ['filesystem.read', 'filesystem.write', 'network.disable', 'environment.allowlist'],
-  },
-  openclaw: {
-    provider: 'openclaw',
-    supported: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
-    advisory: ['network.allowlist', 'credential.broker'],
-  },
-};
-
 export class SandboxPolicyService {
   constructor(private readonly configService: ConfigService = getConfigService()) {}
 
@@ -276,7 +257,7 @@ export class SandboxPolicyService {
     await this.configService.saveConfig(config);
   }
 
-  async dryRun(input: SandboxPolicyDryRunRequest = {}): Promise<SandboxPolicyDryRunResult> {
+  async dryRun(input: SandboxPolicyEvaluationInput = {}): Promise<SandboxPolicyDryRunResult> {
     const preset = input.preset
       ? this.normalizePreset(input.preset)
       : await this.resolvePreset(input.presetId);
@@ -284,17 +265,22 @@ export class SandboxPolicyService {
       return this.resultForDisabledPreset(preset, input);
     }
 
-    const capabilities = input.providerCapabilities ?? this.capabilitiesForProvider(input.provider);
+    const capabilities = sandboxCapabilitiesFromManifest(input.providerRuntimeManifest);
     const evaluations = this.evaluateRules(preset, capabilities);
     const unsupportedRules = evaluations.filter((rule) => rule.status === 'unsupported');
     const advisoryRules = evaluations.filter((rule) => rule.status === 'advisory');
+    const advisoryUnsupportedRules = preset.enforcement === 'advisory' ? unsupportedRules : [];
     const shouldBlock = preset.enforcement === 'required' && unsupportedRules.length > 0;
-    const decision = shouldBlock ? 'block' : advisoryRules.length > 0 ? 'warn' : 'allow';
+    const decision = shouldBlock
+      ? 'block'
+      : advisoryRules.length > 0 || advisoryUnsupportedRules.length > 0
+        ? 'warn'
+        : 'allow';
     const networkAccessEnabled = preset.network.defaultEgress === 'allow';
     return {
       decision,
       preset: this.redactPresetForResult(preset),
-      provider: input.provider ?? capabilities.provider,
+      provider: input.providerRuntimeManifest?.provider ?? input.provider ?? capabilities.provider,
       effective: {
         sandboxMode: this.effectiveSandboxMode(preset),
         networkAccessEnabled,
@@ -305,6 +291,7 @@ export class SandboxPolicyService {
       unsupportedRules,
       warnings: [
         ...advisoryRules.map((rule) => rule.detail),
+        ...advisoryUnsupportedRules.map((rule) => rule.detail),
         ...(networkAccessEnabled ? ['Network egress remains enabled by this preset.'] : []),
       ],
       remediation: shouldBlock
@@ -313,7 +300,7 @@ export class SandboxPolicyService {
     };
   }
 
-  async dryRunWithTrace(input: SandboxPolicyDryRunRequest = {}): Promise<{
+  async dryRunWithTrace(input: SandboxPolicyEvaluationInput = {}): Promise<{
     result: SandboxPolicyDryRunResult;
     trace: CreateGovernanceTraceInput;
   }> {
@@ -325,7 +312,7 @@ export class SandboxPolicyService {
   }
 
   async assertLaunchAllowed(
-    input: SandboxPolicyDryRunRequest = {}
+    input: SandboxPolicyEvaluationInput = {}
   ): Promise<SandboxPolicyDryRunResult> {
     const result = await this.dryRun(input);
     if (result.decision === 'block') {
@@ -343,17 +330,6 @@ export class SandboxPolicyService {
       );
     }
     return result;
-  }
-
-  capabilitiesForProvider(provider?: string): SandboxProviderCapabilities {
-    const key = (provider || 'codex-cli').toLowerCase();
-    return (
-      PROVIDER_CAPABILITIES[key] ?? {
-        provider,
-        supported: [],
-        advisory: [],
-      }
-    );
   }
 
   private async resolvePreset(id?: string): Promise<SandboxPolicyPreset> {
@@ -512,7 +488,7 @@ export class SandboxPolicyService {
 
   private resultForDisabledPreset(
     preset: SandboxPolicyPreset,
-    input: SandboxPolicyDryRunRequest
+    input: SandboxPolicyEvaluationInput
   ): SandboxPolicyDryRunResult {
     return {
       decision: preset.enforcement === 'required' ? 'block' : 'warn',
@@ -545,7 +521,7 @@ export class SandboxPolicyService {
 
   private buildTrace(
     result: SandboxPolicyDryRunResult,
-    input: SandboxPolicyDryRunRequest
+    input: SandboxPolicyEvaluationInput
   ): CreateGovernanceTraceInput {
     const outcome =
       result.decision === 'block' ? 'blocked' : result.decision === 'warn' ? 'warned' : 'allowed';

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -62,7 +62,9 @@ export class WorkflowRunService {
     const resolvedOptions = typeof options === 'string' ? { runsDir: options } : options;
     this.runsDir = resolvedOptions.runsDir || getWorkflowRunsDir();
     this.workflowService = resolvedOptions.workflowService ?? getWorkflowService();
-    this.stepExecutor = new WorkflowStepExecutor(resolvedOptions.runsDir);
+    this.stepExecutor = new WorkflowStepExecutor(resolvedOptions.runsDir, {
+      persistRun: (run) => this.saveRun(run),
+    });
     const storageType =
       resolvedOptions.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -7,7 +7,14 @@ import fs from 'fs/promises';
 import path from 'path';
 import sanitizeFilename from 'sanitize-filename';
 import yaml from 'yaml';
-import type { AgentHostRoutingDecision, SandboxPolicyDryRunResult } from '@veritas-kanban/shared';
+import type {
+  AgentConfig,
+  AgentHostRoutingDecision,
+  ExecutableAgentProvider,
+  ProviderRuntimeCapabilityId,
+  ProviderRuntimeManifest,
+  SandboxPolicyDryRunResult,
+} from '@veritas-kanban/shared';
 import type {
   WorkflowStep,
   WorkflowRun,
@@ -33,6 +40,12 @@ import {
 import { getToolPolicyService } from './tool-policy-service.js';
 import { getAgentHostService } from './agent-host-service.js';
 import { getSandboxPolicyService } from './sandbox-policy-service.js';
+import {
+  assertProviderRuntimeCapabilities,
+  assertProviderRuntimeControl,
+  BASELINE_LAUNCH_CAPABILITIES,
+  providerRuntimeControls,
+} from './provider-runtime-control-service.js';
 
 const log = createLogger('workflow-step-executor');
 
@@ -58,16 +71,29 @@ export class HumanGateBlockError extends Error {
 
 interface WorkflowStepExecutorOptions {
   openClawAdapter?: OpenClawWorkflowAdapter;
+  runtimeManifestResolver?: (agent: AgentConfig) => Promise<ProviderRuntimeManifest>;
+  persistRun?: (run: WorkflowRun) => Promise<void>;
 }
+
+type WorkflowExecutableProvider = Extract<ExecutableAgentProvider, 'codex-sdk' | 'openclaw'>;
 
 export class WorkflowStepExecutor {
   private runsDir: string;
   private openClawAdapter: OpenClawWorkflowAdapter;
+  private runtimeManifestResolver: (agent: AgentConfig) => Promise<ProviderRuntimeManifest>;
+  private persistRun: (run: WorkflowRun) => Promise<void>;
   private appendCountCache?: Map<string, number>; // Performance: Track append counts to reduce stat() calls
 
   constructor(runsDir?: string, options: WorkflowStepExecutorOptions = {}) {
     this.runsDir = runsDir || getWorkflowRunsDir();
     this.openClawAdapter = options.openClawAdapter || new HttpOpenClawWorkflowAdapter();
+    this.runtimeManifestResolver =
+      options.runtimeManifestResolver ??
+      (async (agent) => {
+        const { clawdbotAgentService } = await import('./clawdbot-agent-service.js');
+        return clawdbotAgentService.probeProviderRuntime(agent, agent.type, 'workflow');
+      });
+    this.persistRun = options.persistRun ?? (async () => undefined);
   }
 
   /**
@@ -124,10 +150,27 @@ export class WorkflowStepExecutor {
     // Get tool policy filter for this agent role (#110)
     const toolPolicyFilter = await this.getToolPolicyForAgent(agentDef);
     const workingDirectory = this.expandPath(this.getWorkflowWorkingDirectory(run));
+    const runtimeProvider = this.resolveWorkflowProvider(step, agentDef);
+    const runtimeManifest = await this.resolveRuntimeManifest(step, agentDef, runtimeProvider);
+    const requiredRuntimeCapabilities = this.requiredRuntimeCapabilities(
+      step,
+      run,
+      agentDef,
+      runtimeProvider,
+      sessionConfig,
+      toolPolicyFilter
+    );
+    assertProviderRuntimeCapabilities(
+      runtimeManifest,
+      requiredRuntimeCapabilities,
+      `workflow step ${step.id} launch`
+    );
+    await this.recordRuntimeManifest(run, step, runtimeManifest);
     const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
       presetId: agentDef?.sandboxPresetId,
-      provider: agentDef?.provider,
+      provider: runtimeManifest.provider,
       workspacePath: workingDirectory,
+      providerRuntimeManifest: runtimeManifest,
     });
     const sandboxTrace = await getGovernanceTraceService().record(sandboxPolicy.trace);
     if (sandboxPolicy.result.decision === 'block') {
@@ -137,10 +180,11 @@ export class WorkflowStepExecutor {
     }
     const hostPreview = getAgentHostService().preview({
       agent: step.agent,
-      provider: agentDef?.provider,
+      provider: runtimeManifest.provider,
       model: agentDef?.model,
       workspacePath: workingDirectory,
       requiredTools: this.routingTools(agentDef, toolPolicyFilter),
+      requiredRuntimeCapabilities,
       verificationGates: step.acceptance_criteria,
       sandboxPresetId: sandboxPolicy.result.preset.id,
     });
@@ -156,12 +200,13 @@ export class WorkflowStepExecutor {
         sessionContext: sessionConfig.context,
         sessionCleanup: sessionConfig.cleanup,
         toolPolicy: toolPolicyFilter,
+        runtimeProvider,
         hostRouting: hostPreview.decision,
       },
       'Agent step execution configured'
     );
 
-    if (this.isCodexAgent(agentDef, step.agent)) {
+    if (runtimeProvider === 'codex-sdk') {
       return this.executeCodexAgentStep(
         step,
         run,
@@ -170,7 +215,8 @@ export class WorkflowStepExecutor {
         sessionConfig,
         toolPolicyFilter,
         hostPreview.decision,
-        sandboxPolicy.result
+        sandboxPolicy.result,
+        runtimeManifest
       );
     }
 
@@ -182,7 +228,8 @@ export class WorkflowStepExecutor {
       sessionConfig,
       sessionContext,
       toolPolicyFilter,
-      hostPreview.decision
+      hostPreview.decision,
+      runtimeManifest
     );
   }
 
@@ -194,7 +241,8 @@ export class WorkflowStepExecutor {
     sessionConfig: StepSessionConfig,
     sessionContext: Record<string, unknown>,
     toolPolicyFilter: { allowed?: string[]; denied?: string[] },
-    hostRouting: AgentHostRoutingDecision
+    hostRouting: AgentHostRoutingDecision,
+    runtimeManifest: ProviderRuntimeManifest
   ): Promise<StepExecutionResult> {
     const agentId = step.agent || agentDef?.id || step.id;
     const sessionMap = (run.context._sessions as Record<string, string> | undefined) || {};
@@ -264,6 +312,7 @@ export class WorkflowStepExecutor {
       return {
         output: parsed,
         outputPath,
+        providerRuntimeManifest: runtimeManifest,
       };
     } catch (err) {
       const message = this.sanitizeProviderError(err, prompt);
@@ -347,6 +396,105 @@ export class WorkflowStepExecutor {
       if (tool !== '*') tools.add(tool);
     }
     return Array.from(tools).sort((a, b) => a.localeCompare(b));
+  }
+
+  private async resolveRuntimeManifest(
+    step: WorkflowStep,
+    agentDef: WorkflowAgent | null,
+    provider: WorkflowExecutableProvider
+  ): Promise<ProviderRuntimeManifest> {
+    const type = agentDef?.id || step.agent || step.id;
+    const command = agentDef?.command || (provider === 'openclaw' ? 'openclaw' : 'codex');
+    return this.runtimeManifestResolver({
+      type,
+      name: agentDef?.name || type,
+      command,
+      args: [],
+      enabled: true,
+      provider,
+      model: agentDef?.model,
+      sandboxPresetId: agentDef?.sandboxPresetId,
+      budget: agentDef?.budget,
+    });
+  }
+
+  private resolveWorkflowProvider(
+    step: WorkflowStep,
+    agentDef: WorkflowAgent | null
+  ): WorkflowExecutableProvider {
+    const provider = agentDef?.provider;
+    if (provider === 'openclaw' || provider === 'codex-sdk') {
+      return provider;
+    }
+    if (provider) {
+      throw new Error(
+        `Workflow agent ${agentDef?.id || step.agent || step.id} uses provider ${provider}, which has no workflow execution adapter.`
+      );
+    }
+    return this.isCodexAgent(agentDef, step.agent) ? 'codex-sdk' : 'openclaw';
+  }
+
+  private requiredRuntimeCapabilities(
+    step: WorkflowStep,
+    run: WorkflowRun,
+    agentDef: WorkflowAgent | null,
+    runtimeProvider: WorkflowExecutableProvider,
+    sessionConfig: StepSessionConfig,
+    toolPolicyFilter: { allowed?: string[]; denied?: string[] }
+  ): ProviderRuntimeCapabilityId[] {
+    const required = new Set<ProviderRuntimeCapabilityId>(BASELINE_LAUNCH_CAPABILITIES);
+    const tools = this.routingTools(agentDef, toolPolicyFilter);
+    const hasToolPolicy = tools.length > 0 || (toolPolicyFilter.denied?.length ?? 0) > 0;
+    if (hasToolPolicy) required.add('tool.calls');
+    if (tools.some((tool) => /(^|[_.:/-])mcp([_.:/-]|$)/i.test(tool))) {
+      required.add('tool.mcp');
+    }
+    if (step.output?.schema) required.add('output.structured');
+    required.add('artifact.write');
+    const tokenUsageLimits = [
+      run.budget?.policy?.limits,
+      agentDef?.budget?.enabled ? agentDef.budget.limits : undefined,
+    ];
+    if (
+      tokenUsageLimits.some(
+        (limits) =>
+          limits?.inputTokens !== undefined ||
+          limits?.outputTokens !== undefined ||
+          limits?.totalTokens !== undefined ||
+          limits?.costUsd !== undefined
+      )
+    ) {
+      required.add('usage.tokens');
+    }
+
+    const sessionKey = step.agent || agentDef?.id || step.id;
+    const hasExistingSession = Boolean(
+      sessionConfig.mode === 'reuse' &&
+      (run.context._sessions as Record<string, string> | undefined)?.[sessionKey]
+    );
+    if (hasExistingSession) {
+      if (runtimeProvider === 'codex-sdk') {
+        required.add('run.resume');
+      } else {
+        required.add('run.reattach');
+        required.add('run.follow-up');
+      }
+    }
+
+    return [...required].sort((left, right) => left.localeCompare(right));
+  }
+
+  private async recordRuntimeManifest(
+    run: WorkflowRun,
+    step: WorkflowStep,
+    manifest: ProviderRuntimeManifest
+  ): Promise<void> {
+    const stepRun = run.steps.find((candidate) => candidate.stepId === step.id);
+    if (stepRun) {
+      stepRun.providerRuntimeManifest = manifest;
+      stepRun.runtimeControls = providerRuntimeControls(manifest);
+    }
+    await this.persistRun(run);
   }
 
   private assertOpenClawResult(
@@ -447,7 +595,8 @@ export class WorkflowStepExecutor {
     sessionConfig: StepSessionConfig,
     toolPolicyFilter: { allowed?: string[]; denied?: string[] },
     hostRouting: AgentHostRoutingDecision,
-    sandboxPolicy: SandboxPolicyDryRunResult
+    sandboxPolicy: SandboxPolicyDryRunResult,
+    runtimeManifest: ProviderRuntimeManifest
   ): Promise<StepExecutionResult> {
     this.assertCodexToolPolicySupported(step, agentDef, toolPolicyFilter);
 
@@ -501,8 +650,15 @@ export class WorkflowStepExecutor {
 
     for await (const event of streamed.events) {
       events.push(event);
-      if (this.isCodexToolEvent(event)) toolCalls++;
-      tokenUsage = this.extractCodexBudgetUsage(event) ?? tokenUsage;
+      if (this.isCodexToolEvent(event)) {
+        assertProviderRuntimeControl(runtimeManifest, 'tool-calls');
+        toolCalls++;
+      }
+      const eventUsage = this.extractCodexBudgetUsage(event);
+      if (eventUsage) {
+        assertProviderRuntimeControl(runtimeManifest, 'token-usage');
+        tokenUsage = eventUsage;
+      }
       if (event.type === 'thread.started') {
         threadId = event.thread_id;
         run.context._sessions = {
@@ -568,6 +724,7 @@ export class WorkflowStepExecutor {
         costUsd: tokenUsage?.cost,
         toolCalls,
       },
+      providerRuntimeManifest: runtimeManifest,
     };
   }
 

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -224,6 +224,8 @@ export interface StepRun {
   retries: number;
   output?: string; // Path to output file
   error?: string;
+  providerRuntimeManifest?: import('@veritas-kanban/shared').ProviderRuntimeManifest;
+  runtimeControls?: import('@veritas-kanban/shared').ProviderRuntimeControlSet;
 
   // Loop-specific state
   loopState?: {
@@ -259,6 +261,7 @@ export interface StepExecutionResult {
   output: unknown; // Parsed output (for context passing)
   outputPath: string; // Path to output file
   budgetUsage?: Partial<import('@veritas-kanban/shared').AgentBudgetUsage>;
+  providerRuntimeManifest?: import('@veritas-kanban/shared').ProviderRuntimeManifest;
 }
 
 // ==================== RBAC & Audit Types ====================

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -2,7 +2,7 @@ import type { SandboxProviderCapabilityId } from './sandbox-policy.types.js';
 
 export const PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION = 'provider-runtime-manifest/v1' as const;
 
-export const PROVIDER_RUNTIME_PROBE_REVISION = 1 as const;
+export const PROVIDER_RUNTIME_PROBE_REVISION = 3 as const;
 
 export const KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS = [
   'run.start',
@@ -124,6 +124,45 @@ export interface ProviderRuntimeRouteCandidate {
   selected: boolean;
   reason: string;
   selection: ProviderRuntimeSelection;
+}
+
+export const PROVIDER_RUNTIME_CONTROL_ACTIONS = [
+  'start',
+  'status',
+  'logs',
+  'complete',
+  'stop',
+  'interrupt',
+  'message',
+  'resume',
+  'reattach',
+  'approvals',
+  'tool-calls',
+  'mcp',
+  'structured-output',
+  'token-usage',
+  'artifacts',
+] as const;
+
+export type ProviderRuntimeControlAction = (typeof PROVIDER_RUNTIME_CONTROL_ACTIONS)[number];
+
+export interface ProviderRuntimeControlAssessment {
+  action: ProviderRuntimeControlAction;
+  label: string;
+  capabilityId: ProviderRuntimeCapabilityId;
+  state: ProviderRuntimeCapabilityState;
+  available: boolean;
+  advisory: boolean;
+  reason: string;
+  remediation?: string;
+}
+
+export interface ProviderRuntimeControlSet {
+  manifestDigest?: string;
+  provider?: string;
+  providerVersion?: string;
+  probeState?: ProviderRuntimeProbeState;
+  controls: ProviderRuntimeControlAssessment[];
 }
 
 export function findProviderRuntimeCapability(

--- a/shared/src/types/sandbox-policy.types.ts
+++ b/shared/src/types/sandbox-policy.types.ts
@@ -67,13 +67,22 @@ export interface SandboxProviderCapabilities {
   advisory?: SandboxProviderCapabilityId[];
 }
 
-export interface SandboxPolicyDryRunRequest {
+export interface SandboxPolicyEvaluationInput {
   presetId?: string;
   preset?: SandboxPolicyPreset;
   provider?: string;
   workspacePath?: string;
   requiredCapabilities?: SkillCapabilityId[];
-  providerCapabilities?: SandboxProviderCapabilities;
+  providerRuntimeManifestDigest?: string;
+  /** Internal launch-time snapshot. Never accepted from public dry-run callers. */
+  providerRuntimeManifest?: import('./provider-runtime.types.js').ProviderRuntimeManifest;
+}
+
+export interface SandboxPolicyDryRunRequest extends Omit<
+  SandboxPolicyEvaluationInput,
+  'providerRuntimeManifestDigest' | 'providerRuntimeManifest'
+> {
+  providerRuntimeManifestDigest: string;
 }
 
 export interface SandboxPolicyRuleEvaluation {

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -250,6 +250,9 @@ export interface StepRun {
   retries: number;
   output?: string; // Path to output file
   error?: string;
+  /** Exact provider evidence snapshot used for this step's launch and controls. */
+  providerRuntimeManifest?: import('./provider-runtime.types.js').ProviderRuntimeManifest;
+  runtimeControls?: import('./provider-runtime.types.js').ProviderRuntimeControlSet;
 
   // Loop-specific state
   loopState?: {
@@ -285,6 +288,7 @@ export interface StepExecutionResult {
   output: unknown; // Parsed output (for context passing)
   outputPath: string; // Path to output file
   budgetUsage?: Partial<import('./agent-budget.types.js').AgentBudgetUsage>;
+  providerRuntimeManifest?: import('./provider-runtime.types.js').ProviderRuntimeManifest;
 }
 
 // ==================== RBAC & Audit Types ====================

--- a/web/src/__tests__/run-session-shares-mantine.test.tsx
+++ b/web/src/__tests__/run-session-shares-mantine.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   sendMessageMutateAsync: vi.fn(),
   approvalMutateAsync: vi.fn(),
   forkMutateAsync: vi.fn(),
+  useAgentStatus: vi.fn(),
   useAgentStream: vi.fn(),
   toast: vi.fn(),
   identity: {
@@ -59,6 +60,7 @@ vi.mock('@/hooks/useRunSessions', () => ({
 }));
 
 vi.mock('@/hooks/useAgent', () => ({
+  useAgentStatus: mocks.useAgentStatus,
   useAgentStream: mocks.useAgentStream,
 }));
 
@@ -113,6 +115,33 @@ describe('run session share Mantine surfaces', () => {
     mocks.useRunSessions.mockReturnValue({ data: [baseShare], isLoading: false });
     mocks.useRunSession.mockReturnValue({ data: baseShare, isLoading: false, error: null });
     mocks.useRunSessionEvents.mockReturnValue({ data: [event], isLoading: false });
+    mocks.useAgentStatus.mockReturnValue({
+      data: {
+        running: true,
+        attemptId: 'attempt-721',
+        controls: {
+          controls: [
+            {
+              action: 'message',
+              capabilityId: 'run.steer',
+              state: 'supported',
+              available: true,
+              advisory: false,
+              reason: 'Steering is supported.',
+            },
+            {
+              action: 'approvals',
+              capabilityId: 'run.approvals',
+              state: 'supported',
+              available: true,
+              advisory: false,
+              reason: 'Provider approvals are supported.',
+            },
+          ],
+        },
+      },
+      error: null,
+    });
     mocks.useAgentStream.mockReturnValue({
       outputs: [
         {
@@ -240,5 +269,96 @@ describe('run session share Mantine surfaces', () => {
         reason: 'Forked from shared live run session.',
       },
     });
+  });
+
+  it('disables co-drive messaging when the persisted runtime manifest cannot steer', () => {
+    mocks.useRunSession.mockReturnValue({
+      data: { ...baseShare, permission: 'edit' },
+      isLoading: false,
+      error: null,
+    });
+    mocks.useAgentStatus.mockReturnValue({
+      data: {
+        running: true,
+        attemptId: 'attempt-721',
+        controls: {
+          controls: [
+            {
+              action: 'message',
+              capabilityId: 'run.steer',
+              state: 'unsupported',
+              available: false,
+              advisory: false,
+              reason: 'This provider cannot steer the active run.',
+            },
+          ],
+        },
+      },
+      error: null,
+    });
+
+    renderWithProviders(<RunSessionShareView shareId="run_share_721" />);
+
+    expect(
+      screen.getByText('Message unavailable: This provider cannot steer the active run.')
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole('button', {
+          name: 'Send Message unavailable: This provider cannot steer the active run.',
+        })
+        .getAttribute('disabled')
+    ).not.toBeNull();
+    expect(
+      screen.getByText(
+        'Approval unavailable: Validated provider approval evidence is not available for this run.'
+      )
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Approve' }).getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('fails shared controls closed for a replacement attempt', () => {
+    mocks.useRunSession.mockReturnValue({
+      data: { ...baseShare, permission: 'edit' },
+      isLoading: false,
+      error: null,
+    });
+    mocks.useAgentStatus.mockReturnValue({
+      data: {
+        running: true,
+        attemptId: 'attempt-replacement',
+        controls: {
+          controls: [
+            {
+              action: 'message',
+              capabilityId: 'run.steer',
+              state: 'supported',
+              available: true,
+              advisory: false,
+              reason: 'Steering is supported.',
+            },
+            {
+              action: 'approvals',
+              capabilityId: 'run.approvals',
+              state: 'supported',
+              available: true,
+              advisory: false,
+              reason: 'Provider approvals are supported.',
+            },
+          ],
+        },
+      },
+      error: null,
+    });
+
+    renderWithProviders(<RunSessionShareView shareId="run_share_721" />);
+
+    const replacementReason =
+      'This link is pinned to an earlier attempt and cannot control its replacement.';
+    expect(screen.getByText(`Message unavailable: ${replacementReason}`)).toBeTruthy();
+    expect(screen.getByText(`Approval unavailable: ${replacementReason}`)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Approve' }).getAttribute('disabled')).not.toBeNull();
+    expect(mocks.useAgentStream).toHaveBeenCalledWith(undefined);
+    expect(screen.queryByText('agent streamed output')).toBeNull();
   });
 });

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { AgentsTab } from '@/components/settings/tabs/AgentsTab';
 import { renderWithProviders } from './test-utils';
 import type { AgentConfig, AgentRoutingConfig, AgentType } from '@veritas-kanban/shared';
@@ -57,6 +58,9 @@ const mocks = vi.hoisted(() => ({
   exportProfile: vi.fn(),
   deleteProfile: vi.fn(),
   startAgent: vi.fn(),
+  validateSandboxPolicy: vi.fn(),
+  providerRuntimeManifests: [] as Array<Record<string, unknown>>,
+  additionalAgentHosts: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock('@/hooks/useConfig', () => ({
@@ -282,7 +286,7 @@ vi.mock('@/hooks/useAgent', () => ({
           supportedModels: ['gpt-5'],
           supportedTools: ['tool.calls'],
           sandboxCapabilities: ['filesystem.read', 'filesystem.write', 'environment.allowlist'],
-          providerRuntimeManifests: [],
+          providerRuntimeManifests: mocks.providerRuntimeManifests,
           legacyRuntimePosture: {
             providers: ['codex-cli'],
             models: ['gpt-5'],
@@ -298,6 +302,7 @@ vi.mock('@/hooks/useAgent', () => ({
           diagnostics: [],
           registeredAgentIds: ['codex'],
         },
+        ...mocks.additionalAgentHosts,
       ],
     },
     isFetching: false,
@@ -418,12 +423,26 @@ vi.mock('@/hooks/useSandboxPolicies', () => ({
   useCreateSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false }),
   useDeleteSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false }),
-  useValidateSandboxPolicy: () => ({ mutate: vi.fn(), isPending: false, data: undefined }),
+  useValidateSandboxPolicy: () => ({
+    mutate: mocks.validateSandboxPolicy,
+    mutateAsync: mocks.validateSandboxPolicy,
+    isPending: false,
+    data: undefined,
+    error: null,
+  }),
 }));
 
 describe('Agents settings Mantine migration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    mocks.providerRuntimeManifests.length = 0;
+    mocks.additionalAgentHosts.length = 0;
+    mocks.validateSandboxPolicy.mockResolvedValue({
+      decision: 'allow',
+      effective: { sandboxMode: 'workspace-write', networkAccessEnabled: false },
+      unsupportedRules: [],
+    });
   });
 
   afterEach(() => {
@@ -484,6 +503,138 @@ describe('Agents settings Mantine migration', () => {
       agents[0],
       expect.objectContaining({ type: 'claude-code', enabled: true }),
     ]);
+  });
+
+  it('dry-runs sandbox policy against the newest live registered manifest', async () => {
+    const olderReadyDigest = `sha256:${'a'.repeat(64)}`;
+    const newerFailedDigest = `sha256:${'b'.repeat(64)}`;
+    const newestDisconnectedDigest = `sha256:${'c'.repeat(64)}`;
+    mocks.providerRuntimeManifests.push(
+      {
+        provider: 'codex-sdk',
+        adapter: 'codex-sdk',
+        digest: olderReadyDigest,
+        probe: { state: 'ready', probedAt: '2026-06-01T12:00:00.000Z' },
+      },
+      {
+        provider: 'codex-sdk',
+        adapter: 'codex-sdk',
+        digest: newerFailedDigest,
+        probe: { state: 'failed', probedAt: '2026-06-01T12:05:00.000Z' },
+      }
+    );
+    mocks.additionalAgentHosts.push({
+      id: 'host-disconnected',
+      name: 'Disconnected Supervisor',
+      supervisorType: 'remote-agent',
+      os: 'linux',
+      posture: 'disconnected',
+      authState: 'unknown',
+      supportedAgents: ['codex'],
+      supportedProviders: ['codex-sdk'],
+      supportedModels: ['gpt-5'],
+      supportedTools: ['tool.calls'],
+      sandboxCapabilities: ['filesystem.read'],
+      providerRuntimeManifests: [
+        {
+          provider: 'codex-sdk',
+          adapter: 'codex-sdk',
+          digest: newestDisconnectedDigest,
+          probe: { state: 'ready', probedAt: '2026-06-01T12:10:00.000Z' },
+        },
+      ],
+      legacyRuntimePosture: {
+        providers: ['codex-sdk'],
+        models: ['gpt-5'],
+        tools: ['code'],
+        sandboxCapabilities: [],
+      },
+      workspaceLabels: ['workspace:veritas-kanban'],
+      activeSessions: 0,
+      queueDepth: 0,
+      maxQueueDepth: 2,
+      overloaded: false,
+      lastHeartbeat: '2026-06-01T11:50:00.000Z',
+      diagnostics: ['Heartbeat expired.'],
+      registeredAgentIds: ['codex'],
+    });
+
+    renderWithProviders(<AgentsTab />);
+
+    const runCheck = screen.getByRole('button', { name: 'Run Dry Check' });
+    await waitFor(() => expect(runCheck.getAttribute('disabled')).toBeNull());
+    fireEvent.click(runCheck);
+
+    expect(mocks.validateSandboxPolicy).toHaveBeenCalledWith({
+      presetId: 'legacy-permissive',
+      provider: 'codex-sdk',
+      providerRuntimeManifestDigest: newerFailedDigest,
+    });
+  });
+
+  it('ignores stale dry-run responses after the provider selection changes away and back', async () => {
+    const user = userEvent.setup();
+    const digest = `sha256:${'d'.repeat(64)}`;
+    mocks.providerRuntimeManifests.push({
+      provider: 'codex-sdk',
+      adapter: 'codex-sdk',
+      digest,
+      probe: { state: 'ready', probedAt: '2026-06-01T12:00:00.000Z' },
+    });
+    let resolveOld: ((value: unknown) => void) | undefined;
+    mocks.validateSandboxPolicy.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        })
+    );
+
+    renderWithProviders(<AgentsTab />);
+    await user.click(screen.getByRole('button', { name: 'Run Dry Check' }));
+    const provider = screen.getByRole('combobox', { name: 'Provider' });
+    await user.click(provider);
+    await user.click(await screen.findByRole('option', { name: 'OpenClaw' }));
+    await user.click(provider);
+    await user.click(await screen.findByRole('option', { name: 'Codex SDK' }));
+
+    resolveOld?.({
+      decision: 'allow',
+      effective: { sandboxMode: 'workspace-write', networkAccessEnabled: false },
+      unsupportedRules: [],
+      traceId: 'trace-stale',
+    });
+    await waitFor(() => expect(screen.queryByText('Trace trace-stale')).toBeNull());
+
+    mocks.validateSandboxPolicy.mockResolvedValueOnce({
+      decision: 'allow',
+      effective: { sandboxMode: 'workspace-write', networkAccessEnabled: false },
+      unsupportedRules: [],
+      traceId: 'trace-current',
+    });
+    await user.click(screen.getByRole('button', { name: 'Run Dry Check' }));
+    expect(await screen.findByText('Trace trace-current')).toBeDefined();
+  });
+
+  it('shows live-manifest validation conflicts to the operator', async () => {
+    const user = userEvent.setup();
+    mocks.providerRuntimeManifests.push({
+      provider: 'codex-sdk',
+      adapter: 'codex-sdk',
+      digest: `sha256:${'e'.repeat(64)}`,
+      probe: { state: 'ready', probedAt: '2026-06-01T12:00:00.000Z' },
+    });
+    mocks.validateSandboxPolicy.mockRejectedValueOnce(
+      new Error('The requested provider runtime manifest is not registered on a live agent host')
+    );
+
+    renderWithProviders(<AgentsTab />);
+    await user.click(screen.getByRole('button', { name: 'Run Dry Check' }));
+
+    expect(
+      await screen.findByText(
+        'The requested provider runtime manifest is not registered on a live agent host'
+      )
+    ).toBeDefined();
   });
 
   it('adds custom agents through Mantine text inputs and buttons', () => {

--- a/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-agent-template-metrics-mantine.test.tsx
@@ -48,6 +48,7 @@ vi.mock('@/hooks/useAgent', () => ({
   }),
   useStopAgent: () => ({
     mutate: mocks.stopAgentMutate,
+    isPending: false,
   }),
   useSendMessage: () => ({
     mutate: mocks.sendMessageMutate,
@@ -90,6 +91,10 @@ vi.mock('@/components/dashboard/ExportDialog', () => ({
         Export task metrics
       </div>
     ) : null,
+}));
+
+vi.mock('@/components/task/RunSessionSharesSection', () => ({
+  RunSessionSharesSection: () => <div>Run session shares</div>,
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -225,7 +230,7 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
 
     const { baseElement, container } = renderWithProviders(<AgentPanel task={task} />);
 
-    expect(container.querySelectorAll('.mantine-Select-root')).toHaveLength(3);
+    expect(container.querySelectorAll('.mantine-Select-root')).toHaveLength(2);
     expect(container.querySelector('.mantine-Button-root')).toBeDefined();
     expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
     expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
@@ -306,7 +311,32 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
 
   it('keeps running-agent message send and stop confirmation wired through Mantine modal', async () => {
     const user = userEvent.setup();
-    mocks.useAgentStatus.mockReturnValue({ data: { running: true } });
+    mocks.useAgentStatus.mockReturnValue({
+      data: {
+        running: true,
+        attemptId: 'attempt-1',
+        controls: {
+          controls: [
+            {
+              action: 'stop',
+              capabilityId: 'run.stop',
+              state: 'supported',
+              available: true,
+              advisory: false,
+              reason: 'Stop is supported.',
+            },
+            {
+              action: 'message',
+              capabilityId: 'run.steer',
+              state: 'advisory',
+              available: true,
+              advisory: true,
+              reason: 'Steering is advisory.',
+            },
+          ],
+        },
+      },
+    });
     mocks.useAgentStream.mockReturnValue({
       outputs: [{ type: 'stdout', content: 'working' }],
       isConnected: true,
@@ -330,7 +360,7 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
     expect(messageForm).not.toBeNull();
     fireEvent.submit(messageForm as HTMLFormElement);
 
-    await user.click(screen.getByRole('button', { name: 'Stop' }));
+    await user.click(screen.getByRole('button', { name: 'Stop agent' }));
     const dialog = await screen.findByRole('dialog', { name: 'Stop the agent?' });
     expect(baseElement.querySelector('.mantine-Modal-content')).toBeDefined();
     expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
@@ -338,10 +368,164 @@ describe('task detail agent, template, and metrics Mantine migration', () => {
 
     expect(mocks.sendMessageMutate).toHaveBeenCalledWith({
       taskId: 'task-agent-running',
+      attemptId: 'attempt-1',
       message: 'continue with tests',
     });
-    expect(mocks.stopAgentMutate).toHaveBeenCalledWith('task-agent-running');
+    expect(mocks.stopAgentMutate).toHaveBeenCalledWith({
+      taskId: 'task-agent-running',
+      attemptId: 'attempt-1',
+    });
     expect(dialog).toBeDefined();
+  });
+
+  it('disables unsupported run controls with accessible capability reasons', () => {
+    mocks.useAgentStatus.mockReturnValue({
+      data: {
+        running: true,
+        controls: {
+          controls: [
+            {
+              action: 'stop',
+              capabilityId: 'run.stop',
+              state: 'unsupported',
+              available: false,
+              advisory: false,
+              reason: 'This provider cannot stop task sessions.',
+            },
+            {
+              action: 'message',
+              capabilityId: 'run.steer',
+              state: 'unknown',
+              available: false,
+              advisory: false,
+              reason: 'Steering has not been verified.',
+            },
+          ],
+        },
+      },
+    });
+    mocks.useAgentStream.mockReturnValue({
+      outputs: [],
+      isConnected: true,
+      isRunning: true,
+      clearOutputs: mocks.clearOutputs,
+    });
+
+    renderWithProviders(
+      <AgentPanel
+        task={createMockTask({
+          id: 'task-agent-limited',
+          git: { repo: 'veritas', branch: 'limited', baseBranch: 'main', worktreePath: '/tmp' },
+        })}
+      />
+    );
+
+    expect(
+      screen
+        .getByRole('button', {
+          name: 'Stop agent unavailable: This provider cannot stop task sessions.',
+        })
+        .getAttribute('disabled')
+    ).not.toBeNull();
+    expect(screen.getByText('Message: Steering has not been verified.')).toBeDefined();
+  });
+
+  it('uses terminal status over a stale running WebSocket flag', () => {
+    mocks.useAgentStatus.mockReturnValue({
+      data: { running: false },
+      error: null,
+      isFetching: false,
+    });
+    mocks.useAgentStream.mockReturnValue({
+      outputs: [],
+      isConnected: true,
+      isRunning: true,
+      clearOutputs: mocks.clearOutputs,
+    });
+
+    renderWithProviders(
+      <AgentPanel
+        task={createMockTask({
+          id: 'task-agent-stopped',
+          git: { repo: 'veritas', branch: 'stopped', baseBranch: 'main', worktreePath: '/tmp' },
+        })}
+      />
+    );
+
+    expect(screen.queryByText('Running')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Stop agent' })).toBeNull();
+    expect(screen.getByText('Agent output will appear here')).toBeDefined();
+  });
+
+  it('preserves a realtime start signal while idle status is refreshing', () => {
+    mocks.useAgentStatus.mockReturnValue({
+      data: { running: false },
+      error: null,
+      isFetching: true,
+    });
+    mocks.useAgentStream.mockReturnValue({
+      outputs: [],
+      isConnected: true,
+      isRunning: true,
+      clearOutputs: mocks.clearOutputs,
+    });
+
+    renderWithProviders(
+      <AgentPanel
+        task={createMockTask({
+          id: 'task-agent-starting-externally',
+          git: { repo: 'veritas', branch: 'external', baseBranch: 'main', worktreePath: '/tmp' },
+        })}
+      />
+    );
+
+    expect(screen.getByText('Running')).toBeDefined();
+  });
+
+  it('disables an open stop confirmation when refreshed capability evidence fails', async () => {
+    const user = userEvent.setup();
+    const supportedStatus = {
+      running: true,
+      attemptId: 'attempt-1',
+      controls: {
+        controls: [
+          {
+            action: 'stop',
+            capabilityId: 'run.stop',
+            state: 'supported',
+            available: true,
+            advisory: false,
+            reason: 'Stop is supported.',
+          },
+        ],
+      },
+    };
+    mocks.useAgentStatus.mockReturnValue({ data: supportedStatus, error: null });
+    mocks.useAgentStream.mockReturnValue({
+      outputs: [],
+      isConnected: true,
+      isRunning: true,
+      clearOutputs: mocks.clearOutputs,
+    });
+    const task = createMockTask({
+      id: 'task-agent-stop-race',
+      git: { repo: 'veritas', branch: 'stop-race', baseBranch: 'main', worktreePath: '/tmp' },
+    });
+    const { rerender } = renderWithProviders(<AgentPanel task={task} />);
+
+    await user.click(screen.getByRole('button', { name: 'Stop agent' }));
+    mocks.useAgentStatus.mockReturnValue({
+      data: supportedStatus,
+      error: new Error('Runtime manifest status refresh failed.'),
+    });
+    rerender(<AgentPanel task={task} />);
+
+    const confirm = screen.getByRole('button', { name: 'Stop Agent' });
+    expect(confirm.getAttribute('disabled')).not.toBeNull();
+    expect(
+      screen.getByText('Stop unavailable: Runtime manifest status refresh failed.')
+    ).toBeDefined();
+    expect(mocks.stopAgentMutate).not.toHaveBeenCalled();
   });
 
   it('applies a template through direct Mantine modal, tabs, select, switch, and inputs', async () => {

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -21,6 +21,18 @@ vi.mock('@/hooks/useDebouncedSave', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useWebSocket', () => ({
+  useWebSocket: () => ({
+    isConnected: false,
+    connectionState: 'disconnected',
+    reconnectAttempt: 0,
+    send: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    lastMessage: null,
+  }),
+}));
+
 vi.mock('@/hooks/useTaskTypes', () => ({
   useTaskTypes: () => ({
     data: [

--- a/web/src/__tests__/task-work-view-mantine.test.tsx
+++ b/web/src/__tests__/task-work-view-mantine.test.tsx
@@ -128,7 +128,24 @@ describe('task work view Mantine surface', () => {
     const user = userEvent.setup();
     mocks.useTaskWorkProducts.mockReturnValue({ data: [product], isLoading: false });
     mocks.useAgentStatus.mockReturnValue({
-      data: { running: true, attemptId: 'attempt-1', agent: 'veritas', status: 'running' },
+      data: {
+        running: true,
+        attemptId: 'attempt-1',
+        agent: 'veritas',
+        status: 'running',
+        controls: {
+          controls: [
+            {
+              action: 'stop',
+              capabilityId: 'run.stop',
+              state: 'supported',
+              available: true,
+              advisory: false,
+              reason: 'Stop is supported.',
+            },
+          ],
+        },
+      },
     });
     mocks.useAgentStream.mockReturnValue({
       outputs: [
@@ -256,13 +273,134 @@ describe('task work view Mantine surface', () => {
     await user.click(screen.getByRole('button', { name: 'Open Workflow' }));
     await user.click(screen.getByRole('button', { name: 'Work Products' }));
     await user.click(screen.getByRole('button', { name: 'Workflow' }));
-    await user.click(screen.getByRole('button', { name: 'Stop' }));
+    await user.click(screen.getByRole('button', { name: 'Stop active run' }));
     await user.click(screen.getByRole('button', { name: 'Stop Agent' }));
 
     expect(mocks.onOpenTab).toHaveBeenCalledWith('agent');
     expect(mocks.onOpenTab).toHaveBeenCalledWith('work-products');
     expect(mocks.onOpenWorkflow).toHaveBeenCalled();
-    expect(mocks.stopAgentMutate).toHaveBeenCalledWith('task-work');
+    expect(mocks.stopAgentMutate).toHaveBeenCalledWith({
+      taskId: 'task-work',
+      attemptId: 'attempt-1',
+    });
+  });
+
+  it('does not show a stopped run from stale task and WebSocket state', () => {
+    mocks.useAgentStatus.mockReturnValue({
+      data: { running: false },
+      error: null,
+      isFetching: false,
+    });
+    mocks.useAgentStream.mockReturnValue({
+      outputs: [],
+      isConnected: true,
+      isRunning: true,
+    });
+
+    renderWorkView(
+      createMockTask({
+        id: 'task-work-stopped',
+        status: 'in-progress',
+        git: {
+          repo: 'veritas',
+          branch: 'stopped',
+          baseBranch: 'main',
+          worktreePath: '/tmp',
+        },
+        attempt: {
+          id: 'attempt-stopped',
+          agent: 'codex',
+          status: 'running',
+        },
+      })
+    );
+
+    expect(screen.getAllByText('Failed').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Live')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Stop active run' })).toBeNull();
+  });
+
+  it('disables the Work view stop control when the persisted manifest cannot stop', () => {
+    mocks.useAgentStatus.mockReturnValue({
+      data: {
+        running: true,
+        controls: {
+          controls: [
+            {
+              action: 'stop',
+              capabilityId: 'run.stop',
+              state: 'unsupported',
+              available: false,
+              advisory: false,
+              reason: 'This provider cannot stop the active run.',
+            },
+          ],
+        },
+      },
+    });
+    const task = createMockTask({
+      id: 'task-stop-unsupported',
+      type: 'code',
+      status: 'in-progress',
+      attempt: {
+        id: 'attempt-stop-unsupported',
+        agent: 'openclaw',
+        status: 'running',
+        started: '2026-06-01T11:00:00.000Z',
+      },
+    });
+
+    renderWorkView(task);
+
+    expect(
+      screen
+        .getByRole('button', {
+          name: 'Stop active run unavailable: This provider cannot stop the active run.',
+        })
+        .getAttribute('disabled')
+    ).not.toBeNull();
+  });
+
+  it('does not reuse cached enabled controls after a stale status refetch error', () => {
+    mocks.useAgentStatus.mockReturnValue({
+      data: {
+        running: true,
+        controls: {
+          controls: [
+            {
+              action: 'stop',
+              capabilityId: 'run.stop',
+              state: 'supported',
+              available: true,
+              advisory: false,
+              reason: 'Cached stop evidence was supported.',
+            },
+          ],
+        },
+      },
+      error: new Error('Provider runtime manifest is stale or invalid: digest mismatch'),
+    });
+    const task = createMockTask({
+      id: 'task-stop-stale',
+      type: 'code',
+      status: 'in-progress',
+      attempt: {
+        id: 'attempt-stop-stale',
+        agent: 'codex',
+        status: 'running',
+        started: '2026-06-01T11:00:00.000Z',
+      },
+    });
+
+    renderWorkView(task);
+
+    expect(
+      screen
+        .getByRole('button', {
+          name: 'Stop active run unavailable: Provider runtime manifest is stale or invalid: digest mismatch',
+        })
+        .getAttribute('disabled')
+    ).not.toBeNull();
   });
 
   it('skips unsafe work product source links in the Work view', () => {

--- a/web/src/__tests__/use-agent-status-refresh.test.ts
+++ b/web/src/__tests__/use-agent-status-refresh.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AGENT_STATUS_ACTIVE_REFETCH_MS,
+  AGENT_STATUS_IDLE_REFETCH_MS,
+  agentStatusRefetchInterval,
+  useAgentStream,
+} from '@/hooks/useAgent';
+
+const socketMocks = vi.hoisted(() => ({
+  options: null as null | { onMessage?: (message: Record<string, unknown>) => void },
+  send: vi.fn(),
+  useWebSocket: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWebSocket', () => ({
+  useWebSocket: socketMocks.useWebSocket,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  socketMocks.options = null;
+  socketMocks.useWebSocket.mockImplementation((options) => {
+    socketMocks.options = options;
+    return {
+      isConnected: true,
+      send: socketMocks.send,
+    };
+  });
+});
+
+describe('agent status refresh cadence', () => {
+  it('keeps low-frequency discovery active while idle', () => {
+    expect(agentStatusRefetchInterval(false)).toBe(AGENT_STATUS_IDLE_REFETCH_MS);
+    expect(agentStatusRefetchInterval(undefined)).toBe(AGENT_STATUS_IDLE_REFETCH_MS);
+  });
+
+  it('uses the faster cadence while a run is active', () => {
+    expect(agentStatusRefetchInterval(true)).toBe(AGENT_STATUS_ACTIVE_REFETCH_MS);
+  });
+
+  it('clears prior output when a replacement attempt is discovered', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result, rerender } = renderHook(
+      ({ attemptId }: { attemptId: string }) => useAgentStream('task-runtime', attemptId),
+      {
+        initialProps: { attemptId: 'attempt-1' },
+        wrapper,
+      }
+    );
+
+    act(() => {
+      socketMocks.options?.onMessage?.({
+        type: 'agent:output',
+        outputType: 'stdout',
+        content: 'prior attempt output',
+        timestamp: '2026-07-16T08:00:00.000Z',
+      });
+    });
+    expect(result.current.outputs).toHaveLength(1);
+
+    rerender({ attemptId: 'attempt-2' });
+
+    expect(result.current.outputs).toEqual([]);
+  });
+});

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -1,6 +1,7 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   ActionIcon,
+  Alert,
   Badge,
   Button,
   Modal,
@@ -35,6 +36,7 @@ import {
 } from '@/hooks/useSandboxPolicies';
 import {
   Bot,
+  AlertCircle,
   Plus,
   Pencil,
   Trash2,
@@ -68,6 +70,7 @@ import type {
   AgentProfilePackageSummary,
   SandboxPolicyDryRunResult,
   SandboxPolicyPreset,
+  ProviderRuntimeManifest,
 } from '@veritas-kanban/shared';
 import type {
   CodexHealthStatus,
@@ -1151,10 +1154,23 @@ function SandboxPoliciesSection({
   const updatePreset = useUpdateSandboxPolicy();
   const deletePreset = useDeleteSandboxPolicy();
   const validatePreset = useValidateSandboxPolicy();
+  const { data: hostHealth } = useAgentHosts();
   const [editingPreset, setEditingPreset] = useState<SandboxPolicyPreset | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [previewPresetId, setPreviewPresetId] = useState<string>('');
   const [previewProvider, setPreviewProvider] = useState<AgentProvider>('codex-sdk');
+  const [previewState, setPreviewState] = useState<
+    | { status: 'idle' }
+    | { status: 'pending'; key: string; epoch: number }
+    | {
+        status: 'success';
+        key: string;
+        epoch: number;
+        data: SandboxPolicyDryRunResult & { traceId?: string };
+      }
+    | { status: 'error'; key: string; epoch: number; message: string }
+  >({ status: 'idle' });
+  const previewSelectionRef = useRef({ key: '', epoch: 0 });
 
   useEffect(() => {
     if (!previewPresetId && presets.length > 0) {
@@ -1174,15 +1190,66 @@ function SandboxPoliciesSection({
   }, [agents]);
 
   const selectedPreset = presets.find((preset) => preset.id === previewPresetId);
-  const validation = validatePreset.data as
-    (SandboxPolicyDryRunResult & { traceId?: string }) | undefined;
+  const previewManifest = useMemo<ProviderRuntimeManifest | undefined>(() => {
+    const provider = previewProvider.toLowerCase();
+    return hostHealth?.hosts
+      .filter((host) => host.posture === 'connected')
+      .flatMap((host) => host.providerRuntimeManifests)
+      .filter(
+        (manifest) =>
+          manifest.provider.toLowerCase() === provider ||
+          manifest.adapter.toLowerCase() === provider
+      )
+      .sort((left, right) => right.probe.probedAt.localeCompare(left.probe.probedAt))[0];
+  }, [hostHealth?.hosts, previewProvider]);
+  const previewSelectionKey = `${selectedPreset?.id ?? ''}\u0000${previewProvider.toLowerCase()}\u0000${previewManifest?.digest ?? ''}`;
+  if (previewSelectionRef.current.key !== previewSelectionKey) {
+    previewSelectionRef.current = {
+      key: previewSelectionKey,
+      epoch: previewSelectionRef.current.epoch + 1,
+    };
+  }
+  const previewStateIsCurrent =
+    previewState.status !== 'idle' &&
+    previewState.key === previewSelectionRef.current.key &&
+    previewState.epoch === previewSelectionRef.current.epoch;
+  const validation =
+    previewStateIsCurrent && previewState.status === 'success' ? previewState.data : undefined;
+  const validationError =
+    previewStateIsCurrent && previewState.status === 'error' ? previewState.message : undefined;
+  const validationPending = previewStateIsCurrent && previewState.status === 'pending';
 
-  const handlePreview = () => {
-    if (!selectedPreset) return;
-    validatePreset.mutate({
-      presetId: selectedPreset.id,
-      provider: previewProvider,
-    });
+  const handlePreview = async () => {
+    if (!selectedPreset || !previewManifest) return;
+    const selection = { ...previewSelectionRef.current };
+    setPreviewState({ status: 'pending', ...selection });
+    try {
+      const data = await validatePreset.mutateAsync({
+        presetId: selectedPreset.id,
+        provider: previewProvider,
+        providerRuntimeManifestDigest: previewManifest.digest,
+      });
+      if (
+        previewSelectionRef.current.key === selection.key &&
+        previewSelectionRef.current.epoch === selection.epoch
+      ) {
+        setPreviewState({ status: 'success', ...selection, data });
+      }
+    } catch (error) {
+      if (
+        previewSelectionRef.current.key === selection.key &&
+        previewSelectionRef.current.epoch === selection.epoch
+      ) {
+        setPreviewState({
+          status: 'error',
+          ...selection,
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Sandbox validation failed. Refresh host readiness and try again.',
+        });
+      }
+    }
   };
 
   const handleSavePreset = (preset: SandboxPolicyPreset) => {
@@ -1351,14 +1418,31 @@ function SandboxPoliciesSection({
               allowDeselect={false}
             />
           </div>
+          {!previewManifest && (
+            <p className="text-xs text-yellow-600 dark:text-yellow-400">
+              No validated live manifest is registered for this provider. The check will fail
+              closed.
+            </p>
+          )}
           <Button
             size="xs"
             variant="light"
             onClick={handlePreview}
-            disabled={!selectedPreset || validatePreset.isPending}
+            disabled={!selectedPreset || !previewManifest || validationPending}
+            title={
+              previewManifest
+                ? 'Run dry sandbox check'
+                : 'A live registered provider manifest is required'
+            }
           >
-            {validatePreset.isPending ? 'Checking...' : 'Run Dry Check'}
+            {validationPending ? 'Checking...' : 'Run Dry Check'}
           </Button>
+
+          {validationError && (
+            <Alert color="red" icon={<AlertCircle className="h-4 w-4" />}>
+              {validationError}
+            </Alert>
+          )}
 
           {validation && (
             <div className="space-y-2">

--- a/web/src/components/task/AgentPanel.tsx
+++ b/web/src/components/task/AgentPanel.tsx
@@ -66,8 +66,15 @@ const attemptStatusIcons: Record<AttemptStatus, React.ReactNode> = {
 
 export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
   const { data: config } = useConfig();
-  const { data: agentStatus } = useAgentStatus(task.id);
-  const { outputs, isConnected, isRunning, clearOutputs } = useAgentStream(task.id);
+  const {
+    data: agentStatus,
+    error: agentStatusError,
+    isFetching: isAgentStatusFetching,
+  } = useAgentStatus(task.id);
+  const { outputs, isConnected, isRunning, clearOutputs } = useAgentStream(
+    task.id,
+    agentStatus?.attemptId
+  );
   const { data: attempts, refetch: refetchAttempts } = useAgentAttempts(task.id);
   const { data: routingResult } = useResolveAgent(task.id);
   const { authContext, hasPermission } = useIdentity();
@@ -167,16 +174,18 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
   };
 
   const handleStop = () => {
-    stopAgent.mutate(task.id);
+    if (!canStop || !agentStatus?.attemptId) return;
+    stopAgent.mutate({ taskId: task.id, attemptId: agentStatus.attemptId });
     setStopDialogOpen(false);
   };
 
   const handleSendMessage = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!message.trim()) return;
+    if (!message.trim() || !canSendMessage || !agentStatus?.attemptId) return;
 
     sendMessage.mutate({
       taskId: task.id,
+      attemptId: agentStatus.attemptId,
       message: message.trim(),
     });
     setMessage('');
@@ -185,8 +194,32 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
   // Check if we can start an agent
   const canControlAgent =
     clientAllowsLocalAgentControls(authContext) && hasPermission('agent:write');
-  const canStart = canControlAgent && task.git?.worktreePath && !isRunning && !agentStatus?.running;
-  const isAgentRunning = isRunning || agentStatus?.running;
+  // The polled status is authoritative once it settles. While a realtime start
+  // signal refreshes a stale idle snapshot, preserve the stream's running state.
+  const isAgentRunning = agentStatus?.running === true || (isAgentStatusFetching && isRunning);
+  const canStart = canControlAgent && task.git?.worktreePath && !isAgentRunning;
+  const stopControl = agentStatus?.controls?.controls.find((control) => control.action === 'stop');
+  const messageControl = agentStatus?.controls?.controls.find(
+    (control) => control.action === 'message'
+  );
+  const statusErrorReason =
+    agentStatusError instanceof Error
+      ? agentStatusError.message
+      : agentStatusError
+        ? 'Provider runtime status could not be validated.'
+        : undefined;
+  const stopReason =
+    statusErrorReason ??
+    stopControl?.reason ??
+    'Validated stop capability evidence is not available for this run.';
+  const messageReason =
+    statusErrorReason ??
+    messageControl?.reason ??
+    'Validated steer capability evidence is not available for this run.';
+  const hasActiveAttempt = Boolean(agentStatus?.attemptId);
+  const canStop = !agentStatusError && hasActiveAttempt && stopControl?.available === true;
+  const canSendMessage =
+    !agentStatusError && hasActiveAttempt && messageControl?.available === true;
 
   if (!task.git?.worktreePath) {
     return (
@@ -326,11 +359,28 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
                   color="red"
                   leftSection={<Square className="h-4 w-4" />}
                   onClick={() => setStopDialogOpen(true)}
+                  disabled={!canStop}
+                  aria-label={canStop ? 'Stop agent' : `Stop agent unavailable: ${stopReason}`}
+                  title={canStop ? 'Stop agent' : stopReason}
                 >
                   Stop
                 </Button>
               )}
             </Group>
+          )}
+
+          {isAgentRunning && canControlAgent && (!canStop || !canSendMessage) && (
+            <Alert
+              color="yellow"
+              icon={<ShieldAlert className="h-4 w-4" />}
+              title="Provider runtime controls are limited"
+              className="m-2"
+            >
+              <Stack gap={4}>
+                {!canStop && <Text size="xs">Stop: {stopReason}</Text>}
+                {!canSendMessage && <Text size="xs">Message: {messageReason}</Text>}
+              </Stack>
+            </Alert>
           )}
 
           {/* Output */}
@@ -371,8 +421,23 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
                 onChange={(e) => setMessage(e.currentTarget.value)}
                 placeholder="Send a message to the agent..."
                 className="flex-1 h-8 text-sm"
+                disabled={!canSendMessage}
+                aria-label={
+                  canSendMessage
+                    ? 'Send a message to the agent'
+                    : `Message unavailable: ${messageReason}`
+                }
+                title={canSendMessage ? undefined : messageReason}
               />
-              <Button type="submit" size="sm" disabled={!message.trim() || sendMessage.isPending}>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={!canSendMessage || !message.trim() || sendMessage.isPending}
+                aria-label={
+                  canSendMessage ? 'Send message' : `Send message unavailable: ${messageReason}`
+                }
+                title={canSendMessage ? 'Send message' : messageReason}
+              >
                 <Send className="h-4 w-4" />
               </Button>
             </form>
@@ -537,11 +602,21 @@ export function AgentPanel({ task, onOpenTimeline }: AgentPanelProps) {
             <Text size="sm" c="dimmed">
               This will terminate the running agent. The attempt will be marked as failed.
             </Text>
+            {!canStop && (
+              <Alert color="yellow" icon={<AlertCircle className="h-4 w-4" />}>
+                Stop unavailable: {stopReason}
+              </Alert>
+            )}
             <Group justify="flex-end" gap="xs">
               <Button variant="default" onClick={() => setStopDialogOpen(false)}>
                 Cancel
               </Button>
-              <Button color="red" onClick={handleStop}>
+              <Button
+                color="red"
+                disabled={!canStop || stopAgent.isPending}
+                title={canStop ? 'Stop Agent' : stopReason}
+                onClick={handleStop}
+              >
                 Stop Agent
               </Button>
             </Group>

--- a/web/src/components/task/RunSessionSharesSection.tsx
+++ b/web/src/components/task/RunSessionSharesSection.tsx
@@ -37,7 +37,7 @@ import {
   useSendRunSessionMessage,
   useUpdateRunSessionShare,
 } from '@/hooks/useRunSessions';
-import { useAgentStream } from '@/hooks/useAgent';
+import { useAgentStatus, useAgentStream } from '@/hooks/useAgent';
 import { useToast } from '@/hooks/useToast';
 import { sanitizeText } from '@/lib/sanitize';
 import { useIdentity } from '@/hooks/useIdentity';
@@ -206,8 +206,12 @@ export function RunSessionSharesSection({ task, isAgentRunning }: RunSessionShar
 export function RunSessionShareView({ shareId }: { shareId: string }) {
   const { authContext } = useIdentity();
   const { data: share, isLoading, error } = useRunSession(shareId);
+  const { data: agentStatus, error: agentStatusError } = useAgentStatus(share?.taskId);
   const { data: events = [] } = useRunSessionEvents(shareId);
-  const { outputs, isConnected } = useAgentStream(share?.taskId);
+  const pinnedAttemptActive = Boolean(
+    share && !agentStatusError && agentStatus?.running && agentStatus.attemptId === share.sourceId
+  );
+  const { outputs, isConnected } = useAgentStream(pinnedAttemptActive ? share?.taskId : undefined);
   const sendMessage = useSendRunSessionMessage();
   const respondToApproval = useRunSessionApprovalResponse();
   const forkSession = useForkRunSession();
@@ -239,7 +243,7 @@ export function RunSessionShareView({ shareId }: { shareId: string }) {
 
   const handleSendMessage = async () => {
     const trimmed = message.trim();
-    if (!trimmed) return;
+    if (!trimmed || !messageControlAvailable) return;
     try {
       await sendMessage.mutateAsync({ shareId: share.id, input: { message: trimmed } });
       setMessage('');
@@ -251,7 +255,41 @@ export function RunSessionShareView({ shareId }: { shareId: string }) {
     }
   };
 
+  const messageControl = agentStatus?.controls?.controls.find(
+    (control) => control.action === 'message'
+  );
+  const approvalControl = agentStatus?.controls?.controls.find(
+    (control) => control.action === 'approvals'
+  );
+  const attemptReason =
+    share && agentStatus?.attemptId && agentStatus.attemptId !== share.sourceId
+      ? 'This link is pinned to an earlier attempt and cannot control its replacement.'
+      : !agentStatus?.running
+        ? 'The shared attempt is no longer active.'
+        : undefined;
+  const messageControlAvailable = pinnedAttemptActive && messageControl?.available === true;
+  const messageControlReason =
+    (agentStatusError instanceof Error
+      ? agentStatusError.message
+      : agentStatusError
+        ? 'Provider runtime status could not be validated.'
+        : undefined) ??
+    attemptReason ??
+    messageControl?.reason ??
+    'Validated steer capability evidence is not available for this run.';
+  const approvalControlAvailable = pinnedAttemptActive && approvalControl?.available === true;
+  const approvalControlReason =
+    (agentStatusError instanceof Error
+      ? agentStatusError.message
+      : agentStatusError
+        ? 'Provider runtime status could not be validated.'
+        : undefined) ??
+    attemptReason ??
+    approvalControl?.reason ??
+    'Validated provider approval evidence is not available for this run.';
+
   const handleApproval = async (response: 'approved' | 'rejected') => {
+    if (!approvalControlAvailable) return;
     try {
       await respondToApproval.mutateAsync({
         shareId: share.id,
@@ -307,7 +345,9 @@ export function RunSessionShareView({ shareId }: { shareId: string }) {
             <Badge variant="outline" color={share.status === 'active' ? 'green' : 'red'}>
               {share.status}
             </Badge>
-            <Badge variant="outline">{isConnected ? 'Connected' : 'Disconnected'}</Badge>
+            <Badge variant="outline">
+              {pinnedAttemptActive && isConnected ? 'Connected' : 'Disconnected'}
+            </Badge>
           </Group>
         </div>
         <CopyButton value={shareUrl}>
@@ -347,12 +387,12 @@ export function RunSessionShareView({ shareId }: { shareId: string }) {
           <Text size="sm" fw={600}>
             Live Output
           </Text>
-          <Badge variant="dot" color={share.snapshot.running ? 'green' : 'gray'}>
-            {share.snapshot.running ? 'running' : 'not running'}
+          <Badge variant="dot" color={pinnedAttemptActive ? 'green' : 'gray'}>
+            {pinnedAttemptActive ? 'running' : 'not running'}
           </Badge>
         </Group>
         <div className="h-[320px] overflow-y-auto bg-zinc-950 p-3 font-mono text-xs text-zinc-200">
-          {outputs.length === 0 ? (
+          {!pinnedAttemptActive || outputs.length === 0 ? (
             <Text size="xs" c="dimmed">
               No live output received in this viewer.
             </Text>
@@ -380,8 +420,30 @@ export function RunSessionShareView({ shareId }: { shareId: string }) {
               value={message}
               onChange={(event) => setMessage(event.currentTarget.value)}
               placeholder="Send an attributed message into the run..."
+              disabled={!messageControlAvailable}
+              aria-label={
+                messageControlAvailable
+                  ? 'Co-drive message'
+                  : `Co-drive message unavailable: ${messageControlReason}`
+              }
             />
-            <Button size="xs" loading={sendMessage.isPending} onClick={handleSendMessage}>
+            {!messageControlAvailable && (
+              <Alert color="yellow" icon={<AlertCircle className="h-4 w-4" />}>
+                Message unavailable: {messageControlReason}
+              </Alert>
+            )}
+            <Button
+              size="xs"
+              loading={sendMessage.isPending}
+              disabled={!messageControlAvailable || !message.trim()}
+              aria-label={
+                messageControlAvailable
+                  ? 'Send Message'
+                  : `Send Message unavailable: ${messageControlReason}`
+              }
+              title={messageControlAvailable ? 'Send Message' : messageControlReason}
+              onClick={handleSendMessage}
+            >
               Send Message
             </Button>
           </Stack>
@@ -404,6 +466,7 @@ export function RunSessionShareView({ shareId }: { shareId: string }) {
               onChange={(value) => setApprovalClass(value || 'human-review')}
               data={share.mobileSafeApprovalClasses.map((item) => ({ value: item, label: item }))}
               checkIconPosition="right"
+              disabled={!approvalControlAvailable}
             />
             {mobileClient && (
               <Text size="xs" c="dimmed">
@@ -415,15 +478,28 @@ export function RunSessionShareView({ shareId }: { shareId: string }) {
               size="xs"
               value={approvalNote}
               onChange={(event) => setApprovalNote(event.currentTarget.value)}
+              disabled={!approvalControlAvailable}
             />
+            {!approvalControlAvailable && (
+              <Alert color="yellow" icon={<AlertCircle className="h-4 w-4" />}>
+                Approval unavailable: {approvalControlReason}
+              </Alert>
+            )}
             <Group gap="xs">
-              <Button size="xs" onClick={() => handleApproval('approved')}>
+              <Button
+                size="xs"
+                disabled={!approvalControlAvailable}
+                title={approvalControlAvailable ? 'Approve' : approvalControlReason}
+                onClick={() => handleApproval('approved')}
+              >
                 Approve
               </Button>
               <Button
                 size="xs"
                 color="red"
                 variant="light"
+                disabled={!approvalControlAvailable}
+                title={approvalControlAvailable ? 'Reject' : approvalControlReason}
                 onClick={() => handleApproval('rejected')}
               >
                 Reject

--- a/web/src/components/task/TaskWorkView.tsx
+++ b/web/src/components/task/TaskWorkView.tsx
@@ -365,8 +365,12 @@ export function TaskWorkView({
 }: TaskWorkViewProps) {
   const [stopConfirmOpen, setStopConfirmOpen] = useState(false);
   const { data: workProducts = [], isLoading: workProductsLoading } = useTaskWorkProducts(task.id);
-  const { data: agentStatus } = useAgentStatus(task.id);
-  const { outputs, isConnected, isRunning } = useAgentStream(task.id);
+  const {
+    data: agentStatus,
+    error: agentStatusError,
+    isFetching: isAgentStatusFetching,
+  } = useAgentStatus(task.id);
+  const { outputs, isConnected, isRunning } = useAgentStream(task.id, agentStatus?.attemptId);
   const { data: activeWorkflowRuns = [], isLoading: activeWorkflowRunsLoading } = useActiveRuns();
   const { data: recentWorkflowRuns = [], isLoading: recentWorkflowRunsLoading } = useRecentRuns();
   const stopAgent = useStopAgent();
@@ -384,12 +388,25 @@ export function TaskWorkView({
   const verification = getVerificationSummary(task);
   const latestWorkProducts = workProducts.slice(0, 3);
   const latestOutputs = outputs.slice(-6);
+  const taskAttemptActive =
+    task.attempt?.status === 'running' || task.attempt?.status === 'pending';
   const activeRun =
-    isRunning ||
-    agentStatus?.running ||
-    task.attempt?.status === 'running' ||
-    task.attempt?.status === 'pending';
-  const retryableRun = task.attempt?.status === 'failed' || task.attempt?.status === 'complete';
+    agentStatus?.running === true ||
+    ((agentStatus === undefined || isAgentStatusFetching) && (isRunning || taskAttemptActive));
+  const effectiveAttemptStatus =
+    !activeRun && taskAttemptActive ? ('failed' as const) : task.attempt?.status;
+  const retryableRun = effectiveAttemptStatus === 'failed' || effectiveAttemptStatus === 'complete';
+  const stopControl = agentStatus?.controls?.controls.find((control) => control.action === 'stop');
+  const canStop =
+    !agentStatusError && Boolean(agentStatus?.attemptId) && stopControl?.available === true;
+  const stopReason =
+    (agentStatusError instanceof Error
+      ? agentStatusError.message
+      : agentStatusError
+        ? 'Provider runtime status could not be validated.'
+        : undefined) ??
+    stopControl?.reason ??
+    'Validated stop capability evidence is not available for this run.';
   const attemptDuration = getAttemptDurationMs(task.attempt);
   const trackedTime = formatTrackedSeconds(task.timeTracking?.totalSeconds);
   const runCost = formatCost(task.actualCost);
@@ -437,7 +454,8 @@ export function TaskWorkView({
   };
 
   const handleStopAgent = () => {
-    stopAgent.mutate(task.id);
+    if (!canStop || !agentStatus?.attemptId) return;
+    stopAgent.mutate({ taskId: task.id, attemptId: agentStatus.attemptId });
     setStopConfirmOpen(false);
   };
 
@@ -488,8 +506,8 @@ export function TaskWorkView({
                     Live Session
                   </Text>
                 </Group>
-                <Badge color={getAttemptColor(task.attempt?.status)} variant="light">
-                  {formatAttemptStatus(task.attempt?.status)}
+                <Badge color={getAttemptColor(effectiveAttemptStatus)} variant="light">
+                  {formatAttemptStatus(effectiveAttemptStatus)}
                 </Badge>
               </Group>
               {task.attempt ? (
@@ -620,10 +638,10 @@ export function TaskWorkView({
                   <Terminal className="h-4 w-4 text-muted-foreground" />
                   <Text fw={600}>Activity Console</Text>
                   <Badge
-                    color={activeRun ? 'blue' : getAttemptColor(task.attempt?.status)}
+                    color={activeRun ? 'blue' : getAttemptColor(effectiveAttemptStatus)}
                     variant="light"
                   >
-                    {activeRun ? 'Live' : formatAttemptStatus(task.attempt?.status)}
+                    {activeRun ? 'Live' : formatAttemptStatus(effectiveAttemptStatus)}
                   </Badge>
                   {isConnected ? (
                     <Wifi className="h-3 w-3 text-green-500" />
@@ -647,6 +665,11 @@ export function TaskWorkView({
                     leftSection={<Square className="h-3 w-3" />}
                     loading={stopAgent.isPending}
                     onClick={() => setStopConfirmOpen(true)}
+                    disabled={!canStop}
+                    aria-label={
+                      canStop ? 'Stop active run' : `Stop active run unavailable: ${stopReason}`
+                    }
+                    title={canStop ? 'Stop active run' : stopReason}
                   >
                     Stop
                   </Button>
@@ -1008,7 +1031,13 @@ export function TaskWorkView({
             <Button variant="default" onClick={() => setStopConfirmOpen(false)}>
               Cancel
             </Button>
-            <Button color="red" loading={stopAgent.isPending} onClick={handleStopAgent}>
+            <Button
+              color="red"
+              loading={stopAgent.isPending}
+              onClick={handleStopAgent}
+              disabled={!canStop}
+              title={canStop ? 'Stop agent' : stopReason}
+            >
               Stop Agent
             </Button>
           </Group>

--- a/web/src/hooks/useAgent.ts
+++ b/web/src/hooks/useAgent.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api, AgentOutput } from '@/lib/api';
 import { apiFetch, API_BASE } from '@/lib/api/helpers';
@@ -8,6 +8,7 @@ import type {
   AgentHealthClassificationResponse,
   AgentHostPreviewRequest,
   AgentType,
+  ProviderRuntimeCapabilityId,
 } from '@veritas-kanban/shared';
 
 export interface StartAgentInput {
@@ -17,6 +18,7 @@ export interface StartAgentInput {
   overrideReason?: string;
   sandboxPresetId?: string;
   budget?: AgentBudgetPolicy;
+  requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
 }
 
 export interface AgentApprovalRequest {
@@ -31,6 +33,13 @@ export interface AgentApprovalRequest {
   createdAt: string;
 }
 
+export const AGENT_STATUS_ACTIVE_REFETCH_MS = 2_000;
+export const AGENT_STATUS_IDLE_REFETCH_MS = 10_000;
+
+export function agentStatusRefetchInterval(running: boolean | undefined): number {
+  return running ? AGENT_STATUS_ACTIVE_REFETCH_MS : AGENT_STATUS_IDLE_REFETCH_MS;
+}
+
 function requiredQueryParam(value: string | undefined, name: string): string {
   if (!value) {
     throw new Error(`${name} is required`);
@@ -43,7 +52,8 @@ export function useAgentStatus(taskId: string | undefined) {
     queryKey: ['agent', 'status', taskId],
     queryFn: () => api.agent.status(requiredQueryParam(taskId, 'taskId')),
     enabled: !!taskId,
-    refetchInterval: (query) => (query.state.data?.running ? 2000 : false),
+    refetchInterval: (query) => agentStatusRefetchInterval(query.state.data?.running),
+    refetchIntervalInBackground: true,
   });
 }
 
@@ -58,8 +68,16 @@ export function useStartAgent() {
       overrideReason,
       sandboxPresetId,
       budget,
+      requiredRuntimeCapabilities,
     }: StartAgentInput) =>
-      api.agent.start(taskId, { agent, profileId, overrideReason, sandboxPresetId, budget }),
+      api.agent.start(taskId, {
+        agent,
+        profileId,
+        overrideReason,
+        sandboxPresetId,
+        budget,
+        requiredRuntimeCapabilities,
+      }),
     onSuccess: (_, { taskId }) => {
       queryClient.invalidateQueries({ queryKey: ['agent', 'status', taskId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
@@ -69,8 +87,15 @@ export function useStartAgent() {
 
 export function useSendMessage() {
   return useMutation({
-    mutationFn: ({ taskId, message }: { taskId: string; message: string }) =>
-      api.agent.sendMessage(taskId, message),
+    mutationFn: ({
+      taskId,
+      attemptId,
+      message,
+    }: {
+      taskId: string;
+      attemptId: string;
+      message: string;
+    }) => api.agent.sendMessage(taskId, attemptId, message),
   });
 }
 
@@ -78,8 +103,9 @@ export function useStopAgent() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (taskId: string) => api.agent.stop(taskId),
-    onSuccess: (_, taskId) => {
+    mutationFn: ({ taskId, attemptId }: { taskId: string; attemptId: string }) =>
+      api.agent.stop(taskId, attemptId),
+    onSuccess: (_, { taskId }) => {
       queryClient.invalidateQueries({ queryKey: ['agent', 'status', taskId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
     },
@@ -150,15 +176,20 @@ export function useAgentHostPreview(request: AgentHostPreviewRequest, enabled = 
 }
 
 // WebSocket hook for real-time agent output
-export function useAgentStream(taskId: string | undefined) {
+export function useAgentStream(taskId: string | undefined, attemptId?: string) {
   const [outputs, setOutputs] = useState<AgentOutput[]>([]);
   const [isRunning, setIsRunning] = useState(false);
+  const activeAttemptRef = useRef<string | undefined>(undefined);
   const queryClient = useQueryClient();
 
   const handleMessage = useCallback(
     (message: WebSocketMessage) => {
       if (message.type === 'subscribed') {
-        setIsRunning(message.running as boolean);
+        const running = message.running as boolean;
+        setIsRunning(running);
+        if (running) {
+          queryClient.invalidateQueries({ queryKey: ['agent', 'status', taskId] });
+        }
       } else if (message.type === 'agent:output') {
         setOutputs((prev) => [
           ...prev,
@@ -183,14 +214,32 @@ export function useAgentStream(taskId: string | undefined) {
   // Clear outputs when taskId changes
   useEffect(() => {
     setOutputs([]);
+    activeAttemptRef.current = undefined;
   }, [taskId]);
 
-  const { isConnected } = useWebSocket({
+  useEffect(() => {
+    if (!attemptId) return;
+    if (activeAttemptRef.current && activeAttemptRef.current !== attemptId) {
+      setOutputs([]);
+    }
+    activeAttemptRef.current = attemptId;
+  }, [attemptId]);
+
+  const { isConnected, send } = useWebSocket({
     autoConnect: !!taskId,
     onOpen: taskId ? { type: 'subscribe', taskId } : undefined,
     onMessage: handleMessage,
     autoReconnect: false, // Don't auto-reconnect for agent streams
   });
+
+  // A client can subscribe while the task is idle and then observe a run that
+  // was started by CLI/MCP. Once idle discovery returns the new attempt, renew
+  // the task subscription so the server attaches to that attempt's emitter.
+  useEffect(() => {
+    if (isConnected && taskId && attemptId) {
+      send({ type: 'subscribe', taskId });
+    }
+  }, [attemptId, isConnected, send, taskId]);
 
   const clearOutputs = useCallback(() => {
     setOutputs([]);

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -11,6 +11,7 @@ import type {
   AgentBudgetPolicy,
   ProviderRuntimeManifest,
   ProviderRuntimeCapabilityId,
+  ProviderRuntimeControlSet,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -20,6 +21,7 @@ export interface StartAgentRequest {
   overrideReason?: string;
   sandboxPresetId?: string;
   budget?: AgentBudgetPolicy;
+  requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
 }
 
 export const worktreeApi = {
@@ -75,17 +77,19 @@ export const agentApi = {
     });
   },
 
-  sendMessage: async (taskId: string, message: string): Promise<void> => {
+  sendMessage: async (taskId: string, attemptId: string, message: string): Promise<void> => {
     return apiFetch<void>(`${API_BASE}/agents/${taskId}/message`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ attemptId, message }),
     });
   },
 
-  stop: async (taskId: string): Promise<void> => {
+  stop: async (taskId: string, attemptId: string): Promise<void> => {
     return apiFetch<void>(`${API_BASE}/agents/${taskId}/stop`, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ attemptId }),
     });
   },
 
@@ -243,6 +247,10 @@ export interface AgentStatus {
   status: string;
   pid?: number;
   startedAt?: string;
+  provider?: string;
+  model?: string;
+  providerRuntimeManifest: ProviderRuntimeManifest;
+  controls: ProviderRuntimeControlSet;
 }
 
 export interface AgentStatusResponse {
@@ -252,6 +260,10 @@ export interface AgentStatusResponse {
   agent?: AgentType;
   status?: string;
   pid?: number;
+  provider?: string;
+  model?: string;
+  providerRuntimeManifest?: ProviderRuntimeManifest;
+  controls?: ProviderRuntimeControlSet;
 }
 
 export interface AgentOutput {


### PR DESCRIPTION
## Summary

- make one persisted runtime-manifest evaluator authoritative for launch, sandbox, approval, resume, tool/MCP, output, artifact, interrupt, and steer decisions
- return capability-derived controls and concrete denial reasons consistently across API, CLI, MCP, and web surfaces
- remove provider-name inference from enforcement paths and fail closed for unknown, stale, advisory, or unsupported required capabilities
- render accessible disabled controls and remediation reasons in agent and shared-run interfaces
- harden packaged desktop startup/port selection and grant only local-agent:run after verified loopback owner-session authentication
- update provider, API, workflow, CLI, MCP, architecture, security, feature, and operator documentation

## Why

Issues #885 and #886 established evidence-backed runtime manifests and authoritative routing. This final child makes the same persisted evidence control every launch and user-visible runtime action, eliminating static provider-name assumptions and REST/WebSocket authorization drift.

## Verification

- server: 2,268 tests passed; 2 skipped
- web sequential suite: 420 tests passed
- desktop: 61 tests passed
- focused client-policy suite: 3 tests passed
- pnpm lint: 595 warnings, 0 errors
- pnpm smoke:cli-mcp: 0 failures; 2 expected skips without VK_API_KEY
- pnpm desktop:smoke:mac:local
- full build and typecheck through desktop smoke
- git diff --check and security artifact pre-commit check
- independent GPT review passed with no remaining actionable findings
- post-merge-base rebase produced a tree-equivalent commit

## Native packaged Electron QA

- fresh onboarding, setup, and login
- auth/task persistence across rebuild and restart
- collision-free port 3002 while 3001 was occupied
- Settings to Agents navigation
- fail-closed manifest dry-run with an explicit reason
- real supervised Codex run with stop available and successful
- message disabled with a manifest-derived reason
- no stale Running state after stop
- failed attempt, manifest, and duration persisted after restart

Native QA also exposed and fixed a production packaged-app regression: verified loopback password sessions lacked local-agent:run. The fix grants only that narrow capability after the existing loopback owner-session validation while production localhost bypass remains disabled. REST/WebSocket parity and regression tests are included.

## Review decision

Brad explicitly waived the opposite-model Claude gate on 2026-07-16 and authorized GPT-only review for this backlog execution.

Closes #887
Parent: #851