### PR TITLE
feat: add first-class harness support profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,8 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 - **Path traversal.** `validatePathSegment()` + `ensureWithinBase()` on every user-supplied path.
 - **Env passthrough.** Agents receive only the keys in the configured safe allowlist; see
   `server/src/utils/codex-env.ts` and `server/src/utils/hermes-env.ts`.
+- **Launch arguments.** Never put credential values in provider commands or arguments; use an
+  allowlisted environment key or run-scoped brokered credential reference.
 - **Log redaction.** Trace logs and telemetry run through `TRACE_SECRET_PATTERNS` before storage.
 - **No credentials in PR descriptions, test fixtures, or log snippets.**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,12 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   checks, and provider version/build changes must invalidate cached conformance.
   Increment `PROVIDER_RUNTIME_PROBE_REVISION` whenever probe semantics or the
   built-in adapter capability evidence changes.
+- Normalize every configured harness through `harness-support-profile/v1`.
+  Settings, API diagnostics, `vk doctor`, dispatch, and telemetry must use the
+  same support tier and redacted readiness evidence. Only known legacy records
+  whose built-in type and command both identify `codex` or `hermes` may infer a
+  provider during migration; provider-less or profile/adapter-mismatched records
+  fail closed before an attempt is created.
 
 ---
 

--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -37,6 +37,23 @@ const baseRoutes: Record<string, Response> = {
       provider: 'codex-cli',
     },
   ]),
+  '/api/config/agent-support': jsonResponse([
+    {
+      agentType: 'codex',
+      profileId: 'openai-codex-cli',
+      adapterId: 'codex-cli',
+      transport: 'process-jsonl',
+      supportTier: 'configured',
+      reason: 'Certification evidence is not current.',
+      failureClass: 'none',
+      checkedAt: '2026-06-04T07:00:00.000Z',
+      enabled: true,
+      executableFound: true,
+      authenticated: true,
+      diagnosticCommands: ['codex --version', 'codex login status'],
+      remediation: ['Run vk doctor.'],
+    },
+  ]),
   '/api/agents/routing': jsonResponse({
     enabled: true,
     defaultAgent: 'codex',
@@ -79,6 +96,12 @@ describe('vk doctor', () => {
     expect(report.summary.fail).toBe(0);
     expect(report.checks.find((check) => check.id === 'agents')).toMatchObject({
       status: 'pass',
+    });
+    expect(report.checks.find((check) => check.id === 'harness-support')).toMatchObject({
+      status: 'warn',
+      details: expect.objectContaining({
+        configured: 1,
+      }),
     });
     expect(formatDoctorReport(report)).toContain('Doctor result: clean');
   });
@@ -123,6 +146,55 @@ describe('vk doctor', () => {
     });
     expect(report.checks.find((check) => check.id === 'agents')).toMatchObject({
       status: 'fail',
+    });
+  });
+
+  it('fails closed for an enabled unsupported harness and preserves safe remediation', async () => {
+    const routes = {
+      ...baseRoutes,
+      '/api/config/agent-support': jsonResponse([
+        {
+          agentType: 'claude-code',
+          profileId: 'claude-code',
+          transport: 'process-jsonl',
+          supportTier: 'unsupported',
+          reason: 'No executable adapter is registered.',
+          failureClass: 'adapter-unavailable',
+          checkedAt: '2026-06-04T07:00:00.000Z',
+          enabled: true,
+          executableFound: true,
+          authenticated: true,
+          diagnosticCommands: ['claude --version'],
+          remediation: ['Disable this profile or install a supported adapter.'],
+        },
+      ]),
+    };
+
+    const report = await runDoctorChecks(
+      { apiBase: 'http://vk.test', cwd: '/repo', timeoutMs: 1000 },
+      {
+        fetch: doctorFetch(routes),
+        env: {},
+        findProjectRoot: async () => '/repo',
+        countPromptTemplateFiles: async () => 1,
+        resolveCommand: async (command) =>
+          command === 'vk' ? '/repo/cli/dist/index.js' : `/usr/bin/${command}`,
+        now: () => new Date('2026-06-04T07:00:00.000Z'),
+      }
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((check) => check.id === 'harness-support')).toMatchObject({
+      status: 'fail',
+      details: {
+        blocking: [
+          expect.objectContaining({
+            profileId: 'claude-code',
+            diagnosticCommands: ['claude --version'],
+            remediation: ['Disable this profile or install a supported adapter.'],
+          }),
+        ],
+      },
     });
   });
 

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { API_BASE, buildApiHeaders } from '../utils/api.js';
+import type { HarnessSupportStatus } from '@veritas-kanban/shared';
 
 const execFileAsync = promisify(execFile);
 const CRITICAL_STATUSES = new Set<DoctorCheck['id']>([
@@ -13,6 +14,7 @@ const CRITICAL_STATUSES = new Set<DoctorCheck['id']>([
   'api-auth',
   'tasks',
   'agents',
+  'harness-support',
   'routing',
 ]);
 
@@ -538,6 +540,70 @@ function buildCodexCheck(health: CodexHealthResponse | null): DoctorCheck {
   );
 }
 
+function buildHarnessSupportCheck(statuses: HarnessSupportStatus[] | null): DoctorCheck {
+  if (!statuses) {
+    return check(
+      'harness-support',
+      'Harness support',
+      'skip',
+      'Skipped because harness support evidence was unavailable'
+    );
+  }
+
+  const counts = Object.fromEntries(
+    ['detected', 'configured', 'certified', 'degraded', 'unsupported'].map((tier) => [
+      tier,
+      statuses.filter((status) => status.supportTier === tier).length,
+    ])
+  ) as Record<HarnessSupportStatus['supportTier'], number>;
+  const enabled = statuses.filter((status) => status.enabled);
+  const blocking = enabled.filter(
+    (status) => status.supportTier === 'degraded' || status.supportTier === 'unsupported'
+  );
+
+  if (blocking.length > 0) {
+    return check(
+      'harness-support',
+      'Harness support',
+      'fail',
+      `${blocking.length} enabled harness profile(s) cannot dispatch safely`,
+      {
+        ...counts,
+        blocking: blocking.map((status) => ({
+          profileId: status.profileId,
+          adapterId: status.adapterId,
+          tier: status.supportTier,
+          failureClass: status.failureClass,
+          reason: status.reason,
+          diagnosticCommands: status.diagnosticCommands,
+          remediation: status.remediation,
+        })),
+      },
+      'Disable unsupported profiles or follow the profile remediation before dispatch.'
+    );
+  }
+
+  const uncertified = enabled.filter((status) => status.supportTier !== 'certified');
+  if (uncertified.length > 0) {
+    return check(
+      'harness-support',
+      'Harness support',
+      'warn',
+      `${uncertified.length} enabled harness profile(s) are configured but not certified`,
+      counts,
+      'Run the pinned harness conformance fixtures before treating these runtimes as certified.'
+    );
+  }
+
+  return check(
+    'harness-support',
+    'Harness support',
+    'pass',
+    `${enabled.length} enabled harness profile(s) have current certification evidence`,
+    counts
+  );
+}
+
 export async function runDoctorChecks(
   input: Partial<DoctorOptions> = {},
   depsInput: Partial<DoctorDependencies> = {}
@@ -630,6 +696,7 @@ export async function runDoctorChecks(
   );
 
   let agents: AgentConfigResponse[] | null = null;
+  let harnessSupport: HarnessSupportStatus[] | null = null;
   let routing: RoutingConfigResponse | null = null;
   let settings: FeatureSettingsResponse | null = null;
 
@@ -688,6 +755,13 @@ export async function runDoctorChecks(
       '/api/config/agents'
     );
     agents = agentsResponse.ok ? agentsResponse.data : null;
+
+    const harnessSupportResponse = await requestJson<HarnessSupportStatus[]>(
+      deps,
+      options,
+      '/api/config/agent-support'
+    );
+    harnessSupport = harnessSupportResponse.ok ? harnessSupportResponse.data : null;
 
     const routingResponse = await requestJson<RoutingConfigResponse>(
       deps,
@@ -748,10 +822,14 @@ export async function runDoctorChecks(
     checks.push(
       check('codex-health', 'Codex health', 'skip', 'Skipped because API is unreachable')
     );
+    checks.push(
+      check('harness-support', 'Harness support', 'skip', 'Skipped because API is unreachable')
+    );
   }
 
   const agentResult = await buildAgentCheck(deps, agents);
   checks.push(agentResult.check);
+  if (apiReachable) checks.push(buildHarnessSupportCheck(harnessSupport));
   checks.push(
     buildRoutingCheck(routing, agentResult.availableAgents, agentResult.configuredAgents)
   );

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -22,7 +22,10 @@ The profile records stable profile and adapter IDs, transport, executable and
 non-mutating authentication probes, version/build invalidation policy,
 platforms, launch/worktree behavior, environment and credential allowlists,
 conformance fixture identity, documentation, and remediation. The contract
-contains credential key names only, never credential values.
+contains credential key names only, never credential values. Credential-like
+launch arguments are replaced with `[REDACTED]` before the profile is exposed
+or hashed, so rotating a secret cannot turn the profile digest into a secret
+oracle.
 
 The live status projection uses five tiers:
 
@@ -44,7 +47,10 @@ Task start rechecks the normalized profile before attempt state is created. An
 explicit provider must match the profile's executable adapter. A display-only
 Claude Code or Copilot profile, an unsupported provider, or an unknown
 provider-less profile fails with an actionable `409` and can never fall through
-to OpenClaw.
+to OpenClaw. Recognized credential material in the configured command or launch
+arguments degrades the profile and blocks dispatch before probing or attempt
+creation. Put credentials in an allowlisted environment key or a run-scoped
+brokered credential reference instead.
 
 For backward compatibility, normalization migrates only known provider-less
 Codex and Hermes records when both the built-in type and command identity match

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -9,10 +9,48 @@ Veritas works as a board without any agent runner. When you do enable agents, pr
 Fresh v5 installs use OpenAI Codex as the default agent:
 
 - `codex` is enabled by default and uses `codex exec --sandbox workspace-write --json`.
-- `claude-code`, `amp`, `copilot`, `gemini`, `codex-sdk`, `codex-cloud`, `hermes`, `ollama-local`, `ollama-cloud`, and `lm-studio-local` are available as profiles you can enable or route to.
+- `codex-sdk` and `hermes` have executable adapters but are disabled by default.
+- `claude-code`, `amp`, `copilot`, `gemini`, `codex-cloud`, `ollama-local`, `ollama-cloud`, and `lm-studio-local` remain visible for configuration and migration, but they cannot dispatch until a matching executable adapter ships.
 - Built-in routing sends code, bug, documentation, and review work to `codex` first, with conservative fallbacks for higher-risk code paths.
 
 Existing configs keep the user's chosen default agent. Missing built-in profiles are added during config normalization without overwriting customized commands, arguments, or enabled states.
+
+## Harness Support Profiles And Tiers
+
+Every configured agent is normalized to a `harness-support-profile/v1` contract.
+The profile records stable profile and adapter IDs, transport, executable and
+non-mutating authentication probes, version/build invalidation policy,
+platforms, launch/worktree behavior, environment and credential allowlists,
+conformance fixture identity, documentation, and remediation. The contract
+contains credential key names only, never credential values.
+
+The live status projection uses five tiers:
+
+| Tier          | Meaning                                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `detected`    | The executable is installed, but the profile is disabled or not ready for dispatch.                                          |
+| `configured`  | The explicit adapter is enabled and its runtime probe is ready, but current certification evidence is absent.                |
+| `certified`   | The installed version, build, manifest digest, and probe revision match a passing conformance result.                        |
+| `degraded`    | The adapter exists, but installation, authentication, probe, compatibility, or certification evidence is unhealthy or stale. |
+| `unsupported` | The profile has no executable adapter or does not support the current platform.                                              |
+
+Settings -> Agents displays the same tier returned by
+`GET /api/config/agent-support`. `vk doctor` consumes that endpoint unchanged:
+an enabled `degraded` or `unsupported` profile is a blocking failure, while an
+enabled `configured` profile is a warning until certification is current.
+Reasons and remediation are redacted before leaving the server.
+
+Task start rechecks the normalized profile before attempt state is created. An
+explicit provider must match the profile's executable adapter. A display-only
+Claude Code or Copilot profile, an unsupported provider, or an unknown
+provider-less profile fails with an actionable `409` and can never fall through
+to OpenClaw.
+
+For backward compatibility, normalization migrates only known provider-less
+Codex and Hermes records when both the built-in type and command identity match
+(`codex` -> `codex-cli`, `hermes` -> `hermes-cli`). New and custom profiles must
+set an explicit provider. Command-name inference is not a general
+adapter-selection mechanism.
 
 ## Provider Runtime Manifests
 
@@ -23,9 +61,10 @@ timestamp and diagnostics, and every known runtime or sandbox capability as
 `supported`, `advisory`, `unsupported`, or `unknown`.
 
 Veritas currently has executable task adapters for `codex-cli`, `codex-sdk`,
-`hermes-cli`, and `openclaw`. An explicitly configured Codex Cloud, Ollama, LM
-Studio, or custom profile is not silently sent through OpenClaw; task dispatch
-fails with an actionable `409` until that provider has an execution adapter.
+`hermes-cli`, and `openclaw`. An explicitly configured Claude Code, Copilot,
+Codex Cloud, Ollama, LM Studio, or custom profile is not silently sent through
+OpenClaw; task dispatch fails with an actionable `409` until that provider has
+an execution adapter.
 
 The exact manifest and its `sha256:` digest are stored on the current attempt,
 attempt history, optional run trace, and Markdown run log. Provider identity

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -534,9 +534,17 @@ GET    /api/config/repos/:name/branches # List branches
 
 ```
 GET /api/config/agents        # List configured agents
+GET /api/config/agent-support # Redacted live harness support tiers and remediation
 PUT /api/config/agents        # Update agent config
 PUT /api/config/default-agent # Set default agent
 ```
+
+`GET /api/config/agent-support` is the canonical operator projection used by
+Settings and `vk doctor`. Each row identifies the agent type, support profile,
+explicit adapter and transport, enabled state, tier, redacted reason/failure
+class, executable/authentication posture, version/build evidence, manifest
+digest, safe diagnostic commands, and remediation. It never returns credential
+values.
 
 ---
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -586,9 +586,17 @@ Manage GitHub Issues bidirectional sync.
 | --------------------- | ------------------------------------------------------------------------------ |
 | `vk summary`          | Project stats: status counts, project progress, high-priority items            |
 | `vk summary standup`  | Daily standup summary (`--yesterday`, `--date YYYY-MM-DD`, `--json`, `--text`) |
+| `vk doctor`           | Validate API, routing, executable, and harness support readiness (`--json`)    |
 | `vk notify <message>` | Create a notification (`--type`, `--title`, `--task` options)                  |
 | `vk notify:check`     | Check for tasks that need notifications                                        |
 | `vk notify:pending`   | Get pending notifications formatted for Teams                                  |
+
+`vk doctor` reads the same redacted harness support projection shown in
+Settings. Enabled `degraded` or `unsupported` profiles fail the doctor check;
+enabled `configured` profiles warn until their installed build has current
+certification evidence. Use `vk doctor --json` for support-safe automation and
+diagnostics, including redacted readiness reasons, safe probe commands, and
+remediation.
 
 ---
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -452,6 +452,43 @@ describe('ClawdbotAgentService Codex providers', () => {
     }
   );
 
+  it('redacts provider identity secrets before emitting harness telemetry', async () => {
+    const fixture = await fs.readFile(path.join(fixtureDir, 'success.jsonl'), 'utf-8');
+    mockSpawn.mockReturnValue(createFakeChild(fixture));
+    mockCheckAgent.mockImplementation(async (agent: AgentConfig) => ({
+      type: agent.type,
+      name: agent.name,
+      enabled: agent.enabled,
+      configured: true,
+      command: agent.command,
+      executableFound: true,
+      executablePath: `/usr/local/bin/${agent.command}`,
+      providerVersion: 'codex-cli 0.144.0 token=telemetry-secret',
+      providerVersionSource: 'codex --version',
+      authenticated: true,
+      healthy: true,
+      checkedAt: '2026-06-03T00:00:00.000Z',
+    }));
+    const service = testableService(tmpDir);
+
+    await service.startAgent(task.id, 'codex');
+
+    await waitFor(() => {
+      expect(mockTelemetryEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'run.started',
+          harnessSupport: expect.objectContaining({
+            providerVersion: 'codex-cli 0.144.0 token=[REDACTED]',
+          }),
+        })
+      );
+    });
+    expect(JSON.stringify(mockTelemetryEmit.mock.calls)).not.toContain('telemetry-secret');
+    await waitFor(async () => {
+      expect(await service.getAgentStatus(task.id)).toBeNull();
+    });
+  });
+
   it('persists a run-level commit policy override in the immutable task envelope', async () => {
     const fixture = await fs.readFile(path.join(fixtureDir, 'success.jsonl'), 'utf-8');
     mockSpawn.mockReturnValue(createFakeChild(fixture));

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -343,6 +343,38 @@ describe('ClawdbotAgentService Codex providers', () => {
         providerVersion: 'codex-cli 0.144.0',
       });
       expect(task.attempt?.providerRuntimeManifest?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+      expect(task.attempt?.harnessSupport).toMatchObject({
+        profileId: 'openai-codex-cli',
+        adapterId: 'codex-cli',
+        supportTier: 'configured',
+        failureClass: 'none',
+        manifestDigest: task.attempt?.providerRuntimeManifest?.digest,
+      });
+      expect(mockTelemetryEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'run.started',
+          harnessSupport: expect.objectContaining({
+            profileId: 'openai-codex-cli',
+            adapterId: 'codex-cli',
+            providerVersion: 'codex-cli 0.144.0',
+            manifestDigest: task.attempt?.providerRuntimeManifest?.digest,
+            supportTier: 'configured',
+            failureClass: 'none',
+          }),
+        })
+      );
+      expect(mockTelemetryEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'run.completed',
+          harnessSupport: expect.objectContaining({
+            profileId: 'openai-codex-cli',
+            adapterId: 'codex-cli',
+            manifestDigest: task.attempt?.providerRuntimeManifest?.digest,
+            supportTier: 'configured',
+            failureClass: 'none',
+          }),
+        })
+      );
       expect(task.attempt?.taskEnvelope).toMatchObject({
         schemaVersion: 'task-envelope/v1',
         commitPolicy: 'allowed',

--- a/server/src/__tests__/config-service-extended.test.ts
+++ b/server/src/__tests__/config-service-extended.test.ts
@@ -7,6 +7,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { ConfigService } from '../services/config-service.js';
+import { normalizeHarnessSupportProfile } from '../services/harness-support-profile-registry.js';
 
 describe('ConfigService', () => {
   let tmpDir: string;
@@ -420,6 +421,57 @@ describe('ConfigService', () => {
 
       const config = await service.updateAgents(newAgents);
       expect(config.agents).toHaveLength(1);
+    });
+
+    it('rebuilds system-owned support evidence instead of trusting client input', async () => {
+      await service.getConfig();
+      const forgedProfile = normalizeHarnessSupportProfile({
+        type: 'codex',
+        name: 'OpenAI Codex',
+        command: 'codex',
+        args: [],
+        enabled: true,
+        provider: 'codex-cli',
+      });
+      forgedProfile.id = 'forged-certified-profile';
+      forgedProfile.supportTier = 'certified';
+      forgedProfile.conformance = {
+        fixtureSet: 'forged/v1',
+        status: 'passed',
+        certifiedAt: '2026-07-23T16:00:00.000Z',
+        providerVersion: 'forged 1.0.0',
+        manifestDigest: `sha256:${'1'.repeat(64)}`,
+        configurationDigest: `sha256:${'2'.repeat(64)}`,
+        probeRevision: 999,
+      };
+
+      const config = await service.updateAgents([
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          provider: 'codex-cli',
+          supportProfile: forgedProfile,
+        },
+      ]);
+
+      expect(config.agents).toHaveLength(1);
+      expect(config.agents[0]?.supportProfile).toMatchObject({
+        id: 'openai-codex-cli',
+        adapterId: 'codex-cli',
+        supportTier: 'configured',
+        conformance: {
+          fixtureSet: 'openai-codex-cli/v1',
+          status: 'not-run',
+        },
+      });
+      expect(config.agents[0]?.supportProfile).not.toEqual(forgedProfile);
+
+      const persisted = JSON.parse(await fs.readFile(configFile, 'utf-8'));
+      expect(persisted.agents[0].supportProfile.id).toBe('openai-codex-cli');
+      expect(persisted.agents[0].supportProfile.conformance.status).toBe('not-run');
     });
   });
 

--- a/server/src/__tests__/config-service-extended.test.ts
+++ b/server/src/__tests__/config-service-extended.test.ts
@@ -44,10 +44,33 @@ describe('ConfigService', () => {
       expect(config.agents).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
+            type: 'claude-code',
+            supportProfile: expect.objectContaining({
+              schemaVersion: 'harness-support-profile/v1',
+              id: 'claude-code',
+              transport: 'process-jsonl',
+              supportTier: 'unsupported',
+            }),
+          }),
+          expect.objectContaining({
+            type: 'copilot',
+            supportProfile: expect.objectContaining({
+              schemaVersion: 'harness-support-profile/v1',
+              id: 'github-copilot-cli',
+              transport: 'acp',
+              supportTier: 'unsupported',
+            }),
+          }),
+          expect.objectContaining({
             type: 'codex',
             name: 'OpenAI Codex',
             command: 'codex',
             provider: 'codex-cli',
+            supportProfile: expect.objectContaining({
+              id: 'openai-codex-cli',
+              adapterId: 'codex-cli',
+              transport: 'process-jsonl',
+            }),
             enabled: true,
           }),
           expect.objectContaining({
@@ -88,6 +111,32 @@ describe('ConfigService', () => {
         ])
       );
       expect(config.defaultAgent).toBe('codex');
+
+      const expectedSupport = [
+        ['claude-code', undefined, 'unsupported'],
+        ['amp', undefined, 'unsupported'],
+        ['copilot', undefined, 'unsupported'],
+        ['gemini', undefined, 'unsupported'],
+        ['codex', 'codex-cli', 'configured'],
+        ['codex-sdk', 'codex-sdk', 'configured'],
+        ['codex-cloud', undefined, 'unsupported'],
+        ['hermes', 'hermes-cli', 'configured'],
+        ['ollama-local', undefined, 'unsupported'],
+        ['ollama-cloud', undefined, 'unsupported'],
+        ['lm-studio-local', undefined, 'unsupported'],
+      ] as const;
+      for (const [type, adapterId, supportTier] of expectedSupport) {
+        expect(config.agents.find((agent) => agent.type === type)?.supportProfile).toMatchObject({
+          ...(adapterId ? { adapterId } : {}),
+          supportTier,
+        });
+      }
+
+      const codexProfile = config.agents.find((agent) => agent.type === 'codex')?.supportProfile;
+      expect(codexProfile?.launch.environmentAllowlist).toContain('CODEX_HOME');
+      expect(codexProfile?.launch.credentialAllowlist).toEqual(
+        expect.arrayContaining(['CODEX_API_KEY', 'OPENAI_API_KEY'])
+      );
     });
 
     it('should create config file with defaults when missing', async () => {
@@ -167,6 +216,68 @@ describe('ConfigService', () => {
           }),
         ])
       );
