### PR TITLE
feat: persist provider completion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   launched request. OpenClaw alone receives a completion callback; process and
   stream providers return terminal output through harness-owned capture, and
   mismatched provider/adapter identities fail closed (#892).
+- Added digest-bound, idempotent `completion-result/v1` persistence for process,
+  stream, callback, remote-session, and operator-interruption terminal paths.
+  Provider claims are bounded, redacted, and untrusted while harness evidence
+  attributes post-launch files, commits, artifacts, verification, and side
+  effects without crediting pre-existing off-HEAD history.
+  Commit/output/evidence violations downgrade success to recoverable
+  partial completion; exact duplicate callbacks survive retry or restart and
+  conflicting terminal owners fail closed. Provider-owned transports cannot be
+  replaced by callbacks, completion writes use compare-and-swap retries, and
+  harness-owned restart reconciliation remains inside the same result contract
+  while OpenClaw stays eligible for its callback (#893).
 
 ## [5.2.5] - 2026-07-23
 

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -173,8 +173,50 @@ completion endpoint. None of the renderers claims provider-native structured
 output; Veritas owns validation and completion normalization. The exact
 rendered request is fingerprinted as `instructions.effective-task-request` in
 the run launch manifest, and the provider and adapter must match the envelope
-before dispatch. Completion-result normalization and evidence enforcement are
-tracked separately in #893.
+before dispatch.
+
+### Authoritative Completion Results
+
+Every terminal transport is normalized into one immutable
+`completion-result/v1`: supervised process exit, SDK stream, OpenClaw callback,
+remote-session report, or operator interruption. The result persists on both
+the current attempt and attempt history with a canonical digest, a
+claim-derived idempotency key, completion timestamp, and terminal source.
+Exact duplicate callbacks are safe after persistence or restart. A callback
+with different content, attempt identity, or provider-runtime digest returns
+`409 Conflict` and cannot replace the first terminal owner.
+Callback and remote-session terminal sources are accepted only for OpenClaw.
+CLI process and SDK stream providers reject callback transport even when an
+attempt ID and manifest digest are known.
+
+Provider summaries, evidence, artifacts, and verification claims are bounded,
+redacted, and stored as unverified provider evidence. Veritas independently
+captures Git HEAD, post-launch files and commits, task verification state,
+local file artifacts, and observable side effects through the replaceable
+`CompletionEvidenceSource` port. Unchanged dirty files from the launch
+baseline are excluded. The launch baseline records commits already reachable
+from other refs, so switching or fast-forwarding to pre-existing history is
+not credited to the attempt. Required commits, forbidden commits, missing
+verification, missing required outputs, and unauthorized side effects
+downgrade a claimed success to recoverable `partial`.
+
+Completion status maps to task state as follows:
+
+- `success` marks the attempt complete and the task done.
+- `blocked` marks the attempt failed and the task blocked.
+- `failed`, `interrupted`, and `partial` mark the attempt failed and return the
+  task to in-progress recovery.
+
+The legacy bounded `{ success, summary, error }` OpenClaw callback remains
+accepted and is normalized into the same contract. New callbacks may report
+the explicit status, blockers, provider evidence, artifacts, verification
+claims, and a continuation handle. Codex CLI, Codex SDK, and Hermes still use
+their native harness-owned terminal paths rather than the callback endpoint.
+If the server restarts before a harness-owned process or stream attempt
+persists a terminal result, startup reconciliation records a digest-bound
+`interrupted` result instead of leaving a provider-specific running or failed
+record outside this contract. OpenClaw attempts remain recoverable through
+their authoritative callback path.
 
 ## Effective Run Launch Manifests
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2059,9 +2059,34 @@ OpenClaw completion callbacks must identify the exact run that produced them:
 ```
 
 `POST /api/agents/:taskId/complete` rejects OpenClaw callbacks whose attempt or
-manifest digest does not match the active run. Codex CLI, Codex SDK, and Hermes
-do not call this endpoint; Veritas captures their terminal process or stream
-output and owns completion normalization. Token reports likewise bind
+manifest digest does not match the active run. The bounded legacy body above
+remains supported. A callback can instead send an explicit `status`
+(`success`, `blocked`, `failed`, `interrupted`, or `partial`) plus bounded
+`blockers`, provider `evidence`, `artifacts`, `verification`, and
+`continuation`. The route fixes the terminal source to `callback`; clients
+cannot spoof process, stream, or operator ownership. Only OpenClaw attempts
+accept callback or remote-session completion; process and SDK providers return
+`409 Conflict` for that transport.
+
+Every terminal path persists one digest-bound `completion-result/v1` on the
+current attempt and attempt history. It includes `digest`, `idempotencyKey`,
+`completedAt`, `terminalSource`, envelope/runtime bindings, normalized status,
+bounded redacted claims, harness evidence, attributable files and artifacts,
+verification, side effects, and continuation. Exact duplicate callbacks
+return success without mutating the task again, including after restart.
+Conflicting terminal claims return `409 Conflict`.
+Startup reconciliation also persists `interrupted` completion results for
+harness-owned process or stream attempts that were still running when the
+server restarted. OpenClaw attempts remain eligible for their authoritative
+callback after restart.
+
+Codex CLI, Codex SDK, and Hermes do not call this endpoint; Veritas captures
+their terminal process or stream output and owns completion normalization.
+Claimed success becomes `partial` when required harness evidence is absent,
+commit policy is violated, a required output is missing, or an unauthorized
+side effect is observed. `success` maps the task to `done`, `blocked` maps it
+to `blocked`, and `failed`, `interrupted`, or `partial` leaves it in
+`in-progress` recovery. Token reports likewise bind
 telemetry and budget mutation to their required `attemptId`, so a late event
 from a prior attempt cannot charge or stop a replacement run.
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -118,7 +118,11 @@ import type {
   Task,
 } from '@veritas-kanban/shared';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
-import { TaskEnvelopeService } from '../services/task-envelope-service.js';
+import {
+  TaskEnvelopeService,
+  type CompletionEvidenceSource,
+} from '../services/task-envelope-service.js';
+import { ProviderCompletionService } from '../services/provider-completion-service.js';
 import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
@@ -158,21 +162,42 @@ type TestableClawdbotAgentService = ClawdbotAgentService & {
 };
 
 function testableService(tmpDir: string): TestableClawdbotAgentService {
-  const taskEnvelopes = new TaskEnvelopeService({
+  const completionEvidence = testCompletionEvidence();
+  const taskEnvelopes = new TaskEnvelopeService(completionEvidence);
+  const service = new ClawdbotAgentService(
+    undefined,
+    undefined,
+    taskEnvelopes,
+    undefined,
+    new ProviderCompletionService(completionEvidence)
+  ) as unknown as TestableClawdbotAgentService;
+  service.logsDir = tmpDir;
+  return service;
+}
+
+function testCompletionEvidence(): CompletionEvidenceSource {
+  return {
     captureLaunchBaseline: async (_worktreePath, capturedAt) => ({
       capturedAt,
       headSha: 'a'.repeat(40),
       dirty: false,
       files: [],
     }),
-  });
-  const service = new ClawdbotAgentService(
-    undefined,
-    undefined,
-    taskEnvelopes
-  ) as unknown as TestableClawdbotAgentService;
-  service.logsDir = tmpDir;
-  return service;
+    captureCompletionEvidence: async ({ taskEnvelope, capturedAt }) => ({
+      capturedAt,
+      headSha: taskEnvelope.workspace.baseline.headSha,
+      changedFiles: [],
+      commits: [],
+      artifacts: [],
+      verification: taskEnvelope.verificationGates.map((gate) => ({
+        gateId: gate.id,
+        status: 'passed' as const,
+        summary: 'Mock harness verification passed.',
+        evidenceIds: [`verification-${gate.id}`],
+      })),
+      sideEffects: [],
+    }),
+  };
 }
 
 function createFakeChild(fixture: string, exitCode = 0) {
@@ -1272,6 +1297,131 @@ describe('ClawdbotAgentService Codex providers', () => {
     expect(sdkSignal?.aborted).toBe(true);
   });
 
+  it('retains an SDK terminal result when completion persistence exhausts automatic retries', async () => {
+    let releaseEvents: (() => void) | undefined;
+    const eventGate = new Promise<void>((resolve) => {
+      releaseEvents = resolve;
+    });
+    mockSdkRunStreamed.mockResolvedValue({
+      events: {
+        async *[Symbol.asyncIterator]() {
+          await eventGate;
+          yield {
+            type: 'item.completed',
+            item: { type: 'agent_message', text: 'SDK completed before persistence failed.' },
+          };
+        },
+      },
+    });
+    mockGetConfig.mockResolvedValue({
+      agents: [
+        {
+          type: 'codex-sdk',
+          name: 'OpenAI Codex SDK',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          provider: 'codex-sdk',
+          model: 'gpt-5.5',
+        },
+      ],
+    });
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex-sdk');
+    await waitFor(() => expect(mockSdkRunStreamed).toHaveBeenCalled());
+    let failedWrites = 0;
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (update.attempt?.ended && failedWrites < 3) {
+        failedWrites += 1;
+        throw new Error('persistent completion storage failure');
+      }
+      task = { ...task, ...update } as Task;
+      return task;
+    });
+
+    releaseEvents?.();
+
+    await waitFor(() => expect(failedWrites).toBe(3));
+    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
+      attemptId: active.attemptId,
+      status: 'running',
+    });
+    await service.stopAgent(task.id, active.attemptId);
+
+    expect(task.attempt?.completionResult).toMatchObject({
+      status: 'success',
+      terminalSource: 'stream',
+      summary: 'SDK completed before persistence failed.',
+    });
+    const completionWrites = mockUpdateTask.mock.calls.filter(
+      ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+    );
+    expect(completionWrites).toHaveLength(4);
+    expect(
+      new Set(completionWrites.map(([, update]) => update.attempt?.completionResult?.digest))
+    ).toEqual(new Set([task.attempt?.completionResult?.digest]));
+  });
+
+  it('retains an SDK execution failure when its completion write exhausts retries', async () => {
+    let releaseEvents: (() => void) | undefined;
+    const eventGate = new Promise<void>((resolve) => {
+      releaseEvents = resolve;
+    });
+    mockSdkRunStreamed.mockResolvedValue({
+      events: {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              await eventGate;
+              throw new Error('SDK execution failed before completion');
+            },
+          };
+        },
+      },
+    });
+    mockGetConfig.mockResolvedValue({
+      agents: [
+        {
+          type: 'codex-sdk',
+          name: 'OpenAI Codex SDK',
+          command: 'codex',
+          args: [],
+          enabled: true,
+          provider: 'codex-sdk',
+          model: 'gpt-5.5',
+        },
+      ],
+    });
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex-sdk');
+    await waitFor(() => expect(mockSdkRunStreamed).toHaveBeenCalled());
+    let failedWrites = 0;
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (update.attempt?.ended && failedWrites < 3) {
+        failedWrites += 1;
+        throw new Error('persistent completion storage failure');
+      }
+      task = { ...task, ...update } as Task;
+      return task;
+    });
+
+    releaseEvents?.();
+
+    await waitFor(() => expect(failedWrites).toBe(3));
+    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
+      attemptId: active.attemptId,
+      status: 'running',
+    });
+    await service.stopAgent(task.id, active.attemptId);
+
+    expect(task.attempt?.completionResult).toMatchObject({
+      status: 'failed',
+      terminalSource: 'stream',
+      error: 'SDK execution failed before completion',
+    });
+    expect(task.attempt?.completionResult?.terminalSource).not.toBe('operator-interruption');
+  });
+
   it('does not let a stopped SDK rejection remove its replacement run', async () => {
     let releaseFirst: (() => void) | undefined;
     let releaseSecond: (() => void) | undefined;
@@ -1376,13 +1526,14 @@ describe('ClawdbotAgentService Codex providers', () => {
     await service.stopAgent(task.id, first.attemptId);
   });
 
-  it('coalesces concurrent completion claims for the same active attempt', async () => {
+  it('persists one process completion and rejects a conflicting terminal race', async () => {
     const child = createControllableChild();
     mockSpawn.mockReturnValue(child);
     const service = testableService(tmpDir);
     const active = await service.startAgent(task.id, 'codex');
     const provenance = {
       attemptId: active.attemptId,
+      terminalSource: 'process' as const,
       providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
     };
 
@@ -1391,18 +1542,26 @@ describe('ClawdbotAgentService Codex providers', () => {
       { success: true, summary: 'natural completion won' },
       provenance
     );
-    const competingStopCompletion = service.completeAgent(
-      task.id,
-      { success: false, error: 'competing stop completion' },
-      provenance
-    );
-
-    await Promise.all([naturalCompletion, competingStopCompletion]);
+    await expect(
+      service.completeAgent(
+        task.id,
+        { success: false, error: 'competing stop completion' },
+        provenance
+      )
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await naturalCompletion;
 
     expect(task.attempt).toMatchObject({
       id: active.attemptId,
       status: 'complete',
+      completionResult: {
+        status: 'success',
+        terminalSource: 'process',
+        summary: 'natural completion won',
+      },
     });
+    expect(task.attempt?.completionResult?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(task.attempt?.completionResult?.idempotencyKey).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(
       mockUpdateTask.mock.calls.filter(
         ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
@@ -1414,7 +1573,228 @@ describe('ClawdbotAgentService Codex providers', () => {
     expect(mockLogActivity.mock.calls.filter(([type]) => type === 'agent_completed')).toHaveLength(
       1
     );
+    await expect(
+      service.completeAgent(
+        task.id,
+        { success: true, summary: 'natural completion won' },
+        provenance
+      )
+    ).resolves.toBeUndefined();
     await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('does not let a competing terminal claim poison an in-flight finalizer', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    const provenance = {
+      attemptId: active.attemptId,
+      terminalSource: 'process' as const,
+      providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
+    };
+
+    const interruption = service.stopAgent(task.id, active.attemptId);
+    const competitor = service.completeAgent(
+      task.id,
+      { success: true, summary: 'late process result' },
+      provenance
+    );
+
+    await interruption;
+    await expect(competitor).rejects.toMatchObject({ statusCode: 409 });
+    expect(task.attempt?.completionResult).toMatchObject({
+      status: 'interrupted',
+      terminalSource: 'operator-interruption',
+      error: 'Stopped by user',
+    });
+    expect(
+      mockUpdateTask.mock.calls.filter(
+        ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+      )
+    ).toHaveLength(1);
+  });
+
+  it('rejects callback transport for a provider with harness-owned process completion', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+
+    await expect(
+      service.completeAgent(
+        task.id,
+        { success: true, summary: 'spoofed callback' },
+        {
+          attemptId: active.attemptId,
+          terminalSource: 'callback',
+          providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
+        }
+      )
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    await service.stopAgent(task.id, active.attemptId);
+  });
+
+  it('persists an idempotent OpenClaw callback after server restart', async () => {
+    const completionEvidence = testCompletionEvidence();
+    const taskEnvelopes = new TaskEnvelopeService(completionEvidence);
+    const providerRuntimeManifest = providerRuntimeManifestFixture({
+      provider: 'openclaw',
+      adapter: 'openclaw',
+    });
+    const attemptId = 'attempt_restarted_openclaw';
+    const taskEnvelope = await taskEnvelopes.build({
+      task: { ...task, verificationSteps: [] },
+      attemptId,
+      createdAt: '2026-07-23T17:00:00.000Z',
+      worktreePath: tmpDir,
+      providerRuntimeManifest,
+      commitPolicy: 'allowed',
+    });
+    task = {
+      ...task,
+      status: 'in-progress',
+      revision: undefined,
+      verificationSteps: [],
+      attempt: {
+        id: attemptId,
+        agent: 'veritas',
+        status: 'running',
+        started: '2026-07-23T17:00:00.000Z',
+        provider: 'openclaw',
+        providerRuntimeManifest,
+        taskEnvelope,
+      },
+    };
+    task.attempts = [task.attempt];
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (update.expectedRevision !== (task.revision ?? 1)) {
+        throw Object.assign(new Error('stale revision'), { statusCode: 409 });
+      }
+      task = {
+        ...task,
+        ...update,
+        revision: (task.revision ?? 1) + 1,
+      } as Task;
+      return task;
+    });
+    const service = new ClawdbotAgentService(
+      undefined,
+      undefined,
+      taskEnvelopes,
+      undefined,
+      new ProviderCompletionService(completionEvidence)
+    );
+    const provenance = {
+      attemptId,
+      providerRuntimeManifestDigest: providerRuntimeManifest.digest,
+    };
+    const terminalResult = { success: true, summary: 'Recovered completion callback.' };
+
+    await Promise.all([
+      service.completeAgent(task.id, terminalResult, provenance),
+      service.completeAgent(task.id, terminalResult, provenance),
+    ]);
+
+    expect(task.status).toBe('done');
+    expect(task.attempt).toMatchObject({
+      id: attemptId,
+      status: 'complete',
+      completionResult: {
+        status: 'success',
+        terminalSource: 'callback',
+        summary: 'Recovered completion callback.',
+      },
+    });
+    expect(
+      mockUpdateTask.mock.calls.filter(([, update]) => update.attempt?.id === attemptId)
+    ).toHaveLength(2);
+    expect(task.revision).toBe(2);
+    expect(task.attempts).toHaveLength(1);
+    await expect(
+      service.completeAgent(task.id, terminalResult, provenance)
+    ).resolves.toBeUndefined();
+
+    const persistedAttempt = task.attempt;
+    const persistedCompletion = persistedAttempt?.completionResult;
+    if (!persistedAttempt || !persistedCompletion) {
+      throw new Error('Expected a persisted completion result');
+    }
+    task = {
+      ...task,
+      attempt: {
+        ...persistedAttempt,
+        completionResult: {
+          ...persistedCompletion,
+          summary: 'tampered persisted completion',
+        },
+      },
+    };
+    await expect(service.completeAgent(task.id, terminalResult, provenance)).rejects.toThrow(
+      /integrity|digest/i
+    );
+
+    const mismatchedRuntime = providerRuntimeManifestFixture({
+      provider: 'openclaw',
+      adapter: 'openclaw',
+      providerVersion: 'openclaw changed-after-restart',
+    });
+    const currentAttempt = task.attempt;
+    if (!currentAttempt) throw new Error('Expected the restarted attempt');
+    task = {
+      ...task,
+      status: 'in-progress',
+      attempt: {
+        ...currentAttempt,
+        status: 'running',
+        completionResult: undefined,
+        providerRuntimeManifest: mismatchedRuntime,
+      },
+    };
+    await expect(
+      service.completeAgent(task.id, terminalResult, {
+        attemptId,
+        providerRuntimeManifestDigest: mismatchedRuntime.digest,
+      })
+    ).rejects.toThrow(/bindings do not agree/);
+
+    const mislabeledAttemptId = 'attempt_mislabeled_provider';
+    const codexRuntime = providerRuntimeManifestFixture({
+      provider: 'codex-cli',
+      adapter: 'codex-cli',
+    });
+    const codexEnvelope = await taskEnvelopes.build({
+      task: { ...task, verificationSteps: [] },
+      attemptId: mislabeledAttemptId,
+      createdAt: '2026-07-23T17:30:00.000Z',
+      worktreePath: tmpDir,
+      providerRuntimeManifest: codexRuntime,
+      commitPolicy: 'allowed',
+    });
+    task = {
+      ...task,
+      attempt: {
+        id: mislabeledAttemptId,
+        agent: 'veritas',
+        status: 'running',
+        started: '2026-07-23T17:30:00.000Z',
+        provider: 'openclaw',
+        providerRuntimeManifest: codexRuntime,
+        taskEnvelope: codexEnvelope,
+      },
+    };
+    await expect(
+      service.completeAgent(task.id, terminalResult, {
+        attemptId: mislabeledAttemptId,
+        providerRuntimeManifestDigest: codexRuntime.digest,
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      details: {
+        mismatches: expect.arrayContaining(['attempt runtime provider']),
+      },
+    });
   });
 
   it('coalesces concurrent stops with the provider close terminalizer', async () => {
@@ -1443,6 +1823,11 @@ describe('ClawdbotAgentService Codex providers', () => {
         ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
       )
     ).toHaveLength(1);
+    expect(task.attempt?.completionResult).toMatchObject({
+      status: 'interrupted',
+      terminalSource: 'operator-interruption',
+      error: 'Stopped by user',
+    });
     expect(
       mockTelemetryEmit.mock.calls.filter(([event]) => event.type === 'run.completed')
     ).toHaveLength(1);
@@ -1451,20 +1836,12 @@ describe('ClawdbotAgentService Codex providers', () => {
     await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
   });
 
-  it('retries only the authoritative commit after a persistence failure', async () => {
+  it('automatically retries only the authoritative commit after a persistence failure', async () => {
     const child = createControllableChild();
     mockSpawn.mockReturnValue(child);
     const service = testableService(tmpDir);
     const active = await service.startAgent(task.id, 'codex');
     mockUpdateTask.mockRejectedValueOnce(new Error('persistence unavailable'));
-
-    await expect(service.stopAgent(task.id, active.attemptId)).rejects.toThrow(
-      'persistence unavailable'
-    );
-    await expect(service.getAgentStatus(task.id)).resolves.toMatchObject({
-      attemptId: active.attemptId,
-      status: 'running',
-    });
 
     await service.stopAgent(task.id, active.attemptId);
 
@@ -1479,7 +1856,247 @@ describe('ClawdbotAgentService Codex providers', () => {
         ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
       )
     ).toHaveLength(2);
+    const completionDigests = mockUpdateTask.mock.calls
+      .filter(([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended)
+      .map(([, update]) => update.attempt?.completionResult?.digest);
+    expect(new Set(completionDigests)).toEqual(new Set([task.attempt?.completionResult?.digest]));
     await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('runs local finalization effects when task persistence writes and then reports an error', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    let simulatedPostWriteError = false;
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      task = { ...task, ...update } as Task;
+      if (update.attempt?.ended && !simulatedPostWriteError) {
+        simulatedPostWriteError = true;
+        throw new Error('task status telemetry failed after write');
+      }
+      return task;
+    });
+
+    await service.stopAgent(task.id, active.attemptId);
+
+    expect(
+      mockUpdateTask.mock.calls.filter(
+        ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+      )
+    ).toHaveLength(1);
+    expect(mockTelemetryEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'run.completed',
+        taskId: task.id,
+        attemptId: active.attemptId,
+      })
+    );
+    expect(mockCompleteTrace).toHaveBeenCalledWith(active.attemptId, 'failed');
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      'agent_completed',
+      task.id,
+      task.title,
+      expect.objectContaining({ attemptId: active.attemptId }),
+      'codex'
+    );
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('retries a natural process completion after a transient persistence failure', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    let failedCompletionWrite = false;
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (update.attempt?.ended && !failedCompletionWrite) {
+        failedCompletionWrite = true;
+        throw new Error('transient persistence failure');
+      }
+      task = { ...task, ...update } as Task;
+      return task;
+    });
+
+    child.emit('close', 0, null);
+
+    await waitFor(() => expect(task.status).toBe('done'));
+    expect(
+      mockUpdateTask.mock.calls.filter(
+        ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+      )
+    ).toHaveLength(2);
+    expect(task.attempt?.completionResult).toMatchObject({
+      status: 'success',
+      terminalSource: 'process',
+    });
+  });
+
+  it('uses compare-and-swap and retries against the latest active attempt revision', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    task = { ...task, revision: 7 };
+    let raced = false;
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (update.attempt?.ended) {
+        if (update.expectedRevision !== task.revision) {
+          throw Object.assign(new Error('stale revision'), { statusCode: 409 });
+        }
+        if (!raced) {
+          raced = true;
+          task = { ...task, revision: 8, priority: 'high' };
+          throw Object.assign(new Error('concurrent task mutation'), { statusCode: 409 });
+        }
+      }
+      task = {
+        ...task,
+        ...update,
+        revision: (task.revision ?? 1) + 1,
+      } as Task;
+      return task;
+    });
+
+    await service.stopAgent(task.id, active.attemptId);
+
+    const completionWrites = mockUpdateTask.mock.calls.filter(
+      ([, update]) => update.attempt?.id === active.attemptId && update.attempt?.ended
+    );
+    expect(completionWrites.map(([, update]) => update.expectedRevision)).toEqual([7, 8]);
+    expect(task.priority).toBe('high');
+    expect(task.revision).toBe(9);
+  });
+
+  it('rejects a completion retry when immutable attempt bindings change under the same ID', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    task = { ...task, revision: 7 };
+    const persistedAttempt = task.attempt;
+    if (!persistedAttempt) throw new Error('Expected an active attempt');
+    let raced = false;
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (update.attempt?.ended && !raced) {
+        raced = true;
+        task = {
+          ...task,
+          revision: 8,
+          attempt: {
+            ...persistedAttempt,
+            providerRuntimeManifest: providerRuntimeManifestFixture({
+              provider: 'codex-cli',
+              providerVersion: 'codex-cli changed-under-cas',
+            }),
+          },
+        };
+        throw Object.assign(new Error('concurrent immutable mutation'), { statusCode: 409 });
+      }
+      task = { ...task, ...update } as Task;
+      return task;
+    });
+
+    await expect(service.stopAgent(task.id, active.attemptId)).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    expect(task.attempt?.completionResult).toBeUndefined();
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it('does not finalize locally when the task is archived during the completion write', async () => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (update.attempt?.ended) return null;
+      task = { ...task, ...update } as Task;
+      return task;
+    });
+
+    await expect(service.stopAgent(task.id, active.attemptId)).rejects.toThrow(
+      /archived or deleted/
+    );
+
+    expect(task.attempt?.completionResult).toBeUndefined();
+    expect(
+      mockTelemetryEmit.mock.calls.filter(
+        ([event]) => event.type === 'run.completed' && event.attemptId === active.attemptId
+      )
+    ).toHaveLength(0);
+    expect(
+      mockLogActivity.mock.calls.filter(
+        ([type, , , metadata]) =>
+          type === 'agent_completed' && metadata.attemptId === active.attemptId
+      )
+    ).toHaveLength(0);
+    await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+  });
+
+  it.each([
+    {
+      status: 'blocked' as const,
+      taskStatus: 'blocked',
+      error: undefined,
+      blockers: [
+        {
+          code: 'operator-input',
+          summary: 'Operator input required',
+          detail: 'Choose the deployment target.',
+          retryable: true,
+        },
+      ],
+    },
+    {
+      status: 'failed' as const,
+      taskStatus: 'in-progress',
+      error: 'Provider failed.',
+      blockers: undefined,
+    },
+    {
+      status: 'interrupted' as const,
+      taskStatus: 'in-progress',
+      error: undefined,
+      blockers: undefined,
+    },
+    {
+      status: 'partial' as const,
+      taskStatus: 'in-progress',
+      error: undefined,
+      blockers: undefined,
+    },
+  ])('maps $status completion into $taskStatus recovery state', async (fixture) => {
+    const child = createControllableChild();
+    mockSpawn.mockReturnValue(child);
+    const service = testableService(tmpDir);
+    const active = await service.startAgent(task.id, 'codex');
+
+    await service.completeAgent(
+      task.id,
+      {
+        status: fixture.status,
+        summary: `Provider reported ${fixture.status}.`,
+        error: fixture.error,
+        blockers: fixture.blockers,
+      },
+      {
+        attemptId: active.attemptId,
+        terminalSource: 'process',
+        providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
+      }
+    );
+
+    expect(task.status).toBe(fixture.taskStatus);
+    expect(task.attempt).toMatchObject({
+      id: active.attemptId,
+      status: 'failed',
+      completionResult: {
+        status: fixture.status,
+        terminalSource: 'process',
+      },
+    });
   });
 
   it('does not enforce a budget evaluation that outlives its active run', async () => {
@@ -1546,13 +2163,14 @@ describe('ClawdbotAgentService Codex providers', () => {
     await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
   });
 
-  it('does not replay a committed completion when post-commit telemetry fails', async () => {
+  it('accepts an exact persisted duplicate but rejects a conflicting completion', async () => {
     const child = createControllableChild();
     mockSpawn.mockReturnValue(child);
     const service = testableService(tmpDir);
     const active = await service.startAgent(task.id, 'codex');
     const provenance = {
       attemptId: active.attemptId,
+      terminalSource: 'process' as const,
       providerRuntimeManifestDigest: active.providerRuntimeManifest.digest,
     };
     mockTelemetryEmit.mockRejectedValueOnce(new Error('telemetry unavailable'));
@@ -1567,6 +2185,13 @@ describe('ClawdbotAgentService Codex providers', () => {
 
     expect(task.attempt).toMatchObject({ id: active.attemptId, status: 'complete' });
     await expect(service.getAgentStatus(task.id)).resolves.toBeNull();
+    await expect(
+      service.completeAgent(
+        task.id,
+        { success: true, summary: 'committed before telemetry' },
+        provenance
+      )
+    ).resolves.toBeUndefined();
     await expect(
       service.completeAgent(task.id, { success: true, summary: 'must not replay' }, provenance)
     ).rejects.toMatchObject({ statusCode: 409 });

--- a/server/src/__tests__/provider-completion-service.test.ts
+++ b/server/src/__tests__/provider-completion-service.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COMPLETION_RESULT_SCHEMA_VERSION,
+  TASK_ENVELOPE_SCHEMA_VERSION,
+  type Task,
+  type TaskEnvelope,
+} from '@veritas-kanban/shared';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+import { parseCompletionResultForEnvelope } from '../schemas/task-envelope-schemas.js';
+import {
+  ProviderCompletionService,
+  type CompletionEvidenceSnapshot,
+} from '../services/provider-completion-service.js';
+import { TaskEnvelopeService } from '../services/task-envelope-service.js';
+import { verifyCompletionResultDigest } from '../utils/completion-result-digest.js';
+
+const completedAt = '2026-07-23T18:00:00.000Z';
+
+function task(commitPolicy: 'forbidden' | 'allowed' | 'required' = 'allowed'): Task {
+  return {
+    id: `task_completion_${commitPolicy}`,
+    title: 'Persist an authoritative completion',
+    description: 'Normalize provider output against harness evidence.',
+    type: 'code',
+    status: 'in-progress',
+    priority: 'high',
+    project: 'veritas-kanban',
+    created: '2026-07-23T17:00:00.000Z',
+    updated: '2026-07-23T17:00:00.000Z',
+    git: {
+      repo: 'BradGroux/veritas-kanban',
+      branch: 'feat/provider-completion',
+      baseBranch: 'main',
+      worktreePath: '/tmp/veritas-provider-completion',
+    },
+    executionPolicy: { commitPolicy },
+    verificationSteps: [
+      {
+        id: 'verify-focused',
+        description: 'Run focused completion tests',
+        checked: true,
+        checkedAt: completedAt,
+      },
+    ],
+  };
+}
+
+async function envelope(
+  commitPolicy: 'forbidden' | 'allowed' | 'required' = 'allowed'
+): Promise<TaskEnvelope> {
+  return new TaskEnvelopeService({
+    captureLaunchBaseline: async (_worktreePath, capturedAt) => ({
+      capturedAt,
+      headSha: 'a'.repeat(40),
+      dirty: false,
+      files: [],
+    }),
+    captureCompletionEvidence: async () => snapshot(),
+  }).build({
+    task: task(commitPolicy),
+    attemptId: `attempt_completion_${commitPolicy}`,
+    createdAt: '2026-07-23T17:30:00.000Z',
+    worktreePath: '/tmp/veritas-provider-completion',
+    providerRuntimeManifest: providerRuntimeManifestFixture(),
+    commitPolicy,
+  });
+}
+
+function snapshot(overrides: Partial<CompletionEvidenceSnapshot> = {}): CompletionEvidenceSnapshot {
+  return {
+    capturedAt: completedAt,
+    headSha: 'b'.repeat(40),
+    changedFiles: [
+      {
+        path: 'server/src/services/provider-completion-service.ts',
+        status: 'added',
+        previousPath: null,
+        verified: true,
+      },
+    ],
+    commits: [{ sha: 'b'.repeat(40), summary: 'feat: persist completion results' }],
+    artifacts: [],
+    verification: [
+      {
+        gateId: 'verify-focused',
+        status: 'passed',
+        summary: 'Task verification state records this gate as passed.',
+        evidenceIds: ['verification-verify-focused'],
+      },
+    ],
+    sideEffects: [
+      {
+        kind: 'filesystem-write',
+        description: 'Changed 1 file after launch.',
+        target: '/tmp/veritas-provider-completion',
+        authorized: true,
+        verified: true,
+      },
+      {
+        kind: 'git-commit',
+        description: 'Created 1 commit after launch.',
+        target: 'b'.repeat(40),
+        authorized: true,
+        verified: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function completionService(result: CompletionEvidenceSnapshot = snapshot()) {
+  return new ProviderCompletionService(
+    {
+      captureCompletionEvidence: async () => structuredClone(result),
+    },
+    () => completedAt
+  );
+}
+
+describe('ProviderCompletionService', () => {
+  it('builds a digest-bound successful result from harness evidence', async () => {
+    const taskEnvelope = await envelope('required');
+    const service = completionService();
+    const claim = {
+      terminalSource: 'process' as const,
+      status: 'success' as const,
+      summary: 'Provider completed the requested work.',
+    };
+
+    const result = await service.complete({
+      task: task('required'),
+      taskEnvelope,
+      claim,
+    });
+
+    expect(result).toMatchObject({
+      schemaVersion: COMPLETION_RESULT_SCHEMA_VERSION,
+      taskEnvelopeSchemaVersion: TASK_ENVELOPE_SCHEMA_VERSION,
+      taskEnvelopeDigest: taskEnvelope.digest,
+      taskId: taskEnvelope.subject.id,
+      attemptId: taskEnvelope.attempt.id,
+      providerRuntimeManifestDigest: taskEnvelope.launchManifest.digest,
+      status: 'success',
+      terminalSource: 'process',
+      completedAt,
+      changedFiles: [
+        expect.objectContaining({
+          path: 'server/src/services/provider-completion-service.ts',
+          verified: true,
+        }),
+      ],
+    });
+    expect(result.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(result.idempotencyKey).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(result.evidence.map((entry) => entry.kind)).toEqual(
+      expect.arrayContaining(['provider-output', 'file-change', 'commit', 'verification'])
+    );
+    expect(verifyCompletionResultDigest(result)).toBe(true);
+    expect(parseCompletionResultForEnvelope(result, taskEnvelope)).toEqual(result);
+
+    const duplicate = await service.complete({
+      task: task('required'),
+      taskEnvelope,
+      claim,
+    });
+    expect(duplicate.idempotencyKey).toBe(result.idempotencyKey);
+    expect(duplicate.digest).toBe(result.digest);
+  });
+
+  it.each([
+    ['callback', 'success', 'success'],
+    ['remote-session', 'blocked', 'blocked'],
+    ['stream', 'failed', 'failed'],
+    ['operator-interruption', 'interrupted', 'interrupted'],
+    ['process', 'partial', 'partial'],
+  ] as const)(
+    'normalizes the %s terminal path to %s',
+    async (terminalSource, status, expectedStatus) => {
+      const taskEnvelope = await envelope();
+      const result = await completionService().complete({
+        task: task(),
+        taskEnvelope,
+        claim: {
+          terminalSource,
+          status,
+          summary: `Fixture ${status}`,
+          error: status === 'failed' ? 'Fixture failure' : undefined,
+          blockers:
+            status === 'blocked'
+              ? [
+                  {
+                    code: 'waiting',
+                    summary: 'Waiting',
+                    detail: 'A dependency is unavailable.',
+                    retryable: true,
+                  },
+                ]
+              : undefined,
+        },
+      });
+
+      expect(result.status).toBe(expectedStatus);
+      expect(result.terminalSource).toBe(terminalSource);
+      expect(parseCompletionResultForEnvelope(result, taskEnvelope)).toEqual(result);
+    }
+  );
+
+  it('downgrades successful claims that violate required and forbidden commit policies', async () => {
+    const requiredEnvelope = await envelope('required');
+    const missingCommit = await completionService(
+      snapshot({
+        headSha: requiredEnvelope.workspace.baseline.headSha,
+        commits: [],
+        sideEffects: [],
+      })
+    ).complete({
+      task: task('required'),
+      taskEnvelope: requiredEnvelope,
+      claim: { terminalSource: 'process', status: 'success', summary: 'No commit created.' },
+    });
+
+    expect(missingCommit.status).toBe('partial');
+    expect(missingCommit.blockers).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'required-commit-missing' })])
+    );
+
+    const forbiddenEnvelope = await envelope('forbidden');
+    const forbiddenCommit = await completionService().complete({
+      task: task('forbidden'),
+      taskEnvelope: forbiddenEnvelope,
+      claim: { terminalSource: 'stream', status: 'success', summary: 'Commit was created.' },
+    });
+
+    expect(forbiddenCommit.status).toBe('partial');
+    expect(forbiddenCommit.sideEffects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'git-commit', authorized: false, verified: true }),
+      ])
+    );
+    expect(forbiddenCommit.blockers).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'forbidden-commit-created' })])
+    );
+  });
+
+  it('redacts and bounds provider-controlled completion fields', async () => {
+    const taskEnvelope = await envelope();
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlciJ9.signature-with-secret-material';
+    const oauthToken = `gho_${'o'.repeat(24)}`;
+    const userToken = `ghu_${'u'.repeat(24)}`;
+    const serverToken = `ghs_${'s'.repeat(24)}`;
+    const opaqueToken = 'Z'.repeat(48);
+    const result = await completionService().complete({
+      task: task(),
+      taskEnvelope,
+      claim: {
+        terminalSource: 'callback',
+        status: 'failed',
+        summary: `Bearer secret-token ${jwt} ${oauthToken} ${'x'.repeat(30_000)}`,
+        error: 'OPENAI_API_KEY=sk-secret-value',
+        blockers: [
+          {
+            code: 'credential-blocker',
+            summary: `Leaked ${userToken}`,
+            detail: `Opaque ${opaqueToken}`,
+            retryable: false,
+          },
+        ],
+        evidence: [
+          {
+            id: 'provider-claim',
+            kind: 'other',
+            summary: `Authorization: Basic dXNlcjpwYXNz ${serverToken}`,
+            reference: 'https://example.invalid/result',
+            requirementIds: [],
+          },
+        ],
+        continuation: {
+          provider: 'openclaw',
+          kind: 'session',
+          reference: `session:${opaqueToken}`,
+        },
+      },
+    });
+
+    expect(result.summary.length).toBeLessThanOrEqual(20_000);
+    expect(result.summary).not.toContain('secret-token');
+    expect(result.error).not.toContain('sk-secret-value');
+    expect(result.evidence.find((entry) => entry.id === 'provider-claim')).toMatchObject({
+      source: 'provider',
+      verified: false,
+    });
+    expect(JSON.stringify(result)).not.toMatch(
+      /secret-token|sk-secret-value|dXNlcjpwYXNz|eyJhbGci|gho_|ghu_|ghs_|ZZZZZZ/
+    );
+  });
+});

--- a/server/src/__tests__/provider-task-envelope-renderer.test.ts
+++ b/server/src/__tests__/provider-task-envelope-renderer.test.ts
@@ -20,6 +20,15 @@ const evidenceSource: CompletionEvidenceSource = {
     dirty: false,
     files: [],
   }),
+  captureCompletionEvidence: async ({ taskEnvelope, capturedAt }) => ({
+    capturedAt,
+    headSha: taskEnvelope.workspace.baseline.headSha,
+    changedFiles: [],
+    commits: [],
+    artifacts: [],
+    verification: [],
+    sideEffects: [],
+  }),
 };
 
 function task(provider: string): Task {

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -317,8 +317,53 @@ describe('agent local capability enforcement', () => {
     expect(mockCompleteAgent).toHaveBeenCalledWith(
       'task_1',
       { success: true, summary: 'Done', error: undefined },
-      { attemptId: 'attempt_1', providerRuntimeManifestDigest: digest }
+      {
+        attemptId: 'attempt_1',
+        providerRuntimeManifestDigest: digest,
+        terminalSource: 'callback',
+      }
     );
+
+    const structured = await request(app)
+      .post('/api/agents/task_1/complete')
+      .send({
+        attemptId: 'attempt_1',
+        providerRuntimeManifestDigest: digest,
+        status: 'blocked',
+        summary: 'Waiting on an operator.',
+        blockers: [
+          {
+            code: 'operator-input',
+            summary: 'Operator input required',
+            detail: 'Choose the release channel.',
+            retryable: true,
+          },
+        ],
+      });
+    expect(structured.status).toBe(200);
+    expect(mockCompleteAgent).toHaveBeenLastCalledWith(
+      'task_1',
+      expect.objectContaining({
+        status: 'blocked',
+        summary: 'Waiting on an operator.',
+        blockers: [expect.objectContaining({ code: 'operator-input' })],
+      }),
+      {
+        attemptId: 'attempt_1',
+        providerRuntimeManifestDigest: digest,
+        terminalSource: 'callback',
+      }
+    );
+
+    const oversized = await request(app)
+      .post('/api/agents/task_1/complete')
+      .send({
+        attemptId: 'attempt_1',
+        providerRuntimeManifestDigest: digest,
+        success: false,
+        error: 'x'.repeat(20_001),
+      });
+    expect(oversized.status).toBe(400);
   });
 
   it('binds token budget mutation to the resolved active attempt', async () => {

--- a/server/src/__tests__/services/clawdbot-reconcile.test.ts
+++ b/server/src/__tests__/services/clawdbot-reconcile.test.ts
@@ -5,6 +5,12 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Task, TaskAttempt } from '@veritas-kanban/shared';
+import { providerRuntimeManifestFixture } from '../fixtures/provider-runtime-manifest.js';
+import {
+  TaskEnvelopeService,
+  type CompletionEvidenceSource,
+} from '../../services/task-envelope-service.js';
+import { ProviderCompletionService } from '../../services/provider-completion-service.js';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────
 
@@ -24,11 +30,16 @@ vi.mock('@veritas-kanban/shared', async (importOriginal) => {
 });
 
 const mockListTasks = vi.fn<[], Promise<Task[]>>();
-const mockUpdateTask = vi.fn<[string, Partial<Task>], Promise<Task>>();
+const mockGetTask = vi.fn<[string], Promise<Task | null>>();
+const mockUpdateTask = vi.fn<
+  [string, Partial<Task> & { expectedRevision?: number }],
+  Promise<Task>
+>();
 
 vi.mock('../../services/task-service.js', () => ({
   TaskService: class MockTaskService {
     listTasks = mockListTasks;
+    getTask = mockGetTask;
     updateTask = mockUpdateTask;
   },
 }));
@@ -203,5 +214,172 @@ describe('ClawdbotAgentService.reconcileRunningAttempts (issue #781)', () => {
     expect(update.attempt?.agent).toBe(agent);
     expect(update.attempt?.model).toBe(model);
     expect(update.attempt?.status).toBe('failed');
+  });
+
+  it('persists an interrupted completion result for a current provider attempt after restart', async () => {
+    const completedAt = '2026-07-23T18:00:00.000Z';
+    const evidence: CompletionEvidenceSource = {
+      captureLaunchBaseline: async (_worktreePath, capturedAt) => ({
+        capturedAt,
+        headSha: 'a'.repeat(40),
+        dirty: false,
+        files: [],
+      }),
+      captureCompletionEvidence: async ({ taskEnvelope, capturedAt }) => ({
+        capturedAt,
+        headSha: taskEnvelope.workspace.baseline.headSha,
+        changedFiles: [],
+        commits: [],
+        artifacts: [],
+        verification: [],
+        sideEffects: [],
+      }),
+    };
+    const envelopes = new TaskEnvelopeService(evidence);
+    const providerRuntimeManifest = providerRuntimeManifestFixture({
+      provider: 'codex-cli',
+      adapter: 'codex-cli',
+    });
+    const runningTask = {
+      ...makeTask('task-current-running', 'running'),
+      revision: 4,
+      verificationSteps: [],
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'feat/provider-completion',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-provider-completion',
+      },
+    } as Task;
+    const runningAttempt = runningTask.attempt;
+    const worktreePath = runningTask.git?.worktreePath;
+    if (!runningAttempt || !worktreePath) throw new Error('Expected a runnable task fixture');
+    const taskEnvelope = await envelopes.build({
+      task: runningTask,
+      attemptId: runningAttempt.id,
+      createdAt: '2026-07-23T17:00:00.000Z',
+      worktreePath,
+      providerRuntimeManifest,
+      commitPolicy: 'allowed',
+    });
+    runningTask.attempt = {
+      ...runningAttempt,
+      provider: 'codex-cli',
+      providerRuntimeManifest,
+      taskEnvelope,
+    };
+    runningTask.attempts = [runningTask.attempt];
+    mockListTasks.mockResolvedValue([runningTask]);
+    let persistedTask = runningTask;
+    let raced = false;
+    mockGetTask.mockImplementation(async () => persistedTask);
+    mockUpdateTask.mockImplementation(async (_id, update) => {
+      if (!raced) {
+        raced = true;
+        persistedTask = { ...persistedTask, revision: 5, priority: 'high' };
+        throw Object.assign(new Error('concurrent task mutation'), { statusCode: 409 });
+      }
+      persistedTask = {
+        ...persistedTask,
+        ...update,
+        revision: (persistedTask.revision ?? 1) + 1,
+      } as Task;
+      return persistedTask;
+    });
+    service = new ClawdbotAgentService(
+      undefined,
+      undefined,
+      envelopes,
+      undefined,
+      new ProviderCompletionService(evidence, () => completedAt)
+    );
+
+    await service.reconcileRunningAttempts();
+
+    expect(mockUpdateTask).toHaveBeenLastCalledWith(
+      runningTask.id,
+      expect.objectContaining({
+        expectedRevision: 5,
+        status: 'in-progress',
+        attempt: expect.objectContaining({
+          id: runningTask.attempt.id,
+          status: 'failed',
+          completionResult: expect.objectContaining({
+            status: 'interrupted',
+            terminalSource: 'operator-interruption',
+            completedAt,
+            taskEnvelopeDigest: taskEnvelope.digest,
+          }),
+        }),
+      })
+    );
+    expect(mockUpdateTask.mock.calls.map(([, update]) => update.expectedRevision)).toEqual([4, 5]);
+    expect(persistedTask.priority).toBe('high');
+    const completionResult = mockUpdateTask.mock.calls[1]?.[1].attempt?.completionResult;
+    expect(completionResult?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(completionResult?.idempotencyKey).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it('defers an envelope-backed OpenClaw attempt to its authoritative callback after restart', async () => {
+    const evidence: CompletionEvidenceSource = {
+      captureLaunchBaseline: async (_worktreePath, capturedAt) => ({
+        capturedAt,
+        headSha: 'a'.repeat(40),
+        dirty: false,
+        files: [],
+      }),
+      captureCompletionEvidence: async ({ taskEnvelope, capturedAt }) => ({
+        capturedAt,
+        headSha: taskEnvelope.workspace.baseline.headSha,
+        changedFiles: [],
+        commits: [],
+        artifacts: [],
+        verification: [],
+        sideEffects: [],
+      }),
+    };
+    const envelopes = new TaskEnvelopeService(evidence);
+    const providerRuntimeManifest = providerRuntimeManifestFixture({
+      provider: 'openclaw',
+      adapter: 'openclaw',
+    });
+    const runningTask = {
+      ...makeTask('task-openclaw-callback', 'running'),
+      git: {
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'feat/provider-completion',
+        baseBranch: 'main',
+        worktreePath: '/tmp/veritas-provider-completion',
+      },
+      verificationSteps: [],
+    } as Task;
+    const runningAttempt = runningTask.attempt;
+    if (!runningAttempt) throw new Error('Expected a running attempt fixture');
+    const taskEnvelope = await envelopes.build({
+      task: runningTask,
+      attemptId: runningAttempt.id,
+      createdAt: '2026-07-23T17:00:00.000Z',
+      worktreePath: runningTask.git?.worktreePath ?? '/tmp/veritas-provider-completion',
+      providerRuntimeManifest,
+      commitPolicy: 'allowed',
+    });
+    runningTask.attempt = {
+      ...runningAttempt,
+      provider: 'openclaw',
+      providerRuntimeManifest,
+      taskEnvelope,
+    };
+    mockListTasks.mockResolvedValue([runningTask]);
+    service = new ClawdbotAgentService(
+      undefined,
+      undefined,
+      envelopes,
+      undefined,
+      new ProviderCompletionService(evidence)
+    );
+
+    await service.reconcileRunningAttempts();
+
+    expect(mockUpdateTask).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/task-envelope-service.test.ts
+++ b/server/src/__tests__/task-envelope-service.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, rename, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { simpleGit, type SimpleGit, type StatusResult } from 'simple-git';
@@ -18,6 +18,7 @@ import {
   TaskEnvelopeSchema,
   parseCompletionResultForEnvelope,
 } from '../schemas/task-envelope-schemas.js';
+import { calculateCompletionResultDigest } from '../utils/completion-result-digest.js';
 import {
   GitCompletionEvidenceSource,
   TaskEnvelopeService,
@@ -43,6 +44,15 @@ const baseline: TaskLaunchBaseline = {
 
 const evidenceSource: CompletionEvidenceSource = {
   captureLaunchBaseline: async () => structuredClone(baseline),
+  captureCompletionEvidence: async ({ taskEnvelope, capturedAt }) => ({
+    capturedAt,
+    headSha: taskEnvelope.workspace.baseline.headSha,
+    changedFiles: [],
+    commits: [],
+    artifacts: [],
+    verification: [],
+    sideEffects: [],
+  }),
 };
 
 function task(): Task {
@@ -102,8 +112,11 @@ function completionResult(
   taskEnvelope: Awaited<ReturnType<typeof envelope>>,
   status: CompletionResult['status']
 ): CompletionResult {
-  return {
+  const payload: Omit<CompletionResult, 'digest'> = {
     schemaVersion: COMPLETION_RESULT_SCHEMA_VERSION,
+    idempotencyKey: `sha256:${'d'.repeat(64)}`,
+    completedAt: createdAt,
+    terminalSource: 'process',
     taskEnvelopeSchemaVersion: TASK_ENVELOPE_SCHEMA_VERSION,
     taskEnvelopeDigest: taskEnvelope.digest,
     taskId: taskEnvelope.subject.id,
@@ -154,6 +167,10 @@ function completionResult(
         : [],
     sideEffects: [],
     continuation: null,
+  };
+  return {
+    ...payload,
+    digest: calculateCompletionResultDigest(payload),
   };
 }
 
@@ -304,24 +321,28 @@ describe('TaskEnvelopeService', () => {
 
     const missingVerification = completionResult(taskEnvelope, 'success');
     missingVerification.verification = [];
+    missingVerification.digest = calculateCompletionResultDigest(missingVerification);
     expect(() => parseCompletionResultForEnvelope(missingVerification, taskEnvelope)).toThrow(
       /Missing passed verification evidence/
     );
 
     const wrongEvidenceKind = completionResult(taskEnvelope, 'success');
     wrongEvidenceKind.evidence[0].kind = 'file-change';
+    wrongEvidenceKind.digest = calculateCompletionResultDigest(wrongEvidenceKind);
     expect(() => parseCompletionResultForEnvelope(wrongEvidenceKind, taskEnvelope)).toThrow(
       /Missing verified completion evidence/
     );
 
     const unboundVerification = completionResult(taskEnvelope, 'success');
     unboundVerification.verification[0].evidenceIds = ['missing-evidence'];
+    unboundVerification.digest = calculateCompletionResultDigest(unboundVerification);
     expect(() => parseCompletionResultForEnvelope(unboundVerification, taskEnvelope)).toThrow(
       /Missing passed verification evidence/
     );
 
     const wrongEnvelope = completionResult(taskEnvelope, 'success');
     wrongEnvelope.taskEnvelopeDigest = `sha256:${'f'.repeat(64)}`;
+    wrongEnvelope.digest = calculateCompletionResultDigest(wrongEnvelope);
     expect(() => parseCompletionResultForEnvelope(wrongEnvelope, taskEnvelope)).toThrow(
       /task envelope digest/
     );
@@ -365,6 +386,236 @@ describe('TaskEnvelopeService', () => {
           indexBlobHash: null,
           worktreeSha256: createHash('sha256').update('pre-existing\n').digest('hex'),
         },
+      ])
+    );
+  });
+
+  it('attributes only post-launch files, commits, verification, and side effects', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'veritas-completion-evidence-'));
+    const git = simpleGit(directory);
+    await git.init();
+    await git.addConfig('user.name', 'Veritas Test');
+    await git.addConfig('user.email', 'veritas@example.com');
+    await git.addConfig('commit.gpgsign', 'false');
+    await writeFile(path.join(directory, 'tracked.txt'), 'baseline\n');
+    await git.add('tracked.txt');
+    await git.commit('baseline');
+    await writeFile(path.join(directory, 'tracked.txt'), 'dirty before launch\n');
+    await writeFile(path.join(directory, 'pre-existing.txt'), 'unchanged after launch\n');
+
+    const source = new GitCompletionEvidenceSource();
+    const completionTask = {
+      ...task(),
+      git: {
+        repo: 'veritas-kanban',
+        branch: (await git.status()).current ?? 'master',
+        baseBranch: 'main',
+        worktreePath: directory,
+      },
+      verificationSteps: [
+        {
+          id: 'verify-1',
+          description: 'Run focused tests',
+          checked: true,
+          checkedAt: '2026-07-16T12:15:00.000Z',
+        },
+      ],
+    };
+    const taskEnvelope = await new TaskEnvelopeService(source).build({
+      task: completionTask,
+      attemptId: 'attempt_completion_evidence',
+      createdAt,
+      worktreePath: directory,
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'allowed',
+    });
+
+    await writeFile(path.join(directory, 'attempt.txt'), 'created after launch\n');
+    await git.add('attempt.txt');
+    await git.commit('attempt commit');
+    await writeFile(path.join(directory, 'tracked.txt'), 'changed again after launch\n');
+
+    const captured = await source.captureCompletionEvidence({
+      task: completionTask,
+      taskEnvelope,
+      capturedAt: '2026-07-16T12:30:00.000Z',
+      reportedArtifacts: [
+        {
+          id: 'attempt-artifact',
+          kind: 'file',
+          name: 'Attempt artifact',
+          reference: 'attempt.txt',
+          mediaType: 'text/plain',
+          sha256: null,
+          verified: false,
+        },
+        {
+          id: 'pre-existing-artifact',
+          kind: 'file',
+          name: 'Pre-existing artifact',
+          reference: 'pre-existing.txt',
+          mediaType: 'text/plain',
+          sha256: null,
+          verified: false,
+        },
+      ],
+    });
+
+    expect(captured.changedFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'attempt.txt', status: 'added', verified: true }),
+        expect.objectContaining({ path: 'tracked.txt', status: 'modified', verified: true }),
+      ])
+    );
+    expect(captured.changedFiles).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: 'pre-existing.txt' })])
+    );
+    expect(captured.commits).toEqual([expect.objectContaining({ summary: 'attempt commit' })]);
+    expect(captured.verification).toEqual([
+      expect.objectContaining({ gateId: 'verify-1', status: 'passed' }),
+    ]);
+    expect(captured.artifacts).toEqual([
+      expect.objectContaining({ id: 'attempt-artifact', verified: true }),
+      expect.objectContaining({ id: 'pre-existing-artifact', verified: false }),
+    ]);
+    expect(captured.sideEffects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'filesystem-write', authorized: true }),
+        expect.objectContaining({ kind: 'git-commit', authorized: true }),
+      ])
+    );
+
+    const preLaunchVerification = await source.captureCompletionEvidence({
+      task: {
+        ...completionTask,
+        verificationSteps: [
+          {
+            id: 'verify-1',
+            description: 'Run focused tests',
+            checked: true,
+            checkedAt: '2026-07-16T11:59:00.000Z',
+          },
+        ],
+      },
+      taskEnvelope,
+      capturedAt: '2026-07-16T12:31:00.000Z',
+      reportedArtifacts: [],
+    });
+    expect(preLaunchVerification.verification).toEqual([
+      expect.objectContaining({ gateId: 'verify-1', status: 'unknown', evidenceIds: [] }),
+    ]);
+  });
+
+  it('does not attribute an unchanged rename that already existed at launch', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'veritas-completion-rename-'));
+    const git = simpleGit(directory);
+    await git.init();
+    await git.addConfig('user.name', 'Veritas Test');
+    await git.addConfig('user.email', 'veritas@example.com');
+    await git.addConfig('commit.gpgsign', 'false');
+    await writeFile(path.join(directory, 'before.txt'), 'unchanged rename\n');
+    await git.add('before.txt');
+    await git.commit('baseline');
+    await rename(path.join(directory, 'before.txt'), path.join(directory, 'after.txt'));
+    await git.add(['before.txt', 'after.txt']);
+
+    const source = new GitCompletionEvidenceSource();
+    const completionTask = {
+      ...task(),
+      git: {
+        repo: 'veritas-kanban',
+        branch: (await git.status()).current ?? 'master',
+        baseBranch: 'main',
+        worktreePath: directory,
+      },
+      verificationSteps: [],
+    };
+    const taskEnvelope = await new TaskEnvelopeService(source).build({
+      task: completionTask,
+      attemptId: 'attempt_preexisting_rename',
+      createdAt,
+      worktreePath: directory,
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'allowed',
+    });
+
+    const captured = await source.captureCompletionEvidence({
+      task: completionTask,
+      taskEnvelope,
+      capturedAt: '2026-07-16T12:30:00.000Z',
+      reportedArtifacts: [
+        {
+          id: 'renamed-artifact',
+          kind: 'file',
+          name: 'Renamed artifact',
+          reference: 'after.txt',
+          mediaType: 'text/plain',
+          sha256: null,
+          verified: false,
+        },
+      ],
+    });
+
+    expect(captured.changedFiles).toEqual([]);
+    expect(captured.artifacts).toEqual([
+      expect.objectContaining({ id: 'renamed-artifact', verified: false }),
+    ]);
+  });
+
+  it('fails closed when completion fast-forwards to pre-existing history', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'veritas-completion-branch-'));
+    const git = simpleGit(directory);
+    await git.init();
+    await git.addConfig('user.name', 'Veritas Test');
+    await git.addConfig('user.email', 'veritas@example.com');
+    await git.addConfig('commit.gpgsign', 'false');
+    await writeFile(path.join(directory, 'baseline.txt'), 'baseline\n');
+    await git.add('baseline.txt');
+    await git.commit('baseline');
+    await git.raw(['branch', '-M', 'main']);
+    await git.checkoutLocalBranch('preexisting');
+    await writeFile(path.join(directory, 'preexisting.txt'), 'created before launch\n');
+    await git.add('preexisting.txt');
+    await git.raw(['commit', '--allow-empty-message', '-m', '']);
+    await git.checkout('main');
+
+    const source = new GitCompletionEvidenceSource();
+    const completionTask = {
+      ...task(),
+      git: {
+        repo: 'veritas-kanban',
+        branch: 'main',
+        baseBranch: 'main',
+        worktreePath: directory,
+      },
+      verificationSteps: [],
+    };
+    const taskEnvelope = await new TaskEnvelopeService(source).build({
+      task: completionTask,
+      attemptId: 'attempt_branch_switch',
+      createdAt,
+      worktreePath: directory,
+      providerRuntimeManifest: providerRuntimeManifestFixture(),
+      commitPolicy: 'required',
+    });
+
+    await git.reset(['--hard', 'preexisting']);
+    const captured = await source.captureCompletionEvidence({
+      task: completionTask,
+      taskEnvelope,
+      capturedAt: '2026-07-16T12:30:00.000Z',
+      reportedArtifacts: [],
+    });
+
+    expect(captured.commits).toEqual([]);
+    expect(captured.sideEffects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'git-commit',
+          authorized: false,
+          verified: true,
+          description: expect.stringContaining('not attributable'),
+        }),
       ])
     );
   });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -9,6 +9,13 @@ import type {
   TaskCommitPolicy,
   TokenTelemetryEvent,
 } from '@veritas-kanban/shared';
+import {
+  TASK_ARTIFACT_KINDS,
+  TASK_COMPLETION_STATUSES,
+  TASK_CONTINUATION_KINDS,
+  TASK_EVIDENCE_KINDS,
+  TASK_VERIFICATION_STATUSES,
+} from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js';
 import { requireLocalAgentCapability } from '../middleware/local-agent-capability.js';
@@ -33,13 +40,97 @@ const startAgentSchema = z.object({
   parentAttemptId: z.string().trim().min(1).max(120).optional(),
 });
 
-const completeAgentSchema = z.object({
+const completionProvenanceSchema = {
   attemptId: z.string().trim().min(1).max(120),
   providerRuntimeManifestDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
-  success: z.boolean(),
-  summary: z.string().optional(),
-  error: z.string().optional(),
-});
+};
+
+const completeAgentSchema = z.union([
+  z
+    .object({
+      ...completionProvenanceSchema,
+      success: z.boolean(),
+      summary: z.string().trim().min(1).max(20_000).optional(),
+      error: z.string().trim().min(1).max(20_000).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ...completionProvenanceSchema,
+      status: z.enum(TASK_COMPLETION_STATUSES),
+      summary: z.string().trim().min(1).max(20_000).optional(),
+      error: z.string().trim().min(1).max(20_000).optional(),
+      blockers: z
+        .array(
+          z
+            .object({
+              code: z.string().trim().min(1).max(160),
+              summary: z.string().trim().min(1).max(500),
+              detail: z.string().trim().min(1).max(20_000),
+              retryable: z.boolean(),
+            })
+            .strict()
+        )
+        .max(64)
+        .optional(),
+      evidence: z
+        .array(
+          z
+            .object({
+              id: z.string().trim().min(1).max(160),
+              kind: z.enum(TASK_EVIDENCE_KINDS),
+              summary: z.string().trim().min(1).max(20_000),
+              reference: z.string().trim().min(1).max(4096).nullable().optional(),
+              requirementIds: z.array(z.string().trim().min(1).max(160)).max(64).optional(),
+            })
+            .strict()
+        )
+        .max(128)
+        .optional(),
+      artifacts: z
+        .array(
+          z
+            .object({
+              id: z.string().trim().min(1).max(160),
+              kind: z.enum(TASK_ARTIFACT_KINDS),
+              name: z.string().trim().min(1).max(500),
+              reference: z.string().trim().min(1).max(4096),
+              mediaType: z.string().trim().min(1).max(200).nullable().optional(),
+              sha256: z
+                .string()
+                .regex(/^[a-f0-9]{64}$/)
+                .nullable()
+                .optional(),
+            })
+            .strict()
+        )
+        .max(64)
+        .optional(),
+      verification: z
+        .array(
+          z
+            .object({
+              gateId: z.string().trim().min(1).max(160),
+              status: z.enum(TASK_VERIFICATION_STATUSES),
+              summary: z.string().trim().min(1).max(20_000),
+              evidenceIds: z.array(z.string().trim().min(1).max(160)).max(128),
+            })
+            .strict()
+        )
+        .max(256)
+        .optional(),
+      continuation: z
+        .object({
+          provider: z.string().trim().min(1).max(160),
+          kind: z.enum(TASK_CONTINUATION_KINDS),
+          reference: z.string().trim().min(1).max(4096),
+        })
+        .strict()
+        .nullable()
+        .optional(),
+    })
+    .strict(),
+]);
 
 const sendAgentMessageSchema = z.object({
   attemptId: z.string().trim().min(1).max(120),
@@ -169,14 +260,9 @@ router.post(
 router.post(
   '/:taskId/complete',
   asyncHandler(async (req, res) => {
-    let attemptId: string;
-    let providerRuntimeManifestDigest: string;
-    let success: boolean;
-    let summary: string | undefined;
-    let error: string | undefined;
+    let parsed: z.infer<typeof completeAgentSchema>;
     try {
-      ({ attemptId, providerRuntimeManifestDigest, success, summary, error } =
-        completeAgentSchema.parse(req.body));
+      parsed = completeAgentSchema.parse(req.body);
     } catch (err) {
       if (err instanceof z.ZodError) {
         throw new ValidationError('Validation failed', err.issues);
@@ -186,12 +272,27 @@ router.post(
 
     await clawdbotAgentService.completeAgent(
       req.params.taskId as string,
+      'success' in parsed
+        ? {
+            success: parsed.success,
+            summary: parsed.summary,
+            error: parsed.error,
+          }
+        : {
+            status: parsed.status,
+            summary: parsed.summary,
+            error: parsed.error,
+            blockers: parsed.blockers,
+            evidence: parsed.evidence,
+            artifacts: parsed.artifacts,
+            verification: parsed.verification,
+            continuation: parsed.continuation,
+          },
       {
-        success,
-        summary,
-        error,
-      },
-      { attemptId, providerRuntimeManifestDigest }
+        attemptId: parsed.attemptId,
+        providerRuntimeManifestDigest: parsed.providerRuntimeManifestDigest,
+        terminalSource: 'callback',
+      }
     );
     res.json({ received: true });
   })

--- a/server/src/schemas/task-envelope-schemas.ts
+++ b/server/src/schemas/task-envelope-schemas.ts
@@ -11,11 +11,13 @@ import {
   TASK_EVIDENCE_SOURCES,
   TASK_EXPECTED_OUTPUT_KINDS,
   TASK_SIDE_EFFECT_KINDS,
+  TASK_TERMINAL_SOURCES,
   TASK_VERIFICATION_STATUSES,
   type CompletionResult,
   type TaskEnvelope,
 } from '@veritas-kanban/shared';
 import { verifyTaskEnvelopeDigest } from '../utils/task-envelope-digest.js';
+import { verifyCompletionResultDigest } from '../utils/completion-result-digest.js';
 
 const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const idSchema = z.string().trim().min(1).max(160);
@@ -101,6 +103,10 @@ export const TaskEnvelopeSchema = z
                   .strict()
               )
               .max(1000),
+            preexistingCommitShas: z
+              .array(z.string().regex(/^[a-f0-9]{40,64}$/))
+              .max(4096)
+              .optional(),
           })
           .strict(),
       })
@@ -161,6 +167,10 @@ export const TaskEnvelopeSchema = z
 export const CompletionResultSchema = z
   .object({
     schemaVersion: z.literal(COMPLETION_RESULT_SCHEMA_VERSION),
+    digest: digestSchema,
+    idempotencyKey: digestSchema,
+    completedAt: isoDateSchema,
+    terminalSource: z.enum(TASK_TERMINAL_SOURCES),
     taskEnvelopeSchemaVersion: z.literal(TASK_ENVELOPE_SCHEMA_VERSION),
     taskEnvelopeDigest: digestSchema,
     taskId: idSchema,
@@ -262,6 +272,13 @@ export const CompletionResultSchema = z
   })
   .strict()
   .superRefine((result, ctx) => {
+    if (!verifyCompletionResultDigest(result as CompletionResult)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['digest'],
+        message: 'Completion result digest does not match the canonical payload',
+      });
+    }
     if (result.status === 'success') {
       if (result.error !== null || result.blockers.length > 0) {
         ctx.addIssue({

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -76,7 +76,12 @@ import type {
   ProviderRuntimeControlSet,
   ProviderRuntimeManifest,
   TaskCommitPolicy,
+  TaskCompletionBlocker,
+  TaskCompletionStatus,
+  TaskCompletionVerification,
   TaskEnvelope,
+  TaskTerminalSource,
+  CompletionResult,
   HarnessSupportStatus,
   HarnessSupportTelemetry,
   RunLaunchManifest,
@@ -110,6 +115,17 @@ import { resolveTaskCommitPolicy, TaskEnvelopeService } from './task-envelope-se
 import { evaluateHarnessSupportStatus } from './harness-support-service.js';
 import { normalizeHarnessSupportProfile } from './harness-support-profile-registry.js';
 import { RunLaunchManifestService, diffRunLaunchManifests } from './run-launch-manifest-service.js';
+import {
+  parseCompletionResultForEnvelope,
+  parseTaskEnvelope,
+} from '../schemas/task-envelope-schemas.js';
+import { parseRunLaunchManifest } from '../schemas/run-launch-manifest-schemas.js';
+import {
+  ProviderCompletionService,
+  type ProviderCompletionArtifactClaim,
+  type ProviderCompletionEvidenceClaim,
+  type ProviderTerminalClaim,
+} from './provider-completion-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -199,6 +215,7 @@ export interface AgentMessageOptions {
 export interface AgentCompletionProvenance {
   attemptId: string;
   providerRuntimeManifestDigest: string;
+  terminalSource?: TaskTerminalSource;
 }
 
 export interface AgentMessageDelivery {
@@ -248,6 +265,7 @@ interface PendingAgent {
    * provider-stop, abort-trace, or budget-enforcement side effects.
    */
   preparedFinalizationResult?: AgentTerminalResult;
+  terminalClaimIdempotencyKey?: string;
   completionTiming?: {
     endedAt: string;
     durationMs: number;
@@ -257,19 +275,47 @@ interface PendingAgent {
     status: AttemptStatus;
     taskBeforeCompletion?: Task;
     completedAttempt: TaskAttempt;
+    completionResult: CompletionResult;
   };
 }
 
 interface AgentTerminalResult {
-  success: boolean;
+  success?: boolean;
+  status?: TaskCompletionStatus;
+  terminalSource?: TaskTerminalSource;
   summary?: string;
   error?: string;
+  blockers?: TaskCompletionBlocker[];
+  evidence?: ProviderCompletionEvidenceClaim[];
+  artifacts?: ProviderCompletionArtifactClaim[];
+  verification?: TaskCompletionVerification[];
+  continuation?: CompletionResult['continuation'];
 }
 
 const pendingAgents = new Map<string, PendingAgent>();
 const startingAgents = new Set<string>();
 const finalizingAgents = new Map<PendingAgent, Promise<void>>();
 const budgetEvaluations = new Map<PendingAgent, Promise<void>>();
+const COMPLETION_PERSISTENCE_ATTEMPTS = 3;
+
+class CompletionPersistenceError extends Error {
+  constructor(readonly persistenceCause: unknown) {
+    super(
+      persistenceCause instanceof Error
+        ? persistenceCause.message
+        : 'Provider completion could not be persisted'
+    );
+    this.name = 'CompletionPersistenceError';
+  }
+}
+
+class CompletionOwnershipError extends ConflictError {}
+
+function normalizedTaskRevision(task: Pick<Task, 'revision'>): number {
+  return typeof task.revision === 'number' && Number.isInteger(task.revision) && task.revision >= 0
+    ? task.revision
+    : 1;
+}
 
 export class ClawdbotAgentService {
   private configService: ConfigService;
@@ -278,6 +324,7 @@ export class ClawdbotAgentService {
   private providerRuntimeManifests: ProviderRuntimeManifestService;
   private taskEnvelopes: TaskEnvelopeService;
   private runLaunchManifests: RunLaunchManifestService;
+  private providerCompletions: ProviderCompletionService;
   private workspaceFiles: WorkspaceFileRepository;
   private logsDir: string;
 
@@ -285,7 +332,8 @@ export class ClawdbotAgentService {
     agentHealth?: AgentHealthChecker,
     providerRuntimeManifests = new ProviderRuntimeManifestService(),
     taskEnvelopes = new TaskEnvelopeService(),
-    workspaceFiles: WorkspaceFileRepository = new LocalWorkspaceFileRepository()
+    workspaceFiles: WorkspaceFileRepository = new LocalWorkspaceFileRepository(),
+    providerCompletions = new ProviderCompletionService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -293,6 +341,7 @@ export class ClawdbotAgentService {
     this.providerRuntimeManifests = providerRuntimeManifests;
     this.taskEnvelopes = taskEnvelopes;
     this.runLaunchManifests = new RunLaunchManifestService();
+    this.providerCompletions = providerCompletions;
     this.workspaceFiles = workspaceFiles;
     this.logsDir = getLogsDir();
     this.ensureLogsDir();
@@ -307,8 +356,9 @@ export class ClawdbotAgentService {
    *
    * After an unexpected restart the in-memory `pendingAgents` map is empty,
    * but task files can still contain attempts with status `'running'`.
-   * This method scans all tasks and marks those orphaned attempts as `'failed'`
-   * so the UI and operators have a reliable, actionable state (issue #781).
+   * Current task-envelope attempts receive a digest-bound interrupted completion
+   * result. Legacy attempts without an envelope retain the older failed/todo
+   * migration behavior so the UI and operators have an actionable state.
    *
    * Safe to call multiple times; only tasks whose current attempt is `'running'`
    * and whose taskId is NOT in `pendingAgents` are touched.
@@ -325,7 +375,6 @@ export class ClawdbotAgentService {
       return;
     }
 
-    const now = new Date().toISOString();
     let reconciledCount = 0;
 
     for (const task of tasks) {
@@ -334,6 +383,39 @@ export class ClawdbotAgentService {
       if (pendingAgents.has(task.id)) continue;
 
       try {
+        if (task.attempt.taskEnvelope) {
+          this.assertPersistedAttemptCompletionBinding(task.id, task.attempt);
+          if (task.attempt.provider === 'openclaw') {
+            log.info(
+              { taskId: task.id, attemptId: task.attempt.id },
+              '[ClawdbotAgent] Deferred OpenClaw restart reconciliation to its callback terminal path'
+            );
+            continue;
+          }
+          const claim: ProviderTerminalClaim = {
+            terminalSource: 'operator-interruption',
+            status: 'interrupted',
+            summary: 'Server restarted before the provider terminal result could be persisted.',
+          };
+          await this.persistRestartedProviderCompletion(
+            task,
+            task.attempt,
+            claim,
+            this.providerCompletions.idempotencyKey({
+              taskEnvelope: task.attempt.taskEnvelope,
+              claim,
+            }),
+            { preserveNonActiveTaskStatus: true }
+          );
+          log.info(
+            { taskId: task.id, attemptId: task.attempt.id },
+            '[ClawdbotAgent] Reconciled orphaned running attempt with an interrupted completion result'
+          );
+          reconciledCount++;
+          continue;
+        }
+
+        const now = new Date().toISOString();
         const failedAttempt: TaskAttempt = {
           ...task.attempt,
           status: 'failed',
@@ -920,11 +1002,12 @@ export class ClawdbotAgentService {
         sandboxPolicy: sandboxPolicy.result,
         runLaunchManifest,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const startError = error instanceof Error ? error : new Error(String(error));
       pendingAgents.delete(taskId);
       this.recordTraceStep(attemptId, 'error', {
         eventType: 'run.start_failed',
-        error: this.redactTraceText(error.message || `Failed to start ${adapter.label}`),
+        error: this.redactTraceText(startError.message || `Failed to start ${adapter.label}`),
         provider,
         agent,
         model: agentConfig?.model,
@@ -949,11 +1032,11 @@ export class ClawdbotAgentService {
         attemptId,
         agent,
         project: task.project,
-        error: error.message || `Failed to start ${adapter.label}`,
-        stackTrace: error.stack,
+        error: startError.message || `Failed to start ${adapter.label}`,
+        stackTrace: startError.stack,
         harnessSupport: this.harnessTelemetry(harnessSupport, 'launch-failed'),
       });
-      throw new Error(`Failed to start agent via ${adapter.label}: ${error.message}`, {
+      throw new Error(`Failed to start agent via ${adapter.label}: ${startError.message}`, {
         cause: error,
       });
     }
@@ -1017,34 +1100,346 @@ export class ClawdbotAgentService {
   /**
    * Handle completion callback from Clawdbot sub-agent
    */
+  private normalizeTerminalClaim(
+    result: AgentTerminalResult,
+    terminalSource: TaskTerminalSource
+  ): ProviderTerminalClaim {
+    if (result.status) {
+      return {
+        terminalSource,
+        status: result.status,
+        summary: result.summary,
+        error: result.error,
+        blockers: result.blockers,
+        evidence: result.evidence,
+        artifacts: result.artifacts,
+        verification: result.verification,
+        continuation: result.continuation,
+      };
+    }
+    return this.providerCompletions.normalizeLegacyClaim(
+      {
+        success: result.success === true,
+        summary: result.summary,
+        error: result.error,
+      },
+      terminalSource
+    );
+  }
+
   async completeAgent(
     taskId: string,
     result: AgentTerminalResult,
     provenance: AgentCompletionProvenance
   ): Promise<void> {
     const pending = pendingAgents.get(taskId);
+    if (!pending) {
+      const task = await this.taskService.getTask(taskId);
+      const persistedAttempt = task?.attempt;
+      const terminalSource = provenance.terminalSource ?? 'callback';
+      if (
+        persistedAttempt?.id === provenance.attemptId &&
+        persistedAttempt.providerRuntimeManifest?.digest ===
+          provenance.providerRuntimeManifestDigest &&
+        persistedAttempt.taskEnvelope
+      ) {
+        this.assertPersistedAttemptCompletionBinding(taskId, persistedAttempt);
+        this.assertTerminalTransport(persistedAttempt.provider, terminalSource);
+        const claim = this.normalizeTerminalClaim(result, terminalSource);
+        const idempotencyKey = this.providerCompletions.idempotencyKey({
+          taskEnvelope: persistedAttempt.taskEnvelope,
+          claim,
+        });
+        if (persistedAttempt.completionResult) {
+          const persistedCompletion = this.parsePersistedCompletion(persistedAttempt);
+          if (persistedCompletion.idempotencyKey === idempotencyKey) return;
+          throw new ConflictError(
+            'Provider completion conflicts with the persisted terminal result',
+            {
+              attemptId: provenance.attemptId,
+              persistedIdempotencyKey: persistedCompletion.idempotencyKey,
+              completionIdempotencyKey: idempotencyKey,
+              remediation: 'Discard the conflicting callback; the attempt already has an owner.',
+            }
+          );
+        }
+        if (
+          task &&
+          persistedAttempt.provider === 'openclaw' &&
+          (terminalSource === 'callback' || terminalSource === 'remote-session') &&
+          (persistedAttempt.status === 'running' || persistedAttempt.status === 'failed')
+        ) {
+          await this.persistRestartedProviderCompletion(
+            task,
+            persistedAttempt,
+            claim,
+            idempotencyKey
+          );
+          return;
+        }
+      }
+      throw new ConflictError('Provider completion does not match the active run', {
+        activeAttemptId: task?.attempt?.id,
+        completionAttemptId: provenance.attemptId,
+        activeManifestDigest: task?.attempt?.providerRuntimeManifest?.digest,
+        completionManifestDigest: provenance.providerRuntimeManifestDigest,
+        remediation:
+          'Discard the stale callback and retry only from the provider process bound to the active attempt manifest.',
+      });
+    }
     if (
-      !pending ||
       pending.attemptId !== provenance.attemptId ||
       pending.providerRuntimeManifest.digest !== provenance.providerRuntimeManifestDigest
     ) {
       throw new ConflictError('Provider completion does not match the active run', {
-        activeAttemptId: pending?.attemptId,
+        activeAttemptId: pending.attemptId,
         completionAttemptId: provenance.attemptId,
-        activeManifestDigest: pending?.providerRuntimeManifest.digest,
+        activeManifestDigest: pending.providerRuntimeManifest.digest,
         completionManifestDigest: provenance.providerRuntimeManifestDigest,
         remediation:
           'Discard the stale callback and retry only from the provider process bound to the active attempt manifest.',
       });
     }
 
-    await this.finalizePendingAgent(taskId, pending, async () => result);
+    const terminalSource = provenance.terminalSource ?? 'callback';
+    this.assertTerminalTransport(pending.provider, terminalSource);
+    const claim = this.normalizeTerminalClaim(result, terminalSource);
+    const idempotencyKey = this.providerCompletions.idempotencyKey({
+      taskEnvelope: pending.taskEnvelope,
+      claim,
+    });
+    await this.finalizePendingAgent(
+      taskId,
+      pending,
+      async () => ({
+        ...result,
+        terminalSource,
+      }),
+      idempotencyKey
+    );
+  }
+
+  private assertTerminalTransport(
+    provider: string | undefined,
+    terminalSource: TaskTerminalSource
+  ): void {
+    if (
+      provider !== 'openclaw' &&
+      (terminalSource === 'callback' || terminalSource === 'remote-session')
+    ) {
+      throw new ConflictError(
+        'Provider completion transport is owned by the configured harness adapter',
+        {
+          provider,
+          terminalSource,
+          remediation: 'Use the harness-owned process or stream terminal path for this provider.',
+        }
+      );
+    }
+  }
+
+  private parsePersistedCompletion(attempt: TaskAttempt): CompletionResult {
+    if (!attempt.taskEnvelope || !attempt.completionResult) {
+      throw new CompletionOwnershipError(
+        'Persisted provider completion is missing its task envelope',
+        {
+          attemptId: attempt.id,
+        }
+      );
+    }
+    try {
+      return parseCompletionResultForEnvelope(attempt.completionResult, attempt.taskEnvelope);
+    } catch {
+      throw new CompletionOwnershipError(
+        'Persisted provider completion failed integrity validation',
+        {
+          attemptId: attempt.id,
+          remediation:
+            'Repair or remove the corrupted completion record before accepting another terminal claim.',
+        }
+      );
+    }
+  }
+
+  private assertCompletionRetryBinding(
+    taskId: string,
+    expectedAttempt: TaskAttempt,
+    latestAttempt: TaskAttempt
+  ): void {
+    this.assertPersistedAttemptCompletionBinding(taskId, latestAttempt);
+    const mismatches = [
+      expectedAttempt.provider !== latestAttempt.provider && 'provider',
+      expectedAttempt.providerRuntimeManifest?.digest !==
+        latestAttempt.providerRuntimeManifest?.digest && 'provider runtime manifest',
+      expectedAttempt.taskEnvelope?.digest !== latestAttempt.taskEnvelope?.digest &&
+        'task envelope',
+      expectedAttempt.runLaunchManifest?.digest !== latestAttempt.runLaunchManifest?.digest &&
+        'run launch manifest',
+    ].filter((field): field is string => typeof field === 'string');
+    if (mismatches.length > 0) {
+      throw new CompletionOwnershipError(
+        'Persisted attempt binding changed during completion retry',
+        {
+          attemptId: latestAttempt.id,
+          mismatches,
+          remediation:
+            'Discard the stale local finalizer and reconcile the currently persisted attempt.',
+        }
+      );
+    }
+  }
+
+  private assertPersistedAttemptCompletionBinding(taskId: string, attempt: TaskAttempt): void {
+    const providerRuntimeManifest = attempt.providerRuntimeManifest;
+    const taskEnvelope = attempt.taskEnvelope;
+    if (!providerRuntimeManifest || !taskEnvelope) {
+      throw new CompletionOwnershipError(
+        'Persisted attempt is missing immutable completion bindings',
+        { taskId, attemptId: attempt.id }
+      );
+    }
+    let parsedEnvelope: TaskEnvelope;
+    let parsedRunLaunchManifest: RunLaunchManifest | undefined;
+    try {
+      assertProviderRuntimeManifestSnapshot(providerRuntimeManifest);
+      parsedEnvelope = parseTaskEnvelope(taskEnvelope);
+      parsedRunLaunchManifest = attempt.runLaunchManifest
+        ? parseRunLaunchManifest(attempt.runLaunchManifest)
+        : undefined;
+    } catch {
+      throw new CompletionOwnershipError('Persisted attempt binding failed integrity validation', {
+        taskId,
+        attemptId: attempt.id,
+      });
+    }
+    const mismatches = [
+      attempt.provider !== providerRuntimeManifest.provider && 'attempt runtime provider',
+      parsedEnvelope.subject.id !== taskId && 'task ID',
+      parsedEnvelope.attempt.id !== attempt.id && 'attempt ID',
+      parsedEnvelope.launchManifest.digest !== providerRuntimeManifest.digest &&
+        'envelope runtime digest',
+      parsedEnvelope.launchManifest.provider !== providerRuntimeManifest.provider &&
+        'envelope runtime provider',
+      parsedEnvelope.launchManifest.adapter !== providerRuntimeManifest.adapter &&
+        'envelope runtime adapter',
+      parsedEnvelope.launchManifest.protocolVersion !== providerRuntimeManifest.protocolVersion &&
+        'envelope runtime protocol',
+      parsedRunLaunchManifest?.taskId !== undefined &&
+        parsedRunLaunchManifest.taskId !== taskId &&
+        'run launch task ID',
+      parsedRunLaunchManifest?.attemptId !== undefined &&
+        parsedRunLaunchManifest.attemptId !== attempt.id &&
+        'run launch attempt ID',
+      parsedRunLaunchManifest?.taskEnvelope.digest !== undefined &&
+        parsedRunLaunchManifest.taskEnvelope.digest !== parsedEnvelope.digest &&
+        'run launch task envelope digest',
+      parsedRunLaunchManifest?.providerRuntime.digest !== undefined &&
+        parsedRunLaunchManifest.providerRuntime.digest !== providerRuntimeManifest.digest &&
+        'run launch runtime digest',
+      parsedRunLaunchManifest?.providerRuntime.provider !== undefined &&
+        parsedRunLaunchManifest.providerRuntime.provider !== providerRuntimeManifest.provider &&
+        'run launch runtime provider',
+      parsedRunLaunchManifest?.providerRuntime.adapter !== undefined &&
+        parsedRunLaunchManifest.providerRuntime.adapter !== providerRuntimeManifest.adapter &&
+        'run launch runtime adapter',
+    ].filter((field): field is string => typeof field === 'string');
+    if (mismatches.length > 0) {
+      throw new CompletionOwnershipError('Persisted attempt completion bindings do not agree', {
+        taskId,
+        attemptId: attempt.id,
+        mismatches,
+        remediation: 'Repair the persisted attempt binding before accepting a terminal completion.',
+      });
+    }
+  }
+
+  private async persistRestartedProviderCompletion(
+    task: Task,
+    attempt: TaskAttempt,
+    claim: ProviderTerminalClaim,
+    idempotencyKey: string,
+    options: { preserveNonActiveTaskStatus?: boolean } = {}
+  ): Promise<void> {
+    if (!attempt.taskEnvelope) {
+      throw new ConflictError('Restarted provider completion has no task envelope', {
+        taskId: task.id,
+        attemptId: attempt.id,
+      });
+    }
+    this.assertPersistedAttemptCompletionBinding(task.id, attempt);
+    const completionResult = await this.providerCompletions.complete({
+      task,
+      taskEnvelope: attempt.taskEnvelope,
+      claim,
+    });
+    const completedAttempt: TaskAttempt = {
+      ...attempt,
+      status: completionResult.status === 'success' ? 'complete' : 'failed',
+      ended: completionResult.completedAt,
+      completionResult,
+    };
+    const completionStatus = taskStatusForCompletion(completionResult.status);
+    let taskSnapshot = task;
+    let lastError: unknown;
+    for (
+      let persistenceAttempt = 1;
+      persistenceAttempt <= COMPLETION_PERSISTENCE_ATTEMPTS;
+      persistenceAttempt++
+    ) {
+      const taskStatusUpdate =
+        options.preserveNonActiveTaskStatus && taskSnapshot.status !== 'in-progress'
+          ? {}
+          : { status: completionStatus };
+      try {
+        const updatedTask = await this.taskService.updateTask(task.id, {
+          expectedRevision: normalizedTaskRevision(taskSnapshot),
+          ...taskStatusUpdate,
+          attempt: completedAttempt,
+          attempts: upsertAttemptHistory(taskSnapshot.attempts, completedAttempt),
+        });
+        if (!updatedTask) {
+          throw new CompletionOwnershipError(
+            'Task was archived or deleted before completion could be persisted',
+            { taskId: task.id, attemptId: attempt.id }
+          );
+        }
+        lastError = undefined;
+        break;
+      } catch (error) {
+        if (error instanceof CompletionOwnershipError) throw error;
+        lastError = error;
+        const latestTask = await this.taskService.getTask(task.id);
+        if (latestTask?.attempt?.id !== attempt.id) throw error;
+        this.assertCompletionRetryBinding(task.id, completedAttempt, latestTask.attempt);
+        if (latestTask.attempt.completionResult) {
+          const latestCompletion = this.parsePersistedCompletion(latestTask.attempt);
+          if (latestCompletion.idempotencyKey === idempotencyKey) return;
+          throw new CompletionOwnershipError(
+            'A different terminal result already owns this attempt',
+            {
+              taskId: task.id,
+              attemptId: attempt.id,
+              persistedIdempotencyKey: latestCompletion.idempotencyKey,
+              completionIdempotencyKey: idempotencyKey,
+            }
+          );
+        }
+        taskSnapshot = latestTask;
+      }
+    }
+    if (lastError) throw lastError;
+
+    log.info(
+      { taskId: task.id, attemptId: attempt.id, terminalSource: claim.terminalSource },
+      '[ClawdbotAgent] Persisted provider completion after server restart'
+    );
   }
 
   private async finalizePendingAgent(
     taskId: string,
     pending: PendingAgent,
-    prepareResult: () => Promise<AgentTerminalResult>
+    prepareResult: () => Promise<AgentTerminalResult>,
+    expectedIdempotencyKey?: string
   ): Promise<void> {
     if (pendingAgents.get(taskId) !== pending) {
       throw new ConflictError('Provider finalization does not match the active run', {
@@ -1056,7 +1451,30 @@ export class ClawdbotAgentService {
     const inFlight = finalizingAgents.get(pending);
     if (inFlight) {
       await inFlight;
+      if (
+        expectedIdempotencyKey &&
+        pending.terminalClaimIdempotencyKey !== expectedIdempotencyKey
+      ) {
+        throw new ConflictError('Provider completion conflicts with the claimed terminal result', {
+          attemptId: pending.attemptId,
+          claimedIdempotencyKey: pending.terminalClaimIdempotencyKey,
+          completionIdempotencyKey: expectedIdempotencyKey,
+          remediation: 'Discard the conflicting claim; terminal ownership is already committed.',
+        });
+      }
       return;
+    }
+    if (
+      expectedIdempotencyKey &&
+      pending.terminalClaimIdempotencyKey &&
+      pending.terminalClaimIdempotencyKey !== expectedIdempotencyKey
+    ) {
+      throw new ConflictError('Provider completion conflicts with the claimed terminal result', {
+        attemptId: pending.attemptId,
+        claimedIdempotencyKey: pending.terminalClaimIdempotencyKey,
+        completionIdempotencyKey: expectedIdempotencyKey,
+        remediation: 'Discard the conflicting claim; terminal ownership is already committed.',
+      });
     }
 
     // Defer preparation to the next microtask so the ownership claim is
@@ -1064,11 +1482,39 @@ export class ClawdbotAgentService {
     const finalization = Promise.resolve().then(async () => {
       const result = pending.preparedFinalizationResult ?? (await prepareResult());
       pending.preparedFinalizationResult = result;
+      const claim = this.normalizeTerminalClaim(result, result.terminalSource ?? 'process');
+      const idempotencyKey = this.providerCompletions.idempotencyKey({
+        taskEnvelope: pending.taskEnvelope,
+        claim,
+      });
+      if (expectedIdempotencyKey && expectedIdempotencyKey !== idempotencyKey) {
+        throw new ConflictError('Prepared terminal result changed after ownership was claimed', {
+          attemptId: pending.attemptId,
+          claimedIdempotencyKey: expectedIdempotencyKey,
+          completionIdempotencyKey: idempotencyKey,
+        });
+      }
+      if (
+        pending.terminalClaimIdempotencyKey &&
+        pending.terminalClaimIdempotencyKey !== idempotencyKey
+      ) {
+        throw new ConflictError('Terminal result conflicts with the claimed completion owner', {
+          attemptId: pending.attemptId,
+          claimedIdempotencyKey: pending.terminalClaimIdempotencyKey,
+          completionIdempotencyKey: idempotencyKey,
+        });
+      }
+      pending.terminalClaimIdempotencyKey = idempotencyKey;
       await this.completePendingAgent(taskId, result, pending);
     });
     finalizingAgents.set(pending, finalization);
     try {
       await finalization;
+    } catch (error) {
+      if (error instanceof CompletionOwnershipError && pendingAgents.get(taskId) === pending) {
+        pendingAgents.delete(taskId);
+      }
+      throw error;
     } finally {
       if (finalizingAgents.get(pending) === finalization) {
         finalizingAgents.delete(pending);
@@ -1084,7 +1530,6 @@ export class ClawdbotAgentService {
     await this.assertPendingRunControl(taskId, pending, 'complete');
 
     const { attemptId, emitter } = pending;
-    const status: AttemptStatus = result.success ? 'complete' : 'failed';
     const timing =
       pending.completionTiming ??
       (pending.completionTiming = (() => {
@@ -1113,6 +1558,19 @@ export class ClawdbotAgentService {
       pending.preparedCompletion ??
       (await (async () => {
         const taskBeforeCompletion = (await this.taskService.getTask(taskId)) ?? undefined;
+        if (!taskBeforeCompletion) {
+          throw new ConflictError('Task disappeared before completion could be persisted', {
+            taskId,
+            attemptId,
+          });
+        }
+        const claim = this.normalizeTerminalClaim(result, result.terminalSource ?? 'process');
+        const completionResult = await this.providerCompletions.complete({
+          task: taskBeforeCompletion,
+          taskEnvelope: pending.taskEnvelope,
+          claim,
+        });
+        const status: AttemptStatus = completionResult.status === 'success' ? 'complete' : 'failed';
         const completedAttempt: TaskAttempt = {
           id: attemptId,
           agent: pending.agent,
@@ -1131,29 +1589,28 @@ export class ClawdbotAgentService {
           runLaunchManifestTraceId: pending.runLaunchManifestTraceId,
           runLaunchParentAttemptId: pending.runLaunchParentAttemptId,
           runLaunchManifestDrift: pending.runLaunchManifestDrift,
+          completionResult,
         };
         return (pending.preparedCompletion = {
           status,
           taskBeforeCompletion,
           completedAttempt,
+          completionResult,
         });
       })());
-    const { taskBeforeCompletion, completedAttempt } = preparedCompletion;
+    const { status, taskBeforeCompletion, completionResult } = preparedCompletion;
+    const successful = completionResult.status === 'success';
 
-    // Update task and preserve the exact launch manifest in attempt history.
-    await this.taskService.updateTask(taskId, {
-      status: result.success ? 'done' : 'in-progress',
-      attempt: completedAttempt,
-      attempts: upsertAttemptHistory(taskBeforeCompletion?.attempts, completedAttempt),
-    });
+    const persistedHere = await this.persistPendingCompletion(taskId, pending, preparedCompletion);
     if (pendingAgents.get(taskId) === pending) {
       pendingAgents.delete(taskId);
     }
+    if (!persistedHere) return;
 
     const logPath = path.join(this.logsDir, `${taskId}_${attemptId}.md`);
-    const summary = result.summary || result.error || 'No summary provided';
+    const summary = completionResult.summary;
     const { durationMs } = timing;
-    const completionStepType = result.success ? 'complete' : 'error';
+    const completionStepType = successful ? 'complete' : 'error';
     const requestFile = path.join(getRuntimeDir(), 'agent-requests', `${taskId}.json`);
     const postCommitEffects: Array<[string, () => void | Promise<void>]> = [
       [
@@ -1166,11 +1623,13 @@ export class ClawdbotAgentService {
         'record terminal trace step',
         () =>
           this.recordTraceStep(attemptId, completionStepType, {
-            eventType: result.success ? 'run.completed' : 'run.failed',
+            eventType: successful ? 'run.completed' : 'run.failed',
             summary: this.redactTraceText(summary),
-            success: result.success,
+            success: successful,
             status,
-            error: result.error ? this.redactTraceText(result.error) : undefined,
+            error: completionResult.error
+              ? this.redactTraceText(completionResult.error)
+              : undefined,
             durationMs,
             agent: pending.agent,
             provider: pending.provider,
@@ -1187,17 +1646,17 @@ export class ClawdbotAgentService {
             agent: pending.agent,
             project: taskBeforeCompletion?.project,
             durationMs,
-            success: result.success,
-            error: result.error,
+            success: successful,
+            error: completionResult.error ?? undefined,
             harnessSupport: this.harnessTelemetry(
               pending.harnessSupport,
-              result.success ? 'none' : 'run-failed'
+              successful ? 'none' : 'run-failed'
             ),
           }),
       ],
       [
         'complete trace',
-        () => getTraceService().completeTrace(attemptId, result.success ? 'completed' : 'failed'),
+        () => getTraceService().completeTrace(attemptId, successful ? 'completed' : 'failed'),
       ],
       [
         'record completion activity',
@@ -1210,7 +1669,7 @@ export class ClawdbotAgentService {
               attemptId,
               provider: pending.provider,
               model: pending.model,
-              success: result.success,
+              success: successful,
               summary,
             },
             pending.agent
@@ -1241,6 +1700,76 @@ export class ClawdbotAgentService {
     log.info(`[ClawdbotAgent] Task ${taskId} completed with status: ${status}`);
   }
 
+  private async persistPendingCompletion(
+    taskId: string,
+    pending: PendingAgent,
+    prepared: NonNullable<PendingAgent['preparedCompletion']>
+  ): Promise<boolean> {
+    let taskSnapshot = prepared.taskBeforeCompletion;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= COMPLETION_PERSISTENCE_ATTEMPTS; attempt++) {
+      if (!taskSnapshot) {
+        throw new ConflictError('Task disappeared before completion could be persisted', {
+          taskId,
+          attemptId: pending.attemptId,
+        });
+      }
+      try {
+        const updatedTask = await this.taskService.updateTask(taskId, {
+          expectedRevision: normalizedTaskRevision(taskSnapshot),
+          status: taskStatusForCompletion(prepared.completionResult.status),
+          attempt: prepared.completedAttempt,
+          attempts: upsertAttemptHistory(taskSnapshot.attempts, prepared.completedAttempt),
+        });
+        if (!updatedTask) {
+          throw new CompletionOwnershipError(
+            'Task was archived or deleted before completion could be persisted',
+            { taskId, attemptId: pending.attemptId }
+          );
+        }
+        return true;
+      } catch (error) {
+        if (error instanceof CompletionOwnershipError) throw error;
+        lastError = error;
+        let latestTask: Task | null;
+        try {
+          latestTask = await this.taskService.getTask(taskId);
+        } catch {
+          latestTask = null;
+        }
+        if (!latestTask) continue;
+        if (latestTask.attempt?.id !== pending.attemptId) {
+          throw new CompletionOwnershipError(
+            'Provider finalization no longer matches the active attempt',
+            {
+              taskId,
+              activeAttemptId: latestTask.attempt?.id,
+              finalizationAttemptId: pending.attemptId,
+            }
+          );
+        }
+        this.assertCompletionRetryBinding(taskId, prepared.completedAttempt, latestTask.attempt);
+        if (latestTask.attempt.completionResult) {
+          const persisted = this.parsePersistedCompletion(latestTask.attempt);
+          if (persisted.idempotencyKey === prepared.completionResult.idempotencyKey) return true;
+          throw new CompletionOwnershipError(
+            'A different terminal result already owns this attempt',
+            {
+              taskId,
+              attemptId: pending.attemptId,
+              persistedIdempotencyKey: persisted.idempotencyKey,
+              completionIdempotencyKey: prepared.completionResult.idempotencyKey,
+            }
+          );
+        }
+        taskSnapshot = latestTask;
+      }
+    }
+    throw lastError instanceof Error
+      ? lastError
+      : new Error('Provider completion persistence retry budget was exhausted');
+  }
+
   /**
    * Stop a running agent
    */
@@ -1265,7 +1794,8 @@ export class ClawdbotAgentService {
         model: pending.model,
       });
       return {
-        success: false,
+        status: 'interrupted',
+        terminalSource: 'operator-interruption',
         error: 'Stopped by user',
       };
     });
@@ -1432,7 +1962,8 @@ export class ClawdbotAgentService {
       );
       await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
       return {
-        success: false,
+        status: 'interrupted',
+        terminalSource: 'operator-interruption',
         error: `Budget ${evaluation.decision}: ${evaluation.thresholdEvents
           .map((event) => event.message)
           .join(' ')}`,
@@ -1695,6 +2226,16 @@ export class ClawdbotAgentService {
           ).catch(async (error: unknown) => {
             const current = pendingAgents.get(task.id);
             if (!current || current.attemptId !== attemptId) return;
+            if (error instanceof CompletionPersistenceError) {
+              if (emitter.listenerCount('error') > 0) {
+                emitter.emit('error', error.persistenceCause);
+              }
+              log.error(
+                { err: error.persistenceCause, taskId: task.id, attemptId },
+                'Codex SDK completion could not be persisted after bounded retries'
+              );
+              return;
+            }
             abortController.abort();
             const message = error instanceof Error ? error.message : 'Codex SDK attempt failed';
             try {
@@ -1708,19 +2249,25 @@ export class ClawdbotAgentService {
                 { success: false, error: message },
                 {
                   attemptId,
+                  terminalSource: 'stream',
                   providerRuntimeManifestDigest: current.providerRuntimeManifest.digest,
                 }
               );
             } catch (finalizationError) {
-              if (pendingAgents.get(task.id)?.attemptId === attemptId) {
+              const retryable =
+                current.preparedCompletion !== undefined &&
+                !(finalizationError instanceof CompletionOwnershipError);
+              if (!retryable && pendingAgents.get(task.id)?.attemptId === attemptId) {
                 pendingAgents.delete(task.id);
               }
               if (emitter.listenerCount('error') > 0) {
                 emitter.emit('error', finalizationError);
               }
               log.error(
-                { err: finalizationError, taskId: task.id, attemptId },
-                'Codex SDK failure could not update stale persisted attempt state'
+                { err: finalizationError, taskId: task.id, attemptId, retryable },
+                retryable
+                  ? 'Codex SDK failure completion remains pending after bounded persistence retries'
+                  : 'Codex SDK failure could not update stale persisted attempt state'
               );
             }
           });
@@ -2051,6 +2598,7 @@ export class ClawdbotAgentService {
 
         return {
           success,
+          terminalSource: 'process',
           summary: finalOutput || (success ? 'Hermes completed.' : undefined),
           error: success ? undefined : finalOutput || `Hermes exited with code ${code}`,
         };
@@ -2242,6 +2790,7 @@ export class ClawdbotAgentService {
 
         return {
           success: succeeded,
+          terminalSource: 'process',
           summary: finalSummary,
           error: succeeded ? undefined : finalSummary || `Codex exited with code ${code}`,
         };
@@ -2383,19 +2932,24 @@ export class ClawdbotAgentService {
       `\n## Codex SDK Complete\n\n**Duration:** ${Date.now() - new Date(startedAt).getTime()}ms\n`
     );
 
-    await this.completeAgent(
-      task.id,
-      {
-        success: !failureMessage,
-        summary: finalSummary || failureMessage || 'Codex SDK completed without a final summary.',
-        error: failureMessage || undefined,
-      },
-      {
-        attemptId,
-        providerRuntimeManifestDigest:
-          pendingAgents.get(task.id)?.providerRuntimeManifest.digest ?? '',
-      }
-    );
+    try {
+      await this.completeAgent(
+        task.id,
+        {
+          success: !failureMessage,
+          summary: finalSummary || failureMessage || 'Codex SDK completed without a final summary.',
+          error: failureMessage || undefined,
+        },
+        {
+          attemptId,
+          terminalSource: 'stream',
+          providerRuntimeManifestDigest:
+            pendingAgents.get(task.id)?.providerRuntimeManifest.digest ?? '',
+        }
+      );
+    } catch (error) {
+      throw new CompletionPersistenceError(error);
+    }
     emitter.emit('sdk.complete', { taskId: task.id, attemptId });
   }
 
