### PR TITLE
feat: expose Veritas sessions through ACP stdio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,13 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   Build `v0.2.111` build `94172f2aa4e5`, launches `grok agent --no-leader
 stdio`, and rejects approval bypass, reauthentication, leader, plugin,
   endpoint, prompt, and resume argument injection.
+- `vk acp serve --stdio` exposes one Veritas-managed task as an ACP v1 server
+  view for editors and other ACP clients. Bind with `--task` or require
+  `_meta["veritas/taskId"]` on `session/new`; client-owned MCP catalogs fail
+  closed.
+- ACP client disconnect never stops the durable Veritas run. Reconnect with
+  `session/load` and `_meta["veritas/afterSequence"]`; cancellation uses the
+  conversation interrupt path, not task termination.
 - See `docs/AGENT-PROVIDERS.md` § ACP stdio agent provider.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `vk acp serve --stdio` and `vk acp status --json` to expose a
+  task-bound, provider-neutral ACP v1 server view over Veritas-managed
+  conversations. Fresh prompts retain the immutable task envelope, reconnect
+  replays the causal run journal by cursor, permission requests use the durable
+  approval broker, cancellation interrupts instead of stopping the task, and
+  disconnect leaves the supervised run active. Client-owned MCP catalogs and
+  mismatched worktrees fail closed (#960).
 - Added a disabled-by-default Grok Build profile under the generic ACP
   provider, pinned to released `v0.2.111` build `94172f2aa4e5`. Veritas now
   compiles a dedicated no-leader stdio launch, accepts only bounded model,

--- a/README.md
+++ b/README.md
@@ -728,7 +728,8 @@ vk agents:pending
 - Follow the [Codex Integration SOP](docs/SOP-codex-integration.md) when Codex should implement, review, or delegate Veritas tasks.
 - Use the [Agent Providers guide](docs/AGENT-PROVIDERS.md) when enabling Codex,
   ACP-compatible agents, Ollama, LM Studio, provider-specific routing, or
-  sandbox presets in the web app or macOS app.
+  sandbox presets in the web app or macOS app. It also documents
+  `vk acp serve --stdio` for exposing a Veritas-managed task to ACP clients.
 - Use the [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) when routing work through the HermesAgent roster, enforcing QA evidence, or creating GitHub-backed task templates.
 - Configure Codex MCP access with the [MCP Server Guide](docs/mcp/README.md#codex) so Codex reads and updates Veritas through typed tools instead of one-off HTTP calls.
 

--- a/cli/src/__tests__/acp.test.ts
+++ b/cli/src/__tests__/acp.test.ts
@@ -1,0 +1,400 @@
+import { Buffer } from 'node:buffer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RunApprovalRequest,
+  RunEventEnvelope,
+  RunEventPage,
+  Task,
+} from '@veritas-kanban/shared';
+import { AcpServerView, readAcpStatus, type AcpApiClient } from '../commands/acp.js';
+
+function request(id: number, method: string, params: unknown): string {
+  return JSON.stringify({ jsonrpc: '2.0', id, method, params });
+}
+
+function event(
+  sequence: number,
+  kind: string,
+  payload: Record<string, unknown> = {}
+): RunEventEnvelope {
+  return {
+    schemaVersion: 'run-event/v1',
+    eventId: `event_${sequence}`,
+    taskId: 'task_1',
+    runId: 'attempt_1',
+    attemptId: 'attempt_1',
+    sequence,
+    receivedAt: '2026-07-24T12:00:00.000Z',
+    kind,
+    source: { provider: 'codex-cli', adapter: 'codex-cli', agent: 'codex' },
+    redaction: { status: 'none', fields: [], originalBytes: 1, persistedBytes: 1 },
+    payload,
+    payloadHash: `sha256:${'a'.repeat(64)}`,
+  } as RunEventEnvelope;
+}
+
+function task(attempt?: Task['attempt']): Task {
+  return {
+    id: 'task_1',
+    title: 'ACP task',
+    description: 'Use the ACP view',
+    type: 'code',
+    status: 'in-progress',
+    priority: 'high',
+    project: 'veritas-kanban',
+    created: '2026-07-24T12:00:00.000Z',
+    updated: '2026-07-24T12:00:00.000Z',
+    git: {
+      repo: 'veritas-kanban',
+      branch: 'feat/acp',
+      baseBranch: 'main',
+      worktreePath: '/tmp/task_1',
+    },
+    ...(attempt ? { attempt, attempts: [attempt] } : {}),
+  } as Task;
+}
+
+const approval: RunApprovalRequest = {
+  schemaVersion: 'run-approval/v1',
+  id: 'runapproval_123456789012',
+  workspaceId: 'local',
+  taskId: 'task_1',
+  attemptId: 'attempt_1',
+  provider: 'codex-cli',
+  agentId: 'codex',
+  requestKind: 'approval',
+  actionClass: 'shell',
+  action: 'Run tests',
+  actionHash: `sha256:${'b'.repeat(64)}`,
+  details: 'pnpm test',
+  resourceScope: ['/tmp/task_1'],
+  riskClass: 'medium',
+  evidenceRevision: `sha256:${'c'.repeat(64)}`,
+  providerRequestId: 'provider_approval_1',
+  mobileSafe: true,
+  status: 'pending',
+  revision: 1,
+  createdAt: '2026-07-24T12:00:00.000Z',
+  updatedAt: '2026-07-24T12:00:00.000Z',
+  expiresAt: '2026-07-24T12:30:00.000Z',
+};
+
+describe('vk ACP server view', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('streams one provider-neutral turn through events and the durable approval broker', async () => {
+    const writes: Record<string, unknown>[] = [];
+    const decisions: unknown[] = [];
+    let eventRead = 0;
+    const fakeApi = vi.fn(async (requestPath: string, options?: RequestInit) => {
+      if (requestPath === '/api/auth/context') {
+        return { role: 'admin', workspaceId: 'local', permissions: ['*'] };
+      }
+      if (requestPath === '/api/tasks') return [task()];
+      if (requestPath.endsWith('/status')) return { running: false };
+      if (requestPath.endsWith('/conversation/fresh')) {
+        expect(JSON.parse(String(options?.body))).toMatchObject({
+          message: 'Implement the scoped task',
+          agent: 'codex',
+        });
+        return { attemptId: 'attempt_1' };
+      }
+      if (requestPath.includes('/attempts/attempt_1/events?')) {
+        eventRead += 1;
+        return eventRead === 1
+          ? page([
+              event(1, 'message.delta', { summary: 'Working on it.' }),
+              event(2, 'tool.started', { summary: 'Run tests' }),
+              event(3, 'approval.requested', { approvalId: approval.id }),
+            ])
+          : page([
+              event(4, 'tool.completed', { summary: 'Tests passed', success: true }),
+              event(5, 'run.completed'),
+            ]);
+      }
+      if (requestPath === `/api/run-approvals/${approval.id}`) return approval;
+      if (requestPath === `/api/run-approvals/${approval.id}/decision`) {
+        decisions.push(JSON.parse(String(options?.body)));
+        return { ...approval, status: 'approved' };
+      }
+      throw new Error(`Unexpected API request: ${requestPath}`);
+    }) as AcpApiClient;
+    const server = new AcpServerView({
+      api: fakeApi,
+      agent: 'codex',
+      pollIntervalMs: 1,
+      now: () => Date.parse('2026-07-24T12:00:00.000Z'),
+      write: (record) => writes.push(record as unknown as Record<string, unknown>),
+    });
+
+    await server.acceptLine(
+      request(1, 'initialize', {
+        protocolVersion: 1,
+        clientCapabilities: {},
+        clientInfo: { name: 'fixture', version: '1.0.0' },
+      })
+    );
+    await server.acceptLine(
+      request(2, 'session/new', {
+        cwd: '/tmp/task_1',
+        mcpServers: [],
+        _meta: { 'veritas/taskId': 'task_1' },
+      })
+    );
+    const sessionId = String((writes.at(-1)?.result as Record<string, unknown>).sessionId);
+    const prompt = server.acceptLine(
+      request(3, 'session/prompt', {
+        sessionId,
+        prompt: [{ type: 'text', text: 'Implement the scoped task' }],
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(writes.some((record) => record.method === 'session/request_permission')).toBe(true);
+    });
+    const permission = writes.find((record) => record.method === 'session/request_permission');
+    await server.acceptLine(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: permission?.id,
+        result: { outcome: { outcome: 'selected', optionId: 'allow_once' } },
+      })
+    );
+    await prompt;
+
+    expect(decisions).toEqual([
+      {
+        decision: 'approved',
+        expectedRevision: 1,
+        expectedActionHash: approval.actionHash,
+        note: 'ACP client selected allow once.',
+      },
+    ]);
+    expect(
+      writes.filter((record) => record.method === 'session/update').map((record) => record.params)
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId,
+          update: expect.objectContaining({ sessionUpdate: 'agent_message_chunk' }),
+        }),
+        expect.objectContaining({
+          sessionId,
+          update: expect.objectContaining({ sessionUpdate: 'tool_call' }),
+        }),
+        expect.objectContaining({
+          sessionId,
+          update: expect.objectContaining({ sessionUpdate: 'tool_call_update' }),
+        }),
+      ])
+    );
+    expect(writes.at(-1)).toMatchObject({
+      jsonrpc: '2.0',
+      id: 3,
+      result: { stopReason: 'end_turn' },
+    });
+  });
+
+  it('loads and replays a durable attempt, then cancels it without a stop fallback', async () => {
+    const writes: Record<string, unknown>[] = [];
+    const calls: Array<{ path: string; body?: unknown }> = [];
+    const attempt = {
+      id: 'attempt_1',
+      agent: 'codex',
+      status: 'running',
+      started: '2026-07-24T12:00:00.000Z',
+      conversation: {
+        schemaVersion: 'conversation-lifecycle/v1',
+        mode: 'fresh',
+        intent: 'fresh',
+        state: 'active',
+        contextWindow: {
+          posture: 'healthy',
+          measuredAt: '2026-07-24T12:00:00.000Z',
+        },
+        createdAt: '2026-07-24T12:00:00.000Z',
+        updatedAt: '2026-07-24T12:00:00.000Z',
+      },
+    } as Task['attempt'];
+    const fakeApi = vi.fn(async (requestPath: string, options?: RequestInit) => {
+      calls.push({
+        path: requestPath,
+        ...(options?.body ? { body: JSON.parse(String(options.body)) } : {}),
+      });
+      if (requestPath === '/api/tasks') return [task(attempt)];
+      if (requestPath.includes('/events?')) {
+        return page([event(2, 'message.delta', { summary: 'replayed' })]);
+      }
+      if (requestPath.endsWith('/conversation/interrupt')) {
+        return { delivered: true };
+      }
+      throw new Error(`Unexpected API request: ${requestPath}`);
+    }) as AcpApiClient;
+    const server = new AcpServerView({
+      api: fakeApi,
+      boundTaskId: 'task_1',
+      write: (record) => writes.push(record as unknown as Record<string, unknown>),
+    });
+    const sessionId = `vkacp_${Buffer.from('task_1').toString('base64url')}`;
+
+    await server.acceptLine(
+      request(1, 'session/load', {
+        sessionId,
+        cwd: '/tmp/task_1',
+        mcpServers: [],
+        _meta: { 'veritas/afterSequence': 1 },
+      })
+    );
+    await vi.waitFor(() => {
+      expect(writes.some((record) => record.method === 'session/update')).toBe(true);
+    });
+    await server.acceptLine(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/cancel',
+        params: { sessionId },
+      })
+    );
+
+    expect(calls).toContainEqual({
+      path: '/api/agents/task_1/conversation/interrupt',
+      body: { attemptId: 'attempt_1' },
+    });
+    expect(calls.some((call) => call.path.endsWith('/stop'))).toBe(false);
+  });
+
+  it('disconnects the protocol view without stopping or interrupting the durable run', async () => {
+    const calls: string[] = [];
+    const fakeApi = vi.fn(async (requestPath: string) => {
+      calls.push(requestPath);
+      if (requestPath === '/api/tasks') return [task()];
+      if (requestPath.endsWith('/status')) return { running: false };
+      if (requestPath.endsWith('/conversation/fresh')) return { attemptId: 'attempt_1' };
+      if (requestPath.includes('/events?')) return page([]);
+      throw new Error(`Unexpected API request: ${requestPath}`);
+    }) as AcpApiClient;
+    const server = new AcpServerView({
+      api: fakeApi,
+      boundTaskId: 'task_1',
+      pollIntervalMs: 1,
+      write: vi.fn(),
+    });
+    const sessionId = `vkacp_${Buffer.from('task_1').toString('base64url')}`;
+
+    await server.acceptLine(request(1, 'session/new', { cwd: '/tmp/task_1', mcpServers: [] }));
+    const prompt = server.acceptLine(
+      request(2, 'session/prompt', {
+        sessionId,
+        prompt: [{ type: 'text', text: 'Keep the durable run alive' }],
+      })
+    );
+    await vi.waitFor(() => {
+      expect(calls.some((call) => call.includes('/events?'))).toBe(true);
+    });
+    server.disconnect();
+    await prompt;
+
+    expect(calls.some((call) => call.endsWith('/stop'))).toBe(false);
+    expect(calls.some((call) => call.endsWith('/conversation/interrupt'))).toBe(false);
+  });
+
+  it('uses the same ACP client contract for two configured providers', async () => {
+    const launchedAgents: unknown[] = [];
+
+    for (const agent of ['codex', 'claude']) {
+      const writes: Record<string, unknown>[] = [];
+      const fakeApi = vi.fn(async (requestPath: string, options?: RequestInit) => {
+        if (requestPath === '/api/tasks') return [task()];
+        if (requestPath.endsWith('/status')) return { running: false };
+        if (requestPath.endsWith('/conversation/fresh')) {
+          launchedAgents.push(JSON.parse(String(options?.body)).agent);
+          return { attemptId: 'attempt_1' };
+        }
+        if (requestPath.includes('/events?')) return page([event(1, 'run.completed')]);
+        throw new Error(`Unexpected API request: ${requestPath}`);
+      }) as AcpApiClient;
+      const server = new AcpServerView({
+        api: fakeApi,
+        agent,
+        boundTaskId: 'task_1',
+        write: (record) => writes.push(record as unknown as Record<string, unknown>),
+      });
+
+      await server.acceptLine(request(1, 'session/new', { cwd: '/tmp/task_1', mcpServers: [] }));
+      const sessionId = String((writes.at(-1)?.result as Record<string, unknown>).sessionId);
+      await server.acceptLine(
+        request(2, 'session/prompt', {
+          sessionId,
+          prompt: [{ type: 'text', text: 'Use the selected provider' }],
+        })
+      );
+      expect(writes.at(-1)).toMatchObject({
+        id: 2,
+        result: { stopReason: 'end_turn' },
+      });
+    }
+
+    expect(launchedAgents).toEqual(['codex', 'claude']);
+  });
+
+  it('fails malformed, unsupported, and client-owned tool-catalog requests closed', async () => {
+    const writes: Record<string, unknown>[] = [];
+    const fakeApi = vi.fn(async (requestPath: string) => {
+      if (requestPath === '/api/tasks') return [task()];
+      throw new Error(`Unexpected API request: ${requestPath}`);
+    }) as AcpApiClient;
+    const server = new AcpServerView({
+      api: fakeApi,
+      boundTaskId: 'task_1',
+      write: (record) => writes.push(record as unknown as Record<string, unknown>),
+    });
+
+    await server.acceptLine('{bad');
+    await server.acceptLine(request(2, 'unknown/method', {}));
+    await server.acceptLine(
+      request(3, 'session/new', {
+        cwd: '/tmp/task_1',
+        mcpServers: [{ name: 'unowned', command: 'node', args: [], env: [] }],
+      })
+    );
+
+    expect(writes.map((record) => (record.error as Record<string, unknown>)?.code)).toEqual([
+      -32700, -32601, -32003,
+    ]);
+  });
+
+  it('reports API-backed readiness without claiming provider capabilities', async () => {
+    const ready = await readAcpStatus(
+      vi.fn(async () => ({ role: 'admin', workspaceId: 'local' })) as AcpApiClient
+    );
+    expect(ready).toMatchObject({
+      protocolVersion: 1,
+      transport: 'stdio',
+      ready: true,
+      providerNeutral: true,
+      durableRuns: true,
+      role: 'admin',
+      workspaceId: 'local',
+    });
+
+    const blocked = await readAcpStatus(
+      vi.fn(async () => {
+        throw new Error('API unavailable');
+      }) as AcpApiClient
+    );
+    expect(blocked).toMatchObject({ ready: false, error: 'API unavailable' });
+  });
+});
+
+function page(events: RunEventEnvelope[]): RunEventPage {
+  return {
+    schemaVersion: 'run-event/v1',
+    taskId: 'task_1',
+    attemptId: 'attempt_1',
+    events,
+    nextCursor: events.at(-1)?.sequence ?? 0,
+    hasMore: false,
+  };
+}

