### PR TITLE
fix: raise dependency advisory floors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,11 @@ overrides:
   '@modelcontextprotocol/sdk>express-rate-limit': 8.5.2
   '@xmldom/xmldom': 0.8.13
   esbuild@<0.28.1: 0.28.1
-  fast-uri: '>=3.1.2'
+  fast-uri@<3.1.4: 3.1.4
   form-data@<4.0.6: 4.0.6
   hono: '>=4.12.18'
   ip-address: '>=10.1.1'
+  js-yaml@<4.3.0: 4.3.0
   postcss: '>=8.5.10'
   qs: ^6.14.2
   uuid@^8.3.0: 11.1.1
@@ -2730,8 +2731,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3284,8 +3285,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5280,7 +5281,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -6589,14 +6590,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6647,7 +6648,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -6909,7 +6910,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -7287,7 +7288,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -7426,7 +7427,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -7829,7 +7830,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -8427,7 +8428,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,10 +18,11 @@ overrides:
   '@modelcontextprotocol/sdk>express-rate-limit': 8.5.2
   '@xmldom/xmldom': 0.8.13
   'esbuild@<0.28.1': 0.28.1
-  fast-uri: '>=3.1.2'
+  'fast-uri@<3.1.4': 3.1.4
   'form-data@<4.0.6': 4.0.6
   hono: '>=4.12.18'
   ip-address: '>=10.1.1'
+  'js-yaml@<4.3.0': 4.3.0
   postcss: '>=8.5.10'
   qs: ^6.14.2
   'uuid@^8.3.0': 11.1.1


### PR DESCRIPTION
## Summary

- constrain vulnerable `fast-uri` releases below 3.1.4 to the patched 3.1.4 release
- constrain vulnerable `js-yaml` releases below 4.3.0 to the patched 4.3.0 release
- regenerate the pnpm 11.1.1 lockfile without moving either dependency to a new major version

## Verification

- `pnpm audit --prod --audit-level=high`
- `pnpm check:pnpm-settings`
- `pnpm build`
- `pnpm --filter @veritas-kanban/server test` (2,283 passed, 2 skipped)
- `pnpm --filter @veritas-kanban/desktop test` (61 passed)
- independent dependency and issue-scope reviews: no actionable findings

## Risk

Low. The override selectors affect only vulnerable versions below the patched floors, and all current consumers resolve to the smallest patched release in their existing major line.

Closes #903
