### PR TITLE
feat: import Buzz persona and team definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added one-way Buzz persona/team definition import with signed bounded NIP-33
+  head queries, exact v0.4.24 field policy, preview/diff/collision actions,
+  same-author team resolution, disabled profile and roster materialization,
+  immutable provenance, source-status reporting, optimistic JSON/SQLite
+  mutations, audit history, Settings controls, and malicious-source coverage.
+  Runtime/model/provider preferences remain source-only, and import never
+  launches, enables, routes, fetches, installs, or writes back (#910).
 - Added a reference-only Buzz communication adapter with typed configuration,
   host-preserving HTTP/WS normalization, SSRF-aware bounded relay probes,
   NIP-11 software/version/community checks, NIP-98 identity and membership/read

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [Self-Hosting Guide](docs/guides/SELF_HOST.md) — production deployment, reverse proxy, auth hardening, Docker, and backups.
 - [Agent Task Workflow SOP](docs/SOP-agent-task-workflow.md) — lifecycle, API/CLI snippets, prompts.
 - [Squad Chat Protocol](docs/SQUAD-CHAT-PROTOCOL.md) — agent messaging, system events (spawned/completed/failed), model attribution, and helper scripts.
-- [Buzz Communication Adapter](docs/BUZZ-INTEGRATION.md) — signed Squad Chat channel bridging, mapping, replay, delivery reconciliation, health, and rollback.
+- [Buzz Communication Adapter](docs/BUZZ-INTEGRATION.md) — signed Squad Chat bridging plus explicit, disabled-by-default persona/team definition import with provenance and safe refresh.
 - [Sprint Planning SOP](docs/SOP-sprint-planning.md) — epic → sprint → task breakdown.
 - [Multi-Agent Orchestration](docs/SOP-multi-agent-orchestration.md) — PM + worker handoffs.
 - [Cross-Model Code Review](docs/SOP-cross-model-code-review.md) — enforce Claude ↔ GPT reviews.
@@ -247,7 +247,7 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **@Mention notifications** — @agent-name parsing in comments, thread subscriptions
 - **Broadcast Notifications** — Priority-based persistent notifications with read receipts and agent-specific delivery
 - **Squad Chat Webhook** — Configurable webhooks (generic HTTP or OpenClaw Direct) for external agent integration
-- **Buzz Communication Adapter** — Native signed root/reply bridge between one mapped Buzz community channel and Squad Chat, with durable replay and ambiguous-send reconciliation
+- **Buzz Communication Adapter** — Native signed root/reply bridge between one mapped Buzz community channel and Squad Chat, with durable replay, ambiguous-send reconciliation, and operator-confirmed persona/team definition materialization
 - **Agent registry** — Service discovery with heartbeat tracking, capabilities, and live status
 - **Multi-agent dashboard** — Real-time sidebar with expandable agent cards, status indicators
 - **Multi-agent task assignment** — Assign multiple agents per task with color-coded chips

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -747,6 +747,10 @@ POST /api/integrations/communication/adapters/:adapterId/disconnect
 GET  /api/integrations/communication/adapters/:adapterId/buzz/channels
 PUT  /api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId
 POST /api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId/disable
+GET  /api/integrations/communication/adapters/:adapterId/buzz/definitions
+GET  /api/integrations/communication/adapters/:adapterId/buzz/definitions/links
+POST /api/integrations/communication/adapters/:adapterId/buzz/definitions/preview
+POST /api/integrations/communication/adapters/:adapterId/buzz/definitions/import
 GET  /api/integrations/communication/mappings
 GET  /api/integrations/communication/deliveries
 ```
@@ -846,6 +850,49 @@ Omit `replyToSquadMessageId` for a root. The response includes the signed Buzz
 coordinate and a delivery status. `delivery_unknown` is a durable visible
 state, not a failure alias. `POST .../poll` queries the event ID before any
 safe resubmission. See [Buzz Communication Adapter](BUZZ-INTEGRATION.md).
+
+**Buzz definition preview body**:
+
+```json
+{
+  "coordinate": {
+    "authorPubkey": "<64-hex-public-key>",
+    "kind": 30175,
+    "dTag": "security-reviewer"
+  },
+  "action": "create"
+}
+```
+
+The list returns only signature-verified NIP-33 persona and team heads from the
+current healthy Buzz connection. Preview returns the exact event/content hash,
+mapped/source-only/ignored/rejected field report, proposed disabled
+profile/roster, collisions, unresolved same-author persona slugs, and an
+optimistic `expectedLocalRevision` when a local target or linked persona
+dependency participates in the proposed materialization.
+
+**Buzz definition import body**:
+
+```json
+{
+  "coordinate": {
+    "authorPubkey": "<64-hex-public-key>",
+    "kind": 30175,
+    "dTag": "security-reviewer"
+  },
+  "action": "refresh",
+  "targetId": "buzz-security-reviewer",
+  "expectedEventId": "<64-hex-event-id>",
+  "expectedLocalRevision": "<64-hex-revision>"
+}
+```
+
+Actions are `create`, `link`, `refresh`, or `skip`. Source replacement,
+concurrent local changes, and unresolved collisions return `409`. Created
+profiles, rosters, and roster members are disabled. The link-status endpoint
+reports `current`, `changed`, `missing`, or `unavailable` without deleting the
+local materialization. Preview requires `settings:read`; import requires
+`settings:write`. No endpoint writes definitions back to Buzz.
 
 **Reply ingest body**:
 

--- a/docs/BUZZ-INTEGRATION.md
+++ b/docs/BUZZ-INTEGRATION.md
@@ -7,7 +7,9 @@ native Nostr HTTP and WebSocket contracts. It does not spawn `buzz`,
 
 Buzz is a communication adapter, not an `AgentProvider`. It does not create a
 Veritas task, start an ACP agent, synchronize DMs or forums, or read Buzz
-Desktop's internal state.
+Desktop's internal state. An operator may separately materialize selected
+public Buzz persona and team definitions as disabled Veritas profiles and
+roster members. Definition import is data-only and never starts a process.
 
 ## Supported contract
 
@@ -136,6 +138,73 @@ vk doctor --json
 
 `POST .../buzz-default/test` runs the same read-only probe. It never sends a
 message.
+
+## Import persona and team definitions
+
+In **Settings -> Agents -> Buzz Persona and Team Definitions**, an operator can
+list, preview, and explicitly import public Buzz definition heads:
+
+- kind `30175` persona definitions keyed by `(author, kind, d tag)`;
+- kind `30176` team definitions keyed the same way; and
+- the deterministic NIP-33 head with the greatest `created_at`, using the
+  lowest event ID to break a tie.
+
+The importer reuses the signed, DNS-pinned Buzz `/query` transport and requires
+current healthy compatibility evidence. Every candidate has bounded Nostr
+shape, tags, content, JSON depth, arrays, strings, and batch size. Its
+signature is reconstructed and verified before it can appear in Settings.
+Invalid envelopes contribute only to a rejected count. A signature-valid
+current head with rejected content appears as a non-importable coordinate and
+field-level validation reason, so Veritas never silently falls back to an older
+definition. Unsafe source values are not echoed into the UI or logs.
+
+Preview classifies each field before mutation:
+
+| Buzz definition field                                                                     | Import behavior                                                                    |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Persona `display_name`                                                                    | Source-owned profile display name.                                                 |
+| Persona `system_prompt`                                                                   | Source-owned profile prompt when present.                                          |
+| Persona `avatar_url`                                                                      | Validated public metadata only. Veritas does not fetch it.                         |
+| Persona `runtime`, `model`, `provider`                                                    | Source preferences only, never runtime evidence or active provider configuration.  |
+| Persona `name_pool`                                                                       | Bounded source metadata only.                                                      |
+| Persona reserved response fields                                                          | Source-only. Veritas does not apply them.                                          |
+| Team `name`, `description`                                                                | Source-owned roster fields for create or refresh.                                  |
+| Team `persona_ids`                                                                        | Same-author persona slugs resolved to linked profiles and disabled roster members. |
+| Unknown fields                                                                            | Ignored with a field-level forward-compatibility explanation.                      |
+| Secrets, environment, commands, paths, managed process state, MCP, hooks, skills, engrams | Rejected.                                                                          |
+
+The available actions are:
+
+- `create`: use the deterministic `buzz-<slug>` profile ID or
+  `buzz-team-<slug>` roster ID;
+- `link`: attach provenance to an explicitly selected existing profile or
+  roster without replacing local fields;
+- `refresh`: replace only the saved source-owned fields after a new preview;
+  and
+- `skip`: record no local mutation.
+
+Create, link, and refresh require collision-free preview. A preview returns an
+optimistic local revision and exact source event ID. Import rejects a changed
+local target or replaced source, so the operator must review the current diff
+instead of overwriting concurrent edits. Native profile/roster fields remain
+authoritative; refresh preserves local-only fields and existing routing rules.
+
+New persona profiles, new rosters, and imported roster members are disabled.
+Import never launches, enables, routes, installs, fetches, or writes back to
+Buzz. Removing or replacing a Buzz definition changes its linked-source status
+to `missing` or `changed`; it does not delete the materialized local object.
+
+Definition API:
+
+```text
+GET  /api/integrations/communication/adapters/:adapterId/buzz/definitions
+GET  /api/integrations/communication/adapters/:adapterId/buzz/definitions/links
+POST /api/integrations/communication/adapters/:adapterId/buzz/definitions/preview
+POST /api/integrations/communication/adapters/:adapterId/buzz/definitions/import
+```
+
+Reads and preview require `settings:read`. Import requires `settings:write`.
+There is no continuous synchronization and no Buzz write-back endpoint.
 
 ## Send roots and replies
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -506,6 +506,7 @@ Real-time agent-to-agent communication channel for multi-agent collaboration. Sh
 - **OpenClaw Direct gateway wake** — Optional real-time Squad Chat events pushed to OpenClaw gateway for agent orchestration
 - **Human reply adapters** — Configure Teams reply posture, run health checks and test sends, store external thread mappings, and ingest audited human replies back into the correct Squad Chat thread
 - **Buzz channel bridge** — Map a Buzz community channel to Squad Chat, publish and ingest signed roots/replies exactly once, retain source author/timestamp/deep links, resume through a durable cursor with overlap dedupe, and reconcile ambiguous sends before retry
+- **Buzz persona/team import** — List signature-verified NIP-33 persona and team heads, preview mapped/source-only/ignored/rejected fields, resolve collisions explicitly, and create, link, or refresh disabled profile/roster materializations with provenance and optimistic local revisions
 - **Searchable history** — Browse and search past squad chat messages
 
 ### API Endpoints
@@ -523,6 +524,9 @@ Real-time agent-to-agent communication channel for multi-agent collaboration. Sh
 | `/api/integrations/communication/adapters/:adapterId/replies`                  | POST   | Ingest an external human reply into Squad Chat    |
 | `/api/integrations/communication/adapters/:adapterId/send`                     | POST   | Publish a mapped Teams/Buzz communication message |
 | `/api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId` | PUT    | Map a Buzz channel to Squad Chat                  |
+| `/api/integrations/communication/adapters/:adapterId/buzz/definitions`         | GET    | List validated Buzz persona/team heads            |
+| `/api/integrations/communication/adapters/:adapterId/buzz/definitions/preview` | POST   | Preview field mappings, diffs, and collisions     |
+| `/api/integrations/communication/adapters/:adapterId/buzz/definitions/import`  | POST   | Explicitly create, link, refresh, or skip import  |
 
 ---
 
@@ -1228,6 +1232,7 @@ Notification and broadcast features provide local visibility and optional delive
 - **External delivery boundary** — Local notifications, broadcasts, and Squad Chat can work while external webhook delivery is disabled
 - **Human reply adapter health** — Settings -> Notifications shows Teams reply posture, redacted webhook state, recent delivery audit, test send, and disconnect controls
 - **Buzz communication adapter** — Reference-only relay setup verifies community identity, NIP-98 authentication, membership, and read capability before enabling signed root/reply delivery, supervised subscriptions, durable cursor replay, loop prevention, and delivery-unknown reconciliation
+- **Buzz public definitions** — One-way, operator-confirmed persona/team materialization keeps source preferences as metadata, requires same-author team references, creates disabled local objects, preserves local-only fields on refresh, and never launches a process or writes back
 
 ### API Endpoints
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -176,6 +176,20 @@ Optional command discovery runs without a shell and receives a minimal
 environment that excludes provider and Buzz credentials. See
 [Buzz Communication Adapter](BUZZ-INTEGRATION.md).
 
+Buzz persona/team import accepts only reconstructed, signature-verified kinds
+`30175` and `30176` from the configured signed query path. Event, content,
+JSON depth, key count, array count, string, URL, and batch limits apply before
+preview. Secret-like values and fields for credentials, environment, commands,
+paths, processes, managed agents, MCP, hooks, skills, or engrams reject the
+record. Public avatar URLs are validated but never fetched.
+
+Definition import is an explicit one-way data operation. Newly materialized
+profiles, rosters, and roster members are disabled. Declared Buzz runtime,
+model, and provider values remain source metadata and are not provider-runtime
+evidence. The source event ID and optimistic local revision are checked again
+inside the authoritative JSON-file lock or SQLite transaction before mutation.
+Source removal never deletes local materializations.
+
 ## Provider Runtime Capability Enforcement
 
 Provider runtime manifests are authorization evidence, not display metadata.

--- a/server/src/__tests__/buzz-communication-service.test.ts
+++ b/server/src/__tests__/buzz-communication-service.test.ts
@@ -182,6 +182,43 @@ describe('BuzzCommunicationService', () => {
     await expect(service.eventExists(config(identity.publicKey), eventId)).resolves.toBe(false);
     await expect(service.eventExists(config(identity.publicKey), eventId)).resolves.toBeUndefined();
   });
+
+  it('uses the signed DNS-pinned query transport for bounded definition reads', async () => {
+    const identity = credentials();
+    const definitions = [{ id: 'd'.repeat(64), kind: 30_175 }];
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(definitions), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const service = new BuzzCommunicationService({
+      fetch,
+      resolveSecret: vi.fn().mockResolvedValue(identity.privateKey),
+      nip98Signer: {
+        sign: vi.fn().mockResolvedValue({
+          authorization: 'Nostr signed',
+          publicKey: identity.publicKey,
+        }),
+      },
+    });
+
+    await expect(
+      service.queryEvents(config(identity.publicKey), [{ kinds: [30_175, 30_176], limit: 200 }])
+    ).resolves.toEqual(definitions);
+    expect(fetch).toHaveBeenCalledWith(
+      `https://${COMMUNITY}/query`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Nostr signed' }),
+        body: JSON.stringify([{ kinds: [30_175, 30_176], limit: 200 }]),
+      }),
+      expect.objectContaining({ logFailures: false })
+    );
+    await expect(
+      service.queryEvents(config(identity.publicKey), [{ kinds: [30_177], limit: 1 }])
+    ).rejects.toThrow('outside the allowed definition bounds');
+  });
 });
 
 describe('Buzz inbound event contract', () => {

--- a/server/src/__tests__/buzz-definition-import-service.test.ts
+++ b/server/src/__tests__/buzz-definition-import-service.test.ts
@@ -1,0 +1,472 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { finalizeEvent, generateSecretKey, getPublicKey, type VerifiedEvent } from 'nostr-tools';
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { ConfigService } from '../services/config-service.js';
+import { AgentProfilePackageService } from '../services/agent-profile-package-service.js';
+import { TeamRosterService } from '../services/team-roster-service.js';
+import { BuzzDefinitionImportService } from '../services/buzz-definition-import-service.js';
+import type { BuzzQueryContext } from '../services/communication-adapter-service.js';
+
+const now = Math.floor(Date.now() / 1_000) - 10;
+const context: BuzzQueryContext = {
+  relay: 'https://buzz.example.com',
+  community: 'buzz.example.com',
+  probeConfig: {
+    enabled: true,
+    relayHttpUrl: 'https://buzz.example.com',
+    publicKey: 'a'.repeat(64),
+    credentialRef: 'env:BUZZ_PRIVATE_KEY',
+  },
+};
+
+function definitionEvent(
+  secretKey: Uint8Array,
+  kind: 30_175 | 30_176,
+  dTag: string,
+  content: Record<string, unknown>,
+  createdAt = now
+): VerifiedEvent {
+  return finalizeEvent(
+    {
+      kind,
+      created_at: createdAt,
+      tags: [['d', dTag]],
+      content: JSON.stringify(content),
+    },
+    secretKey
+  );
+}
+
+describe('BuzzDefinitionImportService', () => {
+  let runtimeDir: string;
+  let configService: ConfigService;
+  let profiles: AgentProfilePackageService;
+  let rosters: TeamRosterService;
+  let events: VerifiedEvent[];
+  let service: BuzzDefinitionImportService;
+  let secretKey: Uint8Array;
+  let author: string;
+  const audit = vi.fn(async () => undefined);
+
+  beforeEach(async () => {
+    runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'vk-buzz-definitions-'));
+    configService = new ConfigService({ configDir: runtimeDir, storageType: 'file' });
+    profiles = new AgentProfilePackageService(configService);
+    rosters = new TeamRosterService(configService);
+    secretKey = generateSecretKey();
+    author = getPublicKey(secretKey);
+    events = [];
+    audit.mockClear();
+    service = new BuzzDefinitionImportService({
+      communicationAdapters: {
+        getBuzzQueryContext: vi.fn(async () => context),
+      },
+      buzzCommunication: {
+        queryEvents: vi.fn(async () => events),
+      },
+      profiles,
+      rosters,
+      audit,
+      now: () => new Date(now * 1_000),
+    });
+  });
+
+  afterEach(async () => {
+    configService.dispose();
+    await rm(runtimeDir, { recursive: true, force: true });
+  });
+
+  it('selects deterministic NIP-33 heads and reports forward-compatible fields', async () => {
+    const older = definitionEvent(
+      secretKey,
+      30_175,
+      'reviewer',
+      { display_name: 'Old Reviewer' },
+      now - 10
+    );
+    const candidates = [
+      definitionEvent(
+        secretKey,
+        30_175,
+        'reviewer',
+        { display_name: 'Reviewer B', future_field: 'retained nowhere' },
+        now
+      ),
+      definitionEvent(
+        secretKey,
+        30_175,
+        'reviewer',
+        { display_name: 'Reviewer A', future_field: 'retained nowhere' },
+        now
+      ),
+    ];
+    events = [older, ...candidates];
+
+    const result = await service.listDefinitions('buzz-default');
+    const expectedHead = [...candidates].sort((left, right) => left.id.localeCompare(right.id))[0];
+
+    expect(result.definitions).toHaveLength(1);
+    expect(result.definitions[0]?.eventId).toBe(expectedHead?.id);
+    const preview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'reviewer' },
+      action: 'create',
+    });
+    expect(preview.fieldReport).toContainEqual(
+      expect.objectContaining({ field: 'future_field', disposition: 'ignored' })
+    );
+    expect(preview.diff).toContainEqual(
+      expect.objectContaining({ field: 'displayName', change: 'add' })
+    );
+  });
+
+  it('creates a disabled persona profile without activating source runtime preferences', async () => {
+    events = [
+      definitionEvent(secretKey, 30_175, 'security-reviewer', {
+        display_name: 'Security Reviewer',
+        system_prompt: 'Review security boundaries.',
+        runtime: 'container',
+        model: 'source-model',
+        provider: 'source-provider',
+        avatar_url: 'https://cdn.example.com/avatar.png',
+        name_pool: ['ALPHA'],
+        respond_to: 'mentions',
+      }),
+    ];
+    const preview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'security-reviewer' },
+      action: 'create',
+    });
+    const result = await service.importDefinition(
+      'buzz-default',
+      {
+        coordinate: preview.definition,
+        action: 'create',
+        targetId: preview.targetId,
+        expectedEventId: preview.definition.eventId,
+        expectedLocalRevision: preview.expectedLocalRevision,
+      },
+      'test-admin'
+    );
+
+    expect(result.status).toBe('created');
+    expect(result.profile).toMatchObject({
+      id: 'buzz-security-reviewer',
+      displayName: 'Security Reviewer',
+      enabled: false,
+      instructions: { prompt: 'Review security boundaries.' },
+    });
+    expect(result.profile?.runtime).toEqual({ agent: 'buzz-security-reviewer' });
+    expect(result.profile?.metadata?.buzz?.sourceSnapshot).toMatchObject({
+      runtime: 'container',
+      model: 'source-model',
+      provider: 'source-provider',
+    });
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'buzz_definition.created', actor: 'test-admin' })
+    );
+    expect(
+      profiles.validateContent({
+        content: JSON.stringify(result.profile),
+        format: 'json',
+      })
+    ).toMatchObject({
+      valid: false,
+      issues: [expect.objectContaining({ path: '$.metadata.buzz' })],
+    });
+
+    if (!result.profile) throw new Error('Expected imported profile');
+    const nativeReplacement = structuredClone(result.profile);
+    delete nativeReplacement.metadata?.buzz;
+    nativeReplacement.role = 'Locally replaced role';
+    await profiles.importProfile({
+      content: JSON.stringify(nativeReplacement),
+      format: 'json',
+    });
+    expect(await profiles.getProfile(nativeReplacement.id)).toMatchObject({
+      role: 'Locally replaced role',
+      metadata: { buzz: expect.objectContaining({ provenance: expect.any(Object) }) },
+    });
+  });
+
+  it('imports teams only through same-author linked persona profiles and keeps routing disabled', async () => {
+    const persona = definitionEvent(secretKey, 30_175, 'builder', {
+      display_name: 'Builder',
+    });
+    const team = definitionEvent(secretKey, 30_176, 'delivery-team', {
+      name: 'Delivery Team',
+      description: 'A public Buzz team definition.',
+      persona_ids: ['builder'],
+    });
+    events = [persona, team];
+    const personaPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'builder' },
+      action: 'create',
+    });
+    await service.importDefinition('buzz-default', {
+      coordinate: personaPreview.definition,
+      action: 'create',
+      expectedEventId: personaPreview.definition.eventId,
+    });
+    const teamPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_176, dTag: 'delivery-team' },
+      action: 'create',
+    });
+    const result = await service.importDefinition('buzz-default', {
+      coordinate: teamPreview.definition,
+      action: 'create',
+      expectedEventId: teamPreview.definition.eventId,
+      expectedLocalRevision: teamPreview.expectedLocalRevision,
+    });
+
+    expect(result.roster).toMatchObject({
+      name: 'Delivery Team',
+      enabled: false,
+      routingRules: [],
+      members: [
+        {
+          id: 'buzz-builder',
+          profileId: 'buzz-builder',
+          status: 'disabled',
+        },
+      ],
+    });
+    if (!result.roster) throw new Error('Expected imported roster');
+    const nativeRosterUpdate = structuredClone(result.roster);
+    delete nativeRosterUpdate.metadata?.buzz;
+    nativeRosterUpdate.description = 'Local roster description';
+    const saved = await rosters.saveRoster(nativeRosterUpdate);
+    expect(saved).toMatchObject({
+      description: 'Local roster description',
+      metadata: { buzz: expect.objectContaining({ provenance: expect.any(Object) }) },
+    });
+  });
+
+  it('does not resolve a team persona through a different author link', async () => {
+    const otherSecretKey = generateSecretKey();
+    const otherAuthor = getPublicKey(otherSecretKey);
+    const otherPersona = definitionEvent(otherSecretKey, 30_175, 'builder', {
+      display_name: 'Other Builder',
+    });
+    const team = definitionEvent(secretKey, 30_176, 'delivery-team', {
+      name: 'Delivery Team',
+      persona_ids: ['builder'],
+    });
+    events = [otherPersona, team];
+    const personaPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: otherAuthor, kind: 30_175, dTag: 'builder' },
+      action: 'create',
+    });
+    await service.importDefinition('buzz-default', {
+      coordinate: personaPreview.definition,
+      action: 'create',
+      expectedEventId: personaPreview.definition.eventId,
+    });
+
+    const teamPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_176, dTag: 'delivery-team' },
+      action: 'create',
+    });
+    expect(teamPreview.unresolvedPersonaIds).toEqual(['builder']);
+    expect(teamPreview.proposedRoster?.members).toEqual([]);
+  });
+
+  it('rejects secret-like and managed runtime material before preview', async () => {
+    events = [
+      definitionEvent(secretKey, 30_175, 'unsafe', {
+        display_name: 'Unsafe',
+        command: 'buzz-agent --token=topsecretvalue',
+      }),
+      definitionEvent(secretKey, 30_175, 'unsafe-secret', {
+        display_name: 'Unsafe Secret',
+        system_prompt: 'token=topsecretvalue',
+      }),
+    ];
+
+    const result = await service.listDefinitions('buzz-default');
+    expect(result.definitions).toEqual([
+      expect.objectContaining({ compatibility: 'rejected' }),
+      expect.objectContaining({ compatibility: 'rejected' }),
+    ]);
+    expect(result.rejectedCount).toBe(2);
+  });
+
+  it('does not fall back to an older valid definition when the current head is rejected', async () => {
+    events = [
+      definitionEvent(
+        secretKey,
+        30_175,
+        'reviewer',
+        { display_name: 'Older valid reviewer' },
+        now - 1
+      ),
+      definitionEvent(
+        secretKey,
+        30_175,
+        'reviewer',
+        { display_name: 'Rejected current reviewer', environment: { TOKEN: 'value' } },
+        now
+      ),
+    ];
+
+    const result = await service.listDefinitions('buzz-default');
+    expect(result.definitions).toEqual([
+      expect.objectContaining({
+        dTag: 'reviewer',
+        compatibility: 'rejected',
+        displayName: 'Persona reviewer',
+      }),
+    ]);
+    const preview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'reviewer' },
+      action: 'create',
+    });
+    expect(preview.fieldReport).toEqual([
+      expect.objectContaining({ field: '$', disposition: 'rejected' }),
+    ]);
+    await expect(
+      service.importDefinition('buzz-default', {
+        coordinate: preview.definition,
+        action: 'create',
+        expectedEventId: preview.definition.eventId,
+      })
+    ).rejects.toThrow('failed validation');
+  });
+
+  it('bounds unsafe URLs, traversal slugs, JSON depth, and array counts', async () => {
+    let deep: Record<string, unknown> = { value: 'leaf' };
+    for (let index = 0; index < 12; index += 1) deep = { nested: deep };
+    events = [
+      definitionEvent(secretKey, 30_175, 'unsafe-url', {
+        display_name: 'Unsafe URL',
+        avatar_url: 'http://127.0.0.1/private',
+      }),
+      definitionEvent(secretKey, 30_175, '../traversal', {
+        display_name: 'Traversal',
+      }),
+      definitionEvent(secretKey, 30_175, 'too-deep', {
+        display_name: 'Too Deep',
+        future: deep,
+      }),
+      definitionEvent(secretKey, 30_175, 'too-many', {
+        display_name: 'Too Many',
+        future: Array.from({ length: 201 }, (_, index) => index),
+      }),
+    ];
+
+    const result = await service.listDefinitions('buzz-default');
+    expect(result.rejectedCount).toBe(4);
+    expect(result.definitions).toHaveLength(3);
+    expect(result.definitions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ dTag: 'unsafe-url', compatibility: 'rejected' }),
+        expect.objectContaining({ dTag: 'too-deep', compatibility: 'rejected' }),
+        expect.objectContaining({ dTag: 'too-many', compatibility: 'rejected' }),
+      ])
+    );
+  });
+
+  it('rejects a stale optimistic revision and leaves local edits intact', async () => {
+    events = [
+      definitionEvent(secretKey, 30_175, 'reviewer', {
+        display_name: 'Reviewer',
+        system_prompt: 'Initial instructions.',
+      }),
+    ];
+    const createPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'reviewer' },
+      action: 'create',
+    });
+    await service.importDefinition('buzz-default', {
+      coordinate: createPreview.definition,
+      action: 'create',
+      expectedEventId: createPreview.definition.eventId,
+    });
+    events = [
+      definitionEvent(
+        secretKey,
+        30_175,
+        'reviewer',
+        { display_name: 'Updated Reviewer', system_prompt: 'Updated instructions.' },
+        now + 1
+      ),
+    ];
+    const refreshPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'reviewer' },
+      action: 'refresh',
+    });
+    await profiles.updateProfile('buzz-reviewer', { role: 'Locally edited role' });
+
+    await expect(
+      service.importDefinition('buzz-default', {
+        coordinate: refreshPreview.definition,
+        action: 'refresh',
+        targetId: refreshPreview.targetId,
+        expectedEventId: refreshPreview.definition.eventId,
+        expectedLocalRevision: refreshPreview.expectedLocalRevision,
+      })
+    ).rejects.toThrow('changed after preview');
+    expect(await profiles.getProfile('buzz-reviewer')).toMatchObject({
+      displayName: 'Reviewer',
+      role: 'Locally edited role',
+    });
+  });
+
+  it('returns unchanged for an idempotent explicit refresh', async () => {
+    events = [
+      definitionEvent(secretKey, 30_175, 'reviewer', {
+        display_name: 'Reviewer',
+      }),
+    ];
+    const createPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'reviewer' },
+      action: 'create',
+    });
+    await service.importDefinition('buzz-default', {
+      coordinate: createPreview.definition,
+      action: 'create',
+      expectedEventId: createPreview.definition.eventId,
+    });
+    const refreshPreview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'reviewer' },
+      action: 'refresh',
+    });
+    const result = await service.importDefinition('buzz-default', {
+      coordinate: refreshPreview.definition,
+      action: 'refresh',
+      targetId: refreshPreview.targetId,
+      expectedEventId: refreshPreview.definition.eventId,
+      expectedLocalRevision: refreshPreview.expectedLocalRevision,
+    });
+
+    expect(result.status).toBe('unchanged');
+  });
+
+  it('reports missing and changed linked sources without deleting materialized profiles', async () => {
+    const original = definitionEvent(secretKey, 30_175, 'reviewer', {
+      display_name: 'Reviewer',
+    });
+    events = [original];
+    const preview = await service.preview('buzz-default', {
+      coordinate: { authorPubkey: author, kind: 30_175, dTag: 'reviewer' },
+      action: 'create',
+    });
+    await service.importDefinition('buzz-default', {
+      coordinate: preview.definition,
+      action: 'create',
+      expectedEventId: preview.definition.eventId,
+    });
+    events = [
+      definitionEvent(secretKey, 30_175, 'reviewer', { display_name: 'Reviewer 2' }, now + 1),
+    ];
+    expect(await service.linkedStatus('buzz-default')).toMatchObject([
+      { targetId: 'buzz-reviewer', status: 'changed', linkedEventId: original.id },
+    ]);
+    events = [];
+    expect(await service.linkedStatus('buzz-default')).toMatchObject([
+      { targetId: 'buzz-reviewer', status: 'missing' },
+    ]);
+    expect(await profiles.getProfile('buzz-reviewer')).not.toBeNull();
+  });
+});

