### PR TITLE
feat: add causal run event journal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `run-event/v1`, a provider-neutral causal event journal for OpenClaw,
+  Codex CLI, Codex SDK, and Hermes. Provider mappers now durably append bounded,
+  redacted, deduplicated lifecycle, message, reasoning, command, file, tool,
+  approval, artifact, usage, error, and unknown events before projecting them
+  into legacy logs, traces, telemetry, budgets, and live output. File and SQLite
+  repositories allocate per-attempt monotonic cursors, REST and WebSocket
+  clients can replay after a cursor, and reconnect subscriptions merge replay
+  with concurrent live events without gaps. The published JSON Schema,
+  symlink-safe file storage, SQLite migration, provider fixtures, replay,
+  migration, redaction, and interleaved operator/provider tests define the v1
+  compatibility boundary (#850).
 - Added one-way Buzz persona/team definition import with signed bounded NIP-33
   head queries, exact v0.4.24 field policy, preview/diff/collision actions,
   same-author team resolution, disabled profile and roster materialization,

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -129,6 +129,39 @@ routing. Provider version/build changes invalidate the readiness cache and
 force a new conformance probe; active controls continue to use the immutable
 snapshot persisted for that attempt.
 
+## Causal Run Event Journal
+
+Executable adapters own a mapper into the shared `run-event/v1` envelope.
+OpenClaw, Codex CLI, Codex SDK, and Hermes preserve provider event identity,
+turn/item identity, provider time, receive time, source, causal links, and a
+monotonic per-attempt sequence. Known kinds cover run lifecycle, operator and
+assistant messages, deltas, reasoning, progress, streams, commands, file
+changes, tools, approvals, artifacts, usage, and errors. A new provider event
+that Veritas does not understand is retained as a namespaced kind or
+`provider.unknown`; it is never silently discarded or assigned semantics that
+the adapter cannot prove.
+
+The journal is the ordering boundary for provider output. An event is appended
+and fsynced or committed before legacy Markdown logs, traces, activity,
+telemetry, budget accounting, completion state, or WebSocket output project
+from it. Provider event IDs create stable deduplication keys. File mode stores
+private per-task/per-attempt JSONL under `.veritas-kanban/run-events/`; SQLite
+mode uses migration `0018_causal_run_event_journal` and a transactional
+per-attempt sequence. Each attempt is bounded to 50,000 events and file journals
+to 128 MiB. Payloads are recursively redacted, strings and collections are
+bounded, and payloads larger than 32 KiB are replaced by explicit dropped
+metadata before persistence.
+
+The TypeScript contract is in `shared/src/types/run-event.types.ts`; the
+portable schema is `shared/schemas/run-event-envelope.v1.schema.json`.
+Consumers replay with
+`GET /api/agents/:taskId/attempts/:attemptId/events?afterSequence=<cursor>`.
+WebSocket subscribers send `taskId`, `attemptId`, and `afterSequence`; Veritas
+attaches the live listener before replay, buffers concurrent events, then
+delivers one ordered `agent:event` stream. The older `agent:output` projection
+remains for compatible clients. Existing Markdown attempt logs remain readable
+and are not rewritten by the journal migration.
+
 ## Task Envelopes And Commit Policy
 
 Every launch also persists a provider-neutral `task-envelope/v1` snapshot. It

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1267,8 +1267,19 @@ or `X-API-Key`. In production, do not rely on localhost bypass.
 **Subscribe to task output**:
 
 ```json
-{ "type": "subscribe", "taskId": "TASK-001" }
+{
+  "type": "subscribe",
+  "taskId": "TASK-001",
+  "attemptId": "attempt_001",
+  "afterSequence": 41
+}
 ```
+
+`attemptId` defaults to the active/latest attempt. `afterSequence` defaults to
+`0`. The server attaches the live tail before replaying stored events, so
+events appended during replay are delivered once and in sequence. The
+`subscribed` confirmation returns the resolved `attemptId` and current
+`cursor`.
 
 **Subscribe to chat session**:
 
@@ -1293,14 +1304,51 @@ The server confirms with `run-session:subscribed` after the connection has
 { "type": "task:updated", "task": { "id": "TASK-001", "status": "done" } }
 ```
 
-**Agent output**:
+**Durable agent event**:
+
+```json
+{
+  "type": "agent:event",
+  "taskId": "TASK-001",
+  "attemptId": "attempt_001",
+  "data": {
+    "schemaVersion": "run-event/v1",
+    "eventId": "runevt_abcdefghijklmnopqr",
+    "taskId": "TASK-001",
+    "runId": "attempt_001",
+    "attemptId": "attempt_001",
+    "sequence": 42,
+    "receivedAt": "2026-07-23T20:00:00.000Z",
+    "kind": "message.delta",
+    "source": { "provider": "codex-cli", "adapter": "codex-cli" },
+    "redaction": {
+      "status": "none",
+      "fields": [],
+      "originalBytes": 16,
+      "persistedBytes": 30
+    },
+    "payload": { "content": "Running tests..." },
+    "payloadHash": "<64 lowercase hex characters>"
+  },
+  "timestamp": "2026-07-23T20:00:00.000Z"
+}
+```
+
+Unknown future event kinds remain replayable. Persisted payloads are bounded
+and redacted; `redaction.status: "dropped"` means the provider payload exceeded
+the journal limit and was replaced by safe metadata.
+
+**Legacy agent output projection**:
 
 ```json
 {
   "type": "agent:output",
   "taskId": "TASK-001",
+  "attemptId": "attempt_001",
   "outputType": "stdout",
-  "data": "Running tests..."
+  "content": "Running tests...",
+  "sequence": 42,
+  "timestamp": "2026-07-23T20:00:00.000Z"
 }
 ```
 
@@ -2208,6 +2256,18 @@ Stop, message, completion, token-reporting, and attempt-log endpoints re-check
 both persisted snapshots. Invalid or active/persisted provider or run-launch
 digest mismatches return `409 Conflict`; unsupported capability states return
 the same structured control evidence.
+
+Durable run events can be replayed independently of the Markdown attempt log:
+
+```http
+GET /api/agents/TASK-001/attempts/attempt_123/events?afterSequence=41&limit=200
+```
+
+The response contains `schemaVersion`, `taskId`, `attemptId`, ordered `events`,
+`nextCursor`, and `hasMore`. `afterSequence` must be non-negative and `limit`
+must be between 1 and 500. Access uses the same `run.logs` capability check as
+attempt logs. Clients should persist `nextCursor` and reconnect with it rather
+than inferring order from timestamps.
 
 Stop and message requests must carry the `attemptId` returned by status so a
 delayed control cannot affect a replacement run:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -293,6 +293,7 @@ First-class support for autonomous coding agents.
 - **Agent status indicator** — Header-level indicator showing global agent state (idle, working, sub-agent mode with count)
 - **Running indicator on cards** — Animated spinner on task cards when an agent is actively working
 - **Agent output stream** — Real-time agent output via WebSocket with auto-scroll and clear
+- **Causal run-event journal** — OpenClaw, Codex CLI, Codex SDK, and Hermes map provider output into one bounded, redacted, append-only `run-event/v1` stream with per-attempt ordering, provider deduplication, REST cursor replay, gap-free WebSocket reconnect, and compatible legacy output projections
 - **Send message to agent** — Send text messages to running agents
 - **Optional OpenClaw support** — Built-in integration with [OpenClaw](https://github.com/openclaw/openclaw) (formerly Clawdbot/Moltbot) via gateway URL when you want OpenClaw to execute or wake agents
 - **HermesAgent operating support** — v4.3 documents HermesAgent/Hermes Gateway as the active control plane, with Veritas tracking task truth, QA evidence, and GitHub delivery state

--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -722,6 +722,20 @@ CREATE TABLE telemetry_events (
   created_at TEXT NOT NULL
 );
 
+CREATE TABLE run_events (
+  event_id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL DEFAULT 'local' REFERENCES workspaces(id),
+  task_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  sequence INTEGER NOT NULL CHECK (sequence > 0),
+  provider_event_id TEXT,
+  dedupe_key TEXT,
+  received_at TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  UNIQUE (workspace_id, task_id, attempt_id, sequence),
+  UNIQUE (workspace_id, task_id, attempt_id, dedupe_key)
+);
+
 CREATE TABLE traces (
   id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id),
@@ -743,6 +757,8 @@ CREATE INDEX idx_audit_workspace_created ON audit_events(workspace_id, timestamp
 CREATE INDEX idx_notifications_target ON notifications(workspace_id, target_agent, delivered, created_at DESC);
 CREATE INDEX idx_telemetry_type_created ON telemetry_events(workspace_id, type, created_at DESC);
 CREATE INDEX idx_telemetry_task_created ON telemetry_events(task_id, created_at DESC);
+CREATE INDEX idx_run_events_task_attempt_sequence ON run_events(workspace_id, task_id, attempt_id, sequence);
+CREATE INDEX idx_run_events_received_at ON run_events(workspace_id, received_at);
 CREATE INDEX idx_traces_attempt ON traces(attempt_id, created_at DESC);
 ```
 
@@ -1049,16 +1065,18 @@ SQLite tables with JSON payload columns plus query indexes. This keeps the v4
 service contracts intact while preventing SQLite mode from writing operational
 state back to `.veritas-kanban/*.json` or telemetry NDJSON files.
 
-| Runtime table      | Stored data                                                                              |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| `activity_events`  | Complete activity entries plus type, task, agent, and created-time columns.              |
-| `status_history`   | Complete status transition entries plus previous/new status and task columns.            |
-| `telemetry_events` | Complete telemetry events plus type, task, project, token, duration, and result columns. |
+| Runtime table      | Stored data                                                                                                    |
+| ------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `activity_events`  | Complete activity entries plus type, task, agent, and created-time columns.                                    |
+| `status_history`   | Complete status transition entries plus previous/new status and task columns.                                  |
+| `telemetry_events` | Complete telemetry events plus type, task, project, token, duration, and result columns.                       |
+| `run_events`       | Complete `run-event/v1` envelopes plus ordered attempt cursor, provider identity, dedupe, and receive columns. |
 
-`ActivityService`, `StatusHistoryService`, and `TelemetryService` select these
-SQLite repositories when `VERITAS_STORAGE=sqlite`. File storage still forces the
-file-backed services to `storageType='file'`, so explicit file mode cannot be
-accidentally flipped by the environment.
+`ActivityService`, `StatusHistoryService`, `TelemetryService`, and
+`RunEventJournalService` select these SQLite repositories when
+`VERITAS_STORAGE=sqlite`. File storage still forces the file-backed services to
+`storageType='file'`, so explicit file mode cannot be accidentally flipped by
+the environment.
 
 Dashboard metric aggregation uses the same active storage backend. In SQLite
 mode, `/metrics/all`, `/metrics/trends`, agent comparison, task cost, and

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -13,6 +13,7 @@ const {
   mockGetAgentStatus,
   mockAssertActiveRunControl,
   mockRecordBudgetUsage,
+  mockGetRunEvents,
   mockGetTask,
   mockTelemetryEmit,
 } = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const {
   mockGetAgentStatus: vi.fn(),
   mockAssertActiveRunControl: vi.fn(),
   mockRecordBudgetUsage: vi.fn(),
+  mockGetRunEvents: vi.fn(),
   mockGetTask: vi.fn(),
   mockTelemetryEmit: vi.fn(),
 }));
@@ -50,6 +52,7 @@ vi.mock('../../services/clawdbot-agent-service.js', () => ({
     listPendingRequests: vi.fn(),
     listAttempts: vi.fn(),
     getAttemptLog: vi.fn(),
+    getRunEvents: mockGetRunEvents,
   },
 }));
 
@@ -103,6 +106,14 @@ describe('agent local capability enforcement', () => {
     mockGetAgentStatus.mockReturnValue(null);
     mockAssertActiveRunControl.mockResolvedValue(undefined);
     mockRecordBudgetUsage.mockResolvedValue(undefined);
+    mockGetRunEvents.mockResolvedValue({
+      schemaVersion: 'run-event/v1',
+      taskId: 'task_1',
+      attemptId: 'attempt_1',
+      events: [],
+      nextCursor: 12,
+      hasMore: false,
+    });
     mockGetTask.mockResolvedValue({
       id: 'task_1',
       project: 'veritas',
@@ -389,5 +400,24 @@ describe('agent local capability enforcement', () => {
       totalTokens: 15,
       costUsd: undefined,
     });
+  });
+
+  it('validates and forwards durable run-event replay cursors', async () => {
+    const app = createApp(auth());
+    const response = await request(app)
+      .get('/api/agents/task_1/attempts/attempt_1/events')
+      .query({ afterSequence: 12, limit: 50 });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      schemaVersion: 'run-event/v1',
+      nextCursor: 12,
+    });
+    expect(mockGetRunEvents).toHaveBeenCalledWith('task_1', 'attempt_1', 12, 50);
+
+    const invalid = await request(app)
+      .get('/api/agents/task_1/attempts/attempt_1/events')
+      .query({ afterSequence: -1 });
+    expect(invalid.status).toBe(400);
   });
 });

