### PR TITLE
docs: add web-to-Mac desktop migration guide

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -42,6 +42,11 @@ can be tested without reusing the default development home.
 - Fresh packaged installs store desktop data below the OS app data directory
   returned by Electron `app.getPath('userData')`, then under
   `profiles/<profile>/workspaces/<workspace>/`.
+- Packaged desktop installs do not automatically import an existing web/source
+  checkout. Use
+  [`docs/WEB-TO-MAC-DESKTOP-MIGRATION.md`](../docs/WEB-TO-MAC-DESKTOP-MIGRATION.md)
+  when moving file-backed `tasks/` and `.veritas-kanban/` data from a repo
+  server into the Mac app's SQLite workspace.
 - Desktop runtime secrets are created through Electron `safeStorage`, which uses
   the OS credential backend on macOS. The encrypted metadata file lives at
   `<appHome>/config/desktop-secrets.json`; plaintext admin/JWT secrets are only
@@ -51,7 +56,9 @@ can be tested without reusing the default development home.
   place for manual rollback.
 - Local development mode disables app auth only for the supervised loopback
   runtime. Packaged mode keeps auth enabled and uses the keychain-backed
-  bootstrap secrets for admin and JWT signing.
+  bootstrap secrets for admin and JWT signing. Local automation that talks to
+  the packaged app must send `X-API-Key` or `Authorization: Bearer` rather than
+  assuming unauthenticated localhost writes.
 
 ## Recovery Notes
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -42,11 +42,15 @@ can be tested without reusing the default development home.
 - Fresh packaged installs store desktop data below the OS app data directory
   returned by Electron `app.getPath('userData')`, then under
   `profiles/<profile>/workspaces/<workspace>/`.
-- Packaged desktop installs do not automatically import an existing web/source
-  checkout. Use
+- Packaged desktop installs detect a populated desktop SQLite database and offer
+  **Use Existing Data** so setup can secure it without replacing board records
+  or imported owner metadata. Do not choose recovery import when the expected
+  records are already present. Packaged installs do not automatically import an
+  external web/source checkout. Use
   [`docs/WEB-TO-MAC-DESKTOP-MIGRATION.md`](../docs/WEB-TO-MAC-DESKTOP-MIGRATION.md)
-  when moving file-backed `tasks/` and `.veritas-kanban/` data from a repo
-  server into the Mac app's SQLite workspace.
+  for the already-populated case or when moving file-backed `tasks/` and
+  `.veritas-kanban/` data from a repo server into the Mac app's SQLite
+  workspace.
 - Desktop runtime secrets are created through Electron `safeStorage`, which uses
   the OS credential backend on macOS. The encrypted metadata file lives at
   `<appHome>/config/desktop-secrets.json`; plaintext admin/JWT secrets are only

--- a/docs/MIGRATION-RECOVERY.md
+++ b/docs/MIGRATION-RECOVERY.md
@@ -2,6 +2,12 @@
 
 This document defines the v5 file-to-SQLite rollback and failed-upgrade drill.
 
+For a complete packaged Mac cutover, including the already-populated desktop
+case, use
+[`WEB-TO-MAC-DESKTOP-MIGRATION.md`](WEB-TO-MAC-DESKTOP-MIGRATION.md). Never run
+file-to-SQLite migration against the authoritative database while the desktop
+server has it open, and never copy a live WAL database as a backup.
+
 ## Recovery Contract
 
 The v5 migration must never leave a project in a state where neither file
@@ -38,6 +44,12 @@ If migration fails:
 Interrupted migrations that were writing a new SQLite database use a temporary
 database path and promote it only after writes and checkpointing complete. A
 failed temporary database is removed after journaling the failure.
+
+For desktop cutover, migrate into a fresh staging database with the desktop app
+stopped. After the migration process closes the database, checkpoint it, run
+`PRAGMA quick_check`, and install it only while no process owns the desktop
+target. If the desktop database already contains the expected records, do not
+rerun migration. Back it up and use the first-launch **Use Existing Data** path.
 
 ## Restore Drill
 

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -13,14 +13,15 @@ candidate, belongs in the reusable
 
 ## Choose The Right Path
 
-| Path                    | Use when                                                    | Start here                                               | Do not configure on day one                                               |
-| ----------------------- | ----------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Local board from source | You want a personal board and dev server.                   | `docs/SETUP-PATHS.md` and `docs/GETTING-STARTED.md`.     | OpenClaw, MCP writes, Squad Chat webhooks, workflow gates, notifications. |
-| Mac desktop local       | You want the packaged desktop app and bundled local server. | This guide plus `docs/DESKTOP-RELEASE.md`.               | Remote exposure, tunnels, multi-user invitations, external webhooks.      |
-| v4 to v5 upgrade        | You have file-backed v4 data and need SQLite.               | Migration steps below plus `docs/MIGRATION-RECOVERY.md`. | Deleting old files before the SQLite migration is accepted.               |
-| Remote/server           | You want trusted LAN, VPN, reverse proxy, or tunnel access. | `docs/guides/SELF_HOST.md` and ADR 0002.                 | Public exposure without auth, HTTPS, backup, and WebSocket validation.    |
-| Mobile/PWA              | You want phone/tablet access to a trusted host.             | `docs/guides/PWA_INSTALL.md`.                            | Native offline execution or queued writes.                                |
-| Multi-user admin        | You manage workspaces, roles, invites, devices, and tokens. | `docs/IDENTITY-RBAC.md` and the admin section below.     | Sharing owner/admin tokens with agents.                                   |
+| Path                    | Use when                                                                       | Start here                                               | Do not configure on day one                                                |
+| ----------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Local board from source | You want a personal board and dev server.                                      | `docs/SETUP-PATHS.md` and `docs/GETTING-STARTED.md`.     | OpenClaw, MCP writes, Squad Chat webhooks, workflow gates, notifications.  |
+| Mac desktop local       | You want the packaged desktop app and bundled local server.                    | This guide plus `docs/DESKTOP-RELEASE.md`.               | Remote exposure, tunnels, multi-user invitations, external webhooks.       |
+| Web/source to Mac app   | You already have a file-backed source checkout and want the Mac app to own it. | `docs/WEB-TO-MAC-DESKTOP-MIGRATION.md`.                  | Running the old repo server and desktop app as competing sources of truth. |
+| v4 to v5 upgrade        | You have file-backed v4 data and need SQLite.                                  | Migration steps below plus `docs/MIGRATION-RECOVERY.md`. | Deleting old files before the SQLite migration is accepted.                |
+| Remote/server           | You want trusted LAN, VPN, reverse proxy, or tunnel access.                    | `docs/guides/SELF_HOST.md` and ADR 0002.                 | Public exposure without auth, HTTPS, backup, and WebSocket validation.     |
+| Mobile/PWA              | You want phone/tablet access to a trusted host.                                | `docs/guides/PWA_INSTALL.md`.                            | Native offline execution or queued writes.                                 |
+| Multi-user admin        | You manage workspaces, roles, invites, devices, and tokens.                    | `docs/IDENTITY-RBAC.md` and the admin section below.     | Sharing owner/admin tokens with agents.                                    |
 
 ## Fresh Mac Desktop Install
 
@@ -63,7 +64,20 @@ Desktop secrets use the native safe-storage/keychain path documented in the
 desktop architecture and release docs. Do not copy raw keychain payloads between
 machines.
 
