### PR TITLE
fix: verify macOS desktop readiness after upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Run workspace unit tests
         run: pnpm test:unit
 
+      - name: Run desktop readiness regression tests
+        run: pnpm desktop:test:readiness
+
       - name: Run dual-storage parity tests
         run: pnpm --filter @veritas-kanban/server test -- src/__tests__/storage/dual-storage-parity.test.ts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added bounded macOS desktop startup verification that retries through the
+  LaunchServices readiness window, requires the installed app and health
+  endpoint versions to agree, and reports process, port, and log diagnostics on
+  a real timeout. Updated web-to-desktop migration, routine Homebrew upgrade,
+  automation, troubleshooting, and release guidance to use the readiness gate
+  instead of an immediate health request (#927).
+
 ### Added
 
 - Added the immutable `run-launch-manifest/v1` contract, a preflight preview API

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ brew tap BradGroux/tap
 brew install --cask veritas-kanban
 ```
 
+Existing desktop users should follow the
+[routine Mac upgrade](docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md#routine-mac-desktop-upgrade)
+path so backup, heartbeat pause, app replacement, launch, and exact-version
+server readiness happen in the right order.
+
 For local source development:
 
 ```bash

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -174,6 +174,8 @@ policy is tracked in
   npm install/download shim.
 - Run `pnpm desktop:smoke:mac:local` to verify local packaging does not prune
   root dev tooling.
+- Run `pnpm desktop:test:readiness` and confirm the bounded readiness helper
+  rejects a stale version and reports a useful timeout.
 - Run `pnpm desktop:package:mac:unsigned` and inspect artifact names.
 - Run `pnpm desktop:package:linux:unsigned` on Linux or the
   `Desktop Artifacts` Linux job and inspect preview artifact names. This is not
@@ -195,6 +197,9 @@ policy is tracked in
   matches the shipped onboarding labels and Maintenance import behavior.
 - Confirm update check, download, install, failed-download, and rollback paths
   on the selected channel.
+- For a Homebrew upgrade, confirm `open -a` followed by
+  `pnpm desktop:wait:ready -- --expected-version <version>` tolerates normal
+  startup delay and proves the packaged server owns `3001`.
 - Confirm `pnpm validate:release` passes and verifies root/shared/server/web,
   CLI, MCP, and desktop package versions plus required v5 release docs.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -7,6 +7,7 @@ Common issues and solutions for Veritas Kanban. Can't find your issue? [Open a D
 ## Table of Contents
 
 - [Installation & Build](#installation--build)
+- [macOS Desktop Upgrade](#macos-desktop-upgrade)
 - [Authentication & Rate Limiting](#authentication--rate-limiting)
 - [Networking & Proxies](#networking--proxies)
 - [WebSocket Issues](#websocket-issues)
@@ -16,6 +17,55 @@ Common issues and solutions for Veritas Kanban. Can't find your issue? [Open a D
 - [Data & Storage](#data--storage)
 - [Useful Commands](#useful-commands)
 - [Dev Reliability (ports, hangs, and restarts)](#dev-reliability-ports-hangs-and-restarts)
+
+---
+
+## macOS Desktop Upgrade
+
+### Homebrew upgraded the app but port 3001 refuses connections
+
+`brew upgrade --cask` replaces the app bundle but does not launch it. After
+`open -a "Veritas Kanban"`, LaunchServices can return several seconds before
+Electron starts the bundled server. One immediate failed health request is
+therefore not a startup verdict.
+
+From a Veritas Kanban checkout, require the server to report the version in the
+installed app bundle:
+
+```bash
+EXPECTED_VERSION="$(defaults read "/Applications/Veritas Kanban.app/Contents/Info" CFBundleShortVersionString)"
+open -a "Veritas Kanban"
+pnpm desktop:wait:ready -- --expected-version "$EXPECTED_VERSION"
+```
+
+For a Homebrew-only machine, use the bounded built-in-tools block in
+[Web To Mac Desktop Migration](WEB-TO-MAC-DESKTOP-MIGRATION.md#wait-for-the-desktop-server).
+It waits up to 30 seconds and rejects a stale server with the wrong version.
+
+If the bounded wait times out:
+
+```bash
+lsof -nP -iTCP:3001 -sTCP:LISTEN
+ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)"
+pgrep -ifl 'Veritas Kanban|veritas-kanban|server/dist/index.js'
+tail -n 80 "$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/logs/server.log"
+```
+
+- No desktop process means app launch failed; open the app and inspect macOS
+  Console plus the desktop log.
+- An old source `node`, `tsx`, `vite`, or `pnpm dev` process on `3001` is a
+  competing writer. Stop it and its watchdog before relaunching the app.
+- A desktop process on another loopback port means `3001` was occupied during
+  launch. The renderer may work, but migration and upgrade verification should
+  fail until the packaged server owns `3001`.
+- If a quit is immediately followed by a reopen, wait for both port `3001` and
+  the Electron main process to exit first. LaunchServices can ignore a reopen
+  request while the prior instance is still shutting down.
+- Pause reopen heartbeats before quitting or upgrading. Resume them only after
+  exact-version readiness succeeds.
+
+The complete data-preserving procedure is in
+[Routine Mac Desktop Upgrade](V5-UPGRADE-INSTALL-ADMIN-GUIDE.md#routine-mac-desktop-upgrade).
 
 ---
 

--- a/docs/V5-GA-CHECKLIST.md
+++ b/docs/V5-GA-CHECKLIST.md
@@ -128,6 +128,7 @@ pnpm install --frozen-lockfile
 pnpm typecheck
 pnpm lint:budget
 pnpm test:unit
+pnpm desktop:test:readiness
 pnpm build
 pnpm validate:release
 pnpm smoke:cli-mcp

--- a/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V5-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -82,6 +82,71 @@ both an already-populated desktop database and a file-backed
 `tasks/`/`.veritas-kanban/` source, including one-writer cutover, backups,
 watchdogs, record counts, first-launch selection, rollback, and packaged auth.
 
+## Routine Mac Desktop Upgrade
+
+Homebrew replaces the app bundle, but it does not launch the app or wait for
+the bundled server. macOS also returns from `open -a` before that server is
+necessarily listening. Use this sequence for an existing desktop workspace:
+
+1. Create a governed backup in Settings -> Maintenance. Confirm the completed
+   report before quitting.
+2. Pause any heartbeat, LaunchAgent, or other automation that reopens Veritas
+   Kanban. Otherwise it can race the upgrade.
+3. Quit the app and confirm the preferred port no longer has a listener:
+
+   ```bash
+   osascript -e 'quit app "Veritas Kanban"' 2>/dev/null || true
+   APP_MAIN_PATTERN='^/Applications/Veritas Kanban[.]app/Contents/MacOS/veritas-kanban$'
+   DESKTOP_STOPPED=0
+
+   for ATTEMPT in {1..20}; do
+     if ! lsof -nP -iTCP:3001 -sTCP:LISTEN >/dev/null 2>&1 &&
+       ! pgrep -f "$APP_MAIN_PATTERN" >/dev/null 2>&1; then
+       DESKTOP_STOPPED=1
+       break
+     fi
+     sleep 0.5
+   done
+
+   if test "$DESKTOP_STOPPED" -ne 1; then
+     echo "Veritas Kanban did not finish quitting; inspect it before upgrading." >&2
+     lsof -nP -iTCP:3001 -sTCP:LISTEN
+     pgrep -ifl "$APP_MAIN_PATTERN" || true
+     exit 1
+   fi
+   ```
+
+4. Refresh the tap, upgrade, and read the installed bundle version:
+
+   ```bash
+   brew update
+   brew upgrade --cask bradgroux/tap/veritas-kanban
+   brew list --cask --versions veritas-kanban
+   EXPECTED_VERSION="$(defaults read "/Applications/Veritas Kanban.app/Contents/Info" CFBundleShortVersionString)"
+   printf 'Installed Veritas Kanban %s\n' "$EXPECTED_VERSION"
+   ```
+
+5. Launch and use the bounded exact-version readiness gate from
+   [Web To Mac Desktop Migration](WEB-TO-MAC-DESKTOP-MIGRATION.md#wait-for-the-desktop-server).
+   From a current checkout:
+
+   ```bash
+   open -a "Veritas Kanban"
+   pnpm desktop:wait:ready -- --expected-version "$EXPECTED_VERSION"
+   ```
+
+   Operators without a checkout should use the Homebrew-only block in that
+   linked section. Do not use an immediate `curl` or a fixed `sleep`.
+
+6. Confirm the process listening on `3001` resolves through
+   `/Applications/Veritas Kanban.app`, then verify the board and Settings ->
+   Maintenance.
+7. Resume the heartbeat only after readiness and the app/health version match.
+
+If the app already contains the migrated data, this routine upgrade does not
+require an import, restore, or first-run path change. Preserve the same desktop
+profile and select **Use Existing Data** only if setup is shown.
+
 ## v4 To v5 Upgrade
 
 For a complete operator runbook that upgrades an existing file-backed

--- a/docs/WEB-TO-MAC-DESKTOP-MIGRATION.md
+++ b/docs/WEB-TO-MAC-DESKTOP-MIGRATION.md
@@ -92,6 +92,72 @@ After cutover, the process tree should resolve through:
 
 Only one VK server should accept active writes during the cutover.
 
+## Wait For The Desktop Server
+
+`open -a` asks LaunchServices to open the app and returns before Electron and
+the bundled server are necessarily ready. An immediate failed `curl` is not
+proof that startup failed. Do not replace the readiness check with a fixed
+`sleep`; startup time varies by host.
+
+From a Veritas Kanban checkout, launch the app and wait up to 30 seconds for the
+exact installed version:
+
+```bash
+EXPECTED_VERSION="$(defaults read "/Applications/Veritas Kanban.app/Contents/Info" CFBundleShortVersionString)"
+open -a "Veritas Kanban"
+pnpm desktop:wait:ready -- --expected-version "$EXPECTED_VERSION"
+```
+
+Homebrew-only operators and agents can use the built-in macOS tools instead:
+
+```bash
+EXPECTED_VERSION="$(defaults read "/Applications/Veritas Kanban.app/Contents/Info" CFBundleShortVersionString)"
+HEALTH_URL="http://127.0.0.1:3001/api/health"
+HEALTH_JSON=""
+DESKTOP_READY=0
+DESKTOP_DEADLINE=$((SECONDS + 30))
+
+open -a "Veritas Kanban"
+
+while ((SECONDS < DESKTOP_DEADLINE)); do
+  REMAINING_SECONDS=$((DESKTOP_DEADLINE - SECONDS))
+
+  if HEALTH_JSON="$(curl -fsS --max-time "$REMAINING_SECONDS" "$HEALTH_URL" 2>/dev/null)"; then
+    HEALTH_OK="$(printf '%s' "$HEALTH_JSON" | plutil -extract ok raw -o - - 2>/dev/null || true)"
+    HEALTH_SERVICE="$(printf '%s' "$HEALTH_JSON" | plutil -extract service raw -o - - 2>/dev/null || true)"
+    HEALTH_VERSION="$(printf '%s' "$HEALTH_JSON" | plutil -extract version raw -o - - 2>/dev/null || true)"
+    PORT_PID="$(lsof -tiTCP:3001 -sTCP:LISTEN 2>/dev/null || true)"
+    PORT_COMMAND="$(ps -o command= -p "$PORT_PID" 2>/dev/null || true)"
+
+    if test "$HEALTH_OK" = "true" &&
+      test "$HEALTH_SERVICE" = "veritas-kanban" &&
+      test "$HEALTH_VERSION" = "$EXPECTED_VERSION" &&
+      printf '%s' "$PORT_COMMAND" | grep -Fq "/Applications/Veritas Kanban.app/Contents/"; then
+      printf '%s\n' "$HEALTH_JSON"
+      DESKTOP_READY=1
+      break
+    fi
+  fi
+
+  sleep 0.5
+done
+
+if test "$DESKTOP_READY" -ne 1; then
+  echo "Veritas Kanban $EXPECTED_VERSION did not become ready at $HEALTH_URL." >&2
+  lsof -nP -iTCP:3001 -sTCP:LISTEN || true
+  ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)" 2>/dev/null || true
+  tail -n 80 "$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/logs/server.log" 2>/dev/null || true
+  exit 1
+fi
+```
+
+The version and listener-owner checks prevent a stale source server or an older
+desktop process from satisfying upgrade verification. If another process owns
+`3001`, the desktop app may select another loopback port for its renderer. That
+fallback can keep the UI usable, but it is not an accepted migration cutover:
+stop the competing writer, relaunch the desktop app, and prove that the packaged
+server owns `3001`.
+
 ## Already Migrated Desktop Data
 
 Use this path when a migration tool or operator has already populated
@@ -133,6 +199,9 @@ Use this path when a migration tool or operator has already populated
    brew upgrade --cask veritas-kanban || brew install --cask veritas-kanban
    open -a "Veritas Kanban"
    ```
+
+   Then run **Wait For The Desktop Server**. Do not issue one immediate health
+   request after `open -a`.
 
 4. On first launch, choose **Use Existing Data**. The setup screen displays
    representative record counts read from the active desktop SQLite database.
@@ -399,18 +468,20 @@ Preserve:
 open -a "Veritas Kanban"
 ```
 
+Run **Wait For The Desktop Server** before treating the new database as active.
+
 Choose **Use Existing Data**, then **Secure Existing Data**. Create the admin
 password and save the recovery key. Do not choose **Board Only** or **Restore
 Backup** for the staged database.
 
 ## Verify The Cutover
 
-Confirm the packaged app owns `3001`:
+After **Wait For The Desktop Server** succeeds, confirm the packaged app owns
+`3001`:
 
 ```bash
 lsof -nP -iTCP:3001 -sTCP:LISTEN
 ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:3001 -sTCP:LISTEN)"
-curl -fsS http://127.0.0.1:3001/api/health | jq .
 ```
 
 Verify counts only after closing the app or by using the app/API. Do not use
@@ -459,14 +530,20 @@ export VK_API_KEY="paste-scoped-token-here"
 Store long-lived tokens in the operator's normal secret manager. Do not
 hard-code owner/admin keys into repo scripts.
 
-Heartbeat or service recovery should reopen the desktop app:
+Heartbeat or service recovery should reopen the desktop app and wait for the
+readiness gate:
 
 ```bash
+EXPECTED_VERSION="$(defaults read "/Applications/Veritas Kanban.app/Contents/Info" CFBundleShortVersionString)"
 open -a "Veritas Kanban"
+pnpm desktop:wait:ready -- --expected-version "$EXPECTED_VERSION"
 ```
 
-It should not restart the old source checkout unless the operator explicitly
-wants development mode.
+Use the Homebrew-only readiness block above when the automation does not have a
+Veritas Kanban checkout. Pause any heartbeat or supervisor before quitting the
+app for migration or upgrade. Resume it only after exact-version readiness
+succeeds. It should not restart the old source checkout unless the operator
+explicitly wants development mode.
 
 ## Rollback
 
@@ -498,6 +575,13 @@ path and counts are understood.
 Check who owns `3001`. If it is `node`, `tsx`, `vite`, or `pnpm dev` from the
 source checkout, the desktop app is not authoritative. Stop that process and
 its watchdog, then relaunch the app.
+
+### `open -a` returns but port 3001 refuses connections
+
+Run **Wait For The Desktop Server**. A refusal during the first few seconds is a
+normal asynchronous launch window. If the bounded wait times out, inspect the
+reported port owner and desktop server log. Do not restart the old source server
+as a workaround.
 
 ### APIs return `AUTH_REQUIRED`
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "desktop:dev:fresh": "pnpm --filter @veritas-kanban/desktop dev:fresh",
     "desktop:build": "pnpm --filter @veritas-kanban/desktop build",
     "desktop:check:electron-artifacts": "node --test scripts/check-desktop-electron-artifacts.test.mjs && node scripts/check-desktop-electron-artifacts.mjs",
+    "desktop:test:readiness": "node --test scripts/wait-for-desktop-ready.test.mjs",
+    "desktop:wait:ready": "node scripts/wait-for-desktop-ready.mjs",
     "desktop:package:mac:dir": "pnpm build && pnpm --filter @veritas-kanban/desktop package:mac:dir",
     "desktop:package:mac:unsigned": "pnpm build && pnpm --filter @veritas-kanban/desktop package:mac:unsigned",
     "desktop:package:linux:unsigned": "pnpm build && pnpm --filter @veritas-kanban/desktop package:linux:unsigned",

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -29,6 +29,8 @@ const requiredFiles = [
 const requiredScripts = [
   'audit',
   'build',
+  'desktop:test:readiness',
+  'desktop:wait:ready',
   'lint',
   'lint:budget',
   'qa:mantine',

--- a/scripts/wait-for-desktop-ready.mjs
+++ b/scripts/wait-for-desktop-ready.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { setTimeout as sleepWithTimer } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const DEFAULT_HEALTH_URL = 'http://127.0.0.1:3001/api/health';
+const DEFAULT_INTERVAL_MS = 500;
+const DEFAULT_REQUEST_TIMEOUT_MS = 2_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAC_APP_CONTENTS_PREFIX = '/Applications/Veritas Kanban.app/Contents/';
+const execFile = promisify(execFileCallback);
+
+function positiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function healthError(response, payload, expectedVersion) {
+  if (!response.ok) {
+    return new Error(`health endpoint returned HTTP ${response.status}`);
+  }
+  if (!payload || typeof payload !== 'object') {
+    return new Error('health endpoint did not return a JSON object');
+  }
+  if (payload.ok !== true || payload.service !== 'veritas-kanban') {
+    return new Error('health endpoint did not identify a ready Veritas Kanban server');
+  }
+  if (typeof payload.version !== 'string' || payload.version.length === 0) {
+    return new Error('health endpoint did not report a version');
+  }
+  if (payload.version !== expectedVersion) {
+    return new Error(`expected version ${expectedVersion} but received ${payload.version}`);
+  }
+  return null;
+}
+
+async function defaultCommandRunner(command, args) {
+  const result = await execFile(command, args, { encoding: 'utf8' });
+  return result.stdout;
+}
+
+async function commandOutput(commandRunner, command, args) {
+  try {
+    return (await commandRunner(command, args)).trim();
+  } catch {
+    return '';
+  }
+}
+
+function healthPort(healthUrl) {
+  const parsedUrl = new globalThis.URL(healthUrl);
+  return parsedUrl.port || (parsedUrl.protocol === 'https:' ? '443' : '80');
+}
+
+export async function inspectMacDesktopState(options = {}) {
+  const healthUrl = options.healthUrl ?? DEFAULT_HEALTH_URL;
+  const commandRunner = options.commandRunner ?? defaultCommandRunner;
+  const port = healthPort(healthUrl);
+  const portPidsOutput = await commandOutput(commandRunner, 'lsof', [
+    '-nP',
+    '-t',
+    `-iTCP:${port}`,
+    '-sTCP:LISTEN',
+  ]);
+  const portPids = portPidsOutput.split(/\s+/).filter(Boolean);
+  const portCommands =
+    portPids.length > 0
+      ? await commandOutput(commandRunner, 'ps', ['-o', 'command=', '-p', portPids.join(',')])
+      : '';
+  const packagedPortOwner = portCommands
+    .split('\n')
+    .some((command) => command.includes(MAC_APP_CONTENTS_PREFIX));
+
+  const desktopPidsOutput = await commandOutput(commandRunner, 'pgrep', [
+    '-f',
+    MAC_APP_CONTENTS_PREFIX,
+  ]);
+  const desktopPids = desktopPidsOutput.split(/\s+/).filter(Boolean);
+  const desktopListeners = [];
+
+  for (const pid of desktopPids) {
+    const listeners = await commandOutput(commandRunner, 'lsof', [
+      '-nP',
+      '-a',
+      '-p',
+      pid,
+      '-iTCP',
+      '-sTCP:LISTEN',
+    ]);
+    if (listeners) {
+      desktopListeners.push(listeners);
+    }
+  }
+
+  if (packagedPortOwner) {
+    return {
+      classification: 'packaged-listener',
+      desktopListeners,
+      port,
+      portCommands,
+      summary: `the packaged desktop server owns port ${port}`,
+    };
+  }
+
+  if (portPids.length > 0 && desktopListeners.length > 0) {
+    return {
+      classification: 'competing-listener-with-alternate-port',
+      desktopListeners,
+      port,
+      portCommands,
+      summary: `port ${port} has a competing owner while the desktop app listens on another port`,
+    };
+  }
+
+  if (portPids.length > 0) {
+    return {
+      classification: 'competing-listener',
+      desktopListeners,
+      port,
+      portCommands,
+      summary: `port ${port} is owned by a process outside /Applications/Veritas Kanban.app`,
+    };
+  }
+
+  if (desktopListeners.length > 0) {
+    return {
+      classification: 'alternate-port',
+      desktopListeners,
+      port,
+      portCommands,
+      summary: `the desktop app is listening, but not on required port ${port}`,
+    };
+  }
+
+  if (desktopPids.length > 0) {
+    return {
+      classification: 'desktop-not-listening',
+      desktopListeners,
+      port,
+      portCommands,
+      summary: 'the desktop app is running but has no listening server process',
+    };
+  }
+
+  return {
+    classification: 'launch-failure',
+    desktopListeners,
+    port,
+    portCommands,
+    summary: 'no packaged desktop process is running',
+  };
+}
+
+export async function verifyMacDesktopListener(options = {}) {
+  if (process.platform !== 'darwin' && !options.commandRunner) {
+    throw new Error('packaged desktop listener verification requires macOS');
+  }
+
+  const state = await inspectMacDesktopState(options);
+  if (state.classification !== 'packaged-listener') {
+    throw new Error(state.summary);
+  }
+  return state;
+}
+
+export async function waitForDesktopReady(options = {}) {
+  const healthUrl = options.healthUrl ?? DEFAULT_HEALTH_URL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const expectedVersion = options.expectedVersion;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const now = options.now ?? Date.now;
+  const readyCheck = options.readyCheck ?? (async () => undefined);
+  const sleep = options.sleep ?? ((durationMs) => sleepWithTimer(durationMs));
+
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required.');
+  }
+  if (typeof expectedVersion !== 'string' || expectedVersion.trim().length === 0) {
+    throw new Error('expectedVersion is required.');
+  }
+  positiveInteger(timeoutMs, 'timeoutMs');
+  positiveInteger(intervalMs, 'intervalMs');
+  positiveInteger(requestTimeoutMs, 'requestTimeoutMs');
+
+  const parsedUrl = new globalThis.URL(healthUrl);
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error('healthUrl must use http or https.');
+  }
+
+  const startedAt = now();
+  let attempts = 0;
+  let lastError = new Error('no health request completed');
+
+  while (now() - startedAt <= timeoutMs) {
+    attempts += 1;
+    const elapsedBeforeRequest = now() - startedAt;
+    const remainingMs = Math.max(1, timeoutMs - elapsedBeforeRequest);
+    const signal = globalThis.AbortSignal.timeout(Math.min(requestTimeoutMs, remainingMs));
+
+    try {
+      const response = await fetchImpl(healthUrl, {
+        headers: { Accept: 'application/json' },
+        signal,
+      });
+      const payload = await response.json();
+      const validationError = healthError(response, payload, expectedVersion);
+
+      if (!validationError) {
+        const readiness = await readyCheck({ healthUrl, health: payload });
+        return {
+          attempts,
+          elapsedMs: now() - startedAt,
+          health: payload,
+          healthUrl,
+          readiness,
+        };
+      }
+      lastError = validationError;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+
+    const elapsedMs = now() - startedAt;
+    if (elapsedMs >= timeoutMs) {
+      break;
+    }
+    await sleep(Math.min(intervalMs, timeoutMs - elapsedMs));
+  }
+
+  throw new Error(
+    `Veritas Kanban did not become ready within ${timeoutMs}ms at ${healthUrl}. Last error: ${lastError.message}`
+  );
+}
+
+function usage() {
+  console.log(`Usage: node scripts/wait-for-desktop-ready.mjs [options]
+
+Wait until a desktop Veritas Kanban server reports healthy.
+
+Options:
+  --url <url>                    Health URL. Defaults to ${DEFAULT_HEALTH_URL}
+  --expected-version <version>   Required. Exact version the server must report.
+  --timeout-ms <milliseconds>    Total wait time. Defaults to ${DEFAULT_TIMEOUT_MS}.
+  --interval-ms <milliseconds>   Delay between attempts. Defaults to ${DEFAULT_INTERVAL_MS}.
+  --request-timeout-ms <ms>      Timeout for one health request. Defaults to ${DEFAULT_REQUEST_TIMEOUT_MS}.
+  --help                         Show this help text.
+`);
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--') {
+      continue;
+    }
+    if (argument === '--help' || argument === '-h') {
+      usage();
+      return null;
+    }
+
+    const [flag, inlineValue] = argument.split('=', 2);
+    const nextValue = inlineValue ?? argv[index + 1];
+    if (!nextValue || nextValue.startsWith('--')) {
+      throw new Error(`${flag} requires a value.`);
+    }
+    if (inlineValue === undefined) {
+      index += 1;
+    }
+
+    if (flag === '--url') {
+      options.healthUrl = nextValue;
+    } else if (flag === '--expected-version') {
+      options.expectedVersion = nextValue;
+    } else if (flag === '--timeout-ms') {
+      options.timeoutMs = positiveInteger(nextValue, '--timeout-ms');
+    } else if (flag === '--interval-ms') {
+      options.intervalMs = positiveInteger(nextValue, '--interval-ms');
+    } else if (flag === '--request-timeout-ms') {
+      options.requestTimeoutMs = positiveInteger(nextValue, '--request-timeout-ms');
+    } else {
+      throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+
+  if (typeof options.expectedVersion !== 'string' || options.expectedVersion.length === 0) {
+    throw new Error('--expected-version is required.');
+  }
+
+  return options;
+}
+
+function printFailureGuidance(error, healthUrl, desktopState) {
+  const port = healthPort(healthUrl);
+  console.error(`Desktop readiness check failed: ${error.message}`);
+  if (desktopState) {
+    console.error(`Observed desktop state: ${desktopState.summary}.`);
+    if (desktopState.portCommands) {
+      console.error(`Port ${port} owner:\n${desktopState.portCommands}`);
+    }
+    if (desktopState.desktopListeners.length > 0) {
+      console.error(`Desktop listener details:\n${desktopState.desktopListeners.join('\n')}`);
+    }
+  }
+  console.error(`
+Inspect the launch before retrying:
+  open -a "Veritas Kanban"
+  lsof -nP -iTCP:${port} -sTCP:LISTEN
+  ps -o pid,ppid,pgid,command -p "$(lsof -tiTCP:${port} -sTCP:LISTEN)"
+  pgrep -ifl 'Veritas Kanban|veritas-kanban|server/dist/index.js'
+  tail -n 80 "$HOME/Library/Application Support/@veritas-kanban/desktop/profiles/default/workspaces/local/logs/server.log"
+
+If another process owns ${port}, stop the competing writer before migration or
+upgrade verification. The desktop app may choose another loopback port when its
+preferred port is unavailable.`);
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!options) {
+    return;
+  }
+
+  try {
+    const result = await waitForDesktopReady({
+      ...options,
+      readyCheck: ({ healthUrl }) => verifyMacDesktopListener({ healthUrl }),
+    });
+    console.log(
+      `Desktop ready: version ${result.health.version} at ${result.healthUrl} after ${result.attempts} attempt(s) (${result.elapsedMs}ms); packaged app owns the port.`
+    );
+  } catch (error) {
+    const resolvedError = error instanceof Error ? error : new Error(String(error));
+    const healthUrl = options.healthUrl ?? DEFAULT_HEALTH_URL;
+    const desktopState =
+      process.platform === 'darwin' ? await inspectMacDesktopState({ healthUrl }) : undefined;
+    printFailureGuidance(resolvedError, healthUrl, desktopState);
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/wait-for-desktop-ready.test.mjs
+++ b/scripts/wait-for-desktop-ready.test.mjs
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  inspectMacDesktopState,
+  verifyMacDesktopListener,
+  waitForDesktopReady,
+} from './wait-for-desktop-ready.mjs';
+
+function createFakeClock() {
+  let currentTime = 0;
+
+  return {
+    now: () => currentTime,
+    sleep: async (durationMs) => {
+      currentTime += durationMs;
+    },
+  };
+}
+
+function healthyResponse(version = '5.2.5') {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      ok: true,
+      service: 'veritas-kanban',
+      version,
+    }),
+  };
+}
+
+test('waits through connection failures until the desktop server is ready', async () => {
+  const clock = createFakeClock();
+  let requestCount = 0;
+  const fetchImpl = async () => {
+    requestCount += 1;
+    if (requestCount < 3) {
+      throw new TypeError('fetch failed');
+    }
+    return healthyResponse();
+  };
+
+  const result = await waitForDesktopReady({
+    expectedVersion: '5.2.5',
+    fetchImpl,
+    healthUrl: 'http://127.0.0.1:3001/api/health',
+    intervalMs: 100,
+    now: clock.now,
+    sleep: clock.sleep,
+    timeoutMs: 1_000,
+  });
+
+  assert.equal(result.attempts, 3);
+  assert.equal(result.elapsedMs, 200);
+  assert.equal(result.health.version, '5.2.5');
+});
+
+test('does not accept a stale server with the wrong version', async () => {
+  const clock = createFakeClock();
+
+  await assert.rejects(
+    waitForDesktopReady({
+      expectedVersion: '5.2.5',
+      fetchImpl: async () => healthyResponse('5.2.4'),
+      healthUrl: 'http://127.0.0.1:3001/api/health',
+      intervalMs: 100,
+      now: clock.now,
+      sleep: clock.sleep,
+      timeoutMs: 250,
+    }),
+    /expected version 5\.2\.5 but received 5\.2\.4/
+  );
+});
+
+test('does not accept a same-version server until the packaged app owns the port', async () => {
+  const clock = createFakeClock();
+  let ownerCheckCount = 0;
+
+  const result = await waitForDesktopReady({
+    expectedVersion: '5.2.5',
+    fetchImpl: async () => healthyResponse(),
+    healthUrl: 'http://127.0.0.1:3001/api/health',
+    intervalMs: 100,
+    now: clock.now,
+    readyCheck: async () => {
+      ownerCheckCount += 1;
+      if (ownerCheckCount === 1) {
+        throw new Error('port 3001 is owned by a source checkout');
+      }
+      return { classification: 'packaged-listener' };
+    },
+    sleep: clock.sleep,
+    timeoutMs: 250,
+  });
+
+  assert.equal(result.attempts, 2);
+  assert.deepEqual(result.readiness, { classification: 'packaged-listener' });
+});
+
+test('classifies a same-version writer plus desktop fallback as a competing alternate port', async () => {
+  const commandRunner = async (command, args) => {
+    if (command === 'lsof' && args.includes('-t')) {
+      return '123\n';
+    }
+    if (command === 'ps') {
+      return '/usr/local/bin/node /Users/operator/veritas-kanban/server/dist/index.js\n';
+    }
+    if (command === 'pgrep') {
+      return '456\n';
+    }
+    if (command === 'lsof' && args.includes('-p')) {
+      return 'veritas-k 456 operator TCP 127.0.0.1:43225 (LISTEN)\n';
+    }
+    throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+  };
+
+  const state = await inspectMacDesktopState({
+    commandRunner,
+    healthUrl: 'http://127.0.0.1:3001/api/health',
+  });
+
+  assert.equal(state.classification, 'competing-listener-with-alternate-port');
+  assert.match(state.summary, /competing owner while the desktop app listens on another port/);
+  await assert.rejects(
+    verifyMacDesktopListener({
+      commandRunner,
+      healthUrl: 'http://127.0.0.1:3001/api/health',
+    }),
+    /competing owner while the desktop app listens on another port/
+  );
+});
+
+test('distinguishes launch failure from an alternate desktop port', async () => {
+  const noProcessRunner = async () => {
+    throw new Error('no matching process');
+  };
+  const launchFailure = await inspectMacDesktopState({
+    commandRunner: noProcessRunner,
+    healthUrl: 'http://127.0.0.1:3001/api/health',
+  });
+  assert.equal(launchFailure.classification, 'launch-failure');
+
+  const alternatePortRunner = async (command, args) => {
+    if (command === 'pgrep') {
+      return '456\n';
+    }
+    if (command === 'lsof' && args.includes('-p')) {
+      return 'veritas-k 456 operator TCP 127.0.0.1:43225 (LISTEN)\n';
+    }
+    throw new Error('no preferred-port listener');
+  };
+  const alternatePort = await inspectMacDesktopState({
+    commandRunner: alternatePortRunner,
+    healthUrl: 'http://127.0.0.1:3001/api/health',
+  });
+  assert.equal(alternatePort.classification, 'alternate-port');
+  assert.match(alternatePort.summary, /not on required port 3001/);
+});
+
+test('requires an expected version', async () => {
+  await assert.rejects(
+    waitForDesktopReady({
+      fetchImpl: async () => healthyResponse(),
+    }),
+    /expectedVersion is required/
+  );
+});
+
+test('times out with the target URL and last connection error', async () => {
+  const clock = createFakeClock();
+
+  await assert.rejects(
+    waitForDesktopReady({
+      expectedVersion: '5.2.5',
+      fetchImpl: async () => {
+        throw new TypeError('fetch failed');
+      },
+      healthUrl: 'http://127.0.0.1:3001/api/health',
+      intervalMs: 100,
+      now: clock.now,
+      sleep: clock.sleep,
+      timeoutMs: 250,
+    }),
+    (error) => {
+      assert.match(error.message, /did not become ready within 250ms/);
+      assert.match(error.message, /http:\/\/127\.0\.0\.1:3001\/api\/health/);
+      assert.match(error.message, /fetch failed/);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- add a bounded macOS desktop readiness command that requires the expected version and verifies port ownership through `/Applications/Veritas Kanban.app`
- classify competing writers, alternate desktop ports, app-not-listening, and launch-failure states with process and log diagnostics
- replace immediate post-launch curls with exact-version readiness gates in migration, routine Homebrew upgrade, heartbeat, troubleshooting, and release guidance
- wait for both port 3001 and the Electron main process to stop before replacing or reopening the app
- add CI and release-validation coverage for the helper

Closes #927

Companion Homebrew caveat: BradGroux/homebrew-tap#35

## Root cause

`open -a` returns when LaunchServices accepts the request, before Electron and its bundled server necessarily listen. A second race exists during shutdown: port 3001 can close before the Electron main process exits, so an immediate reopen can be ignored.

## Verification

- `pnpm desktop:test:readiness` (7 tests)
- `pnpm check:pnpm-settings`
- targeted ESLint for the new helper and regression tests
- `pnpm lint` (0 errors, 595 existing warnings)
- `pnpm lint:budget` (595/600)
- `pnpm typecheck`
- `pnpm validate:release -- --version 5.2.5`
- live signed 5.2.5 launch: readiness succeeded after 3 attempts in 1.55 seconds and confirmed the packaged server owned port 3001
- documented Homebrew-only `curl`/`plutil`/`lsof` gate passed against the signed app
- independent standards and issue-spec reviews passed after same-version wrong-owner and timeout-bound findings were fixed

## Review note

The local Claude review command was unavailable because the configured Copilot account had no model quota. A repository Copilot review is requested on this PR as the external review gate.

## Risk

The no-checkout shell fallback assumes the standard Homebrew app location under `/Applications`. The Node helper reports that assumption explicitly by rejecting any listener outside the packaged app path.