### PR TITLE
fix: classify durable agent websocket events

### DIFF
--- a/docs/security/permission-coverage.json
+++ b/docs/security/permission-coverage.json
@@ -124,6 +124,14 @@
       "denialReason": "Agent status subscription confirmations are only sent after agent read authorization."
     },
     {
+      "id": "websocket:agent:event",
+      "kind": "websocket",
+      "classification": "authenticated-read",
+      "permissions": ["task:read"],
+      "source": "server/src/server.ts",
+      "denialReason": "Durable agent event subscriptions require task read access."
+    },
+    {
       "id": "websocket:agent:output",
       "kind": "websocket",
       "classification": "authenticated-read",


### PR DESCRIPTION
## Summary

- add the new `agent:event` WebSocket surface to the permission coverage manifest
- classify durable run-event delivery under the same `task:read` boundary enforced by the server
- restore the CI permission-coverage gate that failed after #949 merged

## Verification

- `node scripts/check-permission-coverage.mjs`
- `node scripts/check-security-artifacts.mjs`
- `git diff --check`

Closes #850