--- a/cli/src/__tests__/api-permissions.test.ts
+++ b/cli/src/__tests__/api-permissions.test.ts
@@ -90,6 +90,32 @@ describe('CLI API permission preflight', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('http://vk.test/api/auth/context');
   });
 
+  it('requires agent write permission to start a fresh conversation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        role: 'read-only',
+        isLocalhost: false,
+        permissions: ['agent:read'],
+      })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const api = createGuardedApiClient('http://vk.test', 'reader-key');
+
+    await expect(
+      api('/api/agents/task_1/conversation/fresh', {
+        method: 'POST',
+        body: JSON.stringify({ message: 'blocked' }),
+      })
+    ).rejects.toMatchObject({
+      required: ['agent:write'],
+      path: '/api/agents/task_1/conversation/fresh',
+      method: 'POST',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('requires task write permission for delegated workspace intake', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/cli/src/commands/acp.ts
+++ b/cli/src/commands/acp.ts
@@ -1,0 +1,846 @@
+import { Buffer } from 'node:buffer';
+import path from 'node:path';
+import readline from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import type { Command } from 'commander';
+import type {
+  AcpContentBlock,
+  AcpJsonRpcId,
+  AcpJsonRpcMessage,
+  AcpPromptResponse,
+  ClientAuthContext,
+  RunApprovalRequest,
+  RunEventEnvelope,
+  RunEventPage,
+  Task,
+  TaskAttempt,
+} from '@veritas-kanban/shared';
+import { ACP_PROTOCOL_VERSION } from '@veritas-kanban/shared';
+import { api } from '../utils/api.js';
+
+const MAX_PROTOCOL_LINE_BYTES = 1024 * 1024;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+const ACP_SERVER_NAME = 'Veritas Kanban';
+const ACP_SERVER_VERSION = '6.0.0';
+
+export const ACP_SERVER_METHODS = [
+  'initialize',
+  'session/new',
+  'session/load',
+  'session/resume',
+  'session/prompt',
+  'session/cancel',
+] as const;
+
+export type AcpApiClient = <T>(requestPath: string, options?: RequestInit) => Promise<T>;
+
+export interface AcpServerViewOptions {
+  api?: AcpApiClient;
+  write: (record: AcpJsonRpcMessage) => void;
+  boundTaskId?: string;
+  agent?: string;
+  profileId?: string;
+  pollIntervalMs?: number;
+  now?: () => number;
+}
+
+interface ViewSession {
+  sessionId: string;
+  taskId: string;
+  cwd: string;
+  attemptId?: string;
+  cursor: number;
+  busy: boolean;
+}
+
+interface MethodOutcome {
+  result: unknown;
+  afterResponse?: () => Promise<void>;
+}
+
+interface PendingClientRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export interface AcpStatus {
+  schemaVersion: 'veritas-acp-server-status/v1';
+  protocolVersion: typeof ACP_PROTOCOL_VERSION;
+  transport: 'stdio';
+  ready: boolean;
+  methods: readonly string[];
+  durableRuns: true;
+  providerNeutral: true;
+  role?: string;
+  workspaceId?: string;
+  error?: string;
+}
+
+export class AcpServerView {
+  private readonly apiClient: AcpApiClient;
+  private readonly writeRecord: (record: AcpJsonRpcMessage) => void;
+  private readonly boundTaskId?: string;
+  private readonly agent?: string;
+  private readonly profileId?: string;
+  private readonly pollIntervalMs: number;
+  private readonly now: () => number;
+  private readonly sessions = new Map<string, ViewSession>();
+  private readonly pendingClientRequests = new Map<string | number, PendingClientRequest>();
+  private nextClientRequestId = 1;
+  private disconnected = false;
+
+  constructor(options: AcpServerViewOptions) {
+    this.apiClient = options.api ?? api;
+    this.writeRecord = (record) => {
+      if (!this.disconnected) options.write(record);
+    };
+    this.boundTaskId = options.boundTaskId;
+    this.agent = options.agent;
+    this.profileId = options.profileId;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+    for (const pending of this.pendingClientRequests.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('ACP client disconnected.'));
+    }
+    this.pendingClientRequests.clear();
+  }
+
+  async acceptLine(line: string): Promise<void> {
+    if (Buffer.byteLength(line, 'utf8') > MAX_PROTOCOL_LINE_BYTES) {
+      this.writeError(null, -32600, 'ACP record exceeds the 1 MiB limit.');
+      return;
+    }
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      this.writeError(null, -32700, 'Invalid JSON.');
+      return;
+    }
+    if (!isRecord(record) || record.jsonrpc !== '2.0') {
+      this.writeError(null, -32600, 'Invalid JSON-RPC record.');
+      return;
+    }
+    if ('result' in record || 'error' in record) {
+      this.acceptClientResponse(record);
+      return;
+    }
+    if (typeof record.method !== 'string') {
+      this.writeError(
+        validId(record.id) ? record.id : null,
+        -32600,
+        'JSON-RPC method is required.'
+      );
+      return;
+    }
+    const id = validId(record.id) ? record.id : undefined;
+    if (id === undefined) {
+      await this.handleNotification(record.method, record.params);
+      return;
+    }
+    await this.handleRequest(id, record.method, record.params);
+  }
+
+  private async handleRequest(id: AcpJsonRpcId, method: string, params: unknown): Promise<void> {
+    try {
+      const outcome = await this.dispatch(method, params);
+      this.writeRecord({ jsonrpc: '2.0', id, result: outcome.result });
+      if (outcome.afterResponse) void outcome.afterResponse();
+    } catch (error) {
+      const rpcError = error instanceof AcpViewError ? error : AcpViewError.internal(error);
+      this.writeError(id, rpcError.code, rpcError.message, rpcError.data);
+    }
+  }
+
+  private async handleNotification(method: string, params: unknown): Promise<void> {
+    if (method !== 'session/cancel') return;
+    try {
+      const input = requiredRecord(params, 'session/cancel params');
+      const session = this.requireSession(requiredString(input.sessionId, 'sessionId'));
+      if (!session.attemptId) return;
+      await this.apiClient(
+        `/api/agents/${encodeURIComponent(session.taskId)}/conversation/interrupt`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ attemptId: session.attemptId }),
+        }
+      );
+    } catch {
+      // Notifications have no response. Durable run state remains authoritative.
+    }
+  }
+
+  private async dispatch(method: string, params: unknown): Promise<MethodOutcome> {
+    switch (method) {
+      case 'initialize':
+        return this.initialize(params);
+      case 'session/new':
+        return this.newSession(params);
+      case 'session/load':
+      case 'session/resume':
+        return this.loadSession(params);
+      case 'session/prompt':
+        return this.prompt(params);
+      default:
+        throw new AcpViewError(-32601, `Unsupported ACP method: ${method}`);
+    }
+  }
+
+  private async initialize(params: unknown): Promise<MethodOutcome> {
+    const input = requiredRecord(params, 'initialize params');
+    if (input.protocolVersion !== ACP_PROTOCOL_VERSION) {
+      throw new AcpViewError(-32602, 'Unsupported ACP protocol version.', {
+        expected: ACP_PROTOCOL_VERSION,
+        received: input.protocolVersion,
+      });
+    }
+    await this.apiClient<ClientAuthContext>('/api/auth/context');
+    return {
+      result: {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        agentCapabilities: {
+          loadSession: true,
+          promptCapabilities: { image: false, audio: false, embeddedContext: false },
+          mcpCapabilities: { http: false, sse: false },
+          sessionCapabilities: { resume: {} },
+        },
+        agentInfo: {
+          name: ACP_SERVER_NAME,
+          title: ACP_SERVER_NAME,
+          version: ACP_SERVER_VERSION,
+        },
+        _meta: {
+          'veritas/providerNeutral': true,
+          'veritas/durableRuns': true,
+          'veritas/supportedMethods': ACP_SERVER_METHODS,
+        },
+      },
+    };
+  }
+
+  private async newSession(params: unknown): Promise<MethodOutcome> {
+    const input = requiredRecord(params, 'session/new params');
+    rejectClientMcp(input.mcpServers);
+    const metadata = optionalRecord(input._meta);
+    const taskReference =
+      this.boundTaskId ??
+      optionalString(metadata['veritas/taskId']) ??
+      optionalString(metadata.veritasTaskId);
+    if (!taskReference) {
+      throw new AcpViewError(
+        -32602,
+        'Bind the server with --task or pass _meta["veritas/taskId"].'
+      );
+    }
+    const task = await this.resolveTask(taskReference);
+    const cwd = requiredString(input.cwd, 'cwd');
+    this.assertTaskWorktree(task, cwd);
+    const sessionId = sessionIdForTask(task.id);
+    this.sessions.set(sessionId, {
+      sessionId,
+      taskId: task.id,
+      cwd,
+      cursor: 0,
+      busy: false,
+    });
+    return {
+      result: {
+        sessionId,
+        _meta: { 'veritas/taskId': task.id },
+      },
+    };
+  }
+
+  private async loadSession(params: unknown): Promise<MethodOutcome> {
+    const input = requiredRecord(params, 'session/load params');
+    rejectClientMcp(input.mcpServers);
+    const sessionId = requiredString(input.sessionId, 'sessionId');
+    const taskId = taskIdFromSession(sessionId);
+    if (this.boundTaskId) {
+      const boundTask = await this.resolveTask(this.boundTaskId);
+      if (boundTask.id !== taskId) {
+        throw new AcpViewError(-32003, 'ACP session is outside the bound task scope.');
+      }
+    }
+    const task = await this.resolveTask(taskId);
+    const cwd = requiredString(input.cwd, 'cwd');
+    this.assertTaskWorktree(task, cwd);
+    const metadata = optionalRecord(input._meta);
+    const requestedAttemptId = optionalString(metadata['veritas/attemptId']);
+    const attempt = requestedAttemptId
+      ? findTaskAttempt(task, requestedAttemptId)
+      : latestTaskAttempt(task);
+    if (requestedAttemptId && !attempt) {
+      throw new AcpViewError(-32602, 'Requested Veritas attempt was not found.');
+    }
+    const afterSequence = optionalNonNegativeInteger(metadata['veritas/afterSequence']) ?? 0;
+    const session: ViewSession = {
+      sessionId,
+      taskId: task.id,
+      cwd,
+      attemptId: attempt?.id,
+      cursor: afterSequence,
+      busy: false,
+    };
+    this.sessions.set(sessionId, session);
+    return {
+      result: {},
+      ...(attempt
+        ? {
+            afterResponse: async () => {
+              await this.replayAvailable(session);
+            },
+          }
+        : {}),
+    };
+  }
+
+  private async prompt(params: unknown): Promise<MethodOutcome> {
+    const input = requiredRecord(params, 'session/prompt params');
+    const session = this.requireSession(requiredString(input.sessionId, 'sessionId'));
+    if (session.busy) throw new AcpViewError(-32004, 'An ACP prompt is already active.');
+    const message = promptText(input.prompt);
+    session.busy = true;
+    try {
+      const task = await this.resolveTask(session.taskId);
+      this.assertTaskWorktree(task, session.cwd);
+      const status = await this.apiClient<{ running: boolean; attemptId?: string }>(
+        `/api/agents/${encodeURIComponent(task.id)}/status`
+      );
+      if (status.running) {
+        throw new AcpViewError(-32004, 'The scoped Veritas task already has an active turn.', {
+          attemptId: status.attemptId,
+        });
+      }
+      const source = session.attemptId
+        ? findTaskAttempt(task, session.attemptId)
+        : latestTaskAttempt(task);
+      const result = source?.conversation
+        ? await this.apiClient<{ attemptId: string }>(
+            `/api/agents/${encodeURIComponent(task.id)}/conversation/follow-up`,
+            {
+              method: 'POST',
+              body: JSON.stringify({
+                sourceAttemptId: source.id,
+                message,
+                profileId: this.profileId,
+              }),
+            }
+          )
+        : await this.apiClient<{ attemptId: string }>(
+            `/api/agents/${encodeURIComponent(task.id)}/conversation/fresh`,
+            {
+              method: 'POST',
+              body: JSON.stringify({
+                message,
+                agent: this.profileId ? undefined : this.agent,
+                profileId: this.profileId,
+              }),
+            }
+          );
+      session.attemptId = result.attemptId;
+      session.cursor = 0;
+      const response = await this.streamUntilTerminal(session);
+      return { result: response };
+    } finally {
+      session.busy = false;
+    }
+  }
+
+  private async streamUntilTerminal(session: ViewSession): Promise<AcpPromptResponse> {
+    for (;;) {
+      if (this.disconnected) {
+        throw new AcpViewError(-32006, 'ACP client disconnected from the durable run.');
+      }
+      const page = await this.readEvents(session);
+      for (const event of page.events) {
+        const terminal = await this.projectEvent(session, event);
+        session.cursor = Math.max(session.cursor, event.sequence);
+        if (terminal) return terminal;
+      }
+      if (page.hasMore) continue;
+      await delay(this.pollIntervalMs);
+    }
+  }
+
+  private async replayAvailable(session: ViewSession): Promise<void> {
+    if (!session.attemptId) return;
+    for (;;) {
+      if (this.disconnected) return;
+      const page = await this.readEvents(session);
+      for (const event of page.events) {
+        await this.projectEvent(session, event);
+        session.cursor = Math.max(session.cursor, event.sequence);
+      }
+      if (!page.hasMore) return;
+    }
+  }
+
+  private readEvents(session: ViewSession): Promise<RunEventPage> {
+    if (!session.attemptId) throw new AcpViewError(-32002, 'ACP session has no Veritas attempt.');
+    const query = new URLSearchParams({
+      afterSequence: String(session.cursor),
+      limit: '250',
+    });
+    return this.apiClient<RunEventPage>(
+      `/api/agents/${encodeURIComponent(session.taskId)}/attempts/${encodeURIComponent(
+        session.attemptId
+      )}/events?${query.toString()}`
+    );
+  }
+
+  private async projectEvent(
+    session: ViewSession,
+    event: RunEventEnvelope
+  ): Promise<AcpPromptResponse | undefined> {
+    if (event.kind === 'approval.requested') {
+      await this.relayApproval(session, event);
+      return undefined;
+    }
+    const update = eventToSessionUpdate(event);
+    if (update) {
+      this.writeRecord({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: session.sessionId,
+          update,
+          _meta: {
+            'veritas/eventId': event.eventId,
+            'veritas/sequence': event.sequence,
+          },
+        },
+      });
+    }
+    if (event.kind === 'run.completed') {
+      return {
+        stopReason: 'end_turn',
+        ...(event.payload.usage ? { usage: event.payload.usage } : {}),
+        _meta: { 'veritas/eventId': event.eventId, 'veritas/sequence': event.sequence },
+      };
+    }
+    if (event.kind === 'run.interrupted') {
+      return {
+        stopReason: 'cancelled',
+        _meta: { 'veritas/eventId': event.eventId, 'veritas/sequence': event.sequence },
+      };
+    }
+    if (event.kind === 'run.failed') {
+      return {
+        stopReason: 'refusal',
+        _meta: { 'veritas/eventId': event.eventId, 'veritas/sequence': event.sequence },
+      };
+    }
+    return undefined;
+  }
+
+  private async relayApproval(session: ViewSession, event: RunEventEnvelope): Promise<void> {
+    const approvalId = optionalString(event.payload.approvalId);
+    if (!approvalId) throw new AcpViewError(-32005, 'Approval event is missing its durable ID.');
+    const approval = await this.apiClient<RunApprovalRequest>(
+      `/api/run-approvals/${encodeURIComponent(approvalId)}`
+    );
+    const expiresIn = Math.max(1, Date.parse(approval.expiresAt) - this.now());
+    let response: unknown;
+    let timedOut = false;
+    try {
+      response = await this.requestClient(
+        'session/request_permission',
+        {
+          sessionId: session.sessionId,
+          toolCall: {
+            toolCallId: approval.providerRequestId,
+            title: approval.action,
+            name: approval.actionClass,
+            kind: approval.actionClass,
+            status: 'pending',
+            rawInput: {
+              details: approval.details,
+              resourceScope: approval.resourceScope,
+              riskClass: approval.riskClass,
+              policyReason: approval.policyReason,
+            },
+          },
+          options: [
+            { optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' },
+            { optionId: 'reject_once', name: 'Reject', kind: 'reject_once' },
+          ],
+        },
+        expiresIn
+      );
+    } catch {
+      timedOut = true;
+    }
+    const outcome = optionalRecord(optionalRecord(response).outcome);
+    const selected = optionalString(outcome.outcome);
+    const selectedOption = optionalString(outcome.optionId);
+    const approved = selected === 'selected' && selectedOption === 'allow_once';
+    await this.apiClient(`/api/run-approvals/${encodeURIComponent(approval.id)}/decision`, {
+      method: 'POST',
+      body: JSON.stringify({
+        decision: approved ? 'approved' : 'rejected',
+        expectedRevision: approval.revision,
+        expectedActionHash: approval.actionHash,
+        note: timedOut
+          ? 'ACP client permission request timed out.'
+          : approved
+            ? 'ACP client selected allow once.'
+            : 'ACP client denied or cancelled the request.',
+      }),
+    });
+  }
+
+  private requestClient(method: string, params: unknown, timeoutMs: number): Promise<unknown> {
+    const id = `vk-client-${this.nextClientRequestId++}`;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingClientRequests.delete(id);
+        reject(new Error('ACP client request timed out.'));
+      }, timeoutMs);
+      this.pendingClientRequests.set(id, { resolve, reject, timer });
+      this.writeRecord({ jsonrpc: '2.0', id, method, params });
+    });
+  }
+
+  private acceptClientResponse(record: Record<string, unknown>): void {
+    if (!validId(record.id)) return;
+    const pending = this.pendingClientRequests.get(record.id);
+    if (!pending) return;
+    this.pendingClientRequests.delete(record.id);
+    clearTimeout(pending.timer);
+    if (isRecord(record.error)) {
+      pending.reject(
+        new Error(optionalString(record.error.message) ?? 'ACP client request failed.')
+      );
+      return;
+    }
+    pending.resolve(record.result);
+  }
+
+  private async resolveTask(reference: string): Promise<Task> {
+    const tasks = await this.apiClient<Task[]>('/api/tasks');
+    const exact = tasks.find((task) => task.id === reference);
+    const suffixMatches = exact ? [] : tasks.filter((task) => task.id.endsWith(reference));
+    const task = exact ?? (suffixMatches.length === 1 ? suffixMatches[0] : undefined);
+    if (!task) {
+      throw new AcpViewError(
+        -32003,
+        suffixMatches.length > 1 ? 'Task reference is ambiguous.' : 'Task was not found.'
+      );
+    }
+    return task;
+  }
+
+  private assertTaskWorktree(task: Task, cwd: string): void {
+    const worktree = task.git?.worktreePath;
+    if (!worktree) throw new AcpViewError(-32003, 'Task has no active worktree.');
+    if (path.resolve(worktree) !== path.resolve(cwd)) {
+      throw new AcpViewError(-32003, 'ACP cwd does not match the task worktree.');
+    }
+  }
+
+  private requireSession(sessionId: string): ViewSession {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new AcpViewError(-32002, 'ACP session is not loaded in this process.');
+    return session;
+  }
+
+  private writeError(id: AcpJsonRpcId | null, code: number, message: string, data?: unknown): void {
+    this.writeRecord({
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code,
+        message,
+        ...(data === undefined ? {} : { data }),
+      },
+    });
+  }
+}
+
+export async function readAcpStatus(apiClient: AcpApiClient = api): Promise<AcpStatus> {
+  try {
+    const context = await apiClient<ClientAuthContext>('/api/auth/context');
+    return {
+      schemaVersion: 'veritas-acp-server-status/v1',
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      transport: 'stdio',
+      ready: true,
+      methods: ACP_SERVER_METHODS,
+      durableRuns: true,
+      providerNeutral: true,
+      role: context.role,
+      workspaceId: context.workspaceId,
+    };
+  } catch (error) {
+    return {
+      schemaVersion: 'veritas-acp-server-status/v1',
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      transport: 'stdio',
+      ready: false,
+      methods: ACP_SERVER_METHODS,
+      durableRuns: true,
+      providerNeutral: true,
+      error: boundedError(error),
+    };
+  }
+}
+
+export function runAcpStdioServer(options: {
+  stdin?: Readable;
+  stdout?: Writable;
+  stderr?: Writable;
+  boundTaskId?: string;
+  agent?: string;
+  profileId?: string;
+  api?: AcpApiClient;
+  pollIntervalMs?: number;
+}): void {
+  const input = options.stdin ?? process.stdin;
+  const output = options.stdout ?? process.stdout;
+  const errors = options.stderr ?? process.stderr;
+  const server = new AcpServerView({
+    ...(options.api ? { api: options.api } : {}),
+    boundTaskId: options.boundTaskId,
+    agent: options.agent,
+    profileId: options.profileId,
+    pollIntervalMs: options.pollIntervalMs,
+    write: (record) => {
+      output.write(`${JSON.stringify(record)}\n`);
+    },
+  });
+  input.setEncoding('utf8');
+  const lines = readline.createInterface({ input });
+  lines.on('line', (line) => {
+    void server.acceptLine(line);
+  });
+  lines.on('error', (error) => {
+    errors.write(`ACP stdio input failed: ${boundedError(error)}\n`);
+  });
+  lines.on('close', () => {
+    server.disconnect();
+  });
+}
+
+export function registerAcpCommands(program: Command): void {
+  const acp = program.command('acp').description('Agent Client Protocol server view');
+  acp
+    .command('status')
+    .description('Report ACP server-view readiness')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { json?: boolean }) => {
+      const status = await readAcpStatus();
+      if (options.json) {
+        console.log(JSON.stringify(status, null, 2));
+      } else {
+        console.log(
+          `${status.ready ? 'ready' : 'not ready'}: ACP v${status.protocolVersion} over ${status.transport}`
+        );
+        if (status.error) console.error(status.error);
+      }
+      if (!status.ready) process.exitCode = 1;
+    });
+
+  acp
+    .command('serve')
+    .description('Serve the provider-neutral Veritas ACP view over stdio')
+    .requiredOption('--stdio', 'Use newline-delimited JSON-RPC over stdio')
+    .option('--task <taskId>', 'Bind this process to one Veritas task')
+    .option('--agent <agent>', 'Agent for a fresh scoped conversation')
+    .option('--profile <profileId>', 'Agent profile for a fresh scoped conversation')
+    .action(
+      (options: { stdio: boolean; task?: string; agent?: string; profile?: string }): void => {
+        runAcpStdioServer({
+          boundTaskId: options.task,
+          agent: options.agent,
+          profileId: options.profile,
+        });
+      }
+    );
+}
+
+function eventToSessionUpdate(event: RunEventEnvelope): Record<string, unknown> | undefined {
+  const summary = eventSummary(event);
+  switch (event.kind) {
+    case 'message.delta':
+      return {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: summary },
+      };
+    case 'reasoning.delta':
+      return {
+        sessionUpdate: 'agent_thought_chunk',
+        content: { type: 'text', text: summary },
+      };
+    case 'tool.started':
+      return {
+        sessionUpdate: 'tool_call',
+        toolCallId: event.itemId ?? event.eventId,
+        title: summary,
+        kind: optionalString(event.payload.actionClass) ?? 'other',
+        status: 'in_progress',
+        rawInput: event.payload.input,
+      };
+    case 'tool.completed':
+      return {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: event.itemId ?? event.eventId,
+        status: event.payload.success === false ? 'failed' : 'completed',
+        content: summary ? [{ type: 'content', content: { type: 'text', text: summary } }] : [],
+      };
+    case 'progress':
+      return {
+        sessionUpdate: 'plan',
+        entries: [{ content: summary, priority: 'medium', status: 'in_progress' }],
+      };
+    case 'approval.resolved':
+      return {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: optionalString(event.payload.approvalId) ?? event.eventId,
+        status: event.payload.status === 'approved' ? 'completed' : 'failed',
+        content: summary ? [{ type: 'content', content: { type: 'text', text: summary } }] : [],
+      };
+    case 'run.failed':
+      return summary
+        ? {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: summary },
+          }
+        : undefined;
+    default:
+      return undefined;
+  }
+}
+
+function eventSummary(event: RunEventEnvelope): string {
+  return (
+    optionalString(event.payload.summary) ??
+    optionalString(event.payload.message) ??
+    optionalString(event.payload.error) ??
+    ''
+  );
+}
+
+function promptText(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new AcpViewError(-32602, 'session/prompt requires at least one text block.');
+  }
+  const blocks = value as AcpContentBlock[];
+  const unsupported = blocks.find((block) => !isRecord(block) || block.type !== 'text');
+  if (unsupported) {
+    throw new AcpViewError(-32602, 'The Veritas ACP server view accepts text prompts only.');
+  }
+  const text = blocks
+    .map((block) => (block.type === 'text' ? block.text : ''))
+    .join('\n')
+    .trim();
+  if (!text || text.length > 20_000) {
+    throw new AcpViewError(-32602, 'ACP prompt must contain 1 to 20,000 text characters.');
+  }
+  return text;
+}
+
+function rejectClientMcp(value: unknown): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new AcpViewError(-32602, 'mcpServers must be an array.');
+  if (value.length > 0) {
+    throw new AcpViewError(
+      -32003,
+      'ACP clients cannot override the immutable Veritas run tool catalog.'
+    );
+  }
+}
+
+function sessionIdForTask(taskId: string): string {
+  return `vkacp_${Buffer.from(taskId, 'utf8').toString('base64url')}`;
+}
+
+function taskIdFromSession(sessionId: string): string {
+  if (!/^vkacp_[A-Za-z0-9_-]+$/.test(sessionId)) {
+    throw new AcpViewError(-32602, 'Invalid Veritas ACP session ID.');
+  }
+  try {
+    const taskId = Buffer.from(sessionId.slice('vkacp_'.length), 'base64url').toString('utf8');
+    if (!taskId || Buffer.byteLength(taskId, 'utf8') > 200) throw new Error('invalid');
+    return taskId;
+  } catch {
+    throw new AcpViewError(-32602, 'Invalid Veritas ACP session ID.');
+  }
+}
+
+function latestTaskAttempt(task: Task): TaskAttempt | undefined {
+  const attempts = [task.attempt, ...(task.attempts ?? [])].filter(
+    (attempt): attempt is TaskAttempt => Boolean(attempt)
+  );
+  return attempts.sort((left, right) => {
+    const leftTime = Date.parse(left.started ?? left.ended ?? '') || 0;
+    const rightTime = Date.parse(right.started ?? right.ended ?? '') || 0;
+    return rightTime - leftTime;
+  })[0];
+}
+
+function findTaskAttempt(task: Task, attemptId: string): TaskAttempt | undefined {
+  return [task.attempt, ...(task.attempts ?? [])]
+    .filter((attempt): attempt is TaskAttempt => Boolean(attempt))
+    .find((attempt) => attempt.id === attemptId);
+}
+
+function requiredRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new AcpViewError(-32602, `${label} must be an object.`);
+  return value;
+}
+
+function optionalRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function requiredString(value: unknown, label: string): string {
+  const result = optionalString(value);
+  if (!result) throw new AcpViewError(-32602, `${label} must be a non-empty string.`);
+  return result;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function optionalNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validId(value: unknown): value is AcpJsonRpcId {
+  return typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value));
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function boundedError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/[\r\n\t]+/g, ' ').slice(0, 1_000);
+}
+
+class AcpViewError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+    readonly data?: unknown
+  ) {
+    super(message);
+  }
+
+  static internal(error: unknown): AcpViewError {
+    return new AcpViewError(-32000, boundedError(error));
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { registerSchedulerCommands } from './commands/scheduler.js';
 import { registerQueueMonitorCommands } from './commands/queue-monitors.js';
 import { registerSqliteCommands } from './commands/sqlite.js';
 import { registerToolServerCommands } from './commands/tool-servers.js';
+import { registerAcpCommands } from './commands/acp.js';
 
 const program = new Command();
 const packageJson = JSON.parse(
@@ -59,5 +60,6 @@ registerSchedulerCommands(program);
 registerQueueMonitorCommands(program);
 registerSqliteCommands(program);
 registerToolServerCommands(program);
+registerAcpCommands(program);
 
 program.parse();

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -223,8 +223,36 @@ rules, so a partial catalog fails closed instead of exposing extra tools.
 Credential-bound server definitions remain blocked until brokered delivery
 lands in #962.
 
-The ACP client-facing server view is separate and tracked by #960. This
-provider adapter does not expose Veritas sessions to external editors.
+### Expose Veritas sessions to ACP clients
+
+The inverse ACP server view lets an editor or another ACP client operate one
+Veritas-managed task without creating a second session store:
+
+```bash
+vk acp status --json
+vk acp serve --stdio --task TASK-001
+```
+
+`vk acp status --json` reports API reachability, protocol methods, and the
+authenticated role/workspace context. Individual operations continue through
+the existing permission guard. `vk acp serve --stdio` writes protocol records
+only to stdout. Diagnostics remain on stderr.
+
+The process may bind one task with `--task`; otherwise `session/new` must
+provide `_meta["veritas/taskId"]`. The client cwd must exactly match the
+task's active worktree. A deterministic task-derived ACP session ID maps
+`session/new`, `session/load`, `session/resume`, `session/prompt`, and
+`session/cancel` onto the existing conversation lifecycle, supervisor,
+run-event journal, approval broker, and launch evidence. Optional
+`_meta["veritas/afterSequence"]` provides cursor replay after reconnect.
+
+The first prompt starts a fresh provider conversation while retaining the
+immutable task envelope. Later prompts use the attributed follow-up path.
+Permission requests are relayed to the ACP client and decided through the
+durable exact-action approval broker. Client-owned MCP server definitions are
+rejected because Veritas owns the run tool catalog. Closing stdin or
+disconnecting the client leaves the durable run active; `session/cancel`
+interrupts the current conversation and never invokes task stop.
 
 See [ACP Provider v1 architecture](architecture/ACP-PROVIDER-V1.md).
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -458,6 +458,8 @@ Manage AI agents on code tasks.
 | `vk agent:compact <id> --attempt <id>`                                        | Compact a supported provider conversation                 |
 | `vk agent:archive <id> --attempt <id>`                                        | Archive a supported provider conversation                 |
 | `vk agent:close <id> --attempt <id>`                                          | Close a supported provider conversation                   |
+| `vk acp status --json`                                                        | Check ACP server-view API and permission readiness        |
+| `vk acp serve --stdio [--task <id>]`                                          | Expose a Veritas-managed task to an ACP v1 client         |
 | `vk agents:pending`                                                           | List pending agent requests                               |
 | `vk agents:status <id>`                                                       | Check agent running status                                |
 | `vk agents:complete <id> -s --attempt-id <id> --manifest-digest <sha256:...>` | Mark the matching agent attempt complete (success)        |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -313,6 +313,10 @@ First-class support for autonomous coding agents.
   an explicit provider with negotiated lifecycle capabilities, causal message,
   plan, and tool events, durable approval brokering, supervised cancellation,
   immutable launch evidence, and fail-closed run-scoped MCP injection
+- **ACP server view** — `vk acp serve --stdio` exposes a task-bound,
+  provider-neutral ACP v1 view over Veritas conversation lifecycle, causal
+  replay, tool events, and durable approvals without creating a parallel
+  session store; disconnect leaves the supervised run active
 - **Buzz Agent ACP profile** — A disabled-by-default `buzz-agent` runtime uses
   the generic ACP provider, pins Buzz v0.4.24 compatibility evidence, exposes
   only its tested configuration and boot-authentication environment keys, and

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -434,6 +434,33 @@ describe('agent local capability enforcement', () => {
     expect(mockInterruptConversation).toHaveBeenCalledWith('task_1', 'attempt_1', 'operator_1');
   });
 
+  it('starts a fresh provider-neutral conversation with the operator prompt', async () => {
+    const app = createApp(
+      auth({
+        clientMode: 'desktop-local',
+        capabilities: ['desktop:local'],
+      })
+    );
+
+    const response = await request(app).post('/api/agents/task_1/conversation/fresh').send({
+      agent: 'codex',
+      message: 'Start this task through ACP',
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockStartAgent).toHaveBeenCalledWith(
+      'task_1',
+      'codex',
+      expect.objectContaining({
+        conversation: {
+          mode: 'fresh',
+          intent: 'fresh',
+          message: 'Start this task through ACP',
+        },
+      })
+    );
+  });
+
   it('requires and forwards completion attempt provenance', async () => {
     const app = createApp(auth());
     const digest = `sha256:${'a'.repeat(64)}`;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -163,6 +163,11 @@ const conversationTurnSchema = z
   })
   .strict();
 
+const conversationFreshSchema = conversationTurnSchema
+  .omit({ sourceAttemptId: true, forkTurnId: true })
+  .extend({ agent: AgentTypeSchema.optional() })
+  .strict();
+
 const conversationControlSchema = runControlSchema.strict();
 
 const reportTokensSchema = z.object({
@@ -363,6 +368,32 @@ router.post(
       expectedAttemptId: attemptId,
     });
     res.json(delivery);
+  })
+);
+
+// POST /api/agents/:taskId/conversation/fresh - Start a provider-neutral first turn.
+router.post(
+  '/:taskId/conversation/fresh',
+  requireLocalAgentCapability,
+  asyncHandler(async (req, res) => {
+    let body: z.infer<typeof conversationFreshSchema>;
+    try {
+      body = conversationFreshSchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+    const status = await clawdbotAgentService.startAgent(
+      req.params.taskId as string,
+      body.agent as AgentType | undefined,
+      {
+        ...conversationStartOptions(body),
+        conversation: { mode: 'fresh', intent: 'fresh', message: body.message },
+      }
+    );
+    res.status(201).json(status);
   })
 );
 
@@ -659,7 +690,7 @@ function parseConversationSteer(input: unknown): z.infer<typeof conversationStee
 }
 
 function conversationStartOptions(
-  body: z.infer<typeof conversationTurnSchema>
+  body: z.infer<typeof conversationTurnSchema> | z.infer<typeof conversationFreshSchema>
 ): Omit<AgentStartOptions, 'conversation' | 'parentAttemptId'> {
   return {
     profileId: body.profileId,

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -1305,7 +1305,12 @@ export class ClawdbotAgentService {
     });
     const providerTransport =
       conversationRequest.mode === 'fresh'
-        ? taskTransport
+        ? conversationRequest.message
+          ? {
+              ...taskTransport,
+              content: `${taskTransport.content}\n\n## Operator turn\n\n${conversationRequest.message}`,
+            }
+          : taskTransport
         : {
             ...taskTransport,
             content: renderConversationTurn(
@@ -8241,7 +8246,12 @@ export class ClawdbotAgentService {
       ) {
         throw new ConflictError('Fresh conversation launch cannot reference prior history.');
       }
-      return { mode: 'fresh', intent: 'fresh' };
+      const message = request?.message?.trim();
+      return {
+        mode: 'fresh',
+        intent: 'fresh',
+        ...(message ? { message } : {}),
+      };
     }
     const intent = request.intent ?? request.mode;
     if (

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -188,7 +188,7 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
       },
       {
         methods: ['POST'],
-        path: /^\/[^/]+\/conversation\/(resume|follow-up|fork|interrupt|compact|archive|close)\/?$/,
+        path: /^\/[^/]+\/conversation\/(fresh|resume|follow-up|fork|interrupt|compact|archive|close)\/?$/,
         permissions: 'agent:write',
       },
     ],


### PR DESCRIPTION
## Summary

- add `vk acp serve --stdio` as a task-bound, provider-neutral ACP v1 server view
- map fresh/load/resume/prompt/cancel onto the existing conversation lifecycle, run journal, supervisor, and approval broker
- keep client disconnect non-destructive and reject worktree or client-owned MCP overrides
- add `vk acp status --json` plus operator documentation

## Verification

- 29 focused tests across ACP protocol, API permissions, and conversation routes
- affected shared/server/CLI typechecks and builds
- focused ESLint
- security artifact scan
- built CLI help smoke check

Closes #960