+If an existing source checkout or web/dev install already owns
+`localhost:3001`, installing the Homebrew cask does not automatically migrate
+or take ownership of that board. Follow
+[`WEB-TO-MAC-DESKTOP-MIGRATION.md`](WEB-TO-MAC-DESKTOP-MIGRATION.md) to import
+file-backed `tasks/` and `.veritas-kanban/` data into the desktop SQLite
+workspace, stop old dev servers, disable stale watchdogs, and update local
+automation for packaged desktop auth.
+
 ## v4 To v5 Upgrade
+
+For a complete operator runbook that upgrades an existing file-backed
+web/source install into the packaged Mac app, use
+[`WEB-TO-MAC-DESKTOP-MIGRATION.md`](WEB-TO-MAC-DESKTOP-MIGRATION.md). The
+summary below is the storage-level migration contract.
 
 1. Stop the app and preserve the current repo or app data directory.
 2. Run a dry-run migration:

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -39,10 +39,16 @@ candidate, belongs in the reusable
 
 2. Launch normally. A stable release should not show a Gatekeeper warning.
 3. Pick the first-run path:
-   - Board Only for a local board with no agents.
+   - Use Existing Data when the detected desktop SQLite database already
+     contains the expected board. Confirm the displayed counts before securing
+     it. Do not rerun migration or restore a backup over it.
+   - Board Only for a new, empty local board with no agents.
    - Agent Ready for local agent tooling.
    - Remote Server to pair with a trusted host.
-   - Restore to import a backup.
+   - Restore Backup is recovery preflight only in v5.2.5. The onboarding card
+     does not perform an import. For a governed SQLite export bundle, follow the
+     exact target, bundle directory, and destructive replacement steps in
+     `docs/WEB-TO-MAC-DESKTOP-MIGRATION.md`.
 4. Create the admin password and save the recovery key.
 5. Open Settings -> Maintenance and verify health checks, storage, logs, backup,
    and debug-bundle previews.
@@ -65,12 +71,12 @@ desktop architecture and release docs. Do not copy raw keychain payloads between
 machines.
 
 If an existing source checkout or web/dev install already owns
-`localhost:3001`, installing the Homebrew cask does not automatically migrate
-or take ownership of that board. Follow
-[`WEB-TO-MAC-DESKTOP-MIGRATION.md`](WEB-TO-MAC-DESKTOP-MIGRATION.md) to import
-file-backed `tasks/` and `.veritas-kanban/` data into the desktop SQLite
-workspace, stop old dev servers, disable stale watchdogs, and update local
-automation for packaged desktop auth.
+`localhost:3001`, installing the Homebrew cask does not automatically stop that
+server or update its automation. Follow
+[`WEB-TO-MAC-DESKTOP-MIGRATION.md`](WEB-TO-MAC-DESKTOP-MIGRATION.md). It covers
+both an already-populated desktop database and a file-backed
+`tasks/`/`.veritas-kanban/` source, including one-writer cutover, backups,
+watchdogs, record counts, first-launch selection, rollback, and packaged auth.
 
 ## v4 To v5 Upgrade
 
@@ -79,25 +85,34 @@ web/source install into the packaged Mac app, use
 [`WEB-TO-MAC-DESKTOP-MIGRATION.md`](WEB-TO-MAC-DESKTOP-MIGRATION.md). The
 summary below is the storage-level migration contract.
 
-1. Stop the app and preserve the current repo or app data directory.
-2. Run a dry-run migration:
+1. Determine whether the desktop SQLite database already contains the expected
+   records. If it does, preserve a backup and choose **Use Existing Data**. Do
+   not rerun migration.
+2. For an authoritative file-backed source, stop the desktop app and every
+   competing source server, then preserve the current repo data directory.
+3. Start a temporary file-storage server on a non-desktop port and run a dry-run
+   migration to a fresh staging database:
 
    ```text
    POST /api/v1/sqlite/migration/dry-run
    ```
 
-3. Review warnings for malformed tasks, duplicate IDs, missing attachments, and
+4. Review warnings for malformed tasks, duplicate IDs, missing attachments, and
    backup copy issues.
-4. Run the migration only after the dry run is clean enough to accept:
+5. Run the migration to that same fresh staging database only after the dry run
+   is clean enough to accept:
 
    ```text
    POST /api/v1/sqlite/migration/run
    ```
 
-5. Preserve the migration journal, backup directory, and report.
-6. Boot v5 with SQLite storage and verify board, task detail, search, workflow,
-   chat, settings, work products, Maintenance Center, and audit history.
-7. Accept the migration only after backup/export and restore drills pass.
+6. Stop the temporary server, checkpoint and validate the staging database, then
+   install it into the desktop workspace while no process has the target open.
+7. Launch v5, choose **Use Existing Data**, and secure the existing database.
+8. Preserve the migration journal, backup directory, and reports.
+9. Verify board, task detail, search, workflow, chat, settings, work products,
+   Maintenance Center, automation auth, and audit history.
+10. Accept the migration only after backup/export and restore drills pass.
 
 Rollback means restoring the pre-migration file-backed backup. Do not rely on
 destructive SQLite down migrations for GA users. Follow

