### PR TITLE
feat: compose Buzz ACP with run-scoped tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,10 +240,14 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 - `session/update` records enter the causal run journal.
   `session/request_permission` uses the durable approval broker.
 - Only immutable all-allow MCP server catalogs can be passed natively because
-  ACP v1 has no per-tool allowlist. Partial catalogs fail closed.
+  ACP v1 has no per-tool allowlist. Profiles may explicitly require the
+  system-owned `veritas-run` bridge for mediated catalogs; otherwise partial
+  native catalogs fail closed.
 - The built-in `buzz-agent` profile remains provider `acp-stdio`, pins Buzz
   `v0.4.24` at commit `710ed9fff57878a1d69f809b80a6ee0416c53fc4`, and rejects
-  `buzz-acp`, version drift, session loading, and network MCP claims.
+  `buzz-acp`, version drift, session loading, and network MCP claims. Selected
+  run tools are delivered only through the opaque, attempt-bound
+  `veritas-run` bridge.
 - The built-in `copilot` profile remains provider `acp-stdio`, pins Copilot CLI
   `v1.0.74`, owns the stdio safety argv, rejects broad allow/remote/TCP/config
   injection, and records public-preview plus incomplete-source limitations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Composed the pinned `buzz-agent` ACP profile with the system-owned
