### PR TITLE
feat: render provider task envelope transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   readiness/override evidence, governance traces, attempt/history/log
   persistence, and completion-packet links to the exact launch and provider
   capability evidence (#854).
+- Added immutable provider-owned task-envelope transports for OpenClaw, Codex
+  CLI, Codex SDK, and Hermes. Each renderer binds the exact envelope and runtime
+  identity, commit policy, bounded attributed profile/checkpoint context,
+  workspace baseline, verification gates, and completion evidence to the
+  launched request. OpenClaw alone receives a completion callback; process and
+  stream providers return terminal output through harness-owned capture, and
+  mismatched provider/adapter identities fail closed (#892).
 
 ## [5.2.5] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **Team roster routing** — Workspace coordinator/member manifests route tasks by capabilities, reviewers, fallbacks, and escalation posture
 - **Workspace capability discovery** — Trusted workspace capability catalogs let Veritas package delegated work intake before handing work across workspace boundaries
 - **Agent profile packages** — Portable YAML/JSON packages that bundle role, runtime, prompt, tools, permissions, sandbox, budget, workflow, and health metadata for reusable launches
+- **Provider-owned task envelopes** — OpenClaw, Codex CLI, Codex SDK, and Hermes render the same immutable task contract through adapter-owned transports with explicit commit policy and completion posture
 - **Decision review sessions** — Multi-participant decision reviews with independent responses, critique rounds, final synthesis packets, work-product attachment, and decision audit links
 - **Shared live run sessions** — Create workspace-scoped view, co-drive, or fork links for active task runs; viewers receive live output and events, editors send attributed messages and mobile-safe approval responses, and forks create linked tasks without mutating the parent run
 - **Sandbox policy presets** — Built-in and custom presets for filesystem scope, network egress, environment passthrough, and credential brokering, with Settings dry-runs before agent launch

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -146,9 +146,35 @@ Requested filesystem, process, commit, and artifact scopes are intersected
 with the effective worktree sandbox; ancestor requests such as `/` are clamped
 to the assigned worktree and disjoint paths are rejected.
 The start response, active status response, task attempt/history, and Markdown
-run log expose the same immutable envelope. Provider-owned rendering and
-normalized completion enforcement land in the ordered follow-up work for
-parent issue #860.
+run log expose the same immutable envelope.
+
+### Provider-Owned Transport Rendering
+
+Each executable task adapter renders the provider-neutral envelope into its
+own immutable `provider-task-envelope-transport/v1` request. OpenClaw, Codex
+CLI, Codex SDK, and Hermes renderers all include the envelope digest, runtime
+identity, objective and bounded context, a bounded workspace-baseline summary,
+explicit commit policy, allowed side effects, expected outputs, verification
+gates, and completion evidence contract. Profile instructions and saved task
+checkpoints are rendered as separate, attributed sections and are capped at
+20,000 characters each. The persisted task envelope retains the complete
+baseline fingerprints used for later attribution.
+
+The callback posture belongs to the adapter:
+
+- OpenClaw receives the attempt-bound Veritas completion callback, including
+  the provider-runtime manifest digest.
+- Codex CLI returns terminal output through the supervised process.
+- Codex SDK returns terminal output through the captured SDK event stream.
+- Hermes returns terminal output through scripted process stdout.
+
+Process and stream adapters are explicitly told not to call the Veritas
+completion endpoint. None of the renderers claims provider-native structured
+output; Veritas owns validation and completion normalization. The exact
+rendered request is fingerprinted as `instructions.effective-task-request` in
+the run launch manifest, and the provider and adapter must match the envelope
+before dispatch. Completion-result normalization and evidence enforcement are
+tracked separately in #893.
 
 ## Effective Run Launch Manifests
 
@@ -245,7 +271,7 @@ policy:
   sandboxPresetId: workspace-write-default
 ```
 
-Profile launches pass `profileId` to `/api/agents/:taskId/start`. Veritas resolves the package runtime against the configured provider profile, applies the package model, sandbox preset, and budget policy, injects package instructions into the run prompt, and records the profile ID/version in the task attempt plus an `agent_event` activity entry.
+Profile launches pass `profileId` to `/api/agents/:taskId/start`. Veritas resolves the package runtime against the configured provider profile, applies the package model, sandbox preset, and budget policy, renders bounded package instructions in an attributed provider-transport section, and records the profile ID/version in the task attempt plus an `agent_event` activity entry.
 
 ## Budget Policies
 
@@ -393,9 +419,9 @@ install at the operator-level endpoint. You must explicitly allow them:
 
 ### Dispatch flow
 
-1. Veritas calls `sessions_spawn` with the full task prompt, including the
-   callback URL and required `attemptId` plus `providerRuntimeManifestDigest`
-   completion provenance.
+1. Veritas calls `sessions_spawn` with the OpenClaw-owned task-envelope
+   transport, including the callback URL and required `attemptId` plus
+   `providerRuntimeManifestDigest` completion provenance.
 2. A policy or connection failure rolls the task attempt back to `todo` with an error message.
 3. OpenClaw returns a `childSessionKey` which Veritas stores in the attempt record.
 4. The OpenClaw sub-session runs autonomously and calls the Veritas callback URL when done.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1945,8 +1945,9 @@ additional runtime capabilities, and compare against a parent attempt:
 ```
 
 The launch path resolves the package runtime against configured provider
-profiles, applies package model/sandbox/budget posture, injects package
-instructions, and records the profile ID and version. Baseline launch
+profiles, applies package model/sandbox/budget posture, and renders bounded
+package instructions in an attributed section of the provider-owned transport.
+It also records the profile ID and version. Baseline launch
 capabilities plus caller, profile, sandbox, and budget requirements must be
 `supported` or `advisory` in one valid manifest before attempt state is
 mutated. Failure returns `409 Conflict` with `requiredCapabilities`, reasons,
@@ -2046,7 +2047,7 @@ delayed control cannot affect a replacement run:
 `actor`) to that body. `POST /api/agents/:taskId/tokens` also requires the exact
 `attemptId`; the server never falls back to the task's current attempt.
 
-Completion callbacks must identify the exact run that produced them:
+OpenClaw completion callbacks must identify the exact run that produced them:
 
 ```json
 {
@@ -2057,10 +2058,12 @@ Completion callbacks must identify the exact run that produced them:
 }
 ```
 
-`POST /api/agents/:taskId/complete` rejects callbacks whose attempt or manifest
-digest does not match the active run. Token reports likewise bind telemetry and
-budget mutation to their required `attemptId`, so a late event from a prior
-attempt cannot charge or stop a replacement run.
+`POST /api/agents/:taskId/complete` rejects OpenClaw callbacks whose attempt or
+manifest digest does not match the active run. Codex CLI, Codex SDK, and Hermes
+do not call this endpoint; Veritas captures their terminal process or stream
+output and owns completion normalization. Token reports likewise bind
+telemetry and budget mutation to their required `attemptId`, so a late event
+from a prior attempt cannot charge or stop a replacement run.
 
 ### Provider Runtime Manifest On Attempts
 
@@ -2127,6 +2130,23 @@ does not authorize. Path scopes wider than the assigned worktree are clamped to
 the worktree, while disjoint path scopes are dropped. Generic task PATCH calls
 cannot set `attempt.taskEnvelope` or `attempt.completionResult`; only the
 launch and finalization services may persist those authoritative contracts.
+
+Before dispatch, the selected adapter renders the envelope through an immutable
+`provider-task-envelope-transport/v1` request. Built-in renderers exist for
+OpenClaw, Codex CLI, Codex SDK, and Hermes. Every rendered request includes the
+envelope and runtime identity, objective and bounded context, workspace
+baseline, explicit commit policy, allowed side effects, outputs, verification
+gates, and completion evidence contract. Profile instructions and task
+checkpoint state are separate attributed sections capped at 20,000 characters
+each. The exact rendered content is fingerprinted in the run launch manifest
+as `instructions.effective-task-request`.
+
+OpenClaw's transport includes the attempt-bound completion callback. Codex CLI,
+Codex SDK, and Hermes transports explicitly forbid calling that callback and
+return terminal output through harness-owned process or stream capture.
+Provider and adapter identity must match the envelope before dispatch. Veritas
+does not infer native structured-output support from prompt rendering and owns
+completion validation and normalization.
 
 The full manifest contains one entry for every known runtime and sandbox
 capability. A provider version/build change invalidates cached conformance

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -280,7 +280,8 @@ First-class support for autonomous coding agents.
 - **Multi-agent support** — Ships with Codex, Codex SDK, Codex Cloud, Hermes Agent, Claude Code, Amp, Copilot, Gemini, Ollama Local, Ollama Cloud, LM Studio Local, and Veritas profiles; add completely custom agents via Settings → Agents
 - **Agent CRUD management** — Full Add/Edit/Remove for agents in Settings → Agents; add agent form with name, type slug (auto-generated), command, and args; inline edit via pencil icon; remove via trash icon with confirmation (blocked for the default agent); `AgentType` accepts any string slug, not just built-in names
 - **Agent request files** — Server writes structured requests to `.veritas-kanban/agent-requests/` for agent pickup
-- **Completion callbacks** — Agents call the completion endpoint with success/failure status and summary
+- **Provider-owned task-envelope transports** — OpenClaw, Codex CLI, Codex SDK, and Hermes each render the immutable task contract through an adapter-owned request with explicit commit policy, bounded attributed profile/checkpoint context, workspace baseline, verification gates, and completion evidence requirements
+- **Provider-specific completion posture** — OpenClaw receives an attempt-bound completion callback; Codex CLI, Codex SDK, and Hermes return terminal output through harness-supervised process or stream capture
 - **Multiple attempts** — Retry tasks with different agents; full attempt history preserved with status (pending, running, complete, failed)
 - **Attempt history viewer** — Browse past attempts with agent name, status, and log output
 - **Time tracking** — Start/stop timer or add manual time entries per task; running timer display with live elapsed counter
@@ -297,6 +298,7 @@ First-class support for autonomous coding agents.
 - **Workspace capability discovery** — Trusted workspace catalogs expose supported task types, SLA/queue posture, intake requirements, and delegated-work packaging so cross-workspace handoffs are explicit
 - **Agent profile packages** — Reusable YAML/JSON packages bundle role, runtime, model, prompt instructions, tools, permissions, sandbox, budget, workflow, and health metadata for portable task launches
 - **Provider runtime manifests** — Every executable adapter records a versioned, evidence-backed capability snapshot and digest on the attempt, history, trace, and log; provider version skew reruns conformance and unsupported configured providers fail closed instead of falling back to OpenClaw
+- **Task-envelope transports** — Provider-owned renderers for OpenClaw, Codex CLI, Codex SDK, and Hermes bind the exact task-envelope digest and commit policy to the launched request; the rendered request is fingerprinted in the run launch manifest and mismatched provider/adapter identities fail closed
 - **Sandbox policy presets** — Built-in and custom presets control filesystem scope, network egress, environment passthrough, and credential brokering for agent profiles, workflow agents, and per-run overrides
 - **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run budgets can cap tokens, provider cost, tool calls, runtime, retries, and workflow fan-out with warning, approval, downgrade, pause, or cancel actions
 - **Platform-agnostic REST API** — Any platform that can make HTTP calls can drive the full agent lifecycle

--- a/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/provider-task-envelope-renderer.test.ts.snap
@@ -1,0 +1,385 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`provider task-envelope renderers > renders a callback-free Codex CLI transport from a forbidden-commit envelope 1`] = `
+"# Codex CLI Task Envelope
+
+## Transport
+
+- Envelope: \`task-envelope/v1\`
+- Digest: \`sha256:9124d04ba445ec2a704a7a180f78897c4c97654e2db2fc0a40dd49fe36ba9f9f\`
+- Provider: \`codex-cli\`
+- Adapter: \`codex-cli\`
+- Runtime manifest: \`sha256:ac8168ea1345156e76f1ebd1dbdcb42ff19b808e52e2164a07257da52a546d24\`
+- Protocol: \`fixture-runtime/v1\`
+- Task: \`task_transport\`
+- Attempt: \`attempt_transport\`
+
+## Objective
+
+Ship the provider transport
+
+## Background
+
+- Translate the immutable task contract without changing completion ownership.
+
+
+## Constraints
+
+- Follow the release checklist.
+- Operate only inside the assigned worktree: /tmp/veritas-kanban-transport
+
+
+## Workspace
+
+- Repository: \`veritas-kanban\`
+- Branch: \`feat/codex-cli-transport\`
+- Base branch: \`main\`
+- Worktree: \`/tmp/veritas-kanban-transport\`
+- Launch HEAD: \`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\`
+- Launch state: clean
+
+### Launch Baseline Files
+
+- None.
+
+
+
+## Commit Policy
+
+Forbidden: do not create a commit. Leave permitted worktree changes uncommitted.
+
+## Acceptance Criteria
+
+- The provider receives the persisted envelope.
+
+
+## Allowed Side Effects
+
+- \`filesystem-write\` within \`/tmp/veritas-kanban-transport\`
+- \`process-execute\` within \`/tmp/veritas-kanban-transport\`
+- \`network-egress\` within \`sandbox policy\`
+
+
+## Expected Outputs
+
+- Required \`text\` \`completion-summary\`: A concise summary of the completed work and remaining risks.
+
+
+## Verification Gates
+
+- Required \`provider-snapshot\`: Run the provider transport snapshot. Evidence is required.
+
+
+## Completion Evidence Contract
+
+- Schema: \`completion-result/v1\`
+- Required \`provider-output\` \`terminal-state\`: Harness-verified provider terminal state from the native transport.
+- Required \`verification\` \`verification\`: Harness-verified evidence for every required verification gate.
+
+
+
+
+## Completion (Codex CLI process)
+
+Return the final response through the process output captured by Veritas.
+
+Do not call the Veritas completion callback. The harness owns terminal-state capture.
+
+No native structured-output support is assumed; Veritas validates and normalizes process output."
+`;
+
+exports[`provider task-envelope renderers > renders a callback-free Codex SDK transport from an allowed-commit envelope 1`] = `
+"# Codex SDK Task Envelope
+
+## Transport
+
+- Envelope: \`task-envelope/v1\`
+- Digest: \`sha256:a3eafc0cbfd2b125c2e63d86614a97643ce5023dafc058499c863c41027a9e39\`
+- Provider: \`codex-sdk\`
+- Adapter: \`codex-sdk\`
+- Runtime manifest: \`sha256:e00151ad599160706e2d814412bbf8c71bdc352317352a9a72df14574def305a\`
+- Protocol: \`fixture-runtime/v1\`
+- Task: \`task_transport\`
+- Attempt: \`attempt_transport\`
+
+## Objective
+
+Ship the provider transport
+
+## Background
+
+- Translate the immutable task contract without changing completion ownership.
+
+
+## Constraints
+
+- Follow the release checklist.
+- Operate only inside the assigned worktree: /tmp/veritas-kanban-transport
+
+
+## Workspace
+
+- Repository: \`veritas-kanban\`
+- Branch: \`feat/codex-sdk-transport\`
+- Base branch: \`main\`
+- Worktree: \`/tmp/veritas-kanban-transport\`
+- Launch HEAD: \`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\`
+- Launch state: clean
+
+### Launch Baseline Files
+
+- None.
+
+
+
+## Commit Policy
+
+Allowed: a commit is permitted, but successful completion does not require one.
+
+## Acceptance Criteria
+
+- The provider receives the persisted envelope.
+
+
+## Allowed Side Effects
+
+- \`filesystem-write\` within \`/tmp/veritas-kanban-transport\`
+- \`process-execute\` within \`/tmp/veritas-kanban-transport\`
+- \`git-commit\` within \`/tmp/veritas-kanban-transport\`
+- \`network-egress\` within \`sandbox policy\`
+
+
+## Expected Outputs
+
+- Required \`text\` \`completion-summary\`: A concise summary of the completed work and remaining risks.
+
+
+## Verification Gates
+
+- Required \`provider-snapshot\`: Run the provider transport snapshot. Evidence is required.
+
+
+## Completion Evidence Contract
+
+- Schema: \`completion-result/v1\`
+- Required \`provider-output\` \`terminal-state\`: Harness-verified provider terminal state from the native transport.
+- Required \`verification\` \`verification\`: Harness-verified evidence for every required verification gate.
+
+
+
+
+## Completion (Codex SDK stream)
+
+Return the final response through the SDK event stream captured by Veritas.
+
+Do not call the Veritas completion callback. The harness owns terminal-state capture.
+
+No native structured-output support is assumed; Veritas validates and normalizes SDK stream events."
+`;
+
+exports[`provider task-envelope renderers > renders a callback-free Hermes scripted transport 1`] = `
+"# Hermes Task Envelope
+
+## Transport
+
+- Envelope: \`task-envelope/v1\`
+- Digest: \`sha256:e5c6eac76fa867f258802075bbd01e46f3842745ee2270eb454d860da4fc65f2\`
+- Provider: \`hermes-cli\`
+- Adapter: \`hermes-cli\`
+- Runtime manifest: \`sha256:35efe1a6d4eee34a91f88ddf751fb2e746969f33a66c3dd1820c7dcc9ebed1eb\`
+- Protocol: \`fixture-runtime/v1\`
+- Task: \`task_transport\`
+- Attempt: \`attempt_transport\`
+
+## Objective
+
+Ship the provider transport
+
+## Background
+
+- Translate the immutable task contract without changing completion ownership.
+
+
+## Constraints
+
+- Follow the release checklist.
+- Operate only inside the assigned worktree: /tmp/veritas-kanban-transport
+
+
+## Workspace
+
+- Repository: \`veritas-kanban\`
+- Branch: \`feat/hermes-cli-transport\`
+- Base branch: \`main\`
+- Worktree: \`/tmp/veritas-kanban-transport\`
+- Launch HEAD: \`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\`
+- Launch state: clean
+
+### Launch Baseline Files
+
+- None.
+
+
+
+## Commit Policy
+
+Required: create at least one new commit attributable to this attempt.
+
+## Acceptance Criteria
+
+- The provider receives the persisted envelope.
+
+
+## Allowed Side Effects
+
+- \`filesystem-write\` within \`/tmp/veritas-kanban-transport\`
+- \`process-execute\` within \`/tmp/veritas-kanban-transport\`
+- \`git-commit\` within \`/tmp/veritas-kanban-transport\`
+- \`network-egress\` within \`sandbox policy\`
+
+
+## Expected Outputs
+
+- Required \`text\` \`completion-summary\`: A concise summary of the completed work and remaining risks.
+- Required \`commit\` \`git-commit\`: At least one new commit attributable to this attempt.
+
+
+## Verification Gates
+
+- Required \`provider-snapshot\`: Run the provider transport snapshot. Evidence is required.
+
+
+## Completion Evidence Contract
+
+- Schema: \`completion-result/v1\`
+- Required \`provider-output\` \`terminal-state\`: Harness-verified provider terminal state from the native transport.
+- Required \`verification\` \`verification\`: Harness-verified evidence for every required verification gate.
+- Required \`commit\` \`commit\`: Harness-verified commit created after the launch baseline.
+
+
+
+
+## Completion (Hermes scripted process)
+
+Return the final response through scripted stdout captured by Veritas.
+
+Do not call the Veritas completion callback. The harness owns terminal-state capture.
+
+No native structured-output support is assumed; Veritas validates and normalizes scripted process output."
+`;
+
+exports[`provider task-envelope renderers > renders an OpenClaw callback transport from a required-commit envelope 1`] = `
+"# OpenClaw Task Envelope
+
+## Transport
+
+- Envelope: \`task-envelope/v1\`
+- Digest: \`sha256:b15c3895ab0b1573673a7079718b3fa45106b0704594932b5ffd1b8761213dc0\`
+- Provider: \`openclaw\`
+- Adapter: \`openclaw\`
+- Runtime manifest: \`sha256:a1b31859e0674254b1a7bffadc0d28b4a56999177a209be10003054f0ebad598\`
+- Protocol: \`fixture-runtime/v1\`
+- Task: \`task_transport\`
+- Attempt: \`attempt_transport\`
+
+## Objective
+
+Ship the provider transport
+
+## Background
+
+- Translate the immutable task contract without changing completion ownership.
+
+
+## Constraints
+
+- Operate only inside the assigned worktree: /tmp/veritas-kanban-transport
+
+
+## Workspace
+
+- Repository: \`veritas-kanban\`
+- Branch: \`feat/openclaw-transport\`
+- Base branch: \`main\`
+- Worktree: \`/tmp/veritas-kanban-transport\`
+- Launch HEAD: \`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\`
+- Launch state: clean
+
+### Launch Baseline Files
+
+- None.
+
+
+
+## Commit Policy
+
+Required: create at least one new commit attributable to this attempt.
+
+## Acceptance Criteria
+
+- The provider receives the persisted envelope.
+
+
+## Allowed Side Effects
+
+- \`filesystem-write\` within \`/tmp/veritas-kanban-transport\`
+- \`process-execute\` within \`/tmp/veritas-kanban-transport\`
+- \`git-commit\` within \`/tmp/veritas-kanban-transport\`
+- \`network-egress\` within \`sandbox policy\`
+
+
+## Expected Outputs
+
+- Required \`text\` \`completion-summary\`: A concise summary of the completed work and remaining risks.
+- Required \`commit\` \`git-commit\`: At least one new commit attributable to this attempt.
+
+
+## Verification Gates
+
+- Required \`provider-snapshot\`: Run the provider transport snapshot. Evidence is required.
+
+
+## Completion Evidence Contract
+
+- Schema: \`completion-result/v1\`
+- Required \`provider-output\` \`terminal-state\`: Harness-verified provider terminal state from the native transport.
+- Required \`verification\` \`verification\`: Harness-verified evidence for every required verification gate.
+- Required \`commit\` \`commit\`: Harness-verified commit created after the launch baseline.
+
+
+## Profile Instructions (agent profile)
+
+Follow the release checklist.
+
+
+## Resume Context (task checkpoint)
+
+- Resume count: 1
+- Captured at: 2026-07-23T20:45:00.000Z
+- Last step: 2
+
+\`\`\`json
+{
+  "next": "dispatch"
+}
+\`\`\`
+
+Continue from this checkpoint. Do not repeat work already represented in the saved state.
+
+
+## Completion (OpenClaw callback)
+
+When the work reaches a terminal state, report it to Veritas.
+
+- Endpoint: \`POST http://localhost:3001/api/agents/task_transport/complete\`
+
+\`\`\`bash
+curl -X POST http://localhost:3001/api/agents/task_transport/complete \\
+  -H "Content-Type: application/json" \\
+  -d '{"attemptId":"attempt_transport","providerRuntimeManifestDigest":"sha256:a1b31859e0674254b1a7bffadc0d28b4a56999177a209be10003054f0ebad598","success":true,"summary":"Brief description of what was done"}'
+\`\`\`
+
+For failure, send \`success: false\` and include an \`error\` message.
+
+No native structured-output support is assumed; Veritas validates and normalizes the callback."
+`;

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -141,6 +141,7 @@ type TestableClawdbotAgentService = ClawdbotAgentService & {
     prompt: string,
     attemptId: string,
     worktreePath: string | undefined,
+    taskEnvelopeDigest: string,
     providerRuntimeDigest: string
   ): string;
   handleCodexEvent(
@@ -355,6 +356,18 @@ describe('ClawdbotAgentService Codex providers', () => {
         expect.arrayContaining(['exec', '--json', '--sandbox', 'workspace-write']),
         expect.objectContaining({ cwd: tmpDir, shell: false })
       );
+      const spawnedArgs = mockSpawn.mock.calls[0]?.[1] as string[] | undefined;
+      const providerRequest = spawnedArgs?.at(-1);
+      expect(providerRequest).toContain('# Codex CLI Task Envelope');
+      expect(providerRequest).toContain(
+        'Allowed: a commit is permitted, but successful completion does not require one.'
+      );
+      expect(providerRequest).not.toContain(`/api/agents/${task.id}/complete`);
+      expect(
+        status.runLaunchManifest.instructions.find(
+          (instruction) => instruction.id === 'effective-task-request'
+        )?.origin
+      ).toBe('task-envelope:task-envelope/v1;adapter:codex-cli');
       const spawnEnvironment = mockSpawn.mock.calls[0]?.[2]?.env as
         Record<string, string> | undefined;
       expect(status.runLaunchManifest.runtime.environmentKeys).toEqual(
@@ -734,15 +747,17 @@ describe('ClawdbotAgentService Codex providers', () => {
   it('normalizes checkpoint age out of material instruction evidence', () => {
     const service = testableService(tmpDir);
     const first = service.normalizeRunLaunchTaskPrompt(
-      'Last Checkpoint: 2026-07-23T20:00:00.000Z (5 minutes ago)',
+      `Envelope sha256:${'c'.repeat(64)} Last Checkpoint: 2026-07-23T20:00:00.000Z (5 minutes ago)`,
       'attempt-a',
       tmpDir,
+      `sha256:${'c'.repeat(64)}`,
       `sha256:${'a'.repeat(64)}`
     );
     const later = service.normalizeRunLaunchTaskPrompt(
-      'Last Checkpoint: 2026-07-23T20:00:00.000Z (125 minutes ago)',
+      `Envelope sha256:${'d'.repeat(64)} Last Checkpoint: 2026-07-23T20:00:00.000Z (125 minutes ago)`,
       'attempt-b',
       tmpDir,
+      `sha256:${'d'.repeat(64)}`,
       `sha256:${'b'.repeat(64)}`
     );
 

--- a/server/src/__tests__/provider-task-envelope-renderer.test.ts
+++ b/server/src/__tests__/provider-task-envelope-renderer.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import type { Task, TaskCommitPolicy } from '@veritas-kanban/shared';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+import {
+  TaskEnvelopeService,
+  type CompletionEvidenceSource,
+} from '../services/task-envelope-service.js';
+import {
+  renderCodexCliTaskEnvelope,
+  renderCodexSdkTaskEnvelope,
+  renderHermesTaskEnvelope,
+  renderOpenClawTaskEnvelope,
+} from '../services/provider-task-envelope-renderer.js';
+
+const createdAt = '2026-07-23T21:00:00.000Z';
+const evidenceSource: CompletionEvidenceSource = {
+  captureLaunchBaseline: async (_worktreePath, capturedAt) => ({
+    capturedAt,
+    headSha: 'a'.repeat(40),
+    dirty: false,
+    files: [],
+  }),
+};
+
+function task(provider: string): Task {
+  return {
+    id: 'task_transport',
+    title: 'Ship the provider transport',
+    description: 'Translate the immutable task contract without changing completion ownership.',
+    type: 'code',
+    status: 'todo',
+    priority: 'high',
+    project: 'veritas-kanban',
+    created: createdAt,
+    updated: createdAt,
+    git: {
+      repo: 'veritas-kanban',
+      branch: `feat/${provider}-transport`,
+      baseBranch: 'main',
+      worktreePath: '/tmp/veritas-kanban-transport',
+    },
+    subtasks: [
+      {
+        id: 'transport-contract',
+        title: 'Transport contract',
+        completed: false,
+        created: createdAt,
+        acceptanceCriteria: ['The provider receives the persisted envelope.'],
+      },
+    ],
+    verificationSteps: [
+      {
+        id: 'provider-snapshot',
+        description: 'Run the provider transport snapshot.',
+        checked: false,
+      },
+    ],
+  };
+}
+
+async function envelope(
+  provider: string,
+  commitPolicy: TaskCommitPolicy,
+  profileInstructions = 'Follow the release checklist.'
+) {
+  return new TaskEnvelopeService(evidenceSource).build({
+    task: task(provider),
+    attemptId: 'attempt_transport',
+    createdAt,
+    worktreePath: '/tmp/veritas-kanban-transport',
+    providerRuntimeManifest: providerRuntimeManifestFixture({ provider }),
+    commitPolicy,
+    profileInstructions,
+    networkAccessEnabled: true,
+  });
+}
+
+describe('provider task-envelope renderers', () => {
+  it('renders an OpenClaw callback transport from a required-commit envelope', async () => {
+    const taskEnvelope = await envelope('openclaw', 'required');
+
+    const transport = renderOpenClawTaskEnvelope({
+      taskEnvelope,
+      profileInstructions: 'Follow the release checklist.',
+      checkpoint: {
+        step: 2,
+        timestamp: '2026-07-23T20:45:00.000Z',
+        resumeCount: 1,
+        state: { next: 'dispatch' },
+      },
+    });
+
+    expect(transport).toMatchObject({
+      schemaVersion: 'provider-task-envelope-transport/v1',
+      provider: 'openclaw',
+      taskEnvelopeDigest: taskEnvelope.digest,
+      callbackPosture: 'veritas-http',
+      completionNormalization: 'harness',
+    });
+    expect(Object.isFrozen(transport)).toBe(true);
+    expect(transport.content).toContain('Required: create at least one new commit');
+    expect(transport.content).toContain('## Profile Instructions (agent profile)');
+    expect(transport.content).toContain('## Resume Context (task checkpoint)');
+    expect(transport.content).toContain(
+      '- Launch HEAD: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`'
+    );
+    expect(transport.content).toContain(
+      '- Required `provider-output` `terminal-state`: Harness-verified provider terminal state from the native transport.'
+    );
+    expect(transport.content).toContain(
+      'POST http://localhost:3001/api/agents/task_transport/complete'
+    );
+    expect(transport.content).toContain(
+      `"providerRuntimeManifestDigest":"${taskEnvelope.launchManifest.digest}"`
+    );
+    expect(transport.content).toContain(
+      'No native structured-output support is assumed; Veritas validates and normalizes the callback.'
+    );
+    expect(transport.content).toMatchSnapshot();
+  });
+
+  it('renders a callback-free Codex CLI transport from a forbidden-commit envelope', async () => {
+    const taskEnvelope = await envelope('codex-cli', 'forbidden');
+
+    const transport = renderCodexCliTaskEnvelope({ taskEnvelope });
+
+    expect(transport).toMatchObject({
+      provider: 'codex-cli',
+      taskEnvelopeDigest: taskEnvelope.digest,
+      callbackPosture: 'harness-owned',
+      completionNormalization: 'harness',
+    });
+    expect(transport.content).toContain(
+      'Forbidden: do not create a commit. Leave permitted worktree changes uncommitted.'
+    );
+    expect(transport.content).toContain('## Completion (Codex CLI process)');
+    expect(transport.content).toContain(
+      'Return the final response through the process output captured by Veritas.'
+    );
+    expect(transport.content).not.toContain('/api/agents/task_transport/complete');
+    expect(transport.content).toContain(
+      'No native structured-output support is assumed; Veritas validates and normalizes process output.'
+    );
+    expect(transport.content).toMatchSnapshot();
+  });
+
+  it('renders a callback-free Codex SDK transport from an allowed-commit envelope', async () => {
+    const taskEnvelope = await envelope('codex-sdk', 'allowed');
+
+    const transport = renderCodexSdkTaskEnvelope({ taskEnvelope });
+
+    expect(transport).toMatchObject({
+      provider: 'codex-sdk',
+      callbackPosture: 'harness-owned',
+      completionNormalization: 'harness',
+    });
+    expect(transport.content).toContain(
+      'Allowed: a commit is permitted, but successful completion does not require one.'
+    );
+    expect(transport.content).toContain('## Completion (Codex SDK stream)');
+    expect(transport.content).toContain(
+      'Return the final response through the SDK event stream captured by Veritas.'
+    );
+    expect(transport.content).not.toContain('/api/agents/task_transport/complete');
+    expect(transport.content).toMatchSnapshot();
+  });
+
+  it('renders a callback-free Hermes scripted transport', async () => {
+    const taskEnvelope = await envelope('hermes-cli', 'required');
+
+    const transport = renderHermesTaskEnvelope({ taskEnvelope });
+
+    expect(transport).toMatchObject({
+      provider: 'hermes-cli',
+      callbackPosture: 'harness-owned',
+      completionNormalization: 'harness',
+    });
+    expect(transport.content).toContain('## Completion (Hermes scripted process)');
+    expect(transport.content).toContain(
+      'Return the final response through scripted stdout captured by Veritas.'
+    );
+    expect(transport.content).not.toContain('/api/agents/task_transport/complete');
+    expect(transport.content).toMatchSnapshot();
+  });
+
+  it('fails closed when the envelope identity does not match the selected transport', async () => {
+    const taskEnvelope = await envelope('openclaw', 'allowed');
+
+    expect(() => renderCodexCliTaskEnvelope({ taskEnvelope })).toThrow(
+      'Task envelope transport mismatch: expected codex-cli, received provider openclaw with adapter openclaw'
+    );
+  });
+
+  it('bounds profile instructions and checkpoint state', async () => {
+    const oversizedProfile = 'p'.repeat(20_001);
+    const taskEnvelope = await envelope('openclaw', 'allowed', oversizedProfile);
+    const transport = renderOpenClawTaskEnvelope({
+      taskEnvelope,
+      profileInstructions: oversizedProfile,
+      checkpoint: {
+        step: 3,
+        timestamp: createdAt,
+        state: { payload: 's'.repeat(20_001) },
+      },
+    });
+
+    expect(transport.content.match(/\[truncated by Veritas\]/g)).toHaveLength(2);
+    expect(transport.content).not.toContain(oversizedProfile);
+    const constraintsSection = transport.content
+      .split('## Constraints\n\n')[1]
+      ?.split('\n\n## Workspace')[0]
+      ?.trim();
+    expect(constraintsSection).toBe(
+      '- Operate only inside the assigned worktree: /tmp/veritas-kanban-transport'
+    );
+  });
+});

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -38,6 +38,14 @@ import {
   HttpOpenClawTaskAdapter,
   isOpenClawGatewayPrivateIpAllowed,
 } from './openclaw-workflow-adapter.js';
+import {
+  renderCodexCliTaskEnvelope,
+  renderCodexSdkTaskEnvelope,
+  renderHermesTaskEnvelope,
+  renderOpenClawTaskEnvelope,
+  type ProviderTaskEnvelopeRenderInput,
+  type ProviderTaskEnvelopeTransport,
+} from './provider-task-envelope-renderer.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
 import { evaluateTaskReadiness, RUN_LAUNCH_MANIFEST_SCHEMA_VERSION } from '@veritas-kanban/shared';
 import type {
@@ -119,7 +127,7 @@ const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
 export interface AgentProviderStartContext {
   task: Task;
   agentConfig?: AgentConfig;
-  prompt: string;
+  transport: ProviderTaskEnvelopeTransport;
   logPath: string;
   attemptId: string;
   startedAt: string;
@@ -142,6 +150,7 @@ export interface AgentProviderProbeContext {
 export interface AgentProviderAdapter {
   id: ExecutableAgentProvider;
   label: string;
+  renderTaskEnvelope(input: ProviderTaskEnvelopeRenderInput): ProviderTaskEnvelopeTransport;
   probe(context: AgentProviderProbeContext): Promise<ProviderRuntimeManifest>;
   start(context: AgentProviderStartContext): Promise<void> | void;
   stop(context: AgentProviderStopContext): Promise<void> | void;
@@ -491,17 +500,15 @@ export class ClawdbotAgentService {
       networkAccessEnabled: sandboxPolicy.result.effective.networkAccessEnabled,
       executionPolicy: task.executionPolicy,
     });
-    const taskPrompt = this.buildTaskPrompt(
-      task,
-      worktreePath,
-      attemptId,
-      providerRuntimeManifest.digest,
-      profileLaunch?.instructions
-    );
+    const taskTransport = adapter.renderTaskEnvelope({
+      taskEnvelope,
+      profileInstructions: profileLaunch?.instructions,
+      checkpoint: task.checkpoint,
+    });
     const manifest = await this.compileRunLaunchManifest({
       task,
       taskEnvelope,
-      taskPrompt,
+      taskTransport,
       attemptId,
       startedAt,
       logPath,
@@ -734,18 +741,15 @@ export class ClawdbotAgentService {
     validatePathSegment(taskId);
     validatePathSegment(attemptId);
 
-    // Build the task prompt for Clawdbot
-    const taskPrompt = this.buildTaskPrompt(
-      task,
-      worktreePath,
-      attemptId,
-      providerRuntimeManifest.digest,
-      profileLaunch?.instructions
-    );
+    const taskTransport = adapter.renderTaskEnvelope({
+      taskEnvelope,
+      profileInstructions: profileLaunch?.instructions,
+      checkpoint: task.checkpoint,
+    });
     const runLaunchManifest = await this.compileRunLaunchManifest({
       task,
       taskEnvelope,
-      taskPrompt,
+      taskTransport,
       attemptId,
       startedAt,
       logPath,
@@ -842,7 +846,7 @@ export class ClawdbotAgentService {
       logPath,
       task,
       agent,
-      taskPrompt,
+      taskTransport.content,
       providerRuntimeManifest,
       taskEnvelope,
       runLaunchManifest
@@ -907,7 +911,7 @@ export class ClawdbotAgentService {
       await adapter.start({
         task,
         agentConfig: launchAgentConfig,
-        prompt: taskPrompt,
+        transport: taskTransport,
         logPath,
         attemptId,
         startedAt,
@@ -1626,11 +1630,12 @@ export class ClawdbotAgentService {
       return {
         id: definition.id,
         label: definition.label,
+        renderTaskEnvelope: renderCodexCliTaskEnvelope,
         probe,
         start: ({
           task,
           agentConfig,
-          prompt,
+          transport,
           logPath,
           attemptId,
           startedAt,
@@ -1638,11 +1643,11 @@ export class ClawdbotAgentService {
           sandboxPolicy,
           runLaunchManifest,
         }) => {
-          this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
+          this.assertProviderAdapterTransport(provider, transport, runLaunchManifest);
           this.startCodexCli(
             task,
             agentConfig,
-            prompt,
+            transport.content,
             logPath,
             attemptId,
             startedAt,
@@ -1660,11 +1665,12 @@ export class ClawdbotAgentService {
       return {
         id: definition.id,
         label: definition.label,
+        renderTaskEnvelope: renderCodexSdkTaskEnvelope,
         probe,
         start: ({
           task,
           agentConfig,
-          prompt,
+          transport,
           logPath,
           attemptId,
           startedAt,
@@ -1672,14 +1678,14 @@ export class ClawdbotAgentService {
           sandboxPolicy,
           runLaunchManifest,
         }) => {
-          this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
+          this.assertProviderAdapterTransport(provider, transport, runLaunchManifest);
           const abortController = new AbortController();
           const pending = pendingAgents.get(task.id);
           if (pending) pending.abortController = abortController;
           void this.startCodexSdk(
             task,
             agentConfig,
-            prompt,
+            transport.content,
             logPath,
             attemptId,
             startedAt,
@@ -1729,11 +1735,12 @@ export class ClawdbotAgentService {
       return {
         id: definition.id,
         label: definition.label,
+        renderTaskEnvelope: renderHermesTaskEnvelope,
         probe,
         start: ({
           task,
           agentConfig,
-          prompt,
+          transport,
           logPath,
           attemptId,
           startedAt,
@@ -1741,11 +1748,11 @@ export class ClawdbotAgentService {
           sandboxPolicy,
           runLaunchManifest,
         }) => {
-          this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
+          this.assertProviderAdapterTransport(provider, transport, runLaunchManifest);
           this.startHermesCli(
             task,
             agentConfig,
-            prompt,
+            transport.content,
             logPath,
             attemptId,
             startedAt,
@@ -1775,9 +1782,10 @@ export class ClawdbotAgentService {
     return {
       id: definition.id,
       label: definition.label,
+      renderTaskEnvelope: renderOpenClawTaskEnvelope,
       probe,
-      start: async ({ prompt, task, attemptId, agentConfig, runLaunchManifest }) => {
-        this.assertProviderAdapterLaunchManifest(provider, runLaunchManifest);
+      start: async ({ transport, task, attemptId, agentConfig, runLaunchManifest }) => {
+        this.assertProviderAdapterTransport(provider, transport, runLaunchManifest);
         // Use the HTTP gateway adapter (sessions_spawn) instead of writing a request file.
         // The real spawn acknowledgement surfaces policy denial or gateway
         // unreachability, which the caller's error handler rolls back to 'todo'.
@@ -1788,7 +1796,7 @@ export class ClawdbotAgentService {
           agentId: agentConfig?.type || 'openclaw',
           agentName: agentConfig?.name,
           model: agentConfig?.model,
-          prompt,
+          prompt: transport.content,
           timeoutSeconds: 900,
         });
         await this.taskService.patchTaskAttempt(task.id, attemptId, {
@@ -1845,6 +1853,28 @@ export class ClawdbotAgentService {
           manifestDigest: manifest.digest,
           remediation:
             'Use a run-scoped tool-control adapter after the tool-server control plane is enabled.',
+        }
+      );
+    }
+  }
+
+  private assertProviderAdapterTransport(
+    provider: ExecutableAgentProvider,
+    transport: ProviderTaskEnvelopeTransport,
+    manifest: RunLaunchManifest
+  ): void {
+    this.assertProviderAdapterLaunchManifest(provider, manifest);
+    if (
+      transport.provider !== provider ||
+      transport.taskEnvelopeDigest !== manifest.taskEnvelope.digest
+    ) {
+      throw new ConflictError(
+        'Provider task-envelope transport does not match the selected launch manifest.',
+        {
+          adapterProvider: provider,
+          transportProvider: transport.provider,
+          transportTaskEnvelopeDigest: transport.taskEnvelopeDigest,
+          manifestTaskEnvelopeDigest: manifest.taskEnvelope.digest,
         }
       );
     }
@@ -3219,7 +3249,7 @@ export class ClawdbotAgentService {
   private async compileRunLaunchManifest(input: {
     task: Task;
     taskEnvelope: TaskEnvelope;
-    taskPrompt: string;
+    taskTransport: ProviderTaskEnvelopeTransport;
     attemptId: string;
     startedAt: string;
     logPath: string;
@@ -3288,14 +3318,17 @@ export class ClawdbotAgentService {
       {
         id: 'effective-task-request',
         kind: 'task' as const,
-        content: input.taskPrompt,
+        content: input.taskTransport.content,
         materialContent: this.normalizeRunLaunchTaskPrompt(
-          input.taskPrompt,
+          input.taskTransport.content,
           input.attemptId,
           worktreePath,
+          input.taskEnvelope.digest,
           input.providerRuntimeManifest.digest
         ),
-        origin: `task-envelope:${input.taskEnvelope.schemaVersion}`,
+        origin:
+          `task-envelope:${input.taskEnvelope.schemaVersion};` +
+          `adapter:${input.taskTransport.provider}`,
         precedence: 100,
       },
       ...(hasRepositoryInstructions
@@ -3447,6 +3480,12 @@ export class ClawdbotAgentService {
         scope: 'task-envelope',
         source: `task-envelope:${input.taskEnvelope.schemaVersion}`,
         precedence: 100,
+      },
+      {
+        field: 'instructions.effective-task-request',
+        scope: 'provider',
+        source: `adapter:${input.taskTransport.provider}:task-envelope-transport`,
+        precedence: 110,
       },
       ...(hasRepositoryInstructions
         ? [
@@ -4028,11 +4067,13 @@ export class ClawdbotAgentService {
     prompt: string,
     attemptId: string,
     worktreePath: string | undefined,
+    taskEnvelopeDigest: string,
     providerRuntimeDigest: string
   ): string {
     const normalizedIdentifiers = [
       [attemptId, '<attempt-id>'],
       [worktreePath, '<worktree>'],
+      [taskEnvelopeDigest, '<task-envelope-digest>'],
       [providerRuntimeDigest, '<provider-runtime-digest>'],
     ].reduce(
       (normalized, [value, replacement]) =>
@@ -4078,64 +4119,6 @@ export class ClawdbotAgentService {
       });
     }
     return parent as TaskAttempt & { runLaunchManifest: RunLaunchManifest };
-  }
-
-  private buildTaskPrompt(
-    task: Task,
-    worktreePath: string,
-    attemptId: string,
-    providerRuntimeManifestDigest: string,
-    profileInstructions?: string
-  ): string {
-    // Build checkpoint context if available
-    let checkpointSection = '';
-    if (task.checkpoint) {
-      const resumeCount = task.checkpoint.resumeCount || 0;
-      const checkpointAge = Math.floor(
-        (Date.now() - new Date(task.checkpoint.timestamp).getTime()) / 1000 / 60
-      );
-      checkpointSection = `
-## ⚠️ CHECKPOINT DETECTED — This is a RESUME (not a fresh start)
-
-**Resume Count:** ${resumeCount} time(s)
-**Last Checkpoint:** ${task.checkpoint.timestamp} (${checkpointAge} minutes ago)
-**Last Step:** ${task.checkpoint.step}
-
-### Saved State:
-\`\`\`json
-${JSON.stringify(task.checkpoint.state, null, 2)}
-\`\`\`
-
-**IMPORTANT:** Continue from where you left off. Review the saved state above to understand what was already done.
-`;
-    }
-
-    return `# Agent Task Request
-
-**Task ID:** ${task.id}
-**Attempt ID:** ${attemptId}
-**Worktree:** ${worktreePath}
-${checkpointSection}
-## Task: ${task.title}
-
-${task.description || 'No description provided.'}
-
-${profileInstructions ? `${profileInstructions}\n` : ''}
-
-## Instructions
-
-1. Work in the directory: \`${worktreePath}\`
-2. Complete the task described above
-3. Commit your changes with a descriptive message
-4. When done, call the completion endpoint:
-   \`\`\`bash
-   curl -X POST http://localhost:3001/api/agents/${task.id}/complete \\
-     -H "Content-Type: application/json" \\
-     -d '{"attemptId": "${attemptId}", "providerRuntimeManifestDigest": "${providerRuntimeManifestDigest}", "success": true, "summary": "Brief description of what was done"}'
-   \`\`\`
-
-If you encounter errors, call with \`success: false\` and include the error message.
-`;
   }
 
   private async initLogFile(

--- a/server/src/services/provider-task-envelope-renderer.ts
+++ b/server/src/services/provider-task-envelope-renderer.ts
@@ -1,0 +1,368 @@
+import type { ExecutableAgentProvider, Task, TaskEnvelope } from '@veritas-kanban/shared';
+import { compactTaskEnvelopeStrings } from './task-envelope-service.js';
+
+export type ProviderTaskEnvelopeCallbackPosture = 'veritas-http' | 'harness-owned';
+
+export const PROVIDER_TASK_ENVELOPE_TRANSPORT_SCHEMA_VERSION =
+  'provider-task-envelope-transport/v1' as const;
+
+export interface ProviderTaskEnvelopeTransport {
+  schemaVersion: typeof PROVIDER_TASK_ENVELOPE_TRANSPORT_SCHEMA_VERSION;
+  provider: ExecutableAgentProvider;
+  taskEnvelopeDigest: string;
+  callbackPosture: ProviderTaskEnvelopeCallbackPosture;
+  completionNormalization: 'harness';
+  content: string;
+}
+
+export interface ProviderTaskEnvelopeRenderInput {
+  taskEnvelope: TaskEnvelope;
+  profileInstructions?: string;
+  checkpoint?: NonNullable<Task['checkpoint']>;
+}
+
+const MAX_PROFILE_INSTRUCTIONS = 20_000;
+const MAX_CHECKPOINT_STATE = 20_000;
+const MAX_BASELINE_FILES = 200;
+
+export function renderOpenClawTaskEnvelope(
+  input: ProviderTaskEnvelopeRenderInput
+): ProviderTaskEnvelopeTransport {
+  assertEnvelopeTransport(input.taskEnvelope, 'openclaw');
+  return immutableTransport({
+    schemaVersion: PROVIDER_TASK_ENVELOPE_TRANSPORT_SCHEMA_VERSION,
+    provider: 'openclaw',
+    taskEnvelopeDigest: input.taskEnvelope.digest,
+    callbackPosture: 'veritas-http',
+    completionNormalization: 'harness',
+    content: renderEnvelopeContent('OpenClaw', input, renderOpenClawCompletion(input.taskEnvelope)),
+  });
+}
+
+export function renderCodexCliTaskEnvelope(
+  input: ProviderTaskEnvelopeRenderInput
+): ProviderTaskEnvelopeTransport {
+  assertEnvelopeTransport(input.taskEnvelope, 'codex-cli');
+  return immutableTransport({
+    schemaVersion: PROVIDER_TASK_ENVELOPE_TRANSPORT_SCHEMA_VERSION,
+    provider: 'codex-cli',
+    taskEnvelopeDigest: input.taskEnvelope.digest,
+    callbackPosture: 'harness-owned',
+    completionNormalization: 'harness',
+    content: renderEnvelopeContent(
+      'Codex CLI',
+      input,
+      renderHarnessOwnedCompletion(
+        'Codex CLI process',
+        'Return the final response through the process output captured by Veritas.',
+        'process output'
+      )
+    ),
+  });
+}
+
+export function renderCodexSdkTaskEnvelope(
+  input: ProviderTaskEnvelopeRenderInput
+): ProviderTaskEnvelopeTransport {
+  assertEnvelopeTransport(input.taskEnvelope, 'codex-sdk');
+  return immutableTransport({
+    schemaVersion: PROVIDER_TASK_ENVELOPE_TRANSPORT_SCHEMA_VERSION,
+    provider: 'codex-sdk',
+    taskEnvelopeDigest: input.taskEnvelope.digest,
+    callbackPosture: 'harness-owned',
+    completionNormalization: 'harness',
+    content: renderEnvelopeContent(
+      'Codex SDK',
+      input,
+      renderHarnessOwnedCompletion(
+        'Codex SDK stream',
+        'Return the final response through the SDK event stream captured by Veritas.',
+        'SDK stream events'
+      )
+    ),
+  });
+}
+
+export function renderHermesTaskEnvelope(
+  input: ProviderTaskEnvelopeRenderInput
+): ProviderTaskEnvelopeTransport {
+  assertEnvelopeTransport(input.taskEnvelope, 'hermes-cli');
+  return immutableTransport({
+    schemaVersion: PROVIDER_TASK_ENVELOPE_TRANSPORT_SCHEMA_VERSION,
+    provider: 'hermes-cli',
+    taskEnvelopeDigest: input.taskEnvelope.digest,
+    callbackPosture: 'harness-owned',
+    completionNormalization: 'harness',
+    content: renderEnvelopeContent(
+      'Hermes',
+      input,
+      renderHarnessOwnedCompletion(
+        'Hermes scripted process',
+        'Return the final response through scripted stdout captured by Veritas.',
+        'scripted process output'
+      )
+    ),
+  });
+}
+
+function immutableTransport(
+  transport: ProviderTaskEnvelopeTransport
+): ProviderTaskEnvelopeTransport {
+  return Object.freeze(transport);
+}
+
+function assertEnvelopeTransport(
+  taskEnvelope: TaskEnvelope,
+  provider: ExecutableAgentProvider
+): void {
+  if (
+    taskEnvelope.launchManifest.provider !== provider ||
+    taskEnvelope.launchManifest.adapter !== provider
+  ) {
+    throw new Error(
+      `Task envelope transport mismatch: expected ${provider}, received provider ` +
+        `${taskEnvelope.launchManifest.provider} with adapter ${taskEnvelope.launchManifest.adapter}`
+    );
+  }
+}
+
+function renderEnvelopeContent(
+  transportName: string,
+  input: ProviderTaskEnvelopeRenderInput,
+  completionSection: string
+): string {
+  const { taskEnvelope } = input;
+  const sourceProfileInstructions = input.profileInstructions?.trim();
+  const profileInstructions = boundedText(sourceProfileInstructions, MAX_PROFILE_INSTRUCTIONS);
+  const profileConstraintChunks = compactTaskEnvelopeStrings([sourceProfileInstructions]);
+  const hasAttributedProfilePrefix = profileConstraintChunks.every(
+    (chunk, index) => taskEnvelope.subject.constraints[index] === chunk
+  );
+  const constraints =
+    profileConstraintChunks.length > 0 && hasAttributedProfilePrefix
+      ? taskEnvelope.subject.constraints.slice(profileConstraintChunks.length)
+      : taskEnvelope.subject.constraints;
+
+  return `# ${transportName} Task Envelope
+
+## Transport
+
+- Envelope: \`${taskEnvelope.schemaVersion}\`
+- Digest: \`${taskEnvelope.digest}\`
+- Provider: \`${taskEnvelope.launchManifest.provider}\`
+- Adapter: \`${taskEnvelope.launchManifest.adapter}\`
+- Runtime manifest: \`${taskEnvelope.launchManifest.digest}\`
+- Protocol: \`${taskEnvelope.launchManifest.protocolVersion}\`
+- Task: \`${taskEnvelope.subject.id}\`
+- Attempt: \`${taskEnvelope.attempt.id}\`
+
+## Objective
+
+${taskEnvelope.subject.objective}
+
+${renderListSection('Background', taskEnvelope.subject.background)}
+${renderListSection('Constraints', constraints)}
+${renderWorkspace(taskEnvelope)}
+## Commit Policy
+
+${renderCommitPolicy(taskEnvelope)}
+
+${renderListSection('Acceptance Criteria', taskEnvelope.subject.acceptanceCriteria)}
+${renderSideEffects(taskEnvelope)}
+${renderExpectedOutputs(taskEnvelope)}
+${renderVerificationGates(taskEnvelope)}
+${renderCompletionContract(taskEnvelope)}
+${renderProfileInstructions(profileInstructions)}
+${renderCheckpoint(input.checkpoint)}
+${completionSection}`.trimEnd();
+}
+
+function renderWorkspace(taskEnvelope: TaskEnvelope): string {
+  const { workspace } = taskEnvelope;
+  const baselineFiles = workspace.baseline.files.slice(0, MAX_BASELINE_FILES);
+  const fileLines =
+    baselineFiles.length > 0
+      ? baselineFiles.map((file) => `- \`${file.status}\` \`${file.path}\``).join('\n')
+      : '- None.';
+  const remainder = workspace.baseline.files.length - baselineFiles.length;
+  return `## Workspace
+
+- Repository: \`${workspace.repo}\`
+- Branch: \`${workspace.branch}\`
+- Base branch: \`${workspace.baseBranch}\`
+- Worktree: \`${workspace.worktreePath}\`
+- Launch HEAD: \`${workspace.baseline.headSha}\`
+- Launch state: ${workspace.baseline.dirty ? 'dirty' : 'clean'}
+
+### Launch Baseline Files
+
+${fileLines}
+${remainder > 0 ? `- ${remainder} additional baseline file(s) omitted by Veritas.` : ''}
+
+`;
+}
+
+function renderCommitPolicy(taskEnvelope: TaskEnvelope): string {
+  if (taskEnvelope.commitPolicy === 'forbidden') {
+    return 'Forbidden: do not create a commit. Leave permitted worktree changes uncommitted.';
+  }
+  if (taskEnvelope.commitPolicy === 'required') {
+    return 'Required: create at least one new commit attributable to this attempt.';
+  }
+  return 'Allowed: a commit is permitted, but successful completion does not require one.';
+}
+
+function renderListSection(title: string, values: string[]): string {
+  return `## ${title}
+
+${values.length > 0 ? values.map((value) => `- ${value}`).join('\n') : '- None.'}
+
+`;
+}
+
+function renderSideEffects(taskEnvelope: TaskEnvelope): string {
+  return `## Allowed Side Effects
+
+${
+  taskEnvelope.allowedSideEffects.length > 0
+    ? taskEnvelope.allowedSideEffects
+        .map((sideEffect) => `- \`${sideEffect.kind}\` within \`${sideEffect.scope}\``)
+        .join('\n')
+    : '- None.'
+}
+
+`;
+}
+
+function renderExpectedOutputs(taskEnvelope: TaskEnvelope): string {
+  return `## Expected Outputs
+
+${
+  taskEnvelope.expectedOutputs.length > 0
+    ? taskEnvelope.expectedOutputs
+        .map(
+          (output) =>
+            `- ${output.required ? 'Required' : 'Optional'} \`${output.kind}\` ` +
+            `\`${output.id}\`: ${output.description}`
+        )
+        .join('\n')
+    : '- None.'
+}
+
+`;
+}
+
+function renderVerificationGates(taskEnvelope: TaskEnvelope): string {
+  return `## Verification Gates
+
+${
+  taskEnvelope.verificationGates.length > 0
+    ? taskEnvelope.verificationGates
+        .map(
+          (gate) =>
+            `- ${gate.required ? 'Required' : 'Optional'} \`${gate.id}\`: ${gate.description}` +
+            `${gate.evidenceRequired ? ' Evidence is required.' : ''}`
+        )
+        .join('\n')
+    : '- None.'
+}
+
+`;
+}
+
+function renderCompletionContract(taskEnvelope: TaskEnvelope): string {
+  return `## Completion Evidence Contract
+
+- Schema: \`${taskEnvelope.completionContract.schemaVersion}\`
+${
+  taskEnvelope.completionContract.evidenceRequirements.length > 0
+    ? taskEnvelope.completionContract.evidenceRequirements
+        .map(
+          (requirement) =>
+            `- ${requirement.required ? 'Required' : 'Optional'} \`${requirement.kind}\` ` +
+            `\`${requirement.id}\`: ${requirement.description}`
+        )
+        .join('\n')
+    : '- None.'
+}
+
+`;
+}
+
+function renderProfileInstructions(profileInstructions: string | undefined): string {
+  if (!profileInstructions) return '';
+  return `## Profile Instructions (agent profile)
+
+${profileInstructions}
+
+`;
+}
+
+function renderCheckpoint(checkpoint: ProviderTaskEnvelopeRenderInput['checkpoint']): string {
+  if (!checkpoint) return '';
+  const checkpointState = boundedText(
+    JSON.stringify(checkpoint.state, null, 2),
+    MAX_CHECKPOINT_STATE
+  );
+  return `## Resume Context (task checkpoint)
+
+- Resume count: ${checkpoint.resumeCount ?? 0}
+- Captured at: ${checkpoint.timestamp}
+- Last step: ${checkpoint.step}
+
+\`\`\`json
+${checkpointState}
+\`\`\`
+
+Continue from this checkpoint. Do not repeat work already represented in the saved state.
+
+`;
+}
+
+function renderOpenClawCompletion(taskEnvelope: TaskEnvelope): string {
+  const callbackUrl = `http://localhost:3001/api/agents/${taskEnvelope.subject.id}/complete`;
+  const payload = JSON.stringify({
+    attemptId: taskEnvelope.attempt.id,
+    providerRuntimeManifestDigest: taskEnvelope.launchManifest.digest,
+    success: true,
+    summary: 'Brief description of what was done',
+  });
+  return `## Completion (OpenClaw callback)
+
+When the work reaches a terminal state, report it to Veritas.
+
+- Endpoint: \`POST ${callbackUrl}\`
+
+\`\`\`bash
+curl -X POST ${callbackUrl} \\
+  -H "Content-Type: application/json" \\
+  -d '${payload}'
+\`\`\`
+
+For failure, send \`success: false\` and include an \`error\` message.
+
+No native structured-output support is assumed; Veritas validates and normalizes the callback.
+`;
+}
+
+function renderHarnessOwnedCompletion(
+  transportName: string,
+  instruction: string,
+  evidenceSource: string
+): string {
+  return `## Completion (${transportName})
+
+${instruction}
+
+Do not call the Veritas completion callback. The harness owns terminal-state capture.
+
+No native structured-output support is assumed; Veritas validates and normalizes ${evidenceSource}.
+`;
+}
+
+function boundedText(value: string | undefined, maxLength: number): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}\n[truncated by Veritas]`;
+}

--- a/server/src/services/task-envelope-service.ts
+++ b/server/src/services/task-envelope-service.ts
@@ -137,7 +137,7 @@ export class TaskEnvelopeService {
         id: input.task.id,
         title: input.task.title,
         objective: input.task.title,
-        background: compactStrings([
+        background: compactTaskEnvelopeStrings([
           input.task.description,
           ...(input.task.observations ?? [])
             .filter(
@@ -145,11 +145,11 @@ export class TaskEnvelopeService {
             )
             .map((observation) => observation.content),
         ]).slice(0, 64),
-        constraints: compactStrings([
+        constraints: compactTaskEnvelopeStrings([
           input.profileInstructions,
           `Operate only inside the assigned worktree: ${input.worktreePath}`,
         ]).slice(0, 128),
-        acceptanceCriteria: compactStrings(
+        acceptanceCriteria: compactTaskEnvelopeStrings(
           (input.task.subtasks ?? []).flatMap((subtask) => subtask.acceptanceCriteria ?? [])
         ).slice(0, 256),
       },
@@ -455,7 +455,7 @@ function normalizeWorkspaceId(value: string): string {
   return `${normalized.slice(0, 143).trimEnd()}~${suffix}`;
 }
 
-function compactStrings(values: Array<string | undefined>): string[] {
+export function compactTaskEnvelopeStrings(values: Array<string | undefined>): string[] {
   return values.flatMap((value) => {
     const normalized = value?.trim();
     if (!normalized) return [];


### PR DESCRIPTION
## Summary

- add immutable provider-owned task-envelope transports for OpenClaw, the built-in CLI and SDK adapters, and Hermes
- bind the exact rendered request to the run launch manifest and fail closed on provider, adapter, or envelope mismatch
- make commit policy, callback ownership, bounded profile/checkpoint context, workspace baseline, verification gates, and completion evidence explicit per transport
- update provider, API, feature, README, and changelog documentation

## Verification

- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/provider-task-envelope-renderer.test.ts src/__tests__/codex-provider-service.test.ts`
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm lint:budget`
- `pnpm build`
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `node scripts/check-permission-coverage.mjs`
- `pnpm smoke:cli-mcp` (artifact checks passed; live read/write skipped because no API key was configured)

## Follow-up

- #893 owns unified completion-result normalization and evidence enforcement.

Closes #892