### PR TITLE
feat: bind credential evidence to tool catalogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,11 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   whose built-in type and command both identify `codex` or `hermes` may infer a
   provider during migration; provider-less or profile/adapter-mismatched records
   fail closed before an attempt is created.
+- Credential-bound tool servers persist only exact definition/scope digests and
+  safe target names in `run-tool-catalog/v1`. Discovery strips their source
+  environment/header values, native provider injection omits them, and
+  mediated invocation remains blocked until exact-action lease consumption is
+  available.
 - Classify launch credentials through `run-launch-credential-plan/v1`.
   Provider boot authentication, task integration definition IDs, and explicit
   high-risk environment passthrough are separate classes. Task integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added value-free credential boundary evidence to `run-tool-catalog/v1`.
+  Credential-bound definitions now require enabled MCP-scoped broker
+  definitions, exact source targets, and immutable definition/scope digests.
+  Discovery strips source environment and header values, native provider
+  configuration omits credential-bound servers, covered launch references
+  report a tool-control-plane boundary, and uncovered, drifted, or invoked
+  references remain fail closed pending exact-action lease consumption (#968).
 - Added `vk acp serve --stdio` and `vk acp status --json` to expose a
   task-bound, provider-neutral ACP v1 server view over Veritas-managed
   conversations. Fresh prompts retain the immutable task envelope, reconnect

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -758,20 +758,23 @@ block outstanding leases. Manifest declarations and sandbox broker references
 must match definition IDs exactly.
 
 This core does not make an uncontrolled provider process broker-capable.
-Required brokered presets treat advisory or externally delegated
-`credential.broker` evidence as unsupported and block launch. Provider-facing
-handles remain disabled until the provider migration and a controlled egress or
-tool boundary are complete. Model-provider boot authentication and explicit
-`env-passthrough` compatibility remain separate, high-risk paths and are never
-labeled as brokered. See [Credential Broker](CREDENTIAL-BROKER.md).
+Credential-bound tool definitions compile only when enabled broker definitions,
+MCP scopes, source targets, and immutable catalog evidence match. They are
+omitted from native provider MCP configuration and provider environment
+passthrough. Mediated calls remain blocked until #969 consumes exact-action
+leases, and system-owned provider bridge injection remains under #970.
+Model-provider boot authentication and explicit `env-passthrough`
+compatibility remain separate, high-risk paths and are never labeled as
+brokered. See [Credential Broker](CREDENTIAL-BROKER.md).
 
 New launches persist `run-launch-credential-plan/v1` evidence. The plan
 classifies known provider boot keys, task integration definition IDs, and
 unknown credential-like environment passthrough; binds the classification to
 the provider runtime manifest and probe revision; and contains no values. Task
-integration references remain blocked until a controlled tool or egress
-boundary proves non-bypassable delivery. A provider-native boot key is reported
-as provider-required authentication, not as `credential.broker` support.
+integration references report a brokered tool-control-plane boundary only when
+the exact run catalog covers every reference; uncovered references remain
+blocked. A provider-native boot key is reported as provider-required
+authentication, not as `credential.broker` support.
 
 ## Agent Profile Packages
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -3799,14 +3799,16 @@ and failed dispatches append bounded, redacted causal events, and an operation
 ID cannot dispatch twice.
 
 Raw environment and credential values are never stored in a definition,
-catalog, event, or launch manifest. Credential-reference definitions,
-header-bound definitions, and credential-like environment keys remain
-fail-closed until a controlled broker boundary is available. Newly compiled
-launch manifests include a value-free `run-launch-credential-plan/v1` section
-that separates provider boot authentication, task integration references, and
-high-risk compatibility passthrough. Task references report `brokerState:
-"blocked"` and make the launch unenforceable until an accepted boundary can
-deliver them without provider bypass.
+catalog, event, or launch manifest. Credential-bound definitions compile only
+when each reference resolves to an enabled MCP-scoped broker definition and an
+exact environment or HTTP-header target. The catalog persists definition and
+scope digests plus safe target names. Discovery removes source values, and
+native provider configuration omits credential-bound entries.
+
+New launch manifests classify a task reference as a brokered
+tool-control-plane boundary only when the exact run catalog covers it.
+Uncovered references remain blocked. Credential-bound calls remain disabled
+until #969 adds exact-action lease consumption.
 See [Tool Control Plane v1](architecture/TOOL-CONTROL-PLANE-V1.md).
 
 ---

--- a/docs/CREDENTIAL-BROKER.md
+++ b/docs/CREDENTIAL-BROKER.md
@@ -17,9 +17,11 @@ The v6 foundation includes:
   authentication, task integration references, and high-risk compatibility
   passthrough without storing values.
 
-It does not yet make a provider broker-capable. A handle in a prompt or
-environment is not a security boundary. Provider use stays disabled until an
-accepted network or tool dispatcher can prevent bypass.
+The tool control plane can now compile value-free credential boundary evidence
+into a run catalog. A handle in a prompt or provider environment is still not a
+security boundary: credential-bound native server injection is omitted, and
+mediated calls stay blocked until exact-action lease consumption lands in
+#969.
 
 ## Credential classes
 
@@ -152,10 +154,10 @@ treated as unsupported and blocks launch.
 Current executable providers classify their launch credentials consistently,
 but classification alone does not make them broker-capable. Controlled HTTP
 consumption belongs to the run-scoped egress gateway; controlled MCP/tool
-consumption belongs to the tool-server control plane. Until those boundaries
-deliver handles without a bypass, task integration references block launch and
-the registry and lease service remain limited to trusted internal dispatch
-code.
+consumption belongs to the tool-server control plane. A task reference is
+reported as brokered only when an immutable run catalog contains the matching
+credential-definition and scope digests. Uncovered references still block
+launch. Catalog evidence alone never resolves a value or enables dispatch.
 
 ## Rotation and revocation
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -370,8 +370,11 @@ persists an immutable `run-tool-catalog/v1` digest in the launch manifest.
   identity.
 - Arguments, schemas, results, and errors are bounded. Causal tool events are
   redacted and deduplicated by the caller's stable operation ID.
-- Credential and header references may be declared, but those definitions
-  remain fail-closed until brokered provider launch handles are available.
+- Credential-bound entries compile only with enabled, scope-compatible broker
+  definitions. Their definition/scope digests and safe target names enter the
+  immutable catalog, discovery receives no source values, and native provider
+  injection omits them. Mediated calls remain blocked until exact-action lease
+  consumption lands in #969.
 
 See [Tool Control Plane v1](architecture/TOOL-CONTROL-PLANE-V1.md).
 

--- a/docs/architecture/TOOL-CONTROL-PLANE-V1.md
+++ b/docs/architecture/TOOL-CONTROL-PLANE-V1.md
@@ -131,13 +131,23 @@ the route singleton first accesses storage.
 ## Credential Boundary
 
 Definitions persist environment key names, header key names, and broker
-reference IDs, never their values. Credential-like environment keys,
-credential references, and HTTP-header-bound definitions currently fail closed
-during discovery, launch, and invocation. Issue
-[#932](https://github.com/BradGroux/veritas-kanban/issues/932) owns resolving
-those references into run-scoped provider launch handles without exposing or
-persisting values. Credential-shaped command arguments and recognizable
-credential literals are rejected during definition validation.
+reference IDs, never their values. Credential-bound discovery removes the
+referenced environment keys and HTTP headers before starting the server. It
+therefore succeeds only when the server can expose its schema without
+credentials.
+
+Each ready catalog entry binds the exact credential-definition digest, scope
+digest, and safe environment or header target name. Missing, disabled,
+unmapped, out-of-scope, external-source, or drifted definitions fail closed.
+Credential-bound entries are omitted from every native provider MCP
+configuration and from provider environment passthrough. The launch credential
+plan reports `brokerState: supported` only when every selected sandbox
+credential reference has this exact tool-control-plane evidence.
+
+This slice does not resolve a source value. Mediated invocation remains blocked
+until #969 adds exact-action lease consumption, and system-owned provider
+bridge injection remains under #970. Credential-shaped command arguments and
+recognizable credential literals remain forbidden.
 
 ## Operator Surfaces
 

--- a/server/src/__tests__/provider-launch-credential-plan-service.test.ts
+++ b/server/src/__tests__/provider-launch-credential-plan-service.test.ts
@@ -159,4 +159,39 @@ describe('provider launch credential plan', () => {
       risk: 'blocked',
     });
   });
