### PR TITLE
ci: tier pull request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,9 +53,84 @@ jobs:
       - name: Type check all packages
         run: pnpm typecheck
 
-  # ─── Workspace Unit Tests ────────────────────────────────────────
+  # ─── Changed PR Tests ────────────────────────────────────────────
+  test-changed:
+    name: Changed Tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared test dependency
+        run: pnpm --filter @veritas-kanban/shared build
+
+      - name: Run changed workspace tests
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          selected_count=0
+          for package_name in server web cli mcp; do
+            package_tests=()
+            while IFS= read -r test_file; do
+              package_tests+=("${test_file#"$package_name/"}")
+            done < <(
+              git diff --name-only --diff-filter=ACMR "$BASE_SHA...HEAD" |
+                grep -E "^${package_name}/.*\\.(test|spec)\\.[cm]?[jt]sx?$" || true
+            )
+            if (( ${#package_tests[@]} > 0 )); then
+              for test_file in "${package_tests[@]}"; do
+                pnpm --filter "@veritas-kanban/${package_name}" exec vitest run \
+                  --passWithNoTests \
+                  "$test_file"
+                selected_count=$((selected_count + 1))
+              done
+            fi
+          done
+          if (( selected_count == 0 )); then
+            echo "No changed server, web, CLI, or MCP test files."
+          fi
+
+      - name: Run changed desktop tests
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          desktop_tests=()
+          while IFS= read -r test_file; do
+            desktop_tests+=("$test_file")
+          done < <(
+            git diff --name-only --diff-filter=ACMR "$BASE_SHA...HEAD" |
+              grep -E '^desktop/.*\.(test|spec)\.[cm]?[jt]sx?$' |
+              sed 's#^desktop/##' || true
+          )
+          if (( ${#desktop_tests[@]} == 0 )); then
+            echo "No changed desktop test files."
+          else
+            for test_file in "${desktop_tests[@]}"; do
+              pnpm --filter @veritas-kanban/desktop exec vitest run \
+                --config vitest.config.ts \
+                --passWithNoTests \
+                "$test_file"
+            done
+          fi
+
+  # ─── Full Workspace Unit Tests ───────────────────────────────────
   test-workspace:
     name: Workspace Unit Tests
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -1,13 +1,24 @@
 name: Desktop Artifacts
 
 on:
-  pull_request:
+  push:
     branches: [main]
     paths:
       - 'desktop/**'
       - 'server/**'
       - 'web/**'
       - 'shared/**'
+      - 'docs/DESKTOP-RELEASE.md'
+      - 'scripts/desktop-after-pack.mjs'
+      - 'scripts/prepare-desktop-release.mjs'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/desktop-artifacts.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'desktop/**'
       - 'docs/DESKTOP-RELEASE.md'
       - 'scripts/desktop-after-pack.mjs'
       - 'scripts/prepare-desktop-release.mjs'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tiered GitHub Actions so pull requests run changed test files with
+  lint/typecheck, security, and build gates, while the complete workspace suite
+  runs on `main`, nightly, by manual dispatch, or with the `ci:full` label.
+  Cross-platform unsigned desktop packaging now runs for desktop/package PRs,
+  after relevant changes merge to `main`, or by manual dispatch (#955).
+
 ### Fixed
 
 - Added bounded macOS desktop startup verification that retries through the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing! This guide will help you get started.
 ## Prerequisites
 
 - **Node.js** 22 or later
-- **pnpm** 9+ (package manager)
+- **pnpm** 11+ (package manager)
 
 ## Development Setup
 
@@ -73,13 +73,16 @@ veritas-kanban/
 
 2. Make your changes — write code, add tests, update docs.
 
-3. Run type checking, linting, and tests before committing:
+3. Run type checking, linting, and focused tests before committing:
 
    ```bash
    pnpm typecheck
    pnpm lint
-   pnpm test
+   pnpm --filter @veritas-kanban/server exec vitest run src/path/to/changed.test.ts
    ```
+
+   Use `pnpm test` at integration or release milestones, or when the change
+   affects shared foundations broadly enough that focused selection is unsafe.
 
 4. Commit using [conventional commits](#commit-conventions).
 
@@ -247,7 +250,9 @@ docs: update README with deployment instructions
 2. **Branch naming:** Use descriptive names like `feat/task-filters`, `fix/login-redirect`, `docs/api-reference`.
 3. **Open a PR** against `main`.
 4. **Fill out the PR template** — describe changes, link related issues, include screenshots for UI changes.
-5. **Ensure CI passes** — all checks must be green.
+5. **Ensure the PR CI tier passes** — all checks started for the pull request
+   must be green. Full workspace and packaging evidence runs after merge, on
+   explicit dispatch, or when the `ci:full` label is applied.
 6. **Request review** — a maintainer will review and may request changes.
 7. **Address feedback** — push additional commits as needed.
 8. **Merge** — once approved, a maintainer will merge.
@@ -291,6 +296,24 @@ Follow the existing conventions in `.eslintrc.*`, `.prettierrc`, and `tsconfig.j
 
 - Write tests for new features and bug fixes.
 - Ensure existing tests pass before submitting.
+
+### CI tiers
+
+| Trigger                                                                                                     | Stable checks                                                   | Scope                                                                              |
+| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Pull request                                                                                                | `Lint & Type Check`, `Changed Tests`, `Build`, `Security Audit` | Static gates, full build, and only test files added or changed by the pull request |
+| Pull request with `ci:full`                                                                                 | Default checks plus `Workspace Unit Tests`                      | Complete workspace, desktop readiness regressions, and dual-storage parity         |
+| Push to `main`, nightly 08:00 UTC, or manual `CI` dispatch                                                  | Static gates, `Workspace Unit Tests`, `Build`, `Security Audit` | Complete authoritative workspace suite                                             |
+| Desktop/package/release-workflow pull request, relevant `main` push, or manual `Desktop Artifacts` dispatch | Unsigned macOS, Linux, and Windows artifact jobs                | Cross-platform packaging                                                           |
+
+Release validation remains the final authority: clean-clone build, full unit
+and integration suites, applicable E2E, and signed artifact verification.
+
+The operational target for the default pull-request tier is under 15 minutes,
+with no desktop packaging. This is a target rather than an SLA; dependency
+installation and hosted-runner availability still vary. Behavior changes
+should include a focused test change so the pull-request selector executes
+relevant coverage.
 
 ## Questions?
 

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -50,7 +50,8 @@ live repository install into a production-only dependency state.
 
 ## GitHub Workflows
 
-`Desktop Artifacts` runs on desktop/server/web/shared changes and on manual
+`Desktop Artifacts` runs on desktop/package/release-workflow pull requests,
+after server/web/shared/desktop changes merge to `main`, and on manual
 dispatch. It builds unsigned artifacts on:
 
 - `macos-15`: DMG, ZIP, blockmap, and update YAML.


### PR DESCRIPTION
## Summary

- run only changed test files on ordinary pull requests
- move the complete workspace suite to `main`, nightly QA, manual dispatch, and the `ci:full` override
- restrict pull-request desktop packaging to desktop/package/release-pipeline changes while keeping relevant `main` pushes and manual artifacts
- document stable check names, scope, and the under-15-minute PR target

Closes #955

## Verification

- parsed both workflow files as YAML
- Prettier passed for both workflows and all changed documentation
- `git diff --check` passed
- replayed the selector against #954: exactly 3 changed server test files / 69 tests selected instead of the 1,690-test workspace suite
- selector completed in seconds and exposed the existing `main` regressions recorded in #956

## Risk

Behavior changes must include a focused test change or opt into `ci:full`; the complete suite remains authoritative on `main`, nightly, and for release.