### PR TITLE
release: prepare v5.2.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 > read this file first. Harness-specific supplements (e.g. `CLAUDE.md`) extend, never duplicate
 > or contradict, these rules.
 >
-> **Version:** 5.2.4
+> **Version:** 5.2.5
 > **Freshness policy:** update within two working days of any toolchain or architecture change.
 > Stale fields (package manager, Node version, provider list, test commands) are caught by
 > `pnpm check:pnpm-settings` and the smoke-test CI job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1861,7 +1861,7 @@ Veritas Kanban is an AI-native project management board built for developers and
 - **Frontend:** React 19, Vite 6, TypeScript 5.7, Tailwind CSS 3.4, Shadcn UI
 - **Backend:** Express 4.21, TypeScript, file-based storage
 - **Testing:** Playwright 1.58, Vitest 4
-- **Runtime:** Node.js 22+, pnpm 9+
+- **Runtime:** Node.js ≥ 22.22.1, pnpm ≥ 11.0.0
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.5] - 2026-07-23
+
 ### Added
 
+- Added a complete web/source-to-Mac migration runbook with a decision path for
+  already-populated desktop SQLite, coherent stopped-writer backups, isolated
+  file-to-SQLite staging, governed bundle replacement, watchdog discovery,
+  authenticated automation cutover, verification, rollback, and warning
+  remediation (#899).
 - Added the versioned `task-envelope/v1` and `completion-result/v1` contracts,
   canonical envelope digests, immutable per-attempt persistence, launch HEAD and
   dirty-file attribution with staged-blob and worktree SHA-256 fingerprints,
@@ -70,6 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Raised vulnerable transitive `fast-uri` and `js-yaml` ranges to patched
+  releases so the production dependency audit passes at the release gate
+  (#903).
 - Made startup, setup, password, recovery, and login surfaces draggable in the
   frameless desktop window, and made first-run setup detect populated desktop
   SQLite data, default to a non-destructive **Use Existing Data** path, show
@@ -1857,7 +1867,11 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.1...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.5...HEAD
+[5.2.5]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.4...v5.2.5
+[5.2.4]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.3...v5.2.4
+[5.2.3]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.2...v5.2.3
+[5.2.2]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.1...v5.2.2
 [5.2.1]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.0...v5.2.1
 [5.2.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.0.1...v5.1.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.2.4-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.5-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,7 +1,7 @@
 # Veritas Kanban — API Reference
 
-**Version**: 5.2.4
-**Last Updated**: 2026-07-13
+**Version**: 5.2.5
+**Last Updated**: 2026-07-23
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)
 

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -187,6 +187,12 @@ policy is tracked in
 - Confirm notarization succeeds with the intended credential mode and the DMG
   installs without Gatekeeper warnings on a clean Mac.
 - Confirm a first run creates the profile/workspace app data directories.
+- Confirm startup/auth/setup surfaces are draggable while their controls remain
+  clickable, and a populated isolated SQLite profile offers **Use Existing
+  Data** with representative counts before password setup.
+- Confirm the
+  [Web To Mac Desktop Migration](WEB-TO-MAC-DESKTOP-MIGRATION.md) decision tree
+  matches the shipped onboarding labels and Maintenance import behavior.
 - Confirm update check, download, install, failed-download, and rollback paths
   on the selected channel.
 - Confirm `pnpm validate:release` passes and verifies root/shared/server/web,

--- a/docs/V5-COMPATIBILITY-AND-RELEASE-POLICY.md
+++ b/docs/V5-COMPATIBILITY-AND-RELEASE-POLICY.md
@@ -39,6 +39,16 @@ preview-only for v5 GA. They keep post-GA packaging paths exercised, but they
 are not supported install targets, release-channel targets, or stable update
 targets until a later compatibility policy explicitly promotes them.
 
+Desktop upgrade selection is data-driven. When the active desktop SQLite
+database contains non-seed records, setup must offer **Use Existing Data** and
+must not require file migration or backup restore. File-backed sources migrate
+offline into a fresh staging database before cutover. Governed export bundles
+import through Maintenance or `/api/v1/sqlite/import`; the v5.2.5 onboarding
+**Restore Backup** card is picker/preflight only and is not an import executor.
+See
+[Web To Mac Desktop Migration](WEB-TO-MAC-DESKTOP-MIGRATION.md) for the
+supported decision tree and one-writer rules.
+
 ## Version Negotiation Rules
 
 1. API clients may send `X-API-Version: v1`; unsupported values fail before the

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -1,11 +1,12 @@
 # Veritas Kanban v5 GA Checklist
 
-v5.0.0 stable is published. The current source line is v5.2.4, including the
+v5.0.0 stable is published. The current source line is v5.2.5, including the
 post-v5.1 backlog train, the July 2026 desktop and responsive UI audit, the
-runtime security artifact gate, and the macOS recovery-screen input and layout
-corrections. This checklist remains the operator reference for release-gate
-review, follow-up evidence debt, and future v5 patch candidates. The GitHub
-release and release issues remain the source of scheduling truth.
+runtime security artifact gate, draggable startup/auth surfaces, and the
+non-destructive existing-desktop-data setup path. This checklist remains the
+operator reference for release-gate review, follow-up evidence debt, and future
+v5 patch candidates. The GitHub release and release issues remain the source of
+scheduling truth.
 
 For future candidates, use
 [v5 Release Candidate Evidence Packet](V5-RC-EVIDENCE-PACKET.md) as the single
@@ -19,6 +20,10 @@ smoke proof, and accepted limits.
       the renderer, and create or open a board.
 - [ ] Upgrade verifies a v4 file-backed project can migrate to SQLite and can
       recover through the rollback drill.
+- [ ] Existing desktop-data upgrade verifies a populated SQLite workspace
+      offers **Use Existing Data**, displays representative counts, preserves
+      board rows and owner metadata through password setup, and does not direct
+      the operator to restore or rerun migration.
 - [ ] Backup and restore verifies SQLite data, task files, settings, templates,
       attachments, workflow state, and audit history.
 - [ ] Data lifecycle controls define retention, export, deletion, privacy, and

--- a/docs/V5-RC-EVIDENCE-PACKET.md
+++ b/docs/V5-RC-EVIDENCE-PACKET.md
@@ -57,7 +57,7 @@ publication are added only after those independent gates pass.
 | Isolated populated SQLite packaged upgrade       | PASS    | Unsigned app selected **Use Existing Data**, showed 2/3/1/1/1 counts, and preserved every count plus migrated owner and task-owner metadata through password setup |
 | Packaged drag-region and control contract        | PASS    | Electron reported `drag` for the setup surface and `no-drag` for controls; Agent Ready remained clickable and selected                                             |
 | Independent standards and specification review   | PASS    | Two separate reviewers found the publication-proof and MCP-version gaps; both were corrected before commit                                                         |
-| Opposite-model review                            | BLOCKED | The Claude Code CLI has no authenticated session and GitHub Copilot CLI returned no quota; the repository Copilot reviewer will be requested on the release PR     |
+| Repository Copilot review                        | PASS    | Reviewed all 19 changed files on PR #922; its two documentation consistency findings were corrected before merge                                                   |
 
 The residual production advisories are `body-parser` low-severity
 `GHSA-v422-hmwv-36x6` and `@hono/node-server` moderate-severity
@@ -66,6 +66,10 @@ transitive MCP dependency; the Veritas MCP package uses stdio and the supported
 desktop target is macOS. Neither advisory crosses the release gate's
 high/critical threshold. Both remain visible rather than being hidden behind an
 unsafe major-version override.
+
+Direct Claude CLI review was unavailable because Claude Code had no
+authenticated session and GitHub Copilot CLI returned no quota. The repository
+Copilot reviewer supplied the available external review gate on PR #922.
 
 ### Publication evidence
 

--- a/docs/V5-RC-EVIDENCE-PACKET.md
+++ b/docs/V5-RC-EVIDENCE-PACKET.md
@@ -1,5 +1,80 @@
 # v5 Release Evidence Packets
 
+## v5.2.5 Release Evidence Packet
+
+This section records the desktop existing-data upgrade fix, migration runbook,
+and release-candidate validation for v5.2.5. Signed artifacts and Homebrew
+publication are added only after those independent gates pass.
+
+### Candidate scope
+
+| Field                  | Value                                                    |
+| ---------------------- | -------------------------------------------------------- |
+| Release version        | 5.2.5                                                    |
+| Release issue          | <https://github.com/BradGroux/veritas-kanban/issues/914> |
+| Desktop setup issue    | <https://github.com/BradGroux/veritas-kanban/issues/901> |
+| Desktop setup PR       | <https://github.com/BradGroux/veritas-kanban/pull/902>   |
+| Migration docs issue   | <https://github.com/BradGroux/veritas-kanban/issues/899> |
+| Migration docs PR      | <https://github.com/BradGroux/veritas-kanban/pull/900>   |
+| Dependency audit issue | <https://github.com/BradGroux/veritas-kanban/issues/903> |
+| Dependency audit PR    | <https://github.com/BradGroux/veritas-kanban/pull/908>   |
+| Release branch         | `release/v5.2.5-914`                                     |
+| Evidence date          | 2026-07-23                                               |
+
+### Upgrade contract
+
+- A populated desktop database is never treated as a fresh board. Setup offers
+  **Use Existing Data**, displays representative counts, and secures the
+  database without replacing board rows or imported owner metadata.
+- Startup, setup, password, recovery, loading, and login surfaces remain
+  draggable while interactive controls remain clickable.
+- Operators whose records already exist in the desktop SQLite workspace do not
+  rerun file migration and do not choose backup recovery.
+- Legacy file-backed data migrates into a fresh staging database with the
+  desktop app stopped. The authoritative desktop database is installed only
+  after every writer closes.
+- Governed export-bundle import is an explicit Maintenance operation with
+  destructive replacement confirmation. The onboarding **Restore Backup** card
+  remains picker/preflight only in v5.2.5.
+
+### Pre-publication gates
+
+| Gate                                             | Result  | Evidence                                                                                                                                                           |
+| ------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pnpm check:pnpm-settings`                       | PASS    | Node 26.5.0, pnpm 11.1.1, and the repository package-manager contract agree                                                                                        |
+| `pnpm audit --prod --audit-level=high`           | PASS    | Zero high or critical advisories; one low and one moderate advisory remain documented below                                                                        |
+| `pnpm lint` and `pnpm lint:budget`               | PASS    | Zero errors; 595 warnings remain within the 600-warning budget                                                                                                     |
+| `pnpm qa:mantine`                                | PASS    | Mantine migration and bundle-size budgets passed                                                                                                                   |
+| `pnpm typecheck` and `pnpm build`                | PASS    | Shared, server, web, CLI, MCP, and desktop workspaces passed                                                                                                       |
+| `pnpm test:unit`                                 | PASS    | All workspace suites passed                                                                                                                                        |
+| Focused existing-data and auth regression suites | PASS    | Web 12/12; server 42/42; desktop 61/61                                                                                                                             |
+| `pnpm desktop:check:electron-artifacts`          | PASS    | Main and preload output preserved Electron runtime imports and rejected installer-shim patterns                                                                    |
+| `pnpm smoke:cli-mcp`                             | PARTIAL | Build and version checks passed; live read/write smoke skipped because no test API key was set                                                                     |
+| `pnpm test:e2e`                                  | PASS    | 36/36 across Chromium, mobile Chromium, and mobile WebKit using an isolated temporary data store                                                                   |
+| `pnpm desktop:smoke:mac:local`                   | PASS    | ARM64 unpacked app and isolated production staging passed                                                                                                          |
+| `pnpm desktop:package:mac:unsigned`              | PASS    | v5.2.5 ARM64 DMG, ZIP, blockmaps, update metadata, and app bundle produced                                                                                         |
+| `pnpm validate:release -- --version 5.2.5`       | PASS    | Versions, scripts, docs, and local build artifacts passed                                                                                                          |
+| Isolated populated SQLite packaged upgrade       | PASS    | Unsigned app selected **Use Existing Data**, showed 2/3/1/1/1 counts, and preserved every count plus migrated owner and task-owner metadata through password setup |
+| Packaged drag-region and control contract        | PASS    | Electron reported `drag` for the setup surface and `no-drag` for controls; Agent Ready remained clickable and selected                                             |
+| Independent standards and specification review   | PASS    | Two separate reviewers found the publication-proof and MCP-version gaps; both were corrected before commit                                                         |
+| Opposite-model review                            | BLOCKED | The Claude Code CLI has no authenticated session and GitHub Copilot CLI returned no quota; the repository Copilot reviewer will be requested on the release PR     |
+
+The residual production advisories are `body-parser` low-severity
+`GHSA-v422-hmwv-36x6` and `@hono/node-server` moderate-severity
+`GHSA-frvp-7c67-39w9`. The latter applies to Windows static-file serving in a
+transitive MCP dependency; the Veritas MCP package uses stdio and the supported
+desktop target is macOS. Neither advisory crosses the release gate's
+high/critical threshold. Both remain visible rather than being hidden behind an
+unsafe major-version override.
+
+### Publication evidence
+
+The release commit, tag object, Desktop Release run, signed artifact URLs and
+SHA-256 values, `latest-mac.yml` verification, notarization/stapling checks, and
+Homebrew tap PR are filled from the published v5.2.5 artifacts. Source merge,
+GitHub release publication, signed runtime verification, and Homebrew
+availability are separate gates; none substitutes for another.
+
 ## v5.2.2 Release Evidence Packet
 
 This section records the July 2026 UI-audit remediation and v5.2.2 release

--- a/docs/V5-RELEASE-NOTES.md
+++ b/docs/V5-RELEASE-NOTES.md
@@ -2,13 +2,93 @@
 
 These notes describe the Veritas Kanban v5 stable release line.
 
-- Current source version: `v5.2.4`
+- Current source version: `v5.2.5`
 - Latest published GitHub release:
   [Veritas Kanban v5.2.4](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
 - Supported packaged install:
   `brew tap BradGroux/tap && brew install --cask veritas-kanban`
 - Manual macOS install:
   [Veritas-Kanban-5.2.4-mac-arm64.zip](https://github.com/BradGroux/veritas-kanban/releases/download/v5.2.4/Veritas-Kanban-5.2.4-mac-arm64.zip)
+
+## v5.2.5 Patch Candidate
+
+The v5.2.5 source candidate makes the signed desktop upgrade path unambiguous
+for operators whose data is already in the desktop SQLite workspace. It also
+prepares the provider runtime contract and SQLite safety work merged since
+v5.2.4 for publication.
+
+### Desktop startup and existing data
+
+- Startup, loading, setup, password, recovery, and login surfaces are draggable
+  throughout the frameless desktop flow. Buttons, fields, links, and other
+  controls remain clickable because interactive regions opt out of window drag.
+- First-run setup detects non-seed rows in the active desktop SQLite database,
+  recommends **Use Existing Data**, and shows task, Squad Chat, telemetry,
+  workflow-definition, and workflow-run counts before the operator continues.
+- **Secure Existing Data** creates the local password and recovery key without
+  replacing board records or imported owner metadata.
+- Interrupted or stale onboarding state returns to the existing-data path when
+  the database remains populated.
+- Packaged port selection checks IPv4 and IPv6 loopback before attaching to a
+  server, reducing the risk of connecting the app to an unrelated local
+  process.
+
+### Migration and recovery guidance
+
+- The new
+  [Web To Mac Desktop Migration](WEB-TO-MAC-DESKTOP-MIGRATION.md) runbook
+  separates four cases: already-populated desktop SQLite, an empty board, a
+  governed export-bundle import, and a legacy file-backed source.
+- The file-backed path uses a fresh staging database and isolated loopback
+  migration server. It stops writers before backups and never writes through a
+  second connection to the authoritative desktop database.
+- The guide includes generic source/watchdog discovery, record-count checks,
+  exact API-token scopes, authenticated helper cutover, destructive replacement
+  warnings, rollback, and remediation for duplicate IDs and missing
+  attachments.
+- The onboarding **Restore Backup** card remains a native picker/preflight in
+  v5.2.5; it does not import during onboarding. Governed imports run from
+  Settings -> Maintenance or `/api/v1/sqlite/import`.
+
+### Provider runtime contracts and storage safety
+
+- Agent launches now persist versioned task envelopes and completion-result
+  contracts with canonical digests, bounded evidence, side-effect policy,
+  verification state, and immutable attempt attribution.
+- Codex CLI, Codex SDK, Hermes, OpenClaw, and custom providers expose validated,
+  versioned runtime manifests. Routing and active controls fail closed when the
+  selected runtime cannot satisfy required capabilities.
+- Launch, stop, steer, resume, tool, MCP, structured-output, token, and artifact
+  controls consume the exact attempt-bound manifest used for execution.
+- SQLite startup classifies the authoritative filesystem before opening the
+  database, refuses unsafe or unverified storage, and reports redacted posture
+  through health and Maintenance.
+- Governed offline journal maintenance adds previews, exclusive restart-time
+  conversion, backups, stage journals, integrity verification, recovery,
+  ownership locks, and expiring/revocable overrides.
+
+### Reliability and security
+
+- Agent start and terminalization ownership is serialized per task and attempt
+  so concurrent starts, stops, provider exits, and callbacks cannot duplicate a
+  run.
+- Verified local-owner password sessions receive only the narrow packaged
+  `local-agent:run` capability; production localhost bypass remains disabled.
+- Mobile notifications stay above safe-area navigation and cannot intercept
+  Task Detail input after close.
+- Patched transitive `fast-uri` and `js-yaml` floors clear the production
+  high-severity dependency audit.
+
+### Compatibility and upgrade notes
+
+- No SQLite schema or configuration migration is required from v5.2.4.
+- If the desktop database already contains the expected records, back it up,
+  install v5.2.5, choose **Use Existing Data**, and then **Secure Existing
+  Data**. Do not rerun file migration or restore over that database.
+- Server, web, CLI, MCP, shared, and desktop package versions move together to
+  5.2.5.
+- macOS Apple Silicon remains the supported signed desktop target. Linux and
+  Windows artifacts remain unsigned previews.
 
 ## v5.2.4 Patch
 
@@ -259,32 +339,37 @@ brew install --cask veritas-kanban
 
 Manual installation is also supported from the stable GitHub release ZIP.
 
-1. Launch Veritas Kanban and choose Board Only unless you already need agent or
-   remote setup.
+1. Launch Veritas Kanban. Choose **Use Existing Data** when setup reports the
+   expected desktop records; choose **Board Only** only for a new empty board.
 2. Save the recovery key.
 3. Verify Settings -> Maintenance health, storage, backup, and debug-bundle
    previews.
 
 ## Upgrade
 
-1. Back up the existing v4 file-backed project or desktop data directory.
-2. Run migration dry-run.
-3. Resolve warnings or record accepted risks.
-4. Run migration and preserve the journal/report.
-5. Verify board, task detail, search, workflows, chat, settings, work products,
-   Maintenance Center, and audit history.
-6. Run backup/export and restore verification before deleting old artifacts.
+1. Inspect the desktop SQLite counts and determine whether the expected data is
+   already present.
+2. If it is present, create a coherent stopped-app backup, upgrade, choose
+   **Use Existing Data**, and do not import or rerun migration.
+3. If the file-backed source remains authoritative, follow
+   [Web To Mac Desktop Migration](WEB-TO-MAC-DESKTOP-MIGRATION.md) to stop
+   competing writers, back up, dry-run and migrate into staging, then install
+   the validated database.
+4. Verify board, task detail, search, workflows, chat, settings, work products,
+   Maintenance Center, authenticated automation, and audit history.
+5. Run backup/export and restore verification before deleting old artifacts.
 
 ## Release Artifacts
 
-The
-[v5.2.4 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
-publishes signed/notarized macOS ZIP and DMG assets, `latest-mac.yml`,
-blockmaps, and SHA-256 sidecars. Use the release-attached `.sha256` files as the
-checksum source of truth.
+When the v5.2.5 release is published, its GitHub release must contain the
+signed/notarized macOS ZIP and DMG assets, `latest-mac.yml`, blockmaps, and
+SHA-256 sidecars. The release-attached `.sha256` files are the checksum source
+of truth after publication.
 
-The v5.2.3 and v5.2.2 desktop assets remain available for provenance and
-rollback.
+The current stable
+[v5.2.4 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
+and the v5.2.3 and v5.2.2 desktop assets remain available for installation,
+provenance, and rollback until v5.2.5 publication completes.
 
 The v5.2.1 desktop assets remain available for provenance, but the application
 bundle is not a supported rollback target because its emitted Electron main
@@ -322,6 +407,7 @@ desktop install, remote/mobile, admin, compatibility, and GA checklist docs.
 - [Post-GA Native Mobile Offline ADR](architecture/ADR-0003-post-ga-native-mobile-offline.md)
 - [Post-GA Cloud Sync And Hosted SaaS ADR](architecture/ADR-0004-post-ga-cloud-sync-hosted-saas.md)
 - [Desktop Release](DESKTOP-RELEASE.md)
+- [Web To Mac Desktop Migration](WEB-TO-MAC-DESKTOP-MIGRATION.md)
 - [Migration Recovery](MIGRATION-RECOVERY.md)
 - [Self-Hosting Guide](guides/SELF_HOST.md)
 - [PWA Install](guides/PWA_INSTALL.md)

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -33,9 +33,13 @@ candidate, belongs in the reusable
    ```
 
    Manual install is also supported from the
-   [stable GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
+   [current stable GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v5.2.4)
    by downloading `Veritas-Kanban-5.2.4-mac-arm64.zip`, unzipping it, and
    moving `Veritas Kanban.app` into `/Applications`.
+
+   The v5.2.5 filename and release URL become valid only after the signed
+   release workflow and publication checks in
+   [the evidence packet](V5-RC-EVIDENCE-PACKET.md) pass.
 
 2. Launch normally. A stable release should not show a Gatekeeper warning.
 3. Pick the first-run path:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1664,12 +1664,12 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">v5.2.4</div>
+          <div class="proof-stat-number">v5.2.5</div>
           <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">
-          <div class="proof-stat-number">Local</div>
-          <div class="proof-stat-label">Markdown task storage</div>
+          <div class="proof-stat-number">SQLite</div>
+          <div class="proof-stat-label">Local-first desktop storage</div>
         </div>
         <div class="proof-stat">
           <div class="proof-stat-number">Agent</div>

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -95,7 +95,7 @@ Don't use it when:
 - **Stdio transport only** — the MCP server is a child process of the client. No network ports opened.
 - **Stateless proxy** — every tool call translates to one or more HTTP requests to the VK server. The MCP process holds no state.
 - **Zod validation** — all tool inputs are validated with Zod schemas before hitting the API.
-- **@modelcontextprotocol/sdk v1.29** — uses the official TypeScript SDK.
+- **@modelcontextprotocol/sdk v1.29.0** — uses the official TypeScript SDK.
 
 ---
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -95,7 +95,7 @@ Don't use it when:
 - **Stdio transport only** — the MCP server is a child process of the client. No network ports opened.
 - **Stateless proxy** — every tool call translates to one or more HTTP requests to the VK server. The MCP process holds no state.
 - **Zod validation** — all tool inputs are validated with Zod schemas before hitting the API.
-- **@modelcontextprotocol/sdk v1.27** — uses the official TypeScript SDK.
+- **@modelcontextprotocol/sdk v1.29** — uses the official TypeScript SDK.
 
 ---
 
@@ -822,9 +822,9 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `5.2.4`      | Matches VK server version   |
-| MCP SDK            | `1.27.1`     | `@modelcontextprotocol/sdk` |
-| MCP protocol       | `2024-11-05` | Latest stable spec          |
+| MCP server package | `5.2.5`      | Matches VK server version   |
+| MCP SDK            | `1.29.0`     | `@modelcontextprotocol/sdk` |
+| MCP protocol       | `2025-11-25` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
 | TypeScript         | `6.0+`       | Build dependency only       |
 
@@ -866,4 +866,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-07-13 · VK v5.2.4 · 36 tools / 8 categories_
+_Last updated: 2026-07-23 · VK v5.2.5 · 36 tools / 8 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump every workspace and release-facing version to 5.2.5
- document the non-destructive populated SQLite upgrade path and the completed web-to-desktop migration runbook
- prepare changelog, release notes, compatibility policy, release checklist, and evidence packet for signed publication
- correct MCP compatibility references to SDK 1.29.0 and protocol 2025-11-25

## Verification

- `pnpm check:pnpm-settings`
- `pnpm audit --prod --audit-level=high` (zero high/critical; residual low/moderate documented)
- `pnpm lint` and `pnpm lint:budget`
- `pnpm qa:mantine`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit`
- focused web 12/12, server 42/42, desktop 61/61
- `pnpm test:e2e` 36/36
- `pnpm desktop:check:electron-artifacts`
- `pnpm smoke:cli-mcp` (live write skipped without a test API key)
- `pnpm desktop:smoke:mac:local`
- `pnpm desktop:package:mac:unsigned`
- `pnpm validate:release -- --version 5.2.5`
- populated isolated packaged upgrade preserved all counts and migrated owner metadata through setup
- independent specification and standards reviews passed

## Review and publication note

Claude Code has no authenticated session and the authenticated Copilot CLI returned no quota. The repository Copilot reviewer is requested on this PR. Signed artifacts, hashes, notarization, Homebrew proof, and final publication evidence are completed after this source PR merges.

Refs #914