--- a/docs/WEB-TO-MAC-DESKTOP-MIGRATION.md
+++ b/docs/WEB-TO-MAC-DESKTOP-MIGRATION.md
@@ -1,0 +1,371 @@
+# Web To Mac Desktop Migration
+
+This guide moves an existing file-backed Veritas Kanban web/source install into
+the packaged macOS desktop app.
+
+Use it when a board currently lives in a checkout such as
+`~/Projects/veritas-kanban` with file-backed data under `tasks/` and
+`.veritas-kanban/`, and the operator wants the signed Mac app installed by
+Homebrew or the GitHub release ZIP to become the owner of `localhost:3001`.
+
+The Homebrew cask installs the app. It does not automatically import a previous
+source checkout's board data, stop a development server, disable old watchdogs,
+or migrate automation tokens.
+
+## What Changes
+
+Before migration:
+
+- the old web/source install may serve `localhost:3001` from `server/src`
+  through `tsx`, `pnpm dev`, `npm run dev`, or a local watchdog
+- the source of truth is usually file-backed data in the repo root:
+  `tasks/` plus `.veritas-kanban/`
+- local automation may assume unauthenticated localhost writes
+
+After migration:
+
+- `/Applications/Veritas Kanban.app` supervises the bundled local server
+- packaged mode uses SQLite storage
+- desktop data lives under the macOS Application Support workspace
+- packaged mode keeps auth enabled, including for localhost write APIs
+- old file-backed source data remains available as rollback/source history
+
+Default desktop workspace:
+
+```text
+~/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/
+```
+
+Default desktop SQLite database:
+
+```text
+~/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/data/.veritas-kanban/veritas.db
+```
+
+## Preconditions
+
+1. Install the Mac app:
+
+   ```bash
+   brew tap BradGroux/tap
+   brew install --cask veritas-kanban
+   ```
+
+2. Confirm the old board source root. For a source checkout, this is usually:
+
+   ```bash
+   cd ~/Projects/veritas-kanban
+   test -d tasks
+   test -d .veritas-kanban
+   ```
+
+3. Confirm which process currently owns port `3001`:
+
+   ```bash
+   lsof -nP -iTCP:3001 -sTCP:LISTEN
+   ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)"
+   ```
+
+   If the command path points at `~/Projects/veritas-kanban`, the old source
+   checkout is still serving the board.
+
+4. Choose an auth method for API-driven migration:
+
+   - Preferred: create or use a scoped admin/operator API token from the
+     desktop UI and export it only for the migration shell.
+   - Acceptable for local break-glass: use the packaged desktop owner/admin
+     key only for the migration session, then clear the shell history or close
+     the terminal.
+
+   Never paste API keys into issue descriptions, task bodies, debug bundles, or
+   support notes.
+
+## Step 1: Preserve The Old Source
+
+Create a recoverable copy before any import attempt:
+
+```bash
+SOURCE_ROOT="$HOME/Projects/veritas-kanban"
+BACKUP_ROOT="$HOME/Library/Application Support/@veritas-kanban/manual-migration-backups/pre-desktop-$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$BACKUP_ROOT"
+ditto "$SOURCE_ROOT/tasks" "$BACKUP_ROOT/tasks"
+ditto "$SOURCE_ROOT/.veritas-kanban" "$BACKUP_ROOT/.veritas-kanban"
+```
+
+Do not delete or move the source checkout yet. The file-backed data remains the
+rollback source of truth until the desktop SQLite board is accepted.
+
+## Step 2: Stop Competing Source Servers
+
+Only one process should own active VK writes during migration. Stop the old
+source server before the desktop app becomes authoritative.
+
+Common source-dev processes:
+
+```bash
+ps aux | rg 'Projects/veritas-kanban|pnpm dev|npm run dev|tsx.*src/index|vite'
+```
+
+Gracefully stop the process group for the source dev server. If a watcher or
+supervisor owns it, stop the supervisor too.
+
+If a user LaunchAgent was created for a local dev watchdog, inspect it before
+disabling:
+
+```bash
+launchctl print "gui/$(id -u)" | rg -i 'veritas|kanban|watchdog' -C 2
+rg -n 'dev-watchdog|veritas-kanban' ~/Library/LaunchAgents
+```
+
+Disable only the old source checkout watchdog:
+
+```bash
+launchctl bootout "gui/$(id -u)" \
+  "$HOME/Library/LaunchAgents/io.digitalmeld.veritas-kanban.watchdog.plist" 2>/dev/null || true
+
+launchctl disable "gui/$(id -u)/io.digitalmeld.veritas-kanban.watchdog" 2>/dev/null || true
+```
+
+Do not disable unrelated production supervisors or remote deployments.
+
+## Step 3: Launch The Mac App
+
+Start the packaged app:
+
+```bash
+open -a "Veritas Kanban"
+```
+
+Wait for the bundled server to bind `127.0.0.1:3001`:
+
+```bash
+for i in {1..30}; do
+  if lsof -nP -iTCP:3001 -sTCP:LISTEN >/dev/null 2>&1; then
+    lsof -nP -iTCP:3001 -sTCP:LISTEN
+    break
+  fi
+  sleep 1
+done
+```
+
+The expected command path is:
+
+```text
+/Applications/Veritas Kanban.app/Contents/MacOS/veritas-kanban
+/Applications/Veritas Kanban.app/Contents/Resources/server/dist/index.js
+```
+
+Health should be available without credentials:
+
+```bash
+curl -fsS http://127.0.0.1:3001/api/health
+```
+
+Write/read APIs require an API key in packaged mode:
+
+```bash
+export VK_API_KEY="paste-a-local-admin-or-scoped-migration-token-here"
+curl -fsS -H "X-API-Key: $VK_API_KEY" http://127.0.0.1:3001/api/auth/status
+```
+
+## Step 4: Back Up The Desktop Target
+
+Back up the desktop SQLite target before import:
+
+```bash
+DESKTOP_ROOT="$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local"
+TARGET_DB="$DESKTOP_ROOT/data/.veritas-kanban/veritas.db"
+TARGET_BACKUP="$DESKTOP_ROOT/backups/pre-import-$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$TARGET_BACKUP"
+cp "$TARGET_DB" "$TARGET_BACKUP/veritas.db" 2>/dev/null || true
+cp "$TARGET_DB-wal" "$TARGET_BACKUP/veritas.db-wal" 2>/dev/null || true
+cp "$TARGET_DB-shm" "$TARGET_BACKUP/veritas.db-shm" 2>/dev/null || true
+```
+
+If the app has never created a database, the `cp` commands may have nothing to
+copy. Keep the backup directory anyway as the migration audit marker.
+
+## Step 5: Dry Run The File-To-SQLite Migration
+
+Run the migration dry run against the desktop server:
+
+```bash
+SOURCE_ROOT="$HOME/Projects/veritas-kanban"
+DESKTOP_ROOT="$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local"
+TARGET_DB="$DESKTOP_ROOT/data/.veritas-kanban/veritas.db"
+JOURNAL="$DESKTOP_ROOT/config/file-to-sqlite-migration-journal.json"
+
+curl -fsS -X POST http://127.0.0.1:3001/api/v1/sqlite/migration/dry-run \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $VK_API_KEY" \
+  -d "{
+    \"sourceRoot\": \"$SOURCE_ROOT\",
+    \"sqlitePath\": \"$TARGET_DB\",
+    \"journalPath\": \"$JOURNAL\"
+  }" | jq .
+```
+
+Review the report before importing. Warnings that usually do not block a
+desktop cutover:
+
+- missing old attachment files, if the task metadata can still load
+- duplicate archived task IDs, if the report shows deterministic skips and the
+  active task set is complete
+- malformed legacy optional records that are reported as skipped, not fatal
+
+Warnings that should stop the migration:
+
+- active task parse failures
+- unreadable `tasks/` or `.veritas-kanban/`
+- backup copy failures for required source folders
+- inability to open or promote the SQLite target
+
+## Step 6: Run The Import
+
+After the dry run is acceptable:
+
+```bash
+IMPORT_BACKUP="$DESKTOP_ROOT/backups/file-storage-pre-sqlite-import"
+
+curl -fsS -X POST http://127.0.0.1:3001/api/v1/sqlite/migration/run \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $VK_API_KEY" \
+  -d "{
+    \"sourceRoot\": \"$SOURCE_ROOT\",
+    \"sqlitePath\": \"$TARGET_DB\",
+    \"backupDir\": \"$IMPORT_BACKUP\",
+    \"journalPath\": \"$JOURNAL\"
+  }" | jq .
+```
+
+Preserve:
+
+- the import response
+- `file-to-sqlite-migration-journal.json`
+- `file-storage-pre-sqlite-import/`
+- the pre-import desktop DB backup
+- the old source checkout
+
+## Step 7: Verify The Desktop SQLite Board
+
+Confirm the packaged app still owns `3001`:
+
+```bash
+lsof -nP -iTCP:3001 -sTCP:LISTEN
+ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)"
+```
+
+Confirm health and representative data:
+
+```bash
+curl -fsS http://127.0.0.1:3001/api/health
+
+curl -fsS -H "X-API-Key: $VK_API_KEY" \
+  "http://127.0.0.1:3001/api/tasks?limit=1" | jq .
+```
+
+Optional direct SQLite count checks:
+
+```bash
+sqlite3 "$TARGET_DB" "
+select 'tasks', count(*) from tasks
+union all select 'squad_messages', count(*) from squad_messages
+union all select 'telemetry_events', count(*) from telemetry_events
+union all select 'workflow_definitions', count(*) from workflow_definitions
+union all select 'workflow_runs', count(*) from workflow_runs;
+"
+```
+
+Smoke these surfaces before accepting the migration:
+
+- board loads
+- task detail opens
+- search returns migrated tasks
+- workflows list loads
+- squad chat history loads
+- telemetry/analytics pages load
+- Settings -> Maintenance reports healthy storage
+- local automation can authenticate with `VK_API_KEY`
+
+## Step 8: Update Local Automation
+
+Packaged desktop mode keeps auth enabled. Scripts, agents, MCP servers, and
+cron jobs that previously wrote to unauthenticated localhost must send an API
+key:
+
+```bash
+export VK_API_URL="http://127.0.0.1:3001"
+export VK_API_KEY="paste-scoped-token-here"
+```
+
+For long-lived automation, create a scoped token in VK and store it in the
+operator's normal secret manager. Do not hard-code owner/admin keys into repo
+scripts.
+
+Heartbeat or service recovery should reopen the app:
+
+```bash
+open -a "Veritas Kanban"
+```
+
+It should not restart `~/Projects/veritas-kanban` unless the operator
+explicitly wants development mode.
+
+## Rollback
+
+Rollback before acceptance:
+
+1. Quit the Mac app.
+2. Restore the desktop DB from the pre-import desktop backup, or move the
+   migrated desktop workspace aside.
+3. Re-enable and start the old source server only if the operator chooses to
+   keep using the source checkout.
+4. Boot the source checkout with file storage.
+5. Verify board, task detail, search, workflows, chat, and settings.
+
+API restore from a pre-migration source backup is documented in
+[`MIGRATION-RECOVERY.md`](MIGRATION-RECOVERY.md). Do not treat SQLite down
+migrations as the rollback path for GA users.
+
+## Troubleshooting
+
+### Homebrew app opens but old board appears
+
+Check who owns `3001`. If it is a `node`, `tsx`, `vite`, or `pnpm dev` command
+from `~/Projects/veritas-kanban`, the Homebrew app is not the active API owner.
+Stop the old process and relaunch the Mac app.
+
+### Homebrew app opens but APIs return `AUTH_REQUIRED`
+
+This is expected in packaged mode. Use the desktop UI session for browser work
+or send `X-API-Key` / `Authorization: Bearer` for API automation.
+
+### The old server comes back after being killed
+
+Look for LaunchAgents, tmux sessions, shells, or process supervisors that start
+`scripts/dev-watchdog.sh`, `pnpm dev`, or `server/src/index.ts`. Disable only
+the stale source-checkout watchdog.
+
+### The app does not bind `3001`
+
+Open the desktop logs:
+
+```bash
+tail -200 "$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/logs/server.log"
+```
+
+Common causes:
+
+- another process already owns `3001`
+- desktop secrets are corrupt; see `desktop/README.md` recovery notes
+- SQLite target is on an unsafe or unsupported filesystem
+- the packaged server exited before startup completed
+
+### Counts are lower than expected
+
+Compare the dry-run report, import report, and direct SQLite counts. Check for
+warnings about duplicate task IDs, skipped malformed records, and missing
+attachments. Do not delete the old file-backed source until the migrated board
+is accepted.