+
+  it('marks only exact catalog-backed task credentials as brokered', () => {
+    const manifest = providerRuntimeManifestFixture({ provider: 'codex-app-server' });
+    const supported = compileProviderLaunchCredentialPlan({
+      provider: 'codex-app-server',
+      providerRuntimeManifest: manifest,
+      runtime: runtime(['OPENAI_API_KEY']),
+      sandbox: sandbox('brokered', ['github-token']),
+      brokeredCredentialReferences: ['github-token'],
+    });
+    expect(supported).toMatchObject({
+      brokerState: 'supported',
+      references: expect.arrayContaining([
+        {
+          reference: 'github-token',
+          classification: 'task-integration',
+          delivery: 'brokered-boundary',
+          boundary: 'tool-control-plane',
+          risk: 'brokered',
+        },
+      ]),
+    });
+
+    const partial = compileProviderLaunchCredentialPlan({
+      provider: 'codex-app-server',
+      providerRuntimeManifest: manifest,
+      runtime: runtime([]),
+      sandbox: sandbox('brokered', ['github-token', 'slack-token']),
+      brokeredCredentialReferences: ['github-token'],
+    });
+    expect(partial.brokerState).toBe('blocked');
+    expect(partial.references).toContainEqual(
+      expect.objectContaining({ reference: 'slack-token', delivery: 'blocked' })
+    );
+  });
 });

--- a/server/src/__tests__/run-launch-manifest-service.test.ts
+++ b/server/src/__tests__/run-launch-manifest-service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
   type HarnessSupportStatus,
+  type RunToolCatalog,
   type SandboxPolicyDryRunResult,
   type TaskEnvelope,
 } from '@veritas-kanban/shared';
@@ -16,6 +17,7 @@ import {
 } from '../services/run-launch-manifest-service.js';
 import { calculateProviderRuntimeManifestDigest } from '../utils/provider-runtime-manifest-digest.js';
 import { verifyRunLaunchManifestDigest } from '../utils/run-launch-manifest-digest.js';
