### PR TITLE
Make worktree lifecycle transactional and remote-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ coverage/
 /blob-report/
 /playwright/.cache/
 .veritas-kanban/worktrees/
+.veritas-kanban/worktree-manifests/
 
 # TypeScript build info
 *.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added transactional, remote-safe worktree lifecycle management with
+  versioned manifests, exact fetched base commits, reasoned offline fallback,
+  task/attempt ownership leases, active-run locks, recovery states, and
+  preview-first stale cleanup. Dirty, untracked, unpushed, unmerged, and
+  externally held worktrees now require an admin-audited override. Attempt
+  leases use exclusive claims, legacy worktrees have a validated adoption path,
+  and restart recovery reconciles partial rebase, integration, push, and
+  cleanup states. Integration uses a dedicated temporary worktree and
+  non-force push without mutating the primary checkout. Task envelopes and run
+  launch manifests bind the exact worktree allocation and base evidence (#858).
 - Added the versioned credential-definition and run-bound lease core with
   metadata-only admin APIs, canonical definition/scope/action fingerprints,
   opaque hashed handles, exact launch-manifest and action binding, atomic TTL

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -131,6 +131,14 @@ worktree-content SHA-256. Capture retries when HEAD, status, or fingerprints
 move and fails closed after three unstable attempts, so later completion
 evidence cannot claim pre-existing changes.
 
+Worktrees created by Veritas also carry a durable `worktree-manifest/v1`
+allocation. Before dispatch, the attempt claims its ownership lease. The task
+envelope and run launch manifest bind the worktree manifest ID, lease ID,
+owning attempt, exact resolved base commit, and whether that base came from a
+successful remote fetch or an explicit stale-local acknowledgement. Legacy
+worktrees remain readable, but their launch manifests identify the launch HEAD
+as legacy evidence instead of presenting it as a remotely resolved base.
+
 Commit behavior is explicit instead of implied by a shared prompt:
 
 - `forbidden` does not authorize a commit.

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -388,13 +388,65 @@ Returns enriched context for agent consumption (task + dependencies + observatio
 ### Worktree (Git)
 
 ```
-POST   /api/tasks/:id/worktree        # Create worktree branch
-GET    /api/tasks/:id/worktree         # Get worktree status
-DELETE /api/tasks/:id/worktree         # Remove worktree
-POST   /api/tasks/:id/worktree/rebase  # Rebase worktree
-POST   /api/tasks/:id/worktree/merge   # Merge worktree
-GET    /api/tasks/:id/worktree/open    # Open in editor
+GET    /api/tasks/worktrees/cleanup-preview     # Preview expired cleanup candidates
+POST   /api/tasks/:id/worktree                  # Resolve base and create worktree
+POST   /api/tasks/:id/worktree/adopt            # Admin: validate and adopt a legacy worktree
+GET    /api/tasks/:id/worktree                   # Get status and manifest evidence
+GET    /api/tasks/:id/worktree/cleanup-preview   # Preview destructive-operation safety
+DELETE /api/tasks/:id/worktree                   # Remove worktree when safe
+POST   /api/tasks/:id/worktree/rebase            # Fetch and rebase onto an exact commit
+POST   /api/tasks/:id/worktree/merge             # Integrate without changing primary checkout
+GET    /api/tasks/:id/worktree/open              # Open in editor
 ```
+
+Creation fetches the configured base from `origin`, resolves the exact commit,
+and persists `worktree-manifest/v1` before Git mutates the repository. A fetch
+failure returns `409`. Offline creation requires an explicit acknowledgement:
+
+```json
+{
+  "allowStaleBase": true,
+  "staleBaseAcknowledgement": {
+    "reason": "Operator confirmed the repository is intentionally offline."
+  }
+}
+```
+
+The response includes the manifest ID, ownership lease, exact base commit and
+source, lifecycle state, remote freshness, ahead/behind counts, and cleanup
+preview. Agent launch claims the same lease for the exact attempt; the task
+envelope and run launch manifest retain the manifest, lease, attempt, and base
+commit references.
+
+Deletion is preview-first. Active attempts cannot be overridden. Dirty,
+untracked, unpushed, unmerged, or externally held worktrees require
+`force=true` plus a reason, which is persisted in the manifest:
+
+```text
+DELETE /api/tasks/:id/worktree?force=true&reason=Operator%20accepted%20the%20risk
+```
+
+Safe cleanup remains available with `task:write`, but a forced cleanup requires
+`admin:manage`. An unavailable external-process inspection is incomplete
+evidence and therefore also requires an admin override. An unexpired attempt
+lease, active run, branch mismatch, or manifest mismatch cannot be overridden.
+
+Pre-6.0 tasks that have a `git.worktreePath` but no manifest are not silently
+trusted. An admin can call `POST /api/tasks/:id/worktree/adopt`; Veritas requires
+an exact registered path and branch, matching common Git directory and remote
+fingerprint, a unique cross-task allocation, and a freshly resolved remote base
+that is proven to be an ancestor of the legacy HEAD before creating the
+manifest. The baseline source is recorded as `legacy-adopted`, not as original
+creation provenance. Local tracked and untracked changes are preserved and
+appear in cleanup preview.
+
+Merge creates a detached integration worktree from the latest exact remote
+base, merges the task branch there, and pushes `HEAD` to the base without
+force. It never checks out, pulls, stages, commits, or otherwise changes the
+configured primary checkout. Interrupted create, rebase, push, and cleanup
+states remain recorded with a recoverable error and path. Restart recovery
+reconciles persisted preparing, merging, pushing, integrated, rebasing, and
+cleanup states against Git and the fetched remote before resuming.
 
 ### Apply Template
 

--- a/docs/DATA-LIFECYCLE.md
+++ b/docs/DATA-LIFECYCLE.md
@@ -96,6 +96,13 @@ rules:
   telemetry ranges, notifications, and workflow snapshots
 - require explicit confirmation for destructive cleanup
 - preserve active worktrees and current run state by default
+- treat `.veritas-kanban/worktree-manifests/*.json` as ownership and recovery
+  records, not disposable cache; a clean worktree is not proof that it is
+  pushed, merged, unowned, or safe to remove
+- preview stale worktree candidates before removal and retain the exact blocked
+  reasons; only reasoned overrides may bypass dirty, untracked, unpushed,
+  unmerged, or external-hold checks, while an active run remains
+  non-overrideable
 - preserve credential broker state during general runtime cleanup; revoke active
   leases before intentional broker-state removal
 - emit audit/activity records for admin cleanup, export, import, restore, and

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -606,16 +606,17 @@ wscat -c "ws://localhost:3001/ws?api_key=<api-key>"
 
 ### Where Data Lives
 
-| Path                              | Contents                                               |
-| --------------------------------- | ------------------------------------------------------ |
-| `tasks/active/`                   | Active task markdown files (YAML frontmatter + body)   |
-| `tasks/archive/`                  | Archived task markdown files                           |
-| `.veritas-kanban/`                | Internal config, logs, worktrees, agent requests       |
-| `.veritas-kanban/config.json`     | Application settings                                   |
-| `.veritas-kanban/security.json`   | JWT secret (if not using `VERITAS_JWT_SECRET` env var) |
-| `.veritas-kanban/logs/`           | Application logs                                       |
-| `.veritas-kanban/worktrees/`      | Git worktree metadata                                  |
-| `.veritas-kanban/agent-requests/` | Pending AI agent requests                              |
+| Path                                  | Contents                                                           |
+| ------------------------------------- | ------------------------------------------------------------------ |
+| `tasks/active/`                       | Active task markdown files (YAML frontmatter + body)               |
+| `tasks/archive/`                      | Archived task markdown files                                       |
+| `.veritas-kanban/`                    | Internal config, logs, worktrees, agent requests                   |
+| `.veritas-kanban/config.json`         | Application settings                                               |
+| `.veritas-kanban/security.json`       | JWT secret (if not using `VERITAS_JWT_SECRET` env var)             |
+| `.veritas-kanban/logs/`               | Application logs                                                   |
+| `.veritas-kanban/worktrees/`          | Task and temporary integration worktree directories                |
+| `.veritas-kanban/worktree-manifests/` | Durable worktree ownership, base, lifecycle, and override evidence |
+| `.veritas-kanban/agent-requests/`     | Pending AI agent requests                                          |
 
 In Docker, the `DATA_DIR` environment variable maps to `/app/data` by default inside the container.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -253,8 +253,12 @@ Create reusable templates for consistent task creation. Added in v1.6.
 
 Integrated git workflow from branch creation to merge.
 
-- **Git worktree integration** — Create isolated worktrees per task, tied to dedicated branches
-- **Worktree status** — See active worktree path, branch, and base branch in the Git tab
+- **Transactional Git worktrees** — Persist a versioned allocation and ownership lease before creating an isolated task worktree
+- **Exact remote bases** — Fetch and record the resolved base commit; offline fallback requires a reasoned stale-base acknowledgement
+- **Worktree status** — See path, branch, exact base, remote freshness, lifecycle state, and cleanup hazards in the Git tab
+- **Primary-checkout-safe integration** — Merge and push from a dedicated temporary integration worktree without switching or pulling the primary checkout
+- **Preview-first cleanup** — Block active runs and require audited overrides for dirty, untracked, unpushed, unmerged, or externally held worktrees
+- **Recoverable lifecycle state** — Keep partial create, rebase, push, and cleanup failures visible in `worktree-manifest/v1`
 - **Git selection form** — Configure repository, branch name, and base branch when setting up a worktree
 - **Diff viewer** — Unified diff view with file tree navigation, hunk-by-hunk display, and line numbers
 - **File tree** — Collapsible file tree showing changed files with add/modify/delete indicators

--- a/docs/multi-agent-git-workflow.md
+++ b/docs/multi-agent-git-workflow.md
@@ -1,128 +1,173 @@
-# Multi-Agent Git Workflow Guide
+# Multi-Agent Git Worktree Workflow
 
-> Lessons learned from the VK v2.0 sprint where multiple AI agents worked on the same repository simultaneously.
+Veritas assigns each code task a dedicated Git branch, worktree, ownership
+lease, and durable lifecycle manifest. The primary checkout is operator-owned;
+task creation, integration, and cleanup must not switch its branch or change
+its files.
 
-## The Problem: Branch Collisions
+## Why Worktrees Are Required
 
-When you spawn multiple sub-agents (via `sessions_spawn` or similar) and they all work on the same git repository, they share a **single working directory**. This causes:
+Multiple agents in one working directory share a checkout and index. A branch
+switch, staged file, reset, or incomplete edit from one run can affect every
+other run. Separate worktrees provide each task with:
 
-1. **Branch stomping**: Agent A creates `feat/task-a`, Agent B creates `feat/task-b`, but `git checkout` in Agent B switches the entire working directory — Agent A's uncommitted changes are now on the wrong branch or lost.
-2. **Mixed commits**: Both agents stage and commit files. Pre-commit hooks run against ALL staged files, including the other agent's work. Lint/typecheck failures from incomplete work block commits.
-3. **Merge confusion**: Changes from different features end up interleaved in the same branch history.
+- an isolated working directory and index
+- a unique branch and path
+- an exact, recorded base commit
+- task and attempt ownership
+- independently inspectable changes and recovery state
 
-### Real Example
+Sequential execution is still appropriate for overlapping tasks, but it is not
+a substitute for isolation.
 
-During the v2.0 sprint, two Sonnet sub-agents were spawned in parallel:
-- **Sonnet-1**: `feat/markdown-rendering-63` (frontend React work)
-- **Sonnet-2**: `feat/cli-usage-reporting-50` (CLI TypeScript work)
+## Veritas-Managed Creation
 
-Both worked in `~/Projects/veritas-kanban`. Sonnet-2's CLI changes ended up staged alongside Sonnet-1's React changes. The pre-commit hook tried to lint `MarkdownText.tsx` (Sonnet-1's file) during Sonnet-2's commit and failed because the file wasn't complete yet.
+Create worktrees from the task Git tab or API:
 
-## Solutions
+```http
+POST /api/tasks/:id/worktree
+Content-Type: application/json
 
-### Option 1: Sequential Execution (Simplest)
-
-Run sub-agents one at a time on the same repo. Each agent:
-1. Creates a feature branch
-2. Does its work
-3. Commits and merges to main
-4. Main agent spawns the next sub-agent
-
-**Pros**: No conflicts, no complexity
-**Cons**: Slower (no parallelism)
-
-**Best for**: Small teams, tasks that touch overlapping files
-
-### Option 2: Git Worktrees (Recommended for Parallel)
-
-Git worktrees let you have multiple working directories for the same repo, each on a different branch:
-
-```bash
-# Create worktrees for each agent
-git worktree add ../vk-agent-1 -b feat/task-a
-git worktree add ../vk-agent-2 -b feat/task-b
-
-# Each sub-agent works in its own directory
-# Agent 1 → ~/Projects/vk-agent-1/
-# Agent 2 → ~/Projects/vk-agent-2/
-
-# After work is done, merge from the main repo
-cd ~/Projects/veritas-kanban
-git merge feat/task-a
-git merge feat/task-b
-
-# Clean up
-git worktree remove ../vk-agent-1
-git worktree remove ../vk-agent-2
+{}
 ```
 
-**Pros**: True parallelism, no branch conflicts, each agent has isolated workspace
-**Cons**: More setup, disk space, orchestrator must manage worktree lifecycle
+Veritas validates the configured repository and branch names, fetches the base
+branch from `origin`, resolves its exact commit, checks all active manifests and
+registered Git worktrees for branch/path collisions, and persists
+`worktree-manifest/v1` before `git worktree add` runs.
 
-**Best for**: Large sprints, independent features, CI/CD parallel builds
+Fetch errors are not ignored. When remote access is intentionally unavailable,
+an operator may acknowledge the risk:
 
-### Option 3: Orchestrator Does Heavy Lifting, Delegates Light Tasks
-
-The orchestrator (main agent) works directly on the repo for complex tasks. Sub-agents handle:
-- Independent research (no git needed)
-- Documentation writing (separate files)
-- Code review (read-only)
-- Tasks in different repos
-
-**Pros**: Minimal coordination overhead
-**Cons**: Limited parallelism on same repo
-
-**Best for**: Mixed workloads where some tasks don't need the repo
-
-## Sub-Agent Task Template
-
-When spawning a sub-agent that touches a git repo, include these instructions:
-
-```
-## Git Rules
-1. Create your feature branch: `git checkout -b feat/your-branch`
-2. Work ONLY in your branch
-3. Before committing: run secret scan on ALL changed files
-4. Use `--no-verify` if pre-commit hooks fail on other agents' files
-5. After committing, switch back to main: `git checkout main`
-6. Do NOT modify files outside your feature scope
+```json
+{
+  "allowStaleBase": true,
+  "staleBaseAcknowledgement": {
+    "reason": "Operator confirmed offline maintenance mode."
+  }
+}
 ```
 
-## Pre-Commit Hook Handling
+The manifest records the local commit, failed-fetch diagnostic, reason, actor,
+and timestamp. Do not use stale-base mode merely to bypass a remote error.
 
-VK uses `lint-staged` which runs ESLint on all staged files. When multiple agents stage files:
+### Adopting pre-6.0 worktrees
 
-- **Problem**: Agent A's half-written file fails Agent B's lint check
-- **Fix**: Use `git commit --no-verify` when you've verified your own files are clean
-- **Better fix**: Use worktrees so each agent has its own staging area
+Existing tasks with a worktree path but no manifest require explicit admin
+adoption:
 
-## Secret Scanning
-
-**MANDATORY before every commit**, regardless of agent:
-
-```bash
-grep -rn "password\|secret\|token\|apiKey\|appPassword\|sk-\|pplx-\|xai-" <changed-files>
+```http
+POST /api/tasks/:id/worktree/adopt
 ```
 
-Filter out false positives (variable names like `tokenProvider`, `inputTokens`, etc.) but NEVER skip the scan.
+Veritas verifies the registered path, branch, common Git directory, redacted
+remote identity, cross-task uniqueness, exact remote base, and current status
+before persisting ownership. The fetched base must be an ancestor of the legacy
+HEAD and is labeled `legacy-adopted`, so adoption evidence is not confused with
+the unknown original creation base. Veritas does not remove or rewrite local
+changes.
 
-## Orchestrator Checklist
+## Launch Ownership
 
-When managing a multi-agent sprint:
+When an agent starts, the new attempt claims and renews the worktree lease. The
+task envelope and run launch manifest record:
 
-- [ ] Decide: sequential or parallel?
-- [ ] If parallel: set up worktrees before spawning
-- [ ] Give each agent a clear branch name convention
-- [ ] Include git rules in every sub-agent task prompt
-- [ ] After each agent finishes: review, secret scan, merge to main
-- [ ] Clean up feature branches and worktrees
-- [ ] Run full test suite after all merges
+- worktree manifest ID
+- ownership lease ID
+- owning attempt ID
+- repository, branch, and base branch
+- exact resolved base commit
+- remote or acknowledged-local resolution source
+- launch HEAD and pre-existing file fingerprints
 
-## Lessons Learned
+Lease claims are compare-and-claim operations. A second live attempt cannot
+replace an unexpired owner, terminal attempts release ownership, and a claim
+that occurs immediately before attempt persistence still locks cleanup. An
+active or pending attempt locks rebase, integration, and cleanup, including
+forced cleanup.
 
-1. **"Mental notes" don't work for stateless agents** — write everything to files
-2. **Pre-commit hooks are global** — they see ALL staged files, not just yours
-3. **Branch names must be unique** — two agents creating `feat/my-feature` = disaster
-4. **Orchestrator must verify merges** — sub-agents can't see each other's work
-5. **Sequential is faster than fixing parallel mistakes** — when in doubt, go serial
-6. **Secret scans are non-negotiable** — one leaked key = delete git history (expensive)
+## Integration
+
+The Merge action does not check out the base branch in the primary repository.
+Veritas:
+
+1. Requires a clean task worktree and no active run.
+2. Fetches and resolves the latest remote base commit.
+3. Creates a detached worktree under
+   `.veritas-kanban/worktrees/.integration/`.
+4. Merges the task branch there with a merge commit.
+5. Pushes `HEAD` to the remote base without force.
+6. Fetches and verifies the resulting remote commit.
+7. Removes the integration and source worktrees when cleanup remains safe.
+8. Marks the task done.
+
+If merge or push fails, the integration path, commit, stage, and bounded error
+remain in the manifest. A clean failed-push worktree can be retried. Conflicts
+or a newly advanced remote base require inspection and resolution in the
+recorded integration worktree before retrying.
+
+## Cleanup
+
+Preview cleanup before removing anything:
+
+```http
+GET /api/tasks/:id/worktree/cleanup-preview
+GET /api/tasks/worktrees/cleanup-preview
+```
+
+The task endpoint evaluates one worktree. The collection endpoint lists
+expired-lease candidates without deleting them.
+
+Cleanup blocks when Veritas finds:
+
+- an active or pending attempt
+- a task/manifest or branch mismatch
+- tracked staged or unstaged changes
+- untracked files
+- commits not reachable from the remote base
+- a HEAD not merged into the remote base
+- a known external process hold
+- an unavailable external-hold probe, missing path, or other incomplete safety
+  evidence
+
+An active run, unexpired attempt lease, branch mismatch, or manifest mismatch
+is not overrideable. Other findings require `admin:manage`, `force=true`, and
+an explicit reason:
+
+```http
+DELETE /api/tasks/:id/worktree?force=true&reason=Operator%20accepted%20the%20risk
+```
+
+The branch is retained. The override reason, actor, time, and bypassed checks
+are appended to the manifest. A clean status alone never proves that a
+worktree is pushed, merged, unowned, or safe to remove.
+
+## Recovery
+
+Lifecycle state is durable:
+
+| Failure point       | Recorded state                                  | Recovery                                                                  |
+| ------------------- | ----------------------------------------------- | ------------------------------------------------------------------------- |
+| Worktree creation   | exact base, branch, path, `creation: failed`    | Retry creation; Veritas adopts only an unambiguous partial branch/path    |
+| Task metadata write | Git worktree and `creation: ready`              | Retry creation to reconcile the task reference                            |
+| Rebase              | target exact base and `rebase: rebasing/failed` | Retry; Veritas aborts partial Git state and reapplies the recorded intent |
+| Integration prepare | integration path/base and `preparing`           | Retry; Veritas validates or recreates the detached worktree               |
+| Integration merge   | integration path and `merging` or merge error   | Retry; completed merges are recognized, partial merges are aborted        |
+| Integration push    | integration HEAD and `pushing` or push error    | Retry; Veritas first checks whether the commit already reached remote     |
+| Cleanup             | path and `cleanup: failed` or `blocked`         | Retry; a post-removal task-write failure reconciles without re-deleting   |
+
+Repository allocation locks serialize cross-task branch/path reservation.
+Worktree manifest lock files are ownership records. Veritas never guesses that
+a stale-looking lock is abandoned. Confirm that no Veritas process owns the
+lock before removing it manually.
+
+## Operator Checklist
+
+- Give every code task a unique branch.
+- Create or reconcile the worktree before starting an agent.
+- Treat the recorded worktree path as the run boundary.
+- Stop the run before rebase, integration, or cleanup.
+- Review the cleanup preview and preserve ambiguous work.
+- Prefer pull-request review when repository policy requires it.
+- Never force-push as part of automated integration.
+- Keep `.veritas-kanban/worktree-manifests/` in runtime backups.

--- a/docs/security.md
+++ b/docs/security.md
@@ -94,6 +94,21 @@ agent routing and permission checks require `agent:read`; approval requests
 require `task:write`; approval review, routing configuration, and permission
 elevation require `admin:manage`.
 
+Worktree mutations are fail-closed around repository ownership. Creation
+records a credential-redacted repository fingerprint, exact base commit,
+unique path/branch, and ownership lease before running `git worktree add`.
+Active attempts lock rebase, integration, and cleanup. Cleanup inspects tracked
+changes, untracked files, commits not reachable from the remote base, merge
+reachability, and external process holds. An unavailable hold probe is treated
+as incomplete evidence, not a clean result. Overrideable findings require
+`admin:manage` plus an explicit actor-attributed reason in the durable manifest;
+active runs, unexpired attempt leases, branch mismatches, and manifest
+mismatches cannot be overridden. Integration resume revalidates path
+containment, registered-worktree identity, common Git directory, and
+credential-redacted remote identity before any push. Integration uses a
+detached temporary worktree and a non-force push, so the configured primary
+checkout is not mutated.
+
 ### v5 Auth Context
 
 Authenticated REST requests and WebSocket connections now carry a shared auth

--- a/server/src/__tests__/routes/tasks-coverage.test.ts
+++ b/server/src/__tests__/routes/tasks-coverage.test.ts
@@ -31,6 +31,9 @@ const {
     rebaseWorktree: vi.fn(),
     mergeWorktree: vi.fn(),
     openInVSCode: vi.fn(),
+    previewCleanup: vi.fn(),
+    previewCleanupCandidates: vi.fn(),
+    adoptLegacyWorktree: vi.fn(),
   },
   mockBlockingService: {
     getBlockingStatus: vi.fn(),
@@ -101,6 +104,16 @@ describe('Tasks Routes (actual module)', () => {
     vi.clearAllMocks();
     app = express();
     app.use(express.json());
+    app.use((req, _res, next) => {
+      if (req.query.force === 'true' || req.path.endsWith('/worktree/adopt')) {
+        (req as import('../../middleware/auth.js').AuthenticatedRequest).auth = {
+          role: 'admin',
+          isLocalhost: true,
+          permissions: ['*'],
+        };
+      }
+      next();
+    });
     app.use('/api/tasks', taskRoutes);
     app.use(errorHandler);
   });
@@ -492,6 +505,31 @@ describe('Tasks Routes (actual module)', () => {
       mockWorktreeService.createWorktree.mockResolvedValue({ path: '/tmp/wt', branch: 'task/t1' });
       const res = await request(app).post('/api/tasks/t1/worktree');
       expect(res.status).toBe(201);
+      expect(mockWorktreeService.createWorktree).toHaveBeenCalledWith('t1', {});
+    });
+
+    it('POST requires a reasoned stale-base acknowledgement', async () => {
+      const invalid = await request(app)
+        .post('/api/tasks/t1/worktree')
+        .send({ allowStaleBase: true });
+      expect(invalid.status).toBe(400);
+
+      mockWorktreeService.createWorktree.mockResolvedValue({ path: '/tmp/wt' });
+      const valid = await request(app)
+        .post('/api/tasks/t1/worktree')
+        .send({
+          allowStaleBase: true,
+          staleBaseAcknowledgement: { reason: 'Confirmed offline maintenance.' },
+        });
+
+      expect(valid.status).toBe(201);
+      expect(mockWorktreeService.createWorktree).toHaveBeenCalledWith('t1', {
+        allowStaleBase: true,
+        staleBaseAcknowledgement: {
+          reason: 'Confirmed offline maintenance.',
+          actor: 'system:unknown',
+        },
+      });
     });
 
     it('GET should get worktree status', async () => {
@@ -504,13 +542,72 @@ describe('Tasks Routes (actual module)', () => {
       mockWorktreeService.deleteWorktree.mockResolvedValue(undefined);
       const res = await request(app).delete('/api/tasks/t1/worktree');
       expect(res.status).toBe(204);
+      expect(mockWorktreeService.deleteWorktree).toHaveBeenCalledWith('t1', {
+        force: false,
+        reason: undefined,
+        actor: 'system:unknown',
+      });
     });
 
-    it('DELETE with force=true should force delete', async () => {
+    it('DELETE with force=true requires and records an explicit reason', async () => {
       mockWorktreeService.deleteWorktree.mockResolvedValue(undefined);
-      const res = await request(app).delete('/api/tasks/t1/worktree?force=true');
+      const rejected = await request(app).delete('/api/tasks/t1/worktree?force=true');
+      expect(rejected.status).toBe(400);
+
+      const res = await request(app)
+        .delete('/api/tasks/t1/worktree')
+        .query({ force: 'true', reason: 'Operator inspected and accepted the risk.' });
       expect(res.status).toBe(204);
-      expect(mockWorktreeService.deleteWorktree).toHaveBeenCalledWith('t1', true);
+      expect(mockWorktreeService.deleteWorktree).toHaveBeenCalledWith('t1', {
+        force: true,
+        reason: 'Operator inspected and accepted the risk.',
+        actor: 'service:unknown',
+      });
+    });
+
+    it('requires admin permission for reasoned cleanup overrides', async () => {
+      const agentApp = express();
+      agentApp.use(express.json());
+      agentApp.use((req, _res, next) => {
+        (req as import('../../middleware/auth.js').AuthenticatedRequest).auth = {
+          role: 'agent',
+          isLocalhost: false,
+          permissions: ['task:write'],
+        };
+        next();
+      });
+      agentApp.use('/api/tasks', taskRoutes);
+      agentApp.use(errorHandler);
+
+      const res = await request(agentApp)
+        .delete('/api/tasks/t1/worktree')
+        .query({ force: 'true', reason: 'Agent attempts to bypass safety.' });
+
+      expect(res.status).toBe(403);
+      expect(mockWorktreeService.deleteWorktree).not.toHaveBeenCalled();
+    });
+
+    it('adopts a validated legacy worktree through an admin-only endpoint', async () => {
+      mockWorktreeService.adoptLegacyWorktree.mockResolvedValue({
+        path: '/tmp/legacy-worktree',
+      });
+
+      const res = await request(app).post('/api/tasks/t1/worktree/adopt');
+
+      expect(res.status).toBe(201);
+      expect(mockWorktreeService.adoptLegacyWorktree).toHaveBeenCalledWith('t1');
+    });
+
+    it('GET cleanup previews should remain read-only', async () => {
+      mockWorktreeService.previewCleanup.mockResolvedValue({ eligible: false });
+      mockWorktreeService.previewCleanupCandidates.mockResolvedValue([{ taskId: 't1' }]);
+
+      const taskPreview = await request(app).get('/api/tasks/t1/worktree/cleanup-preview');
+      const stalePreview = await request(app).get('/api/tasks/worktrees/cleanup-preview');
+
+      expect(taskPreview.status).toBe(200);
+      expect(stalePreview.status).toBe(200);
+      expect(mockWorktreeService.deleteWorktree).not.toHaveBeenCalled();
     });
 
     it('POST /rebase should rebase', async () => {
@@ -520,7 +617,10 @@ describe('Tasks Routes (actual module)', () => {
     });
 
     it('POST /merge should merge', async () => {
-      mockWorktreeService.mergeWorktree.mockResolvedValue(undefined);
+      mockWorktreeService.mergeWorktree.mockResolvedValue({
+        merged: true,
+        targetCommit: 'a'.repeat(40),
+      });
       const res = await request(app).post('/api/tasks/t1/worktree/merge');
       expect(res.status).toBe(200);
       expect(res.body.merged).toBe(true);

--- a/server/src/__tests__/run-launch-manifest-service.test.ts
+++ b/server/src/__tests__/run-launch-manifest-service.test.ts
@@ -41,9 +41,14 @@ const taskEnvelope: TaskEnvelope = {
   workspace: {
     workspaceId: 'workspace-854',
     worktreeId: 'worktree-854',
+    worktreeManifestId: 'manifest-854',
+    ownershipLeaseId: 'lease-854',
+    ownershipAttemptId: 'attempt-854',
     repo: 'BradGroux/veritas-kanban',
     branch: 'feat/run-launch-manifest-854',
     baseBranch: 'main',
+    resolvedBaseCommit: 'b'.repeat(40),
+    baseResolutionSource: 'remote',
     worktreePath: '/workspace/veritas-kanban',
     baseline: {
       capturedAt: '2026-07-23T20:00:00.000Z',
@@ -254,6 +259,17 @@ describe('RunLaunchManifestService', () => {
         digest: expect.stringMatching(/^sha256:/),
         provider: 'codex-cli',
         probeRevision: expect.any(Number),
+      },
+      workspace: {
+        worktreeId: 'worktree-854',
+        worktreeManifestId: 'manifest-854',
+        ownershipLeaseId: 'lease-854',
+        ownershipAttemptId: 'attempt-854',
+        repo: 'BradGroux/veritas-kanban',
+        branch: 'feat/run-launch-manifest-854',
+        baseBranch: 'main',
+        resolvedBaseCommit: 'b'.repeat(40),
+        baseResolutionSource: 'remote',
       },
       enforcement: {
         enforceable: true,

--- a/server/src/__tests__/task-envelope-service.test.ts
+++ b/server/src/__tests__/task-envelope-service.test.ts
@@ -71,6 +71,11 @@ function task(): Task {
       branch: 'feat/task-envelope',
       baseBranch: 'main',
       worktreePath: '/tmp/veritas-kanban-task',
+      worktreeManifestId: 'manifest-task-envelope',
+      worktreeBaseCommit: 'd'.repeat(40),
+      worktreeBaseSource: 'remote',
+      worktreeLeaseId: 'lease-task-envelope',
+      worktreeLeaseOwnerAttemptId: 'attempt_contract',
     },
     subtasks: [
       {
@@ -180,6 +185,13 @@ describe('TaskEnvelopeService', () => {
 
     expect(result.schemaVersion).toBe(TASK_ENVELOPE_SCHEMA_VERSION);
     expect(result.workspace.baseline).toEqual(baseline);
+    expect(result.workspace).toMatchObject({
+      worktreeManifestId: 'manifest-task-envelope',
+      ownershipLeaseId: 'lease-task-envelope',
+      ownershipAttemptId: 'attempt_contract',
+      resolvedBaseCommit: 'd'.repeat(40),
+      baseResolutionSource: 'remote',
+    });
     expect(result.subject.acceptanceCriteria).toEqual(['The envelope is versioned.']);
     expect(result.subject.background).toContain('Existing callbacks must remain readable.');
     expect(result.allowedSideEffects.map((item) => item.kind)).toEqual([

--- a/server/src/__tests__/worktree-manifest-repository.test.ts
+++ b/server/src/__tests__/worktree-manifest-repository.test.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { WORKTREE_MANIFEST_SCHEMA_VERSION, type WorktreeManifest } from '@veritas-kanban/shared';
+import { FileWorktreeManifestRepository } from '../storage/worktree-manifest-repository.js';
+
+describe('FileWorktreeManifestRepository', () => {
+  let root: string;
+  let manifestsDir: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-worktree-manifests-'));
+    manifestsDir = path.join(root, 'manifests');
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  function manifest(): WorktreeManifest {
+    return {
+      schemaVersion: WORKTREE_MANIFEST_SCHEMA_VERSION,
+      id: 'worktree_fixture',
+      revision: 0,
+      taskId: 'task_858',
+      repository: {
+        name: 'veritas',
+        rootPath: '/tmp/veritas',
+        commonGitDir: '/tmp/veritas/.git',
+        originFingerprint: `sha256:${'a'.repeat(64)}`,
+      },
+      path: '/tmp/veritas-worktree',
+      branch: 'feat/worktree-858',
+      base: {
+        branch: 'main',
+        commit: 'b'.repeat(40),
+        source: 'remote',
+        resolvedAt: '2026-07-23T20:00:00.000Z',
+        fetchedAt: '2026-07-23T20:00:00.000Z',
+      },
+      lease: {
+        id: 'lease_fixture',
+        ownerTaskId: 'task_858',
+        acquiredAt: '2026-07-23T20:00:00.000Z',
+        expiresAt: '2026-08-22T20:00:00.000Z',
+      },
+      lifecycle: {
+        creation: 'ready',
+        integration: 'idle',
+        cleanup: 'active',
+      },
+      rebase: { state: 'idle' },
+      integration: {},
+      createdAt: '2026-07-23T20:00:00.000Z',
+      updatedAt: '2026-07-23T20:00:00.000Z',
+      overrides: [],
+    };
+  }
+
+  it('atomically validates, versions, reads, and lists manifests', async () => {
+    const repository = new FileWorktreeManifestRepository({ manifestsDir });
+
+    const first = await repository.withTaskLock('task_858', () => repository.save(manifest()));
+    const second = await repository.withTaskLock('task_858', () =>
+      repository.save({
+        ...first,
+        lifecycle: { ...first.lifecycle, integration: 'preparing' },
+      })
+    );
+
+    expect(first.revision).toBe(0);
+    expect(second.revision).toBe(1);
+    expect(await repository.read('task_858')).toEqual(second);
+    expect(await repository.list()).toEqual([second]);
+  });
+
+  it('surfaces invalid persisted state instead of silently replacing it', async () => {
+    const repository = new FileWorktreeManifestRepository({ manifestsDir });
+    await fs.mkdir(manifestsDir, { recursive: true });
+    await fs.writeFile(path.join(manifestsDir, 'task_858.json'), '{}\n');
+
+    await expect(repository.read('task_858')).rejects.toThrow();
+  });
+
+  it('never auto-removes an ambiguous stale-looking lock', async () => {
+    const repository = new FileWorktreeManifestRepository({
+      manifestsDir,
+      lockTimeoutMs: 75,
+    });
+    await fs.mkdir(manifestsDir, { recursive: true });
+    const lockPath = path.join(manifestsDir, 'task_858.json.lock');
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: 999_999,
+        createdAt: '2020-01-01T00:00:00.000Z',
+        token: 'ambiguous-owner',
+      })
+    );
+
+    await expect(repository.withTaskLock('task_858', async () => undefined)).rejects.toThrow(
+      /held or stale/
+    );
+    expect(await fs.readFile(lockPath, 'utf8')).toContain('ambiguous-owner');
+  });
+});

--- a/server/src/__tests__/worktree-service.test.ts
+++ b/server/src/__tests__/worktree-service.test.ts
@@ -1,0 +1,756 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { AppConfig, Task, UpdateTaskInput } from '@veritas-kanban/shared';
+import {
+  DefaultWorktreeGitRunner,
+  WorktreeService,
+  type WorktreeGitRunner,
+} from '../services/worktree-service.js';
+import { FileWorktreeManifestRepository } from '../storage/worktree-manifest-repository.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const result = await execFileAsync('git', args, { cwd });
+  return result.stdout.trim();
+}
+
+class FakeTaskStore {
+  failNextUpdate = false;
+
+  constructor(public task: Task) {}
+
+  async getTask(taskId: string): Promise<Task | null> {
+    return taskId === this.task.id ? structuredClone(this.task) : null;
+  }
+
+  async updateTask(taskId: string, update: UpdateTaskInput): Promise<Task> {
+    if (taskId !== this.task.id) throw new Error('task not found');
+    if (this.failNextUpdate) {
+      this.failNextUpdate = false;
+      throw new Error('simulated task persistence failure');
+    }
+    this.task = {
+      ...this.task,
+      ...structuredClone(update),
+      git: update.git
+        ? ({ ...this.task.git, ...structuredClone(update.git) } as Task['git'])
+        : this.task.git,
+      updated: new Date().toISOString(),
+    };
+    return structuredClone(this.task);
+  }
+}
+
+class MultiTaskStore {
+  constructor(public tasks: Map<string, Task>) {}
+
+  async getTask(taskId: string): Promise<Task | null> {
+    const task = this.tasks.get(taskId);
+    return task ? structuredClone(task) : null;
+  }
+
+  async updateTask(taskId: string, update: UpdateTaskInput): Promise<Task> {
+    const task = this.tasks.get(taskId);
+    if (!task) throw new Error('task not found');
+    const updated = {
+      ...task,
+      ...structuredClone(update),
+      git: update.git ? ({ ...task.git, ...structuredClone(update.git) } as Task['git']) : task.git,
+      updated: new Date().toISOString(),
+    };
+    this.tasks.set(taskId, updated);
+    return structuredClone(updated);
+  }
+}
+
+describe('WorktreeService transactional lifecycle', () => {
+  let root: string;
+  let remotePath: string;
+  let primaryPath: string;
+  let worktreesDir: string;
+  let taskStore: FakeTaskStore;
+  let nowMs: number;
+  let externalHoldState: 'clear' | 'held' | 'unavailable' = 'clear';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-worktree-service-'));
+    remotePath = path.join(root, 'remote.git');
+    primaryPath = path.join(root, 'primary');
+    worktreesDir = path.join(root, 'runtime', 'worktrees');
+    nowMs = Date.parse('2026-07-23T20:00:00.000Z');
+    externalHoldState = 'clear';
+
+    await fs.mkdir(remotePath, { recursive: true });
+    await git(remotePath, 'init', '--bare', '--initial-branch=main');
+    await git(root, 'clone', remotePath, primaryPath);
+    await git(primaryPath, 'config', 'user.name', 'Veritas Test');
+    await git(primaryPath, 'config', 'user.email', 'veritas@example.test');
+    await fs.writeFile(path.join(primaryPath, 'README.md'), 'baseline\n');
+    await git(primaryPath, 'add', 'README.md');
+    await git(primaryPath, 'commit', '-m', 'baseline');
+    await git(primaryPath, 'push', '-u', 'origin', 'main');
+
+    taskStore = new FakeTaskStore({
+      id: 'task_858',
+      title: 'Remote-safe worktrees',
+      description: '',
+      type: 'code',
+      status: 'todo',
+      priority: 'high',
+      created: '2026-07-23T19:00:00.000Z',
+      updated: '2026-07-23T19:00:00.000Z',
+      git: {
+        repo: 'veritas',
+        branch: 'feat/remote-safe-worktrees-858',
+        baseBranch: 'main',
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  function service(gitRunner?: WorktreeGitRunner): WorktreeService {
+    const config: AppConfig = {
+      repos: [{ name: 'veritas', path: primaryPath, defaultBranch: 'main' }],
+      agents: [],
+      defaultAgent: 'codex',
+    };
+    return new WorktreeService({
+      worktreesDir,
+      taskService: taskStore,
+      configService: { getConfig: async () => structuredClone(config) },
+      manifestRepository: new FileWorktreeManifestRepository({
+        manifestsDir: path.join(root, 'runtime', 'worktree-manifests'),
+      }),
+      externalHoldProbe: async () => ({
+        state: externalHoldState,
+        detail:
+          externalHoldState === 'held'
+            ? 'test process holds the worktree'
+            : externalHoldState === 'unavailable'
+              ? 'test probe is unavailable'
+              : undefined,
+      }),
+      now: () => new Date(nowMs),
+      ...(gitRunner ? { gitRunner } : {}),
+    });
+  }
+
+  function manifestRepository(): FileWorktreeManifestRepository {
+    return new FileWorktreeManifestRepository({
+      manifestsDir: path.join(root, 'runtime', 'worktree-manifests'),
+    });
+  }
+
+  it('waits for a timed-out Git child to close before rejecting the operation', async () => {
+    const runner = new DefaultWorktreeGitRunner(100, process.execPath, 50);
+    const startedAt = Date.now();
+
+    await expect(
+      runner.run(root, ['-e', "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"])
+    ).rejects.toThrow(/timed out/i);
+
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(140);
+  });
+
+  it('resolves and persists the exact remote base commit before creating a unique worktree', async () => {
+    const expectedBaseCommit = await git(primaryPath, 'rev-parse', 'refs/remotes/origin/main');
+
+    const info = await service().createWorktree('task_858');
+    const createdHead = await git(info.path, 'rev-parse', 'HEAD');
+
+    expect(createdHead).toBe(expectedBaseCommit);
+    expect(info.baseCommit).toBe(expectedBaseCommit);
+    expect(info.baseSource).toBe('remote');
+    expect(info.lifecycle.creation).toBe('ready');
+    expect(taskStore.task.git).toMatchObject({
+      worktreePath: info.path,
+      worktreeManifestId: info.manifestId,
+      worktreeBaseCommit: expectedBaseCommit,
+      worktreeBaseSource: 'remote',
+    });
+
+    const claimed = await service().claimOwnership('task_858', 'attempt_858');
+    expect(claimed.lease.ownerAttemptId).toBe('attempt_858');
+    expect(taskStore.task.git?.worktreeLeaseOwnerAttemptId).toBe('attempt_858');
+  });
+
+  it('fails closed on fetch failure unless stale local state is explicitly acknowledged', async () => {
+    await git(primaryPath, 'remote', 'set-url', 'origin', path.join(root, 'missing.git'));
+    const worktrees = service();
+
+    await expect(worktrees.createWorktree('task_858')).rejects.toThrow(
+      /fetch.*explicit stale-base acknowledgement/i
+    );
+
+    const info = await worktrees.createWorktree('task_858', {
+      allowStaleBase: true,
+      staleBaseAcknowledgement: {
+        reason: 'Operator confirmed offline maintenance mode.',
+        actor: 'operator:test',
+      },
+    });
+
+    expect(info.baseSource).toBe('local-stale');
+    expect(info.remoteState.stale).toBe(true);
+    expect(info.manifest.base.staleBaseAcknowledgement?.reason).toBe(
+      'Operator confirmed offline maintenance mode.'
+    );
+  });
+
+  it('redacts URL credentials and query tokens from retained fetch diagnostics', async () => {
+    const githubToken = 'github_pat_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    const queryToken = 'query-secret-value-123456789';
+    await git(
+      primaryPath,
+      'remote',
+      'set-url',
+      'origin',
+      `https://operator:${githubToken}@example.invalid/repo.git?access_token=${queryToken}`
+    );
+
+    const info = await service().createWorktree('task_858', {
+      allowStaleBase: true,
+      staleBaseAcknowledgement: {
+        reason: 'Offline test with a deliberately invalid credential-bearing URL.',
+      },
+    });
+    const retained = JSON.stringify(info.manifest.base);
+
+    expect(retained).not.toContain(githubToken);
+    expect(retained).not.toContain(queryToken);
+    expect(retained).toContain('[redacted]');
+  });
+
+  it('recovers creation after the git worktree succeeds but task persistence fails', async () => {
+    const worktrees = service();
+    taskStore.failNextUpdate = true;
+
+    await expect(worktrees.createWorktree('task_858')).rejects.toThrow(/task persistence failure/);
+
+    const persisted = await worktrees.getManifest('task_858');
+    expect(persisted?.lifecycle.creation).toBe('ready');
+    expect(persisted?.lastError?.operation).toBe('task-update');
+
+    const recovered = await worktrees.createWorktree('task_858');
+    expect(recovered.lifecycle.creation).toBe('ready');
+    expect(taskStore.task.git?.worktreePath).toBe(recovered.path);
+  });
+
+  it('blocks active runs and previews dirty, untracked, unpushed, and unmerged hazards', async () => {
+    const worktrees = service();
+    const info = await worktrees.createWorktree('task_858');
+    taskStore.task.attempt = {
+      id: 'attempt_active',
+      agent: 'codex',
+      status: 'running',
+    };
+
+    const activePreview = await worktrees.previewCleanup('task_858');
+    expect(activePreview.blockedReasons.map((reason) => reason.code)).toContain('active-run');
+    await expect(worktrees.deleteWorktree('task_858')).rejects.toThrow(/active run/i);
+    await expect(
+      worktrees.deleteWorktree('task_858', {
+        force: true,
+        reason: 'Do not allow this override.',
+      })
+    ).rejects.toThrow(/active run/i);
+
+    taskStore.task.attempt.status = 'complete';
+    await fs.writeFile(path.join(info.path, 'untracked.txt'), 'untracked\n');
+    await fs.writeFile(path.join(info.path, 'README.md'), 'feature\n');
+    await git(info.path, 'add', 'README.md');
+    await git(info.path, 'commit', '-m', 'feature commit');
+    await fs.writeFile(path.join(info.path, 'README.md'), 'feature plus local edit\n');
+
+    const hazardPreview = await worktrees.previewCleanup('task_858');
+    expect(hazardPreview.blockedReasons.map((reason) => reason.code)).toEqual(
+      expect.arrayContaining(['dirty', 'untracked', 'unpushed', 'unmerged'])
+    );
+
+    await worktrees.deleteWorktree('task_858', {
+      force: true,
+      reason: 'Disposable test worktree; preserve branch for recovery.',
+      actor: 'operator:test',
+    });
+    expect(taskStore.task.git?.worktreePath).toBeUndefined();
+  });
+
+  it('blocks an externally held worktree unless a reasoned override is supplied', async () => {
+    const worktrees = service();
+    await worktrees.createWorktree('task_858');
+    externalHoldState = 'held';
+
+    const preview = await worktrees.previewCleanup('task_858');
+    expect(preview.blockedReasons.map((reason) => reason.code)).toContain('external-hold');
+    await expect(worktrees.deleteWorktree('task_858')).rejects.toThrow(/externally held/i);
+
+    await worktrees.deleteWorktree('task_858', {
+      force: true,
+      reason: 'The test hold is known and disposable.',
+      actor: 'operator:test',
+    });
+  });
+
+  it('requires an override when external hold inspection is unavailable', async () => {
+    const worktrees = service();
+    await worktrees.createWorktree('task_858');
+    externalHoldState = 'unavailable';
+
+    const preview = await worktrees.previewCleanup('task_858');
+    expect(preview.eligible).toBe(false);
+    expect(preview.blockedReasons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'inspection-failed', overrideable: true }),
+      ])
+    );
+    await expect(worktrees.deleteWorktree('task_858')).rejects.toThrow(
+      /inspection is unavailable/i
+    );
+  });
+
+  it('enforces exclusive attempt claims and releases terminal ownership', async () => {
+    const worktrees = service();
+    await worktrees.createWorktree('task_858');
+    await worktrees.claimOwnership('task_858', 'attempt_owner');
+
+    await expect(worktrees.claimOwnership('task_858', 'attempt_competing')).rejects.toThrow(
+      /already owned/i
+    );
+    await expect(worktrees.rebaseWorktree('task_858')).rejects.toThrow(
+      /active attempt ownership lease/i
+    );
+    expect(
+      (await worktrees.previewCleanup('task_858')).blockedReasons.map((reason) => reason.code)
+    ).toContain('active-lease');
+
+    await worktrees.releaseOwnership('task_858', 'attempt_owner');
+    const claimed = await worktrees.claimOwnership('task_858', 'attempt_competing');
+    expect(claimed.lease.ownerAttemptId).toBe('attempt_competing');
+  });
+
+  it('recovers cleanup when task metadata persistence fails after Git removal', async () => {
+    const worktrees = service();
+    const info = await worktrees.createWorktree('task_858');
+    taskStore.failNextUpdate = true;
+
+    await expect(worktrees.deleteWorktree('task_858')).rejects.toThrow(/task persistence failure/);
+    await expect(fs.stat(info.path)).rejects.toThrow();
+    expect(await worktrees.getManifest('task_858')).toMatchObject({
+      lifecycle: { cleanup: 'failed' },
+      lastError: { operation: 'task-update' },
+    });
+
+    const recovered = await worktrees.deleteWorktree('task_858');
+    expect(recovered.lifecycle.cleanup).toBe('removed');
+    expect(taskStore.task.git?.worktreePath).toBeUndefined();
+  });
+
+  it('integrates through a dedicated worktree without changing the primary checkout', async () => {
+    const worktrees = service();
+    const info = await worktrees.createWorktree('task_858');
+    await fs.writeFile(path.join(info.path, 'feature.txt'), 'shipped\n');
+    await git(info.path, 'add', 'feature.txt');
+    await git(info.path, 'commit', '-m', 'ship feature');
+    await fs.writeFile(path.join(primaryPath, 'operator-note.txt'), 'preserve me\n');
+
+    const primaryBefore = {
+      branch: await git(primaryPath, 'branch', '--show-current'),
+      head: await git(primaryPath, 'rev-parse', 'HEAD'),
+      status: await git(primaryPath, 'status', '--porcelain=v1', '--untracked-files=all'),
+    };
+
+    const result = await worktrees.mergeWorktree('task_858');
+    const primaryAfter = {
+      branch: await git(primaryPath, 'branch', '--show-current'),
+      head: await git(primaryPath, 'rev-parse', 'HEAD'),
+      status: await git(primaryPath, 'status', '--porcelain=v1', '--untracked-files=all'),
+    };
+    const remoteMain = await git(remotePath, 'rev-parse', 'refs/heads/main');
+
+    expect(primaryAfter).toEqual(primaryBefore);
+    expect(result.targetCommit).toBe(remoteMain);
+    expect(taskStore.task.status).toBe('done');
+    expect(taskStore.task.git?.worktreePath).toBeUndefined();
+    expect((await worktrees.getManifest('task_858'))?.lifecycle.cleanup).toBe('removed');
+  });
+
+  it('persists a failed push and resumes it from the dedicated integration worktree', async () => {
+    let failPush = true;
+    const retryingRunner: WorktreeGitRunner = {
+      run: async (cwd, args, options = {}) => {
+        if (
+          failPush &&
+          args[0] === 'push' &&
+          args[1] === 'origin' &&
+          cwd.includes('.integration')
+        ) {
+          failPush = false;
+          throw new Error('simulated remote push failure');
+        }
+        try {
+          const result = await execFileAsync('git', args, { cwd });
+          return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+        } catch (error) {
+          const code = Number((error as { code?: number }).code);
+          if (options.allowedExitCodes?.includes(code)) {
+            return {
+              stdout: String((error as { stdout?: string }).stdout ?? ''),
+              stderr: String((error as { stderr?: string }).stderr ?? ''),
+              code,
+            };
+          }
+          throw error;
+        }
+      },
+    };
+    const worktrees = service(retryingRunner);
+    const info = await worktrees.createWorktree('task_858');
+    await fs.writeFile(path.join(info.path, 'retry.txt'), 'retry\n');
+    await git(info.path, 'add', 'retry.txt');
+    await git(info.path, 'commit', '-m', 'retryable integration');
+
+    await expect(worktrees.mergeWorktree('task_858')).rejects.toThrow(
+      /simulated remote push failure/
+    );
+    const failed = await worktrees.getManifest('task_858');
+    expect(failed).toMatchObject({
+      lifecycle: { integration: 'failed' },
+      lastError: { operation: 'integration-push', recoverable: true },
+    });
+    if (!failed?.integration.worktreePath) throw new Error('missing recovery worktree path');
+    expect(await fs.stat(failed.integration.worktreePath)).toBeDefined();
+
+    const recovered = await worktrees.mergeWorktree('task_858');
+    expect(recovered.merged).toBe(true);
+    expect((await worktrees.getManifest('task_858'))?.lifecycle.cleanup).toBe('removed');
+  });
+
+  it('rejects a corrupted integration path before running a resumed push', async () => {
+    let failPush = true;
+    const runner: WorktreeGitRunner = {
+      run: async (cwd, args, options = {}) => {
+        if (failPush && args[0] === 'push' && cwd.includes('.integration')) {
+          failPush = false;
+          throw new Error('simulated push interruption');
+        }
+        try {
+          const result = await execFileAsync('git', args, { cwd });
+          return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+        } catch (error) {
+          const code = Number((error as { code?: number }).code);
+          if (options.allowedExitCodes?.includes(code)) {
+            return {
+              stdout: String((error as { stdout?: string }).stdout ?? ''),
+              stderr: String((error as { stderr?: string }).stderr ?? ''),
+              code,
+            };
+          }
+          throw error;
+        }
+      },
+    };
+    const worktrees = service(runner);
+    const info = await worktrees.createWorktree('task_858');
+    await fs.writeFile(path.join(info.path, 'secure-resume.txt'), 'secure\n');
+    await git(info.path, 'add', 'secure-resume.txt');
+    await git(info.path, 'commit', '-m', 'secure integration resume');
+    await expect(worktrees.mergeWorktree('task_858')).rejects.toThrow(/push interruption/);
+
+    const repository = new FileWorktreeManifestRepository({
+      manifestsDir: path.join(root, 'runtime', 'worktree-manifests'),
+    });
+    const manifest = await repository.read('task_858');
+    if (!manifest) throw new Error('missing failed integration manifest');
+    await repository.save({
+      ...manifest,
+      integration: {
+        ...manifest.integration,
+        worktreePath: primaryPath,
+      },
+    });
+
+    await expect(service().mergeWorktree('task_858')).rejects.toThrow(/outside the base/i);
+  });
+
+  it('resumes a persisted preparing state after restart', async () => {
+    const worktrees = service();
+    const info = await worktrees.createWorktree('task_858');
+    await fs.writeFile(path.join(info.path, 'prepare-restart.txt'), 'recover\n');
+    await git(info.path, 'add', 'prepare-restart.txt');
+    await git(info.path, 'commit', '-m', 'prepare restart');
+
+    const manifest = await worktrees.getManifest('task_858');
+    if (!manifest) throw new Error('missing worktree manifest');
+    const integrationPath = path.join(
+      worktreesDir,
+      '.integration',
+      `task_858-${manifest.id.slice(-8)}`
+    );
+    await manifestRepository().save({
+      ...manifest,
+      lifecycle: { ...manifest.lifecycle, integration: 'preparing' },
+      integration: {
+        worktreePath: integrationPath,
+        baseCommit: manifest.base.commit,
+        startedAt: new Date(nowMs).toISOString(),
+      },
+    });
+
+    const recovered = await service().mergeWorktree('task_858');
+    expect(recovered.merged).toBe(true);
+    expect(recovered.manifest.lifecycle.cleanup).toBe('removed');
+  });
+
+  it('reconciles a restart after the remote accepted a push before state persisted', async () => {
+    let reportCrashAfterPush = true;
+    const crashAfterPushRunner: WorktreeGitRunner = {
+      run: async (cwd, args, options = {}) => {
+        try {
+          const result = await execFileAsync('git', args, { cwd });
+          if (
+            reportCrashAfterPush &&
+            args[0] === 'push' &&
+            args[1] === 'origin' &&
+            cwd.includes('.integration')
+          ) {
+            reportCrashAfterPush = false;
+            throw new Error('simulated process death after push');
+          }
+          return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+        } catch (error) {
+          const code = Number((error as { code?: number }).code);
+          if (options.allowedExitCodes?.includes(code)) {
+            return {
+              stdout: String((error as { stdout?: string }).stdout ?? ''),
+              stderr: String((error as { stderr?: string }).stderr ?? ''),
+              code,
+            };
+          }
+          throw error;
+        }
+      },
+    };
+    const worktrees = service(crashAfterPushRunner);
+    const info = await worktrees.createWorktree('task_858');
+    await fs.writeFile(path.join(info.path, 'landed.txt'), 'landed\n');
+    await git(info.path, 'add', 'landed.txt');
+    await git(info.path, 'commit', '-m', 'land before crash');
+
+    await expect(worktrees.mergeWorktree('task_858')).rejects.toThrow(/process death after push/);
+    const failed = await worktrees.getManifest('task_858');
+    expect(failed).toMatchObject({
+      lifecycle: { integration: 'failed' },
+      lastError: { operation: 'integration-push' },
+    });
+    expect(await git(remotePath, 'rev-parse', 'refs/heads/main')).toBe(
+      failed?.integration.integrationHead
+    );
+    if (!failed) throw new Error('missing failed push manifest');
+    await manifestRepository().save({
+      ...failed,
+      lifecycle: { ...failed.lifecycle, integration: 'pushing' },
+      lastError: undefined,
+    });
+
+    const recovered = await service().mergeWorktree('task_858');
+    expect(recovered.merged).toBe(true);
+    expect(recovered.manifest.lifecycle.cleanup).toBe('removed');
+  });
+
+  it('reconciles a restart after merge completion before the pushing state persisted', async () => {
+    let reportCrashAfterMerge = true;
+    const crashAfterMergeRunner: WorktreeGitRunner = {
+      run: async (cwd, args, options = {}) => {
+        try {
+          const result = await execFileAsync('git', args, { cwd });
+          if (
+            reportCrashAfterMerge &&
+            args[0] === 'merge' &&
+            args.includes('--no-ff') &&
+            cwd.includes('.integration')
+          ) {
+            reportCrashAfterMerge = false;
+            throw new Error('simulated process death after merge');
+          }
+          return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+        } catch (error) {
+          const code = Number((error as { code?: number }).code);
+          if (options.allowedExitCodes?.includes(code)) {
+            return {
+              stdout: String((error as { stdout?: string }).stdout ?? ''),
+              stderr: String((error as { stderr?: string }).stderr ?? ''),
+              code,
+            };
+          }
+          throw error;
+        }
+      },
+    };
+    const worktrees = service(crashAfterMergeRunner);
+    const info = await worktrees.createWorktree('task_858');
+    await fs.writeFile(path.join(info.path, 'merge-crash.txt'), 'recover\n');
+    await git(info.path, 'add', 'merge-crash.txt');
+    await git(info.path, 'commit', '-m', 'merge before crash');
+
+    await expect(worktrees.mergeWorktree('task_858')).rejects.toThrow(/process death after merge/);
+    expect(await worktrees.getManifest('task_858')).toMatchObject({
+      lifecycle: { integration: 'failed' },
+      lastError: { operation: 'integration-merge' },
+    });
+    const failed = await worktrees.getManifest('task_858');
+    if (!failed) throw new Error('missing failed merge manifest');
+    await manifestRepository().save({
+      ...failed,
+      lifecycle: { ...failed.lifecycle, integration: 'merging' },
+      lastError: undefined,
+    });
+
+    const recovered = await service().mergeWorktree('task_858');
+    expect(recovered.merged).toBe(true);
+  });
+
+  it('persists rebase intent and recovers after the Git rebase completed before state persisted', async () => {
+    let reportCrashAfterRebase = true;
+    const crashAfterRebaseRunner: WorktreeGitRunner = {
+      run: async (cwd, args, options = {}) => {
+        try {
+          const result = await execFileAsync('git', args, { cwd });
+          if (reportCrashAfterRebase && args[0] === 'rebase' && args[1] !== '--abort') {
+            reportCrashAfterRebase = false;
+            throw new Error('simulated process death after rebase');
+          }
+          return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+        } catch (error) {
+          const code = Number((error as { code?: number }).code);
+          if (options.allowedExitCodes?.includes(code)) {
+            return {
+              stdout: String((error as { stdout?: string }).stdout ?? ''),
+              stderr: String((error as { stderr?: string }).stderr ?? ''),
+              code,
+            };
+          }
+          throw error;
+        }
+      },
+    };
+    const worktrees = service(crashAfterRebaseRunner);
+    await worktrees.createWorktree('task_858');
+
+    await expect(worktrees.rebaseWorktree('task_858')).rejects.toThrow(
+      /process death after rebase/
+    );
+    expect(await worktrees.getManifest('task_858')).toMatchObject({
+      rebase: {
+        state: 'failed',
+        targetBase: { source: 'remote' },
+      },
+      lastError: { operation: 'rebase' },
+    });
+    const failed = await worktrees.getManifest('task_858');
+    if (!failed) throw new Error('missing failed rebase manifest');
+    await manifestRepository().save({
+      ...failed,
+      rebase: { ...failed.rebase, state: 'rebasing' },
+      lastError: undefined,
+    });
+
+    const recovered = await service().rebaseWorktree('task_858');
+    expect(recovered.manifest.rebase.state).toBe('idle');
+    expect(recovered.manifest.rebase.completedAt).toBeDefined();
+  });
+
+  it('serializes cross-task allocation for the same repository branch', async () => {
+    const secondTask: Task = {
+      ...structuredClone(taskStore.task),
+      id: 'task_858_competing',
+      title: 'Competing allocation',
+    };
+    const tasks = new MultiTaskStore(
+      new Map([
+        [taskStore.task.id, structuredClone(taskStore.task)],
+        [secondTask.id, secondTask],
+      ])
+    );
+    const config: AppConfig = {
+      repos: [{ name: 'veritas', path: primaryPath, defaultBranch: 'main' }],
+      agents: [],
+      defaultAgent: 'codex',
+    };
+    const manifestsDir = path.join(root, 'runtime', 'worktree-manifests');
+    const makeService = () =>
+      new WorktreeService({
+        worktreesDir,
+        taskService: tasks,
+        configService: { getConfig: async () => structuredClone(config) },
+        manifestRepository: new FileWorktreeManifestRepository({ manifestsDir }),
+        externalHoldProbe: async () => ({ state: 'clear' }),
+        now: () => new Date(nowMs),
+      });
+
+    const results = await Promise.allSettled([
+      makeService().createWorktree('task_858'),
+      makeService().createWorktree('task_858_competing'),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    const manifests = await new FileWorktreeManifestRepository({ manifestsDir }).list();
+    expect(manifests.filter((manifest) => manifest.lifecycle.cleanup !== 'removed')).toHaveLength(
+      1
+    );
+  });
+
+  it('adopts a validated legacy worktree without discarding local changes', async () => {
+    const legacyPath = path.join(root, 'legacy-worktree');
+    await git(
+      primaryPath,
+      'worktree',
+      'add',
+      '-b',
+      taskStore.task.git?.branch as string,
+      legacyPath,
+      'main'
+    );
+    await fs.writeFile(path.join(legacyPath, 'legacy-untracked.txt'), 'preserve\n');
+    taskStore.task.git = {
+      ...taskStore.task.git,
+      worktreePath: legacyPath,
+    };
+
+    const adopted = await service().adoptLegacyWorktree('task_858');
+
+    expect(adopted.path).toBe(await fs.realpath(legacyPath));
+    expect(adopted.manifest.lifecycle.creation).toBe('ready');
+    expect(adopted.baseSource).toBe('legacy-adopted');
+    expect(adopted.cleanupPreview.blockedReasons.map((reason) => reason.code)).toContain(
+      'untracked'
+    );
+    expect(await fs.readFile(path.join(legacyPath, 'legacy-untracked.txt'), 'utf8')).toBe(
+      'preserve\n'
+    );
+  });
+
+  it('returns preview-first stale cleanup candidates without removing them', async () => {
+    const worktrees = service();
+    const info = await worktrees.createWorktree('task_858', { leaseSeconds: 60 });
+    nowMs += 120_000;
+
+    const candidates = await worktrees.previewCleanupCandidates();
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      taskId: 'task_858',
+      path: info.path,
+      stale: true,
+    });
+    expect(await fs.stat(info.path)).toBeDefined();
+  });
+});

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1,4 +1,4 @@
-import { Router, type Response, type Router as RouterType } from 'express';
+import { Router, type NextFunction, type Response, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { getTaskService } from '../services/task-service.js';
 import { WorktreeService } from '../services/worktree-service.js';
@@ -20,7 +20,7 @@ import { sendPaginated } from '../middleware/response-envelope.js';
 import { setLastModified } from '../middleware/cache-control.js';
 import { sanitizeTaskFields } from '../utils/sanitize.js';
 import { auditLog } from '../services/audit-service.js';
-import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { authorizePermission, type AuthenticatedRequest } from '../middleware/auth.js';
 import { actorFromRequest, assertFreshRevision, setRevisionHeaders } from '../utils/concurrency.js';
 import type { TaskIdentityDiagnostics } from '../services/task-identity-diagnostics.js';
 import { TaskExecutionPolicySchema } from '../schemas/task-envelope-schemas.js';
@@ -31,6 +31,18 @@ const worktreeService = new WorktreeService();
 const blockingService = getBlockingService();
 const delegationService = getDelegationService();
 const progressService = getProgressService();
+
+function requireAdminForCleanupOverride(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  if (req.query.force !== 'true') {
+    next();
+    return;
+  }
+  authorizePermission('admin:manage')(req, res, next);
+}
 
 function attachTaskIdentityDiagnostics(res: Response, diagnostics: TaskIdentityDiagnostics): void {
   if (!diagnostics.hasConflicts) return;
@@ -96,6 +108,63 @@ const attemptSchema = z
     completionResult: z.never().optional(),
   })
   .optional();