--- a/docs/WEB-TO-MAC-DESKTOP-MIGRATION.md
+++ b/docs/WEB-TO-MAC-DESKTOP-MIGRATION.md
@@ -1,34 +1,64 @@
 # Web To Mac Desktop Migration
 
-This guide moves an existing file-backed Veritas Kanban web/source install into
-the packaged macOS desktop app.
+This guide moves an existing Veritas Kanban board from a source checkout or an
+already-populated desktop SQLite database into the signed macOS app.
 
-Use it when a board currently lives in a checkout such as
-`~/Projects/veritas-kanban` with file-backed data under `tasks/` and
-`.veritas-kanban/`, and the operator wants the signed Mac app installed by
-Homebrew or the GitHub release ZIP to become the owner of `localhost:3001`.
+Use it when `/Applications/Veritas Kanban.app` should become the only owner of
+`localhost:3001`. The Homebrew cask installs the app, but it does not stop an old
+development server, disable an old watchdog, or update automation credentials.
 
-The Homebrew cask installs the app. It does not automatically import a previous
-source checkout's board data, stop a development server, disable old watchdogs,
-or migrate automation tokens.
+## Choose The Correct Path
 
-## What Changes
+Check the desktop database before importing anything. Quit the app first so the
+direct inspection does not race the authoritative writer:
 
-Before migration:
+```bash
+osascript -e 'quit app "Veritas Kanban"' 2>/dev/null || true
+sleep 2
 
-- the old web/source install may serve `localhost:3001` from `server/src`
-  through `tsx`, `pnpm dev`, `npm run dev`, or a local watchdog
-- the source of truth is usually file-backed data in the repo root:
-  `tasks/` plus `.veritas-kanban/`
-- local automation may assume unauthenticated localhost writes
+DESKTOP_ROOT="$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local"
+TARGET_DB="$DESKTOP_ROOT/data/.veritas-kanban/veritas.db"
 
-After migration:
+if lsof -nP -iTCP:3001 -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "Port 3001 still has a listener. Stop it before inspecting the database." >&2
+  exit 1
+fi
 
-- `/Applications/Veritas Kanban.app` supervises the bundled local server
-- packaged mode uses SQLite storage
-- desktop data lives under the macOS Application Support workspace
-- packaged mode keeps auth enabled, including for localhost write APIs
-- old file-backed source data remains available as rollback/source history
+if test -f "$TARGET_DB" && lsof "$TARGET_DB" >/dev/null 2>&1; then
+  echo "The desktop database is still open. Stop its owner before continuing." >&2
+  exit 1
+fi
+
+if test -f "$TARGET_DB"; then
+  sqlite3 "$TARGET_DB" "
+  select 'tasks', count(*) from tasks where deleted_at is null
+  union all select 'squad_messages', count(*) from squad_messages
+  union all select 'telemetry_events', count(*) from telemetry_events
+  union all select 'workflow_definitions', count(*) from workflow_definitions
+  union all select 'workflow_runs', count(*) from workflow_runs;
+  "
+else
+  echo "No desktop database exists yet."
+fi
+```
+
+Then use exactly one path:
+
+| Current state                                                              | Path                                                                                                               |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| The desktop database already contains the expected data                    | Follow **Already Migrated Desktop Data**. Do not import, restore, or rerun file-to-SQLite migration.               |
+| The desktop database is empty or disposable and the old repo has file data | Follow **File-Backed Source To Desktop SQLite**. Create a staging database while the desktop app is fully stopped. |
+| You have a governed Veritas SQLite export bundle                           | Follow **Governed Backup Bundle Import**. The target replacement is explicit and destructive.                      |
+| You only want a new empty board                                            | Launch the app and choose **Board Only**.                                                                          |
+
+In v5.2.5, the onboarding **Restore Backup** card is recovery preflight only. It
+opens the native bundle picker but does not import the selected bundle during
+onboarding. Complete or sign in to a local setup, then follow **Governed Backup
+Bundle Import** or use the documented `/api/v1/sqlite/import` endpoint. The card
+is not the right choice when the expected records are already present in the
+desktop database.
+
+## Desktop Paths And Runtime Ownership
 
 Default desktop workspace:
 
