### PR TITLE
Classify provider launch credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,11 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   whose built-in type and command both identify `codex` or `hermes` may infer a
   provider during migration; provider-less or profile/adapter-mismatched records
   fail closed before an attempt is created.
+- Classify launch credentials through `run-launch-credential-plan/v1`.
+  Provider boot authentication, task integration definition IDs, and explicit
+  high-risk environment passthrough are separate classes. Task integration
+  credentials fail closed until an accepted tool or egress boundary proves
+  brokered, non-bypassable delivery.
 - Persist `run-supervisor/v1` before provider dispatch. Restart recovery must
   validate the exact runtime, task-envelope, launch-manifest, worktree, host,
   lease, and process/session identity; replay only after the durable event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `run-launch-credential-plan/v1` to classify provider boot
+  authentication, broker-targeted task credentials, and explicit high-risk
+  environment passthrough in immutable launch evidence. Plans bind to provider
+  runtime evidence, remain value-free, ignore timestamp-only probe refreshes,
+  and block task credential launches until an accepted tool or egress boundary
+  proves brokered delivery (#932).
 - Added a generic stable ACP v1 stdio provider adapter with no-shell supervised
   launch, initialize-time identity and capability evidence, fresh/resume/fork/
   close session lifecycle, bounded bidirectional JSON-RPC, causal message,

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -636,6 +636,14 @@ tool boundary are complete. Model-provider boot authentication and explicit
 `env-passthrough` compatibility remain separate, high-risk paths and are never
 labeled as brokered. See [Credential Broker](CREDENTIAL-BROKER.md).
 
+New launches persist `run-launch-credential-plan/v1` evidence. The plan
+classifies known provider boot keys, task integration definition IDs, and
+unknown credential-like environment passthrough; binds the classification to
+the provider runtime manifest and probe revision; and contains no values. Task
+integration references remain blocked until a controlled tool or egress
+boundary proves non-bypassable delivery. A provider-native boot key is reported
+as provider-required authentication, not as `credential.broker` support.
+
 ## Agent Profile Packages
 
 Use **Settings -> Agents -> Agent Profile Packages** or `vk profiles` to import reusable YAML/JSON packages that sit above provider profiles. Provider profiles still own low-level command, args, and availability. Profile packages add portable launch metadata:

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3801,7 +3801,12 @@ ID cannot dispatch twice.
 Raw environment and credential values are never stored in a definition,
 catalog, event, or launch manifest. Credential-reference definitions,
 header-bound definitions, and credential-like environment keys remain
-fail-closed until the provider launch credential broker is available.
+fail-closed until a controlled broker boundary is available. Newly compiled
+launch manifests include a value-free `run-launch-credential-plan/v1` section
+that separates provider boot authentication, task integration references, and
+high-risk compatibility passthrough. Task references report `brokerState:
+"blocked"` and make the launch unenforceable until an accepted boundary can
+deliver them without provider bypass.
 See [Tool Control Plane v1](architecture/TOOL-CONTROL-PLANE-V1.md).
 
 ---

--- a/docs/CREDENTIAL-BROKER.md
+++ b/docs/CREDENTIAL-BROKER.md
@@ -13,6 +13,9 @@ The v6 foundation includes:
 - metadata-only audit events; and
 - a controlled in-process callback that is the only API allowed to receive the
   resolved value.
+- `run-launch-credential-plan/v1` evidence that classifies provider boot
+  authentication, task integration references, and high-risk compatibility
+  passthrough without storing values.
 
 It does not yet make a provider broker-capable. A handle in a prompt or
 environment is not a security boundary. Provider use stays disabled until an
@@ -28,6 +31,16 @@ Treat these as separate:
    action during a run. These are the broker target.
 3. **Compatibility passthrough** explicitly places a raw value in the provider
    environment. It is high risk and never counts as brokered.
+
+Every newly compiled run launch manifest records those classes, delivery
+posture, boundary posture, and provider-runtime evidence in a deterministic
+credential plan. Known native provider authentication keys are classified as
+boot authentication. Unknown credential-like environment keys are classified
+as high-risk compatibility passthrough. Broker definition IDs are classified
+as task integration credentials and block launch while their controlled
+boundary is unavailable. Probe timestamp-only refreshes do not create material
+drift, but provider build, classification, mode, reference, delivery, boundary,
+or risk changes do.
 
 ## Register a definition
 
@@ -136,11 +149,13 @@ A required brokered sandbox preset needs `credential.broker: supported`.
 `advisory`, externally delegated, unknown, stale, or bypassable evidence is
 treated as unsupported and blocks launch.
 
-Current executable providers have not completed provider-facing handle
-migration. Controlled HTTP consumption belongs to the run-scoped egress
-gateway; controlled MCP/tool consumption belongs to the tool-server control
-plane. Until those boundaries and provider migration are complete, use the
-registry and lease service only from trusted internal dispatch code.
+Current executable providers classify their launch credentials consistently,
+but classification alone does not make them broker-capable. Controlled HTTP
+consumption belongs to the run-scoped egress gateway; controlled MCP/tool
+consumption belongs to the tool-server control plane. Until those boundaries
+deliver handles without a bypass, task integration references block launch and
+the registry and lease service remain limited to trusted internal dispatch
+code.
 
 ## Rotation and revocation
 

--- a/server/src/__tests__/provider-launch-credential-plan-service.test.ts
+++ b/server/src/__tests__/provider-launch-credential-plan-service.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ExecutableAgentProvider,
+  RunLaunchRuntime,
+  SandboxPolicyDryRunResult,
+} from '@veritas-kanban/shared';
+import { compileProviderLaunchCredentialPlan } from '../services/provider-launch-credential-plan-service.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+
+const sandbox = (
+  mode: SandboxPolicyDryRunResult['preset']['credentials']['mode'] = 'none',
+  credentialRefs: string[] = []
+): SandboxPolicyDryRunResult => ({
+  decision: 'allow',
+  preset: {
+    id: 'fixture',
+    name: 'Fixture',
+    enabled: true,
+    enforcement: 'required',
+    requiredCapabilities: [],
+    filesystem: {
+      readPaths: ['<workspace>'],
+      writePaths: ['<workspace>'],
+      deniedPaths: [],
+      dotfileMasking: false,
+      localOnlyHandles: true,
+    },
+    network: {
+      defaultEgress: 'deny',
+      allowedHosts: [],
+      allowedMethods: [],
+      allowedPathPrefixes: [],
+      blockPrivateNetwork: true,
+      blockMetadataEndpoints: true,
+      blockLoopback: true,
+    },
+    environment: { passthrough: [], redactDisplay: true },
+    credentials: { mode, brokerRefs: credentialRefs },
+    createdAt: '2026-07-24T00:00:00.000Z',
+    updatedAt: '2026-07-24T00:00:00.000Z',
+  },
+  effective: {
+    sandboxMode: 'workspace-write',
+    networkAccessEnabled: false,
+    envPassthrough: [],
+    credentialRefs,
+  },
+  evaluations: [],
+  unsupportedRules: [],
+  warnings: [],
+});
+
+const runtime = (environmentKeys: string[]): RunLaunchRuntime => ({
+  command: 'fixture',
+  args: [],
+  workingDirectory: 'task-worktree',
+  worktree: 'required',
+  environmentKeys,
+  credentialReferences: environmentKeys.map((key) => `env:${key}`),
+});
+
+describe('provider launch credential plan', () => {
+  it.each([
+    ['openclaw', 'OPENCLAW_GATEWAY_TOKEN'],
+    ['codex-cli', 'OPENAI_API_KEY'],
+    ['codex-sdk', 'CODEX_API_KEY'],
+    ['codex-app-server', 'OPENAI_API_KEY'],
+    ['claude-code', 'CLAUDE_CODE_OAUTH_TOKEN'],
+    ['hermes-cli', 'HERMES_API_KEY'],
+  ] satisfies Array<[ExecutableAgentProvider, string]>)(
+    'classifies %s boot authentication without claiming it is brokered',
+    (provider, key) => {
+      const manifest = providerRuntimeManifestFixture({ provider });
+      const plan = compileProviderLaunchCredentialPlan({
+        provider,
+        providerRuntimeManifest: manifest,
+        runtime: runtime([key]),
+        sandbox: sandbox(),
+      });
+
+      expect(plan).toMatchObject({
+        mode: 'none',
+        brokerState: 'not-required',
+        providerRuntimeManifestDigest: manifest.digest,
+        providerRuntimeProbeRevision: manifest.probeRevision,
+        references: [
+          {
+            reference: `env:${key}`,
+            classification: 'harness-boot-authentication',
+            delivery: 'provider-native-environment',
+            boundary: 'provider-process',
+            risk: 'provider-required',
+          },
+        ],
+      });
+    }
+  );
+
+  it('marks unknown credential environment keys as explicit high-risk passthrough', () => {
+    const plan = compileProviderLaunchCredentialPlan({
+      provider: 'acp-stdio',
+      providerRuntimeManifest: providerRuntimeManifestFixture({ provider: 'acp-stdio' }),
+      runtime: runtime(['CUSTOM_AUTH_TOKEN']),
+      sandbox: sandbox('env-passthrough'),
+    });
+
+    expect(plan.references).toEqual([
+      {
+        reference: 'env:CUSTOM_AUTH_TOKEN',
+        classification: 'compatibility-passthrough',
+        delivery: 'raw-environment',
+        boundary: 'provider-process',
+        risk: 'high-risk',
+      },
+    ]);
+  });
+
+  it('fails task integration references closed until a controlled boundary is present', () => {
+    const manifest = providerRuntimeManifestFixture({ provider: 'codex-cli' });
+    const plan = compileProviderLaunchCredentialPlan({
+      provider: 'codex-cli',
+      providerRuntimeManifest: manifest,
+      runtime: runtime(['OPENAI_API_KEY']),
+      sandbox: sandbox('brokered', ['github-token']),
+    });
+
+    expect(plan.brokerState).toBe('blocked');
+    expect(plan.references).toContainEqual({
+      reference: 'github-token',
+      classification: 'task-integration',
+      delivery: 'blocked',
+      boundary: 'unavailable',
+      risk: 'blocked',
+    });
+  });
+});

