### PR TITLE
feat: add bidirectional Buzz Squad Chat adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   diagnostics with built-in hexadecimal/`nsec` signing, stable machine-readable
   reason codes, evidence invalidation, shell-free optional command discovery,
   Settings controls, `vk doctor` reporting, and operator/API/security
-  documentation. Buzz message delivery and reply subscription remain
-  fail-closed for their dedicated follow-up issue (#905).
+  documentation. The resulting compatibility evidence is the fail-closed gate
+  consumed by Buzz communication delivery (#906).
+- Added a native bidirectional Buzz channel bridge for Squad Chat with signed
+  Nostr root/reply events, channel mapping APIs and Settings controls, NIP-42
+  WebSocket subscriptions, source author/timestamp/deep-link metadata,
+  `(created_at,event_id)` cursors, overlap dedupe, out-of-order reply recovery,
+  loop prevention, non-destructive edit/delete auditing, delivery-unknown
+  reconciliation, runtime health facets, safe disable/rollback, fake-relay
+  contract coverage, and operator/API/security documentation (#906).
 - Added transactional, remote-safe worktree lifecycle management with
   versioned manifests, exact fetched base commits, reasoned offline fallback,
   task/attempt ownership leases, active-run locks, recovery states, and

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [Self-Hosting Guide](docs/guides/SELF_HOST.md) — production deployment, reverse proxy, auth hardening, Docker, and backups.
 - [Agent Task Workflow SOP](docs/SOP-agent-task-workflow.md) — lifecycle, API/CLI snippets, prompts.
 - [Squad Chat Protocol](docs/SQUAD-CHAT-PROTOCOL.md) — agent messaging, system events (spawned/completed/failed), model attribution, and helper scripts.
+- [Buzz Communication Adapter](docs/BUZZ-INTEGRATION.md) — signed Squad Chat channel bridging, mapping, replay, delivery reconciliation, health, and rollback.
 - [Sprint Planning SOP](docs/SOP-sprint-planning.md) — epic → sprint → task breakdown.
 - [Multi-Agent Orchestration](docs/SOP-multi-agent-orchestration.md) — PM + worker handoffs.
 - [Cross-Model Code Review](docs/SOP-cross-model-code-review.md) — enforce Claude ↔ GPT reviews.
@@ -246,6 +247,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **@Mention notifications** — @agent-name parsing in comments, thread subscriptions
 - **Broadcast Notifications** — Priority-based persistent notifications with read receipts and agent-specific delivery
 - **Squad Chat Webhook** — Configurable webhooks (generic HTTP or OpenClaw Direct) for external agent integration
+- **Buzz Communication Adapter** — Native signed root/reply bridge between one mapped Buzz community channel and Squad Chat, with durable replay and ambiguous-send reconciliation
 - **Agent registry** — Service discovery with heartbeat tracking, capabilities, and live status
 - **Multi-agent dashboard** — Real-time sidebar with expandable agent cards, status indicators
 - **Multi-agent task assignment** — Assign multiple agents per task with color-coded chips

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -730,9 +730,9 @@ Search returns redacted snippets only. Mention notifications link back to the sq
 ### Communication Adapters
 
 Communication adapters live under integrations. Microsoft Teams provides the
-existing human reply/send posture. Buzz provides a reference-only connection
-configuration and read-only relay compatibility probe. It does not send or
-subscribe to messages in this slice. External thread mappings remain separate
+existing human reply/send posture. Buzz adds a native signed-event bridge
+between one mapped community channel and Squad Chat. External thread mappings,
+Buzz event coordinates, delivery audits, and replay cursors remain separate
 from message content.
 
 ```
@@ -744,6 +744,9 @@ POST /api/integrations/communication/adapters/:adapterId/send
 POST /api/integrations/communication/adapters/:adapterId/replies
 POST /api/integrations/communication/adapters/:adapterId/poll
 POST /api/integrations/communication/adapters/:adapterId/disconnect
+GET  /api/integrations/communication/adapters/:adapterId/buzz/channels
+PUT  /api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId
+POST /api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId/disable
 GET  /api/integrations/communication/mappings
 GET  /api/integrations/communication/deliveries
 ```
@@ -801,14 +804,48 @@ Buzz rejects raw credentials, URL userinfo/query/fragment components, and
 credential-like command arguments. Health returns an exact status and
 `reasonCode`, redacted configured/resolved endpoints, expected/observed
 community, public-key fingerprint, tested Buzz release/commit, probe revision,
-relay contract, independent verification checks, and optional command
-diagnostics. `POST .../buzz-default/test` runs the same read-only probe;
-`canSend` and `canReceiveReplies` remain `false`. See
-[Buzz Connection Diagnostics](BUZZ-INTEGRATION.md).
+relay contract, independent verification checks, optional command diagnostics,
+and runtime transport/subscription/cursor/send facets.
+
+`POST .../buzz-default/test` runs the read-only compatibility probe. It does
+not send. Runtime `canSend` additionally requires an enabled mapped channel;
+`canReceiveReplies` requires an active authenticated subscription.
 
 Send `null` for `relayWebSocketUrl`, `expectedCommunity`, `authTagRef`, or
 `command` to clear that optional setting. Omitting one preserves its current
 value.
+
+**Buzz channel mapping body**:
+
+```json
+{
+  "target": { "kind": "squad" },
+  "enabled": true,
+  "actor": "operator"
+}
+```
+
+The `channelId` path value is a Buzz channel UUID. One enabled channel may map
+to Squad Chat. Disabling retains the mapping and cursor.
+
+**Buzz send body**:
+
+```json
+{
+  "target": {
+    "kind": "squad",
+    "squadMessageId": "msg_local_reply"
+  },
+  "replyToSquadMessageId": "msg_local_root",
+  "message": "Reply from Veritas",
+  "actor": "VERITAS"
+}
+```
+
+Omit `replyToSquadMessageId` for a root. The response includes the signed Buzz
+coordinate and a delivery status. `delivery_unknown` is a durable visible
+state, not a failure alias. `POST .../poll` queries the event ID before any
+safe resubmission. See [Buzz Communication Adapter](BUZZ-INTEGRATION.md).
 
 **Reply ingest body**:
 

--- a/docs/BUZZ-INTEGRATION.md
+++ b/docs/BUZZ-INTEGRATION.md
@@ -1,19 +1,17 @@
-# Buzz Connection Diagnostics
+# Buzz Communication Adapter
 
-Veritas Kanban can register a Buzz relay as a communication adapter and verify
-its compatibility without sending a message or changing relay state. This
-first integration slice covers connection configuration, relay/community
-identity, NIP-98 authentication, relay membership, channel/message read
-capability, and optional local command discovery.
+Veritas Kanban can map a Buzz community channel to Squad Chat and move signed
+root messages and replies in both directions. The integration uses Buzz's
+native Nostr HTTP and WebSocket contracts. It does not spawn `buzz`,
+`buzz-acp`, or `buzz-agent` for delivery.
 
-Buzz is a communication harness in this integration. It is not an
-`AgentProvider`, and Veritas does not start `buzz`, `buzz-acp`, or `buzz-agent`.
-Message send, reply subscription, persona import, and composed agent execution
-are separate roadmap capabilities.
+Buzz is a communication adapter, not an `AgentProvider`. It does not create a
+Veritas task, start an ACP agent, synchronize DMs or forums, or read Buzz
+Desktop's internal state.
 
 ## Supported contract
 
-The probe is fixture-pinned to:
+The adapter is fixture-pinned to:
 
 - Buzz release `0.4.24`
 - Buzz commit `710ed9fff57878a1d69f809b80a6ee0416c53fc4`
@@ -22,49 +20,77 @@ The probe is fixture-pinned to:
 - Required NIPs `11`, `29`, and `42`
 - Optional enforced relay membership advertised as NIP `43`
 
-An unknown Buzz version is reported as `unsupported`. Veritas still reads
-public NIP-11 metadata, but it does not treat that version as safe evidence for
-later message delivery.
+The initial event projection is:
 
-## Configure the identity
+| Buzz surface                          | Veritas behavior                                                           |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| Kind `9` root message                 | Creates one Squad Chat message in the mapped target.                       |
+| Kind `9` reply                        | Creates one threaded Squad Chat reply using Buzz root/reply tags.          |
+| Veritas root                          | Signs and publishes one kind `9` event with the mapped `h` channel tag.    |
+| Veritas reply                         | Publishes a direct or nested reply with the exact Buzz root/reply markers. |
+| Kind `40003` edit                     | Records bounded audit metadata. Existing Squad Chat text is unchanged.     |
+| Kind `9005` or NIP-09 kind `5` delete | Records bounded deletion metadata. Local content is not removed.           |
+| Unknown or malformed kind             | Ignores it with a redacted delivery audit entry.                           |
+| Reactions, files, canvas, forums, DMs | Not projected.                                                             |
 
-Use a dedicated Buzz/Nostr identity. Keep the private key in the Veritas server
-environment and store only its environment-variable reference in Veritas.
+An unknown Buzz version is `unsupported`. Veritas may still read public NIP-11
+metadata, but it will not connect the worker or send messages until the pinned
+compatibility contract passes.
+
+## Identity and least privilege
+
+Use a dedicated Buzz/Nostr identity. Add that public identity only to the
+community and channels that Veritas must bridge. Veritas does not need channel
+creation, moderation, desktop storage, or broad community administration.
+
+Keep the private key in the Veritas server environment and store only its
+environment-variable reference:
 
 ```dotenv
 BUZZ_PRIVATE_KEY=<set outside source control>
 BUZZ_AUTH_TAG=<optional NIP-OA owner attestation>
 ```
 
-The signing key may be a 64-character hexadecimal private key or its `nsec`
-encoding and must match the configured 64-character hexadecimal public key.
-Veritas signs the Buzz-specific NIP-98 event with its pinned `nostr-tools`
-runtime. `BUZZ_AUTH_TAG` is needed only when an agent identity receives relay
-membership through a NIP-OA owner. Never put an `nsec`, private-key hex, auth
-tag, token, or authorization header in the Settings form, API body, task, log,
-screenshot, or support packet.
+The signing key may be 64-character private-key hex or `nsec`. It must match
+the configured 64-character public-key hex. `BUZZ_AUTH_TAG` is needed only
+when an agent identity receives membership through a NIP-OA owner.
+
+Never put an `nsec`, private-key hex, auth tag, token, authorization header, or
+raw signed event in a Settings field, API response, task, log, screenshot, or
+support packet.
+
+## Configure and map a channel
 
 In **Settings -> Notifications -> Buzz Connection**, configure:
 
 - Relay HTTP URL, such as `https://community.example.com`
 - Optional matching WebSocket URL; Veritas derives it when omitted
 - Expected community host and optional non-default port
-- Public key hex
+- Buzz channel UUID to map to Squad Chat
+- Public-key hex
 - `env:BUZZ_PRIVATE_KEY`
 - Optional `env:BUZZ_AUTH_TAG`
 - Explicit localhost/private-network allowances when required
 - Optional `buzz`, `buzz-acp`, or `buzz-agent` executable for version
   diagnostics
 
-HTTP/WS endpoints must have the same host, port, path, and TLS posture.
-Credentials, query strings, and fragments are rejected. Veritas preserves a
-configured path and non-default port because Buzz binds the community to the
-request host.
+HTTP and WebSocket endpoints must have the same host, port, path, and TLS
+posture. Credentials, query strings, and fragments are rejected. A configured
+path and non-default port are preserved because Buzz binds the community to
+the request authority.
+
+The Settings save writes the reference-only adapter first, then writes the
+Squad Chat channel mapping. Changing a channel disables the old mapping before
+enabling the new one. Conflicting enabled mappings for the same target are
+rejected.
 
 ## API setup
 
-`settings:write` is required to configure, test, disable, or disconnect an
-adapter. `settings:read` is sufficient to read the adapter and health result.
+`settings:write` is required to configure, map, send, reconcile, disable, or
+disconnect. `settings:read` can read adapters, mappings, health, and delivery
+history.
+
+Configure the connection:
 
 ```bash
 curl -X PUT http://localhost:3001/api/integrations/communication/adapters/buzz-default \
@@ -82,92 +108,171 @@ curl -X PUT http://localhost:3001/api/integrations/communication/adapters/buzz-d
   }'
 ```
 
-The response returns public configuration and reference posture only. It never
-resolves or returns an environment value.
-
-Run the read-only probe:
+Map one Buzz channel to Squad Chat:
 
 ```bash
-curl http://localhost:3001/api/integrations/communication/adapters/buzz-default/health \
+CHANNEL_ID=123e4567-e89b-42d3-a456-426614174000
+
+curl -X PUT \
+  "http://localhost:3001/api/integrations/communication/adapters/buzz-default/buzz/channels/${CHANNEL_ID}" \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: <veritas-api-key>' \
+  --data '{
+    "target": { "kind": "squad" },
+    "enabled": true,
+    "actor": "operator"
+  }'
+```
+
+Run the compatibility probe:
+
+```bash
+curl \
+  http://localhost:3001/api/integrations/communication/adapters/buzz-default/health \
   -H 'X-API-Key: <veritas-api-key>'
 
 vk doctor --json
 ```
 
-`POST .../buzz-default/test` runs the same read-only compatibility probe. It
-does not use the generic test-send path.
+`POST .../buzz-default/test` runs the same read-only probe. It never sends a
+message.
 
-## Probe sequence
+## Send roots and replies
 
-The probe:
+Send a root and associate it with a local Squad Chat message:
 
-1. validates and normalizes HTTP/HTTPS and WS/WSS endpoints;
-2. fetches bounded NIP-11 metadata from `/info` through the SSRF-protected,
-   DNS-pinned outbound client;
-3. verifies Buzz software, version, relay public identity, NIPs, and the
-   configured/observed community authority;
-4. resolves the signing key and optional auth tag only for the active probe;
-5. signs a fresh, host-bound NIP-98 `POST /query` request with the required
-   URL, method, random nonce, and exact request-body hash tags;
-6. performs separately signed, read-only channel metadata and message filters
-   so each capability has independent evidence;
-7. classifies authentication, relay membership, and read capability
-   independently; and
-8. probes optional commands with executable-plus-argv process spawning, a
-   timeout, bounded output, no shell, and a minimal environment that excludes
-   provider and Buzz credentials.
+```bash
+curl -X POST \
+  http://localhost:3001/api/integrations/communication/adapters/buzz-default/send \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: <veritas-api-key>' \
+  --data '{
+    "target": {
+      "kind": "squad",
+      "squadMessageId": "msg_local_root"
+    },
+    "message": "Root message from Veritas",
+    "actor": "VERITAS"
+  }'
+```
 
-Configured endpoint strings and separately resolved endpoints are retained in
-the redacted result. The compatibility evidence key changes when the endpoint,
-expected community, configured or observed public identity, secret reference,
-auth-tag reference, network allowance, command configuration/version, Buzz
-contract, or Veritas probe revision changes. Persisted evidence from an older
-probe release, commit, or revision is not restored as current.
+Send a reply by identifying both the new local message and the local parent:
 
-## Status and remediation
+```bash
+curl -X POST \
+  http://localhost:3001/api/integrations/communication/adapters/buzz-default/send \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: <veritas-api-key>' \
+  --data '{
+    "target": {
+      "kind": "squad",
+      "squadMessageId": "msg_local_reply"
+    },
+    "replyToSquadMessageId": "msg_local_root",
+    "message": "Reply from Veritas",
+    "actor": "VERITAS"
+  }'
+```
 
-| Status          | Meaning                                                          |
-| --------------- | ---------------------------------------------------------------- |
-| `healthy`       | Relay, identity, membership posture, and reads were verified.    |
-| `degraded`      | Public contract is usable, but a bounded diagnostic is partial.  |
-| `unsupported`   | Relay software, version, or contract is outside tested support.  |
-| `unauthorized`  | Identity proof or read authorization was rejected.               |
-| `not_member`    | Identity was authenticated but is not a relay member.            |
-| `misconfigured` | Endpoints, community, identity, or secret reference disagree.    |
-| `unreachable`   | Network policy, DNS, TLS, timeout, or relay availability failed. |
-| `disabled`      | Configuration is retained but no probe is run.                   |
+The parent must already have a durable Buzz event mapping. A missing parent is
+blocked instead of publishing a detached root.
 
-Machine-readable `reasonCode` values distinguish endpoint mismatch,
-community mismatch, missing credential reference, malformed NIP-OA auth tags,
-public-key mismatch, authentication rejection, membership denial,
-read-capability denial, rate-limiting, oversized/invalid responses, and
-unsupported builds.
+Each outbound event includes the mapped `h` tag, a `client=veritas-kanban`
+marker, and a stable `veritas-id` delivery marker. Veritas persists the signed
+event and event ID before submitting it to `/events`.
 
-The probe never claims send/reply verification. `canSend` and
-`canReceiveReplies` remain `false` for this integration slice.
+## Inbound subscription and replay
 
-## Local and private relays
+One supervised WebSocket worker runs per enabled, compatible Buzz connection.
+It:
 
-Public HTTPS is the default. Plain HTTP requires an explicit localhost or
-private-network allowance. Localhost and RFC1918/IPv6 ULA private ranges are
-denied unless the operator enables the matching setting. Link-local, cloud
-metadata, and CGNAT ranges remain blocked even when private-network access is
-enabled. Both allowances are explicit because a Buzz relay URL is an outbound
-request target. DNS is still resolved and pinned for every request, redirects
-remain disabled, reads are bounded, and the probe has a fixed timeout.
+1. resolves and pins the configured relay address through the outbound network
+   policy;
+2. answers the NIP-42 challenge with kind `22242` and the optional NIP-OA auth
+   tag;
+3. subscribes only to enabled mapped channel UUIDs and kinds `9`, `40003`,
+   `9005`, and `5`;
+4. resumes from the persisted cursor with a five-second overlap;
+5. verifies each Nostr event signature, channel, kind, timestamp, and size;
+6. projects and audits the Squad Chat message; and
+7. commits the total-order cursor `(created_at, event_id)` only after the
+   projection and audit are durable.
 
-Enable only the narrow network class required by the relay. Do not use a
-private-network allowance to reach cloud metadata or unrelated internal
-services.
+Deduplication uses `(community, event_id)`, never timestamp alone. Squad Chat
+uses the deterministic local ID `msg_buzz_<event-id>`, so a crash after the
+chat write but before adapter-state persistence replays safely. The original
+Buzz author public key, source timestamp, event kind, channel, community,
+event ID, and `buzz://message` link remain attached as external metadata.
 
-## Upgrade, disable, and rollback
+An out-of-order reply is persisted but does not advance the cursor past its
+missing root. When the root arrives, queued replies are replayed in
+`(created_at, event_id)` order. A root that never arrives remains bounded
+pending state rather than becoming a detached Squad Chat message.
 
-After a Buzz upgrade, run `vk doctor --json`. A version/build change invalidates
-the prior evidence and must pass the pinned compatibility fixtures before it is
-considered supported.
+Adapter-originated event IDs are retained and ignored when echoed by the
+subscription, preventing a reply loop.
 
-Use **Disable** or the disconnect endpoint to stop probes. Buzz reference-only
-configuration is retained so rollback does not destroy operator setup. Remove
-the environment secrets separately if the identity is being retired. Veritas
-does not remove relay membership, change communities, or modify Buzz desktop
-state.
+## Ambiguous delivery recovery
+
+Network failure after a write can leave delivery status unknown. Veritas does
+not blindly retry:
+
+1. the delivery remains visible as `delivery_unknown`;
+2. `POST .../buzz-default/poll` queries `/query` by the signed event ID;
+3. if the event exists, the original delivery becomes `success`;
+4. if the relay definitively reports absence, Veritas resubmits the exact
+   persisted signed event; and
+5. if the query is inconclusive, the delivery remains unresolved.
+
+Before query or resubmission, the persisted event is re-verified against its
+signature, configured public identity, mapped community/channel, and event ID.
+A corrupted record is failed and never retried.
+
+## Health and audit
+
+Health separates:
+
+- compatibility and authorization checks;
+- relay transport connection;
+- active subscription state;
+- mapped-channel count;
+- reconnect attempts and last connection;
+- last inbound event;
+- cursor lag;
+- last send time and status; and
+- the latest redacted worker error.
+
+Compatibility can be healthy while runtime status is `degraded`, such as when
+no channel is mapped or the subscription is still connecting. `canSend`
+requires an enabled adapter, current healthy compatibility evidence, and at
+least one mapped channel. `canReceiveReplies` additionally requires an active
+subscription.
+
+Delivery history exposes `queued`, `success`, `delivery_unknown`, `replayed`,
+`ignored`, `failed`, `blocked`, and `skipped`. It retains bounded coordinates
+and redacted details, not credentials or raw authorization material.
+
+## Network policy
+
+Public HTTPS/WSS is the default. Plain HTTP/WS requires an explicit localhost
+or private-network allowance. Localhost and RFC1918/IPv6 ULA ranges are denied
+unless their matching setting is enabled. Link-local, cloud metadata, and
+CGNAT ranges remain blocked. DNS is resolved and pinned, redirects are
+disabled, payloads are bounded, and requests have fixed timeouts.
+
+Enable only the narrow network class required by the relay.
+
+## Disable, upgrade, and rollback
+
+Disabling a channel mapping closes and rebuilds the worker without deleting
+the mapping, cursor, event coordinates, or delivery audit. Disconnecting the
+adapter closes the worker and disables delivery while retaining reference-only
+configuration and recovery state.
+
+Remove environment secrets separately only when retiring the identity.
+Veritas never removes relay membership, changes a Buzz community, or modifies
+Buzz Desktop state.
+
+After a Buzz upgrade, run `vk doctor --json`. A version/build change
+invalidates prior compatibility evidence and must pass the pinned contract
+before workers or sends resume.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -505,21 +505,24 @@ Real-time agent-to-agent communication channel for multi-agent collaboration. Sh
 - **Squad Chat Webhook** — Optional outbound delivery for chat messages; supports generic HTTP and OpenClaw Direct modes
 - **OpenClaw Direct gateway wake** — Optional real-time Squad Chat events pushed to OpenClaw gateway for agent orchestration
 - **Human reply adapters** — Configure Teams reply posture, run health checks and test sends, store external thread mappings, and ingest audited human replies back into the correct Squad Chat thread
+- **Buzz channel bridge** — Map a Buzz community channel to Squad Chat, publish and ingest signed roots/replies exactly once, retain source author/timestamp/deep links, resume through a durable cursor with overlap dedupe, and reconcile ambiguous sends before retry
 - **Searchable history** — Browse and search past squad chat messages
 
 ### API Endpoints
 
-| Endpoint                                                      | Method | Description                                    |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------- |
-| `/api/chat/squad`                                             | POST   | Send a squad chat message                      |
-| `/api/chat/squad`                                             | GET    | Retrieve squad chat history                    |
-| `/api/chat/squad/search`                                      | GET    | Search redacted snippets                       |
-| `/api/chat/squad/unread`                                      | GET    | Get actor-scoped unread state                  |
-| `/api/chat/squad/read`                                        | POST   | Mark messages read for an actor                |
-| `/api/chat/squad/:messageId/thread`                           | GET    | Read a compact thread                          |
-| `/api/chat/squad/:messageId/pin`                              | POST   | Pin/unpin or mark/unmark a decision            |
-| `/api/chat/squad/:messageId/react`                            | POST   | Add a lightweight reaction or acknowledgement  |
-| `/api/integrations/communication/adapters/:adapterId/replies` | POST   | Ingest an external human reply into Squad Chat |
+| Endpoint                                                                       | Method | Description                                       |
+| ------------------------------------------------------------------------------ | ------ | ------------------------------------------------- |
+| `/api/chat/squad`                                                              | POST   | Send a squad chat message                         |
+| `/api/chat/squad`                                                              | GET    | Retrieve squad chat history                       |
+| `/api/chat/squad/search`                                                       | GET    | Search redacted snippets                          |
+| `/api/chat/squad/unread`                                                       | GET    | Get actor-scoped unread state                     |
+| `/api/chat/squad/read`                                                         | POST   | Mark messages read for an actor                   |
+| `/api/chat/squad/:messageId/thread`                                            | GET    | Read a compact thread                             |
+| `/api/chat/squad/:messageId/pin`                                               | POST   | Pin/unpin or mark/unmark a decision               |
+| `/api/chat/squad/:messageId/react`                                             | POST   | Add a lightweight reaction or acknowledgement     |
+| `/api/integrations/communication/adapters/:adapterId/replies`                  | POST   | Ingest an external human reply into Squad Chat    |
+| `/api/integrations/communication/adapters/:adapterId/send`                     | POST   | Publish a mapped Teams/Buzz communication message |
+| `/api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId` | PUT    | Map a Buzz channel to Squad Chat                  |
 
 ---
 
@@ -1224,7 +1227,7 @@ Notification and broadcast features provide local visibility and optional delive
 - **Broadcast messages** — Durable system-wide messages at `/api/broadcasts` with `info`, `action-required`, and `urgent` priorities
 - **External delivery boundary** — Local notifications, broadcasts, and Squad Chat can work while external webhook delivery is disabled
 - **Human reply adapter health** — Settings -> Notifications shows Teams reply posture, redacted webhook state, recent delivery audit, test send, and disconnect controls
-- **Buzz compatibility diagnostics** — Reference-only Buzz relay setup verifies host-derived community identity, NIP-98 authentication, relay membership, channel/message read capability, tested release evidence, and optional command versions without sending a message
+- **Buzz communication adapter** — Reference-only relay setup verifies community identity, NIP-98 authentication, membership, and read capability before enabling signed root/reply delivery, supervised subscriptions, durable cursor replay, loop prevention, and delivery-unknown reconciliation
 
 ### API Endpoints
 

--- a/docs/features/squad-chat.md
+++ b/docs/features/squad-chat.md
@@ -27,15 +27,16 @@ fields used for approved external human replies.
 
 ## Terminology
 
-| Term                    | What it means                                                                                                                                    | External delivery?                                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| **Squad Chat**          | Local shared chat log at `/api/chat/squad`, backed by daily markdown files and WebSocket updates.                                                | No. It stores and streams messages to VK clients only.                                                |
-| **Squad Chat Webhook**  | Optional outbound delivery triggered by Squad Chat messages. Supports generic HTTP and OpenClaw Direct modes.                                    | Yes, when enabled and configured. HTTP success means VK delivered the event to the configured URL.    |
-| **Human reply adapter** | Adapter posture, thread mapping, health, and reply ingestion for approved external channels such as Teams.                                       | Yes. External replies are accepted through an authenticated ingest API and become Squad Chat replies. |
-| **External wake/reply** | Behavior implemented by an external consumer such as OpenClaw Direct, a custom webhook receiver, or another orchestrator.                        | Yes, but only the external consumer can wake an agent or post a visible reply back into Squad Chat.   |
-| **Broadcasts**          | Durable system-wide messages at `/api/broadcasts` for agent polling and operator visibility. Priorities are `info`, `action-required`, `urgent`. | No. Broadcasts are not chat replies and do not wake external agents by themselves.                    |
-| **Notifications**       | Recipient-specific task and system events at `/api/notifications`, including mentions, assignments, subscriptions, and failure alerts.           | Optional. Local records exist even when delivery channels are disabled.                               |
-| **Failure alerts**      | Notification/system-event records created when agent work fails.                                                                                 | Optional. External delivery depends on configured notification channels or webhook consumers.         |
+| Term                           | What it means                                                                                                                                    | External delivery?                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| **Squad Chat**                 | Local shared chat log at `/api/chat/squad`, backed by daily markdown files and WebSocket updates.                                                | No. It stores and streams messages to VK clients only.                                                |
+| **Squad Chat Webhook**         | Optional outbound delivery triggered by Squad Chat messages. Supports generic HTTP and OpenClaw Direct modes.                                    | Yes, when enabled and configured. HTTP success means VK delivered the event to the configured URL.    |
+| **Human reply adapter**        | Adapter posture, thread mapping, health, and reply ingestion for approved external channels such as Teams.                                       | Yes. External replies are accepted through an authenticated ingest API and become Squad Chat replies. |
+| **Buzz communication adapter** | Native signed-event bridge between one mapped Buzz channel and Squad Chat, with durable cursor replay and send reconciliation.                   | Yes. Enabled mappings publish and subscribe through the configured Buzz relay.                        |
+| **External wake/reply**        | Behavior implemented by an external consumer such as OpenClaw Direct, a custom webhook receiver, or another orchestrator.                        | Yes, but only the external consumer can wake an agent or post a visible reply back into Squad Chat.   |
+| **Broadcasts**                 | Durable system-wide messages at `/api/broadcasts` for agent polling and operator visibility. Priorities are `info`, `action-required`, `urgent`. | No. Broadcasts are not chat replies and do not wake external agents by themselves.                    |
+| **Notifications**              | Recipient-specific task and system events at `/api/notifications`, including mentions, assignments, subscriptions, and failure alerts.           | Optional. Local records exist even when delivery channels are disabled.                               |
+| **Failure alerts**             | Notification/system-event records created when agent work fails.                                                                                 | Optional. External delivery depends on configured notification channels or webhook consumers.         |
 
 ## Features
 
@@ -51,6 +52,7 @@ fields used for approved external human replies.
 - **Message persistence** — Daily markdown files stored in `.veritas-kanban/chats/squad/`
 - **Webhook integration** — Route messages to external systems (OpenClaw, custom webhooks)
 - **Human reply ingestion** — Map external threads to Squad Chat targets and ingest human replies with attribution, sanitization, idempotency, and audit records
+- **Buzz channel bridge** — Publish and ingest signed Buzz roots/replies with source attribution, threaded projection, overlap dedupe, external links, and visible delivery state
 
 ## API Endpoints
 
@@ -207,6 +209,20 @@ same approval-capable authority as in-app approvals. Inbound reply bodies are
 HTML-stripped, secret-redacted, size-limited, and deduped by external reply ID.
 Adapter responses expose only redacted connection posture such as
 `webhookUrlConfigured`, `webhookUrlRedacted`, and `hasCredential`.
+
+### Buzz Channel Bridge
+
+Buzz uses the same communication-adapter APIs with an additional channel
+mapping. Its supervised NIP-42 subscription projects verified roots and
+replies with deterministic local IDs, public author identity, source
+timestamps, and `buzz://message` links. A `(created_at,event_id)` cursor and
+five-second overlap prevent loss without treating same-second events as
+duplicates. Ambiguous outbound writes remain `delivery_unknown` until an
+event-ID query proves acceptance or absence.
+
+See [Buzz Communication Adapter](../BUZZ-INTEGRATION.md) for identity setup,
+mapping and send examples, edit/delete policy, health facets, least privilege,
+replay behavior, and rollback.
 
 ## System Message Events
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -154,9 +154,10 @@ limits are tracked in
 Compatibility errors and debug bundles must redact tokens, cookies, private
 keys, local private paths, raw chat content, and task body text.
 
-Buzz communication diagnostics store environment-variable references and
-public/redacted metadata only. The Nostr private key and optional NIP-OA auth
-tag are resolved only for the active read-only probe and are never returned.
+Buzz communication diagnostics and delivery store environment-variable
+references and public/redacted metadata only. The Nostr private key and
+optional NIP-OA auth tag are resolved only for an active probe or signing
+operation and are never returned.
 The built-in signer accepts hexadecimal or `nsec` private-key material,
 constructs the Buzz-required nonce and exact request-body hash, and clears its
 decoded key bytes after signing on a best-effort basis.
@@ -164,11 +165,16 @@ Relay URLs reject userinfo, query strings, and fragments. Outbound requests use
 scheme validation, explicit plaintext/local/RFC1918/ULA opt-ins, DNS pinning,
 manual redirects, fixed timeouts, and bounded response reads. Link-local,
 cloud-metadata, and CGNAT ranges remain blocked under the private-network
-opt-in. The default probe reads NIP-11 metadata and authenticated query filters
-only; it does not send a Buzz event. Optional command discovery runs without a
-shell and receives a minimal environment that excludes provider and Buzz
-credentials. See
-[Buzz Connection Diagnostics](BUZZ-INTEGRATION.md).
+opt-in. The compatibility probe reads NIP-11 metadata and authenticated query
+filters only. The communication worker uses a DNS-pinned, channel-allowlisted
+NIP-42 WebSocket subscription and verifies event signatures, kinds, channel
+IDs, timestamps, and bounded sizes before projection. Outbound signed events
+are persisted before submission. Ambiguous writes are queried by event ID and
+the persisted signature, configured identity, and mapped channel are
+re-verified before any resubmission. Echoed adapter event IDs are suppressed.
+Optional command discovery runs without a shell and receives a minimal
+environment that excludes provider and Buzz credentials. See
+[Buzz Communication Adapter](BUZZ-INTEGRATION.md).
 
 ## Provider Runtime Capability Enforcement
 

--- a/server/src/__tests__/buzz-communication-adapter-service.test.ts
+++ b/server/src/__tests__/buzz-communication-adapter-service.test.ts
@@ -1,0 +1,646 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools';
+import type { ChatService } from '../services/chat-service.js';
+import type { OutboundIntegrationService } from '../services/outbound-integration-service.js';
+import type { BuzzCompatibilityService } from '../services/buzz-compatibility-service.js';
+import type { BuzzCommunicationService } from '../services/buzz-communication-service.js';
+import {
+  BUZZ_DELETE_KIND,
+  BUZZ_EDIT_KIND,
+  BUZZ_MESSAGE_KIND,
+} from '../services/buzz-communication-service.js';
+import {
+  CommunicationAdapterService,
+  type CommunicationAdapterServiceOptions,
+} from '../services/communication-adapter-service.js';
+import type {
+  BuzzSubscriptionWorkerCallbacks,
+  BuzzSubscriptionWorkerConfig,
+  BuzzSubscriptionWorkerFactory,
+  BuzzSubscriptionWorkerHandle,
+} from '../services/buzz-subscription-worker.js';
+
+const CHANNEL_ID = '123e4567-e89b-42d3-a456-426614174000';
+const OTHER_CHANNEL_ID = '223e4567-e89b-42d3-a456-426614174000';
+const COMMUNITY = 'relay.example.test';
+const ADAPTER_ID = 'buzz-default';
+
+function healthyCompatibility(publicKey: string) {
+  return {
+    schemaVersion: 'buzz-compatibility/v1' as const,
+    probeRevision: 1 as const,
+    testedRelease: '0.4.24' as const,
+    testedCommit: '710ed9fff57878a1d69f809b80a6ee0416c53fc4' as const,
+    status: 'healthy' as const,
+    reasonCode: 'ok' as const,
+    detail: 'Buzz relay and read capabilities are compatible.',
+    configuredRelayHttpUrl: `https://${COMMUNITY}`,
+    resolvedRelayHttpUrl: `https://${COMMUNITY}`,
+    resolvedRelayWebSocketUrl: `wss://${COMMUNITY}`,
+    expectedCommunity: COMMUNITY,
+    observedCommunity: COMMUNITY,
+    publicKeyFingerprint: publicKey.slice(0, 12),
+    checks: {
+      relayIdentity: 'verified' as const,
+      communityBinding: 'verified' as const,
+      configuredIdentity: 'verified' as const,
+      authentication: 'verified' as const,
+      membership: 'verified' as const,
+      channelRead: 'verified' as const,
+      messageRead: 'verified' as const,
+    },
+    commands: [],
+    evidenceKey: 'evidence-key',
+    checkedAt: '2026-07-23T20:00:00.000Z',
+  };
+}
+
+class FakeWorkerFactory implements BuzzSubscriptionWorkerFactory {
+  readonly created: Array<{
+    config: BuzzSubscriptionWorkerConfig;
+    callbacks: BuzzSubscriptionWorkerCallbacks;
+    handle: BuzzSubscriptionWorkerHandle;
+  }> = [];
+
+  create(config: BuzzSubscriptionWorkerConfig, callbacks: BuzzSubscriptionWorkerCallbacks) {
+    const handle = {
+      start: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    this.created.push({ config, callbacks, handle });
+    return handle;
+  }
+}
+
+describe('Buzz communication adapter', () => {
+  let temporaryDirectory: string;
+  let authorSecretKey: Uint8Array;
+  let authorPublicKey: string;
+  let chatService: Pick<ChatService, 'sendSquadMessage' | 'getSquadMessages'>;
+  let buzzCommunication: {
+    prepareMessage: ReturnType<typeof vi.fn>;
+    submitEvent: ReturnType<typeof vi.fn>;
+    eventExists: ReturnType<typeof vi.fn>;
+  };
+  let workerFactory: FakeWorkerFactory;
+  let service: CommunicationAdapterService;
+
+  function event(input: {
+    content: string;
+    createdAt?: number;
+    kind?: number;
+    rootEventId?: string;
+    parentEventId?: string;
+    tags?: string[][];
+  }) {
+    const tags: string[][] = [['h', CHANNEL_ID]];
+    if (input.rootEventId && input.parentEventId) {
+      if (input.rootEventId === input.parentEventId) {
+        tags.push(['e', input.rootEventId, '', 'reply']);
+      } else {
+        tags.push(['e', input.rootEventId, '', 'root']);
+        tags.push(['e', input.parentEventId, '', 'reply']);
+      }
+    } else if (input.rootEventId) {
+      tags.push(['e', input.rootEventId]);
+    }
+    tags.push(...(input.tags ?? []));
+    return finalizeEvent(
+      {
+        kind: input.kind ?? BUZZ_MESSAGE_KIND,
+        created_at: input.createdAt ?? Math.floor(Date.now() / 1000),
+        tags,
+        content: input.content,
+      },
+      authorSecretKey
+    );
+  }
+
+  async function configure() {
+    await service.configureAdapter(ADAPTER_ID, {
+      kind: 'buzz',
+      enabled: true,
+      relayHttpUrl: `https://${COMMUNITY}`,
+      expectedCommunity: COMMUNITY,
+      publicKey: authorPublicKey,
+      credentialRef: 'env:BUZZ_PRIVATE_KEY',
+    });
+    const mapping = await service.configureBuzzChannelMapping(ADAPTER_ID, CHANNEL_ID, {
+      target: { kind: 'squad' },
+      actor: 'operator',
+    });
+    await service.checkHealth(ADAPTER_ID);
+    return mapping;
+  }
+
+  beforeEach(async () => {
+    temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'buzz-communication-adapter-'));
+    authorSecretKey = generateSecretKey();
+    authorPublicKey = getPublicKey(authorSecretKey);
+    chatService = {
+      sendSquadMessage: vi.fn(async (input, displayName) => ({
+        id: input.id ?? `msg_${vi.mocked(chatService.sendSquadMessage).mock.calls.length}`,
+        agent: input.agent,
+        displayName,
+        message: input.message,
+        timestamp: input.timestamp ?? new Date().toISOString(),
+        replyToId: input.replyToId,
+        taskId: input.taskId,
+        runId: input.runId,
+        tags: input.tags,
+        links: input.links,
+        external: input.external,
+      })),
+      getSquadMessages: vi.fn().mockResolvedValue([]),
+    } as unknown as Pick<ChatService, 'sendSquadMessage' | 'getSquadMessages'>;
+    buzzCommunication = {
+      prepareMessage: vi.fn(),
+      submitEvent: vi.fn(),
+      eventExists: vi.fn(),
+    };
+    workerFactory = new FakeWorkerFactory();
+    const options: CommunicationAdapterServiceOptions = {
+      storageDir: temporaryDirectory,
+      persist: true,
+      chatService: chatService as ChatService,
+      outboundIntegrations: {
+        deliver: vi.fn(),
+      } as unknown as OutboundIntegrationService,
+      buzzCompatibility: {
+        probe: vi.fn().mockResolvedValue(healthyCompatibility(authorPublicKey)),
+      } as unknown as BuzzCompatibilityService,
+      buzzCommunication: buzzCommunication as unknown as BuzzCommunicationService,
+      buzzWorkerFactory: workerFactory,
+      audit: vi.fn().mockResolvedValue(undefined),
+    };
+    service = new CommunicationAdapterService(options);
+  });
+
+  afterEach(async () => {
+    await service.shutdown();
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it('rejects conflicting channel-to-target mappings and retains disabled mappings', async () => {
+    const mapping = await configure();
+    await expect(
+      service.configureBuzzChannelMapping(ADAPTER_ID, OTHER_CHANNEL_ID, {
+        target: { kind: 'squad' },
+      })
+    ).rejects.toThrow('already mapped');
+
+    await service.disableBuzzChannelMapping(ADAPTER_ID, CHANNEL_ID, 'operator');
+    expect(await service.listBuzzChannelMappings(ADAPTER_ID)).toEqual([
+      expect.objectContaining({
+        id: mapping.id,
+        channelId: CHANNEL_ID,
+        enabled: false,
+      }),
+    ]);
+    const state = JSON.parse(
+      await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8')
+    );
+    expect(state.buzzChannelMappings[mapping.id]).toMatchObject({ enabled: false });
+    expect(state.buzzCursors).toEqual({});
+  });
+
+  it('persists a signed outbound event before send and reconciles ambiguity by event ID', async () => {
+    await configure();
+    const outboundEvent = event({ content: 'outbound root' });
+    buzzCommunication.prepareMessage.mockResolvedValue({
+      event: outboundEvent,
+      coordinate: {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        eventId: outboundEvent.id,
+        authorPubkey: outboundEvent.pubkey,
+        kind: BUZZ_MESSAGE_KIND,
+        externalUrl: `buzz://message?channel=${CHANNEL_ID}&id=${outboundEvent.id}`,
+      },
+    });
+    buzzCommunication.submitEvent.mockResolvedValue({
+      status: 'delivery_unknown',
+      eventId: outboundEvent.id,
+      detail: 'connection closed after write',
+    });
+
+    const result = await service.send(ADAPTER_ID, {
+      target: { kind: 'squad', squadMessageId: 'msg_local_root' },
+      message: 'outbound root',
+      actor: 'VERITAS',
+    });
+    expect(result.delivery).toMatchObject({
+      status: 'delivery_unknown',
+      buzz: { eventId: outboundEvent.id, channelId: CHANNEL_ID },
+    });
+    const persisted = JSON.parse(
+      await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8')
+    );
+    expect(persisted.buzzOutbound[outboundEvent.id]).toMatchObject({
+      status: 'delivery_unknown',
+      attemptCount: 1,
+      squadMessageId: 'msg_local_root',
+      event: { id: outboundEvent.id },
+    });
+
+    buzzCommunication.eventExists.mockResolvedValue(true);
+    const reconciled = await service.pollReplies(ADAPTER_ID);
+    expect(reconciled.delivery.status).toBe('success');
+    expect(buzzCommunication.eventExists).toHaveBeenCalledWith(
+      expect.any(Object),
+      outboundEvent.id
+    );
+    expect(buzzCommunication.submitEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('resubmits the exact signed event only after a definitive absence check', async () => {
+    await configure();
+    const outboundEvent = event({ content: 'outbound root' });
+    buzzCommunication.prepareMessage.mockResolvedValue({
+      event: outboundEvent,
+      coordinate: {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        eventId: outboundEvent.id,
+        authorPubkey: outboundEvent.pubkey,
+        kind: BUZZ_MESSAGE_KIND,
+      },
+    });
+    buzzCommunication.submitEvent
+      .mockResolvedValueOnce({
+        status: 'delivery_unknown',
+        eventId: outboundEvent.id,
+      })
+      .mockResolvedValueOnce({ status: 'accepted', eventId: outboundEvent.id });
+    buzzCommunication.eventExists.mockResolvedValue(false);
+
+    await service.send(ADAPTER_ID, {
+      target: { kind: 'squad' },
+      message: 'outbound root',
+    });
+    await service.pollReplies(ADAPTER_ID);
+
+    expect(buzzCommunication.submitEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Object),
+      outboundEvent
+    );
+    const state = JSON.parse(
+      await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8')
+    );
+    expect(state.buzzOutbound[outboundEvent.id]).toMatchObject({
+      status: 'accepted',
+      attemptCount: 2,
+    });
+  });
+
+  it('never reconciles a tampered persisted outbound event', async () => {
+    await configure();
+    const outboundEvent = event({ content: 'signed content' });
+    buzzCommunication.prepareMessage.mockResolvedValue({
+      event: outboundEvent,
+      coordinate: {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        eventId: outboundEvent.id,
+        authorPubkey: outboundEvent.pubkey,
+        kind: BUZZ_MESSAGE_KIND,
+      },
+    });
+    buzzCommunication.submitEvent.mockResolvedValue({
+      status: 'delivery_unknown',
+      eventId: outboundEvent.id,
+    });
+    await service.send(ADAPTER_ID, {
+      target: { kind: 'squad' },
+      message: 'signed content',
+    });
+    await service.shutdown();
+
+    const statePath = path.join(temporaryDirectory, 'state.json');
+    const state = JSON.parse(await fs.readFile(statePath, 'utf8'));
+    state.buzzOutbound[outboundEvent.id].event.content = 'tampered content';
+    await fs.writeFile(statePath, JSON.stringify(state));
+    buzzCommunication.eventExists.mockClear();
+    buzzCommunication.submitEvent.mockClear();
+    service = new CommunicationAdapterService({
+      storageDir: temporaryDirectory,
+      persist: true,
+      chatService: chatService as ChatService,
+      outboundIntegrations: { deliver: vi.fn() } as unknown as OutboundIntegrationService,
+      buzzCompatibility: {
+        probe: vi.fn().mockResolvedValue(healthyCompatibility(authorPublicKey)),
+      } as unknown as BuzzCompatibilityService,
+      buzzCommunication: buzzCommunication as unknown as BuzzCommunicationService,
+      buzzWorkerFactory: workerFactory,
+      audit: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect((await service.pollReplies(ADAPTER_ID)).delivery).toMatchObject({
+      status: 'failed',
+      detail: expect.stringContaining('rejected 1'),
+    });
+    expect(buzzCommunication.eventExists).not.toHaveBeenCalled();
+    expect(buzzCommunication.submitEvent).not.toHaveBeenCalled();
+  });
+
+  it('projects inbound roots and replies exactly once with external metadata', async () => {
+    const mapping = await configure();
+    const root = event({ content: '<b>root</b>' });
+    const reply = event({
+      content: 'reply',
+      rootEventId: root.id,
+      parentEventId: root.id,
+    });
+
+    const rootDelivery = await service.ingestBuzzEvent(ADAPTER_ID, mapping, root);
+    const replyDelivery = await service.ingestBuzzEvent(ADAPTER_ID, mapping, reply);
+    const duplicate = await service.ingestBuzzEvent(ADAPTER_ID, mapping, reply);
+
+    expect(rootDelivery).toMatchObject({
+      status: 'success',
+      squadMessageId: `msg_buzz_${root.id}`,
+    });
+    expect(replyDelivery).toMatchObject({
+      status: 'success',
+      squadMessageId: `msg_buzz_${reply.id}`,
+      buzz: { rootEventId: root.id, parentEventId: root.id },
+    });
+    expect(duplicate.status).toBe('replayed');
+    expect(chatService.sendSquadMessage).toHaveBeenCalledTimes(2);
+    expect(chatService.sendSquadMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        id: `msg_buzz_${root.id}`,
+        agent: 'BUZZ',
+        message: 'root',
+        links: [
+          expect.objectContaining({
+            href: expect.stringContaining(`id=${root.id}`),
+            label: 'Open in Buzz',
+          }),
+        ],
+        external: expect.objectContaining({
+          provider: 'buzz',
+          messageId: root.id,
+          authorId: authorPublicKey,
+        }),
+      }),
+      expect.stringContaining(authorPublicKey.slice(0, 12))
+    );
+    expect(chatService.sendSquadMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        replyToId: `msg_buzz_${root.id}`,
+        timestamp: new Date(reply.created_at * 1000).toISOString(),
+      }),
+      expect.any(String)
+    );
+  });
+
+  it('publishes a mapped Veritas reply with the Buzz root and parent coordinates', async () => {
+    const mapping = await configure();
+    const root = event({ content: 'Buzz root' });
+    await service.ingestBuzzEvent(ADAPTER_ID, mapping, root);
+    const outboundReply = event({
+      content: 'Veritas reply',
+      rootEventId: root.id,
+      parentEventId: root.id,
+    });
+    buzzCommunication.prepareMessage.mockResolvedValue({
+      event: outboundReply,
+      coordinate: {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        eventId: outboundReply.id,
+        authorPubkey: outboundReply.pubkey,
+        kind: BUZZ_MESSAGE_KIND,
+        rootEventId: root.id,
+        parentEventId: root.id,
+      },
+    });
+    buzzCommunication.submitEvent.mockResolvedValue({
+      status: 'accepted',
+      eventId: outboundReply.id,
+    });
+
+    const result = await service.send(ADAPTER_ID, {
+      target: { kind: 'squad', squadMessageId: 'msg_local_reply' },
+      replyToSquadMessageId: `msg_buzz_${root.id}`,
+      message: 'Veritas reply',
+    });
+
+    expect(result.delivery.status).toBe('success');
+    expect(buzzCommunication.prepareMessage).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        channelId: CHANNEL_ID,
+        rootEventId: root.id,
+        parentEventId: root.id,
+      })
+    );
+    const state = JSON.parse(
+      await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8')
+    );
+    expect(state.buzzOutbound[outboundReply.id]).toMatchObject({
+      squadMessageId: 'msg_local_reply',
+      coordinate: { rootEventId: root.id, parentEventId: root.id },
+    });
+  });
+
+  it('holds an out-of-order reply without advancing the cursor, then drains it after the root', async () => {
+    const mapping = await configure();
+    const root = event({ content: 'late root', createdAt: Math.floor(Date.now() / 1000) - 20 });
+    const reply = event({
+      content: 'early reply',
+      createdAt: root.created_at + 10,
+      rootEventId: root.id,
+      parentEventId: root.id,
+    });
+
+    expect(await service.ingestBuzzEvent(ADAPTER_ID, mapping, reply)).toMatchObject({
+      status: 'queued',
+    });
+    let state = JSON.parse(await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8'));
+    expect(Object.keys(state.buzzCursors)).toHaveLength(0);
+    expect(Object.keys(state.buzzPendingEvents)).toHaveLength(1);
+
+    await service.ingestBuzzEvent(ADAPTER_ID, mapping, root);
+    expect(chatService.sendSquadMessage).toHaveBeenCalledTimes(2);
+    expect(chatService.sendSquadMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ replyToId: `msg_buzz_${root.id}` }),
+      expect.any(String)
+    );
+    state = JSON.parse(await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8'));
+    expect(Object.keys(state.buzzPendingEvents)).toHaveLength(0);
+    expect(Object.values(state.buzzCursors)[0]).toMatchObject({
+      createdAt: reply.created_at,
+      eventId: reply.id,
+    });
+  });
+
+  it('drains persisted pending replies when an already-projected root is replayed after restart', async () => {
+    const mapping = await configure();
+    const root = event({
+      content: 'persisted root',
+      createdAt: Math.floor(Date.now() / 1000) - 20,
+    });
+    const reply = event({
+      content: 'persisted pending reply',
+      createdAt: root.created_at + 10,
+      rootEventId: root.id,
+      parentEventId: root.id,
+    });
+
+    expect(await service.ingestBuzzEvent(ADAPTER_ID, mapping, reply)).toMatchObject({
+      status: 'queued',
+    });
+    const statePath = path.join(temporaryDirectory, 'state.json');
+    const persisted = JSON.parse(await fs.readFile(statePath, 'utf8'));
+    const rootKey = `${COMMUNITY}:${root.id}`;
+    persisted.buzzEvents[rootKey] = {
+      key: rootKey,
+      adapterId: ADAPTER_ID,
+      direction: 'inbound',
+      coordinate: {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        eventId: root.id,
+        authorPubkey: root.pubkey,
+        kind: BUZZ_MESSAGE_KIND,
+      },
+      squadMessageId: `msg_buzz_${root.id}`,
+      recordedAt: new Date().toISOString(),
+    };
+    await fs.writeFile(statePath, JSON.stringify(persisted));
+    await service.shutdown();
+
+    service = new CommunicationAdapterService({
+      storageDir: temporaryDirectory,
+      persist: true,
+      chatService: chatService as ChatService,
+      outboundIntegrations: { deliver: vi.fn() } as unknown as OutboundIntegrationService,
+      buzzCompatibility: {
+        probe: vi.fn().mockResolvedValue(healthyCompatibility(authorPublicKey)),
+      } as unknown as BuzzCompatibilityService,
+      buzzCommunication: buzzCommunication as unknown as BuzzCommunicationService,
+      buzzWorkerFactory: new FakeWorkerFactory(),
+      audit: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(await service.ingestBuzzEvent(ADAPTER_ID, mapping, root)).toMatchObject({
+      status: 'replayed',
+    });
+    expect(chatService.sendSquadMessage).toHaveBeenCalledTimes(1);
+    expect(chatService.sendSquadMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `msg_buzz_${reply.id}`,
+        replyToId: `msg_buzz_${root.id}`,
+      }),
+      expect.any(String)
+    );
+    const recovered = JSON.parse(await fs.readFile(statePath, 'utf8'));
+    expect(Object.keys(recovered.buzzPendingEvents)).toHaveLength(0);
+    expect(Object.values(recovered.buzzCursors)[0]).toMatchObject({
+      createdAt: reply.created_at,
+      eventId: reply.id,
+    });
+  });
+
+  it('suppresses its own outbound echo and records edits and deletes without local mutation', async () => {
+    const mapping = await configure();
+    const outboundEvent = event({ content: 'outbound root' });
+    buzzCommunication.prepareMessage.mockResolvedValue({
+      event: outboundEvent,
+      coordinate: {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        eventId: outboundEvent.id,
+        authorPubkey: outboundEvent.pubkey,
+        kind: BUZZ_MESSAGE_KIND,
+      },
+    });
+    buzzCommunication.submitEvent.mockResolvedValue({
+      status: 'accepted',
+      eventId: outboundEvent.id,
+    });
+    await service.send(ADAPTER_ID, {
+      target: { kind: 'squad' },
+      message: 'outbound root',
+    });
+    expect(await service.ingestBuzzEvent(ADAPTER_ID, mapping, outboundEvent)).toMatchObject({
+      status: 'ignored',
+      detail: expect.stringContaining('reply loop'),
+    });
+
+    const delayedEcho = event({
+      content: 'outbound record already pruned',
+      tags: [
+        ['client', 'veritas-kanban'],
+        ['veritas-id', 'delivery-pruned'],
+      ],
+    });
+    expect(await service.ingestBuzzEvent(ADAPTER_ID, mapping, delayedEcho)).toMatchObject({
+      status: 'ignored',
+      detail: expect.stringContaining('reply loop'),
+    });
+
+    const edit = event({
+      content: 'edited',
+      kind: BUZZ_EDIT_KIND,
+      rootEventId: outboundEvent.id,
+    });
+    const deletion = event({
+      content: '',
+      kind: BUZZ_DELETE_KIND,
+      rootEventId: outboundEvent.id,
+    });
+    expect(await service.ingestBuzzEvent(ADAPTER_ID, mapping, edit)).toMatchObject({
+      status: 'ignored',
+      detail: expect.stringContaining('no edit projection'),
+    });
+    expect(await service.ingestBuzzEvent(ADAPTER_ID, mapping, deletion)).toMatchObject({
+      status: 'ignored',
+      detail: expect.stringContaining('not removed'),
+    });
+    expect(chatService.sendSquadMessage).not.toHaveBeenCalled();
+  });
+
+  it('starts from a five-second overlap cursor and closes the worker on disable', async () => {
+    const mapping = await configure();
+    const root = event({ content: 'cursor root' });
+    await service.ingestBuzzEvent(ADAPTER_ID, mapping, root);
+    await service.shutdown();
+
+    const reloadedFactory = new FakeWorkerFactory();
+    const reloaded = new CommunicationAdapterService({
+      storageDir: temporaryDirectory,
+      persist: true,
+      chatService: chatService as ChatService,
+      outboundIntegrations: { deliver: vi.fn() } as unknown as OutboundIntegrationService,
+      buzzCompatibility: {
+        probe: vi.fn().mockResolvedValue(healthyCompatibility(authorPublicKey)),
+      } as unknown as BuzzCompatibilityService,
+      buzzCommunication: buzzCommunication as unknown as BuzzCommunicationService,
+      buzzWorkerFactory: reloadedFactory,
+      audit: vi.fn().mockResolvedValue(undefined),
+    });
+    await reloaded.start();
+    const worker = reloadedFactory.created.at(-1);
+    expect(worker?.config.cursors).toEqual([
+      expect.objectContaining({ eventId: root.id, createdAt: root.created_at }),
+    ]);
+
+    await reloaded.disconnectAdapter(ADAPTER_ID);
+    expect(worker?.handle.stop).toHaveBeenCalled();
+    const state = JSON.parse(
+      await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8')
+    );
+    expect(Object.keys(state.buzzChannelMappings)).toHaveLength(1);
+    expect(Object.keys(state.buzzCursors)).toHaveLength(1);
+    await reloaded.shutdown();
+  });
+});

--- a/server/src/__tests__/buzz-communication-service.test.ts
+++ b/server/src/__tests__/buzz-communication-service.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from 'vitest';
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools';
+import type { BuzzProbeConfig } from '../services/buzz-compatibility-service.js';
+import {
+  BUZZ_DELETE_KIND,
+  BUZZ_EDIT_KIND,
+  BUZZ_MESSAGE_KIND,
+  BuzzCommunicationService,
+  buildBuzzMessageDeepLink,
+  parseBuzzInboundEvent,
+} from '../services/buzz-communication-service.js';
+
+const CHANNEL_ID = '123e4567-e89b-42d3-a456-426614174000';
+const COMMUNITY = 'relay.example.test';
+const NOW = new Date('2026-07-23T20:00:00.000Z');
+
+function credentials() {
+  const secretKey = generateSecretKey();
+  const privateKey = Buffer.from(secretKey).toString('hex');
+  return { secretKey, privateKey, publicKey: getPublicKey(secretKey) };
+}
+
+function config(publicKey: string): BuzzProbeConfig {
+  return {
+    enabled: true,
+    relayHttpUrl: `https://${COMMUNITY}`,
+    expectedCommunity: COMMUNITY,
+    publicKey,
+    credentialRef: 'env:BUZZ_PRIVATE_KEY',
+  };
+}
+
+function signedEvent(
+  secretKey: Uint8Array,
+  input: {
+    kind?: number;
+    content?: string;
+    tags?: string[][];
+    createdAt?: number;
+  } = {}
+) {
+  return finalizeEvent(
+    {
+      kind: input.kind ?? BUZZ_MESSAGE_KIND,
+      created_at: input.createdAt ?? Math.floor(NOW.getTime() / 1000),
+      tags: input.tags ?? [['h', CHANNEL_ID]],
+      content: input.content ?? 'hello from Buzz',
+    },
+    secretKey
+  );
+}
+
+describe('BuzzCommunicationService', () => {
+  it('signs exact root, direct-reply, and nested-reply tags', async () => {
+    const identity = credentials();
+    const service = new BuzzCommunicationService({
+      resolveSecret: vi.fn().mockResolvedValue(identity.privateKey),
+      now: () => NOW,
+    });
+    const root = await service.prepareMessage(config(identity.publicKey), {
+      channelId: CHANNEL_ID,
+      content: 'root',
+      idempotencyKey: 'delivery-root',
+    });
+    expect(root.event.kind).toBe(BUZZ_MESSAGE_KIND);
+    expect(root.event.tags).toEqual([
+      ['h', CHANNEL_ID],
+      ['client', 'veritas-kanban'],
+      ['veritas-id', 'delivery-root'],
+    ]);
+
+    const rootEventId = 'a'.repeat(64);
+    const direct = await service.prepareMessage(config(identity.publicKey), {
+      channelId: CHANNEL_ID,
+      content: 'direct reply',
+      idempotencyKey: 'delivery-direct',
+      rootEventId,
+      parentEventId: rootEventId,
+    });
+    expect(direct.event.tags).toContainEqual(['e', rootEventId, '', 'reply']);
+    expect(direct.coordinate).toMatchObject({
+      rootEventId,
+      parentEventId: rootEventId,
+      channelId: CHANNEL_ID,
+    });
+
+    const parentEventId = 'b'.repeat(64);
+    const nested = await service.prepareMessage(config(identity.publicKey), {
+      channelId: CHANNEL_ID,
+      content: 'nested reply',
+      idempotencyKey: 'delivery-nested',
+      rootEventId,
+      parentEventId,
+    });
+    expect(nested.event.tags).toContainEqual(['e', rootEventId, '', 'root']);
+    expect(nested.event.tags).toContainEqual(['e', parentEventId, '', 'reply']);
+  });
+
+  it('rejects a signing key that does not match the configured public key', async () => {
+    const identity = credentials();
+    const service = new BuzzCommunicationService({
+      resolveSecret: vi.fn().mockResolvedValue(identity.privateKey),
+      now: () => NOW,
+    });
+
+    await expect(
+      service.prepareMessage(config('f'.repeat(64)), {
+        channelId: CHANNEL_ID,
+        content: 'must not send',
+        idempotencyKey: 'delivery-mismatch',
+      })
+    ).rejects.toThrow('does not match');
+  });
+
+  it('classifies accepted, rejected, and ambiguous acknowledgements without blind retry', async () => {
+    const identity = credentials();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ event_id: 'a'.repeat(64), accepted: true }), {
+          status: 202,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepted: false, message: 'membership denied' }), {
+          status: 403,
+        })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 202 }))
+      .mockRejectedValueOnce(new Error('socket closed after write'));
+    const service = new BuzzCommunicationService({
+      fetch,
+      resolveSecret: vi.fn().mockResolvedValue(identity.privateKey),
+      nip98Signer: {
+        sign: vi.fn().mockResolvedValue({
+          authorization: 'Nostr signed',
+          publicKey: identity.publicKey,
+        }),
+      },
+    });
+    const event = { ...signedEvent(identity.secretKey), id: 'a'.repeat(64) };
+
+    await expect(service.submitEvent(config(identity.publicKey), event)).resolves.toMatchObject({
+      status: 'accepted',
+      eventId: event.id,
+    });
+    await expect(service.submitEvent(config(identity.publicKey), event)).resolves.toMatchObject({
+      status: 'rejected',
+      detail: 'membership denied',
+    });
+    await expect(service.submitEvent(config(identity.publicKey), event)).resolves.toMatchObject({
+      status: 'delivery_unknown',
+      detail: expect.stringContaining('did not confirm'),
+    });
+    await expect(service.submitEvent(config(identity.publicKey), event)).resolves.toMatchObject({
+      status: 'delivery_unknown',
+      detail: 'socket closed after write',
+    });
+    expect(fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('queries a signed event ID for safe reconciliation', async () => {
+    const identity = credentials();
+    const eventId = 'c'.repeat(64);
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ id: eventId }]), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+      .mockResolvedValueOnce(new Response('unavailable', { status: 503 }));
+    const service = new BuzzCommunicationService({
+      fetch,
+      resolveSecret: vi.fn().mockResolvedValue(identity.privateKey),
+      nip98Signer: {
+        sign: vi.fn().mockResolvedValue({
+          authorization: 'Nostr signed',
+          publicKey: identity.publicKey,
+        }),
+      },
+    });
+
+    await expect(service.eventExists(config(identity.publicKey), eventId)).resolves.toBe(true);
+    await expect(service.eventExists(config(identity.publicKey), eventId)).resolves.toBe(false);
+    await expect(service.eventExists(config(identity.publicKey), eventId)).resolves.toBeUndefined();
+  });
+});
+
+describe('Buzz inbound event contract', () => {
+  it('verifies authorship and preserves root, parent, timestamp, and deep-link coordinates', () => {
+    const identity = credentials();
+    const rootEventId = 'a'.repeat(64);
+    const parentEventId = 'b'.repeat(64);
+    const event = signedEvent(identity.secretKey, {
+      tags: [
+        ['h', CHANNEL_ID],
+        ['e', rootEventId, '', 'root'],
+        ['e', parentEventId, '', 'reply'],
+      ],
+    });
+
+    expect(
+      parseBuzzInboundEvent(event, { community: COMMUNITY, channelId: CHANNEL_ID, now: NOW })
+    ).toMatchObject({
+      event: { id: event.id, pubkey: identity.publicKey },
+      content: 'hello from Buzz',
+      coordinate: {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        eventId: event.id,
+        authorPubkey: identity.publicKey,
+        rootEventId,
+        parentEventId,
+        externalUrl: buildBuzzMessageDeepLink({
+          channelId: CHANNEL_ID,
+          eventId: event.id,
+          rootEventId,
+        }),
+      },
+    });
+  });
+
+  it.each([
+    ['wrong channel', { tags: [['h', '223e4567-e89b-42d3-a456-426614174000']] }],
+    ['future timestamp', { createdAt: Math.floor(NOW.getTime() / 1000) + 301 }],
+    ['unknown kind', { kind: 99_999 }],
+  ])('rejects %s events', (_label, override) => {
+    const identity = credentials();
+    const event = signedEvent(identity.secretKey, override);
+    expect(() =>
+      parseBuzzInboundEvent(event, { community: COMMUNITY, channelId: CHANNEL_ID, now: NOW })
+    ).toThrow();
+  });
+
+  it('rejects invalid signatures and oversized content', () => {
+    const identity = credentials();
+    const event = signedEvent(identity.secretKey);
+    expect(() =>
+      parseBuzzInboundEvent(
+        { ...event, content: 'tampered' },
+        { community: COMMUNITY, channelId: CHANNEL_ID, now: NOW }
+      )
+    ).toThrow('signature');
+
+    const oversized = signedEvent(identity.secretKey, { content: 'x'.repeat(64 * 1024 + 1) });
+    expect(() =>
+      parseBuzzInboundEvent(oversized, {
+        community: COMMUNITY,
+        channelId: CHANNEL_ID,
+        now: NOW,
+      })
+    ).toThrow('message limit');
+  });
+
+  it.each([BUZZ_EDIT_KIND, BUZZ_DELETE_KIND])('extracts the target event for kind %i', (kind) => {
+    const identity = credentials();
+    const target = 'd'.repeat(64);
+    const event = signedEvent(identity.secretKey, {
+      kind,
+      tags: [
+        ['h', CHANNEL_ID],
+        ['e', target],
+      ],
+    });
+    expect(
+      parseBuzzInboundEvent(event, { community: COMMUNITY, channelId: CHANNEL_ID, now: NOW })
+    ).toMatchObject({ targetEventId: target, coordinate: { kind } });
+  });
+});