@@ -42,330 +72,477 @@ Default desktop SQLite database:
 ~/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/data/.veritas-kanban/veritas.db
 ```
 
-## Preconditions
-
-1. Install the Mac app:
-
-   ```bash
-   brew tap BradGroux/tap
-   brew install --cask veritas-kanban
-   ```
-
-2. Confirm the old board source root. For a source checkout, this is usually:
-
-   ```bash
-   cd ~/Projects/veritas-kanban
-   test -d tasks
-   test -d .veritas-kanban
-   ```
-
-3. Confirm which process currently owns port `3001`:
-
-   ```bash
-   lsof -nP -iTCP:3001 -sTCP:LISTEN
-   ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)"
-   ```
-
-   If the command path points at `~/Projects/veritas-kanban`, the old source
-   checkout is still serving the board.
-
-4. Choose an auth method for API-driven migration:
-
-   - Preferred: create or use a scoped admin/operator API token from the
-     desktop UI and export it only for the migration shell.
-   - Acceptable for local break-glass: use the packaged desktop owner/admin
-     key only for the migration session, then clear the shell history or close
-     the terminal.
-
-   Never paste API keys into issue descriptions, task bodies, debug bundles, or
-   support notes.
-
-## Step 1: Preserve The Old Source
-
-Create a recoverable copy before any import attempt:
-
-```bash
-SOURCE_ROOT="$HOME/Projects/veritas-kanban"
-BACKUP_ROOT="$HOME/Library/Application Support/@veritas-kanban/manual-migration-backups/pre-desktop-$(date +%Y%m%d-%H%M%S)"
-
-mkdir -p "$BACKUP_ROOT"
-ditto "$SOURCE_ROOT/tasks" "$BACKUP_ROOT/tasks"
-ditto "$SOURCE_ROOT/.veritas-kanban" "$BACKUP_ROOT/.veritas-kanban"
-```
-
-Do not delete or move the source checkout yet. The file-backed data remains the
-rollback source of truth until the desktop SQLite board is accepted.
-
-## Step 2: Stop Competing Source Servers
-
-Only one process should own active VK writes during migration. Stop the old
-source server before the desktop app becomes authoritative.
-
-Common source-dev processes:
-
-```bash
-ps aux | rg 'Projects/veritas-kanban|pnpm dev|npm run dev|tsx.*src/index|vite'
-```
-
-Gracefully stop the process group for the source dev server. If a watcher or
-supervisor owns it, stop the supervisor too.
-
-If a user LaunchAgent was created for a local dev watchdog, inspect it before
-disabling:
-
-```bash
-launchctl print "gui/$(id -u)" | rg -i 'veritas|kanban|watchdog' -C 2
-rg -n 'dev-watchdog|veritas-kanban' ~/Library/LaunchAgents
-```
-
-Disable only the old source checkout watchdog:
-
-```bash
-launchctl bootout "gui/$(id -u)" \
-  "$HOME/Library/LaunchAgents/io.digitalmeld.veritas-kanban.watchdog.plist" 2>/dev/null || true
-
-launchctl disable "gui/$(id -u)/io.digitalmeld.veritas-kanban.watchdog" 2>/dev/null || true
-```
-
-Do not disable unrelated production supervisors or remote deployments.
-
-## Step 3: Launch The Mac App
-
-Start the packaged app:
-
-```bash
-open -a "Veritas Kanban"
-```
-
-Wait for the bundled server to bind `127.0.0.1:3001`:
-
-```bash
-for i in {1..30}; do
-  if lsof -nP -iTCP:3001 -sTCP:LISTEN >/dev/null 2>&1; then
-    lsof -nP -iTCP:3001 -sTCP:LISTEN
-    break
-  fi
-  sleep 1
-done
-```
-
-The expected command path is:
-
-```text
-/Applications/Veritas Kanban.app/Contents/MacOS/veritas-kanban
-/Applications/Veritas Kanban.app/Contents/Resources/server/dist/index.js
-```
-
-Health should be available without credentials:
-
-```bash
-curl -fsS http://127.0.0.1:3001/api/health
-```
-
-Write/read APIs require an API key in packaged mode:
-
-```bash
-export VK_API_KEY="paste-a-local-admin-or-scoped-migration-token-here"
-curl -fsS -H "X-API-Key: $VK_API_KEY" http://127.0.0.1:3001/api/auth/status
-```
-
-## Step 4: Back Up The Desktop Target
-
-Back up the desktop SQLite target before import:
-
-```bash
-DESKTOP_ROOT="$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local"
-TARGET_DB="$DESKTOP_ROOT/data/.veritas-kanban/veritas.db"
-TARGET_BACKUP="$DESKTOP_ROOT/backups/pre-import-$(date +%Y%m%d-%H%M%S)"
-
-mkdir -p "$TARGET_BACKUP"
-cp "$TARGET_DB" "$TARGET_BACKUP/veritas.db" 2>/dev/null || true
-cp "$TARGET_DB-wal" "$TARGET_BACKUP/veritas.db-wal" 2>/dev/null || true
-cp "$TARGET_DB-shm" "$TARGET_BACKUP/veritas.db-shm" 2>/dev/null || true
-```
-
-If the app has never created a database, the `cp` commands may have nothing to
-copy. Keep the backup directory anyway as the migration audit marker.
-
-## Step 5: Dry Run The File-To-SQLite Migration
-
-Run the migration dry run against the desktop server:
-
-```bash
-SOURCE_ROOT="$HOME/Projects/veritas-kanban"
-DESKTOP_ROOT="$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local"
-TARGET_DB="$DESKTOP_ROOT/data/.veritas-kanban/veritas.db"
-JOURNAL="$DESKTOP_ROOT/config/file-to-sqlite-migration-journal.json"
-
-curl -fsS -X POST http://127.0.0.1:3001/api/v1/sqlite/migration/dry-run \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: $VK_API_KEY" \
-  -d "{
-    \"sourceRoot\": \"$SOURCE_ROOT\",
-    \"sqlitePath\": \"$TARGET_DB\",
-    \"journalPath\": \"$JOURNAL\"
-  }" | jq .
-```
-
-Review the report before importing. Warnings that usually do not block a
-desktop cutover:
-
-- missing old attachment files, if the task metadata can still load
-- duplicate archived task IDs, if the report shows deterministic skips and the
-  active task set is complete
-- malformed legacy optional records that are reported as skipped, not fatal
-
-Warnings that should stop the migration:
-
-- active task parse failures
-- unreadable `tasks/` or `.veritas-kanban/`
-- backup copy failures for required source folders
-- inability to open or promote the SQLite target
-
-## Step 6: Run The Import
-
-After the dry run is acceptable:
-
-```bash
-IMPORT_BACKUP="$DESKTOP_ROOT/backups/file-storage-pre-sqlite-import"
-
-curl -fsS -X POST http://127.0.0.1:3001/api/v1/sqlite/migration/run \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: $VK_API_KEY" \
-  -d "{
-    \"sourceRoot\": \"$SOURCE_ROOT\",
-    \"sqlitePath\": \"$TARGET_DB\",
-    \"backupDir\": \"$IMPORT_BACKUP\",
-    \"journalPath\": \"$JOURNAL\"
-  }" | jq .
-```
-
-Preserve:
-
-- the import response
-- `file-to-sqlite-migration-journal.json`
-- `file-storage-pre-sqlite-import/`
-- the pre-import desktop DB backup
-- the old source checkout
-
-## Step 7: Verify The Desktop SQLite Board
-
-Confirm the packaged app still owns `3001`:
+Before accepting any cutover, identify the process that owns port `3001`:
 
 ```bash
 lsof -nP -iTCP:3001 -sTCP:LISTEN
 ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)"
 ```
 
-Confirm health and representative data:
+After cutover, the process tree should resolve through:
 
-```bash
-curl -fsS http://127.0.0.1:3001/api/health
-
-curl -fsS -H "X-API-Key: $VK_API_KEY" \
-  "http://127.0.0.1:3001/api/tasks?limit=1" | jq .
+```text
+/Applications/Veritas Kanban.app/Contents/MacOS/veritas-kanban
+/Applications/Veritas Kanban.app/Contents/Resources/server/dist/index.js
 ```
 