--- a/server/src/__tests__/config-service-extended.test.ts
+++ b/server/src/__tests__/config-service-extended.test.ts
@@ -333,6 +333,58 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('mutateConfig', () => {
+    it('serializes cross-instance file mutations without losing either update', async () => {
+      await service.getConfig();
+      const second = new ConfigService({ configDir, configFile, storageType: 'file' });
+      const profile = (id: string) =>
+        ({
+          id,
+          schemaVersion: 'agent-profile-package/v1',
+          version: '1.0.0',
+          displayName: id,
+          role: 'test',
+          enabled: false,
+          capabilities: [],
+          defaultTaskTypes: [],
+          runtime: { agent: id },
+        }) as const;
+
+      await Promise.all([
+        service.mutateConfig((config) => ({
+          config: { ...config, agentProfiles: [...(config.agentProfiles ?? []), profile('one')] },
+          result: 'one',
+        })),
+        second.mutateConfig((config) => ({
+          config: { ...config, agentProfiles: [...(config.agentProfiles ?? []), profile('two')] },
+          result: 'two',
+        })),
+      ]);
+      second.dispose();
+
+      service.invalidateCache();
+      expect((await service.getConfig()).agentProfiles?.map((item) => item.id).sort()).toEqual([
+        'one',
+        'two',
+      ]);
+    });
+
+    it('commits a SQLite read-modify-write mutation transactionally', async () => {
+      const sqlite = new ConfigService({
+        storageType: 'sqlite',
+        sqliteConnectionOptions: { databasePath: path.join(tmpDir, 'settings.db') },
+      });
+      const result = await sqlite.mutateConfig((config) => ({
+        config: { ...config, defaultAgent: 'hermes' },
+        result: { updated: true },
+      }));
+
+      expect(result).toEqual({ updated: true });
+      expect((await sqlite.getConfig()).defaultAgent).toBe('hermes');
+      sqlite.dispose();
+    });
+  });
+
   describe('invalidateCache', () => {
     it('should force re-read on next getConfig', async () => {
       const config1 = await service.getConfig();

--- a/server/src/__tests__/routes/integrations.test.ts
+++ b/server/src/__tests__/routes/integrations.test.ts
@@ -29,6 +29,15 @@ const { mockCommunicationAdapters, mockBroadcastSquadMessage } = vi.hoisted(() =
   mockBroadcastSquadMessage: vi.fn(),
 }));
 
+const { mockBuzzDefinitions } = vi.hoisted(() => ({
+  mockBuzzDefinitions: {
+    listDefinitions: vi.fn(),
+    linkedStatus: vi.fn(),
+    preview: vi.fn(),
+    importDefinition: vi.fn(),
+  },
+}));
+
 vi.mock('node:dns/promises', () => ({
   lookup: mockLookup,
 }));
@@ -60,6 +69,10 @@ vi.mock('../../services/communication-adapter-service.js', () => ({
 
 vi.mock('../../services/broadcast-service.js', () => ({
   broadcastSquadMessage: mockBroadcastSquadMessage,
+}));
+
+vi.mock('../../services/buzz-definition-import-service.js', () => ({
+  getBuzzDefinitionImportService: () => mockBuzzDefinitions,
 }));
 
 import { integrationsRoutes } from '../../routes/integrations.js';
@@ -133,6 +146,14 @@ describe('integrations routes', () => {
       createdAt: '2026-07-23T20:00:00.000Z',
       updatedAt: '2026-07-23T20:01:00.000Z',
     });
+    mockBuzzDefinitions.listDefinitions.mockResolvedValue({
+      adapterId: 'buzz-default',
+      relay: 'https://relay.example.test',
+      community: 'relay.example.test',
+      definitions: [],
+      rejectedCount: 0,
+    });
+    mockBuzzDefinitions.linkedStatus.mockResolvedValue([]);
     mockCommunicationAdapters.send.mockResolvedValue({
       delivery: {
         id: 'comm_1',
@@ -487,6 +508,109 @@ describe('integrations routes', () => {
       channelId,
       'operator'
     );
+  });
+
+  it('lists, previews, and imports Buzz definitions through explicit actions', async () => {
+    mockCommunicationAdapters.getAdapter.mockResolvedValue({
+      id: 'buzz-default',
+      kind: 'buzz',
+      displayName: 'Buzz',
+      enabled: true,
+    });
+    const definition = {
+      type: 'persona',
+      displayName: 'Reviewer',
+      authorPubkey: 'a'.repeat(64),
+      kind: 30_175,
+      dTag: 'reviewer',
+      eventId: 'b'.repeat(64),
+      createdAt: 1_784_848_400,
+      contentHash: 'c'.repeat(64),
+      community: 'relay.example.test',
+      compatibility: 'compatible',
+    };
+    mockBuzzDefinitions.listDefinitions.mockResolvedValueOnce({
+      adapterId: 'buzz-default',
+      relay: 'https://relay.example.test',
+      community: 'relay.example.test',
+      definitions: [definition],
+      rejectedCount: 0,
+    });
+    mockBuzzDefinitions.preview.mockResolvedValueOnce({
+      definition,
+      action: 'create',
+      targetId: 'buzz-reviewer',
+      changed: true,
+      diff: [],
+      fieldReport: [],
+      collisions: [],
+      unresolvedPersonaIds: [],
+    });
+    mockBuzzDefinitions.importDefinition.mockResolvedValueOnce({
+      status: 'created',
+      definition,
+      profile: { id: 'buzz-reviewer', enabled: false },
+    });
+
+    const listed = await request(app).get(
+      '/api/integrations/communication/adapters/buzz-default/buzz/definitions'
+    );
+    expect(listed.status).toBe(200);
+    expect(listed.body.definitions).toEqual([definition]);
+
+    const input = {
+      coordinate: {
+        authorPubkey: definition.authorPubkey,
+        kind: definition.kind,
+        dTag: definition.dTag,
+      },
+      action: 'create',
+      targetId: 'buzz-reviewer',
+    };
+    const previewed = await request(app)
+      .post('/api/integrations/communication/adapters/buzz-default/buzz/definitions/preview')
+      .send(input);
+    expect(previewed.status).toBe(200);
+    expect(mockBuzzDefinitions.preview).toHaveBeenCalledWith('buzz-default', input);
+
+    const imported = await request(app)
+      .post('/api/integrations/communication/adapters/buzz-default/buzz/definitions/import')
+      .send({ ...input, expectedEventId: definition.eventId });
+    expect(imported.status).toBe(201);
+    expect(imported.body).toMatchObject({
+      status: 'created',
+      profile: { id: 'buzz-reviewer', enabled: false },
+    });
+  });
+
+  it('maps stale Buzz definition imports to a conflict response', async () => {
+    mockCommunicationAdapters.getAdapter.mockResolvedValue({
+      id: 'buzz-default',
+      kind: 'buzz',
+      displayName: 'Buzz',
+      enabled: true,
+    });
+    mockBuzzDefinitions.importDefinition.mockRejectedValueOnce(
+      new Error('Local target changed after preview; preview the import again')
+    );
+    const response = await request(app)
+      .post('/api/integrations/communication/adapters/buzz-default/buzz/definitions/import')
+      .send({
+        coordinate: {
+          authorPubkey: 'a'.repeat(64),
+          kind: 30_175,
+          dTag: 'reviewer',
+        },
+        action: 'refresh',
+        targetId: 'buzz-reviewer',
+        expectedEventId: 'b'.repeat(64),
+        expectedLocalRevision: 'c'.repeat(64),
+      });
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      code: 'CONFLICT',
+      message: expect.stringContaining('changed after preview'),
+    });
   });
 
   it('returns deterministic client errors for invalid and conflicting Buzz mappings', async () => {

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -379,4 +379,35 @@ describe('v1 REST permission guard presets', () => {
       })
     );
   });
+
+  it('keeps Buzz definition preview read-only while guarding materialization', () => {
+    expect(
+      runGuard(
+        integrationsAccess,
+        mockRequest(
+          'POST',
+          '/communication/adapters/buzz-default/buzz/definitions/preview',
+          'read-only',
+          ['settings:read']
+        )
+      ).next
+    ).toHaveBeenCalled();
+
+    const imported = runGuard(
+      integrationsAccess,
+      mockRequest(
+        'POST',
+        '/communication/adapters/buzz-default/buzz/definitions/import',
+        'read-only',
+        ['settings:read']
+      )
+    );
+    expect(imported.next).not.toHaveBeenCalled();
+    expect(imported.res.status).toHaveBeenCalledWith(403);
+    expect(imported.res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['settings:write'] }),
+      })
+    );
+  });
 });