--- a/server/src/__tests__/run-launch-manifest-service.test.ts
+++ b/server/src/__tests__/run-launch-manifest-service.test.ts
@@ -120,8 +120,8 @@ const sandboxPolicy: SandboxPolicyDryRunResult = {
       redactDisplay: true,
     },
     credentials: {
-      mode: 'brokered',
-      brokerRefs: ['openai=provider-sensitive-value'],
+      mode: 'none',
+      brokerRefs: [],
     },
     createdAt: '2026-07-23T20:00:00.000Z',
     updatedAt: '2026-07-23T20:00:00.000Z',
@@ -130,7 +130,7 @@ const sandboxPolicy: SandboxPolicyDryRunResult = {
     sandboxMode: 'workspace-write',
     networkAccessEnabled: false,
     envPassthrough: ['PATH', 'OPENAI_API_KEY'],
-    credentialRefs: ['openai=[redacted]'],
+    credentialRefs: [],
   },
   evaluations: [],
   unsupportedRules: [],
@@ -194,7 +194,7 @@ function input(
       workingDirectory: 'task-worktree',
       worktree: 'required',
       environmentKeys: ['PATH', 'OPENAI_API_KEY'],
-      credentialReferences: ['openai=[redacted]'],
+      credentialReferences: ['env:OPENAI_API_KEY'],
     },
     tools: {
       allowed: [],
@@ -260,6 +260,20 @@ describe('RunLaunchManifestService', () => {
         provider: 'codex-cli',
         probeRevision: expect.any(Number),
       },
+      credentials: {
+        schemaVersion: 'run-launch-credential-plan/v1',
+        mode: 'none',
+        brokerState: 'not-required',
+        references: [
+          {
+            reference: 'env:OPENAI_API_KEY',
+            classification: 'harness-boot-authentication',
+            delivery: 'provider-native-environment',
+            boundary: 'provider-process',
+            risk: 'provider-required',
+          },
+        ],
+      },
       workspace: {
         worktreeId: 'worktree-854',
         worktreeManifestId: 'manifest-854',
@@ -288,6 +302,12 @@ describe('RunLaunchManifestService', () => {
         byteLength: expect.any(Number),
       }),
     ]);
+    expect(manifest.credentials?.providerRuntimeManifestDigest).toBe(
+      manifest.providerRuntime.digest
+    );
+    expect(manifest.credentials?.providerRuntimeProbeRevision).toBe(
+      manifest.providerRuntime.probeRevision
+    );
     expect(JSON.stringify(manifest)).not.toContain('Implement the task envelope');
     expect(JSON.stringify(manifest)).not.toContain('provider-sensitive-value');
     expect(RunLaunchManifestSchema.safeParse(manifest).success).toBe(true);
@@ -295,6 +315,49 @@ describe('RunLaunchManifestService', () => {
     expect(Object.isFrozen(manifest)).toBe(true);
     expect(Object.isFrozen(manifest.runtime.args)).toBe(true);
     expect(() => manifest.runtime.args.push('--tamper')).toThrow(TypeError);
+  });
+
+  it('fails closed when task credentials lack a controlled broker boundary', () => {
+    const brokeredPolicy: SandboxPolicyDryRunResult = {
+      ...sandboxPolicy,
+      preset: {
+        ...sandboxPolicy.preset,
+        credentials: {
+          mode: 'brokered',
+          brokerRefs: ['github-token'],
+        },
+      },
+      effective: {
+        ...sandboxPolicy.effective,
+        credentialRefs: ['github-token'],
+      },
+    };
+    const manifest = new RunLaunchManifestService().compile(
+      input({
+        sandboxPolicy: brokeredPolicy,
+        runtime: {
+          ...input().runtime,
+          credentialReferences: ['env:OPENAI_API_KEY', 'github-token'],
+        },
+      })
+    );
+
+    expect(manifest.credentials).toMatchObject({
+      brokerState: 'blocked',
+      references: expect.arrayContaining([
+        expect.objectContaining({
+          reference: 'github-token',
+          classification: 'task-integration',
+          delivery: 'blocked',
+        }),
+      ]),
+    });
+    expect(manifest.enforcement).toMatchObject({
+      enforceable: false,
+      blockers: expect.arrayContaining([
+        expect.objectContaining({ code: 'credential-boundary-unavailable' }),
+      ]),
+    });
   });
 
   it('fails closed for declared tools, MCP servers, permissions, and health checks without enforcement', () => {

--- a/server/src/schemas/run-launch-manifest-schemas.ts
+++ b/server/src/schemas/run-launch-manifest-schemas.ts
@@ -1,11 +1,13 @@
 import { z } from 'zod';
 import {
   HARNESS_SUPPORT_TIERS,
+  RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION,
   RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
   type RunLaunchManifest,
 } from '@veritas-kanban/shared';
 import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
 import { calculateRunLaunchManifestDigest } from '../utils/run-launch-manifest-digest.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
 import { containsUnredactedProviderRuntimeSecret } from '../utils/provider-runtime-manifest-sanitize.js';
 
 const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
@@ -155,6 +157,44 @@ export const RunLaunchManifestSchema = z
         credentialReferences: z.array(z.string().trim().min(1).max(300)).max(128),
       })
       .strict(),
+    credentials: z
+      .object({
+        schemaVersion: z.literal(RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION),
+        digest: digestSchema,
+        mode: z.enum(['none', 'brokered', 'env-passthrough']),
+        brokerState: z.enum(['not-required', 'supported', 'blocked']),
+        providerRuntimeManifestDigest: digestSchema,
+        providerRuntimeProbeRevision: z.number().int().positive(),
+        references: z
+          .array(
+            z
+              .object({
+                reference: z.string().trim().min(1).max(300),
+                classification: z.enum([
+                  'harness-boot-authentication',
+                  'task-integration',
+                  'compatibility-passthrough',
+                ]),
+                delivery: z.enum([
+                  'provider-native-environment',
+                  'brokered-boundary',
+                  'raw-environment',
+                  'blocked',
+                ]),
+                boundary: z.enum([
+                  'provider-process',
+                  'tool-control-plane',
+                  'egress-gateway',
+                  'unavailable',
+                ]),
+                risk: z.enum(['provider-required', 'brokered', 'high-risk', 'blocked']),
+              })
+              .strict()
+          )
+          .max(256),
+      })
+      .strict()
+      .optional(),
     tools: z
       .object({
         allowed: stringListSchema,
@@ -259,6 +299,26 @@ export const RunLaunchManifestSchema = z
   })
   .strict()
   .superRefine((manifest, context) => {
+    if (manifest.credentials) {
+      const { digest, ...payload } = manifest.credentials;
+      if (digest !== digestRunLaunchValue(payload)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['credentials', 'digest'],
+          message: 'Credential plan digest does not match its canonical payload',
+        });
+      }
+      if (
+        manifest.credentials.providerRuntimeManifestDigest !== manifest.providerRuntime.digest ||
+        manifest.credentials.providerRuntimeProbeRevision !== manifest.providerRuntime.probeRevision
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['credentials', 'providerRuntimeManifestDigest'],
+          message: 'Credential plan provider evidence does not match the launch manifest',
+        });
+      }
+    }
     if (manifest.enforcement.enforceable !== (manifest.enforcement.blockers.length === 0)) {
       context.addIssue({
         code: 'custom',

--- a/server/src/services/provider-launch-credential-plan-service.ts
+++ b/server/src/services/provider-launch-credential-plan-service.ts
@@ -1,0 +1,92 @@
+import type {
+  ExecutableAgentProvider,
+  ProviderRuntimeManifest,
+  RunLaunchCredentialPlan,
+  RunLaunchCredentialReference,
+  RunLaunchRuntime,
+  SandboxPolicyDryRunResult,
+} from '@veritas-kanban/shared';
+import { RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
+
+const CREDENTIAL_ENV_KEY_PATTERN =
+  /(?:^|_)(?:API_KEYS?|AUTHORIZATION|AUTH_TOKEN|BEARER|BEARER_TOKEN|COOKIE|CREDENTIALS?|DATABASE_URL|DB_URL|PASSWORD|PASS|PRIVATE_KEY|SECRET|SESSION|SESSION_TOKEN|TOKEN|WEBHOOK)(?:_|$)/i;
+
+const PROVIDER_BOOT_AUTH_KEYS: Record<ExecutableAgentProvider, ReadonlySet<string>> = {
+  openclaw: new Set(['CLAWDBOT_GATEWAY_TOKEN', 'OPENCLAW_GATEWAY_TOKEN']),
+  'codex-cli': new Set(['CODEX_API_KEY', 'OPENAI_API_KEY']),
+  'codex-sdk': new Set(['CODEX_API_KEY', 'OPENAI_API_KEY']),
+  'codex-app-server': new Set(['CODEX_API_KEY', 'OPENAI_API_KEY']),
+  'claude-code': new Set(['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN']),
+  'acp-stdio': new Set(),
+  'hermes-cli': new Set([
+    'ANTHROPIC_API_KEY',
+    'HERMES_API_KEY',
+    'OPENAI_API_KEY',
+    'OPENROUTER_API_KEY',
+  ]),
+};
+
+export function compileProviderLaunchCredentialPlan(input: {
+  provider: string;
+  providerRuntimeManifest: ProviderRuntimeManifest;
+  runtime: RunLaunchRuntime;
+  sandbox: SandboxPolicyDryRunResult;
+}): RunLaunchCredentialPlan {
+  const providerBootAuthKeys =
+    PROVIDER_BOOT_AUTH_KEYS[input.provider as ExecutableAgentProvider] ?? new Set<string>();
+  const taskReferences = new Set(input.sandbox.effective.credentialRefs);
+  const environmentReferences = new Set(
+    input.runtime.credentialReferences
+      .filter((reference) => reference.startsWith('env:'))
+      .map((reference) => reference.slice(4))
+  );
+  for (const key of input.runtime.environmentKeys) {
+    if (CREDENTIAL_ENV_KEY_PATTERN.test(key)) environmentReferences.add(key);
+  }
+
+  const references: RunLaunchCredentialReference[] = [
+    ...[...environmentReferences].map((key): RunLaunchCredentialReference => {
+      const bootAuthentication = providerBootAuthKeys.has(key);
+      return bootAuthentication
+        ? {
+            reference: `env:${key}`,
+            classification: 'harness-boot-authentication',
+            delivery: 'provider-native-environment',
+            boundary: 'provider-process',
+            risk: 'provider-required',
+          }
+        : {
+            reference: `env:${key}`,
+            classification: 'compatibility-passthrough',
+            delivery: 'raw-environment',
+            boundary: 'provider-process',
+            risk: 'high-risk',
+          };
+    }),
+    ...[...taskReferences].map((reference): RunLaunchCredentialReference => ({
+      reference,
+      classification: 'task-integration',
+      delivery: 'blocked',
+      boundary: 'unavailable',
+      risk: 'blocked',
+    })),
+  ].sort(
+    (left, right) =>
+      left.classification.localeCompare(right.classification) ||
+      left.reference.localeCompare(right.reference)
+  );
+
+  const payload: Omit<RunLaunchCredentialPlan, 'digest'> = {
+    schemaVersion: RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION,
+    mode: input.sandbox.preset.credentials.mode,
+    brokerState: taskReferences.size > 0 ? 'blocked' : 'not-required',
+    providerRuntimeManifestDigest: input.providerRuntimeManifest.digest,
+    providerRuntimeProbeRevision: input.providerRuntimeManifest.probeRevision,
+    references,
+  };
+  return {
+    ...payload,
+    digest: digestRunLaunchValue(payload),
+  };
+}

--- a/server/src/services/run-launch-manifest-service.ts
+++ b/server/src/services/run-launch-manifest-service.ts
@@ -6,6 +6,7 @@ import type {
   RunLaunchInstructionReference,
   RunLaunchManifest,
   RunLaunchManifestBlocker,
+  RunLaunchCredentialPlan,
   RunLaunchManifestDriftResult,
   RunLaunchManifestInstructionKind,
   RunLaunchManifestOrigin,
@@ -29,6 +30,7 @@ import {
   digestRunLaunchValue,
 } from '../utils/run-launch-manifest-digest.js';
 import { sanitizeProviderRuntimeDiagnostic } from '../utils/provider-runtime-manifest-sanitize.js';
+import { compileProviderLaunchCredentialPlan } from './provider-launch-credential-plan-service.js';
 
 export interface RunLaunchManifestInstructionInput {
   id: string;
@@ -77,6 +79,7 @@ const MATERIAL_SECTIONS: Array<keyof RunLaunchManifest> = [
   'instructions',
   'workspace',
   'runtime',
+  'credentials',
   'tools',
   'permissions',
   'resources',
@@ -145,11 +148,19 @@ export class RunLaunchManifestService {
         .sort((left, right) => left.id.localeCompare(right.id)),
       warnings: uniqueSorted(input.sandboxPolicy.warnings.map(sanitizeProviderRuntimeDiagnostic)),
     };
+    const runtime = normalizeRuntime(input.runtime);
+    const credentials = compileProviderLaunchCredentialPlan({
+      provider: providerRuntime.provider,
+      providerRuntimeManifest: providerRuntime,
+      runtime,
+      sandbox: input.sandboxPolicy,
+    });
     const blockers = collectBlockers({
       input,
       tools,
       permissions,
       resources,
+      credentials,
       providerRequirements,
       requiredHealthChecks,
       satisfiedHealthChecks,
@@ -233,7 +244,8 @@ export class RunLaunchManifestService {
         baseResolutionSource:
           input.taskEnvelope.workspace.baseResolutionSource ?? 'legacy-launch-head',
       },
-      runtime: normalizeRuntime(input.runtime),
+      runtime,
+      credentials,
       tools,
       permissions,
       resources,
@@ -320,7 +332,9 @@ export function diffRunLaunchManifests(
             ? materialInstructions(parentManifest.instructions)
             : field === 'runtime'
               ? materialRuntime(parentManifest)
-              : parentManifest[field];
+              : field === 'credentials'
+                ? materialCredentials(parentManifest)
+                : parentManifest[field];
     const afterValue =
       field === 'taskEnvelope'
         ? {
@@ -336,7 +350,9 @@ export function diffRunLaunchManifests(
             ? materialInstructions(currentManifest.instructions)
             : field === 'runtime'
               ? materialRuntime(currentManifest)
-              : currentManifest[field];
+              : field === 'credentials'
+                ? materialCredentials(currentManifest)
+                : currentManifest[field];
     const beforeDigest = digestRunLaunchValue(beforeValue);
     const afterDigest = digestRunLaunchValue(afterValue);
     return beforeDigest === afterDigest ? [] : [{ field, beforeDigest, afterDigest }];
@@ -371,6 +387,18 @@ function materialRuntime(manifest: RunLaunchManifest): RunLaunchRuntime {
       )
     ),
   };
+}
+
+function materialCredentials(
+  manifest: RunLaunchManifest
+): Omit<RunLaunchCredentialPlan, 'digest' | 'providerRuntimeManifestDigest'> | undefined {
+  if (!manifest.credentials) return undefined;
+  const {
+    digest: _digest,
+    providerRuntimeManifestDigest: _providerRuntimeManifestDigest,
+    ...material
+  } = manifest.credentials;
+  return material;
 }
 
 function normalizeRuntime(runtime: RunLaunchRuntime): RunLaunchRuntime {
@@ -419,6 +447,7 @@ function collectBlockers({
   tools,
   permissions,
   resources,
+  credentials,
   providerRequirements,
   requiredHealthChecks,
   satisfiedHealthChecks,
@@ -427,6 +456,7 @@ function collectBlockers({
   tools: RunLaunchTools;
   permissions: RunLaunchPermissions;
   resources: RunLaunchResources;
+  credentials: RunLaunchCredentialPlan;
   providerRequirements: RunLaunchManifest['providerRequirements'];
   requiredHealthChecks: string[];
   satisfiedHealthChecks: Set<string>;
@@ -435,6 +465,14 @@ function collectBlockers({
   const add = (code: string, field: string, detail: string, remediation: string): void => {
     blockers.push({ code, field, detail, remediation });
   };
+  if (credentials.brokerState === 'blocked') {
+    add(
+      'credential-boundary-unavailable',
+      'credentials',
+      'Task integration credentials do not have an accepted brokered dispatch boundary.',
+      'Select a credential-free preset until a controlled tool or egress boundary is configured.'
+    );
+  }
   if (
     tools.enforcement !== 'enforced' &&
     (tools.allowed.length > 0 || tools.denied.length > 0 || tools.policyIds.length > 0)

--- a/shared/src/types/run-launch-manifest.types.ts
+++ b/shared/src/types/run-launch-manifest.types.ts
@@ -3,6 +3,7 @@ import type { HarnessSupportTier, HarnessTransport } from './provider-runtime.ty
 import type { ProviderRuntimeCapabilityState } from './provider-runtime.types.js';
 
 export const RUN_LAUNCH_MANIFEST_SCHEMA_VERSION = 'run-launch-manifest/v1' as const;
+export const RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION = 'run-launch-credential-plan/v1' as const;
 
 export type RunLaunchManifestEnforcementState = 'enforced' | 'not-required' | 'unavailable';
 
@@ -104,6 +105,30 @@ export interface RunLaunchRuntime {
   worktree: 'required' | 'supported' | 'provider-managed';
   environmentKeys: string[];
   credentialReferences: string[];
+}
+
+export type RunLaunchCredentialClass =
+  'harness-boot-authentication' | 'task-integration' | 'compatibility-passthrough';
+
+export type RunLaunchCredentialDelivery =
+  'provider-native-environment' | 'brokered-boundary' | 'raw-environment' | 'blocked';
+
+export interface RunLaunchCredentialReference {
+  reference: string;
+  classification: RunLaunchCredentialClass;
+  delivery: RunLaunchCredentialDelivery;
+  boundary: 'provider-process' | 'tool-control-plane' | 'egress-gateway' | 'unavailable';
+  risk: 'provider-required' | 'brokered' | 'high-risk' | 'blocked';
+}
+
+export interface RunLaunchCredentialPlan {
+  schemaVersion: typeof RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION;
+  digest: string;
+  mode: import('./sandbox-policy.types.js').SandboxCredentialMode;
+  brokerState: 'not-required' | 'supported' | 'blocked';
+  providerRuntimeManifestDigest: string;
+  providerRuntimeProbeRevision: number;
+  references: RunLaunchCredentialReference[];
 }
 
 export interface RunLaunchWorkspace {
@@ -209,6 +234,8 @@ export interface RunLaunchManifest {
   /** Present on newly compiled manifests; absent only on pre-6.0 legacy records. */
   workspace?: RunLaunchWorkspace;
   runtime: RunLaunchRuntime;
+  /** Present on newly compiled manifests; absent only on pre-6.0 legacy records. */
+  credentials?: RunLaunchCredentialPlan;
   tools: RunLaunchTools;
   permissions: RunLaunchPermissions;
   resources: RunLaunchResources;


### PR DESCRIPTION
## Summary

- add a versioned, value-free credential plan to new immutable run launch manifests
- classify provider boot authentication, task integration references, and explicit high-risk environment passthrough across every executable adapter
- bind credential evidence to provider runtime evidence and ignore timestamp-only probe refreshes
- fail task integration credentials closed until a controlled tool or egress boundary is available
- split controlled tool-boundary delivery into #962 and update operator, API, security, and release documentation

## Verification

- `pnpm lint`
- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/provider-launch-credential-plan-service.test.ts src/__tests__/run-launch-manifest-service.test.ts`
- `node scripts/check-security-artifacts.mjs`
- `git diff --check`

## Risk and rollback

Pre-v6 manifests remain readable because the credential plan is optional during parsing. Newly compiled task credential launches become stricter and block when no accepted boundary exists. Rollback removes new plan compilation and its blocker; it must not convert task references to raw environment passthrough.

Closes #932