-Optional direct SQLite count checks:
+Only one VK server should accept active writes during the cutover.
+
+## Already Migrated Desktop Data
+
+Use this path when a migration tool or operator has already populated
+`veritas.db`.
+
+1. Record the counts from **Choose The Correct Path**.
+2. Confirm that a recoverable backup exists. If the app is running, create a
+   governed export in Settings -> Maintenance. For a raw database snapshot,
+   quit the app first and copy the database only while no process owns it:
+
+   ```bash
+   osascript -e 'quit app "Veritas Kanban"' 2>/dev/null || true
+   sleep 2
+
+   DESKTOP_ROOT="$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local"
+   TARGET_DB="$DESKTOP_ROOT/data/.veritas-kanban/veritas.db"
+   TARGET_BACKUP="$DESKTOP_ROOT/backups/pre-upgrade-$(date +%Y%m%d-%H%M%S)"
+
+   if lsof -nP -iTCP:3001 -sTCP:LISTEN >/dev/null 2>&1; then
+     echo "Port 3001 still has a listener. Stop it before backing up." >&2
+     exit 1
+   fi
+
+   if test -f "$TARGET_DB" && lsof "$TARGET_DB" >/dev/null 2>&1; then
+     echo "The desktop database is still open. Stop its owner before backing up." >&2
+     exit 1
+   fi
+
+   mkdir -p "$TARGET_BACKUP"
+   test -f "$TARGET_DB" && ditto "$TARGET_DB" "$TARGET_BACKUP/veritas.db"
+   test -f "$TARGET_DB-wal" && ditto "$TARGET_DB-wal" "$TARGET_BACKUP/veritas.db-wal"
+   test -f "$TARGET_DB-shm" && ditto "$TARGET_DB-shm" "$TARGET_BACKUP/veritas.db-shm"
+   ```
+
+3. Install or upgrade the signed app:
+
+   ```bash
+   brew tap BradGroux/tap
+   brew upgrade --cask veritas-kanban || brew install --cask veritas-kanban
+   open -a "Veritas Kanban"
+   ```
+
+4. On first launch, choose **Use Existing Data**. The setup screen displays
+   representative record counts read from the active desktop SQLite database.
+5. Select **Secure Existing Data**, create the admin password, and save the
+   recovery key. This secures the current database without replacing its board
+   records or imported owner metadata.
+6. Verify the board and compare the post-upgrade counts with the recorded
+   counts. Do not use the onboarding **Restore Backup** card to replace data; it
+   does not perform an import. Actual replacement is available in Settings ->
+   Maintenance and through `/api/v1/sqlite/import`.
+
+If setup was interrupted, relaunch the app. A populated database remains on the
+existing-data path; it should not be presented as a new empty board.
+
+## Governed Backup Bundle Import
+
+Use this path only when a completed Veritas SQLite export bundle is the intended
+source of truth.
+
+1. Preserve the current desktop target using the stopped-app backup procedure
+   in **Already Migrated Desktop Data**.
+2. Launch the app:
+   - For an empty target, choose **Board Only** and create the admin password.
+   - For a populated target with incomplete setup, choose **Use Existing Data**
+     and secure it.
+   - For a configured target, sign in normally.
+     Then open Settings -> Maintenance.
+3. In the SQLite backup/import section, enter:
+   - **SQLite database path**:
+     `~/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/data/.veritas-kanban/veritas.db`
+   - **Bundle directory**: the export directory containing `manifest.json` and
+     `data/sqlite/`
+   - **Replace existing SQLite rows**: enabled
+4. Select **Import Backup** and wait for the completed report.
+
+The replacement checkbox is required because setup seeds configuration rows and
+a populated target already has governed data, so the default non-replacing
+import rejects either target as non-empty. Enabling it deletes and replaces the
+governed SQLite table rows inside a transaction. It overwrites any target-only
+board, configuration, identity, workflow, chat, telemetry, and audit data
+represented by those tables. Proceed only when the bundle is authoritative and
+the stopped-app target backup is recoverable.
+
+After import, restart the app to clear runtime caches. If setup is presented
+again, choose **Use Existing Data** and secure the imported database. Then run
+the verification steps below.
+
+## File-Backed Source To Desktop SQLite
+
+Use this path only when the old source checkout still contains the authoritative
+file-backed data under `tasks/` and `.veritas-kanban/`.
+
+The safe cutover has four phases:
+
+1. identify and stop the authoritative writer
+2. preserve the quiescent file-backed source
+3. create and validate a staging SQLite database with an isolated temporary
+   server
+4. stop every writer, install the staged database, and launch the desktop app
+
+Do not run `/api/v1/sqlite/migration/run` against the live desktop
+`veritas.db`. The desktop server already has that database open. Do not copy a
+live WAL database as a backup.
+
+### 1. Identify The Source, Server, And Watchdog
+
+Start with the listener rather than assuming a checkout path:
 
 ```bash
-sqlite3 "$TARGET_DB" "
-select 'tasks', count(*) from tasks
-union all select 'squad_messages', count(*) from squad_messages
-union all select 'telemetry_events', count(*) from telemetry_events
-union all select 'workflow_definitions', count(*) from workflow_definitions
-union all select 'workflow_runs', count(*) from workflow_runs;
-"
+VK_PID="$(lsof -tiTCP:3001 -sTCP:LISTEN | head -1)"
+
+if test -n "$VK_PID"; then
+  ps -ww -o pid,ppid,pgid,command -p "$VK_PID"
+  lsof -a -p "$VK_PID" -d cwd -Fn
+fi
 ```
 
-Smoke these surfaces before accepting the migration:
+The `cwd` line begins with `n` and identifies the listener's working directory.
+Use the repository root that contains both `tasks/` and `.veritas-kanban/`:
 
-- board loads
-- task detail opens
-- search returns migrated tasks
-- workflows list loads
-- squad chat history loads
-- telemetry/analytics pages load
-- Settings -> Maintenance reports healthy storage
-- local automation can authenticate with `VK_API_KEY`
+```bash
+SOURCE_ROOT="/absolute/path/from-the-process-inspection"
+test -f "$SOURCE_ROOT/pnpm-workspace.yaml"
+test -d "$SOURCE_ROOT/tasks"
+test -d "$SOURCE_ROOT/.veritas-kanban"
+```
 