+    });
+
+    it.each([
+      ['codex', 'codex', 'codex-cli'],
+      ['hermes', 'hermes', 'hermes-cli'],
+    ] as const)(
+      'migrates known provider-less %s records to the explicit %s adapter',
+      async (type, command, provider) => {
+        await fs.writeFile(
+          configFile,
+          JSON.stringify({
+            repos: [],
+            agents: [
+              {
+                type,
+                name: type,
+                command,
+                args: [],
+                enabled: true,
+              },
+            ],
+            defaultAgent: type,
+          })
+        );
+
+        const config = await service.getConfig();
+        expect(config.agents.find((agent) => agent.type === type)).toMatchObject({
+          provider,
+          supportProfile: {
+            adapterId: provider,
+            supportTier: 'configured',
+          },
+        });
+      }
+    );
+
+    it('does not infer an adapter for a new provider-less custom profile by command name', async () => {
+      await fs.writeFile(
+        configFile,
+        JSON.stringify({
+          repos: [],
+          agents: [
+            {
+              type: 'custom-codex-wrapper',
+              name: 'Custom Codex Wrapper',
+              command: 'codex',
+              args: [],
+              enabled: true,
+            },
+          ],
+          defaultAgent: 'custom-codex-wrapper',
+        })
+      );
+
+      const config = await service.getConfig();
+      const custom = config.agents.find((agent) => agent.type === 'custom-codex-wrapper');
+      expect(custom?.provider).toBeUndefined();
+      expect(custom).toMatchObject({
+        supportProfile: {
+          supportTier: 'unsupported',
+        },
+      });
     });
 
     it('should use cache on subsequent calls', async () => {

--- a/server/src/__tests__/fixtures/provider-runtime-manifest.ts
+++ b/server/src/__tests__/fixtures/provider-runtime-manifest.ts
@@ -13,6 +13,7 @@ interface ProviderRuntimeManifestFixtureOptions {
   provider?: string;
   adapter?: string;
   providerVersion?: string;
+  providerBuild?: string;
   models?: string[];
   probeState?: ProviderRuntimeProbeState;
   capabilityStates?: Partial<Record<ProviderRuntimeCapabilityId, ProviderRuntimeCapabilityState>>;
@@ -37,6 +38,7 @@ export function providerRuntimeManifestFixture(
     adapter: options.adapter ?? provider,
     protocolVersion: 'fixture-runtime/v1',
     providerVersion: options.providerVersion ?? `${provider} 1.0.0`,
+    ...(options.providerBuild ? { providerBuild: options.providerBuild } : {}),
     models: options.models ?? ['gpt-5'],
     capabilities: KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS.map((id) => {
       const state =

--- a/server/src/__tests__/harness-support-profile-schemas.test.ts
+++ b/server/src/__tests__/harness-support-profile-schemas.test.ts
@@ -36,4 +36,88 @@ describe('HarnessSupportProfileSchema', () => {
       })
     ).toThrow();
   });
+
+  it('redacts credential-bearing launch arguments without encoding values in the digest', () => {
+    const base: AgentConfig = {
+      type: 'custom-secure-runner',
+      name: 'Secure Runner',
+      command: 'runner',
+      args: [
+        '--api-key',
+        'first-sensitive-value',
+        '--token=inline-sensitive-value',
+        '--credentials=credential-sensitive-value',
+      ],
+      enabled: true,
+      provider: 'codex-cli',
+    };
+    const first = normalizeHarnessSupportProfile(base);
+    const rotated = normalizeHarnessSupportProfile({
+      ...base,
+      args: [
+        '--api-key',
+        'rotated-sensitive-value',
+        '--token=inline-sensitive-value',
+        '--credentials=rotated-credential-sensitive-value',
+      ],
+    });
+
+    expect(first.launch.args).toEqual([
+      '--api-key',
+      '[REDACTED]',
+      '--token=[REDACTED]',
+      '--credentials=[REDACTED]',
+    ]);
+    expect(JSON.stringify(first)).not.toContain('first-sensitive-value');
+    expect(JSON.stringify(first)).not.toContain('inline-sensitive-value');
+    expect(JSON.stringify(first)).not.toContain('credential-sensitive-value');
+    expect(first.compatibility.configurationDigest).toBe(rotated.compatibility.configurationDigest);
+    expect(first).toMatchObject({
+      supportTier: 'degraded',
+      supportReason: expect.stringMatching(/credential material/i),
+    });
+    expect(() => HarnessSupportProfileSchema.parse(first)).not.toThrow();
+  });
+
+  it('redacts and degrades a command containing a credential argument', () => {
+    const profile = normalizeHarnessSupportProfile({
+      type: 'custom-secure-runner',
+      name: 'Secure Runner',
+      command:
+        'runner token=inline-command-sensitive-value --authorization command-sensitive-value',
+      args: [],
+      enabled: true,
+      provider: 'codex-cli',
+    });
+
+    expect(profile).toMatchObject({
+      supportTier: 'degraded',
+      executable: {
+        command: 'runner token=[REDACTED] --authorization [REDACTED]',
+      },
+    });
+    expect(JSON.stringify(profile)).not.toContain('inline-command-sensitive-value');
+    expect(JSON.stringify(profile)).not.toContain('command-sensitive-value');
+  });
+
+  it('rejects unredacted credential material anywhere in public profile evidence', () => {
+    const profile = normalizeHarnessSupportProfile({
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      args: [],
+      enabled: true,
+      provider: 'codex-cli',
+    });
+
+    expect(() =>
+      HarnessSupportProfileSchema.parse({
+        ...profile,
+        conformance: {
+          ...profile.conformance,
+          providerBuild: 'build token=unredacted-sensitive-value',
+        },
+      })
+    ).toThrow(/credentials|secrets/i);
+  });
 });

--- a/server/src/__tests__/harness-support-profile-schemas.test.ts
+++ b/server/src/__tests__/harness-support-profile-schemas.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentConfig } from '@veritas-kanban/shared';
+import { HarnessSupportProfileSchema } from '../schemas/harness-support-profile-schemas.js';
+import { normalizeHarnessSupportProfile } from '../services/harness-support-profile-registry.js';
+
+describe('HarnessSupportProfileSchema', () => {
+  it('rejects a configured harness profile without an executable adapter', () => {
+    const agent: AgentConfig = {
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      args: [],
+      enabled: true,
+      provider: 'codex-cli',
+    };
+    const profile = normalizeHarnessSupportProfile(agent);
+    const { adapterId: _adapterId, ...withoutAdapter } = profile;
+
+    expect(() => HarnessSupportProfileSchema.parse(withoutAdapter)).toThrow(/executable adapter/i);
+  });
+
+  it('rejects an unknown executable adapter', () => {
+    const profile = normalizeHarnessSupportProfile({
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      args: [],
+      enabled: true,
+      provider: 'codex-cli',
+    });
+
+    expect(() =>
+      HarnessSupportProfileSchema.parse({
+        ...profile,
+        adapterId: 'implicit-openclaw-fallback',
+      })
+    ).toThrow();
+  });
+});

