### PR TITLE
feat: add immutable run launch manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the immutable `run-launch-manifest/v1` contract, a preflight preview API
+  and CLI command, per-field configuration provenance, fail-closed profile
+  tool/MCP/permission/health enforcement, parent-attempt material drift,
+  readiness/override evidence, governance traces, attempt/history/log
+  persistence, and completion-packet links to the exact launch and provider
+  capability evidence (#854).
+
 ## [5.2.5] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ vk github mappings               # List issue↔task mappings
 vk agents:pending                # List pending agent requests
 vk agents:status <id>            # Check if agent running
 vk agents:complete <id> -s --attempt-id <id> --manifest-digest <sha256:...>
+vk launch-preview <id> --json    # Inspect effective launch evidence without dispatch
 vk profiles list                 # List reusable agent profile packages
 vk profiles validate ./agent.yml # Validate a package before import
 vk profiles import ./agent.yml   # Import or replace a package

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -9,6 +9,7 @@ import type {
   AgentProfilePackageFormat,
   AgentProfilePackageSummary,
   AgentProfileValidationResult,
+  RunLaunchManifestPreview,
 } from '@veritas-kanban/shared';
 
 function inferProfileFormat(filePath: string): AgentProfilePackageFormat {
@@ -35,6 +36,7 @@ export function registerAgentCommands(program: Command): void {
       '--commit-policy <policy>',
       'Commit policy for this run (forbidden, allowed, or required)'
     )
+    .option('--parent-attempt <attemptId>', 'Compare launch inputs with a parent attempt')
     .option('--json', 'Output as JSON')
     .action(async (id, options) => {
       try {
@@ -62,6 +64,7 @@ export function registerAgentCommands(program: Command): void {
             profileId: options.profile,
             requiredRuntimeCapabilities: options.requireCapability,
             commitPolicy: options.commitPolicy,
+            parentAttemptId: options.parentAttempt,
           }),
         });
 
@@ -71,6 +74,63 @@ export function registerAgentCommands(program: Command): void {
           console.log(chalk.green(`✓ Agent started: ${options.profile || options.agent}`));
           console.log(chalk.dim(`Attempt ID: ${result.attemptId}`));
           console.log(chalk.dim(`Working in: ${task.git.worktreePath}`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('launch-preview <id>')
+    .description('Preview the immutable effective launch manifest without starting an agent')
+    .option('-a, --agent <agent>', 'Agent to use', 'codex')
+    .option('-p, --profile <profileId>', 'Agent profile package to preview')
+    .option(
+      '--require-capability <capabilities...>',
+      'Require provider runtime capabilities before launch'
+    )
+    .option(
+      '--commit-policy <policy>',
+      'Commit policy for this run (forbidden, allowed, or required)'
+    )
+    .option('--parent-attempt <attemptId>', 'Compare launch inputs with a parent attempt')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const task = await findTask(id);
+        if (!task) throw new Error(`Task not found: ${id}`);
+        const preview = await api<RunLaunchManifestPreview>(
+          `/api/agents/${task.id}/launch-preview`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              agent: options.profile ? undefined : options.agent,
+              profileId: options.profile,
+              requiredRuntimeCapabilities: options.requireCapability,
+              commitPolicy: options.commitPolicy,
+              parentAttemptId: options.parentAttempt,
+            }),
+          }
+        );
+        if (options.json) {
+          console.log(JSON.stringify(preview, null, 2));
+          return;
+        }
+        console.log(chalk.bold('Run launch manifest'));
+        console.log(`  Digest: ${preview.manifest.digest}`);
+        console.log(`  Provider: ${preview.manifest.providerRuntime.provider}`);
+        console.log(`  Model: ${preview.manifest.runtime.model ?? 'provider default'}`);
+        console.log(
+          `  Enforceable: ${preview.manifest.enforcement.enforceable ? chalk.green('yes') : chalk.red('no')}`
+        );
+        for (const blocker of preview.manifest.enforcement.blockers) {
+          console.log(chalk.red(`  Blocker ${blocker.code}: ${blocker.detail}`));
+        }
+        if (preview.drift) {
+          console.log(
+            `  Parent drift: ${preview.drift.material ? chalk.yellow('material') : chalk.green('none')}`
+          );
         }
       } catch (err) {
         console.error(chalk.red(`Error: ${(err as Error).message}`));

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -150,6 +150,41 @@ run log expose the same immutable envelope. Provider-owned rendering and
 normalized completion enforcement land in the ordered follow-up work for
 parent issue #860.
 
+## Effective Run Launch Manifests
+
+Every executable task launch also compiles `run-launch-manifest/v1` before
+attempt state is mutated. It references the task envelope instead of copying
+its task contract, and records the selected provider/model/transport, redacted
+command and arguments, instruction fingerprints and precedence, environment
+key names and broker references, profile tools/MCP/permissions/health checks,
+sandbox/network posture, readiness and any hashed operator override, budget,
+routing/fallback, workspace trust, and the origin of each effective value.
+Prompt content, override text, and credential values are never stored in this
+manifest.
+
+`POST /api/agents/:taskId/launch-preview` returns the same compiled contract
+without creating an attempt or dispatching a process. The CLI equivalent is
+`vk launch-preview <task>`. Preview applies the same readiness gate as start.
+A profile restriction that the selected adapter
+cannot enforce is returned as a concrete blocker, and `start` rejects it before
+pending or task attempt state changes. Declaring `tool.calls` support is not
+treated as proof that an adapter can enforce a named allowlist.
+
+Current task adapters do not inject a positive named-tool or MCP catalog, so
+any non-empty declaration remains a launch blocker. Issue #857 owns the
+run-scoped tool-server lifecycle and positive catalog injection; until that
+lands, no profile can substitute tool names in prompt prose for enforcement.
+
+Launches can pass `parentAttemptId` to compare replay, resume, or fork inputs.
+The comparison ignores attempt IDs, capture/probe timestamps, and other
+ephemeral metadata while detecting changes to task policy, provider capability
+posture, model, instructions, sandbox, budget, routing, and profile controls.
+The manifest, optional parent drift, and governance trace ID are persisted on
+the attempt and copied into attempt history. Active run controls compare the
+stored launch digest as well as the provider-runtime digest. Completion packet
+metadata links both digests, the provider probe revision/version/build, the
+governance trace, and parent drift result.
+
 Sandbox launch checks resolve every preset rule through the same manifest.
 Settings dry-runs send the digest of the newest matching manifest registered by
 a live host; the server resolves that digest rather than trusting a

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1925,18 +1925,22 @@ PUT /api/agents/routing
 ### Start Agent And Require Runtime Capabilities
 
 ```
+POST /api/agents/:taskId/launch-preview
 POST /api/agents/:taskId/start
 ```
 
-Callers can select an agent or portable profile package and require additional
-runtime capabilities:
+The preview and start endpoints accept the same request. Preview compiles the
+effective `run-launch-manifest/v1` without creating an attempt or dispatching a
+provider. Callers can select an agent or portable profile package, require
+additional runtime capabilities, and compare against a parent attempt:
 
 ```json
 {
   "profileId": "docs-reviewer",
   "sandboxPresetId": "codex-repo-contained",
   "requiredRuntimeCapabilities": ["tool.mcp", "output.structured"],
-  "commitPolicy": "allowed"
+  "commitPolicy": "allowed",
+  "parentAttemptId": "attempt_parent"
 }
 ```
 
@@ -1947,6 +1951,21 @@ capabilities plus caller, profile, sandbox, and budget requirements must be
 `supported` or `advisory` in one valid manifest before attempt state is
 mutated. Failure returns `409 Conflict` with `requiredCapabilities`, reasons,
 manifest identity, and remediation.
+
+The preview response contains `manifest`, plus optional `parentAttemptId` and
+`drift`. The manifest contains redacted effective runtime inputs, instruction
+fingerprints, per-field origins, and an `enforcement` object. Prompt content,
+readiness override text, credential values, and raw local output paths are
+excluded. Preview and start apply the same readiness gate; an accepted operator
+override is represented by its digest and run-level origin. Start records the
+same contract in the active attempt, history, run log, and a policy governance
+trace before provider dispatch. Named tool/MCP/permission restrictions and
+required profile health checks block launch when the adapter cannot enforce
+them explicitly.
+
+Current task adapters reject every non-empty named-tool or MCP catalog. The
+run-scoped tool-server control plane tracked in #857 owns positive catalog
+injection; prompt text is never accepted as equivalent enforcement.
 
 `commitPolicy` accepts `forbidden`, `allowed`, or `required`. A run value
 overrides `task.executionPolicy.commitPolicy`, then the legacy
@@ -1963,6 +1982,24 @@ controls:
   "attemptId": "attempt_123",
   "provider": "codex-cli",
   "providerRuntimeManifest": { "digest": "sha256:..." },
+  "runLaunchManifest": {
+    "schemaVersion": "run-launch-manifest/v1",
+    "digest": "sha256:...",
+    "providerRuntime": {
+      "digest": "sha256:...",
+      "provider": "codex-cli",
+      "probeRevision": 3
+    },
+    "runtime": {
+      "command": "codex",
+      "model": "gpt-5.5"
+    },
+    "enforcement": {
+      "enforceable": true,
+      "blockers": [],
+      "warnings": []
+    }
+  },
   "taskEnvelope": {
     "schemaVersion": "task-envelope/v1",
     "digest": "sha256:...",
@@ -1994,9 +2031,9 @@ controls:
 ```
 
 Stop, message, completion, token-reporting, and attempt-log endpoints re-check
-the persisted snapshot. Invalid or active/persisted digest mismatches return
-`409 Conflict`; unsupported capability states return the same structured
-control evidence.
+both persisted snapshots. Invalid or active/persisted provider or run-launch
+digest mismatches return `409 Conflict`; unsupported capability states return
+the same structured control evidence.
 
 Stop and message requests must carry the `attemptId` returned by status so a
 delayed control cannot affect a replacement run:

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -448,6 +448,7 @@ Manage AI agents on code tasks.
 | Command                                                                       | Description                                               |
 | ----------------------------------------------------------------------------- | --------------------------------------------------------- |
 | `vk start <id>`                                                               | Start an agent; optionally require runtime capabilities   |
+| `vk launch-preview <id>`                                                      | Preview effective launch inputs, blockers, and drift      |
 | `vk stop <id>`                                                                | Stop a run only when its persisted manifest supports stop |
 | `vk agents:pending`                                                           | List pending agent requests                               |
 | `vk agents:status <id>`                                                       | Check agent running status                                |
@@ -462,6 +463,18 @@ vk start TASK-001 --agent codex \
   --commit-policy allowed \
   --json
 ```
+
+Preview without dispatching, or compare a new launch with a parent attempt:
+
+```bash
+vk launch-preview TASK-001 --agent codex --parent-attempt attempt_parent --json
+vk start TASK-001 --agent codex --parent-attempt attempt_parent
+```
+
+Preview output includes the immutable run-launch digest, redacted command and
+argument plan, per-field origins, enforcement blockers, and material drift.
+It applies the same readiness gate and override rules as start. Attempt IDs and
+probe timestamps do not count as material drift.
 
 `--require-capability <capabilities...>` is additive to the baseline launch,
 profile, sandbox, and budget requirements. The server returns a structured

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1617,6 +1617,7 @@ Added in v3.3.2.
 | Command                                                                       | Description                                         |
 | ----------------------------------------------------------------------------- | --------------------------------------------------- |
 | `vk start <id>`                                                               | Start an agent on a code task (`--agent` to choose) |
+| `vk launch-preview <id>`                                                      | Preview immutable launch evidence without dispatch  |
 | `vk stop <id>`                                                                | Stop a running agent                                |
 | `vk agents:pending`                                                           | List pending agent requests                         |
 | `vk agents:status <id>`                                                       | Check agent running status                          |

--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -620,6 +620,14 @@
       "denialReason": "Starting an agent requires task read and task write access."
     },
     {
+      "id": "cli:agents:launch-preview",
+      "kind": "cli",
+      "classification": "agent-scoped",
+      "permissions": ["task:read", "agent:read"],
+      "source": "cli/src/commands/agents.ts",
+      "denialReason": "Previewing effective launch evidence requires task and agent read access."
+    },
+    {
       "id": "cli:agents:stop",
       "kind": "cli",
       "classification": "agent-scoped",

--- a/mcp/src/__tests__/agent-tools.test.ts
+++ b/mcp/src/__tests__/agent-tools.test.ts
@@ -33,6 +33,25 @@ describe('MCP agent runtime capability controls', () => {
     expect(start?.inputSchema.properties.commitPolicy).toMatchObject({
       enum: ['forbidden', 'allowed', 'required'],
     });
+    expect(start?.inputSchema.properties.parentAttemptId).toMatchObject({
+      type: 'string',
+    });
+  });
+
+  it('forwards a parent attempt for material launch drift', async () => {
+    await handleAgentTool('start_agent', {
+      id: 'task_1',
+      agent: 'claude-code',
+      parentAttemptId: 'attempt_parent',
+    });
+
+    expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
+      method: 'POST',
+      body: JSON.stringify({
+        agent: 'claude-code',
+        parentAttemptId: 'attempt_parent',
+      }),
+    });
   });
 
   it('forwards an explicit run commit policy', async () => {

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -15,6 +15,7 @@ const StartAgentSchema = z.object({
     .max(64)
     .optional(),
   commitPolicy: z.enum(['forbidden', 'allowed', 'required']).optional(),
+  parentAttemptId: z.string().trim().min(1).max(120).optional(),
 });
 
 const TaskIdSchema = z.object({
@@ -47,6 +48,10 @@ export const agentTools = [
           enum: ['forbidden', 'allowed', 'required'],
           description: 'Commit policy override for this run',
         },
+        parentAttemptId: {
+          type: 'string',
+          description: 'Parent attempt to compare for material launch drift',
+        },
       },
       required: ['id'],
     },
@@ -70,7 +75,8 @@ export const agentTools = [
 export async function handleAgentTool(name: string, args: any): Promise<any> {
   switch (name) {
     case 'start_agent': {
-      const { id, agent, requiredRuntimeCapabilities, commitPolicy } = StartAgentSchema.parse(args);
+      const { id, agent, requiredRuntimeCapabilities, commitPolicy, parentAttemptId } =
+        StartAgentSchema.parse(args);
       const task = await findTask(id);
 
       if (!task) {
@@ -96,7 +102,12 @@ export async function handleAgentTool(name: string, args: any): Promise<any> {
 
       const result = await api<{ attemptId: string }>(`/api/agents/${task.id}/start`, {
         method: 'POST',
-        body: JSON.stringify({ agent, requiredRuntimeCapabilities, commitPolicy }),
+        body: JSON.stringify({
+          agent,
+          requiredRuntimeCapabilities,
+          commitPolicy,
+          parentAttemptId,
+        }),
       });
 
       return {

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetConfig,
   mockSaveConfig,
   mockGetTask,
+  mockListTasks,
   mockUpdateTask,
   mockPatchTaskAttempt,
   mockCheckAgent,
@@ -28,6 +29,7 @@ const {
   mockGetConfig: vi.fn(),
   mockSaveConfig: vi.fn(),
   mockGetTask: vi.fn(),
+  mockListTasks: vi.fn(),
   mockUpdateTask: vi.fn(),
   mockPatchTaskAttempt: vi.fn(),
   mockCheckAgent: vi.fn(),
@@ -63,6 +65,7 @@ vi.mock('../services/task-service.js', () => ({
   TaskService: function () {
     return {
       getTask: mockGetTask,
+      listTasks: mockListTasks,
       updateTask: mockUpdateTask,
       patchTaskAttempt: mockPatchTaskAttempt,
     };
@@ -108,14 +111,38 @@ vi.mock('../services/circuit-registry.js', () => ({
 
 import { AgentReadinessError, ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
-import type { AgentConfig, Task } from '@veritas-kanban/shared';
+import type {
+  AgentConfig,
+  RunLaunchRuntime,
+  SandboxPolicyDryRunResult,
+  Task,
+} from '@veritas-kanban/shared';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 import { TaskEnvelopeService } from '../services/task-envelope-service.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
 
 type TestableClawdbotAgentService = ClawdbotAgentService & {
   logsDir: string;
+  buildRunLaunchEnvironment(
+    provider: 'openclaw' | 'codex-sdk',
+    sandboxPolicy: SandboxPolicyDryRunResult
+  ): Pick<RunLaunchRuntime, 'environmentKeys' | 'credentialReferences'>;
+  buildRunLaunchRuntime(
+    provider: 'openclaw' | 'codex-sdk',
+    agentConfig: AgentConfig | undefined,
+    taskId: string,
+    logPath: string,
+    attemptId: string,
+    sandboxPolicy: SandboxPolicyDryRunResult
+  ): RunLaunchRuntime;
+  normalizeRunLaunchTaskPrompt(
+    prompt: string,
+    attemptId: string,
+    worktreePath: string | undefined,
+    providerRuntimeDigest: string
+  ): string;
   handleCodexEvent(
     event: Record<string, unknown>,
     logPath: string,
@@ -249,6 +276,7 @@ describe('ClawdbotAgentService Codex providers', () => {
     } as Task;
 
     mockGetTask.mockImplementation(async () => task);
+    mockListTasks.mockImplementation(async () => [task]);
     mockUpdateTask.mockImplementation(async (_id, update) => {
       task = { ...task, ...update } as Task;
       return task;
@@ -290,6 +318,7 @@ describe('ClawdbotAgentService Codex providers', () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -304,11 +333,34 @@ describe('ClawdbotAgentService Codex providers', () => {
       const status = await service.startAgent(task.id, 'codex');
 
       expect(status.status).toBe('running');
+      expect(status.runLaunchManifest).toMatchObject({
+        schemaVersion: 'run-launch-manifest/v1',
+        taskId: task.id,
+        providerRuntime: {
+          digest: status.providerRuntimeManifest.digest,
+          provider: 'codex-cli',
+        },
+        runtime: {
+          command: 'codex',
+          model: 'gpt-5.5',
+        },
+        enforcement: {
+          enforceable: true,
+          blockers: [],
+        },
+      });
+      expect(status.runLaunchManifest.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
       expect(mockSpawn).toHaveBeenCalledWith(
         'codex',
         expect.arrayContaining(['exec', '--json', '--sandbox', 'workspace-write']),
         expect.objectContaining({ cwd: tmpDir, shell: false })
       );
+      const spawnEnvironment = mockSpawn.mock.calls[0]?.[2]?.env as
+        Record<string, string> | undefined;
+      expect(status.runLaunchManifest.runtime.environmentKeys).toEqual(
+        Object.keys(spawnEnvironment ?? {}).sort((left, right) => left.localeCompare(right))
+      );
+      expect(status.runLaunchManifest.runtime.environmentKeys).toContain('VK_API_URL');
 
       await waitFor(() => {
         expect(mockUpdateTask).toHaveBeenCalledWith(
@@ -386,9 +438,14 @@ describe('ClawdbotAgentService Codex providers', () => {
         },
       });
       expect(task.attempt?.taskEnvelope?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+      expect(task.attempt?.runLaunchManifest?.digest).toBe(status.runLaunchManifest.digest);
+      expect(task.attempt?.runLaunchManifestTraceId).toBe('governance_trace_fixture');
       expect(task.attempts).toEqual([
         expect.objectContaining({
           id: task.attempt?.id,
+          runLaunchManifest: expect.objectContaining({
+            digest: status.runLaunchManifest.digest,
+          }),
           providerRuntimeManifest: expect.objectContaining({
             digest: task.attempt?.providerRuntimeManifest?.digest,
           }),
@@ -408,6 +465,18 @@ describe('ClawdbotAgentService Codex providers', () => {
         `Provider manifest:** ${task.attempt?.providerRuntimeManifest?.digest}`
       );
       expect(log).toContain(`Task envelope:** ${task.attempt?.taskEnvelope?.digest}`);
+      expect(log).toContain(`Run launch manifest:** ${status.runLaunchManifest.digest}`);
+      expect(mockGovernanceRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Run launch manifest compiled',
+          outcome: 'allowed',
+          raw: expect.objectContaining({
+            runLaunchManifest: expect.objectContaining({
+              digest: status.runLaunchManifest.digest,
+            }),
+          }),
+        })
+      );
       expect(mockStartStep).toHaveBeenCalledWith(
         expect.any(String),
         'stream',
@@ -504,6 +573,458 @@ describe('ClawdbotAgentService Codex providers', () => {
     await waitFor(async () => {
       expect(await service.getAgentStatus(task.id)).toBeNull();
     });
+  });
+
+  it('previews the effective launch manifest without mutating attempt state', async () => {
+    const service = testableService(tmpDir);
+
+    const preview = await service.previewAgentLaunch(task.id, 'codex');
+
+    expect(preview.manifest).toMatchObject({
+      schemaVersion: 'run-launch-manifest/v1',
+      taskId: task.id,
+      attemptId: expect.stringMatching(/^preview_/),
+      providerRuntime: { provider: 'codex-cli' },
+      enforcement: { enforceable: true, blockers: [] },
+    });
+    expect(preview.manifest.origins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'providerRequirements',
+          scope: 'provider',
+          source: expect.stringMatching(/^provider-capabilities:codex-cli:\d+$/),
+        }),
+        expect.objectContaining({
+          field: 'runtime.workingDirectory',
+          source: 'adapter:codex-cli',
+        }),
+        expect.objectContaining({
+          field: 'runtime.worktree',
+          source: 'adapter:codex-cli',
+        }),
+      ])
+    );
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+    expect(mockGovernanceRecord).not.toHaveBeenCalled();
+    expect(task.attempt).toBeUndefined();
+  });
+
+  it('applies the same readiness gate to preview and fingerprints operator overrides', async () => {
+    task = {
+      ...task,
+      description: 'Too short',
+      subtasks: [],
+      verificationSteps: [],
+    } as Task;
+    const service = testableService(tmpDir);
+
+    await expect(service.previewAgentLaunch(task.id, 'codex')).rejects.toBeInstanceOf(
+      AgentReadinessError
+    );
+    const overrideReason = 'Operator accepts the incomplete task definition';
+    const preview = await service.previewAgentLaunch(task.id, 'codex', { overrideReason });
+
+    expect(preview.manifest.readiness).toMatchObject({
+      ready: false,
+      overridden: true,
+      overrideReasonDigest: expect.stringMatching(/^sha256:/),
+    });
+    expect(preview.manifest.readiness.missingRequired.length).toBeGreaterThan(0);
+    expect(preview.manifest.origins).toContainEqual(
+      expect.objectContaining({
+        field: 'readiness',
+        scope: 'run',
+        source: 'operator-readiness-override',
+      })
+    );
+    expect(JSON.stringify(preview.manifest)).not.toContain(overrideReason);
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it('fingerprints repository instructions byte-for-byte through workspace storage', async () => {
+    const repositoryInstructions = '\n  # Indented repository instructions\n\n';
+    await fs.writeFile(path.join(tmpDir, 'AGENTS.md'), repositoryInstructions, 'utf8');
+    const service = testableService(tmpDir);
+
+    const preview = await service.previewAgentLaunch(task.id, 'codex');
+    const evidence = preview.manifest.instructions.find(
+      (instruction) => instruction.id === 'repository:AGENTS.md'
+    );
+
+    expect(evidence).toMatchObject({
+      byteLength: Buffer.byteLength(repositoryInstructions, 'utf8'),
+      digest: digestRunLaunchValue(repositoryInstructions),
+    });
+    expect(evidence?.digest).not.toBe(
+      preview.manifest.instructions.find(
+        (instruction) => instruction.id === 'effective-task-request'
+      )?.digest
+    );
+  });
+
+  it('records every contributing budget source and runtime requirement origin', async () => {
+    mockGetConfig.mockResolvedValue({
+      features: {
+        agents: {
+          autoCommitOnComplete: false,
+        },
+        budget: {
+          enabled: true,
+          defaultRunBudget: {
+            enabled: true,
+            scope: 'workspace',
+            limits: { totalTokens: 100_000 },
+          },
+        },
+      },
+      agents: [
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: ['exec', '--json'],
+          enabled: true,
+          provider: 'codex-cli',
+          model: 'gpt-5.5',
+          budget: {
+            enabled: true,
+            scope: 'agent',
+            limits: { totalTokens: 75_000 },
+          },
+        },
+      ],
+    });
+    const service = testableService(tmpDir);
+
+    const preview = await service.previewAgentLaunch(task.id, 'codex', {
+      budget: {
+        enabled: true,
+        scope: 'run',
+        limits: { totalTokens: 50_000 },
+      },
+    });
+
+    expect(preview.manifest.budget.limits?.totalTokens).toBe(50_000);
+    expect(preview.manifest.origins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'budget', scope: 'workspace' }),
+        expect.objectContaining({ field: 'budget', scope: 'provider' }),
+        expect.objectContaining({
+          field: 'budget',
+          scope: 'run',
+          source: 'operator-run-budget',
+        }),
+        expect.objectContaining({ field: 'providerRequirements', scope: 'system-default' }),
+        expect.objectContaining({ field: 'providerRequirements', scope: 'workspace' }),
+        expect.objectContaining({
+          field: 'providerRequirements',
+          scope: 'provider',
+          source: expect.stringContaining(':budget'),
+        }),
+        expect.objectContaining({
+          field: 'providerRequirements',
+          scope: 'run',
+          source: 'operator-run-budget',
+        }),
+      ])
+    );
+  });
+
+  it('normalizes checkpoint age out of material instruction evidence', () => {
+    const service = testableService(tmpDir);
+    const first = service.normalizeRunLaunchTaskPrompt(
+      'Last Checkpoint: 2026-07-23T20:00:00.000Z (5 minutes ago)',
+      'attempt-a',
+      tmpDir,
+      `sha256:${'a'.repeat(64)}`
+    );
+    const later = service.normalizeRunLaunchTaskPrompt(
+      'Last Checkpoint: 2026-07-23T20:00:00.000Z (125 minutes ago)',
+      'attempt-b',
+      tmpDir,
+      `sha256:${'b'.repeat(64)}`
+    );
+
+    expect(first).toBe(later);
+  });
+
+  it('records the same non-empty OpenClaw environment alias used by adapter precedence', () => {
+    vi.stubEnv('OPENCLAW_GATEWAY_URL', '');
+    vi.stubEnv('CLAWDBOT_GATEWAY', 'http://127.0.0.1:18789');
+    vi.stubEnv('CLAWDBOT_GATEWAY_URL', 'http://127.0.0.1:18790');
+    vi.stubEnv('OPENCLAW_GATEWAY_TOKEN', '');
+    vi.stubEnv('CLAWDBOT_GATEWAY_TOKEN', 'configured-token');
+    vi.stubEnv('OPENCLAW_GATEWAY_SESSION_KEY', '');
+    vi.stubEnv('OPENCLAW_GATEWAY_ALLOW_PRIVATE', '');
+    const service = testableService(tmpDir);
+
+    const environment = service.buildRunLaunchEnvironment(
+      'openclaw',
+      {} as SandboxPolicyDryRunResult
+    );
+
+    expect(environment.environmentKeys).toEqual(['CLAWDBOT_GATEWAY', 'CLAWDBOT_GATEWAY_TOKEN']);
+    expect(environment.credentialReferences).toEqual(['env:CLAWDBOT_GATEWAY_TOKEN']);
+  });
+
+  it('records the exact redacted OpenClaw sessions_spawn request plan', () => {
+    vi.stubEnv('OPENCLAW_GATEWAY_URL', '');
+    vi.stubEnv('CLAWDBOT_GATEWAY', '');
+    vi.stubEnv('CLAWDBOT_GATEWAY_URL', '');
+    vi.stubEnv('OPENCLAW_GATEWAY_TOKEN', '');
+    vi.stubEnv('CLAWDBOT_GATEWAY_TOKEN', '');
+    vi.stubEnv('OPENCLAW_GATEWAY_SESSION_KEY', '');
+    vi.stubEnv('OPENCLAW_GATEWAY_ALLOW_PRIVATE', '');
+    const service = testableService(tmpDir);
+
+    const runtime = service.buildRunLaunchRuntime(
+      'openclaw',
+      {
+        type: 'openclaw',
+        name: 'OpenClaw',
+        enabled: true,
+        model: 'provider-model',
+      },
+      task.id,
+      path.join(tmpDir, 'run.md'),
+      'attempt-openclaw',
+      {} as SandboxPolicyDryRunResult
+    );
+
+    expect(runtime.args).toEqual([
+      'tool=sessions_spawn',
+      'task=<prompt>',
+      'taskName=task_task_codex_fixture_attempt_openclaw',
+      'label=Veritas task task_codex_fixture / attempt attempt-openclaw / OpenClaw',
+      'runtime=subagent',
+      'agentId=openclaw',
+      'mode=run',
+      'cleanup=keep',
+      'context=isolated',
+      'model=provider-model',
+      'sessionKey=default:main',
+      'gatewayUrl=default:http://127.0.0.1:18789',
+      'allowPrivateIp=false',
+      'requestTimeoutMs=60000',
+    ]);
+    expect(runtime.args.join(' ')).not.toContain('timeoutSeconds');
+  });
+
+  it('records the effective OpenClaw private-network exception', () => {
+    vi.stubEnv('OPENCLAW_GATEWAY_ALLOW_PRIVATE', 'true');
+    const service = testableService(tmpDir);
+
+    const runtime = service.buildRunLaunchRuntime(
+      'openclaw',
+      {
+        type: 'openclaw',
+        name: 'OpenClaw',
+        enabled: true,
+      },
+      task.id,
+      path.join(tmpDir, 'run.md'),
+      'attempt-openclaw-private',
+      {} as SandboxPolicyDryRunResult
+    );
+
+    expect(runtime.args).toContain('allowPrivateIp=true');
+    expect(runtime.environmentKeys).toContain('OPENCLAW_GATEWAY_ALLOW_PRIVATE');
+  });
+
+  it('records the Codex SDK executable override and thread safety settings', () => {
+    const service = testableService(tmpDir);
+    const sandboxPolicy = {
+      effective: {
+        sandboxMode: 'workspace-write',
+        networkAccessEnabled: false,
+        envPassthrough: [],
+        credentialRefs: [],
+      },
+    } as SandboxPolicyDryRunResult;
+
+    const overridden = service.buildRunLaunchRuntime(
+      'codex-sdk',
+      {
+        type: 'codex-sdk',
+        name: 'Codex SDK',
+        command: '/opt/codex-custom',
+        enabled: true,
+      },
+      task.id,
+      path.join(tmpDir, 'run.md'),
+      'attempt-sdk',
+      sandboxPolicy
+    );
+    const bundled = service.buildRunLaunchRuntime(
+      'codex-sdk',
+      {
+        type: 'codex-sdk',
+        name: 'Codex SDK',
+        command: 'codex',
+        enabled: true,
+      },
+      task.id,
+      path.join(tmpDir, 'run.md'),
+      'attempt-sdk',
+      sandboxPolicy
+    );
+
+    expect(overridden.command).toBe('/opt/codex-custom');
+    expect(overridden.args).toEqual([
+      'startThread',
+      'skipGitRepoCheck=true',
+      'sandboxMode=workspace-write',
+      'approvalPolicy=never',
+      'networkAccessEnabled=false',
+      'runStreamed',
+      '<prompt>',
+    ]);
+    expect(bundled.command).toBe('@openai/codex-sdk:bundled-codex');
+  });
+
+  it('returns unsupported runtime capabilities as launch-preview blockers', async () => {
+    const service = testableService(tmpDir);
+
+    const preview = await service.previewAgentLaunch(task.id, 'codex', {
+      requiredRuntimeCapabilities: ['run.resume'],
+    });
+
+    expect(preview.manifest.providerRequirements.capabilities).toContainEqual(
+      expect.objectContaining({
+        id: 'run.resume',
+        satisfied: false,
+      })
+    );
+    expect(preview.manifest.enforcement.blockers).toContainEqual(
+      expect.objectContaining({
+        code: 'provider-capability-unavailable',
+        field: 'providerRequirements.run.resume',
+      })
+    );
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it('compares replay and fork previews with compatible and incompatible parent manifests', async () => {
+    const service = testableService(tmpDir);
+    const parent = await service.previewAgentLaunch(task.id, 'codex');
+    const parentTask = {
+      ...task,
+      id: 'task_parent',
+      attempt: {
+        id: 'attempt_parent',
+        agent: 'codex',
+        status: 'complete',
+        runLaunchManifest: parent.manifest,
+      },
+    } as Task;
+    mockListTasks.mockImplementation(async () => [task, parentTask]);
+
+    const compatible = await service.previewAgentLaunch(task.id, 'codex', {
+      parentAttemptId: 'attempt_parent',
+    });
+    expect(compatible).toMatchObject({
+      parentAttemptId: 'attempt_parent',
+      drift: { material: false, changes: [] },
+    });
+
+    mockGetConfig.mockResolvedValue({
+      agents: [
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: ['exec', '--json'],
+          enabled: true,
+          provider: 'codex-cli',
+          model: 'gpt-5.6',
+        },
+      ],
+    });
+    const incompatible = await service.previewAgentLaunch(task.id, 'codex', {
+      parentAttemptId: 'attempt_parent',
+    });
+    expect(incompatible.drift).toMatchObject({
+      material: true,
+      changes: expect.arrayContaining([expect.objectContaining({ field: 'runtime' })]),
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it('fails before attempt mutation when profile tool restrictions cannot be enforced', async () => {
+    mockGetConfig.mockResolvedValue({
+      agents: [
+        {
+          type: 'codex',
+          name: 'OpenAI Codex',
+          command: 'codex',
+          args: ['exec', '--json'],
+          enabled: true,
+          provider: 'codex-cli',
+          model: 'gpt-5.5',
+        },
+      ],
+      agentProfiles: [
+        {
+          id: 'restricted-reviewer',
+          schemaVersion: 'agent-profile-package/v1',
+          version: '1.0.0',
+          displayName: 'Restricted reviewer',
+          role: 'reviewer',
+          enabled: true,
+          capabilities: ['review'],
+          defaultTaskTypes: ['code'],
+          runtime: { agent: 'codex', provider: 'codex-cli' },
+          instructions: { promptFile: 'prompts/reviewer.md' },
+          tools: { allowed: ['Read'] },
+          workflow: { id: 'restricted-review' },
+        },
+      ],
+    });
+    const service = testableService(tmpDir);
+
+    const preview = await service.previewAgentLaunch(task.id, undefined, {
+      profileId: 'restricted-reviewer',
+    });
+    expect(preview.manifest.enforcement).toMatchObject({
+      enforceable: false,
+      blockers: expect.arrayContaining([
+        expect.objectContaining({ code: 'tool-policy-unenforceable' }),
+        expect.objectContaining({ code: 'shared-resource-unavailable' }),
+      ]),
+    });
+    expect(preview.manifest.resources.shared).toEqual([
+      'instruction-file:prompts/reviewer.md',
+      'workflow:restricted-review',
+    ]);
+    expect(preview.manifest.origins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'providerRequirements',
+          scope: 'agent-profile',
+        }),
+        expect.objectContaining({
+          field: 'resources',
+          scope: 'workflow',
+          source: 'workflow:restricted-review',
+        }),
+      ])
+    );
+
+    await expect(
+      service.startAgent(task.id, undefined, { profileId: 'restricted-reviewer' })
+    ).rejects.toThrow(/cannot be enforced/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+    expect(task.attempt).toBeUndefined();
+    expect(mockGovernanceRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Run launch manifest compiled',
+        outcome: 'blocked',
+      })
+    );
   });
 
   it('does not trust Codex file events without a persisted runtime snapshot', async () => {

--- a/server/src/__tests__/openclaw-provider.test.ts
+++ b/server/src/__tests__/openclaw-provider.test.ts
@@ -115,9 +115,20 @@ describe('HttpOpenClawTaskAdapter.spawnTask()', () => {
     const body = JSON.parse(String(request?.body)) as {
       tool: string;
       args: Record<string, unknown>;
+      sessionKey: string;
     };
     expect(body.tool).toBe('sessions_spawn');
-    expect(body.args).toMatchObject({ mode: 'run', runtime: 'subagent' });
+    expect(body.sessionKey).toBe('main');
+    expect(body.args).toEqual({
+      task: 'Complete the task',
+      taskName: 'task_task_abc_attempt_001',
+      label: 'Veritas task task-abc / attempt attempt-001 / ClaudeCode',
+      runtime: 'subagent',
+      agentId: 'claude-code',
+      mode: 'run',
+      cleanup: 'keep',
+      context: 'isolated',
+    });
     expect(body.args).not.toHaveProperty('runTimeoutSeconds');
     expect(body.args).not.toHaveProperty('dry_run');
   });

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -6,6 +6,7 @@ import { errorHandler } from '../../middleware/error-handler.js';
 
 const {
   mockStartAgent,
+  mockPreviewAgentLaunch,
   mockStopAgent,
   mockSendMessage,
   mockCompleteAgent,
@@ -16,6 +17,7 @@ const {
   mockTelemetryEmit,
 } = vi.hoisted(() => ({
   mockStartAgent: vi.fn(),
+  mockPreviewAgentLaunch: vi.fn(),
   mockStopAgent: vi.fn(),
   mockSendMessage: vi.fn(),
   mockCompleteAgent: vi.fn(),
@@ -28,10 +30,16 @@ const {
 
 vi.mock('../../services/clawdbot-agent-service.js', () => ({
   AgentReadinessError: class AgentReadinessError extends Error {
-    readiness: unknown;
+    constructor(
+      public readiness: unknown,
+      message = 'Task readiness override required'
+    ) {
+      super(message);
+    }
   },
   clawdbotAgentService: {
     startAgent: mockStartAgent,
+    previewAgentLaunch: mockPreviewAgentLaunch,
     stopAgent: mockStopAgent,
     sendMessage: mockSendMessage,
     completeAgent: mockCompleteAgent,
@@ -83,6 +91,12 @@ describe('agent local capability enforcement', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockStartAgent.mockResolvedValue({ taskId: 'task_1', agent: 'codex', status: 'running' });
+    mockPreviewAgentLaunch.mockResolvedValue({
+      manifest: {
+        digest: `sha256:${'a'.repeat(64)}`,
+        enforcement: { enforceable: true, blockers: [] },
+      },
+    });
     mockStopAgent.mockResolvedValue(undefined);
     mockSendMessage.mockResolvedValue({ delivered: true, note: 'delivered' });
     mockCompleteAgent.mockResolvedValue(undefined);
@@ -125,6 +139,57 @@ describe('agent local capability enforcement', () => {
       budget: undefined,
       requiredRuntimeCapabilities: undefined,
       commitPolicy: undefined,
+      parentAttemptId: undefined,
+    });
+  });
+
+  it('previews launch evidence without dispatching an agent', async () => {
+    const app = createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }));
+    const response = await request(app)
+      .post('/api/agents/task_1/launch-preview')
+      .send({ agent: 'codex', parentAttemptId: 'attempt_parent' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.manifest.digest).toBe(`sha256:${'a'.repeat(64)}`);
+    expect(mockPreviewAgentLaunch).toHaveBeenCalledWith('task_1', 'codex', {
+      profileId: undefined,
+      overrideReason: undefined,
+      sandboxPresetId: undefined,
+      budget: undefined,
+      requiredRuntimeCapabilities: undefined,
+      commitPolicy: undefined,
+      parentAttemptId: 'attempt_parent',
+    });
+    expect(mockStartAgent).not.toHaveBeenCalled();
+  });
+
+  it('requires local agent capability for launch preview', async () => {
+    const response = await request(createApp(auth()))
+      .post('/api/agents/task_1/launch-preview')
+      .send({ agent: 'codex' });
+
+    expect(response.status).toBe(403);
+    expect(mockPreviewAgentLaunch).not.toHaveBeenCalled();
+  });
+
+  it('returns the same readiness validation evidence for preview as start', async () => {
+    const { AgentReadinessError } = await import('../../services/clawdbot-agent-service.js');
+    const readiness = {
+      ready: false,
+      missingRequired: [{ id: 'acceptance', label: 'Acceptance criteria' }],
+    };
+    mockPreviewAgentLaunch.mockRejectedValue(new AgentReadinessError(readiness));
+
+    const response = await request(
+      createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }))
+    )
+      .post('/api/agents/task_1/launch-preview')
+      .send({ agent: 'codex' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      details: { readiness },
     });
   });
 

--- a/server/src/__tests__/run-launch-manifest-service.test.ts
+++ b/server/src/__tests__/run-launch-manifest-service.test.ts
@@ -1,0 +1,596 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
+  type HarnessSupportStatus,
+  type SandboxPolicyDryRunResult,
+  type TaskEnvelope,
+} from '@veritas-kanban/shared';
+import {
+  RunLaunchManifestSchema,
+  parseRunLaunchManifest,
+} from '../schemas/run-launch-manifest-schemas.js';
+import {
+  RunLaunchManifestService,
+  diffRunLaunchManifests,
+  type RunLaunchManifestCompileInput,
+} from '../services/run-launch-manifest-service.js';
+import { calculateProviderRuntimeManifestDigest } from '../utils/provider-runtime-manifest-digest.js';
+import { verifyRunLaunchManifestDigest } from '../utils/run-launch-manifest-digest.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+
+const providerRuntimeManifest = providerRuntimeManifestFixture({
+  provider: 'codex-cli',
+  providerVersion: 'codex-cli 1.0.0',
+});
+
+const taskEnvelope: TaskEnvelope = {
+  schemaVersion: 'task-envelope/v1',
+  digest: `sha256:${'a'.repeat(64)}`,
+  subject: {
+    id: 'task-854',
+    title: 'Compile launch manifest',
+    objective: 'Compile the effective runtime launch plan.',
+    background: [],
+    constraints: [],
+    acceptanceCriteria: [],
+  },
+  attempt: {
+    id: 'attempt-854',
+    createdAt: '2026-07-23T20:00:00.000Z',
+  },
+  workspace: {
+    workspaceId: 'workspace-854',
+    worktreeId: 'worktree-854',
+    repo: 'BradGroux/veritas-kanban',
+    branch: 'feat/run-launch-manifest-854',
+    baseBranch: 'main',
+    worktreePath: '/workspace/veritas-kanban',
+    baseline: {
+      capturedAt: '2026-07-23T20:00:00.000Z',
+      headSha: 'a'.repeat(40),
+      dirty: false,
+      files: [],
+    },
+  },
+  commitPolicy: 'allowed',
+  allowedSideEffects: [],
+  expectedOutputs: [],
+  verificationGates: [],
+  launchManifest: {
+    schemaVersion: providerRuntimeManifest.schemaVersion,
+    digest: providerRuntimeManifest.digest,
+    provider: providerRuntimeManifest.provider,
+    adapter: providerRuntimeManifest.adapter,
+    protocolVersion: providerRuntimeManifest.protocolVersion,
+  },
+  completionContract: {
+    schemaVersion: 'completion-result/v1',
+    evidenceRequirements: [],
+  },
+};
+
+const harnessSupport: HarnessSupportStatus = {
+  agentType: 'codex',
+  enabled: true,
+  profileId: 'openai-codex-cli',
+  adapterId: 'codex-cli',
+  transport: 'process-jsonl',
+  supportTier: 'configured',
+  reason: 'Configured for test.',
+  failureClass: 'none',
+  checkedAt: '2026-07-23T20:00:00.000Z',
+  executableFound: true,
+  authenticated: true,
+  diagnosticCommands: ['codex --version'],
+  remediation: [],
+};
+
+const sandboxPolicy: SandboxPolicyDryRunResult = {
+  decision: 'allow',
+  provider: 'codex-cli',
+  preset: {
+    id: 'workspace-write-default',
+    name: 'Workspace write',
+    enabled: true,
+    enforcement: 'required',
+    requiredCapabilities: [],
+    filesystem: {
+      readPaths: ['<workspace>'],
+      writePaths: ['<workspace>'],
+      deniedPaths: [],
+      dotfileMasking: false,
+      localOnlyHandles: true,
+    },
+    network: {
+      defaultEgress: 'deny',
+      allowedHosts: [],
+      allowedMethods: [],
+      allowedPathPrefixes: [],
+      blockPrivateNetwork: true,
+      blockMetadataEndpoints: true,
+      blockLoopback: true,
+    },
+    environment: {
+      passthrough: ['PATH', 'OPENAI_API_KEY'],
+      redactDisplay: true,
+    },
+    credentials: {
+      mode: 'brokered',
+      brokerRefs: ['openai=provider-sensitive-value'],
+    },
+    createdAt: '2026-07-23T20:00:00.000Z',
+    updatedAt: '2026-07-23T20:00:00.000Z',
+  },
+  effective: {
+    sandboxMode: 'workspace-write',
+    networkAccessEnabled: false,
+    envPassthrough: ['PATH', 'OPENAI_API_KEY'],
+    credentialRefs: ['openai=[redacted]'],
+  },
+  evaluations: [],
+  unsupportedRules: [],
+  warnings: [],
+};
+
+function input(
+  overrides: Partial<RunLaunchManifestCompileInput> = {}
+): RunLaunchManifestCompileInput {
+  return {
+    taskId: 'task-854',
+    attemptId: 'attempt-854',
+    createdAt: '2026-07-23T20:00:00.000Z',
+    taskEnvelope,
+    providerRuntimeManifest,
+    harnessSupport,
+    routing: {
+      requestedAgent: 'auto',
+      selectedAgent: 'codex',
+      selectedHost: 'local-process',
+      reason: 'Routing engine selected the configured coding harness.',
+      fallbackAgent: null,
+      fallbackAllowed: false,
+    },
+    profile: {
+      id: 'developer-profile',
+      version: '1.0.0',
+      role: 'developer',
+    },
+    readiness: {
+      summary: {
+        checks: [],
+        passed: 8,
+        total: 8,
+        percent: 100,
+        ready: true,
+        missingRequired: [],
+        warnings: [],
+      },
+    },
+    instructions: [
+      {
+        id: 'task-prompt',
+        kind: 'task',
+        content: 'Implement the task envelope launch contract.',
+        origin: 'task-envelope',
+        precedence: 10,
+      },
+      {
+        id: 'profile-prompt',
+        kind: 'profile',
+        content: 'Use the repository conventions.',
+        origin: 'agent-profile:developer-profile',
+        precedence: 20,
+      },
+    ],
+    runtime: {
+      model: 'gpt-5.6',
+      command: 'codex',
+      args: ['exec', '--json', '<prompt>'],
+      workingDirectory: 'task-worktree',
+      worktree: 'required',
+      environmentKeys: ['PATH', 'OPENAI_API_KEY'],
+      credentialReferences: ['openai=[redacted]'],
+    },
+    tools: {
+      allowed: [],
+      denied: [],
+      policyIds: [],
+      mcpServers: [],
+      enforcement: 'not-required',
+    },
+    permissions: {
+      level: 'specialist',
+      required: [],
+      enforcement: 'not-required',
+    },
+    resources: {
+      skills: [],
+      shared: [],
+      enforcement: 'not-required',
+    },
+    requiredHealthChecks: [],
+    sandboxPolicy,
+    budgetPolicy: {
+      enabled: true,
+      scope: 'run',
+      limits: { totalTokens: 50_000 },
+      hardAction: 'require-approval',
+    },
+    workspaceTrust: {
+      status: 'not-required',
+      source: 'No repository-controlled executable components were selected.',
+    },
+    origins: [
+      {
+        field: 'runtime.model',
+        scope: 'agent-profile',
+        source: 'agent-profile:developer-profile',
+        precedence: 30,
+      },
+      {
+        field: 'sandbox.presetId',
+        scope: 'system-default',
+        source: 'sandbox:workspace-write-default',
+        precedence: 10,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('RunLaunchManifestService', () => {
+  it('compiles a canonical immutable manifest without prompt or credential values', () => {
+    const manifest = new RunLaunchManifestService().compile(input());
+
+    expect(manifest).toMatchObject({
+      schemaVersion: RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
+      taskId: 'task-854',
+      attemptId: 'attempt-854',
+      taskEnvelope: {
+        schemaVersion: 'task-envelope/v1',
+        digest: taskEnvelope.digest,
+      },
+      providerRuntime: {
+        digest: expect.stringMatching(/^sha256:/),
+        provider: 'codex-cli',
+        probeRevision: expect.any(Number),
+      },
+      enforcement: {
+        enforceable: true,
+        blockers: [],
+      },
+    });
+    expect(manifest.instructions).toEqual([
+      expect.objectContaining({
+        id: 'task-prompt',
+        digest: expect.stringMatching(/^sha256:/),
+        byteLength: expect.any(Number),
+      }),
+      expect.objectContaining({
+        id: 'profile-prompt',
+        digest: expect.stringMatching(/^sha256:/),
+        byteLength: expect.any(Number),
+      }),
+    ]);
+    expect(JSON.stringify(manifest)).not.toContain('Implement the task envelope');
+    expect(JSON.stringify(manifest)).not.toContain('provider-sensitive-value');
+    expect(RunLaunchManifestSchema.safeParse(manifest).success).toBe(true);
+    expect(verifyRunLaunchManifestDigest(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.runtime.args)).toBe(true);
+    expect(() => manifest.runtime.args.push('--tamper')).toThrow(TypeError);
+  });
+
+  it('fails closed for declared tools, MCP servers, permissions, and health checks without enforcement', () => {
+    const manifest = new RunLaunchManifestService().compile(
+      input({
+        tools: {
+          allowed: ['Read'],
+          denied: ['exec'],
+          policyIds: ['reviewer'],
+          mcpServers: ['veritas'],
+          enforcement: 'unavailable',
+        },
+        permissions: {
+          level: 'specialist',
+          required: ['repository.read'],
+          enforcement: 'unavailable',
+        },
+        resources: {
+          skills: ['review'],
+          shared: ['workspace-guidelines'],
+          enforcement: 'unavailable',
+        },
+        requiredHealthChecks: ['profile-health'],
+      })
+    );
+
+    expect(manifest.enforcement).toMatchObject({
+      enforceable: false,
+      blockers: expect.arrayContaining([
+        expect.objectContaining({ code: 'tool-policy-unenforceable' }),
+        expect.objectContaining({ code: 'mcp-unavailable' }),
+        expect.objectContaining({ code: 'permission-unenforceable' }),
+        expect.objectContaining({ code: 'skill-resource-unavailable' }),
+        expect.objectContaining({ code: 'shared-resource-unavailable' }),
+        expect.objectContaining({ code: 'health-check-unavailable' }),
+      ]),
+    });
+    expect(() => new RunLaunchManifestService().assertEnforceable(manifest)).toThrow(
+      /cannot be enforced/i
+    );
+  });
+
+  it('surfaces unsupported provider capability requirements as preview blockers', () => {
+    const manifest = new RunLaunchManifestService().compile(
+      input({
+        requiredRuntimeCapabilities: ['run.start', 'run.stop'],
+      })
+    );
+
+    expect(manifest.providerRequirements).toMatchObject({
+      required: ['run.start', 'run.stop'],
+      capabilities: expect.arrayContaining([
+        expect.objectContaining({ id: 'run.start', satisfied: true }),
+        expect.objectContaining({ id: 'run.stop', state: 'unknown', satisfied: false }),
+      ]),
+    });
+    expect(manifest.enforcement.blockers).toContainEqual(
+      expect.objectContaining({
+        code: 'provider-capability-unavailable',
+        field: 'providerRequirements.run.stop',
+      })
+    );
+  });
+
+  it('preserves effective-field origins across precedence scopes', () => {
+    const manifest = new RunLaunchManifestService().compile(
+      input({
+        origins: [
+          {
+            field: 'runtime.model',
+            scope: 'system-default',
+            source: 'default-model',
+            precedence: 10,
+          },
+          {
+            field: 'runtime.model',
+            scope: 'workspace',
+            source: 'workspace-model-policy',
+            precedence: 20,
+          },
+          {
+            field: 'runtime.model',
+            scope: 'workflow',
+            source: 'workflow:release',
+            precedence: 25,
+          },
+          {
+            field: 'runtime.model',
+            scope: 'agent-profile',
+            source: 'agent-profile:developer-profile',
+            precedence: 30,
+          },
+          {
+            field: 'runtime.model',
+            scope: 'run',
+            source: 'operator-run-override',
+            precedence: 40,
+          },
+          {
+            field: 'instructions',
+            scope: 'template',
+            source: 'prompt-template:implementation',
+            precedence: 25,
+          },
+        ],
+      })
+    );
+
+    expect(manifest.origins).toEqual([
+      expect.objectContaining({
+        field: 'instructions',
+        scope: 'template',
+        precedence: 25,
+      }),
+      expect.objectContaining({
+        field: 'runtime.model',
+        scope: 'system-default',
+        precedence: 10,
+      }),
+      expect.objectContaining({
+        field: 'runtime.model',
+        scope: 'workspace',
+        precedence: 20,
+      }),
+      expect.objectContaining({
+        field: 'runtime.model',
+        scope: 'workflow',
+        precedence: 25,
+      }),
+      expect.objectContaining({
+        field: 'runtime.model',
+        scope: 'agent-profile',
+        precedence: 30,
+      }),
+      expect.objectContaining({
+        field: 'runtime.model',
+        scope: 'run',
+        source: 'operator-run-override',
+        precedence: 40,
+      }),
+    ]);
+  });
+
+  it('reports material drift without treating attempt metadata as configuration drift', () => {
+    const service = new RunLaunchManifestService();
+    const parent = service.compile(input());
+    const nextTaskEnvelope = structuredClone(taskEnvelope);
+    nextTaskEnvelope.digest = `sha256:${'c'.repeat(64)}`;
+    nextTaskEnvelope.attempt = {
+      id: 'attempt-855',
+      createdAt: '2026-07-23T20:05:00.000Z',
+    };
+    nextTaskEnvelope.workspace.baseline.capturedAt = '2026-07-23T20:05:00.000Z';
+    const sameConfiguration = service.compile(
+      input({
+        attemptId: 'attempt-855',
+        createdAt: '2026-07-23T20:05:00.000Z',
+        taskEnvelope: nextTaskEnvelope,
+      })
+    );
+    const changedConfiguration = service.compile(
+      input({
+        runtime: {
+          ...input().runtime,
+          model: 'gpt-5.6-mini',
+        },
+      })
+    );
+
+    expect(diffRunLaunchManifests(sameConfiguration, parent)).toEqual({
+      material: false,
+      changes: [],
+    });
+    expect(diffRunLaunchManifests(changedConfiguration, parent)).toMatchObject({
+      material: true,
+      changes: [
+        expect.objectContaining({
+          field: 'runtime',
+          beforeDigest: expect.stringMatching(/^sha256:/),
+          afterDigest: expect.stringMatching(/^sha256:/),
+        }),
+      ],
+    });
+
+    const changedPolicyEnvelope = structuredClone(nextTaskEnvelope);
+    changedPolicyEnvelope.digest = `sha256:${'d'.repeat(64)}`;
+    changedPolicyEnvelope.commitPolicy = 'forbidden';
+    const changedPolicy = service.compile(input({ taskEnvelope: changedPolicyEnvelope }));
+    expect(diffRunLaunchManifests(changedPolicy, parent)).toMatchObject({
+      material: true,
+      changes: [expect.objectContaining({ field: 'taskEnvelope' })],
+    });
+
+    const noProfileParent = service.compile(input({ profile: undefined }));
+    const noProfileCurrent = service.compile(
+      input({
+        profile: undefined,
+        attemptId: 'attempt-856',
+        createdAt: '2026-07-23T20:06:00.000Z',
+      })
+    );
+    expect(diffRunLaunchManifests(noProfileCurrent, noProfileParent)).toEqual({
+      material: false,
+      changes: [],
+    });
+  });
+
+  it('does not report drift when only the provider probe timestamp and exact digest refresh', () => {
+    const service = new RunLaunchManifestService();
+    const parent = service.compile(input());
+    const { digest: _providerDigest, ...refreshedProviderPayload } =
+      structuredClone(providerRuntimeManifest);
+    refreshedProviderPayload.probe.probedAt = '2026-07-23T20:30:00.000Z';
+    const refreshedProviderRuntime = {
+      ...refreshedProviderPayload,
+      digest: calculateProviderRuntimeManifestDigest(refreshedProviderPayload),
+    };
+    const refreshedEnvelope = structuredClone(taskEnvelope);
+    refreshedEnvelope.digest = `sha256:${'e'.repeat(64)}`;
+    refreshedEnvelope.attempt = {
+      id: 'attempt-857',
+      createdAt: '2026-07-23T20:30:00.000Z',
+    };
+    refreshedEnvelope.launchManifest.digest = refreshedProviderRuntime.digest;
+    const current = service.compile(
+      input({
+        attemptId: 'attempt-857',
+        createdAt: '2026-07-23T20:30:00.000Z',
+        taskEnvelope: refreshedEnvelope,
+        providerRuntimeManifest: refreshedProviderRuntime,
+      })
+    );
+
+    expect(parent.providerRuntime.digest).not.toBe(current.providerRuntime.digest);
+    expect(parent.providerRuntime.materialDigest).toBe(current.providerRuntime.materialDigest);
+    expect(diffRunLaunchManifests(current, parent)).toEqual({
+      material: false,
+      changes: [],
+    });
+  });
+
+  it('normalizes raw and gateway-safe attempt IDs in runtime drift evidence', () => {
+    const service = new RunLaunchManifestService();
+    const parent = service.compile(
+      input({
+        attemptId: 'attempt-parent-id',
+        runtime: {
+          ...input().runtime,
+          args: [
+            'label=Veritas task task-854 / attempt attempt-parent-id',
+            'taskName=task_task_854_attempt_parent_id',
+          ],
+        },
+      })
+    );
+    const current = service.compile(
+      input({
+        attemptId: 'attempt-current-id',
+        runtime: {
+          ...input().runtime,
+          args: [
+            'label=Veritas task task-854 / attempt attempt-current-id',
+            'taskName=task_task_854_attempt_current_id',
+          ],
+        },
+      })
+    );
+
+    expect(diffRunLaunchManifests(current, parent)).toEqual({
+      material: false,
+      changes: [],
+    });
+  });
+
+  it('rejects tampered or unredacted public evidence', () => {
+    const manifest = new RunLaunchManifestService().compile(input());
+
+    expect(() =>
+      parseRunLaunchManifest({
+        ...manifest,
+        runtime: {
+          ...manifest.runtime,
+          credentialReferences: ['token=unredacted-sensitive-value'],
+        },
+      })
+    ).toThrow(/credential|secret|digest/i);
+
+    expect(() =>
+      parseRunLaunchManifest({
+        ...manifest,
+        runtime: {
+          ...manifest.runtime,
+          model: 'different-model',
+        },
+      })
+    ).toThrow(/digest/i);
+  });
+
+  it('does not change persisted evidence when source configuration mutates after compile', () => {
+    const source = input();
+    const manifest = new RunLaunchManifestService().compile(source);
+    const original = structuredClone(manifest);
+
+    source.runtime.model = 'mutated-model';
+    source.runtime.args.push('--new-flag');
+    source.tools.allowed.push('Write');
+    source.sandboxPolicy.effective.envPassthrough.push('MUTATED_SECRET');
+    source.budgetPolicy.limits = { totalTokens: 1 };
+    const firstOrigin = source.origins[0];
+    if (firstOrigin) firstOrigin.source = 'mutated-origin';
+
+    expect(manifest).toEqual(original);
+    expect(verifyRunLaunchManifestDigest(manifest)).toBe(true);
+  });
+});

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -12,6 +12,13 @@ describe('shared API permission metadata', () => {
     ).toEqual(['agent:write']);
   });
 
+  it('keeps launch-manifest preview read-scoped', () => {
+    expect(
+      getApiPermissionRequirement('/api/agents/task_1/launch-preview', { method: 'POST' })
+        .permissions
+    ).toEqual(['agent:read']);
+  });
+
   it('requires workflow execution for Codex review diff posts', () => {
     expect(
       getApiPermissionRequirement('/api/diff/task_1/codex-review', { method: 'POST' }).permissions

--- a/server/src/__tests__/work-product-run-launch-manifest.test.ts
+++ b/server/src/__tests__/work-product-run-launch-manifest.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Task } from '@veritas-kanban/shared';
+import { WorkProductService } from '../services/work-product-service.js';
+
+describe('completion packet launch evidence', () => {
+  let tmpDir: string | undefined;
+
+  afterEach(async () => {
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('links the run launch manifest and provider capability version', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'completion-launch-manifest-'));
+    const task = {
+      id: 'task_854',
+      title: 'Compile launch evidence',
+      type: 'code',
+      status: 'done',
+      priority: 'high',
+      agent: 'codex',
+      created: '2026-07-23T20:00:00.000Z',
+      updated: '2026-07-23T20:05:00.000Z',
+      attempt: {
+        id: 'attempt_854',
+        agent: 'codex',
+        status: 'complete',
+        runLaunchManifest: {
+          schemaVersion: 'run-launch-manifest/v1',
+          digest: `sha256:${'a'.repeat(64)}`,
+        },
+        runLaunchManifestTraceId: 'govtrace_launch_854',
+        runLaunchParentAttemptId: 'attempt_parent',
+        runLaunchManifestDrift: { material: true, changes: [] },
+        providerRuntimeManifest: {
+          digest: `sha256:${'b'.repeat(64)}`,
+          probeRevision: 3,
+          providerVersion: 'codex-cli 1.0.0',
+          providerBuild: 'build-854',
+        },
+      },
+    } as unknown as Task;
+    const service = new WorkProductService({ dataDir: tmpDir, storageType: 'file' });
+
+    const packet = await service.generateCompletionPacket(task);
+
+    expect(packet.metadata).toMatchObject({
+      runLaunchManifestSchemaVersion: 'run-launch-manifest/v1',
+      runLaunchManifestDigest: `sha256:${'a'.repeat(64)}`,
+      runLaunchManifestTraceId: 'govtrace_launch_854',
+      runLaunchParentAttemptId: 'attempt_parent',
+      runLaunchMaterialDrift: true,
+      providerRuntimeManifestDigest: `sha256:${'b'.repeat(64)}`,
+      providerRuntimeProbeRevision: 3,
+      providerRuntimeVersion: 'codex-cli 1.0.0',
+      providerRuntimeBuild: 'build-854',
+    });
+  });
+
+  it('links historical completion evidence from the requested attempt', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'completion-launch-history-'));
+    const historicalDigest = `sha256:${'c'.repeat(64)}`;
+    const currentDigest = `sha256:${'d'.repeat(64)}`;
+    const task = {
+      id: 'task_854_history',
+      title: 'Regenerate historical completion evidence',
+      type: 'code',
+      status: 'done',
+      priority: 'high',
+      agent: 'codex',
+      created: '2026-07-23T20:00:00.000Z',
+      updated: '2026-07-23T20:05:00.000Z',
+      attempt: {
+        id: 'attempt_current',
+        agent: 'codex',
+        status: 'complete',
+        runLaunchManifest: {
+          schemaVersion: 'run-launch-manifest/v1',
+          digest: currentDigest,
+        },
+      },
+      attempts: [
+        {
+          id: 'attempt_historical',
+          agent: 'codex',
+          status: 'complete',
+          runLaunchManifest: {
+            schemaVersion: 'run-launch-manifest/v1',
+            digest: historicalDigest,
+          },
+          providerRuntimeManifest: {
+            digest: `sha256:${'e'.repeat(64)}`,
+            probeRevision: 4,
+            providerVersion: 'codex-cli historical',
+          },
+        },
+      ],
+    } as unknown as Task;
+    const service = new WorkProductService({ dataDir: tmpDir, storageType: 'file' });
+
+    const packet = await service.generateCompletionPacket(task, {
+      sourceRunId: 'attempt_historical',
+    });
+
+    expect(packet.metadata).toMatchObject({
+      sourceRunId: 'attempt_historical',
+      runLaunchManifestDigest: historicalDigest,
+      providerRuntimeVersion: 'codex-cli historical',
+    });
+    expect(packet.metadata?.runLaunchManifestDigest).not.toBe(currentDigest);
+  });
+});

--- a/server/src/__tests__/workspace-file-repository.test.ts
+++ b/server/src/__tests__/workspace-file-repository.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LocalWorkspaceFileRepository } from '../storage/workspace-file-repository.js';
+
+describe('LocalWorkspaceFileRepository', () => {
+  let workspaceRoot: string;
+  const repository = new LocalWorkspaceFileRepository();
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'workspace-file-repository-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('reads optional workspace text and distinguishes missing files', async () => {
+    await writeFile(path.join(workspaceRoot, 'AGENTS.md'), '# Repository instructions\n', 'utf8');
+
+    await expect(repository.readOptionalText(workspaceRoot, 'AGENTS.md')).resolves.toBe(
+      '# Repository instructions\n'
+    );
+    await expect(repository.readOptionalText(workspaceRoot, 'CLAUDE.md')).resolves.toBeNull();
+  });
+
+  it('rejects paths outside the workspace root', async () => {
+    await expect(repository.readOptionalText(workspaceRoot, '../AGENTS.md')).rejects.toThrow(
+      /outside the base directory/i
+    );
+  });
+
+  it('rejects workspace symlinks that resolve outside the root', async () => {
+    const outsideRoot = await mkdtemp(path.join(os.tmpdir(), 'workspace-file-outside-'));
+    try {
+      await writeFile(path.join(outsideRoot, 'AGENTS.md'), '# Outside instructions\n', 'utf8');
+      await symlink(path.join(outsideRoot, 'AGENTS.md'), path.join(workspaceRoot, 'AGENTS.md'));
+
+      await expect(repository.readOptionalText(workspaceRoot, 'AGENTS.md')).rejects.toThrow(
+        /outside the base directory/i
+      );
+    } finally {
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -30,6 +30,7 @@ const startAgentSchema = z.object({
   budget: AgentBudgetPolicySchema.optional(),
   requiredRuntimeCapabilities: z.array(ProviderRuntimeCapabilityIdSchema).max(64).optional(),
   commitPolicy: TaskCommitPolicySchema.optional(),
+  parentAttemptId: z.string().trim().min(1).max(120).optional(),
 });
 
 const completeAgentSchema = z.object({
@@ -60,6 +61,48 @@ const reportTokensSchema = z.object({
   agent: AgentTypeSchema.optional(),
 });
 
+// POST /api/agents/:taskId/launch-preview - Compile effective launch evidence without dispatch.
+router.post(
+  '/:taskId/launch-preview',
+  requireLocalAgentCapability,
+  asyncHandler(async (req, res) => {
+    let parsed: z.infer<typeof startAgentSchema>;
+    try {
+      parsed = startAgentSchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+    let preview;
+    try {
+      preview = await clawdbotAgentService.previewAgentLaunch(
+        req.params.taskId as string,
+        parsed.agent as AgentType | undefined,
+        {
+          profileId: parsed.profileId,
+          overrideReason: parsed.overrideReason,
+          sandboxPresetId: parsed.sandboxPresetId,
+          budget: parsed.budget,
+          requiredRuntimeCapabilities: parsed.requiredRuntimeCapabilities as
+            ProviderRuntimeCapabilityId[] | undefined,
+          commitPolicy: parsed.commitPolicy as TaskCommitPolicy | undefined,
+          parentAttemptId: parsed.parentAttemptId,
+        }
+      );
+    } catch (error) {
+      if (error instanceof AgentReadinessError) {
+        throw new ValidationError(error.message, {
+          readiness: error.readiness,
+        });
+      }
+      throw error;
+    }
+    res.json(preview);
+  })
+);
+
 // POST /api/agents/:taskId/start - Start agent on task (delegates to Clawdbot)
 router.post(
   '/:taskId/start',
@@ -72,6 +115,7 @@ router.post(
     let budget: z.infer<typeof AgentBudgetPolicySchema> | undefined;
     let requiredRuntimeCapabilities: ProviderRuntimeCapabilityId[] | undefined;
     let commitPolicy: TaskCommitPolicy | undefined;
+    let parentAttemptId: string | undefined;
     try {
       ({
         agent,
@@ -81,6 +125,7 @@ router.post(
         budget,
         requiredRuntimeCapabilities,
         commitPolicy,
+        parentAttemptId,
       } = startAgentSchema.parse(req.body) as {
         agent?: AgentType;
         profileId?: string;
@@ -89,6 +134,7 @@ router.post(
         budget?: z.infer<typeof AgentBudgetPolicySchema>;
         requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
         commitPolicy?: TaskCommitPolicy;
+        parentAttemptId?: string;
       });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -105,6 +151,7 @@ router.post(
         budget,
         requiredRuntimeCapabilities,
         commitPolicy,
+        parentAttemptId,
       });
     } catch (error) {
       if (error instanceof AgentReadinessError) {

--- a/server/src/schemas/run-launch-manifest-schemas.ts
+++ b/server/src/schemas/run-launch-manifest-schemas.ts
@@ -1,0 +1,291 @@
+import { z } from 'zod';
+import {
+  HARNESS_SUPPORT_TIERS,
+  RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
+  type RunLaunchManifest,
+} from '@veritas-kanban/shared';
+import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
+import { calculateRunLaunchManifestDigest } from '../utils/run-launch-manifest-digest.js';
+import { containsUnredactedProviderRuntimeSecret } from '../utils/provider-runtime-manifest-sanitize.js';
+
+const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const identifierSchema = z.string().trim().min(1).max(160);
+const safeTextSchema = z.string().trim().min(1).max(1000);
+const stringListSchema = z.array(identifierSchema).max(128);
+const resourceReferenceListSchema = z.array(z.string().trim().min(1).max(600)).max(128);
+const environmentKeySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(120)
+  .regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
+const enforcementSchema = z.enum(['enforced', 'not-required', 'unavailable']);
+
+const manifestReferenceSchema = z
+  .object({
+    schemaVersion: identifierSchema,
+    digest: digestSchema,
+  })
+  .strict();
+
+export const RunLaunchManifestSchema = z
+  .object({
+    schemaVersion: z.literal(RUN_LAUNCH_MANIFEST_SCHEMA_VERSION),
+    digest: digestSchema,
+    createdAt: z.iso.datetime(),
+    taskId: identifierSchema,
+    attemptId: identifierSchema,
+    taskEnvelope: manifestReferenceSchema.extend({ materialDigest: digestSchema }).strict(),
+    providerRuntime: manifestReferenceSchema
+      .extend({
+        materialDigest: digestSchema,
+        probeRevision: z.number().int().positive(),
+        provider: identifierSchema,
+        adapter: identifierSchema,
+        protocolVersion: identifierSchema,
+        providerVersion: z.string().trim().min(1).max(200),
+        providerBuild: z.string().trim().min(1).max(300).optional(),
+      })
+      .strict(),
+    providerRequirements: z
+      .object({
+        required: stringListSchema,
+        capabilities: z
+          .array(
+            z
+              .object({
+                id: identifierSchema,
+                state: z.enum(['supported', 'advisory', 'unsupported', 'unknown']),
+                satisfied: z.boolean(),
+                advisory: z.boolean(),
+                reason: safeTextSchema,
+              })
+              .strict()
+          )
+          .max(128),
+      })
+      .strict(),
+    harnessSupport: z
+      .object({
+        profileId: identifierSchema,
+        adapterId: identifierSchema.optional(),
+        transport: z.enum([
+          'process-jsonl',
+          'process-text',
+          'sdk',
+          'http-tools',
+          'acp',
+          'app-server',
+          'unsupported',
+        ]),
+        supportTier: z.enum(HARNESS_SUPPORT_TIERS),
+      })
+      .strict(),
+    routing: z
+      .object({
+        requestedAgent: identifierSchema,
+        selectedAgent: identifierSchema,
+        selectedHost: identifierSchema,
+        reason: safeTextSchema,
+        fallbackAgent: identifierSchema.nullable(),
+        fallbackAllowed: z.boolean(),
+      })
+      .strict(),
+    profile: z
+      .object({
+        id: identifierSchema,
+        version: identifierSchema,
+        role: identifierSchema,
+      })
+      .strict()
+      .optional(),
+    readiness: z
+      .object({
+        ready: z.boolean(),
+        overridden: z.boolean(),
+        passed: z.number().int().nonnegative(),
+        total: z.number().int().nonnegative(),
+        missingRequired: stringListSchema,
+        warnings: stringListSchema,
+        overrideReasonDigest: digestSchema.optional(),
+      })
+      .strict(),
+    instructions: z
+      .array(
+        z
+          .object({
+            id: identifierSchema,
+            kind: z.enum(['task', 'profile', 'template', 'repository', 'system', 'other']),
+            digest: digestSchema,
+            materialDigest: digestSchema,
+            byteLength: z.number().int().min(0).max(5_000_000),
+            origin: identifierSchema,
+            precedence: z.number().int().min(0).max(10_000),
+          })
+          .strict()
+      )
+      .max(128),
+    runtime: z
+      .object({
+        model: z.string().trim().min(1).max(200).optional(),
+        command: z.string().trim().min(1).max(500),
+        args: z.array(z.string().max(1000)).max(128),
+        workingDirectory: z.enum(['task-worktree', 'workspace', 'provider-managed']),
+        worktree: z.enum(['required', 'supported', 'provider-managed']),
+        environmentKeys: z.array(environmentKeySchema).max(128),
+        credentialReferences: z.array(z.string().trim().min(1).max(300)).max(128),
+      })
+      .strict(),
+    tools: z
+      .object({
+        allowed: stringListSchema,
+        denied: stringListSchema,
+        policyIds: stringListSchema,
+        mcpServers: stringListSchema,
+        enforcement: enforcementSchema,
+      })
+      .strict(),
+    permissions: z
+      .object({
+        level: z.enum(['intern', 'specialist', 'lead']),
+        required: stringListSchema,
+        enforcement: enforcementSchema,
+      })
+      .strict(),
+    resources: z
+      .object({
+        skills: resourceReferenceListSchema,
+        shared: resourceReferenceListSchema,
+        enforcement: enforcementSchema,
+      })
+      .strict(),
+    requiredHealthChecks: stringListSchema,
+    sandbox: z
+      .object({
+        presetId: identifierSchema,
+        enforcement: z.enum(['required', 'advisory']),
+        decision: z.enum(['allow', 'warn', 'block']),
+        effective: z
+          .object({
+            sandboxMode: z.enum(['read-only', 'workspace-write', 'danger-full-access']),
+            networkAccessEnabled: z.boolean(),
+            environmentKeys: z.array(environmentKeySchema).max(128),
+            credentialReferences: z.array(z.string().trim().min(1).max(300)).max(128),
+          })
+          .strict(),
+        unsupportedRules: z
+          .array(
+            z
+              .object({
+                id: identifierSchema,
+                capability: identifierSchema,
+                status: z.enum(['supported', 'unsupported', 'advisory']),
+              })
+              .strict()
+          )
+          .max(128),
+        warnings: z.array(safeTextSchema).max(128),
+      })
+      .strict(),
+    budget: AgentBudgetPolicySchema,
+    workspaceTrust: z
+      .object({
+        status: z.enum(['trusted', 'untrusted', 'not-required']),
+        source: safeTextSchema,
+      })
+      .strict(),
+    origins: z
+      .array(
+        z
+          .object({
+            field: identifierSchema,
+            scope: z.enum([
+              'run',
+              'task-envelope',
+              'agent-profile',
+              'workflow',
+              'template',
+              'provider',
+              'workspace',
+              'system-default',
+            ]),
+            source: identifierSchema,
+            precedence: z.number().int().min(0).max(10_000),
+          })
+          .strict()
+      )
+      .max(256),
+    enforcement: z
+      .object({
+        enforceable: z.boolean(),
+        blockers: z
+          .array(
+            z
+              .object({
+                code: identifierSchema,
+                field: identifierSchema,
+                detail: safeTextSchema,
+                remediation: safeTextSchema,
+              })
+              .strict()
+          )
+          .max(128),
+        warnings: z.array(safeTextSchema).max(128),
+      })
+      .strict(),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    if (manifest.enforcement.enforceable !== (manifest.enforcement.blockers.length === 0)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['enforcement', 'enforceable'],
+        message: 'Launch manifest enforceable state must match the blocker set',
+      });
+    }
+    if (manifest.readiness.overridden !== Boolean(manifest.readiness.overrideReasonDigest)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['readiness', 'overridden'],
+        message: 'Readiness override state must match the override reason fingerprint',
+      });
+    }
+    if (manifest.digest !== calculateRunLaunchManifestDigest(manifest)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['digest'],
+        message: 'Run launch manifest digest does not match its canonical payload',
+      });
+    }
+    for (const [path, value] of collectStringLeaves(manifest)) {
+      if (containsUnredactedProviderRuntimeSecret(value)) {
+        context.addIssue({
+          code: 'custom',
+          path,
+          message: 'Run launch manifest evidence must redact credentials and secrets',
+        });
+      }
+    }
+  });
+
+export function parseRunLaunchManifest(input: unknown): RunLaunchManifest {
+  return RunLaunchManifestSchema.parse(input) as RunLaunchManifest;
+}
+
+function collectStringLeaves(
+  value: unknown,
+  path: Array<string | number> = []
+): Array<[Array<string | number>, string]> {
+  if (typeof value === 'string') {
+    return [[path, value]];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) => collectStringLeaves(entry, [...path, index]));
+  }
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) =>
+    collectStringLeaves(entry, [...path, key])
+  );
+}

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -33,9 +33,13 @@ import { validatePathSegment, ensureWithinBase } from '../utils/sanitize.js';
 import { buildSafeCodexEnv } from '../utils/codex-env.js';
 import { getRuntimeDir, getLogsDir } from '../utils/paths.js';
 import { buildSafeHermesEnv } from '../utils/hermes-env.js';
-import { HttpOpenClawTaskAdapter } from './openclaw-workflow-adapter.js';
+import {
+  buildOpenClawTaskSpawnArguments,
+  HttpOpenClawTaskAdapter,
+  isOpenClawGatewayPrivateIpAllowed,
+} from './openclaw-workflow-adapter.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
-import { evaluateTaskReadiness } from '@veritas-kanban/shared';
+import { evaluateTaskReadiness, RUN_LAUNCH_MANIFEST_SCHEMA_VERSION } from '@veritas-kanban/shared';
 import type {
   Task,
   AgentType,
@@ -57,6 +61,7 @@ import type {
   AgentBudgetDecision,
   AgentBudgetEvaluation,
   AgentProfileLaunchMetadata,
+  AgentProfileResolvedLaunch,
   ExecutableAgentProvider,
   ProviderRuntimeCapabilityId,
   ProviderRuntimeControlAction,
@@ -66,6 +71,11 @@ import type {
   TaskEnvelope,
   HarnessSupportStatus,
   HarnessSupportTelemetry,
+  RunLaunchManifest,
+  RunLaunchManifestDriftResult,
+  RunLaunchManifestOrigin,
+  RunLaunchManifestPreview,
+  RunLaunchRuntime,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError } from '../middleware/error-handler.js';
@@ -75,13 +85,14 @@ import {
   ProviderRuntimeManifestService,
   type ProviderRuntimeProbeRequest,
 } from './provider-runtime-manifest-service.js';
+import type { WorkspaceFileRepository } from '../storage/interfaces.js';
+import { LocalWorkspaceFileRepository } from '../storage/workspace-file-repository.js';
 import {
   getProviderRuntimeAdapterDefinition,
   type ProviderRuntimeSurface,
 } from './provider-runtime-adapter-registry.js';
 import { getInstalledPackageVersion } from '../utils/package-version.js';
 import {
-  assertProviderRuntimeCapabilities,
   assertProviderRuntimeControl,
   assertProviderRuntimeManifestSnapshot,
   BASELINE_LAUNCH_CAPABILITIES,
@@ -90,6 +101,7 @@ import {
 import { resolveTaskCommitPolicy, TaskEnvelopeService } from './task-envelope-service.js';
 import { evaluateHarnessSupportStatus } from './harness-support-service.js';
 import { normalizeHarnessSupportProfile } from './harness-support-profile-registry.js';
+import { RunLaunchManifestService, diffRunLaunchManifests } from './run-launch-manifest-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -114,6 +126,7 @@ export interface AgentProviderStartContext {
   emitter: EventEmitter;
   attempt: TaskAttempt;
   sandboxPolicy?: SandboxPolicyDryRunResult;
+  runLaunchManifest: RunLaunchManifest;
 }
 
 export interface AgentProviderStopContext {
@@ -146,6 +159,9 @@ export interface AgentStatus {
   providerRuntimeManifest: ProviderRuntimeManifest;
   harnessSupport: HarnessSupportStatus;
   taskEnvelope: TaskEnvelope;
+  runLaunchManifest: RunLaunchManifest;
+  runLaunchParentAttemptId?: string;
+  runLaunchManifestDrift?: RunLaunchManifestDriftResult;
   controls: ProviderRuntimeControlSet;
 }
 
@@ -162,6 +178,7 @@ export interface AgentStartOptions {
   budget?: AgentBudgetPolicy;
   requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
   commitPolicy?: TaskCommitPolicy;
+  parentAttemptId?: string;
 }
 
 export interface AgentMessageOptions {
@@ -205,6 +222,10 @@ interface PendingAgent {
   providerRuntimeManifest: ProviderRuntimeManifest;
   harnessSupport: HarnessSupportStatus;
   taskEnvelope: TaskEnvelope;
+  runLaunchManifest: RunLaunchManifest;
+  runLaunchManifestTraceId: string;
+  runLaunchParentAttemptId?: string;
+  runLaunchManifestDrift?: RunLaunchManifestDriftResult;
   threadId?: string;
   abortController?: AbortController;
   process?: ChildProcessWithoutNullStreams;
@@ -247,18 +268,23 @@ export class ClawdbotAgentService {
   private agentHealth: AgentHealthChecker;
   private providerRuntimeManifests: ProviderRuntimeManifestService;
   private taskEnvelopes: TaskEnvelopeService;
+  private runLaunchManifests: RunLaunchManifestService;
+  private workspaceFiles: WorkspaceFileRepository;
   private logsDir: string;
 
   constructor(
     agentHealth?: AgentHealthChecker,
     providerRuntimeManifests = new ProviderRuntimeManifestService(),
-    taskEnvelopes = new TaskEnvelopeService()
+    taskEnvelopes = new TaskEnvelopeService(),
+    workspaceFiles: WorkspaceFileRepository = new LocalWorkspaceFileRepository()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
     this.agentHealth = agentHealth || new AgentHealthService();
     this.providerRuntimeManifests = providerRuntimeManifests;
     this.taskEnvelopes = taskEnvelopes;
+    this.runLaunchManifests = new RunLaunchManifestService();
+    this.workspaceFiles = workspaceFiles;
     this.logsDir = getLogsDir();
     this.ensureLogsDir();
   }
@@ -338,6 +364,178 @@ export class ClawdbotAgentService {
   }
 
   /**
+   * Compile the effective launch evidence without creating an attempt or
+   * dispatching a provider process.
+   */
+  async previewAgentLaunch(
+    taskId: string,
+    agentType?: AgentType,
+    options: AgentStartOptions = {}
+  ): Promise<RunLaunchManifestPreview> {
+    const task = await this.taskService.getTask(taskId);
+    if (!task) throw new Error(`Task "${taskId}" not found`);
+    if (task.type !== 'code') throw new Error('Agents can only be started on code tasks');
+    if (!task.git?.worktreePath) {
+      throw new Error('Task must have an active worktree to start an agent');
+    }
+
+    const config = await this.configService.getConfig();
+    const profileLaunch = options.profileId
+      ? await getAgentProfilePackageService().resolveLaunch(options.profileId)
+      : undefined;
+    let agent: AgentType;
+    let routingReason: string;
+    let routingFallback: AgentType | undefined;
+    const requestedAgent = profileLaunch ? profileLaunch.agent : (agentType ?? 'auto');
+    if (profileLaunch) {
+      agent = profileLaunch.agent;
+      routingReason = `Agent profile ${profileLaunch.profile.id}@${profileLaunch.profile.version} selected ${agent}.`;
+      routingFallback = profileLaunch.profile.runtime.fallbackAgent;
+    } else if (!agentType || agentType === 'auto') {
+      const result = await getAgentRoutingService().resolveAgent(task);
+      agent = result.agent;
+      routingReason = result.reason;
+      routingFallback = result.fallback;
+    } else {
+      agent = agentType;
+      routingReason = `Operator explicitly selected ${agent}.`;
+    }
+    const readiness = this.assertLaunchReadiness(task, agent, options.overrideReason);
+    const overrideReason = options.overrideReason?.trim();
+
+    const agentConfig = profileLaunch?.agentConfig ?? this.resolveAgentConfig(config.agents, agent);
+    const profileAgentConfig =
+      profileLaunch && agentConfig
+        ? {
+            ...agentConfig,
+            provider: profileLaunch.profile.runtime.provider ?? agentConfig.provider,
+            model: profileLaunch.model ?? agentConfig.model,
+          }
+        : agentConfig;
+    const provider = this.resolveAgentProvider(profileAgentConfig, agent);
+    const agentHealth = await this.assertAgentAvailable(agent, profileAgentConfig);
+    const adapter = this.resolveProviderAdapter(provider);
+    const budgetService = getAgentBudgetService();
+    const budgetSources = {
+      workspaceBudget: config.features?.budget?.enabled
+        ? config.features.budget.defaultRunBudget
+        : undefined,
+      agentBudget: profileAgentConfig?.budget,
+      profileBudget: options.budget ? undefined : profileLaunch?.profile.policy?.budget,
+      runBudget: options.budget,
+    };
+    const budgetPolicy = budgetService.resolve({
+      workspaceBudget: budgetSources.workspaceBudget,
+      agentBudget: budgetSources.agentBudget,
+      runBudget: budgetSources.runBudget ?? profileLaunch?.budget,
+    });
+    const budgetEvaluation = budgetService.evaluate(
+      budgetPolicy,
+      { fanOut: 1 },
+      {
+        taskId,
+        agentId: agent,
+        actionType: 'agent.launch-preview',
+        project: task.project,
+      }
+    );
+    if (this.isBlockingBudgetDecision(budgetEvaluation.decision)) {
+      throw new ConflictError('Agent run budget requires operator action before launch', {
+        decision: budgetEvaluation.decision,
+        thresholdEvents: budgetEvaluation.thresholdEvents,
+      });
+    }
+    const launchAgentConfig =
+      budgetEvaluation.modelOverride && profileAgentConfig
+        ? { ...profileAgentConfig, model: budgetEvaluation.modelOverride }
+        : profileAgentConfig;
+    const providerRuntimeManifest = await adapter.probe({
+      agentConfig: launchAgentConfig,
+      health: agentHealth,
+    });
+    const harnessSupport = evaluateHarnessSupportStatus(
+      launchAgentConfig as AgentConfig,
+      agentHealth,
+      providerRuntimeManifest
+    );
+    const requiredRuntimeCapabilities = this.resolveLaunchRuntimeCapabilities(
+      profileLaunch,
+      budgetPolicy,
+      options.requiredRuntimeCapabilities
+    );
+    const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
+      presetId:
+        options.sandboxPresetId ??
+        profileLaunch?.sandboxPresetId ??
+        launchAgentConfig?.sandboxPresetId,
+      provider,
+      workspacePath: task.git.worktreePath,
+      providerRuntimeManifest,
+    });
+    const attemptId = `preview_${nanoid(8)}`;
+    const startedAt = new Date().toISOString();
+    const logPath = path.join(this.logsDir, `${taskId}_${attemptId}.md`);
+    const worktreePath = this.expandPath(task.git.worktreePath);
+    const taskEnvelope = await this.taskEnvelopes.build({
+      task,
+      attemptId,
+      createdAt: startedAt,
+      worktreePath,
+      providerRuntimeManifest,
+      commitPolicy: resolveTaskCommitPolicy({
+        runPolicy: options.commitPolicy,
+        taskPolicy: task.executionPolicy,
+        legacyAutoCommitOnComplete: config.features?.agents.autoCommitOnComplete,
+      }),
+      profileInstructions: profileLaunch?.instructions,
+      networkAccessEnabled: sandboxPolicy.result.effective.networkAccessEnabled,
+      executionPolicy: task.executionPolicy,
+    });
+    const taskPrompt = this.buildTaskPrompt(
+      task,
+      worktreePath,
+      attemptId,
+      providerRuntimeManifest.digest,
+      profileLaunch?.instructions
+    );
+    const manifest = await this.compileRunLaunchManifest({
+      task,
+      taskEnvelope,
+      taskPrompt,
+      attemptId,
+      startedAt,
+      logPath,
+      requestedAgent,
+      routingReason,
+      routingFallback,
+      agent,
+      launchAgentConfig,
+      provider,
+      providerRuntimeManifest,
+      requiredRuntimeCapabilities,
+      harnessSupport,
+      profileLaunch,
+      readiness,
+      overrideReason,
+      sandboxPolicy: sandboxPolicy.result,
+      budgetPolicy,
+      budgetModelOverride: budgetEvaluation.modelOverride,
+      budgetSources,
+      options,
+    });
+    const parentAttempt = await this.resolveParentAttempt(task, options.parentAttemptId);
+    return {
+      manifest,
+      ...(parentAttempt
+        ? {
+            parentAttemptId: parentAttempt.id,
+            drift: diffRunLaunchManifests(manifest, parentAttempt.runLaunchManifest),
+          }
+        : {}),
+    };
+  }
+
+  /**
    * Start an agent on a task by delegating to Clawdbot
    */
   async startAgent(
@@ -387,9 +585,14 @@ export class ClawdbotAgentService {
       ? await getAgentProfilePackageService().resolveLaunch(options.profileId)
       : undefined;
     let agent: AgentType;
+    let routingReason: string;
+    let routingFallback: AgentType | undefined;
+    const requestedAgent = profileLaunch ? profileLaunch.agent : (agentType ?? 'auto');
 
     if (profileLaunch) {
       agent = profileLaunch.agent;
+      routingReason = `Agent profile ${profileLaunch.profile.id}@${profileLaunch.profile.version} selected ${agent}.`;
+      routingFallback = profileLaunch.profile.runtime.fallbackAgent;
       log.info(
         `[ClawdbotAgent] Profile ${profileLaunch.profile.id}@${profileLaunch.profile.version} selected ${agent} for task ${taskId}`
       );
@@ -397,13 +600,17 @@ export class ClawdbotAgentService {
       const routing = getAgentRoutingService();
       const result = await routing.resolveAgent(task);
       agent = result.agent;
-      const routingReason = result.reason;
+      routingReason = result.reason;
+      routingFallback = result.fallback;
       log.info(
         `[ClawdbotAgent] Routing resolved agent for task ${taskId}: ${agent} (${routingReason})`
       );
     } else {
       agent = agentType;
+      routingReason = `Operator explicitly selected ${agent}.`;
     }
+    const readiness = this.assertLaunchReadiness(task, agent, options.overrideReason);
+    const overrideReason = options.overrideReason?.trim();
 
     const agentConfig = profileLaunch?.agentConfig ?? this.resolveAgentConfig(config.agents, agent);
     const profileAgentConfig =
@@ -418,12 +625,18 @@ export class ClawdbotAgentService {
     const agentHealth = await this.assertAgentAvailable(agent, profileAgentConfig);
     const adapter = this.resolveProviderAdapter(provider);
     const budgetService = getAgentBudgetService();
-    const budgetPolicy = budgetService.resolve({
+    const budgetSources = {
       workspaceBudget: config.features?.budget?.enabled
         ? config.features.budget.defaultRunBudget
         : undefined,
       agentBudget: profileAgentConfig?.budget,
-      runBudget: options.budget ?? profileLaunch?.budget,
+      profileBudget: options.budget ? undefined : profileLaunch?.profile.policy?.budget,
+      runBudget: options.budget,
+    };
+    const budgetPolicy = budgetService.resolve({
+      workspaceBudget: budgetSources.workspaceBudget,
+      agentBudget: budgetSources.agentBudget,
+      runBudget: budgetSources.runBudget ?? profileLaunch?.budget,
     });
     const budgetEvaluation = budgetService.evaluate(
       budgetPolicy,
@@ -460,31 +673,10 @@ export class ClawdbotAgentService {
       agentHealth,
       providerRuntimeManifest
     );
-    const launchRuntimeCapabilities = new Set<ProviderRuntimeCapabilityId>([
-      ...BASELINE_LAUNCH_CAPABILITIES,
-      ...(options.requiredRuntimeCapabilities ?? []),
-    ]);
-    if ((profileLaunch?.profile.tools?.allowed?.length ?? 0) > 0) {
-      launchRuntimeCapabilities.add('tool.calls');
-    }
-    if ((profileLaunch?.profile.tools?.mcpServers?.length ?? 0) > 0) {
-      launchRuntimeCapabilities.add('tool.calls');
-      launchRuntimeCapabilities.add('tool.mcp');
-    }
-    const budgetLimits = budgetPolicy?.enabled ? budgetPolicy.limits : undefined;
-    if (
-      budgetLimits?.inputTokens !== undefined ||
-      budgetLimits?.outputTokens !== undefined ||
-      budgetLimits?.totalTokens !== undefined ||
-      budgetLimits?.costUsd !== undefined
-    ) {
-      launchRuntimeCapabilities.add('usage.tokens');
-    }
-    if (budgetLimits?.toolCalls !== undefined) launchRuntimeCapabilities.add('tool.calls');
-    assertProviderRuntimeCapabilities(
-      providerRuntimeManifest,
-      [...launchRuntimeCapabilities],
-      'agent launch'
+    const requiredRuntimeCapabilities = this.resolveLaunchRuntimeCapabilities(
+      profileLaunch,
+      budgetPolicy,
+      options.requiredRuntimeCapabilities
     );
     const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
       presetId:
@@ -496,31 +688,6 @@ export class ClawdbotAgentService {
       providerRuntimeManifest,
     });
     const sandboxTrace = await getGovernanceTraceService().record(sandboxPolicy.trace);
-    if (sandboxPolicy.result.decision === 'block') {
-      throw new ConflictError('Sandbox preset cannot be enforced by the selected provider', {
-        presetId: sandboxPolicy.result.preset.id,
-        provider,
-        traceId: sandboxTrace.id,
-        unsupportedRules: sandboxPolicy.result.unsupportedRules.map((rule) => ({
-          id: rule.id,
-          capability: rule.capability,
-          detail: rule.detail,
-        })),
-      });
-    }
-    const readiness = evaluateTaskReadiness(task, { isCodeTask: true, selectedAgent: agent });
-    const overrideReason = options.overrideReason?.trim();
-
-    if (!readiness.ready && !overrideReason) {
-      throw new AgentReadinessError(readiness);
-    }
-
-    if (!readiness.ready && overrideReason && overrideReason.length < 8) {
-      throw new AgentReadinessError(
-        readiness,
-        'Task readiness override reason must be at least 8 characters'
-      );
-    }
 
     if (!readiness.ready && overrideReason) {
       await activityService.logActivity(
@@ -563,10 +730,83 @@ export class ClawdbotAgentService {
       executionPolicy: task.executionPolicy,
     });
 
+    // Validate path segments for log file
+    validatePathSegment(taskId);
+    validatePathSegment(attemptId);
+
+    // Build the task prompt for Clawdbot
+    const taskPrompt = this.buildTaskPrompt(
+      task,
+      worktreePath,
+      attemptId,
+      providerRuntimeManifest.digest,
+      profileLaunch?.instructions
+    );
+    const runLaunchManifest = await this.compileRunLaunchManifest({
+      task,
+      taskEnvelope,
+      taskPrompt,
+      attemptId,
+      startedAt,
+      logPath,
+      requestedAgent,
+      routingReason,
+      routingFallback,
+      agent,
+      launchAgentConfig,
+      provider,
+      providerRuntimeManifest,
+      requiredRuntimeCapabilities,
+      harnessSupport,
+      profileLaunch,
+      readiness,
+      overrideReason,
+      sandboxPolicy: sandboxPolicy.result,
+      budgetPolicy,
+      budgetModelOverride: budgetEvaluation.modelOverride,
+      budgetSources,
+      options,
+    });
+    const parentAttempt = await this.resolveParentAttempt(task, options.parentAttemptId);
+    const runLaunchManifestDrift = parentAttempt?.runLaunchManifest
+      ? diffRunLaunchManifests(runLaunchManifest, parentAttempt.runLaunchManifest)
+      : undefined;
+    const runLaunchTrace = await getGovernanceTraceService().record({
+      kind: 'policy',
+      outcome: runLaunchManifest.enforcement.enforceable ? 'allowed' : 'blocked',
+      title: 'Run launch manifest compiled',
+      summary: runLaunchManifest.enforcement.enforceable
+        ? 'The effective run launch manifest is enforceable.'
+        : 'The effective run launch manifest contains launch blockers.',
+      remediation:
+        runLaunchManifest.enforcement.blockers.map((blocker) => blocker.remediation).join(' ') ||
+        undefined,
+      subject: {
+        taskId,
+        agentId: agent,
+        actionType: 'agent.start',
+      },
+      evaluatedRules: runLaunchManifest.enforcement.blockers.map((blocker) => ({
+        id: blocker.code,
+        label: blocker.field,
+        type: 'policy',
+        status: 'matched',
+        outcome: 'blocked',
+        message: blocker.detail,
+      })),
+      raw: {
+        runLaunchManifest,
+        parentAttemptId: parentAttempt?.id,
+        drift: runLaunchManifestDrift,
+        sandboxTraceId: sandboxTrace.id,
+      },
+    });
+    this.runLaunchManifests.assertEnforceable(runLaunchManifest);
+
     // Create event emitter for status updates
     const emitter = new EventEmitter();
 
-    // Store pending agent
+    // Store the exact immutable launch evidence before provider dispatch.
     pendingAgents.set(taskId, {
       taskId,
       attemptId,
@@ -579,6 +819,10 @@ export class ClawdbotAgentService {
       providerRuntimeManifest,
       harnessSupport,
       taskEnvelope,
+      runLaunchManifest,
+      runLaunchManifestTraceId: runLaunchTrace.id,
+      runLaunchParentAttemptId: parentAttempt?.id,
+      runLaunchManifestDrift,
       budget: budgetPolicy
         ? {
             ...budgetService.initialState(budgetPolicy),
@@ -592,22 +836,17 @@ export class ClawdbotAgentService {
         : undefined,
     });
 
-    // Validate path segments for log file
-    validatePathSegment(taskId);
-    validatePathSegment(attemptId);
-
-    // Build the task prompt for Clawdbot
-    const taskPrompt = this.buildTaskPrompt(
-      task,
-      worktreePath,
-      attemptId,
-      providerRuntimeManifest.digest,
-      profileLaunch?.instructions
-    );
-
     // Initialize log file (ensure it stays within logs dir)
     ensureWithinBase(this.logsDir, logPath);
-    await this.initLogFile(logPath, task, agent, taskPrompt, providerRuntimeManifest, taskEnvelope);
+    await this.initLogFile(
+      logPath,
+      task,
+      agent,
+      taskPrompt,
+      providerRuntimeManifest,
+      taskEnvelope,
+      runLaunchManifest
+    );
 
     // Update task with attempt info
     const attempt: TaskAttempt = {
@@ -622,6 +861,10 @@ export class ClawdbotAgentService {
       providerRuntimeManifest,
       harnessSupport,
       taskEnvelope,
+      runLaunchManifest,
+      runLaunchManifestTraceId: runLaunchTrace.id,
+      runLaunchParentAttemptId: parentAttempt?.id,
+      runLaunchManifestDrift,
     };
 
     await this.taskService.updateTask(taskId, {
@@ -671,6 +914,7 @@ export class ClawdbotAgentService {
         emitter,
         attempt,
         sandboxPolicy: sandboxPolicy.result,
+        runLaunchManifest,
       });
     } catch (error: any) {
       pendingAgents.delete(taskId);
@@ -721,6 +965,9 @@ export class ClawdbotAgentService {
       providerRuntimeManifest,
       harnessSupport,
       taskEnvelope,
+      runLaunchManifest,
+      runLaunchParentAttemptId: parentAttempt?.id,
+      runLaunchManifestDrift,
       controls: providerRuntimeControls(providerRuntimeManifest),
     };
   }
@@ -876,6 +1123,10 @@ export class ClawdbotAgentService {
           providerRuntimeManifest: pending.providerRuntimeManifest,
           harnessSupport: pending.harnessSupport,
           taskEnvelope: pending.taskEnvelope,
+          runLaunchManifest: pending.runLaunchManifest,
+          runLaunchManifestTraceId: pending.runLaunchManifestTraceId,
+          runLaunchParentAttemptId: pending.runLaunchParentAttemptId,
+          runLaunchManifestDrift: pending.runLaunchManifestDrift,
         };
         return (pending.preparedCompletion = {
           status,
@@ -1185,6 +1436,54 @@ export class ClawdbotAgentService {
     });
   }
 
+  private resolveLaunchRuntimeCapabilities(
+    profileLaunch: AgentProfileResolvedLaunch | undefined,
+    budgetPolicy: AgentBudgetPolicy | undefined,
+    requiredRuntimeCapabilities: ProviderRuntimeCapabilityId[] | undefined
+  ): ProviderRuntimeCapabilityId[] {
+    const launchRuntimeCapabilities = new Set<ProviderRuntimeCapabilityId>([
+      ...BASELINE_LAUNCH_CAPABILITIES,
+      ...(requiredRuntimeCapabilities ?? []),
+    ]);
+    if ((profileLaunch?.profile.tools?.allowed?.length ?? 0) > 0) {
+      launchRuntimeCapabilities.add('tool.calls');
+    }
+    if ((profileLaunch?.profile.tools?.mcpServers?.length ?? 0) > 0) {
+      launchRuntimeCapabilities.add('tool.calls');
+      launchRuntimeCapabilities.add('tool.mcp');
+    }
+    const budgetLimits = budgetPolicy?.enabled ? budgetPolicy.limits : undefined;
+    if (
+      budgetLimits?.inputTokens !== undefined ||
+      budgetLimits?.outputTokens !== undefined ||
+      budgetLimits?.totalTokens !== undefined ||
+      budgetLimits?.costUsd !== undefined
+    ) {
+      launchRuntimeCapabilities.add('usage.tokens');
+    }
+    if (budgetLimits?.toolCalls !== undefined) launchRuntimeCapabilities.add('tool.calls');
+    return [...launchRuntimeCapabilities].sort((left, right) => left.localeCompare(right));
+  }
+
+  private assertLaunchReadiness(
+    task: Task,
+    agent: AgentType,
+    overrideReason: string | undefined
+  ): TaskReadinessSummary {
+    const readiness = evaluateTaskReadiness(task, { isCodeTask: true, selectedAgent: agent });
+    const normalizedOverrideReason = overrideReason?.trim();
+    if (!readiness.ready && !normalizedOverrideReason) {
+      throw new AgentReadinessError(readiness);
+    }
+    if (!readiness.ready && normalizedOverrideReason && normalizedOverrideReason.length < 8) {
+      throw new AgentReadinessError(
+        readiness,
+        'Task readiness override reason must be at least 8 characters'
+      );
+    }
+    return readiness;
+  }
+
   private resolveAgentConfig(agents: AgentConfig[], agent: AgentType): AgentConfig | undefined {
     return agents.find((a) => a.type === agent);
   }
@@ -1337,7 +1636,9 @@ export class ClawdbotAgentService {
           startedAt,
           emitter,
           sandboxPolicy,
+          runLaunchManifest,
         }) => {
+          this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
           this.startCodexCli(
             task,
             agentConfig,
@@ -1369,7 +1670,9 @@ export class ClawdbotAgentService {
           startedAt,
           emitter,
           sandboxPolicy,
+          runLaunchManifest,
         }) => {
+          this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
           const abortController = new AbortController();
           const pending = pendingAgents.get(task.id);
           if (pending) pending.abortController = abortController;
@@ -1436,7 +1739,9 @@ export class ClawdbotAgentService {
           startedAt,
           emitter,
           sandboxPolicy,
+          runLaunchManifest,
         }) => {
+          this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
           this.startHermesCli(
             task,
             agentConfig,
@@ -1471,7 +1776,8 @@ export class ClawdbotAgentService {
       id: definition.id,
       label: definition.label,
       probe,
-      start: async ({ prompt, task, attemptId, agentConfig }) => {
+      start: async ({ prompt, task, attemptId, agentConfig, runLaunchManifest }) => {
+        this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
         // Use the HTTP gateway adapter (sessions_spawn) instead of writing a request file.
         // The real spawn acknowledgement surfaces policy denial or gateway
         // unreachability, which the caller's error handler rolls back to 'todo'.
@@ -1513,6 +1819,35 @@ export class ClawdbotAgentService {
         );
       },
     };
+  }
+
+  private assertProviderAdapterLaunchManifest(
+    provider: ExecutableAgentProvider,
+    manifest: RunLaunchManifest
+  ): void {
+    this.runLaunchManifests.assertEnforceable(manifest);
+    if (manifest.providerRuntime.provider !== provider) {
+      throw new ConflictError('Run launch manifest provider does not match the selected adapter.', {
+        manifestProvider: manifest.providerRuntime.provider,
+        adapterProvider: provider,
+      });
+    }
+    if (
+      manifest.tools.allowed.length > 0 ||
+      manifest.tools.denied.length > 0 ||
+      manifest.tools.policyIds.length > 0 ||
+      manifest.tools.mcpServers.length > 0
+    ) {
+      throw new ConflictError(
+        'The selected adapter cannot inject the manifest tool and MCP catalog.',
+        {
+          provider,
+          manifestDigest: manifest.digest,
+          remediation:
+            'Use a run-scoped tool-control adapter after the tool-server control plane is enabled.',
+        }
+      );
+    }
   }
 
   private buildProviderRuntimeProbeRequest(
@@ -1931,19 +2266,16 @@ export class ClawdbotAgentService {
       throw new Error('Task worktree path is required for Codex SDK');
     }
 
+    const sdkExecutable = this.resolveCodexSdkExecutable(agentConfig);
     const { Codex } = await import('@openai/codex-sdk');
     const codex = new Codex({
-      codexPathOverride:
-        agentConfig?.command && agentConfig.command !== 'codex' ? agentConfig.command : undefined,
+      codexPathOverride: sdkExecutable.codexPathOverride,
       env: buildSafeCodexEnv(process.env, sandboxPolicy?.effective.envPassthrough),
     });
 
     const thread = codex.startThread({
       workingDirectory: worktreePath,
-      skipGitRepoCheck: true,
-      sandboxMode: sandboxPolicy?.effective.sandboxMode ?? 'workspace-write',
-      approvalPolicy: 'never',
-      networkAccessEnabled: sandboxPolicy?.effective.networkAccessEnabled ?? true,
+      ...this.buildCodexSdkThreadSettings(sandboxPolicy),
       model: agentConfig?.model,
     });
 
@@ -2701,6 +3033,9 @@ export class ClawdbotAgentService {
       providerRuntimeManifest: pending.providerRuntimeManifest,
       harnessSupport: pending.harnessSupport,
       taskEnvelope: pending.taskEnvelope,
+      runLaunchManifest: pending.runLaunchManifest,
+      runLaunchParentAttemptId: pending.runLaunchParentAttemptId,
+      runLaunchManifestDrift: pending.runLaunchManifestDrift,
       controls: providerRuntimeControls(pending.providerRuntimeManifest),
     };
   }
@@ -2804,6 +3139,23 @@ export class ClawdbotAgentService {
       pending.providerRuntimeManifest,
       persistedAttempt.providerRuntimeManifest?.digest
     );
+    if (
+      !persistedAttempt.runLaunchManifest ||
+      persistedAttempt.runLaunchManifest.digest !== pending.runLaunchManifest.digest
+    ) {
+      throw new ConflictError(
+        'Run launch manifest is stale or invalid: persisted launch evidence does not match the active run',
+        {
+          action,
+          activeRunLaunchManifestDigest: pending.runLaunchManifest.digest,
+          persistedRunLaunchManifestDigest: persistedAttempt.runLaunchManifest?.digest,
+          remediation:
+            'Terminate the detached provider, reconcile persisted attempt state, and launch again.',
+        }
+      );
+    }
+    this.runLaunchManifests.assertEnforceable(persistedAttempt.runLaunchManifest);
+    this.runLaunchManifests.assertEnforceable(pending.runLaunchManifest);
   }
 
   /**
@@ -2862,6 +3214,870 @@ export class ClawdbotAgentService {
     return files
       .filter((f) => f.startsWith(`${taskId}_`) && f.endsWith('.md'))
       .map((f) => f.replace(`${taskId}_`, '').replace('.md', ''));
+  }
+
+  private async compileRunLaunchManifest(input: {
+    task: Task;
+    taskEnvelope: TaskEnvelope;
+    taskPrompt: string;
+    attemptId: string;
+    startedAt: string;
+    logPath: string;
+    requestedAgent: AgentType;
+    routingReason: string;
+    routingFallback?: AgentType;
+    agent: AgentType;
+    launchAgentConfig?: AgentConfig;
+    provider: ExecutableAgentProvider;
+    providerRuntimeManifest: ProviderRuntimeManifest;
+    requiredRuntimeCapabilities: ProviderRuntimeCapabilityId[];
+    harnessSupport: HarnessSupportStatus;
+    profileLaunch?: AgentProfileResolvedLaunch;
+    readiness: TaskReadinessSummary;
+    overrideReason?: string;
+    sandboxPolicy: SandboxPolicyDryRunResult;
+    budgetPolicy?: AgentBudgetPolicy;
+    budgetModelOverride?: string;
+    budgetSources: {
+      workspaceBudget?: AgentBudgetPolicy;
+      agentBudget?: AgentBudgetPolicy;
+      profileBudget?: AgentBudgetPolicy;
+      runBudget?: AgentBudgetPolicy;
+    };
+    options: AgentStartOptions;
+  }): Promise<RunLaunchManifest> {
+    const profile = input.profileLaunch?.profile;
+    const hasToolRestrictions =
+      (profile?.tools?.allowed?.length ?? 0) > 0 ||
+      (profile?.policy?.toolPolicyIds?.length ?? 0) > 0;
+    const hasMcpRestrictions = (profile?.tools?.mcpServers?.length ?? 0) > 0;
+    const hasPermissionRequirements =
+      Boolean(profile?.permissions?.level) || (profile?.permissions?.required?.length ?? 0) > 0;
+    const requiredHealthChecks = (profile?.health?.checks ?? [])
+      .filter((check) => check.required)
+      .map((check) => check.id);
+    const selectedSkills = (profile?.tools?.allowed ?? []).filter((tool) =>
+      /^skill(?::|\/)/i.test(tool)
+    );
+    const selectedSharedResources = [
+      ...(profile?.instructions?.promptFile
+        ? [`instruction-file:${profile.instructions.promptFile}`]
+        : []),
+      ...(profile?.instructions?.files ?? []).map((file) => `instruction-file:${file}`),
+      ...(profile?.workflow?.id ? [`workflow:${profile.workflow.id}`] : []),
+      ...(profile?.workflow?.entrypoint
+        ? [`workflow-entrypoint:${profile.workflow.entrypoint}`]
+        : []),
+    ];
+    const runtime = this.buildRunLaunchRuntime(
+      input.provider,
+      input.launchAgentConfig,
+      input.task.id,
+      input.logPath,
+      input.attemptId,
+      input.sandboxPolicy
+    );
+    const worktreePath = input.task.git?.worktreePath
+      ? this.expandPath(input.task.git.worktreePath)
+      : undefined;
+    const repositoryInstructions = worktreePath
+      ? ((await this.workspaceFiles.readOptionalText(worktreePath, 'AGENTS.md')) ?? '')
+      : '';
+    const hasRepositoryInstructions = Boolean(repositoryInstructions.trim());
+    const instructions = [
+      {
+        id: 'effective-task-request',
+        kind: 'task' as const,
+        content: input.taskPrompt,
+        materialContent: this.normalizeRunLaunchTaskPrompt(
+          input.taskPrompt,
+          input.attemptId,
+          worktreePath,
+          input.providerRuntimeManifest.digest
+        ),
+        origin: `task-envelope:${input.taskEnvelope.schemaVersion}`,
+        precedence: 100,
+      },
+      ...(hasRepositoryInstructions
+        ? [
+            {
+              id: 'repository:AGENTS.md',
+              kind: 'repository' as const,
+              content: repositoryInstructions,
+              origin: 'repository:AGENTS.md',
+              precedence: 150,
+            },
+          ]
+        : []),
+      ...(input.profileLaunch?.instructions
+        ? [
+            {
+              id: `agent-profile:${profile?.id ?? 'unknown'}`,
+              kind: 'profile' as const,
+              content: input.profileLaunch.instructions,
+              origin: `agent-profile:${profile?.id ?? 'unknown'}@${profile?.version ?? 'unknown'}`,
+              precedence: 200,
+            },
+          ]
+        : []),
+    ];
+    const sandboxOrigin: Omit<RunLaunchManifestOrigin, 'field'> = {
+      scope: input.options.sandboxPresetId
+        ? 'run'
+        : profile?.policy?.sandboxPresetId
+          ? 'agent-profile'
+          : input.launchAgentConfig?.sandboxPresetId
+            ? 'provider'
+            : 'system-default',
+      source: input.options.sandboxPresetId
+        ? `operator-sandbox:${input.sandboxPolicy.preset.id}`
+        : profile?.policy?.sandboxPresetId
+          ? `agent-profile:${profile.id}@${profile.version}`
+          : input.launchAgentConfig?.sandboxPresetId
+            ? `agent-config:${input.agent}`
+            : `sandbox-default:${input.sandboxPolicy.preset.id}`,
+      precedence: input.options.sandboxPresetId
+        ? 300
+        : profile?.policy?.sandboxPresetId
+          ? 200
+          : input.launchAgentConfig?.sandboxPresetId
+            ? 100
+            : 0,
+    };
+    const sandboxAffectsRuntimeArgs =
+      input.provider === 'codex-cli' || input.provider === 'codex-sdk';
+    const sandboxAffectsEnvironment =
+      input.provider !== 'openclaw' && input.sandboxPolicy.effective.envPassthrough.length > 0;
+    const sandboxAffectsCredentials =
+      input.provider !== 'openclaw' && input.sandboxPolicy.effective.credentialRefs.length > 0;
+    const origins = [
+      {
+        field: 'taskEnvelope',
+        scope: 'task-envelope' as const,
+        source: `task-envelope:${input.taskEnvelope.schemaVersion}`,
+        precedence: 100,
+      },
+      {
+        field: 'providerRuntime',
+        scope: 'provider' as const,
+        source: `provider-runtime:${input.providerRuntimeManifest.provider}:${input.providerRuntimeManifest.probeRevision}`,
+        precedence: 100,
+      },
+      {
+        field: 'providerRequirements',
+        scope: 'provider',
+        source: `provider-capabilities:${input.providerRuntimeManifest.provider}:${input.providerRuntimeManifest.probeRevision}`,
+        precedence: 100,
+      },
+      {
+        field: 'providerRequirements',
+        scope: 'system-default',
+        source: 'baseline-launch-capabilities',
+        precedence: 0,
+      },
+      ...((profile?.tools?.allowed?.length ?? 0) > 0 ||
+      (profile?.tools?.mcpServers?.length ?? 0) > 0
+        ? [
+            {
+              field: 'providerRequirements',
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile?.id}@${profile?.version}`,
+              precedence: 200,
+            },
+          ]
+        : []),
+      ...(this.budgetRequiresRuntimeEvidence(input.budgetSources.workspaceBudget)
+        ? [
+            {
+              field: 'providerRequirements',
+              scope: 'workspace' as const,
+              source: 'workspace-budget',
+              precedence: 50,
+            },
+          ]
+        : []),
+      ...(this.budgetRequiresRuntimeEvidence(input.budgetSources.agentBudget)
+        ? [
+            {
+              field: 'providerRequirements',
+              scope: 'provider' as const,
+              source: `agent-config:${input.agent}:budget`,
+              precedence: 100,
+            },
+          ]
+        : []),
+      ...(this.budgetRequiresRuntimeEvidence(input.budgetSources.profileBudget)
+        ? [
+            {
+              field: 'providerRequirements',
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile?.id}@${profile?.version}:budget`,
+              precedence: 200,
+            },
+          ]
+        : []),
+      ...(this.budgetRequiresRuntimeEvidence(input.budgetSources.runBudget)
+        ? [
+            {
+              field: 'providerRequirements',
+              scope: 'run' as const,
+              source: 'operator-run-budget',
+              precedence: 300,
+            },
+          ]
+        : []),
+      ...(input.options.requiredRuntimeCapabilities?.length
+        ? [
+            {
+              field: 'providerRequirements',
+              scope: 'run' as const,
+              source: 'operator-required-capabilities',
+              precedence: 300,
+            },
+          ]
+        : []),
+      {
+        field: 'harnessSupport',
+        scope: 'provider',
+        source: `harness-support:${input.harnessSupport.profileId}`,
+        precedence: 100,
+      },
+      {
+        field: 'instructions.effective-task-request',
+        scope: 'task-envelope',
+        source: `task-envelope:${input.taskEnvelope.schemaVersion}`,
+        precedence: 100,
+      },
+      ...(hasRepositoryInstructions
+        ? [
+            {
+              field: 'instructions.repository:AGENTS.md',
+              scope: 'workspace' as const,
+              source: 'repository:AGENTS.md',
+              precedence: 150,
+            },
+          ]
+        : []),
+      ...(input.profileLaunch?.instructions
+        ? [
+            {
+              field: `instructions.agent-profile:${profile?.id ?? 'unknown'}`,
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile?.id}@${profile?.version}`,
+              precedence: 200,
+            },
+          ]
+        : []),
+      {
+        field: 'readiness',
+        scope: 'system-default',
+        source: 'task-readiness-policy',
+        precedence: 0,
+      },
+      ...(!input.readiness.ready && input.overrideReason
+        ? [
+            {
+              field: 'readiness',
+              scope: 'run' as const,
+              source: 'operator-readiness-override',
+              precedence: 300,
+            },
+          ]
+        : []),
+      {
+        field: 'routing',
+        scope: input.profileLaunch
+          ? ('agent-profile' as const)
+          : input.requestedAgent === 'auto'
+            ? ('workspace' as const)
+            : ('run' as const),
+        source: input.profileLaunch
+          ? `agent-profile:${profile?.id}@${profile?.version}`
+          : input.requestedAgent === 'auto'
+            ? 'agent-routing:auto'
+            : `operator-selection:${input.requestedAgent}`,
+        precedence: input.profileLaunch ? 200 : input.requestedAgent === 'auto' ? 100 : 300,
+      },
+      {
+        field: 'runtime.command',
+        scope: 'provider' as const,
+        source: `adapter:${input.provider}`,
+        precedence: 100,
+      },
+      ...(input.launchAgentConfig?.command
+        ? [
+            {
+              field: 'runtime.command',
+              scope: 'provider' as const,
+              source: `agent-config:${input.agent}`,
+              precedence: 110,
+            },
+          ]
+        : []),
+      {
+        field: 'runtime.args',
+        scope: 'provider',
+        source: `adapter:${input.provider}`,
+        precedence: 100,
+      },
+      ...(input.launchAgentConfig?.args?.length
+        ? [
+            {
+              field: 'runtime.args',
+              scope: 'provider' as const,
+              source: `agent-config:${input.agent}:args`,
+              precedence: 110,
+            },
+          ]
+        : []),
+      ...(sandboxAffectsRuntimeArgs
+        ? [
+            {
+              field: 'runtime.args',
+              ...sandboxOrigin,
+            },
+          ]
+        : []),
+      ...(input.provider === 'openclaw' && input.launchAgentConfig
+        ? [
+            {
+              field: 'runtime.args',
+              scope: 'provider' as const,
+              source: `agent-config:${input.agent}`,
+              precedence: 110,
+            },
+          ]
+        : []),
+      {
+        field: 'runtime.workingDirectory',
+        scope: 'provider',
+        source: `adapter:${input.provider}`,
+        precedence: 100,
+      },
+      {
+        field: 'runtime.worktree',
+        scope: 'provider',
+        source: `adapter:${input.provider}`,
+        precedence: 100,
+      },
+      {
+        field: 'runtime.environmentKeys',
+        scope: 'provider',
+        source: `adapter-env:${input.provider}`,
+        precedence: 100,
+      },
+      {
+        field: 'runtime.environmentKeys',
+        scope: 'system-default',
+        source: 'host-environment:configured-key-presence',
+        precedence: 0,
+      },
+      ...(sandboxAffectsEnvironment
+        ? [
+            {
+              field: 'runtime.environmentKeys',
+              ...sandboxOrigin,
+            },
+          ]
+        : []),
+      {
+        field: 'runtime.credentialReferences',
+        scope: 'provider',
+        source: `adapter-credentials:${input.provider}`,
+        precedence: 100,
+      },
+      ...(sandboxAffectsCredentials
+        ? [
+            {
+              field: 'runtime.credentialReferences',
+              ...sandboxOrigin,
+            },
+          ]
+        : []),
+      ...(input.profileLaunch?.agentConfig?.model
+        ? [
+            {
+              field: 'runtime.model',
+              scope: 'provider' as const,
+              source: `agent-config:${input.agent}`,
+              precedence: 100,
+            },
+          ]
+        : !input.profileLaunch && input.launchAgentConfig?.model
+          ? [
+              {
+                field: 'runtime.model',
+                scope: 'provider' as const,
+                source: `agent-config:${input.agent}`,
+                precedence: 100,
+              },
+            ]
+          : []),
+      ...(input.profileLaunch?.model
+        ? [
+            {
+              field: 'runtime.model',
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile?.id}@${profile?.version}`,
+              precedence: 200,
+            },
+            ...(input.provider === 'openclaw'
+              ? [
+                  {
+                    field: 'runtime.args',
+                    scope: 'agent-profile' as const,
+                    source: `agent-profile:${profile?.id}@${profile?.version}:model`,
+                    precedence: 200,
+                  },
+                ]
+              : []),
+          ]
+        : []),
+      ...(input.budgetModelOverride
+        ? [
+            {
+              field: 'runtime.model',
+              scope: 'run' as const,
+              source: 'budget-policy:model-downgrade',
+              precedence: 300,
+            },
+            ...(input.provider === 'openclaw'
+              ? [
+                  {
+                    field: 'runtime.args',
+                    scope: 'run' as const,
+                    source: 'budget-policy:model-downgrade',
+                    precedence: 300,
+                  },
+                ]
+              : []),
+          ]
+        : []),
+      {
+        field: 'sandbox',
+        ...sandboxOrigin,
+      },
+      ...(input.budgetSources.workspaceBudget
+        ? [
+            {
+              field: 'budget',
+              scope: 'workspace' as const,
+              source: 'workspace-budget',
+              precedence: 50,
+            },
+          ]
+        : []),
+      ...(input.budgetSources.agentBudget
+        ? [
+            {
+              field: 'budget',
+              scope: 'provider' as const,
+              source: `agent-config:${input.agent}`,
+              precedence: 100,
+            },
+          ]
+        : []),
+      ...(input.budgetSources.profileBudget && profile
+        ? [
+            {
+              field: 'budget',
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile.id}@${profile.version}`,
+              precedence: 200,
+            },
+          ]
+        : []),
+      ...(input.budgetSources.runBudget
+        ? [
+            {
+              field: 'budget',
+              scope: 'run' as const,
+              source: 'operator-run-budget',
+              precedence: 300,
+            },
+          ]
+        : []),
+      ...(!input.budgetSources.workspaceBudget &&
+      !input.budgetSources.agentBudget &&
+      !input.budgetSources.profileBudget &&
+      !input.budgetSources.runBudget
+        ? [
+            {
+              field: 'budget',
+              scope: 'system-default' as const,
+              source: 'budget:disabled',
+              precedence: 0,
+            },
+          ]
+        : []),
+      ...(profile
+        ? [
+            {
+              field: 'profile',
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile.id}@${profile.version}`,
+              precedence: 200,
+            },
+            {
+              field: 'tools',
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile.id}@${profile.version}`,
+              precedence: 200,
+            },
+            {
+              field: 'permissions',
+              scope: 'agent-profile' as const,
+              source: `agent-profile:${profile.id}@${profile.version}`,
+              precedence: 200,
+            },
+          ]
+        : [
+            {
+              field: 'tools',
+              scope: 'system-default',
+              source: 'tool-catalog:none',
+              precedence: 0,
+            },
+            {
+              field: 'permissions',
+              scope: 'system-default',
+              source: 'permission-requirements:none',
+              precedence: 0,
+            },
+          ]),
+      {
+        field: 'resources',
+        scope: profile ? 'agent-profile' : 'system-default',
+        source: profile
+          ? `agent-profile:${profile.id}@${profile.version}`
+          : 'resource-selection:none',
+        precedence: profile ? 200 : 0,
+      },
+      ...(profile?.workflow
+        ? [
+            {
+              field: 'resources',
+              scope: 'workflow' as const,
+              source: `workflow:${profile.workflow.id ?? profile.workflow.entrypoint ?? 'unknown'}`,
+              precedence: 250,
+            },
+          ]
+        : []),
+      {
+        field: 'requiredHealthChecks',
+        scope: profile ? 'agent-profile' : 'system-default',
+        source: profile ? `agent-profile:${profile.id}@${profile.version}` : 'health-checks:none',
+        precedence: profile ? 200 : 0,
+      },
+      {
+        field: 'workspaceTrust',
+        scope: 'system-default',
+        source:
+          selectedSharedResources.length > 0
+            ? 'workspace-trust:resources-blocked'
+            : 'workspace-trust:not-required',
+        precedence: 0,
+      },
+      {
+        field: 'enforcement',
+        scope: 'system-default',
+        source: `run-launch-compiler:${RUN_LAUNCH_MANIFEST_SCHEMA_VERSION}`,
+        precedence: 1_000,
+      },
+    ].map((origin): RunLaunchManifestOrigin => ({
+      ...origin,
+      scope: origin.scope as RunLaunchManifestOrigin['scope'],
+    }));
+
+    return this.runLaunchManifests.compile({
+      taskId: input.task.id,
+      attemptId: input.attemptId,
+      createdAt: input.startedAt,
+      taskEnvelope: input.taskEnvelope,
+      providerRuntimeManifest: input.providerRuntimeManifest,
+      requiredRuntimeCapabilities: input.requiredRuntimeCapabilities,
+      harnessSupport: input.harnessSupport,
+      routing: {
+        requestedAgent: input.requestedAgent,
+        selectedAgent: input.agent,
+        selectedHost: input.provider === 'openclaw' ? 'openclaw-gateway' : 'local-process',
+        reason: input.routingReason,
+        fallbackAgent: input.routingFallback ?? null,
+        fallbackAllowed: Boolean(input.routingFallback),
+      },
+      ...(profile
+        ? {
+            profile: {
+              id: profile.id,
+              version: profile.version,
+              role: profile.role,
+            },
+          }
+        : {}),
+      readiness: {
+        summary: input.readiness,
+        overrideReason: input.overrideReason,
+      },
+      instructions,
+      runtime,
+      tools: {
+        allowed: profile?.tools?.allowed ?? [],
+        denied: [],
+        policyIds: profile?.policy?.toolPolicyIds ?? [],
+        mcpServers: profile?.tools?.mcpServers ?? [],
+        enforcement: hasToolRestrictions || hasMcpRestrictions ? 'unavailable' : 'not-required',
+      },
+      permissions: {
+        level: profile?.permissions?.level ?? 'specialist',
+        required: profile?.permissions?.required ?? [],
+        enforcement: hasPermissionRequirements ? 'unavailable' : 'not-required',
+      },
+      resources: {
+        skills: selectedSkills,
+        shared: selectedSharedResources,
+        enforcement:
+          selectedSkills.length > 0 || selectedSharedResources.length > 0
+            ? 'unavailable'
+            : 'not-required',
+      },
+      requiredHealthChecks,
+      sandboxPolicy: input.sandboxPolicy,
+      budgetPolicy: input.budgetPolicy ?? {
+        enabled: false,
+        scope: 'run',
+      },
+      workspaceTrust: {
+        status: 'not-required',
+        source:
+          selectedSharedResources.length > 0
+            ? 'Referenced profile files and workflow entrypoints are not loaded by the current adapter and are blocked as unavailable resources.'
+            : 'No repository-controlled executable profile components were selected.',
+      },
+      origins,
+    });
+  }
+
+  private buildRunLaunchRuntime(
+    provider: ExecutableAgentProvider,
+    agentConfig: AgentConfig | undefined,
+    taskId: string,
+    logPath: string,
+    attemptId: string,
+    sandboxPolicy: SandboxPolicyDryRunResult
+  ): RunLaunchRuntime {
+    const environment = this.buildRunLaunchEnvironment(provider, sandboxPolicy);
+    const runtimeBase = {
+      ...(agentConfig?.model ? { model: agentConfig.model } : {}),
+      workingDirectory: 'task-worktree' as const,
+      worktree: 'required' as const,
+      ...environment,
+    };
+    if (provider === 'codex-cli') {
+      const finalPath = this.getCodexFinalPath(logPath, attemptId);
+      return {
+        ...runtimeBase,
+        command: agentConfig?.command || 'codex',
+        args: this.buildCodexArgs(agentConfig, '<prompt>', logPath, attemptId, sandboxPolicy).map(
+          (argument) => (argument === finalPath ? '<run-log>/final-message.md' : argument)
+        ),
+      };
+    }
+    if (provider === 'codex-sdk') {
+      const sdkExecutable = this.resolveCodexSdkExecutable(agentConfig);
+      const threadSettings = this.buildCodexSdkThreadSettings(sandboxPolicy);
+      return {
+        ...runtimeBase,
+        command: sdkExecutable.manifestCommand,
+        args: [
+          'startThread',
+          `skipGitRepoCheck=${threadSettings.skipGitRepoCheck}`,
+          `sandboxMode=${threadSettings.sandboxMode}`,
+          `approvalPolicy=${threadSettings.approvalPolicy}`,
+          `networkAccessEnabled=${threadSettings.networkAccessEnabled}`,
+          'runStreamed',
+          '<prompt>',
+        ],
+      };
+    }
+    if (provider === 'hermes-cli') {
+      return {
+        ...runtimeBase,
+        command: agentConfig?.command || 'hermes',
+        args: ['-z', ...(agentConfig?.args ?? []), '<prompt>'],
+      };
+    }
+    const spawnArguments = buildOpenClawTaskSpawnArguments({
+      taskId,
+      attemptId,
+      agentId: agentConfig?.type || 'openclaw',
+      agentName: agentConfig?.name,
+      model: agentConfig?.model,
+      prompt: '<prompt>',
+      timeoutSeconds: 900,
+    });
+    const sessionKeySource =
+      this.firstConfiguredEnvironmentKey(['OPENCLAW_GATEWAY_SESSION_KEY']) ?? 'default:main';
+    const gatewayUrlSource =
+      this.firstConfiguredEnvironmentKey([
+        'OPENCLAW_GATEWAY_URL',
+        'CLAWDBOT_GATEWAY',
+        'CLAWDBOT_GATEWAY_URL',
+      ]) ?? 'default:http://127.0.0.1:18789';
+    return {
+      ...runtimeBase,
+      command: 'openclaw.sessions_spawn',
+      args: [
+        'tool=sessions_spawn',
+        ...Object.entries(spawnArguments).map(([key, value]) => `${key}=${String(value)}`),
+        `sessionKey=${sessionKeySource.startsWith('default:') ? sessionKeySource : `env:${sessionKeySource}`}`,
+        `gatewayUrl=${gatewayUrlSource.startsWith('default:') ? gatewayUrlSource : `env:${gatewayUrlSource}`}`,
+        `allowPrivateIp=${isOpenClawGatewayPrivateIpAllowed()}`,
+        'requestTimeoutMs=60000',
+      ],
+      workingDirectory: 'provider-managed',
+      worktree: 'provider-managed',
+    };
+  }
+
+  private resolveCodexSdkExecutable(agentConfig: AgentConfig | undefined): {
+    manifestCommand: string;
+    codexPathOverride?: string;
+  } {
+    const codexPathOverride =
+      agentConfig?.command && agentConfig.command !== 'codex' ? agentConfig.command : undefined;
+    return {
+      manifestCommand: codexPathOverride ?? '@openai/codex-sdk:bundled-codex',
+      ...(codexPathOverride ? { codexPathOverride } : {}),
+    };
+  }
+
+  private buildCodexSdkThreadSettings(sandboxPolicy: SandboxPolicyDryRunResult | undefined): {
+    skipGitRepoCheck: true;
+    sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access';
+    approvalPolicy: 'never';
+    networkAccessEnabled: boolean;
+  } {
+    return {
+      skipGitRepoCheck: true,
+      sandboxMode: sandboxPolicy?.effective.sandboxMode ?? 'workspace-write',
+      approvalPolicy: 'never',
+      networkAccessEnabled: sandboxPolicy?.effective.networkAccessEnabled ?? true,
+    };
+  }
+
+  private buildRunLaunchEnvironment(
+    provider: ExecutableAgentProvider,
+    sandboxPolicy: SandboxPolicyDryRunResult
+  ): Pick<RunLaunchRuntime, 'environmentKeys' | 'credentialReferences'> {
+    if (provider === 'codex-cli' || provider === 'codex-sdk') {
+      const environmentKeys = Object.keys(
+        buildSafeCodexEnv(process.env, sandboxPolicy.effective.envPassthrough)
+      );
+      return {
+        environmentKeys,
+        credentialReferences: [
+          ...sandboxPolicy.effective.credentialRefs,
+          ...environmentKeys
+            .filter((key) => key === 'CODEX_API_KEY' || key === 'OPENAI_API_KEY')
+            .map((key) => `env:${key}`),
+        ],
+      };
+    }
+    if (provider === 'hermes-cli') {
+      const environmentKeys = Object.keys(
+        buildSafeHermesEnv(process.env, sandboxPolicy.effective.envPassthrough)
+      );
+      return {
+        environmentKeys,
+        credentialReferences: [
+          ...sandboxPolicy.effective.credentialRefs,
+          ...environmentKeys
+            .filter((key) => key === 'ANTHROPIC_API_KEY' || key === 'HERMES_API_KEY')
+            .map((key) => `env:${key}`),
+        ],
+      };
+    }
+
+    const gatewayUrlKey = this.firstConfiguredEnvironmentKey([
+      'OPENCLAW_GATEWAY_URL',
+      'CLAWDBOT_GATEWAY',
+      'CLAWDBOT_GATEWAY_URL',
+    ]);
+    const gatewayTokenKey = this.firstConfiguredEnvironmentKey([
+      'OPENCLAW_GATEWAY_TOKEN',
+      'CLAWDBOT_GATEWAY_TOKEN',
+    ]);
+    const gatewaySessionKey = this.firstConfiguredEnvironmentKey(['OPENCLAW_GATEWAY_SESSION_KEY']);
+    const environmentKeys = [
+      gatewayUrlKey,
+      gatewayTokenKey,
+      gatewaySessionKey,
+      this.firstConfiguredEnvironmentKey(['OPENCLAW_GATEWAY_ALLOW_PRIVATE']),
+    ].filter((key): key is string => Boolean(key));
+    return {
+      environmentKeys,
+      credentialReferences: gatewayTokenKey ? [`env:${gatewayTokenKey}`] : [],
+    };
+  }
+
+  private firstConfiguredEnvironmentKey(keys: string[]): string | undefined {
+    return keys.find((key) => Boolean(process.env[key]));
+  }
+
+  private normalizeRunLaunchTaskPrompt(
+    prompt: string,
+    attemptId: string,
+    worktreePath: string | undefined,
+    providerRuntimeDigest: string
+  ): string {
+    const normalizedIdentifiers = [
+      [attemptId, '<attempt-id>'],
+      [worktreePath, '<worktree>'],
+      [providerRuntimeDigest, '<provider-runtime-digest>'],
+    ].reduce(
+      (normalized, [value, replacement]) =>
+        value ? normalized.replaceAll(value, replacement ?? '') : normalized,
+      prompt
+    );
+    return normalizedIdentifiers.replace(/\(\d+ minutes ago\)/g, '(<elapsed-minutes> minutes ago)');
+  }
+
+  private budgetRequiresRuntimeEvidence(policy: AgentBudgetPolicy | undefined): boolean {
+    if (!policy || policy.enabled === false || !policy.limits) return false;
+    return (
+      policy.limits.inputTokens !== undefined ||
+      policy.limits.outputTokens !== undefined ||
+      policy.limits.totalTokens !== undefined ||
+      policy.limits.costUsd !== undefined ||
+      policy.limits.toolCalls !== undefined
+    );
+  }
+
+  private async resolveParentAttempt(
+    task: Task,
+    parentAttemptId?: string
+  ): Promise<(TaskAttempt & { runLaunchManifest: RunLaunchManifest }) | undefined> {
+    if (!parentAttemptId) return undefined;
+    const currentTaskParent = [task.attempt, ...(task.attempts ?? [])]
+      .filter((attempt): attempt is TaskAttempt => Boolean(attempt))
+      .find((attempt) => attempt.id === parentAttemptId);
+    const parent =
+      currentTaskParent ??
+      (await this.taskService.listTasks())
+        .flatMap((candidate) => [candidate.attempt, ...(candidate.attempts ?? [])])
+        .filter((attempt): attempt is TaskAttempt => Boolean(attempt))
+        .find((attempt) => attempt.id === parentAttemptId);
+    if (!parent) {
+      throw new ConflictError('Parent attempt was not found for launch-manifest comparison.', {
+        parentAttemptId,
+      });
+    }
+    if (!parent.runLaunchManifest) {
+      throw new ConflictError('Parent attempt has no run launch manifest to compare.', {
+        parentAttemptId,
+      });
+    }
+    return parent as TaskAttempt & { runLaunchManifest: RunLaunchManifest };
   }
 
   private buildTaskPrompt(
@@ -2928,7 +4144,8 @@ If you encounter errors, call with \`success: false\` and include the error mess
     agent: AgentType,
     prompt: string,
     providerRuntimeManifest: ProviderRuntimeManifest,
-    taskEnvelope: TaskEnvelope
+    taskEnvelope: TaskEnvelope,
+    runLaunchManifest: RunLaunchManifest
   ): Promise<void> {
     const header = `# Agent Log: ${task.title}
 
@@ -2938,6 +4155,7 @@ If you encounter errors, call with \`success: false\` and include the error mess
 **Worktree:** ${task.git?.worktreePath}
 **Provider manifest:** ${providerRuntimeManifest.digest}
 **Task envelope:** ${taskEnvelope.digest}
+**Run launch manifest:** ${runLaunchManifest.digest}
 
 <details><summary>Provider runtime manifest</summary>
 
@@ -2951,6 +4169,14 @@ ${JSON.stringify(providerRuntimeManifest, null, 2)}
 
 \`\`\`json
 ${JSON.stringify(taskEnvelope, null, 2)}
+\`\`\`
+
+</details>
+
+<details><summary>Run launch manifest</summary>
+
+\`\`\`json
+${JSON.stringify(runLaunchManifest, null, 2)}
 \`\`\`
 
 </details>

--- a/server/src/services/openclaw-workflow-adapter.ts
+++ b/server/src/services/openclaw-workflow-adapter.ts
@@ -87,6 +87,45 @@ export interface OpenClawTaskSpawnResult {
   raw?: unknown;
 }
 
+export function buildOpenClawTaskSpawnArguments(
+  input: OpenClawTaskSpawnInput
+): Record<string, unknown> {
+  const taskName = buildOpenClawTaskName(input);
+  const label =
+    `Veritas task ${input.taskId} / attempt ${input.attemptId} / ${input.agentName || input.agentId}`.slice(
+      0,
+      180
+    );
+  return {
+    task: input.prompt,
+    taskName,
+    label,
+    runtime: 'subagent',
+    agentId: input.agentId,
+    mode: 'run',
+    cleanup: input.cleanup ?? 'keep',
+    context: 'isolated',
+    ...(input.model ? { model: input.model } : {}),
+  };
+}
+
+export function isOpenClawGatewayPrivateIpAllowed(
+  environment: NodeJS.ProcessEnv = process.env
+): boolean {
+  return environment.OPENCLAW_GATEWAY_ALLOW_PRIVATE === 'true';
+}
+
+function buildOpenClawTaskName(input: OpenClawTaskSpawnInput): string {
+  const raw = `task_${input.taskId}_${input.attemptId}`
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  const candidate = raw || `task_${input.taskId}`;
+  const withLetter = /^[a-z]/.test(candidate) ? candidate : `t_${candidate}`;
+  return withLetter.slice(0, 64);
+}
+
 export interface HttpOpenClawWorkflowAdapterOptions {
   gatewayUrl?: string;
   token?: string;
@@ -135,7 +174,7 @@ export class HttpOpenClawWorkflowAdapter implements OpenClawWorkflowAdapter {
     this.validationOptions = {
       allowHttp: true,
       allowLocalhost: true,
-      allowPrivateIp: process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE === 'true',
+      allowPrivateIp: isOpenClawGatewayPrivateIpAllowed(),
       ...options.validationOptions,
     };
   }
@@ -437,32 +476,14 @@ export class HttpOpenClawTaskAdapter {
     this.validationOptions = {
       allowHttp: true,
       allowLocalhost: true,
-      allowPrivateIp: process.env.OPENCLAW_GATEWAY_ALLOW_PRIVATE === 'true',
+      allowPrivateIp: isOpenClawGatewayPrivateIpAllowed(),
       ...options.validationOptions,
     };
   }
 
   /** Spawn an OpenClaw sub-session for a Veritas task. */
   async spawnTask(input: OpenClawTaskSpawnInput): Promise<OpenClawTaskSpawnResult> {
-    const taskName = this.buildTaskName(input);
-    const label =
-      `Veritas task ${input.taskId} / attempt ${input.attemptId} / ${input.agentName || input.agentId}`.slice(
-        0,
-        180
-      );
-    const args: Record<string, unknown> = {
-      task: input.prompt,
-      taskName,
-      label,
-      runtime: 'subagent',
-      agentId: input.agentId,
-      mode: 'run',
-      cleanup: input.cleanup ?? 'keep',
-      context: 'isolated',
-    };
-    if (input.model) args.model = input.model;
-
-    const result = await this.invokeTool('sessions_spawn', args);
+    const result = await this.invokeTool('sessions_spawn', buildOpenClawTaskSpawnArguments(input));
     const sessionKey =
       this.readString(result, 'childSessionKey') || this.readString(result, 'sessionKey');
 
@@ -559,17 +580,6 @@ export class HttpOpenClawTaskAdapter {
     }
 
     return toolResult;
-  }
-
-  private buildTaskName(input: OpenClawTaskSpawnInput): string {
-    const raw = `task_${input.taskId}_${input.attemptId}`
-      .toLowerCase()
-      .replace(/[^a-z0-9_]+/g, '_')
-      .replace(/_+/g, '_')
-      .replace(/^_+|_+$/g, '');
-    const candidate = raw || `task_${input.taskId}`;
-    const withLetter = /^[a-z]/.test(candidate) ? candidate : `t_${candidate}`;
-    return withLetter.slice(0, 64);
   }
 
   private parseJson(text: string | undefined): unknown {

--- a/server/src/services/run-launch-manifest-service.ts
+++ b/server/src/services/run-launch-manifest-service.ts
@@ -1,0 +1,585 @@
+import { Buffer } from 'node:buffer';
+import type {
+  AgentBudgetPolicy,
+  HarnessSupportStatus,
+  ProviderRuntimeManifest,
+  RunLaunchInstructionReference,
+  RunLaunchManifest,
+  RunLaunchManifestBlocker,
+  RunLaunchManifestDriftResult,
+  RunLaunchManifestInstructionKind,
+  RunLaunchManifestOrigin,
+  RunLaunchPermissions,
+  RunLaunchProfileReference,
+  RunLaunchResources,
+  RunLaunchRouting,
+  RunLaunchRuntime,
+  RunLaunchTools,
+  RunLaunchWorkspaceTrust,
+  SandboxPolicyDryRunResult,
+  TaskEnvelope,
+  TaskReadinessSummary,
+} from '@veritas-kanban/shared';
+import { RUN_LAUNCH_MANIFEST_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import { ConflictError, ValidationError } from '../middleware/error-handler.js';
+import { parseProviderRuntimeManifest } from '../schemas/provider-runtime-manifest-schemas.js';
+import { parseRunLaunchManifest } from '../schemas/run-launch-manifest-schemas.js';
+import {
+  calculateRunLaunchManifestDigest,
+  digestRunLaunchValue,
+} from '../utils/run-launch-manifest-digest.js';
+import { sanitizeProviderRuntimeDiagnostic } from '../utils/provider-runtime-manifest-sanitize.js';
+
+export interface RunLaunchManifestInstructionInput {
+  id: string;
+  kind: RunLaunchManifestInstructionKind;
+  content: string;
+  materialContent?: string;
+  origin: string;
+  precedence: number;
+}
+
+export interface RunLaunchManifestCompileInput {
+  taskId: string;
+  attemptId: string;
+  createdAt?: string;
+  taskEnvelope: TaskEnvelope;
+  providerRuntimeManifest: ProviderRuntimeManifest;
+  requiredRuntimeCapabilities?: string[];
+  harnessSupport: HarnessSupportStatus;
+  routing: RunLaunchRouting;
+  profile?: RunLaunchProfileReference;
+  readiness: {
+    summary: TaskReadinessSummary;
+    overrideReason?: string;
+  };
+  instructions: RunLaunchManifestInstructionInput[];
+  runtime: RunLaunchRuntime;
+  tools: RunLaunchTools;
+  permissions: RunLaunchPermissions;
+  resources?: RunLaunchResources;
+  requiredHealthChecks: string[];
+  satisfiedHealthChecks?: string[];
+  sandboxPolicy: SandboxPolicyDryRunResult;
+  budgetPolicy: AgentBudgetPolicy;
+  workspaceTrust: RunLaunchWorkspaceTrust;
+  origins: RunLaunchManifestOrigin[];
+}
+
+const MATERIAL_SECTIONS: Array<keyof RunLaunchManifest> = [
+  'taskEnvelope',
+  'providerRuntime',
+  'providerRequirements',
+  'harnessSupport',
+  'routing',
+  'profile',
+  'readiness',
+  'instructions',
+  'runtime',
+  'tools',
+  'permissions',
+  'resources',
+  'requiredHealthChecks',
+  'sandbox',
+  'budget',
+  'workspaceTrust',
+  'origins',
+  'enforcement',
+];
+
+export class RunLaunchManifestService {
+  compile(input: RunLaunchManifestCompileInput): RunLaunchManifest {
+    const providerRuntime = parseProviderRuntimeManifest(input.providerRuntimeManifest);
+    this.assertProviderRuntimeLink(input.taskEnvelope, providerRuntime);
+
+    const instructions = [...input.instructions]
+      .map<RunLaunchInstructionReference>((instruction) => ({
+        id: instruction.id.trim(),
+        kind: instruction.kind,
+        digest: digestRunLaunchValue(instruction.content),
+        materialDigest: digestRunLaunchValue(instruction.materialContent ?? instruction.content),
+        byteLength: Buffer.byteLength(instruction.content, 'utf8'),
+        origin: instruction.origin.trim(),
+        precedence: instruction.precedence,
+      }))
+      .sort(
+        (left, right) =>
+          left.precedence - right.precedence ||
+          left.kind.localeCompare(right.kind) ||
+          left.id.localeCompare(right.id)
+      );
+    const tools = normalizeTools(input.tools);
+    const permissions = normalizePermissions(input.permissions);
+    const resources = normalizeResources(
+      input.resources ?? {
+        skills: [],
+        shared: [],
+        enforcement: 'not-required',
+      }
+    );
+    const requiredHealthChecks = uniqueSorted(input.requiredHealthChecks);
+    const providerRequirements = compileProviderRequirements(
+      providerRuntime,
+      input.requiredRuntimeCapabilities ?? []
+    );
+    const satisfiedHealthChecks = new Set(uniqueSorted(input.satisfiedHealthChecks ?? []));
+    const sandbox = {
+      presetId: input.sandboxPolicy.preset.id,
+      enforcement: input.sandboxPolicy.preset.enforcement,
+      decision: input.sandboxPolicy.decision,
+      effective: {
+        sandboxMode: input.sandboxPolicy.effective.sandboxMode,
+        networkAccessEnabled: input.sandboxPolicy.effective.networkAccessEnabled,
+        environmentKeys: uniqueSorted(input.sandboxPolicy.effective.envPassthrough),
+        credentialReferences: uniqueSorted(
+          input.sandboxPolicy.effective.credentialRefs.map(sanitizeProviderRuntimeDiagnostic)
+        ),
+      },
+      unsupportedRules: [...input.sandboxPolicy.unsupportedRules]
+        .map((rule) => ({
+          id: rule.id,
+          capability: rule.capability,
+          status: rule.status,
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id)),
+      warnings: uniqueSorted(input.sandboxPolicy.warnings.map(sanitizeProviderRuntimeDiagnostic)),
+    };
+    const blockers = collectBlockers({
+      input,
+      tools,
+      permissions,
+      resources,
+      providerRequirements,
+      requiredHealthChecks,
+      satisfiedHealthChecks,
+    });
+    const enforcementWarnings = uniqueSorted([
+      ...sandbox.warnings,
+      ...providerRequirements.capabilities
+        .filter((capability) => capability.advisory)
+        .map((capability) => `${capability.id}: ${capability.reason}`),
+      ...(input.harnessSupport.supportTier === 'degraded' ? [input.harnessSupport.reason] : []),
+    ]).map(sanitizeProviderRuntimeDiagnostic);
+    const payload: Omit<RunLaunchManifest, 'digest'> = {
+      schemaVersion: RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
+      createdAt: input.createdAt ?? new Date().toISOString(),
+      taskId: input.taskId.trim(),
+      attemptId: input.attemptId.trim(),
+      taskEnvelope: {
+        schemaVersion: input.taskEnvelope.schemaVersion,
+        digest: input.taskEnvelope.digest,
+        materialDigest: digestTaskEnvelopeMaterial(input.taskEnvelope),
+      },
+      providerRuntime: {
+        schemaVersion: providerRuntime.schemaVersion,
+        digest: providerRuntime.digest,
+        materialDigest: digestProviderRuntimeMaterial(providerRuntime),
+        probeRevision: providerRuntime.probeRevision,
+        provider: providerRuntime.provider,
+        adapter: providerRuntime.adapter,
+        protocolVersion: providerRuntime.protocolVersion,
+        providerVersion: sanitizeProviderRuntimeDiagnostic(providerRuntime.providerVersion),
+        ...(providerRuntime.providerBuild
+          ? {
+              providerBuild: sanitizeProviderRuntimeDiagnostic(providerRuntime.providerBuild),
+            }
+          : {}),
+      },
+      providerRequirements,
+      harnessSupport: {
+        profileId: input.harnessSupport.profileId,
+        ...(input.harnessSupport.adapterId ? { adapterId: input.harnessSupport.adapterId } : {}),
+        transport: input.harnessSupport.transport,
+        supportTier: input.harnessSupport.supportTier,
+      },
+      routing: {
+        ...input.routing,
+        reason: sanitizeProviderRuntimeDiagnostic(input.routing.reason),
+      },
+      ...(input.profile ? { profile: { ...input.profile } } : {}),
+      readiness: {
+        ready: input.readiness.summary.ready,
+        overridden:
+          !input.readiness.summary.ready && Boolean(input.readiness.overrideReason?.trim()),
+        passed: input.readiness.summary.passed,
+        total: input.readiness.summary.total,
+        missingRequired: uniqueSorted(
+          input.readiness.summary.missingRequired.map((check) => check.id)
+        ),
+        warnings: uniqueSorted(input.readiness.summary.warnings.map((check) => check.id)),
+        ...(!input.readiness.summary.ready && input.readiness.overrideReason?.trim()
+          ? { overrideReasonDigest: digestRunLaunchValue(input.readiness.overrideReason.trim()) }
+          : {}),
+      },
+      instructions,
+      runtime: normalizeRuntime(input.runtime),
+      tools,
+      permissions,
+      resources,
+      requiredHealthChecks,
+      sandbox,
+      budget: structuredClone(input.budgetPolicy),
+      workspaceTrust: {
+        ...input.workspaceTrust,
+        source: sanitizeProviderRuntimeDiagnostic(input.workspaceTrust.source),
+      },
+      origins: [...input.origins]
+        .map((origin) => ({
+          ...origin,
+          field: origin.field.trim(),
+          source: sanitizeProviderRuntimeDiagnostic(origin.source),
+        }))
+        .sort(
+          (left, right) =>
+            left.field.localeCompare(right.field) ||
+            left.precedence - right.precedence ||
+            left.source.localeCompare(right.source)
+        ),
+      enforcement: {
+        enforceable: blockers.length === 0,
+        blockers,
+        warnings: enforcementWarnings,
+      },
+    };
+    return immutableClone(
+      parseRunLaunchManifest({
+        ...payload,
+        digest: calculateRunLaunchManifestDigest(payload),
+      })
+    );
+  }
+
+  assertEnforceable(manifest: RunLaunchManifest): void {
+    const parsed = parseRunLaunchManifest(manifest);
+    if (parsed.enforcement.enforceable) return;
+    throw new ConflictError('The effective run launch manifest cannot be enforced.', {
+      manifestDigest: parsed.digest,
+      blockers: parsed.enforcement.blockers,
+    });
+  }
+
+  private assertProviderRuntimeLink(
+    taskEnvelope: TaskEnvelope,
+    providerRuntime: ProviderRuntimeManifest
+  ): void {
+    const reference = taskEnvelope.launchManifest;
+    if (
+      reference.schemaVersion !== providerRuntime.schemaVersion ||
+      reference.digest !== providerRuntime.digest ||
+      reference.provider !== providerRuntime.provider ||
+      reference.adapter !== providerRuntime.adapter ||
+      reference.protocolVersion !== providerRuntime.protocolVersion
+    ) {
+      throw new ValidationError(
+        'Task envelope provider runtime reference does not match the selected runtime manifest.'
+      );
+    }
+  }
+}
+
+export function diffRunLaunchManifests(
+  current: RunLaunchManifest,
+  parent: RunLaunchManifest
+): RunLaunchManifestDriftResult {
+  const currentManifest = parseRunLaunchManifest(current);
+  const parentManifest = parseRunLaunchManifest(parent);
+  const changes = MATERIAL_SECTIONS.flatMap((field) => {
+    const beforeValue =
+      field === 'taskEnvelope'
+        ? {
+            schemaVersion: parentManifest.taskEnvelope.schemaVersion,
+            materialDigest: parentManifest.taskEnvelope.materialDigest,
+          }
+        : field === 'providerRuntime'
+          ? {
+              ...parentManifest.providerRuntime,
+              digest: undefined,
+            }
+          : field === 'instructions'
+            ? materialInstructions(parentManifest.instructions)
+            : field === 'runtime'
+              ? materialRuntime(parentManifest)
+              : parentManifest[field];
+    const afterValue =
+      field === 'taskEnvelope'
+        ? {
+            schemaVersion: currentManifest.taskEnvelope.schemaVersion,
+            materialDigest: currentManifest.taskEnvelope.materialDigest,
+          }
+        : field === 'providerRuntime'
+          ? {
+              ...currentManifest.providerRuntime,
+              digest: undefined,
+            }
+          : field === 'instructions'
+            ? materialInstructions(currentManifest.instructions)
+            : field === 'runtime'
+              ? materialRuntime(currentManifest)
+              : currentManifest[field];
+    const beforeDigest = digestRunLaunchValue(beforeValue);
+    const afterDigest = digestRunLaunchValue(afterValue);
+    return beforeDigest === afterDigest ? [] : [{ field, beforeDigest, afterDigest }];
+  });
+  return {
+    material: changes.length > 0,
+    changes,
+  };
+}
+
+function materialInstructions(
+  instructions: RunLaunchManifest['instructions']
+): Array<Omit<RunLaunchInstructionReference, 'digest' | 'byteLength'>> {
+  return instructions.map(
+    ({ digest: _digest, byteLength: _byteLength, ...instruction }) => instruction
+  );
+}
+
+function materialRuntime(manifest: RunLaunchManifest): RunLaunchRuntime {
+  const normalizedAttemptId = manifest.attemptId
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  const attemptVariants = [...new Set([manifest.attemptId, normalizedAttemptId].filter(Boolean))];
+  return {
+    ...manifest.runtime,
+    args: manifest.runtime.args.map((argument) =>
+      attemptVariants.reduce(
+        (normalized, attemptId) => normalized.replaceAll(attemptId, '<attempt-id>'),
+        argument
+      )
+    ),
+  };
+}
+
+function normalizeRuntime(runtime: RunLaunchRuntime): RunLaunchRuntime {
+  return {
+    ...(runtime.model ? { model: sanitizeProviderRuntimeDiagnostic(runtime.model) } : {}),
+    command: sanitizeProviderRuntimeDiagnostic(runtime.command),
+    args: runtime.args.map(sanitizeProviderRuntimeDiagnostic),
+    workingDirectory: runtime.workingDirectory,
+    worktree: runtime.worktree,
+    environmentKeys: uniqueSorted(runtime.environmentKeys),
+    credentialReferences: uniqueSorted(
+      runtime.credentialReferences.map(sanitizeProviderRuntimeDiagnostic)
+    ),
+  };
+}
+
+function normalizeTools(tools: RunLaunchTools): RunLaunchTools {
+  return {
+    allowed: uniqueSorted(tools.allowed),
+    denied: uniqueSorted(tools.denied),
+    policyIds: uniqueSorted(tools.policyIds),
+    mcpServers: uniqueSorted(tools.mcpServers),
+    enforcement: tools.enforcement,
+  };
+}
+
+function normalizePermissions(permissions: RunLaunchPermissions): RunLaunchPermissions {
+  return {
+    level: permissions.level,
+    required: uniqueSorted(permissions.required),
+    enforcement: permissions.enforcement,
+  };
+}
+
+function normalizeResources(resources: RunLaunchResources): RunLaunchResources {
+  return {
+    skills: uniqueSorted(resources.skills),
+    shared: uniqueSorted(resources.shared),
+    enforcement: resources.enforcement,
+  };
+}
+
+function collectBlockers({
+  input,
+  tools,
+  permissions,
+  resources,
+  providerRequirements,
+  requiredHealthChecks,
+  satisfiedHealthChecks,
+}: {
+  input: RunLaunchManifestCompileInput;
+  tools: RunLaunchTools;
+  permissions: RunLaunchPermissions;
+  resources: RunLaunchResources;
+  providerRequirements: RunLaunchManifest['providerRequirements'];
+  requiredHealthChecks: string[];
+  satisfiedHealthChecks: Set<string>;
+}): RunLaunchManifestBlocker[] {
+  const blockers: RunLaunchManifestBlocker[] = [];
+  const add = (code: string, field: string, detail: string, remediation: string): void => {
+    blockers.push({ code, field, detail, remediation });
+  };
+  if (
+    tools.enforcement !== 'enforced' &&
+    (tools.allowed.length > 0 || tools.denied.length > 0 || tools.policyIds.length > 0)
+  ) {
+    add(
+      'tool-policy-unenforceable',
+      'tools',
+      'The profile declares tool restrictions that the selected adapter cannot enforce.',
+      'Select an adapter with tool-policy enforcement or remove the declared restrictions.'
+    );
+  }
+  for (const capability of providerRequirements.capabilities) {
+    if (capability.satisfied) continue;
+    add(
+      'provider-capability-unavailable',
+      `providerRequirements.${capability.id}`,
+      `${capability.id}: ${capability.reason}`,
+      'Select a provider that evidences every required runtime capability.'
+    );
+  }
+  if (tools.enforcement !== 'enforced' && tools.mcpServers.length > 0) {
+    add(
+      'mcp-unavailable',
+      'tools.mcpServers',
+      'The profile declares MCP servers that the selected adapter cannot inject safely.',
+      'Select an adapter with explicit MCP injection or remove the MCP declarations.'
+    );
+  }
+  if (permissions.enforcement !== 'enforced' && permissions.required.length > 0) {
+    add(
+      'permission-unenforceable',
+      'permissions.required',
+      'The profile declares permissions that the selected adapter cannot enforce.',
+      'Select an adapter with permission enforcement or remove the required permissions.'
+    );
+  }
+  if (resources.enforcement !== 'enforced' && resources.skills.length > 0) {
+    add(
+      'skill-resource-unavailable',
+      'resources.skills',
+      'The launch selects skills that the adapter cannot inject and verify.',
+      'Select an adapter with explicit skill injection or remove the selected skills.'
+    );
+  }
+  if (resources.enforcement !== 'enforced' && resources.shared.length > 0) {
+    add(
+      'shared-resource-unavailable',
+      'resources.shared',
+      'The launch selects shared resources that the adapter cannot inject and verify.',
+      'Select an adapter with explicit shared-resource injection or remove the resources.'
+    );
+  }
+  const missingHealthChecks = requiredHealthChecks.filter(
+    (checkId) => !satisfiedHealthChecks.has(checkId)
+  );
+  if (missingHealthChecks.length > 0) {
+    add(
+      'health-check-unavailable',
+      'requiredHealthChecks',
+      `Required profile health checks were not satisfied: ${missingHealthChecks.join(', ')}.`,
+      'Run and satisfy every required profile health check before launch.'
+    );
+  }
+  if (input.sandboxPolicy.decision === 'block') {
+    add(
+      'sandbox-policy-blocked',
+      'sandbox.decision',
+      'The resolved sandbox policy blocks this launch.',
+      input.sandboxPolicy.remediation ?? 'Resolve the sandbox policy blockers before launch.'
+    );
+  } else if (
+    input.sandboxPolicy.preset.enforcement === 'required' &&
+    input.sandboxPolicy.unsupportedRules.length > 0
+  ) {
+    add(
+      'sandbox-policy-unenforceable',
+      'sandbox.unsupportedRules',
+      'The required sandbox policy contains rules the selected adapter cannot enforce.',
+      input.sandboxPolicy.remediation ?? 'Select a compatible adapter or sandbox preset.'
+    );
+  }
+  if (input.workspaceTrust.status === 'untrusted') {
+    add(
+      'workspace-untrusted',
+      'workspaceTrust',
+      'The selected workspace trust posture does not permit launch.',
+      'Trust the workspace explicitly or choose a non-executable profile.'
+    );
+  }
+  if (!input.harnessSupport.enabled || input.harnessSupport.supportTier === 'unsupported') {
+    add(
+      'harness-unavailable',
+      'harnessSupport',
+      sanitizeProviderRuntimeDiagnostic(input.harnessSupport.reason),
+      'Configure a supported executable harness before launch.'
+    );
+  }
+  if (input.providerRuntimeManifest.probe.state === 'failed') {
+    add(
+      'provider-probe-failed',
+      'providerRuntime',
+      'The provider runtime probe failed.',
+      'Resolve the provider runtime diagnostics and probe again.'
+    );
+  }
+  return blockers.sort(
+    (left, right) => left.field.localeCompare(right.field) || left.code.localeCompare(right.code)
+  );
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+function compileProviderRequirements(
+  providerRuntime: ProviderRuntimeManifest,
+  requiredCapabilities: string[]
+): RunLaunchManifest['providerRequirements'] {
+  const required = uniqueSorted(requiredCapabilities);
+  return {
+    required,
+    capabilities: required.map((id) => {
+      const evidence = providerRuntime.capabilities.find((capability) => capability.id === id);
+      const state = evidence?.state ?? 'unknown';
+      return {
+        id,
+        state,
+        satisfied: state === 'supported' || state === 'advisory',
+        advisory: state === 'advisory',
+        reason: evidence?.reason ?? 'No capability evidence is present.',
+      };
+    }),
+  };
+}
+
+function digestTaskEnvelopeMaterial(taskEnvelope: TaskEnvelope): string {
+  const { digest: _digest, attempt: _attempt, workspace, ...stableEnvelope } = taskEnvelope;
+  const { capturedAt: _capturedAt, ...baseline } = workspace.baseline;
+  const { digest: _launchDigest, ...stableLaunchManifest } = stableEnvelope.launchManifest;
+  return digestRunLaunchValue({
+    ...stableEnvelope,
+    launchManifest: stableLaunchManifest,
+    workspace: {
+      ...workspace,
+      baseline,
+    },
+  });
+}
+
+function digestProviderRuntimeMaterial(providerRuntime: ProviderRuntimeManifest): string {
+  const { digest: _digest, probe, ...stableRuntime } = providerRuntime;
+  const { probedAt: _probedAt, ...stableProbe } = probe;
+  return digestRunLaunchValue({
+    ...stableRuntime,
+    probe: stableProbe,
+  });
+}
+
+function immutableClone<T>(value: T): T {
+  return deepFreeze(structuredClone(value));
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  return value;
+}

--- a/server/src/services/work-product-service.ts
+++ b/server/src/services/work-product-service.ts
@@ -14,6 +14,7 @@ import type {
   WorkProductRender,
   WorkProductVersion,
   Task,
+  TaskAttempt,
   WorkflowPipelineSummary,
 } from '@veritas-kanban/shared';
 import { SqliteDatabase, type SqliteConnectionOptions } from '../storage/sqlite/database.js';
@@ -415,6 +416,7 @@ export class WorkProductService {
 
   private buildCompletionPacketInput(task: Task, sourceRunId?: string): CreateWorkProductInput {
     const sourceLinks = this.buildCompletionPacketSourceLinks(task, sourceRunId);
+    const sourceAttempt = this.completionPacketAttempt(task, sourceRunId);
     const render: WorkProductRender = {
       schemaVersion: 1,
       kind: 'report',
@@ -437,8 +439,8 @@ export class WorkProductService {
       render,
       taskId: task.id,
       sourceRunId,
-      agent: task.attempt?.agent ?? (task.agent === 'auto' ? undefined : task.agent),
-      model: task.attempt?.model,
+      agent: sourceAttempt?.agent ?? (task.agent === 'auto' ? undefined : task.agent),
+      model: sourceAttempt?.model,
       redaction: {
         level: 'standard',
         containsSensitiveContent: false,
@@ -449,7 +451,7 @@ export class WorkProductService {
         exportDefault: 'redacted',
       },
       sourceLinks,
-      metadata: this.completionPacketMetadata(task, sourceRunId),
+      metadata: this.completionPacketMetadata(task, sourceRunId, sourceAttempt),
     };
   }
 
@@ -461,7 +463,8 @@ export class WorkProductService {
 
   private completionPacketMetadata(
     task: Task,
-    sourceRunId?: string
+    sourceRunId: string | undefined,
+    sourceAttempt: TaskAttempt | undefined
   ): Record<string, WorkProductPrimitive> {
     return {
       packetType: 'completion_packet',
@@ -475,12 +478,28 @@ export class WorkProductService {
       attachmentCount: task.attachments?.length ?? 0,
       reviewDecision: task.review?.decision ?? null,
       qaGatePassed: task.qaGate?.passed ?? null,
-      orchestrationRoles: task.attempt?.orchestration?.totals.roles ?? 0,
-      orchestrationBlocked: task.attempt?.orchestration?.totals.blocked ?? 0,
-      orchestrationFailed: task.attempt?.orchestration?.totals.failed ?? 0,
-      budgetDecision: task.attempt?.budget?.decision ?? null,
-      budgetTraceCount: task.attempt?.budget?.traceIds.length ?? 0,
+      orchestrationRoles: sourceAttempt?.orchestration?.totals.roles ?? 0,
+      orchestrationBlocked: sourceAttempt?.orchestration?.totals.blocked ?? 0,
+      orchestrationFailed: sourceAttempt?.orchestration?.totals.failed ?? 0,
+      budgetDecision: sourceAttempt?.budget?.decision ?? null,
+      budgetTraceCount: sourceAttempt?.budget?.traceIds.length ?? 0,
+      runLaunchManifestSchemaVersion: sourceAttempt?.runLaunchManifest?.schemaVersion ?? null,
+      runLaunchManifestDigest: sourceAttempt?.runLaunchManifest?.digest ?? null,
+      runLaunchManifestTraceId: sourceAttempt?.runLaunchManifestTraceId ?? null,
+      runLaunchParentAttemptId: sourceAttempt?.runLaunchParentAttemptId ?? null,
+      runLaunchMaterialDrift: sourceAttempt?.runLaunchManifestDrift?.material ?? null,
+      providerRuntimeManifestDigest: sourceAttempt?.providerRuntimeManifest?.digest ?? null,
+      providerRuntimeProbeRevision: sourceAttempt?.providerRuntimeManifest?.probeRevision ?? null,
+      providerRuntimeVersion: sourceAttempt?.providerRuntimeManifest?.providerVersion ?? null,
+      providerRuntimeBuild: sourceAttempt?.providerRuntimeManifest?.providerBuild ?? null,
     };
+  }
+
+  private completionPacketAttempt(task: Task, sourceRunId?: string): TaskAttempt | undefined {
+    if (!sourceRunId) return task.attempt;
+    return [task.attempt, ...(task.attempts ?? [])]
+      .filter((attempt): attempt is TaskAttempt => Boolean(attempt))
+      .find((attempt) => attempt.id === sourceRunId);
   }
 
   private buildCompletionPacketSourceLinks(

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -24,8 +24,10 @@ export type {
   ManagedListProvider,
   TelemetryRepository,
   SetupContextRepository,
+  WorkspaceFileRepository,
   StorageProvider,
 } from './interfaces.js';
+export { LocalWorkspaceFileRepository } from './workspace-file-repository.js';
 export {
   FileStorageProvider,
   FileTaskRepository,

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -290,6 +290,20 @@ export interface SetupContextRepository {
 }
 
 // ---------------------------------------------------------------------------
+// Workspace File Repository
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceFileRepository {
+  /**
+   * Read an optional UTF-8 file beneath a workspace root.
+   *
+   * Implementations must reject traversal outside `workspaceRoot`. A missing
+   * file returns null; other I/O failures remain visible to the caller.
+   */
+  readOptionalText(workspaceRoot: string, relativePath: string): Promise<string | null>;
+}
+
+// ---------------------------------------------------------------------------
 // Storage Provider (top-level aggregate)
 // ---------------------------------------------------------------------------
 

--- a/server/src/storage/workspace-file-repository.ts
+++ b/server/src/storage/workspace-file-repository.ts
@@ -1,0 +1,28 @@
+import { readFile, realpath } from 'node:fs/promises';
+import path from 'node:path';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import type { WorkspaceFileRepository } from './interfaces.js';
+
+export class LocalWorkspaceFileRepository implements WorkspaceFileRepository {
+  async readOptionalText(workspaceRoot: string, relativePath: string): Promise<string | null> {
+    const resolvedPath = ensureWithinBase(workspaceRoot, path.resolve(workspaceRoot, relativePath));
+    try {
+      const [canonicalRoot, canonicalPath] = await Promise.all([
+        realpath(workspaceRoot),
+        realpath(resolvedPath),
+      ]);
+      ensureWithinBase(canonicalRoot, canonicalPath);
+      return await readFile(canonicalPath, 'utf8');
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+}

--- a/server/src/utils/run-launch-manifest-digest.ts
+++ b/server/src/utils/run-launch-manifest-digest.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto';
+import type { RunLaunchManifest } from '@veritas-kanban/shared';
+
+export type RunLaunchManifestPayload = Omit<RunLaunchManifest, 'digest'>;
+
+export function calculateRunLaunchManifestDigest(
+  manifest: RunLaunchManifestPayload | RunLaunchManifest
+): string {
+  const { digest: _digest, ...payload } = manifest as RunLaunchManifest;
+  return digestRunLaunchValue(payload);
+}
+
+export function verifyRunLaunchManifestDigest(manifest: RunLaunchManifest): boolean {
+  return manifest.digest === calculateRunLaunchManifestDigest(manifest);
+}
+
+export function digestRunLaunchValue(value: unknown): string {
+  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortObjectKeys(value)) ?? 'undefined';
+}
+
+function sortObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortObjectKeys(entry));
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, sortObjectKeys(entry)])
+  );
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -48,4 +48,5 @@ export * from './watcher-policy.types.js';
 export * from './evidence.types.js';
 export * from './time-breakdown.types.js';
 export * from './task-envelope.types.js';
+export * from './run-launch-manifest.types.js';
 export * from './auth.types.js';

--- a/shared/src/types/run-launch-manifest.types.ts
+++ b/shared/src/types/run-launch-manifest.types.ts
@@ -1,0 +1,221 @@
+import type { AgentBudgetPolicy } from './agent-budget.types.js';
+import type { HarnessSupportTier, HarnessTransport } from './provider-runtime.types.js';
+import type { ProviderRuntimeCapabilityState } from './provider-runtime.types.js';
+
+export const RUN_LAUNCH_MANIFEST_SCHEMA_VERSION = 'run-launch-manifest/v1' as const;
+
+export type RunLaunchManifestEnforcementState = 'enforced' | 'not-required' | 'unavailable';
+
+export type RunLaunchManifestInstructionKind =
+  'task' | 'profile' | 'template' | 'repository' | 'system' | 'other';
+
+export type RunLaunchManifestOriginScope =
+  | 'run'
+  | 'task-envelope'
+  | 'agent-profile'
+  | 'workflow'
+  | 'template'
+  | 'provider'
+  | 'workspace'
+  | 'system-default';
+
+export interface RunLaunchManifestReference {
+  schemaVersion: string;
+  digest: string;
+}
+
+export interface RunLaunchTaskEnvelopeReference extends RunLaunchManifestReference {
+  /** Digest excluding attempt identity and capture timestamps for material drift comparison. */
+  materialDigest: string;
+}
+
+export interface RunLaunchProviderRuntimeReference extends RunLaunchManifestReference {
+  /** Digest excluding probe timestamp for material drift comparison. */
+  materialDigest: string;
+  probeRevision: number;
+  provider: string;
+  adapter: string;
+  protocolVersion: string;
+  providerVersion: string;
+  providerBuild?: string;
+}
+
+export interface RunLaunchHarnessSupport {
+  profileId: string;
+  adapterId?: string;
+  transport: HarnessTransport;
+  supportTier: HarnessSupportTier;
+}
+
+export interface RunLaunchProviderRequirement {
+  id: string;
+  state: ProviderRuntimeCapabilityState;
+  satisfied: boolean;
+  advisory: boolean;
+  reason: string;
+}
+
+export interface RunLaunchProviderRequirements {
+  required: string[];
+  capabilities: RunLaunchProviderRequirement[];
+}
+
+export interface RunLaunchRouting {
+  requestedAgent: string;
+  selectedAgent: string;
+  selectedHost: string;
+  reason: string;
+  fallbackAgent: string | null;
+  fallbackAllowed: boolean;
+}
+
+export interface RunLaunchProfileReference {
+  id: string;
+  version: string;
+  role: string;
+}
+
+export interface RunLaunchReadiness {
+  ready: boolean;
+  overridden: boolean;
+  passed: number;
+  total: number;
+  missingRequired: string[];
+  warnings: string[];
+  overrideReasonDigest?: string;
+}
+
+export interface RunLaunchInstructionReference {
+  id: string;
+  kind: RunLaunchManifestInstructionKind;
+  digest: string;
+  /** Digest with attempt-local identifiers normalized for material drift comparison. */
+  materialDigest: string;
+  byteLength: number;
+  origin: string;
+  precedence: number;
+}
+
+export interface RunLaunchRuntime {
+  model?: string;
+  command: string;
+  args: string[];
+  workingDirectory: 'task-worktree' | 'workspace' | 'provider-managed';
+  worktree: 'required' | 'supported' | 'provider-managed';
+  environmentKeys: string[];
+  credentialReferences: string[];
+}
+
+export interface RunLaunchTools {
+  allowed: string[];
+  denied: string[];
+  policyIds: string[];
+  mcpServers: string[];
+  enforcement: RunLaunchManifestEnforcementState;
+}
+
+export interface RunLaunchPermissions {
+  level: 'intern' | 'specialist' | 'lead';
+  required: string[];
+  enforcement: RunLaunchManifestEnforcementState;
+}
+
+export interface RunLaunchResources {
+  skills: string[];
+  shared: string[];
+  enforcement: RunLaunchManifestEnforcementState;
+}
+
+export interface RunLaunchSandboxRule {
+  id: string;
+  capability: string;
+  status: 'supported' | 'unsupported' | 'advisory';
+}
+
+export interface RunLaunchSandbox {
+  presetId: string;
+  enforcement: 'required' | 'advisory';
+  decision: 'allow' | 'warn' | 'block';
+  effective: {
+    sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access';
+    networkAccessEnabled: boolean;
+    environmentKeys: string[];
+    credentialReferences: string[];
+  };
+  unsupportedRules: RunLaunchSandboxRule[];
+  warnings: string[];
+}
+
+export interface RunLaunchWorkspaceTrust {
+  status: 'trusted' | 'untrusted' | 'not-required';
+  source: string;
+}
+
+export interface RunLaunchManifestOrigin {
+  field: string;
+  scope: RunLaunchManifestOriginScope;
+  source: string;
+  precedence: number;
+}
+
+export interface RunLaunchManifestBlocker {
+  code: string;
+  field: string;
+  detail: string;
+  remediation: string;
+}
+
+export interface RunLaunchManifestEnforcement {
+  enforceable: boolean;
+  blockers: RunLaunchManifestBlocker[];
+  warnings: string[];
+}
+
+/**
+ * Immutable, redacted record of the effective launch inputs and their origin.
+ *
+ * Prompt content and credential values are intentionally excluded. References
+ * and fingerprints let operators prove what was selected without disclosing it.
+ */
+export interface RunLaunchManifest {
+  schemaVersion: typeof RUN_LAUNCH_MANIFEST_SCHEMA_VERSION;
+  digest: string;
+  createdAt: string;
+  taskId: string;
+  attemptId: string;
+  taskEnvelope: RunLaunchTaskEnvelopeReference;
+  providerRuntime: RunLaunchProviderRuntimeReference;
+  providerRequirements: RunLaunchProviderRequirements;
+  harnessSupport: RunLaunchHarnessSupport;
+  routing: RunLaunchRouting;
+  profile?: RunLaunchProfileReference;
+  readiness: RunLaunchReadiness;
+  instructions: RunLaunchInstructionReference[];
+  runtime: RunLaunchRuntime;
+  tools: RunLaunchTools;
+  permissions: RunLaunchPermissions;
+  resources: RunLaunchResources;
+  requiredHealthChecks: string[];
+  sandbox: RunLaunchSandbox;
+  budget: AgentBudgetPolicy;
+  workspaceTrust: RunLaunchWorkspaceTrust;
+  origins: RunLaunchManifestOrigin[];
+  enforcement: RunLaunchManifestEnforcement;
+}
+
+export interface RunLaunchManifestDrift {
+  field: string;
+  beforeDigest: string;
+  afterDigest: string;
+}
+
+export interface RunLaunchManifestDriftResult {
+  material: boolean;
+  changes: RunLaunchManifestDrift[];
+}
+
+export interface RunLaunchManifestPreview {
+  manifest: RunLaunchManifest;
+  parentAttemptId?: string;
+  drift?: RunLaunchManifestDriftResult;
+}

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -64,6 +64,10 @@ export interface TaskAttempt {
   providerRuntimeManifest?: import('./provider-runtime.types.js').ProviderRuntimeManifest;
   harnessSupport?: import('./provider-runtime.types.js').HarnessSupportStatus;
   taskEnvelope?: import('./task-envelope.types.js').TaskEnvelope;
+  runLaunchManifest?: import('./run-launch-manifest.types.js').RunLaunchManifest;
+  runLaunchManifestTraceId?: string;
+  runLaunchParentAttemptId?: string;
+  runLaunchManifestDrift?: import('./run-launch-manifest.types.js').RunLaunchManifestDriftResult;
   completionResult?: import('./task-envelope.types.js').CompletionResult;
 }
 

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -178,6 +178,7 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
     overrides: [
       { methods: ['POST'], path: /^\/route\/?$/, permissions: 'agent:read' },
       { methods: ['POST'], path: /^\/hosts\/preview\/?$/, permissions: 'agent:read' },
+      { methods: ['POST'], path: /^\/[^/]+\/launch-preview\/?$/, permissions: 'agent:read' },
       { methods: ['POST'], path: /^\/[^/]+\/(start|stop)\/?$/, permissions: 'agent:write' },
       { methods: ['POST'], path: /^\/[^/]+\/message\/?$/, permissions: 'task:write' },
     ],

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -15,6 +15,9 @@ import type {
   TaskCommitPolicy,
   TaskEnvelope,
   HarnessSupportStatus,
+  RunLaunchManifest,
+  RunLaunchManifestDriftResult,
+  RunLaunchManifestPreview,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -26,6 +29,7 @@ export interface StartAgentRequest {
   budget?: AgentBudgetPolicy;
   requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
   commitPolicy?: TaskCommitPolicy;
+  parentAttemptId?: string;
 }
 
 export const worktreeApi = {
@@ -78,6 +82,17 @@ export const agentApi = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+    });
+  },
+
+  previewLaunch: async (
+    taskId: string,
+    request: StartAgentRequest = {}
+  ): Promise<RunLaunchManifestPreview> => {
+    return apiFetch<RunLaunchManifestPreview>(`${API_BASE}/agents/${taskId}/launch-preview`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
     });
   },
 
@@ -256,6 +271,9 @@ export interface AgentStatus {
   providerRuntimeManifest: ProviderRuntimeManifest;
   harnessSupport: HarnessSupportStatus;
   taskEnvelope: TaskEnvelope;
+  runLaunchManifest: RunLaunchManifest;
+  runLaunchParentAttemptId?: string;
+  runLaunchManifestDrift?: RunLaunchManifestDriftResult;
   controls: ProviderRuntimeControlSet;
 }
 
@@ -271,6 +289,9 @@ export interface AgentStatusResponse {
   providerRuntimeManifest?: ProviderRuntimeManifest;
   harnessSupport?: HarnessSupportStatus;
   taskEnvelope?: TaskEnvelope;
+  runLaunchManifest?: RunLaunchManifest;
+  runLaunchParentAttemptId?: string;
+  runLaunchManifestDrift?: RunLaunchManifestDriftResult;
   controls?: ProviderRuntimeControlSet;
 }
 


### PR DESCRIPTION
## Summary

- compile a redacted, immutable `run-launch-manifest/v1` before dispatch, with task-envelope and provider-runtime references, effective runtime settings, instruction fingerprints, and per-field origins
- expose launch preview through REST, CLI, web client, and MCP-compatible start options, with readiness parity and parent-attempt drift evidence
- fail closed on unenforceable tools, MCP selections, permissions, resources, health checks, and provider capabilities
- persist the manifest and digest with attempts, governance traces, status/history/log output, and completion packets
- document the API, CLI, provider behavior, security coverage, and the #857 boundary for positive tool/MCP catalog injection

Closes #854

## Verification

- `pnpm lint:budget` (0 errors, 595 warnings, budget 600)
- `pnpm typecheck`
- `pnpm test:unit` (desktop 61, server 2,344 with 2 skipped, web 425)
- `pnpm --filter @veritas-kanban/server test` (209 files, 2,346 passed, 2 skipped)
- focused launch-manifest/provider suite (50 passed)
- `pnpm build` plus final server rebuild
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `node scripts/check-permission-coverage.mjs`
- `pnpm smoke:cli-mcp` (0 failures, 2 expected credential-gated skips)
- `git diff --check`