+
+const createWorktreeRequestSchema = z
+  .object({
+    allowStaleBase: z.boolean().optional(),
+    staleBaseAcknowledgement: z
+      .object({
+        reason: z.string().trim().min(1).max(1000),
+      })
+      .strict()
+      .optional(),
+    leaseSeconds: z
+      .number()
+      .int()
+      .min(60)
+      .max(365 * 24 * 60 * 60)
+      .optional(),
+  })
+  .strict()
+  .superRefine((request, context) => {
+    if (request.allowStaleBase && !request.staleBaseAcknowledgement) {
+      context.addIssue({
+        code: 'custom',
+        path: ['staleBaseAcknowledgement'],
+        message: 'A reason is required when allowStaleBase is true.',
+      });
+    }
+  });
+
+const deleteWorktreeRequestSchema = z
+  .object({
+    force: z
+      .enum(['true', 'false'])
+      .optional()
+      .transform((value) => value === 'true'),
+    reason: z.string().trim().min(1).max(1000).optional(),
+  })
+  .strict()
+  .superRefine((request, context) => {
+    if (request.force && !request.reason) {
+      context.addIssue({
+        code: 'custom',
+        path: ['reason'],
+        message: 'An explicit reason is required when force=true.',
+      });
+    }
+  });
+
+function parseWorktreeRequest<T>(schema: z.ZodType<T>, input: unknown): T {
+  try {
+    return schema.parse(input);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new ValidationError('Validation failed', error.issues);
+    }
+    throw error;
+  }
+}
 
 const automationSchema = z
   .object({
@@ -888,11 +957,40 @@ router.delete(
 
 // === Worktree Routes ===
 
+// GET /api/tasks/worktrees/cleanup-preview - Preview stale cleanup candidates
+router.get(
+  '/worktrees/cleanup-preview',
+  asyncHandler(async (_req, res) => {
+    res.json(await worktreeService.previewCleanupCandidates());
+  })
+);
+
+// POST /api/tasks/:id/worktree/adopt - Adopt a validated pre-6.0 worktree
+router.post(
+  '/:id/worktree/adopt',
+  authorizePermission('admin:manage'),
+  asyncHandler(async (req, res) => {
+    res.status(201).json(await worktreeService.adoptLegacyWorktree(req.params.id as string));
+  })
+);
+
 // POST /api/tasks/:id/worktree - Create worktree
 router.post(
   '/:id/worktree',
   asyncHandler(async (req, res) => {
-    const worktree = await worktreeService.createWorktree(req.params.id as string);
+    const request = parseWorktreeRequest(createWorktreeRequestSchema, req.body ?? {});
+    const actor = actorFromRequest(req as AuthenticatedRequest);
+    const worktree = await worktreeService.createWorktree(req.params.id as string, {
+      ...request,
+      ...(request.staleBaseAcknowledgement
+        ? {
+            staleBaseAcknowledgement: {
+              ...request.staleBaseAcknowledgement,
+              actor,
+            },
+          }
+        : {}),
+    });
     res.status(201).json(worktree);
   })
 );
@@ -906,12 +1004,27 @@ router.get(
   })
 );
 
+// GET /api/tasks/:id/worktree/cleanup-preview - Preview cleanup safety
+router.get(
+  '/:id/worktree/cleanup-preview',
+  asyncHandler(async (req, res) => {
+    res.json(await worktreeService.previewCleanup(req.params.id as string));
+  })
+);
+
 // DELETE /api/tasks/:id/worktree - Delete worktree
 router.delete(
   '/:id/worktree',
+  requireAdminForCleanupOverride,
   asyncHandler(async (req, res) => {
-    const force = req.query.force === 'true';
-    await worktreeService.deleteWorktree(req.params.id as string, force);
+    const request = parseWorktreeRequest(deleteWorktreeRequestSchema, {
+      force: typeof req.query.force === 'string' ? req.query.force : undefined,
+      reason: typeof req.query.reason === 'string' ? req.query.reason : undefined,
+    });
+    await worktreeService.deleteWorktree(req.params.id as string, {
+      ...request,
+      actor: actorFromRequest(req as AuthenticatedRequest),
+    });
     res.status(204).send();
   })
 );
@@ -929,8 +1042,7 @@ router.post(
 router.post(
   '/:id/worktree/merge',
   asyncHandler(async (req, res) => {
-    await worktreeService.mergeWorktree(req.params.id as string);
-    res.json({ merged: true });
+    res.json(await worktreeService.mergeWorktree(req.params.id as string));
   })
 );
 

--- a/server/src/schemas/run-launch-manifest-schemas.ts
+++ b/server/src/schemas/run-launch-manifest-schemas.ts
@@ -125,6 +125,25 @@ export const RunLaunchManifestSchema = z
           .strict()
       )
       .max(128),
+    workspace: z
+      .object({
+        worktreeId: identifierSchema,
+        worktreeManifestId: identifierSchema.optional(),
+        ownershipLeaseId: identifierSchema.optional(),
+        ownershipAttemptId: identifierSchema.optional(),
+        repo: identifierSchema,
+        branch: identifierSchema,
+        baseBranch: identifierSchema,
+        resolvedBaseCommit: z.string().regex(/^[a-f0-9]{40,64}$/),
+        baseResolutionSource: z.enum([
+          'remote',
+          'local-stale',
+          'legacy-adopted',
+          'legacy-launch-head',
+        ]),
+      })
+      .strict()
+      .optional(),
     runtime: z
       .object({
         model: z.string().trim().min(1).max(200).optional(),

--- a/server/src/schemas/task-envelope-schemas.ts
+++ b/server/src/schemas/task-envelope-schemas.ts
@@ -76,9 +76,17 @@ export const TaskEnvelopeSchema = z
       .object({
         workspaceId: idSchema,
         worktreeId: idSchema,
+        worktreeManifestId: idSchema.optional(),
+        ownershipLeaseId: idSchema.optional(),
+        ownershipAttemptId: idSchema.optional(),
         repo: shortTextSchema,
         branch: shortTextSchema,
         baseBranch: shortTextSchema,
+        resolvedBaseCommit: z
+          .string()
+          .regex(/^[a-f0-9]{40,64}$/)
+          .optional(),
+        baseResolutionSource: z.enum(['remote', 'local-stale', 'legacy-adopted']).optional(),
         worktreePath: pathSchema,
         baseline: z
           .object({

--- a/server/src/schemas/worktree-manifest-schemas.ts
+++ b/server/src/schemas/worktree-manifest-schemas.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod';
+import { WORKTREE_MANIFEST_SCHEMA_VERSION, type WorktreeManifest } from '@veritas-kanban/shared';
+
+const identifierSchema = z.string().trim().min(1).max(240);
+const pathSchema = z.string().trim().min(1).max(4096);
+const timestampSchema = z.iso.datetime();
+const gitCommitSchema = z.string().regex(/^[a-f0-9]{40,64}$/);
+const cleanupReasonCodeSchema = z.enum([
+  'active-run',
+  'active-lease',
+  'dirty',
+  'untracked',
+  'unpushed',
+  'unmerged',
+  'external-hold',
+  'manifest-mismatch',
+  'worktree-missing',
+  'branch-mismatch',
+  'inspection-failed',
+]);
+
+export const WorktreeManifestSchema = z
+  .object({
+    schemaVersion: z.literal(WORKTREE_MANIFEST_SCHEMA_VERSION),
+    id: identifierSchema,
+    revision: z.number().int().min(0),
+    taskId: identifierSchema,
+    repository: z
+      .object({
+        name: identifierSchema,
+        rootPath: pathSchema,
+        commonGitDir: pathSchema,
+        originFingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+      })
+      .strict(),
+    path: pathSchema,
+    branch: identifierSchema,
+    base: z
+      .object({
+        branch: identifierSchema,
+        commit: gitCommitSchema,
+        source: z.enum(['remote', 'local-stale', 'legacy-adopted']),
+        resolvedAt: timestampSchema,
+        fetchedAt: timestampSchema.optional(),
+        fetchError: z.string().trim().min(1).max(2000).optional(),
+        staleBaseAcknowledgement: z
+          .object({
+            reason: z.string().trim().min(1).max(1000),
+            acknowledgedAt: timestampSchema,
+            actor: identifierSchema.optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict(),
+    lease: z
+      .object({
+        id: identifierSchema,
+        ownerTaskId: identifierSchema,
+        ownerAttemptId: identifierSchema.optional(),
+        acquiredAt: timestampSchema,
+        expiresAt: timestampSchema,
+      })
+      .strict(),
+    lifecycle: z
+      .object({
+        creation: z.enum(['planned', 'creating', 'ready', 'failed']),
+        integration: z.enum(['idle', 'preparing', 'merging', 'pushing', 'integrated', 'failed']),
+        cleanup: z.enum(['active', 'blocked', 'removing', 'removed', 'failed']),
+      })
+      .strict(),
+    rebase: z
+      .object({
+        state: z.enum(['idle', 'rebasing', 'failed']),
+        targetBase: z
+          .object({
+            branch: identifierSchema,
+            commit: gitCommitSchema,
+            source: z.enum(['remote', 'local-stale', 'legacy-adopted']),
+            resolvedAt: timestampSchema,
+            fetchedAt: timestampSchema.optional(),
+            fetchError: z.string().trim().min(1).max(2000).optional(),
+            staleBaseAcknowledgement: z
+              .object({
+                reason: z.string().trim().min(1).max(1000),
+                acknowledgedAt: timestampSchema,
+                actor: identifierSchema.optional(),
+              })
+              .strict()
+              .optional(),
+          })
+          .strict()
+          .optional(),
+        startedAt: timestampSchema.optional(),
+        completedAt: timestampSchema.optional(),
+      })
+      .strict(),
+    integration: z
+      .object({
+        worktreePath: pathSchema.optional(),
+        baseCommit: gitCommitSchema.optional(),
+        integrationHead: gitCommitSchema.optional(),
+        targetCommit: gitCommitSchema.optional(),
+        startedAt: timestampSchema.optional(),
+        completedAt: timestampSchema.optional(),
+      })
+      .strict(),
+    createdAt: timestampSchema,
+    updatedAt: timestampSchema,
+    removedAt: timestampSchema.optional(),
+    lastError: z
+      .object({
+        operation: z.enum([
+          'create',
+          'task-update',
+          'rebase',
+          'integration-prepare',
+          'integration-merge',
+          'integration-push',
+          'cleanup',
+        ]),
+        code: identifierSchema,
+        message: z.string().trim().min(1).max(2000),
+        at: timestampSchema,
+        recoverable: z.boolean(),
+      })
+      .strict()
+      .optional(),
+    overrides: z
+      .array(
+        z
+          .object({
+            operation: z.literal('cleanup'),
+            reason: z.string().trim().min(1).max(1000),
+            actor: identifierSchema.optional(),
+            recordedAt: timestampSchema,
+            bypassedReasons: z.array(cleanupReasonCodeSchema).max(32),
+          })
+          .strict()
+      )
+      .max(100),
+  })
+  .strict();
+
+export function parseWorktreeManifest(value: unknown): WorktreeManifest {
+  return WorktreeManifestSchema.parse(value) as WorktreeManifest;
+}

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -129,6 +129,7 @@ import {
   type ProviderTerminalClaim,
 } from './provider-completion-service.js';
 import { getCredentialBrokerService } from './credential-broker-service.js';
+import { WorktreeService } from './worktree-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -339,6 +340,7 @@ export class ClawdbotAgentService {
   private providerCompletions: ProviderCompletionService;
   private credentialLeases: CredentialLeaseLifecycle;
   private workspaceFiles: WorkspaceFileRepository;
+  private worktrees: Pick<WorktreeService, 'claimOwnership' | 'releaseOwnership'>;
   private logsDir: string;
 
   constructor(
@@ -347,7 +349,8 @@ export class ClawdbotAgentService {
     taskEnvelopes = new TaskEnvelopeService(),
     workspaceFiles: WorkspaceFileRepository = new LocalWorkspaceFileRepository(),
     providerCompletions = new ProviderCompletionService(),
-    credentialLeases: CredentialLeaseLifecycle = NOOP_CREDENTIAL_LEASE_LIFECYCLE
+    credentialLeases: CredentialLeaseLifecycle = NOOP_CREDENTIAL_LEASE_LIFECYCLE,
+    worktrees?: Pick<WorktreeService, 'claimOwnership' | 'releaseOwnership'>
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -358,6 +361,12 @@ export class ClawdbotAgentService {
     this.providerCompletions = providerCompletions;
     this.credentialLeases = credentialLeases;
     this.workspaceFiles = workspaceFiles;
+    this.worktrees =
+      worktrees ??
+      new WorktreeService({
+        taskService: this.taskService,
+        configService: this.configService,
+      });
     this.logsDir = getLogsDir();
     this.ensureLogsDir();
   }
@@ -665,7 +674,7 @@ export class ClawdbotAgentService {
     options: AgentStartOptions = {}
   ): Promise<AgentStatus> {
     // Get task
-    const task = await this.taskService.getTask(taskId);
+    let task = await this.taskService.getTask(taskId);
     if (!task) {
       throw new Error(`Task "${taskId}" not found`);
     }
@@ -815,6 +824,9 @@ export class ClawdbotAgentService {
     // Create attempt
     const attemptId = `attempt_${nanoid(8)}`;
     const startedAt = new Date().toISOString();
+    if (!task.git?.worktreePath) {
+      throw new Error(`Task "${taskId}" lost its worktree allocation before launch`);
+    }
     const logPath = path.join(this.logsDir, `${taskId}_${attemptId}.md`);
     const worktreePath = this.expandPath(task.git.worktreePath);
     const commitPolicy = resolveTaskCommitPolicy({
@@ -968,11 +980,39 @@ export class ClawdbotAgentService {
       runLaunchManifestDrift,
     };
 
-    await this.taskService.updateTask(taskId, {
-      status: 'in-progress',
-      attempt,
-      attempts: task.attempt ? upsertAttemptHistory(task.attempts, task.attempt) : task.attempts,
-    });
+    const usesManagedWorktree = Boolean(task.git.worktreeManifestId && task.git.worktreeLeaseId);
+    if (usesManagedWorktree) {
+      try {
+        await this.worktrees.claimOwnership(taskId, attemptId);
+      } catch (error) {
+        pendingAgents.delete(taskId);
+        throw error;
+      }
+      const claimedTask = await this.taskService.getTask(taskId);
+      if (!claimedTask) {
+        await this.worktrees.releaseOwnership(taskId, attemptId);
+        throw new Error(`Task "${taskId}" disappeared while claiming its worktree`);
+      }
+      task = claimedTask;
+    }
+    try {
+      await this.taskService.updateTask(taskId, {
+        status: 'in-progress',
+        attempt,
+        attempts: task.attempt ? upsertAttemptHistory(task.attempts, task.attempt) : task.attempts,
+      });
+    } catch (error) {
+      pendingAgents.delete(taskId);
+      if (usesManagedWorktree) {
+        await this.worktrees.releaseOwnership(taskId, attemptId).catch((releaseError) => {
+          log.error(
+            { err: releaseError, taskId, attemptId },
+            '[ClawdbotAgent] Failed to release worktree ownership after launch persistence failed'
+          );
+        });
+      }
+      throw error;
+    }
 
     if (profileLaunch) {
       await activityService.logActivity(
@@ -1461,6 +1501,14 @@ export class ClawdbotAgentService {
       completionResult.status,
       attempt.runLaunchManifest?.digest
     );
+    if (attempt.taskEnvelope.workspace.worktreeManifestId) {
+      await this.worktrees.releaseOwnership(task.id, attempt.id).catch((error) => {
+        log.error(
+          { err: error, taskId: task.id, attemptId: attempt.id },
+          '[ClawdbotAgent] Failed to release worktree ownership after restarted completion'
+        );
+      });
+    }
 
     log.info(
       { taskId: task.id, attemptId: attempt.id, terminalSource: claim.terminalSource },
@@ -1646,6 +1694,13 @@ export class ClawdbotAgentService {
     const completionStepType = successful ? 'complete' : 'error';
     const requestFile = path.join(getRuntimeDir(), 'agent-requests', `${taskId}.json`);
     const postCommitEffects: Array<[string, () => void | Promise<void>]> = [
+      [
+        'release worktree ownership',
+        () =>
+          pending.taskEnvelope.workspace.worktreeManifestId
+            ? this.worktrees.releaseOwnership(taskId, pending.attemptId)
+            : undefined,
+      ],
       [
         'revoke run credential leases',
         () =>
@@ -4419,6 +4474,12 @@ export class ClawdbotAgentService {
             },
           ]
         : []),
+      {
+        field: 'workspace',
+        scope: 'task-envelope',
+        source: 'task-envelope:worktree-allocation',
+        precedence: 100,
+      },
       {
         field: 'requiredHealthChecks',
         scope: profile ? 'agent-profile' : 'system-default',

--- a/server/src/services/run-launch-manifest-service.ts
+++ b/server/src/services/run-launch-manifest-service.ts
@@ -75,6 +75,7 @@ const MATERIAL_SECTIONS: Array<keyof RunLaunchManifest> = [
   'profile',
   'readiness',
   'instructions',
+  'workspace',
   'runtime',
   'tools',
   'permissions',
@@ -212,6 +213,26 @@ export class RunLaunchManifestService {
           : {}),
       },
       instructions,
+      workspace: {
+        worktreeId: input.taskEnvelope.workspace.worktreeId,
+        ...(input.taskEnvelope.workspace.worktreeManifestId
+          ? { worktreeManifestId: input.taskEnvelope.workspace.worktreeManifestId }
+          : {}),
+        ...(input.taskEnvelope.workspace.ownershipLeaseId
+          ? { ownershipLeaseId: input.taskEnvelope.workspace.ownershipLeaseId }
+          : {}),
+        ...(input.taskEnvelope.workspace.ownershipAttemptId
+          ? { ownershipAttemptId: input.taskEnvelope.workspace.ownershipAttemptId }
+          : {}),
+        repo: input.taskEnvelope.workspace.repo,
+        branch: input.taskEnvelope.workspace.branch,
+        baseBranch: input.taskEnvelope.workspace.baseBranch,
+        resolvedBaseCommit:
+          input.taskEnvelope.workspace.resolvedBaseCommit ??
+          input.taskEnvelope.workspace.baseline.headSha,
+        baseResolutionSource:
+          input.taskEnvelope.workspace.baseResolutionSource ?? 'legacy-launch-head',
+      },
       runtime: normalizeRuntime(input.runtime),
       tools,
       permissions,

--- a/server/src/services/task-envelope-service.ts
+++ b/server/src/services/task-envelope-service.ts
@@ -291,9 +291,26 @@ export class TaskEnvelopeService {
           input.task.project?.trim() || input.task.git?.repo || input.task.id
         ),
         worktreeId: input.task.id,
+        ...(input.task.git?.worktreeManifestId
+          ? { worktreeManifestId: input.task.git.worktreeManifestId }
+          : {}),
+        ...(input.task.git?.worktreeLeaseId
+          ? { ownershipLeaseId: input.task.git.worktreeLeaseId }
+          : {}),
+        ...(input.task.git?.worktreeManifestId && input.task.git.worktreeLeaseId
+          ? { ownershipAttemptId: input.attemptId }
+          : input.task.git?.worktreeLeaseOwnerAttemptId
+            ? { ownershipAttemptId: input.task.git.worktreeLeaseOwnerAttemptId }
+            : {}),
         repo: input.task.git?.repo || 'unknown',
         branch: input.task.git?.branch || 'unknown',
         baseBranch: input.task.git?.baseBranch || 'unknown',
+        ...(input.task.git?.worktreeBaseCommit
+          ? { resolvedBaseCommit: input.task.git.worktreeBaseCommit }
+          : {}),
+        ...(input.task.git?.worktreeBaseSource
+          ? { baseResolutionSource: input.task.git.worktreeBaseSource }
+          : {}),
         worktreePath: input.worktreePath,
         baseline,
       },

--- a/server/src/services/worktree-service.ts
+++ b/server/src/services/worktree-service.ts
@@ -1,325 +1,1936 @@
-import fs from 'fs/promises';
-import path from 'path';
-import { simpleGit, SimpleGit } from 'simple-git';
+import { createHash } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { nanoid } from 'nanoid';
+import { simpleGit } from 'simple-git';
+import type {
+  AppConfig,
+  CreateWorktreeRequest,
+  DeleteWorktreeRequest,
+  Task,
+  UpdateTaskInput,
+  WorktreeCleanupPreview,
+  WorktreeCleanupReason,
+  WorktreeCleanupReasonCode,
+  WorktreeInfo,
+  WorktreeIntegrationResult,
+  WorktreeManifest,
+  WorktreeManifestError,
+  WorktreeRepositoryIdentity,
+  WorktreeResolvedBase,
+} from '@veritas-kanban/shared';
+import { WORKTREE_MANIFEST_SCHEMA_VERSION } from '@veritas-kanban/shared';
 import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
-import { spawn } from 'child_process';
-import { createLogger } from '../lib/logger.js';
-const log = createLogger('worktree-service');
+import { ConflictError, NotFoundError, ValidationError } from '../middleware/error-handler.js';
+import { fileExists, mkdir, realpath } from '../storage/fs-helpers.js';
+import {
+  FileWorktreeManifestRepository,
+  type WorktreeManifestRepository,
+} from '../storage/worktree-manifest-repository.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { getRuntimeDir, getWorktreesDir } from '../utils/paths.js';
+import { redactString } from '../lib/redact.js';
 
-// Default paths
-const PROJECT_ROOT = path.resolve(process.cwd(), '..');
-const WORKTREES_DIR = path.join(PROJECT_ROOT, '.veritas-kanban', 'worktrees');
+const WORKTREES_DIR = getWorktreesDir();
+const MANIFESTS_DIR = path.join(getRuntimeDir(), 'worktree-manifests');
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+const DEFAULT_LEASE_SECONDS = 30 * 24 * 60 * 60;
+const MIN_LEASE_SECONDS = 60;
+const MAX_LEASE_SECONDS = 365 * 24 * 60 * 60;
 
-export interface WorktreeInfo {
-  path: string;
-  branch: string;
-  baseBranch: string;
-  aheadBehind: {
-    ahead: number;
-    behind: number;
+interface WorktreeTaskStore {
+  getTask(taskId: string): Promise<Task | null>;
+  updateTask(taskId: string, update: UpdateTaskInput): Promise<Task | null>;
+}
+
+type CodeTask = Task & {
+  git: NonNullable<Task['git']> & {
+    repo: string;
+    branch: string;
+    baseBranch: string;
   };
-  hasChanges: boolean;
-  changedFiles: number;
+};
+
+interface WorktreeConfigSource {
+  getConfig(): Promise<AppConfig>;
+}
+
+export interface ExternalHoldProbeResult {
+  state: 'clear' | 'held' | 'unavailable';
+  detail?: string;
+}
+
+export type ExternalHoldProbe = (worktreePath: string) => Promise<ExternalHoldProbeResult>;
+
+export interface WorktreeGitCommandResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export interface WorktreeGitCommandOptions {
+  allowedExitCodes?: number[];
+}
+
+export interface WorktreeGitRunner {
+  run(
+    cwd: string,
+    args: string[],
+    options?: WorktreeGitCommandOptions
+  ): Promise<WorktreeGitCommandResult>;
+}
+
+class GitCommandError extends Error {
+  constructor(
+    message: string,
+    readonly code: number | null,
+    readonly stderr: string
+  ) {
+    super(message);
+    this.name = 'GitCommandError';
+  }
+}
+
+export class DefaultWorktreeGitRunner implements WorktreeGitRunner {
+  constructor(
+    private readonly timeoutMs = DEFAULT_GIT_TIMEOUT_MS,
+    private readonly executable = 'git',
+    private readonly killGraceMs = 5_000
+  ) {}
+
+  run(
+    cwd: string,
+    args: string[],
+    options: WorktreeGitCommandOptions = {}
+  ): Promise<WorktreeGitCommandResult> {
+    return new Promise((resolve, reject) => {
+      const allowed = new Set(options.allowedExitCodes ?? [0]);
+      const processHandle = spawn(this.executable, args, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+      let timedOut = false;
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const finish = (callback: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (killTimer) clearTimeout(killTimer);
+        callback();
+      };
+
+      processHandle.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+      processHandle.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+      processHandle.once('error', (error) => {
+        finish(() =>
+          reject(
+            new GitCommandError(
+              `Git command could not start: ${sanitizeDiagnostic(error.message)}`,
+              null,
+              ''
+            )
+          )
+        );
+      });
+      processHandle.once('close', (code) => {
+        finish(() => {
+          if (timedOut) {
+            reject(
+              new GitCommandError(`Git operation timed out after ${this.timeoutMs}ms`, null, '')
+            );
+            return;
+          }
+          if (code !== null && allowed.has(code)) {
+            resolve({ stdout, stderr, code });
+            return;
+          }
+          reject(
+            new GitCommandError(
+              `Git command failed${code === null ? '' : ` with code ${code}`}: ${
+                sanitizeDiagnostic(stderr.trim()) || 'no diagnostic output'
+              }`,
+              code,
+              sanitizeDiagnostic(stderr)
+            )
+          );
+        });
+      });
+
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        processHandle.kill('SIGTERM');
+        killTimer = setTimeout(() => processHandle.kill('SIGKILL'), this.killGraceMs);
+      }, this.timeoutMs);
+    });
+  }
+}
+
+interface RepoContext {
+  rootPath: string;
+  identity: WorktreeRepositoryIdentity;
 }
 
 export interface WorktreeServiceOptions {
   worktreesDir?: string;
+  taskService?: WorktreeTaskStore;
+  configService?: WorktreeConfigSource;
+  manifestRepository?: WorktreeManifestRepository;
+  gitRunner?: WorktreeGitRunner;
+  externalHoldProbe?: ExternalHoldProbe;
+  now?: () => Date;
 }
 
 export class WorktreeService {
-  private worktreesDir: string;
-  private configService: ConfigService;
-  private taskService: TaskService;
-  private readonly GIT_TIMEOUT = 30000; // 30 seconds timeout for git operations
+  private readonly worktreesDir: string;
+  private readonly integrationDir: string;
+  private readonly taskService: WorktreeTaskStore;
+  private readonly configService: WorktreeConfigSource;
+  private readonly manifests: WorktreeManifestRepository;
+  private readonly git: WorktreeGitRunner;
+  private readonly externalHoldProbe: ExternalHoldProbe;
+  private readonly now: () => Date;
 
   constructor(options: WorktreeServiceOptions = {}) {
-    this.worktreesDir = options.worktreesDir || WORKTREES_DIR;
-    this.configService = new ConfigService();
-    this.taskService = new TaskService();
+    this.worktreesDir = path.resolve(options.worktreesDir ?? WORKTREES_DIR);
+    this.integrationDir = path.join(this.worktreesDir, '.integration');
+    this.taskService = options.taskService ?? new TaskService();
+    this.configService = options.configService ?? new ConfigService();
+    this.manifests =
+      options.manifestRepository ??
+      new FileWorktreeManifestRepository({ manifestsDir: MANIFESTS_DIR });
+    this.git = options.gitRunner ?? new DefaultWorktreeGitRunner();
+    this.externalHoldProbe = options.externalHoldProbe ?? probeExternalHold;
+    this.now = options.now ?? (() => new Date());
   }
 
-  /**
-   * Execute a git command with timeout
-   */
-  private async execGitWithTimeout(repoPath: string, args: string[]): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const proc = spawn('git', args, {
-        cwd: repoPath,
-        timeout: this.GIT_TIMEOUT,
-      });
+  async createWorktree(taskId: string, request: CreateWorktreeRequest = {}): Promise<WorktreeInfo> {
+    validatePathSegment(taskId);
+    return this.manifests.withTaskLock(taskId, async () => {
+      const task = await this.requireCodeTask(taskId);
+      const repo = await this.getRepoContext(task.git.repo);
+      return this.manifests.withAllocationLock(repo.identity.commonGitDir, async () => {
+        await this.validateRefNames(repo.rootPath, task.git.branch, task.git.baseBranch);
+        await mkdir(this.worktreesDir, { recursive: true });
 
-      let stdout = '';
-      let stderr = '';
-
-      proc.stdout?.on('data', (data) => {
-        stdout += data.toString();
-      });
-
-      proc.stderr?.on('data', (data) => {
-        stderr += data.toString();
-      });
-
-      proc.on('error', (error) => {
-        reject(new Error(`Git command failed: ${error.message}`));
-      });
-
-      proc.on('close', (code) => {
-        if (code === 0) {
-          resolve(stdout);
-        } else if (code === null) {
-          reject(new Error(`Git command timed out after ${this.GIT_TIMEOUT}ms`));
-        } else {
-          reject(new Error(`Git command failed with code ${code}: ${stderr}`));
-        }
-      });
-
-      // Set timeout manually as backup — SIGTERM first, SIGKILL after grace period
-      const timeoutId = setTimeout(() => {
-        proc.kill('SIGTERM');
-        // Force-kill after 5s grace period if SIGTERM is ignored
-        setTimeout(() => {
-          try {
-            proc.kill('SIGKILL');
-          } catch {
-            /* already dead */
+        const existing = await this.manifests.read(taskId);
+        if (existing && existing.lifecycle.cleanup !== 'removed') {
+          this.assertManifestOwnership(existing, task, repo);
+          if (existing.lifecycle.creation === 'ready' && (await fileExists(existing.path))) {
+            await this.persistTaskAllocation(task, existing);
+            const reconciled =
+              existing.lastError?.operation === 'task-update'
+                ? await this.saveManifest(existing, { lastError: undefined })
+                : existing;
+            return this.buildWorktreeInfo(taskId, task, reconciled);
           }
-        }, 5000);
-        reject(new Error(`Git operation timed out after ${this.GIT_TIMEOUT}ms`));
-      }, this.GIT_TIMEOUT);
+          return this.recoverCreation(task, repo, existing);
+        }
 
-      proc.on('exit', () => {
-        clearTimeout(timeoutId);
+        const worktreePath = ensureWithinBase(
+          this.worktreesDir,
+          path.join(this.worktreesDir, taskId)
+        );
+        if (await fileExists(worktreePath)) {
+          throw new ConflictError('The requested worktree path already exists without ownership.', {
+            taskId,
+            worktreePath,
+            remediation: 'Inspect the path and register or move it before retrying.',
+          });
+        }
+
+        const base = await this.resolveBase(repo.rootPath, task.git.baseBranch, request);
+        await this.assertUniqueAllocation(taskId, repo.rootPath, task.git.branch, worktreePath);
+
+        const branchCommit = await this.tryResolveCommit(
+          repo.rootPath,
+          `refs/heads/${task.git.branch}^{commit}`
+        );
+        const canReuseOwnedBranch =
+          existing?.lifecycle.cleanup === 'removed' &&
+          existing.branch === task.git.branch &&
+          existing.repository.commonGitDir === repo.identity.commonGitDir;
+        if (branchCommit && !canReuseOwnedBranch) {
+          throw new ConflictError(
+            `Branch "${task.git.branch}" already exists without an active ownership lease.`,
+            {
+              taskId,
+              branch: task.git.branch,
+              remediation:
+                'Choose a unique task branch or explicitly adopt the branch through a new task.',
+            }
+          );
+        }
+
+        const now = this.now().toISOString();
+        const leaseSeconds = normalizeLeaseSeconds(request.leaseSeconds);
+        let manifest = await this.manifests.save({
+          schemaVersion: WORKTREE_MANIFEST_SCHEMA_VERSION,
+          id: `worktree_${nanoid(16)}`,
+          revision: 0,
+          taskId,
+          repository: repo.identity,
+          path: worktreePath,
+          branch: task.git.branch,
+          base,
+          lease: {
+            id: `lease_${nanoid(16)}`,
+            ownerTaskId: taskId,
+            ...(task.attempt?.status === 'running' || task.attempt?.status === 'pending'
+              ? { ownerAttemptId: task.attempt.id }
+              : {}),
+            acquiredAt: now,
+            expiresAt: new Date(this.now().getTime() + leaseSeconds * 1_000).toISOString(),
+          },
+          lifecycle: {
+            creation: 'planned',
+            integration: 'idle',
+            cleanup: 'active',
+          },
+          rebase: { state: 'idle' },
+          integration: {},
+          createdAt: now,
+          updatedAt: now,
+          overrides: [],
+        });
+
+        manifest = await this.saveManifest(manifest, {
+          lifecycle: { ...manifest.lifecycle, creation: 'creating' },
+          lastError: undefined,
+        });
+
+        try {
+          if (branchCommit) {
+            await this.git.run(repo.rootPath, ['worktree', 'add', worktreePath, task.git.branch]);
+          } else {
+            await this.git.run(repo.rootPath, [
+              'worktree',
+              'add',
+              '-b',
+              task.git.branch,
+              worktreePath,
+              base.commit,
+            ]);
+          }
+          manifest = await this.saveManifest(manifest, {
+            lifecycle: { ...manifest.lifecycle, creation: 'ready' },
+            lastError: undefined,
+          });
+        } catch (error) {
+          await this.recordFailure(manifest, 'create', error, {
+            creation: 'failed',
+          });
+          throw error;
+        }
+
+        try {
+          await this.persistTaskAllocation(task, manifest);
+        } catch (error) {
+          await this.recordFailure(manifest, 'task-update', error);
+          throw error;
+        }
+        return this.buildWorktreeInfo(taskId, task, manifest);
       });
     });
   }
 
-  private async ensureWorktreesDir(): Promise<void> {
-    await fs.mkdir(this.worktreesDir, { recursive: true });
+  async getManifest(taskId: string): Promise<WorktreeManifest | null> {
+    validatePathSegment(taskId);
+    return this.manifests.read(taskId);
   }
 
-  private expandPath(p: string): string {
-    return p.replace(/^~/, process.env.HOME || '');
-  }
+  async adoptLegacyWorktree(taskId: string): Promise<WorktreeInfo> {
+    validatePathSegment(taskId);
+    return this.manifests.withTaskLock(taskId, async () => {
+      const task = await this.requireCodeTask(taskId);
+      if (!task.git.worktreePath || task.git.worktreeManifestId) {
+        throw new ValidationError(
+          'Legacy adoption requires a task worktree path without an existing manifest.'
+        );
+      }
+      const repo = await this.getRepoContext(task.git.repo);
+      return this.manifests.withAllocationLock(repo.identity.commonGitDir, async () => {
+        const existing = await this.manifests.read(taskId);
+        if (existing && existing.lifecycle.cleanup !== 'removed') {
+          throw new ConflictError('The task already has an active worktree manifest.', {
+            taskId,
+            manifestId: existing.id,
+          });
+        }
 
-  private async getRepoGit(repoName: string): Promise<{ git: SimpleGit; repoPath: string }> {
-    const config = await this.configService.getConfig();
-    const repo = config.repos.find(
-      (r: { name: string; path: string; defaultBranch: string; devServer?: any }) =>
-        r.name === repoName
-    );
+        const configuredLegacyPath = path.resolve(expandPath(task.git.worktreePath as string));
+        if (!(await fileExists(configuredLegacyPath))) {
+          throw new ConflictError('The legacy worktree path does not exist.', {
+            taskId,
+            path: configuredLegacyPath,
+          });
+        }
+        const legacyPath = await realpath(configuredLegacyPath);
+        await this.assertPathRepositoryIdentity(legacyPath, repo.identity);
+        const actualBranch = await this.currentBranch(legacyPath);
+        if (actualBranch !== task.git.branch) {
+          throw new ConflictError('The legacy worktree branch does not match the task.', {
+            taskId,
+            expected: task.git.branch,
+            actual: actualBranch,
+          });
+        }
 
-    if (!repo) {
-      throw new Error(`Repository "${repoName}" not found in config`);
-    }
+        const registered = parseWorktreeList(
+          (await this.git.run(repo.rootPath, ['worktree', 'list', '--porcelain'])).stdout
+        );
+        const registeredWithCanonicalPaths = await Promise.all(
+          registered.map(async (worktree) => ({
+            ...worktree,
+            canonicalPath: await realpath(worktree.path).catch(() => path.resolve(worktree.path)),
+          }))
+        );
+        const exactRegistration = registeredWithCanonicalPaths.find(
+          (worktree) => worktree.canonicalPath === legacyPath && worktree.branch === task.git.branch
+        );
+        if (!exactRegistration) {
+          throw new ConflictError(
+            'The legacy path and branch are not an exact registered Git worktree.',
+            {
+              taskId,
+              path: legacyPath,
+              branch: task.git.branch,
+            }
+          );
+        }
+        const conflictingRegistration = registeredWithCanonicalPaths.find(
+          (worktree) => worktree.branch === task.git.branch && worktree.canonicalPath !== legacyPath
+        );
+        if (conflictingRegistration) {
+          throw new ConflictError('The task branch is registered to another worktree path.', {
+            taskId,
+            branch: task.git.branch,
+            conflictingPath: conflictingRegistration.path,
+          });
+        }
+        const collision = (await this.manifests.list()).find(
+          (candidate) =>
+            candidate.taskId !== taskId &&
+            candidate.lifecycle.cleanup !== 'removed' &&
+            (candidate.branch === task.git.branch || path.resolve(candidate.path) === legacyPath)
+        );
+        if (collision) {
+          throw new ConflictError('The legacy worktree is leased to another task.', {
+            taskId,
+            collidingTaskId: collision.taskId,
+            collidingManifestId: collision.id,
+          });
+        }
 
-    const repoPath = this.expandPath(repo.path);
-    const git = simpleGit(repoPath);
-
-    return { git, repoPath };
-  }
-
-  async createWorktree(taskId: string): Promise<WorktreeInfo> {
-    await this.ensureWorktreesDir();
-
-    // Get task
-    const task = await this.taskService.getTask(taskId);
-    if (!task) {
-      throw new Error(`Task "${taskId}" not found`);
-    }
-
-    if (task.type !== 'code') {
-      throw new Error('Worktrees can only be created for code tasks');
-    }
-
-    if (!task.git?.repo || !task.git?.branch || !task.git?.baseBranch) {
-      throw new Error('Task must have git repo, branch, and base branch configured');
-    }
-
-    const { git, repoPath } = await this.getRepoGit(task.git.repo);
-    const worktreePath = path.join(this.worktreesDir, taskId);
-
-    // Check if worktree already exists
-    // Intentionally silent: fs.access throws if path doesn't exist — false means no worktree
-    const worktreeExists = await fs
-      .access(worktreePath)
-      .then(() => true)
-      .catch(() => false);
-    if (worktreeExists) {
-      throw new Error('Worktree already exists for this task');
-    }
-
-    // Fetch latest from remote with timeout
-    try {
-      await this.execGitWithTimeout(repoPath, ['fetch']);
-    } catch (e: any) {
-      // Ignore fetch errors (might be offline)
-      log.warn('Could not fetch from remote:', e.message);
-    }
-
-    // Check if branch already exists
-    const branches = await git.branchLocal();
-    const branchExists = branches.all.includes(task.git.branch);
-
-    if (branchExists) {
-      // Use existing branch with timeout
-      await this.execGitWithTimeout(repoPath, ['worktree', 'add', worktreePath, task.git.branch]);
-    } else {
-      // Create new branch from base with timeout
-      await this.execGitWithTimeout(repoPath, [
-        'worktree',
-        'add',
-        '-b',
-        task.git.branch,
-        worktreePath,
-        task.git.baseBranch,
-      ]);
-    }
-
-    // Update task with worktree path
-    await this.taskService.updateTask(taskId, {
-      git: {
-        ...task.git,
-        worktreePath,
-      },
+        await this.git.run(legacyPath, ['status', '--porcelain=v1', '-z', '--untracked-files=all']);
+        const resolvedRemoteBase = await this.resolveBase(repo.rootPath, task.git.baseBranch, {});
+        const legacyHead = await this.resolveCommit(legacyPath, 'HEAD^{commit}');
+        const descendsFromAdoptionBase = await this.git.run(
+          legacyPath,
+          ['merge-base', '--is-ancestor', resolvedRemoteBase.commit, legacyHead],
+          { allowedExitCodes: [0, 1] }
+        );
+        if (descendsFromAdoptionBase.code !== 0) {
+          throw new ConflictError(
+            'The legacy worktree HEAD does not descend from the fetched remote base.',
+            {
+              taskId,
+              legacyHead,
+              remoteBaseCommit: resolvedRemoteBase.commit,
+              remediation:
+                'Rebase or merge the current remote base into the legacy branch before adoption.',
+            }
+          );
+        }
+        const base: WorktreeResolvedBase = {
+          ...resolvedRemoteBase,
+          source: 'legacy-adopted',
+        };
+        const now = this.now().toISOString();
+        let manifest = await this.manifests.save({
+          schemaVersion: WORKTREE_MANIFEST_SCHEMA_VERSION,
+          id: `worktree_${nanoid(16)}`,
+          revision: 0,
+          taskId,
+          repository: repo.identity,
+          path: legacyPath,
+          branch: task.git.branch,
+          base,
+          lease: {
+            id: `lease_${nanoid(16)}`,
+            ownerTaskId: taskId,
+            ...(task.attempt?.status === 'running' || task.attempt?.status === 'pending'
+              ? { ownerAttemptId: task.attempt.id }
+              : {}),
+            acquiredAt: now,
+            expiresAt: new Date(this.now().getTime() + DEFAULT_LEASE_SECONDS * 1_000).toISOString(),
+          },
+          lifecycle: {
+            creation: 'ready',
+            integration: 'idle',
+            cleanup: 'active',
+          },
+          rebase: { state: 'idle' },
+          integration: {},
+          createdAt: now,
+          updatedAt: now,
+          overrides: [],
+        });
+        await this.persistTaskAllocation(task, manifest);
+        manifest = (await this.manifests.read(taskId)) ?? manifest;
+        return this.buildWorktreeInfo(taskId, task, manifest);
+      });
     });
+  }
 
-    // Get worktree status
-    return this.getWorktreeStatus(taskId);
+  async claimOwnership(taskId: string, attemptId: string): Promise<WorktreeManifest> {
+    validatePathSegment(taskId);
+    validatePathSegment(attemptId);
+    return this.manifests.withTaskLock(taskId, async () => {
+      const task = await this.requireCodeTask(taskId);
+      let manifest = await this.requireActiveManifest(taskId);
+      if (!(await fileExists(manifest.path))) {
+        throw new ConflictError('The worktree cannot be claimed because its path is missing.', {
+          taskId,
+          manifestId: manifest.id,
+          path: manifest.path,
+        });
+      }
+      const repo = await this.getRepoContext(task.git.repo);
+      this.assertManifestOwnership(manifest, task, repo);
+      await this.assertWorktreeIdentity(manifest);
+      const branch = await this.currentBranch(manifest.path);
+      if (branch !== manifest.branch) {
+        throw new ConflictError('The worktree branch does not match its ownership manifest.', {
+          taskId,
+          expected: manifest.branch,
+          actual: branch,
+        });
+      }
+      if (
+        task.git?.worktreeManifestId !== manifest.id ||
+        task.git.worktreeLeaseId !== manifest.lease.id ||
+        task.git.worktreePath !== manifest.path
+      ) {
+        throw new ConflictError(
+          'The task allocation does not match the worktree manifest and cannot be claimed.',
+          {
+            taskId,
+            manifestId: manifest.id,
+            remediation: 'Reconcile the worktree allocation before starting an agent.',
+          }
+        );
+      }
+      const now = this.now();
+      const currentOwner = manifest.lease.ownerAttemptId;
+      const currentTaskAttemptIsTerminal =
+        currentOwner === task.attempt?.id &&
+        (task.attempt?.status === 'complete' || task.attempt?.status === 'failed');
+      if (
+        currentOwner &&
+        currentOwner !== attemptId &&
+        !currentTaskAttemptIsTerminal &&
+        Date.parse(manifest.lease.expiresAt) > now.getTime()
+      ) {
+        throw new ConflictError('The worktree lease is already owned by another attempt.', {
+          taskId,
+          manifestId: manifest.id,
+          ownerAttemptId: currentOwner,
+          requestedAttemptId: attemptId,
+          expiresAt: manifest.lease.expiresAt,
+        });
+      }
+      manifest = await this.saveManifest(manifest, {
+        lease: {
+          ...manifest.lease,
+          ownerAttemptId: attemptId,
+          acquiredAt: now.toISOString(),
+          expiresAt: new Date(now.getTime() + DEFAULT_LEASE_SECONDS * 1_000).toISOString(),
+        },
+      });
+      await this.persistTaskAllocation(task, manifest);
+      return manifest;
+    });
+  }
+
+  async releaseOwnership(taskId: string, attemptId: string): Promise<WorktreeManifest | null> {
+    validatePathSegment(taskId);
+    validatePathSegment(attemptId);
+    return this.manifests.withTaskLock(taskId, async () => {
+      const manifest = await this.manifests.read(taskId);
+      if (!manifest || manifest.lifecycle.cleanup === 'removed') return manifest;
+      if (!manifest.lease.ownerAttemptId) {
+        const task = await this.taskService.getTask(taskId);
+        if (
+          task?.git?.worktreeManifestId === manifest.id &&
+          task.git.worktreeLeaseOwnerAttemptId === attemptId
+        ) {
+          await this.persistTaskAllocation(task, manifest);
+        }
+        return manifest;
+      }
+      if (manifest.lease.ownerAttemptId !== attemptId) {
+        throw new ConflictError('The attempt cannot release a worktree lease it does not own.', {
+          taskId,
+          manifestId: manifest.id,
+          ownerAttemptId: manifest.lease.ownerAttemptId,
+          requestedAttemptId: attemptId,
+        });
+      }
+      const released = await this.saveManifest(manifest, {
+        lease: {
+          ...manifest.lease,
+          ownerAttemptId: undefined,
+          expiresAt: this.now().toISOString(),
+        },
+      });
+      const task = await this.taskService.getTask(taskId);
+      if (task?.git?.worktreeManifestId === manifest.id) {
+        await this.persistTaskAllocation(task, released);
+      }
+      return released;
+    });
   }
 
   async getWorktreeStatus(taskId: string): Promise<WorktreeInfo> {
-    const task = await this.taskService.getTask(taskId);
-    if (!task?.git?.worktreePath) {
-      throw new Error('Task does not have an active worktree');
-    }
-
-    const worktreePath = task.git.worktreePath;
-    const worktreeGit = simpleGit(worktreePath);
-
-    // Get branch info
-    const status = await worktreeGit.status();
-
-    // Get ahead/behind info
-    let aheadBehind = { ahead: 0, behind: 0 };
-    try {
-      const { repoPath: mainRepoPath } = await this.getRepoGit(task.git.repo);
-
-      // Fetch to get latest with timeout (intentionally silent: may be offline)
-      await this.execGitWithTimeout(mainRepoPath, ['fetch']).catch(() => {});
-
-      // Compare with base branch with timeout
-      const log = await this.execGitWithTimeout(worktreePath, [
-        'rev-list',
-        '--left-right',
-        '--count',
-        `${task.git.baseBranch}...HEAD`,
-      ]);
-      const [behind, ahead] = log.trim().split('\t').map(Number);
-      aheadBehind = { ahead: ahead || 0, behind: behind || 0 };
-    } catch (e: any) {
-      log.warn('Could not get ahead/behind info:', e.message);
-    }
-
-    return {
-      path: worktreePath,
-      branch: task.git.branch,
-      baseBranch: task.git.baseBranch,
-      aheadBehind,
-      hasChanges: !status.isClean(),
-      changedFiles: status.files.length,
-    };
+    const task = await this.requireTask(taskId);
+    const manifest = await this.requireActiveManifest(taskId);
+    return this.buildWorktreeInfo(taskId, task, manifest);
   }
 
-  async deleteWorktree(taskId: string, force: boolean = false): Promise<void> {
+  async previewCleanup(taskId: string): Promise<WorktreeCleanupPreview> {
     const task = await this.taskService.getTask(taskId);
-    if (!task?.git?.worktreePath) {
-      throw new Error('Task does not have an active worktree');
-    }
+    const manifest = await this.requireActiveManifest(taskId);
+    return this.buildCleanupPreview(task, manifest);
+  }
 
-    const worktreePath = task.git.worktreePath;
+  async previewCleanupCandidates(): Promise<WorktreeCleanupPreview[]> {
+    const manifests = await this.manifests.list();
+    const previews = await Promise.all(
+      manifests
+        .filter((manifest) => manifest.lifecycle.cleanup !== 'removed')
+        .map(async (manifest) =>
+          this.buildCleanupPreview(await this.taskService.getTask(manifest.taskId), manifest)
+        )
+    );
+    return previews.filter((preview) => preview.stale);
+  }
 
-    // Check for uncommitted changes
-    if (!force) {
-      const worktreeGit = simpleGit(worktreePath);
-      const status = await worktreeGit.status();
-
-      if (!status.isClean()) {
-        throw new Error('Worktree has uncommitted changes. Use force=true to delete anyway.');
+  async deleteWorktree(
+    taskId: string,
+    request: DeleteWorktreeRequest = {}
+  ): Promise<WorktreeManifest> {
+    validatePathSegment(taskId);
+    return this.manifests.withTaskLock(taskId, async () => {
+      const task = await this.taskService.getTask(taskId);
+      let manifest = await this.requireActiveManifest(taskId);
+      if (
+        manifest.lifecycle.cleanup === 'failed' &&
+        manifest.lastError?.operation === 'task-update' &&
+        task?.git?.worktreeManifestId === manifest.id &&
+        task.git.worktreePath === manifest.path &&
+        !(await fileExists(manifest.path))
+      ) {
+        const repo = await this.repoContextForManifest(task, manifest);
+        await this.git.run(repo.rootPath, ['worktree', 'prune']);
+        if (task?.git) await this.clearTaskAllocation(task, false);
+        return this.saveManifest(manifest, {
+          lifecycle: { ...manifest.lifecycle, cleanup: 'removed' },
+          removedAt: this.now().toISOString(),
+          lastError: undefined,
+        });
       }
-    }
+      const preview = await this.buildCleanupPreview(task, manifest);
+      const nonOverrideable = preview.blockedReasons.filter((reason) => !reason.overrideable);
+      if (nonOverrideable.length > 0) {
+        await this.markCleanupBlocked(manifest, nonOverrideable);
+        throw cleanupConflict(nonOverrideable);
+      }
+      if (preview.blockedReasons.length > 0) {
+        const reason = request.reason?.trim();
+        if (!request.force || !reason) {
+          await this.markCleanupBlocked(manifest, preview.blockedReasons);
+          throw cleanupConflict(preview.blockedReasons);
+        }
+        manifest = await this.saveManifest(manifest, {
+          overrides: [
+            ...manifest.overrides,
+            {
+              operation: 'cleanup' as const,
+              reason,
+              ...(request.actor?.trim() ? { actor: request.actor.trim() } : {}),
+              recordedAt: this.now().toISOString(),
+              bypassedReasons: preview.blockedReasons.map((item) => item.code),
+            },
+          ].slice(-100),
+        });
+      }
 
-    // Get main repo git
-    const { repoPath } = await this.getRepoGit(task.git.repo);
+      const repo = await this.repoContextForManifest(task, manifest);
+      manifest = await this.saveManifest(manifest, {
+        lifecycle: { ...manifest.lifecycle, cleanup: 'removing' },
+        lastError: undefined,
+      });
 
-    // Remove worktree with timeout
-    const args = ['worktree', 'remove', worktreePath];
-    if (force) args.push('--force');
-    await this.execGitWithTimeout(repoPath, args);
+      try {
+        if (await fileExists(manifest.path)) {
+          const args = ['worktree', 'remove', manifest.path];
+          if (request.force && preview.blockedReasons.length > 0) args.push('--force');
+          await this.git.run(repo.rootPath, args);
+        } else {
+          await this.git.run(repo.rootPath, ['worktree', 'prune']);
+        }
+      } catch (error) {
+        await this.recordFailure(manifest, 'cleanup', error, { cleanup: 'failed' });
+        throw error;
+      }
 
-    // Update task to remove worktree path
-    await this.taskService.updateTask(taskId, {
-      git: {
-        ...task.git,
-        worktreePath: undefined,
-      },
+      if (task?.git) {
+        try {
+          await this.clearTaskAllocation(task, false);
+        } catch (error) {
+          await this.recordFailure(manifest, 'task-update', error, { cleanup: 'failed' });
+          throw error;
+        }
+      }
+      manifest = await this.saveManifest(manifest, {
+        lifecycle: { ...manifest.lifecycle, cleanup: 'removed' },
+        removedAt: this.now().toISOString(),
+        lastError: undefined,
+      });
+      return manifest;
     });
   }
 
   async rebaseWorktree(taskId: string): Promise<WorktreeInfo> {
-    const task = await this.taskService.getTask(taskId);
-    if (!task?.git?.worktreePath) {
-      throw new Error('Task does not have an active worktree');
-    }
+    validatePathSegment(taskId);
+    return this.manifests.withTaskLock(taskId, async () => {
+      const task = await this.requireCodeTask(taskId);
+      this.assertNoActiveRun(task);
+      let manifest = await this.requireActiveManifest(taskId);
+      const repo = await this.getRepoContext(task.git.repo);
+      this.assertManifestOwnership(manifest, task, repo);
+      this.assertNoCompetingLease(task, manifest);
+      await this.assertWorktreeIdentity(manifest);
+      if (manifest.rebase.state !== 'idle') {
+        await this.git.run(manifest.path, ['rebase', '--abort'], {
+          allowedExitCodes: [0, 1, 128],
+        });
+        manifest = await this.saveManifest(manifest, {
+          rebase: { state: 'idle' },
+          lastError: undefined,
+        });
+      }
+      await this.assertWorktreeClean(manifest.path);
 
-    const worktreePath = task.git.worktreePath;
-
-    // Fetch latest with timeout
-    await this.execGitWithTimeout(worktreePath, ['fetch']);
-
-    // Rebase onto base branch with timeout
-    await this.execGitWithTimeout(worktreePath, ['rebase', `origin/${task.git.baseBranch}`]);
-
-    return this.getWorktreeStatus(taskId);
+      const base = await this.resolveBase(repo.rootPath, task.git.baseBranch, {});
+      manifest = await this.saveManifest(manifest, {
+        rebase: {
+          state: 'rebasing',
+          targetBase: base,
+          startedAt: this.now().toISOString(),
+        },
+        lastError: undefined,
+      });
+      try {
+        await this.git.run(manifest.path, ['rebase', base.commit]);
+        manifest = await this.saveManifest(manifest, {
+          base,
+          rebase: {
+            state: 'idle',
+            targetBase: base,
+            startedAt: manifest.rebase.startedAt,
+            completedAt: this.now().toISOString(),
+          },
+          lastError: undefined,
+        });
+        await this.persistTaskAllocation(task, manifest);
+      } catch (error) {
+        await this.saveManifest(manifest, {
+          rebase: { ...manifest.rebase, state: 'failed' },
+          lastError: manifestError('rebase', error, this.now()),
+        });
+        throw error;
+      }
+      return this.buildWorktreeInfo(taskId, task, manifest);
+    });
   }
 
-  async mergeWorktree(taskId: string): Promise<void> {
-    const task = await this.taskService.getTask(taskId);
-    if (!task?.git?.worktreePath || !task.git?.repo) {
-      throw new Error('Task does not have an active worktree');
-    }
+  async mergeWorktree(taskId: string): Promise<WorktreeIntegrationResult> {
+    validatePathSegment(taskId);
+    return this.manifests.withTaskLock(taskId, async () => {
+      const task = await this.requireCodeTask(taskId);
+      this.assertNoActiveRun(task);
+      let manifest = await this.requireActiveManifest(taskId);
+      const repo = await this.getRepoContext(task.git.repo);
+      this.assertManifestOwnership(manifest, task, repo);
+      this.assertNoCompetingLease(task, manifest);
+      const sourceExists = await fileExists(manifest.path);
+      if (manifest.lifecycle.integration !== 'integrated' || sourceExists) {
+        if (!sourceExists) {
+          throw new ConflictError('The source worktree is missing before integration completed.', {
+            taskId,
+            manifestId: manifest.id,
+          });
+        }
+        await this.assertWorktreeIdentity(manifest);
+        await this.assertWorktreeClean(manifest.path);
+        const actualBranch = await this.currentBranch(manifest.path);
+        if (actualBranch !== manifest.branch) {
+          throw new ConflictError('The worktree branch no longer matches its manifest.', {
+            expected: manifest.branch,
+            actual: actualBranch,
+          });
+        }
+      }
 
-    const { repoPath } = await this.getRepoGit(task.git.repo);
+      let targetBase = await this.resolveBase(repo.rootPath, manifest.base.branch, {});
+      const integrationPath =
+        manifest.integration.worktreePath ??
+        ensureWithinBase(
+          this.integrationDir,
+          path.join(this.integrationDir, `${taskId}-${manifest.id.slice(-8)}`)
+        );
+      ensureWithinBase(this.integrationDir, path.resolve(integrationPath));
+      await mkdir(this.integrationDir, { recursive: true });
 
-    // Checkout base branch in main repo with timeout
-    await this.execGitWithTimeout(repoPath, ['checkout', task.git.baseBranch]);
+      let integrationExists = await fileExists(integrationPath);
+      let integrationHead = manifest.integration.integrationHead;
 
-    // Pull latest with timeout
-    await this.execGitWithTimeout(repoPath, ['pull']);
+      if (manifest.lifecycle.integration === 'integrated') {
+        if (!integrationHead) {
+          throw new ConflictError(
+            'The integrated manifest is missing its integration commit evidence.',
+            {
+              taskId,
+              manifestId: manifest.id,
+            }
+          );
+        }
+        const landed = await this.git.run(
+          repo.rootPath,
+          ['merge-base', '--is-ancestor', integrationHead, targetBase.commit],
+          { allowedExitCodes: [0, 1] }
+        );
+        if (landed.code !== 0) {
+          throw new ConflictError(
+            'The recorded integration commit is not reachable from the remote base.',
+            {
+              taskId,
+              integrationHead,
+              remoteBaseCommit: targetBase.commit,
+            }
+          );
+        }
+      } else if (!integrationExists) {
+        if (
+          integrationHead &&
+          (manifest.lifecycle.integration === 'pushing' ||
+            (manifest.lifecycle.integration === 'failed' &&
+              manifest.lastError?.operation === 'integration-push'))
+        ) {
+          const landed = await this.git.run(
+            repo.rootPath,
+            ['merge-base', '--is-ancestor', integrationHead, targetBase.commit],
+            { allowedExitCodes: [0, 1] }
+          );
+          if (landed.code === 0) {
+            manifest = await this.markIntegrated(manifest, integrationHead, targetBase);
+          } else {
+            throw new ConflictError(
+              'The integration worktree is missing and the recorded commit is not on the remote base.',
+              {
+                taskId,
+                integrationHead,
+                integrationPath,
+                remediation:
+                  'Restore the recorded integration worktree or integrate the source branch through an explicit operator workflow.',
+              }
+            );
+          }
+        } else {
+          const baseCommit =
+            manifest.lifecycle.integration === 'preparing' && manifest.integration.baseCommit
+              ? manifest.integration.baseCommit
+              : targetBase.commit;
+          const startedAt = manifest.integration.startedAt ?? this.now().toISOString();
+          manifest = await this.saveManifest(manifest, {
+            lifecycle: { ...manifest.lifecycle, integration: 'preparing' },
+            integration: {
+              worktreePath: integrationPath,
+              baseCommit,
+              startedAt,
+            },
+            lastError: undefined,
+          });
 
-    // Merge feature branch with timeout
-    await this.execGitWithTimeout(repoPath, ['merge', task.git.branch]);
+          try {
+            await this.git.run(repo.rootPath, [
+              'worktree',
+              'add',
+              '--detach',
+              integrationPath,
+              baseCommit,
+            ]);
+            integrationExists = true;
+          } catch (error) {
+            await this.recordFailure(manifest, 'integration-prepare', error, {
+              integration: 'failed',
+            });
+            throw error;
+          }
+        }
+      }
 
-    // Push with timeout
-    await this.execGitWithTimeout(repoPath, ['push']);
+      if (integrationExists) {
+        await this.assertIntegrationWorktreeIdentity(repo, integrationPath);
+      }
 
-    // Delete worktree
-    await this.deleteWorktree(taskId, true);
+      if (
+        manifest.lifecycle.integration !== 'integrated' &&
+        !(
+          integrationHead &&
+          (manifest.lifecycle.integration === 'pushing' ||
+            (manifest.lifecycle.integration === 'failed' &&
+              manifest.lastError?.operation === 'integration-push'))
+        )
+      ) {
+        const mergeInProgress = await this.git.run(
+          integrationPath,
+          ['rev-parse', '--verify', '--quiet', 'MERGE_HEAD'],
+          { allowedExitCodes: [0, 1, 128] }
+        );
+        if (mergeInProgress.code === 0) {
+          await this.git.run(integrationPath, ['merge', '--abort']);
+        }
+        await this.assertWorktreeClean(integrationPath);
 
-    // Update task status to done
-    await this.taskService.updateTask(taskId, {
-      status: 'done',
+        const currentHead = await this.resolveCommit(integrationPath, 'HEAD^{commit}');
+        const recordedBase = manifest.integration.baseCommit ?? targetBase.commit;
+        const sourceAlreadyMerged = await this.git.run(
+          integrationPath,
+          ['merge-base', '--is-ancestor', manifest.branch, currentHead],
+          { allowedExitCodes: [0, 1] }
+        );
+        const recordedBaseIsAncestor = await this.git.run(
+          integrationPath,
+          ['merge-base', '--is-ancestor', recordedBase, currentHead],
+          { allowedExitCodes: [0, 1] }
+        );
+
+        if (
+          currentHead !== recordedBase &&
+          sourceAlreadyMerged.code === 0 &&
+          recordedBaseIsAncestor.code === 0
+        ) {
+          integrationHead = currentHead;
+        } else {
+          if (currentHead !== recordedBase) {
+            throw new ConflictError(
+              'The integration worktree HEAD does not match its recoverable base state.',
+              {
+                taskId,
+                integrationPath,
+                currentHead,
+                recordedBase,
+              }
+            );
+          }
+          manifest = await this.saveManifest(manifest, {
+            lifecycle: { ...manifest.lifecycle, integration: 'merging' },
+            lastError: undefined,
+          });
+          try {
+            await this.git.run(integrationPath, ['merge', '--no-ff', '--no-edit', manifest.branch]);
+          } catch (error) {
+            await this.recordFailure(manifest, 'integration-merge', error, {
+              integration: 'failed',
+            });
+            throw error;
+          }
+          integrationHead = await this.resolveCommit(integrationPath, 'HEAD^{commit}');
+        }
+      }
+
+      if (manifest.lifecycle.integration !== 'integrated') {
+        if (!integrationHead) {
+          throw new ConflictError('Integration did not produce a commit to publish.', {
+            taskId,
+            integrationPath,
+          });
+        }
+        manifest = await this.saveManifest(manifest, {
+          lifecycle: { ...manifest.lifecycle, integration: 'pushing' },
+          integration: {
+            ...manifest.integration,
+            integrationHead,
+          },
+          lastError: undefined,
+        });
+        await this.assertIntegrationWorktreeIdentity(repo, integrationPath);
+        try {
+          const landed = await this.git.run(
+            repo.rootPath,
+            ['merge-base', '--is-ancestor', integrationHead, targetBase.commit],
+            { allowedExitCodes: [0, 1] }
+          );
+          if (landed.code !== 0) {
+            const stillBasedOnRemote = await this.git.run(
+              integrationPath,
+              ['merge-base', '--is-ancestor', targetBase.commit, integrationHead],
+              { allowedExitCodes: [0, 1] }
+            );
+            if (stillBasedOnRemote.code !== 0) {
+              throw new ConflictError(
+                'The remote base advanced beyond the recoverable integration commit.',
+                {
+                  taskId,
+                  integrationPath,
+                  integrationHead,
+                  remoteBaseCommit: targetBase.commit,
+                }
+              );
+            }
+            await this.git.run(integrationPath, [
+              'push',
+              'origin',
+              `HEAD:refs/heads/${manifest.base.branch}`,
+            ]);
+          }
+          targetBase = await this.resolveBase(repo.rootPath, manifest.base.branch, {});
+          const verified = await this.git.run(
+            repo.rootPath,
+            ['merge-base', '--is-ancestor', integrationHead, targetBase.commit],
+            { allowedExitCodes: [0, 1] }
+          );
+          if (verified.code !== 0) {
+            throw new ConflictError(
+              'The push returned, but the integration commit is not reachable from the remote base.',
+              {
+                taskId,
+                integrationHead,
+                remoteBaseCommit: targetBase.commit,
+              }
+            );
+          }
+          manifest = await this.markIntegrated(manifest, integrationHead, targetBase);
+        } catch (error) {
+          await this.recordFailure(manifest, 'integration-push', error, {
+            integration: 'failed',
+          });
+          throw error;
+        }
+      }
+
+      if (integrationExists) {
+        try {
+          await this.assertIntegrationWorktreeIdentity(repo, integrationPath);
+          await this.git.run(repo.rootPath, ['worktree', 'remove', integrationPath]);
+          integrationExists = false;
+        } catch (error) {
+          await this.recordFailure(manifest, 'cleanup', error, { cleanup: 'blocked' });
+          throw new ConflictError(
+            'Integration reached the remote, but its temporary worktree could not be removed.',
+            {
+              taskId,
+              targetCommit: targetBase.commit,
+              integrationPath,
+              remediation:
+                'Inspect and remove the recorded integration worktree, then retry cleanup.',
+            }
+          );
+        }
+      }
+
+      if (await fileExists(manifest.path)) {
+        const cleanupPreview = await this.buildCleanupPreview(task, manifest);
+        if (cleanupPreview.blockedReasons.length > 0) {
+          await this.markCleanupBlocked(manifest, cleanupPreview.blockedReasons);
+          throw new ConflictError(
+            'Integration reached the remote, but source worktree cleanup is blocked.',
+            {
+              taskId,
+              targetCommit: targetBase.commit,
+              cleanupPreview,
+              remediation:
+                'Resolve the reported safety conditions and use the cleanup endpoint; the remote integration is already complete.',
+            }
+          );
+        }
+      }
+
+      manifest = await this.saveManifest(manifest, {
+        lifecycle: { ...manifest.lifecycle, cleanup: 'removing' },
+      });
+      try {
+        if (await fileExists(manifest.path)) {
+          await this.git.run(repo.rootPath, ['worktree', 'remove', manifest.path]);
+        } else {
+          await this.git.run(repo.rootPath, ['worktree', 'prune']);
+        }
+        await this.clearTaskAllocation(task, true);
+        manifest = await this.saveManifest(manifest, {
+          lifecycle: { ...manifest.lifecycle, cleanup: 'removed' },
+          removedAt: this.now().toISOString(),
+          lastError: undefined,
+        });
+      } catch (error) {
+        await this.recordFailure(manifest, 'cleanup', error, { cleanup: 'failed' });
+        throw error;
+      }
+
+      return {
+        merged: true,
+        targetCommit: targetBase.commit,
+        manifest,
+      };
     });
   }
 
   async openInVSCode(taskId: string): Promise<string> {
-    const task = await this.taskService.getTask(taskId);
-    if (!task?.git?.worktreePath) {
-      throw new Error('Task does not have an active worktree');
+    const manifest = await this.requireActiveManifest(taskId);
+    return `code "${manifest.path}"`;
+  }
+
+  private async recoverCreation(
+    task: Task,
+    repo: RepoContext,
+    manifest: WorktreeManifest
+  ): Promise<WorktreeInfo> {
+    if (await fileExists(manifest.path)) {
+      await this.assertWorktreeIdentity(manifest);
+      const branch = await this.currentBranch(manifest.path);
+      if (branch !== manifest.branch) {
+        throw new ConflictError('Partial worktree creation has a branch mismatch.', {
+          expected: manifest.branch,
+          actual: branch,
+          path: manifest.path,
+        });
+      }
+      manifest = await this.saveManifest(manifest, {
+        lifecycle: { ...manifest.lifecycle, creation: 'ready' },
+        lastError: undefined,
+      });
+      await this.persistTaskAllocation(task, manifest);
+      return this.buildWorktreeInfo(task.id, task, manifest);
     }
 
-    // Return the command to open in VS Code
-    // The frontend can use this to open via a protocol handler or display instructions
-    return `code "${task.git.worktreePath}"`;
+    const branchCommit = await this.tryResolveCommit(
+      repo.rootPath,
+      `refs/heads/${manifest.branch}^{commit}`
+    );
+    if (branchCommit && branchCommit !== manifest.base.commit) {
+      throw new ConflictError(
+        'Partial creation left a branch with commits that cannot be adopted automatically.',
+        {
+          branch: manifest.branch,
+          branchCommit,
+          expectedBaseCommit: manifest.base.commit,
+          remediation: 'Inspect the branch and explicitly preserve or remove it before retrying.',
+        }
+      );
+    }
+
+    manifest = await this.saveManifest(manifest, {
+      lifecycle: { ...manifest.lifecycle, creation: 'creating' },
+      lastError: undefined,
+    });
+    try {
+      if (branchCommit) {
+        await this.git.run(repo.rootPath, ['worktree', 'add', manifest.path, manifest.branch]);
+      } else {
+        await this.git.run(repo.rootPath, [
+          'worktree',
+          'add',
+          '-b',
+          manifest.branch,
+          manifest.path,
+          manifest.base.commit,
+        ]);
+      }
+      manifest = await this.saveManifest(manifest, {
+        lifecycle: { ...manifest.lifecycle, creation: 'ready' },
+      });
+      await this.persistTaskAllocation(task, manifest);
+      return this.buildWorktreeInfo(task.id, task, manifest);
+    } catch (error) {
+      await this.recordFailure(manifest, 'create', error, { creation: 'failed' });
+      throw error;
+    }
   }
+
+  private async buildWorktreeInfo(
+    taskId: string,
+    task: Task,
+    manifest: WorktreeManifest
+  ): Promise<WorktreeInfo> {
+    if (!(await fileExists(manifest.path))) {
+      throw new ConflictError('The worktree manifest exists, but its path is missing.', {
+        taskId,
+        manifestId: manifest.id,
+        path: manifest.path,
+        remediation:
+          'Use cleanup preview or retry worktree creation to reconcile the partial state.',
+      });
+    }
+    const status = await simpleGit(manifest.path).status(['--untracked-files=all']);
+    const comparisonBase =
+      (await this.tryResolveCommit(
+        manifest.repository.rootPath,
+        `refs/remotes/origin/${manifest.base.branch}^{commit}`
+      )) ?? manifest.base.commit;
+    const counts = await this.git.run(manifest.path, [
+      'rev-list',
+      '--left-right',
+      '--count',
+      `${comparisonBase}...HEAD`,
+    ]);
+    const [behind = 0, ahead = 0] = counts.stdout
+      .trim()
+      .split(/\s+/)
+      .map((value) => Number(value) || 0);
+    const currentTask = (await this.taskService.getTask(taskId)) ?? task;
+    const cleanupPreview = await this.buildCleanupPreview(currentTask, manifest);
+    return {
+      path: manifest.path,
+      branch: manifest.branch,
+      baseBranch: manifest.base.branch,
+      baseCommit: manifest.base.commit,
+      baseSource: manifest.base.source,
+      manifestId: manifest.id,
+      manifest: structuredClone(manifest),
+      lifecycle: structuredClone(manifest.lifecycle),
+      remoteState: {
+        stale: manifest.base.source === 'local-stale',
+        ...(manifest.base.fetchedAt ? { fetchedAt: manifest.base.fetchedAt } : {}),
+        ...(manifest.base.fetchError ? { error: manifest.base.fetchError } : {}),
+      },
+      aheadBehind: { ahead, behind },
+      hasChanges: !status.isClean(),
+      changedFiles: status.files.length,
+      cleanupPreview,
+    };
+  }
+
+  private async buildCleanupPreview(
+    task: Task | null,
+    manifest: WorktreeManifest
+  ): Promise<WorktreeCleanupPreview> {
+    const blockedReasons: WorktreeCleanupReason[] = [];
+    const checkedAt = this.now().toISOString();
+    const add = (code: WorktreeCleanupReasonCode, message: string, overrideable: boolean): void => {
+      if (!blockedReasons.some((reason) => reason.code === code)) {
+        blockedReasons.push({ code, message, overrideable });
+      }
+    };
+
+    if (task?.attempt?.status === 'running' || task?.attempt?.status === 'pending') {
+      add(
+        'active-run',
+        `Attempt ${task.attempt.id} is ${task.attempt.status}; active runs lock destructive operations.`,
+        false
+      );
+    }
+    const leaseOwner = manifest.lease.ownerAttemptId;
+    const leaseIsUnexpired = Date.parse(manifest.lease.expiresAt) > this.now().getTime();
+    const ownerAttemptIsTerminal =
+      leaseOwner === task?.attempt?.id &&
+      (task?.attempt?.status === 'complete' || task?.attempt?.status === 'failed');
+    if (leaseOwner && leaseIsUnexpired && !ownerAttemptIsTerminal) {
+      add(
+        'active-lease',
+        `Attempt ${leaseOwner} owns the worktree lease until ${manifest.lease.expiresAt}.`,
+        false
+      );
+    }
+    if (
+      !task ||
+      task.git?.worktreeManifestId !== manifest.id ||
+      task.git?.worktreePath !== manifest.path
+    ) {
+      add(
+        'manifest-mismatch',
+        'Task allocation metadata does not match the durable worktree manifest.',
+        false
+      );
+    }
+
+    const snapshot = {
+      dirty: false,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      mergedIntoBase: false,
+      externalHold: 'unavailable' as 'clear' | 'held' | 'unavailable',
+    };
+
+    if (!(await fileExists(manifest.path))) {
+      add('worktree-missing', 'The registered worktree path is missing.', true);
+      return {
+        taskId: manifest.taskId,
+        manifestId: manifest.id,
+        path: manifest.path,
+        checkedAt,
+        stale: this.now().getTime() > Date.parse(manifest.lease.expiresAt),
+        eligible: false,
+        requiresOverride:
+          blockedReasons.length > 0 && blockedReasons.every((reason) => reason.overrideable),
+        blockedReasons,
+        snapshot,
+      };
+    }
+
+    try {
+      const status = await this.git.run(manifest.path, [
+        'status',
+        '--porcelain=v1',
+        '-z',
+        '--untracked-files=all',
+      ]);
+      const entries = status.stdout.split('\0').filter(Boolean);
+      snapshot.untrackedFiles = entries.filter((entry) => entry.startsWith('?? ')).length;
+      snapshot.dirty = entries.some((entry) => !entry.startsWith('?? '));
+      if (snapshot.dirty) {
+        add('dirty', 'The worktree has tracked staged or unstaged changes.', true);
+      }
+      if (snapshot.untrackedFiles > 0) {
+        add(
+          'untracked',
+          `The worktree has ${snapshot.untrackedFiles} untracked file${
+            snapshot.untrackedFiles === 1 ? '' : 's'
+          }.`,
+          true
+        );
+      }
+
+      const actualBranch = await this.currentBranch(manifest.path);
+      if (actualBranch !== manifest.branch) {
+        add(
+          'branch-mismatch',
+          `Expected branch "${manifest.branch}", but found "${actualBranch}".`,
+          false
+        );
+      }
+      try {
+        await this.assertWorktreeIdentity(manifest);
+      } catch (error) {
+        add('manifest-mismatch', errorMessage(error), false);
+      }
+
+      const head = await this.resolveCommit(manifest.path, 'HEAD^{commit}');
+      const remoteBase = await this.tryResolveCommit(
+        manifest.repository.rootPath,
+        `refs/remotes/origin/${manifest.base.branch}^{commit}`
+      );
+      if (!remoteBase) {
+        add(
+          'inspection-failed',
+          'The remote base ref is unavailable, so pushed and merged state cannot be proven.',
+          true
+        );
+      } else {
+        const unpushed = await this.git.run(manifest.path, [
+          'rev-list',
+          '--count',
+          `${remoteBase}..${head}`,
+        ]);
+        snapshot.unpushedCommits = Number(unpushed.stdout.trim()) || 0;
+        const merged = await this.git.run(
+          manifest.path,
+          ['merge-base', '--is-ancestor', head, remoteBase],
+          { allowedExitCodes: [0, 1] }
+        );
+        snapshot.mergedIntoBase = merged.code === 0;
+        if (snapshot.unpushedCommits > 0) {
+          add(
+            'unpushed',
+            `${snapshot.unpushedCommits} commit${
+              snapshot.unpushedCommits === 1 ? ' is' : 's are'
+            } not reachable from the remote base.`,
+            true
+          );
+        }
+        if (!snapshot.mergedIntoBase) {
+          add('unmerged', 'The worktree HEAD is not merged into the remote base.', true);
+        }
+      }
+
+      const hold = await this.externalHoldProbe(manifest.path);
+      snapshot.externalHold = hold.state;
+      if (hold.state === 'held') {
+        add(
+          'external-hold',
+          hold.detail
+            ? `The worktree is externally held: ${sanitizeDiagnostic(hold.detail)}.`
+            : 'The worktree is externally held by another process.',
+          true
+        );
+      } else if (hold.state === 'unavailable') {
+        add(
+          'inspection-failed',
+          hold.detail
+            ? `External hold inspection is unavailable: ${sanitizeDiagnostic(hold.detail)}.`
+            : 'External hold inspection is unavailable.',
+          true
+        );
+      }
+    } catch (error) {
+      add('inspection-failed', `Cleanup safety inspection failed: ${errorMessage(error)}.`, true);
+    }
+
+    return {
+      taskId: manifest.taskId,
+      manifestId: manifest.id,
+      path: manifest.path,
+      checkedAt,
+      stale: this.now().getTime() > Date.parse(manifest.lease.expiresAt),
+      eligible: blockedReasons.length === 0,
+      requiresOverride:
+        blockedReasons.length > 0 && blockedReasons.every((reason) => reason.overrideable),
+      blockedReasons,
+      snapshot,
+    };
+  }
+
+  private async resolveBase(
+    repoPath: string,
+    baseBranch: string,
+    request: CreateWorktreeRequest
+  ): Promise<WorktreeResolvedBase> {
+    const resolvedAt = this.now().toISOString();
+    try {
+      await this.git.run(repoPath, [
+        'fetch',
+        '--no-tags',
+        'origin',
+        `+refs/heads/${baseBranch}:refs/remotes/origin/${baseBranch}`,
+      ]);
+      return {
+        branch: baseBranch,
+        commit: await this.resolveCommit(repoPath, `refs/remotes/origin/${baseBranch}^{commit}`),
+        source: 'remote',
+        resolvedAt,
+        fetchedAt: resolvedAt,
+      };
+    } catch (error) {
+      const acknowledgement = request.staleBaseAcknowledgement;
+      if (!request.allowStaleBase || !acknowledgement?.reason?.trim()) {
+        throw new ConflictError(
+          'Remote fetch failed; worktree creation requires an explicit stale-base acknowledgement.',
+          {
+            baseBranch,
+            fetchError: errorMessage(error),
+            remediation:
+              'Restore remote access, or retry with allowStaleBase=true and a non-empty acknowledgement reason.',
+          }
+        );
+      }
+      const localCommit = await this.tryResolveCommit(repoPath, `${baseBranch}^{commit}`);
+      if (!localCommit) {
+        throw new ConflictError('Remote fetch failed and no local base commit is available.', {
+          baseBranch,
+          fetchError: errorMessage(error),
+        });
+      }
+      return {
+        branch: baseBranch,
+        commit: localCommit,
+        source: 'local-stale',
+        resolvedAt,
+        fetchError: errorMessage(error),
+        staleBaseAcknowledgement: {
+          reason: acknowledgement.reason.trim(),
+          acknowledgedAt: resolvedAt,
+          ...(acknowledgement.actor?.trim() ? { actor: acknowledgement.actor.trim() } : {}),
+        },
+      };
+    }
+  }
+
+  private async getRepoContext(repoName: string): Promise<RepoContext> {
+    const config = await this.configService.getConfig();
+    const configured = config.repos.find((repo) => repo.name === repoName);
+    if (!configured) throw new NotFoundError(`Repository "${repoName}" not found in config`);
+
+    const configuredPath = path.resolve(expandPath(configured.path));
+    const rootPath = path.resolve(
+      (await this.git.run(configuredPath, ['rev-parse', '--show-toplevel'])).stdout.trim()
+    );
+    const commonGitDirOutput = (
+      await this.git.run(rootPath, ['rev-parse', '--git-common-dir'])
+    ).stdout.trim();
+    const commonGitDir = path.resolve(rootPath, commonGitDirOutput);
+    const origin = await this.git
+      .run(rootPath, ['remote', 'get-url', 'origin'])
+      .then((result) => result.stdout.trim())
+      .catch(() => 'origin-unavailable');
+    return {
+      rootPath,
+      identity: {
+        name: repoName,
+        rootPath,
+        commonGitDir,
+        originFingerprint: fingerprintRemote(origin),
+      },
+    };
+  }
+
+  private async repoContextForManifest(
+    task: Task | null,
+    manifest: WorktreeManifest
+  ): Promise<RepoContext> {
+    if (!task?.git?.repo) {
+      return { rootPath: manifest.repository.rootPath, identity: manifest.repository };
+    }
+    const current = await this.getRepoContext(task.git.repo);
+    if (
+      current.identity.commonGitDir !== manifest.repository.commonGitDir ||
+      current.identity.originFingerprint !== manifest.repository.originFingerprint
+    ) {
+      throw new ConflictError(
+        'The configured repository no longer matches the worktree manifest.',
+        {
+          taskId: manifest.taskId,
+          manifestRepository: manifest.repository.name,
+          configuredRepository: current.identity.name,
+        }
+      );
+    }
+    return current;
+  }
+
+  private async assertUniqueAllocation(
+    taskId: string,
+    repoPath: string,
+    branch: string,
+    worktreePath: string
+  ): Promise<void> {
+    const manifests = await this.manifests.list();
+    const collision = manifests.find(
+      (manifest) =>
+        manifest.taskId !== taskId &&
+        manifest.lifecycle.cleanup !== 'removed' &&
+        (manifest.branch === branch || path.resolve(manifest.path) === path.resolve(worktreePath))
+    );
+    if (collision) {
+      throw new ConflictError('Worktree branch or path is already leased to another task.', {
+        taskId,
+        collidingTaskId: collision.taskId,
+        collidingManifestId: collision.id,
+      });
+    }
+
+    const registered = parseWorktreeList(
+      (await this.git.run(repoPath, ['worktree', 'list', '--porcelain'])).stdout
+    );
+    const gitCollision = registered.find(
+      (worktree) =>
+        path.resolve(worktree.path) === path.resolve(worktreePath) || worktree.branch === branch
+    );
+    if (gitCollision) {
+      throw new ConflictError('Git already has the requested branch or path checked out.', {
+        taskId,
+        branch,
+        worktreePath,
+        registeredWorktree: gitCollision.path,
+      });
+    }
+  }
+
+  private async validateRefNames(
+    repoPath: string,
+    branch: string,
+    baseBranch: string
+  ): Promise<void> {
+    for (const candidate of [branch, baseBranch]) {
+      const result = await this.git.run(repoPath, ['check-ref-format', '--branch', candidate], {
+        allowedExitCodes: [0, 128],
+      });
+      if (result.code !== 0) {
+        throw new ValidationError(`Invalid Git branch name: "${candidate}"`);
+      }
+    }
+  }
+
+  private assertManifestOwnership(manifest: WorktreeManifest, task: Task, repo: RepoContext): void {
+    if (
+      manifest.taskId !== task.id ||
+      manifest.branch !== task.git?.branch ||
+      manifest.base.branch !== task.git?.baseBranch ||
+      manifest.repository.commonGitDir !== repo.identity.commonGitDir ||
+      manifest.repository.originFingerprint !== repo.identity.originFingerprint
+    ) {
+      throw new ConflictError('Task Git settings do not match the durable worktree manifest.', {
+        taskId: task.id,
+        manifestId: manifest.id,
+        remediation: 'Restore the recorded task Git settings or clean up the manifest explicitly.',
+      });
+    }
+  }
+
+  private assertNoActiveRun(task: Task): void {
+    if (task.attempt?.status === 'running' || task.attempt?.status === 'pending') {
+      throw new ConflictError(
+        `Task has an active run (${task.attempt.id}); destructive worktree operations are locked.`,
+        {
+          taskId: task.id,
+          attemptId: task.attempt.id,
+          attemptStatus: task.attempt.status,
+        }
+      );
+    }
+  }
+
+  private assertNoCompetingLease(task: Task, manifest: WorktreeManifest): void {
+    const ownerAttemptId = manifest.lease.ownerAttemptId;
+    if (!ownerAttemptId || Date.parse(manifest.lease.expiresAt) <= this.now().getTime()) return;
+    const ownerIsTerminal =
+      task.attempt?.id === ownerAttemptId &&
+      (task.attempt.status === 'complete' || task.attempt.status === 'failed');
+    if (ownerIsTerminal) return;
+    throw new ConflictError('The worktree has an active attempt ownership lease.', {
+      taskId: task.id,
+      manifestId: manifest.id,
+      ownerAttemptId,
+      expiresAt: manifest.lease.expiresAt,
+    });
+  }
+
+  private async assertWorktreeClean(worktreePath: string): Promise<void> {
+    const status = await this.git.run(worktreePath, [
+      'status',
+      '--porcelain=v1',
+      '-z',
+      '--untracked-files=all',
+    ]);
+    if (status.stdout.length > 0) {
+      throw new ConflictError(
+        'The worktree has staged, unstaged, or untracked changes and cannot be rebased or integrated.'
+      );
+    }
+  }
+
+  private async persistTaskAllocation(task: Task, manifest: WorktreeManifest): Promise<void> {
+    const updated = await this.taskService.updateTask(task.id, {
+      git: {
+        ...task.git,
+        worktreePath: manifest.path,
+        worktreeManifestId: manifest.id,
+        worktreeBaseCommit: manifest.base.commit,
+        worktreeBaseSource: manifest.base.source,
+        worktreeLeaseId: manifest.lease.id,
+        worktreeLeaseOwnerAttemptId: manifest.lease.ownerAttemptId,
+      },
+    });
+    if (!updated) throw new NotFoundError(`Task "${task.id}" not found during allocation update`);
+  }
+
+  private async assertWorktreeIdentity(manifest: WorktreeManifest): Promise<void> {
+    await this.assertPathRepositoryIdentity(manifest.path, manifest.repository);
+  }
+
+  private async assertIntegrationWorktreeIdentity(
+    repo: RepoContext,
+    integrationPath: string
+  ): Promise<void> {
+    ensureWithinBase(this.integrationDir, path.resolve(integrationPath));
+    const resolvedIntegrationDir = await realpath(this.integrationDir);
+    const resolvedIntegrationPath = await realpath(integrationPath);
+    ensureWithinBase(resolvedIntegrationDir, resolvedIntegrationPath);
+    await this.assertPathRepositoryIdentity(resolvedIntegrationPath, repo.identity);
+    const registered = parseWorktreeList(
+      (await this.git.run(repo.rootPath, ['worktree', 'list', '--porcelain'])).stdout
+    );
+    if (
+      !registered.some(
+        (worktree) => path.resolve(worktree.path) === path.resolve(resolvedIntegrationPath)
+      )
+    ) {
+      throw new ConflictError('The integration path is not a registered Git worktree.', {
+        integrationPath,
+      });
+    }
+  }
+
+  private async assertPathRepositoryIdentity(
+    worktreePath: string,
+    repository: WorktreeRepositoryIdentity
+  ): Promise<void> {
+    const commonGitDirOutput = (
+      await this.git.run(worktreePath, ['rev-parse', '--git-common-dir'])
+    ).stdout.trim();
+    const commonGitDir = path.resolve(worktreePath, commonGitDirOutput);
+    if (commonGitDir !== path.resolve(repository.commonGitDir)) {
+      throw new ConflictError('The worktree belongs to a different Git repository.', {
+        path: worktreePath,
+        expectedCommonGitDir: repository.commonGitDir,
+      });
+    }
+    const origin = (
+      await this.git.run(worktreePath, ['remote', 'get-url', 'origin'])
+    ).stdout.trim();
+    if (fingerprintRemote(origin) !== repository.originFingerprint) {
+      throw new ConflictError('The worktree origin does not match its repository manifest.', {
+        path: worktreePath,
+      });
+    }
+  }
+
+  private async markIntegrated(
+    manifest: WorktreeManifest,
+    integrationHead: string,
+    targetBase: WorktreeResolvedBase
+  ): Promise<WorktreeManifest> {
+    return this.saveManifest(manifest, {
+      lifecycle: { ...manifest.lifecycle, integration: 'integrated' },
+      integration: {
+        ...manifest.integration,
+        integrationHead,
+        targetCommit: targetBase.commit,
+        completedAt: this.now().toISOString(),
+      },
+      lastError: undefined,
+    });
+  }
+
+  private async clearTaskAllocation(task: Task, markDone: boolean): Promise<void> {
+    const updated = await this.taskService.updateTask(task.id, {
+      ...(markDone ? { status: 'done' } : {}),
+      git: {
+        ...task.git,
+        worktreePath: undefined,
+        worktreeManifestId: undefined,
+        worktreeBaseCommit: undefined,
+        worktreeBaseSource: undefined,
+        worktreeLeaseId: undefined,
+        worktreeLeaseOwnerAttemptId: undefined,
+      },
+    });
+    if (!updated) throw new NotFoundError(`Task "${task.id}" not found during allocation cleanup`);
+  }
+
+  private async markCleanupBlocked(
+    manifest: WorktreeManifest,
+    reasons: WorktreeCleanupReason[]
+  ): Promise<void> {
+    await this.saveManifest(manifest, {
+      lifecycle: { ...manifest.lifecycle, cleanup: 'blocked' },
+      lastError: {
+        operation: 'cleanup',
+        code: reasons
+          .map((reason) => reason.code)
+          .join('+')
+          .slice(0, 240),
+        message: reasons
+          .map((reason) => reason.message)
+          .join(' ')
+          .slice(0, 2000),
+        at: this.now().toISOString(),
+        recoverable: true,
+      },
+    });
+  }
+
+  private async recordFailure(
+    manifest: WorktreeManifest,
+    operation: WorktreeManifestError['operation'],
+    error: unknown,
+    lifecycle: Partial<WorktreeManifest['lifecycle']> = {}
+  ): Promise<WorktreeManifest> {
+    return this.saveManifest(manifest, {
+      lifecycle: { ...manifest.lifecycle, ...lifecycle },
+      lastError: {
+        operation,
+        code:
+          error instanceof GitCommandError
+            ? `git-${error.code ?? 'unavailable'}`
+            : 'operation-failed',
+        message: errorMessage(error),
+        at: this.now().toISOString(),
+        recoverable: true,
+      },
+    });
+  }
+
+  private async saveManifest(
+    manifest: WorktreeManifest,
+    patch: Partial<WorktreeManifest>
+  ): Promise<WorktreeManifest> {
+    return this.manifests.save({
+      ...manifest,
+      ...structuredClone(patch),
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  private async requireTask(taskId: string): Promise<Task> {
+    const task = await this.taskService.getTask(taskId);
+    if (!task) throw new NotFoundError(`Task "${taskId}" not found`);
+    return task;
+  }
+
+  private async requireCodeTask(taskId: string): Promise<CodeTask> {
+    const task = await this.requireTask(taskId);
+    if (task.type !== 'code') {
+      throw new ValidationError('Worktrees can only be created for code tasks');
+    }
+    if (!task.git?.repo || !task.git.branch || !task.git.baseBranch) {
+      throw new ValidationError('Task must have git repo, branch, and base branch configured');
+    }
+    return task as CodeTask;
+  }
+
+  private async requireActiveManifest(taskId: string): Promise<WorktreeManifest> {
+    const manifest = await this.manifests.read(taskId);
+    if (!manifest || manifest.lifecycle.cleanup === 'removed') {
+      throw new NotFoundError('Task does not have an active worktree manifest');
+    }
+    return manifest;
+  }
+
+  private async resolveCommit(cwd: string, ref: string): Promise<string> {
+    return (await this.git.run(cwd, ['rev-parse', '--verify', ref])).stdout.trim();
+  }
+
+  private async tryResolveCommit(cwd: string, ref: string): Promise<string | null> {
+    try {
+      return await this.resolveCommit(cwd, ref);
+    } catch {
+      return null;
+    }
+  }
+
+  private async currentBranch(worktreePath: string): Promise<string> {
+    return (
+      await this.git.run(worktreePath, ['symbolic-ref', '--quiet', '--short', 'HEAD'])
+    ).stdout.trim();
+  }
+}
+
+function normalizeLeaseSeconds(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LEASE_SECONDS;
+  if (!Number.isInteger(value) || value < MIN_LEASE_SECONDS || value > MAX_LEASE_SECONDS) {
+    throw new ValidationError(
+      `leaseSeconds must be an integer between ${MIN_LEASE_SECONDS} and ${MAX_LEASE_SECONDS}`
+    );
+  }
+  return value;
+}
+
+function expandPath(value: string): string {
+  if (!value.startsWith('~')) return value;
+  const home = process.env.HOME;
+  if (!home) throw new ValidationError('Cannot expand repository path because HOME is unset');
+  return path.join(home, value.slice(1));
+}
+
+function fingerprintRemote(remote: string): string {
+  const withoutCredentials = remote
+    .trim()
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/@\s]+@/gi, '$1')
+    .replace(/\/\/[^/@\s]+@/g, '//')
+    .replace(/([?&](?:access_token|api_key|token|key|secret|password)=)[^&#\s]+/gi, '$1[redacted]');
+  return `sha256:${createHash('sha256').update(withoutCredentials).digest('hex')}`;
+}
+
+function parseWorktreeList(
+  output: string
+): Array<{ path: string; branch?: string; detached: boolean }> {
+  return output
+    .trim()
+    .split(/\n\n+/)
+    .filter(Boolean)
+    .map((block) => {
+      const lines = block.split('\n');
+      const worktreePath = lines.find((line) => line.startsWith('worktree '))?.slice(9) ?? '';
+      const branchRef = lines.find((line) => line.startsWith('branch '))?.slice(7);
+      return {
+        path: worktreePath,
+        ...(branchRef?.startsWith('refs/heads/')
+          ? { branch: branchRef.slice('refs/heads/'.length) }
+          : {}),
+        detached: lines.includes('detached'),
+      };
+    })
+    .filter((worktree) => Boolean(worktree.path));
+}
+
+function cleanupConflict(reasons: WorktreeCleanupReason[]): ConflictError {
+  const activeRun = reasons.find((reason) => reason.code === 'active-run');
+  return new ConflictError(
+    activeRun
+      ? 'Worktree cleanup is blocked by an active run.'
+      : `Worktree cleanup is blocked: ${reasons.map((reason) => reason.message).join(' ')}`,
+    {
+      reasons,
+      remediation: reasons.every((reason) => reason.overrideable)
+        ? 'Resolve the conditions, or retry with force=true and an explicit reason.'
+        : 'Resolve every non-overrideable condition before retrying.',
+    }
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return sanitizeDiagnostic(error instanceof Error ? error.message : String(error)).slice(0, 2000);
+}
+
+function manifestError(
+  operation: WorktreeManifestError['operation'],
+  error: unknown,
+  now: Date
+): WorktreeManifestError {
+  return {
+    operation,
+    code:
+      error instanceof GitCommandError ? `git-${error.code ?? 'unavailable'}` : 'operation-failed',
+    message: errorMessage(error),
+    at: now.toISOString(),
+    recoverable: true,
+  };
+}
+
+function sanitizeDiagnostic(value: string): string {
+  return redactString(value)
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/@\s]+@/gi, '$1[redacted]@')
+    .replace(/\b(?:ghp|github_pat)[_-][A-Za-z0-9_-]{8,}\b/gi, '[redacted]')
+    .replace(/\b(?:sk|xai)[_-][A-Za-z0-9_-]{8,}\b/gi, '[redacted]')
+    .replace(/([?&](?:access_token|api_key|token|key|secret|password)=)[^&#\s]+/gi, '$1[redacted]')
+    .replace(
+      /\b((?:ACCESS_TOKEN|API_KEY|TOKEN|SECRET|PASSWORD)\s*[=:]\s*)[^\s,;]+/gi,
+      '$1[redacted]'
+    )
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function probeExternalHold(worktreePath: string): Promise<ExternalHoldProbeResult> {
+  if (process.platform === 'win32') return { state: 'unavailable' };
+  return new Promise((resolve) => {
+    const processHandle = spawn('lsof', ['+D', worktreePath], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    const timeout = setTimeout(() => {
+      processHandle.kill('SIGTERM');
+      resolve({ state: 'unavailable', detail: 'lsof timed out' });
+    }, 5_000);
+    processHandle.once('error', (error) => {
+      clearTimeout(timeout);
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        resolve({ state: 'unavailable', detail: 'lsof is not installed' });
+      } else {
+        resolve({ state: 'unavailable', detail: sanitizeDiagnostic(error.message) });
+      }
+    });
+    processHandle.once('close', (code) => {
+      clearTimeout(timeout);
+      resolve(code === 0 ? { state: 'held' } : { state: 'clear' });
+    });
+  });
 }

--- a/server/src/storage/fs-helpers.ts
+++ b/server/src/storage/fs-helpers.ts
@@ -71,6 +71,7 @@ export const createWriteStream = fs.createWriteStream;
 export const mkdir = mkdirAsync;
 export const readFile = readFileAsync;
 export const readdir = readdirAsync;
+export const realpath = fs.promises.realpath;
 export const rename = renameAsync;
 export const rm = rmAsync;
 export const unlink = unlinkAsync;

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -29,6 +29,11 @@ export type {
 } from './interfaces.js';
 export { LocalWorkspaceFileRepository } from './workspace-file-repository.js';
 export {
+  FileWorktreeManifestRepository,
+  InMemoryWorktreeManifestRepository,
+  type WorktreeManifestRepository,
+} from './worktree-manifest-repository.js';
+export {
   FileStorageProvider,
   FileTaskRepository,
   FileSettingsRepository,

--- a/server/src/storage/worktree-manifest-lock.ts
+++ b/server/src/storage/worktree-manifest-lock.ts
@@ -1,0 +1,130 @@
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createLogger } from '../lib/logger.js';
+
+const log = createLogger('worktree-manifest-lock');
+const DEFAULT_TIMEOUT_MS = 5_000;
+const POLL_INTERVAL_MS = 50;
+const inProcessQueues = new Map<string, Promise<void>>();
+
+interface WorktreeManifestLockInfo {
+  pid: number;
+  createdAt: string;
+  token: string;
+}
+
+async function enqueue(key: string, timeoutMs: number): Promise<() => void> {
+  const previous = inProcessQueues.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  inProcessQueues.set(key, current);
+
+  const timedOut = Symbol('timeout');
+  const result = await Promise.race([
+    previous.then(() => 'ready' as const),
+    new Promise<symbol>((resolve) => setTimeout(() => resolve(timedOut), timeoutMs)),
+  ]);
+  if (result === timedOut) {
+    previous.then(release, release);
+    throw new Error('worktree manifest in-process lock queue timed out');
+  }
+
+  return () => {
+    if (inProcessQueues.get(key) === current) inProcessQueues.delete(key);
+    release();
+  };
+}
+
+async function publishLock(lockFile: string): Promise<string | null> {
+  const token = randomBytes(24).toString('hex');
+  const candidateFile = `${lockFile}.${token}.candidate`;
+  const metadata: WorktreeManifestLockInfo = {
+    pid: process.pid,
+    createdAt: new Date().toISOString(),
+    token,
+  };
+
+  try {
+    await fs.mkdir(path.dirname(lockFile), { recursive: true });
+    await fs.writeFile(candidateFile, JSON.stringify(metadata), { flag: 'wx' });
+    await fs.link(candidateFile, lockFile);
+    return token;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return null;
+    throw error;
+  } finally {
+    await fs.unlink(candidateFile).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        log.warn({ err: error, candidateFile }, 'Failed to remove worktree lock candidate');
+      }
+    });
+  }
+}
+
+async function releaseLock(lockFile: string, expectedToken: string): Promise<void> {
+  try {
+    const content = await fs.readFile(lockFile, 'utf8');
+    const current = JSON.parse(content) as Partial<WorktreeManifestLockInfo>;
+    if (current.token !== expectedToken) {
+      log.warn({ lockFile }, 'Worktree manifest lock ownership changed before release');
+      return;
+    }
+    await fs.unlink(lockFile);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log.warn({ err: error, lockFile }, 'Failed to release worktree manifest lock');
+    }
+  }
+}
+
+async function acquireLock(lockKey: string, timeoutMs: number): Promise<() => Promise<void>> {
+  const key = path.resolve(lockKey);
+  const lockFile = `${lockKey}.lock`;
+  const deadline = Date.now() + timeoutMs;
+  let releaseQueue: (() => void) | undefined;
+
+  try {
+    releaseQueue = await enqueue(key, timeoutMs);
+  } catch {
+    throw new Error(`Worktree manifest lock timed out after ${timeoutMs}ms`);
+  }
+
+  try {
+    while (Date.now() < deadline) {
+      const token = await publishLock(lockFile);
+      if (token) {
+        const queueRelease = releaseQueue;
+        return async () => {
+          await releaseLock(lockFile, token);
+          queueRelease();
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+  } catch (error) {
+    releaseQueue();
+    throw error;
+  }
+
+  releaseQueue();
+  throw new Error(
+    `Worktree manifest lock is held or stale at ${lockFile}; confirm that no Veritas ` +
+      'process owns it before removing the lock file'
+  );
+}
+
+export async function withWorktreeManifestLock<T>(
+  lockKey: string,
+  operation: () => Promise<T>,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
+): Promise<T> {
+  const release = await acquireLock(lockKey, timeoutMs);
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}

--- a/server/src/storage/worktree-manifest-repository.ts
+++ b/server/src/storage/worktree-manifest-repository.ts
@@ -1,0 +1,129 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import type { WorktreeManifest } from '@veritas-kanban/shared';
+import { parseWorktreeManifest } from '../schemas/worktree-manifest-schemas.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { atomicWriteFile, fileExists, mkdir, readFile, readdir } from './fs-helpers.js';
+import { withWorktreeManifestLock } from './worktree-manifest-lock.js';
+
+export interface WorktreeManifestRepository {
+  read(taskId: string): Promise<WorktreeManifest | null>;
+  list(): Promise<WorktreeManifest[]>;
+  save(manifest: WorktreeManifest): Promise<WorktreeManifest>;
+  withTaskLock<T>(taskId: string, operation: () => Promise<T>): Promise<T>;
+  withAllocationLock<T>(repositoryKey: string, operation: () => Promise<T>): Promise<T>;
+}
+
+export interface FileWorktreeManifestRepositoryOptions {
+  manifestsDir: string;
+  lockTimeoutMs?: number;
+}
+
+export class FileWorktreeManifestRepository implements WorktreeManifestRepository {
+  private readonly manifestsDir: string;
+  private readonly lockTimeoutMs: number;
+
+  constructor(options: FileWorktreeManifestRepositoryOptions) {
+    this.manifestsDir = path.resolve(options.manifestsDir);
+    this.lockTimeoutMs = options.lockTimeoutMs ?? 5_000;
+  }
+
+  async read(taskId: string): Promise<WorktreeManifest | null> {
+    const manifestPath = this.manifestPath(taskId);
+    if (!(await fileExists(manifestPath))) return null;
+    return parseWorktreeManifest(JSON.parse(await readFile(manifestPath, 'utf8')));
+  }
+
+  async list(): Promise<WorktreeManifest[]> {
+    if (!(await fileExists(this.manifestsDir))) return [];
+    const files = (await readdir(this.manifestsDir))
+      .filter((file) => file.endsWith('.json'))
+      .sort();
+    const manifests = await Promise.all(
+      files.map(async (file) => {
+        const manifestPath = ensureWithinBase(
+          this.manifestsDir,
+          path.join(this.manifestsDir, file)
+        );
+        return parseWorktreeManifest(JSON.parse(await readFile(manifestPath, 'utf8')));
+      })
+    );
+    return manifests;
+  }
+
+  async save(manifest: WorktreeManifest): Promise<WorktreeManifest> {
+    const manifestPath = this.manifestPath(manifest.taskId);
+    const current = await this.read(manifest.taskId);
+    const next = parseWorktreeManifest({
+      ...structuredClone(manifest),
+      revision: (current?.revision ?? -1) + 1,
+    });
+    await mkdir(this.manifestsDir, { recursive: true });
+    await atomicWriteFile(manifestPath, `${JSON.stringify(next, null, 2)}\n`);
+    return structuredClone(next);
+  }
+
+  async withTaskLock<T>(taskId: string, operation: () => Promise<T>): Promise<T> {
+    return withWorktreeManifestLock(this.manifestPath(taskId), operation, this.lockTimeoutMs);
+  }
+
+  async withAllocationLock<T>(repositoryKey: string, operation: () => Promise<T>): Promise<T> {
+    const key = createHash('sha256').update(repositoryKey).digest('hex');
+    const lockPath = ensureWithinBase(
+      this.manifestsDir,
+      path.join(this.manifestsDir, `.allocation-${key}`)
+    );
+    return withWorktreeManifestLock(lockPath, operation, this.lockTimeoutMs);
+  }
+
+  private manifestPath(taskId: string): string {
+    validatePathSegment(taskId);
+    return ensureWithinBase(this.manifestsDir, path.join(this.manifestsDir, `${taskId}.json`));
+  }
+}
+
+export class InMemoryWorktreeManifestRepository implements WorktreeManifestRepository {
+  private readonly manifests = new Map<string, WorktreeManifest>();
+  private readonly queues = new Map<string, Promise<void>>();
+
+  async read(taskId: string): Promise<WorktreeManifest | null> {
+    const manifest = this.manifests.get(taskId);
+    return manifest ? structuredClone(manifest) : null;
+  }
+
+  async list(): Promise<WorktreeManifest[]> {
+    return [...this.manifests.values()]
+      .sort((left, right) => left.taskId.localeCompare(right.taskId))
+      .map((manifest) => structuredClone(manifest));
+  }
+
+  async save(manifest: WorktreeManifest): Promise<WorktreeManifest> {
+    const current = this.manifests.get(manifest.taskId);
+    const next = parseWorktreeManifest({
+      ...structuredClone(manifest),
+      revision: (current?.revision ?? -1) + 1,
+    });
+    this.manifests.set(next.taskId, next);
+    return structuredClone(next);
+  }
+
+  async withTaskLock<T>(taskId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.queues.get(taskId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.queues.set(taskId, current);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      if (this.queues.get(taskId) === current) this.queues.delete(taskId);
+      release();
+    }
+  }
+
+  async withAllocationLock<T>(repositoryKey: string, operation: () => Promise<T>): Promise<T> {
+    return this.withTaskLock(`allocation:${repositoryKey}`, operation);
+  }
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -51,3 +51,4 @@ export * from './task-envelope.types.js';
 export * from './run-launch-manifest.types.js';
 export * from './auth.types.js';
 export * from './credential-broker.types.js';
+export * from './worktree-manifest.types.js';

--- a/shared/src/types/run-launch-manifest.types.ts
+++ b/shared/src/types/run-launch-manifest.types.ts
@@ -106,6 +106,19 @@ export interface RunLaunchRuntime {
   credentialReferences: string[];
 }
 
+export interface RunLaunchWorkspace {
+  worktreeId: string;
+  worktreeManifestId?: string;
+  ownershipLeaseId?: string;
+  ownershipAttemptId?: string;
+  repo: string;
+  branch: string;
+  baseBranch: string;
+  resolvedBaseCommit: string;
+  baseResolutionSource:
+    import('./worktree-manifest.types.js').WorktreeBaseSource | 'legacy-launch-head';
+}
+
 export interface RunLaunchTools {
   allowed: string[];
   denied: string[];
@@ -191,6 +204,8 @@ export interface RunLaunchManifest {
   profile?: RunLaunchProfileReference;
   readiness: RunLaunchReadiness;
   instructions: RunLaunchInstructionReference[];
+  /** Present on newly compiled manifests; absent only on pre-6.0 legacy records. */
+  workspace?: RunLaunchWorkspace;
   runtime: RunLaunchRuntime;
   tools: RunLaunchTools;
   permissions: RunLaunchPermissions;

--- a/shared/src/types/task-envelope.types.ts
+++ b/shared/src/types/task-envelope.types.ts
@@ -115,9 +115,14 @@ export interface TaskEnvelopeAttempt {
 export interface TaskEnvelopeWorkspace {
   workspaceId: string;
   worktreeId: string;
+  worktreeManifestId?: string;
+  ownershipLeaseId?: string;
+  ownershipAttemptId?: string;
   repo: string;
   branch: string;
   baseBranch: string;
+  resolvedBaseCommit?: string;
+  baseResolutionSource?: import('./worktree-manifest.types.js').WorktreeBaseSource;
   worktreePath: string;
   baseline: TaskLaunchBaseline;
 }

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -42,6 +42,16 @@ export interface TaskGit {
   branch: string;
   baseBranch: string;
   worktreePath?: string;
+  /** System-owned reference to the durable worktree allocation record. */
+  worktreeManifestId?: string;
+  /** Exact commit used to create or most recently rebase the task worktree. */
+  worktreeBaseCommit?: string;
+  /** Whether the exact base came from the remote or an acknowledged stale local ref. */
+  worktreeBaseSource?: import('./worktree-manifest.types.js').WorktreeBaseSource;
+  /** Opaque ownership lease identifier. */
+  worktreeLeaseId?: string;
+  /** Attempt currently bound to the ownership lease, when a run has claimed it. */
+  worktreeLeaseOwnerAttemptId?: string;
   prUrl?: string;
   prNumber?: number;
 }

--- a/shared/src/types/worktree-manifest.types.ts
+++ b/shared/src/types/worktree-manifest.types.ts
@@ -1,0 +1,186 @@
+export const WORKTREE_MANIFEST_SCHEMA_VERSION = 'worktree-manifest/v1' as const;
+
+export type WorktreeBaseSource = 'remote' | 'local-stale' | 'legacy-adopted';
+export type WorktreeCreationState = 'planned' | 'creating' | 'ready' | 'failed';
+export type WorktreeIntegrationState =
+  'idle' | 'preparing' | 'merging' | 'pushing' | 'integrated' | 'failed';
+export type WorktreeCleanupState = 'active' | 'blocked' | 'removing' | 'removed' | 'failed';
+
+export interface WorktreeStaleBaseAcknowledgement {
+  reason: string;
+  acknowledgedAt: string;
+  actor?: string;
+}
+
+export interface WorktreeResolvedBase {
+  branch: string;
+  commit: string;
+  source: WorktreeBaseSource;
+  resolvedAt: string;
+  fetchedAt?: string;
+  fetchError?: string;
+  staleBaseAcknowledgement?: WorktreeStaleBaseAcknowledgement;
+}
+
+export interface WorktreeRepositoryIdentity {
+  name: string;
+  rootPath: string;
+  commonGitDir: string;
+  originFingerprint: string;
+}
+
+export interface WorktreeOwnershipLease {
+  id: string;
+  ownerTaskId: string;
+  ownerAttemptId?: string;
+  acquiredAt: string;
+  expiresAt: string;
+}
+
+export interface WorktreeLifecycle {
+  creation: WorktreeCreationState;
+  integration: WorktreeIntegrationState;
+  cleanup: WorktreeCleanupState;
+}
+
+export interface WorktreeRebaseEvidence {
+  state: 'idle' | 'rebasing' | 'failed';
+  targetBase?: WorktreeResolvedBase;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface WorktreeManifestError {
+  operation:
+    | 'create'
+    | 'task-update'
+    | 'rebase'
+    | 'integration-prepare'
+    | 'integration-merge'
+    | 'integration-push'
+    | 'cleanup';
+  code: string;
+  message: string;
+  at: string;
+  recoverable: boolean;
+}
+
+export interface WorktreeIntegrationEvidence {
+  worktreePath?: string;
+  baseCommit?: string;
+  integrationHead?: string;
+  targetCommit?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface WorktreeOverrideAudit {
+  operation: 'cleanup';
+  reason: string;
+  actor?: string;
+  recordedAt: string;
+  bypassedReasons: WorktreeCleanupReasonCode[];
+}
+
+export interface WorktreeManifest {
+  schemaVersion: typeof WORKTREE_MANIFEST_SCHEMA_VERSION;
+  id: string;
+  revision: number;
+  taskId: string;
+  repository: WorktreeRepositoryIdentity;
+  path: string;
+  branch: string;
+  base: WorktreeResolvedBase;
+  lease: WorktreeOwnershipLease;
+  lifecycle: WorktreeLifecycle;
+  rebase: WorktreeRebaseEvidence;
+  integration: WorktreeIntegrationEvidence;
+  createdAt: string;
+  updatedAt: string;
+  removedAt?: string;
+  lastError?: WorktreeManifestError;
+  overrides: WorktreeOverrideAudit[];
+}
+
+export type WorktreeCleanupReasonCode =
+  | 'active-run'
+  | 'active-lease'
+  | 'dirty'
+  | 'untracked'
+  | 'unpushed'
+  | 'unmerged'
+  | 'external-hold'
+  | 'manifest-mismatch'
+  | 'worktree-missing'
+  | 'branch-mismatch'
+  | 'inspection-failed';
+
+export interface WorktreeCleanupReason {
+  code: WorktreeCleanupReasonCode;
+  message: string;
+  overrideable: boolean;
+}
+
+export interface WorktreeCleanupSnapshot {
+  dirty: boolean;
+  untrackedFiles: number;
+  unpushedCommits: number;
+  mergedIntoBase: boolean;
+  externalHold: 'clear' | 'held' | 'unavailable';
+}
+
+export interface WorktreeCleanupPreview {
+  taskId: string;
+  manifestId: string;
+  path: string;
+  checkedAt: string;
+  stale: boolean;
+  eligible: boolean;
+  requiresOverride: boolean;
+  blockedReasons: WorktreeCleanupReason[];
+  snapshot: WorktreeCleanupSnapshot;
+}
+
+export interface WorktreeInfo {
+  path: string;
+  branch: string;
+  baseBranch: string;
+  baseCommit: string;
+  baseSource: WorktreeBaseSource;
+  manifestId: string;
+  manifest: WorktreeManifest;
+  lifecycle: WorktreeLifecycle;
+  remoteState: {
+    stale: boolean;
+    fetchedAt?: string;
+    error?: string;
+  };
+  aheadBehind: {
+    ahead: number;
+    behind: number;
+  };
+  hasChanges: boolean;
+  changedFiles: number;
+  cleanupPreview: WorktreeCleanupPreview;
+}
+
+export interface WorktreeIntegrationResult {
+  merged: true;
+  targetCommit: string;
+  manifest: WorktreeManifest;
+}
+
+export interface CreateWorktreeRequest {
+  allowStaleBase?: boolean;
+  staleBaseAcknowledgement?: {
+    reason: string;
+    actor?: string;
+  };
+  leaseSeconds?: number;
+}
+
+export interface DeleteWorktreeRequest {
+  force?: boolean;
+  reason?: string;
+  actor?: string;
+}

--- a/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   useGitHubStatus: vi.fn(),
   useConflictStatus: vi.fn(),
   createWorktreeMutate: vi.fn(),
+  adoptWorktreeMutate: vi.fn(),
   deleteWorktreeMutate: vi.fn(),
   rebaseWorktreeMutate: vi.fn(),
   mergeWorktreeMutate: vi.fn(),
@@ -38,6 +39,11 @@ vi.mock('@/hooks/useWorktree', () => ({
   useWorktreeStatus: mocks.useWorktreeStatus,
   useCreateWorktree: () => ({
     mutate: mocks.createWorktreeMutate,
+    isPending: false,
+    error: null,
+  }),
+  useAdoptWorktree: () => ({
+    mutate: mocks.adoptWorktreeMutate,
     isPending: false,
     error: null,
   }),
@@ -108,9 +114,24 @@ describe('task detail Git and workflow Mantine migration', () => {
         path: '/tmp/veritas-worktree',
         branch: 'feature/mantine-git',
         baseBranch: 'main',
+        baseCommit: 'a'.repeat(40),
+        baseSource: 'remote',
+        manifestId: 'worktree-mantine',
+        remoteState: { stale: false, fetchedAt: '2026-07-23T20:00:00.000Z' },
         aheadBehind: { ahead: 2, behind: 1 },
         hasChanges: false,
         changedFiles: 0,
+        cleanupPreview: {
+          eligible: false,
+          requiresOverride: true,
+          blockedReasons: [
+            {
+              code: 'unmerged',
+              message: 'The worktree HEAD is not merged into the remote base.',
+              overrideable: true,
+            },
+          ],
+        },
       },
       isLoading: false,
       error: null,
@@ -175,6 +196,8 @@ describe('task detail Git and workflow Mantine migration', () => {
         baseBranch: 'main',
         branch: 'feature/mantine-git',
         worktreePath: '/tmp/veritas-worktree',
+        worktreeManifestId: 'worktree-mantine',
+        worktreeLeaseId: 'lease-mantine',
       },
     });
 
@@ -184,6 +207,7 @@ describe('task detail Git and workflow Mantine migration', () => {
     expect(container.querySelector('.mantine-Badge-root')).toBeDefined();
     expect(container.querySelector('.mantine-Button-root')).toBeDefined();
     expect(container.querySelector('.mantine-Code-root')).toBeDefined();
+    expect(screen.getByText(/Base a{12} from remote; manifest worktree-mantine/)).toBeDefined();
     expect(baseElement.querySelector('[data-slot="alert-dialog-content"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
 
@@ -212,6 +236,61 @@ describe('task detail Git and workflow Mantine migration', () => {
       '_blank',
       'noopener,noreferrer'
     );
+  });
+
+  it('requires an explicit reason before overriding cleanup hazards', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-cleanup',
+      git: {
+        repo: 'veritas',
+        baseBranch: 'main',
+        branch: 'feature/mantine-git',
+        worktreePath: '/tmp/veritas-worktree',
+        worktreeManifestId: 'worktree-mantine',
+        worktreeLeaseId: 'lease-mantine',
+      },
+    });
+
+    renderWithProviders(<WorktreeStatus task={task} />);
+    await user.click(screen.getByRole('button', { name: 'Delete Worktree' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Delete worktree?' });
+    const deleteButton = within(dialog).getByRole('button', { name: 'Delete' });
+
+    expect(within(dialog).getByText(/not merged into the remote base/)).toBeDefined();
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(true);
+    await user.type(
+      within(dialog).getByRole('textbox', { name: 'Override reason' }),
+      'Operator reviewed and accepted the retained branch risk.'
+    );
+    await user.click(deleteButton);
+
+    expect(mocks.deleteWorktreeMutate).toHaveBeenCalledWith({
+      taskId: 'task-cleanup',
+      force: true,
+      reason: 'Operator reviewed and accepted the retained branch risk.',
+    });
+  });
+
+  it('offers admin adoption for a pre-6.0 worktree without running status actions', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({
+      id: 'task-legacy-worktree',
+      git: {
+        repo: 'veritas',
+        baseBranch: 'main',
+        branch: 'feature/legacy',
+        worktreePath: '/tmp/legacy-worktree',
+      },
+    });
+
+    renderWithProviders(<WorktreeStatus task={task} />);
+
+    expect(screen.getByText('Legacy worktree needs adoption')).toBeDefined();
+    expect(screen.getByText(/Local changes are preserved/)).toBeDefined();
+    expect(mocks.useWorktreeStatus).toHaveBeenCalledWith('task-legacy-worktree', false);
+    await user.click(screen.getByRole('button', { name: 'Adopt existing worktree' }));
+    expect(mocks.adoptWorktreeMutate).toHaveBeenCalledWith('task-legacy-worktree');
   });
 
   it('renders workflow runs through direct Mantine modal controls and starts a run', async () => {

--- a/web/src/components/task/git/WorktreeStatus.tsx
+++ b/web/src/components/task/git/WorktreeStatus.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { Alert, Badge, Button, Code, Group, Modal, Stack, Text } from '@mantine/core';
+import { Alert, Badge, Button, Code, Group, Modal, Stack, Text, Textarea } from '@mantine/core';
 import {
   useWorktreeStatus,
   useCreateWorktree,
+  useAdoptWorktree,
   useDeleteWorktree,
   useRebaseWorktree,
   useMergeWorktree,
@@ -33,12 +34,14 @@ interface WorktreeStatusProps {
 
 export function WorktreeStatus({ task }: WorktreeStatusProps) {
   const hasWorktree = !!task.git?.worktreePath;
+  const hasManagedWorktree = hasWorktree && !!task.git?.worktreeManifestId;
   const hasPR = !!task.git?.prUrl;
-  const { data: status, isLoading, error } = useWorktreeStatus(task.id, hasWorktree);
+  const { data: status, isLoading, error } = useWorktreeStatus(task.id, hasManagedWorktree);
   const { data: ghStatus } = useGitHubStatus();
   const { data: conflictStatus } = useConflictStatus(hasWorktree ? task.id : undefined);
 
   const createWorktree = useCreateWorktree();
+  const adoptWorktree = useAdoptWorktree();
   const deleteWorktree = useDeleteWorktree();
   const rebaseWorktree = useRebaseWorktree();
   const mergeWorktree = useMergeWorktree();
@@ -48,6 +51,8 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [cleanupOverrideReason, setCleanupOverrideReason] = useState('');
+  const [staleBaseReason, setStaleBaseReason] = useState('');
 
   const handleOpenInVSCode = () => {
     if (task.git?.worktreePath) {
@@ -85,11 +90,76 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
           Create Worktree
         </Button>
         {createWorktree.error && (
-          <Text size="xs" c="red">
-            {(createWorktree.error as Error).message}
-          </Text>
+          <>
+            <Text size="xs" c="red">
+              {(createWorktree.error as Error).message}
+            </Text>
+            {(createWorktree.error as Error).message.includes('stale-base acknowledgement') && (
+              <Stack gap="xs">
+                <Textarea
+                  label="Offline base acknowledgement"
+                  description="The exact local base commit and this reason will be persisted."
+                  value={staleBaseReason}
+                  onChange={(event) => setStaleBaseReason(event.currentTarget.value)}
+                  minRows={2}
+                />
+                <Button
+                  variant="outline"
+                  color="orange"
+                  disabled={staleBaseReason.trim().length === 0 || createWorktree.isPending}
+                  onClick={() =>
+                    createWorktree.mutate({
+                      taskId: task.id,
+                      request: {
+                        allowStaleBase: true,
+                        staleBaseAcknowledgement: { reason: staleBaseReason.trim() },
+                      },
+                    })
+                  }
+                >
+                  Retry with acknowledged local base
+                </Button>
+              </Stack>
+            )}
+          </>
         )}
       </Stack>
+    );
+  }
+
+  if (!hasManagedWorktree) {
+    return (
+      <Alert
+        className="mt-3"
+        color="orange"
+        icon={<AlertTriangle className="h-5 w-5" />}
+        title="Legacy worktree needs adoption"
+      >
+        <Stack gap="xs">
+          <Text size="sm">
+            This pre-6.0 worktree has no durable ownership manifest. An administrator must validate
+            its repository, branch, path, remote base, and current status before agent launch or
+            lifecycle actions can continue. Local changes are preserved.
+          </Text>
+          <Code className="truncate" color="dark">
+            {task.git.worktreePath}
+          </Code>
+          <Button
+            variant="outline"
+            color="orange"
+            size="xs"
+            onClick={() => adoptWorktree.mutate(task.id)}
+            disabled={adoptWorktree.isPending}
+          >
+            {adoptWorktree.isPending ? 'Validating...' : 'Adopt existing worktree'}
+          </Button>
+          {adoptWorktree.error && (
+            <Text size="xs" c="red">
+              {(adoptWorktree.error as Error).message}
+            </Text>
+          )}
+        </Stack>
+      </Alert>
     );
   }
 
@@ -121,6 +191,19 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
   return (
     <Stack gap="sm" className="mt-3 border-t pt-3">
       {/* Conflict warning banner */}
+      {status?.remoteState?.stale && status.baseCommit && (
+        <Alert
+          color="orange"
+          icon={<AlertTriangle className="h-5 w-5" />}
+          title="Stale base acknowledged"
+        >
+          <Text size="xs">
+            This worktree was created from an explicitly acknowledged local base because the remote
+            fetch failed. Exact base: {status.baseCommit.slice(0, 12)}.
+          </Text>
+        </Alert>
+      )}
+
       {conflictStatus?.hasConflicts && (
         <Alert
           color="yellow"
@@ -271,6 +354,12 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
       <Code className="truncate" color="dark">
         {task.git.worktreePath}
       </Code>
+      {status?.baseCommit && status.baseSource && status.manifestId && (
+        <Text size="xs" c="dimmed">
+          Base {status.baseCommit.slice(0, 12)} from {status.baseSource}; manifest{' '}
+          {status.manifestId}
+        </Text>
+      )}
 
       {/* Conflict Resolver */}
       <ConflictResolver
@@ -291,7 +380,8 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
         <Stack gap="md">
           <Text size="sm" c="dimmed">
             This will merge {task.git?.branch} into {task.git?.baseBranch}, push to remote, delete
-            the worktree, and mark the task as Done.
+            the worktree, and mark the task as Done. Integration runs in a dedicated temporary
+            worktree and does not change your primary checkout.
           </Text>
           <Group justify="flex-end" gap="xs">
             <Button variant="default" onClick={() => setMergeDialogOpen(false)}>
@@ -319,10 +409,29 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
       >
         <Stack gap="md">
           <Text size="sm" c="dimmed">
-            {status?.hasChanges
-              ? 'Warning: This worktree has uncommitted changes that will be lost.'
-              : 'This will remove the worktree but keep the branch.'}
+            This will remove the worktree but keep the branch.
           </Text>
+          {(status?.cleanupPreview?.blockedReasons.length ?? 0) > 0 && (
+            <Alert color="red" title="Cleanup is blocked">
+              <Stack gap={4}>
+                {status?.cleanupPreview?.blockedReasons.map((reason) => (
+                  <Text size="xs" key={reason.code}>
+                    {reason.message}
+                  </Text>
+                ))}
+              </Stack>
+            </Alert>
+          )}
+          {status?.cleanupPreview?.requiresOverride && (
+            <Textarea
+              label="Override reason"
+              description="This reason is stored in the worktree manifest."
+              value={cleanupOverrideReason}
+              onChange={(event) => setCleanupOverrideReason(event.currentTarget.value)}
+              minRows={2}
+              required
+            />
+          )}
           <Group justify="flex-end" gap="xs">
             <Button variant="default" onClick={() => setDeleteDialogOpen(false)}>
               Cancel
@@ -332,10 +441,21 @@ export function WorktreeStatus({ task }: WorktreeStatusProps) {
               onClick={() => {
                 deleteWorktree.mutate({
                   taskId: task.id,
-                  force: status?.hasChanges,
+                  force: (status?.cleanupPreview?.blockedReasons.length ?? 0) > 0,
+                  reason: status?.cleanupPreview?.requiresOverride
+                    ? cleanupOverrideReason.trim()
+                    : undefined,
                 });
                 setDeleteDialogOpen(false);
+                setCleanupOverrideReason('');
               }}
+              disabled={
+                Boolean(
+                  status?.cleanupPreview?.blockedReasons.some((reason) => !reason.overrideable)
+                ) ||
+                (Boolean(status?.cleanupPreview?.requiresOverride) &&
+                  cleanupOverrideReason.trim().length === 0)
+              }
             >
               Delete
             </Button>

--- a/web/src/hooks/useWorktree.ts
+++ b/web/src/hooks/useWorktree.ts
@@ -1,10 +1,14 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
+import type { CreateWorktreeRequest, DeleteWorktreeRequest } from '@veritas-kanban/shared';
 
 export function useWorktreeStatus(taskId: string | undefined, hasWorktree: boolean) {
   return useQuery({
     queryKey: ['worktree', taskId],
-    queryFn: () => api.worktree.status(taskId!),
+    queryFn: () => {
+      if (!taskId) throw new Error('Task ID is required');
+      return api.worktree.status(taskId);
+    },
     enabled: !!taskId && hasWorktree,
     refetchInterval: 10000, // Refresh every 10 seconds
   });
@@ -14,7 +18,23 @@ export function useCreateWorktree() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (taskId: string) => api.worktree.create(taskId),
+    mutationFn: (input: string | { taskId: string; request?: CreateWorktreeRequest }) =>
+      typeof input === 'string'
+        ? api.worktree.create(input)
+        : api.worktree.create(input.taskId, input.request),
+    onSuccess: (_, input) => {
+      const taskId = typeof input === 'string' ? input : input.taskId;
+      queryClient.invalidateQueries({ queryKey: ['worktree', taskId] });
+      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+    },
+  });
+}
+
+export function useAdoptWorktree() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (taskId: string) => api.worktree.adopt(taskId),
     onSuccess: (_, taskId) => {
       queryClient.invalidateQueries({ queryKey: ['worktree', taskId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
@@ -26,8 +46,8 @@ export function useDeleteWorktree() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ taskId, force }: { taskId: string; force?: boolean }) =>
-      api.worktree.delete(taskId, force),
+    mutationFn: ({ taskId, ...request }: { taskId: string } & DeleteWorktreeRequest) =>
+      api.worktree.delete(taskId, request),
     onSuccess: (_, { taskId }) => {
       queryClient.invalidateQueries({ queryKey: ['worktree', taskId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });

--- a/web/src/lib/api/agent.ts
+++ b/web/src/lib/api/agent.ts
@@ -18,6 +18,11 @@ import type {
   RunLaunchManifest,
   RunLaunchManifestDriftResult,
   RunLaunchManifestPreview,
+  WorktreeInfo,
+  WorktreeCleanupPreview,
+  WorktreeIntegrationResult,
+  CreateWorktreeRequest,
+  DeleteWorktreeRequest,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
 
@@ -33,8 +38,16 @@ export interface StartAgentRequest {
 }
 
 export const worktreeApi = {
-  create: async (taskId: string): Promise<WorktreeInfo> => {
+  create: async (taskId: string, request: CreateWorktreeRequest = {}): Promise<WorktreeInfo> => {
     return apiFetch<WorktreeInfo>(`${API_BASE}/tasks/${taskId}/worktree`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+  },
+
+  adopt: async (taskId: string): Promise<WorktreeInfo> => {
+    return apiFetch<WorktreeInfo>(`${API_BASE}/tasks/${taskId}/worktree/adopt`, {
       method: 'POST',
     });
   },
@@ -43,8 +56,19 @@ export const worktreeApi = {
     return apiFetch<WorktreeInfo>(`${API_BASE}/tasks/${taskId}/worktree`);
   },
 
-  delete: async (taskId: string, force: boolean = false): Promise<void> => {
-    return apiFetch<void>(`${API_BASE}/tasks/${taskId}/worktree?force=${force}`, {
+  cleanupPreview: async (taskId: string): Promise<WorktreeCleanupPreview> => {
+    return apiFetch<WorktreeCleanupPreview>(`${API_BASE}/tasks/${taskId}/worktree/cleanup-preview`);
+  },
+
+  cleanupCandidates: async (): Promise<WorktreeCleanupPreview[]> => {
+    return apiFetch<WorktreeCleanupPreview[]>(`${API_BASE}/tasks/worktrees/cleanup-preview`);
+  },
+
+  delete: async (taskId: string, request: DeleteWorktreeRequest = {}): Promise<void> => {
+    const query = new URLSearchParams();
+    query.set('force', String(request.force === true));
+    if (request.reason) query.set('reason', request.reason);
+    return apiFetch<void>(`${API_BASE}/tasks/${taskId}/worktree?${query.toString()}`, {
       method: 'DELETE',
     });
   },
@@ -55,8 +79,8 @@ export const worktreeApi = {
     });
   },
 
-  merge: async (taskId: string): Promise<void> => {
-    return apiFetch<void>(`${API_BASE}/tasks/${taskId}/worktree/merge`, {
+  merge: async (taskId: string): Promise<WorktreeIntegrationResult> => {
+    return apiFetch<WorktreeIntegrationResult>(`${API_BASE}/tasks/${taskId}/worktree/merge`, {
       method: 'POST',
     });
   },
@@ -318,18 +342,6 @@ export interface GlobalAgentStatus {
   activeAgents: ActiveAgentInfo[];
   lastUpdated: string;
   error?: string;
-}
-
-export interface WorktreeInfo {
-  path: string;
-  branch: string;
-  baseBranch: string;
-  aheadBehind: {
-    ahead: number;
-    behind: number;
-  };
-  hasChanges: boolean;
-  changedFiles: number;
 }
 
 export interface PreviewServer {

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -187,9 +187,9 @@ export type {
   AgentOutput,
   GlobalAgentStatus,
   ActiveAgentInfo,
-  WorktreeInfo,
   PreviewServer,
 } from './agent';
+export type { WorktreeInfo } from '@veritas-kanban/shared';
 
 export type {
   FileChange,


### PR DESCRIPTION
## Description

Implements the durable worktree lifecycle required by #858.

- Persists `worktree-manifest/v1` with repository fingerprint, exact base/source evidence, task ownership, attempt lease, lifecycle state, recovery evidence, and override audit.
- Serializes allocation and claim operations across processes, fails closed on ambiguous locks, and prevents rebase, integration, or cleanup while a run owns the worktree.
- Resolves new worktrees from an exact fetched remote commit. Stale local creation requires an explicit acknowledgement and reason.
- Uses a dedicated integration worktree so the primary checkout branch and working tree are never mutated.
- Recovers interrupted create, rebase, merge, push, and cleanup transitions.
- Adds preview-first cleanup blockers for active leases, dirt, untracked files, unpushed or unmerged commits, inspection failures, and external holds.
- Adds admin-only legacy adoption and force cleanup with recorded reasons.
- Extends task launch evidence, REST APIs, UI controls, operator docs, lifecycle docs, security docs, and changelog coverage.

Pre-6.0 task worktrees are not silently trusted. They require admin adoption with repository, branch, remote, path, uniqueness, and remote-base ancestry validation.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor

## Testing

**Test commands:**

```bash
pnpm test:unit
pnpm typecheck
pnpm build
pnpm lint:budget
pnpm check:pnpm-settings
pnpm check:security-artifacts
pnpm smoke:cli-mcp
```

Sequential workspace results:

- Desktop: 61 passed.
- Server: 2,431 passed, 2 skipped.
- Web: 427 passed.
- Focused worktree, repository, route, launch-envelope, launch-manifest, UI, and reconciliation coverage: 152 passed.
- Lint budget: 0 errors, 589 warnings against the existing 600-warning ceiling.
- Security artifact scan: 1,465 tracked files scanned.
- CLI/MCP smoke passed; two credential-gated live checks skipped because `VK_API_KEY` is not configured.

The root parallel `pnpm test` command still exposes unrelated repository runner assumptions: localhost MCP tests, web tests using the root working directory, a root `tsx` lookup, and the existing rate-limit route expectation. The sequential project-supported `pnpm test:unit` gate is green.

Independent correctness and security reviews found no remaining issue after fixes for timeout lock release, exclusive leases, recovery state, unavailable hold inspection, atomic allocation, integration resume validation, rebase ownership, and legacy provenance.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any breaking changes have been documented in the PR description

Closes #858