--- a/server/src/__tests__/harness-support-service.test.ts
+++ b/server/src/__tests__/harness-support-service.test.ts
@@ -312,4 +312,34 @@ describe('evaluateHarnessSupportStatus', () => {
     expect(status.diagnosticCommands).toContain('codex login status --token=[REDACTED]');
     expect(JSON.stringify(status)).not.toContain('diagnostic-secret');
   });
+
+  it('degrades unsafe launch configuration before evaluating runtime readiness', () => {
+    const candidate = agent({
+      type: 'custom-secure-runner',
+      name: 'Secure Runner',
+      command: 'codex',
+      args: ['--api-key', 'status-sensitive-value'],
+      provider: 'codex-cli',
+    });
+
+    const status = evaluateHarnessSupportStatus(candidate, {
+      type: candidate.type,
+      name: candidate.name,
+      enabled: true,
+      configured: true,
+      command: candidate.command,
+      executableFound: true,
+      authenticated: true,
+      healthy: true,
+      checkedAt: '2026-07-23T16:00:00.000Z',
+    });
+
+    expect(status).toMatchObject({
+      profileId: 'openai-codex-cli',
+      supportTier: 'degraded',
+      failureClass: 'unsafe-configuration',
+      reason: expect.stringMatching(/credential material/i),
+    });
+    expect(JSON.stringify(status)).not.toContain('status-sensitive-value');
+  });
 });