--- a/server/src/__tests__/run-event-journal-service.test.ts
+++ b/server/src/__tests__/run-event-journal-service.test.ts
@@ -1,0 +1,455 @@
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  RUN_EVENT_KINDS,
+  RUN_EVENT_SCHEMA_VERSION,
+  type RunEventAppendInput,
+  type RunEventEnvelope,
+} from '@veritas-kanban/shared';
+import { FileRunEventRepository } from '../storage/run-event-repository.js';
+import type { RunEventRepository } from '../storage/interfaces.js';
+import { SqliteRunEventRepository } from '../storage/sqlite/run-event-repository.js';
+import { SqliteDatabase } from '../storage/sqlite/database.js';
+import { SQLITE_BASE_MIGRATIONS } from '../storage/sqlite/migrations.js';
+import { RunEventJournalService } from '../services/run-event-journal-service.js';
+import { getProviderRunEventMapper } from '../services/provider-run-event-mappers.js';
+import { RunEventEnvelopeSchema, RunEventKindSchema } from '../schemas/run-event-schemas.js';
+
+const cleanupPaths: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'veritas-run-events-'));
+  cleanupPaths.push(directory);
+  return directory;
+}
+
+function appendInput(overrides: Partial<RunEventAppendInput> = {}): RunEventAppendInput {
+  return {
+    taskId: 'task_1',
+    attemptId: 'attempt_1',
+    kind: 'progress',
+    source: {
+      provider: 'codex-cli',
+      adapter: 'codex-cli',
+      agent: 'codex',
+    },
+    payload: { summary: 'working' },
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((entry) => rm(entry, { recursive: true })));
+});
+
+describe('RunEventJournalService', () => {
+  it('allocates ordered cursors, replays after a cursor, and rejects duplicate provider events', async () => {
+    const directory = await temporaryDirectory();
+    const journal = new RunEventJournalService(new FileRunEventRepository(directory));
+    const first = await journal.append(
+      appendInput({
+        providerEventId: 'provider_event_1',
+        payload: { summary: 'first' },
+      })
+    );
+    const duplicate = await journal.append(
+      appendInput({
+        providerEventId: 'provider_event_1',
+        payload: { summary: 'duplicate must not replace the first event' },
+      })
+    );
+    const concurrent = await Promise.all([
+      journal.append(appendInput({ payload: { summary: 'second' } })),
+      journal.append(appendInput({ payload: { summary: 'third' } })),
+    ]);
+
+    expect(first.appended).toBe(true);
+    expect(duplicate).toEqual({ event: first.event, appended: false });
+    expect(concurrent.map((result) => result.event.sequence).sort((a, b) => a - b)).toEqual([2, 3]);
+
+    const page = await journal.list({
+      taskId: 'task_1',
+      attemptId: 'attempt_1',
+      afterSequence: 1,
+      limit: 1,
+    });
+    expect(page.events).toHaveLength(1);
+    expect(page.events[0].sequence).toBe(2);
+    expect(page.nextCursor).toBe(2);
+    expect(page.hasMore).toBe(true);
+  });
+
+  it('redacts structured and embedded secrets before persistence', async () => {
+    const directory = await temporaryDirectory();
+    const journal = new RunEventJournalService(new FileRunEventRepository(directory));
+    const result = await journal.append(
+      appendInput({
+        payload: {
+          authorization: 'Bearer abcdefghijklmnop',
+          summary: 'failed with Bearer abcdefghijklmnop',
+          nested: { api_key: 'sk-secret-secret-secret' },
+          inputTokens: 123,
+          outputTokens: 45,
+        },
+      })
+    );
+
+    expect(result.event.redaction.status).toBe('redacted');
+    expect(result.event.redaction.fields).toContain('$.authorization');
+    expect(JSON.stringify(result.event.payload)).not.toContain('abcdefghijklmnop');
+    expect(JSON.stringify(result.event.payload)).not.toContain('sk-secret');
+    expect(result.event.payload.inputTokens).toBe(123);
+    expect(result.event.payload.outputTokens).toBe(45);
+
+    const raw = await readFile(path.join(directory, 'task_1', 'attempt_1.jsonl'), 'utf-8');
+    expect(raw).not.toContain('abcdefghijklmnop');
+    expect(raw).not.toContain('sk-secret');
+  });
+
+  it('drops payload bodies that remain oversized after bounded normalization', async () => {
+    const directory = await temporaryDirectory();
+    const journal = new RunEventJournalService(new FileRunEventRepository(directory));
+    const result = await journal.append(
+      appendInput({
+        payload: {
+          chunks: Array.from(
+            { length: 10 },
+            (_, index) => `${index}:${'bounded provider output '.repeat(360)}`
+          ),
+        },
+      })
+    );
+
+    expect(result.event.redaction.status).toBe('dropped');
+    expect(result.event.payload).toMatchObject({ dropped: true });
+    expect(result.event.redaction.persistedBytes).toBeLessThan(32 * 1024);
+  });
+
+  it.runIf(process.platform !== 'win32')('refuses a symlinked journal target', async () => {
+    const directory = await temporaryDirectory();
+    const taskDirectory = path.join(directory, 'task_1');
+    await mkdir(taskDirectory, { recursive: true });
+    const target = path.join(directory, 'outside.jsonl');
+    await writeFile(target, '');
+    await symlink(target, path.join(taskDirectory, 'attempt_1.jsonl'));
+    const journal = new RunEventJournalService(new FileRunEventRepository(directory));
+
+    await expect(journal.append(appendInput())).rejects.toThrow(
+      'Run event journal is not a bounded regular file'
+    );
+  });
+
+  it('uses transactional ordering and deduplication in SQLite', async () => {
+    const database = new SqliteDatabase({ databasePath: ':memory:' });
+    database.open();
+    try {
+      const journal = new RunEventJournalService(new SqliteRunEventRepository(database));
+      const first = await journal.append(
+        appendInput({ providerEventId: 'sqlite_event', payload: { summary: 'one' } })
+      );
+      const duplicate = await journal.append(
+        appendInput({ providerEventId: 'sqlite_event', payload: { summary: 'two' } })
+      );
+      const second = await journal.append(appendInput({ payload: { summary: 'three' } }));
+      const otherTask = await journal.append(
+        appendInput({
+          taskId: 'task_2',
+          providerEventId: 'sqlite_event',
+          payload: { summary: 'same provider identity in a different task' },
+        })
+      );
+
+      expect(first.event.sequence).toBe(1);
+      expect(duplicate.appended).toBe(false);
+      expect(duplicate.event.eventId).toBe(first.event.eventId);
+      expect(second.event.sequence).toBe(2);
+      expect(otherTask).toMatchObject({
+        appended: true,
+        event: { taskId: 'task_2', sequence: 1 },
+      });
+      expect(
+        (
+          await journal.list({
+            taskId: 'task_1',
+            attemptId: 'attempt_1',
+            afterSequence: 0,
+          })
+        ).events.map((event) => event.sequence)
+      ).toEqual([1, 2]);
+    } finally {
+      database.close();
+    }
+  });
+
+  it('replays and live-tails provider and operator events through one ordered subscription', async () => {
+    const directory = await temporaryDirectory();
+    const journal = new RunEventJournalService(new FileRunEventRepository(directory));
+    const providerMapper = getProviderRunEventMapper('codex-cli');
+    const firstProviderEvent = providerMapper.mapEvent(
+      'item.completed',
+      {
+        id: 'provider_event_1',
+        item: { type: 'agent_message', text: 'first provider output' },
+      },
+      'first provider output'
+    );
+    await journal.append(
+      appendInput({
+        ...firstProviderEvent,
+        source: { provider: 'codex-cli', adapter: 'codex-cli', agent: 'codex' },
+      })
+    );
+
+    const received: RunEventEnvelope[] = [];
+    const subscription = await journal.subscribe(
+      { taskId: 'task_1', attemptId: 'attempt_1', afterSequence: 0 },
+      (event) => received.push(event)
+    );
+    expect(subscription.cursor).toBe(1);
+
+    await journal.append(
+      appendInput({
+        kind: 'message.operator',
+        source: { provider: 'operator', adapter: 'veritas-operator-message' },
+        payload: { content: 'operator follow-up' },
+      })
+    );
+    await journal.append(
+      appendInput({
+        kind: 'message.delta',
+        payload: { content: 'provider response' },
+      })
+    );
+    expect(received.map((event) => event.sequence)).toEqual([1, 2, 3]);
+    expect(received.map((event) => event.source.provider)).toEqual([
+      'codex-cli',
+      'operator',
+      'codex-cli',
+    ]);
+    subscription.unsubscribe();
+
+    const reconnected: number[] = [];
+    const reconnect = await journal.subscribe(
+      { taskId: 'task_1', attemptId: 'attempt_1', afterSequence: 1 },
+      (event) => reconnected.push(event.sequence)
+    );
+    expect(reconnected).toEqual([2, 3]);
+    expect(reconnect.cursor).toBe(3);
+    reconnect.unsubscribe();
+  });
+
+  it('buffers an event appended while a reconnect replay is in flight', async () => {
+    const directory = await temporaryDirectory();
+    const repository = new FileRunEventRepository(directory);
+    const writer = new RunEventJournalService(repository);
+    await writer.append(appendInput({ payload: { summary: 'before reconnect' } }));
+
+    let releaseReplay!: () => void;
+    let replayStarted!: () => void;
+    const replayGate = new Promise<void>((resolve) => {
+      releaseReplay = resolve;
+    });
+    const replayObserved = new Promise<void>((resolve) => {
+      replayStarted = resolve;
+    });
+    let firstReplay = true;
+    const delayedRepository: RunEventRepository = {
+      append: (event) => repository.append(event),
+      list: async (query) => {
+        const page = await repository.list(query);
+        if (firstReplay) {
+          firstReplay = false;
+          replayStarted();
+          await replayGate;
+        }
+        return page;
+      },
+    };
+    const subscriber = new RunEventJournalService(delayedRepository);
+    const received: number[] = [];
+    const pendingSubscription = subscriber.subscribe(
+      { taskId: 'task_1', attemptId: 'attempt_1' },
+      (event) => received.push(event.sequence)
+    );
+
+    await replayObserved;
+    await subscriber.append(
+      appendInput({
+        kind: 'message.operator',
+        source: { provider: 'operator', adapter: 'veritas-operator-message' },
+        payload: { content: 'arrived during replay' },
+      })
+    );
+    releaseReplay();
+    const subscription = await pendingSubscription;
+
+    expect(received).toEqual([1, 2]);
+    expect(subscription.cursor).toBe(2);
+    subscription.unsubscribe();
+  });
+
+  it('does not let a live projection failure invalidate a durable append', async () => {
+    const directory = await temporaryDirectory();
+    const journal = new RunEventJournalService(new FileRunEventRepository(directory));
+    journal.onEvent(() => {
+      throw new Error('closed WebSocket');
+    });
+
+    await expect(journal.append(appendInput())).resolves.toMatchObject({ appended: true });
+    await expect(journal.list({ taskId: 'task_1', attemptId: 'attempt_1' })).resolves.toMatchObject(
+      { nextCursor: 1 }
+    );
+  });
+});
+
+describe('provider run event mappers', () => {
+  it('maps every executable provider and preserves unknown future events', () => {
+    expect(getProviderRunEventMapper('hermes-cli').mapStream('stdout', 'hello')).toMatchObject({
+      kind: 'message.delta',
+    });
+    expect(
+      getProviderRunEventMapper('codex-cli').mapEvent('item.completed', {
+        type: 'item.completed',
+        item: { id: 'item_1', type: 'agent_message', text: 'done' },
+      })
+    ).toMatchObject({
+      kind: 'message.assistant',
+      providerEventId: 'item_1',
+      itemId: 'item_1',
+    });
+    expect(
+      getProviderRunEventMapper('codex-sdk').mapEvent('future.capability', {
+        type: 'future.capability',
+        id: 'future_1',
+        future: true,
+      })
+    ).toMatchObject({
+      kind: 'provider.unknown',
+      providerEventId: 'future_1',
+      payload: { providerType: 'future.capability' },
+    });
+    expect(
+      getProviderRunEventMapper('openclaw').mapEvent('tool.started', {
+        type: 'tool.started',
+        id: 'tool_1',
+      })
+    ).toMatchObject({
+      kind: 'tool.started',
+      providerEventId: 'tool_1',
+    });
+  });
+
+  it('deduplicates retries without collapsing distinct phases that share one item ID', () => {
+    const mapper = getProviderRunEventMapper('codex-cli');
+    const started = mapper.mapEvent('item.started', {
+      item: { id: 'shared_item', type: 'command_execution' },
+    });
+    const completed = mapper.mapEvent('item.completed', {
+      item: { id: 'shared_item', type: 'command_execution' },
+    });
+    const longIdentity = mapper.mapEvent('item.completed', {
+      item: { id: 'x'.repeat(500), type: 'agent_message' },
+    });
+
+    expect(started).toMatchObject({
+      kind: 'command.started',
+      providerEventId: 'shared_item',
+    });
+    expect(completed).toMatchObject({
+      kind: 'command.completed',
+      providerEventId: 'shared_item',
+    });
+    expect(started.dedupeKey).not.toBe(completed.dedupeKey);
+    expect(longIdentity.providerEventId).toMatch(/^sha256_[a-f0-9]{64}$/);
+    expect(longIdentity.dedupeKey?.length).toBeLessThanOrEqual(240);
+    expect(
+      getProviderRunEventMapper('openclaw').mapEvent(
+        'message.completed',
+        { event_id: 'callback_1' },
+        'OpenClaw completed the task'
+      )
+    ).toMatchObject({
+      kind: 'message.assistant',
+      providerEventId: 'callback_1',
+    });
+  });
+});
+
+describe('run event schema artifacts', () => {
+  it('keeps the TypeScript/Zod contract and published JSON Schema on v1', async () => {
+    const schemaPath = new URL(
+      '../../../shared/schemas/run-event-envelope.v1.schema.json',
+      import.meta.url
+    );
+    const jsonSchema = JSON.parse(await readFile(schemaPath, 'utf-8')) as {
+      properties: Record<
+        string,
+        {
+          const?: string;
+          anyOf?: Array<{ enum?: string[] }>;
+        }
+      >;
+      required: string[];
+    };
+    expect(jsonSchema.properties.schemaVersion.const).toBe(RUN_EVENT_SCHEMA_VERSION);
+    expect(jsonSchema.required).toContain('payloadHash');
+    expect(RUN_EVENT_KINDS).toContain('provider.unknown');
+    expect(jsonSchema.properties.kind.anyOf?.[0]?.enum).toEqual([...RUN_EVENT_KINDS]);
+    expect(RunEventKindSchema.safeParse('progress').success).toBe(true);
+    expect(RunEventKindSchema.safeParse('provider.future-event').success).toBe(true);
+    expect(RunEventKindSchema.safeParse('future').success).toBe(false);
+
+    const parsed = RunEventEnvelopeSchema.safeParse({
+      schemaVersion: RUN_EVENT_SCHEMA_VERSION,
+      eventId: 'runevt_abcdefghijklmnopqr',
+      taskId: 'task_1',
+      runId: 'attempt_1',
+      attemptId: 'attempt_1',
+      sequence: 1,
+      receivedAt: '2026-07-23T12:00:00.000Z',
+      kind: 'provider.future-event',
+      source: { provider: 'system', adapter: 'fixture' },
+      redaction: {
+        status: 'none',
+        fields: [],
+        originalBytes: 2,
+        persistedBytes: 2,
+      },
+      payload: {},
+      payloadHash: 'a'.repeat(64),
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('adds the journal table without rewriting existing attempt logs', async () => {
+    const directory = await temporaryDirectory();
+    const databasePath = path.join(directory, 'veritas.db');
+    const logsDirectory = path.join(directory, 'logs');
+    const legacyLogPath = path.join(logsDirectory, 'task_legacy_attempt_legacy.md');
+    const legacyLog = '# Legacy attempt\n\nExisting provider output remains readable.\n';
+    await mkdir(logsDirectory, { recursive: true });
+    await writeFile(legacyLogPath, legacyLog);
+
+    const legacyDatabase = new SqliteDatabase({
+      databasePath,
+      migrations: SQLITE_BASE_MIGRATIONS.filter((migration) => migration.version < 18),
+    });
+    legacyDatabase.open();
+    legacyDatabase.close();
+
+    const migratedDatabase = new SqliteDatabase({ databasePath });
+    migratedDatabase.open();
+    try {
+      const table = migratedDatabase
+        .getConnection()
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'run_events'")
+        .get() as { name?: string } | undefined;
+      expect(table?.name).toBe('run_events');
+      expect(await readFile(legacyLogPath, 'utf-8')).toBe(legacyLog);
+    } finally {
+      migratedDatabase.close();
+    }
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -23,6 +23,7 @@ import { AgentBudgetPolicySchema } from '../schemas/agent-budget-schemas.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { ProviderRuntimeCapabilityIdSchema } from '../schemas/provider-runtime-manifest-schemas.js';
 import { TaskCommitPolicySchema } from '../schemas/task-envelope-schemas.js';
+import { RunEventQuerySchema } from '../schemas/run-event-schemas.js';
 
 const router: RouterType = Router();
 
@@ -393,6 +394,33 @@ router.get(
       req.params.attemptId as string
     );
     res.type('text/markdown').send(log);
+  })
+);
+
+// GET /api/agents/:taskId/attempts/:attemptId/events - Replay durable run events
+router.get(
+  '/:taskId/attempts/:attemptId/events',
+  asyncHandler(async (req, res) => {
+    let query: z.infer<typeof RunEventQuerySchema>;
+    try {
+      query = RunEventQuerySchema.parse({
+        ...req.query,
+        attemptId: req.params.attemptId,
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+    res.json(
+      await clawdbotAgentService.getRunEvents(
+        req.params.taskId as string,
+        query.attemptId,
+        query.afterSequence,
+        query.limit
+      )
+    );
   })
 );
 

--- a/server/src/schemas/run-event-schemas.ts
+++ b/server/src/schemas/run-event-schemas.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import {
+  EXECUTABLE_AGENT_PROVIDERS,
+  RUN_EVENT_KINDS,
+  RUN_EVENT_SCHEMA_VERSION,
+  type RunEventEnvelope,
+  type RunEventJsonValue,
+} from '@veritas-kanban/shared';
+
+const IdentifierSchema = z.string().trim().min(1).max(160);
+const IsoTimestampSchema = z.string().datetime();
+
+const JsonValueSchema: z.ZodType<RunEventJsonValue> = z.lazy(() =>
+  z.union([
+    z.null(),
+    z.boolean(),
+    z.number().finite(),
+    z.string(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ])
+);
+
+const NamespacedRunEventKindSchema = z
+  .string()
+  .trim()
+  .min(3)
+  .max(120)
+  .regex(
+    /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$/,
+    'Unknown run event kinds must be lower-case namespaced identifiers'
+  );
+
+export const RunEventKindSchema = z.union([z.enum(RUN_EVENT_KINDS), NamespacedRunEventKindSchema]);
+
+export const RunEventEnvelopeSchema: z.ZodType<RunEventEnvelope> = z
+  .object({
+    schemaVersion: z.literal(RUN_EVENT_SCHEMA_VERSION),
+    eventId: z.string().regex(/^runevt_[A-Za-z0-9_-]{12,32}$/),
+    taskId: IdentifierSchema,
+    runId: IdentifierSchema,
+    attemptId: IdentifierSchema,
+    turnId: IdentifierSchema.optional(),
+    itemId: IdentifierSchema.optional(),
+    providerEventId: IdentifierSchema.optional(),
+    parentEventId: IdentifierSchema.optional(),
+    causalEventId: IdentifierSchema.optional(),
+    sequence: z.number().int().positive(),
+    providerTimestamp: IsoTimestampSchema.optional(),
+    receivedAt: IsoTimestampSchema,
+    kind: RunEventKindSchema,
+    source: z
+      .object({
+        provider: z.enum([...EXECUTABLE_AGENT_PROVIDERS, 'operator', 'system']),
+        adapter: IdentifierSchema,
+        agent: IdentifierSchema.optional(),
+        model: z.string().trim().min(1).max(240).optional(),
+      })
+      .strict(),
+    redaction: z
+      .object({
+        status: z.enum(['none', 'redacted', 'dropped']),
+        fields: z.array(z.string().min(1).max(240)).max(256),
+        originalBytes: z.number().int().nonnegative(),
+        persistedBytes: z.number().int().nonnegative(),
+      })
+      .strict(),
+    payload: z.record(z.string(), JsonValueSchema),
+    payloadHash: z.string().regex(/^[a-f0-9]{64}$/),
+    dedupeKey: z.string().trim().min(1).max(240).optional(),
+  })
+  .strict();
+
+export const RunEventQuerySchema = z
+  .object({
+    attemptId: IdentifierSchema,
+    afterSequence: z.coerce.number().int().nonnegative().default(0),
+    limit: z.coerce.number().int().min(1).max(500).default(200),
+  })
+  .strict();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -60,7 +60,7 @@ import { swaggerSpec } from './config/swagger.js';
 import { apiRateLimit, authRateLimit } from './middleware/rate-limit.js';
 import { apiVersionMiddleware } from './middleware/api-version.js';
 import { apiCacheHeaders } from './middleware/cache-control.js';
-import type { AgentOutput } from './services/clawdbot-agent-service.js';
+import type { RunEventEnvelope } from '@veritas-kanban/shared';
 import { webhookN8nRouter } from './routes/webhook-n8n.js';
 import { cspNonceMiddleware, injectCspNonceAttributes } from './middleware/csp-nonce.js';
 import { apiDocsCspOverride, buildCspDirectives } from './config/csp.js';
@@ -70,6 +70,7 @@ import { prometheusMetricsRouter } from './routes/prometheus.js';
 import { getStorageTypeFromEnv, initStorage, shutdownStorage } from './storage/index.js';
 import {
   canReceiveWebSocketEvent,
+  sendWebSocketEvent,
   subscribeWebSocketChatSession,
   subscribeWebSocketChannel,
   unsubscribeWebSocketChatSession,
@@ -78,6 +79,7 @@ import {
 import { closeWebSocketSafely } from './utils/websocket-close.js';
 import { startAfterInitialization } from './utils/startup-gate.js';
 import { getCommunicationAdapterService } from './services/communication-adapter-service.js';
+import { getRunEventJournalService } from './services/run-event-journal-service.js';
 
 const log = createLogger('server');
 
@@ -764,20 +766,20 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
   );
 
   let subscribedTaskId: string | null = null;
+  let subscribedAttemptId: string | null = null;
   let subscribedChatSession: string | null = null;
+  let agentSubscriptionGeneration = 0;
 
   // Track current emitter listeners for cleanup on re-subscribe or close
   let currentEmitter: import('events').EventEmitter | null = null;
-  let currentOutputHandler: ((output: AgentOutput) => void) | null = null;
   let currentCompleteHandler:
     ((result: { code: number; signal: string | null; status: string }) => void) | null = null;
   let currentErrorHandler: ((error: Error) => void) | null = null;
+  let currentRunEventUnsubscribe: (() => void) | null = null;
+  const runEventJournal = getRunEventJournalService();
 
   const cleanupEmitterListeners = () => {
     if (currentEmitter) {
-      if (currentOutputHandler) {
-        currentEmitter.off('output', currentOutputHandler);
-      }
       if (currentCompleteHandler) {
         currentEmitter.off('complete', currentCompleteHandler);
       }
@@ -785,10 +787,59 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
         currentEmitter.off('error', currentErrorHandler);
       }
       currentEmitter = null;
-      currentOutputHandler = null;
       currentCompleteHandler = null;
       currentErrorHandler = null;
     }
+    if (currentRunEventUnsubscribe) {
+      currentRunEventUnsubscribe();
+      currentRunEventUnsubscribe = null;
+    }
+  };
+
+  const sendRunEvent = (event: RunEventEnvelope): boolean => {
+    const delivery = {
+      permissions: ['task:read'] as AuthPermission[],
+      channel: 'agent-output' as const,
+    };
+    const eventSent = sendWebSocketEvent(
+      ws,
+      JSON.stringify({
+        type: 'agent:event',
+        taskId: event.taskId,
+        attemptId: event.attemptId,
+        data: event,
+        timestamp: event.receivedAt,
+      }),
+      delivery
+    );
+    if (!eventSent) return false;
+    const content =
+      typeof event.payload.content === 'string'
+        ? event.payload.content
+        : typeof event.payload.summary === 'string'
+          ? event.payload.summary
+          : undefined;
+    if (!content) return true;
+    return sendWebSocketEvent(
+      ws,
+      JSON.stringify({
+        type: 'agent:output',
+        taskId: event.taskId,
+        attemptId: event.attemptId,
+        outputType:
+          event.source.provider === 'operator'
+            ? 'stdin'
+            : event.kind === 'stream.stderr' || event.kind === 'run.error'
+              ? 'stderr'
+              : event.source.provider === 'system'
+                ? 'system'
+                : 'stdout',
+        content,
+        sequence: event.sequence,
+        timestamp: event.receivedAt,
+      }),
+      delivery
+    );
   };
 
   // ---- Message rate limiting ----
@@ -797,7 +848,9 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
   const WS_MESSAGE_RATE_LIMIT = 30; // messages per window
   const WS_MESSAGE_RATE_WINDOW_MS = 10_000; // 10 second window
 
-  ws.on('message', (data) => {
+  ws.on('message', async (data) => {
+    let failedAgentSubscriptionGeneration: number | null = null;
+    let failedAgentSubscriptionTaskId: string | null = null;
     // Rate limit check
     const now = Date.now();
     if (now - messageWindowStart > WS_MESSAGE_RATE_WINDOW_MS) {
@@ -966,25 +1019,46 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
 
         // Clean up previous emitter listeners before subscribing to new task
         cleanupEmitterListeners();
+        const generation = ++agentSubscriptionGeneration;
+        failedAgentSubscriptionGeneration = generation;
+        failedAgentSubscriptionTaskId = newTaskId;
+        const requestedAttemptId =
+          typeof message.attemptId === 'string' ? message.attemptId : undefined;
+        const afterSequence =
+          Number.isInteger(message.afterSequence) && message.afterSequence >= 0
+            ? message.afterSequence
+            : 0;
+        const attemptId = await agentService.resolveRunEventAttemptId(
+          newTaskId,
+          requestedAttemptId
+        );
+        if (generation !== agentSubscriptionGeneration) return;
+        subscribedAttemptId = attemptId;
 
-        // Set up listener for agent output
+        await agentService.assertRunControl(newTaskId, 'logs', attemptId);
+        const runEventSubscription = await runEventJournal.subscribe(
+          {
+            taskId: newTaskId,
+            attemptId,
+            afterSequence,
+          },
+          (event) => {
+            if (generation === agentSubscriptionGeneration && !sendRunEvent(event)) {
+              throw new Error('Run event WebSocket delivery stopped');
+            }
+          }
+        );
+        if (generation !== agentSubscriptionGeneration) {
+          runEventSubscription.unsubscribe();
+          return;
+        }
+        currentRunEventUnsubscribe = runEventSubscription.unsubscribe;
+        const replayCursor = runEventSubscription.cursor;
+
+        // Retain terminal/error compatibility events for existing clients.
         const emitter = agentService.getAgentEmitter(newTaskId);
         if (emitter) {
           const taskIdForHandlers = newTaskId;
-
-          currentOutputHandler = (output: AgentOutput) => {
-            if (ws.readyState === WebSocket.OPEN) {
-              ws.send(
-                JSON.stringify({
-                  type: 'agent:output',
-                  taskId: taskIdForHandlers,
-                  outputType: output.type,
-                  content: output.content,
-                  timestamp: output.timestamp,
-                })
-              );
-            }
-          };
 
           currentCompleteHandler = (result: {
             code: number;
@@ -1015,7 +1089,6 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
           };
 
           currentEmitter = emitter;
-          emitter.on('output', currentOutputHandler);
           emitter.on('complete', currentCompleteHandler);
           emitter.on('error', currentErrorHandler);
         }
@@ -1025,11 +1098,30 @@ wss.on('connection', (ws: HeartbeatWebSocket, req) => {
           JSON.stringify({
             type: 'subscribed',
             taskId: subscribedTaskId,
+            attemptId: subscribedAttemptId,
+            cursor: replayCursor,
             running: !!emitter,
           })
         );
+        failedAgentSubscriptionGeneration = null;
+        failedAgentSubscriptionTaskId = null;
       }
     } catch (error) {
+      if (
+        failedAgentSubscriptionGeneration !== null &&
+        failedAgentSubscriptionGeneration === agentSubscriptionGeneration
+      ) {
+        cleanupEmitterListeners();
+        if (failedAgentSubscriptionTaskId) {
+          const subscribers = agentSubscriptions.get(failedAgentSubscriptionTaskId);
+          subscribers?.delete(ws);
+          if (subscribers?.size === 0) {
+            agentSubscriptions.delete(failedAgentSubscriptionTaskId);
+          }
+        }
+        subscribedTaskId = null;
+        subscribedAttemptId = null;
+      }
       log.error({ err: error }, 'WebSocket message error');
     }
   });

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -47,7 +47,11 @@ import {
   type ProviderTaskEnvelopeTransport,
 } from './provider-task-envelope-renderer.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
-import { evaluateTaskReadiness, RUN_LAUNCH_MANIFEST_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import {
+  evaluateTaskReadiness,
+  EXECUTABLE_AGENT_PROVIDERS,
+  RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
+} from '@veritas-kanban/shared';
 import type {
   Task,
   AgentType,
@@ -91,6 +95,8 @@ import type {
   RunLaunchRuntime,
   CredentialRunRevocationRequest,
   CredentialLeaseTerminalReason,
+  RunEventEnvelope,
+  RunEventKind,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError } from '../middleware/error-handler.js';
@@ -130,6 +136,15 @@ import {
 } from './provider-completion-service.js';
 import { getCredentialBrokerService } from './credential-broker-service.js';
 import { WorktreeService } from './worktree-service.js';
+import {
+  getRunEventJournalService,
+  type RunEventJournalService,
+} from './run-event-journal-service.js';
+import {
+  getProviderRunEventMapper,
+  type ProviderMappedRunEvent,
+  type ProviderRunEventMapper,
+} from './provider-run-event-mappers.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -172,6 +187,7 @@ export interface AgentProviderAdapter {
   label: string;
   renderTaskEnvelope(input: ProviderTaskEnvelopeRenderInput): ProviderTaskEnvelopeTransport;
   probe(context: AgentProviderProbeContext): Promise<ProviderRuntimeManifest>;
+  runEventMapper: ProviderRunEventMapper;
   start(context: AgentProviderStartContext): Promise<void> | void;
   stop(context: AgentProviderStopContext): Promise<void> | void;
 }
@@ -281,7 +297,7 @@ interface PendingAgent {
   completionBudgetEvaluated?: boolean;
   preparedCompletion?: {
     status: AttemptStatus;
-    taskBeforeCompletion?: Task;
+    taskBeforeCompletion: Task;
     completedAttempt: TaskAttempt;
     completionResult: CompletionResult;
   };
@@ -330,6 +346,12 @@ function normalizedTaskRevision(task: Pick<Task, 'revision'>): number {
     : 1;
 }
 
+function executableProvider(value: string | undefined): ExecutableAgentProvider | 'system' {
+  return EXECUTABLE_AGENT_PROVIDERS.includes(value as ExecutableAgentProvider)
+    ? (value as ExecutableAgentProvider)
+    : 'system';
+}
+
 export class ClawdbotAgentService {
   private configService: ConfigService;
   private taskService: TaskService;
@@ -341,6 +363,7 @@ export class ClawdbotAgentService {
   private credentialLeases: CredentialLeaseLifecycle;
   private workspaceFiles: WorkspaceFileRepository;
   private worktrees: Pick<WorktreeService, 'claimOwnership' | 'releaseOwnership'>;
+  private runEvents: RunEventJournalService;
   private logsDir: string;
 
   constructor(
@@ -350,7 +373,8 @@ export class ClawdbotAgentService {
     workspaceFiles: WorkspaceFileRepository = new LocalWorkspaceFileRepository(),
     providerCompletions = new ProviderCompletionService(),
     credentialLeases: CredentialLeaseLifecycle = NOOP_CREDENTIAL_LEASE_LIFECYCLE,
-    worktrees?: Pick<WorktreeService, 'claimOwnership' | 'releaseOwnership'>
+    worktrees?: Pick<WorktreeService, 'claimOwnership' | 'releaseOwnership'>,
+    runEvents: RunEventJournalService = getRunEventJournalService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -367,6 +391,7 @@ export class ClawdbotAgentService {
         taskService: this.taskService,
         configService: this.configService,
       });
+    this.runEvents = runEvents;
     this.logsDir = getLogsDir();
     this.ensureLogsDir();
   }
@@ -502,6 +527,7 @@ export class ClawdbotAgentService {
     let routingReason: string;
     let routingFallback: AgentType | undefined;
     const requestedAgent = profileLaunch ? profileLaunch.agent : (agentType ?? 'auto');
+
     if (profileLaunch) {
       agent = profileLaunch.agent;
       routingReason = `Agent profile ${profileLaunch.profile.id}@${profileLaunch.profile.version} selected ${agent}.`;
@@ -1014,37 +1040,57 @@ export class ClawdbotAgentService {
       throw error;
     }
 
-    if (profileLaunch) {
-      await activityService.logActivity(
-        'agent_event',
-        taskId,
-        task.title,
-        {
-          event: 'profile_launch',
-          profile: profileLaunch.metadata,
-          effectivePolicy: {
-            sandboxPresetId: options.sandboxPresetId ?? profileLaunch.sandboxPresetId,
-            budgetEnabled: pendingAgents.get(taskId)?.budget?.enabled ?? false,
-            model: launchAgentConfig?.model,
-            provider,
-          },
-        },
-        agent
-      );
-    }
-
     const telemetry = getTelemetryService();
-    await telemetry.emit<RunStartedEvent>({
-      type: 'run.started',
-      taskId,
-      attemptId,
-      agent,
-      model: launchAgentConfig?.model,
-      project: task.project,
-      harnessSupport: this.harnessTelemetry(harnessSupport),
-    });
-
     try {
+      await this.appendRunEvent(
+        taskId,
+        attemptId,
+        'run.started',
+        {
+          summary: 'Agent run initialized',
+          taskEnvelopeDigest: taskEnvelope.digest,
+          runLaunchManifestDigest: runLaunchManifest.digest,
+          providerRuntimeManifestDigest: providerRuntimeManifest.digest,
+          worktreeManifestId: taskEnvelope.workspace.worktreeManifestId,
+        },
+        {
+          provider,
+          adapter: adapter.id,
+          agent,
+          model: launchAgentConfig?.model,
+          dedupeKey: 'run.started',
+        }
+      );
+
+      if (profileLaunch) {
+        await activityService.logActivity(
+          'agent_event',
+          taskId,
+          task.title,
+          {
+            event: 'profile_launch',
+            profile: profileLaunch.metadata,
+            effectivePolicy: {
+              sandboxPresetId: options.sandboxPresetId ?? profileLaunch.sandboxPresetId,
+              budgetEnabled: pendingAgents.get(taskId)?.budget?.enabled ?? false,
+              model: launchAgentConfig?.model,
+              provider,
+            },
+          },
+          agent
+        );
+      }
+
+      await telemetry.emit<RunStartedEvent>({
+        type: 'run.started',
+        taskId,
+        attemptId,
+        agent,
+        model: launchAgentConfig?.model,
+        project: task.project,
+        harnessSupport: this.harnessTelemetry(harnessSupport),
+      });
+
       await adapter.start({
         task,
         agentConfig: launchAgentConfig,
@@ -1059,6 +1105,27 @@ export class ClawdbotAgentService {
       });
     } catch (error: unknown) {
       const startError = error instanceof Error ? error : new Error(String(error));
+      await this.appendRunEvent(
+        taskId,
+        attemptId,
+        'run.failed',
+        {
+          summary: this.redactTraceText(startError.message || `Failed to start ${adapter.label}`),
+          phase: 'launch',
+        },
+        {
+          provider,
+          adapter: adapter.id,
+          agent,
+          model: launchAgentConfig?.model,
+          dedupeKey: 'run.launch-failed',
+        }
+      ).catch((journalError) => {
+        log.error(
+          { err: journalError, taskId, attemptId },
+          'Failed to record launch failure in run event journal'
+        );
+      });
       pendingAgents.delete(taskId);
       this.recordTraceStep(attemptId, 'error', {
         eventType: 'run.start_failed',
@@ -1442,6 +1509,61 @@ export class ClawdbotAgentService {
       completionResult,
     };
     const completionStatus = taskStatusForCompletion(completionResult.status);
+    if (attempt.provider === 'openclaw' && completionResult.summary) {
+      await this.appendMappedProviderEvent(
+        task,
+        attempt.id,
+        undefined,
+        'openclaw',
+        this.resolveProviderAdapter('openclaw').runEventMapper.mapEvent(
+          'message.completed',
+          {
+            type: 'message.completed',
+            event_id: `completion_${completionResult.idempotencyKey}`,
+          },
+          completionResult.summary
+        )
+      );
+    }
+    await this.appendRunEvent(
+      task.id,
+      attempt.id,
+      'run.recovered',
+      {
+        summary: completionResult.summary,
+        status: completionResult.status,
+        terminalSource: completionResult.terminalSource,
+      },
+      {
+        provider: executableProvider(attempt.provider),
+        adapter: attempt.provider ?? 'restart-reconciliation',
+        agent: attempt.agent,
+        model: attempt.model,
+        dedupeKey: `run.recovery:${completionResult.idempotencyKey}`,
+      }
+    );
+    await this.appendRunEvent(
+      task.id,
+      attempt.id,
+      completionResult.status === 'success'
+        ? 'run.completed'
+        : completionResult.status === 'interrupted'
+          ? 'run.interrupted'
+          : 'run.failed',
+      {
+        summary: completionResult.summary,
+        error: completionResult.error,
+        status: completionResult.status,
+        terminalSource: completionResult.terminalSource,
+      },
+      {
+        provider: executableProvider(attempt.provider),
+        adapter: attempt.provider ?? 'restart-reconciliation',
+        agent: attempt.agent,
+        model: attempt.model,
+        dedupeKey: `run.terminal:${completionResult.idempotencyKey}`,
+      }
+    );
     let taskSnapshot = task;
     let lastError: unknown;
     for (
@@ -1624,6 +1746,22 @@ export class ClawdbotAgentService {
       // Terminal ownership wins over an older usage report. Waiting behind that
       // report can deadlock when it is itself waiting for this finalization.
       if (!budgetEvaluations.has(pending)) {
+        await this.appendRunEvent(
+          taskId,
+          attemptId,
+          'usage.updated',
+          {
+            runtimeSeconds: Math.ceil(timing.durationMs / 1000),
+            source: 'run-completion',
+          },
+          {
+            provider: pending.provider,
+            adapter: pending.provider,
+            agent: pending.agent,
+            model: pending.model,
+            dedupeKey: 'usage.runtime-terminal',
+          }
+        );
         await this.evaluatePendingBudget(
           taskId,
           attemptId,
@@ -1682,6 +1820,47 @@ export class ClawdbotAgentService {
     const { status, taskBeforeCompletion, completionResult } = preparedCompletion;
     const successful = completionResult.status === 'success';
 
+    if (pending.provider === 'openclaw' && completionResult.summary) {
+      await this.appendMappedProviderEvent(
+        taskBeforeCompletion,
+        attemptId,
+        undefined,
+        'openclaw',
+        this.resolveProviderAdapter('openclaw').runEventMapper.mapEvent(
+          'message.completed',
+          {
+            type: 'message.completed',
+            event_id: `completion_${completionResult.idempotencyKey}`,
+          },
+          completionResult.summary
+        )
+      );
+    }
+    const terminalKind: RunEventKind =
+      completionResult.status === 'success'
+        ? 'run.completed'
+        : completionResult.status === 'interrupted'
+          ? 'run.interrupted'
+          : 'run.failed';
+    await this.appendRunEvent(
+      taskId,
+      attemptId,
+      terminalKind,
+      {
+        summary: completionResult.summary,
+        error: completionResult.error,
+        status: completionResult.status,
+        terminalSource: completionResult.terminalSource,
+        durationMs: timing.durationMs,
+      },
+      {
+        provider: pending.provider,
+        adapter: pending.provider,
+        agent: pending.agent,
+        model: pending.model,
+        dedupeKey: `run.terminal:${completionResult.idempotencyKey}`,
+      }
+    );
     const persistedHere = await this.persistPendingCompletion(taskId, pending, preparedCompletion);
     if (pendingAgents.get(taskId) === pending) {
       pendingAgents.delete(taskId);
@@ -1903,6 +2082,19 @@ export class ClawdbotAgentService {
     await this.finalizePendingAgent(taskId, pending, async () => {
       await this.assertPendingRunControl(taskId, pending, 'stop');
       await this.resolveProviderAdapter(pending.provider).stop({ taskId, pending });
+      await this.appendRunEvent(
+        taskId,
+        pending.attemptId,
+        'run.interrupted',
+        { summary: 'Stopped by user', phase: 'requested' },
+        {
+          provider: 'operator',
+          adapter: 'veritas-run-control',
+          agent: pending.agent,
+          model: pending.model,
+          dedupeKey: 'run.interruption-requested',
+        }
+      );
       this.recordTraceStep(pending.attemptId, 'abort', {
         eventType: 'run.aborted',
         summary: 'Stopped by user',
@@ -1937,21 +2129,32 @@ export class ClawdbotAgentService {
     }
 
     const actor = options.actor?.trim() || 'operator';
-    const timestamp = new Date().toISOString();
     const redacted = this.redactTraceText(content);
     const logPath = path.join(this.logsDir, `${taskId}_${pending.attemptId}.md`);
 
+    const journalEvent = await this.appendRunEvent(
+      taskId,
+      pending.attemptId,
+      'message.operator',
+      {
+        content: `${actor}: ${redacted}`,
+        actor,
+        source: options.source || 'agent-panel',
+      },
+      {
+        provider: 'operator',
+        adapter: 'veritas-operator-message',
+        agent: pending.agent,
+        model: pending.model,
+      }
+    );
     await this.appendLog(
       logPath,
       `\n## Operator Message\n\n**Actor:** ${actor}\n**Source:** ${
         options.source || 'agent-panel'
       }\n\n${redacted}\n`
     );
-    pending.emitter.emit('output', {
-      type: 'stdin',
-      content: `${actor}: ${redacted}`,
-      timestamp,
-    } satisfies AgentOutput);
+    this.emitJournalOutput(journalEvent);
     this.recordTraceStep(pending.attemptId, 'execute', {
       eventType: 'operator.message',
       actor,
@@ -1978,6 +2181,10 @@ export class ClawdbotAgentService {
     attemptId: string,
     delta: Partial<AgentBudgetUsage>
   ): Promise<void> {
+    await this.appendRunEvent(taskId, attemptId, 'usage.updated', {
+      ...delta,
+      source: 'external-report',
+    });
     await this.evaluatePendingBudget(taskId, attemptId, delta, 'agent.usage', true);
   }
 
@@ -2281,6 +2488,7 @@ export class ClawdbotAgentService {
         label: definition.label,
         renderTaskEnvelope: renderCodexCliTaskEnvelope,
         probe,
+        runEventMapper: getProviderRunEventMapper(provider),
         start: ({
           task,
           agentConfig,
@@ -2316,6 +2524,7 @@ export class ClawdbotAgentService {
         label: definition.label,
         renderTaskEnvelope: renderCodexSdkTaskEnvelope,
         probe,
+        runEventMapper: getProviderRunEventMapper(provider),
         start: ({
           task,
           agentConfig,
@@ -2355,11 +2564,29 @@ export class ClawdbotAgentService {
               return;
             }
             abortController.abort();
-            const message = error instanceof Error ? error.message : 'Codex SDK attempt failed';
+            const message = this.redactTraceText(
+              error instanceof Error ? error.message : 'Codex SDK attempt failed'
+            );
             try {
+              const journalEvent = await this.appendRunEvent(
+                task.id,
+                attemptId,
+                'run.error',
+                { summary: message, error: message, phase: 'stream' },
+                {
+                  provider: 'codex-sdk',
+                  adapter: 'codex-sdk',
+                  agent: agentConfig?.type || 'codex-sdk',
+                  model: agentConfig?.model,
+                }
+              );
+              this.emitJournalOutput(journalEvent);
               await this.appendLog(logPath, `\n## Codex SDK Error\n\n${message}\n`);
             } catch (logError) {
-              log.error({ err: logError, taskId: task.id }, 'Failed to append Codex SDK error');
+              log.error(
+                { err: logError, taskId: task.id },
+                'Failed to record Codex SDK error evidence'
+              );
             }
             try {
               await this.completeAgent(
@@ -2402,6 +2629,7 @@ export class ClawdbotAgentService {
         label: definition.label,
         renderTaskEnvelope: renderHermesTaskEnvelope,
         probe,
+        runEventMapper: getProviderRunEventMapper(provider),
         start: ({
           task,
           agentConfig,
@@ -2449,6 +2677,7 @@ export class ClawdbotAgentService {
       label: definition.label,
       renderTaskEnvelope: renderOpenClawTaskEnvelope,
       probe,
+      runEventMapper: getProviderRunEventMapper(provider),
       start: async ({ transport, task, attemptId, agentConfig, runLaunchManifest }) => {
         this.assertProviderAdapterTransport(provider, transport, runLaunchManifest);
         // Use the HTTP gateway adapter (sessions_spawn) instead of writing a request file.
@@ -2650,45 +2879,82 @@ export class ClawdbotAgentService {
 
     let stdoutBuffer = '';
     let stderrBuffer = '';
+    let eventProcessing = Promise.resolve();
+    let eventProcessingError: Error | undefined;
+    const enqueueEventProcessing = (work: () => Promise<void>) => {
+      eventProcessing = eventProcessing.then(async () => {
+        if (eventProcessingError) return;
+        try {
+          await work();
+        } catch (error) {
+          eventProcessingError =
+            error instanceof Error ? error : new Error('Provider event ingestion failed closed.');
+          child.kill('SIGTERM');
+        }
+      });
+    };
     const SESSION_ID_PATTERN = /hermes[_-]session[_-]id[:\s]+([a-zA-Z0-9_-]{8,})/i;
 
     child.stdout.setEncoding('utf-8');
     child.stdout.on('data', (chunk: string) => {
       stdoutBuffer += chunk;
-      this.recordStreamChunk(task, attemptId, agentConfig, 'hermes-cli', 'stdout', chunk);
+      enqueueEventProcessing(() =>
+        this.recordStreamChunk(task, attemptId, agentConfig, 'hermes-cli', 'stdout', chunk)
+      );
     });
 
     child.stderr.setEncoding('utf-8');
     child.stderr.on('data', (chunk: string) => {
       stderrBuffer += chunk;
-      this.recordStreamChunk(task, attemptId, agentConfig, 'hermes-cli', 'stderr', chunk);
-      void this.appendLog(logPath, `\n### stderr\n\n\`\`\`\n${chunk.trimEnd()}\n\`\`\`\n`);
+      enqueueEventProcessing(async () => {
+        await this.recordStreamChunk(task, attemptId, agentConfig, 'hermes-cli', 'stderr', chunk);
+        await this.appendLog(
+          logPath,
+          `\n### stderr\n\n\`\`\`\n${this.redactTraceText(chunk.trimEnd())}\n\`\`\`\n`
+        );
 
-      // Extract session identity from stderr output if Hermes emits it
-      const sessionMatch = SESSION_ID_PATTERN.exec(chunk);
-      if (sessionMatch) {
-        const hermesSessionId = sessionMatch[1];
-        const p = pendingAgents.get(task.id);
-        if (p && !p.hermesSessionId) {
-          p.hermesSessionId = hermesSessionId;
-          log.debug(
-            { taskId: task.id, hermesSessionId },
-            '[ClawdbotAgent] Hermes session ID captured'
-          );
+        // Extract session identity from stderr output if Hermes emits it
+        const sessionMatch = SESSION_ID_PATTERN.exec(chunk);
+        if (sessionMatch) {
+          const hermesSessionId = sessionMatch[1];
+          const p = pendingAgents.get(task.id);
+          if (p && !p.hermesSessionId) {
+            p.hermesSessionId = hermesSessionId;
+            log.debug(
+              { taskId: task.id, hermesSessionId },
+              '[ClawdbotAgent] Hermes session ID captured'
+            );
+          }
         }
-      }
+      });
     });
 
     child.on('error', (error) => {
-      this.recordTraceStep(attemptId, 'error', {
-        eventType: 'process.error',
-        error: this.redactTraceText(error.message),
-        provider: 'hermes-cli',
-        agent: agentConfig?.type || 'hermes',
-        model: agentConfig?.model,
+      enqueueEventProcessing(async () => {
+        const message = this.redactTraceText(error.message);
+        const event = await this.appendRunEvent(
+          task.id,
+          attemptId,
+          'run.error',
+          { summary: message, error: message, phase: 'process' },
+          {
+            provider: 'hermes-cli',
+            adapter: 'hermes-cli',
+            agent: agentConfig?.type || 'hermes',
+            model: agentConfig?.model,
+          }
+        );
+        this.emitJournalOutput(event);
+        this.recordTraceStep(attemptId, 'error', {
+          eventType: 'process.error',
+          error: message,
+          provider: 'hermes-cli',
+          agent: agentConfig?.type || 'hermes',
+          model: agentConfig?.model,
+        });
+        await this.appendLog(logPath, `\n## Hermes Process Error\n\n${message}\n`);
+        emitter.emit('error', error);
       });
-      void this.appendLog(logPath, `\n## Hermes Process Error\n\n${error.message}\n`);
-      emitter.emit('error', error);
     });
 
     child.on('close', (code, signal) => {
@@ -2696,12 +2962,14 @@ export class ClawdbotAgentService {
         return;
       }
       void this.finalizePendingAgent(task.id, pending, async () => {
+        await eventProcessing;
         const finalOutput = stdoutBuffer.trim() || stderrBuffer.trim();
-        const success = code === 0;
+        const success = code === 0 && !eventProcessingError;
+        const boundedOutput = eventProcessingError?.message || finalOutput;
 
         await this.appendLog(
           logPath,
-          `\n## Hermes Exit\n\n**Exit code:** ${code ?? 'none'}\n**Signal:** ${signal ?? 'none'}\n**Duration:** ${Date.now() - new Date(startedAt).getTime()}ms\n\n**Output:**\n\`\`\`\n${this.redactTraceText(finalOutput)}\n\`\`\`\n`
+          `\n## Hermes Exit\n\n**Exit code:** ${code ?? 'none'}\n**Signal:** ${signal ?? 'none'}\n**Duration:** ${Date.now() - new Date(startedAt).getTime()}ms\n\n**Output:**\n\`\`\`\n${this.redactTraceText(boundedOutput)}\n\`\`\`\n`
         );
         this.recordTraceStep(attemptId, 'finalize', {
           eventType: 'run.finalizing',
@@ -2717,8 +2985,8 @@ export class ClawdbotAgentService {
         return {
           success,
           terminalSource: 'process',
-          summary: finalOutput || (success ? 'Hermes completed.' : undefined),
-          error: success ? undefined : finalOutput || `Hermes exited with code ${code}`,
+          summary: boundedOutput || (success ? 'Hermes completed.' : undefined),
+          error: success ? undefined : boundedOutput || `Hermes exited with code ${code}`,
         };
       }).catch((error) => {
         if (pendingAgents.get(task.id) !== pending) return;
@@ -2798,7 +3066,7 @@ export class ClawdbotAgentService {
     child.stdout.on('data', (chunk: string) => {
       enqueueEventProcessing(async () => {
         await this.assertPendingManifestSnapshotForAttempt(task.id, attemptId);
-        this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stdout', chunk);
+        await this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stdout', chunk);
         stdoutBuffer += chunk;
         const lines = stdoutBuffer.split(/\r?\n/);
         stdoutBuffer = lines.pop() || '';
@@ -2821,21 +3089,40 @@ export class ClawdbotAgentService {
       enqueueEventProcessing(async () => {
         await this.assertPendingManifestSnapshotForAttempt(task.id, attemptId);
         stderrBuffer += chunk;
-        this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stderr', chunk);
-        await this.appendLog(logPath, `\n### stderr\n\n\`\`\`\n${chunk.trimEnd()}\n\`\`\`\n`);
+        await this.recordStreamChunk(task, attemptId, agentConfig, 'codex-cli', 'stderr', chunk);
+        await this.appendLog(
+          logPath,
+          `\n### stderr\n\n\`\`\`\n${this.redactTraceText(chunk.trimEnd())}\n\`\`\`\n`
+        );
       });
     });
 
     child.on('error', (error) => {
-      this.recordTraceStep(attemptId, 'error', {
-        eventType: 'process.error',
-        error: this.redactTraceText(error.message),
-        provider: 'codex-cli',
-        agent: agentConfig?.type || 'codex',
-        model: agentConfig?.model,
+      enqueueEventProcessing(async () => {
+        const message = this.redactTraceText(error.message);
+        const journalEvent = await this.appendRunEvent(
+          task.id,
+          attemptId,
+          'run.error',
+          { summary: message, error: message, phase: 'process' },
+          {
+            provider: 'codex-cli',
+            adapter: 'codex-cli',
+            agent: agentConfig?.type || 'codex',
+            model: agentConfig?.model,
+          }
+        );
+        this.emitJournalOutput(journalEvent);
+        this.recordTraceStep(attemptId, 'error', {
+          eventType: 'process.error',
+          error: message,
+          provider: 'codex-cli',
+          agent: agentConfig?.type || 'codex',
+          model: agentConfig?.model,
+        });
+        await this.appendLog(logPath, `\n## Codex Process Error\n\n${message}\n`);
+        emitter.emit('error', error);
       });
-      void this.appendLog(logPath, `\n## Codex Process Error\n\n${error.message}\n`);
-      emitter.emit('error', error);
     });
 
     child.on('close', (code, signal) => {
@@ -3129,13 +3416,14 @@ export class ClawdbotAgentService {
         'token-usage'
       );
     }
-    await this.appendLog(
-      logPath,
-      `\n### ${type}\n\n${summary ? `${summary}\n\n` : ''}<details><summary>Raw event</summary>\n\n\`\`\`json\n${JSON.stringify(record, null, 2)}\n\`\`\`\n\n</details>\n`
-    );
     if (task && attemptId) {
       await this.recordCodexEvent(task, attemptId, agentConfig, type, record, summary);
     }
+    const redactedRecord = this.redactTraceText(JSON.stringify(record, null, 2));
+    await this.appendLog(
+      logPath,
+      `\n### ${type}\n\n${summary ? `${this.redactTraceText(summary)}\n\n` : ''}<details><summary>Raw event</summary>\n\n\`\`\`json\n${redactedRecord}\n\`\`\`\n\n</details>\n`
+    );
     return { summary, usage };
   }
 
@@ -3196,16 +3484,102 @@ export class ClawdbotAgentService {
     traceService.endStep(attemptId, stepType);
   }
 
-  private recordStreamChunk(
+  private async appendRunEvent(
+    taskId: string,
+    attemptId: string,
+    kind: RunEventKind,
+    payload: Record<string, unknown>,
+    options: Partial<ProviderMappedRunEvent> & {
+      provider?: ExecutableAgentProvider | 'operator' | 'system';
+      adapter?: string;
+      agent?: string;
+      model?: string;
+    } = {}
+  ): Promise<RunEventEnvelope> {
+    const pending = pendingAgents.get(taskId);
+    const provider = options.provider ?? pending?.provider ?? 'system';
+    const result = await this.runEvents.append({
+      taskId,
+      attemptId,
+      kind,
+      payload,
+      providerEventId: options.providerEventId,
+      providerTimestamp: options.providerTimestamp,
+      turnId: options.turnId,
+      itemId: options.itemId,
+      parentEventId: options.parentEventId,
+      causalEventId: options.causalEventId,
+      dedupeKey: options.dedupeKey,
+      source: {
+        provider,
+        adapter: options.adapter ?? (typeof provider === 'string' ? provider : 'system'),
+        agent: options.agent ?? pending?.agent,
+        model: options.model ?? pending?.model,
+      },
+    });
+    return result.event;
+  }
+
+  private async appendMappedProviderEvent(
+    task: Task,
+    attemptId: string,
+    agentConfig: AgentConfig | undefined,
+    provider: ExecutableAgentProvider,
+    mapped: ProviderMappedRunEvent
+  ): Promise<RunEventEnvelope> {
+    return this.appendRunEvent(task.id, attemptId, mapped.kind, mapped.payload, {
+      ...mapped,
+      provider,
+      adapter: provider,
+      agent: agentConfig?.type || task.agent || provider,
+      model: agentConfig?.model,
+    });
+  }
+
+  private emitJournalOutput(event: RunEventEnvelope): void {
+    const pending = pendingAgents.get(event.taskId);
+    if (!pending || pending.attemptId !== event.attemptId) return;
+    const content =
+      typeof event.payload.content === 'string'
+        ? event.payload.content
+        : typeof event.payload.summary === 'string'
+          ? event.payload.summary
+          : undefined;
+    if (!content?.trim()) return;
+    const type: AgentOutput['type'] =
+      event.source.provider === 'operator'
+        ? 'stdin'
+        : event.kind === 'stream.stderr' || event.kind === 'run.error'
+          ? 'stderr'
+          : event.source.provider === 'system'
+            ? 'system'
+            : 'stdout';
+    pending.emitter.emit('output', {
+      type,
+      content,
+      timestamp: event.receivedAt,
+    } satisfies AgentOutput);
+  }
+
+  private async recordStreamChunk(
     task: Task,
     attemptId: string,
     agentConfig: AgentConfig | undefined,
     provider: ExecutableAgentProvider,
     stream: 'stdout' | 'stderr',
     chunk: string
-  ): void {
+  ): Promise<void> {
     const content = this.redactTraceText(chunk.trimEnd());
     if (!content.trim()) return;
+    const mapper = this.resolveProviderAdapter(provider).runEventMapper;
+    const event = await this.appendMappedProviderEvent(
+      task,
+      attemptId,
+      agentConfig,
+      provider,
+      mapper.mapStream(stream, content)
+    );
+    this.emitJournalOutput(event);
     this.recordTraceStep(attemptId, 'stream', {
       eventType: `stream.${stream}`,
       stream,
@@ -3271,8 +3645,39 @@ export class ClawdbotAgentService {
     const sanitizedSummary = summary ? this.redactTraceText(summary) : undefined;
     const stepType = this.codexTraceStepType(type, event);
     const stream = this.extractCodexStream(event, type);
+    const provider = agentConfig?.provider === 'codex-sdk' ? 'codex-sdk' : 'codex-cli';
+    const journalEvent = await this.appendMappedProviderEvent(
+      task,
+      attemptId,
+      agentConfig,
+      provider,
+      this.resolveProviderAdapter(provider).runEventMapper.mapEvent(type, event, sanitizedSummary)
+    );
+    this.emitJournalOutput(journalEvent);
+    if (usage) {
+      await this.appendRunEvent(
+        task.id,
+        attemptId,
+        'usage.updated',
+        {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          totalTokens: usage.totalTokens,
+          cost: usage.cost,
+          model: usage.model || agentConfig?.model,
+        },
+        {
+          provider,
+          adapter: provider,
+          agent,
+          model: usage.model || agentConfig?.model,
+          causalEventId: journalEvent.eventId,
+          dedupeKey: `${journalEvent.eventId}:usage`,
+        }
+      );
+    }
     this.recordTraceStep(attemptId, stepType, {
-      provider: agentConfig?.provider || 'codex-cli',
+      provider,
       eventType: type,
       summary: sanitizedSummary,
       content: stepType === 'stream' ? sanitizedSummary : undefined,
@@ -3909,6 +4314,30 @@ export class ClawdbotAgentService {
     } catch {
       throw new Error('Log file not found');
     }
+  }
+
+  async resolveRunEventAttemptId(taskId: string, requestedAttemptId?: string): Promise<string> {
+    validatePathSegment(taskId);
+    if (requestedAttemptId) validatePathSegment(requestedAttemptId);
+    const pending = pendingAgents.get(taskId);
+    if (pending && (!requestedAttemptId || pending.attemptId === requestedAttemptId)) {
+      return pending.attemptId;
+    }
+    const task = await this.taskService.getTask(taskId);
+    if (!task) throw new Error('Task not found');
+    const attempts = [task.attempt, ...(task.attempts ?? [])].filter(
+      (attempt): attempt is TaskAttempt => Boolean(attempt)
+    );
+    const resolved = requestedAttemptId
+      ? attempts.find((attempt) => attempt.id === requestedAttemptId)
+      : task.attempt;
+    if (!resolved) throw new Error('Run attempt not found');
+    return resolved.id;
+  }
+
+  async getRunEvents(taskId: string, attemptId: string, afterSequence = 0, limit = 200) {
+    await this.assertRunControl(taskId, 'logs', attemptId);
+    return this.runEvents.list({ taskId, attemptId, afterSequence, limit });
   }
 
   async listAttempts(taskId: string): Promise<string[]> {

--- a/server/src/services/provider-run-event-mappers.ts
+++ b/server/src/services/provider-run-event-mappers.ts
@@ -1,0 +1,219 @@
+import { createHash } from 'node:crypto';
+import type { ExecutableAgentProvider, RunEventKind } from '@veritas-kanban/shared';
+
+export interface ProviderMappedRunEvent {
+  kind: RunEventKind;
+  payload: Record<string, unknown>;
+  providerEventId?: string;
+  providerTimestamp?: string;
+  turnId?: string;
+  itemId?: string;
+  parentEventId?: string;
+  causalEventId?: string;
+  dedupeKey?: string;
+}
+
+export interface ProviderRunEventMapper {
+  mapStream(stream: 'stdout' | 'stderr', content: string): ProviderMappedRunEvent;
+  mapEvent(
+    providerType: string,
+    event: Record<string, unknown>,
+    summary?: string
+  ): ProviderMappedRunEvent;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function boundedIdentifier(value: unknown): string | undefined {
+  const identifier = optionalString(value);
+  if (!identifier || identifier.length <= 160) return identifier;
+  return `sha256_${createHash('sha256').update(identifier).digest('hex')}`;
+}
+
+function providerDedupeKey(
+  provider: ExecutableAgentProvider,
+  providerType: string,
+  providerEventId: string | undefined
+): string | undefined {
+  if (!providerEventId) return undefined;
+  const candidate = `${provider}:${providerType}:${providerEventId}`;
+  return candidate.length <= 240
+    ? candidate
+    : `${provider}:sha256:${createHash('sha256').update(candidate).digest('hex')}`;
+}
+
+function nestedRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function eventIdentity(event: Record<string, unknown>): {
+  providerEventId?: string;
+  turnId?: string;
+  itemId?: string;
+  providerTimestamp?: string;
+} {
+  const item = nestedRecord(event.item);
+  const providerEventId =
+    boundedIdentifier(event.event_id) ??
+    boundedIdentifier(event.eventId) ??
+    boundedIdentifier(event.id) ??
+    boundedIdentifier(item?.id);
+  const turnId =
+    boundedIdentifier(event.turn_id) ??
+    boundedIdentifier(event.turnId) ??
+    boundedIdentifier(nestedRecord(event.turn)?.id);
+  const itemId =
+    boundedIdentifier(event.item_id) ??
+    boundedIdentifier(event.itemId) ??
+    boundedIdentifier(item?.id);
+  const timestamp =
+    optionalString(event.timestamp) ??
+    optionalString(event.created_at) ??
+    optionalString(event.createdAt);
+  const providerTimestamp =
+    timestamp && !Number.isNaN(Date.parse(timestamp))
+      ? new Date(timestamp).toISOString()
+      : undefined;
+  return { providerEventId, turnId, itemId, providerTimestamp };
+}
+
+function itemKind(type: string, event: Record<string, unknown>): RunEventKind {
+  const normalized = type.toLowerCase();
+  const item = nestedRecord(event.item);
+  const itemType = optionalString(item?.type)?.toLowerCase() ?? '';
+  const completed = /(?:completed|finished|done)$/.test(normalized);
+  const started = /(?:started|begin)$/.test(normalized);
+
+  if (normalized.includes('approval')) {
+    return completed || normalized.includes('resolved')
+      ? 'approval.resolved'
+      : 'approval.requested';
+  }
+  if (normalized.includes('token') || normalized.includes('usage') || itemType.includes('usage')) {
+    return 'usage.updated';
+  }
+  if (normalized.includes('failed') || normalized === 'error' || itemType.includes('error')) {
+    return 'run.error';
+  }
+  if (itemType.includes('agent_message') || itemType === 'message') {
+    return normalized.includes('delta') || normalized.includes('updated')
+      ? 'message.delta'
+      : 'message.assistant';
+  }
+  if (normalized.includes('message')) {
+    return normalized.includes('delta') || normalized.includes('updated')
+      ? 'message.delta'
+      : 'message.assistant';
+  }
+  if (itemType.includes('reasoning') || normalized.includes('reasoning')) {
+    return 'reasoning.delta';
+  }
+  if (itemType.includes('command') || normalized.includes('command')) {
+    return completed ? 'command.completed' : 'command.started';
+  }
+  if (
+    itemType.includes('file_change') ||
+    itemType.includes('filechange') ||
+    normalized.includes('file.change')
+  ) {
+    return 'file.changed';
+  }
+  if (
+    itemType.includes('tool') ||
+    itemType.includes('mcp') ||
+    itemType.includes('web_search') ||
+    normalized.includes('tool')
+  ) {
+    return completed ? 'tool.completed' : 'tool.started';
+  }
+  if (itemType.includes('artifact') || normalized.includes('artifact')) {
+    return 'artifact.created';
+  }
+  if (
+    normalized.includes('progress') ||
+    normalized.includes('turn.started') ||
+    normalized.includes('turn.completed') ||
+    started ||
+    completed
+  ) {
+    return 'progress';
+  }
+  return 'provider.unknown';
+}
+
+function codexMapper(provider: 'codex-cli' | 'codex-sdk'): ProviderRunEventMapper {
+  return {
+    mapStream(stream, content) {
+      return {
+        kind: stream === 'stdout' ? 'stream.stdout' : 'stream.stderr',
+        payload: { stream, content },
+      };
+    },
+    mapEvent(providerType, event, summary) {
+      const identity = eventIdentity(event);
+      return {
+        ...identity,
+        kind: itemKind(providerType, event),
+        dedupeKey: providerDedupeKey(provider, providerType, identity.providerEventId),
+        payload: {
+          providerType,
+          summary,
+          raw: event,
+        },
+      };
+    },
+  };
+}
+
+const HERMES_MAPPER: ProviderRunEventMapper = {
+  mapStream(stream, content) {
+    return {
+      kind: stream === 'stdout' ? 'message.delta' : 'stream.stderr',
+      payload: { stream, content },
+    };
+  },
+  mapEvent(providerType, event, summary) {
+    const identity = eventIdentity(event);
+    return {
+      ...identity,
+      kind: itemKind(providerType, event),
+      dedupeKey: providerDedupeKey('hermes-cli', providerType, identity.providerEventId),
+      payload: { providerType, summary, raw: event },
+    };
+  },
+};
+
+const OPENCLAW_MAPPER: ProviderRunEventMapper = {
+  mapStream(stream, content) {
+    return {
+      kind: stream === 'stdout' ? 'message.delta' : 'stream.stderr',
+      payload: { stream, content },
+    };
+  },
+  mapEvent(providerType, event, summary) {
+    const identity = eventIdentity(event);
+    return {
+      ...identity,
+      kind: itemKind(providerType, event),
+      dedupeKey: providerDedupeKey('openclaw', providerType, identity.providerEventId),
+      payload: { providerType, summary, raw: event },
+    };
+  },
+};
+
+const MAPPERS: Record<ExecutableAgentProvider, ProviderRunEventMapper> = {
+  openclaw: OPENCLAW_MAPPER,
+  'codex-cli': codexMapper('codex-cli'),
+  'codex-sdk': codexMapper('codex-sdk'),
+  'hermes-cli': HERMES_MAPPER,
+};
+
+export function getProviderRunEventMapper(
+  provider: ExecutableAgentProvider
+): ProviderRunEventMapper {
+  return MAPPERS[provider];
+}

--- a/server/src/services/run-event-journal-service.ts
+++ b/server/src/services/run-event-journal-service.ts
@@ -1,0 +1,313 @@
+import { createHash } from 'node:crypto';
+import { nanoid } from 'nanoid';
+import {
+  RUN_EVENT_SCHEMA_VERSION,
+  type RunEventAppendInput,
+  type RunEventAppendResult,
+  type RunEventEnvelope,
+  type RunEventJsonValue,
+  type RunEventPage,
+  type RunEventQuery,
+} from '@veritas-kanban/shared';
+import type { RunEventRepository } from '../storage/interfaces.js';
+import { FileRunEventRepository } from '../storage/run-event-repository.js';
+import { getStorage, getStorageTypeFromEnv } from '../storage/index.js';
+import { RunEventEnvelopeSchema } from '../schemas/run-event-schemas.js';
+import { redactString } from '../lib/redact.js';
+import { createLogger } from '../lib/logger.js';
+import { validatePathSegment } from '../utils/sanitize.js';
+
+const MAX_PAYLOAD_BYTES = 32 * 1024;
+const MAX_STRING_BYTES = 8 * 1024;
+const MAX_DEPTH = 12;
+const MAX_OBJECT_KEYS = 256;
+const MAX_ARRAY_ITEMS = 200;
+const MAX_REPLAY_BUFFER_EVENTS = 1_000;
+const SENSITIVE_KEY =
+  /(?:^|_)(?:authorization|api_key|apikey|token|access_token|refresh_token|auth_token|id_token|bearer_token|secret|client_secret|password|credential|credentials|private_key|cookie|set_cookie)$/i;
+
+interface SanitizeState {
+  redactedFields: string[];
+  objectKeys: number;
+  originalBytes: number;
+  seen: WeakSet<object>;
+}
+
+type RunEventListener = (event: RunEventEnvelope) => void;
+const log = createLogger('run-event-journal-service');
+
+export interface RunEventSubscription {
+  cursor: number;
+  unsubscribe: () => void;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function countBytes(value: string): number {
+  return Buffer.byteLength(value, 'utf-8');
+}
+
+function addOriginalBytes(state: SanitizeState, value: string): void {
+  state.originalBytes = Math.min(Number.MAX_SAFE_INTEGER, state.originalBytes + countBytes(value));
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').replace(/-/g, '_');
+  return SENSITIVE_KEY.test(normalized);
+}
+
+function normalizeJson(
+  value: unknown,
+  state: SanitizeState,
+  fieldPath: string,
+  depth = 0
+): RunEventJsonValue {
+  if (depth > MAX_DEPTH) {
+    state.redactedFields.push(fieldPath);
+    return '[depth limit]';
+  }
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'string') {
+    addOriginalBytes(state, value);
+    const redacted = redactString(value);
+    const bounded =
+      countBytes(redacted) > MAX_STRING_BYTES
+        ? `${Buffer.from(redacted, 'utf-8').subarray(0, MAX_STRING_BYTES).toString('utf-8')}[truncated]`
+        : redacted;
+    if (bounded !== value) state.redactedFields.push(fieldPath);
+    return bounded;
+  }
+  if (typeof value !== 'object') {
+    state.redactedFields.push(fieldPath);
+    return `[unsupported ${typeof value}]`;
+  }
+  if (state.seen.has(value)) {
+    state.redactedFields.push(fieldPath);
+    return '[circular]';
+  }
+  state.seen.add(value);
+  if (Array.isArray(value)) {
+    if (value.length > MAX_ARRAY_ITEMS) state.redactedFields.push(fieldPath);
+    const normalized = value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map((entry, index) => normalizeJson(entry, state, `${fieldPath}[${index}]`, depth + 1));
+    state.seen.delete(value);
+    return normalized;
+  }
+  const normalized: Record<string, RunEventJsonValue> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    state.objectKeys += 1;
+    if (state.objectKeys > MAX_OBJECT_KEYS) {
+      state.redactedFields.push(fieldPath);
+      break;
+    }
+    const nextPath = `${fieldPath}.${key}`;
+    if (isSensitiveKey(key)) {
+      normalized[key] = '[REDACTED]';
+      state.redactedFields.push(nextPath);
+      addOriginalBytes(state, typeof entry === 'string' ? entry : '[structured secret]');
+    } else {
+      normalized[key] = normalizeJson(entry, state, nextPath, depth + 1);
+    }
+  }
+  state.seen.delete(value);
+  return normalized;
+}
+
+function sanitizePayload(payload: Record<string, unknown>): {
+  payload: Record<string, RunEventJsonValue>;
+  status: 'none' | 'redacted' | 'dropped';
+  fields: string[];
+  originalBytes: number;
+  persistedBytes: number;
+} {
+  const state: SanitizeState = {
+    redactedFields: [],
+    objectKeys: 0,
+    originalBytes: 0,
+    seen: new WeakSet(),
+  };
+  const normalized = normalizeJson(payload, state, '$');
+  const record =
+    normalized && typeof normalized === 'object' && !Array.isArray(normalized)
+      ? normalized
+      : { value: normalized };
+  let serialized = JSON.stringify(record);
+  if (countBytes(serialized) > MAX_PAYLOAD_BYTES) {
+    const dropped = {
+      dropped: true,
+      reason: 'Provider payload exceeded the persisted run-event size limit',
+      boundedBytes: MAX_PAYLOAD_BYTES,
+    } satisfies Record<string, RunEventJsonValue>;
+    serialized = JSON.stringify(dropped);
+    return {
+      payload: dropped,
+      status: 'dropped',
+      fields: ['$'],
+      originalBytes: Math.max(state.originalBytes, countBytes(serialized)),
+      persistedBytes: countBytes(serialized),
+    };
+  }
+  return {
+    payload: record,
+    status: state.redactedFields.length ? 'redacted' : 'none',
+    fields: [...new Set(state.redactedFields)].slice(0, 256),
+    originalBytes: Math.max(state.originalBytes, countBytes(serialized)),
+    persistedBytes: countBytes(serialized),
+  };
+}
+
+let fileRepository: FileRunEventRepository | undefined;
+
+function defaultRepository(): RunEventRepository {
+  if (getStorageTypeFromEnv() === 'sqlite') return getStorage().runEvents;
+  fileRepository ??= new FileRunEventRepository();
+  return fileRepository;
+}
+
+export class RunEventJournalService {
+  private readonly listeners = new Set<RunEventListener>();
+
+  constructor(private readonly repository?: RunEventRepository) {}
+
+  async append(input: RunEventAppendInput): Promise<RunEventAppendResult> {
+    validatePathSegment(input.taskId);
+    validatePathSegment(input.attemptId);
+    const sanitized = sanitizePayload(input.payload);
+    const payloadJson = JSON.stringify(sanitized.payload);
+    const event = RunEventEnvelopeSchema.parse({
+      schemaVersion: RUN_EVENT_SCHEMA_VERSION,
+      eventId: `runevt_${nanoid(18)}`,
+      taskId: input.taskId,
+      runId: input.attemptId,
+      attemptId: input.attemptId,
+      turnId: input.turnId,
+      itemId: input.itemId,
+      providerEventId: input.providerEventId,
+      parentEventId: input.parentEventId,
+      causalEventId: input.causalEventId,
+      sequence: 1,
+      providerTimestamp: input.providerTimestamp,
+      receivedAt: new Date().toISOString(),
+      kind: input.kind,
+      source: input.source,
+      redaction: {
+        status: sanitized.status,
+        fields: sanitized.fields,
+        originalBytes: sanitized.originalBytes,
+        persistedBytes: sanitized.persistedBytes,
+      },
+      payload: sanitized.payload,
+      payloadHash: sha256(payloadJson),
+      dedupeKey:
+        input.dedupeKey ??
+        (input.providerEventId ? `${input.source.provider}:${input.providerEventId}` : undefined),
+    });
+    const { sequence: _sequence, ...appendable } = event;
+    const result = await (this.repository ?? defaultRepository()).append(appendable);
+    if (result.appended) {
+      for (const listener of this.listeners) {
+        try {
+          listener(result.event);
+        } catch (error) {
+          log.warn(
+            { err: error, eventId: result.event.eventId },
+            'Run event projection listener failed after durable append'
+          );
+        }
+      }
+    }
+    return result;
+  }
+
+  async list(query: RunEventQuery): Promise<RunEventPage> {
+    validatePathSegment(query.taskId);
+    validatePathSegment(query.attemptId);
+    return (this.repository ?? defaultRepository()).list(query);
+  }
+
+  async subscribe(query: RunEventQuery, listener: RunEventListener): Promise<RunEventSubscription> {
+    validatePathSegment(query.taskId);
+    validatePathSegment(query.attemptId);
+    let cursor = Math.max(0, query.afterSequence ?? 0);
+    let replaying = true;
+    let replayBufferOverflowed = false;
+    const buffered: RunEventEnvelope[] = [];
+    const liveListener: RunEventListener = (event) => {
+      if (
+        event.taskId !== query.taskId ||
+        event.attemptId !== query.attemptId ||
+        event.sequence <= cursor
+      ) {
+        return;
+      }
+      if (replaying) {
+        if (buffered.length >= MAX_REPLAY_BUFFER_EVENTS) {
+          replayBufferOverflowed = true;
+          return;
+        }
+        buffered.push(event);
+        return;
+      }
+      cursor = event.sequence;
+      listener(event);
+    };
+
+    this.onEvent(liveListener);
+    try {
+      for (;;) {
+        const page = await this.list({
+          ...query,
+          afterSequence: cursor,
+          limit: 500,
+        });
+        for (const event of page.events) {
+          cursor = event.sequence;
+          listener(event);
+        }
+        if (replayBufferOverflowed) {
+          throw new Error('Run event replay live buffer exceeded its bounded event limit');
+        }
+        if (!page.hasMore) break;
+      }
+      replaying = false;
+      for (const event of buffered.sort((left, right) => left.sequence - right.sequence)) {
+        if (event.sequence <= cursor) continue;
+        cursor = event.sequence;
+        listener(event);
+      }
+      return {
+        cursor,
+        unsubscribe: () => this.offEvent(liveListener),
+      };
+    } catch (error) {
+      this.offEvent(liveListener);
+      throw error;
+    }
+  }
+
+  onEvent(listener: RunEventListener): void {
+    this.listeners.add(listener);
+  }
+
+  offEvent(listener: RunEventListener): void {
+    this.listeners.delete(listener);
+  }
+}
+
+let runEventJournalService: RunEventJournalService | undefined;
+
+export function getRunEventJournalService(): RunEventJournalService {
+  runEventJournalService ??= new RunEventJournalService();
+  return runEventJournalService;
+}
+
+export function resetRunEventJournalServiceForTests(): void {
+  runEventJournalService = undefined;
+  fileRepository = undefined;
+}

--- a/server/src/storage/file-storage.ts
+++ b/server/src/storage/file-storage.ts
@@ -39,6 +39,7 @@ import type {
   ManagedListRepository,
   ManagedListProvider,
   TelemetryRepository,
+  RunEventRepository,
 } from './interfaces.js';
 import { TaskService, type TaskServiceOptions } from '../services/task-service.js';
 import { ConfigService, type ConfigServiceOptions } from '../services/config-service.js';
@@ -62,6 +63,7 @@ import {
 } from '../services/status-history-service.js';
 import { ManagedListService } from '../services/managed-list-service.js';
 import { TelemetryService, type TelemetryServiceOptions } from '../services/telemetry-service.js';
+import { FileRunEventRepository } from './run-event-repository.js';
 
 // ---------------------------------------------------------------------------
 // FileTaskRepository
@@ -478,6 +480,7 @@ export interface FileStorageOptions {
   promptRegistryServiceOptions?: PromptRegistryServiceOptions;
   statusHistoryServiceOptions?: StatusHistoryServiceOptions;
   telemetryServiceOptions?: TelemetryServiceOptions;
+  runEventsDir?: string;
 }
 
 export class FileStorageProvider implements StorageProvider {
@@ -489,6 +492,7 @@ export class FileStorageProvider implements StorageProvider {
   readonly statusHistory: FileStatusHistoryRepository;
   readonly managedLists: FileManagedListProvider;
   readonly telemetry: FileTelemetryRepository;
+  readonly runEvents: RunEventRepository;
 
   private taskService: TaskService;
   private configService: ConfigService;
@@ -538,6 +542,7 @@ export class FileStorageProvider implements StorageProvider {
     this.statusHistory = new FileStatusHistoryRepository(this.statusHistoryService);
     this.managedLists = new FileManagedListProvider();
     this.telemetry = new FileTelemetryRepository(this.telemetryService);
+    this.runEvents = new FileRunEventRepository(options.runEventsDir);
   }
 
   async initialize(): Promise<void> {

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -23,6 +23,8 @@ export type {
   ManagedListRepository,
   ManagedListProvider,
   TelemetryRepository,
+  RunEventRepository,
+  RunEventRepositoryAppendInput,
   SetupContextRepository,
   WorkspaceFileRepository,
   StorageProvider,
@@ -45,6 +47,7 @@ export {
   FileManagedListProvider,
   FileTelemetryRepository,
 } from './file-storage.js';
+export { FileRunEventRepository, getRunEventsDir } from './run-event-repository.js';
 export type { FileStorageOptions } from './file-storage.js';
 export {
   DEFAULT_SQLITE_FILENAME,
@@ -70,6 +73,7 @@ export { SqlitePromptRegistryRepository } from './sqlite/prompt-registry-reposit
 export { SqliteActivityRepository } from './sqlite/activity-repository.js';
 export { SqliteStatusHistoryRepository } from './sqlite/status-history-repository.js';
 export { SqliteTelemetryRepository } from './sqlite/telemetry-repository.js';
+export { SqliteRunEventRepository } from './sqlite/run-event-repository.js';
 export { SqliteSetupContextRepository } from './sqlite/setup-context-repository.js';
 export {
   SqliteDecisionRepository,

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -28,6 +28,10 @@ import type {
   RenderPreviewRequest,
   RenderPreviewResponse,
   DesktopSetupContext,
+  RunEventAppendResult,
+  RunEventEnvelope,
+  RunEventPage,
+  RunEventQuery,
 } from '@veritas-kanban/shared';
 import type { Activity, ActivityType } from '../services/activity-service.js';
 import type {
@@ -304,6 +308,25 @@ export interface WorkspaceFileRepository {
 }
 
 // ---------------------------------------------------------------------------
+// Run Event Journal Repository
+// ---------------------------------------------------------------------------
+
+export type RunEventRepositoryAppendInput = Omit<RunEventEnvelope, 'sequence'>;
+
+export interface RunEventRepository {
+  /**
+   * Append one event and allocate the next attempt-local sequence.
+   *
+   * Implementations must enforce `(attemptId, dedupeKey)` idempotency when a
+   * dedupe key is present and return the prior event with `appended: false`.
+   */
+  append(event: RunEventRepositoryAppendInput): Promise<RunEventAppendResult>;
+
+  /** Replay one attempt in ascending sequence order. */
+  list(query: RunEventQuery): Promise<RunEventPage>;
+}
+
+// ---------------------------------------------------------------------------
 // Storage Provider (top-level aggregate)
 // ---------------------------------------------------------------------------
 
@@ -316,6 +339,7 @@ export interface StorageProvider {
   readonly statusHistory: StatusHistoryRepository;
   readonly managedLists: ManagedListProvider;
   readonly telemetry: TelemetryRepository;
+  readonly runEvents: RunEventRepository;
   readonly setupContext?: SetupContextRepository;
 
   /** One-time startup hook (create dirs, open connections, etc.). */

--- a/server/src/storage/run-event-repository.ts
+++ b/server/src/storage/run-event-repository.ts
@@ -1,0 +1,125 @@
+import { constants } from 'node:fs';
+import { open, lstat, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  RUN_EVENT_SCHEMA_VERSION,
+  type RunEventAppendResult,
+  type RunEventEnvelope,
+  type RunEventPage,
+  type RunEventQuery,
+} from '@veritas-kanban/shared';
+import type { RunEventRepository, RunEventRepositoryAppendInput } from './interfaces.js';
+import { withFileLock } from '../services/file-lock.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { RunEventEnvelopeSchema } from '../schemas/run-event-schemas.js';
+
+const MAX_EVENTS_PER_ATTEMPT = 50_000;
+const MAX_JOURNAL_BYTES = 128 * 1024 * 1024;
+const DEFAULT_REPLAY_LIMIT = 200;
+const MAX_REPLAY_LIMIT = 500;
+
+export function getRunEventsDir(): string {
+  return path.join(getRuntimeDir(), 'run-events');
+}
+
+function parseEvents(content: string): RunEventEnvelope[] {
+  if (!content.trim()) return [];
+  return content
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => RunEventEnvelopeSchema.parse(JSON.parse(line)));
+}
+
+export class FileRunEventRepository implements RunEventRepository {
+  constructor(private readonly baseDir = getRunEventsDir()) {}
+
+  async append(event: RunEventRepositoryAppendInput): Promise<RunEventAppendResult> {
+    const journalPath = this.journalPath(event.taskId, event.attemptId);
+    const taskDir = path.dirname(journalPath);
+    await mkdir(taskDir, { recursive: true, mode: 0o700 });
+    const taskDirStat = await lstat(taskDir);
+    if (!taskDirStat.isDirectory() || taskDirStat.isSymbolicLink()) {
+      throw new Error('Run event journal directory is not a private regular directory');
+    }
+    return withFileLock(journalPath, async () => {
+      const events = await this.readJournal(journalPath);
+      if (event.dedupeKey) {
+        const duplicate = events.find((candidate) => candidate.dedupeKey === event.dedupeKey);
+        if (duplicate) return { event: duplicate, appended: false };
+      }
+      if (events.length >= MAX_EVENTS_PER_ATTEMPT) {
+        throw new Error('Run event journal reached its bounded event limit');
+      }
+      const sequence = (events.at(-1)?.sequence ?? 0) + 1;
+      const persisted = RunEventEnvelopeSchema.parse({ ...event, sequence });
+      const line = `${JSON.stringify(persisted)}\n`;
+      const existingBytes = events.reduce(
+        (total, candidate) => total + Buffer.byteLength(JSON.stringify(candidate), 'utf-8') + 1,
+        0
+      );
+      if (existingBytes + Buffer.byteLength(line, 'utf-8') > MAX_JOURNAL_BYTES) {
+        throw new Error('Run event journal reached its bounded byte limit');
+      }
+      const handle = await open(
+        journalPath,
+        constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW,
+        0o600
+      );
+      try {
+        await handle.write(line, undefined, 'utf-8');
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      return { event: persisted, appended: true };
+    });
+  }
+
+  async list(query: RunEventQuery): Promise<RunEventPage> {
+    const journalPath = this.journalPath(query.taskId, query.attemptId);
+    const afterSequence = Math.max(0, query.afterSequence ?? 0);
+    const limit = Math.min(Math.max(query.limit ?? DEFAULT_REPLAY_LIMIT, 1), MAX_REPLAY_LIMIT);
+    const events = (await this.readJournal(journalPath)).filter(
+      (event) => event.sequence > afterSequence
+    );
+    const page = events.slice(0, limit);
+    return {
+      schemaVersion: RUN_EVENT_SCHEMA_VERSION,
+      taskId: query.taskId,
+      attemptId: query.attemptId,
+      events: page,
+      nextCursor: page.at(-1)?.sequence ?? afterSequence,
+      hasMore: events.length > page.length,
+    };
+  }
+
+  private journalPath(taskId: string, attemptId: string): string {
+    validatePathSegment(taskId);
+    validatePathSegment(attemptId);
+    const taskDir = path.join(this.baseDir, taskId);
+    const journalPath = path.join(taskDir, `${attemptId}.jsonl`);
+    ensureWithinBase(this.baseDir, journalPath);
+    return journalPath;
+  }
+
+  private async readJournal(journalPath: string): Promise<RunEventEnvelope[]> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(journalPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const journalStat = await handle.stat();
+      if (!journalStat.isFile() || journalStat.size > MAX_JOURNAL_BYTES) {
+        throw new Error('Run event journal is not a bounded regular file');
+      }
+      return parseEvents(await handle.readFile({ encoding: 'utf-8' }));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+        throw new Error('Run event journal is not a bounded regular file', { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -1110,6 +1110,32 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON governance_decision_traces(task_id, created_at DESC);
     `,
   },
+  {
+    version: 18,
+    name: '0018_causal_run_event_journal',
+    up: `
+      CREATE TABLE run_events (
+        event_id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local'
+          REFERENCES workspaces(id) ON DELETE CASCADE,
+        task_id TEXT NOT NULL,
+        attempt_id TEXT NOT NULL,
+        sequence INTEGER NOT NULL CHECK (sequence > 0),
+        provider_event_id TEXT,
+        dedupe_key TEXT,
+        received_at TEXT NOT NULL,
+        event_json TEXT NOT NULL,
+        UNIQUE (workspace_id, task_id, attempt_id, sequence),
+        UNIQUE (workspace_id, task_id, attempt_id, dedupe_key)
+      );
+
+      CREATE INDEX idx_run_events_task_attempt_sequence
+        ON run_events(workspace_id, task_id, attempt_id, sequence);
+
+      CREATE INDEX idx_run_events_received_at
+        ON run_events(workspace_id, received_at);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/run-event-repository.ts
+++ b/server/src/storage/sqlite/run-event-repository.ts
@@ -1,0 +1,137 @@
+import {
+  RUN_EVENT_SCHEMA_VERSION,
+  type RunEventAppendResult,
+  type RunEventPage,
+  type RunEventQuery,
+} from '@veritas-kanban/shared';
+import type { RunEventRepository, RunEventRepositoryAppendInput } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+import { RunEventEnvelopeSchema } from '../../schemas/run-event-schemas.js';
+
+const MAX_EVENTS_PER_ATTEMPT = 50_000;
+const DEFAULT_REPLAY_LIMIT = 200;
+const MAX_REPLAY_LIMIT = 500;
+
+interface EventRow {
+  event_json: string;
+}
+
+interface SequenceRow {
+  sequence: number;
+}
+
+interface CountRow {
+  count: number;
+}
+
+export class SqliteRunEventRepository implements RunEventRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async append(event: RunEventRepositoryAppendInput): Promise<RunEventAppendResult> {
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      if (event.dedupeKey) {
+        const duplicate = connection
+          .prepare(
+            `SELECT event_json
+             FROM run_events
+             WHERE workspace_id = 'local'
+               AND task_id = ?
+               AND attempt_id = ?
+               AND dedupe_key = ?`
+          )
+          .get(event.taskId, event.attemptId, event.dedupeKey) as EventRow | undefined;
+        if (duplicate) {
+          connection.exec('COMMIT');
+          return {
+            event: RunEventEnvelopeSchema.parse(JSON.parse(duplicate.event_json)),
+            appended: false,
+          };
+        }
+      }
+      const count = connection
+        .prepare(
+          `SELECT COUNT(*) AS count
+           FROM run_events
+           WHERE workspace_id = 'local' AND task_id = ? AND attempt_id = ?`
+        )
+        .get(event.taskId, event.attemptId) as unknown as CountRow;
+      if (count.count >= MAX_EVENTS_PER_ATTEMPT) {
+        throw new Error('Run event journal reached its bounded event limit');
+      }
+      const latest = connection
+        .prepare(
+          `SELECT sequence
+           FROM run_events
+           WHERE workspace_id = 'local' AND task_id = ? AND attempt_id = ?
+           ORDER BY sequence DESC
+           LIMIT 1`
+        )
+        .get(event.taskId, event.attemptId) as SequenceRow | undefined;
+      const persisted = RunEventEnvelopeSchema.parse({
+        ...event,
+        sequence: (latest?.sequence ?? 0) + 1,
+      });
+      connection
+        .prepare(
+          `INSERT INTO run_events (
+             event_id,
+             workspace_id,
+             task_id,
+             attempt_id,
+             sequence,
+             provider_event_id,
+             dedupe_key,
+             received_at,
+             event_json
+           ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          persisted.eventId,
+          persisted.taskId,
+          persisted.attemptId,
+          persisted.sequence,
+          persisted.providerEventId ?? null,
+          persisted.dedupeKey ?? null,
+          persisted.receivedAt,
+          JSON.stringify(persisted)
+        );
+      connection.exec('COMMIT');
+      return { event: persisted, appended: true };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async list(query: RunEventQuery): Promise<RunEventPage> {
+    const afterSequence = Math.max(0, query.afterSequence ?? 0);
+    const limit = Math.min(Math.max(query.limit ?? DEFAULT_REPLAY_LIMIT, 1), MAX_REPLAY_LIMIT);
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `SELECT event_json
+         FROM run_events
+         WHERE workspace_id = 'local'
+           AND task_id = ?
+           AND attempt_id = ?
+           AND sequence > ?
+         ORDER BY sequence ASC
+         LIMIT ?`
+      )
+      .all(query.taskId, query.attemptId, afterSequence, limit + 1) as unknown as EventRow[];
+    const hasMore = rows.length > limit;
+    const events = rows
+      .slice(0, limit)
+      .map((row) => RunEventEnvelopeSchema.parse(JSON.parse(row.event_json)));
+    return {
+      schemaVersion: RUN_EVENT_SCHEMA_VERSION,
+      taskId: query.taskId,
+      attemptId: query.attemptId,
+      events,
+      nextCursor: events.at(-1)?.sequence ?? afterSequence,
+      hasMore,
+    };
+  }
+}

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -11,6 +11,7 @@ import { SqliteStatusHistoryRepository } from './status-history-repository.js';
 import { SqliteTelemetryRepository } from './telemetry-repository.js';
 import { SqliteOperationalProvenanceRepository } from './provenance-repository.js';
 import { SqliteSetupContextRepository } from './setup-context-repository.js';
+import { SqliteRunEventRepository } from './run-event-repository.js';
 import { createDefaultConfig, normalizeAppConfig } from '../../services/config-service.js';
 
 export interface SqliteStorageOptions {
@@ -29,6 +30,7 @@ export class SqliteStorageProvider implements StorageProvider {
   readonly telemetry: SqliteTelemetryRepository;
   readonly provenance: SqliteOperationalProvenanceRepository;
   readonly setupContext: SqliteSetupContextRepository;
+  readonly runEvents: SqliteRunEventRepository;
 
   private readonly sqlite: SqliteDatabase;
 
@@ -48,6 +50,7 @@ export class SqliteStorageProvider implements StorageProvider {
     this.telemetry = new SqliteTelemetryRepository(this.sqlite);
     this.provenance = new SqliteOperationalProvenanceRepository(this.sqlite);
     this.setupContext = new SqliteSetupContextRepository(this.sqlite);
+    this.runEvents = new SqliteRunEventRepository(this.sqlite);
   }
 
   getDatabase(): SqliteDatabase {

--- a/shared/package.json
+++ b/shared/package.json
@@ -21,7 +21,8 @@
     "./types/workflow": {
       "types": "./dist/types/workflow.d.ts",
       "import": "./dist/types/workflow.js"
-    }
+    },
+    "./schemas/run-event-envelope.v1.json": "./schemas/run-event-envelope.v1.schema.json"
   },
   "scripts": {
     "build": "tsc",

--- a/shared/schemas/run-event-envelope.v1.schema.json
+++ b/shared/schemas/run-event-envelope.v1.schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://veritaskanban.com/schemas/run-event-envelope.v1.schema.json",
+  "title": "Veritas Run Event Envelope v1",
+  "description": "Versioned, append-only provider-neutral run event. Unknown namespaced kinds remain storable and replayable.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "eventId",
+    "taskId",
+    "runId",
+    "attemptId",
+    "sequence",
+    "receivedAt",
+    "kind",
+    "source",
+    "redaction",
+    "payload",
+    "payloadHash"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "run-event/v1"
+    },
+    "eventId": {
+      "type": "string",
+      "pattern": "^runevt_[A-Za-z0-9_-]{12,32}$"
+    },
+    "taskId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "runId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "attemptId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "turnId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "itemId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "providerEventId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "parentEventId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "causalEventId": {
+      "$ref": "#/$defs/identifier"
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "providerTimestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "receivedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "kind": {
+      "anyOf": [
+        {
+          "enum": [
+            "run.started",
+            "run.completed",
+            "run.failed",
+            "run.interrupted",
+            "run.recovered",
+            "message.operator",
+            "message.assistant",
+            "message.delta",
+            "reasoning.delta",
+            "progress",
+            "stream.stdout",
+            "stream.stderr",
+            "command.started",
+            "command.completed",
+            "file.changed",
+            "tool.started",
+            "tool.completed",
+            "approval.requested",
+            "approval.resolved",
+            "artifact.created",
+            "usage.updated",
+            "run.error",
+            "provider.unknown"
+          ]
+        },
+        {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 120,
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+        }
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "adapter"],
+      "properties": {
+        "provider": {
+          "enum": ["openclaw", "codex-cli", "codex-sdk", "hermes-cli", "operator", "system"]
+        },
+        "adapter": {
+          "$ref": "#/$defs/identifier"
+        },
+        "agent": {
+          "$ref": "#/$defs/identifier"
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "fields", "originalBytes", "persistedBytes"],
+      "properties": {
+        "status": {
+          "enum": ["none", "redacted", "dropped"]
+        },
+        "fields": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 240
+          }
+        },
+        "originalBytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "persistedBytes": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/jsonValue"
+      }
+    },
+    "payloadHash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "dedupeKey": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240
+    }
+  },
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160
+    },
+    "jsonValue": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -50,6 +50,7 @@ export * from './evidence.types.js';
 export * from './time-breakdown.types.js';
 export * from './task-envelope.types.js';
 export * from './run-launch-manifest.types.js';
+export * from './run-event.types.js';
 export * from './auth.types.js';
 export * from './credential-broker.types.js';
 export * from './worktree-manifest.types.js';

--- a/shared/src/types/run-event.types.ts
+++ b/shared/src/types/run-event.types.ts
@@ -1,0 +1,123 @@
+import type { ExecutableAgentProvider } from './config.types.js';
+
+export const RUN_EVENT_SCHEMA_VERSION = 'run-event/v1' as const;
+
+export const RUN_EVENT_KINDS = [
+  'run.started',
+  'run.completed',
+  'run.failed',
+  'run.interrupted',
+  'run.recovered',
+  'message.operator',
+  'message.assistant',
+  'message.delta',
+  'reasoning.delta',
+  'progress',
+  'stream.stdout',
+  'stream.stderr',
+  'command.started',
+  'command.completed',
+  'file.changed',
+  'tool.started',
+  'tool.completed',
+  'approval.requested',
+  'approval.resolved',
+  'artifact.created',
+  'usage.updated',
+  'run.error',
+  'provider.unknown',
+] as const;
+
+export type KnownRunEventKind = (typeof RUN_EVENT_KINDS)[number];
+
+/**
+ * Known event kinds receive stable projection semantics. Namespaced unknown
+ * kinds remain valid so newer provider events can be stored and replayed
+ * without pretending Veritas understands them.
+ */
+export type RunEventKind = KnownRunEventKind | (string & {});
+
+export type RunEventRedactionStatus = 'none' | 'redacted' | 'dropped';
+
+export type RunEventJsonValue =
+  null | boolean | number | string | RunEventJsonValue[] | { [key: string]: RunEventJsonValue };
+
+export interface RunEventSource {
+  provider: ExecutableAgentProvider | 'operator' | 'system';
+  adapter: string;
+  agent?: string;
+  model?: string;
+}
+
+export interface RunEventRedaction {
+  status: RunEventRedactionStatus;
+  fields: string[];
+  originalBytes: number;
+  persistedBytes: number;
+}
+
+export interface RunEventEnvelope {
+  schemaVersion: typeof RUN_EVENT_SCHEMA_VERSION;
+  eventId: string;
+  taskId: string;
+  runId: string;
+  attemptId: string;
+  turnId?: string;
+  itemId?: string;
+  providerEventId?: string;
+  parentEventId?: string;
+  causalEventId?: string;
+  sequence: number;
+  providerTimestamp?: string;
+  receivedAt: string;
+  kind: RunEventKind;
+  source: RunEventSource;
+  redaction: RunEventRedaction;
+  payload: Record<string, RunEventJsonValue>;
+  payloadHash: string;
+  dedupeKey?: string;
+}
+
+export interface RunEventAppendInput {
+  taskId: string;
+  attemptId: string;
+  turnId?: string;
+  itemId?: string;
+  providerEventId?: string;
+  parentEventId?: string;
+  causalEventId?: string;
+  providerTimestamp?: string;
+  kind: RunEventKind;
+  source: RunEventSource;
+  payload: Record<string, unknown>;
+  dedupeKey?: string;
+}
+
+export interface RunEventAppendResult {
+  event: RunEventEnvelope;
+  appended: boolean;
+}
+
+export interface RunEventQuery {
+  taskId: string;
+  attemptId: string;
+  afterSequence?: number;
+  limit?: number;
+}
+
+export interface RunEventPage {
+  schemaVersion: typeof RUN_EVENT_SCHEMA_VERSION;
+  taskId: string;
+  attemptId: string;
+  events: RunEventEnvelope[];
+  nextCursor: number;
+  hasMore: boolean;
+}
+
+export interface RunEventSubscriptionRequest {
+  type: 'subscribe';
+  taskId: string;
+  attemptId?: string;
+  afterSequence?: number;
+  workspaceId?: string;
+}

--- a/shared/src/types/websocket.types.ts
+++ b/shared/src/types/websocket.types.ts
@@ -2,9 +2,11 @@
 
 import type { AttemptStatus } from './task.types.js';
 import type { ChatMessage } from './chat.types.js';
+import type { RunEventEnvelope } from './run-event.types.js';
 
 export type WSMessageType =
   | 'agent:output'
+  | 'agent:event'
   | 'agent:status'
   | 'agent:complete'
   | 'task:updated'
@@ -20,12 +22,20 @@ export interface WSMessage {
   timestamp: string;
 }
 
-export interface AgentOutputMessage extends WSMessage {
+export interface AgentOutputMessage extends Omit<WSMessage, 'data'> {
   type: 'agent:output';
-  data: {
-    stream: 'stdout' | 'stderr';
-    content: string;
-  };
+  taskId: string;
+  attemptId: string;
+  outputType: 'stdout' | 'stderr' | 'stdin' | 'system';
+  content: string;
+  sequence: number;
+}
+
+export interface AgentRunEventMessage extends WSMessage {
+  type: 'agent:event';
+  taskId: string;
+  attemptId: string;
+  data: RunEventEnvelope;
 }
 
 export interface AgentStatusMessage extends WSMessage {

--- a/web/src/__tests__/use-agent-status-refresh.test.ts
+++ b/web/src/__tests__/use-agent-status-refresh.test.ts
@@ -61,13 +61,31 @@ describe('agent status refresh cadence', () => {
         type: 'agent:output',
         outputType: 'stdout',
         content: 'prior attempt output',
+        sequence: 7,
         timestamp: '2026-07-16T08:00:00.000Z',
       });
     });
     expect(result.current.outputs).toHaveLength(1);
+    expect(socketMocks.options).toMatchObject({
+      onOpen: {
+        type: 'subscribe',
+        taskId: 'task-runtime',
+        attemptId: 'attempt-1',
+        afterSequence: 7,
+      },
+    });
 
     rerender({ attemptId: 'attempt-2' });
 
     expect(result.current.outputs).toEqual([]);
+    expect(socketMocks.send).toHaveBeenLastCalledWith({
+      type: 'subscribe',
+      taskId: 'task-runtime',
+      attemptId: 'attempt-2',
+      afterSequence: 0,
+    });
+    expect(socketMocks.options).toMatchObject({
+      autoReconnect: true,
+    });
   });
 });

--- a/web/src/hooks/useAgent.ts
+++ b/web/src/hooks/useAgent.ts
@@ -184,17 +184,34 @@ export function useAgentStream(taskId: string | undefined, attemptId?: string) {
   const [outputs, setOutputs] = useState<AgentOutput[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const activeAttemptRef = useRef<string | undefined>(undefined);
+  const eventCursorRef = useRef(0);
   const queryClient = useQueryClient();
 
   const handleMessage = useCallback(
     (message: WebSocketMessage) => {
       if (message.type === 'subscribed') {
         const running = message.running as boolean;
+        const cursor = message.cursor;
+        if (typeof cursor === 'number' && Number.isSafeInteger(cursor) && cursor >= 0) {
+          eventCursorRef.current = Math.max(eventCursorRef.current, cursor);
+        }
         setIsRunning(running);
         if (running) {
           queryClient.invalidateQueries({ queryKey: ['agent', 'status', taskId] });
         }
+      } else if (message.type === 'agent:event') {
+        const data = message.data;
+        if (data && typeof data === 'object') {
+          const sequence = (data as Record<string, unknown>).sequence;
+          if (typeof sequence === 'number' && Number.isSafeInteger(sequence) && sequence > 0) {
+            eventCursorRef.current = Math.max(eventCursorRef.current, sequence);
+          }
+        }
       } else if (message.type === 'agent:output') {
+        const sequence = message.sequence;
+        if (typeof sequence === 'number' && Number.isSafeInteger(sequence) && sequence > 0) {
+          eventCursorRef.current = Math.max(eventCursorRef.current, sequence);
+        }
         setOutputs((prev) => [
           ...prev,
           {
@@ -219,21 +236,30 @@ export function useAgentStream(taskId: string | undefined, attemptId?: string) {
   useEffect(() => {
     setOutputs([]);
     activeAttemptRef.current = undefined;
+    eventCursorRef.current = 0;
   }, [taskId]);
 
   useEffect(() => {
     if (!attemptId) return;
     if (activeAttemptRef.current && activeAttemptRef.current !== attemptId) {
       setOutputs([]);
+      eventCursorRef.current = 0;
     }
     activeAttemptRef.current = attemptId;
   }, [attemptId]);
 
   const { isConnected, send } = useWebSocket({
     autoConnect: !!taskId,
-    onOpen: taskId ? { type: 'subscribe', taskId } : undefined,
+    onOpen: taskId
+      ? {
+          type: 'subscribe',
+          taskId,
+          attemptId,
+          afterSequence: eventCursorRef.current,
+        }
+      : undefined,
     onMessage: handleMessage,
-    autoReconnect: false, // Don't auto-reconnect for agent streams
+    autoReconnect: true,
   });
 
   // A client can subscribe while the task is idle and then observe a run that
@@ -241,7 +267,12 @@ export function useAgentStream(taskId: string | undefined, attemptId?: string) {
   // the task subscription so the server attaches to that attempt's emitter.
   useEffect(() => {
     if (isConnected && taskId && attemptId) {
-      send({ type: 'subscribe', taskId });
+      send({
+        type: 'subscribe',
+        taskId,
+        attemptId,
+        afterSequence: eventCursorRef.current,
+      });
     }
   }, [attemptId, isConnected, send, taskId]);
 


### PR DESCRIPTION
## Summary

- add the versioned `run-event/v1` envelope, runtime validation, and published JSON Schema
- durably append provider and operator events before trace, log, telemetry, budget, completion, and WebSocket projections
- support ordered cursor replay and live tailing across file and SQLite storage with deduplication and bounded redacted payloads
- map OpenClaw, Codex CLI, Codex SDK, and Hermes events through adapter-owned mappers while preserving unknown provider events
- add REST replay, reconnectable WebSocket delivery, web cursor tracking, migrations, tests, and operator documentation

## Verification

- `pnpm test:unit` (server: 2,566 passed, 2 skipped; web: 433 passed)
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm check:pnpm-settings`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/run-event-journal-service.test.ts` (12 passed after the final redaction regression fix)
- targeted server and web run-event, route, provider, and reconnect suites

## Notes

- Runtime payloads are capped at 32 KiB, strings at 8 KiB, file journals at 50,000 events or 128 MiB per attempt, and replay pages at 500 events.
- Existing Markdown attempt logs remain available and are now projections beside the authoritative event journal.
- Cross-model review was explicitly waived for this release workstream. A same-model correctness and security review found and fixed overly broad token-field redaction before publication.

Closes #850