### PR TITLE
feat: add Grok Build ACP profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,10 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 - The built-in `copilot` profile remains provider `acp-stdio`, pins Copilot CLI
   `v1.0.74`, owns the stdio safety argv, rejects broad allow/remote/TCP/config
   injection, and records public-preview plus incomplete-source limitations.
+- The built-in `grok-build` profile remains provider `acp-stdio`, pins Grok
+  Build `v0.2.111` build `94172f2aa4e5`, launches `grok agent --no-leader
+stdio`, and rejects approval bypass, reauthentication, leader, plugin,
+  endpoint, prompt, and resume argument injection.
 - See `docs/AGENT-PROVIDERS.md` § ACP stdio agent provider.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a disabled-by-default Grok Build profile under the generic ACP
+  provider, pinned to released `v0.2.111` build `94172f2aa4e5`. Veritas now
+  compiles a dedicated no-leader stdio launch, accepts only bounded model,
+  effort, deny, tool, sandbox, and feature-disable controls, classifies Grok
+  boot credentials separately from task credentials, and validates the exact
+  version, capability, and xAI extension handshake. Unknown builds, approval
+  bypass, reauthentication, leader/plugin/endpoint injection, and source
+  provenance claims fail closed. Provider probe evidence advances to revision
+  13 (#920).
 - Added a disabled-by-default GitHub Copilot CLI profile under the generic ACP
   provider, pinned to the `Copilot 1.0.74` public-preview handshake. Veritas
   now owns a safe stdio baseline, compiles bounded restrictive model/effort/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [Buzz Integration](docs/BUZZ-INTEGRATION.md) — signed Squad Chat bridging,
   explicit persona/team import, and a separate disabled-by-default
   `buzz-agent` profile under the generic ACP provider.
+- [Agent Providers](docs/AGENT-PROVIDERS.md#grok-build-acp) — exact-version
+  Grok Build, GitHub Copilot CLI, Buzz Agent, Claude Code, and Codex runtime
+  setup, safety policy, and known limitations.
 - [Sprint Planning SOP](docs/SOP-sprint-planning.md) — epic → sprint → task breakdown.
 - [Multi-Agent Orchestration](docs/SOP-multi-agent-orchestration.md) — PM + worker handoffs.
 - [Cross-Model Code Review](docs/SOP-cross-model-code-review.md) — enforce Claude ↔ GPT reviews.

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -65,7 +65,7 @@ Readiness runs bounded `claude --version`, `claude auth status`, and
 `claude agents --json` probes without a shell. The auth status probe is useful
 diagnostic evidence, but only the explicit bare-mode environment satisfies
 launch authentication. The runtime profile requires an exact
-`2.1.218 (Claude Code)` version match and probe revision 12; version or build
+`2.1.218 (Claude Code)` version match and probe revision 13; version or build
 drift invalidates conformance evidence.
 
 Claude's stream is consumed as bounded JSONL. Partial text/thinking, tool
@@ -192,7 +192,7 @@ starts it without a shell in the assigned task worktree.
 Before changing attempt state, Veritas starts a bounded probe process and sends
 ACP `initialize` with protocol version `1`. The returned agent name, version,
 capabilities, and a deterministic capability digest become
-`provider-runtime-manifest/v1` evidence at probe revision 12. Launch starts a
+`provider-runtime-manifest/v1` evidence at probe revision 13. Launch starts a
 fresh process and rejects capability drift before opening or prompting a
 session.
 
@@ -289,6 +289,45 @@ records that provenance mismatch as a limitation and certifies the exact
 release/version/handshake contract, not unprovable binary-to-source lineage.
 Provider-managed `COPILOT_HOME` is inherited for login state, so the profile
 also reports that it is not a fully isolated bare configuration.
+
+### Grok Build ACP
+
+`grok-build` is a built-in, disabled-by-default runtime profile under
+`acp-stdio`. Veritas tests the released Grok Build `v0.2.111` executable,
+which reports `grok 0.2.111 (94172f2aa4e5) [alpha]` and advertises
+`agentVersion: 0.2.111` in its ACP initialize metadata. The profile requires
+session loading, HTTP/SSE MCP, embedded-context input, no ACP image input, and
+the negotiated `x.ai/fs_notify` and `x.ai/capabilities` extensions.
+
+Veritas owns this process baseline:
+
+```text
+grok [restrictive global policy] agent --no-leader \
+  [--model=<model>] [--reasoning-effort=low|medium|high] stdio
+```
+
+The optional global policy accepts only bounded deny rules, tool allow/removal
+lists, sandbox selection, and feature-disable flags. Approval bypass,
+reauthentication, shared-leader attachment, plugin/profile injection, endpoint
+overrides, prompts, worktree creation, and resume flags fail closed before an
+attempt is created. Veritas starts a dedicated process in the assigned
+worktree and owns session creation or loading through ACP.
+
+Authentication is provider-managed. `grok --version` is the only readiness
+probe; it does not authenticate or consume inference. Existing login state is
+read through `GROK_HOME`, or operators can provide the allowlisted
+`XAI_API_KEY`, legacy `GROK_CODE_XAI_API_KEY`, or `GROK_DEPLOYMENT_KEY` boot
+credential. These remain provider authentication, not task credentials.
+
+The exact macOS arm64 release artifact tested on 2026-07-24 has SHA-256
+`e1fafdfffe14f339460befaf194360e8f90bfd02efe8a4f24cfa1c7aea657ffe`.
+The stable channel currently serves an artifact that self-reports `[alpha]`.
+The reported build `94172f2aa4e5` is not present in the public repository, and
+the current public source snapshot is newer than the release artifact.
+Veritas records both provenance limits and certifies the exact executable
+version/build/handshake contract instead of claiming an unprovable source
+mapping. Other platform artifacts must report the same pinned version/build;
+the macOS arm64 artifact is the credential-free smoke baseline.
 
 ## Buzz communication harness
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -424,7 +424,7 @@ Implemented:
   successful provider result fails closed.
 - **Session continuity evidence** — Claude `session_id` is stored on the attempt
   and separately from turn/item identity in the event schema.
-- **Versioned readiness** — The exact v2.1.218 runtime, probe revision 12,
+- **Versioned readiness** — The exact v2.1.218 runtime, probe revision 13,
   authentication posture, and safe agent-discovery summary determine support
   status.
 - **Capability truth** — The shared approval broker is available, but this

--- a/server/src/__tests__/acp-stdio-provider.test.ts
+++ b/server/src/__tests__/acp-stdio-provider.test.ts
@@ -5,10 +5,17 @@ import {
   BUZZ_AGENT_TESTED_COMMIT,
   BUZZ_AGENT_TESTED_RELEASE,
   buildCopilotAcpArgs,
+  buildGrokBuildAcpArgs,
   COPILOT_ACP_REQUIRED_ARGS,
   COPILOT_ACP_RUNTIME_PROFILE_ID,
   COPILOT_ACP_TESTED_COMMIT,
   COPILOT_ACP_TESTED_RELEASE,
+  GROK_BUILD_ACP_VERSION,
+  GROK_BUILD_REQUIRED_ARGS,
+  GROK_BUILD_RUNTIME_PROFILE_ID,
+  GROK_BUILD_TESTED_BUILD,
+  GROK_BUILD_TESTED_RELEASE,
+  GROK_BUILD_VERSION_OUTPUT,
   openAcpStdio,
   probeAcpStdioRuntime,
 } from '../services/acp-stdio-adapter.js';
@@ -62,7 +69,7 @@ describe('ACP v1 stdio provider adapter', () => {
       protocolVersion: 'acp/v1',
       providerVersion: 'VK ACP fixture 1.3.0',
       providerBuild: expect.stringMatching(/^acp-v1:sha256:[a-f0-9]{64}$/),
-      probeRevision: 12,
+      probeRevision: 13,
     });
     expect(manifest.capabilities.find((capability) => capability.id === 'run.resume')?.state).toBe(
       'supported'
@@ -113,7 +120,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: 'buzz-agent 0.1.0',
       providerBuild: expect.stringMatching(/profile:buzz-agent@1:sha256:/),
-      probeRevision: 12,
+      probeRevision: 13,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(BUZZ_AGENT_TESTED_RELEASE),
@@ -223,7 +230,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: 'Copilot 1.0.74',
       providerBuild: expect.stringMatching(/profile:github-copilot-cli@1:sha256:/),
-      probeRevision: 12,
+      probeRevision: 13,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(COPILOT_ACP_TESTED_RELEASE),
@@ -324,6 +331,203 @@ describe('ACP v1 stdio provider adapter', () => {
     ]) {
       expect(() => buildCopilotAcpArgs({ extraArgs: [argument] })).toThrow(
         /not governed by Veritas/i
+      );
+    }
+  });
+
+  it('recognizes the exact Grok Build profile through the generic ACP provider', async () => {
+    const agent = {
+      type: 'grok-build',
+      name: 'Grok Build',
+      command: FIXTURE_PATH,
+      args: ['--reasoning-effort=high', '--deny=bash(rm)', '--no-memory'],
+      enabled: true,
+      provider: 'acp-stdio' as const,
+      model: 'grok-4.5',
+    };
+    const supportProfile = normalizeHarnessSupportProfile(agent);
+    expect(supportProfile).toMatchObject({
+      id: GROK_BUILD_RUNTIME_PROFILE_ID,
+      adapterId: 'acp-stdio',
+      transport: 'acp',
+      authentication: { kind: 'provider-managed', nonMutating: true },
+      compatibility: { testedVersions: [`Grok Build ${GROK_BUILD_ACP_VERSION}`] },
+      launch: {
+        args: [
+          '--deny=bash(rm)',
+          '--no-memory',
+          ...GROK_BUILD_REQUIRED_ARGS,
+          '--model=grok-4.5',
+          '--reasoning-effort=high',
+          'stdio',
+        ],
+      },
+    });
+
+    const service = new ClawdbotAgentService({
+      async checkAgent() {
+        return {
+          type: agent.type,
+          name: agent.name,
+          enabled: true,
+          configured: true,
+          command: agent.command,
+          executableFound: true,
+          executablePath: agent.command,
+          providerVersion: GROK_BUILD_VERSION_OUTPUT,
+          providerVersionSource: 'grok --version',
+          authenticated: null,
+          healthy: true,
+          checkedAt: '2026-07-24T12:00:00.000Z',
+        };
+      },
+    });
+    const manifest = await service.probeProviderRuntime(agent);
+
+    expect(manifest).toMatchObject({
+      provider: 'acp-stdio',
+      adapter: 'acp-stdio',
+      providerVersion: `Grok Build ${GROK_BUILD_ACP_VERSION}`,
+      providerBuild: expect.stringMatching(/profile:grok-build@1:sha256:/),
+      probeRevision: 13,
+      probe: {
+        diagnostics: expect.arrayContaining([
+          expect.stringContaining(GROK_BUILD_TESTED_RELEASE),
+          expect.stringContaining(GROK_BUILD_TESTED_BUILD),
+          expect.stringContaining('stable-artifact-reports-alpha-channel'),
+        ]),
+      },
+    });
+    expect(manifest.capabilities.find((capability) => capability.id === 'run.resume')?.state).toBe(
+      'supported'
+    );
+  });
+
+  it('uses the safe Grok Build version probe without attempting authentication', async () => {
+    const agent = {
+      type: 'grok-build',
+      name: 'Grok Build',
+      command: 'grok',
+      args: [],
+      enabled: true,
+      provider: 'acp-stdio' as const,
+    };
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'which') return { stdout: '/usr/local/bin/grok\n', stderr: '' };
+      if (command === 'grok' && args.join(' ') === '--version') {
+        return { stdout: `${GROK_BUILD_VERSION_OUTPUT}\n`, stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+    });
+    const health = await new AgentHealthService(runCommand).checkAgent({
+      ...agent,
+      supportProfile: normalizeHarnessSupportProfile(agent),
+    });
+
+    expect(health).toMatchObject({
+      executableFound: true,
+      providerVersion: GROK_BUILD_VERSION_OUTPUT,
+      providerVersionSource: 'grok --version',
+      authenticated: null,
+      healthy: true,
+    });
+    expect(runCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails Grok Build identity, version, capability, and extension drift closed', async () => {
+    for (const mode of [
+      'grok-wrong-name',
+      'grok-wrong-version',
+      'grok-wrong-capabilities',
+      'grok-wrong-extension',
+    ]) {
+      await expect(
+        probeAcpStdioRuntime({
+          ...options(mode),
+          runtimeProfileId: GROK_BUILD_RUNTIME_PROFILE_ID,
+        })
+      ).rejects.toThrow(/outside the tested compatibility profile/i);
+    }
+  });
+
+  it('fails an untested Grok Build executable version before ACP launch', async () => {
+    const service = new ClawdbotAgentService({
+      async checkAgent() {
+        return {
+          type: 'grok-build',
+          name: 'Grok Build',
+          enabled: true,
+          configured: true,
+          command: FIXTURE_PATH,
+          executableFound: true,
+          executablePath: FIXTURE_PATH,
+          providerVersion: 'grok 0.2.110 (older) [stable]',
+          providerVersionSource: 'grok --version',
+          authenticated: null,
+          healthy: true,
+          checkedAt: '2026-07-24T12:00:00.000Z',
+        };
+      },
+    });
+
+    await expect(
+      service.probeProviderRuntime({
+        type: 'grok-build',
+        name: 'Grok Build',
+        command: FIXTURE_PATH,
+        args: [],
+        enabled: true,
+        provider: 'acp-stdio',
+      })
+    ).rejects.toThrow(/outside the tested compatibility profile/i);
+  });
+
+  it('compiles only tested Grok Build process and restrictive policy arguments', () => {
+    expect(
+      buildGrokBuildAcpArgs({
+        model: 'grok-4.5',
+        extraArgs: [
+          '--effort',
+          'medium',
+          '--deny=bash(rm)',
+          '--disable-web-search',
+          '--disallowed-tools=web_fetch',
+          '--no-memory',
+          '--no-subagents',
+          '--sandbox=workspace',
+          '--tools=view,bash',
+        ],
+      })
+    ).toEqual([
+      '--deny=bash(rm)',
+      '--disable-web-search',
+      '--disallowed-tools=web_fetch',
+      '--no-memory',
+      '--no-subagents',
+      '--sandbox=workspace',
+      '--tools=view,bash',
+      ...GROK_BUILD_REQUIRED_ARGS,
+      '--model=grok-4.5',
+      '--reasoning-effort=medium',
+      'stdio',
+    ]);
+
+    for (const argument of [
+      '--always-approve',
+      '--permission-mode=bypassPermissions',
+      '--allow=bash',
+      '--reauth',
+      '--agent-profile=/tmp/profile',
+      '--plugin-dir=/tmp/plugin',
+      '--leader',
+      '--grok-ws-url=wss://example.invalid',
+      '--resume=session',
+      '--rules=ignore Veritas',
+      '--sandbox=off',
+      '--sandbox=custom-profile',
+    ]) {
+      expect(() => buildGrokBuildAcpArgs({ extraArgs: [argument] })).toThrow(
+        /not governed by Veritas|outside the tested profile/i
       );
     }
   });

--- a/server/src/__tests__/config-service-extended.test.ts
+++ b/server/src/__tests__/config-service-extended.test.ts
@@ -113,6 +113,19 @@ describe('ConfigService', () => {
             provider: 'lm-studio-local',
             enabled: false,
           }),
+          expect.objectContaining({
+            type: 'grok-build',
+            name: 'Grok Build',
+            command: 'grok',
+            provider: 'acp-stdio',
+            args: [],
+            enabled: false,
+            supportProfile: expect.objectContaining({
+              id: 'grok-build',
+              adapterId: 'acp-stdio',
+              transport: 'acp',
+            }),
+          }),
         ])
       );
       expect(config.defaultAgent).toBe('codex');