+import { calculateRunToolCatalogDigest } from '../utils/tool-control-plane-digest.js';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 
 const providerRuntimeManifest = providerRuntimeManifestFixture({
@@ -243,6 +245,40 @@ function input(
   };
 }
 
+function brokeredCatalog(): RunToolCatalog {
+  const payload: RunToolCatalog = {
+    schemaVersion: 'run-tool-catalog/v1',
+    taskId: 'task-854',
+    attemptId: 'attempt-854',
+    provider: 'codex-cli',
+    providerRuntimeManifestDigest: providerRuntimeManifest.digest,
+    taskEnvelopeDigest: taskEnvelope.digest,
+    entries: [
+      {
+        serverId: 'github-tools',
+        serverVersion: '1.0.0',
+        definitionDigest: `sha256:${'b'.repeat(64)}`,
+        discoveryDigest: `sha256:${'c'.repeat(64)}`,
+        transport: 'stdio',
+        requirement: 'required',
+        status: 'ready',
+        credentialBindings: [
+          {
+            credentialReference: 'github-token',
+            credentialDefinitionDigest: `sha256:${'d'.repeat(64)}`,
+            scopeDigest: `sha256:${'e'.repeat(64)}`,
+            target: { kind: 'environment', name: 'GITHUB_TOKEN' },
+          },
+        ],
+        tools: [],
+      },
+    ],
+    createdAt: '2026-07-23T20:00:00.000Z',
+    digest: `sha256:${'0'.repeat(64)}`,
+  };
+  return { ...payload, digest: calculateRunToolCatalogDigest(payload) };
+}
+
 describe('RunLaunchManifestService', () => {
   it('compiles a canonical immutable manifest without prompt or credential values', () => {
     const manifest = new RunLaunchManifestService().compile(input());
@@ -357,6 +393,59 @@ describe('RunLaunchManifestService', () => {
       blockers: expect.arrayContaining([
         expect.objectContaining({ code: 'credential-boundary-unavailable' }),
       ]),
+    });
+  });
+
+  it('accepts an exact tool-control-plane credential boundary', () => {
+    const brokeredPolicy: SandboxPolicyDryRunResult = {
+      ...sandboxPolicy,
+      preset: {
+        ...sandboxPolicy.preset,
+        credentials: {
+          mode: 'brokered',
+          brokerRefs: ['github-token'],
+        },
+      },
+      effective: {
+        ...sandboxPolicy.effective,
+        credentialRefs: ['github-token'],
+      },
+    };
+    const runToolCatalog = brokeredCatalog();
+    const manifest = new RunLaunchManifestService().compile(
+      input({
+        sandboxPolicy: brokeredPolicy,
+        runToolCatalog,
+        tools: {
+          allowed: [],
+          denied: [],
+          policyIds: [],
+          mcpServers: ['github-tools'],
+          catalogDigest: runToolCatalog.digest,
+          enforcement: 'enforced',
+        },
+        runtime: {
+          ...input().runtime,
+          credentialReferences: ['env:OPENAI_API_KEY', 'github-token'],
+        },
+      })
+    );
+
+    expect(manifest.credentials).toMatchObject({
+      brokerState: 'supported',
+      references: expect.arrayContaining([
+        {
+          reference: 'github-token',
+          classification: 'task-integration',
+          delivery: 'brokered-boundary',
+          boundary: 'tool-control-plane',
+          risk: 'brokered',
+        },
+      ]),
+    });
+    expect(manifest.enforcement).toMatchObject({
+      enforceable: true,
+      blockers: [],
     });
   });
 

--- a/server/src/__tests__/tool-control-plane-service.test.ts
+++ b/server/src/__tests__/tool-control-plane-service.test.ts
@@ -5,6 +5,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
+  CredentialDefinition,
+  CredentialDefinitionInput,
   RunEventEnvelope,
   ToolServerDefinition,
   ToolServerDefinitionInput,
@@ -19,6 +21,7 @@ import {
 } from '../storage/tool-control-plane-repository.js';
 import { SqliteDatabase } from '../storage/sqlite/database.js';
 import { SqliteToolControlPlaneRepository } from '../storage/sqlite/tool-control-plane-repository.js';
+import { calculateCredentialDefinitionDigest } from '../utils/credential-broker-digest.js';
 
 const DIGEST = `sha256:${'a'.repeat(64)}`;
 const roots: string[] = [];
@@ -51,6 +54,46 @@ function definition(overrides: Partial<ToolServerDefinitionInput> = {}): ToolSer
   };
 }
 
+function credentialDefinition(
+  overrides: Partial<CredentialDefinitionInput> = {}
+): CredentialDefinition {
+  const input: CredentialDefinitionInput = {
+    id: 'github-token',
+    name: 'GitHub token',
+    enabled: true,
+    source: {
+      kind: 'environment',
+      reference: 'FIXTURE_TOKEN',
+    },
+    scope: {
+      dispatchTypes: ['mcp'],
+      hosts: [],
+      tools: ['fixture/search'],
+      destinations: [],
+      methods: [],
+      actions: ['fixture/search'],
+      pathPrefixes: [],
+    },
+    lease: {
+      ttlSeconds: 60,
+      maxUses: 1,
+      renewable: false,
+    },
+    approval: 'not-required',
+    ...overrides,
+  };
+  const payload = {
+    ...input,
+    schemaVersion: 'credential-definition/v1' as const,
+    createdAt: '2026-07-24T12:00:00.000Z',
+    updatedAt: '2026-07-24T12:00:00.000Z',
+  };
+  return {
+    ...payload,
+    digest: calculateCredentialDefinitionDigest(payload),
+  };
+}
+
 function fixture(
   options: {
     tools?: Array<Record<string, unknown>>;
@@ -59,6 +102,7 @@ function fixture(
     approval?: 'pending' | 'approved';
     environment?: NodeJS.ProcessEnv;
     journal?: RunEventJournalService;
+    credentialDefinitions?: CredentialDefinition[];
   } = {}
 ) {
   const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -120,6 +164,12 @@ function fixture(
     runtime: { open },
     journal: options.journal ?? ({ append } as unknown as RunEventJournalService),
     approvals: { request: requestApproval } as unknown as RunApprovalBrokerService,
+    credentialBroker: {
+      getDefinition: vi.fn(async (id: string) => {
+        const credential = options.credentialDefinitions?.find((candidate) => candidate.id === id);
+        return credential ? structuredClone(credential) : null;
+      }),
+    },
     now: () => new Date('2026-07-24T12:00:00.000Z'),
     environment: options.environment ?? {},
   });
@@ -440,8 +490,12 @@ describe('ToolControlPlaneService', () => {
     }
   });
 
-  it('fails closed on credential references until brokered launch handles are active', async () => {
-    const { service } = fixture();
+  it('compiles value-free credential evidence and omits brokered servers from native injection', async () => {
+    const credential = credentialDefinition();
+    const { service, open } = fixture({
+      environment: { FIXTURE_TOKEN: 'credential-sensitive-value' },
+      credentialDefinitions: [credential],
+    });
     await expect(
       service.createDefinition(
         definition({
@@ -455,6 +509,152 @@ describe('ToolControlPlaneService', () => {
         })
       )
     ).rejects.toThrow('Credential-shaped tool server arguments');
+    const runCatalog = await catalog(service, {
+      transport: {
+        kind: 'stdio',
+        command: '/usr/bin/fixture',
+        args: [],
+        environmentKeys: ['FIXTURE_TOKEN'],
+        credentialReferences: ['github-token'],
+      },
+    });
+    if (!runCatalog) throw new Error('Expected a run tool catalog.');
+
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: expect.objectContaining({ environmentKeys: [] }),
+      }),
+      '/tmp/worktree'
+    );
+    expect(runCatalog.entries[0].credentialBindings).toEqual([
+      {
+        credentialReference: 'github-token',
+        credentialDefinitionDigest: credential.digest,
+        scopeDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        target: { kind: 'environment', name: 'FIXTURE_TOKEN' },
+      },
+    ]);
+    expect(await service.providerConfig(runCatalog)).toEqual({});
+    expect(await service.claudeConfig(runCatalog)).toEqual({
+      config: { mcpServers: {} },
+      allowedToolNames: [],
+    });
+    expect(await service.acpConfig(runCatalog)).toEqual([]);
+    expect(await service.environmentKeys(runCatalog)).toEqual([]);
+    expect(JSON.stringify({ runCatalog })).not.toContain('credential-sensitive-value');
+    await expect(
+      service.invoke(
+        {
+          taskId: 'task-tools',
+          attemptId: 'attempt-tools',
+          serverId: 'fixture',
+          tool: 'search',
+          arguments: { query: 'kanban' },
+          operationId: 'brokered-before-lease-consumption',
+        },
+        'agent-a'
+      )
+    ).rejects.toThrow('mediated lease consumption');
+  });
+
+  it('fails closed when credential evidence is missing, disabled, out of scope, or unmapped', async () => {
+    const cases = [
+      {
+        name: 'missing',
+        credentials: [],
+        transport: {
+          kind: 'stdio' as const,
+          command: '/usr/bin/fixture',
+          args: [],
+          environmentKeys: ['FIXTURE_TOKEN'],
+          credentialReferences: ['github-token'],
+        },
+      },
+      {
+        name: 'disabled',
+        credentials: [credentialDefinition({ enabled: false })],
+        transport: {
+          kind: 'stdio' as const,
+          command: '/usr/bin/fixture',
+          args: [],
+          environmentKeys: ['FIXTURE_TOKEN'],
+          credentialReferences: ['github-token'],
+        },
+      },
+      {
+        name: 'out of scope',
+        credentials: [
+          credentialDefinition({
+            scope: {
+              ...credentialDefinition().scope,
+              tools: ['fixture/other'],
+              actions: ['fixture/other'],
+            },
+          }),
+        ],
+        transport: {
+          kind: 'stdio' as const,
+          command: '/usr/bin/fixture',
+          args: [],
+          environmentKeys: ['FIXTURE_TOKEN'],
+          credentialReferences: ['github-token'],
+        },
+      },
+      {
+        name: 'unmapped',
+        credentials: [credentialDefinition()],
+        transport: {
+          kind: 'stdio' as const,
+          command: '/usr/bin/fixture',
+          args: [],
+          environmentKeys: [],
+          credentialReferences: ['github-token'],
+        },
+      },
+    ];
+
+    for (const candidate of cases) {
+      const { service } = fixture({ credentialDefinitions: candidate.credentials });
+      await service.createDefinition(
+        definition({
+          transport: candidate.transport,
+        })
+      );
+      await expect(
+        service.prepareRunCatalog({
+          taskId: 'task-tools',
+          attemptId: `attempt-${candidate.name.replaceAll(' ', '-')}`,
+          provider: 'codex-app-server',
+          providerRuntimeManifestDigest: DIGEST,
+          taskEnvelopeDigest: DIGEST,
+          serverIds: ['fixture'],
+        })
+      ).rejects.toThrow();
+    }
+  });
+
+  it('rejects credential definition drift after catalog compilation', async () => {
+    const definitions = [credentialDefinition()];
+    const { service } = fixture({ credentialDefinitions: definitions });
+    const runCatalog = await catalog(service, {
+      transport: {
+        kind: 'stdio',
+        command: '/usr/bin/fixture',
+        args: [],
+        environmentKeys: ['FIXTURE_TOKEN'],
+        credentialReferences: ['github-token'],
+      },
+    });
+    if (!runCatalog) throw new Error('Expected a run tool catalog.');
+    definitions[0] = credentialDefinition({
+      lease: { ttlSeconds: 120, maxUses: 1, renewable: false },
+    });
+
+    await expect(service.providerConfig(runCatalog)).rejects.toThrow('drifted');
+  });
+
+  it('keeps unbound credential-shaped environment keys fail closed', async () => {
+    const { service } = fixture();
     await service.createDefinition(
       definition({
         transport: {
@@ -466,38 +666,7 @@ describe('ToolControlPlaneService', () => {
         },
       })
     );
-    await expect(service.discover('fixture')).rejects.toThrow('brokered provider launch handles');
-
-    const optional = fixture();
-    await optional.service.createDefinition(
-      definition({
-        requirement: 'optional',
-        transport: {
-          kind: 'stdio',
-          command: '/usr/bin/fixture',
-          args: [],
-          environmentKeys: [],
-          credentialReferences: ['github-token'],
-        },
-      })
-    );
-    await expect(
-      optional.service.prepareRunCatalog({
-        taskId: 'task-tools',
-        attemptId: 'attempt-tools',
-        provider: 'codex-app-server',
-        providerRuntimeManifestDigest: DIGEST,
-        taskEnvelopeDigest: DIGEST,
-        serverIds: ['fixture'],
-      })
-    ).resolves.toMatchObject({
-      entries: [
-        expect.objectContaining({
-          status: 'degraded',
-          error: expect.stringContaining('brokered provider launch handles'),
-        }),
-      ],
-    });
+    await expect(service.discover('fixture')).rejects.toThrow('exact broker definitions');
   });
 
   it('validates, dispatches, journals, and rejects replay of an allowed tool call', async () => {

--- a/server/src/schemas/tool-control-plane-schemas.ts
+++ b/server/src/schemas/tool-control-plane-schemas.ts
@@ -174,6 +174,33 @@ const catalogToolSchema = discoveryToolSchema
   })
   .strict();
 
+const catalogCredentialBindingSchema = z
+  .object({
+    credentialReference: serverIdSchema,
+    credentialDefinitionDigest: digestSchema,
+    scopeDigest: digestSchema,
+    target: z.discriminatedUnion('kind', [
+      z
+        .object({
+          kind: z.literal('environment'),
+          name: environmentKeySchema,
+        })
+        .strict(),
+      z
+        .object({
+          kind: z.literal('http-header'),
+          name: z
+            .string()
+            .trim()
+            .min(1)
+            .max(120)
+            .regex(/^[A-Za-z][A-Za-z0-9-]*$/),
+        })
+        .strict(),
+    ]),
+  })
+  .strict();
+
 const catalogEntrySchema = z
   .object({
     serverId: serverIdSchema,
@@ -183,6 +210,7 @@ const catalogEntrySchema = z
     transport: z.enum(['stdio', 'http']),
     requirement: z.enum(['required', 'optional']),
     status: z.enum(['ready', 'degraded']),
+    credentialBindings: z.array(catalogCredentialBindingSchema).max(50).optional(),
     tools: z.array(catalogToolSchema).max(1_000),
     error: z.string().trim().min(1).max(4_000).optional(),
   })

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -7898,6 +7898,7 @@ export class ClawdbotAgentService {
       },
       requiredHealthChecks,
       sandboxPolicy: input.sandboxPolicy,
+      runToolCatalog: input.runToolCatalog,
       budgetPolicy: input.budgetPolicy ?? {
         enabled: false,
         scope: 'run',

--- a/server/src/services/provider-launch-credential-plan-service.ts
+++ b/server/src/services/provider-launch-credential-plan-service.ts
@@ -41,6 +41,7 @@ export function compileProviderLaunchCredentialPlan(input: {
   runtime: RunLaunchRuntime;
   sandbox: SandboxPolicyDryRunResult;
   harnessProfileId?: string;
+  brokeredCredentialReferences?: string[];
 }): RunLaunchCredentialPlan {
   const providerBootAuthKeys = new Set([
     ...(PROVIDER_BOOT_AUTH_KEYS[input.provider as ExecutableAgentProvider] ?? []),
@@ -55,6 +56,7 @@ export function compileProviderLaunchCredentialPlan(input: {
       : []),
   ]);
   const taskReferences = new Set(input.sandbox.effective.credentialRefs);
+  const brokeredReferences = new Set(input.brokeredCredentialReferences ?? []);
   const environmentReferences = new Set(
     input.runtime.credentialReferences
       .filter((reference) => reference.startsWith('env:'))
@@ -83,13 +85,16 @@ export function compileProviderLaunchCredentialPlan(input: {
             risk: 'high-risk',
           };
     }),
-    ...[...taskReferences].map((reference): RunLaunchCredentialReference => ({
-      reference,
-      classification: 'task-integration',
-      delivery: 'blocked',
-      boundary: 'unavailable',
-      risk: 'blocked',
-    })),
+    ...[...taskReferences].map((reference): RunLaunchCredentialReference => {
+      const brokered = brokeredReferences.has(reference);
+      return {
+        reference,
+        classification: 'task-integration',
+        delivery: brokered ? 'brokered-boundary' : 'blocked',
+        boundary: brokered ? 'tool-control-plane' : 'unavailable',
+        risk: brokered ? 'brokered' : 'blocked',
+      };
+    }),
   ].sort(
     (left, right) =>
       left.classification.localeCompare(right.classification) ||
@@ -99,7 +104,12 @@ export function compileProviderLaunchCredentialPlan(input: {
   const payload: Omit<RunLaunchCredentialPlan, 'digest'> = {
     schemaVersion: RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION,
     mode: input.sandbox.preset.credentials.mode,
-    brokerState: taskReferences.size > 0 ? 'blocked' : 'not-required',
+    brokerState:
+      taskReferences.size === 0
+        ? 'not-required'
+        : [...taskReferences].every((reference) => brokeredReferences.has(reference))
+          ? 'supported'
+          : 'blocked',
     providerRuntimeManifestDigest: input.providerRuntimeManifest.digest,
     providerRuntimeProbeRevision: input.providerRuntimeManifest.probeRevision,
     references,

--- a/server/src/services/run-launch-manifest-service.ts
+++ b/server/src/services/run-launch-manifest-service.ts
@@ -13,6 +13,7 @@ import type {
   RunLaunchPermissions,
   RunLaunchProfileReference,
   RunLaunchResources,
+  RunToolCatalog,
   RunLaunchRouting,
   RunLaunchRuntime,
   RunLaunchTools,
@@ -25,11 +26,13 @@ import { RUN_LAUNCH_MANIFEST_SCHEMA_VERSION } from '@veritas-kanban/shared';
 import { ConflictError, ValidationError } from '../middleware/error-handler.js';
 import { parseProviderRuntimeManifest } from '../schemas/provider-runtime-manifest-schemas.js';
 import { parseRunLaunchManifest } from '../schemas/run-launch-manifest-schemas.js';
+import { runToolCatalogSchema } from '../schemas/tool-control-plane-schemas.js';
 import {
   calculateRunLaunchManifestDigest,
   digestRunLaunchValue,
 } from '../utils/run-launch-manifest-digest.js';
 import { sanitizeProviderRuntimeDiagnostic } from '../utils/provider-runtime-manifest-sanitize.js';
+import { calculateRunToolCatalogDigest } from '../utils/tool-control-plane-digest.js';
 import { compileProviderLaunchCredentialPlan } from './provider-launch-credential-plan-service.js';
 
 export interface RunLaunchManifestInstructionInput {
@@ -63,6 +66,7 @@ export interface RunLaunchManifestCompileInput {
   requiredHealthChecks: string[];
   satisfiedHealthChecks?: string[];
   sandboxPolicy: SandboxPolicyDryRunResult;
+  runToolCatalog?: RunToolCatalog;
   budgetPolicy: AgentBudgetPolicy;
   workspaceTrust: RunLaunchWorkspaceTrust;
   origins: RunLaunchManifestOrigin[];
@@ -149,12 +153,14 @@ export class RunLaunchManifestService {
       warnings: uniqueSorted(input.sandboxPolicy.warnings.map(sanitizeProviderRuntimeDiagnostic)),
     };
     const runtime = normalizeRuntime(input.runtime);
+    const brokeredCredentialReferences = brokeredReferencesFromCatalog(input, providerRuntime);
     const credentials = compileProviderLaunchCredentialPlan({
       provider: providerRuntime.provider,
       providerRuntimeManifest: providerRuntime,
       runtime,
       sandbox: input.sandboxPolicy,
       harnessProfileId: input.harnessSupport.profileId,
+      brokeredCredentialReferences,
     });
     const blockers = collectBlockers({
       input,
@@ -441,6 +447,40 @@ function normalizeResources(resources: RunLaunchResources): RunLaunchResources {
     shared: uniqueSorted(resources.shared),
     enforcement: resources.enforcement,
   };
+}
+
+function brokeredReferencesFromCatalog(
+  input: RunLaunchManifestCompileInput,
+  providerRuntime: ProviderRuntimeManifest
+): string[] {
+  if (!input.runToolCatalog) return [];
+  const catalog = runToolCatalogSchema.parse(input.runToolCatalog);
+  if (
+    catalog.taskId !== input.taskId.trim() ||
+    catalog.attemptId !== input.attemptId.trim() ||
+    catalog.provider !== providerRuntime.provider ||
+    catalog.providerRuntimeManifestDigest !== providerRuntime.digest ||
+    catalog.taskEnvelopeDigest !== input.taskEnvelope.digest ||
+    catalog.digest !== input.tools.catalogDigest ||
+    catalog.digest !== calculateRunToolCatalogDigest(catalog)
+  ) {
+    throw new ConflictError(
+      'Brokered credential evidence does not match the exact run tool catalog.',
+      {
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        catalogDigest: catalog.digest,
+        manifestCatalogDigest: input.tools.catalogDigest,
+      }
+    );
+  }
+  return uniqueSorted(
+    catalog.entries
+      .filter((entry) => entry.status === 'ready')
+      .flatMap((entry) =>
+        (entry.credentialBindings ?? []).map((binding) => binding.credentialReference)
+      )
+  );
 }
 
 function collectBlockers({

--- a/server/src/services/tool-control-plane-service.ts
+++ b/server/src/services/tool-control-plane-service.ts
@@ -8,8 +8,10 @@ import {
   TOOL_SERVER_DEFINITION_SCHEMA_VERSION,
   type ExecutableAgentProvider,
   type AcpMcpServer,
+  type CredentialDefinition,
   type RunToolCatalog,
   type RunToolCatalogEntry,
+  type RunToolCredentialBinding,
   type ToolInvocationRequest,
   type ToolInvocationResult,
   type ToolServerDefinition,
@@ -37,9 +39,14 @@ import {
   calculateToolDiscoveryDigest,
   calculateToolServerDefinitionDigest,
 } from '../utils/tool-control-plane-digest.js';
+import { calculateCredentialScopeDigest } from '../utils/credential-broker-digest.js';
 import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
 import { RunApprovalBrokerService } from './run-approval-broker-service.js';
 import { RunEventJournalService } from './run-event-journal-service.js';
+import {
+  getCredentialBrokerService,
+  type CredentialBrokerService,
+} from './credential-broker-service.js';
 
 const MCP_PROTOCOL_VERSION = '2025-06-18';
 const MAX_RPC_BYTES = 4 * 1024 * 1024;
@@ -79,6 +86,7 @@ export interface ToolControlPlaneServiceOptions {
   runtime?: ToolControlPlaneRuntime;
   journal?: RunEventJournalService;
   approvals?: RunApprovalBrokerService;
+  credentialBroker?: Pick<CredentialBrokerService, 'getDefinition'>;
   now?: () => Date;
   environment?: NodeJS.ProcessEnv;
 }
@@ -97,6 +105,7 @@ export class ToolControlPlaneService {
   private readonly runtime: ToolControlPlaneRuntime;
   private readonly journal: RunEventJournalService;
   private readonly approvals: RunApprovalBrokerService;
+  private readonly credentialBroker: Pick<CredentialBrokerService, 'getDefinition'>;
   private readonly now: () => Date;
   private readonly environment: NodeJS.ProcessEnv;
   private readonly sessions = new Map<string, Promise<RpcSession>>();
@@ -108,6 +117,7 @@ export class ToolControlPlaneService {
     this.runtime = options.runtime ?? new McpJsonRpcRuntime(this.environment);
     this.journal = options.journal ?? new RunEventJournalService();
     this.approvals = options.approvals ?? new RunApprovalBrokerService();
+    this.credentialBroker = options.credentialBroker ?? getCredentialBrokerService();
     this.now = options.now ?? (() => new Date());
   }
 
@@ -165,13 +175,13 @@ export class ToolControlPlaneService {
   async discover(id: string, force = false, cwd?: string): Promise<ToolServerDiscovery> {
     const definition = await this.getDefinition(id);
     if (!definition.enabled) throw new ConflictError('Tool server definition is disabled.');
-    this.assertCredentialBoundary(definition);
+    const runtimeDefinition = await this.credentialFreeDiscoveryDefinition(definition);
     const cached = await this.repository().getDiscovery(definition.digest);
 
     let session: RpcSession | undefined;
     let discovery: ToolServerDiscovery;
     try {
-      session = await this.runtime.open(definition, cwd);
+      session = await this.runtime.open(runtimeDefinition, cwd);
       const protocolVersion = await initializeSession(
         session,
         definition.startupTimeoutMs,
@@ -266,6 +276,55 @@ export class ToolControlPlaneService {
         );
         continue;
       }
+      const catalogTools = discovery.tools.map((tool) => {
+        const qualifiedName = `${definition.id}/${tool.name}`;
+        const definitionAllows =
+          definition.allowedTools.length === 0 ||
+          definition.allowedTools.includes('*') ||
+          matchesTool(definition.allowedTools, tool.name, qualifiedName);
+        const runAllows =
+          allowed.size === 0 ||
+          allowed.has('*') ||
+          allowed.has(tool.name) ||
+          allowed.has(qualifiedName);
+        const isDenied =
+          matchesTool(definition.deniedTools, tool.name, qualifiedName) ||
+          denied.has(tool.name) ||
+          denied.has(qualifiedName);
+        const approval =
+          definition.approvalMode === 'always' ||
+          matchesTool(definition.approvalRequiredTools, tool.name, qualifiedName);
+        return {
+          ...tool,
+          qualifiedName,
+          decision:
+            !definitionAllows || !runAllows || isDenied
+              ? ('deny' as const)
+              : approval
+                ? ('approval' as const)
+                : ('allow' as const),
+        };
+      });
+      const brokeredToolNames = new Set(
+        catalogTools.filter((tool) => tool.decision !== 'deny').map((tool) => tool.name)
+      );
+      let credentialBindings: RunToolCredentialBinding[];
+      try {
+        credentialBindings = await this.compileCredentialBindings(definition, {
+          ...discovery,
+          tools: discovery.tools.filter((tool) => brokeredToolNames.has(tool.name)),
+        });
+      } catch (error) {
+        const message = boundedError(error);
+        if (definition.requirement === 'required') {
+          throw new ConflictError(
+            `Required tool server ${serverId} has invalid credential boundary evidence.`,
+            { error: message }
+          );
+        }
+        entries.push(degradedEntry(definition, message, discovery));
+        continue;
+      }
       entries.push({
         serverId: definition.id,
         serverVersion: definition.version,
@@ -274,35 +333,8 @@ export class ToolControlPlaneService {
         transport: definition.transport.kind,
         requirement: definition.requirement,
         status: 'ready',
-        tools: discovery.tools.map((tool) => {
-          const qualifiedName = `${definition.id}/${tool.name}`;
-          const definitionAllows =
-            definition.allowedTools.length === 0 ||
-            definition.allowedTools.includes('*') ||
-            matchesTool(definition.allowedTools, tool.name, qualifiedName);
-          const runAllows =
-            allowed.size === 0 ||
-            allowed.has('*') ||
-            allowed.has(tool.name) ||
-            allowed.has(qualifiedName);
-          const isDenied =
-            matchesTool(definition.deniedTools, tool.name, qualifiedName) ||
-            denied.has(tool.name) ||
-            denied.has(qualifiedName);
-          const approval =
-            definition.approvalMode === 'always' ||
-            matchesTool(definition.approvalRequiredTools, tool.name, qualifiedName);
-          return {
-            ...tool,
-            qualifiedName,
-            decision:
-              !definitionAllows || !runAllows || isDenied
-                ? ('deny' as const)
-                : approval
-                  ? ('approval' as const)
-                  : ('allow' as const),
-          };
-        }),
+        ...(credentialBindings.length > 0 ? { credentialBindings } : {}),
+        tools: catalogTools,
       });
     }
 
@@ -378,6 +410,16 @@ export class ToolControlPlaneService {
       });
     }
     const definition = await this.getCatalogDefinition(entry);
+    if ((entry.credentialBindings?.length ?? 0) > 0) {
+      throw new ConflictError(
+        'Credential-bound tool calls require mediated lease consumption through the Veritas bridge.',
+        {
+          serverId: entry.serverId,
+          catalogDigest: catalog.digest,
+          remediation: 'Complete #969 before invoking this credential-bound tool.',
+        }
+      );
+    }
 
     if (tool.decision === 'approval') {
       const approval = await this.approvals.request({
@@ -539,6 +581,7 @@ export class ToolControlPlaneService {
     const servers: Record<string, unknown> = {};
     for (const entry of catalog.entries.filter((candidate) => candidate.status === 'ready')) {
       const definition = await this.getCatalogDefinition(entry);
+      if ((entry.credentialBindings?.length ?? 0) > 0) continue;
       const allowedTools = entry.tools
         .filter((tool) => tool.decision === 'allow')
         .map((tool) => tool.name);
@@ -581,6 +624,7 @@ export class ToolControlPlaneService {
     const allowedToolNames: string[] = [];
     for (const entry of catalog.entries.filter((candidate) => candidate.status === 'ready')) {
       const definition = await this.getCatalogDefinition(entry);
+      if ((entry.credentialBindings?.length ?? 0) > 0) continue;
       servers[entry.serverId] =
         definition.transport.kind === 'stdio'
           ? {
@@ -607,6 +651,10 @@ export class ToolControlPlaneService {
   ): Promise<AcpMcpServer[]> {
     const servers: AcpMcpServer[] = [];
     for (const entry of catalog.entries.filter((candidate) => candidate.status === 'ready')) {
+      if ((entry.credentialBindings?.length ?? 0) > 0) {
+        await this.getCatalogDefinition(entry);
+        continue;
+      }
       const restricted = entry.tools.filter((tool) => tool.decision !== 'allow');
       if (restricted.length > 0) {
         throw new ConflictError(
@@ -655,6 +703,7 @@ export class ToolControlPlaneService {
     const keys = new Set<string>();
     for (const entry of catalog.entries.filter((candidate) => candidate.status === 'ready')) {
       const definition = await this.getCatalogDefinition(entry);
+      if ((entry.credentialBindings?.length ?? 0) > 0) continue;
       if (definition.transport.kind === 'stdio') {
         for (const key of definition.transport.environmentKeys) keys.add(key);
       } else {
@@ -723,32 +772,228 @@ export class ToolControlPlaneService {
         }
       );
     }
-    this.assertCredentialBoundary(definition);
+    await this.assertCredentialEvidence(entry, definition);
     return definition;
   }
 
-  private assertCredentialBoundary(definition: ToolServerDefinition): void {
+  private async credentialFreeDiscoveryDefinition(
+    definition: ToolServerDefinition
+  ): Promise<ToolServerDefinition> {
     assertSafeDefinition(definition);
-    const credentialReferences = definition.transport.credentialReferences;
-    const credentialEnvironmentKeys =
-      definition.transport.kind === 'stdio'
-        ? definition.transport.environmentKeys.filter((key) => isCredentialLikeKey(key))
-        : [];
-    const headerReferences =
-      definition.transport.kind === 'http' ? definition.transport.headers : [];
-    if (
-      credentialReferences.length > 0 ||
-      credentialEnvironmentKeys.length > 0 ||
-      headerReferences.length > 0
-    ) {
+    const resolved = await this.resolveCredentialTargets(definition);
+    if (definition.transport.kind === 'stdio') {
+      const credentialKeys = new Set(
+        resolved.flatMap((entry) =>
+          entry.binding.target.kind === 'environment' ? [entry.binding.target.name] : []
+        )
+      );
+      const unbound = definition.transport.environmentKeys.filter(
+        (key) => isCredentialLikeKey(key) && !credentialKeys.has(key)
+      );
+      if (unbound.length > 0) {
+        throw new ConflictError(
+          'Credential-shaped tool server environment keys require exact broker definitions.',
+          { serverId: definition.id, environmentKeys: unbound }
+        );
+      }
+      return {
+        ...definition,
+        transport: {
+          ...definition.transport,
+          environmentKeys: definition.transport.environmentKeys.filter(
+            (key) => !credentialKeys.has(key)
+          ),
+        },
+      };
+    }
+    const credentialHeaders = new Set(
+      resolved.flatMap((entry) =>
+        entry.binding.target.kind === 'http-header' ? [entry.binding.target.name.toLowerCase()] : []
+      )
+    );
+    const unbound = definition.transport.headers.filter(
+      (header) => !credentialHeaders.has(header.name.toLowerCase())
+    );
+    if (unbound.length > 0) {
+      throw new ConflictError('HTTP tool server headers require exact broker definitions.', {
+        serverId: definition.id,
+        headerNames: unbound.map((header) => header.name),
+      });
+    }
+    return {
+      ...definition,
+      transport: {
+        ...definition.transport,
+        headers: [],
+      },
+    };
+  }
+
+  private async compileCredentialBindings(
+    definition: ToolServerDefinition,
+    discovery: ToolServerDiscovery
+  ): Promise<RunToolCredentialBinding[]> {
+    const resolved = await this.resolveCredentialTargets(definition);
+    if (resolved.length > 0 && discovery.tools.length === 0) {
       throw new ConflictError(
-        'Credential-bound tool servers remain disabled until brokered provider launch handles are active.',
-        {
+        'Credential-bound tool server has no callable tools in the exact run policy.',
+        { serverId: definition.id }
+      );
+    }
+    for (const { credential } of resolved) {
+      const scope = credential.scope;
+      if (
+        scope.hosts.length > 0 ||
+        scope.destinations.length > 0 ||
+        scope.methods.length > 0 ||
+        scope.pathPrefixes.length > 0
+      ) {
+        throw new ConflictError(
+          'MCP credential definitions cannot require HTTP-only scope dimensions.',
+          { credentialReference: credential.id, serverId: definition.id }
+        );
+      }
+      for (const tool of discovery.tools) {
+        const qualifiedName = `${definition.id}/${tool.name}`;
+        if (
+          scope.tools.length > 0 &&
+          !scope.tools.includes(tool.name) &&
+          !scope.tools.includes(qualifiedName)
+        ) {
+          throw new ConflictError('Credential definition does not accept every discovered tool.', {
+            credentialReference: credential.id,
+            serverId: definition.id,
+            tool: tool.name,
+          });
+        }
+        if (
+          scope.actions.length > 0 &&
+          !scope.actions.includes(tool.name) &&
+          !scope.actions.includes(qualifiedName)
+        ) {
+          throw new ConflictError(
+            'Credential definition does not accept every discovered MCP action.',
+            {
+              credentialReference: credential.id,
+              serverId: definition.id,
+              action: qualifiedName,
+            }
+          );
+        }
+      }
+    }
+    return resolved.map((entry) => entry.binding);
+  }
+
+  private async resolveCredentialTargets(definition: ToolServerDefinition): Promise<
+    Array<{
+      credential: CredentialDefinition;
+      binding: RunToolCredentialBinding;
+    }>
+  > {
+    const resolved: Array<{
+      credential: CredentialDefinition;
+      binding: RunToolCredentialBinding;
+    }> = [];
+    const targetKeys = new Set<string>();
+    for (const reference of [...definition.transport.credentialReferences].sort()) {
+      const credential = await this.credentialBroker.getDefinition(reference);
+      if (!credential) {
+        throw new ConflictError('Tool server credential definition was not found.', {
           serverId: definition.id,
-          credentialReferences,
-          credentialEnvironmentKeys,
-          headerEnvironmentKeys: headerReferences.map((header) => header.environmentKey),
-          remediation: 'Complete #932 before selecting this definition for a run.',
+          credentialReference: reference,
+        });
+      }
+      if (!credential.enabled) {
+        throw new ConflictError('Tool server credential definition is disabled.', {
+          serverId: definition.id,
+          credentialReference: reference,
+        });
+      }
+      if (!credential.scope.dispatchTypes.includes('mcp')) {
+        throw new ConflictError('Tool server credential definition does not allow MCP dispatch.', {
+          serverId: definition.id,
+          credentialReference: reference,
+        });
+      }
+      if (credential.source.kind !== 'environment') {
+        throw new ConflictError(
+          'External credential sources require an explicit bridge target mapping.',
+          { serverId: definition.id, credentialReference: reference }
+        );
+      }
+      let target: RunToolCredentialBinding['target'];
+      if (definition.transport.kind === 'stdio') {
+        if (!definition.transport.environmentKeys.includes(credential.source.reference)) {
+          throw new ConflictError(
+            'Credential source key is not an environment target on the stdio tool server.',
+            { serverId: definition.id, credentialReference: reference }
+          );
+        }
+        target = { kind: 'environment', name: credential.source.reference };
+      } else {
+        const matches = definition.transport.headers.filter(
+          (header) => header.environmentKey === credential.source.reference
+        );
+        if (matches.length !== 1) {
+          throw new ConflictError(
+            'Credential source key must map to exactly one HTTP tool server header.',
+            { serverId: definition.id, credentialReference: reference }
+          );
+        }
+        target = { kind: 'http-header', name: matches[0].name };
+      }
+      const targetKey = `${target.kind}:${target.name.toLowerCase()}`;
+      if (targetKeys.has(targetKey)) {
+        throw new ConflictError('Tool server credential target is ambiguous.', {
+          serverId: definition.id,
+          target,
+        });
+      }
+      targetKeys.add(targetKey);
+      resolved.push({
+        credential,
+        binding: {
+          credentialReference: credential.id,
+          credentialDefinitionDigest: credential.digest,
+          scopeDigest: calculateCredentialScopeDigest(credential.scope),
+          target,
+        },
+      });
+    }
+    return resolved.sort((left, right) =>
+      left.binding.credentialReference.localeCompare(right.binding.credentialReference)
+    );
+  }
+
+  private async assertCredentialEvidence(
+    entry: RunToolCatalogEntry,
+    definition: ToolServerDefinition
+  ): Promise<void> {
+    const current = await this.compileCredentialBindings(definition, {
+      schemaVersion: TOOL_DISCOVERY_SCHEMA_VERSION,
+      serverId: entry.serverId,
+      serverVersion: entry.serverVersion,
+      definitionDigest: entry.definitionDigest,
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      status: 'ready',
+      tools: entry.tools
+        .filter((tool) => tool.decision !== 'deny')
+        .map(({ name, description, inputSchema, inputSchemaDigest }) => ({
+          name,
+          ...(description ? { description } : {}),
+          inputSchema,
+          inputSchemaDigest,
+        })),
+      discoveredAt: this.now().toISOString(),
+      digest: entry.discoveryDigest,
+    });
+    if (digestRunLaunchValue(current) !== digestRunLaunchValue(entry.credentialBindings ?? [])) {
+      throw new ConflictError(
+        'Credential definition or scope drifted after the run catalog was compiled.',
+        {
+          serverId: entry.serverId,
+          remediation: 'Compile a new launch manifest and run tool catalog.',
         }
       );
     }

--- a/shared/src/types/tool-control-plane.types.ts
+++ b/shared/src/types/tool-control-plane.types.ts
@@ -79,6 +79,21 @@ export interface ToolServerDiscovery {
 
 export type RunToolPolicyDecision = 'allow' | 'deny' | 'approval';
 
+export interface RunToolCredentialBinding {
+  credentialReference: string;
+  credentialDefinitionDigest: string;
+  scopeDigest: string;
+  target:
+    | {
+        kind: 'environment';
+        name: string;
+      }
+    | {
+        kind: 'http-header';
+        name: string;
+      };
+}
+
 export interface RunToolCatalogEntry {
   serverId: string;
   serverVersion: string;
@@ -87,6 +102,8 @@ export interface RunToolCatalogEntry {
   transport: ToolServerTransportKind;
   requirement: ToolServerRequirement;
   status: 'ready' | 'degraded';
+  /** Value-free credential evidence for calls that must use the Veritas bridge. */
+  credentialBindings?: RunToolCredentialBinding[];
   tools: Array<{
     name: string;
     qualifiedName: string;


### PR DESCRIPTION
## Summary

- resolve enabled MCP-scoped credential definitions during run catalog compilation
- bind exact credential definition/scope digests and safe delivery targets into value-free catalog evidence
- strip credential sources during discovery and omit credential-bound servers from native provider injection
- mark launch credentials brokered only when the exact catalog proves the tool-control-plane boundary
- keep credential-bound invocation blocked until #969

## Verification

- 39 tests from the three focused tool-control, credential-plan, and launch-manifest files
- shared build
- server typecheck and build
- focused ESLint
- security artifact scan

Part of #962
Closes #968