@@ -4181,6 +4735,12 @@ ${prompt}
 
 // Export singleton
 export const clawdbotAgentService = new ClawdbotAgentService();
+
+function taskStatusForCompletion(status: TaskCompletionStatus): 'done' | 'blocked' | 'in-progress' {
+  if (status === 'success') return 'done';
+  if (status === 'blocked') return 'blocked';
+  return 'in-progress';
+}
 
 function upsertAttemptHistory(
   history: TaskAttempt[] | undefined,

--- a/server/src/services/provider-completion-service.ts
+++ b/server/src/services/provider-completion-service.ts
@@ -1,0 +1,464 @@
+import {
+  COMPLETION_RESULT_SCHEMA_VERSION,
+  TASK_ENVELOPE_SCHEMA_VERSION,
+  type CompletionResult,
+  type Task,
+  type TaskCompletionArtifact,
+  type TaskCompletionBlocker,
+  type TaskCompletionEvidence,
+  type TaskCompletionStatus,
+  type TaskCompletionVerification,
+  type TaskEnvelope,
+  type TaskEvidenceKind,
+  type TaskTerminalSource,
+} from '@veritas-kanban/shared';
+import {
+  parseCompletionResultForEnvelope,
+  parseTaskEnvelope,
+} from '../schemas/task-envelope-schemas.js';
+import {
+  calculateCompletionResultDigest,
+  type CompletionResultPayload,
+} from '../utils/completion-result-digest.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
+import {
+  GitCompletionEvidenceSource,
+  type CompletionEvidenceSnapshot,
+  type CompletionEvidenceSource,
+} from './task-envelope-service.js';
+import { redactString } from '../lib/redact.js';
+
+const MAX_TEXT_LENGTH = 20_000;
+const MAX_SHORT_TEXT_LENGTH = 500;
+const MAX_PROVIDER_EVIDENCE = 128;
+const MAX_PROVIDER_ARTIFACTS = 64;
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
+  [/\bBasic\s+[A-Za-z0-9+/=]+/gi, 'Basic [REDACTED]'],
+  [/\bsk-[A-Za-z0-9_-]{8,}/g, 'sk-[REDACTED]'],
+  [/\bgh[pousr]_[A-Za-z0-9_]{8,}/gi, '[REDACTED_GITHUB_TOKEN]'],
+  [/\bgithub_pat_[A-Za-z0-9_]{8,}/g, 'github_pat_[REDACTED]'],
+  [
+    /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*)\s*=\s*([^\s"'`]+)/gi,
+    '$1=[REDACTED]',
+  ],
+  [/\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*([^\s"'`,}]+)/gi, '$1=[REDACTED]'],
+];
+
+export interface ProviderCompletionEvidenceClaim {
+  id: string;
+  kind: TaskEvidenceKind;
+  summary: string;
+  reference?: string | null;
+  requirementIds?: string[];
+}
+
+export interface ProviderCompletionArtifactClaim {
+  id: string;
+  kind: TaskCompletionArtifact['kind'];
+  name: string;
+  reference: string;
+  mediaType?: string | null;
+  sha256?: string | null;
+}
+
+export interface ProviderTerminalClaim {
+  terminalSource: TaskTerminalSource;
+  status: TaskCompletionStatus;
+  summary?: string;
+  error?: string;
+  blockers?: TaskCompletionBlocker[];
+  evidence?: ProviderCompletionEvidenceClaim[];
+  artifacts?: ProviderCompletionArtifactClaim[];
+  verification?: TaskCompletionVerification[];
+  continuation?: CompletionResult['continuation'];
+}
+
+export interface LegacyProviderTerminalClaim {
+  success: boolean;
+  summary?: string;
+  error?: string;
+}
+
+export interface CompleteProviderRunInput {
+  task: Task;
+  taskEnvelope: TaskEnvelope;
+  claim: ProviderTerminalClaim;
+}
+
+type TerminalEvidenceSource = Pick<CompletionEvidenceSource, 'captureCompletionEvidence'>;
+
+export class ProviderCompletionService {
+  constructor(
+    private readonly evidenceSource: TerminalEvidenceSource = new GitCompletionEvidenceSource(),
+    private readonly now: () => string = () => new Date().toISOString()
+  ) {}
+
+  normalizeLegacyClaim(
+    claim: LegacyProviderTerminalClaim,
+    terminalSource: TaskTerminalSource
+  ): ProviderTerminalClaim {
+    return {
+      terminalSource,
+      status: claim.success ? 'success' : 'failed',
+      summary: claim.summary,
+      error: claim.success
+        ? undefined
+        : claim.error || claim.summary || 'Provider reported failure.',
+    };
+  }
+
+  idempotencyKey(input: { taskEnvelope: TaskEnvelope; claim: ProviderTerminalClaim }): string {
+    const taskEnvelope = parseTaskEnvelope(input.taskEnvelope);
+    return digestRunLaunchValue({
+      taskId: taskEnvelope.subject.id,
+      attemptId: taskEnvelope.attempt.id,
+      taskEnvelopeDigest: taskEnvelope.digest,
+      providerRuntimeManifestDigest: taskEnvelope.launchManifest.digest,
+      claim: sanitizeClaim(input.claim),
+    });
+  }
+
+  async complete(input: CompleteProviderRunInput): Promise<CompletionResult> {
+    const taskEnvelope = parseTaskEnvelope(input.taskEnvelope);
+    if (taskEnvelope.subject.id !== input.task.id) {
+      throw new Error('Completion task does not match the persisted task envelope');
+    }
+    const claim = sanitizeClaim(input.claim);
+    const completedAt = this.now();
+    const idempotencyKey = this.idempotencyKey({
+      taskEnvelope: input.taskEnvelope,
+      claim,
+    });
+    const reportedArtifacts: TaskCompletionArtifact[] = claim.artifacts.map((artifact) => ({
+      id: artifact.id,
+      kind: artifact.kind,
+      name: artifact.name,
+      reference: artifact.reference,
+      mediaType: artifact.mediaType ?? null,
+      sha256: artifact.sha256 ?? null,
+      verified: false,
+    }));
+    const snapshot = await this.evidenceSource.captureCompletionEvidence({
+      task: input.task,
+      taskEnvelope,
+      capturedAt: completedAt,
+      reportedArtifacts,
+    });
+    assertBoundedSnapshot(snapshot);
+
+    const policy = evaluateCompletionPolicy(taskEnvelope, claim.status, snapshot);
+    const status = policy.status;
+    const evidence = buildCompletionEvidence(taskEnvelope, claim, snapshot);
+    const verification = mergeVerification(taskEnvelope, claim.verification, snapshot.verification);
+    const error =
+      status === 'success'
+        ? null
+        : status === 'failed'
+          ? sanitizeText(claim.error || claim.summary || 'Provider reported failure.')
+          : claim.error
+            ? sanitizeText(claim.error)
+            : null;
+    const blockers =
+      status === 'blocked' && claim.blockers.length === 0
+        ? [
+            {
+              code: 'provider-blocked',
+              summary: 'Provider reported a blocked run',
+              detail: claim.summary,
+              retryable: true,
+            },
+          ]
+        : [...claim.blockers, ...policy.blockers].slice(0, 64);
+    const payload: CompletionResultPayload = {
+      schemaVersion: COMPLETION_RESULT_SCHEMA_VERSION,
+      idempotencyKey,
+      completedAt,
+      terminalSource: claim.terminalSource,
+      taskEnvelopeSchemaVersion: TASK_ENVELOPE_SCHEMA_VERSION,
+      taskEnvelopeDigest: taskEnvelope.digest,
+      taskId: taskEnvelope.subject.id,
+      attemptId: taskEnvelope.attempt.id,
+      providerRuntimeManifestDigest: taskEnvelope.launchManifest.digest,
+      status,
+      summary: claim.summary,
+      error,
+      blockers,
+      evidence,
+      changedFiles: snapshot.changedFiles.slice(0, 2000),
+      artifacts: snapshot.artifacts.slice(0, 256),
+      verification,
+      sideEffects: snapshot.sideEffects
+        .slice(0, 256)
+        .map((sideEffect) =>
+          sideEffect.kind === 'git-commit' && taskEnvelope.commitPolicy === 'forbidden'
+            ? { ...sideEffect, authorized: false }
+            : sideEffect
+        ),
+      continuation: claim.continuation,
+    };
+    const result = parseCompletionResultForEnvelope(
+      {
+        ...payload,
+        digest: calculateCompletionResultDigest(payload),
+      },
+      taskEnvelope
+    );
+    return deepFreeze(structuredClone(result));
+  }
+}
+
+function sanitizeClaim(claim: ProviderTerminalClaim): Required<ProviderTerminalClaim> {
+  const summary = sanitizeText(
+    claim.summary ||
+      claim.error ||
+      (claim.status === 'success'
+        ? 'Provider completed without a final summary.'
+        : `Provider reported ${claim.status}.`)
+  );
+  return {
+    terminalSource: claim.terminalSource,
+    status: claim.status,
+    summary,
+    error: claim.error ? sanitizeText(claim.error) : '',
+    blockers: (claim.blockers ?? []).slice(0, 64).map((blocker) => ({
+      code: sanitizeIdentifier(blocker.code),
+      summary: sanitizeText(blocker.summary, MAX_SHORT_TEXT_LENGTH),
+      detail: sanitizeText(blocker.detail),
+      retryable: blocker.retryable,
+    })),
+    evidence: (claim.evidence ?? []).slice(0, MAX_PROVIDER_EVIDENCE).map((evidence) => ({
+      id: sanitizeIdentifier(evidence.id),
+      kind: evidence.kind,
+      summary: sanitizeText(evidence.summary),
+      reference: evidence.reference ? sanitizeText(evidence.reference, 4096) : null,
+      requirementIds: (evidence.requirementIds ?? [])
+        .slice(0, 64)
+        .map((id) => sanitizeIdentifier(id)),
+    })),
+    artifacts: (claim.artifacts ?? []).slice(0, MAX_PROVIDER_ARTIFACTS).map((artifact) => ({
+      id: sanitizeIdentifier(artifact.id),
+      kind: artifact.kind,
+      name: sanitizeText(artifact.name, MAX_SHORT_TEXT_LENGTH),
+      reference: sanitizeText(artifact.reference, 4096),
+      mediaType: artifact.mediaType ? sanitizeText(artifact.mediaType, 200) : null,
+      sha256: /^[a-f0-9]{64}$/.test(artifact.sha256 ?? '') ? (artifact.sha256 ?? null) : null,
+    })),
+    verification: (claim.verification ?? []).slice(0, 256).map((verification) => ({
+      gateId: sanitizeIdentifier(verification.gateId),
+      status: verification.status,
+      summary: sanitizeText(verification.summary),
+      evidenceIds: verification.evidenceIds.slice(0, 128).map((id) => sanitizeIdentifier(id)),
+    })),
+    continuation: claim.continuation
+      ? {
+          provider: sanitizeIdentifier(claim.continuation.provider),
+          kind: claim.continuation.kind,
+          reference: sanitizeText(claim.continuation.reference, 4096),
+        }
+      : null,
+  };
+}
+
+function evaluateCompletionPolicy(
+  envelope: TaskEnvelope,
+  claimedStatus: TaskCompletionStatus,
+  snapshot: CompletionEvidenceSnapshot
+): { status: TaskCompletionStatus; blockers: TaskCompletionBlocker[] } {
+  if (claimedStatus !== 'success') return { status: claimedStatus, blockers: [] };
+
+  const blockers: TaskCompletionBlocker[] = [];
+  if (envelope.commitPolicy === 'required' && snapshot.commits.length === 0) {
+    blockers.push({
+      code: 'required-commit-missing',
+      summary: 'Required commit was not created',
+      detail: 'The launch contract required at least one commit attributable to this attempt.',
+      retryable: true,
+    });
+  }
+  if (envelope.commitPolicy === 'forbidden' && snapshot.commits.length > 0) {
+    blockers.push({
+      code: 'forbidden-commit-created',
+      summary: 'Forbidden commit was created',
+      detail: 'The launch contract prohibited commits, but the harness observed a new commit.',
+      retryable: false,
+    });
+  }
+  for (const sideEffect of snapshot.sideEffects.filter((effect) => !effect.authorized)) {
+    blockers.push({
+      code: `unauthorized-${sideEffect.kind}`,
+      summary: 'Unauthorized side effect observed',
+      detail: `${sideEffect.description}${sideEffect.target ? ` Target: ${sideEffect.target}` : ''}`,
+      retryable: false,
+    });
+  }
+  const verificationByGate = new Map(snapshot.verification.map((gate) => [gate.gateId, gate]));
+  for (const gate of envelope.verificationGates.filter((entry) => entry.required)) {
+    if (verificationByGate.get(gate.id)?.status !== 'passed') {
+      blockers.push({
+        code: `verification-missing-${gate.id}`,
+        summary: 'Required verification evidence is missing',
+        detail: gate.description,
+        retryable: true,
+      });
+    }
+  }
+  for (const output of envelope.expectedOutputs.filter((entry) => entry.required)) {
+    if (output.kind === 'text' && output.id === 'completion-summary') continue;
+    if (output.kind === 'commit') continue;
+    if (
+      (output.kind === 'file' || output.kind === 'artifact') &&
+      !snapshot.artifacts.some((artifact) => artifact.id === output.id && artifact.verified)
+    ) {
+      blockers.push({
+        code: `expected-output-missing-${output.id}`,
+        summary: 'Required output is missing or unverified',
+        detail: output.description,
+        retryable: true,
+      });
+    }
+  }
+  return {
+    status: blockers.length > 0 ? 'partial' : 'success',
+    blockers: blockers.slice(0, 64),
+  };
+}
+
+function buildCompletionEvidence(
+  envelope: TaskEnvelope,
+  claim: Required<ProviderTerminalClaim>,
+  snapshot: CompletionEvidenceSnapshot
+): TaskCompletionEvidence[] {
+  const evidence: TaskCompletionEvidence[] = [
+    {
+      id: `terminal-${claim.terminalSource}`,
+      kind: 'provider-output',
+      source: 'harness',
+      summary: `Harness observed the ${claim.terminalSource} terminal path.`,
+      reference: null,
+      requirementIds: ['terminal-state'],
+      verified: true,
+    },
+  ];
+  for (const providerEvidence of claim.evidence) {
+    evidence.push({
+      id: providerEvidence.id.startsWith('provider-')
+        ? providerEvidence.id
+        : `provider-${providerEvidence.id}`,
+      kind: providerEvidence.kind,
+      source: 'provider',
+      summary: providerEvidence.summary,
+      reference: providerEvidence.reference ?? null,
+      requirementIds: providerEvidence.requirementIds ?? [],
+      verified: false,
+    });
+  }
+  if (snapshot.changedFiles.length > 0) {
+    evidence.push({
+      id: 'file-changes',
+      kind: 'file-change',
+      source: 'harness',
+      summary: `Harness attributed ${snapshot.changedFiles.length} changed file${snapshot.changedFiles.length === 1 ? '' : 's'} to this attempt.`,
+      reference: snapshot.headSha,
+      requirementIds: [],
+      verified: true,
+    });
+  }
+  if (snapshot.commits.length > 0) {
+    evidence.push({
+      id: 'commits',
+      kind: 'commit',
+      source: 'harness',
+      summary: `Harness attributed ${snapshot.commits.length} commit${snapshot.commits.length === 1 ? '' : 's'} to this attempt.`,
+      reference: snapshot.commits[0]?.sha ?? null,
+      requirementIds: envelope.commitPolicy === 'required' ? ['commit'] : [],
+      verified: true,
+    });
+  }
+  for (const verification of snapshot.verification.filter((gate) => gate.status === 'passed')) {
+    evidence.push({
+      id: `verification-${verification.gateId}`,
+      kind: 'verification',
+      source: 'harness',
+      summary: verification.summary,
+      reference: null,
+      requirementIds: ['verification'],
+      verified: true,
+    });
+  }
+  for (const artifact of snapshot.artifacts.filter((entry) => entry.verified)) {
+    evidence.push({
+      id: `artifact-${artifact.id}`,
+      kind: 'artifact',
+      source: 'harness',
+      summary: `Harness verified artifact ${artifact.name}.`,
+      reference: artifact.reference,
+      requirementIds: [],
+      verified: true,
+    });
+  }
+  return evidence.slice(0, 512);
+}
+
+function mergeVerification(
+  envelope: TaskEnvelope,
+  providerVerification: TaskCompletionVerification[],
+  harnessVerification: TaskCompletionVerification[]
+): TaskCompletionVerification[] {
+  const providerByGate = new Map(providerVerification.map((entry) => [entry.gateId, entry]));
+  const harnessByGate = new Map(harnessVerification.map((entry) => [entry.gateId, entry]));
+  return envelope.verificationGates.map((gate) => {
+    const harness = harnessByGate.get(gate.id);
+    if (harness?.status === 'passed') {
+      return {
+        ...harness,
+        evidenceIds: [`verification-${gate.id}`],
+      };
+    }
+    const provider = providerByGate.get(gate.id);
+    return {
+      gateId: gate.id,
+      status: harness?.status ?? 'unknown',
+      summary:
+        harness?.summary ??
+        (provider
+          ? `Provider reported ${provider.status}, but no harness-verifiable evidence corroborated it.`
+          : 'No completion verification was reported.'),
+      evidenceIds: [],
+    };
+  });
+}
+
+function assertBoundedSnapshot(snapshot: CompletionEvidenceSnapshot): void {
+  if (snapshot.changedFiles.length > 2000)
+    throw new Error('Completion evidence exceeds 2000 files');
+  if (snapshot.commits.length > 256) throw new Error('Completion evidence exceeds 256 commits');
+  if (snapshot.artifacts.length > 256) throw new Error('Completion evidence exceeds 256 artifacts');
+  if (snapshot.verification.length > 256) {
+    throw new Error('Completion evidence exceeds 256 verification results');
+  }
+  if (snapshot.sideEffects.length > 256) {
+    throw new Error('Completion evidence exceeds 256 side effects');
+  }
+}
+
+function sanitizeText(value: string, maxLength = MAX_TEXT_LENGTH): string {
+  let sanitized = redactString(value.trim());
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    sanitized = sanitized.replace(pattern, replacement);
+  }
+  sanitized = sanitized.slice(0, maxLength).trim();
+  return sanitized || 'No details provided.';
+}
+
+function sanitizeIdentifier(value: string): string {
+  return sanitizeText(value, 160).replace(/\s+/g, '-');
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  return value;
+}

--- a/server/src/services/task-envelope-service.ts
+++ b/server/src/services/task-envelope-service.ts
@@ -8,6 +8,10 @@ import {
   type ProviderRuntimeManifest,
   type Task,
   type TaskAllowedSideEffect,
+  type TaskCompletionArtifact,
+  type TaskCompletionChangedFile,
+  type TaskCompletionSideEffect,
+  type TaskCompletionVerification,
   type TaskCommitPolicy,
   type TaskEnvelope,
   type TaskEvidenceRequirement,
@@ -26,6 +30,7 @@ import { sha256WorktreeEntry } from '../utils/worktree-fingerprint.js';
 const MAX_BASELINE_FILES = 1000;
 const BASELINE_GIT_TIMEOUT_MS = 10_000;
 const MAX_BASELINE_CAPTURE_ATTEMPTS = 3;
+const MAX_PREEXISTING_COMMITS = 4096;
 const INDEX_PATHSPEC_CHUNK_LENGTH = 48_000;
 const WORKTREE_HASH_CONCURRENCY = 8;
 
@@ -42,6 +47,31 @@ function createBaselineGit(worktreePath: string): BaselineGitClient {
 
 export interface CompletionEvidenceSource {
   captureLaunchBaseline(worktreePath: string, capturedAt: string): Promise<TaskLaunchBaseline>;
+  captureCompletionEvidence(
+    input: CaptureCompletionEvidenceInput
+  ): Promise<CompletionEvidenceSnapshot>;
+}
+
+export interface CaptureCompletionEvidenceInput {
+  task: Task;
+  taskEnvelope: TaskEnvelope;
+  capturedAt: string;
+  reportedArtifacts: TaskCompletionArtifact[];
+}
+
+export interface CompletionEvidenceCommit {
+  sha: string;
+  summary: string;
+}
+
+export interface CompletionEvidenceSnapshot {
+  capturedAt: string;
+  headSha: string;
+  changedFiles: TaskCompletionChangedFile[];
+  commits: CompletionEvidenceCommit[];
+  artifacts: TaskCompletionArtifact[];
+  verification: TaskCompletionVerification[];
+  sideEffects: TaskCompletionSideEffect[];
 }
 
 export class GitCompletionEvidenceSource implements CompletionEvidenceSource {
@@ -58,13 +88,16 @@ export class GitCompletionEvidenceSource implements CompletionEvidenceSource {
       const statusBefore = await git.status(['--untracked-files=all']);
       assertBaselineFileLimit(statusBefore);
       const filesBefore = await captureBaselineFiles(git, worktreePath, statusBefore);
+      const preexistingCommitsBefore = await capturePreexistingCommits(git, headBefore);
 
       const headAfter = (await git.revparse(['HEAD'])).trim();
       const statusAfter = await git.status(['--untracked-files=all']);
       assertBaselineFileLimit(statusAfter);
+      const preexistingCommitsAfter = await capturePreexistingCommits(git, headAfter);
       if (
         headBefore !== headAfter ||
-        statusSignature(statusBefore) !== statusSignature(statusAfter)
+        statusSignature(statusBefore) !== statusSignature(statusAfter) ||
+        JSON.stringify(preexistingCommitsBefore) !== JSON.stringify(preexistingCommitsAfter)
       ) {
         continue;
       }
@@ -73,10 +106,12 @@ export class GitCompletionEvidenceSource implements CompletionEvidenceSource {
       const headFinal = (await git.revparse(['HEAD'])).trim();
       const statusFinal = await git.status(['--untracked-files=all']);
       assertBaselineFileLimit(statusFinal);
+      const preexistingCommitsFinal = await capturePreexistingCommits(git, headFinal);
       if (
         headAfter !== headFinal ||
         statusSignature(statusAfter) !== statusSignature(statusFinal) ||
-        JSON.stringify(filesBefore) !== JSON.stringify(filesAfter)
+        JSON.stringify(filesBefore) !== JSON.stringify(filesAfter) ||
+        JSON.stringify(preexistingCommitsAfter) !== JSON.stringify(preexistingCommitsFinal)
       ) {
         continue;
       }
@@ -86,11 +121,105 @@ export class GitCompletionEvidenceSource implements CompletionEvidenceSource {
         headSha: headFinal,
         dirty: !statusFinal.isClean(),
         files: filesAfter,
+        preexistingCommitShas: preexistingCommitsFinal,
       };
     }
 
     throw new Error(
       `Task worktree changed while capturing the launch baseline after ${MAX_BASELINE_CAPTURE_ATTEMPTS} attempts`
+    );
+  }
+
+  async captureCompletionEvidence(
+    input: CaptureCompletionEvidenceInput
+  ): Promise<CompletionEvidenceSnapshot> {
+    const worktreePath = input.taskEnvelope.workspace.worktreePath;
+    const git = this.gitFactory(worktreePath);
+
+    for (let attempt = 1; attempt <= MAX_BASELINE_CAPTURE_ATTEMPTS; attempt++) {
+      const before = await captureCompletionGitState(
+        git,
+        worktreePath,
+        input.taskEnvelope.workspace.baseline,
+        input.taskEnvelope.workspace.branch
+      );
+      const after = await captureCompletionGitState(
+        git,
+        worktreePath,
+        input.taskEnvelope.workspace.baseline,
+        input.taskEnvelope.workspace.branch
+      );
+      if (JSON.stringify(before) !== JSON.stringify(after)) continue;
+
+      const artifacts = await verifyReportedArtifacts(
+        worktreePath,
+        input.reportedArtifacts,
+        before.changedFiles
+      );
+      const verification = input.taskEnvelope.verificationGates.map((gate) => {
+        const taskStep = input.task.verificationSteps?.find((step) => step.id === gate.id);
+        const checkedAt = taskStep?.checkedAt ? Date.parse(taskStep.checkedAt) : Number.NaN;
+        const verifiedAfterLaunch =
+          taskStep?.checked === true &&
+          Number.isFinite(checkedAt) &&
+          checkedAt >= Date.parse(input.taskEnvelope.attempt.createdAt);
+        return {
+          gateId: gate.id,
+          status: verifiedAfterLaunch ? ('passed' as const) : ('unknown' as const),
+          summary: verifiedAfterLaunch
+            ? 'Task verification state records this gate as passed.'
+            : taskStep?.checked
+              ? 'The verification gate predates this attempt or has no attributable timestamp.'
+              : 'No harness-verifiable completion evidence was recorded for this gate.',
+          evidenceIds: verifiedAfterLaunch ? [`verification-${gate.id}`] : [],
+        };
+      });
+      const allowedKinds = new Set(
+        input.taskEnvelope.allowedSideEffects.map((sideEffect) => sideEffect.kind)
+      );
+      const sideEffects: TaskCompletionSideEffect[] = [];
+      if (before.changedFiles.length > 0) {
+        sideEffects.push({
+          kind: 'filesystem-write',
+          description: `Changed ${before.changedFiles.length} file${before.changedFiles.length === 1 ? '' : 's'} after launch.`,
+          target: worktreePath,
+          authorized: allowedKinds.has('filesystem-write'),
+          verified: true,
+        });
+      }
+      if (before.commits.length > 0) {
+        sideEffects.push({
+          kind: 'git-commit',
+          description: `Created ${before.commits.length} commit${before.commits.length === 1 ? '' : 's'} after launch.`,
+          target: before.commits[0]?.sha ?? null,
+          authorized:
+            input.taskEnvelope.commitPolicy !== 'forbidden' && allowedKinds.has('git-commit'),
+          verified: true,
+        });
+      }
+      if (!before.historyAttributable) {
+        sideEffects.push({
+          kind: 'git-commit',
+          description:
+            'Completion HEAD is not attributable to commits created on the launch branch after the baseline.',
+          target: before.headSha,
+          authorized: false,
+          verified: true,
+        });
+      }
+      return {
+        capturedAt: input.capturedAt,
+        headSha: before.headSha,
+        changedFiles: before.changedFiles,
+        commits: before.commits,
+        artifacts,
+        verification,
+        sideEffects: sideEffects.slice(0, 256),
+      };
+    }
+
+    throw new Error(
+      `Task worktree changed while capturing completion evidence after ${MAX_BASELINE_CAPTURE_ATTEMPTS} attempts`
     );
   }
 }
@@ -375,6 +504,227 @@ async function captureBaselineFiles(
     );
   }
   return result;
+}
+
+interface CompletionGitState {
+  headSha: string;
+  historyAttributable: boolean;
+  changedFiles: TaskCompletionChangedFile[];
+  commits: CompletionEvidenceCommit[];
+}
+
+interface GitNameStatus {
+  path: string;
+  previousPath: string | null;
+  status: TaskCompletionChangedFile['status'];
+}
+
+async function captureCompletionGitState(
+  git: BaselineGitClient,
+  worktreePath: string,
+  baseline: TaskLaunchBaseline,
+  expectedBranch: string
+): Promise<CompletionGitState> {
+  const headSha = (await git.revparse(['HEAD'])).trim();
+  const status = await git.status(['--untracked-files=all']);
+  if (status.files.length > 2000) {
+    throw new Error(
+      `Task worktree completion has ${status.files.length} changed files; maximum is 2000`
+    );
+  }
+  const currentStatusFiles = await captureBaselineFiles(git, worktreePath, status);
+  const currentByPath = new Map(currentStatusFiles.map((file) => [file.path, file]));
+  const baselineByPath = new Map(baseline.files.map((file) => [file.path, file]));
+  const candidateCommits =
+    baseline.headSha === headSha
+      ? []
+      : parseCompletionCommits(
+          await git.raw([
+            'log',
+            '--format=%H%x00%s%x00',
+            '--max-count=256',
+            `${baseline.headSha}..${headSha}`,
+          ])
+        );
+  const containsPreexistingHistory =
+    baseline.preexistingCommitShas === undefined ||
+    candidateCommits.some((commit) => baseline.preexistingCommitShas?.includes(commit.sha));
+  const historyAttributable =
+    baseline.headSha === headSha ||
+    (status.current === expectedBranch &&
+      (await isAncestorCommit(git, baseline.headSha, headSha)) &&
+      !containsPreexistingHistory);
+  const committedChanges =
+    baseline.headSha === headSha || !historyAttributable
+      ? []
+      : parseGitNameStatus(
+          await git.raw([
+            'diff',
+            '--name-status',
+            '-z',
+            '--find-renames',
+            baseline.headSha,
+            headSha,
+            '--',
+          ])
+        );
+  const candidates = new Map<string, GitNameStatus>();
+  for (const change of committedChanges) candidates.set(change.path, change);
+  for (const file of status.files) {
+    candidates.set(file.path, {
+      path: file.path,
+      previousPath: file.from ?? null,
+      status: mapBaselineFile(file, null, null).status,
+    });
+  }
+  if (candidates.size > 2000) {
+    throw new Error(
+      `Task worktree completion has ${candidates.size} attributable file candidates; maximum is 2000`
+    );
+  }
+
+  const candidatePaths = [...candidates.keys()].sort((left, right) => left.localeCompare(right));
+  const indexBlobHashes = await readIndexBlobHashes(git, candidatePaths);
+  const changedFiles: TaskCompletionChangedFile[] = [];
+  for (let offset = 0; offset < candidatePaths.length; offset += WORKTREE_HASH_CONCURRENCY) {
+    const batch = candidatePaths.slice(offset, offset + WORKTREE_HASH_CONCURRENCY);
+    const entries = await Promise.all(
+      batch.map(async (filePath) => {
+        const change = candidates.get(filePath);
+        if (!change) return null;
+        const baselineFile =
+          baselineByPath.get(filePath) ??
+          (change.previousPath ? baselineByPath.get(change.previousPath) : undefined);
+        const currentFile = currentByPath.get(filePath);
+        const currentWorktreeSha256 = await sha256WorktreeEntry(worktreePath, filePath);
+        const currentIndexBlobHash = indexBlobHashes.get(filePath) ?? null;
+        if (
+          baselineFile &&
+          baselineFile.worktreeSha256 === currentWorktreeSha256 &&
+          baselineFile.indexBlobHash === currentIndexBlobHash
+        ) {
+          return null;
+        }
+        if (!currentFile && baselineFile && baselineFile.worktreeSha256 === currentWorktreeSha256) {
+          return null;
+        }
+        return {
+          path: filePath,
+          status: change.status,
+          previousPath: change.previousPath,
+          verified: true,
+        } satisfies TaskCompletionChangedFile;
+      })
+    );
+    for (const entry of entries) {
+      if (entry) changedFiles.push(entry);
+    }
+  }
+
+  const commits = baseline.headSha === headSha || !historyAttributable ? [] : candidateCommits;
+  return { headSha, historyAttributable, changedFiles, commits };
+}
+
+async function capturePreexistingCommits(
+  git: BaselineGitClient,
+  headSha: string
+): Promise<string[]> {
+  const commits = (await git.raw(['rev-list', '--all', '--not', headSha]))
+    .split(/\s+/)
+    .map((commit) => commit.trim())
+    .filter((commit) => /^[a-f0-9]{40,64}$/.test(commit));
+  const unique = [...new Set(commits)].sort((left, right) => left.localeCompare(right));
+  if (unique.length > MAX_PREEXISTING_COMMITS) {
+    throw new Error(
+      `Task repository has ${unique.length} pre-existing commits outside the launch HEAD; maximum is ${MAX_PREEXISTING_COMMITS}`
+    );
+  }
+  return unique;
+}
+
+async function isAncestorCommit(
+  git: BaselineGitClient,
+  possibleAncestor: string,
+  descendant: string
+): Promise<boolean> {
+  try {
+    await git.raw(['merge-base', '--is-ancestor', possibleAncestor, descendant]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseGitNameStatus(output: string): GitNameStatus[] {
+  const fields = output.split('\0');
+  const changes: GitNameStatus[] = [];
+  for (let index = 0; index < fields.length;) {
+    const code = fields[index++];
+    if (!code) continue;
+    const firstPath = fields[index++];
+    if (!firstPath) break;
+    if (code.startsWith('R') || code.startsWith('C')) {
+      const nextPath = fields[index++];
+      if (!nextPath) break;
+      changes.push({ path: nextPath, previousPath: firstPath, status: 'renamed' });
+      continue;
+    }
+    changes.push({
+      path: firstPath,
+      previousPath: null,
+      status: code.startsWith('A') ? 'added' : code.startsWith('D') ? 'deleted' : 'modified',
+    });
+  }
+  return changes;
+}
+
+function parseCompletionCommits(output: string): CompletionEvidenceCommit[] {
+  const fields = output.split('\0');
+  const commits: CompletionEvidenceCommit[] = [];
+  for (let index = 0; index + 1 < fields.length && commits.length < 256; index += 2) {
+    const sha = fields[index]?.trim();
+    const summary = fields[index + 1]?.trim();
+    if (sha && /^[a-f0-9]{40,64}$/.test(sha)) {
+      commits.push({
+        sha,
+        summary: summary ? summary.slice(0, 500) : '(no commit subject)',
+      });
+    }
+  }
+  return commits;
+}
+
+async function verifyReportedArtifacts(
+  worktreePath: string,
+  artifacts: TaskCompletionArtifact[],
+  changedFiles: TaskCompletionChangedFile[]
+): Promise<TaskCompletionArtifact[]> {
+  const verified: TaskCompletionArtifact[] = [];
+  const attributablePaths = new Set(changedFiles.map((file) => file.path));
+  for (const artifact of artifacts.slice(0, 256)) {
+    if (artifact.kind !== 'file') {
+      verified.push({ ...artifact, verified: false });
+      continue;
+    }
+    const absolutePath = path.resolve(worktreePath, artifact.reference);
+    if (!isPathWithin(path.resolve(worktreePath), absolutePath)) {
+      verified.push({ ...artifact, sha256: null, verified: false });
+      continue;
+    }
+    const relativePath = path.relative(worktreePath, absolutePath);
+    if (!attributablePaths.has(relativePath)) {
+      verified.push({ ...artifact, reference: relativePath, sha256: null, verified: false });
+      continue;
+    }
+    const sha256 = await sha256WorktreeEntry(worktreePath, relativePath);
+    verified.push({
+      ...artifact,
+      reference: relativePath,
+      sha256,
+      verified: sha256 !== null,
+    });
+  }
+  return verified;
 }
 
 async function readIndexBlobHashes(

--- a/server/src/utils/completion-result-digest.ts
+++ b/server/src/utils/completion-result-digest.ts
@@ -1,0 +1,15 @@
+import type { CompletionResult } from '@veritas-kanban/shared';
+import { digestRunLaunchValue } from './run-launch-manifest-digest.js';
+
+export type CompletionResultPayload = Omit<CompletionResult, 'digest'>;
+
+export function calculateCompletionResultDigest(
+  result: CompletionResultPayload | CompletionResult
+): string {
+  const { digest: _digest, ...payload } = result as CompletionResult;
+  return digestRunLaunchValue(payload);
+}
+
+export function verifyCompletionResultDigest(result: CompletionResult): boolean {
+  return result.digest === calculateCompletionResultDigest(result);
+}

--- a/shared/src/types/task-envelope.types.ts
+++ b/shared/src/types/task-envelope.types.ts
@@ -20,6 +20,15 @@ export const TASK_COMPLETION_STATUSES = [
 ] as const;
 export type TaskCompletionStatus = (typeof TASK_COMPLETION_STATUSES)[number];
 
+export const TASK_TERMINAL_SOURCES = [
+  'process',
+  'stream',
+  'callback',
+  'remote-session',
+  'operator-interruption',
+] as const;
+export type TaskTerminalSource = (typeof TASK_TERMINAL_SOURCES)[number];
+
 export const TASK_SIDE_EFFECT_KINDS = [
   'filesystem-write',
   'process-execute',
@@ -82,6 +91,11 @@ export interface TaskLaunchBaseline {
   headSha: string;
   dirty: boolean;
   files: TaskLaunchBaselineFile[];
+  /**
+   * Commits reachable from another launch-time ref but not from `headSha`.
+   * Missing only on legacy v1 envelopes; completion then fails closed if HEAD moves.
+   */
+  preexistingCommitShas?: string[];
 }
 
 export interface TaskEnvelopeSubject {
@@ -220,6 +234,10 @@ export interface TaskContinuationHandle {
 /** Normalized terminal result returned by every provider transport. */
 export interface CompletionResult {
   schemaVersion: typeof COMPLETION_RESULT_SCHEMA_VERSION;
+  digest: string;
+  idempotencyKey: string;
+  completedAt: string;
+  terminalSource: TaskTerminalSource;
   taskEnvelopeSchemaVersion: typeof TASK_ENVELOPE_SCHEMA_VERSION;
   taskEnvelopeDigest: string;
   taskId: string;


### PR DESCRIPTION
## Summary

- normalize provider terminal claims into digest-bound completion results with persisted current and history records
- collect attributable Git, verification, artifact, and side-effect evidence with bounded redaction
- enforce idempotent terminal ownership plus callback and restart binding validation

## Verification

- `pnpm typecheck`
- `pnpm lint:budget`
- `LOG_LEVEL=silent pnpm --filter @veritas-kanban/server exec vitest run --reporter=dot --silent`
- `pnpm build`
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `pnpm smoke:cli-mcp` (live read/write skipped because `VK_API_KEY` is not configured)

Closes #893