-## Step 8: Update Local Automation
+Search user LaunchAgents and running service metadata for the same resolved
+checkout path:
+
+```bash
+launchctl print "gui/$(id -u)" | rg -i 'veritas|kanban|watchdog' -C 2
+rg -l "$SOURCE_ROOT|dev-watchdog|veritas-kanban" \
+  "$HOME/Library/LaunchAgents" --glob '*.plist'
+```
+
+Inspect the matching plist before changing it. If it is the obsolete source
+watchdog, derive its label and disable only that exact service:
+
+```bash
+WATCHDOG_PLIST="/absolute/path/to/the-confirmed-source-watchdog.plist"
+plutil -p "$WATCHDOG_PLIST"
+WATCHDOG_LABEL="$(/usr/libexec/PlistBuddy -c 'Print :Label' "$WATCHDOG_PLIST")"
+
+launchctl bootout "gui/$(id -u)" "$WATCHDOG_PLIST"
+launchctl disable "gui/$(id -u)/$WATCHDOG_LABEL"
+```
+
+Gracefully stop the old server from its owning shell or supervisor, then quit
+the desktop app:
+
+```bash
+osascript -e 'quit app "Veritas Kanban"' 2>/dev/null || true
+sleep 2
+
+if lsof -nP -iTCP:3001 -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "Port 3001 still has a listener. Stop it before backing up." >&2
+  exit 1
+fi
+```
+
+Do not disable unrelated production supervisors or remote deployments.
+
+### 2. Preserve The Quiescent Source
+
+Create the backup only after the old writer and its watchdog are stopped:
+
+```bash
+SOURCE_BACKUP="$HOME/Library/Application Support/@veritas-kanban/manual-migration-backups/pre-desktop-$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$SOURCE_BACKUP"
+ditto "$SOURCE_ROOT/tasks" "$SOURCE_BACKUP/tasks"
+ditto "$SOURCE_ROOT/.veritas-kanban" "$SOURCE_BACKUP/.veritas-kanban"
+```
+
+Keep the source checkout and this backup until the desktop board is accepted.
+
+### 3. Start A Temporary File-Storage Migration Server
+
+Use a current Veritas Kanban checkout that includes the v5 SQLite migration API.
+Run it on loopback port `3101`, not on the desktop port. Its own file storage is
+an isolated empty temporary directory, so background services cannot mutate the
+source being migrated:
+
+```bash
+cd "$SOURCE_ROOT"
+corepack pnpm install --frozen-lockfile
+MIGRATION_RUNTIME="$(mktemp -d /tmp/veritas-kanban-migration-runtime.XXXXXX)"
+
+HOST=127.0.0.1 \
+PORT=3101 \
+NODE_ENV=development \
+VERITAS_STORAGE=file \
+DATA_DIR="$MIGRATION_RUNTIME" \
+VERITAS_DATA_DIR="$MIGRATION_RUNTIME" \
+VERITAS_DISABLE_WATCHERS=1 \
+VERITAS_AUTH_ENABLED=true \
+VERITAS_AUTH_LOCALHOST_BYPASS=true \
+VERITAS_AUTH_LOCALHOST_ROLE=admin \
+corepack pnpm --filter @veritas-kanban/server dev
+```
+
+Keep this foreground process visible. The admin bypass is limited to the
+temporary loopback development server and disappears when the process exits.
+
+In a second terminal:
+
+```bash
+curl -fsS http://127.0.0.1:3101/api/health | jq .
+```
+
+### 4. Dry Run Into A Staging Path
+
+The dry run scans the source without creating or mutating the staging database:
+
+```bash
+SOURCE_ROOT="/absolute/path/confirmed-in-step-1"
+DESKTOP_ROOT="$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local"
+STAGING_ROOT="$DESKTOP_ROOT/import-staging/$(date +%Y%m%d-%H%M%S)"
+STAGING_DB="$STAGING_ROOT/veritas.db"
+JOURNAL="$STAGING_ROOT/file-to-sqlite-migration-journal.json"
+SOURCE_MIGRATION_BACKUP="$STAGING_ROOT/file-storage-pre-sqlite-import"
+
+mkdir -p "$STAGING_ROOT"
+
+curl -fsS -X POST http://127.0.0.1:3101/api/v1/sqlite/migration/dry-run \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"sourceRoot\": \"$SOURCE_ROOT\",
+    \"sqlitePath\": \"$STAGING_DB\",
+    \"journalPath\": \"$JOURNAL\"
+  }" | tee "$STAGING_ROOT/dry-run-report.json" | jq .
+```
+
+Stop and investigate active-task parse failures or unreadable source
+directories. Optional malformed records, missing old attachments, and duplicate
+archived IDs may be acceptable only when the report shows deterministic skips
+and the retained data is complete. Backup, SQLite open, write, and promote
+failures occur during the run step and always stop the cutover.
+
+### 5. Create The Staging Database
+
+After accepting the dry-run report:
+
+```bash
+curl -fsS -X POST http://127.0.0.1:3101/api/v1/sqlite/migration/run \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"sourceRoot\": \"$SOURCE_ROOT\",
+    \"sqlitePath\": \"$STAGING_DB\",
+    \"backupDir\": \"$SOURCE_MIGRATION_BACKUP\",
+    \"journalPath\": \"$JOURNAL\"
+  }" | tee "$STAGING_ROOT/import-report.json" | jq .
+```
+
+Stop the temporary server with `Ctrl-C`. Confirm neither `3001` nor `3101` has
+a listener before touching the desktop target:
+
+```bash
+lsof -nP -iTCP:3001 -sTCP:LISTEN
+lsof -nP -iTCP:3101 -sTCP:LISTEN
+```
+
+Checkpoint and validate the closed staging database:
+
+```bash
+sqlite3 "$STAGING_DB" "PRAGMA wal_checkpoint(TRUNCATE); PRAGMA quick_check;"
+```
+
+The final line must be `ok`.
+
+### 6. Back Up And Install The Staged Database
+
+With all writers stopped:
+
+```bash
+TARGET_DB="$DESKTOP_ROOT/data/.veritas-kanban/veritas.db"
+TARGET_BACKUP="$DESKTOP_ROOT/backups/pre-cutover-$(date +%Y%m%d-%H%M%S)"
+
+if test -f "$TARGET_DB" && lsof "$TARGET_DB" >/dev/null 2>&1; then
+  echo "The desktop database is still open. Stop its owner before cutover." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$TARGET_DB")" "$TARGET_BACKUP"
+test -f "$TARGET_DB" && mv "$TARGET_DB" "$TARGET_BACKUP/veritas.db"
+test -f "$TARGET_DB-wal" && mv "$TARGET_DB-wal" "$TARGET_BACKUP/veritas.db-wal"
+test -f "$TARGET_DB-shm" && mv "$TARGET_DB-shm" "$TARGET_BACKUP/veritas.db-shm"
+install -m 600 "$STAGING_DB" "$TARGET_DB"
+```
+
+Preserve:
+
+- `dry-run-report.json`
+- `import-report.json`
+- `file-to-sqlite-migration-journal.json`
+- `file-storage-pre-sqlite-import/`
+- the pre-cutover desktop database backup
+- the old source checkout and manual source backup
+
+### 7. Launch And Secure Existing Data
+
+```bash
+open -a "Veritas Kanban"
+```
+
+Choose **Use Existing Data**, then **Secure Existing Data**. Create the admin
+password and save the recovery key. Do not choose **Board Only** or **Restore
+Backup** for the staged database.
+
+## Verify The Cutover
+
+Confirm the packaged app owns `3001`:
+
+```bash
+lsof -nP -iTCP:3001 -sTCP:LISTEN
+ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)"
+curl -fsS http://127.0.0.1:3001/api/health | jq .
+```
+
+Verify counts only after closing the app or by using the app/API. Do not use
+direct SQLite reads as a routine concurrent inspection method for the
+authoritative database.
+
+Smoke these surfaces:
+
+- board and task detail
+- search
+- workflows and workflow runs
+- squad chat history
+- telemetry/analytics
+- Settings -> Maintenance storage health
+- backup/export preview
+- authenticated local automation
+
+After creating a scoped API token in Settings with `task:read`,
+`workflow:read`, and `telemetry:read`, representative API checks are:
+
+```bash
+export VK_API_URL="http://127.0.0.1:3001"
+export VK_API_KEY="paste-scoped-token-here"
+
+curl -fsS -H "X-API-Key: $VK_API_KEY" "$VK_API_URL/api/tasks/counts" | jq .
+curl -fsS -H "X-API-Key: $VK_API_KEY" "$VK_API_URL/api/tasks?limit=1" | jq .
+curl -fsS -H "X-API-Key: $VK_API_KEY" "$VK_API_URL/api/workflows" | jq .
+curl -fsS -H "X-API-Key: $VK_API_KEY" "$VK_API_URL/api/telemetry/count" | jq .
+curl -fsS -H "X-API-Key: $VK_API_KEY" "$VK_API_URL/api/chat/squad?limit=1" | jq .
+```
+
+Do not delete the old source until the counts and representative records are
+accepted.
+
+## Update Local Automation
 
 Packaged desktop mode keeps auth enabled. Scripts, agents, MCP servers, and