--- a/server/src/__tests__/buzz-compatibility-integration.test.ts
+++ b/server/src/__tests__/buzz-compatibility-integration.test.ts
@@ -95,7 +95,7 @@ describe('Buzz compatibility fake relay', () => {
     const persisted = await fs.readFile(path.join(temporaryDirectory, 'state.json'), 'utf8');
 
     expect(result).toMatchObject({
-      status: 'healthy',
+      status: 'degraded',
       reasonCode: 'ok',
       canSend: false,
       canReceiveReplies: false,

--- a/server/src/__tests__/buzz-subscription-worker.test.ts
+++ b/server/src/__tests__/buzz-subscription-worker.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { finalizeEvent, generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools';
+import { WebSocketServer, type WebSocket } from 'ws';
+import type { BuzzRuntimeHealth } from '@veritas-kanban/shared';
+import { BuzzCommunicationService } from '../services/buzz-communication-service.js';
+import { BuzzSubscriptionWorker } from '../services/buzz-subscription-worker.js';
+
+const CHANNEL_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+interface FakeRelay {
+  server: Server;
+  webSocketServer: WebSocketServer;
+  url: string;
+  frames: unknown[][];
+  connections: number;
+}
+
+async function startRelay(
+  onFrame: (relay: FakeRelay, socket: WebSocket, frame: unknown[]) => void
+): Promise<FakeRelay> {
+  const server = createServer();
+  const webSocketServer = new WebSocketServer({ server });
+  const relay = {
+    server,
+    webSocketServer,
+    url: '',
+    frames: [],
+    connections: 0,
+  };
+  webSocketServer.on('connection', (socket) => {
+    relay.connections += 1;
+    socket.send(JSON.stringify(['AUTH', 'challenge-1']));
+    socket.on('message', (data) => {
+      const frame = JSON.parse(data.toString('utf8')) as unknown[];
+      relay.frames.push(frame);
+      onFrame(relay, socket, frame);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+  relay.url = `http://127.0.0.1:${address.port}`;
+  return relay;
+}
+
+describe('BuzzSubscriptionWorker fake-relay contract', () => {
+  const relays: FakeRelay[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      relays.splice(0).map(
+        (relay) =>
+          new Promise<void>((resolve) => {
+            for (const client of relay.webSocketServer.clients) client.terminate();
+            relay.webSocketServer.close(() => relay.server.close(() => resolve()));
+          })
+      )
+    );
+  });
+
+  it('authenticates, subscribes with cursor overlap, dispatches events, and closes cleanly', async () => {
+    const secretKey = generateSecretKey();
+    const privateKey = Buffer.from(secretKey).toString('hex');
+    const publicKey = getPublicKey(secretKey);
+    const createdAt = Math.floor(Date.now() / 1000) - 10;
+    const inbound = finalizeEvent(
+      {
+        kind: 9,
+        created_at: createdAt,
+        tags: [['h', CHANNEL_ID]],
+        content: 'from fake relay',
+      },
+      secretKey
+    );
+    const relay = await startRelay((_relay, socket, frame) => {
+      if (frame[0] === 'AUTH') {
+        const auth = frame[1] as ReturnType<typeof finalizeEvent>;
+        expect(verifyEvent(auth)).toBe(true);
+        expect(auth.kind).toBe(22_242);
+        expect(auth.tags).toContainEqual(['challenge', 'challenge-1']);
+        expect(auth.tags).toContainEqual(['relay', relay.url.replace('http:', 'ws:')]);
+        socket.send(JSON.stringify(['OK', auth.id, true, 'authenticated']));
+      }
+      if (frame[0] === 'REQ') {
+        socket.send(JSON.stringify(['EOSE', frame[1]]));
+        socket.send(JSON.stringify(['EVENT', frame[1], inbound]));
+      }
+    });
+    relays.push(relay);
+
+    const events = vi.fn().mockResolvedValue(undefined);
+    const health: Array<Partial<BuzzRuntimeHealth>> = [];
+    const worker = new BuzzSubscriptionWorker(
+      {
+        adapterId: 'buzz-default',
+        probeConfig: {
+          enabled: true,
+          relayHttpUrl: relay.url,
+          expectedCommunity: '127.0.0.1',
+          publicKey,
+          credentialRef: 'env:BUZZ_PRIVATE_KEY',
+          allowLocalhost: true,
+        },
+        mappings: [
+          {
+            id: 'buzz_map_1',
+            adapterId: 'buzz-default',
+            community: '127.0.0.1',
+            channelId: CHANNEL_ID,
+            target: { kind: 'squad' },
+            enabled: true,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        ],
+        cursors: [
+          {
+            adapterId: 'buzz-default',
+            community: '127.0.0.1',
+            channelId: CHANNEL_ID,
+            createdAt,
+            eventId: 'a'.repeat(64),
+            committedAt: new Date().toISOString(),
+          },
+        ],
+      },
+      {
+        onEvent: events,
+        onHealth: (patch) => {
+          health.push(patch);
+        },
+      },
+      {
+        communication: new BuzzCommunicationService({
+          resolveSecret: vi.fn().mockResolvedValue(privateKey),
+        }),
+        random: () => 0.5,
+      }
+    );
+
+    worker.start();
+    await vi.waitFor(() => {
+      expect(events).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: CHANNEL_ID }),
+        expect.objectContaining({
+          id: inbound.id,
+          pubkey: inbound.pubkey,
+          content: inbound.content,
+        })
+      );
+      expect(health).toContainEqual(expect.objectContaining({ subscriptionActive: true }));
+    });
+    const request = relay.frames.find((frame) => frame[0] === 'REQ');
+    expect(request).toEqual([
+      'REQ',
+      `vk-buzz-${CHANNEL_ID}`,
+      {
+        kinds: [9, 40_003, 9_005, 5],
+        '#h': [CHANNEL_ID],
+        since: createdAt - 5,
+      },
+    ]);
+
+    await worker.stop();
+    await vi.waitFor(() => {
+      expect(relay.frames).toContainEqual(['CLOSE', `vk-buzz-${CHANNEL_ID}`]);
+    });
+    expect(health.at(-1)).toMatchObject({
+      relayConnected: false,
+      subscriptionActive: false,
+    });
+  });
+
+  it('treats authentication rejection as terminal instead of reconnecting', async () => {
+    const secretKey = generateSecretKey();
+    const privateKey = Buffer.from(secretKey).toString('hex');
+    const publicKey = getPublicKey(secretKey);
+    const relay = await startRelay((_relay, socket, frame) => {
+      if (frame[0] === 'AUTH') {
+        const auth = frame[1] as { id: string };
+        socket.send(JSON.stringify(['OK', auth.id, false, 'membership required']));
+      }
+    });
+    relays.push(relay);
+    const health: Array<Partial<BuzzRuntimeHealth>> = [];
+    const worker = new BuzzSubscriptionWorker(
+      {
+        adapterId: 'buzz-default',
+        probeConfig: {
+          enabled: true,
+          relayHttpUrl: relay.url,
+          expectedCommunity: '127.0.0.1',
+          publicKey,
+          credentialRef: 'env:BUZZ_PRIVATE_KEY',
+          allowLocalhost: true,
+        },
+        mappings: [
+          {
+            id: 'buzz_map_1',
+            adapterId: 'buzz-default',
+            community: '127.0.0.1',
+            channelId: CHANNEL_ID,
+            target: { kind: 'squad' },
+            enabled: true,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        ],
+        cursors: [],
+      },
+      {
+        onEvent: vi.fn(),
+        onHealth: (patch) => {
+          health.push(patch);
+        },
+      },
+      {
+        communication: new BuzzCommunicationService({
+          resolveSecret: vi.fn().mockResolvedValue(privateKey),
+        }),
+      }
+    );
+
+    worker.start();
+    await vi.waitFor(() => {
+      expect(health).toContainEqual(
+        expect.objectContaining({ lastError: expect.stringContaining('membership required') })
+      );
+    });
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(relay.connections).toBe(1);
+    await worker.stop();
+  });
+
+  it('reconnects a transiently closed subscription and overlaps the initial cursor', async () => {
+    const secretKey = generateSecretKey();
+    const privateKey = Buffer.from(secretKey).toString('hex');
+    const publicKey = getPublicKey(secretKey);
+    const now = new Date('2026-07-23T20:00:00.000Z');
+    const inbound = finalizeEvent(
+      {
+        kind: 9,
+        created_at: Math.floor(now.getTime() / 1000) - 2,
+        tags: [['h', CHANNEL_ID]],
+        content: 'advance reconnect cursor',
+      },
+      secretKey
+    );
+    const relay = await startRelay((currentRelay, socket, frame) => {
+      if (frame[0] === 'AUTH') {
+        const auth = frame[1] as { id: string };
+        socket.send(JSON.stringify(['OK', auth.id, true, 'authenticated']));
+      }
+      if (frame[0] === 'REQ') {
+        if (currentRelay.connections === 1) {
+          socket.send(JSON.stringify(['EVENT', frame[1], inbound]));
+          socket.send(JSON.stringify(['CLOSED', frame[1], 'temporary relay throttle']));
+        } else {
+          socket.send(JSON.stringify(['EOSE', frame[1]]));
+        }
+      }
+    });
+    relays.push(relay);
+    const health: Array<Partial<BuzzRuntimeHealth>> = [];
+    const committedCursor = {
+      adapterId: 'buzz-default',
+      community: '127.0.0.1',
+      channelId: CHANNEL_ID,
+      createdAt: inbound.created_at,
+      eventId: inbound.id,
+      committedAt: now.toISOString(),
+    };
+    const worker = new BuzzSubscriptionWorker(
+      {
+        adapterId: 'buzz-default',
+        probeConfig: {
+          enabled: true,
+          relayHttpUrl: relay.url,
+          expectedCommunity: '127.0.0.1',
+          publicKey,
+          credentialRef: 'env:BUZZ_PRIVATE_KEY',
+          allowLocalhost: true,
+        },
+        mappings: [
+          {
+            id: 'buzz_map_1',
+            adapterId: 'buzz-default',
+            community: '127.0.0.1',
+            channelId: CHANNEL_ID,
+            target: { kind: 'squad' },
+            enabled: true,
+            createdAt: now.toISOString(),
+            updatedAt: now.toISOString(),
+          },
+        ],
+        cursors: [],
+      },
+      {
+        onEvent: vi.fn().mockResolvedValue(committedCursor),
+        onHealth: (patch) => {
+          health.push(patch);
+        },
+      },
+      {
+        communication: new BuzzCommunicationService({
+          resolveSecret: vi.fn().mockResolvedValue(privateKey),
+        }),
+        now: () => now,
+        random: () => 0,
+      }
+    );
+
+    worker.start();
+    await vi.waitFor(
+      () => {
+        expect(relay.connections).toBeGreaterThanOrEqual(2);
+        expect(health).toContainEqual(expect.objectContaining({ subscriptionActive: true }));
+      },
+      { timeout: 2_000 }
+    );
+    const requests = relay.frames.filter((frame) => frame[0] === 'REQ');
+    expect(requests[0]?.[2]).toMatchObject({
+      since: Math.floor(now.getTime() / 1000) - 5,
+    });
+    expect(requests[1]?.[2]).toMatchObject({
+      since: inbound.created_at - 5,
+    });
+    await worker.stop();
+  });
+});

--- a/server/src/__tests__/chat-service.test.ts
+++ b/server/src/__tests__/chat-service.test.ts
@@ -128,6 +128,50 @@ describe('ChatService', () => {
     expect((await service.getSquadMessages({ limit: 1 })).length).toBe(1);
   });
 
+  it('deduplicates deterministic external message IDs and preserves source metadata', async () => {
+    const timestamp = '2026-07-23T20:15:00.000Z';
+    const input = {
+      id: `msg_buzz_${'a'.repeat(64)}`,
+      timestamp,
+      agent: 'BUZZ',
+      message: 'Signed relay message',
+      links: [
+        {
+          href: `buzz://message?channel=123e4567-e89b-42d3-a456-426614174000&id=${'a'.repeat(64)}`,
+          label: 'Open in Buzz',
+        },
+      ],
+      external: {
+        provider: 'buzz' as const,
+        adapterId: 'buzz-default',
+        community: 'relay.example.test',
+        channelId: '123e4567-e89b-42d3-a456-426614174000',
+        messageId: 'a'.repeat(64),
+        authorId: 'b'.repeat(64),
+        kind: 9,
+      },
+    };
+
+    const first = await service.sendSquadMessage(input, 'Buzz member');
+    const replay = await service.sendSquadMessage(
+      { ...input, message: 'must not duplicate or replace' },
+      'Buzz member'
+    );
+    const stored = (await service.getSquadMessages()).filter(
+      (message: any) => message.id === input.id
+    );
+
+    expect(replay).toEqual(first);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      id: input.id,
+      timestamp,
+      message: 'Signed relay message',
+      links: input.links,
+      external: input.external,
+    });
+  });
+
   it('tracks squad threads, mentions, unread state, pins, reactions, and redacted search', async () => {
     const root = await service.sendSquadMessage({
       agent: 'VERITAS',

--- a/server/src/__tests__/communication-adapter-service.test.ts
+++ b/server/src/__tests__/communication-adapter-service.test.ts
@@ -242,7 +242,7 @@ describe('CommunicationAdapterService', () => {
     });
     expect(adapter.relayWebSocketUrl).toBeUndefined();
     expect(health).toMatchObject({
-      status: 'healthy',
+      status: 'degraded',
       reasonCode: 'ok',
       canSend: false,
       canReceiveReplies: false,
@@ -370,7 +370,7 @@ describe('CommunicationAdapterService', () => {
     expect(adapter?.lastHealth).toBeUndefined();
   });
 
-  it('fails closed for Buzz sends while leaving Microsoft Teams behavior intact', async () => {
+  it('fails closed for Buzz sends without current compatibility evidence or a channel mapping', async () => {
     await service.configureAdapter('buzz-default', {
       kind: 'buzz',
       enabled: true,
@@ -387,15 +387,20 @@ describe('CommunicationAdapterService', () => {
     expect(result.delivery).toMatchObject({
       operation: 'send',
       status: 'blocked',
-      error: expect.stringContaining('not implemented'),
+      error: expect.stringContaining('compatibility evidence'),
     });
-    expect(await service.listMappings('buzz-default')).toEqual([]);
+    expect(await service.listMappings('buzz-default')).toEqual([
+      expect.objectContaining({
+        adapterId: 'buzz-default',
+        target: expect.objectContaining({ kind: 'squad', squadMessageId: 'message-1' }),
+      }),
+    ]);
 
     const poll = await service.pollReplies('buzz-default');
     expect(poll.delivery).toMatchObject({
-      operation: 'poll',
-      status: 'skipped',
-      error: expect.stringContaining('Buzz reply polling is not implemented'),
+      operation: 'reconcile',
+      status: 'blocked',
+      error: expect.stringContaining('compatibility evidence'),
     });
     expect(outboundIntegrations.deliver).not.toHaveBeenCalled();
   });

--- a/server/src/__tests__/routes/integrations.test.ts
+++ b/server/src/__tests__/routes/integrations.test.ts
@@ -16,6 +16,9 @@ const { mockCommunicationAdapters, mockBroadcastSquadMessage } = vi.hoisted(() =
     getAdapter: vi.fn(),
     configureAdapter: vi.fn(),
     checkHealth: vi.fn(),
+    listBuzzChannelMappings: vi.fn(),
+    configureBuzzChannelMapping: vi.fn(),
+    disableBuzzChannelMapping: vi.fn(),
     send: vi.fn(),
     ingestReply: vi.fn(),
     pollReplies: vi.fn(),
@@ -108,6 +111,27 @@ describe('integrations routes', () => {
       canReceiveReplies: true,
       checkedAt: '2026-06-26T18:00:00.000Z',
       detail: 'ok',
+    });
+    mockCommunicationAdapters.listBuzzChannelMappings.mockResolvedValue([]);
+    mockCommunicationAdapters.configureBuzzChannelMapping.mockResolvedValue({
+      id: 'buzz_map_1',
+      adapterId: 'buzz-default',
+      community: 'relay.example.test',
+      channelId: '123e4567-e89b-42d3-a456-426614174000',
+      target: { kind: 'squad' },
+      enabled: true,
+      createdAt: '2026-07-23T20:00:00.000Z',
+      updatedAt: '2026-07-23T20:00:00.000Z',
+    });
+    mockCommunicationAdapters.disableBuzzChannelMapping.mockResolvedValue({
+      id: 'buzz_map_1',
+      adapterId: 'buzz-default',
+      community: 'relay.example.test',
+      channelId: '123e4567-e89b-42d3-a456-426614174000',
+      target: { kind: 'squad' },
+      enabled: false,
+      createdAt: '2026-07-23T20:00:00.000Z',
+      updatedAt: '2026-07-23T20:01:00.000Z',
     });
     mockCommunicationAdapters.send.mockResolvedValue({
       delivery: {
@@ -415,6 +439,121 @@ describe('integrations routes', () => {
       'buzz-default',
       expect.anything()
     );
+  });
+
+  it('configures, lists, and disables a Buzz Squad Chat channel mapping', async () => {
+    mockCommunicationAdapters.getAdapter.mockResolvedValue({
+      id: 'buzz-default',
+      kind: 'buzz',
+      displayName: 'Buzz',
+      enabled: true,
+    });
+    const channelId = '123e4567-e89b-42d3-a456-426614174000';
+
+    const configured = await request(app)
+      .put(`/api/integrations/communication/adapters/buzz-default/buzz/channels/${channelId}`)
+      .send({
+        target: { kind: 'squad' },
+        enabled: true,
+        actor: 'operator',
+      });
+    expect(configured.status).toBe(200);
+    expect(mockCommunicationAdapters.configureBuzzChannelMapping).toHaveBeenCalledWith(
+      'buzz-default',
+      channelId,
+      {
+        target: { kind: 'squad' },
+        enabled: true,
+        actor: 'operator',
+      }
+    );
+
+    mockCommunicationAdapters.listBuzzChannelMappings.mockResolvedValueOnce([configured.body]);
+    const listed = await request(app).get(
+      '/api/integrations/communication/adapters/buzz-default/buzz/channels'
+    );
+    expect(listed.status).toBe(200);
+    expect(listed.body).toEqual([configured.body]);
+
+    const disabled = await request(app)
+      .post(
+        `/api/integrations/communication/adapters/buzz-default/buzz/channels/${channelId}/disable`
+      )
+      .send({ actor: 'operator' });
+    expect(disabled.status).toBe(200);
+    expect(disabled.body).toMatchObject({ enabled: false });
+    expect(mockCommunicationAdapters.disableBuzzChannelMapping).toHaveBeenCalledWith(
+      'buzz-default',
+      channelId,
+      'operator'
+    );
+  });
+
+  it('returns deterministic client errors for invalid and conflicting Buzz mappings', async () => {
+    mockCommunicationAdapters.getAdapter.mockResolvedValue({
+      id: 'buzz-default',
+      kind: 'buzz',
+      displayName: 'Buzz',
+      enabled: true,
+    });
+    const invalid = await request(app)
+      .put('/api/integrations/communication/adapters/buzz-default/buzz/channels/not-a-uuid')
+      .send({ target: { kind: 'squad' } });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('valid UUID'),
+    });
+
+    mockCommunicationAdapters.configureBuzzChannelMapping.mockRejectedValueOnce(
+      new Error('The Buzz adapter target is already mapped to another channel')
+    );
+    const conflict = await request(app)
+      .put(
+        '/api/integrations/communication/adapters/buzz-default/buzz/channels/223e4567-e89b-42d3-a456-426614174000'
+      )
+      .send({ target: { kind: 'squad' } });
+    expect(conflict.status).toBe(409);
+    expect(conflict.body).toMatchObject({
+      code: 'CONFLICT',
+      message: expect.stringContaining('already mapped'),
+    });
+  });
+
+  it('returns a visible accepted response for delivery-unknown Buzz sends', async () => {
+    mockCommunicationAdapters.getAdapter.mockResolvedValue({
+      id: 'buzz-default',
+      kind: 'buzz',
+      displayName: 'Buzz',
+      enabled: true,
+    });
+    mockCommunicationAdapters.send.mockResolvedValueOnce({
+      delivery: {
+        id: 'comm_buzz_1',
+        adapterId: 'buzz-default',
+        operation: 'send',
+        status: 'delivery_unknown',
+        detail: 'Buzz delivery is ambiguous and will be reconciled by event ID.',
+        createdAt: '2026-07-23T20:00:00.000Z',
+      },
+      mapping: {
+        id: 'map_buzz_1',
+        adapterId: 'buzz-default',
+        externalThreadId: 'a'.repeat(64),
+        target: { kind: 'squad' },
+        createdAt: '2026-07-23T20:00:00.000Z',
+        updatedAt: '2026-07-23T20:00:00.000Z',
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/integrations/communication/adapters/buzz-default/send')
+      .send({ target: { kind: 'squad' }, message: 'message' });
+    expect(response.status).toBe(202);
+    expect(response.body.delivery).toMatchObject({
+      status: 'delivery_unknown',
+      detail: expect.stringContaining('reconciled'),
+    });
   });
 
   it('ingests communication replies and broadcasts the resulting squad message', async () => {

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -119,13 +119,25 @@ describe('v1 REST permission guard presets', () => {
         ])
       ).next
     ).toHaveBeenCalled();
+    expect(
+      runGuard(
+        integrationsAccess,
+        mockRequest('GET', '/communication/adapters/buzz-default/buzz/channels', 'read-only', [
+          'settings:read',
+        ])
+      ).next
+    ).toHaveBeenCalled();
 
-    for (const path of [
-      '/communication/adapters/buzz-default',
-      '/communication/adapters/buzz-default/test',
-      '/communication/adapters/buzz-default/disconnect',
+    for (const [method, path] of [
+      ['PUT', '/communication/adapters/buzz-default'],
+      ['POST', '/communication/adapters/buzz-default/test'],
+      ['POST', '/communication/adapters/buzz-default/disconnect'],
+      [
+        'PUT',
+        '/communication/adapters/buzz-default/buzz/channels/123e4567-e89b-42d3-a456-426614174000',
+      ],
+      ['POST', '/communication/adapters/buzz-default/send'],
     ]) {
-      const method = path.endsWith('buzz-default') ? 'PUT' : 'POST';
       const { res, next } = runGuard(
         integrationsAccess,
         mockRequest(method, path, 'read-only', ['settings:read'])

--- a/server/src/routes/integrations.ts
+++ b/server/src/routes/integrations.ts
@@ -10,7 +10,12 @@ import { isIP } from 'node:net';
 import { z } from 'zod';
 import { ConfigService } from '../services/config-service.js';
 import { asyncHandler } from '../middleware/async-handler.js';
-import { ForbiddenError, NotFoundError } from '../middleware/error-handler.js';
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from '../middleware/error-handler.js';
 import { validate } from '../middleware/validate.js';
 import { hasPermission, type AuthenticatedRequest } from '../middleware/auth.js';
 import type { CoolifyServiceConfig, CoolifyServicesConfig } from '@veritas-kanban/shared';
@@ -63,6 +68,7 @@ const sendSchema = z.object({
   target: replyTargetSchema,
   message: z.string().min(1),
   actor: z.string().optional(),
+  replyToSquadMessageId: z.string().optional(),
   externalThreadId: z.string().optional(),
   externalUrl: z.string().optional(),
 });
@@ -77,8 +83,23 @@ const replyIngestSchema = z.object({
   externalUrl: z.string().optional(),
 });
 
+const buzzChannelMappingSchema = z.object({
+  target: replyTargetSchema.extend({ kind: z.literal('squad') }),
+  enabled: z.boolean().optional(),
+  actor: z.string().trim().min(1).max(200).optional(),
+});
+const buzzChannelIdSchema = z.uuid();
+
 function adapterIdParam(value: unknown): string {
   return typeof value === 'string' && value.trim() ? value : DEFAULT_ADAPTER_ID;
+}
+
+function buzzChannelIdParam(value: unknown): string {
+  const parsed = buzzChannelIdSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new BadRequestError('Buzz channel ID must be a valid UUID');
+  }
+  return parsed.data.toLowerCase();
 }
 
 async function ensureAdapterExists(adapterId: string): Promise<void> {
@@ -230,6 +251,63 @@ router.get(
 
     log.debug({ results }, 'Integration status check complete');
     res.json({ data: results });
+  })
+);
+
+// GET /api/integrations/communication/adapters/:adapterId/buzz/channels
+router.get(
+  '/communication/adapters/:adapterId/buzz/channels',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    res.json(await communicationAdapters.listBuzzChannelMappings(adapterId));
+  })
+);
+
+// PUT /api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId
+router.put(
+  '/communication/adapters/:adapterId/buzz/channels/:channelId',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    const input = buzzChannelMappingSchema.parse(req.body);
+    const channelId = buzzChannelIdParam(req.params.channelId);
+    try {
+      res.json(
+        await communicationAdapters.configureBuzzChannelMapping(adapterId, channelId, input)
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Buzz channel mapping failed';
+      if (message.includes('already mapped')) throw new ConflictError(message);
+      if (
+        message.includes('requires a Buzz adapter') ||
+        message.includes('configuration is invalid')
+      ) {
+        throw new BadRequestError(message);
+      }
+      throw error;
+    }
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId/disable
+router.post(
+  '/communication/adapters/:adapterId/buzz/channels/:channelId/disable',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    const channelId = buzzChannelIdParam(req.params.channelId);
+    const actor =
+      typeof req.body?.actor === 'string' && req.body.actor.trim()
+        ? req.body.actor.trim().slice(0, 200)
+        : undefined;
+    try {
+      res.json(await communicationAdapters.disableBuzzChannelMapping(adapterId, channelId, actor));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Buzz channel mapping failed';
+      if (message.includes('not found')) throw new NotFoundError(message);
+      throw error;
+    }
   })
 );
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -77,6 +77,7 @@ import {
 } from './services/websocket-permissions.js';
 import { closeWebSocketSafely } from './utils/websocket-close.js';
 import { startAfterInitialization } from './utils/startup-gate.js';
+import { getCommunicationAdapterService } from './services/communication-adapter-service.js';
 
 const log = createLogger('server');
 
@@ -577,6 +578,8 @@ async function initializeServices(): Promise<void> {
     storageInitialized = true;
     log.info('SQLite storage initialized');
   }
+  await getCommunicationAdapterService().start();
+  log.info('Communication adapter workers initialized');
 
   // 4. Reconcile any agent attempts that were left in `running` state from
   //    a previous server crash/restart (issue #781).
@@ -1115,6 +1118,9 @@ async function gracefulShutdown(signal: string) {
 
     stopScheduledDeliverablesRunner();
     log.info('Scheduled deliverables runner stopped');
+
+    await getCommunicationAdapterService().shutdown();
+    log.info('Communication adapter workers stopped');
 
     // Flush pending telemetry writes (timeout: 5s)
     await Promise.race([

--- a/server/src/services/buzz-communication-service.ts
+++ b/server/src/services/buzz-communication-service.ts
@@ -1,0 +1,452 @@
+import type { Event, VerifiedEvent } from 'nostr-tools';
+import { verifyEvent } from 'nostr-tools';
+import type { BuzzExternalCoordinate } from '@veritas-kanban/shared';
+import { EnvironmentCredentialSecretSource } from './credential-broker-service.js';
+import {
+  NostrToolsBuzzEventSigner,
+  NostrToolsBuzzNip98Signer,
+  type BuzzNip98Signer,
+  type BuzzNostrEventSigner,
+} from './buzz-nip98-signer.js';
+import {
+  normalizeBuzzEndpoints,
+  validateBuzzAuthTag,
+  type BuzzProbeConfig,
+} from './buzz-compatibility-service.js';
+import { redactString } from '../lib/redact.js';
+import { safeFetch, type UrlValidationOptions } from '../utils/url-validation.js';
+
+export const BUZZ_MESSAGE_KIND = 9;
+export const BUZZ_EDIT_KIND = 40_003;
+export const BUZZ_DELETE_KIND = 9_005;
+export const BUZZ_DELETE_COMPAT_KIND = 5;
+export const BUZZ_SUBSCRIBED_KINDS = [
+  BUZZ_MESSAGE_KIND,
+  BUZZ_EDIT_KIND,
+  BUZZ_DELETE_KIND,
+  BUZZ_DELETE_COMPAT_KIND,
+] as const;
+
+const MAX_EVENT_BYTES = 256 * 1024;
+const MAX_MESSAGE_BYTES = 64 * 1024;
+const DEFAULT_TIMEOUT_MS = 8_000;
+const EVENT_ID_PATTERN = /^[a-f0-9]{64}$/;
+const CHANNEL_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface BuzzOutboundMessage {
+  channelId: string;
+  content: string;
+  idempotencyKey: string;
+  rootEventId?: string;
+  parentEventId?: string;
+}
+
+export interface BuzzPreparedMessage {
+  event: VerifiedEvent;
+  coordinate: BuzzExternalCoordinate;
+}
+
+export interface BuzzSubmitResult {
+  status: 'accepted' | 'rejected' | 'delivery_unknown';
+  eventId: string;
+  detail?: string;
+}
+
+export interface BuzzInboundEvent {
+  event: VerifiedEvent;
+  coordinate: BuzzExternalCoordinate;
+  content: string;
+  targetEventId?: string;
+}
+
+interface BuzzCommunicationServiceOptions {
+  fetch?: (
+    url: string,
+    init?: RequestInit,
+    validationOptions?: UrlValidationOptions
+  ) => Promise<Response | null>;
+  resolveSecret?: (reference: string) => Promise<string | undefined>;
+  nip98Signer?: BuzzNip98Signer;
+  eventSigner?: BuzzNostrEventSigner;
+  now?: () => Date;
+  timeoutMs?: number;
+}
+
+function sanitizeDetail(value: unknown): string {
+  const raw = value instanceof Error ? value.message : String(value);
+  return redactString(raw)
+    .replace(/nsec1[a-z0-9]+/gi, '[REDACTED]')
+    .replace(/\b[a-f0-9]{64,128}\b/gi, '[REDACTED]')
+    .slice(0, 500);
+}
+
+function extractTag(tags: string[][], name: string): string | undefined {
+  return tags.find((tag) => tag[0] === name && typeof tag[1] === 'string')?.[1];
+}
+
+function threadCoordinate(tags: string[][]): {
+  rootEventId?: string;
+  parentEventId?: string;
+} {
+  let rootEventId: string | undefined;
+  let parentEventId: string | undefined;
+  for (const tag of tags) {
+    if (tag[0] !== 'e' || !EVENT_ID_PATTERN.test(tag[1] ?? '')) continue;
+    if (tag[3] === 'root') rootEventId = tag[1];
+    if (tag[3] === 'reply') parentEventId = tag[1];
+  }
+  if (!rootEventId && parentEventId) rootEventId = parentEventId;
+  return { rootEventId, parentEventId };
+}
+
+function targetEventId(tags: string[][]): string | undefined {
+  return tags.find((tag) => tag[0] === 'e' && EVENT_ID_PATTERN.test(tag[1] ?? ''))?.[1];
+}
+
+function validationOptions(config: BuzzProbeConfig): UrlValidationOptions {
+  return {
+    allowHttp: config.relayHttpUrl.startsWith('http://'),
+    allowLocalhost: Boolean(config.allowLocalhost),
+    allowPrivateNetwork: Boolean(config.allowPrivateNetwork),
+    logFailures: false,
+  };
+}
+
+async function readBoundedBody(response: Response, limit = MAX_EVENT_BYTES): Promise<string> {
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let result = '';
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      bytes += chunk.value.byteLength;
+      if (bytes > limit) throw new Error('Buzz response exceeded the configured size limit');
+      result += decoder.decode(chunk.value, { stream: true });
+    }
+    result += decoder.decode();
+    return result;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function buildBuzzMessageDeepLink(input: {
+  channelId: string;
+  eventId: string;
+  rootEventId?: string;
+}): string {
+  const params = new URLSearchParams({ channel: input.channelId, id: input.eventId });
+  if (input.rootEventId) params.set('thread', input.rootEventId);
+  return `buzz://message?${params.toString()}`;
+}
+
+export function parseBuzzInboundEvent(
+  value: unknown,
+  input: { community: string; channelId: string; now?: Date }
+): BuzzInboundEvent {
+  if (!value || typeof value !== 'object') throw new Error('Buzz event is not an object');
+  const candidate = value as Partial<VerifiedEvent>;
+  const { id, pubkey, created_at: createdAt, kind, tags, content, sig } = candidate;
+  if (
+    typeof id !== 'string' ||
+    !EVENT_ID_PATTERN.test(id) ||
+    typeof pubkey !== 'string' ||
+    !EVENT_ID_PATTERN.test(pubkey) ||
+    typeof createdAt !== 'number' ||
+    !Number.isInteger(createdAt) ||
+    typeof kind !== 'number' ||
+    typeof content !== 'string' ||
+    !Array.isArray(tags) ||
+    !tags.every((tag) => Array.isArray(tag) && tag.every((entry) => typeof entry === 'string')) ||
+    typeof sig !== 'string' ||
+    !/^[a-f0-9]{128}$/i.test(sig)
+  ) {
+    throw new Error('Buzz event has an invalid Nostr shape');
+  }
+  // Reconstruct the wire schema so nostr-tools never trusts a cached verification
+  // symbol attached by another in-process caller.
+  const event: Event = {
+    id,
+    pubkey,
+    created_at: createdAt,
+    kind,
+    tags: tags.map((tag) => [...tag]),
+    content,
+    sig,
+  };
+  if (!BUZZ_SUBSCRIBED_KINDS.includes(event.kind as (typeof BUZZ_SUBSCRIBED_KINDS)[number])) {
+    throw new Error('Buzz event kind is not allowlisted');
+  }
+  if (Buffer.byteLength(JSON.stringify(event), 'utf8') > MAX_EVENT_BYTES) {
+    throw new Error('Buzz event exceeds the configured size limit');
+  }
+  if (Buffer.byteLength(event.content, 'utf8') > MAX_MESSAGE_BYTES) {
+    throw new Error('Buzz event content exceeds the supported message limit');
+  }
+  const nowSeconds = Math.floor((input.now ?? new Date()).getTime() / 1000);
+  if (event.created_at < 1 || event.created_at > nowSeconds + 300) {
+    throw new Error('Buzz event timestamp is outside the accepted range');
+  }
+  if (!CHANNEL_ID_PATTERN.test(input.channelId)) throw new Error('Buzz channel ID is invalid');
+  const channelId = extractTag(event.tags, 'h');
+  if (channelId?.toLowerCase() !== input.channelId.toLowerCase()) {
+    throw new Error('Buzz event channel does not match the mapped channel');
+  }
+  if (!verifyEvent(event)) throw new Error('Buzz event signature is invalid');
+
+  const thread = event.kind === BUZZ_MESSAGE_KIND ? threadCoordinate(event.tags) : {};
+  const coordinate: BuzzExternalCoordinate = {
+    community: input.community,
+    channelId: input.channelId.toLowerCase(),
+    eventId: event.id,
+    authorPubkey: event.pubkey,
+    kind: event.kind,
+    rootEventId: thread.rootEventId,
+    parentEventId: thread.parentEventId,
+    externalUrl: buildBuzzMessageDeepLink({
+      channelId: input.channelId,
+      eventId: event.id,
+      rootEventId: thread.rootEventId,
+    }),
+  };
+
+  return {
+    event,
+    coordinate,
+    content: event.content,
+    targetEventId:
+      event.kind === BUZZ_EDIT_KIND ||
+      event.kind === BUZZ_DELETE_KIND ||
+      event.kind === BUZZ_DELETE_COMPAT_KIND
+        ? targetEventId(event.tags)
+        : undefined,
+  };
+}
+
+export class BuzzCommunicationService {
+  private readonly fetch: NonNullable<BuzzCommunicationServiceOptions['fetch']>;
+  private readonly resolveSecret: NonNullable<BuzzCommunicationServiceOptions['resolveSecret']>;
+  private readonly nip98Signer: BuzzNip98Signer;
+  private readonly eventSigner: BuzzNostrEventSigner;
+  private readonly now: () => Date;
+  private readonly timeoutMs: number;
+
+  constructor(options: BuzzCommunicationServiceOptions = {}) {
+    this.fetch = options.fetch ?? safeFetch;
+    this.resolveSecret =
+      options.resolveSecret ??
+      (async (reference) => {
+        if (!reference.startsWith('env:')) return undefined;
+        return new EnvironmentCredentialSecretSource().resolve({
+          kind: 'environment',
+          reference: reference.slice(4),
+        });
+      });
+    this.nip98Signer = options.nip98Signer ?? new NostrToolsBuzzNip98Signer();
+    this.eventSigner = options.eventSigner ?? new NostrToolsBuzzEventSigner();
+    this.now = options.now ?? (() => new Date());
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async prepareMessage(
+    config: BuzzProbeConfig,
+    input: BuzzOutboundMessage
+  ): Promise<BuzzPreparedMessage> {
+    if (!CHANNEL_ID_PATTERN.test(input.channelId)) throw new Error('Buzz channel ID is invalid');
+    if (!input.content.trim()) throw new Error('Buzz message is empty');
+    if (Buffer.byteLength(input.content, 'utf8') > MAX_MESSAGE_BYTES) {
+      throw new Error('Buzz message exceeds the 64 KiB relay limit');
+    }
+    if (
+      input.rootEventId &&
+      (!EVENT_ID_PATTERN.test(input.rootEventId) ||
+        !input.parentEventId ||
+        !EVENT_ID_PATTERN.test(input.parentEventId))
+    ) {
+      throw new Error('Buzz reply coordinates are invalid');
+    }
+
+    const privateKey = await this.requireSecret(config.credentialRef, 'signing key');
+    const tags: string[][] = [['h', input.channelId.toLowerCase()]];
+    if (input.rootEventId && input.parentEventId) {
+      if (input.rootEventId === input.parentEventId) {
+        tags.push(['e', input.rootEventId, '', 'reply']);
+      } else {
+        tags.push(['e', input.rootEventId, '', 'root']);
+        tags.push(['e', input.parentEventId, '', 'reply']);
+      }
+    }
+    tags.push(['client', 'veritas-kanban']);
+    tags.push(['veritas-id', input.idempotencyKey]);
+
+    const event = await this.eventSigner.sign({
+      privateKey,
+      kind: BUZZ_MESSAGE_KIND,
+      createdAt: Math.floor(this.now().getTime() / 1000),
+      tags,
+      content: input.content,
+    });
+    if (event.pubkey.toLowerCase() !== config.publicKey.toLowerCase()) {
+      throw new Error('Buzz signing key does not match the configured public identity');
+    }
+    const endpoints = normalizeBuzzEndpoints(config);
+    const coordinate: BuzzExternalCoordinate = {
+      community: endpoints.community,
+      channelId: input.channelId.toLowerCase(),
+      eventId: event.id,
+      authorPubkey: event.pubkey,
+      kind: event.kind,
+      rootEventId: input.rootEventId,
+      parentEventId: input.parentEventId,
+      externalUrl: buildBuzzMessageDeepLink({
+        channelId: input.channelId,
+        eventId: event.id,
+        rootEventId: input.rootEventId,
+      }),
+    };
+    return { event, coordinate };
+  }
+
+  async submitEvent(config: BuzzProbeConfig, event: VerifiedEvent): Promise<BuzzSubmitResult> {
+    const endpoints = normalizeBuzzEndpoints(config);
+    const url = `${endpoints.httpUrl}/events`;
+    const body = JSON.stringify(event);
+    try {
+      const response = await this.signedRequest(config, url, body);
+      if (!response) {
+        return {
+          status: 'rejected',
+          eventId: event.id,
+          detail: 'Buzz relay request was blocked by outbound network policy.',
+        };
+      }
+      const responseBody = await readBoundedBody(response);
+      let parsed: Record<string, unknown> = {};
+      try {
+        parsed = JSON.parse(responseBody) as Record<string, unknown>;
+      } catch {
+        if (response.ok) {
+          return {
+            status: 'delivery_unknown',
+            eventId: event.id,
+            detail: 'Buzz returned an unreadable acknowledgement.',
+          };
+        }
+      }
+      const responseEventId =
+        typeof parsed.event_id === 'string' && EVENT_ID_PATTERN.test(parsed.event_id)
+          ? parsed.event_id
+          : event.id;
+      if (response.ok && parsed.accepted === true && responseEventId === event.id) {
+        return { status: 'accepted', eventId: event.id };
+      }
+      if (response.ok) {
+        return {
+          status: 'delivery_unknown',
+          eventId: event.id,
+          detail: 'Buzz returned an acknowledgement that did not confirm this event ID.',
+        };
+      }
+      return {
+        status: response.status >= 500 ? 'delivery_unknown' : 'rejected',
+        eventId: event.id,
+        detail: sanitizeDetail(
+          typeof parsed.message === 'string'
+            ? parsed.message
+            : `Buzz relay returned HTTP ${response.status}.`
+        ),
+      };
+    } catch (error) {
+      return {
+        status: 'delivery_unknown',
+        eventId: event.id,
+        detail: sanitizeDetail(error),
+      };
+    }
+  }
+
+  async eventExists(config: BuzzProbeConfig, eventId: string): Promise<boolean | undefined> {
+    if (!EVENT_ID_PATTERN.test(eventId)) throw new Error('Buzz event ID is invalid');
+    const endpoints = normalizeBuzzEndpoints(config);
+    const url = `${endpoints.httpUrl}/query`;
+    const body = JSON.stringify([{ ids: [eventId], limit: 1 }]);
+    try {
+      const response = await this.signedRequest(config, url, body);
+      if (!response || !response.ok) return undefined;
+      const responseBody = await readBoundedBody(response);
+      const parsed = JSON.parse(responseBody) as unknown;
+      if (!Array.isArray(parsed)) return undefined;
+      return parsed.some(
+        (candidate) =>
+          candidate &&
+          typeof candidate === 'object' &&
+          (candidate as { id?: unknown }).id === eventId
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  async resolveCredentials(
+    config: BuzzProbeConfig
+  ): Promise<{ privateKey: string; authTag?: string }> {
+    const privateKey = await this.requireSecret(config.credentialRef, 'signing key');
+    const rawAuthTag = config.authTagRef
+      ? await this.requireSecret(config.authTagRef, 'NIP-OA auth tag')
+      : undefined;
+    return {
+      privateKey,
+      authTag: rawAuthTag ? validateBuzzAuthTag(rawAuthTag) : undefined,
+    };
+  }
+
+  private async signedRequest(
+    config: BuzzProbeConfig,
+    url: string,
+    body: string
+  ): Promise<Response | null> {
+    const { privateKey, authTag } = await this.resolveCredentials(config);
+    const signed = await this.nip98Signer.sign({
+      privateKey,
+      method: 'POST',
+      url,
+      body,
+    });
+    if (signed.publicKey.toLowerCase() !== config.publicKey.toLowerCase()) {
+      throw new Error('Buzz signing key does not match the configured public identity');
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    timeout.unref?.();
+    try {
+      return await this.fetch(
+        url,
+        {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            Authorization: signed.authorization,
+            'Content-Type': 'application/json',
+            ...(authTag ? { 'x-auth-tag': authTag } : {}),
+          },
+          body,
+          signal: controller.signal,
+          redirect: 'manual',
+        },
+        validationOptions(config)
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async requireSecret(reference: string, label: string): Promise<string> {
+    const value = await this.resolveSecret(reference);
+    if (!value) throw new Error(`Buzz ${label} reference is unavailable`);
+    return value;
+  }
+}

--- a/server/src/services/buzz-nip98-signer.ts
+++ b/server/src/services/buzz-nip98-signer.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { finalizeEvent, nip19 } from 'nostr-tools';
+import { finalizeEvent, nip19, type VerifiedEvent } from 'nostr-tools';
 
 const NIP_98_KIND = 27_235;
 
@@ -21,7 +21,7 @@ function invalidPrivateKey(): Error {
   return new Error('Invalid Buzz private key format');
 }
 
-function decodePrivateKey(value: string): Uint8Array {
+export function decodeBuzzPrivateKey(value: string): Uint8Array {
   const candidate = value.trim();
   if (/^[a-fA-F0-9]{64}$/.test(candidate)) {
     return Uint8Array.from(Buffer.from(candidate, 'hex'));
@@ -58,7 +58,7 @@ export class NostrToolsBuzzNip98Signer implements BuzzNip98Signer {
     url: string;
     body: string;
   }): Promise<{ authorization: string; publicKey: string }> {
-    const secretKey = decodePrivateKey(input.privateKey);
+    const secretKey = decodeBuzzPrivateKey(input.privateKey);
     try {
       const event = finalizeEvent(
         {
@@ -78,6 +78,43 @@ export class NostrToolsBuzzNip98Signer implements BuzzNip98Signer {
         authorization: `Nostr ${Buffer.from(JSON.stringify(event), 'utf8').toString('base64')}`,
         publicKey: event.pubkey,
       };
+    } catch {
+      throw invalidPrivateKey();
+    } finally {
+      secretKey.fill(0);
+    }
+  }
+}
+
+export interface BuzzNostrEventSigner {
+  sign(input: {
+    privateKey: string;
+    kind: number;
+    createdAt: number;
+    tags: string[][];
+    content: string;
+  }): Promise<VerifiedEvent>;
+}
+
+export class NostrToolsBuzzEventSigner implements BuzzNostrEventSigner {
+  async sign(input: {
+    privateKey: string;
+    kind: number;
+    createdAt: number;
+    tags: string[][];
+    content: string;
+  }): Promise<VerifiedEvent> {
+    const secretKey = decodeBuzzPrivateKey(input.privateKey);
+    try {
+      return finalizeEvent(
+        {
+          kind: input.kind,
+          created_at: input.createdAt,
+          tags: input.tags,
+          content: input.content,
+        },
+        secretKey
+      );
     } catch {
       throw invalidPrivateKey();
     } finally {

--- a/server/src/services/buzz-subscription-worker.ts
+++ b/server/src/services/buzz-subscription-worker.ts
@@ -1,0 +1,402 @@
+import WebSocket, { type ClientOptions, type RawData } from 'ws';
+import type { LookupFunction } from 'node:net';
+import type { BuzzChannelMapping, BuzzCursor, BuzzRuntimeHealth } from '@veritas-kanban/shared';
+import { NostrToolsBuzzEventSigner, type BuzzNostrEventSigner } from './buzz-nip98-signer.js';
+import { BuzzCommunicationService, BUZZ_SUBSCRIBED_KINDS } from './buzz-communication-service.js';
+import { normalizeBuzzEndpoints, type BuzzProbeConfig } from './buzz-compatibility-service.js';
+import { resolveOutboundUrl } from '../utils/url-validation.js';
+import { redactString } from '../lib/redact.js';
+
+const MAX_FRAME_BYTES = 256 * 1024;
+const CONNECT_TIMEOUT_MS = 10_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const REPLAY_OVERLAP_SECONDS = 5;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+export interface BuzzSubscriptionWorkerConfig {
+  adapterId: string;
+  probeConfig: BuzzProbeConfig;
+  mappings: BuzzChannelMapping[];
+  cursors: BuzzCursor[];
+}
+
+export interface BuzzSubscriptionWorkerCallbacks {
+  onEvent: (mapping: BuzzChannelMapping, event: unknown) => Promise<BuzzCursor | undefined>;
+  onHealth: (health: Partial<BuzzRuntimeHealth>) => Promise<void> | void;
+}
+
+export interface BuzzSubscriptionWorkerHandle {
+  start(): void;
+  stop(): Promise<void>;
+}
+
+export interface BuzzSubscriptionWorkerFactory {
+  create(
+    config: BuzzSubscriptionWorkerConfig,
+    callbacks: BuzzSubscriptionWorkerCallbacks
+  ): BuzzSubscriptionWorkerHandle;
+}
+
+interface BuzzSubscriptionWorkerOptions {
+  communication?: BuzzCommunicationService;
+  eventSigner?: BuzzNostrEventSigner;
+  createSocket?: (url: string, options: BuzzSocketOptions) => WebSocket;
+  now?: () => Date;
+  random?: () => number;
+}
+
+type BuzzSocketOptions = ClientOptions & { lookup?: LookupFunction };
+
+function safeDetail(value: unknown): string {
+  const raw = value instanceof Error ? value.message : String(value);
+  return redactString(raw)
+    .replace(/nsec1[a-z0-9]+/gi, '[REDACTED]')
+    .replace(/\b[a-f0-9]{64,128}\b/gi, '[REDACTED]')
+    .slice(0, 500);
+}
+
+function rawDataToString(data: RawData): string {
+  if (typeof data === 'string') return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString('utf8');
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  return data.toString('utf8');
+}
+
+function webSocketValidationUrl(webSocketUrl: string): string {
+  const parsed = new URL(webSocketUrl);
+  parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+  return parsed.toString();
+}
+
+export class BuzzSubscriptionWorker implements BuzzSubscriptionWorkerHandle {
+  private readonly communication: BuzzCommunicationService;
+  private readonly eventSigner: BuzzNostrEventSigner;
+  private readonly createSocket: NonNullable<BuzzSubscriptionWorkerOptions['createSocket']>;
+  private readonly now: () => Date;
+  private readonly random: () => number;
+  private socket?: WebSocket;
+  private stopped = true;
+  private terminal = false;
+  private authenticated = false;
+  private authEventId?: string;
+  private reconnectAttempts = 0;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private heartbeatTimer?: ReturnType<typeof setInterval>;
+  private processing: Promise<void> = Promise.resolve();
+  private awaitingPong = false;
+  private readonly cursors = new Map<string, BuzzCursor>();
+
+  constructor(
+    private readonly config: BuzzSubscriptionWorkerConfig,
+    private readonly callbacks: BuzzSubscriptionWorkerCallbacks,
+    options: BuzzSubscriptionWorkerOptions = {}
+  ) {
+    this.communication = options.communication ?? new BuzzCommunicationService();
+    this.eventSigner = options.eventSigner ?? new NostrToolsBuzzEventSigner();
+    this.createSocket =
+      options.createSocket ?? ((url, socketOptions) => new WebSocket(url, socketOptions));
+    this.now = options.now ?? (() => new Date());
+    this.random = options.random ?? Math.random;
+    for (const cursor of config.cursors) {
+      this.cursors.set(cursor.channelId.toLowerCase(), cursor);
+    }
+  }
+
+  start(): void {
+    if (!this.stopped) return;
+    this.stopped = false;
+    this.terminal = false;
+    void this.connect();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.terminal = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.stopHeartbeat();
+    const socket = this.socket;
+    this.socket = undefined;
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      for (const mapping of this.config.mappings) {
+        socket.send(JSON.stringify(['CLOSE', this.subscriptionId(mapping.channelId)]));
+      }
+      socket.close(1000, 'Adapter disabled');
+    } else if (socket && socket.readyState === WebSocket.CONNECTING) {
+      socket.terminate();
+    }
+    await this.processing.catch(() => {});
+    await this.callbacks.onHealth({
+      relayConnected: false,
+      subscriptionActive: false,
+    });
+  }
+
+  private async connect(): Promise<void> {
+    if (this.stopped || this.terminal || this.config.mappings.length === 0) return;
+    try {
+      const endpoints = normalizeBuzzEndpoints(this.config.probeConfig);
+      const resolved = await resolveOutboundUrl(webSocketValidationUrl(endpoints.webSocketUrl), {
+        allowHttp: endpoints.webSocketUrl.startsWith('ws://'),
+        allowLocalhost: Boolean(this.config.probeConfig.allowLocalhost),
+        allowPrivateNetwork: Boolean(this.config.probeConfig.allowPrivateNetwork),
+        logFailures: false,
+      });
+      if (!resolved) throw new Error('Buzz WebSocket endpoint was blocked by network policy');
+      const pinnedLookup: LookupFunction = (_hostname, options, callback) => {
+        if (options.all) {
+          callback(null, [resolved.resolvedAddress]);
+          return;
+        }
+        callback(null, resolved.resolvedAddress.address, resolved.resolvedAddress.family);
+      };
+      const socketOptions: BuzzSocketOptions = {
+        handshakeTimeout: CONNECT_TIMEOUT_MS,
+        maxPayload: MAX_FRAME_BYTES,
+        perMessageDeflate: false,
+        lookup: pinnedLookup,
+      };
+      const socket = this.createSocket(endpoints.webSocketUrl, socketOptions);
+      this.socket = socket;
+      this.authenticated = false;
+      this.authEventId = undefined;
+      socket.on('open', () => {
+        if (this.stopped) {
+          socket.close(1000, 'Adapter disabled');
+          return;
+        }
+        this.reconnectAttempts = 0;
+        this.startHeartbeat(socket);
+        void this.callbacks.onHealth({
+          relayConnected: true,
+          subscriptionActive: false,
+          reconnectAttempts: 0,
+          lastConnectedAt: this.now().toISOString(),
+          lastError: undefined,
+        });
+      });
+      socket.on('pong', () => {
+        this.awaitingPong = false;
+      });
+      socket.on('message', (data) => {
+        this.processing = this.processing
+          .then(() => this.handleMessage(socket, rawDataToString(data)))
+          .catch(async (error) => {
+            await this.callbacks.onHealth({ lastError: safeDetail(error) });
+          });
+      });
+      socket.on('error', (error) => {
+        void this.callbacks.onHealth({ lastError: safeDetail(error) });
+      });
+      socket.on('close', (code, reason) => {
+        if (this.socket === socket) this.socket = undefined;
+        this.authenticated = false;
+        this.stopHeartbeat();
+        void this.callbacks.onHealth({
+          relayConnected: false,
+          subscriptionActive: false,
+          lastError:
+            code === 1000 && this.stopped
+              ? undefined
+              : safeDetail(reason.toString('utf8') || `Buzz WebSocket closed with code ${code}`),
+        });
+        this.scheduleReconnect();
+      });
+    } catch (error) {
+      await this.callbacks.onHealth({
+        relayConnected: false,
+        subscriptionActive: false,
+        lastError: safeDetail(error),
+      });
+      this.scheduleReconnect();
+    }
+  }
+
+  private async handleMessage(socket: WebSocket, text: string): Promise<void> {
+    if (Buffer.byteLength(text, 'utf8') > MAX_FRAME_BYTES) {
+      throw new Error('Buzz WebSocket frame exceeded the configured size limit');
+    }
+    let frame: unknown;
+    try {
+      frame = JSON.parse(text);
+    } catch {
+      throw new Error('Buzz WebSocket sent invalid JSON');
+    }
+    if (!Array.isArray(frame) || typeof frame[0] !== 'string') {
+      throw new Error('Buzz WebSocket sent an invalid NIP-01 frame');
+    }
+    switch (frame[0]) {
+      case 'AUTH':
+        if (typeof frame[1] !== 'string' || !frame[1]) {
+          throw new Error('Buzz WebSocket AUTH challenge is invalid');
+        }
+        await this.sendAuth(socket, frame[1]);
+        return;
+      case 'OK':
+        if (
+          typeof frame[1] === 'string' &&
+          frame[1] === this.authEventId &&
+          typeof frame[2] === 'boolean'
+        ) {
+          if (!frame[2]) {
+            this.terminal = true;
+            const detail =
+              typeof frame[3] === 'string' && frame[3]
+                ? frame[3]
+                : 'Buzz WebSocket authentication was rejected';
+            await this.callbacks.onHealth({ lastError: safeDetail(detail) });
+            socket.close(4003, 'Authentication rejected');
+            return;
+          }
+          this.authenticated = true;
+          await this.subscribe(socket);
+        }
+        return;
+      case 'EOSE':
+        if (typeof frame[1] === 'string' && frame[1].startsWith('vk-buzz-')) {
+          await this.callbacks.onHealth({ subscriptionActive: true });
+        }
+        return;
+      case 'EVENT': {
+        if (!this.authenticated || typeof frame[1] !== 'string') return;
+        const mapping = this.mappingForSubscription(frame[1]);
+        if (!mapping) return;
+        const cursor = await this.callbacks.onEvent(mapping, frame[2]);
+        if (cursor) this.cursors.set(mapping.channelId.toLowerCase(), cursor);
+        await this.callbacks.onHealth({ lastEventAt: this.now().toISOString() });
+        return;
+      }
+      case 'CLOSED': {
+        const message = typeof frame[2] === 'string' ? frame[2] : 'Subscription closed';
+        if (/auth|membership|forbidden|unsupported/i.test(message)) {
+          this.terminal = true;
+        }
+        await this.callbacks.onHealth({
+          subscriptionActive: false,
+          lastError: safeDetail(message),
+        });
+        socket.close(
+          this.terminal ? 4003 : 1012,
+          this.terminal ? 'Subscription rejected' : 'Subscription interrupted'
+        );
+        return;
+      }
+      case 'NOTICE':
+        await this.callbacks.onHealth({
+          lastError: safeDetail(typeof frame[1] === 'string' ? frame[1] : 'Buzz relay notice'),
+        });
+        return;
+      default:
+        return;
+    }
+  }
+
+  private async sendAuth(socket: WebSocket, challenge: string): Promise<void> {
+    const endpoints = normalizeBuzzEndpoints(this.config.probeConfig);
+    const { privateKey, authTag } = await this.communication.resolveCredentials(
+      this.config.probeConfig
+    );
+    const tags: string[][] = [
+      ['relay', endpoints.webSocketUrl],
+      ['challenge', challenge],
+    ];
+    if (authTag) tags.push(JSON.parse(authTag) as string[]);
+    const event = await this.eventSigner.sign({
+      privateKey,
+      kind: 22_242,
+      createdAt: Math.floor(this.now().getTime() / 1000),
+      tags,
+      content: '',
+    });
+    if (event.pubkey.toLowerCase() !== this.config.probeConfig.publicKey.toLowerCase()) {
+      throw new Error('Buzz WebSocket signing key does not match the configured identity');
+    }
+    this.authEventId = event.id;
+    socket.send(JSON.stringify(['AUTH', event]));
+  }
+
+  private async subscribe(socket: WebSocket): Promise<void> {
+    const nowSeconds = Math.floor(this.now().getTime() / 1000);
+    for (const mapping of this.config.mappings) {
+      const cursor = this.cursors.get(mapping.channelId.toLowerCase());
+      const since = cursor
+        ? Math.max(0, cursor.createdAt - REPLAY_OVERLAP_SECONDS)
+        : Math.max(0, nowSeconds - REPLAY_OVERLAP_SECONDS);
+      socket.send(
+        JSON.stringify([
+          'REQ',
+          this.subscriptionId(mapping.channelId),
+          {
+            kinds: [...BUZZ_SUBSCRIBED_KINDS],
+            '#h': [mapping.channelId],
+            since,
+          },
+        ])
+      );
+    }
+    await this.callbacks.onHealth({
+      subscriptionActive: false,
+      mappedChannels: this.config.mappings.length,
+    });
+  }
+
+  private mappingForSubscription(subscriptionId: string): BuzzChannelMapping | undefined {
+    return this.config.mappings.find(
+      (mapping) => this.subscriptionId(mapping.channelId) === subscriptionId
+    );
+  }
+
+  private subscriptionId(channelId: string): string {
+    return `vk-buzz-${channelId}`;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.terminal || this.reconnectTimer) return;
+    this.reconnectAttempts += 1;
+    const ceiling = Math.min(
+      MAX_RECONNECT_DELAY_MS,
+      1_000 * 2 ** Math.min(this.reconnectAttempts - 1, 5)
+    );
+    const delay = Math.max(250, Math.floor(this.random() * ceiling));
+    void this.callbacks.onHealth({ reconnectAttempts: this.reconnectAttempts });
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      void this.connect();
+    }, delay);
+    this.reconnectTimer.unref?.();
+  }
+
+  private startHeartbeat(socket: WebSocket): void {
+    this.stopHeartbeat();
+    this.awaitingPong = false;
+    this.heartbeatTimer = setInterval(() => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+      if (this.awaitingPong) {
+        socket.terminate();
+        return;
+      }
+      this.awaitingPong = true;
+      socket.ping();
+    }, HEARTBEAT_INTERVAL_MS);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+    this.awaitingPong = false;
+  }
+}
+
+export class DefaultBuzzSubscriptionWorkerFactory implements BuzzSubscriptionWorkerFactory {
+  create(
+    config: BuzzSubscriptionWorkerConfig,
+    callbacks: BuzzSubscriptionWorkerCallbacks
+  ): BuzzSubscriptionWorkerHandle {
+    return new BuzzSubscriptionWorker(config, callbacks);
+  }
+}

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -14,6 +14,7 @@ import type {
   ChatSession,
   ChatMessage,
   SquadMention,
+  SquadExternalMessage,
   SquadMessage,
   SquadMessageLink,
   SquadReaction,
@@ -52,6 +53,7 @@ interface SquadMessageMetadata {
   pinned?: boolean;
   decision?: boolean;
   reactions?: SquadReaction[];
+  external?: SquadExternalMessage;
   updatedAt?: string;
 }
 
@@ -567,8 +569,12 @@ export class ChatService {
     return mentions;
   }
 
-  private buildLinks(input: { taskId?: string; runId?: string }): SquadMessageLink[] | undefined {
-    const links: SquadMessageLink[] = [];
+  private buildLinks(input: {
+    taskId?: string;
+    runId?: string;
+    links?: SquadMessageLink[];
+  }): SquadMessageLink[] | undefined {
+    const links: SquadMessageLink[] = [...(input.links ?? []).slice(0, 20)];
     if (input.taskId) links.push({ taskId: input.taskId, label: `Task ${input.taskId}` });
     if (input.runId) links.push({ runId: input.runId, label: `Run ${input.runId}` });
     return links.length > 0 ? links : undefined;
@@ -663,6 +669,8 @@ export class ChatService {
    */
   async sendSquadMessage(
     input: {
+      id?: string;
+      timestamp?: string;
       agent: string;
       message: string;
       tags?: string[];
@@ -676,20 +684,35 @@ export class ChatService {
       mentions?: Array<string | SquadMention>;
       taskId?: string;
       runId?: string;
+      links?: SquadMessageLink[];
       pinned?: boolean;
       decision?: boolean;
+      external?: SquadExternalMessage;
     },
     displayName?: string
   ): Promise<SquadMessage> {
-    const messageId = this.generateMessageId();
-    const timestamp = new Date().toISOString();
+    const messageId = input.id ?? this.generateMessageId();
+    validatePathSegment(messageId);
+    if (input.id) {
+      const existing = await this.findSquadMessage(messageId);
+      if (existing) return existing;
+    }
+    const parsedTimestamp = input.timestamp ? Date.parse(input.timestamp) : Date.now();
+    if (!Number.isFinite(parsedTimestamp)) {
+      throw new Error('Squad message timestamp is invalid');
+    }
+    const timestamp = new Date(parsedTimestamp).toISOString();
     const parentMessage = input.replyToId ? await this.findSquadMessage(input.replyToId) : null;
     const mentions = this.normalizeMentions({
       message: input.message,
       mentions: input.mentions,
       fromAgent: input.agent,
     });
-    const links = this.buildLinks({ taskId: input.taskId, runId: input.runId });
+    const links = this.buildLinks({
+      taskId: input.taskId,
+      runId: input.runId,
+      links: input.links,
+    });
     const threadId = input.replyToId
       ? (parentMessage?.threadId ?? parentMessage?.id ?? input.replyToId)
       : undefined;
@@ -713,6 +736,7 @@ export class ChatService {
       ...(links && { links }),
       ...(input.pinned !== undefined && { pinned: input.pinned }),
       ...(input.decision !== undefined && { decision: input.decision }),
+      ...(input.external && { external: input.external }),
     };
 
     if (this.repository) {
@@ -721,7 +745,7 @@ export class ChatService {
       await this.ensureFileStorageReady();
 
       // Store as daily markdown file: squad/YYYY-MM-DD.md
-      const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+      const date = timestamp.split('T')[0]; // YYYY-MM-DD
       const filePath = path.join(this.squadDir, `${date}.md`);
       ensureWithinBase(this.squadDir, filePath);
 
@@ -759,6 +783,7 @@ export class ChatService {
       links: squadMessage.links,
       pinned: squadMessage.pinned,
       decision: squadMessage.decision,
+      external: squadMessage.external,
       updatedAt: this.hasSquadMessageMetadata({
         threadId: squadMessage.threadId,
         replyToId: squadMessage.replyToId,
@@ -766,6 +791,7 @@ export class ChatService {
         links: squadMessage.links,
         pinned: squadMessage.pinned,
         decision: squadMessage.decision,
+        external: squadMessage.external,
       })
         ? timestamp
         : undefined,

--- a/server/src/services/communication-adapter-service.ts
+++ b/server/src/services/communication-adapter-service.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { nanoid } from 'nanoid';
+import type { VerifiedEvent } from 'nostr-tools';
 import type {
   CommunicationAdapterHealth,
   CommunicationAdapterInput,
@@ -13,6 +14,10 @@ import type {
   CommunicationSendInput,
   CommunicationSendResult,
   CommunicationThreadMapping,
+  BuzzChannelMapping,
+  BuzzCursor,
+  BuzzExternalCoordinate,
+  BuzzRuntimeHealth,
   SquadMessage,
 } from '@veritas-kanban/shared';
 import {
@@ -40,6 +45,20 @@ import {
   type NormalizedBuzzEndpoints,
 } from './buzz-compatibility-service.js';
 import {
+  BuzzCommunicationService,
+  BUZZ_DELETE_COMPAT_KIND,
+  BUZZ_DELETE_KIND,
+  BUZZ_EDIT_KIND,
+  BUZZ_MESSAGE_KIND,
+  parseBuzzInboundEvent,
+} from './buzz-communication-service.js';
+import {
+  DefaultBuzzSubscriptionWorkerFactory,
+  type BuzzSubscriptionWorkerFactory,
+  type BuzzSubscriptionWorkerHandle,
+} from './buzz-subscription-worker.js';
+import { broadcastSquadMessage } from './broadcast-service.js';
+import {
   buzzAdapterConfigSchema,
   type BuzzAdapterConfig,
 } from '../schemas/communication-adapter-schemas.js';
@@ -47,6 +66,9 @@ import {
 const DEFAULT_ADAPTER_ID = 'msteams-default';
 const MAX_DELIVERIES = 500;
 const MAX_MESSAGE_LENGTH = 4000;
+const MAX_BUZZ_EVENTS = 2_000;
+const MAX_BUZZ_PENDING_EVENTS = 250;
+const MAX_BUZZ_OUTBOUND_RECORDS = 1_000;
 
 interface InternalCommunicationAdapterRecord extends CommunicationAdapterRecord {
   webhookUrlRaw?: string;
@@ -54,11 +76,49 @@ interface InternalCommunicationAdapterRecord extends CommunicationAdapterRecord 
 }
 
 interface CommunicationAdapterState {
-  version: 1;
+  version: 2;
   adapters: Record<string, InternalCommunicationAdapterRecord>;
   mappings: Record<string, CommunicationThreadMapping>;
+  buzzChannelMappings: Record<string, BuzzChannelMapping>;
+  buzzCursors: Record<string, BuzzCursor>;
+  buzzEvents: Record<string, BuzzEventRecord>;
+  buzzPendingEvents: Record<string, BuzzPendingEvent>;
+  buzzOutbound: Record<string, BuzzOutboundRecord>;
+  buzzRuntime: Record<string, BuzzRuntimeHealth>;
   replyIds: Record<string, string>;
   deliveries: CommunicationDeliveryAudit[];
+  updatedAt: string;
+}
+
+interface BuzzEventRecord {
+  key: string;
+  adapterId: string;
+  direction: 'inbound' | 'outbound';
+  coordinate: BuzzExternalCoordinate;
+  squadMessageId?: string;
+  deliveryId?: string;
+  recordedAt: string;
+}
+
+interface BuzzPendingEvent {
+  key: string;
+  adapterId: string;
+  mappingId: string;
+  event: VerifiedEvent;
+  recordedAt: string;
+}
+
+interface BuzzOutboundRecord {
+  eventId: string;
+  adapterId: string;
+  event: VerifiedEvent;
+  coordinate: BuzzExternalCoordinate;
+  target: CommunicationReplyTarget;
+  squadMessageId?: string;
+  deliveryId: string;
+  status: 'queued' | 'accepted' | 'delivery_unknown' | 'rejected';
+  attemptCount: number;
+  createdAt: string;
   updatedAt: string;
 }
 
@@ -68,6 +128,8 @@ export interface CommunicationAdapterServiceOptions {
   chatService?: ChatService;
   outboundIntegrations?: OutboundIntegrationService;
   buzzCompatibility?: BuzzCompatibilityService;
+  buzzCommunication?: BuzzCommunicationService;
+  buzzWorkerFactory?: BuzzSubscriptionWorkerFactory;
   audit?: (event: AuditEvent) => Promise<void>;
 }
 
@@ -171,6 +233,31 @@ function sanitizeUrl(url?: string): string | undefined {
   if (!url) return undefined;
   try {
     const parsed = new URL(url);
+    if (parsed.protocol === 'buzz:') {
+      const channel = parsed.searchParams.get('channel');
+      const eventId = parsed.searchParams.get('id');
+      const rootEventId = parsed.searchParams.get('thread');
+      if (
+        parsed.hostname !== 'message' ||
+        parsed.username ||
+        parsed.password ||
+        parsed.hash ||
+        !channel ||
+        !/^[0-9a-f-]{36}$/i.test(channel) ||
+        !eventId ||
+        !/^[a-f0-9]{64}$/i.test(eventId) ||
+        (rootEventId && !/^[a-f0-9]{64}$/i.test(rootEventId))
+      ) {
+        return '[invalid-url]';
+      }
+      const params = new URLSearchParams({
+        channel: channel.toLowerCase(),
+        id: eventId.toLowerCase(),
+      });
+      if (rootEventId) params.set('thread', rootEventId.toLowerCase());
+      return `buzz://message?${params.toString()}`;
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) return '[invalid-url]';
     parsed.username = '';
     parsed.password = '';
     parsed.search = '';
@@ -195,6 +282,82 @@ function normalizeTarget(target: CommunicationReplyTarget): CommunicationReplyTa
     approvalId: trimOrUndefined(target.approvalId),
     notificationId: trimOrUndefined(target.notificationId),
   };
+}
+
+function normalizeBuzzChannelId(value: string): string {
+  const channelId = value.trim().toLowerCase();
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(channelId)
+  ) {
+    throw new Error('Buzz channel ID must be a valid UUID');
+  }
+  return channelId;
+}
+
+function isUsableBuzzChannelMapping(
+  mapping: BuzzChannelMapping,
+  adapterId: string,
+  community: string
+): boolean {
+  try {
+    return (
+      mapping.adapterId === adapterId &&
+      mapping.community.toLowerCase() === community.toLowerCase() &&
+      mapping.target.kind === 'squad' &&
+      normalizeBuzzChannelId(mapping.channelId) === mapping.channelId.toLowerCase()
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isUsableBuzzCursor(cursor: BuzzCursor, mappings: BuzzChannelMapping[]): boolean {
+  return Boolean(
+    Number.isInteger(cursor.createdAt) &&
+    cursor.createdAt >= 0 &&
+    /^[a-f0-9]{64}$/i.test(cursor.eventId) &&
+    mappings.some(
+      (mapping) =>
+        mapping.adapterId === cursor.adapterId &&
+        mapping.community === cursor.community &&
+        mapping.channelId === cursor.channelId
+    )
+  );
+}
+
+function buzzEventKey(community: string, eventId: string): string {
+  return `${community.toLowerCase()}:${eventId.toLowerCase()}`;
+}
+
+function isVeritasBuzzOrigin(event: VerifiedEvent, adapterPublicKey?: string): boolean {
+  return (
+    Boolean(adapterPublicKey) &&
+    event.pubkey === adapterPublicKey &&
+    event.tags.some((tag) => tag[0] === 'client' && tag[1] === 'veritas-kanban') &&
+    event.tags.some((tag) => tag[0] === 'veritas-id' && Boolean(tag[1]))
+  );
+}
+
+function buzzCursorKey(adapterId: string, community: string, channelId: string): string {
+  return `${adapterId}:${community.toLowerCase()}:${channelId.toLowerCase()}`;
+}
+
+function mappingMatchesTarget(
+  mapping: BuzzChannelMapping,
+  target: CommunicationReplyTarget
+): boolean {
+  if (mapping.target.kind !== target.kind) return false;
+  const keys = ['squadMessageId', 'taskId', 'runId', 'approvalId', 'notificationId'] as const;
+  return keys.every((key) => !mapping.target[key] || mapping.target[key] === target[key]);
+}
+
+function mappingTargetsOverlap(
+  left: CommunicationReplyTarget,
+  right: CommunicationReplyTarget
+): boolean {
+  if (left.kind !== right.kind) return false;
+  const keys = ['squadMessageId', 'taskId', 'runId', 'approvalId', 'notificationId'] as const;
+  return keys.every((key) => !left[key] || !right[key] || left[key] === right[key]);
 }
 
 function targetKey(target: CommunicationReplyTarget): string {
@@ -231,7 +394,11 @@ export class CommunicationAdapterService {
   private readonly chatService: ChatService;
   private readonly outboundIntegrations: OutboundIntegrationService;
   private readonly buzzCompatibility: BuzzCompatibilityService;
+  private readonly buzzCommunication: BuzzCommunicationService;
+  private readonly buzzWorkerFactory: BuzzSubscriptionWorkerFactory;
   private readonly audit: (event: AuditEvent) => Promise<void>;
+  private readonly buzzWorkers = new Map<string, BuzzSubscriptionWorkerHandle>();
+  private readonly buzzWorkerGenerations = new Map<string, number>();
   private loaded = false;
   private state: CommunicationAdapterState = this.emptyState();
 
@@ -241,7 +408,22 @@ export class CommunicationAdapterService {
     this.chatService = options.chatService || getChatService();
     this.outboundIntegrations = options.outboundIntegrations || getOutboundIntegrationService();
     this.buzzCompatibility = options.buzzCompatibility || new BuzzCompatibilityService();
+    this.buzzCommunication = options.buzzCommunication || new BuzzCommunicationService();
+    this.buzzWorkerFactory =
+      options.buzzWorkerFactory || new DefaultBuzzSubscriptionWorkerFactory();
     this.audit = options.audit || auditLog;
+  }
+
+  async start(): Promise<void> {
+    await this.ensureLoaded();
+    for (const adapter of Object.values(this.state.adapters)) {
+      if (adapter.kind === 'buzz') await this.refreshBuzzWorker(adapter.id);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    const adapterIds = [...this.buzzWorkers.keys()];
+    await Promise.all(adapterIds.map((adapterId) => this.stopBuzzWorker(adapterId)));
   }
 
   async listAdapters(): Promise<CommunicationAdapterRecord[]> {
@@ -255,6 +437,120 @@ export class CommunicationAdapterService {
     await this.ensureLoaded();
     const adapter = this.state.adapters[adapterId];
     return adapter ? this.publicAdapter(adapter) : null;
+  }
+
+  async listBuzzChannelMappings(adapterId?: string): Promise<BuzzChannelMapping[]> {
+    await this.ensureLoaded();
+    return Object.values(this.state.buzzChannelMappings)
+      .filter((mapping) => !adapterId || mapping.adapterId === adapterId)
+      .sort((a, b) => a.channelId.localeCompare(b.channelId));
+  }
+
+  async configureBuzzChannelMapping(
+    adapterId: string,
+    channelIdInput: string,
+    input: { target: CommunicationReplyTarget; enabled?: boolean; actor?: string }
+  ): Promise<BuzzChannelMapping> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    if (adapter.kind !== 'buzz') throw new Error('Channel mapping requires a Buzz adapter');
+    const validated = validateStoredBuzzConfig(adapter);
+    if (!validated) throw new Error('Buzz adapter configuration is invalid');
+    const channelId = normalizeBuzzChannelId(channelIdInput);
+    const target = normalizeTarget(input.target);
+    if (target.kind !== 'squad') {
+      throw new Error('Buzz communication mappings currently support Squad Chat targets');
+    }
+    const existing = Object.values(this.state.buzzChannelMappings).find(
+      (mapping) =>
+        mapping.adapterId === adapterId &&
+        mapping.community === validated.endpoints.community &&
+        mapping.channelId === channelId
+    );
+    const conflicting = Object.values(this.state.buzzChannelMappings).find(
+      (mapping) =>
+        mapping.id !== existing?.id &&
+        mapping.adapterId === adapterId &&
+        mapping.community === validated.endpoints.community &&
+        mapping.enabled &&
+        mappingTargetsOverlap(mapping.target, target)
+    );
+    if (conflicting) {
+      throw new Error('The Buzz adapter target is already mapped to another channel');
+    }
+    const timestamp = nowIso();
+    for (const staleMapping of Object.values(this.state.buzzChannelMappings)) {
+      if (
+        staleMapping.adapterId === adapterId &&
+        staleMapping.community !== validated.endpoints.community &&
+        staleMapping.enabled &&
+        mappingTargetsOverlap(staleMapping.target, target)
+      ) {
+        staleMapping.enabled = false;
+        staleMapping.updatedAt = timestamp;
+      }
+    }
+    const mapping: BuzzChannelMapping = {
+      id: existing?.id ?? `buzz_map_${nanoid(10)}`,
+      adapterId,
+      community: validated.endpoints.community,
+      channelId,
+      target,
+      enabled: input.enabled ?? true,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+      createdBy: existing?.createdBy ?? trimOrUndefined(input.actor),
+    };
+    this.state.buzzChannelMappings[mapping.id] = mapping;
+    const delivery = this.recordDelivery({
+      adapterId,
+      operation: 'configure',
+      status: 'success',
+      target,
+      actor: input.actor,
+      buzz: {
+        community: mapping.community,
+        channelId: mapping.channelId,
+      },
+      detail: mapping.enabled ? 'Buzz channel mapping enabled.' : 'Buzz channel mapping disabled.',
+    });
+    await this.saveState();
+    await this.auditDelivery(delivery);
+    await this.refreshBuzzWorker(adapterId);
+    return mapping;
+  }
+
+  async disableBuzzChannelMapping(
+    adapterId: string,
+    channelIdInput: string,
+    actor?: string
+  ): Promise<BuzzChannelMapping> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const channelId = normalizeBuzzChannelId(channelIdInput);
+    const existing = Object.values(this.state.buzzChannelMappings).find(
+      (mapping) => mapping.adapterId === adapterId && mapping.channelId === channelId
+    );
+    if (!existing) throw new Error('Buzz channel mapping not found');
+    const mapping = { ...existing, enabled: false, updatedAt: nowIso() };
+    this.state.buzzChannelMappings[mapping.id] = mapping;
+    const delivery = this.recordDelivery({
+      adapterId,
+      operation: 'disconnect',
+      status: 'success',
+      target: mapping.target,
+      actor,
+      buzz: {
+        community: mapping.community,
+        channelId: mapping.channelId,
+      },
+      detail: 'Buzz channel mapping disabled; cursor and event history retained.',
+    });
+    await this.saveState();
+    await this.auditDelivery(delivery);
+    await this.refreshBuzzWorker(adapterId);
+    return mapping;
   }
 
   async configureAdapter(
@@ -272,7 +568,9 @@ export class CommunicationAdapterService {
     }
     if (kind === 'buzz') {
       const validated = buzzAdapterConfigSchema.parse({ ...input, kind: 'buzz' });
-      return this.configureBuzzAdapter(adapterId, validated, existing, timestamp);
+      const configured = await this.configureBuzzAdapter(adapterId, validated, existing, timestamp);
+      await this.refreshBuzzWorker(adapterId);
+      return configured;
     }
 
     const rawWebhook =
@@ -314,6 +612,7 @@ export class CommunicationAdapterService {
     validatePathSegment(adapterId);
     await this.ensureLoaded();
     const adapter = this.requireAdapter(adapterId);
+    if (adapter.kind === 'buzz') await this.stopBuzzWorker(adapterId);
     const timestamp = nowIso();
     const disconnected: InternalCommunicationAdapterRecord = {
       ...adapter,
@@ -380,31 +679,7 @@ export class CommunicationAdapterService {
     await this.ensureLoaded();
     const adapter = this.requireAdapter(adapterId);
     if (adapter.kind === 'buzz') {
-      const timestamp = nowIso();
-      const target = normalizeTarget(input.target);
-      const mapping: CommunicationThreadMapping = {
-        id: `map_${nanoid(10)}`,
-        adapterId,
-        externalThreadId:
-          trimOrUndefined(input.externalThreadId) ?? this.buildExternalThreadId(adapterId, target),
-        externalUrl: sanitizeUrl(input.externalUrl),
-        target,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-        createdBy: trimOrUndefined(input.actor),
-      };
-      const delivery = this.recordDelivery({
-        adapterId,
-        operation: 'send',
-        status: 'blocked',
-        target: mapping.target,
-        externalThreadId: mapping.externalThreadId,
-        actor: input.actor,
-        error: 'Buzz message delivery is not implemented by the connection diagnostic adapter.',
-      });
-      await this.saveState();
-      await this.auditDelivery(delivery);
-      return { delivery, mapping };
+      return this.sendBuzz(adapter, input);
     }
     const target = normalizeTarget(input.target);
     const externalThreadId =
@@ -467,7 +742,8 @@ export class CommunicationAdapterService {
         target: mapping.target,
         externalThreadId,
         actor: input.actor,
-        error: 'Buzz reply ingestion is not implemented by the connection diagnostic adapter.',
+        error:
+          'Manual Buzz reply ingestion is disabled; replies arrive through the authenticated relay subscription.',
       });
       await this.saveState();
       await this.auditDelivery(delivery);
@@ -591,14 +867,15 @@ export class CommunicationAdapterService {
     validatePathSegment(adapterId);
     await this.ensureLoaded();
     const adapter = this.requireAdapter(adapterId);
+    if (adapter.kind === 'buzz') {
+      const delivery = await this.reconcileBuzzDeliveries(adapter);
+      return { delivery, replies: [] };
+    }
     const delivery = this.recordDelivery({
       adapterId,
       operation: 'poll',
       status: 'skipped',
-      error:
-        adapter.kind === 'buzz'
-          ? 'Buzz reply polling is not implemented by the connection diagnostic adapter.'
-          : 'Reply polling is adapter-defined; this adapter uses the ingest API.',
+      error: 'Reply polling is adapter-defined; this adapter uses the ingest API.',
     });
     await this.saveState();
     await this.auditDelivery(delivery);
@@ -619,6 +896,609 @@ export class CommunicationAdapterService {
       .filter((delivery) => !adapterId || delivery.adapterId === adapterId)
       .slice(-safeLimit)
       .reverse();
+  }
+
+  async ingestBuzzEvent(
+    adapterId: string,
+    mappingInput: BuzzChannelMapping,
+    rawEvent: unknown
+  ): Promise<CommunicationDeliveryAudit> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    if (adapter.kind !== 'buzz' || !adapter.enabled) {
+      throw new Error('Buzz adapter is not enabled');
+    }
+    const mapping = this.state.buzzChannelMappings[mappingInput.id];
+    if (
+      !mapping ||
+      !mapping.enabled ||
+      mapping.adapterId !== adapterId ||
+      mapping.channelId !== mappingInput.channelId
+    ) {
+      throw new Error('Buzz channel mapping is not active');
+    }
+
+    let inbound;
+    try {
+      inbound = parseBuzzInboundEvent(rawEvent, {
+        community: mapping.community,
+        channelId: mapping.channelId,
+      });
+    } catch (error) {
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'event-ingest',
+        status: 'ignored',
+        target: mapping.target,
+        error: sanitizeError(error),
+        buzz: { community: mapping.community, channelId: mapping.channelId },
+        detail: 'Malformed or unsupported Buzz event ignored.',
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return delivery;
+    }
+
+    const coordinate = inbound.coordinate;
+    const eventId = inbound.event.id;
+    const key = buzzEventKey(mapping.community, eventId);
+    const outbound = this.state.buzzOutbound[eventId];
+    const adapterOrigin = isVeritasBuzzOrigin(inbound.event, adapter.publicKey);
+    const existing = this.state.buzzEvents[key];
+    if (existing && !outbound && !adapterOrigin) {
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'event-ingest',
+        status: 'replayed',
+        target: mapping.target,
+        squadMessageId: existing.squadMessageId,
+        actor: coordinate.authorPubkey,
+        buzz: coordinate,
+        detail: 'Buzz overlap replay deduplicated by community and event ID.',
+      });
+      await this.auditDelivery(delivery);
+      this.commitBuzzCursor(mapping, inbound.event);
+      await this.saveState();
+      await this.replayPendingBuzzReplies(adapterId, mapping, eventId);
+      return delivery;
+    }
+
+    delete this.state.buzzPendingEvents[key];
+    if (outbound || adapterOrigin) {
+      this.recordBuzzEvent({
+        key,
+        adapterId,
+        direction: 'outbound',
+        coordinate,
+        squadMessageId: outbound?.squadMessageId,
+        deliveryId: outbound?.deliveryId,
+        recordedAt: nowIso(),
+      });
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'event-ingest',
+        status: 'ignored',
+        target: outbound?.target ?? mapping.target,
+        squadMessageId: outbound?.squadMessageId,
+        actor: coordinate.authorPubkey,
+        buzz: coordinate,
+        detail: 'Adapter-originated Buzz event suppressed to prevent a reply loop.',
+      });
+      await this.auditDelivery(delivery);
+      this.commitBuzzCursor(mapping, inbound.event);
+      await this.saveState();
+      return delivery;
+    }
+
+    if (
+      inbound.event.kind === BUZZ_EDIT_KIND ||
+      inbound.event.kind === BUZZ_DELETE_KIND ||
+      inbound.event.kind === BUZZ_DELETE_COMPAT_KIND
+    ) {
+      this.recordBuzzEvent({
+        key,
+        adapterId,
+        direction: 'inbound',
+        coordinate,
+        recordedAt: nowIso(),
+      });
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'event-ingest',
+        status: 'ignored',
+        target: mapping.target,
+        actor: coordinate.authorPubkey,
+        buzz: coordinate,
+        detail:
+          inbound.event.kind === BUZZ_EDIT_KIND
+            ? `Buzz edit for ${inbound.targetEventId ?? 'unknown target'} retained as audit metadata; Squad Chat has no edit projection contract.`
+            : `Buzz deletion for ${inbound.targetEventId ?? 'unknown target'} retained as audit metadata; local content was not removed.`,
+      });
+      await this.auditDelivery(delivery);
+      this.commitBuzzCursor(mapping, inbound.event);
+      await this.saveState();
+      return delivery;
+    }
+
+    if (inbound.event.kind !== BUZZ_MESSAGE_KIND) {
+      throw new Error('Buzz event kind is not supported by the message projection');
+    }
+    const replyReference = coordinate.rootEventId
+      ? this.state.buzzEvents[buzzEventKey(mapping.community, coordinate.rootEventId)]
+      : undefined;
+    const replyToId = coordinate.rootEventId
+      ? replyReference?.squadMessageId
+      : mapping.target.squadMessageId;
+    if (coordinate.rootEventId && !replyToId) {
+      this.state.buzzPendingEvents[key] = {
+        key,
+        adapterId,
+        mappingId: mapping.id,
+        event: inbound.event,
+        recordedAt: nowIso(),
+      };
+      this.trimBuzzPendingEvents();
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'event-ingest',
+        status: 'queued',
+        target: mapping.target,
+        actor: coordinate.authorPubkey,
+        buzz: coordinate,
+        detail: 'Buzz reply queued until its mapped root event is available.',
+      });
+      await this.auditDelivery(delivery);
+      await this.saveState();
+      return delivery;
+    }
+
+    const cleanedMessage = cleanInboundMessage(inbound.content);
+    if (!cleanedMessage) {
+      const delivery = this.recordDelivery({
+        adapterId,
+        operation: 'event-ingest',
+        status: 'ignored',
+        target: mapping.target,
+        actor: coordinate.authorPubkey,
+        buzz: coordinate,
+        detail: 'Buzz message was empty after sanitization.',
+      });
+      await this.auditDelivery(delivery);
+      this.commitBuzzCursor(mapping, inbound.event);
+      await this.saveState();
+      return delivery;
+    }
+
+    const squadMessage = await this.chatService.sendSquadMessage(
+      {
+        id: `msg_buzz_${eventId}`,
+        timestamp: new Date(inbound.event.created_at * 1000).toISOString(),
+        agent: 'BUZZ',
+        message: cleanedMessage,
+        replyToId,
+        taskId: mapping.target.taskId,
+        runId: mapping.target.runId,
+        links: coordinate.externalUrl
+          ? [{ href: coordinate.externalUrl, label: 'Open in Buzz' }]
+          : undefined,
+        decision: mapping.target.kind === 'approval' ? true : undefined,
+        tags: ['external-reply', 'adapter:buzz', `buzz-channel:${mapping.channelId}`],
+        external: {
+          provider: 'buzz',
+          adapterId,
+          community: mapping.community,
+          channelId: mapping.channelId,
+          messageId: eventId,
+          authorId: coordinate.authorPubkey,
+          kind: coordinate.kind,
+          url: coordinate.externalUrl,
+        },
+      },
+      `Buzz ${coordinate.authorPubkey?.slice(0, 12) ?? 'member'}`
+    );
+
+    this.recordBuzzEvent({
+      key,
+      adapterId,
+      direction: 'inbound',
+      coordinate,
+      squadMessageId: squadMessage.id,
+      recordedAt: nowIso(),
+    });
+    const externalThreadId = coordinate.rootEventId ?? eventId;
+    this.upsertMapping({
+      adapterId,
+      externalThreadId,
+      externalUrl: coordinate.externalUrl,
+      target: {
+        ...mapping.target,
+        squadMessageId: coordinate.rootEventId ? replyToId : squadMessage.id,
+      },
+      createdBy: coordinate.authorPubkey,
+      buzz: coordinate,
+    });
+    this.state.replyIds[`${adapterId}:${externalThreadId}:${eventId}`] = squadMessage.id;
+    const delivery = this.recordDelivery({
+      adapterId,
+      operation: 'event-ingest',
+      status: 'success',
+      target: mapping.target,
+      externalThreadId,
+      squadMessageId: squadMessage.id,
+      actor: coordinate.authorPubkey,
+      buzz: coordinate,
+      detail: coordinate.rootEventId
+        ? 'Buzz reply projected into its Squad Chat thread.'
+        : 'Buzz root message projected into Squad Chat.',
+    });
+    await this.auditDelivery(delivery);
+    this.commitBuzzCursor(mapping, inbound.event);
+    await this.saveState();
+    broadcastSquadMessage(squadMessage);
+    await this.replayPendingBuzzReplies(adapterId, mapping, eventId);
+    return delivery;
+  }
+
+  private async sendBuzz(
+    adapter: InternalCommunicationAdapterRecord,
+    input: CommunicationSendInput
+  ): Promise<CommunicationSendResult> {
+    const target = normalizeTarget(input.target);
+    const validated = validateStoredBuzzConfig(adapter);
+    const channelMapping = Object.values(this.state.buzzChannelMappings).find(
+      (mapping) =>
+        mapping.adapterId === adapter.id && mapping.enabled && mappingMatchesTarget(mapping, target)
+    );
+    const placeholderThreadId =
+      trimOrUndefined(input.externalThreadId) ??
+      channelMapping?.channelId ??
+      this.buildExternalThreadId(adapter.id, target);
+    let mapping = this.upsertMapping({
+      adapterId: adapter.id,
+      externalThreadId: placeholderThreadId,
+      externalUrl: trimOrUndefined(input.externalUrl),
+      target,
+      createdBy: trimOrUndefined(input.actor),
+    });
+    const compatibilityReady = Boolean(
+      validated &&
+      isCurrentBuzzCompatibility(adapter, validated) &&
+      adapter.compatibility?.status === 'healthy'
+    );
+    if (!adapter.enabled || !validated || !compatibilityReady || !channelMapping) {
+      const error = !adapter.enabled
+        ? 'Buzz adapter disabled'
+        : !validated
+          ? 'Buzz adapter configuration invalid'
+          : !compatibilityReady
+            ? 'Buzz compatibility evidence is missing, stale, or unhealthy'
+            : 'Buzz channel mapping missing for the requested target';
+      const delivery = this.recordDelivery({
+        adapterId: adapter.id,
+        operation: 'send',
+        status: 'blocked',
+        target,
+        externalThreadId: mapping.externalThreadId,
+        actor: input.actor,
+        error,
+        buzz: channelMapping
+          ? {
+              community: channelMapping.community,
+              channelId: channelMapping.channelId,
+            }
+          : undefined,
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping };
+    }
+
+    const replyToSquadMessageId = trimOrUndefined(input.replyToSquadMessageId);
+    const parentRecord = replyToSquadMessageId
+      ? Object.values(this.state.buzzEvents).find(
+          (record) =>
+            record.adapterId === adapter.id && record.squadMessageId === replyToSquadMessageId
+        )
+      : undefined;
+    if (replyToSquadMessageId && !parentRecord?.coordinate.eventId) {
+      const delivery = this.recordDelivery({
+        adapterId: adapter.id,
+        operation: 'send',
+        status: 'blocked',
+        target,
+        externalThreadId: mapping.externalThreadId,
+        actor: input.actor,
+        error: 'Buzz reply root mapping is missing',
+        buzz: {
+          community: channelMapping.community,
+          channelId: channelMapping.channelId,
+        },
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping };
+    }
+
+    const message = stripUnsafeControlCharacters(input.message).trim().slice(0, MAX_MESSAGE_LENGTH);
+    if (!message) {
+      const delivery = this.recordDelivery({
+        adapterId: adapter.id,
+        operation: 'send',
+        status: 'blocked',
+        target,
+        externalThreadId: mapping.externalThreadId,
+        actor: input.actor,
+        error: 'Buzz message is empty after sanitization',
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping };
+    }
+    const unresolvedOutboundCount = Object.values(this.state.buzzOutbound).filter(
+      (record) =>
+        record.adapterId === adapter.id &&
+        (record.status === 'queued' || record.status === 'delivery_unknown')
+    ).length;
+    if (unresolvedOutboundCount >= MAX_BUZZ_OUTBOUND_RECORDS) {
+      const delivery = this.recordDelivery({
+        adapterId: adapter.id,
+        operation: 'send',
+        status: 'blocked',
+        target,
+        externalThreadId: mapping.externalThreadId,
+        actor: input.actor,
+        error: 'Buzz unresolved delivery queue is full; reconcile before sending more messages.',
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping };
+    }
+    const delivery = this.recordDelivery({
+      adapterId: adapter.id,
+      operation: 'send',
+      status: 'queued',
+      target,
+      externalThreadId: mapping.externalThreadId,
+      actor: input.actor,
+      buzz: {
+        community: channelMapping.community,
+        channelId: channelMapping.channelId,
+      },
+      detail: 'Signed Buzz event persisted before relay submission.',
+    });
+    try {
+      const parentEventId = parentRecord?.coordinate.eventId;
+      const rootEventId = parentRecord
+        ? (parentRecord.coordinate.rootEventId ?? parentEventId)
+        : undefined;
+      const prepared = await this.buzzCommunication.prepareMessage(validated.probeConfig, {
+        channelId: channelMapping.channelId,
+        content: message,
+        idempotencyKey: delivery.id,
+        rootEventId,
+        parentEventId,
+      });
+      delivery.buzz = prepared.coordinate;
+      delivery.externalThreadId = rootEventId ?? prepared.event.id;
+      mapping = this.upsertMapping({
+        adapterId: adapter.id,
+        externalThreadId: delivery.externalThreadId,
+        externalUrl: prepared.coordinate.externalUrl,
+        target,
+        createdBy: trimOrUndefined(input.actor),
+        buzz: prepared.coordinate,
+      });
+      const timestamp = nowIso();
+      const outbound: BuzzOutboundRecord = {
+        eventId: prepared.event.id,
+        adapterId: adapter.id,
+        event: prepared.event,
+        coordinate: prepared.coordinate,
+        target,
+        squadMessageId: target.squadMessageId,
+        deliveryId: delivery.id,
+        status: 'queued',
+        attemptCount: 0,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      this.state.buzzOutbound[prepared.event.id] = outbound;
+      this.recordBuzzEvent({
+        key: buzzEventKey(channelMapping.community, prepared.event.id),
+        adapterId: adapter.id,
+        direction: 'outbound',
+        coordinate: prepared.coordinate,
+        squadMessageId: target.squadMessageId,
+        deliveryId: delivery.id,
+        recordedAt: timestamp,
+      });
+      await this.saveState();
+
+      outbound.attemptCount += 1;
+      const result = await this.buzzCommunication.submitEvent(
+        validated.probeConfig,
+        prepared.event
+      );
+      outbound.updatedAt = nowIso();
+      if (result.status === 'accepted') {
+        outbound.status = 'accepted';
+        delivery.status = 'success';
+        delivery.detail = 'Buzz relay accepted the signed event.';
+        delivery.error = undefined;
+      } else if (result.status === 'delivery_unknown') {
+        outbound.status = 'delivery_unknown';
+        delivery.status = 'delivery_unknown';
+        delivery.detail = 'Buzz delivery is ambiguous and will be reconciled by event ID.';
+        delivery.error = result.detail;
+      } else {
+        outbound.status = 'rejected';
+        delivery.status = 'failed';
+        delivery.error = result.detail ?? 'Buzz relay rejected the signed event.';
+      }
+      this.updateLastBuzzSend(adapter.id, delivery);
+      this.trimBuzzOutboundRecords();
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping };
+    } catch (error) {
+      delivery.status = 'failed';
+      delivery.error = sanitizeError(error);
+      delivery.detail = 'Buzz event preparation failed before relay submission.';
+      this.updateLastBuzzSend(adapter.id, delivery);
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return { delivery, mapping };
+    }
+  }
+
+  private async reconcileBuzzDeliveries(
+    adapter: InternalCommunicationAdapterRecord
+  ): Promise<CommunicationDeliveryAudit> {
+    const validated = validateStoredBuzzConfig(adapter);
+    if (
+      !validated ||
+      !isCurrentBuzzCompatibility(adapter, validated) ||
+      adapter.compatibility?.status !== 'healthy'
+    ) {
+      const delivery = this.recordDelivery({
+        adapterId: adapter.id,
+        operation: 'reconcile',
+        status: 'blocked',
+        error: 'Healthy, current Buzz compatibility evidence is required for reconciliation.',
+      });
+      await this.saveState();
+      await this.auditDelivery(delivery);
+      return delivery;
+    }
+    const candidates = Object.values(this.state.buzzOutbound)
+      .filter(
+        (record) =>
+          record.adapterId === adapter.id &&
+          (record.status === 'queued' || record.status === 'delivery_unknown')
+      )
+      .slice(0, 25);
+    let accepted = 0;
+    let ambiguous = 0;
+    let rejected = 0;
+    for (const record of candidates) {
+      const eventMapping = Object.values(this.state.buzzChannelMappings).find(
+        (mapping) =>
+          mapping.adapterId === adapter.id &&
+          mapping.community === record.coordinate.community &&
+          mapping.channelId === record.coordinate.channelId &&
+          isUsableBuzzChannelMapping(mapping, adapter.id, validated.endpoints.community)
+      );
+      let persistedEventIsValid = false;
+      if (eventMapping) {
+        try {
+          const parsed = parseBuzzInboundEvent(record.event, {
+            community: eventMapping.community,
+            channelId: eventMapping.channelId,
+          });
+          persistedEventIsValid =
+            parsed.event.id === record.eventId &&
+            parsed.event.pubkey.toLowerCase() === validated.probeConfig.publicKey.toLowerCase();
+        } catch {
+          persistedEventIsValid = false;
+        }
+      }
+      if (!persistedEventIsValid) {
+        record.status = 'rejected';
+        record.updatedAt = nowIso();
+        const linkedDelivery = this.state.deliveries.find(
+          (delivery) => delivery.id === record.deliveryId
+        );
+        if (linkedDelivery) {
+          linkedDelivery.status = 'failed';
+          linkedDelivery.error = 'Persisted Buzz event failed validation and was not retried.';
+        }
+        rejected += 1;
+        continue;
+      }
+      const exists = await this.buzzCommunication.eventExists(
+        validated.probeConfig,
+        record.eventId
+      );
+      const linkedDelivery = this.state.deliveries.find(
+        (delivery) => delivery.id === record.deliveryId
+      );
+      if (exists === true) {
+        record.status = 'accepted';
+        record.updatedAt = nowIso();
+        if (linkedDelivery) {
+          linkedDelivery.status = 'success';
+          linkedDelivery.error = undefined;
+          linkedDelivery.detail = 'Ambiguous Buzz delivery reconciled by event ID.';
+        }
+        accepted += 1;
+        continue;
+      }
+      if (exists === false) {
+        if (!eventMapping?.enabled) {
+          const linkedDelivery = this.state.deliveries.find(
+            (delivery) => delivery.id === record.deliveryId
+          );
+          if (linkedDelivery) {
+            linkedDelivery.detail =
+              'Buzz event was absent, but its channel mapping is disabled; it was not resubmitted.';
+          }
+          ambiguous += 1;
+          continue;
+        }
+        record.attemptCount += 1;
+        const result = await this.buzzCommunication.submitEvent(
+          validated.probeConfig,
+          record.event
+        );
+        record.updatedAt = nowIso();
+        record.status =
+          result.status === 'accepted'
+            ? 'accepted'
+            : result.status === 'rejected'
+              ? 'rejected'
+              : 'delivery_unknown';
+        if (linkedDelivery) {
+          linkedDelivery.status =
+            result.status === 'accepted'
+              ? 'success'
+              : result.status === 'rejected'
+                ? 'failed'
+                : 'delivery_unknown';
+          linkedDelivery.error = result.detail;
+          linkedDelivery.detail =
+            result.status === 'accepted'
+              ? 'Buzz event safely resubmitted after an event-ID absence check.'
+              : 'Buzz delivery remains unresolved after reconciliation.';
+        }
+        if (result.status === 'accepted') accepted += 1;
+        else if (result.status === 'rejected') rejected += 1;
+        else ambiguous += 1;
+        continue;
+      }
+      ambiguous += 1;
+    }
+    const delivery = this.recordDelivery({
+      adapterId: adapter.id,
+      operation: 'reconcile',
+      status:
+        rejected > 0
+          ? 'failed'
+          : ambiguous > 0
+            ? 'delivery_unknown'
+            : candidates.length > 0
+              ? 'success'
+              : 'skipped',
+      detail:
+        candidates.length === 0
+          ? 'No ambiguous Buzz deliveries required reconciliation.'
+          : `Buzz reconciliation accepted ${accepted}, rejected ${rejected}, and left ${ambiguous} delivery or deliveries unresolved.`,
+    });
+    this.updateLastBuzzSend(adapter.id, delivery);
+    this.trimBuzzOutboundRecords();
+    await this.saveState();
+    await this.auditDelivery(delivery);
+    return delivery;
   }
 
   private async deliverOutbound(
@@ -693,6 +1573,7 @@ export class CommunicationAdapterService {
     externalUrl?: string;
     target: CommunicationReplyTarget;
     createdBy?: string;
+    buzz?: BuzzExternalCoordinate;
   }): CommunicationThreadMapping {
     const existing = this.findMapping(input.adapterId, input.externalThreadId);
     const timestamp = nowIso();
@@ -705,6 +1586,7 @@ export class CommunicationAdapterService {
       createdAt: existing?.createdAt ?? timestamp,
       updatedAt: timestamp,
       createdBy: existing?.createdBy ?? input.createdBy,
+      buzz: input.buzz ?? existing?.buzz,
     };
     this.state.mappings[mapping.id] = mapping;
     return mapping;
@@ -719,6 +1601,8 @@ export class CommunicationAdapterService {
     squadMessageId?: string;
     actor?: string;
     error?: string;
+    detail?: string;
+    buzz?: BuzzExternalCoordinate;
   }): CommunicationDeliveryAudit {
     const delivery: CommunicationDeliveryAudit = {
       id: `comm_${nanoid(10)}`,
@@ -730,6 +1614,8 @@ export class CommunicationAdapterService {
       squadMessageId: input.squadMessageId,
       actor: input.actor,
       error: input.error ? sanitizeError(input.error) : undefined,
+      detail: input.detail ? sanitizeError(input.detail) : undefined,
+      buzz: input.buzz,
       createdAt: nowIso(),
     };
     this.state.deliveries.push(delivery);
@@ -737,6 +1623,222 @@ export class CommunicationAdapterService {
       this.state.deliveries = this.state.deliveries.slice(-MAX_DELIVERIES);
     }
     return delivery;
+  }
+
+  private recordBuzzEvent(record: BuzzEventRecord): void {
+    this.state.buzzEvents[record.key] = record;
+    const records = Object.values(this.state.buzzEvents);
+    if (records.length <= MAX_BUZZ_EVENTS) return;
+    records
+      .sort((a, b) => a.recordedAt.localeCompare(b.recordedAt))
+      .slice(0, records.length - MAX_BUZZ_EVENTS)
+      .forEach((candidate) => delete this.state.buzzEvents[candidate.key]);
+  }
+
+  private trimBuzzPendingEvents(): void {
+    const records = Object.values(this.state.buzzPendingEvents);
+    if (records.length <= MAX_BUZZ_PENDING_EVENTS) return;
+    records
+      .sort((a, b) => a.recordedAt.localeCompare(b.recordedAt))
+      .slice(0, records.length - MAX_BUZZ_PENDING_EVENTS)
+      .forEach((candidate) => delete this.state.buzzPendingEvents[candidate.key]);
+  }
+
+  private trimBuzzOutboundRecords(): void {
+    const records = Object.values(this.state.buzzOutbound);
+    if (records.length <= MAX_BUZZ_OUTBOUND_RECORDS) return;
+    const removable = records
+      .filter((record) => record.status === 'accepted' || record.status === 'rejected')
+      .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+    for (const record of removable) {
+      if (Object.keys(this.state.buzzOutbound).length <= MAX_BUZZ_OUTBOUND_RECORDS) break;
+      delete this.state.buzzOutbound[record.eventId];
+    }
+  }
+
+  private commitBuzzCursor(mapping: BuzzChannelMapping, event: VerifiedEvent): void {
+    const key = buzzCursorKey(mapping.adapterId, mapping.community, mapping.channelId);
+    const existing = this.state.buzzCursors[key];
+    const shouldAdvance =
+      !existing ||
+      event.created_at > existing.createdAt ||
+      (event.created_at === existing.createdAt && event.id.localeCompare(existing.eventId) > 0);
+    if (!shouldAdvance) return;
+    this.state.buzzCursors[key] = {
+      adapterId: mapping.adapterId,
+      community: mapping.community,
+      channelId: mapping.channelId,
+      createdAt: event.created_at,
+      eventId: event.id,
+      committedAt: nowIso(),
+    };
+  }
+
+  private async replayPendingBuzzReplies(
+    adapterId: string,
+    mapping: BuzzChannelMapping,
+    resolvedEventId: string
+  ): Promise<void> {
+    const pending = Object.values(this.state.buzzPendingEvents)
+      .filter(
+        (record) =>
+          record.adapterId === adapterId &&
+          record.mappingId === mapping.id &&
+          record.event.tags.some(
+            (tag) =>
+              tag[0] === 'e' &&
+              tag[1] === resolvedEventId &&
+              (tag[3] === 'root' || tag[3] === 'reply')
+          )
+      )
+      .sort(
+        (a, b) => a.event.created_at - b.event.created_at || a.event.id.localeCompare(b.event.id)
+      );
+    for (const record of pending) {
+      await this.ingestBuzzEvent(adapterId, mapping, record.event);
+    }
+  }
+
+  private updateLastBuzzSend(adapterId: string, delivery: CommunicationDeliveryAudit): void {
+    const current = this.state.buzzRuntime[adapterId] ?? {
+      relayConnected: false,
+      subscriptionActive: false,
+      mappedChannels: 0,
+      reconnectAttempts: 0,
+    };
+    this.state.buzzRuntime[adapterId] = {
+      ...current,
+      lastSendAt: delivery.createdAt,
+      lastSendStatus: delivery.status,
+    };
+  }
+
+  private async refreshBuzzWorker(adapterId: string): Promise<void> {
+    await this.stopBuzzWorker(adapterId);
+    const adapter = this.state.adapters[adapterId];
+    if (!adapter || adapter.kind !== 'buzz') return;
+    const validated = validateStoredBuzzConfig(adapter);
+    const mappings = Object.values(this.state.buzzChannelMappings).filter(
+      (mapping) =>
+        mapping.enabled &&
+        validated &&
+        isUsableBuzzChannelMapping(mapping, adapterId, validated.endpoints.community)
+    );
+    const generation = (this.buzzWorkerGenerations.get(adapterId) ?? 0) + 1;
+    this.buzzWorkerGenerations.set(adapterId, generation);
+    const baseRuntime: BuzzRuntimeHealth = {
+      relayConnected: false,
+      subscriptionActive: false,
+      mappedChannels: mappings.length,
+      reconnectAttempts: 0,
+    };
+    this.state.buzzRuntime[adapterId] = {
+      ...baseRuntime,
+      lastSendAt: this.state.buzzRuntime[adapterId]?.lastSendAt,
+      lastSendStatus: this.state.buzzRuntime[adapterId]?.lastSendStatus,
+    };
+    if (
+      !validated ||
+      !adapter.enabled ||
+      mappings.length === 0 ||
+      !isCurrentBuzzCompatibility(adapter, validated) ||
+      adapter.compatibility?.status !== 'healthy'
+    ) {
+      this.applyBuzzRuntimeHealth(adapterId);
+      await this.saveState();
+      return;
+    }
+    const worker = this.buzzWorkerFactory.create(
+      {
+        adapterId,
+        probeConfig: validated.probeConfig,
+        mappings,
+        cursors: Object.values(this.state.buzzCursors).filter(
+          (cursor) => cursor.adapterId === adapterId && isUsableBuzzCursor(cursor, mappings)
+        ),
+      },
+      {
+        onEvent: async (mapping, event) => {
+          if (this.buzzWorkerGenerations.get(adapterId) !== generation) return;
+          await this.ingestBuzzEvent(adapterId, mapping, event);
+          return this.state.buzzCursors[
+            buzzCursorKey(mapping.adapterId, mapping.community, mapping.channelId)
+          ];
+        },
+        onHealth: async (patch) => {
+          if (this.buzzWorkerGenerations.get(adapterId) !== generation) return;
+          this.state.buzzRuntime[adapterId] = {
+            ...(this.state.buzzRuntime[adapterId] ?? baseRuntime),
+            ...patch,
+            mappedChannels: mappings.length,
+          };
+          this.applyBuzzRuntimeHealth(adapterId);
+          await this.saveState();
+        },
+      }
+    );
+    this.buzzWorkers.set(adapterId, worker);
+    this.applyBuzzRuntimeHealth(adapterId);
+    await this.saveState();
+    worker.start();
+  }
+
+  private async stopBuzzWorker(adapterId: string): Promise<void> {
+    this.buzzWorkerGenerations.set(adapterId, (this.buzzWorkerGenerations.get(adapterId) ?? 0) + 1);
+    const worker = this.buzzWorkers.get(adapterId);
+    this.buzzWorkers.delete(adapterId);
+    if (worker) await worker.stop();
+  }
+
+  private applyBuzzRuntimeHealth(adapterId: string): void {
+    const adapter = this.state.adapters[adapterId];
+    if (!adapter || adapter.kind !== 'buzz') return;
+    const runtime = this.state.buzzRuntime[adapterId];
+    if (!runtime) return;
+    const compatibility = adapter.compatibility;
+    const compatibilityHealthy = compatibility?.status === 'healthy';
+    const cursor = Object.values(this.state.buzzCursors)
+      .filter((candidate) => candidate.adapterId === adapterId)
+      .sort((a, b) => b.createdAt - a.createdAt || b.eventId.localeCompare(a.eventId))[0];
+    runtime.cursorLagSeconds = cursor
+      ? Math.max(0, Math.floor(Date.now() / 1000) - cursor.createdAt)
+      : undefined;
+    const status = !adapter.enabled
+      ? 'disabled'
+      : !compatibilityHealthy
+        ? (compatibility?.status ?? 'degraded')
+        : runtime.lastError || !runtime.subscriptionActive
+          ? 'degraded'
+          : 'healthy';
+    adapter.lastHealth = {
+      adapterId,
+      status,
+      configured: true,
+      canSend: Boolean(adapter.enabled && compatibilityHealthy && runtime.mappedChannels > 0),
+      canReceiveReplies: Boolean(
+        adapter.enabled && compatibilityHealthy && runtime.subscriptionActive
+      ),
+      checkedAt: nowIso(),
+      detail: !adapter.enabled
+        ? 'Buzz adapter is disabled; mappings and cursor state are retained.'
+        : !compatibilityHealthy
+          ? (compatibility?.detail ?? 'Buzz compatibility evidence is unavailable.')
+          : runtime.subscriptionActive
+            ? `Buzz relay subscription is active for ${runtime.mappedChannels} mapped channel or channels.`
+            : runtime.mappedChannels === 0
+              ? 'Configure a Buzz channel mapping to enable send and receive.'
+              : runtime.lastError
+                ? `Buzz worker is degraded: ${runtime.lastError}`
+                : 'Buzz worker is connecting and authenticating.',
+      reasonCode: compatibility?.reasonCode,
+      remediation:
+        runtime.lastError && compatibilityHealthy
+          ? 'Review relay authorization, channel membership, and WebSocket reachability, then resave or recheck the adapter.'
+          : compatibility?.remediation,
+      buzz: compatibility,
+      buzzRuntime: { ...runtime },
+    };
+    adapter.updatedAt = adapter.lastHealth.checkedAt;
   }
 
   private hasDestination(adapter: InternalCommunicationAdapterRecord): boolean {
@@ -830,7 +1932,7 @@ export class CommunicationAdapterService {
       const raw = await readFile(this.statePath, 'utf-8');
       const parsed = JSON.parse(raw) as Partial<CommunicationAdapterState>;
       this.state = {
-        version: 1,
+        version: 2,
         adapters:
           parsed.adapters && typeof parsed.adapters === 'object'
             ? (parsed.adapters as Record<string, InternalCommunicationAdapterRecord>)
@@ -838,6 +1940,30 @@ export class CommunicationAdapterService {
         mappings:
           parsed.mappings && typeof parsed.mappings === 'object'
             ? (parsed.mappings as Record<string, CommunicationThreadMapping>)
+            : {},
+        buzzChannelMappings:
+          parsed.buzzChannelMappings && typeof parsed.buzzChannelMappings === 'object'
+            ? (parsed.buzzChannelMappings as Record<string, BuzzChannelMapping>)
+            : {},
+        buzzCursors:
+          parsed.buzzCursors && typeof parsed.buzzCursors === 'object'
+            ? (parsed.buzzCursors as Record<string, BuzzCursor>)
+            : {},
+        buzzEvents:
+          parsed.buzzEvents && typeof parsed.buzzEvents === 'object'
+            ? (parsed.buzzEvents as Record<string, BuzzEventRecord>)
+            : {},
+        buzzPendingEvents:
+          parsed.buzzPendingEvents && typeof parsed.buzzPendingEvents === 'object'
+            ? (parsed.buzzPendingEvents as Record<string, BuzzPendingEvent>)
+            : {},
+        buzzOutbound:
+          parsed.buzzOutbound && typeof parsed.buzzOutbound === 'object'
+            ? (parsed.buzzOutbound as Record<string, BuzzOutboundRecord>)
+            : {},
+        buzzRuntime:
+          parsed.buzzRuntime && typeof parsed.buzzRuntime === 'object'
+            ? (parsed.buzzRuntime as Record<string, BuzzRuntimeHealth>)
             : {},
         replyIds:
           parsed.replyIds && typeof parsed.replyIds === 'object'
@@ -872,9 +1998,15 @@ export class CommunicationAdapterService {
 
   private emptyState(): CommunicationAdapterState {
     return {
-      version: 1,
+      version: 2,
       adapters: {},
       mappings: {},
+      buzzChannelMappings: {},
+      buzzCursors: {},
+      buzzEvents: {},
+      buzzPendingEvents: {},
+      buzzOutbound: {},
+      buzzRuntime: {},
       replyIds: {},
       deliveries: [],
       updatedAt: nowIso(),
@@ -913,6 +2045,8 @@ export class CommunicationAdapterService {
         externalThreadId: delivery.externalThreadId,
         squadMessageId: delivery.squadMessageId,
         error: delivery.error,
+        detail: delivery.detail,
+        buzz: delivery.buzz,
       },
     });
   }
@@ -1106,7 +2240,8 @@ export class CommunicationAdapterService {
       error: compatibility.status === 'healthy' ? undefined : compatibility.detail,
     });
     await this.saveState();
-    return health;
+    await this.refreshBuzzWorker(adapter.id);
+    return adapter.lastHealth ?? health;
   }
 }
 

--- a/server/src/utils/url-validation.ts
+++ b/server/src/utils/url-validation.ts
@@ -207,9 +207,15 @@ export interface UrlValidationResult {
   normalized?: string;
 }
 
-interface ResolvedOutboundAddress {
+export interface ResolvedOutboundAddress {
   address: string;
   family: 4 | 6;
+}
+
+export interface ResolvedOutboundUrl {
+  url: string;
+  hostname: string;
+  resolvedAddress: ResolvedOutboundAddress;
 }
 
 interface ResolvedUrlValidationResult extends UrlValidationResult {
@@ -502,20 +508,31 @@ export async function safeFetch(
   init?: RequestInit,
   validationOptions?: UrlValidationOptions
 ): Promise<Response | null> {
-  const opts = { ...DEFAULT_OPTIONS, ...validationOptions };
-  const validation = validateWebhookUrl(url, opts);
-  if (!validation.valid) {
-    return null;
-  }
-
-  const parsed = new URL(validation.normalized ?? url);
-  const resolved = await validateResolvedHostname(parsed, opts);
-  if (!resolved.valid || !resolved.resolvedAddress) {
-    return null;
-  }
+  const resolved = await resolveOutboundUrl(url, validationOptions);
+  if (!resolved) return null;
+  const parsed = new URL(resolved.url);
 
   return fetchPinnedUrl(parsed, resolved.resolvedAddress, {
     ...init,
     redirect: 'manual',
   });
+}
+
+export async function resolveOutboundUrl(
+  url: string,
+  validationOptions?: UrlValidationOptions
+): Promise<ResolvedOutboundUrl | null> {
+  const opts = { ...DEFAULT_OPTIONS, ...validationOptions };
+  const validation = validateWebhookUrl(url, opts);
+  if (!validation.valid) return null;
+
+  const parsed = new URL(validation.normalized ?? url);
+  const resolved = await validateResolvedHostname(parsed, opts);
+  if (!resolved.valid || !resolved.resolvedAddress) return null;
+
+  return {
+    url: parsed.href,
+    hostname: unbracketHostname(parsed.hostname),
+    resolvedAddress: resolved.resolvedAddress,
+  };
 }

--- a/shared/src/types/chat.types.ts
+++ b/shared/src/types/chat.types.ts
@@ -66,6 +66,18 @@ export interface SquadMessage {
   decision?: boolean; // Message records a decision
   reactions?: SquadReaction[]; // Lightweight acknowledgements/reactions
   replyCount?: number; // Derived count of direct/indirect replies in the current result set
+  external?: SquadExternalMessage;
+}
+
+export interface SquadExternalMessage {
+  provider: 'buzz' | 'msteams' | 'custom';
+  adapterId: string;
+  community?: string;
+  channelId?: string;
+  messageId: string;
+  authorId?: string;
+  kind?: number;
+  url?: string;
 }
 
 export type SquadMentionKind = 'user' | 'agent' | 'role' | 'owner';
@@ -105,8 +117,10 @@ export interface SquadMessageInput {
   mentions?: Array<string | SquadMention>;
   taskId?: string;
   runId?: string;
+  links?: SquadMessageLink[];
   pinned?: boolean;
   decision?: boolean;
+  external?: SquadExternalMessage;
 }
 
 export interface SquadUnreadState {

--- a/shared/src/types/communication-adapter.types.ts
+++ b/shared/src/types/communication-adapter.types.ts
@@ -184,6 +184,52 @@ export interface CommunicationAdapterHealth {
   reasonCode?: BuzzCompatibilityReasonCode;
   remediation?: string;
   buzz?: BuzzCompatibilityResult;
+  buzzRuntime?: BuzzRuntimeHealth;
+}
+
+export interface BuzzExternalCoordinate {
+  community: string;
+  channelId: string;
+  eventId?: string;
+  authorPubkey?: string;
+  kind?: number;
+  rootEventId?: string;
+  parentEventId?: string;
+  externalUrl?: string;
+}
+
+export interface BuzzChannelMapping {
+  id: string;
+  adapterId: string;
+  community: string;
+  channelId: string;
+  target: CommunicationReplyTarget;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+}
+
+export interface BuzzCursor {
+  adapterId: string;
+  community: string;
+  channelId: string;
+  createdAt: number;
+  eventId: string;
+  committedAt: string;
+}
+
+export interface BuzzRuntimeHealth {
+  relayConnected: boolean;
+  subscriptionActive: boolean;
+  mappedChannels: number;
+  reconnectAttempts: number;
+  lastConnectedAt?: string;
+  lastEventAt?: string;
+  cursorLagSeconds?: number;
+  lastSendAt?: string;
+  lastSendStatus?: CommunicationDeliveryStatus;
+  lastError?: string;
 }
 
 export interface CommunicationThreadMapping {
@@ -195,12 +241,28 @@ export interface CommunicationThreadMapping {
   createdAt: string;
   updatedAt: string;
   createdBy?: string;
+  buzz?: BuzzExternalCoordinate;
 }
 
 export type CommunicationDeliveryOperation =
-  'configure' | 'health' | 'send' | 'reply-ingest' | 'poll' | 'disconnect';
+  | 'configure'
+  | 'health'
+  | 'send'
+  | 'reply-ingest'
+  | 'event-ingest'
+  | 'reconcile'
+  | 'poll'
+  | 'disconnect';
 
-export type CommunicationDeliveryStatus = 'success' | 'queued' | 'failed' | 'blocked' | 'skipped';
+export type CommunicationDeliveryStatus =
+  | 'success'
+  | 'queued'
+  | 'delivery_unknown'
+  | 'replayed'
+  | 'ignored'
+  | 'failed'
+  | 'blocked'
+  | 'skipped';
 
 export interface CommunicationDeliveryAudit {
   id: string;
@@ -212,6 +274,8 @@ export interface CommunicationDeliveryAudit {
   squadMessageId?: string;
   actor?: string;
   error?: string;
+  detail?: string;
+  buzz?: BuzzExternalCoordinate;
   createdAt: string;
 }
 
@@ -219,6 +283,7 @@ export interface CommunicationSendInput {
   target: CommunicationReplyTarget;
   message: string;
   actor?: string;
+  replyToSquadMessageId?: string;
   externalThreadId?: string;
   externalUrl?: string;
 }

--- a/web/src/__tests__/SquadChatPanel.test.tsx
+++ b/web/src/__tests__/SquadChatPanel.test.tsx
@@ -174,4 +174,42 @@ describe('SquadChatPanel', () => {
       reaction: 'ack',
     });
   });
+
+  it('renders a Buzz external-message deep link as an accessible action', () => {
+    const eventId = 'a'.repeat(64);
+    const href = `buzz://message?channel=123e4567-e89b-42d3-a456-426614174000&id=${eventId}`;
+    mocks.useSquadMessages.mockReturnValue({
+      data: [
+        {
+          id: `msg_buzz_${eventId}`,
+          agent: 'BUZZ',
+          displayName: 'Buzz member',
+          message: 'Signed relay message',
+          timestamp: '2026-07-23T20:00:00.000Z',
+          links: [
+            { href, label: 'Open in Buzz' },
+            { href: 'javascript:alert(1)', label: 'Unsafe link' },
+          ],
+          external: {
+            provider: 'buzz',
+            adapterId: 'buzz-default',
+            community: 'relay.example.test',
+            channelId: '123e4567-e89b-42d3-a456-426614174000',
+            messageId: eventId,
+            authorId: 'b'.repeat(64),
+            kind: 9,
+            url: href,
+          },
+        },
+      ],
+      isLoading: false,
+    });
+
+    renderWithProviders(<SquadChatPanel open={true} onOpenChange={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: 'Open in Buzz' });
+    expect(link.getAttribute('href')).toBe(href);
+    expect(screen.queryByRole('link', { name: 'Unsafe link' })).toBeNull();
+    expect(screen.getByText('Signed relay message')).toBeDefined();
+  });
 });

--- a/web/src/__tests__/settings-tabs-mantine-controls.test.tsx
+++ b/web/src/__tests__/settings-tabs-mantine-controls.test.tsx
@@ -134,6 +134,16 @@ const mocks = vi.hoisted(() => ({
           checkedAt: '2026-07-23T18:00:00.000Z',
           detail: 'Buzz relay and read capabilities are compatible.',
           reasonCode: 'ok',
+          buzzRuntime: {
+            relayConnected: true,
+            subscriptionActive: true,
+            mappedChannels: 1,
+            reconnectAttempts: 0,
+            cursorLagSeconds: 4,
+            lastEventAt: '2026-07-23T18:00:00.000Z',
+            lastSendAt: '2026-07-23T18:00:00.000Z',
+            lastSendStatus: 'delivery_unknown',
+          },
           buzz: {
             schemaVersion: 'buzz-compatibility/v1',
             probeRevision: 1,
@@ -189,7 +199,48 @@ const mocks = vi.hoisted(() => ({
       target: { kind: 'notification' },
       createdAt: '2026-06-04T08:00:00.000Z',
     },
+    {
+      id: 'comm_buzz_1',
+      adapterId: 'buzz-default',
+      operation: 'send',
+      status: 'delivery_unknown',
+      detail: 'Buzz delivery is ambiguous and will be reconciled by event ID.',
+      target: { kind: 'squad' },
+      createdAt: '2026-07-23T18:00:00.000Z',
+    },
   ]),
+  buzzChannelMappings: vi.fn(async () => [
+    {
+      id: 'buzz_map_1',
+      adapterId: 'buzz-default',
+      community: 'relay.example.test',
+      channelId: '123e4567-e89b-42d3-a456-426614174000',
+      target: { kind: 'squad' },
+      enabled: true,
+      createdAt: '2026-07-23T18:00:00.000Z',
+      updatedAt: '2026-07-23T18:00:00.000Z',
+    },
+  ]),
+  configureBuzzChannelMapping: vi.fn(async () => ({
+    id: 'buzz_map_1',
+    adapterId: 'buzz-default',
+    community: 'relay.example.test',
+    channelId: '123e4567-e89b-42d3-a456-426614174000',
+    target: { kind: 'squad' },
+    enabled: true,
+    createdAt: '2026-07-23T18:00:00.000Z',
+    updatedAt: '2026-07-23T18:00:00.000Z',
+  })),
+  disableBuzzChannelMapping: vi.fn(async () => ({
+    id: 'buzz_map_1',
+    adapterId: 'buzz-default',
+    community: 'relay.example.test',
+    channelId: '123e4567-e89b-42d3-a456-426614174000',
+    target: { kind: 'squad' },
+    enabled: false,
+    createdAt: '2026-07-23T18:00:00.000Z',
+    updatedAt: '2026-07-23T18:01:00.000Z',
+  })),
   configureCommunicationAdapter: vi.fn(async () => ({
     id: 'msteams-default',
     kind: 'msteams',
@@ -301,6 +352,9 @@ vi.mock('@/lib/api', () => ({
       communicationAdapters: mocks.communicationAdapters,
       communicationHealth: mocks.communicationHealth,
       communicationDeliveries: mocks.communicationDeliveries,
+      buzzChannelMappings: mocks.buzzChannelMappings,
+      configureBuzzChannelMapping: mocks.configureBuzzChannelMapping,
+      disableBuzzChannelMapping: mocks.disableBuzzChannelMapping,
       configureCommunicationAdapter: mocks.configureCommunicationAdapter,
       testCommunicationAdapter: mocks.testCommunicationAdapter,
       disconnectCommunicationAdapter: mocks.disconnectCommunicationAdapter,
@@ -378,6 +432,7 @@ describe('Settings tab Mantine controls', () => {
     expect(screen.getByLabelText(/Relay HTTP URL/)).toBeDefined();
     expect(screen.getByLabelText(/Relay WebSocket URL/)).toBeDefined();
     expect(screen.getByLabelText(/Expected community/)).toBeDefined();
+    expect(await screen.findByDisplayValue('123e4567-e89b-42d3-a456-426614174000')).toBeDefined();
     expect(screen.getByLabelText(/Public key/)).toBeDefined();
     expect(screen.getByLabelText(/Signing key reference/)).toBeDefined();
     expect(screen.getByText('Signing reference:').parentElement?.textContent).toContain(
@@ -385,6 +440,10 @@ describe('Settings tab Mantine controls', () => {
     );
     expect(await screen.findByText('Buzz 0.4.24, probe 1')).toBeDefined();
     expect(screen.getByText('Compatibility chain')).toBeDefined();
+    expect(screen.getByText('Runtime and delivery')).toBeDefined();
+    expect(screen.getByText('connected')).toBeDefined();
+    expect(screen.getByText('active')).toBeDefined();
+    expect(screen.getAllByText('delivery_unknown').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Community binding')).toBeDefined();
     expect(screen.queryByText(/nsec1/)).toBeNull();
     expect(screen.getAllByText('Squad Chat Webhook').length).toBeGreaterThanOrEqual(1);
@@ -447,6 +506,29 @@ describe('Settings tab Mantine controls', () => {
     expect(
       screen.getByText('relay_membership_required: Add the public identity as a relay member.')
     ).toBeDefined();
+  });
+
+  it('saves the Buzz connection and Squad Chat channel mapping together', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NotificationsTab />);
+
+    await screen.findByDisplayValue('123e4567-e89b-42d3-a456-426614174000');
+    await user.click(screen.getByRole('button', { name: 'Save Buzz' }));
+
+    expect(mocks.configureCommunicationAdapter).toHaveBeenCalledWith(
+      'buzz-default',
+      expect.objectContaining({
+        kind: 'buzz',
+        enabled: true,
+        relayHttpUrl: 'https://relay.example.test',
+      })
+    );
+    expect(mocks.configureBuzzChannelMapping).toHaveBeenCalledWith(
+      'buzz-default',
+      '123e4567-e89b-42d3-a456-426614174000',
+      { kind: 'squad' },
+      true
+    );
   });
 
   it('renders Enforcement ceremony and agent selection through direct Mantine Select', async () => {

--- a/web/src/components/chat/SquadChatPanel.tsx
+++ b/web/src/components/chat/SquadChatPanel.tsx
@@ -60,6 +60,35 @@ const agentColors: Record<string, string> = {
   Marvin: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
 };
 
+function safeSquadLinkHref(value?: string): string | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      if (parsed.username || parsed.password) return undefined;
+      return parsed.toString();
+    }
+    if (parsed.protocol !== 'buzz:' || parsed.hostname !== 'message') return undefined;
+    const channelId = parsed.searchParams.get('channel');
+    const eventId = parsed.searchParams.get('id');
+    const threadId = parsed.searchParams.get('thread');
+    if (
+      !channelId ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        channelId
+      ) ||
+      !eventId ||
+      !/^[a-f0-9]{64}$/i.test(eventId) ||
+      (threadId && !/^[a-f0-9]{64}$/i.test(threadId))
+    ) {
+      return undefined;
+    }
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
 function readIncludeSystemPreference(): boolean {
   try {
     const saved = window.localStorage.getItem('squadChat.includeSystem');
@@ -605,15 +634,26 @@ const SquadMessageBubble = React.memo(function SquadMessageBubble({
               ))}
             </div>
           )}
-          {message.links?.map((link) => (
-            <Badge
-              key={`${link.taskId ?? ''}-${link.runId ?? ''}-${link.href ?? ''}`}
-              size="xs"
-              variant="outline"
-            >
-              {link.label || link.taskId || link.runId || 'link'}
-            </Badge>
-          ))}
+          {message.links?.map((link) => {
+            const safeHref = safeSquadLinkHref(link.href);
+            return (
+              <Badge
+                key={`${link.taskId ?? ''}-${link.runId ?? ''}-${link.href ?? ''}`}
+                size="xs"
+                variant="outline"
+                {...(safeHref
+                  ? {
+                      component: 'a',
+                      href: safeHref,
+                      rel: 'noreferrer',
+                      'aria-label': link.label || 'Open linked item',
+                    }
+                  : {})}
+              >
+                {link.label || link.taskId || link.runId || 'link'}
+              </Badge>
+            );
+          })}
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <span className="text-xs opacity-70">

--- a/web/src/components/settings/tabs/BuzzConnectionPanel.tsx
+++ b/web/src/components/settings/tabs/BuzzConnectionPanel.tsx
@@ -11,7 +11,12 @@ import {
 } from '@mantine/core';
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api, type CommunicationAdapterInput, type CommunicationAdapterRecord } from '@/lib/api';
+import {
+  api,
+  type BuzzChannelMapping,
+  type CommunicationAdapterInput,
+  type CommunicationAdapterRecord,
+} from '@/lib/api';
 import { SectionHeader, ToggleRow } from '../shared';
 
 const BUZZ_ADAPTER_ID = 'buzz-default';
@@ -28,9 +33,13 @@ interface BuzzFormState {
   commandArgs: string[];
   allowLocalhost: boolean;
   allowPrivateNetwork: boolean;
+  channelId: string;
 }
 
-function adapterToForm(adapter?: CommunicationAdapterRecord): BuzzFormState {
+function adapterToForm(
+  adapter?: CommunicationAdapterRecord,
+  mapping?: BuzzChannelMapping
+): BuzzFormState {
   return {
     enabled: adapter?.enabled ?? false,
     relayHttpUrl: adapter?.relayHttpUrl ?? '',
@@ -43,6 +52,7 @@ function adapterToForm(adapter?: CommunicationAdapterRecord): BuzzFormState {
     commandArgs: adapter?.command?.args ?? [],
     allowLocalhost: adapter?.allowLocalhost ?? false,
     allowPrivateNetwork: adapter?.allowPrivateNetwork ?? false,
+    channelId: mapping?.channelId ?? '',
   };
 }
 
@@ -91,6 +101,21 @@ export function BuzzConnectionPanel() {
     retry: false,
   });
   const adapter = adapters.find((candidate) => candidate.id === BUZZ_ADAPTER_ID);
+  const { data: mappings = [] } = useQuery({
+    queryKey: ['integrations', 'communication', 'buzz-mappings', BUZZ_ADAPTER_ID],
+    queryFn: () => api.integrations.buzzChannelMappings(BUZZ_ADAPTER_ID),
+    enabled: Boolean(adapter),
+    staleTime: 30_000,
+    retry: false,
+  });
+  const activeMapping = mappings.find((mapping) => mapping.enabled) ?? mappings[0];
+  const { data: deliveries = [] } = useQuery({
+    queryKey: ['integrations', 'communication', 'deliveries', BUZZ_ADAPTER_ID, 8],
+    queryFn: () => api.integrations.communicationDeliveries(8, BUZZ_ADAPTER_ID),
+    enabled: Boolean(adapter),
+    staleTime: 10_000,
+    retry: false,
+  });
   const { data: health } = useQuery({
     queryKey: ['integrations', 'communication', 'health', BUZZ_ADAPTER_ID],
     queryFn: () => api.integrations.communicationHealth(BUZZ_ADAPTER_ID),
@@ -100,19 +125,55 @@ export function BuzzConnectionPanel() {
   });
   const effectiveHealth = health ?? adapter?.lastHealth;
   const compatibility = effectiveHealth?.buzz ?? adapter?.compatibility;
-  const [form, setForm] = useState<BuzzFormState>(() => adapterToForm(adapter));
+  const [form, setForm] = useState<BuzzFormState>(() => adapterToForm(adapter, activeMapping));
   const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
-    if (!dirty) setForm(adapterToForm(adapter));
-  }, [adapter, dirty]);
+    if (!dirty) setForm(adapterToForm(adapter, activeMapping));
+  }, [activeMapping, adapter, dirty]);
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['integrations', 'communication'] });
   };
   const save = useMutation({
-    mutationFn: () =>
-      api.integrations.configureCommunicationAdapter(BUZZ_ADAPTER_ID, formToInput(form)),
+    mutationFn: async () => {
+      const configured = await api.integrations.configureCommunicationAdapter(
+        BUZZ_ADAPTER_ID,
+        formToInput(form)
+      );
+      const channelId = form.channelId.trim();
+      let disabledPrevious = false;
+      if (
+        activeMapping?.enabled &&
+        activeMapping.channelId.toLowerCase() !== channelId.toLowerCase()
+      ) {
+        await api.integrations.disableBuzzChannelMapping(BUZZ_ADAPTER_ID, activeMapping.channelId);
+        disabledPrevious = true;
+      }
+      try {
+        if (channelId) {
+          await api.integrations.configureBuzzChannelMapping(
+            BUZZ_ADAPTER_ID,
+            channelId,
+            { kind: 'squad' },
+            form.enabled
+          );
+        }
+      } catch (error) {
+        if (disabledPrevious && activeMapping) {
+          await api.integrations
+            .configureBuzzChannelMapping(
+              BUZZ_ADAPTER_ID,
+              activeMapping.channelId,
+              activeMapping.target,
+              true
+            )
+            .catch(() => undefined);
+        }
+        throw error;
+      }
+      return configured;
+    },
     onSuccess: () => {
       setDirty(false);
       invalidate();
@@ -203,6 +264,15 @@ export function BuzzConnectionPanel() {
               size="xs"
             />
             <TextInput
+              label="Squad Chat channel mapping"
+              value={form.channelId}
+              onChange={(event) => update('channelId', event.target.value)}
+              placeholder="Buzz channel UUID"
+              description="Maps this Buzz channel to the local Squad Chat surface."
+              required={form.enabled}
+              size="xs"
+            />
+            <TextInput
               label="Public key"
               value={form.publicKey}
               onChange={(event) => update('publicKey', event.target.value)}
@@ -238,8 +308,8 @@ export function BuzzConnectionPanel() {
           </SimpleGrid>
 
           <ToggleRow
-            label="Enable Buzz diagnostics"
-            description="Allow read-only relay and identity probes. Message delivery remains disabled."
+            label="Enable Buzz adapter"
+            description="Enable compatibility checks, signed outbound delivery, and the supervised inbound subscription."
             checked={form.enabled}
             onCheckedChange={(value) => update('enabled', value)}
           />
@@ -282,6 +352,77 @@ export function BuzzConnectionPanel() {
                 </Paper>
               ))}
             </SimpleGrid>
+          </Paper>
+
+          <Paper withBorder radius="sm" p="xs">
+            <Text size="xs" fw={600} mb={6}>
+              Runtime and delivery
+            </Text>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing={4}>
+              <Text size="xs">
+                Relay:{' '}
+                <Code>
+                  {effectiveHealth?.buzzRuntime?.relayConnected ? 'connected' : 'disconnected'}
+                </Code>
+              </Text>
+              <Text size="xs">
+                Subscription:{' '}
+                <Code>
+                  {effectiveHealth?.buzzRuntime?.subscriptionActive ? 'active' : 'inactive'}
+                </Code>
+              </Text>
+              <Text size="xs">
+                Mapped channels:{' '}
+                <Code>{effectiveHealth?.buzzRuntime?.mappedChannels ?? mappings.length}</Code>
+              </Text>
+              <Text size="xs">
+                Cursor lag:{' '}
+                <Code>
+                  {effectiveHealth?.buzzRuntime?.cursorLagSeconds === undefined
+                    ? 'not established'
+                    : `${effectiveHealth.buzzRuntime.cursorLagSeconds}s`}
+                </Code>
+              </Text>
+              <Text size="xs">
+                Last event:{' '}
+                <Code>
+                  {effectiveHealth?.buzzRuntime?.lastEventAt
+                    ? new Date(effectiveHealth.buzzRuntime.lastEventAt).toLocaleString()
+                    : 'not recorded'}
+                </Code>
+              </Text>
+              <Text size="xs">
+                Last send:{' '}
+                <Code>{effectiveHealth?.buzzRuntime?.lastSendStatus ?? 'not recorded'}</Code>
+              </Text>
+            </SimpleGrid>
+            {deliveries.length > 0 && (
+              <Stack gap={3} mt="xs" aria-label="Recent Buzz deliveries">
+                {deliveries.slice(0, 5).map((delivery) => (
+                  <Group key={delivery.id} justify="space-between" gap="xs" wrap="nowrap">
+                    <Text size="xs" truncate>
+                      {delivery.operation}: {delivery.detail ?? delivery.error ?? 'recorded'}
+                    </Text>
+                    <Badge
+                      size="xs"
+                      variant="light"
+                      color={
+                        delivery.status === 'success'
+                          ? 'green'
+                          : delivery.status === 'delivery_unknown'
+                            ? 'yellow'
+                            : delivery.status === 'failed' || delivery.status === 'blocked'
+                              ? 'red'
+                              : 'gray'
+                      }
+                      tt="none"
+                    >
+                      {delivery.status}
+                    </Badge>
+                  </Group>
+                ))}
+              </Stack>
+            )}
           </Paper>
 
           <Paper withBorder radius="sm" p="xs">

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -97,6 +97,9 @@ export type { ReflectionListFilters } from './reflections';
 export type { TraceStatus } from './traces';
 export type { SqlitePortabilityReport } from './maintenance';
 export type {
+  BuzzChannelMapping,
+  BuzzExternalCoordinate,
+  BuzzRuntimeHealth,
   CommunicationAdapterHealth,
   CommunicationAdapterInput,
   CommunicationAdapterRecord,

--- a/web/src/lib/api/integrations.ts
+++ b/web/src/lib/api/integrations.ts
@@ -1,5 +1,6 @@
 import { API_BASE, apiFetch } from './helpers';
 import type {
+  BuzzChannelMapping,
   CommunicationAdapterHealth,
   CommunicationAdapterInput,
   CommunicationAdapterRecord,
@@ -106,6 +107,38 @@ export const integrationsApi = {
   communicationHealth: async (adapterId: string): Promise<CommunicationAdapterHealth> => {
     return apiFetch<CommunicationAdapterHealth>(
       `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/health`
+    );
+  },
+
+  buzzChannelMappings: async (adapterId: string): Promise<BuzzChannelMapping[]> => {
+    return apiFetch<BuzzChannelMapping[]>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/channels`
+    );
+  },
+
+  configureBuzzChannelMapping: async (
+    adapterId: string,
+    channelId: string,
+    target: CommunicationReplyIngestInput['target'],
+    enabled = true
+  ): Promise<BuzzChannelMapping> => {
+    return apiFetch<BuzzChannelMapping>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/channels/${encodeURIComponent(channelId)}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target, enabled }),
+      }
+    );
+  },
+
+  disableBuzzChannelMapping: async (
+    adapterId: string,
+    channelId: string
+  ): Promise<BuzzChannelMapping> => {
+    return apiFetch<BuzzChannelMapping>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/channels/${encodeURIComponent(channelId)}/disable`,
+      { method: 'POST' }
     );
   },
 


### PR DESCRIPTION
## Summary

- add native signed Buzz root and reply delivery behind the existing communication adapter service
- add authenticated, DNS-pinned NIP-42 subscriptions with mapped-channel allowlists, durable total-order cursors, overlap replay, loop prevention, and clean worker shutdown
- project verified Buzz roots and replies into Squad Chat with deterministic IDs, public authorship, source timestamps, thread coordinates, and safe external links
- persist signed outbound events before submission and reconcile ambiguous delivery by event ID before exact-event resubmission
- add mapping APIs, permission coverage, runtime health and delivery UI, operator docs, API docs, security docs, and changelog coverage

## Verification

- `pnpm test:unit`
- `pnpm build`
- `pnpm lint:budget` (0 errors, 590 warnings within the 600 warning budget)
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `pnpm smoke:cli-mcp` (static compatibility passed; live read/write skipped because `VK_API_KEY` is not configured)

## Risk and rollout

- A live credentialed Buzz relay smoke was not run. Credential-free fake-relay coverage verifies authentication, subscription, event delivery, cursor overlap, transient reconnect, terminal rejection, and clean shutdown.
- Buzz edit and delete events are audit-only because Squad Chat has no edit or destructive delete projection contract.
- Disabling the mapping or adapter stops the worker while retaining mappings, cursor, coordinates, and delivery history for recovery.

Closes #906