--- a/server/src/routes/integrations.ts
+++ b/server/src/routes/integrations.ts
@@ -32,12 +32,19 @@ import { getOutboundIntegrationService } from '../services/outbound-integration-
 import { externalTrackerRoutes } from './external-trackers.js';
 import { safeFetch } from '../utils/url-validation.js';
 import { createLogger } from '../lib/logger.js';
+import { getBuzzDefinitionImportService } from '../services/buzz-definition-import-service.js';
+import {
+  BuzzDefinitionImportBodySchema,
+  BuzzDefinitionPreviewBodySchema,
+} from '../schemas/buzz-definition-schemas.js';
+import type { BuzzDefinitionImportInput, BuzzDefinitionPreviewInput } from '@veritas-kanban/shared';
 
 const log = createLogger('integrations');
 const router = Router();
 const configService = new ConfigService();
 const outboundIntegrations = getOutboundIntegrationService();
 const communicationAdapters = getCommunicationAdapterService();
+const buzzDefinitions = () => getBuzzDefinitionImportService();
 
 const SERVICE_NAMES = ['supabase', 'openpanel', 'n8n', 'plane', 'appsmith'] as const;
 type ServiceName = (typeof SERVICE_NAMES)[number];
@@ -261,6 +268,73 @@ router.get(
     const adapterId = adapterIdParam(req.params.adapterId);
     await ensureAdapterExists(adapterId);
     res.json(await communicationAdapters.listBuzzChannelMappings(adapterId));
+  })
+);
+
+// GET /api/integrations/communication/adapters/:adapterId/buzz/definitions
+router.get(
+  '/communication/adapters/:adapterId/buzz/definitions',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    res.json(await buzzDefinitions().listDefinitions(adapterId));
+  })
+);
+
+// GET /api/integrations/communication/adapters/:adapterId/buzz/definitions/links
+router.get(
+  '/communication/adapters/:adapterId/buzz/definitions/links',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    res.json(await buzzDefinitions().linkedStatus(adapterId));
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/buzz/definitions/preview
+router.post(
+  '/communication/adapters/:adapterId/buzz/definitions/preview',
+  validate({ body: BuzzDefinitionPreviewBodySchema }),
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    const input = req.validated?.body as BuzzDefinitionPreviewInput;
+    try {
+      res.json(await buzzDefinitions().preview(adapterId, input));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Buzz definition preview failed';
+      if (message.includes('not found')) throw new NotFoundError(message);
+      throw new BadRequestError(message);
+    }
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/buzz/definitions/import
+router.post(
+  '/communication/adapters/:adapterId/buzz/definitions/import',
+  validate({ body: BuzzDefinitionImportBodySchema }),
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    await ensureAdapterExists(adapterId);
+    const input = req.validated?.body as BuzzDefinitionImportInput;
+    const actor = (req as AuthenticatedRequest).auth?.keyName ?? 'system';
+    try {
+      const result = await buzzDefinitions().importDefinition(adapterId, input, actor);
+      res.status(result.status === 'created' ? 201 : 200).json(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Buzz definition import failed';
+      if (
+        message.includes('changed after preview') ||
+        message.includes('collision') ||
+        message.includes('unresolved') ||
+        message.includes('link target') ||
+        message.includes('refresh target')
+      ) {
+        throw new ConflictError(message);
+      }
+      if (message.includes('not found')) throw new NotFoundError(message);
+      throw new BadRequestError(message);
+    }
   })
 );
 

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -87,6 +87,11 @@ export const feedbackAccess = routeAccess('report:read', 'comment:write');
 export const integrationsAccess = routeAccess('settings:read', 'settings:write', [
   {
     methods: ['POST'],
+    path: /^\/communication\/adapters\/[^/]+\/buzz\/definitions\/preview\/?$/,
+    permissions: 'settings:read',
+  },
+  {
+    methods: ['POST'],
     path: /^\/communication\/adapters\/[^/]+\/replies\/?$/,
     permissions: 'comment:write',
   },

--- a/server/src/schemas/agent-profile-package-schemas.ts
+++ b/server/src/schemas/agent-profile-package-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
+import { BuzzDefinitionLinkSchema } from './buzz-definition-schemas.js';
 
 const AgentTypeSchema = z
   .string()
@@ -104,6 +105,7 @@ export const AgentProfilePackageMetadataSchema = z
     source: z.string().trim().min(1).max(500).optional(),
     importedAt: z.string().datetime().optional(),
     updatedAt: z.string().datetime().optional(),
+    buzz: BuzzDefinitionLinkSchema.optional(),
   })
   .strict()
   .optional();

--- a/server/src/schemas/buzz-definition-schemas.ts
+++ b/server/src/schemas/buzz-definition-schemas.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+
+const Hex64Schema = z.string().regex(/^[a-f0-9]{64}$/i);
+const SlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-_]*$/);
+const BuzzSlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_-]*$/, 'Buzz definition IDs must be slugs');
+
+export const BuzzDefinitionCoordinateSchema = z
+  .object({
+    authorPubkey: Hex64Schema,
+    kind: z.union([z.literal(30175), z.literal(30176)]),
+    dTag: BuzzSlugSchema,
+  })
+  .strict();
+
+export const BuzzDefinitionActionSchema = z.enum(['create', 'link', 'refresh', 'skip']);
+
+export const BuzzDefinitionPreviewBodySchema = z
+  .object({
+    coordinate: BuzzDefinitionCoordinateSchema,
+    action: BuzzDefinitionActionSchema,
+    targetId: SlugSchema.optional(),
+  })
+  .strict();
+
+export const BuzzDefinitionImportBodySchema = BuzzDefinitionPreviewBodySchema.extend({
+  expectedEventId: Hex64Schema,
+  expectedLocalRevision: Hex64Schema.optional(),
+}).strict();
+
+export const BuzzPersonaContentSchema = z
+  .object({
+    display_name: z.string().trim().min(1).max(120),
+    system_prompt: z.string().max(10_000).nullable().optional(),
+    avatar_url: z.url().max(2_048).nullable().optional(),
+    runtime: z.string().trim().min(1).max(120).nullable().optional(),
+    model: z.string().trim().min(1).max(120).nullable().optional(),
+    provider: z.string().trim().min(1).max(120).nullable().optional(),
+    name_pool: z.array(z.string().trim().min(1).max(120)).max(50).optional(),
+    respond_to: z.string().trim().min(1).max(120).nullable().optional(),
+    respond_to_allowlist: z.array(z.string().trim().min(1).max(160)).max(100).nullable().optional(),
+    parallelism: z.number().int().min(1).max(100).nullable().optional(),
+  })
+  .passthrough();
+
+export const BuzzTeamContentSchema = z
+  .object({
+    name: z.string().trim().min(1).max(160),
+    description: z.string().trim().max(2_000).nullable().optional(),
+    persona_ids: z.array(BuzzSlugSchema).min(1).max(100),
+  })
+  .passthrough();
+
+const BuzzDefinitionProvenanceSchema = z
+  .object({
+    schemaVersion: z.literal('buzz-definition-link/v1'),
+    adapterId: z.string().trim().min(1).max(80),
+    relay: z.url().max(2_048),
+    community: z.string().trim().min(1).max(253),
+    authorPubkey: Hex64Schema,
+    kind: z.union([z.literal(30175), z.literal(30176)]),
+    dTag: z.string().trim().min(1).max(80),
+    eventId: Hex64Schema,
+    createdAt: z.number().int().positive(),
+    contentHash: Hex64Schema,
+    importedAt: z.string().datetime(),
+    refreshedAt: z.string().datetime().optional(),
+  })
+  .strict();
+
+const BuzzDefinitionSourceSnapshotSchema = z
+  .object({
+    displayName: z.string().max(120).optional(),
+    systemPrompt: z.string().max(10_000).optional(),
+    avatarUrl: z.url().max(2_048).optional(),
+    runtime: z.string().max(120).optional(),
+    model: z.string().max(120).optional(),
+    provider: z.string().max(120).optional(),
+    namePool: z.array(z.string().max(120)).max(50).optional(),
+    respondTo: z.string().max(120).optional(),
+    respondToAllowlist: z.array(z.string().max(160)).max(100).optional(),
+    parallelism: z.number().int().min(1).max(100).optional(),
+    name: z.string().max(160).optional(),
+    description: z.string().max(2_000).optional(),
+    personaIds: z.array(z.string().max(80)).max(100).optional(),
+  })
+  .strict();
+
+const BuzzDefinitionFieldReportSchema = z
+  .object({
+    field: z.string().trim().min(1).max(160),
+    disposition: z.enum(['mapped', 'source-only', 'ignored', 'rejected', 'conflict']),
+    detail: z.string().trim().min(1).max(500),
+  })
+  .strict();
+
+export const BuzzDefinitionLinkSchema = z
+  .object({
+    provenance: BuzzDefinitionProvenanceSchema,
+    sourceSnapshot: BuzzDefinitionSourceSnapshotSchema,
+    fieldReport: z.array(BuzzDefinitionFieldReportSchema).max(100),
+    sourceOwnedFields: z.array(z.string().trim().min(1).max(160)).max(50),
+    localRevision: Hex64Schema,
+    materializedIds: z.array(SlugSchema).max(100).optional(),
+  })
+  .strict();

--- a/server/src/schemas/team-roster-schemas.ts
+++ b/server/src/schemas/team-roster-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BuzzDefinitionLinkSchema } from './buzz-definition-schemas.js';
 
 const SlugSchema = z
   .string()
@@ -85,6 +86,7 @@ export const TeamRosterManifestSchema = z
         source: z.string().trim().min(1).max(500).optional(),
         importedAt: z.string().datetime().optional(),
         updatedAt: z.string().datetime().optional(),
+        buzz: BuzzDefinitionLinkSchema.optional(),
       })
       .strict()
       .optional(),

--- a/server/src/services/agent-profile-package-service.ts
+++ b/server/src/services/agent-profile-package-service.ts
@@ -7,6 +7,7 @@ import type {
   AgentProfilePackageSummary,
   AgentProfileResolvedLaunch,
   AgentProfileValidationResult,
+  AgentConfig,
 } from '@veritas-kanban/shared';
 import { getConfigService, type ConfigService } from './config-service.js';
 import { AgentProfilePackageSchema } from '../schemas/agent-profile-package-schemas.js';
@@ -34,14 +35,54 @@ export class AgentProfilePackageService {
     return (config.agentProfiles ?? []).map((profile) => this.toSummary(profile));
   }
 
+  async listProfilePackages(): Promise<AgentProfilePackage[]> {
+    const config = await this.configService.getConfig();
+    return structuredClone(config.agentProfiles ?? []);
+  }
+
+  async listConfiguredAgents(): Promise<AgentConfig[]> {
+    const config = await this.configService.getConfig();
+    return structuredClone(config.agents);
+  }
+
   async getProfile(id: string): Promise<AgentProfilePackage | null> {
     const config = await this.configService.getConfig();
     return (config.agentProfiles ?? []).find((profile) => profile.id === id) ?? null;
   }
 