-cron jobs that previously wrote to unauthenticated localhost must send an API
-key:
+scheduled jobs that previously wrote to unauthenticated localhost must send a
+scoped API token:
 
 ```bash
 export VK_API_URL="http://127.0.0.1:3001"
 export VK_API_KEY="paste-scoped-token-here"
 ```
 
-For long-lived automation, create a scoped token in VK and store it in the
-operator's normal secret manager. Do not hard-code owner/admin keys into repo
-scripts.
+Store long-lived tokens in the operator's normal secret manager. Do not
+hard-code owner/admin keys into repo scripts.
 
-Heartbeat or service recovery should reopen the app:
+Heartbeat or service recovery should reopen the desktop app:
 
 ```bash
 open -a "Veritas Kanban"
 ```
 
-It should not restart `~/Projects/veritas-kanban` unless the operator
-explicitly wants development mode.
+It should not restart the old source checkout unless the operator explicitly
+wants development mode.
 
 ## Rollback
 
-Rollback before acceptance:
+Before acceptance:
 
 1. Quit the Mac app.
-2. Restore the desktop DB from the pre-import desktop backup, or move the
-   migrated desktop workspace aside.
-3. Re-enable and start the old source server only if the operator chooses to
-   keep using the source checkout.
-4. Boot the source checkout with file storage.
-5. Verify board, task detail, search, workflows, chat, and settings.
+2. Move the new target database and any sidecars into a retained incident
+   directory.
+3. Restore the pre-cutover desktop database and its matching sidecars, or
+   restart the old file-backed server if that remains the chosen source of
+   truth.
+4. Verify board, task detail, search, workflows, chat, settings, and automation.
 
-API restore from a pre-migration source backup is documented in
-[`MIGRATION-RECOVERY.md`](MIGRATION-RECOVERY.md). Do not treat SQLite down
-migrations as the rollback path for GA users.
+API restore from the migration-created source backup is documented in
+[`MIGRATION-RECOVERY.md`](MIGRATION-RECOVERY.md). Do not use destructive SQLite
+down migrations as the GA rollback path.
 
 ## Troubleshooting
 
-### Homebrew app opens but old board appears
+### The setup screen offers Board Only instead of Use Existing Data
 
-Check who owns `3001`. If it is a `node`, `tsx`, `vite`, or `pnpm dev` command
-from `~/Projects/veritas-kanban`, the Homebrew app is not the active API owner.
-Stop the old process and relaunch the Mac app.
+Quit the app and verify that `TARGET_DB` resolves to the default desktop
+workspace and contains non-seed rows. Confirm that the staging database was
+installed after every server stopped. Do not continue with Board Only until the
+path and counts are understood.
 
-### Homebrew app opens but APIs return `AUTH_REQUIRED`
+### Homebrew app opens but the old board or server appears
 
-This is expected in packaged mode. Use the desktop UI session for browser work
-or send `X-API-Key` / `Authorization: Bearer` for API automation.
+Check who owns `3001`. If it is `node`, `tsx`, `vite`, or `pnpm dev` from the
+source checkout, the desktop app is not authoritative. Stop that process and
+its watchdog, then relaunch the app.
 
-### The old server comes back after being killed
+### APIs return `AUTH_REQUIRED`
 
-Look for LaunchAgents, tmux sessions, shells, or process supervisors that start
-`scripts/dev-watchdog.sh`, `pnpm dev`, or `server/src/index.ts`. Disable only
-the stale source-checkout watchdog.
+This is expected in packaged mode. Use the desktop UI session or a scoped token
+with `X-API-Key` or `Authorization: Bearer`.
 
 ### The app does not bind `3001`
 
-Open the desktop logs:
+Inspect the desktop log:
 
 ```bash
 tail -200 "$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/logs/server.log"
 ```
 
-Common causes:
+Common causes are another process on `3001`, corrupt desktop secret state, an
+unsafe SQLite filesystem, or a server startup failure.
 
-- another process already owns `3001`
-- desktop secrets are corrupt; see `desktop/README.md` recovery notes
-- SQLite target is on an unsafe or unsupported filesystem
-- the packaged server exited before startup completed
+### The dry run reports duplicate task IDs
+
+Stop the cutover. A duplicate ID is not reported as a skipped record; a later
+active, archived, or backlog record can replace the earlier record and determine
+its final state. The warning names the duplicated ID, not every file. Locate all
+matching source records:
+
+```bash
+DUPLICATE_TASK_ID="task_id_from_the_warning"
+rg -l -F "$DUPLICATE_TASK_ID" \
+  "$SOURCE_ROOT/tasks/active" \
+  "$SOURCE_ROOT/tasks/archive" \
+  "$SOURCE_ROOT/tasks/backlog" \
+  --glob '*.md'
+```
+
+Inspect every result, decide which record is authoritative, and give any
+distinct task a unique ID. Preserve the original files, then rerun the dry run
+and migration into a new staging database. Do not accept a run that still
+reports duplicate task IDs.
+
+### The dry run reports a missing attachment
+
+The task metadata can migrate while the referenced attachment file remains
+absent. Restore the file at the exact `source` path in the warning, or explicitly
+remove the stale attachment reference after confirming the binary is
+unrecoverable. Rerun into a new staging database and open representative
+attachments before accepting the cutover.
 
 ### Counts are lower than expected
 
-Compare the dry-run report, import report, and direct SQLite counts. Check for
-warnings about duplicate task IDs, skipped malformed records, and missing
-attachments. Do not delete the old file-backed source until the migrated board
-is accepted.
+Compare the dry-run report, import report, setup-screen counts, and
+post-migration API counts. Parsed migration counts exclude malformed source
+records, while setup task counts exclude soft-deleted tasks. Check each warning
+and keep all rollback artifacts until the difference is explained.


### PR DESCRIPTION
## Summary

- Adds a dedicated decision tree for already-populated desktop SQLite, governed export-bundle replacement, and legacy file-backed source cutover.
- Uses a fresh staging database and an isolated loopback migration server so the packaged server never receives out-of-band writes to its open SQLite target.
- Documents coherent stopped-writer backups, port/database ownership checks, generic source and LaunchAgent discovery, exact desktop paths, required auth scopes, verification, rollback, and warning remediation.
- Links the complete runbook from the v5 upgrade/admin, recovery, and desktop runtime docs.

Closes #899.

## Verification

- Prettier check passed for all four changed docs.
- `git diff --check` passed.
- Standards review passed with no remaining findings.
- Requirements review against #899 and the populated-desktop upgrade case passed with no remaining findings.
- Branch includes the merged desktop onboarding fix and production audit fix from main.