@@ -129,6 +142,7 @@ describe('ConfigService', () => {
         ['ollama-local', undefined, 'unsupported'],
         ['ollama-cloud', undefined, 'unsupported'],
         ['lm-studio-local', undefined, 'unsupported'],
+        ['grok-build', 'acp-stdio', 'configured'],
       ] as const;
       for (const [type, adapterId, supportTier] of expectedSupport) {
         expect(config.agents.find((agent) => agent.type === type)?.supportProfile).toMatchObject({
@@ -218,6 +232,11 @@ describe('ConfigService', () => {
             type: 'lm-studio-local',
             command: 'lms',
             provider: 'lm-studio-local',
+          }),
+          expect.objectContaining({
+            type: 'grok-build',
+            command: 'grok',
+            provider: 'acp-stdio',
           }),
         ])
       );

--- a/server/src/__tests__/fixtures/acp-v1-agent.mjs
+++ b/server/src/__tests__/fixtures/acp-v1-agent.mjs
@@ -3,9 +3,14 @@ import process from 'node:process';
 import readline from 'node:readline';
 
 // Stable ACP v1 fixture aligned with @agentclientprotocol/sdk 1.3.0.
-const mode = process.argv.includes('--acp') ? 'copilot' : (process.argv[2] ?? 'complete');
+const mode = process.argv.includes('--acp')
+  ? 'copilot'
+  : process.argv.includes('--no-leader') && process.argv.includes('stdio')
+    ? 'grok'
+    : (process.argv[2] ?? 'complete');
 const buzzMode = mode.startsWith('buzz');
 const copilotMode = mode.startsWith('copilot');
+const grokMode = mode.startsWith('grok');
 const lines = readline.createInterface({ input: process.stdin });
 let activeSessionId;
 let pendingPromptId;
@@ -27,49 +32,85 @@ lines.on('line', (line) => {
     }
     result(record.id, {
       protocolVersion: 1,
-      agentCapabilities: copilotMode
-        ? mode === 'copilot-wrong-capabilities'
+      agentCapabilities: grokMode
+        ? mode === 'grok-wrong-capabilities'
           ? {
               loadSession: false,
-              promptCapabilities: { image: false, audio: false, embeddedContext: false },
+              promptCapabilities: { image: true, audio: false, embeddedContext: false },
               mcpCapabilities: { http: false, sse: false },
               sessionCapabilities: {},
             }
           : {
               loadSession: true,
-              promptCapabilities: { image: true, audio: false, embeddedContext: true },
+              promptCapabilities: { image: false, audio: false, embeddedContext: true },
               mcpCapabilities: { http: true, sse: true },
-              sessionCapabilities: { list: {} },
+              sessionCapabilities: {},
+              _meta: {
+                'x.ai/fs_notify': mode !== 'grok-wrong-extension',
+                'x.ai/capabilities': {
+                  toolOverrides: {
+                    x_keyword_search: true,
+                  },
+                },
+              },
             }
-        : buzzMode
-          ? {
-              loadSession: false,
-              promptCapabilities: { image: false, audio: false, embeddedContext: false },
-              mcpCapabilities: { http: false, sse: false },
-            }
-          : mode === 'no-resume'
-            ? { loadSession: false, sessionCapabilities: {} }
+        : copilotMode
+          ? mode === 'copilot-wrong-capabilities'
+            ? {
+                loadSession: false,
+                promptCapabilities: { image: false, audio: false, embeddedContext: false },
+                mcpCapabilities: { http: false, sse: false },
+                sessionCapabilities: {},
+              }
             : {
                 loadSession: true,
+                promptCapabilities: { image: true, audio: false, embeddedContext: true },
                 mcpCapabilities: { http: true, sse: true },
-                sessionCapabilities: { resume: {}, fork: {}, close: {} },
-              },
+                sessionCapabilities: { list: {} },
+              }
+          : buzzMode
+            ? {
+                loadSession: false,
+                promptCapabilities: { image: false, audio: false, embeddedContext: false },
+                mcpCapabilities: { http: false, sse: false },
+              }
+            : mode === 'no-resume'
+              ? { loadSession: false, sessionCapabilities: {} }
+              : {
+                  loadSession: true,
+                  mcpCapabilities: { http: true, sse: true },
+                  sessionCapabilities: { resume: {}, fork: {}, close: {} },
+                },
       ...(mode === 'no-info'
         ? {}
         : {
-            agentInfo: copilotMode
-              ? {
-                  name: mode === 'copilot-wrong-name' ? 'copilot-cli' : 'Copilot',
-                  title: 'Copilot',
-                  version: mode === 'copilot-wrong-version' ? '1.0.75' : '1.0.74',
-                }
-              : buzzMode
-                ? {
-                    name: mode === 'buzz-wrong-name' ? 'buzz-acp' : 'buzz-agent',
-                    version: mode === 'buzz-wrong-version' ? '0.2.0' : '0.1.0',
-                  }
-                : { name: 'VK ACP fixture', version: '1.3.0' },
+            ...(grokMode && mode !== 'grok-wrong-name'
+              ? {}
+              : {
+                  agentInfo: copilotMode
+                    ? {
+                        name: mode === 'copilot-wrong-name' ? 'copilot-cli' : 'Copilot',
+                        title: 'Copilot',
+                        version: mode === 'copilot-wrong-version' ? '1.0.75' : '1.0.74',
+                      }
+                    : buzzMode
+                      ? {
+                          name: mode === 'buzz-wrong-name' ? 'buzz-acp' : 'buzz-agent',
+                          version: mode === 'buzz-wrong-version' ? '0.2.0' : '0.1.0',
+                        }
+                      : grokMode
+                        ? { name: 'grok', version: '0.2.111' }
+                        : { name: 'VK ACP fixture', version: '1.3.0' },
+                }),
           }),
+      ...(grokMode
+        ? {
+            _meta: {
+              grokShell: true,
+              agentVersion: mode === 'grok-wrong-version' ? '0.2.112' : '0.2.111',
+            },
+          }
+        : {}),
     });
     return;
   }