+  async mutateProfiles<T>(
+    mutator: (
+      profiles: AgentProfilePackage[],
+      agents: AgentConfig[]
+    ) => { profiles: AgentProfilePackage[]; result: T }
+  ): Promise<T> {
+    return this.configService.mutateConfig((config) => {
+      const mutation = mutator(config.agentProfiles ?? [], config.agents);
+      const profiles = mutation.profiles.map(
+        (profile) => AgentProfilePackageSchema.parse(profile) as AgentProfilePackage
+      );
+      return {
+        config: { ...config, agentProfiles: profiles },
+        result: mutation.result,
+      };
+    });
+  }
+
   validateContent(input: ImportProfileInput): AgentProfileValidationResult {
     try {
-      return this.validateUnknown(this.parseContent(input.content, input.format));
+      const validation = this.validateUnknown(this.parseContent(input.content, input.format));
+      if (validation.valid && validation.profile?.metadata?.buzz) {
+        return {
+          valid: false,
+          issues: [
+            {
+              path: '$.metadata.buzz',
+              message: 'Buzz provenance is system-owned and cannot be imported directly',
+            },
+          ],
+        };
+      }
+      return validation;
     } catch (error) {
       return {
         valid: false,
@@ -75,6 +116,13 @@ export class AgentProfilePackageService {
     const config = await this.configService.getConfig();
     const profiles = config.agentProfiles ?? [];
     const index = profiles.findIndex((candidate) => candidate.id === profile.id);
+    const existing = index >= 0 ? profiles[index] : undefined;
+    if (existing?.metadata?.buzz) {
+      profile.metadata = {
+        ...profile.metadata,
+        buzz: existing.metadata.buzz,
+      };
+    }
     const created = index === -1;
     config.agentProfiles = created
       ? [...profiles, profile]

--- a/server/src/services/buzz-communication-service.ts
+++ b/server/src/services/buzz-communication-service.ts
@@ -28,6 +28,8 @@ export const BUZZ_SUBSCRIBED_KINDS = [
 ] as const;
 
 const MAX_EVENT_BYTES = 256 * 1024;
+const MAX_QUERY_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_QUERY_RESULTS = 200;
 const MAX_MESSAGE_BYTES = 64 * 1024;
 const DEFAULT_TIMEOUT_MS = 8_000;
 const EVENT_ID_PATTERN = /^[a-f0-9]{64}$/;
@@ -51,6 +53,12 @@ export interface BuzzSubmitResult {
   status: 'accepted' | 'rejected' | 'delivery_unknown';
   eventId: string;
   detail?: string;
+}
+
+export interface BuzzEventQueryFilter {
+  kinds: number[];
+  authors?: string[];
+  limit: number;
 }
 
 export interface BuzzInboundEvent {
@@ -389,6 +397,38 @@ export class BuzzCommunicationService {
     } catch {
       return undefined;
     }
+  }
+
+  async queryEvents(config: BuzzProbeConfig, filters: BuzzEventQueryFilter[]): Promise<unknown[]> {
+    if (
+      filters.length < 1 ||
+      filters.length > 4 ||
+      filters.some(
+        (filter) =>
+          filter.kinds.length < 1 ||
+          filter.kinds.length > 4 ||
+          filter.kinds.some((kind) => ![30_175, 30_176].includes(kind)) ||
+          !Number.isInteger(filter.limit) ||
+          filter.limit < 1 ||
+          filter.limit > MAX_QUERY_RESULTS ||
+          filter.authors?.some((author) => !EVENT_ID_PATTERN.test(author))
+      )
+    ) {
+      throw new Error('Buzz event query is outside the allowed definition bounds');
+    }
+    const endpoints = normalizeBuzzEndpoints(config);
+    const response = await this.signedRequest(
+      config,
+      `${endpoints.httpUrl}/query`,
+      JSON.stringify(filters)
+    );
+    if (!response) throw new Error('Buzz definition query was blocked by outbound network policy');
+    if (!response.ok) throw new Error(`Buzz definition query returned HTTP ${response.status}`);
+    const parsed = JSON.parse(await readBoundedBody(response, MAX_QUERY_RESPONSE_BYTES)) as unknown;
+    if (!Array.isArray(parsed) || parsed.length > MAX_QUERY_RESULTS) {
+      throw new Error('Buzz definition query returned an invalid or oversized result set');
+    }
+    return parsed;
   }
 
   async resolveCredentials(

--- a/server/src/services/buzz-definition-import-service.ts
+++ b/server/src/services/buzz-definition-import-service.ts
@@ -1,0 +1,1401 @@
+import { createHash } from 'node:crypto';
+import { isIP } from 'node:net';
+import type { Event } from 'nostr-tools';
+import { verifyEvent } from 'nostr-tools';
+import type {
+  AgentProfilePackage,
+  BuzzDefinitionCollision,
+  BuzzDefinitionCoordinate,
+  BuzzDefinitionDiff,
+  BuzzDefinitionFieldReport,
+  BuzzDefinitionImportInput,
+  BuzzDefinitionImportResult,
+  BuzzDefinitionLink,
+  BuzzDefinitionLinkedStatus,
+  BuzzDefinitionListResult,
+  BuzzDefinitionPreview,
+  BuzzDefinitionPreviewInput,
+  BuzzDefinitionSourceSnapshot,
+  BuzzDefinitionSummary,
+  TeamRosterManifest,
+  TeamRosterMember,
+} from '@veritas-kanban/shared';
+import { auditLog, type AuditEvent } from './audit-service.js';
+import {
+  getAgentProfilePackageService,
+  type AgentProfilePackageService,
+} from './agent-profile-package-service.js';
+import {
+  getCommunicationAdapterService,
+  type BuzzQueryContext,
+  type CommunicationAdapterService,
+} from './communication-adapter-service.js';
+import {
+  BuzzCommunicationService,
+  type BuzzEventQueryFilter,
+} from './buzz-communication-service.js';
+import { getTeamRosterService, type TeamRosterService } from './team-roster-service.js';
+import {
+  BuzzPersonaContentSchema,
+  BuzzTeamContentSchema,
+} from '../schemas/buzz-definition-schemas.js';
+
+const PERSONA_KIND = 30_175 as const;
+const TEAM_KIND = 30_176 as const;
+const MAX_EVENT_BYTES = 256 * 1024;
+const MAX_CONTENT_BYTES = 64 * 1024;
+const MAX_JSON_DEPTH = 10;
+const MAX_OBJECT_KEYS = 200;
+const MAX_TAGS = 50;
+const HEX_64 = /^[a-f0-9]{64}$/i;
+const FORBIDDEN_KEY =
+  /(?:^|_)(?:env(?:ironment)?(?:_variables?)?|env_vars?|secrets?|tokens?|passwords?|api_?keys?|private_?keys?|nsec|commands?(?:_args?)?|cwd|working_directory|file_?paths?|paths?|pid|process(?:_state)?|managed_agent|runtime_state|agent_status|mcp(?:_servers?)?|hooks?|skills?(?:_files?)?|engrams?)(?:_|$)/i;
+const FORBIDDEN_VALUE = [
+  /\bnsec1[023456789acdefghjklmnpqrstuvwxyz]{20,}\b/i,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/,
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  /(?:api[_-]?key|secret|token|password|private[_-]?key)\s*[:=]\s*\S{8,}/i,
+] as const;
+
+const PERSONA_KNOWN_FIELDS = new Set([
+  'display_name',
+  'system_prompt',
+  'avatar_url',
+  'runtime',
+  'model',
+  'provider',
+  'name_pool',
+  'respond_to',
+  'respond_to_allowlist',
+  'parallelism',
+]);
+const TEAM_KNOWN_FIELDS = new Set(['name', 'description', 'persona_ids']);
+
+interface ParsedDefinition {
+  event: Event;
+  coordinate: BuzzDefinitionCoordinate;
+  summary: BuzzDefinitionSummary;
+  snapshot: BuzzDefinitionSourceSnapshot;
+  fieldReport: BuzzDefinitionFieldReport[];
+}
+
+type ProfileMutationResult = {
+  status: 'created' | 'linked' | 'refreshed' | 'unchanged';
+  profile: AgentProfilePackage;
+};
+
+type RosterMutationResult = {
+  status: 'created' | 'linked' | 'refreshed' | 'unchanged';
+  roster: TeamRosterManifest;
+};
+
+interface BuzzDefinitionImportServiceOptions {
+  communicationAdapters?: Pick<CommunicationAdapterService, 'getBuzzQueryContext'>;
+  buzzCommunication?: Pick<BuzzCommunicationService, 'queryEvents'>;
+  profiles?: AgentProfilePackageService;
+  rosters?: TeamRosterService;
+  audit?: (event: AuditEvent) => Promise<void>;
+  now?: () => Date;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function localRevision(value: AgentProfilePackage | TeamRosterManifest): string {
+  const clone = structuredClone(value);
+  if (clone.metadata?.buzz) clone.metadata.buzz.localRevision = '';
+  return sha256(stableJson(clone));
+}
+
+function withLocalRevision<T extends AgentProfilePackage | TeamRosterManifest>(value: T): T {
+  if (!value.metadata?.buzz) return value;
+  value.metadata.buzz.localRevision = localRevision(value);
+  return value;
+}
+
+function teamImportRevision(
+  roster: TeamRosterManifest | null | undefined,
+  profiles: Map<string, AgentProfilePackage>
+): string {
+  return sha256(
+    stableJson({
+      roster: roster ? localRevision(roster) : null,
+      profiles: [...profiles.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([personaId, profile]) => ({
+          personaId,
+          profileId: profile.id,
+          revision: localRevision(profile),
+        })),
+    })
+  );
+}
+
+function cleanText(value: string): string {
+  return Array.from(value)
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127);
+    })
+    .join('')
+    .trim();
+}
+
+function stableSlug(value: string, prefix = 'buzz'): string {
+  const cleaned = value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return `${prefix}-${cleaned || sha256(value).slice(0, 12)}`.slice(0, 80);
+}
+
+function jsonDepth(value: unknown, depth = 0): number {
+  if (!value || typeof value !== 'object') return depth;
+  if (depth >= MAX_JSON_DEPTH) return depth + 1;
+  const children = Array.isArray(value) ? value : Object.values(value as Record<string, unknown>);
+  return children.reduce((max, entry) => Math.max(max, jsonDepth(entry, depth + 1)), depth);
+}
+
+function countObjectKeys(value: unknown): number {
+  if (!value || typeof value !== 'object') return 0;
+  if (Array.isArray(value)) return value.reduce((sum, entry) => sum + countObjectKeys(entry), 0);
+  return Object.entries(value as Record<string, unknown>).reduce(
+    (sum, [, entry]) => sum + 1 + countObjectKeys(entry),
+    0
+  );
+}
+
+function arraysWithinBounds(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length <= 200 && value.every(arraysWithinBounds);
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).every(arraysWithinBounds);
+  }
+  return true;
+}
+
+function findForbiddenMaterial(
+  value: unknown,
+  path = '$'
+): { path: string; reason: string } | undefined {
+  if (typeof value === 'string') {
+    if (FORBIDDEN_VALUE.some((pattern) => pattern.test(value))) {
+      return { path, reason: 'secret-like value' };
+    }
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findForbiddenMaterial(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      if (['__proto__', 'constructor', 'prototype'].includes(key) || FORBIDDEN_KEY.test(key)) {
+        return { path: `${path}.${key}`, reason: 'forbidden field' };
+      }
+      const found = findForbiddenMaterial(entry, `${path}.${key}`);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function validatePublicUrl(value: string): string {
+  const parsed = new URL(value);
+  if (
+    !['http:', 'https:'].includes(parsed.protocol) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.hostname === 'localhost' ||
+    parsed.hostname.endsWith('.local') ||
+    isIP(parsed.hostname)
+  ) {
+    throw new Error('Buzz avatar URL must be a credential-free public HTTP(S) URL');
+  }
+  return parsed.toString();
+}
+
+function sourceCoordinateKey(coordinate: BuzzDefinitionCoordinate): string {
+  return `${coordinate.authorPubkey.toLowerCase()}:${coordinate.kind}:${coordinate.dTag}`;
+}
+
+function sameCoordinate(left: BuzzDefinitionCoordinate, right: BuzzDefinitionCoordinate): boolean {
+  return sourceCoordinateKey(left) === sourceCoordinateKey(right);
+}
+
+function linkCoordinate(link: BuzzDefinitionLink): BuzzDefinitionCoordinate {
+  return {
+    authorPubkey: link.provenance.authorPubkey,
+    kind: link.provenance.kind,
+    dTag: link.provenance.dTag,
+  };
+}
+
+function parseEventShape(value: unknown): Event {
+  if (!value || typeof value !== 'object') throw new Error('Buzz definition is not an object');
+  const candidate = value as Partial<Event>;
+  if (
+    typeof candidate.id !== 'string' ||
+    !HEX_64.test(candidate.id) ||
+    typeof candidate.pubkey !== 'string' ||
+    !HEX_64.test(candidate.pubkey) ||
+    !Number.isInteger(candidate.created_at) ||
+    (candidate.created_at ?? 0) < 1 ||
+    ![PERSONA_KIND, TEAM_KIND].includes(candidate.kind as typeof PERSONA_KIND) ||
+    typeof candidate.content !== 'string' ||
+    typeof candidate.sig !== 'string' ||
+    !/^[a-f0-9]{128}$/i.test(candidate.sig) ||
+    !Array.isArray(candidate.tags) ||
+    candidate.tags.length > MAX_TAGS ||
+    !candidate.tags.every(
+      (tag) =>
+        Array.isArray(tag) &&
+        tag.length <= 10 &&
+        tag.every((entry) => typeof entry === 'string' && entry.length <= 2_048)
+    )
+  ) {
+    throw new Error('Buzz definition has an invalid Nostr shape');
+  }
+  const event: Event = {
+    id: candidate.id,
+    pubkey: candidate.pubkey,
+    created_at: Number(candidate.created_at),
+    kind: Number(candidate.kind),
+    tags: candidate.tags.map((tag) => [...tag]),
+    content: candidate.content,
+    sig: candidate.sig,
+  };
+  if (event.created_at > Math.floor(Date.now() / 1000) + 300) {
+    throw new Error('Buzz definition timestamp is outside the accepted range');
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(event), 'utf8') > MAX_EVENT_BYTES ||
+    Buffer.byteLength(event.content, 'utf8') > MAX_CONTENT_BYTES
+  ) {
+    throw new Error('Buzz definition exceeds the supported size limit');
+  }
+  if (!verifyEvent(event)) throw new Error('Buzz definition signature is invalid');
+  return event;
+}
+
+function buildFieldReport(
+  kind: typeof PERSONA_KIND | typeof TEAM_KIND,
+  content: Record<string, unknown>
+): BuzzDefinitionFieldReport[] {
+  const report: BuzzDefinitionFieldReport[] = [];
+  const known = kind === PERSONA_KIND ? PERSONA_KNOWN_FIELDS : TEAM_KNOWN_FIELDS;
+  const mapped =
+    kind === PERSONA_KIND
+      ? new Map([
+          ['display_name', 'Mapped to profile displayName.'],
+          ['system_prompt', 'Mapped to profile instructions.prompt when present.'],
+        ])
+      : new Map([
+          ['name', 'Mapped to roster name.'],
+          ['description', 'Mapped to roster description when present.'],
+          ['persona_ids', 'Resolved to disabled roster members by same-author persona link.'],
+        ]);
+  const sourceOnly =
+    kind === PERSONA_KIND
+      ? new Map([
+          ['avatar_url', 'Retained as public source metadata; no asset is fetched.'],
+          ['runtime', 'Retained as a declared source preference, not runtime evidence.'],
+          ['model', 'Retained as a declared source preference, not active configuration.'],
+          ['provider', 'Retained as a declared source preference, not active configuration.'],
+          ['name_pool', 'Retained as bounded source metadata; no agents are created from it.'],
+          ['respond_to', 'Retained as reserved Buzz behavior; Veritas does not apply it.'],
+          [
+            'respond_to_allowlist',
+            'Retained as reserved Buzz behavior; Veritas does not apply it.',
+          ],
+          ['parallelism', 'Retained as reserved Buzz behavior; Veritas does not apply it.'],
+        ])
+      : new Map<string, string>();
+  for (const key of Object.keys(content).sort()) {
+    const mappedDetail = mapped.get(key);
+    const sourceOnlyDetail = sourceOnly.get(key);
+    if (mappedDetail) {
+      report.push({ field: key, disposition: 'mapped', detail: mappedDetail });
+    } else if (sourceOnlyDetail) {
+      report.push({ field: key, disposition: 'source-only', detail: sourceOnlyDetail });
+    } else if (!known.has(key)) {
+      report.push({
+        field: key,
+        disposition: 'ignored',
+        detail: 'Unknown Buzz field ignored for forward compatibility.',
+      });
+    }
+  }
+  return report;
+}
+
+function parseDefinitionEnvelope(value: unknown, context: BuzzQueryContext): ParsedDefinition {
+  const event = parseEventShape(value);
+  const dTags = event.tags.filter((tag) => tag[0] === 'd' && tag.length >= 2);
+  if (
+    dTags.length !== 1 ||
+    !dTags[0]?.[1] ||
+    !/^[A-Za-z0-9][A-Za-z0-9_-]{0,79}$/.test(dTags[0][1])
+  ) {
+    throw new Error('Buzz definition must contain exactly one bounded d tag');
+  }
+  const coordinate: BuzzDefinitionCoordinate = {
+    authorPubkey: event.pubkey.toLowerCase(),
+    kind: event.kind as typeof PERSONA_KIND | typeof TEAM_KIND,
+    dTag: cleanText(dTags[0][1]),
+  };
+  return {
+    event,
+    coordinate,
+    snapshot: {},
+    fieldReport: [],
+    summary: {
+      ...coordinate,
+      type: event.kind === PERSONA_KIND ? 'persona' : 'team',
+      displayName: `${event.kind === PERSONA_KIND ? 'Persona' : 'Team'} ${coordinate.dTag}`,
+      eventId: event.id,
+      createdAt: event.created_at,
+      contentHash: sha256(event.content),
+      community: context.community,
+      compatibility: 'rejected',
+      detail: 'Definition content validation pending.',
+    },
+  };
+}
+
+function parseDefinition(value: unknown, context: BuzzQueryContext): ParsedDefinition {
+  const envelope = parseDefinitionEnvelope(value, context);
+  const { event, coordinate } = envelope;
+  let content: unknown;
+  try {
+    content = JSON.parse(event.content);
+  } catch {
+    throw new Error('Buzz definition content is not valid JSON');
+  }
+  if (
+    !content ||
+    typeof content !== 'object' ||
+    Array.isArray(content) ||
+    jsonDepth(content) > MAX_JSON_DEPTH ||
+    countObjectKeys(content) > MAX_OBJECT_KEYS ||
+    !arraysWithinBounds(content)
+  ) {
+    throw new Error('Buzz definition JSON is outside the accepted structural bounds');
+  }
+  const forbidden = findForbiddenMaterial(content);
+  if (forbidden) {
+    throw new Error(`Buzz definition rejected ${forbidden.reason} at ${forbidden.path}`);
+  }
+  const raw = content as Record<string, unknown>;
+  let displayName: string;
+  let snapshot: BuzzDefinitionSourceSnapshot;
+  if (event.kind === PERSONA_KIND) {
+    const parsed = BuzzPersonaContentSchema.parse(raw);
+    displayName = cleanText(parsed.display_name);
+    snapshot = {
+      displayName,
+      systemPrompt: parsed.system_prompt ? cleanText(parsed.system_prompt) : undefined,
+      avatarUrl: parsed.avatar_url ? validatePublicUrl(parsed.avatar_url) : undefined,
+      runtime: parsed.runtime ? cleanText(parsed.runtime) : undefined,
+      model: parsed.model ? cleanText(parsed.model) : undefined,
+      provider: parsed.provider ? cleanText(parsed.provider) : undefined,
+      namePool: parsed.name_pool?.map(cleanText),
+      respondTo: parsed.respond_to ? cleanText(parsed.respond_to) : undefined,
+      respondToAllowlist: parsed.respond_to_allowlist?.map(cleanText) ?? undefined,
+      parallelism: parsed.parallelism ?? undefined,
+    };
+  } else {
+    const parsed = BuzzTeamContentSchema.parse(raw);
+    displayName = cleanText(parsed.name);
+    snapshot = {
+      name: displayName,
+      description: parsed.description ? cleanText(parsed.description) : undefined,
+      personaIds: parsed.persona_ids.map(cleanText),
+    };
+  }
+  const contentHash = sha256(event.content);
+  return {
+    event,
+    coordinate,
+    snapshot,
+    fieldReport: buildFieldReport(event.kind as typeof PERSONA_KIND | typeof TEAM_KIND, raw),
+    summary: {
+      ...coordinate,
+      type: event.kind === PERSONA_KIND ? 'persona' : 'team',
+      displayName,
+      eventId: event.id,
+      createdAt: event.created_at,
+      contentHash,
+      community: context.community,
+      compatibility: 'compatible',
+    },
+  };
+}
+
+function rejectedDefinition(envelope: ParsedDefinition, error: unknown): ParsedDefinition {
+  const detail = cleanText(error instanceof Error ? error.message : 'Definition content rejected')
+    .replace(/\s+/g, ' ')
+    .slice(0, 300);
+  return {
+    ...envelope,
+    fieldReport: [
+      {
+        field: '$',
+        disposition: 'rejected',
+        detail: detail || 'Definition content rejected.',
+      },
+    ],
+    summary: {
+      ...envelope.summary,
+      compatibility: 'rejected',
+      detail: detail || 'Definition content rejected.',
+    },
+  };
+}
+
+function selectHeads(definitions: ParsedDefinition[]): ParsedDefinition[] {
+  const heads = new Map<string, ParsedDefinition>();
+  for (const definition of definitions) {
+    const key = sourceCoordinateKey(definition.coordinate);
+    const current = heads.get(key);
+    if (
+      !current ||
+      definition.event.created_at > current.event.created_at ||
+      (definition.event.created_at === current.event.created_at &&
+        definition.event.id.localeCompare(current.event.id) < 0)
+    ) {
+      heads.set(key, definition);
+    }
+  }
+  return [...heads.values()].sort(
+    (left, right) =>
+      left.summary.type.localeCompare(right.summary.type) ||
+      left.summary.displayName.localeCompare(right.summary.displayName) ||
+      left.summary.authorPubkey.localeCompare(right.summary.authorPubkey)
+  );
+}
+
+function buildLink(
+  definition: ParsedDefinition,
+  context: BuzzQueryContext,
+  input: {
+    adapterId: string;
+    fieldReport: BuzzDefinitionFieldReport[];
+    sourceOwnedFields: string[];
+    importedAt: string;
+    refreshedAt?: string;
+    materializedIds?: string[];
+  }
+): BuzzDefinitionLink {
+  return {
+    provenance: {
+      schemaVersion: 'buzz-definition-link/v1',
+      adapterId: input.adapterId,
+      relay: context.relay,
+      community: context.community,
+      ...definition.coordinate,
+      eventId: definition.event.id,
+      createdAt: definition.event.created_at,
+      contentHash: definition.summary.contentHash,
+      importedAt: input.importedAt,
+      refreshedAt: input.refreshedAt,
+    },
+    sourceSnapshot: definition.snapshot,
+    fieldReport: input.fieldReport,
+    sourceOwnedFields: input.sourceOwnedFields,
+    localRevision: '0'.repeat(64),
+    materializedIds: input.materializedIds,
+  };
+}
+
+function sourceLinkMatches(
+  link: BuzzDefinitionLink | undefined,
+  coordinate: BuzzDefinitionCoordinate
+) {
+  return Boolean(link && sameCoordinate(linkCoordinate(link), coordinate));
+}
+
+function textSummary(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : value ? `present (${value.length} chars)` : 'empty';
+}
+
+function diffField(
+  field: string,
+  beforeSummary: string | undefined,
+  afterSummary: string | undefined
+): BuzzDefinitionDiff | undefined {
+  if (beforeSummary === afterSummary) return undefined;
+  return {
+    field,
+    change: beforeSummary === undefined ? 'add' : afterSummary === undefined ? 'remove' : 'update',
+    beforeSummary,
+    afterSummary,
+  };
+}
+
+export class BuzzDefinitionImportService {
+  private readonly communicationAdapters: Pick<CommunicationAdapterService, 'getBuzzQueryContext'>;
+  private readonly buzzCommunication: Pick<BuzzCommunicationService, 'queryEvents'>;
+  private readonly profiles: AgentProfilePackageService;
+  private readonly rosters: TeamRosterService;
+  private readonly audit: (event: AuditEvent) => Promise<void>;
+  private readonly now: () => Date;
+
+  constructor(options: BuzzDefinitionImportServiceOptions = {}) {
+    this.communicationAdapters = options.communicationAdapters ?? getCommunicationAdapterService();
+    this.buzzCommunication = options.buzzCommunication ?? new BuzzCommunicationService();
+    this.profiles = options.profiles ?? getAgentProfilePackageService();
+    this.rosters = options.rosters ?? getTeamRosterService();
+    this.audit = options.audit ?? auditLog;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async listDefinitions(adapterId: string): Promise<BuzzDefinitionListResult> {
+    const { context, definitions, rejectedCount } = await this.loadDefinitions(adapterId);
+    return {
+      adapterId,
+      relay: context.relay,
+      community: context.community,
+      definitions: definitions.map((definition) => definition.summary),
+      rejectedCount,
+    };
+  }
+
+  async preview(
+    adapterId: string,
+    input: BuzzDefinitionPreviewInput
+  ): Promise<BuzzDefinitionPreview> {
+    const loaded = await this.loadDefinitions(adapterId);
+    const definition = this.requireDefinition(loaded.definitions, input.coordinate);
+    if (definition.summary.compatibility === 'rejected') {
+      return {
+        definition: definition.summary,
+        action: input.action,
+        targetId: input.targetId,
+        changed: false,
+        diff: [],
+        fieldReport: definition.fieldReport,
+        collisions: [
+          {
+            field: 'source',
+            value: definition.coordinate.dTag,
+            detail: 'The current Buzz definition head failed content validation.',
+          },
+        ],
+        unresolvedPersonaIds: [],
+      };
+    }
+    return definition.coordinate.kind === PERSONA_KIND
+      ? this.previewPersona(adapterId, loaded.context, definition, input)
+      : this.previewTeam(adapterId, loaded.context, definition, input);
+  }
+
+  async importDefinition(
+    adapterId: string,
+    input: BuzzDefinitionImportInput,
+    actor = 'system'
+  ): Promise<BuzzDefinitionImportResult> {
+    const loaded = await this.loadDefinitions(adapterId);
+    const definition = this.requireDefinition(loaded.definitions, input.coordinate);
+    if (definition.event.id !== input.expectedEventId) {
+      throw new Error('Buzz source changed after preview; preview the current definition again');
+    }
+    if (input.action === 'skip') {
+      const result: BuzzDefinitionImportResult = {
+        status: 'skipped',
+        definition: definition.summary,
+      };
+      await this.audit({
+        action: 'buzz_definition.skipped',
+        actor,
+        resource: definition.coordinate.dTag,
+        details: {
+          adapterId,
+          action: input.action,
+          kind: definition.coordinate.kind,
+          authorPubkey: definition.coordinate.authorPubkey,
+          dTag: definition.coordinate.dTag,
+          eventId: definition.event.id,
+          status: result.status,
+        },
+      });
+      return result;
+    }
+    if (definition.summary.compatibility === 'rejected') {
+      throw new Error('Buzz definition content failed validation');
+    }
+    const preview =
+      definition.coordinate.kind === PERSONA_KIND
+        ? await this.previewPersona(adapterId, loaded.context, definition, input)
+        : await this.previewTeam(adapterId, loaded.context, definition, input);
+    if (preview.collisions.length || preview.unresolvedPersonaIds.length) {
+      throw new Error('Buzz definition has unresolved import conflicts');
+    }
+    if (preview.expectedLocalRevision !== input.expectedLocalRevision) {
+      throw new Error('Local target changed after preview; preview the import again');
+    }
+
+    const result =
+      definition.coordinate.kind === PERSONA_KIND
+        ? await this.importPersona(adapterId, loaded.context, definition, input)
+        : await this.importTeam(adapterId, loaded.context, definition, input);
+    await this.audit({
+      action: `buzz_definition.${result.status}`,
+      actor,
+      resource: result.profile?.id ?? result.roster?.id ?? definition.coordinate.dTag,
+      details: {
+        adapterId,
+        action: input.action,
+        kind: definition.coordinate.kind,
+        authorPubkey: definition.coordinate.authorPubkey,
+        dTag: definition.coordinate.dTag,
+        eventId: definition.event.id,
+        status: result.status,
+      },
+    });
+    return result;
+  }
+
+  async linkedStatus(adapterId: string): Promise<BuzzDefinitionLinkedStatus[]> {
+    const configProfiles = await this.profiles.listProfilePackages();
+    const roster = await this.rosters.getRoster();
+    const linked = [
+      ...configProfiles.flatMap((profile) => {
+        const link = profile.metadata?.buzz;
+        return link?.provenance.adapterId === adapterId
+          ? [{ targetType: 'profile' as const, targetId: profile.id, link }]
+          : [];
+      }),
+      ...(roster?.metadata?.buzz?.provenance.adapterId === adapterId
+        ? [{ targetType: 'roster' as const, targetId: roster.id, link: roster.metadata.buzz }]
+        : []),
+    ];
+    if (!linked.length) return [];
+    try {
+      const loaded = await this.loadDefinitions(adapterId);
+      return linked.map(({ targetType, targetId, link }) => {
+        const current = loaded.definitions.find((definition) =>
+          sameCoordinate(definition.coordinate, linkCoordinate(link))
+        );
+        return {
+          targetType,
+          targetId,
+          coordinate: linkCoordinate(link),
+          status: !current
+            ? ('missing' as const)
+            : current.summary.compatibility === 'rejected'
+              ? ('changed' as const)
+              : current.event.id === link.provenance.eventId
+                ? ('current' as const)
+                : ('changed' as const),
+          linkedEventId: link.provenance.eventId,
+          currentEventId: current?.event.id,
+          detail:
+            current?.summary.compatibility === 'rejected'
+              ? 'The current Buzz definition head failed content validation.'
+              : undefined,
+        };
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message.slice(0, 500) : 'Buzz unavailable';
+      return linked.map(({ targetType, targetId, link }) => ({
+        targetType,
+        targetId,
+        coordinate: linkCoordinate(link),
+        status: 'unavailable',
+        linkedEventId: link.provenance.eventId,
+        detail,
+      }));
+    }
+  }
+
+  private async loadDefinitions(adapterId: string): Promise<{
+    context: BuzzQueryContext;
+    definitions: ParsedDefinition[];
+    rejectedCount: number;
+  }> {
+    const context = await this.communicationAdapters.getBuzzQueryContext(adapterId);
+    const filters: BuzzEventQueryFilter[] = [{ kinds: [PERSONA_KIND, TEAM_KIND], limit: 200 }];
+    const events = await this.buzzCommunication.queryEvents(context.probeConfig, filters);
+    const envelopes: ParsedDefinition[] = [];
+    let rejectedCount = 0;
+    for (const event of events) {
+      try {
+        envelopes.push(parseDefinitionEnvelope(event, context));
+      } catch {
+        rejectedCount += 1;
+      }
+    }
+    const definitions = selectHeads(envelopes).map((envelope) => {
+      try {
+        return parseDefinition(envelope.event, context);
+      } catch (error) {
+        rejectedCount += 1;
+        return rejectedDefinition(envelope, error);
+      }
+    });
+    return { context, definitions, rejectedCount };
+  }
+
+  private requireDefinition(
+    definitions: ParsedDefinition[],
+    coordinate: BuzzDefinitionCoordinate
+  ): ParsedDefinition {
+    const definition = definitions.find((candidate) =>
+      sameCoordinate(candidate.coordinate, coordinate)
+    );
+    if (!definition) throw new Error('Buzz definition was not found in the current relay heads');
+    return definition;
+  }
+
+  private async previewPersona(
+    adapterId: string,
+    context: BuzzQueryContext,
+    definition: ParsedDefinition,
+    input: BuzzDefinitionPreviewInput
+  ): Promise<BuzzDefinitionPreview> {
+    const [profiles, configuredAgents] = await Promise.all([
+      this.profiles.listProfilePackages(),
+      this.profiles.listConfiguredAgents(),
+    ]);
+    const linked = profiles.filter((profile) =>
+      sourceLinkMatches(profile.metadata?.buzz, definition.coordinate)
+    );
+    const targetId =
+      input.targetId ??
+      (input.action === 'refresh' ? linked[0]?.id : undefined) ??
+      stableSlug(definition.coordinate.dTag);
+    const target = profiles.find((profile) => profile.id === targetId);
+    const collisions: BuzzDefinitionCollision[] = [];
+    if (input.action === 'create') {
+      const deterministicId = stableSlug(definition.coordinate.dTag);
+      if (input.targetId && input.targetId !== deterministicId) {
+        collisions.push({
+          field: 'id',
+          value: input.targetId,
+          detail: `Create uses the deterministic profile ID ${deterministicId}; use link for an existing target.`,
+        });
+      }
+      if (target) {
+        collisions.push({
+          field: 'id',
+          value: targetId,
+          detail: 'A profile already uses the proposed deterministic ID.',
+        });
+      }
+      const nameMatch = profiles.find(
+        (profile) =>
+          profile.displayName.toLowerCase() === definition.summary.displayName.toLowerCase()
+      );
+      if (nameMatch) {
+        collisions.push({
+          field: 'name',
+          value: nameMatch.displayName,
+          detail: `Profile ${nameMatch.id} already uses this display name.`,
+        });
+      }
+      const agentTypeMatch = configuredAgents.find((agent) => agent.type === targetId);
+      if (agentTypeMatch) {
+        collisions.push({
+          field: 'id',
+          value: targetId,
+          detail: `Configured agent ${agentTypeMatch.name} already uses this runtime ID.`,
+        });
+      }
+      const agentNameMatch = configuredAgents.find(
+        (agent) => agent.name.toLowerCase() === definition.summary.displayName.toLowerCase()
+      );
+      if (agentNameMatch) {
+        collisions.push({
+          field: 'name',
+          value: agentNameMatch.name,
+          detail: `Configured agent ${agentNameMatch.type} already uses this display name.`,
+        });
+      }
+      if (linked.length) {
+        collisions.push({
+          field: 'source',
+          value: definition.coordinate.dTag,
+          detail: `Buzz source is already linked to ${linked.map((item) => item.id).join(', ')}.`,
+        });
+      }
+    } else if (input.action === 'link') {
+      if (!target) {
+        collisions.push({
+          field: 'id',
+          value: targetId,
+          detail: 'Link requires an existing profile target.',
+        });
+      } else if (
+        target.metadata?.buzz &&
+        !sourceLinkMatches(target.metadata.buzz, definition.coordinate)
+      ) {
+        collisions.push({
+          field: 'source',
+          value: targetId,
+          detail: 'Target profile is linked to a different Buzz source.',
+        });
+      }
+      const otherLinks = linked.filter((profile) => profile.id !== targetId);
+      if (otherLinks.length) {
+        collisions.push({
+          field: 'source',
+          value: definition.coordinate.dTag,
+          detail: `Buzz source is already linked to ${otherLinks.map((profile) => profile.id).join(', ')}.`,
+        });
+      }
+    } else if (input.action === 'refresh') {
+      if (!target || !sourceLinkMatches(target.metadata?.buzz, definition.coordinate)) {
+        collisions.push({
+          field: 'source',
+          value: targetId,
+          detail: 'Refresh requires the profile already linked to this Buzz source.',
+        });
+      }
+      if (linked.length > 1) {
+        collisions.push({
+          field: 'source',
+          value: definition.coordinate.dTag,
+          detail: 'Buzz source has multiple profile links; resolve them before refresh.',
+        });
+      }
+      const nameMatch = profiles.find(
+        (profile) =>
+          profile.id !== targetId &&
+          profile.displayName.toLowerCase() === definition.summary.displayName.toLowerCase()
+      );
+      if (nameMatch) {
+        collisions.push({
+          field: 'name',
+          value: definition.summary.displayName,
+          detail: `Profile ${nameMatch.id} already uses the refreshed display name.`,
+        });
+      }
+    }
+    const proposed = this.materializePersona(
+      adapterId,
+      context,
+      definition,
+      input.action,
+      target,
+      targetId
+    );
+    const unchanged =
+      target?.metadata?.buzz?.provenance.eventId === definition.event.id &&
+      target.metadata.buzz.provenance.contentHash === definition.summary.contentHash;
+    const diff = [
+      diffField('displayName', target?.displayName, proposed?.displayName),
+      diffField(
+        'instructions.prompt',
+        textSummary(target?.instructions?.prompt),
+        textSummary(proposed?.instructions?.prompt)
+      ),
+      diffField(
+        'source link',
+        target?.metadata?.buzz ? target.metadata.buzz.provenance.eventId.slice(0, 12) : undefined,
+        proposed?.metadata?.buzz
+          ? proposed.metadata.buzz.provenance.eventId.slice(0, 12)
+          : undefined
+      ),
+    ].filter((entry): entry is BuzzDefinitionDiff => Boolean(entry));
+    return {
+      definition: definition.summary,
+      action: input.action,
+      targetId,
+      expectedLocalRevision: target ? localRevision(target) : undefined,
+      changed: !unchanged,
+      diff,
+      fieldReport: definition.fieldReport,
+      collisions,
+      unresolvedPersonaIds: [],
+      proposedProfile: proposed,
+    };
+  }
+
+  private materializePersona(
+    adapterId: string,
+    context: BuzzQueryContext,
+    definition: ParsedDefinition,
+    action: BuzzDefinitionPreviewInput['action'],
+    existing?: AgentProfilePackage,
+    targetId = stableSlug(definition.coordinate.dTag)
+  ): AgentProfilePackage | undefined {
+    if (action === 'skip') return undefined;
+    const displayName = definition.snapshot.displayName;
+    if (!displayName) throw new Error('Buzz persona display name is unavailable');
+    const now = this.now().toISOString();
+    const importedAt = existing?.metadata?.buzz?.provenance.importedAt ?? now;
+    const link = buildLink(definition, context, {
+      adapterId,
+      fieldReport: definition.fieldReport,
+      sourceOwnedFields: action === 'link' ? [] : ['displayName', 'instructions.prompt'],
+      importedAt,
+      refreshedAt: action === 'refresh' ? now : undefined,
+    });
+    if (action === 'link' && existing) {
+      return withLocalRevision({
+        ...existing,
+        metadata: {
+          ...existing.metadata,
+          source: existing.metadata?.source ?? `buzz:${sourceCoordinateKey(definition.coordinate)}`,
+          importedAt: existing.metadata?.importedAt ?? now,
+          updatedAt: now,
+          buzz: link,
+        },
+      });
+    }
+    if (action === 'refresh' && existing) {
+      const instructions = definition.snapshot.systemPrompt
+        ? { ...existing.instructions, prompt: definition.snapshot.systemPrompt }
+        : existing.instructions
+          ? { ...existing.instructions, prompt: undefined }
+          : undefined;
+      return withLocalRevision({
+        ...existing,
+        displayName,
+        instructions,
+        metadata: { ...existing.metadata, updatedAt: now, buzz: link },
+      });
+    }
+    const profile: AgentProfilePackage = {
+      id: targetId,
+      schemaVersion: 'agent-profile-package/v1',
+      version: '1.0.0',
+      displayName,
+      role: 'Buzz persona',
+      description:
+        'Imported public Buzz persona definition. Configure a compatible runtime before enabling.',
+      enabled: false,
+      capabilities: [],
+      defaultTaskTypes: [],
+      runtime: { agent: stableSlug(definition.coordinate.dTag) },
+      instructions: definition.snapshot.systemPrompt
+        ? { prompt: definition.snapshot.systemPrompt }
+        : undefined,
+      metadata: {
+        source: `buzz:${sourceCoordinateKey(definition.coordinate)}`,
+        importedAt: now,
+        updatedAt: now,
+        buzz: link,
+      },
+    };
+    return withLocalRevision(profile);
+  }
+
+  private async previewTeam(
+    adapterId: string,
+    context: BuzzQueryContext,
+    definition: ParsedDefinition,
+    input: BuzzDefinitionPreviewInput
+  ): Promise<BuzzDefinitionPreview> {
+    const profiles = await this.profiles.listProfilePackages();
+    const existing = await this.rosters.getRoster();
+    const targetId =
+      input.targetId ?? existing?.id ?? stableSlug(definition.coordinate.dTag, 'buzz-team');
+    const matchingProfiles = new Map<string, AgentProfilePackage>();
+    for (const personaId of definition.snapshot.personaIds ?? []) {
+      const profile = profiles.find(
+        (candidate) =>
+          candidate.metadata?.buzz?.provenance.kind === PERSONA_KIND &&
+          candidate.metadata.buzz.provenance.authorPubkey.toLowerCase() ===
+            definition.coordinate.authorPubkey.toLowerCase() &&
+          candidate.metadata.buzz.provenance.dTag === personaId
+      );
+      if (profile) matchingProfiles.set(personaId, profile);
+    }
+    const unresolvedPersonaIds = (definition.snapshot.personaIds ?? []).filter(
+      (personaId) => !matchingProfiles.has(personaId)
+    );
+    const collisions: BuzzDefinitionCollision[] = [];
+    if (input.action === 'create') {
+      const deterministicId = stableSlug(definition.coordinate.dTag, 'buzz-team');
+      if (input.targetId && input.targetId !== deterministicId) {
+        collisions.push({
+          field: 'id',
+          value: input.targetId,
+          detail: `Create uses the deterministic roster ID ${deterministicId}; use link for an existing target.`,
+        });
+      }
+      if (existing) {
+        collisions.push({
+          field: 'id',
+          value: existing.id,
+          detail: 'A team roster already exists; use link or refresh.',
+        });
+      }
+    } else if (input.action === 'link') {
+      if (!existing || existing.id !== targetId) {
+        collisions.push({
+          field: 'id',
+          value: targetId,
+          detail: 'Link requires the existing team roster target.',
+        });
+      } else if (
+        existing.metadata?.buzz &&
+        !sourceLinkMatches(existing.metadata.buzz, definition.coordinate)
+      ) {
+        collisions.push({
+          field: 'source',
+          value: existing.id,
+          detail: 'Roster is linked to a different Buzz source.',
+        });
+      }
+    } else if (
+      input.action === 'refresh' &&
+      (!existing ||
+        existing.id !== targetId ||
+        !sourceLinkMatches(existing.metadata?.buzz, definition.coordinate))
+    ) {
+      collisions.push({
+        field: 'source',
+        value: targetId,
+        detail: 'Refresh requires the roster already linked to this Buzz source.',
+      });
+    }
+    for (const profile of matchingProfiles.values()) {
+      const source = profile.metadata?.buzz;
+      if (!source) continue;
+      const memberId = stableSlug(source.provenance.dTag);
+      const conflicting = existing?.members.find(
+        (member) => member.id === memberId && member.profileId !== profile.id
+      );
+      if (conflicting) {
+        collisions.push({
+          field: 'persona',
+          value: memberId,
+          detail: `Roster member ${memberId} points to a different profile.`,
+        });
+      }
+    }
+    const proposed = this.materializeTeam(
+      adapterId,
+      context,
+      definition,
+      input.action,
+      existing ?? undefined,
+      matchingProfiles,
+      targetId
+    );
+    const unchanged =
+      existing?.metadata?.buzz?.provenance.eventId === definition.event.id &&
+      existing.metadata.buzz.provenance.contentHash === definition.summary.contentHash;
+    const diff = [
+      diffField('name', existing?.name, proposed?.name),
+      diffField(
+        'description',
+        textSummary(existing?.description),
+        textSummary(proposed?.description)
+      ),
+      diffField(
+        'members',
+        existing?.members
+          .map((member) => member.profileId ?? member.id)
+          .sort()
+          .join(', '),
+        proposed?.members
+          .map((member) => member.profileId ?? member.id)
+          .sort()
+          .join(', ')
+      ),
+      diffField(
+        'source link',
+        existing?.metadata?.buzz
+          ? existing.metadata.buzz.provenance.eventId.slice(0, 12)
+          : undefined,
+        proposed?.metadata?.buzz
+          ? proposed.metadata.buzz.provenance.eventId.slice(0, 12)
+          : undefined
+      ),
+    ].filter((entry): entry is BuzzDefinitionDiff => Boolean(entry));
+    return {
+      definition: definition.summary,
+      action: input.action,
+      targetId,
+      expectedLocalRevision: teamImportRevision(existing, matchingProfiles),
+      changed: !unchanged,
+      diff,
+      fieldReport: definition.fieldReport,
+      collisions,
+      unresolvedPersonaIds,
+      proposedRoster: proposed,
+    };
+  }
+
+  private materializeTeam(
+    adapterId: string,
+    context: BuzzQueryContext,
+    definition: ParsedDefinition,
+    action: BuzzDefinitionPreviewInput['action'],
+    existing: TeamRosterManifest | undefined,
+    matchingProfiles: Map<string, AgentProfilePackage>,
+    targetId = stableSlug(definition.coordinate.dTag, 'buzz-team')
+  ): TeamRosterManifest | undefined {
+    if (action === 'skip') return undefined;
+    const name = definition.snapshot.name;
+    if (!name) throw new Error('Buzz team name is unavailable');
+    const now = this.now().toISOString();
+    const importedMembers: TeamRosterMember[] = [...matchingProfiles.entries()].map(
+      ([personaId, profile]) => ({
+        id: stableSlug(personaId),
+        displayName: profile.displayName,
+        role: profile.role,
+        agent: profile.runtime.agent,
+        profileId: profile.id,
+        status: 'disabled',
+        capabilities: profile.capabilities,
+        defaultTaskTypes: profile.defaultTaskTypes,
+      })
+    );
+    const importedIds = importedMembers.map((member) => member.id);
+    const link = buildLink(definition, context, {
+      adapterId,
+      fieldReport: definition.fieldReport,
+      sourceOwnedFields: action === 'link' ? [] : ['name', 'description', 'members'],
+      importedAt: existing?.metadata?.buzz?.provenance.importedAt ?? now,
+      refreshedAt: action === 'refresh' ? now : undefined,
+      materializedIds: importedIds,
+    });
+    if (action === 'link' && existing) {
+      return withLocalRevision({
+        ...existing,
+        metadata: {
+          ...existing.metadata,
+          source: existing.metadata?.source ?? `buzz:${sourceCoordinateKey(definition.coordinate)}`,
+          importedAt: existing.metadata?.importedAt ?? now,
+          updatedAt: now,
+          buzz: link,
+        },
+      });
+    }
+    const currentImported = new Set(importedIds);
+    const localMembers = (existing?.members ?? []).filter(
+      (member) => !currentImported.has(member.id)
+    );
+    const roster: TeamRosterManifest = {
+      id: existing?.id ?? targetId,
+      schemaVersion: 'team-roster/v1',
+      workspaceId: existing?.workspaceId ?? 'local',
+      name,
+      description: definition.snapshot.description,
+      enabled: existing?.enabled ?? false,
+      coordinatorMemberId: existing?.coordinatorMemberId,
+      members: [...localMembers, ...importedMembers],
+      routingRules: existing?.routingRules ?? [],
+      metadata: {
+        ...existing?.metadata,
+        source: existing?.metadata?.source ?? `buzz:${sourceCoordinateKey(definition.coordinate)}`,
+        importedAt: existing?.metadata?.importedAt ?? now,
+        updatedAt: now,
+        buzz: link,
+      },
+    };
+    return withLocalRevision(roster);
+  }
+
+  private async importPersona(
+    adapterId: string,
+    context: BuzzQueryContext,
+    definition: ParsedDefinition,
+    input: BuzzDefinitionImportInput
+  ): Promise<BuzzDefinitionImportResult> {
+    const result = await this.profiles.mutateProfiles<ProfileMutationResult>(
+      (profiles, configuredAgents) => {
+        const linked = profiles.filter((profile) =>
+          sourceLinkMatches(profile.metadata?.buzz, definition.coordinate)
+        );
+        const targetId =
+          input.targetId ??
+          (input.action === 'refresh' ? linked[0]?.id : undefined) ??
+          stableSlug(definition.coordinate.dTag);
+        const index = profiles.findIndex((profile) => profile.id === targetId);
+        const existing = index >= 0 ? profiles[index] : undefined;
+        if ((existing ? localRevision(existing) : undefined) !== input.expectedLocalRevision) {
+          throw new Error('Local profile changed after preview; preview the import again');
+        }
+        if (
+          existing?.metadata?.buzz?.provenance.eventId === definition.event.id &&
+          existing.metadata.buzz.provenance.contentHash === definition.summary.contentHash &&
+          sourceLinkMatches(existing.metadata.buzz, definition.coordinate)
+        ) {
+          return {
+            profiles,
+            result: { status: 'unchanged' as const, profile: existing },
+          };
+        }
+        if (input.action === 'create' && (existing || linked.length)) {
+          throw new Error('Profile collision changed after preview');
+        }
+        const duplicateName = profiles.some(
+          (profile) =>
+            profile.id !== targetId &&
+            profile.displayName.toLowerCase() === definition.summary.displayName.toLowerCase()
+        );
+        if (input.action === 'create' && duplicateName) {
+          throw new Error('Profile name collision changed after preview');
+        }
+        if (
+          input.action === 'create' &&
+          configuredAgents.some(
+            (agent) =>
+              agent.type === targetId ||
+              agent.name.toLowerCase() === definition.summary.displayName.toLowerCase()
+          )
+        ) {
+          throw new Error('Configured agent collision changed after preview');
+        }
+        if (
+          input.action === 'link' &&
+          (!existing ||
+            (existing.metadata?.buzz &&
+              !sourceLinkMatches(existing.metadata.buzz, definition.coordinate)))
+        ) {
+          throw new Error('Profile link target changed after preview');
+        }
+        if (input.action === 'link' && linked.some((profile) => profile.id !== targetId)) {
+          throw new Error('Profile source collision changed after preview');
+        }
+        if (
+          input.action === 'refresh' &&
+          (!existing || !sourceLinkMatches(existing.metadata?.buzz, definition.coordinate))
+        ) {
+          throw new Error('Profile refresh target changed after preview');
+        }
+        if (input.action === 'refresh' && (linked.length > 1 || duplicateName)) {
+          throw new Error('Profile refresh collision changed after preview');
+        }
+        const profile = this.materializePersona(
+          adapterId,
+          context,
+          definition,
+          input.action,
+          existing,
+          targetId
+        );
+        if (!profile) throw new Error('Buzz persona materialization was skipped unexpectedly');
+        const next =
+          index >= 0
+            ? profiles.map((candidate, candidateIndex) =>
+                candidateIndex === index ? profile : candidate
+              )
+            : [...profiles, profile];
+        return {
+          profiles: next,
+          result: {
+            status:
+              input.action === 'create'
+                ? ('created' as const)
+                : input.action === 'link'
+                  ? ('linked' as const)
+                  : ('refreshed' as const),
+            profile,
+          },
+        };
+      }
+    );
+    return { ...result, definition: definition.summary };
+  }
+
+  private async importTeam(
+    adapterId: string,
+    context: BuzzQueryContext,
+    definition: ParsedDefinition,
+    input: BuzzDefinitionImportInput
+  ): Promise<BuzzDefinitionImportResult> {
+    const result = await this.rosters.mutateRoster<RosterMutationResult>((existing, profiles) => {
+      const matchingProfiles = new Map<string, AgentProfilePackage>();
+      for (const personaId of definition.snapshot.personaIds ?? []) {
+        const profile = profiles.find(
+          (candidate) =>
+            candidate.metadata?.buzz?.provenance.kind === PERSONA_KIND &&
+            candidate.metadata.buzz.provenance.authorPubkey.toLowerCase() ===
+              definition.coordinate.authorPubkey.toLowerCase() &&
+            candidate.metadata.buzz.provenance.dTag === personaId
+        );
+        if (!profile) throw new Error(`Buzz team persona is unresolved: ${personaId}`);
+        matchingProfiles.set(personaId, profile);
+      }
+      if (teamImportRevision(existing, matchingProfiles) !== input.expectedLocalRevision) {
+        throw new Error('Local roster changed after preview; preview the import again');
+      }
+      if (
+        existing?.metadata?.buzz?.provenance.eventId === definition.event.id &&
+        existing.metadata.buzz.provenance.contentHash === definition.summary.contentHash &&
+        sourceLinkMatches(existing.metadata.buzz, definition.coordinate)
+      ) {
+        return { roster: existing, result: { status: 'unchanged' as const, roster: existing } };
+      }
+      if (input.action === 'create' && existing) {
+        throw new Error('Roster collision changed after preview');
+      }
+      if (
+        input.action === 'link' &&
+        (!existing ||
+          (existing.metadata?.buzz &&
+            !sourceLinkMatches(existing.metadata.buzz, definition.coordinate)))
+      ) {
+        throw new Error('Roster link target changed after preview');
+      }
+      if (
+        input.action === 'refresh' &&
+        (!existing || !sourceLinkMatches(existing.metadata?.buzz, definition.coordinate))
+      ) {
+        throw new Error('Roster refresh target changed after preview');
+      }
+      const roster = this.materializeTeam(
+        adapterId,
+        context,
+        definition,
+        input.action,
+        existing ?? undefined,
+        matchingProfiles,
+        input.targetId ?? existing?.id ?? stableSlug(definition.coordinate.dTag, 'buzz-team')
+      );
+      if (!roster) throw new Error('Buzz team materialization was skipped unexpectedly');
+      return {
+        roster,
+        result: {
+          status:
+            input.action === 'create'
+              ? ('created' as const)
+              : input.action === 'link'
+                ? ('linked' as const)
+                : ('refreshed' as const),
+          roster,
+        },
+      };
+    });
+    return { ...result, definition: definition.summary };
+  }
+}
+
+let buzzDefinitionImportService: BuzzDefinitionImportService | null = null;
+
+export function getBuzzDefinitionImportService(): BuzzDefinitionImportService {
+  if (!buzzDefinitionImportService) {
+    buzzDefinitionImportService = new BuzzDefinitionImportService();
+  }
+  return buzzDefinitionImportService;
+}
+
+export function resetBuzzDefinitionImportServiceForTests(): void {
+  buzzDefinitionImportService = null;
+}

--- a/server/src/services/communication-adapter-service.ts
+++ b/server/src/services/communication-adapter-service.ts
@@ -149,6 +149,12 @@ interface ValidatedBuzzAdapterConfig {
   configKey: string;
 }
 
+export interface BuzzQueryContext {
+  probeConfig: BuzzProbeConfig;
+  relay: string;
+  community: string;
+}
+
 function buzzConfigKey(config: BuzzProbeConfig, endpoints: NormalizedBuzzEndpoints): string {
   return JSON.stringify({
     probeRevision: BUZZ_PROBE_REVISION,
@@ -437,6 +443,29 @@ export class CommunicationAdapterService {
     await this.ensureLoaded();
     const adapter = this.state.adapters[adapterId];
     return adapter ? this.publicAdapter(adapter) : null;
+  }
+
+  async getBuzzQueryContext(adapterId: string): Promise<BuzzQueryContext> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    if (adapter.kind !== 'buzz') throw new Error('Definition import requires a Buzz adapter');
+    if (!adapter.enabled) throw new Error('Buzz adapter is disabled');
+    const validated = validateStoredBuzzConfig(adapter);
+    if (!validated) throw new Error('Buzz adapter configuration is invalid');
+    const health = await this.checkBuzzHealth(adapter);
+    if (
+      health.status !== 'healthy' ||
+      !isCurrentBuzzCompatibility(adapter, validated) ||
+      adapter.compatibility?.status !== 'healthy'
+    ) {
+      throw new Error('Buzz compatibility evidence is missing, stale, or unhealthy');
+    }
+    return {
+      probeConfig: validated.probeConfig,
+      relay: validated.endpoints.httpUrl,
+      community: validated.endpoints.community,
+    };
   }
 
   async listBuzzChannelMappings(adapterId?: string): Promise<BuzzChannelMapping[]> {

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -421,6 +421,46 @@ export class ConfigService {
     this.setupWatcher();
   }
 
+  /**
+   * Read, validate, and write one configuration mutation under the authoritative
+   * storage lock. The callback must remain synchronous so SQLite can keep the
+   * transaction open without yielding.
+   */
+  async mutateConfig<T>(
+    mutator: (config: AppConfig) => { config: AppConfig; result: T }
+  ): Promise<T> {
+    if (this.sqliteSettings) {
+      const mutation = this.sqliteSettings.mutateConfig((config) =>
+        mutator(normalizeAppConfig(config))
+      );
+      this.config = mutation.config;
+      this.cacheTimestamp = Date.now();
+      return mutation.result;
+    }
+
+    await this.ensureConfigDir();
+    const mutation = await withFileLock(this.configFile, async () => {
+      let current: AppConfig;
+      try {
+        current = normalizeAppConfig(
+          JSON.parse(await fs.readFile(this.configFile, 'utf-8')) as AppConfig
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        current = createDefaultConfig();
+      }
+      const result = mutator(cloneJson(current));
+      const normalized = normalizeAppConfig(result.config);
+      await fs.writeFile(this.configFile, JSON.stringify(normalized, null, 2), 'utf-8');
+      return { config: normalized, result: result.result };
+    });
+    this.lastWriteTime = Date.now();
+    this.config = mutation.config;
+    this.cacheTimestamp = Date.now();
+    this.setupWatcher();
+    return mutation.result;
+  }
+
   async addRepo(repo: RepoConfig): Promise<AppConfig> {
     const config = await this.getConfig();
 

--- a/server/src/services/team-roster-service.ts
+++ b/server/src/services/team-roster-service.ts
@@ -1,6 +1,7 @@
 import yaml from 'yaml';
 import type {
   AgentType,
+  AgentProfilePackage,
   TeamRosterExportResult,
   TeamRosterFormat,
   TeamRosterManifest,
@@ -27,9 +28,27 @@ export class TeamRosterService {
     return config.teamRoster ?? null;
   }
 
+  async mutateRoster<T>(
+    mutator: (
+      roster: TeamRosterManifest | null,
+      profiles: AgentProfilePackage[]
+    ) => { roster: TeamRosterManifest; result: T }
+  ): Promise<T> {
+    return this.configService.mutateConfig((config) => {
+      const mutation = mutator(config.teamRoster ?? null, config.agentProfiles ?? []);
+      const parsed = TeamRosterManifestSchema.parse(mutation.roster) as TeamRosterManifest;
+      return {
+        config: { ...config, teamRoster: parsed },
+        result: mutation.result,
+      };
+    });
+  }
+
   validateContent(input: ImportRosterInput): TeamRosterValidationResult {
     try {
-      return this.validateUnknown(this.parseContent(input.content, input.format));
+      return this.rejectSystemOwnedBuzz(
+        this.validateUnknown(this.parseContent(input.content, input.format))
+      );
     } catch (error) {
       return {
         valid: false,
@@ -39,7 +58,7 @@ export class TeamRosterService {
   }
 
   validateRoster(roster: unknown): TeamRosterValidationResult {
-    return this.validateUnknown(roster);
+    return this.rejectSystemOwnedBuzz(this.validateUnknown(roster));
   }
 
   async saveRoster(roster: TeamRosterManifest): Promise<TeamRosterManifest> {
@@ -50,12 +69,20 @@ export class TeamRosterService {
     }
 
     const config = await this.configService.getConfig();
+    const existingBuzz = config.teamRoster?.metadata?.buzz;
+    if (
+      parsed.roster.metadata?.buzz &&
+      JSON.stringify(parsed.roster.metadata.buzz) !== JSON.stringify(existingBuzz)
+    ) {
+      throw new Error('Buzz provenance is system-owned and cannot be replaced directly');
+    }
     const now = new Date().toISOString();
     const next: TeamRosterManifest = {
       ...parsed.roster,
       metadata: {
         ...parsed.roster.metadata,
         updatedAt: now,
+        buzz: existingBuzz,
       },
     };
     config.teamRoster = next;
@@ -202,6 +229,23 @@ export class TeamRosterService {
     }
 
     return { valid: true, roster: parsed.data as TeamRosterManifest, issues: [] };
+  }
+
+  private rejectSystemOwnedBuzz(
+    validation: TeamRosterValidationResult
+  ): TeamRosterValidationResult {
+    if (validation.valid && validation.roster?.metadata?.buzz) {
+      return {
+        valid: false,
+        issues: [
+          {
+            path: '$.metadata.buzz',
+            message: 'Buzz provenance is system-owned and cannot be imported directly',
+          },
+        ],
+      };
+    }
+    return validation;
   }
 
   private parseContent(content: string, format?: TeamRosterFormat): unknown {

--- a/server/src/storage/sqlite/settings-repository.ts
+++ b/server/src/storage/sqlite/settings-repository.ts
@@ -81,6 +81,44 @@ export class SqliteSettingsRepository implements SettingsRepository {
       .run(APP_CONFIG_KEY, documentJson, now, now);
   }
 
+  mutateConfig<T>(mutator: (config: AppConfig) => { config: AppConfig; result: T }): {
+    config: AppConfig;
+    result: T;
+  } {
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const row = connection
+        .prepare('SELECT document_json FROM app_config_documents WHERE key = ?')
+        .get(APP_CONFIG_KEY) as ConfigRow | undefined;
+      const current = row
+        ? this.normalize(JSON.parse(row.document_json) as AppConfig)
+        : this.normalize(cloneJson(this.options.defaultConfig));
+      const mutation = mutator(cloneJson(current));
+      const normalized = this.normalize(mutation.config);
+      if (hasDangerousKeys(normalized)) {
+        throw new Error('Invalid input: dangerous keys detected');
+      }
+      const now = new Date().toISOString();
+      connection
+        .prepare(
+          `
+            INSERT INTO app_config_documents (key, document_json, created_at, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+              document_json = excluded.document_json,
+              updated_at = excluded.updated_at
+          `
+        )
+        .run(APP_CONFIG_KEY, JSON.stringify(normalized), now, now);
+      connection.exec('COMMIT');
+      return { config: normalized, result: mutation.result };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
   private normalize(config: AppConfig): AppConfig {
     return this.options.normalizeConfig ? this.options.normalizeConfig(config) : config;
   }

--- a/shared/src/types/agent-profile-package.types.ts
+++ b/shared/src/types/agent-profile-package.types.ts
@@ -1,6 +1,7 @@
 import type { AgentBudgetPolicy } from './agent-budget.types.js';
 import type { AgentProvider, AgentConfig } from './config.types.js';
 import type { AgentType, TaskType } from './task.types.js';
+import type { BuzzDefinitionLink } from './buzz-definition.types.js';
 
 export type AgentProfilePackageFormat = 'json' | 'yaml';
 
@@ -56,6 +57,7 @@ export interface AgentProfilePackageMetadata {
   source?: string;
   importedAt?: string;
   updatedAt?: string;
+  buzz?: BuzzDefinitionLink;
 }
 
 export interface AgentProfilePackage {

--- a/shared/src/types/buzz-definition.types.ts
+++ b/shared/src/types/buzz-definition.types.ts
@@ -1,0 +1,134 @@
+import type { AgentProfilePackage } from './agent-profile-package.types.js';
+import type { TeamRosterManifest } from './team-roster.types.js';
+
+export type BuzzDefinitionKind = 30175 | 30176;
+export type BuzzDefinitionType = 'persona' | 'team';
+export type BuzzDefinitionAction = 'create' | 'link' | 'refresh' | 'skip';
+export type BuzzDefinitionDisposition =
+  'mapped' | 'source-only' | 'ignored' | 'rejected' | 'conflict';
+
+export interface BuzzDefinitionCoordinate {
+  authorPubkey: string;
+  kind: BuzzDefinitionKind;
+  dTag: string;
+}
+
+export interface BuzzDefinitionFieldReport {
+  field: string;
+  disposition: BuzzDefinitionDisposition;
+  detail: string;
+}
+
+export interface BuzzDefinitionSourceSnapshot {
+  displayName?: string;
+  systemPrompt?: string;
+  avatarUrl?: string;
+  runtime?: string;
+  model?: string;
+  provider?: string;
+  namePool?: string[];
+  respondTo?: string;
+  respondToAllowlist?: string[];
+  parallelism?: number;
+  name?: string;
+  description?: string;
+  personaIds?: string[];
+}
+
+export interface BuzzDefinitionProvenance {
+  schemaVersion: 'buzz-definition-link/v1';
+  adapterId: string;
+  relay: string;
+  community: string;
+  authorPubkey: string;
+  kind: BuzzDefinitionKind;
+  dTag: string;
+  eventId: string;
+  createdAt: number;
+  contentHash: string;
+  importedAt: string;
+  refreshedAt?: string;
+}
+
+export interface BuzzDefinitionLink {
+  provenance: BuzzDefinitionProvenance;
+  sourceSnapshot: BuzzDefinitionSourceSnapshot;
+  fieldReport: BuzzDefinitionFieldReport[];
+  sourceOwnedFields: string[];
+  localRevision: string;
+  materializedIds?: string[];
+}
+
+export interface BuzzDefinitionSummary extends BuzzDefinitionCoordinate {
+  type: BuzzDefinitionType;
+  displayName: string;
+  eventId: string;
+  createdAt: number;
+  contentHash: string;
+  community: string;
+  compatibility: 'compatible' | 'rejected';
+  detail?: string;
+}
+
+export interface BuzzDefinitionListResult {
+  adapterId: string;
+  relay: string;
+  community: string;
+  definitions: BuzzDefinitionSummary[];
+  rejectedCount: number;
+}
+
+export interface BuzzDefinitionPreviewInput {
+  coordinate: BuzzDefinitionCoordinate;
+  action: BuzzDefinitionAction;
+  targetId?: string;
+}
+
+export interface BuzzDefinitionCollision {
+  field: 'id' | 'name' | 'source' | 'persona';
+  value: string;
+  detail: string;
+}
+
+export interface BuzzDefinitionDiff {
+  field: string;
+  change: 'add' | 'update' | 'remove';
+  beforeSummary?: string;
+  afterSummary?: string;
+}
+
+export interface BuzzDefinitionPreview {
+  definition: BuzzDefinitionSummary;
+  action: BuzzDefinitionAction;
+  targetId?: string;
+  expectedLocalRevision?: string;
+  changed: boolean;
+  diff: BuzzDefinitionDiff[];
+  fieldReport: BuzzDefinitionFieldReport[];
+  collisions: BuzzDefinitionCollision[];
+  unresolvedPersonaIds: string[];
+  proposedProfile?: AgentProfilePackage;
+  proposedRoster?: TeamRosterManifest;
+}
+
+export interface BuzzDefinitionImportInput extends BuzzDefinitionPreviewInput {
+  expectedEventId: string;
+  expectedLocalRevision?: string;
+}
+
+export interface BuzzDefinitionImportResult {
+  status: 'created' | 'linked' | 'refreshed' | 'unchanged' | 'skipped';
+  definition: BuzzDefinitionSummary;
+  profile?: AgentProfilePackage;
+  roster?: TeamRosterManifest;
+}
+
+export interface BuzzDefinitionLinkedStatus {
+  targetType: 'profile' | 'roster';
+  targetId: string;
+  coordinate: BuzzDefinitionCoordinate;
+  status: 'current' | 'changed' | 'missing' | 'unavailable';
+  linkedEventId: string;
+  currentEventId?: string;
+  detail?: string;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -41,6 +41,7 @@ export * from './sandbox-policy.types.js';
 export * from './agent-budget.types.js';
 export * from './agent-profile-package.types.js';
 export * from './team-roster.types.js';
+export * from './buzz-definition.types.js';
 export * from './workspace-capability.types.js';
 export * from './scheduler.types.js';
 export * from './queue-monitor.types.js';

--- a/shared/src/types/team-roster.types.ts
+++ b/shared/src/types/team-roster.types.ts
@@ -1,4 +1,5 @@
 import type { AgentType, TaskPriority, TaskType } from './task.types.js';
+import type { BuzzDefinitionLink } from './buzz-definition.types.js';
 
 export type TeamRosterFormat = 'json' | 'yaml';
 export type TeamRosterMemberStatus = 'enabled' | 'disabled';
@@ -42,6 +43,7 @@ export interface TeamRosterManifestMetadata {
   source?: string;
   importedAt?: string;
   updatedAt?: string;
+  buzz?: BuzzDefinitionLink;
 }
 
 export interface TeamRosterManifest {

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -61,7 +61,28 @@ const mocks = vi.hoisted(() => ({
   validateSandboxPolicy: vi.fn(),
   providerRuntimeManifests: [] as Array<Record<string, unknown>>,
   additionalAgentHosts: [] as Array<Record<string, unknown>>,
+  buzzDefinitions: vi.fn(),
+  buzzDefinitionLinks: vi.fn(),
+  previewBuzzDefinition: vi.fn(),
+  importBuzzDefinition: vi.fn(),
 }));
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      integrations: {
+        ...actual.api.integrations,
+        buzzDefinitions: mocks.buzzDefinitions,
+        buzzDefinitionLinks: mocks.buzzDefinitionLinks,
+        previewBuzzDefinition: mocks.previewBuzzDefinition,
+        importBuzzDefinition: mocks.importBuzzDefinition,
+      },
+    },
+  };
+});
 
 vi.mock('@/hooks/useConfig', () => ({
   useConfig: () => ({
@@ -478,6 +499,79 @@ describe('Agents settings Mantine migration', () => {
       effective: { sandboxMode: 'workspace-write', networkAccessEnabled: false },
       unsupportedRules: [],
     });
+    mocks.buzzDefinitions.mockResolvedValue({
+      adapterId: 'buzz-default',
+      relay: 'https://relay.example.test',
+      community: 'relay.example.test',
+      definitions: [
+        {
+          type: 'persona',
+          displayName: 'Buzz Reviewer',
+          authorPubkey: 'a'.repeat(64),
+          kind: 30_175,
+          dTag: 'reviewer',
+          eventId: 'b'.repeat(64),
+          createdAt: 1_784_848_400,
+          contentHash: 'c'.repeat(64),
+          community: 'relay.example.test',
+          compatibility: 'compatible',
+        },
+      ],
+      rejectedCount: 1,
+    });
+    mocks.buzzDefinitionLinks.mockResolvedValue([
+      {
+        targetType: 'profile',
+        targetId: 'buzz-existing',
+        coordinate: { authorPubkey: 'a'.repeat(64), kind: 30_175, dTag: 'existing' },
+        status: 'changed',
+        linkedEventId: 'd'.repeat(64),
+        currentEventId: 'e'.repeat(64),
+      },
+    ]);
+    mocks.previewBuzzDefinition.mockResolvedValue({
+      definition: {
+        type: 'persona',
+        displayName: 'Buzz Reviewer',
+        authorPubkey: 'a'.repeat(64),
+        kind: 30_175,
+        dTag: 'reviewer',
+        eventId: 'b'.repeat(64),
+        createdAt: 1_784_848_400,
+        contentHash: 'c'.repeat(64),
+        community: 'relay.example.test',
+        compatibility: 'compatible',
+      },
+      action: 'create',
+      targetId: 'buzz-reviewer',
+      changed: true,
+      diff: [
+        {
+          field: 'displayName',
+          change: 'add',
+          afterSummary: 'Buzz Reviewer',
+        },
+      ],
+      fieldReport: [
+        {
+          field: 'display_name',
+          disposition: 'mapped',
+          detail: 'Mapped to profile displayName.',
+        },
+        {
+          field: 'provider',
+          disposition: 'source-only',
+          detail: 'Retained as a declared source preference, not active configuration.',
+        },
+      ],
+      collisions: [],
+      unresolvedPersonaIds: [],
+    });
+    mocks.importBuzzDefinition.mockResolvedValue({
+      status: 'created',
+      definition: { eventId: 'b'.repeat(64) },
+      profile: { id: 'buzz-reviewer', enabled: false },
+    });
   });
 
   afterEach(() => {
@@ -764,5 +858,91 @@ describe('Agents settings Mantine migration', () => {
       taskId: 'task_123',
       profileId: 'qa-reviewer',
     });
+  });
+
+  it('previews and confirms a disabled Buzz persona import with field dispositions', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AgentsTab />);
+
+    expect(await screen.findByText('Buzz Persona and Team Definitions')).toBeDefined();
+    await user.click(screen.getByRole('combobox', { name: 'Definition' }));
+    await user.click(
+      await screen.findByRole('option', { name: 'persona: Buzz Reviewer (reviewer)' })
+    );
+    await user.click(screen.getByRole('button', { name: 'Preview' }));
+
+    expect(await screen.findByText('Mapped to profile displayName.')).toBeDefined();
+    expect(screen.getByText('Proposed changes')).toBeDefined();
+    expect(
+      screen.getByText('Retained as a declared source preference, not active configuration.')
+    ).toBeDefined();
+    expect(screen.getByText('buzz-existing: changed')).toBeDefined();
+    await user.click(screen.getByRole('button', { name: 'Confirm create' }));
+
+    await waitFor(() =>
+      expect(mocks.importBuzzDefinition).toHaveBeenCalledWith(
+        'buzz-default',
+        expect.objectContaining({
+          action: 'create',
+          targetId: 'buzz-reviewer',
+          expectedEventId: 'b'.repeat(64),
+        })
+      )
+    );
+  });
+
+  it('blocks a Buzz team import while same-author personas remain unresolved', async () => {
+    const user = userEvent.setup();
+    mocks.buzzDefinitions.mockResolvedValueOnce({
+      adapterId: 'buzz-default',
+      relay: 'https://relay.example.test',
+      community: 'relay.example.test',
+      definitions: [
+        {
+          type: 'team',
+          displayName: 'Delivery Team',
+          authorPubkey: 'a'.repeat(64),
+          kind: 30_176,
+          dTag: 'delivery',
+          eventId: 'f'.repeat(64),
+          createdAt: 1_784_848_400,
+          contentHash: '1'.repeat(64),
+          community: 'relay.example.test',
+          compatibility: 'compatible',
+        },
+      ],
+      rejectedCount: 0,
+    });
+    mocks.previewBuzzDefinition.mockResolvedValueOnce({
+      definition: {
+        type: 'team',
+        displayName: 'Delivery Team',
+        authorPubkey: 'a'.repeat(64),
+        kind: 30_176,
+        dTag: 'delivery',
+        eventId: 'f'.repeat(64),
+        createdAt: 1_784_848_400,
+        contentHash: '1'.repeat(64),
+        community: 'relay.example.test',
+        compatibility: 'compatible',
+      },
+      action: 'create',
+      targetId: 'buzz-team-delivery',
+      changed: true,
+      diff: [],
+      fieldReport: [],
+      collisions: [],
+      unresolvedPersonaIds: ['builder'],
+    });
+    renderWithProviders(<AgentsTab />);
+    await user.click(await screen.findByRole('combobox', { name: 'Definition' }));
+    await user.click(await screen.findByRole('option', { name: 'team: Delivery Team (delivery)' }));
+    await user.click(screen.getByRole('button', { name: 'Preview' }));
+
+    expect(await screen.findByText('Unresolved personas: builder')).toBeDefined();
+    expect(
+      screen.getByRole('button', { name: 'Confirm create' }).getAttribute('disabled')
+    ).not.toBeNull();
+    expect(mocks.importBuzzDefinition).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ActionIcon,
   Alert,
@@ -69,6 +70,8 @@ import type {
   AgentBudgetLimits,
   AgentProfilePackageFormat,
   AgentProfilePackageSummary,
+  BuzzDefinitionAction,
+  BuzzDefinitionPreview,
   SandboxPolicyDryRunResult,
   SandboxPolicyPreset,
   ProviderRuntimeManifest,
@@ -80,6 +83,7 @@ import type {
   ContextProviderPostureStatus,
   ContextProviderHealthResponse,
 } from '@/lib/api';
+import { api } from '@/lib/api';
 import { DEFAULT_FEATURE_SETTINGS, DEFAULT_ROUTING_CONFIG } from '@veritas-kanban/shared';
 import { cn } from '@/lib/utils';
 import { ToggleRow, NumberRow, SectionHeader, SaveIndicator } from '../shared';
@@ -233,6 +237,8 @@ export function AgentsTab() {
         isLoading={isAgentProfilesLoading}
       />
 
+      <BuzzDefinitionImportSection />
+
       <CodexHealthPanel
         health={codexHealth}
         isFetching={isCodexHealthFetching}
@@ -304,6 +310,334 @@ export function AgentsTab() {
 
       {/* Agent Routing Rules */}
       <RoutingRulesSection agents={config?.agents || []} />
+    </div>
+  );
+}
+
+const BUZZ_DEFINITION_ADAPTER_ID = 'buzz-default';
+
+function BuzzDefinitionImportSection() {
+  const queryClient = useQueryClient();
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const [action, setAction] = useState<BuzzDefinitionAction>('create');
+  const [targetId, setTargetId] = useState('');
+  const [preview, setPreview] = useState<BuzzDefinitionPreview | null>(null);
+  const definitionsQuery = useQuery({
+    queryKey: ['integrations', 'communication', 'buzz-definitions', BUZZ_DEFINITION_ADAPTER_ID],
+    queryFn: () => api.integrations.buzzDefinitions(BUZZ_DEFINITION_ADAPTER_ID),
+    retry: false,
+    staleTime: 30_000,
+  });
+  const linksQuery = useQuery({
+    queryKey: [
+      'integrations',
+      'communication',
+      'buzz-definition-links',
+      BUZZ_DEFINITION_ADAPTER_ID,
+    ],
+    queryFn: () => api.integrations.buzzDefinitionLinks(BUZZ_DEFINITION_ADAPTER_ID),
+    retry: false,
+    staleTime: 30_000,
+  });
+  const selected = definitionsQuery.data?.definitions.find(
+    (definition) => definition.eventId === selectedEventId
+  );
+  const previewMutation = useMutation({
+    mutationFn: () => {
+      if (!selected) throw new Error('Select a Buzz definition first');
+      return api.integrations.previewBuzzDefinition(BUZZ_DEFINITION_ADAPTER_ID, {
+        coordinate: {
+          authorPubkey: selected.authorPubkey,
+          kind: selected.kind,
+          dTag: selected.dTag,
+        },
+        action,
+        targetId: targetId.trim() || undefined,
+      });
+    },
+    onSuccess: setPreview,
+  });
+  const importMutation = useMutation({
+    mutationFn: () => {
+      if (!preview) throw new Error('Preview the Buzz definition first');
+      return api.integrations.importBuzzDefinition(BUZZ_DEFINITION_ADAPTER_ID, {
+        coordinate: {
+          authorPubkey: preview.definition.authorPubkey,
+          kind: preview.definition.kind,
+          dTag: preview.definition.dTag,
+        },
+        action: preview.action,
+        targetId: preview.targetId,
+        expectedEventId: preview.definition.eventId,
+        expectedLocalRevision: preview.expectedLocalRevision,
+      });
+    },
+    onSuccess: async () => {
+      setPreview(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['config'] }),
+        queryClient.invalidateQueries({ queryKey: ['config', 'agent-profiles'] }),
+        queryClient.invalidateQueries({
+          queryKey: [
+            'integrations',
+            'communication',
+            'buzz-definitions',
+            BUZZ_DEFINITION_ADAPTER_ID,
+          ],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [
+            'integrations',
+            'communication',
+            'buzz-definition-links',
+            BUZZ_DEFINITION_ADAPTER_ID,
+          ],
+        }),
+      ]);
+    },
+  });
+  const resetPreview = () => {
+    setPreview(null);
+    previewMutation.reset();
+    importMutation.reset();
+  };
+  const error = previewMutation.error ?? importMutation.error;
+  const blocked = Boolean(
+    preview &&
+    preview.action !== 'skip' &&
+    (preview.collisions.length || preview.unresolvedPersonaIds.length)
+  );
+
+  return (
+    <div className="rounded-md border bg-card p-3 space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">Buzz Persona and Team Definitions</h3>
+          <p className="text-xs text-muted-foreground">
+            One-way import from the configured signed Buzz connection. Imports never start, enable,
+            or reroute an agent.
+          </p>
+        </div>
+        <Button
+          size="xs"
+          variant="outline"
+          leftSection={<RefreshCw className="h-3.5 w-3.5" />}
+          loading={definitionsQuery.isFetching}
+          onClick={() => {
+            resetPreview();
+            void definitionsQuery.refetch();
+            void linksQuery.refetch();
+          }}
+        >
+          Refresh Sources
+        </Button>
+      </div>
+
+      {definitionsQuery.error ? (
+        <Alert color="yellow" icon={<AlertCircle className="h-4 w-4" />}>
+          Configure and verify Buzz under Notifications before importing definitions.{' '}
+          {definitionsQuery.error.message}
+        </Alert>
+      ) : (
+        <>
+          <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_160px_minmax(180px,260px)_auto]">
+            <Select
+              label="Definition"
+              placeholder={
+                definitionsQuery.isLoading
+                  ? 'Loading Buzz definitions...'
+                  : 'Select persona or team'
+              }
+              value={selectedEventId}
+              onChange={(value) => {
+                setSelectedEventId(value);
+                resetPreview();
+              }}
+              data={(definitionsQuery.data?.definitions ?? []).map((definition) => ({
+                value: definition.eventId,
+                label: `${definition.type}: ${definition.displayName} (${definition.dTag})${
+                  definition.compatibility === 'rejected' ? ' [rejected]' : ''
+                }`,
+              }))}
+              searchable
+              disabled={definitionsQuery.isLoading}
+            />
+            <Select
+              label="Action"
+              value={action}
+              onChange={(value) => {
+                const next = (value as BuzzDefinitionAction) ?? 'create';
+                setAction(next);
+                if (next === 'create' || next === 'skip') setTargetId('');
+                resetPreview();
+              }}
+              data={[
+                { value: 'create', label: 'Create' },
+                { value: 'link', label: 'Link existing' },
+                { value: 'refresh', label: 'Refresh linked' },
+                { value: 'skip', label: 'Skip' },
+              ]}
+              allowDeselect={false}
+            />
+            <TextInput
+              label="Target ID"
+              value={targetId}
+              onChange={(event) => {
+                setTargetId(event.currentTarget.value);
+                resetPreview();
+              }}
+              placeholder="Deterministic when omitted"
+              disabled={action === 'create' || action === 'skip'}
+            />
+            <Button
+              className="self-end"
+              variant="outline"
+              onClick={() => previewMutation.mutate()}
+              loading={previewMutation.isPending}
+              disabled={!selected}
+            >
+              Preview
+            </Button>
+          </div>
+
+          {definitionsQuery.data && (
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              <span>{definitionsQuery.data.definitions.length} validated heads</span>
+              <span>•</span>
+              <span>{definitionsQuery.data.rejectedCount} rejected records</span>
+              <span>•</span>
+              <span>{definitionsQuery.data.community}</span>
+            </div>
+          )}
+
+          {preview && (
+            <div className="rounded-md border bg-background/70 p-3 space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge
+                  variant="light"
+                  color={preview.definition.type === 'persona' ? 'blue' : 'teal'}
+                >
+                  {preview.definition.type}
+                </Badge>
+                <Text size="sm" fw={600}>
+                  {preview.definition.displayName}
+                </Text>
+                <Badge variant="outline">{preview.action}</Badge>
+                <Badge
+                  variant="light"
+                  color={preview.definition.compatibility === 'compatible' ? 'green' : 'red'}
+                >
+                  {preview.definition.compatibility}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {preview.definition.authorPubkey.slice(0, 12)}… / {preview.definition.dTag}
+                </span>
+              </div>
+              <div className="grid gap-1 text-xs text-muted-foreground md:grid-cols-2">
+                <div>Community: {preview.definition.community}</div>
+                <div>
+                  Created: {new Date(preview.definition.createdAt * 1_000).toLocaleString()}
+                </div>
+                <div>Event: {preview.definition.eventId.slice(0, 16)}…</div>
+                <div>Content SHA-256: {preview.definition.contentHash.slice(0, 16)}…</div>
+              </div>
+
+              {blocked && (
+                <Alert color="red" icon={<ShieldAlert className="h-4 w-4" />}>
+                  Resolve every collision and unresolved same-author persona before importing.
+                  {preview.collisions.map((collision) => (
+                    <div key={`${collision.field}:${collision.value}`}>
+                      {collision.field}: {collision.detail}
+                    </div>
+                  ))}
+                  {preview.unresolvedPersonaIds.length > 0 && (
+                    <div>Unresolved personas: {preview.unresolvedPersonaIds.join(', ')}</div>
+                  )}
+                </Alert>
+              )}
+
+              {preview.diff.length > 0 && (
+                <div className="rounded border p-2" aria-label="Buzz definition proposed changes">
+                  <div className="mb-1 text-xs font-medium">Proposed changes</div>
+                  <div className="space-y-1">
+                    {preview.diff.map((entry) => (
+                      <div key={entry.field} className="text-xs text-muted-foreground">
+                        <span className="font-medium text-foreground">{entry.field}</span>{' '}
+                        {entry.change}: {entry.beforeSummary ?? 'not set'} →{' '}
+                        {entry.afterSummary ?? 'not set'}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="grid gap-2 md:grid-cols-2">
+                {preview.fieldReport.map((field) => (
+                  <div
+                    key={field.field}
+                    className="flex items-start justify-between gap-2 rounded border p-2"
+                  >
+                    <div>
+                      <div className="text-xs font-medium">{field.field}</div>
+                      <div className="text-xs text-muted-foreground">{field.detail}</div>
+                    </div>
+                    <Badge
+                      size="xs"
+                      variant="light"
+                      color={
+                        field.disposition === 'mapped'
+                          ? 'green'
+                          : field.disposition === 'rejected' || field.disposition === 'conflict'
+                            ? 'red'
+                            : 'gray'
+                      }
+                    >
+                      {field.disposition}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex justify-end">
+                <Button
+                  size="xs"
+                  onClick={() => importMutation.mutate()}
+                  loading={importMutation.isPending}
+                  disabled={blocked}
+                >
+                  {preview.action === 'skip' ? 'Confirm Skip' : `Confirm ${preview.action}`}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {linksQuery.data && linksQuery.data.length > 0 && (
+            <div className="flex flex-wrap gap-2" aria-label="Linked Buzz source status">
+              {linksQuery.data.map((link) => (
+                <Badge
+                  key={`${link.targetType}:${link.targetId}`}
+                  variant="light"
+                  color={
+                    link.status === 'current'
+                      ? 'green'
+                      : link.status === 'changed'
+                        ? 'yellow'
+                        : 'red'
+                  }
+                >
+                  {link.targetId}: {link.status}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {error && (
+        <Alert color="red" icon={<AlertCircle className="h-4 w-4" />}>
+          {error.message}
+        </Alert>
+      )}
     </div>
   );
 }

--- a/web/src/lib/api/integrations.ts
+++ b/web/src/lib/api/integrations.ts
@@ -1,6 +1,12 @@
 import { API_BASE, apiFetch } from './helpers';
 import type {
   BuzzChannelMapping,
+  BuzzDefinitionImportInput,
+  BuzzDefinitionImportResult,
+  BuzzDefinitionLinkedStatus,
+  BuzzDefinitionListResult,
+  BuzzDefinitionPreview,
+  BuzzDefinitionPreviewInput,
   CommunicationAdapterHealth,
   CommunicationAdapterInput,
   CommunicationAdapterRecord,
@@ -113,6 +119,46 @@ export const integrationsApi = {
   buzzChannelMappings: async (adapterId: string): Promise<BuzzChannelMapping[]> => {
     return apiFetch<BuzzChannelMapping[]>(
       `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/channels`
+    );
+  },
+
+  buzzDefinitions: async (adapterId: string): Promise<BuzzDefinitionListResult> => {
+    return apiFetch<BuzzDefinitionListResult>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/definitions`
+    );
+  },
+
+  buzzDefinitionLinks: async (adapterId: string): Promise<BuzzDefinitionLinkedStatus[]> => {
+    return apiFetch<BuzzDefinitionLinkedStatus[]>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/definitions/links`
+    );
+  },
+
+  previewBuzzDefinition: async (
+    adapterId: string,
+    input: BuzzDefinitionPreviewInput
+  ): Promise<BuzzDefinitionPreview> => {
+    return apiFetch<BuzzDefinitionPreview>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/definitions/preview`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    );
+  },
+
+  importBuzzDefinition: async (
+    adapterId: string,
+    input: BuzzDefinitionImportInput
+  ): Promise<BuzzDefinitionImportResult> => {
+    return apiFetch<BuzzDefinitionImportResult>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/definitions/import`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
     );
   },
 


### PR DESCRIPTION
## Summary

- add signed, bounded Buzz kind 30175 persona and kind 30176 team discovery through the verified Buzz adapter
- add explicit preview, create, link, refresh, and skip workflows with deterministic collisions, safe diffs, provenance, and audit events
- materialize imported profiles and roster members disabled, preserve local-only fields, and never execute source runtime declarations
- add the Agents settings UI plus API, security, feature, README, and changelog documentation

## Security and compatibility

- verifies Nostr event signatures and NIP-33 heads before content validation
- rejects secret-like material, commands, paths, process state, managed agents, MCP servers, hooks, skills, and oversized input
- requires current healthy Buzz compatibility evidence and uses the existing DNS-pinned signed query transport
- prevents direct forging or replacement of system-owned Buzz provenance
- serializes JSON and SQLite configuration mutations atomically

## Verification

- `pnpm test:unit` (223 server test files, 2,553 passed, 2 skipped; 74 web test files, 433 passed)
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:budget` (0 errors, 590 warnings, baseline budget 600)
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- `node scripts/check-permission-coverage.mjs`
- `pnpm smoke:cli-mcp` (static checks pass; live smoke skipped because `VK_API_KEY` is unavailable)

Closes #910
Parent: #904