+  `veritas-run` bridge. Buzz sessions now receive only that bridge for selected
+  run tools, so catalog allow, deny, approval, attribution, and cleanup remain
+  under the provider-neutral control plane without native server credentials
+  or a Buzz-specific MCP implementation. Provider capability evidence advances
+  to probe revision 14 (#909).
 - Added the system-owned `veritas-run` MCP bridge for credential-bound tools.
   Opaque, in-memory authority binds the exact task, attempt, catalog, launch
   manifest, and two allowed bridge methods. Codex CLI/SDK, Codex app-server,

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -65,7 +65,7 @@ Readiness runs bounded `claude --version`, `claude auth status`, and
 `claude agents --json` probes without a shell. The auth status probe is useful
 diagnostic evidence, but only the explicit bare-mode environment satisfies
 launch authentication. The runtime profile requires an exact
-`2.1.218 (Claude Code)` version match and probe revision 13; version or build
+`2.1.218 (Claude Code)` version match and probe revision 14; version or build
 drift invalidates conformance evidence.
 
 Claude's stream is consumed as bounded JSONL. Partial text/thinking, tool
@@ -192,7 +192,7 @@ starts it without a shell in the assigned task worktree.
 Before changing attempt state, Veritas starts a bounded probe process and sends
 ACP `initialize` with protocol version `1`. The returned agent name, version,
 capabilities, and a deterministic capability digest become
-`provider-runtime-manifest/v1` evidence at probe revision 13. Launch starts a
+`provider-runtime-manifest/v1` evidence at probe revision 14. Launch starts a
 fresh process and rejects capability drift before opening or prompting a
 session.
 
@@ -270,6 +270,14 @@ message/tool updates, and stdio MCP. It reports in-memory sessions, no
 `session/load`, no HTTP/SSE MCP, and non-streaming LLM calls truthfully. Resume
 therefore fails closed. `buzz-acp` is the inverse relay-side ACP client and is
 never accepted by this profile.
+
+When a run selects tools, the profile receives exactly one system-owned
+`veritas-run` stdio MCP descriptor. The opaque handle is bound to the task,
+attempt, immutable catalog, launch manifest, and lifecycle. Buzz reads the
+selected catalog and makes allowed or approval-backed calls through that
+bridge; unrelated or denied tools are absent or rejected. Native MCP
+definitions, task credential values, the global Veritas MCP inventory, and
+HTTP/SSE fallback are never injected.
 
 Veritas does not install Buzz or Rust. Build or install `buzz-agent`, then
 configure `BUZZ_AGENT_PROVIDER` plus the matching model and authentication
@@ -440,8 +448,10 @@ Capability states describe behavior that the current adapter actually proves.
 They do not imply that adjacent roadmap work already exists. For example,
 provider-neutral controls remain unsupported or unknown for an adapter until
 the runtime exposes a verified native operation. MCP governance is supported
-only for Codex app-server and Claude Code through the immutable run catalog;
-other task adapters fail closed on a positive MCP selection.
+through the system-owned run bridge for Codex CLI, Codex SDK, Codex app-server,
+Claude Code, and ACP stdio. All-allow native catalogs remain available where
+the adapter can enforce them; Hermes and OpenClaw fail closed when a selected
+catalog requires the bridge.
 
 One evaluator maps those capabilities to launch and run controls. Agent starts
 always require `run.start`, `run.status`, `run.logs`, `run.complete`, and

--- a/docs/BUZZ-INTEGRATION.md
+++ b/docs/BUZZ-INTEGRATION.md
@@ -14,6 +14,10 @@ roster members. Definition import is data-only and never starts a process.
 Task execution is a separate seam. A disabled-by-default `buzz-agent`
 configuration uses provider `acp-stdio` and the generic ACP client. It never
 turns relay delivery into task completion and never launches `buzz-acp`.
+Selected task tools are exposed only through the provider-neutral
+`veritas-run` bridge, with an opaque task/attempt/catalog/manifest binding;
+native server credentials and the global Veritas MCP inventory are not passed
+to Buzz.
 See [Buzz Agent ACP](AGENT-PROVIDERS.md#buzz-agent-acp).
 
 ## Supported contract

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -321,7 +321,8 @@ First-class support for autonomous coding agents.
   the generic ACP provider, pins Buzz v0.4.24 compatibility evidence, exposes
   only its tested configuration and boot-authentication environment keys, and
   reports no persistent session loading or network MCP instead of inventing
-  capabilities
+  capabilities; selected run tools arrive only through the opaque
+  system-owned `veritas-run` bridge
 - **GitHub Copilot CLI ACP profile** — A disabled-by-default `copilot` runtime
   uses the generic ACP provider with a system-owned stdio/public-preview
   baseline, exact v1.0.74 handshake evidence, bounded restrictive process
@@ -356,9 +357,9 @@ persists an immutable `run-tool-catalog/v1` digest in the launch manifest.
   `mcp_servers`; Claude Code receives it through `--strict-mcp-config` and an
   exact MCP `--allowedTools` list.
 - ACP stdio sessions receive a native catalog only when every discovered tool
-  is allowed; partial catalogs fail closed because ACP v1 has no per-tool
-  filtering contract. Other providers reject a positive MCP catalog until they
-  have a conforming adapter.
+  is allowed. Bridge-only profiles such as `buzz-agent` receive exactly one
+  system-owned `veritas-run` descriptor so partial and approval-backed catalogs
+  stay mediated; other partial native catalogs fail closed.
 - Profile-wide named-tool policies still fail closed when a provider cannot
   constrain its built-in tools alongside MCP; prompt instructions do not count
   as enforcement.
@@ -437,7 +438,7 @@ Implemented:
   successful provider result fails closed.
 - **Session continuity evidence** — Claude `session_id` is stored on the attempt
   and separately from turn/item identity in the event schema.
-- **Versioned readiness** — The exact v2.1.218 runtime, probe revision 13,
+- **Versioned readiness** — The exact v2.1.218 runtime, probe revision 14,
   authentication posture, and safe agent-discovery summary determine support
   status.
 - **Capability truth** — The shared approval broker is available, but this

--- a/server/src/__tests__/acp-stdio-provider.test.ts
+++ b/server/src/__tests__/acp-stdio-provider.test.ts
@@ -1,4 +1,6 @@
 import path from 'node:path';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -21,10 +23,19 @@ import {
 } from '../services/acp-stdio-adapter.js';
 import { ClawdbotAgentService } from '../services/clawdbot-agent-service.js';
 import { AgentHealthService } from '../services/agent-health-service.js';
-import { normalizeHarnessSupportProfile } from '../services/harness-support-profile-registry.js';
+import {
+  harnessToolCatalogDelivery,
+  normalizeHarnessSupportProfile,
+} from '../services/harness-support-profile-registry.js';
 import { getProviderRuntimeAdapterDefinition } from '../services/provider-runtime-adapter-registry.js';
+import { RunToolBridgeService } from '../services/run-tool-bridge-service.js';
 
 const FIXTURE_PATH = fileURLToPath(new URL('./fixtures/acp-v1-agent.mjs', import.meta.url));
+const BRIDGE_RUNTIME_PATH = fileURLToPath(
+  new URL('../../runtime/run-tool-bridge.mjs', import.meta.url)
+);
+const BRIDGE_HANDLE = `vkbridge_${'b'.repeat(43)}`;
+const DIGEST = `sha256:${'a'.repeat(64)}`;
 
 function options(mode = 'complete') {
   return {
@@ -69,7 +80,7 @@ describe('ACP v1 stdio provider adapter', () => {
       protocolVersion: 'acp/v1',
       providerVersion: 'VK ACP fixture 1.3.0',
       providerBuild: expect.stringMatching(/^acp-v1:sha256:[a-f0-9]{64}$/),
-      probeRevision: 13,
+      probeRevision: 14,
     });
     expect(manifest.capabilities.find((capability) => capability.id === 'run.resume')?.state).toBe(
       'supported'
@@ -96,6 +107,8 @@ describe('ACP v1 stdio provider adapter', () => {
       executable: { versionArgs: [] },
       compatibility: { testedVersions: ['buzz-agent 0.1.0'] },
     });
+    expect(harnessToolCatalogDelivery(supportProfile.id)).toBe('veritas-bridge');
+    expect(harnessToolCatalogDelivery(COPILOT_ACP_RUNTIME_PROFILE_ID)).toBe('native');
 
     const service = new ClawdbotAgentService({
       async checkAgent() {
@@ -120,7 +133,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: 'buzz-agent 0.1.0',
       providerBuild: expect.stringMatching(/profile:buzz-agent@1:sha256:/),
-      probeRevision: 13,
+      probeRevision: 14,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(BUZZ_AGENT_TESTED_RELEASE),
@@ -146,6 +159,119 @@ describe('ACP v1 stdio provider adapter', () => {
         runtimeProfileId: 'buzz-agent',
       })
     ).rejects.toThrow(/outside the tested compatibility profile/i);
+  });
+
+  it('composes Buzz ACP with only the run-scoped Veritas bridge', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const api = createServer((request, response) => {
+      let body = '';
+      request.setEncoding('utf8');
+      request.on('data', (chunk) => {
+        body += chunk;
+      });
+      request.on('end', () => {
+        response.setHeader('content-type', 'application/json');
+        if (request.url?.endsWith('/catalog')) {
+          response.end(
+            JSON.stringify({
+              digest: DIGEST,
+              entries: [
+                {
+                  serverId: 'veritas',
+                  tools: [
+                    { name: 'read_task', decision: 'allow' },
+                    { name: 'update_task', decision: 'approval' },
+                  ],
+                },
+              ],
+            })
+          );
+          return;
+        }
+        const call = JSON.parse(body) as Record<string, unknown>;
+        calls.push(call);
+        if (call.tool === 'delete_task') {
+          response.statusCode = 403;
+          response.end(JSON.stringify({ error: { message: 'Tool denied by immutable catalog.' } }));
+          return;
+        }
+        response.end(JSON.stringify({ success: true, operationId: call.operationId }));
+      });
+    });
+    await new Promise<void>((resolve) => api.listen(0, '127.0.0.1', resolve));
+    const port = (api.address() as AddressInfo).port;
+    const bridge = new RunToolBridgeService({
+      apiUrl: `http://127.0.0.1:${port}`,
+      entrypoint: BRIDGE_RUNTIME_PATH,
+      randomHandle: () => BRIDGE_HANDLE,
+    });
+    const launch = bridge.issue({
+      taskId: 'task-buzz',
+      attemptId: 'attempt-buzz',
+      catalogDigest: DIGEST,
+      runLaunchManifestDigest: `sha256:${'b'.repeat(64)}`,
+    });
+    const messages: string[] = [];
+    const control = await openAcpStdio({
+      ...options('buzz-bridge'),
+      onNotification(notification) {
+        if (
+          notification.update.sessionUpdate === 'agent_message_chunk' &&
+          notification.update.content.type === 'text'
+        ) {
+          messages.push(notification.update.content.text);
+        }
+      },
+    });
+
+    try {
+      await expect(
+        control.openSession({
+          mode: 'fresh',
+          cwd: process.cwd(),
+          mcpServers: [bridge.acpServer(launch)],
+        })
+      ).resolves.toBe('session-new');
+      await expect(control.prompt('Use only the selected Veritas tools.')).resolves.toEqual({
+        stopReason: 'end_turn',
+      });
+      expect(JSON.parse(messages[0])).toEqual({
+        serverCount: 1,
+        toolNames: ['get_run_tool_catalog', 'call_run_tool'],
+        catalogVisible: true,
+        allowed: true,
+        denied: true,
+        approved: true,
+      });
+      expect(calls).toEqual([
+        {
+          serverId: 'veritas',
+          tool: 'read_task',
+          arguments: { task: 'selected' },
+          operationId: 'buzz-read-1',
+        },
+        {
+          serverId: 'veritas',
+          tool: 'delete_task',
+          arguments: { task: 'unrelated' },
+          operationId: 'buzz-denied-1',
+        },
+        {
+          serverId: 'veritas',
+          tool: 'update_task',
+          arguments: { task: 'selected', status: 'done' },
+          operationId: 'buzz-write-1',
+          approvalId: 'approval-buzz-write-1',
+        },
+      ]);
+    } finally {
+      await control.close();
+      await new Promise<void>((resolve, reject) =>
+        api.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
+    expect(bridge.revokeRun('task-buzz', 'attempt-buzz')).toBe(1);
+    expect(() => bridge.authorize(launch.handle, 'catalog.read')).toThrow(/stale or revoked/);
   });
 
   it('uses ACP initialize instead of a hanging buzz-agent --version health probe', async () => {
@@ -230,7 +356,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: 'Copilot 1.0.74',
       providerBuild: expect.stringMatching(/profile:github-copilot-cli@1:sha256:/),
-      probeRevision: 13,
+      probeRevision: 14,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(COPILOT_ACP_TESTED_RELEASE),
@@ -389,7 +515,7 @@ describe('ACP v1 stdio provider adapter', () => {
       adapter: 'acp-stdio',
       providerVersion: `Grok Build ${GROK_BUILD_ACP_VERSION}`,
       providerBuild: expect.stringMatching(/profile:grok-build@1:sha256:/),
-      probeRevision: 13,
+      probeRevision: 14,
       probe: {
         diagnostics: expect.arrayContaining([
           expect.stringContaining(GROK_BUILD_TESTED_RELEASE),
@@ -653,6 +779,24 @@ describe('ACP v1 stdio provider adapter', () => {
     expect(state('run.streaming')).toBe('supported');
     expect(state('run.approvals')).toBe('supported');
     expect(state('tool.mcp')).toBe('supported');
-    expect(state('credential.broker')).toBe('unsupported');
+    expect(state('credential.broker')).toBe('supported');
+  });
+
+  it('reports the shared bridge capabilities for every supported executable adapter', () => {
+    for (const provider of [
+      'codex-cli',
+      'codex-sdk',
+      'codex-app-server',
+      'claude-code',
+      'acp-stdio',
+    ] as const) {
+      const capabilities = getProviderRuntimeAdapterDefinition(provider).capabilities;
+      expect(capabilities.find((item) => item.id === 'tool.mcp')?.state, provider).toBe(
+        'supported'
+      );
+      expect(capabilities.find((item) => item.id === 'credential.broker')?.state, provider).toBe(
+        'supported'
+      );
+    }
   });
 });

--- a/server/src/__tests__/fixtures/acp-v1-agent.mjs
+++ b/server/src/__tests__/fixtures/acp-v1-agent.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process';
+import { spawn } from 'node:child_process';
 import readline from 'node:readline';
 
 // Stable ACP v1 fixture aligned with @agentclientprotocol/sdk 1.3.0.
@@ -14,6 +15,7 @@ const grokMode = mode.startsWith('grok');
 const lines = readline.createInterface({ input: process.stdin });
 let activeSessionId;
 let pendingPromptId;
+let bridgeEvidence;
 
 function send(record) {
   process.stdout.write(`${JSON.stringify(record)}\n`);
@@ -23,7 +25,79 @@ function result(id, value = {}) {
   send({ jsonrpc: '2.0', id, result: value });
 }
 
-lines.on('line', (line) => {
+async function exerciseRunToolBridge(server) {
+  const environment = Object.fromEntries(
+    (server.env ?? []).map((entry) => [entry.name, entry.value])
+  );
+  const child = spawn(server.command, server.args ?? [], {
+    env: { ...process.env, ...environment },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const output = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+  const pending = new Map();
+  output.on('line', (line) => {
+    const record = JSON.parse(line);
+    pending.get(record.id)?.(record);
+    pending.delete(record.id);
+  });
+  let id = 0;
+  const rpc = (method, params) =>
+    new Promise((resolve) => {
+      id += 1;
+      pending.set(id, resolve);
+      child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+    });
+
+  try {
+    await rpc('initialize', { protocolVersion: '2025-06-18' });
+    const listed = await rpc('tools/list', {});
+    const catalog = await rpc('tools/call', {
+      name: 'get_run_tool_catalog',
+      arguments: {},
+    });
+    const allowed = await rpc('tools/call', {
+      name: 'call_run_tool',
+      arguments: {
+        serverId: 'veritas',
+        tool: 'read_task',
+        arguments: { task: 'selected' },
+        operationId: 'buzz-read-1',
+      },
+    });
+    const denied = await rpc('tools/call', {
+      name: 'call_run_tool',
+      arguments: {
+        serverId: 'veritas',
+        tool: 'delete_task',
+        arguments: { task: 'unrelated' },
+        operationId: 'buzz-denied-1',
+      },
+    });
+    const approved = await rpc('tools/call', {
+      name: 'call_run_tool',
+      arguments: {
+        serverId: 'veritas',
+        tool: 'update_task',
+        arguments: { task: 'selected', status: 'done' },
+        operationId: 'buzz-write-1',
+        approvalId: 'approval-buzz-write-1',
+      },
+    });
+    return {
+      serverCount: 1,
+      toolNames: listed.result.tools.map((tool) => tool.name),
+      catalogVisible: Boolean(catalog.result),
+      allowed: Boolean(allowed.result),
+      denied: Boolean(denied.error),
+      approved: Boolean(approved.result),
+    };
+  } finally {
+    child.stdin.end();
+    await new Promise((resolve) => child.once('close', resolve));
+  }
+}
+
+lines.on('line', async (line) => {
   const record = JSON.parse(line);
   if (record.method === 'initialize') {
     if (mode === 'malformed') {
@@ -116,6 +190,30 @@ lines.on('line', (line) => {
   }
   if (record.method === 'session/new') {
     activeSessionId = 'session-new';
+    if (mode === 'buzz-bridge') {
+      const servers = record.params.mcpServers ?? [];
+      if (servers.length !== 1 || servers[0].name !== 'Veritas run tools') {
+        send({
+          jsonrpc: '2.0',
+          id: record.id,
+          error: { code: -32602, message: 'Buzz expected exactly one Veritas run tool bridge.' },
+        });
+        return;
+      }
+      try {
+        bridgeEvidence = await exerciseRunToolBridge(servers[0]);
+      } catch (error) {
+        send({
+          jsonrpc: '2.0',
+          id: record.id,
+          error: {
+            code: -32603,
+            message: error instanceof Error ? error.message : 'Buzz bridge fixture failed.',
+          },
+        });
+        return;
+      }
+    }
     result(record.id, { sessionId: activeSessionId });
     return;
   }
@@ -143,10 +241,18 @@ lines.on('line', (line) => {
         sessionId: updateSessionId,
         update: {
           sessionUpdate: 'agent_message_chunk',
-          content: { type: 'text', text: 'ACP fixture response.' },
+          content: {
+            type: 'text',
+            text: mode === 'buzz-bridge' ? JSON.stringify(bridgeEvidence) : 'ACP fixture response.',
+          },
         },
       },
     });
+    if (mode === 'buzz-bridge') {
+      result(pendingPromptId, { stopReason: 'end_turn' });
+      pendingPromptId = undefined;
+      return;
+    }
     if (mode === 'cancel') return;
     send({
       jsonrpc: '2.0',

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -141,7 +141,10 @@ import {
 } from './provider-runtime-control-service.js';
 import { resolveTaskCommitPolicy, TaskEnvelopeService } from './task-envelope-service.js';
 import { evaluateHarnessSupportStatus } from './harness-support-service.js';
-import { normalizeHarnessSupportProfile } from './harness-support-profile-registry.js';
+import {
+  harnessToolCatalogDelivery,
+  normalizeHarnessSupportProfile,
+} from './harness-support-profile-registry.js';
 import { RunLaunchManifestService, diffRunLaunchManifests } from './run-launch-manifest-service.js';
 import {
   parseCompletionResultForEnvelope,
@@ -1495,8 +1498,13 @@ export class ClawdbotAgentService {
       if (!pending || pending.attemptId !== attemptId) {
         throw new ConflictError('Run launch no longer matches the pending attempt.');
       }
+      const toolCatalogDelivery = launchAgentConfig
+        ? harnessToolCatalogDelivery(normalizeHarnessSupportProfile(launchAgentConfig).id)
+        : 'native';
       pending.runToolBridge =
-        runToolCatalog && this.runToolBridge.requiresBridge(runToolCatalog)
+        runToolCatalog &&
+        (toolCatalogDelivery === 'veritas-bridge' ||
+          this.runToolBridge.requiresBridge(runToolCatalog))
           ? this.runToolBridge.issue({
               taskId,
               attemptId,
@@ -4099,13 +4107,19 @@ export class ClawdbotAgentService {
     if (runToolCatalog && runToolCatalog.digest !== runLaunchManifest.tools.catalogDigest) {
       throw new ConflictError('ACP run tool catalog does not match launch evidence.');
     }
-    const mcpServers = runToolCatalog ? await this.toolControlPlane.acpConfig(runToolCatalog) : [];
+    const bridgeOnly = harnessToolCatalogDelivery(supportProfile.id) === 'veritas-bridge';
+    if (bridgeOnly && runToolCatalog && !pending.runToolBridge) {
+      throw new ConflictError('ACP profile requires the Veritas run tool bridge.');
+    }
+    const mcpServers =
+      runToolCatalog && !bridgeOnly ? await this.toolControlPlane.acpConfig(runToolCatalog) : [];
     if (pending.runToolBridge) {
       mcpServers.push(this.runToolBridge.acpServer(pending.runToolBridge));
     }
-    const toolEnvironmentKeys = runToolCatalog
-      ? await this.toolControlPlane.environmentKeys(runToolCatalog)
-      : [];
+    const toolEnvironmentKeys =
+      runToolCatalog && !bridgeOnly
+        ? await this.toolControlPlane.environmentKeys(runToolCatalog)
+        : [];
     const approvalAbort = new AbortController();
     pending.abortController = approvalAbort;
     let activeSessionId: string | undefined;
@@ -7330,6 +7344,9 @@ export class ClawdbotAgentService {
     runToolCatalog?: RunToolCatalog;
   }): Promise<RunLaunchManifest> {
     const profile = input.profileLaunch?.profile;
+    const toolCatalogDelivery = input.launchAgentConfig
+      ? harnessToolCatalogDelivery(normalizeHarnessSupportProfile(input.launchAgentConfig).id)
+      : 'native';
     const hasToolRestrictions =
       (profile?.tools?.allowed?.length ?? 0) > 0 ||
       (profile?.policy?.toolPolicyIds?.length ?? 0) > 0;
@@ -7366,8 +7383,11 @@ export class ClawdbotAgentService {
       runtime.environmentKeys = [
         ...new Set([
           ...runtime.environmentKeys,
-          ...(await this.toolControlPlane.environmentKeys(input.runToolCatalog)),
-          ...(this.runToolBridge.requiresBridge(input.runToolCatalog) &&
+          ...(toolCatalogDelivery === 'native'
+            ? await this.toolControlPlane.environmentKeys(input.runToolCatalog)
+            : []),
+          ...((toolCatalogDelivery === 'veritas-bridge' ||
+            this.runToolBridge.requiresBridge(input.runToolCatalog)) &&
           this.runToolBridge.support(input.provider).injection === 'codex-config'
             ? [RUN_TOOL_BRIDGE_ENV_KEY]
             : []),

--- a/server/src/services/harness-support-profile-registry.ts
+++ b/server/src/services/harness-support-profile-registry.ts
@@ -82,6 +82,7 @@ interface ProfileDefinition {
   testedVersions?: string[];
   documentationUrl: string;
   remediation: string[];
+  toolCatalogDelivery?: 'native' | 'veritas-bridge';
 }
 
 interface RedactedLaunchArgs {
@@ -109,6 +110,7 @@ const DEFINITIONS: Record<string, ProfileDefinition> = {
     versionArgs: [],
     testedVersions: [`buzz-agent ${BUZZ_AGENT_ACP_VERSION}`],
     documentationUrl: '/docs/AGENT-PROVIDERS.md#buzz-agent-acp',
+    toolCatalogDelivery: 'veritas-bridge',
     remediation: [
       `Install buzz-agent from Buzz ${BUZZ_AGENT_TESTED_RELEASE}; Veritas does not install Buzz or Rust.`,
       'Set BUZZ_AGENT_PROVIDER and the matching model and authentication environment keys, then run `vk doctor`.',
@@ -271,6 +273,10 @@ const PROVIDER_DEFINITIONS: Record<string, ProfileDefinition> = {
   'hermes-cli': DEFINITIONS.hermes,
 };
 
+export function harnessToolCatalogDelivery(profileId: string): 'native' | 'veritas-bridge' {
+  return DEFINITIONS[profileId]?.toolCatalogDelivery ?? 'native';
+}
+
 export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSupportProfile {
   const definition =
     DEFINITIONS[agent.type] ??
@@ -373,6 +379,7 @@ export function normalizeHarnessSupportProfile(agent: AgentConfig): HarnessSuppo
     authentication,
     platforms: ALL_PLATFORMS,
     launch,
+    toolCatalogDelivery: harnessToolCatalogDelivery(definition.id),
   });
   const unsafeConfigurationReason =
     'Credential material is not allowed in harness launch commands or arguments.';

--- a/server/src/services/provider-runtime-adapter-registry.ts
+++ b/server/src/services/provider-runtime-adapter-registry.ts
@@ -56,12 +56,18 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     'run.interrupt': advisory('Process termination is available; semantic interrupt is not.'),
     'run.resume': supported('Codex CLI resumes a persisted session by its exact ID.'),
     'tool.calls': supported('Codex tool events are parsed and recorded.'),
+    'tool.mcp': supported(
+      'The system-owned run bridge is injected through a required Codex MCP config override.'
+    ),
     'output.structured': advisory(
       'Structured events are available without output-schema enforcement.'
     ),
     'usage.tokens': supported('Codex token usage events are parsed and persisted.'),
     'artifact.write': supported('Codex file events create task deliverable records.'),
     'workspace.worktrees': supported('Codex runs with the task worktree as its working directory.'),
+    'credential.broker': supported(
+      'Task credentials remain inside mediated bridge calls; the Codex process receives only an opaque run handle.'
+    ),
   }),
   'codex-sdk': definition('codex-sdk', 'Codex SDK', 'openai-codex-sdk/v1', {
     ...COMMON_SUPPORTED,
@@ -74,6 +80,9 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     'run.interrupt': advisory('Abort is available; semantic interrupt is not wired.'),
     'run.resume': supported('The SDK resumes a persisted thread by its exact ID.'),
     'tool.calls': supported('Codex SDK tool events are parsed and recorded.'),
+    'tool.mcp': supported(
+      'The SDK receives the system-owned run bridge through its thread-scoped Codex configuration.'
+    ),
     'output.structured': advisory('Typed events are available without output-schema enforcement.'),
     'usage.tokens': supported('Codex SDK token usage events are parsed and persisted.'),
     'artifact.write': supported('Codex SDK file events create task deliverable records.'),
@@ -81,6 +90,9 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     'network.disable': supported('The SDK sandbox can disable network access.'),
     'network.block-private': supported('Disabling network access blocks private network ranges.'),
     'network.block-metadata': supported('Disabling network access blocks metadata endpoints.'),
+    'credential.broker': supported(
+      'Task credentials remain inside mediated bridge calls; the SDK process receives only an opaque run handle.'
+    ),
   }),
   'codex-app-server': definition(
     'codex-app-server',
@@ -132,7 +144,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
         'Command, file, tool, and item lifecycle notifications are journaled and budgeted.'
       ),
       'tool.mcp': supported(
-        'Only the immutable run-scoped MCP catalog is injected through thread configuration; inherited servers remain disabled.'
+        'The immutable catalog and system-owned run bridge are injected through thread configuration; inherited servers remain disabled.'
       ),
       'output.structured': advisory(
         'The transport is schema-validated JSON-RPC; caller output-schema enforcement is not yet exposed.'
@@ -147,8 +159,8 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
       'environment.allowlist': supported(
         'The adapter uses the safe Codex environment and forces remote-control disablement.'
       ),
-      'credential.broker': unsupported(
-        'Provider authentication uses the existing safe Codex environment until issue #932 migrates launches to brokered handles.'
+      'credential.broker': supported(
+        'Task credentials remain inside mediated bridge calls; app-server receives only an opaque run handle. Provider boot authentication stays separately allowlisted.'
       ),
     }
   ),
@@ -181,7 +193,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
       'Claude assistant tool-use and user tool-result records are journaled and budgeted.'
     ),
     'tool.mcp': supported(
-      'Strict MCP mode exposes only the immutable run-scoped catalog and its allowed tools.'
+      'Strict MCP mode exposes the immutable catalog plus the system-owned run bridge and no inherited servers.'
     ),
     'output.structured': advisory(
       'The adapter validates bounded JSONL stream records without enforcing a caller output schema.'
@@ -206,8 +218,8 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     'environment.allowlist': supported(
       'The adapter constructs an explicit process environment allowlist.'
     ),
-    'credential.broker': unsupported(
-      'Claude Code currently receives only explicitly allowlisted environment authentication; brokered handles remain gated by issue #932.'
+    'credential.broker': supported(
+      'Task credentials remain inside mediated bridge calls; Claude receives only an opaque run handle. Provider boot authentication stays separately allowlisted.'
     ),
   }),
   'acp-stdio': definition('acp-stdio', 'ACP stdio', 'acp/v1', {
@@ -236,7 +248,7 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     ),
     'tool.calls': supported('ACP tool_call and tool_call_update records are journaled.'),
     'tool.mcp': supported(
-      'An immutable all-allow run catalog is mapped into ACP session setup; partial native catalogs fail closed.'
+      'All-allow catalogs may map natively; bridge-only profiles and credential-bound catalogs receive the system-owned run bridge through session setup.'
     ),
     'output.structured': advisory(
       'ACP v1 uses structured transport records, but caller output-schema enforcement is not exposed.'
@@ -254,8 +266,8 @@ const DEFINITIONS: Record<ExecutableAgentProvider, ProviderRuntimeAdapterDefinit
     'environment.allowlist': supported(
       'The ACP process receives an explicit environment allowlist.'
     ),
-    'credential.broker': unsupported(
-      'ACP provider boot and task credentials remain unbrokered until issue #932.'
+    'credential.broker': supported(
+      'Task credentials remain inside mediated bridge calls; ACP agents receive only the run-scoped bridge descriptor. Provider boot authentication stays separately allowlisted.'
     ),
   }),
   'hermes-cli': definition('hermes-cli', 'Hermes Agent', 'hermes-one-shot/v1', {

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -110,7 +110,7 @@ export interface HarnessSupportStatus {
 
 export const PROVIDER_RUNTIME_MANIFEST_SCHEMA_VERSION = 'provider-runtime-manifest/v1' as const;
 
-export const PROVIDER_RUNTIME_PROBE_REVISION = 13 as const;
+export const PROVIDER_RUNTIME_PROBE_REVISION = 14 as const;
 
 export const KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS = [
   'run.start',


### PR DESCRIPTION
## Summary

- make the pinned Buzz ACP profile select the provider-neutral veritas-run bridge for every selected catalog
- withhold native task-tool definitions and environment keys from Buzz while retaining native all-allow behavior for other ACP profiles
- align tool MCP and credential-broker capability evidence across Codex CLI, Codex SDK, Codex app-server, Claude Code, and ACP stdio; advance probe revision to 14
- add one composed Buzz ACP fixture covering catalog visibility, an allowed read, a denied unrelated action, an approval-backed write, and revocation
- update Buzz, provider, feature, changelog, and canonical agent guidance

## Verification

- 41 focused tests across three affected files in 1.7 seconds
- shared build
- server typecheck and build
- changed-file ESLint and Prettier
- security artifact scan

Closes #909