--- a/server/src/__tests__/harness-support-service.test.ts
+++ b/server/src/__tests__/harness-support-service.test.ts
@@ -114,6 +114,7 @@ describe('evaluateHarnessSupportStatus', () => {
     const manifest = providerRuntimeManifestFixture({
       provider: 'codex-cli',
       providerVersion: 'codex-cli 1.0.0',
+      providerBuild: 'build-a',
     });
     const candidate = agent({
       type: 'codex',
@@ -131,6 +132,7 @@ describe('evaluateHarnessSupportStatus', () => {
         status: 'passed',
         certifiedAt: '2026-07-23T16:00:00.000Z',
         providerVersion: manifest.providerVersion,
+        providerBuild: manifest.providerBuild,
         manifestDigest: manifest.digest,
         configurationDigest: candidate.supportProfile.compatibility.configurationDigest,
         probeRevision: manifest.probeRevision,
@@ -169,9 +171,25 @@ describe('evaluateHarnessSupportStatus', () => {
     expect(
       evaluateHarnessSupportStatus(candidate, health, {
         ...manifest,
+        providerBuild: 'build-b',
+      })
+    ).toMatchObject({
+      supportTier: 'degraded',
+      failureClass: 'certification-stale',
+    });
+
+    expect(
+      evaluateHarnessSupportStatus(candidate, health, {
+        ...manifest,
         probeRevision: manifest.probeRevision + 1,
       })
     ).toMatchObject({
+      supportTier: 'degraded',
+      failureClass: 'certification-stale',
+    });
+
+    candidate.supportProfile.compatibility.configurationDigest = `sha256:${'f'.repeat(64)}`;
+    expect(evaluateHarnessSupportStatus(candidate, health, manifest)).toMatchObject({
       supportTier: 'degraded',
       failureClass: 'certification-stale',
     });
@@ -213,6 +231,40 @@ describe('evaluateHarnessSupportStatus', () => {
     ).toMatchObject({
       supportTier: 'degraded',
       failureClass: 'incompatible-build',
+    });
+  });
+
+  it('uses the probed runtime manifest as the canonical provider version', () => {
+    const manifest = providerRuntimeManifestFixture({
+      provider: 'codex-cli',
+      providerVersion: 'codex-cli 2.0.0',
+    });
+    const candidate = agent({
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      provider: 'codex-cli',
+    });
+
+    expect(
+      evaluateHarnessSupportStatus(
+        candidate,
+        {
+          type: candidate.type,
+          name: candidate.name,
+          enabled: true,
+          configured: true,
+          command: candidate.command,
+          executableFound: true,
+          providerVersion: 'stale health version',
+          authenticated: true,
+          healthy: true,
+          checkedAt: '2026-07-23T16:00:00.000Z',
+        },
+        manifest
+      )
+    ).toMatchObject({
+      providerVersion: 'codex-cli 2.0.0',
     });
   });
 

--- a/server/src/__tests__/harness-support-service.test.ts
+++ b/server/src/__tests__/harness-support-service.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentConfig } from '@veritas-kanban/shared';
+import { normalizeHarnessSupportProfile } from '../services/harness-support-profile-registry.js';
+import { evaluateHarnessSupportStatus } from '../services/harness-support-service.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+
+function agent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  const base: AgentConfig = {
+    type: 'claude-code',
+    name: 'Claude Code',
+    command: 'claude',
+    args: [],
+    enabled: true,
+  };
+  const candidate = { ...base, ...overrides };
+  return {
+    ...candidate,
+    supportProfile: normalizeHarnessSupportProfile(candidate),
+  };
+}
+
+describe('evaluateHarnessSupportStatus', () => {
+  it('classifies a display-only profile as unsupported even when its executable is installed', () => {
+    const candidate = agent();
+
+    expect(
+      evaluateHarnessSupportStatus(candidate, {
+        type: candidate.type,
+        name: candidate.name,
+        enabled: true,
+        configured: true,
+        command: candidate.command,
+        executableFound: true,
+        authenticated: true,
+        healthy: true,
+        checkedAt: '2026-07-23T16:00:00.000Z',
+      })
+    ).toMatchObject({
+      profileId: 'claude-code',
+      supportTier: 'unsupported',
+      failureClass: 'adapter-unavailable',
+      executableFound: true,
+    });
+  });
+
+  it.each([
+    {
+      name: 'installed but disabled',
+      enabled: false,
+      executableFound: true,
+      authenticated: true,
+      healthy: false,
+      expectedTier: 'detected',
+      expectedFailure: 'disabled',
+    },
+    {
+      name: 'missing executable',
+      enabled: true,
+      executableFound: false,
+      authenticated: null,
+      healthy: false,
+      expectedTier: 'degraded',
+      expectedFailure: 'not-installed',
+    },
+    {
+      name: 'failed authentication',
+      enabled: true,
+      executableFound: true,
+      authenticated: false,
+      healthy: false,
+      expectedTier: 'degraded',
+      expectedFailure: 'unauthenticated',
+    },
+    {
+      name: 'configured without current certification',
+      enabled: true,
+      executableFound: true,
+      authenticated: true,
+      healthy: true,
+      expectedTier: 'configured',
+      expectedFailure: 'none',
+    },
+  ] as const)(
+    'classifies an executable adapter as $expectedTier when $name',
+    ({ enabled, executableFound, authenticated, healthy, expectedTier, expectedFailure }) => {
+      const candidate = agent({
+        type: 'codex',
+        name: 'OpenAI Codex',
+        command: 'codex',
+        provider: 'codex-cli',
+        enabled,
+      });
+
+      expect(
+        evaluateHarnessSupportStatus(candidate, {
+          type: candidate.type,
+          name: candidate.name,
+          enabled,
+          configured: true,
+          command: candidate.command,
+          executableFound,
+          authenticated,
+          healthy,
+          checkedAt: '2026-07-23T16:00:00.000Z',
+        })
+      ).toMatchObject({
+        supportTier: expectedTier,
+        failureClass: expectedFailure,
+      });
+    }
+  );
+
+  it('certifies only the exact runtime manifest recorded by passing conformance evidence', () => {
+    const manifest = providerRuntimeManifestFixture({
+      provider: 'codex-cli',
+      providerVersion: 'codex-cli 1.0.0',
+    });
+    const candidate = agent({
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      provider: 'codex-cli',
+    });
+    if (!candidate.supportProfile) {
+      throw new Error('Expected a normalized Codex support profile');
+    }
+    candidate.supportProfile = {
+      ...candidate.supportProfile,
+      conformance: {
+        fixtureSet: 'openai-codex-cli/v1',
+        status: 'passed',
+        certifiedAt: '2026-07-23T16:00:00.000Z',
+        providerVersion: manifest.providerVersion,
+        manifestDigest: manifest.digest,
+        configurationDigest: candidate.supportProfile.compatibility.configurationDigest,
+        probeRevision: manifest.probeRevision,
+      },
+    };
+    const health = {
+      type: candidate.type,
+      name: candidate.name,
+      enabled: true,
+      configured: true,
+      command: candidate.command,
+      executableFound: true,
+      providerVersion: manifest.providerVersion,
+      authenticated: true,
+      healthy: true,
+      checkedAt: '2026-07-23T16:00:00.000Z',
+    };
+
+    expect(evaluateHarnessSupportStatus(candidate, health, manifest)).toMatchObject({
+      supportTier: 'certified',
+      failureClass: 'none',
+      manifestDigest: manifest.digest,
+      diagnosticCommands: ['codex --version', 'codex login status'],
+    });
+
+    expect(
+      evaluateHarnessSupportStatus(candidate, health, {
+        ...manifest,
+        providerVersion: 'codex-cli 2.0.0',
+      })
+    ).toMatchObject({
+      supportTier: 'degraded',
+      failureClass: 'certification-stale',
+    });
+
+    expect(
+      evaluateHarnessSupportStatus(candidate, health, {
+        ...manifest,
+        probeRevision: manifest.probeRevision + 1,
+      })
+    ).toMatchObject({
+      supportTier: 'degraded',
+      failureClass: 'certification-stale',
+    });
+  });
+
+  it('degrades an installed provider version outside the tested compatibility policy', () => {
+    const manifest = providerRuntimeManifestFixture({
+      provider: 'codex-cli',
+      providerVersion: 'codex-cli 2.0.0',
+    });
+    const candidate = agent({
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      provider: 'codex-cli',
+    });
+    if (!candidate.supportProfile) {
+      throw new Error('Expected a normalized Codex support profile');
+    }
+    candidate.supportProfile.compatibility.testedVersions = ['codex-cli 1.0.0'];
+
+    expect(
+      evaluateHarnessSupportStatus(
+        candidate,
+        {
+          type: candidate.type,
+          name: candidate.name,
+          enabled: true,
+          configured: true,
+          command: candidate.command,
+          executableFound: true,
+          providerVersion: manifest.providerVersion,
+          authenticated: true,
+          healthy: true,
+          checkedAt: '2026-07-23T16:00:00.000Z',
+        },
+        manifest
+      )
+    ).toMatchObject({
+      supportTier: 'degraded',
+      failureClass: 'incompatible-build',
+    });
+  });
+
+  it('degrades and redacts a failed runtime probe', () => {
+    const candidate = agent({
+      type: 'codex',
+      name: 'OpenAI Codex',
+      command: 'codex',
+      provider: 'codex-cli',
+    });
+    if (!candidate.supportProfile) {
+      throw new Error('Expected a normalized Codex support profile');
+    }
+    candidate.supportProfile.authentication = {
+      kind: 'command',
+      commandArgs: ['login', 'status', '--token=diagnostic-secret'],
+      nonMutating: true,
+    };
+    const health = {
+      type: candidate.type,
+      name: candidate.name,
+      enabled: true,
+      configured: true,
+      command: candidate.command,
+      executableFound: true,
+      authenticated: true,
+      healthy: true,
+      checkedAt: '2026-07-23T16:00:00.000Z',
+    };
+
+    const status = evaluateHarnessSupportStatus(
+      candidate,
+      health,
+      undefined,
+      'linux',
+      'probe failed token=super-secret-value'
+    );
+
+    expect(status).toMatchObject({
+      supportTier: 'degraded',
+      failureClass: 'probe-failed',
+    });
+    expect(status.reason).toContain('token=[REDACTED]');
+    expect(status.reason).not.toContain('super-secret-value');
+    expect(status.diagnosticCommands).toContain('codex login status --token=[REDACTED]');
+    expect(JSON.stringify(status)).not.toContain('diagnostic-secret');
+  });
+});

--- a/server/src/__tests__/provider-runtime-adapters.test.ts
+++ b/server/src/__tests__/provider-runtime-adapters.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentConfig } from '@veritas-kanban/shared';
 import { ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import type { AgentHealthChecker } from '../services/agent-health-service.js';
@@ -125,6 +125,29 @@ describe('ClawdbotAgentService provider runtime adapters', () => {
         reason: 'Harness support profile has no executable adapter',
       }),
     });
+  });
+
+  it('fails closed when launch arguments contain credential material', async () => {
+    const checkAgent = vi.fn(health.checkAgent);
+
+    await expect(
+      new ClawdbotAgentService({ checkAgent }).probeProviderRuntime({
+        type: 'custom-secure-runner',
+        name: 'Secure Runner',
+        command: 'codex',
+        args: ['--api-key', 'sensitive-launch-value'],
+        enabled: true,
+        provider: 'codex-cli',
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'CONFLICT',
+      details: expect.objectContaining({
+        profileId: 'openai-codex-cli',
+        reason: 'Credential material is not allowed in harness launch commands or arguments',
+      }),
+    });
+    expect(checkAgent).not.toHaveBeenCalled();
   });
 
   it('rejects a new custom provider-less profile even when its command is codex', async () => {

--- a/server/src/__tests__/provider-runtime-adapters.test.ts
+++ b/server/src/__tests__/provider-runtime-adapters.test.ts
@@ -96,6 +96,37 @@ describe('ClawdbotAgentService provider runtime adapters', () => {
     });
   });
 
+  it('does not trust a caller-supplied profile to authorize an unsupported built-in adapter', async () => {
+    const openClawProfile = normalizeHarnessSupportProfile({
+      type: 'custom-openclaw',
+      name: 'Custom OpenClaw',
+      command: 'openclaw',
+      args: [],
+      enabled: true,
+      provider: 'openclaw',
+    });
+
+    await expect(
+      new ClawdbotAgentService(health).probeProviderRuntime({
+        type: 'claude-code',
+        name: 'Claude Code',
+        command: 'claude',
+        args: [],
+        enabled: true,
+        provider: 'openclaw',
+        supportProfile: openClawProfile,
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'CONFLICT',
+      details: expect.objectContaining({
+        profileId: 'claude-code',
+        provider: 'openclaw',
+        reason: 'Harness support profile has no executable adapter',
+      }),
+    });
+  });
+
   it('rejects a new custom provider-less profile even when its command is codex', async () => {
     await expect(
       new ClawdbotAgentService(health).probeProviderRuntime({

--- a/server/src/__tests__/provider-runtime-adapters.test.ts
+++ b/server/src/__tests__/provider-runtime-adapters.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { AgentConfig } from '@veritas-kanban/shared';
 import { ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import type { AgentHealthChecker } from '../services/agent-health-service.js';
+import { normalizeHarnessSupportProfile } from '../services/harness-support-profile-registry.js';
 
 const originalOpenClawVersion = process.env.OPENCLAW_GATEWAY_VERSION;
 
@@ -45,6 +46,75 @@ function config(provider: AgentConfig['provider']): AgentConfig {
 }
 
 describe('ClawdbotAgentService provider runtime adapters', () => {
+  it.each([
+    ['claude-code', 'claude'],
+    ['copilot', 'copilot'],
+  ] as const)(
+    'fails closed when the provider-less %s display profile is probed',
+    async (type, command) => {
+      await expect(
+        new ClawdbotAgentService(health).probeProviderRuntime({
+          type,
+          name: type,
+          command,
+          args: [],
+          enabled: true,
+        })
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        code: 'CONFLICT',
+        details: expect.objectContaining({
+          agent: type,
+          reason: 'No executable provider adapter is configured',
+        }),
+      });
+    }
+  );
+
+  it('rejects a configured provider that does not match the normalized support profile', async () => {
+    const displayOnly: AgentConfig = {
+      type: 'claude-code',
+      name: 'Claude Code',
+      command: 'claude',
+      args: [],
+      enabled: true,
+    };
+
+    await expect(
+      new ClawdbotAgentService(health).probeProviderRuntime({
+        ...displayOnly,
+        provider: 'codex-cli',
+        supportProfile: normalizeHarnessSupportProfile(displayOnly),
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'CONFLICT',
+      details: expect.objectContaining({
+        profileId: 'claude-code',
+        provider: 'codex-cli',
+      }),
+    });
+  });
+
+  it('rejects a new custom provider-less profile even when its command is codex', async () => {
+    await expect(
+      new ClawdbotAgentService(health).probeProviderRuntime({
+        type: 'custom-codex-wrapper',
+        name: 'Custom Codex Wrapper',
+        command: 'codex',
+        args: [],
+        enabled: true,
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'CONFLICT',
+      details: expect.objectContaining({
+        agent: 'custom-codex-wrapper',
+        reason: 'No executable provider adapter is configured',
+      }),
+    });
+  });
+
   it.each([
     ['codex-cli', 'codex-exec-json/v1', 'supported', 'ready'],
     ['codex-sdk', 'openai-codex-sdk/v1', 'supported', 'ready'],

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -489,6 +489,38 @@ runtime:
       expect(mockConfigService.updateAgents).toHaveBeenCalledWith(agents);
     });
 
+    it('strips client-supplied system support evidence before updating agents', async () => {
+      const agents = [
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: ['exec', '--json'],
+          enabled: true,
+          provider: 'codex-cli',
+          supportProfile: {
+            id: 'forged-certified-profile',
+            supportTier: 'certified',
+          },
+        },
+      ];
+      mockConfigService.updateAgents.mockResolvedValue({ agents: [] });
+
+      const res = await request(app).put('/api/config/agents').send(agents);
+
+      expect(res.status).toBe(200);
+      expect(mockConfigService.updateAgents).toHaveBeenCalledWith([
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: ['exec', '--json'],
+          enabled: true,
+          provider: 'codex-cli',
+        },
+      ]);
+    });
+
     it('should reject invalid agent data', async () => {
       const res = await request(app)
         .put('/api/config/agents')

--- a/server/src/__tests__/routes/config-coverage.test.ts
+++ b/server/src/__tests__/routes/config-coverage.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
-const { mockConfigService } = vi.hoisted(() => ({
+const { mockConfigService, mockHarnessSupportService } = vi.hoisted(() => ({
   mockConfigService: {
     getConfig: vi.fn(),
     addRepo: vi.fn(),
@@ -17,11 +17,20 @@ const { mockConfigService } = vi.hoisted(() => ({
     setDefaultAgent: vi.fn(),
     saveConfig: vi.fn(),
   },
+  mockHarnessSupportService: {
+    list: vi.fn(),
+  },
 }));
 
 vi.mock('../../services/config-service.js', () => ({
   ConfigService: function () {
     return mockConfigService;
+  },
+}));
+
+vi.mock('../../services/harness-support-service.js', () => ({
+  HarnessSupportService: function () {
+    return mockHarnessSupportService;
   },
 }));
 
@@ -68,6 +77,40 @@ describe('Config Routes (actual module)', () => {
       mockConfigService.getConfig.mockRejectedValue(new Error('fail'));
       const res = await request(app).get('/api/config/repos');
       expect(res.status).toBe(500);
+    });
+  });
+
+  describe('GET /api/config/agent-support', () => {
+    it('returns the shared redacted harness support projection', async () => {
+      mockHarnessSupportService.list.mockResolvedValue([
+        {
+          agentType: 'codex',
+          profileId: 'openai-codex-cli',
+          adapterId: 'codex-cli',
+          transport: 'process-jsonl',
+          supportTier: 'configured',
+          reason: 'Certification evidence is not current.',
+          failureClass: 'none',
+          checkedAt: '2026-07-23T16:00:00.000Z',
+          enabled: true,
+          executableFound: true,
+          authenticated: true,
+          diagnosticCommands: ['codex --version', 'codex login status'],
+          remediation: ['Run vk doctor.'],
+        },
+      ]);
+
+      const res = await request(app).get('/api/config/agent-support');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([
+        expect.objectContaining({
+          profileId: 'openai-codex-cli',
+          supportTier: 'configured',
+          failureClass: 'none',
+          diagnosticCommands: ['codex --version', 'codex login status'],
+        }),
+      ]);
     });
   });
 

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -21,7 +21,6 @@ import {
   TeamRosterRoutePreviewBodySchema,
   TeamRosterValidateBodySchema,
 } from '../schemas/team-roster-schemas.js';
-import { HarnessSupportProfileSchema } from '../schemas/harness-support-profile-schemas.js';
 import { HarnessSupportService } from '../services/harness-support-service.js';
 
 const router: RouterType = Router();
@@ -63,7 +62,6 @@ const agentSchema = z.object({
   model: z.string().optional(),
   sandboxPresetId: z.string().min(1).max(80).optional(),
   budget: AgentBudgetPolicySchema.optional(),
-  supportProfile: HarnessSupportProfileSchema.optional(),
 });
 
 const setDefaultAgentSchema = z.object({

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -21,9 +21,12 @@ import {
   TeamRosterRoutePreviewBodySchema,
   TeamRosterValidateBodySchema,
 } from '../schemas/team-roster-schemas.js';
+import { HarnessSupportProfileSchema } from '../schemas/harness-support-profile-schemas.js';
+import { HarnessSupportService } from '../services/harness-support-service.js';
 
 const router: RouterType = Router();
 const configService = new ConfigService();
+const harnessSupportService = new HarnessSupportService({ configService });
 const agentProfilePackageService = new AgentProfilePackageService(configService);
 const teamRosterService = new TeamRosterService(configService);
 
@@ -60,6 +63,7 @@ const agentSchema = z.object({
   model: z.string().optional(),
   sandboxPresetId: z.string().min(1).max(80).optional(),
   budget: AgentBudgetPolicySchema.optional(),
+  supportProfile: HarnessSupportProfileSchema.optional(),
 });
 
 const setDefaultAgentSchema = z.object({
@@ -351,6 +355,14 @@ router.get(
     } catch (error: any) {
       throw new BadRequestError(error.message || 'Failed to get branches');
     }
+  })
+);
+
+// GET /api/config/agent-support - Canonical redacted harness readiness projection
+router.get(
+  '/agent-support',
+  asyncHandler(async (_req, res) => {
+    res.json(await harnessSupportService.list());
   })
 );
 

--- a/server/src/schemas/harness-support-profile-schemas.ts
+++ b/server/src/schemas/harness-support-profile-schemas.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+import {
+  EXECUTABLE_AGENT_PROVIDERS,
+  HARNESS_SUPPORT_PROFILE_SCHEMA_VERSION,
+  HARNESS_SUPPORT_TIERS,
+} from '@veritas-kanban/shared';
+import { containsUnredactedProviderRuntimeSecret } from '../utils/provider-runtime-manifest-sanitize.js';
+
+const identifier = z
+  .string()
+  .trim()
+  .min(1)
+  .max(120)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:/-]*$/);
+const safeText = z.string().trim().min(1).max(1000);
+const environmentKey = z.string().regex(/^[A-Z][A-Z0-9_]{1,79}$/);
+
+export const HarnessSupportProfileSchema = z
+  .object({
+    schemaVersion: z.literal(HARNESS_SUPPORT_PROFILE_SCHEMA_VERSION),
+    id: identifier,
+    displayName: z.string().trim().min(1).max(120),
+    adapterId: z.enum(EXECUTABLE_AGENT_PROVIDERS).optional(),
+    transport: z.enum([
+      'process-jsonl',
+      'process-text',
+      'sdk',
+      'http-tools',
+      'acp',
+      'app-server',
+      'unsupported',
+    ]),
+    supportTier: z.enum(HARNESS_SUPPORT_TIERS),
+    supportReason: safeText,
+    executable: z
+      .object({
+        command: z.string().trim().min(1).max(500),
+        versionArgs: z.array(z.string().max(500)).max(16),
+      })
+      .strict(),
+    authentication: z
+      .object({
+        kind: z.enum(['command', 'environment', 'provider-managed', 'none']),
+        commandArgs: z.array(z.string().max(500)).max(16).optional(),
+        environmentKeys: z.array(environmentKey).max(32).optional(),
+        nonMutating: z.literal(true),
+      })
+      .strict(),
+    compatibility: z
+      .object({
+        policy: safeText,
+        testedVersions: z.array(z.string().trim().min(1).max(200)).max(100),
+        invalidateOn: z
+          .array(
+            z.enum(['provider-version', 'provider-build', 'configuration-digest', 'probe-revision'])
+          )
+          .min(1)
+          .max(4),
+        configurationDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+      })
+      .strict(),
+    platforms: z
+      .array(z.enum(['darwin', 'linux', 'win32']))
+      .min(1)
+      .max(3),
+    launch: z
+      .object({
+        args: z.array(z.string().max(500)).max(64),
+        workingDirectory: z.enum(['task-worktree', 'workspace', 'provider-managed']),
+        worktree: z.enum(['required', 'supported', 'provider-managed']),
+        environmentAllowlist: z.array(environmentKey).max(64),
+        credentialAllowlist: z.array(environmentKey).max(64),
+      })
+      .strict(),
+    conformance: z
+      .object({
+        fixtureSet: identifier,
+        status: z.enum(['not-run', 'passed', 'failed', 'stale']),
+        certifiedAt: z.iso.datetime().optional(),
+        providerVersion: z.string().trim().min(1).max(200).optional(),
+        providerBuild: z.string().trim().min(1).max(300).optional(),
+        manifestDigest: z
+          .string()
+          .regex(/^sha256:[a-f0-9]{64}$/)
+          .optional(),
+        configurationDigest: z
+          .string()
+          .regex(/^sha256:[a-f0-9]{64}$/)
+          .optional(),
+        probeRevision: z.number().int().positive().optional(),
+      })
+      .strict(),
+    documentationUrl: z.string().trim().min(1).max(500),
+    remediation: z.array(safeText).min(1).max(16),
+  })
+  .strict()
+  .superRefine((profile, context) => {
+    if (profile.supportTier !== 'unsupported' && !profile.adapterId) {
+      context.addIssue({
+        code: 'custom',
+        path: ['adapterId'],
+        message: 'A configured executable support profile must name an executable adapter.',
+      });
+    }
+    if (profile.adapterId && profile.transport === 'unsupported') {
+      context.addIssue({
+        code: 'custom',
+        path: ['transport'],
+        message: 'An executable adapter must declare its real transport.',
+      });
+    }
+    if (
+      profile.conformance.status === 'passed' &&
+      (!profile.conformance.certifiedAt ||
+        !profile.conformance.providerVersion ||
+        !profile.conformance.manifestDigest ||
+        !profile.conformance.configurationDigest ||
+        !profile.conformance.probeRevision)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['conformance'],
+        message: 'Passing certification requires timestamp, provider version, and manifest digest.',
+      });
+    }
+    const publicText = [
+      profile.supportReason,
+      profile.compatibility.policy,
+      ...profile.remediation,
+    ];
+    if (publicText.some(containsUnredactedProviderRuntimeSecret)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['remediation'],
+        message: 'Harness support diagnostics must not contain credentials or secrets.',
+      });
+    }
+  });

--- a/server/src/schemas/harness-support-profile-schemas.ts
+++ b/server/src/schemas/harness-support-profile-schemas.ts
@@ -124,8 +124,17 @@ export const HarnessSupportProfileSchema = z
       });
     }
     const publicText = [
+      profile.displayName,
       profile.supportReason,
+      profile.executable.command,
+      ...profile.executable.versionArgs,
+      ...(profile.authentication.commandArgs ?? []),
       profile.compatibility.policy,
+      ...profile.compatibility.testedVersions,
+      ...profile.launch.args,
+      ...(profile.conformance.providerVersion ? [profile.conformance.providerVersion] : []),
+      ...(profile.conformance.providerBuild ? [profile.conformance.providerBuild] : []),
+      profile.documentationUrl,
       ...profile.remediation,
     ];
     if (publicText.some(containsUnredactedProviderRuntimeSecret)) {

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -89,6 +89,7 @@ import {
 } from './provider-runtime-control-service.js';
 import { resolveTaskCommitPolicy, TaskEnvelopeService } from './task-envelope-service.js';
 import { evaluateHarnessSupportStatus } from './harness-support-service.js';
+import { normalizeHarnessSupportProfile } from './harness-support-profile-registry.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -1276,7 +1277,10 @@ export class ClawdbotAgentService {
       });
     }
 
-    const profile = agentConfig?.supportProfile;
+    // Adapter identity is derived from system-owned profile definitions at the
+    // dispatch boundary. A caller-provided supportProfile may carry future
+    // certification evidence, but it cannot authorize a different adapter.
+    const profile = agentConfig ? normalizeHarnessSupportProfile(agentConfig) : undefined;
     if (profile && profile.adapterId !== provider) {
       throw new ConflictError(
         `Harness support profile "${profile.id}" cannot dispatch through "${provider}"`,

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -414,8 +414,8 @@ export class ClawdbotAgentService {
             model: profileLaunch.model ?? agentConfig.model,
           }
         : agentConfig;
-    const agentHealth = await this.assertAgentAvailable(agent, profileAgentConfig);
     const provider = this.resolveAgentProvider(profileAgentConfig, agent);
+    const agentHealth = await this.assertAgentAvailable(agent, profileAgentConfig);
     const adapter = this.resolveProviderAdapter(provider);
     const budgetService = getAgentBudgetService();
     const budgetPolicy = budgetService.resolve({
@@ -1194,8 +1194,8 @@ export class ClawdbotAgentService {
     agent: AgentType = agentConfig.type,
     surface: ProviderRuntimeSurface = 'task'
   ): Promise<ProviderRuntimeManifest> {
-    const health = await this.assertAgentAvailable(agent, agentConfig);
     const provider = this.resolveAgentProvider(agentConfig, agent);
+    const health = await this.assertAgentAvailable(agent, agentConfig);
     return this.resolveProviderAdapter(provider, surface).probe({ agentConfig, health });
   }
 
@@ -1281,6 +1281,19 @@ export class ClawdbotAgentService {
     // dispatch boundary. A caller-provided supportProfile may carry future
     // certification evidence, but it cannot authorize a different adapter.
     const profile = agentConfig ? normalizeHarnessSupportProfile(agentConfig) : undefined;
+    if (profile?.supportTier === 'degraded') {
+      throw new ConflictError(
+        `Harness support profile "${profile.id}" has an unsafe launch configuration`,
+        {
+          agent,
+          profileId: profile.id,
+          adapterId: profile.adapterId,
+          provider,
+          reason: 'Credential material is not allowed in harness launch commands or arguments',
+          remediation: profile.remediation,
+        }
+      );
+    }
     if (profile && profile.adapterId !== provider) {
       throw new ConflictError(
         `Harness support profile "${profile.id}" cannot dispatch through "${provider}"`,

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -64,6 +64,8 @@ import type {
   ProviderRuntimeManifest,
   TaskCommitPolicy,
   TaskEnvelope,
+  HarnessSupportStatus,
+  HarnessSupportTelemetry,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError } from '../middleware/error-handler.js';
@@ -86,6 +88,7 @@ import {
   providerRuntimeControls,
 } from './provider-runtime-control-service.js';
 import { resolveTaskCommitPolicy, TaskEnvelopeService } from './task-envelope-service.js';
+import { evaluateHarnessSupportStatus } from './harness-support-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -140,6 +143,7 @@ export interface AgentStatus {
   provider?: ExecutableAgentProvider;
   model?: string;
   providerRuntimeManifest: ProviderRuntimeManifest;
+  harnessSupport: HarnessSupportStatus;
   taskEnvelope: TaskEnvelope;
   controls: ProviderRuntimeControlSet;
 }
@@ -198,6 +202,7 @@ interface PendingAgent {
   budgetStopped?: boolean;
   agentProfile?: AgentProfileLaunchMetadata;
   providerRuntimeManifest: ProviderRuntimeManifest;
+  harnessSupport: HarnessSupportStatus;
   taskEnvelope: TaskEnvelope;
   threadId?: string;
   abortController?: AbortController;
@@ -449,6 +454,11 @@ export class ClawdbotAgentService {
       agentConfig: launchAgentConfig,
       health: agentHealth,
     });
+    const harnessSupport = evaluateHarnessSupportStatus(
+      launchAgentConfig as AgentConfig,
+      agentHealth,
+      providerRuntimeManifest
+    );
     const launchRuntimeCapabilities = new Set<ProviderRuntimeCapabilityId>([
       ...BASELINE_LAUNCH_CAPABILITIES,
       ...(options.requiredRuntimeCapabilities ?? []),
@@ -566,6 +576,7 @@ export class ClawdbotAgentService {
       model: launchAgentConfig?.model,
       agentProfile: profileLaunch?.metadata,
       providerRuntimeManifest,
+      harnessSupport,
       taskEnvelope,
       budget: budgetPolicy
         ? {
@@ -608,6 +619,7 @@ export class ClawdbotAgentService {
       budget: pendingAgents.get(taskId)?.budget,
       agentProfile: profileLaunch?.metadata,
       providerRuntimeManifest,
+      harnessSupport,
       taskEnvelope,
     };
 
@@ -644,6 +656,7 @@ export class ClawdbotAgentService {
       agent,
       model: launchAgentConfig?.model,
       project: task.project,
+      harnessSupport: this.harnessTelemetry(harnessSupport),
     });
 
     try {
@@ -689,6 +702,7 @@ export class ClawdbotAgentService {
         project: task.project,
         error: error.message || `Failed to start ${adapter.label}`,
         stackTrace: error.stack,
+        harnessSupport: this.harnessTelemetry(harnessSupport, 'launch-failed'),
       });
       throw new Error(`Failed to start agent via ${adapter.label}: ${error.message}`, {
         cause: error,
@@ -704,6 +718,7 @@ export class ClawdbotAgentService {
       provider,
       model: launchAgentConfig?.model,
       providerRuntimeManifest,
+      harnessSupport,
       taskEnvelope,
       controls: providerRuntimeControls(providerRuntimeManifest),
     };
@@ -858,6 +873,7 @@ export class ClawdbotAgentService {
           budget: pending.budget,
           agentProfile: pending.agentProfile,
           providerRuntimeManifest: pending.providerRuntimeManifest,
+          harnessSupport: pending.harnessSupport,
           taskEnvelope: pending.taskEnvelope,
         };
         return (pending.preparedCompletion = {
@@ -917,6 +933,10 @@ export class ClawdbotAgentService {
             durationMs,
             success: result.success,
             error: result.error,
+            harnessSupport: this.harnessTelemetry(
+              pending.harnessSupport,
+              result.success ? 'none' : 'run-failed'
+            ),
           }),
       ],
       [
@@ -1215,6 +1235,7 @@ export class ClawdbotAgentService {
     agentConfig: AgentConfig | undefined,
     agent: AgentType
   ): ExecutableAgentProvider {
+    let provider: ExecutableAgentProvider | undefined;
     if (agentConfig?.provider) {
       if (
         agentConfig.provider === 'openclaw' ||
@@ -1222,21 +1243,57 @@ export class ClawdbotAgentService {
         agentConfig.provider === 'codex-cli' ||
         agentConfig.provider === 'hermes-cli'
       ) {
-        return agentConfig.provider;
+        provider = agentConfig.provider;
+      } else {
+        throw new ConflictError(
+          `Provider "${agentConfig.provider}" is configured but has no execution adapter`,
+          {
+            agent,
+            provider: agentConfig.provider,
+            reason: 'No executable provider adapter is registered',
+          }
+        );
       }
+    } else if (
+      agent === 'codex' &&
+      path.basename(agentConfig?.command.trim().split(/\s+/)[0] ?? '') === 'codex'
+    ) {
+      provider = 'codex-cli';
+    } else if (
+      agent === 'hermes' &&
+      path.basename(agentConfig?.command.trim().split(/\s+/)[0] ?? '') === 'hermes'
+    ) {
+      provider = 'hermes-cli';
+    }
+
+    if (!provider) {
+      throw new ConflictError(`Agent "${agent}" has no executable provider adapter`, {
+        agent,
+        command: agentConfig?.command,
+        reason: 'No executable provider adapter is configured',
+        remediation:
+          'Select an agent profile with an explicit executable provider or configure a supported adapter.',
+      });
+    }
+
+    const profile = agentConfig?.supportProfile;
+    if (profile && profile.adapterId !== provider) {
       throw new ConflictError(
-        `Provider "${agentConfig.provider}" is configured but has no execution adapter`,
+        `Harness support profile "${profile.id}" cannot dispatch through "${provider}"`,
         {
           agent,
-          provider: agentConfig.provider,
-          reason: 'No executable provider adapter is registered',
+          profileId: profile.id,
+          adapterId: profile.adapterId,
+          provider,
+          reason: profile.adapterId
+            ? 'Harness support profile adapter does not match the configured provider'
+            : 'Harness support profile has no executable adapter',
+          remediation: profile.remediation,
         }
       );
     }
-    if (agent === 'codex') return 'codex-cli';
-    if (agentConfig?.command === 'codex') return 'codex-cli';
-    if (agentConfig?.command === 'hermes') return 'hermes-cli';
-    return 'openclaw';
+
+    return provider;
   }
 
   private resolveProviderAdapter(
@@ -2063,6 +2120,21 @@ export class ClawdbotAgentService {
     );
   }
 
+  private harnessTelemetry(
+    status: HarnessSupportStatus,
+    failureClass: HarnessSupportTelemetry['failureClass'] = status.failureClass
+  ): HarnessSupportTelemetry {
+    return {
+      profileId: status.profileId,
+      ...(status.adapterId ? { adapterId: status.adapterId } : {}),
+      ...(status.providerVersion ? { providerVersion: status.providerVersion } : {}),
+      ...(status.providerBuild ? { providerBuild: status.providerBuild } : {}),
+      ...(status.manifestDigest ? { manifestDigest: status.manifestDigest } : {}),
+      supportTier: status.supportTier,
+      failureClass,
+    };
+  }
+
   private recordTraceStep(
     attemptId: string,
     stepType: AgentRunTraceStepType,
@@ -2610,6 +2682,7 @@ export class ClawdbotAgentService {
       provider: pending.provider,
       model: pending.model,
       providerRuntimeManifest: pending.providerRuntimeManifest,
+      harnessSupport: pending.harnessSupport,
       taskEnvelope: pending.taskEnvelope,
       controls: providerRuntimeControls(pending.providerRuntimeManifest),
     };

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -128,13 +128,7 @@ export function createDefaultConfig(): AppConfig {
 export function normalizeAppConfig(config: AppConfig): AppConfig {
   const normalized = cloneJson(config);
   normalized.features = deepMergeDefaults(normalized.features || {}, DEFAULT_FEATURE_SETTINGS);
-  normalized.agents = mergeDefaultAgents(normalized.agents || []).map((agent) => {
-    const migrated = migrateLegacyAgentProvider(agent);
-    return {
-      ...migrated,
-      supportProfile: normalizeHarnessSupportProfile(migrated),
-    };
-  });
+  normalized.agents = mergeDefaultAgents(normalized.agents || []).map(normalizeAgentConfig);
   normalized.agentProfiles = normalized.agentProfiles || [];
   return normalized;
 }
@@ -155,6 +149,14 @@ function migrateLegacyAgentProvider(agent: AgentConfig): AgentConfig {
     return { ...agent, provider: 'hermes-cli' };
   }
   return agent;
+}
+
+function normalizeAgentConfig(agent: AgentConfig): AgentConfig {
+  const migrated = migrateLegacyAgentProvider(agent);
+  return {
+    ...migrated,
+    supportProfile: normalizeHarnessSupportProfile(migrated),
+  };
 }
 
 function cloneJson<T>(value: T): T {
@@ -526,7 +528,10 @@ export class ConfigService {
 
   async updateAgents(agents: AgentConfig[]): Promise<AppConfig> {
     const config = await this.getConfig();
-    config.agents = agents;
+    // Harness support profiles are system-owned evidence. Always rebuild them
+    // after parsing API input so clients cannot spoof adapter or certification
+    // state in the file-backed cache between writes and the next reload.
+    config.agents = agents.map(normalizeAgentConfig);
     await this.saveConfig(config);
     return config;
   }

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -14,6 +14,7 @@ import { withFileLock } from './file-lock.js';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
 import { SqliteSettingsRepository } from '../storage/sqlite/settings-repository.js';
 import { getRuntimeDir } from '../utils/paths.js';
+import { normalizeHarnessSupportProfile } from './harness-support-profile-registry.js';
 
 /** How long cached config stays valid before re-reading from disk */
 const CACHE_TTL_MS = 60_000; // 60 seconds
@@ -127,7 +128,13 @@ export function createDefaultConfig(): AppConfig {
 export function normalizeAppConfig(config: AppConfig): AppConfig {
   const normalized = cloneJson(config);
   normalized.features = deepMergeDefaults(normalized.features || {}, DEFAULT_FEATURE_SETTINGS);
-  normalized.agents = mergeDefaultAgents(normalized.agents || []);
+  normalized.agents = mergeDefaultAgents(normalized.agents || []).map((agent) => {
+    const migrated = migrateLegacyAgentProvider(agent);
+    return {
+      ...migrated,
+      supportProfile: normalizeHarnessSupportProfile(migrated),
+    };
+  });
   normalized.agentProfiles = normalized.agentProfiles || [];
   return normalized;
 }
@@ -136,6 +143,18 @@ function mergeDefaultAgents(agents: AgentConfig[]): AgentConfig[] {
   const existingTypes = new Set(agents.map((agent) => agent.type));
   const missingDefaults = DEFAULT_CONFIG.agents.filter((agent) => !existingTypes.has(agent.type));
   return [...agents, ...cloneJson(missingDefaults)];
+}
+
+function migrateLegacyAgentProvider(agent: AgentConfig): AgentConfig {
+  if (agent.provider) return agent;
+  const command = path.basename(agent.command.trim().split(/\s+/)[0] ?? '');
+  if (agent.type === 'codex' && command === 'codex') {
+    return { ...agent, provider: 'codex-cli' };
+  }
+  if (agent.type === 'hermes' && command === 'hermes') {
+    return { ...agent, provider: 'hermes-cli' };
+  }
+  return agent;
 }
 
 function cloneJson<T>(value: T): T {

--- a/server/src/services/harness-support-profile-registry.ts
+++ b/server/src/services/harness-support-profile-registry.ts
@@ -1,0 +1,266 @@
+import { createHash } from 'node:crypto';
+import {
+  HARNESS_SUPPORT_PROFILE_SCHEMA_VERSION,
+  type AgentConfig,
+  type HarnessSupportProfile,
+  type HarnessTransport,
+} from '@veritas-kanban/shared';
+
+const ALL_PLATFORMS: HarnessSupportProfile['platforms'] = ['darwin', 'linux', 'win32'];
+const INVALIDATION_KEYS: HarnessSupportProfile['compatibility']['invalidateOn'] = [
+  'provider-version',
+  'provider-build',
+  'configuration-digest',
+  'probe-revision',
+];
+const PROCESS_ENVIRONMENT_ALLOWLIST = [
+  'CI',
+  'FORCE_COLOR',
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'LOGNAME',
+  'NODE_EXTRA_CA_CERTS',
+  'NO_COLOR',
+  'PATH',
+  'SHELL',
+  'SSL_CERT_FILE',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'USER',
+  'VK_API_URL',
+];
+
+interface ProfileDefinition {
+  id: string;
+  displayName: string;
+  adapterId?: string;
+  transport: HarnessTransport;
+  auth:
+    | { kind: 'command'; commandArgs: string[] }
+    | { kind: 'environment'; environmentKeys: string[] }
+    | { kind: 'provider-managed' }
+    | { kind: 'none' };
+  environmentAllowlist?: string[];
+  credentialAllowlist?: string[];
+  documentationUrl: string;
+  remediation: string[];
+}
+
+const DEFINITIONS: Record<string, ProfileDefinition> = {
+  'claude-code': unsupported(
+    'claude-code',
+    'Claude Code',
+    'process-jsonl',
+    'The Claude Code adapter is tracked by issue #916.'
+  ),
+  amp: unsupported('amp', 'Amp', 'process-text', 'No executable Amp adapter is registered.'),
+  copilot: unsupported(
+    'github-copilot-cli',
+    'GitHub Copilot CLI',
+    'acp',
+    'The GitHub Copilot CLI ACP adapter is tracked by issue #917.'
+  ),
+  gemini: unsupported(
+    'gemini-cli',
+    'Gemini CLI',
+    'process-text',
+    'No executable Gemini CLI adapter is registered.'
+  ),
+  codex: executable(
+    'openai-codex-cli',
+    'OpenAI Codex CLI',
+    'codex-cli',
+    'process-jsonl',
+    ['login', 'status'],
+    ['CODEX_API_KEY', 'OPENAI_API_KEY'],
+    ['CODEX_HOME', 'OPENAI_BASE_URL', 'OPENAI_ORG_ID', 'OPENAI_ORGANIZATION', 'OPENAI_PROJECT']
+  ),
+  'codex-sdk': executable(
+    'openai-codex-sdk',
+    'OpenAI Codex SDK',
+    'codex-sdk',
+    'sdk',
+    ['login', 'status'],
+    ['CODEX_API_KEY', 'OPENAI_API_KEY'],
+    ['CODEX_HOME', 'OPENAI_BASE_URL', 'OPENAI_ORG_ID', 'OPENAI_ORGANIZATION', 'OPENAI_PROJECT']
+  ),
+  'codex-cloud': unsupported(
+    'openai-codex-cloud',
+    'OpenAI Codex Cloud',
+    'unsupported',
+    'Codex Cloud is configurable but has no task execution adapter.'
+  ),
+  hermes: executable(
+    'hermes-cli',
+    'Hermes Agent',
+    'hermes-cli',
+    'process-text',
+    [],
+    ['HERMES_API_KEY', 'ANTHROPIC_API_KEY'],
+    ['HERMES_CONFIG_DIR']
+  ),
+  'ollama-local': unsupported(
+    'ollama-local',
+    'Ollama Local',
+    'unsupported',
+    'Ollama Local is configurable but has no task execution adapter.'
+  ),
+  'ollama-cloud': unsupported(
+    'ollama-cloud',
+    'Ollama Cloud',
+    'unsupported',
+    'Ollama Cloud is configurable but has no task execution adapter.'
+  ),
+  'lm-studio-local': unsupported(
+    'lm-studio-local',
+    'LM Studio Local',
+    'unsupported',
+    'LM Studio Local is configurable but has no task execution adapter.'
+  ),
+};
+
+const PROVIDER_DEFINITIONS: Record<string, ProfileDefinition> = {
+  openclaw: executable(
+    'openclaw',
+    'OpenClaw',
+    'openclaw',
+    'http-tools',
+    [],
+    ['CLAWDBOT_GATEWAY_TOKEN', 'OPENCLAW_GATEWAY_TOKEN'],
+    [
+      'CLAWDBOT_GATEWAY',
+      'CLAWDBOT_GATEWAY_URL',
+      'OPENCLAW_GATEWAY_ALLOW_PRIVATE',
+      'OPENCLAW_GATEWAY_SESSION_KEY',
+      'OPENCLAW_GATEWAY_URL',
+      'OPENCLAW_GATEWAY_VERSION',
+    ]
+  ),
+  'codex-cli': DEFINITIONS.codex,
+  'codex-sdk': DEFINITIONS['codex-sdk'],
+  'hermes-cli': DEFINITIONS.hermes,
+};
+
+export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSupportProfile {
+  const definition =
+    DEFINITIONS[agent.type] ??
+    (agent.provider ? PROVIDER_DEFINITIONS[agent.provider] : undefined) ??
+    unsupported(
+      `custom:${agent.type}`,
+      agent.name,
+      'unsupported',
+      'No executable provider adapter is registered for this agent profile.'
+    );
+
+  const executableProfile = Boolean(definition.adapterId);
+  const executable = {
+    command: agent.command,
+    versionArgs: ['--version'],
+  };
+  const authentication = {
+    ...definition.auth,
+    nonMutating: true as const,
+  };
+  const launch = {
+    args: [...agent.args],
+    workingDirectory: 'task-worktree' as const,
+    worktree: 'required' as const,
+    environmentAllowlist: [
+      ...(definition.transport === 'process-jsonl' ||
+      definition.transport === 'process-text' ||
+      definition.transport === 'sdk'
+        ? PROCESS_ENVIRONMENT_ALLOWLIST
+        : []),
+      ...(definition.environmentAllowlist ?? []),
+    ],
+    credentialAllowlist: [...(definition.credentialAllowlist ?? [])],
+  };
+  const configurationDigest = digestConfiguration({
+    profileId: definition.id,
+    adapterId: definition.adapterId,
+    transport: definition.transport,
+    executable,
+    authentication,
+    platforms: ALL_PLATFORMS,
+    launch,
+  });
+
+  return {
+    schemaVersion: HARNESS_SUPPORT_PROFILE_SCHEMA_VERSION,
+    id: definition.id,
+    displayName: definition.displayName,
+    ...(definition.adapterId ? { adapterId: definition.adapterId } : {}),
+    transport: definition.transport,
+    supportTier: executableProfile ? 'configured' : 'unsupported',
+    supportReason: executableProfile
+      ? 'An explicit executable adapter is registered; live readiness requires a runtime probe.'
+      : (definition.remediation[0] ?? 'No executable adapter is registered.'),
+    executable,
+    authentication,
+    compatibility: {
+      policy:
+        'When testedVersions is populated, require an exact provider-version match; always invalidate certification on runtime drift.',
+      testedVersions: [],
+      invalidateOn: [...INVALIDATION_KEYS],
+      configurationDigest,
+    },
+    platforms: [...ALL_PLATFORMS],
+    launch,
+    conformance: {
+      fixtureSet: `${definition.id}/v1`,
+      status: 'not-run',
+    },
+    documentationUrl: definition.documentationUrl,
+    remediation: [...definition.remediation],
+  };
+}
+
+function digestConfiguration(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+
+function executable(
+  id: string,
+  displayName: string,
+  adapterId: string,
+  transport: HarnessTransport,
+  commandArgs: string[],
+  credentialAllowlist: string[],
+  environmentAllowlist: string[] = []
+): ProfileDefinition {
+  return {
+    id,
+    displayName,
+    adapterId,
+    transport,
+    auth: commandArgs.length
+      ? { kind: 'command', commandArgs }
+      : credentialAllowlist.length
+        ? { kind: 'environment', environmentKeys: credentialAllowlist }
+        : { kind: 'provider-managed' },
+    credentialAllowlist,
+    environmentAllowlist,
+    documentationUrl: '/docs/AGENT-PROVIDERS.md',
+    remediation: ['Run `vk doctor` and resolve the reported harness readiness checks.'],
+  };
+}
+
+function unsupported(
+  id: string,
+  displayName: string,
+  transport: HarnessTransport,
+  reason: string
+): ProfileDefinition {
+  return {
+    id,
+    displayName,
+    transport,
+    auth: { kind: 'none' },
+    documentationUrl: '/docs/AGENT-PROVIDERS.md#support-tiers',
+    remediation: [reason],
+  };
+}

--- a/server/src/services/harness-support-profile-registry.ts
+++ b/server/src/services/harness-support-profile-registry.ts
@@ -5,6 +5,10 @@ import {
   type HarnessSupportProfile,
   type HarnessTransport,
 } from '@veritas-kanban/shared';
+import {
+  containsUnredactedProviderRuntimeSecret,
+  sanitizeProviderRuntimeDiagnostic,
+} from '../utils/provider-runtime-manifest-sanitize.js';
 
 const ALL_PLATFORMS: HarnessSupportProfile['platforms'] = ['darwin', 'linux', 'win32'];
 const INVALIDATION_KEYS: HarnessSupportProfile['compatibility']['invalidateOn'] = [
@@ -48,6 +52,16 @@ interface ProfileDefinition {
   credentialAllowlist?: string[];
   documentationUrl: string;
   remediation: string[];
+}
+
+interface RedactedLaunchArgs {
+  args: string[];
+  containsCredentialMaterial: boolean;
+}
+
+interface RedactedCommand {
+  command: string;
+  containsCredentialMaterial: boolean;
 }
 
 const DEFINITIONS: Record<string, ProfileDefinition> = {
@@ -157,8 +171,12 @@ export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSuppo
     );
 
   const executableProfile = Boolean(definition.adapterId);
+  const redactedCommand = redactCommand(agent.command);
+  const redactedLaunchArgs = redactLaunchArgs(agent.args);
+  const unsafeLaunchConfiguration =
+    redactedCommand.containsCredentialMaterial || redactedLaunchArgs.containsCredentialMaterial;
   const executable = {
-    command: agent.command,
+    command: redactedCommand.command,
     versionArgs: ['--version'],
   };
   const authentication = {
@@ -166,7 +184,7 @@ export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSuppo
     nonMutating: true as const,
   };
   const launch = {
-    args: [...agent.args],
+    args: redactedLaunchArgs.args,
     workingDirectory: 'task-worktree' as const,
     worktree: 'required' as const,
     environmentAllowlist: [
@@ -188,6 +206,10 @@ export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSuppo
     platforms: ALL_PLATFORMS,
     launch,
   });
+  const unsafeConfigurationReason =
+    'Credential material is not allowed in harness launch commands or arguments.';
+  const unsafeConfigurationRemediation =
+    'Remove credential values from launch arguments and use an allowlisted environment key or run-scoped credential reference.';
 
   return {
     schemaVersion: HARNESS_SUPPORT_PROFILE_SCHEMA_VERSION,
@@ -195,10 +217,16 @@ export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSuppo
     displayName: definition.displayName,
     ...(definition.adapterId ? { adapterId: definition.adapterId } : {}),
     transport: definition.transport,
-    supportTier: executableProfile ? 'configured' : 'unsupported',
-    supportReason: executableProfile
-      ? 'An explicit executable adapter is registered; live readiness requires a runtime probe.'
-      : (definition.remediation[0] ?? 'No executable adapter is registered.'),
+    supportTier: !executableProfile
+      ? 'unsupported'
+      : unsafeLaunchConfiguration
+        ? 'degraded'
+        : 'configured',
+    supportReason: !executableProfile
+      ? (definition.remediation[0] ?? 'No executable adapter is registered.')
+      : unsafeLaunchConfiguration
+        ? unsafeConfigurationReason
+        : 'An explicit executable adapter is registered; live readiness requires a runtime probe.',
     executable,
     authentication,
     compatibility: {
@@ -215,8 +243,63 @@ export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSuppo
       status: 'not-run',
     },
     documentationUrl: definition.documentationUrl,
-    remediation: [...definition.remediation],
+    remediation: [
+      ...(unsafeLaunchConfiguration ? [unsafeConfigurationRemediation] : []),
+      ...definition.remediation,
+    ],
   };
+}
+
+function redactCommand(command: string): RedactedCommand {
+  const containsDiagnosticSecret = containsUnredactedProviderRuntimeSecret(command);
+  const sanitized = containsDiagnosticSecret ? sanitizeProviderRuntimeDiagnostic(command) : command;
+  const redacted = redactLaunchArgs(sanitized.trim().split(/\s+/));
+  return containsDiagnosticSecret || redacted.containsCredentialMaterial
+    ? {
+        command: redacted.args.join(' '),
+        containsCredentialMaterial: true,
+      }
+    : {
+        command,
+        containsCredentialMaterial: false,
+      };
+}
+
+function redactLaunchArgs(args: string[]): RedactedLaunchArgs {
+  const redacted: string[] = [];
+  let redactNext = false;
+  let containsCredentialMaterial = false;
+
+  for (const arg of args) {
+    if (redactNext) {
+      redacted.push('[REDACTED]');
+      redactNext = false;
+      containsCredentialMaterial = true;
+      continue;
+    }
+
+    const normalized = arg.trim();
+    const credentialArgument = normalized.match(
+      /^(--?(?:api[-_]?key|access[-_]?token|auth[-_]?token|token|secret|password|authorization|credentials?))(?:=(.*))?$/i
+    );
+    if (credentialArgument) {
+      const [, flag, inlineValue] = credentialArgument;
+      redacted.push(inlineValue === undefined ? flag : `${flag}=[REDACTED]`);
+      redactNext = inlineValue === undefined;
+      containsCredentialMaterial = true;
+      continue;
+    }
+
+    if (containsUnredactedProviderRuntimeSecret(arg)) {
+      redacted.push(sanitizeProviderRuntimeDiagnostic(arg));
+      containsCredentialMaterial = true;
+      continue;
+    }
+
+    redacted.push(arg);
+  }
+
+  return { args: redacted, containsCredentialMaterial };
 }
 
 function digestConfiguration(value: unknown): string {

--- a/server/src/services/harness-support-service.ts
+++ b/server/src/services/harness-support-service.ts
@@ -1,0 +1,248 @@
+import type {
+  AgentConfig,
+  HarnessSupportFailureClass,
+  HarnessSupportStatus,
+  HarnessSupportTier,
+  ProviderRuntimeManifest,
+} from '@veritas-kanban/shared';
+import {
+  AgentHealthService,
+  type AgentHealthChecker,
+  type AgentHealthStatus,
+} from './agent-health-service.js';
+import { ConfigService } from './config-service.js';
+import { normalizeHarnessSupportProfile } from './harness-support-profile-registry.js';
+import { sanitizeProviderRuntimeDiagnostic } from '../utils/provider-runtime-manifest-sanitize.js';
+
+export type HarnessRuntimeProbe = (
+  agent: AgentConfig
+) => Promise<ProviderRuntimeManifest | undefined>;
+
+export interface HarnessSupportServiceOptions {
+  configService?: ConfigService;
+  health?: AgentHealthChecker;
+  runtimeProbe?: HarnessRuntimeProbe;
+  platform?: NodeJS.Platform;
+}
+
+export class HarnessSupportService {
+  private readonly configService: ConfigService;
+  private readonly health: AgentHealthChecker;
+  private readonly runtimeProbe?: HarnessRuntimeProbe;
+  private readonly platform: NodeJS.Platform;
+
+  constructor(options: HarnessSupportServiceOptions = {}) {
+    this.configService = options.configService ?? new ConfigService();
+    this.health = options.health ?? new AgentHealthService();
+    this.runtimeProbe =
+      options.runtimeProbe ??
+      (async (agent) => {
+        const { clawdbotAgentService } = await import('./clawdbot-agent-service.js');
+        return clawdbotAgentService.probeProviderRuntime(agent);
+      });
+    this.platform = options.platform ?? process.platform;
+  }
+
+  async list(): Promise<HarnessSupportStatus[]> {
+    const config = await this.configService.getConfig();
+    return Promise.all(
+      config.agents.map(async (agent) => {
+        const health = await this.health.checkAgent(agent);
+        let manifest: ProviderRuntimeManifest | undefined;
+        let probeError: string | undefined;
+        if (agent.supportProfile?.adapterId && health.healthy && this.runtimeProbe) {
+          try {
+            manifest = await this.runtimeProbe(agent);
+          } catch (error) {
+            probeError = error instanceof Error ? error.message : 'Provider runtime probe failed.';
+          }
+        }
+        return evaluateHarnessSupportStatus(agent, health, manifest, this.platform, probeError);
+      })
+    );
+  }
+}
+
+export function evaluateHarnessSupportStatus(
+  agent: AgentConfig,
+  health: AgentHealthStatus,
+  manifest?: ProviderRuntimeManifest,
+  platform: NodeJS.Platform = process.platform,
+  probeError?: string
+): HarnessSupportStatus {
+  const profile = agent.supportProfile ?? normalizeHarnessSupportProfile(agent);
+  const base = {
+    agentType: agent.type,
+    enabled: agent.enabled,
+    profileId: profile.id,
+    ...(profile.adapterId ? { adapterId: profile.adapterId } : {}),
+    transport: profile.transport,
+    checkedAt: health.checkedAt,
+    executableFound: health.executableFound,
+    authenticated: health.authenticated,
+    ...(health.providerVersion ? { providerVersion: sanitized(health.providerVersion) } : {}),
+    ...(manifest?.providerBuild ? { providerBuild: sanitized(manifest.providerBuild) } : {}),
+    ...(manifest?.digest ? { manifestDigest: manifest.digest } : {}),
+    diagnosticCommands: buildDiagnosticCommands(profile),
+    remediation: profile.remediation.map(sanitized),
+  };
+
+  if (!profile.platforms.includes(platform as 'darwin' | 'linux' | 'win32')) {
+    return status(
+      base,
+      'unsupported',
+      'unsupported-platform',
+      `The ${profile.displayName} support profile does not support ${platform}.`
+    );
+  }
+
+  if (!profile.adapterId) {
+    return status(base, 'unsupported', 'adapter-unavailable', profile.supportReason);
+  }
+
+  if (agent.provider && agent.provider !== profile.adapterId) {
+    return status(
+      base,
+      'unsupported',
+      'adapter-unavailable',
+      `Configured provider ${agent.provider} does not match support adapter ${profile.adapterId}.`
+    );
+  }
+
+  if (!health.executableFound) {
+    return status(
+      base,
+      'degraded',
+      'not-installed',
+      `Executable ${profile.executable.command} was not found.`
+    );
+  }
+
+  if (!agent.enabled) {
+    return status(
+      base,
+      'detected',
+      'disabled',
+      'The executable is installed but the agent is disabled.'
+    );
+  }
+
+  if (health.authenticated === false) {
+    return status(
+      base,
+      'degraded',
+      'unauthenticated',
+      health.reason ?? 'The non-mutating authentication probe failed.'
+    );
+  }
+
+  if (probeError) {
+    return status(base, 'degraded', 'probe-failed', probeError);
+  }
+
+  if (manifest?.probe.state === 'failed' || manifest?.probe.state === 'degraded') {
+    return status(
+      base,
+      'degraded',
+      'probe-failed',
+      manifest.probe.diagnostics[0] ?? 'The provider runtime probe did not return ready evidence.'
+    );
+  }
+
+  const installedVersion = manifest?.providerVersion ?? health.providerVersion;
+  if (
+    (manifest && manifest.adapter !== profile.adapterId) ||
+    (profile.compatibility.testedVersions.length > 0 &&
+      (!installedVersion || !profile.compatibility.testedVersions.includes(installedVersion)))
+  ) {
+    return status(
+      base,
+      'degraded',
+      'incompatible-build',
+      manifest && manifest.adapter !== profile.adapterId
+        ? `Runtime adapter ${manifest.adapter} does not match support adapter ${profile.adapterId}.`
+        : `Provider version ${installedVersion ?? 'unknown'} is outside the tested compatibility policy.`
+    );
+  }
+
+  const certification = profile.conformance;
+  if (certification.status === 'failed') {
+    return status(
+      base,
+      'degraded',
+      'probe-failed',
+      'The most recent harness conformance certification failed.'
+    );
+  }
+
+  const certificationMatches =
+    certification.status === 'passed' &&
+    Boolean(manifest) &&
+    certification.manifestDigest === manifest?.digest &&
+    (!profile.compatibility.invalidateOn.includes('provider-version') ||
+      certification.providerVersion === manifest?.providerVersion) &&
+    (!profile.compatibility.invalidateOn.includes('provider-build') ||
+      certification.providerBuild === manifest?.providerBuild) &&
+    (!profile.compatibility.invalidateOn.includes('configuration-digest') ||
+      certification.configurationDigest === profile.compatibility.configurationDigest) &&
+    (!profile.compatibility.invalidateOn.includes('probe-revision') ||
+      certification.probeRevision === manifest?.probeRevision);
+  if (
+    certification.status === 'stale' ||
+    (certification.status === 'passed' && !certificationMatches)
+  ) {
+    return status(
+      base,
+      'degraded',
+      'certification-stale',
+      'The certified provider evidence no longer matches the installed runtime.'
+    );
+  }
+
+  if (certificationMatches) {
+    return status(
+      base,
+      'certified',
+      'none',
+      'The installed runtime matches the most recent passing conformance evidence.'
+    );
+  }
+
+  return status(
+    base,
+    'configured',
+    'none',
+    'The executable adapter is configured; certification evidence is not current.'
+  );
+}
+
+function status(
+  base: Omit<HarnessSupportStatus, 'supportTier' | 'failureClass' | 'reason'>,
+  supportTier: HarnessSupportTier,
+  failureClass: HarnessSupportFailureClass,
+  reason: string
+): HarnessSupportStatus {
+  return {
+    ...base,
+    supportTier,
+    failureClass,
+    reason: sanitized(reason),
+  };
+}
+
+function sanitized(value: string): string {
+  return sanitizeProviderRuntimeDiagnostic(value);
+}
+
+function buildDiagnosticCommands(profile: NonNullable<AgentConfig['supportProfile']>): string[] {
+  const executable = profile.executable.command.trim().split(/\s+/)[0]?.split(/[\\/]/).pop();
+  if (!executable) return [];
+
+  const commands = [
+    [executable, ...profile.executable.versionArgs],
+    ...(profile.authentication.kind === 'command' && profile.authentication.commandArgs
+      ? [[executable, ...profile.authentication.commandArgs]]
+      : []),
+  ];
+  return commands.map((parts) => sanitized(parts.join(' ')));
+}

--- a/server/src/services/harness-support-service.ts
+++ b/server/src/services/harness-support-service.ts
@@ -110,6 +110,10 @@ export function evaluateHarnessSupportStatus(
     );
   }
 
+  if (profile.supportTier === 'degraded') {
+    return status(base, 'degraded', 'unsafe-configuration', profile.supportReason);
+  }
+
   if (!health.executableFound) {
     return status(
       base,

--- a/server/src/services/harness-support-service.ts
+++ b/server/src/services/harness-support-service.ts
@@ -71,6 +71,7 @@ export function evaluateHarnessSupportStatus(
   probeError?: string
 ): HarnessSupportStatus {
   const profile = agent.supportProfile ?? normalizeHarnessSupportProfile(agent);
+  const providerVersion = manifest?.providerVersion ?? health.providerVersion;
   const base = {
     agentType: agent.type,
     enabled: agent.enabled,
@@ -80,7 +81,7 @@ export function evaluateHarnessSupportStatus(
     checkedAt: health.checkedAt,
     executableFound: health.executableFound,
     authenticated: health.authenticated,
-    ...(health.providerVersion ? { providerVersion: sanitized(health.providerVersion) } : {}),
+    ...(providerVersion ? { providerVersion: sanitized(providerVersion) } : {}),
     ...(manifest?.providerBuild ? { providerBuild: sanitized(manifest.providerBuild) } : {}),
     ...(manifest?.digest ? { manifestDigest: manifest.digest } : {}),
     diagnosticCommands: buildDiagnosticCommands(profile),

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -7,6 +7,7 @@ import type { SandboxPolicyPreset } from './sandbox-policy.types.js';
 import type { AgentBudgetPolicy } from './agent-budget.types.js';
 import type { AgentProfilePackage } from './agent-profile-package.types.js';
 import type { TeamRosterManifest } from './team-roster.types.js';
+import type { HarnessSupportProfile } from './provider-runtime.types.js';
 import type {
   WorkspaceCapabilityManifest,
   WorkspaceDelegationRecord,
@@ -35,6 +36,8 @@ export interface AgentConfig {
   model?: string;
   sandboxPresetId?: string;
   budget?: AgentBudgetPolicy;
+  /** System-normalized harness support contract. */
+  supportProfile?: HarnessSupportProfile;
 }
 
 export type AgentProvider =

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -80,6 +80,7 @@ export type HarnessSupportFailureClass =
   | 'unauthenticated'
   | 'incompatible-build'
   | 'adapter-unavailable'
+  | 'unsafe-configuration'
   | 'probe-failed'
   | 'launch-failed'
   | 'run-failed'

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -1,5 +1,111 @@
 import type { SandboxProviderCapabilityId } from './sandbox-policy.types.js';
 
+export const HARNESS_SUPPORT_PROFILE_SCHEMA_VERSION = 'harness-support-profile/v1' as const;
+
+export const HARNESS_SUPPORT_TIERS = [
+  'detected',
+  'configured',
+  'certified',
+  'degraded',
+  'unsupported',
+] as const;
+
+export type HarnessSupportTier = (typeof HARNESS_SUPPORT_TIERS)[number];
+
+export type HarnessTransport =
+  'process-jsonl' | 'process-text' | 'sdk' | 'http-tools' | 'acp' | 'app-server' | 'unsupported';
+
+export type HarnessSupportInvalidationKey =
+  'provider-version' | 'provider-build' | 'configuration-digest' | 'probe-revision';
+
+export interface HarnessCertificationEvidence {
+  fixtureSet: string;
+  status: 'not-run' | 'passed' | 'failed' | 'stale';
+  certifiedAt?: string;
+  providerVersion?: string;
+  providerBuild?: string;
+  manifestDigest?: string;
+  configurationDigest?: string;
+  probeRevision?: number;
+}
+
+/**
+ * Stable product contract for a configured agent harness.
+ *
+ * Runtime readiness and certification are projected separately through
+ * `HarnessSupportStatus`; this profile records how the harness is discovered,
+ * launched, invalidated, remediated, and documented without carrying secrets.
+ */
+export interface HarnessSupportProfile {
+  schemaVersion: typeof HARNESS_SUPPORT_PROFILE_SCHEMA_VERSION;
+  id: string;
+  displayName: string;
+  adapterId?: string;
+  transport: HarnessTransport;
+  supportTier: HarnessSupportTier;
+  supportReason: string;
+  executable: {
+    command: string;
+    versionArgs: string[];
+  };
+  authentication: {
+    kind: 'command' | 'environment' | 'provider-managed' | 'none';
+    commandArgs?: string[];
+    environmentKeys?: string[];
+    nonMutating: boolean;
+  };
+  compatibility: {
+    policy: string;
+    testedVersions: string[];
+    invalidateOn: HarnessSupportInvalidationKey[];
+    configurationDigest: string;
+  };
+  platforms: Array<'darwin' | 'linux' | 'win32'>;
+  launch: {
+    args: string[];
+    workingDirectory: 'task-worktree' | 'workspace' | 'provider-managed';
+    worktree: 'required' | 'supported' | 'provider-managed';
+    environmentAllowlist: string[];
+    credentialAllowlist: string[];
+  };
+  conformance: HarnessCertificationEvidence;
+  documentationUrl: string;
+  remediation: string[];
+}
+
+export type HarnessSupportFailureClass =
+  | 'none'
+  | 'not-installed'
+  | 'disabled'
+  | 'unauthenticated'
+  | 'incompatible-build'
+  | 'adapter-unavailable'
+  | 'probe-failed'
+  | 'launch-failed'
+  | 'run-failed'
+  | 'certification-stale'
+  | 'unsupported-platform';
+
+/** Live, redacted projection consumed unchanged by API, CLI, and web. */
+export interface HarnessSupportStatus {
+  agentType: string;
+  enabled: boolean;
+  profileId: string;
+  adapterId?: string;
+  transport: HarnessTransport;
+  supportTier: HarnessSupportTier;
+  reason: string;
+  failureClass: HarnessSupportFailureClass;
+  checkedAt: string;
+  executableFound: boolean;
+  authenticated: boolean | null;
+  providerVersion?: string;
+  providerBuild?: string;
+  manifestDigest?: string;
+  diagnosticCommands: string[];
+  remediation: string[];
+}
+
 export const PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION = 'provider-runtime-manifest/v1' as const;
 
 export const PROVIDER_RUNTIME_PROBE_REVISION = 3 as const;

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -62,6 +62,7 @@ export interface TaskAttempt {
   budget?: import('./agent-budget.types.js').AgentBudgetState;
   agentProfile?: import('./agent-profile-package.types.js').AgentProfileLaunchMetadata;
   providerRuntimeManifest?: import('./provider-runtime.types.js').ProviderRuntimeManifest;
+  harnessSupport?: import('./provider-runtime.types.js').HarnessSupportStatus;
   taskEnvelope?: import('./task-envelope.types.js').TaskEnvelope;
   completionResult?: import('./task-envelope.types.js').CompletionResult;
 }

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -1,6 +1,7 @@
 // Telemetry Types
 
 import type { TaskStatus, AgentType } from './task.types.js';
+import type { HarnessSupportFailureClass, HarnessSupportTier } from './provider-runtime.types.js';
 
 export type TelemetryEventType =
   | 'task.created'
@@ -37,6 +38,7 @@ export interface RunStartedEvent extends TelemetryEvent {
   model?: string;
   sessionKey?: string;
   attemptId?: string;
+  harnessSupport?: HarnessSupportTelemetry;
 }
 
 /** Agent run completed event */
@@ -49,6 +51,7 @@ export interface RunCompletedEvent extends TelemetryEvent {
   error?: string;
   exitCode?: number;
   attemptId?: string;
+  harnessSupport?: HarnessSupportTelemetry;
 }
 
 /** Agent run error event */
@@ -59,6 +62,17 @@ export interface RunErrorEvent extends TelemetryEvent {
   error: string;
   stackTrace?: string;
   attemptId?: string;
+  harnessSupport?: HarnessSupportTelemetry;
+}
+
+export interface HarnessSupportTelemetry {
+  profileId: string;
+  adapterId?: string;
+  providerVersion?: string;
+  providerBuild?: string;
+  manifestDigest?: string;
+  supportTier: HarnessSupportTier;
+  failureClass: HarnessSupportFailureClass;
 }
 
 /** Legacy combined run event (for backward compatibility) */
@@ -74,6 +88,7 @@ export interface RunTelemetryEvent extends TelemetryEvent {
   model?: string;
   sessionKey?: string;
   stackTrace?: string;
+  harnessSupport?: HarnessSupportTelemetry;
 }
 
 /** Token usage events */

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -179,6 +179,41 @@ vi.mock('@/hooks/useConfig', () => ({
     isFetching: false,
     refetch: mocks.refetchProviderHealth,
   }),
+  useHarnessSupport: () => ({
+    data: [
+      {
+        agentType: 'codex',
+        profileId: 'openai-codex-cli',
+        adapterId: 'codex-cli',
+        transport: 'process-jsonl',
+        supportTier: 'configured',
+        reason: 'Certification evidence is not current.',
+        failureClass: 'none',
+        checkedAt: '2026-06-01T12:00:00.000Z',
+        enabled: true,
+        executableFound: true,
+        authenticated: true,
+        diagnosticCommands: ['codex --version', 'codex login status'],
+        remediation: ['Run vk doctor.'],
+      },
+      {
+        agentType: 'claude-code',
+        profileId: 'claude-code',
+        transport: 'process-jsonl',
+        supportTier: 'unsupported',
+        reason: 'No executable Claude Code adapter is registered.',
+        failureClass: 'adapter-unavailable',
+        checkedAt: '2026-06-01T12:00:00.000Z',
+        enabled: false,
+        executableFound: true,
+        authenticated: true,
+        diagnosticCommands: ['claude --version'],
+        remediation: ['Use a supported adapter.'],
+      },
+    ],
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
   useUpdateAgents: () => ({
     mutate: mocks.updateAgents,
   }),
@@ -474,6 +509,10 @@ describe('Agents settings Mantine migration', () => {
     expect(screen.getByRole('button', { name: 'Refresh Codex health' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Refresh host health' })).toBeDefined();
     expect(screen.getByRole('switch', { name: 'Enable Claude Code' })).toBeDefined();
+    expect(screen.getByText('Configured')).toBeDefined();
+    expect(screen.getByText('Unsupported')).toBeDefined();
+    expect(screen.getByText('Certification evidence is not current.')).toBeDefined();
+    expect(screen.getByText('No executable Claude Code adapter is registered.')).toBeDefined();
     expect(screen.getByRole('combobox', { name: 'Default Agent' })).toBeDefined();
     expect(screen.getByRole('textbox', { name: 'Default Model' })).toBeDefined();
 

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -18,6 +18,7 @@ import {
   useConfig,
   useDeleteAgentProfile,
   useExportAgentProfile,
+  useHarnessSupport,
   useImportAgentProfile,
   useProviderHealth,
   useUpdateAgentProfile,
@@ -71,6 +72,7 @@ import type {
   SandboxPolicyDryRunResult,
   SandboxPolicyPreset,
   ProviderRuntimeManifest,
+  HarnessSupportStatus,
 } from '@veritas-kanban/shared';
 import type {
   CodexHealthStatus,
@@ -114,6 +116,7 @@ export function AgentsTab() {
     refetch: refetchProviderHealth,
   } = useProviderHealth();
   const { data: agentProfiles = [], isLoading: isAgentProfilesLoading } = useAgentProfiles();
+  const { data: harnessSupport = [] } = useHarnessSupport();
   const { data: sandboxPresets = [], isLoading: isSandboxPoliciesLoading } = useSandboxPolicies();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
@@ -211,6 +214,7 @@ export function AgentsTab() {
                 <AgentItem
                   key={agent.type}
                   agent={agent}
+                  supportStatus={harnessSupport.find((status) => status.agentType === agent.type)}
                   sandboxPresets={sandboxPresets}
                   isDefault={isDefault(agent.type)}
                   onToggle={() => handleToggleAgent(agent.type)}
@@ -315,6 +319,20 @@ function providerStateColor(state: ContextProviderHealth['state']): string {
       return 'red';
     case 'unknown':
       return 'gray';
+  }
+}
+
+function harnessSupportTierColor(tier: HarnessSupportStatus['supportTier']): string {
+  switch (tier) {
+    case 'certified':
+      return 'green';
+    case 'configured':
+    case 'detected':
+      return 'blue';
+    case 'degraded':
+      return 'yellow';
+    case 'unsupported':
+      return 'red';
   }
 }
 
@@ -1817,6 +1835,7 @@ function CodexHealthPanel({
 
 interface AgentItemProps {
   agent: AgentConfig;
+  supportStatus?: HarnessSupportStatus;
   sandboxPresets: SandboxPolicyPreset[];
   isDefault: boolean;
   onToggle: () => void;
@@ -1826,6 +1845,7 @@ interface AgentItemProps {
 
 function AgentItem({
   agent,
+  supportStatus,
   sandboxPresets,
   isDefault,
   onToggle,
@@ -1867,6 +1887,16 @@ function AgentItem({
                   {formatAgentProvider(agent.provider)}
                 </Badge>
               )}
+              {supportStatus && (
+                <Badge
+                  size="xs"
+                  variant="light"
+                  color={harnessSupportTierColor(supportStatus.supportTier)}
+                  title={supportStatus.reason}
+                >
+                  {formatProviderState(supportStatus.supportTier)}
+                </Badge>
+              )}
               {agent.model && (
                 <Badge size="xs" variant="light" color="gray">
                   {agent.model}
@@ -1883,6 +1913,9 @@ function AgentItem({
                 </Badge>
               )}
             </div>
+            {supportStatus && (
+              <p className="mt-1 max-w-2xl text-xs text-muted-foreground">{supportStatus.reason}</p>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -26,6 +26,14 @@ export function useProviderHealth() {
   });
 }
 
+export function useHarnessSupport() {
+  return useQuery({
+    queryKey: ['config', 'agent-support'],
+    queryFn: api.config.agents.support,
+    staleTime: 30 * 1000,
+  });
+}
+
 export function useRepos() {
   return useQuery({
     queryKey: ['config', 'repos'],
@@ -88,6 +96,7 @@ export function useUpdateAgents() {
     mutationFn: (agents: AgentConfig[]) => api.config.agents.update(agents),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['config'] });
+      queryClient.invalidateQueries({ queryKey: ['config', 'agent-support'] });
     },
   });
 }

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -14,6 +14,7 @@ import type {
   ProviderRuntimeControlSet,
   TaskCommitPolicy,
   TaskEnvelope,
+  HarnessSupportStatus,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -253,6 +254,7 @@ export interface AgentStatus {
   provider?: string;
   model?: string;
   providerRuntimeManifest: ProviderRuntimeManifest;
+  harnessSupport: HarnessSupportStatus;
   taskEnvelope: TaskEnvelope;
   controls: ProviderRuntimeControlSet;
 }
@@ -267,6 +269,7 @@ export interface AgentStatusResponse {
   provider?: string;
   model?: string;
   providerRuntimeManifest?: ProviderRuntimeManifest;
+  harnessSupport?: HarnessSupportStatus;
   taskEnvelope?: TaskEnvelope;
   controls?: ProviderRuntimeControlSet;
 }

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -12,6 +12,7 @@ import type {
   AgentProfilePackageFormat,
   AgentProfilePackageSummary,
   AgentProfileValidationResult,
+  HarnessSupportStatus,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -71,13 +72,7 @@ export type ContextProviderState = 'connected' | 'degraded' | 'stale' | 'disconn
 export type ContextProviderRisk = 'safe' | 'normal' | 'risky';
 export type ContextProviderBoundary = 'local' | 'cloud' | 'mixed' | 'unknown';
 export type ContextProviderPostureStatus =
-  | 'safe'
-  | 'normal'
-  | 'risky'
-  | 'degraded'
-  | 'stale'
-  | 'disconnected'
-  | 'unknown';
+  'safe' | 'normal' | 'risky' | 'degraded' | 'stale' | 'disconnected' | 'unknown';
 
 export interface ContextProviderPostureCheck {
   id: string;
@@ -167,6 +162,10 @@ export const configApi = {
   },
 
   agents: {
+    support: async (): Promise<HarnessSupportStatus[]> => {
+      return apiFetch<HarnessSupportStatus[]>(`${API_BASE}/config/agent-support`);
+    },
+
     update: async (agents: AgentConfig[]): Promise<AppConfig> => {
       return apiFetch<AppConfig>(`${API_BASE}/config/agents`, {
         method: 'PUT',


### PR DESCRIPTION
Closes #919

## Summary

- add the versioned harness support profile schema, built-in registry, compatibility invalidation, and redacted live readiness projection
- fail closed for unsupported, provider-less, profile/adapter-mismatched, caller-spoofed, and credential-bearing dispatch while preserving the narrow built-in legacy migration
- redact credential-like launch evidence before publication or hashing and block unsafe configuration before health/runtime probes
- expose one canonical status through the API, `vk doctor`, Settings, persisted attempts, and run telemetry
- keep profile identity and certification state system-owned across file and SQLite configuration backends
- document support tiers, diagnostics, migration, credential handling, and operator remediation

## Verification

- 119 focused server, CLI, and web tests pass
- `pnpm typecheck`
- `pnpm lint` with zero errors and 595 existing warnings
- `pnpm lint:budget`
- `pnpm build`
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `pnpm smoke:cli-mcp` with the credential-gated live mutation check skipped
- isolated runtime smoke: 11 built-in profiles returned by the API; Settings rendered matching tiers and reasons; no browser console errors
- all required GitHub checks pass, including workspace tests and unsigned macOS, Linux, and Windows artifacts
- `pnpm test` still hits the existing credential-dependent MCP task/sprint failures reproduced unchanged on `main`; the SQLite recovery and web primitive files that flaked in the parallel run pass independently

## Review gate

- repository standards review completed with all findings fixed
- issue specification review completed with all findings fixed
- security review found and fixed credential leakage through public launch evidence and configuration digests
- the repository's cross-model review gate was explicitly waived by the maintainer for this v6 workstream on 2026-07-23