--- a/server/src/__tests__/provider-launch-credential-plan-service.test.ts
+++ b/server/src/__tests__/provider-launch-credential-plan-service.test.ts
@@ -119,6 +119,7 @@ describe('provider launch credential plan', () => {
     for (const [harnessProfileId, key] of [
       ['buzz-agent', 'OPENAI_COMPAT_API_KEY'],
       ['github-copilot-cli', 'COPILOT_GITHUB_TOKEN'],
+      ['grok-build', 'XAI_API_KEY'],
     ] as const) {
       const plan = compileProviderLaunchCredentialPlan({
         provider: 'acp-stdio',

--- a/server/src/services/acp-stdio-adapter.ts
+++ b/server/src/services/acp-stdio-adapter.ts
@@ -88,6 +88,121 @@ export const COPILOT_ACP_ENVIRONMENT_KEYS = [
   'COPILOT_PROVIDER_WIRE_MODEL',
   'GH_HOST',
 ] as const;
+
+export const GROK_BUILD_RUNTIME_PROFILE_ID = 'grok-build';
+export const GROK_BUILD_RUNTIME_PROFILE_REVISION = 1;
+export const GROK_BUILD_TESTED_RELEASE = 'v0.2.111';
+export const GROK_BUILD_TESTED_BUILD = '94172f2aa4e5';
+export const GROK_BUILD_TESTED_BINARY_SHA256 =
+  'e1fafdfffe14f339460befaf194360e8f90bfd02efe8a4f24cfa1c7aea657ffe';
+export const GROK_BUILD_ACP_VERSION = '0.2.111';
+export const GROK_BUILD_VERSION_OUTPUT = `grok ${GROK_BUILD_ACP_VERSION} (${GROK_BUILD_TESTED_BUILD}) [alpha]`;
+export const GROK_BUILD_CREDENTIAL_ENV_KEYS = [
+  'GROK_CODE_XAI_API_KEY',
+  'GROK_DEPLOYMENT_KEY',
+  'XAI_API_KEY',
+] as const;
+export const GROK_BUILD_ENVIRONMENT_KEYS = [
+  'GROK_DISABLE_API_KEY_AUTH',
+  'GROK_FEEDBACK_ENABLED',
+  'GROK_HOME',
+  'GROK_SANDBOX',
+  'GROK_TELEMETRY_ENABLED',
+  'GROK_TRACE_UPLOAD',
+] as const;
+export const GROK_BUILD_REQUIRED_ARGS = ['agent', '--no-leader'] as const;
+const GROK_BUILD_RESTRICTIVE_BOOLEAN_FLAGS = new Set([
+  '--disable-web-search',
+  '--no-memory',
+  '--no-plan',
+  '--no-subagents',
+]);
+const GROK_BUILD_RESTRICTIVE_REPEATABLE_FLAGS = new Set(['--deny']);
+const GROK_BUILD_RESTRICTIVE_SINGLE_VALUE_FLAGS = new Set([
+  '--disallowed-tools',
+  '--sandbox',
+  '--tools',
+]);
+const GROK_BUILD_SANDBOX_PROFILES = new Set(['read-only', 'strict', 'workspace']);
+const GROK_BUILD_EFFORT_FLAGS = new Set(['--effort', '--reasoning-effort']);
+const GROK_BUILD_EFFORT_LEVELS = new Set(['low', 'medium', 'high']);
+
+export function buildGrokBuildAcpArgs(input: {
+  model?: string;
+  extraArgs?: readonly string[];
+}): string[] {
+  const globalArgs: string[] = [];
+  const agentArgs: string[] = ['--no-leader'];
+  if (input.model !== undefined) {
+    agentArgs.push(`--model=${boundedGrokBuildArgumentValue('--model', input.model, 200)}`);
+  }
+
+  const extraArgs = input.extraArgs ?? [];
+  const seenSingleValueFlags = new Set<string>();
+  for (let index = 0; index < extraArgs.length; index += 1) {
+    const raw = extraArgs[index]?.trim() ?? '';
+    const separator = raw.indexOf('=');
+    const flag = separator >= 0 ? raw.slice(0, separator) : raw;
+    if (GROK_BUILD_RESTRICTIVE_BOOLEAN_FLAGS.has(flag)) {
+      if (separator >= 0 || seenSingleValueFlags.has(flag)) {
+        throw new ConflictError(`Grok Build ACP ${flag} may be configured only once.`);
+      }
+      seenSingleValueFlags.add(flag);
+      globalArgs.push(flag);
+      continue;
+    }
+
+    const isEffort = GROK_BUILD_EFFORT_FLAGS.has(flag);
+    const accepted =
+      isEffort ||
+      GROK_BUILD_RESTRICTIVE_REPEATABLE_FLAGS.has(flag) ||
+      GROK_BUILD_RESTRICTIVE_SINGLE_VALUE_FLAGS.has(flag);
+    if (!accepted) {
+      throw new ConflictError('Grok Build ACP launch argument is not governed by Veritas.', {
+        argument: sanitizeProviderRuntimeDiagnostic(raw),
+        remediation:
+          'Use the agent model field or the documented restrictive Grok Build ACP profile arguments.',
+      });
+    }
+
+    let value = separator >= 0 ? raw.slice(separator + 1) : undefined;
+    if (value === undefined) {
+      index += 1;
+      value = extraArgs[index];
+    }
+    const normalizedValue = boundedGrokBuildArgumentValue(flag, value, 1_000);
+    const canonicalFlag = isEffort ? '--reasoning-effort' : flag;
+    if (isEffort || GROK_BUILD_RESTRICTIVE_SINGLE_VALUE_FLAGS.has(flag)) {
+      if (seenSingleValueFlags.has(canonicalFlag)) {
+        throw new ConflictError(`Grok Build ACP ${canonicalFlag} may be configured only once.`);
+      }
+      seenSingleValueFlags.add(canonicalFlag);
+    }
+    if (isEffort && !GROK_BUILD_EFFORT_LEVELS.has(normalizedValue)) {
+      throw new ConflictError('Grok Build ACP reasoning effort is outside the tested profile.', {
+        effort: normalizedValue,
+      });
+    }
+    if (canonicalFlag === '--sandbox' && !GROK_BUILD_SANDBOX_PROFILES.has(normalizedValue)) {
+      throw new ConflictError('Grok Build ACP sandbox is outside the tested profile.', {
+        sandbox: normalizedValue,
+      });
+    }
+    const target = isEffort ? agentArgs : globalArgs;
+    target.push(`${canonicalFlag}=${normalizedValue}`);
+  }
+  return [...globalArgs, ...GROK_BUILD_REQUIRED_ARGS, ...agentArgs.slice(1), 'stdio'];
+}
+
+export function assertGrokBuildVersionEvidence(version: string | undefined): void {
+  if (version?.trim() === GROK_BUILD_VERSION_OUTPUT) return;
+  throw new ConflictError('Grok Build executable is outside the tested compatibility profile.', {
+    expected: GROK_BUILD_VERSION_OUTPUT,
+    received: sanitizeProviderRuntimeDiagnostic(version?.trim() || 'unknown'),
+    remediation: `Install Grok Build ${GROK_BUILD_TESTED_RELEASE}, then run \`vk doctor\`.`,
+  });
+}
+
 const COPILOT_ACP_SECRET_ENV_ARG = `--secret-env-vars=${COPILOT_ACP_CREDENTIAL_ENV_KEYS.join(',')}`;
 export const COPILOT_ACP_REQUIRED_ARGS = [
   '--acp',
@@ -327,7 +442,7 @@ class AcpStdioConnection implements AcpStdioControl {
         ACP_STARTUP_TIMEOUT_MS
       );
       const probe = applyAcpRuntimeProfile(
-        parseInitializeResponse(initialized, path.basename(command)),
+        parseInitializeResponse(initialized, path.basename(command), options.runtimeProfileId),
         options.runtimeProfileId
       );
       return new AcpStdioConnection(child, peer, probe, options);
@@ -438,7 +553,11 @@ class AcpStdioConnection implements AcpStdioControl {
   }
 }
 
-function parseInitializeResponse(value: unknown, fallbackName: string): AcpRuntimeProbe {
+function parseInitializeResponse(
+  value: unknown,
+  fallbackName: string,
+  runtimeProfileId?: string
+): AcpRuntimeProbe {
   const record = requiredRecord(value, 'ACP initialize response');
   if (record.protocolVersion !== ACP_PROTOCOL_VERSION) {
     throw new ConflictError('ACP agent selected an unsupported protocol version.', {
@@ -448,13 +567,23 @@ function parseInitializeResponse(value: unknown, fallbackName: string): AcpRunti
   }
   const capabilities = optionalRecord(record.agentCapabilities) as AcpAgentCapabilities;
   const agentInfoRecord = optionalRecord(record.agentInfo);
+  const extensionMetadata = optionalRecord(record._meta);
+  const grokBuildExtension =
+    runtimeProfileId === GROK_BUILD_RUNTIME_PROFILE_ID &&
+    extensionMetadata.grokShell === true &&
+    optionalString(extensionMetadata.agentVersion)
+      ? {
+          name: 'Grok Build',
+          version: optionalString(extensionMetadata.agentVersion),
+        }
+      : undefined;
   const agentInfo = {
-    name: optionalString(agentInfoRecord.name) ?? fallbackName,
+    name: optionalString(agentInfoRecord.name) ?? grokBuildExtension?.name ?? fallbackName,
     ...(optionalString(agentInfoRecord.title)
       ? { title: optionalString(agentInfoRecord.title) }
       : {}),
-    ...(optionalString(agentInfoRecord.version)
-      ? { version: optionalString(agentInfoRecord.version) }
+    ...((optionalString(agentInfoRecord.version) ?? grokBuildExtension?.version)
+      ? { version: optionalString(agentInfoRecord.version) ?? grokBuildExtension?.version }
       : {}),
   };
   return {
@@ -473,6 +602,9 @@ function applyAcpRuntimeProfile(
   if (runtimeProfileId === BUZZ_AGENT_RUNTIME_PROFILE_ID) return applyBuzzRuntimeProfile(probe);
   if (runtimeProfileId === COPILOT_ACP_RUNTIME_PROFILE_ID) {
     return applyCopilotRuntimeProfile(probe);
+  }
+  if (runtimeProfileId === GROK_BUILD_RUNTIME_PROFILE_ID) {
+    return applyGrokBuildRuntimeProfile(probe);
   }
   throw new ConflictError('Configured ACP runtime profile is not registered.', {
     runtimeProfileId,
@@ -590,6 +722,72 @@ function applyCopilotRuntimeProfile(probe: AcpRuntimeProbe): AcpRuntimeProbe {
   };
 }
 
+function applyGrokBuildRuntimeProfile(probe: AcpRuntimeProbe): AcpRuntimeProbe {
+  const extensionMetadata = optionalRecord(probe.capabilities._meta);
+  const failures = [
+    ...(probe.agentInfo.name !== 'Grok Build'
+      ? [`Expected Grok Build ACP identity, received ${probe.agentInfo.name}.`]
+      : []),
+    ...(probe.agentInfo.version !== GROK_BUILD_ACP_VERSION
+      ? [
+          `Expected Grok Build ACP version ${GROK_BUILD_ACP_VERSION}, received ${
+            probe.agentInfo.version ?? 'unknown'
+          }.`,
+        ]
+      : []),
+    ...(probe.capabilities.loadSession === true
+      ? []
+      : ['The tested Grok Build profile requires loadSession: true.']),
+    ...(probe.capabilities.mcpCapabilities?.http === true &&
+    probe.capabilities.mcpCapabilities?.sse === true
+      ? []
+      : ['The tested Grok Build profile requires HTTP and SSE MCP capability evidence.']),
+    ...(probe.capabilities.promptCapabilities?.image === false &&
+    probe.capabilities.promptCapabilities?.embeddedContext === true
+      ? []
+      : [
+          'The tested Grok Build profile requires image: false and embeddedContext: true prompt capability evidence.',
+        ]),
+    ...(extensionMetadata['x.ai/fs_notify'] === true
+      ? []
+      : ['The tested Grok Build profile requires negotiated x.ai/fs_notify extension evidence.']),
+    ...(optionalRecord(extensionMetadata['x.ai/capabilities']).toolOverrides
+      ? []
+      : ['The tested Grok Build profile requires negotiated x.ai/capabilities evidence.']),
+  ];
+  if (failures.length > 0) {
+    throw new ConflictError('Grok Build ACP runtime is outside the tested compatibility profile.', {
+      runtimeProfileId: GROK_BUILD_RUNTIME_PROFILE_ID,
+      testedRelease: GROK_BUILD_TESTED_RELEASE,
+      testedBuild: GROK_BUILD_TESTED_BUILD,
+      failures,
+    });
+  }
+  const payload = {
+    schemaVersion: ACP_RUNTIME_PROFILE_SCHEMA_VERSION,
+    id: GROK_BUILD_RUNTIME_PROFILE_ID,
+    revision: GROK_BUILD_RUNTIME_PROFILE_REVISION,
+    testedRelease: GROK_BUILD_TESTED_RELEASE,
+    testedCommit: GROK_BUILD_TESTED_BUILD,
+    limitations: [
+      'provider-managed-authentication-not-probed',
+      'inherited-grok-home',
+      'no-acp-image-input',
+      'xai-extensions-version-gated',
+      'public-source-not-binary-provenance',
+      'stable-artifact-reports-alpha-channel',
+      'veritas-stdio-transport-only',
+    ],
+  };
+  return {
+    ...probe,
+    runtimeProfile: {
+      ...payload,
+      digest: `sha256:${createHash('sha256').update(stableJson(payload)).digest('hex')}`,
+    },
+  };
+}
+
 function boundedCopilotArgumentValue(
   flag: string,
   value: string | undefined,
@@ -602,6 +800,22 @@ function boundedCopilotArgumentValue(
   });
   if (!normalized || normalized.length > maxLength || containsControlCharacter) {
     throw new ConflictError(`Copilot ACP ${flag} requires a bounded non-empty value.`);
+  }
+  return normalized;
+}
+
+function boundedGrokBuildArgumentValue(
+  flag: string,
+  value: string | undefined,
+  maxLength: number
+): string {
+  const normalized = value?.trim() ?? '';
+  const containsControlCharacter = [...normalized].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 31 || codePoint === 127;
+  });
+  if (!normalized || normalized.length > maxLength || containsControlCharacter) {
+    throw new ConflictError(`Grok Build ACP ${flag} requires a bounded non-empty value.`);
   }
   return normalized;
 }

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -199,9 +199,12 @@ import {
   type ConversationSource,
 } from './conversation-lifecycle-service.js';
 import {
+  assertGrokBuildVersionEvidence,
   buildCopilotAcpArgs,
+  buildGrokBuildAcpArgs,
   buildSafeAcpEnv,
   COPILOT_ACP_RUNTIME_PROFILE_ID,
+  GROK_BUILD_RUNTIME_PROFILE_ID,
   openAcpStdio,
   probeAcpStdioRuntime,
   type AcpStdioControl,
@@ -3911,6 +3914,9 @@ export class ClawdbotAgentService {
       throw new ConflictError('ACP runtime probe requires an explicit agent configuration.');
     }
     const supportProfile = normalizeHarnessSupportProfile(agentConfig);
+    if (supportProfile.id === GROK_BUILD_RUNTIME_PROFILE_ID) {
+      assertGrokBuildVersionEvidence(context.health.providerVersion);
+    }
     const args = this.buildAcpProviderArgs(agentConfig, supportProfile.id);
     const runtime = await probeAcpStdioRuntime({
       command: agentConfig.command,
@@ -8145,12 +8151,19 @@ export class ClawdbotAgentService {
   }
 
   private buildAcpProviderArgs(agentConfig: AgentConfig, supportProfileId?: string): string[] {
-    return supportProfileId === COPILOT_ACP_RUNTIME_PROFILE_ID
-      ? buildCopilotAcpArgs({
-          model: agentConfig.model,
-          extraArgs: agentConfig.args,
-        })
-      : [...agentConfig.args];
+    if (supportProfileId === COPILOT_ACP_RUNTIME_PROFILE_ID) {
+      return buildCopilotAcpArgs({
+        model: agentConfig.model,
+        extraArgs: agentConfig.args,
+      });
+    }
+    if (supportProfileId === GROK_BUILD_RUNTIME_PROFILE_ID) {
+      return buildGrokBuildAcpArgs({
+        model: agentConfig.model,
+        extraArgs: agentConfig.args,
+      });
+    }
+    return [...agentConfig.args];
   }
 
   private firstConfiguredEnvironmentKey(keys: string[]): string | undefined {

--- a/server/src/services/config-service.ts
+++ b/server/src/services/config-service.ts
@@ -106,6 +106,14 @@ const DEFAULT_CONFIG: AppConfig = {
       provider: 'acp-stdio',
     },
     {
+      type: 'grok-build',
+      name: 'Grok Build',
+      command: 'grok',
+      args: [],
+      enabled: false,
+      provider: 'acp-stdio',
+    },
+    {
       type: 'ollama-local',
       name: 'Ollama Local',
       command: 'ollama',

--- a/server/src/services/harness-support-profile-registry.ts
+++ b/server/src/services/harness-support-profile-registry.ts
@@ -25,11 +25,17 @@ import {
   BUZZ_AGENT_ENVIRONMENT_KEYS,
   BUZZ_AGENT_TESTED_RELEASE,
   buildCopilotAcpArgs,
+  buildGrokBuildAcpArgs,
   COPILOT_ACP_CREDENTIAL_ENV_KEYS,
   COPILOT_ACP_ENVIRONMENT_KEYS,
   COPILOT_ACP_RUNTIME_PROFILE_ID,
   COPILOT_ACP_TESTED_RELEASE,
   COPILOT_ACP_VERSION,
+  GROK_BUILD_ACP_VERSION,
+  GROK_BUILD_CREDENTIAL_ENV_KEYS,
+  GROK_BUILD_ENVIRONMENT_KEYS,
+  GROK_BUILD_RUNTIME_PROFILE_ID,
+  GROK_BUILD_TESTED_RELEASE,
 } from './acp-stdio-adapter.js';
 
 const ALL_PLATFORMS: HarnessSupportProfile['platforms'] = ['darwin', 'linux', 'win32'];
@@ -147,6 +153,22 @@ const DEFINITIONS: Record<string, ProfileDefinition> = {
     'process-text',
     'No executable Gemini CLI adapter is registered.'
   ),
+  'grok-build': {
+    id: GROK_BUILD_RUNTIME_PROFILE_ID,
+    displayName: 'Grok Build',
+    adapterId: 'acp-stdio',
+    transport: 'acp',
+    auth: { kind: 'provider-managed' },
+    environmentAllowlist: [...GROK_BUILD_ENVIRONMENT_KEYS],
+    credentialAllowlist: [...GROK_BUILD_CREDENTIAL_ENV_KEYS],
+    testedVersions: [`Grok Build ${GROK_BUILD_ACP_VERSION}`],
+    documentationUrl: '/docs/AGENT-PROVIDERS.md#grok-build-acp',
+    remediation: [
+      `Install Grok Build ${GROK_BUILD_TESTED_RELEASE} and authenticate with \`grok login\` or XAI_API_KEY.`,
+      'Remove approval bypass, reauthentication, leader, plugin, endpoint, prompt, resume, and arbitrary profile launch arguments.',
+      'Veritas owns the ACP stdio and isolated process baseline; the tested stable artifact currently self-reports an alpha channel.',
+    ],
+  },
   codex: executable(
     'openai-codex-cli',
     'OpenAI Codex CLI',
@@ -302,6 +324,21 @@ export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSuppo
     } catch (error) {
       providerLaunchError =
         error instanceof Error ? error.message : 'Copilot ACP launch configuration is unsafe.';
+    }
+  }
+  if (
+    definition.id === GROK_BUILD_RUNTIME_PROFILE_ID &&
+    definition.adapterId === 'acp-stdio' &&
+    !unsafeLaunchConfiguration
+  ) {
+    try {
+      normalizedProviderArgs = buildGrokBuildAcpArgs({
+        model: agent.model,
+        extraArgs: agent.args,
+      });
+    } catch (error) {
+      providerLaunchError =
+        error instanceof Error ? error.message : 'Grok Build ACP launch configuration is unsafe.';
     }
   }
   const executable = {

--- a/server/src/services/provider-launch-credential-plan-service.ts
+++ b/server/src/services/provider-launch-credential-plan-service.ts
@@ -13,6 +13,8 @@ import {
   BUZZ_AGENT_RUNTIME_PROFILE_ID,
   COPILOT_ACP_CREDENTIAL_ENV_KEYS,
   COPILOT_ACP_RUNTIME_PROFILE_ID,
+  GROK_BUILD_CREDENTIAL_ENV_KEYS,
+  GROK_BUILD_RUNTIME_PROFILE_ID,
 } from './acp-stdio-adapter.js';
 
 const CREDENTIAL_ENV_KEY_PATTERN =
@@ -47,6 +49,9 @@ export function compileProviderLaunchCredentialPlan(input: {
       : []),
     ...(input.harnessProfileId === COPILOT_ACP_RUNTIME_PROFILE_ID
       ? COPILOT_ACP_CREDENTIAL_ENV_KEYS
+      : []),
+    ...(input.harnessProfileId === GROK_BUILD_RUNTIME_PROFILE_ID
+      ? GROK_BUILD_CREDENTIAL_ENV_KEYS
       : []),
   ]);
   const taskReferences = new Set(input.sandbox.effective.credentialRefs);

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -110,7 +110,7 @@ export interface HarnessSupportStatus {
 
 export const PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION = 'provider-runtime-manifest/v1' as const;
 
-export const PROVIDER_RUNTIME_PROBE_REVISION = 12 as const;
+export const PROVIDER_RUNTIME_PROBE_REVISION = 13 as const;
 
 export const KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS = [
   'run.start',


### PR DESCRIPTION
## Summary

- add a disabled `grok-build` runtime profile on the shared ACP v1 stdio adapter
- pin released Grok Build v0.2.111 build `94172f2aa4e5` and fail closed on executable, ACP metadata, capability, or xAI extension drift
- compile a dedicated no-leader launch with bounded model, effort, deny, tool, sandbox, and feature-disable controls
- reject approval bypass, reauthentication, leader, plugin/profile, endpoint, prompt, worktree, resume, and arbitrary launch arguments
- classify Grok login/API credentials as provider boot authentication without mutating auth or consuming inference
- add disabled defaults, readiness remediation, docs, changelog, and probe revision 13

Closes #920

## Verified

- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/acp-stdio-provider.test.ts src/__tests__/provider-launch-credential-plan-service.test.ts src/__tests__/config-service-extended.test.ts` (53 tests)
- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server build`
- `pnpm --filter @veritas-kanban/server typecheck`
- focused ESLint on changed TypeScript files
- `pnpm check:security-artifacts`
- credential-free live initialize using the downloaded macOS arm64 v0.2.111 artifact through the built Veritas adapter

## Provenance limits

The stable-channel artifact self-reports `[alpha]`. Its build identifier is not present in the public repository, whose current source snapshot is newer. The profile records those limits and certifies the exact released executable/version/handshake evidence without claiming an unprovable source mapping. The user's installed Grok binary and authentication were not changed.