### PR TITLE
feat: add reproducible harness conformance suites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,11 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   Build `v0.2.111` build `94172f2aa4e5`, launches `grok agent --no-leader
 stdio`, and rejects approval bypass, reauthentication, leader, plugin,
   endpoint, prompt, and resume argument injection.
+- Harness certification uses `harness-conformance-suite/v1`; run the committed
+  mock lane with `pnpm --filter @veritas-kanban/server exec tsx
+src/scripts/run-harness-conformance.ts -- --suite <suite.json>
+--observations <observations.json>`. Credential-gated lanes require explicit
+  opt-in and never commit raw provider output or secrets.
 - `vk acp serve --stdio` exposes one Veritas-managed task as an ACP v1 server
   view for editors and other ACP clients. Bind with `--task` or require
   `_meta["veritas/taskId"]` on `session/new`; client-owned MCP catalogs fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `harness-conformance-suite/v1` and a deterministic runner for seeded,
+  repeated provider/model/profile/policy/sandbox comparisons. Explicit
+  assertions cover outcomes, files, tools, approvals, network, policy,
+  completion, and capability evidence; normalized results aggregate pass rate,
+  variance, latency, tokens, cost, retries, failure classes, immutable evidence
+  references, and versioned baseline regressions. A credential-free recorded
+  mock command provides the CI/local foundation while credential-gated lanes
+  require explicit opt-in (#859).
 - Composed the pinned `buzz-agent` ACP profile with the system-owned
   `veritas-run` bridge. Buzz sessions now receive only that bridge for selected
   run tools, so catalog allow, deny, approval, attribution, and cleanup remain

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -387,6 +387,16 @@ launch arguments are replaced with `[REDACTED]` before the profile is exposed
 or hashed, so rotating a secret cannot turn the profile digest into a secret
 oracle.
 
+Deterministic certification inputs use
+`harness-conformance-suite/v1`. The runner resets a seeded fixture before each
+trial, applies the same scenario across provider/model/profile/policy/sandbox
+combinations, and emits `harness-conformance-result/v1` with assertion,
+failure-class, pass-rate, variance, latency, token, cost, retry, baseline, and
+immutable evidence references. Run the credential-free recorded lane with the
+documented `run-harness-conformance.ts` command; credential-gated lanes require
+explicit opt-in.
+See [Harness Conformance v1](architecture/HARNESS-CONFORMANCE-V1.md).
+
 The live status projection uses five tiers:
 
 | Tier          | Meaning                                                                                                                      |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -333,6 +333,11 @@ First-class support for autonomous coding agents.
 - **Workspace capability discovery** — Trusted workspace catalogs expose supported task types, SLA/queue posture, intake requirements, and delegated-work packaging so cross-workspace handoffs are explicit
 - **Agent profile packages** — Reusable YAML/JSON packages bundle role, runtime, model, prompt instructions, tools, permissions, sandbox, budget, workflow, and health metadata for portable task launches
 - **Provider runtime manifests** — Every executable adapter records a versioned, evidence-backed capability snapshot and digest on the attempt, history, trace, and log; provider version skew reruns conformance and unsupported configured providers fail closed instead of falling back to OpenClaw
+- **Harness conformance suites** — Versioned seeded scenarios compare
+  provider/model/profile/policy/sandbox combinations across repeated trials,
+  retain immutable launch/runtime/event evidence references, assert governed
+  outcomes, and fail CI or promotion on versioned pass-rate, variance, latency,
+  token, or cost regression
 - **Task-envelope transports** — Provider-owned renderers for OpenClaw, Codex CLI, Codex SDK, Codex app-server, Claude Code, ACP stdio, and Hermes bind the exact task-envelope digest and commit policy to the launched request; the rendered request is fingerprinted in the run launch manifest and mismatched provider/adapter identities fail closed
 - **Sandbox policy presets** — Built-in and custom presets control filesystem scope, network egress, environment passthrough, and credential brokering for agent profiles, workflow agents, and per-run overrides
 - **Agent budget enforcement** — Workspace, agent, workflow, workflow-agent, and per-run budgets can cap tokens, provider cost, tool calls, runtime, retries, and workflow fan-out with warning, approval, downgrade, pause, or cancel actions

--- a/docs/architecture/HARNESS-CONFORMANCE-V1.md
+++ b/docs/architecture/HARNESS-CONFORMANCE-V1.md
@@ -1,0 +1,94 @@
+# Harness Conformance v1
+
+`harness-conformance-suite/v1` is the provider-neutral contract for repeating
+the same seeded scenario across provider, model, profile, policy, and sandbox
+combinations. It complements unit, integration, E2E, load, and security tests;
+it does not replace them or reduce provider quality to one synthetic score.
+
+## Contract
+
+A suite contains:
+
+- a versioned fixture ID, revision, digest, and optional repository/seed;
+- one or more provider/model/profile/policy/sandbox combinations;
+- bounded scenarios with explicit repetitions and assertions;
+- capability claims linked to scenarios that actually assert those claims; and
+- versioned pass-rate, latency, variance, token, and cost baselines.
+
+The initial assertion vocabulary covers outcome, files, tool calls, approvals,
+network attempts, policy decisions, completion schema, and runtime capability
+state. It is deliberately declarative. Suites cannot contain executable code,
+environment values, credentials, arbitrary expressions, or unbounded matchers.
+
+Suites are limited to 20 combinations, 50 scenarios, 20 repetitions per
+scenario, and 500 total trials. IDs and references must be unique and complete.
+File assertions accept bounded relative paths only.
+
+## Runner
+
+`HarnessConformanceService` accepts a validated suite and an executor:
+
+```ts
+type HarnessConformanceExecutor = {
+  reset(input): Promise<void>;
+  execute(input): Promise<HarnessConformanceObservation>;
+};
+```
+
+The runner resets the fixture before every trial, executes combinations and
+scenarios in stable declaration order, validates each observation, evaluates
+assertions, and returns `harness-conformance-result/v1`. A production executor
+can drive Veritas task APIs; deterministic tests can use an in-process mock.
+Credential-gated combinations require explicit opt-in and are never enabled by
+the suite alone.
+
+Each successful observation references the exact run launch manifest and
+provider runtime manifest digests. Optional task, attempt, and causal event
+sequence references retain traceability without copying raw provider output
+into committed fixtures.
+
+Results report per-trial failure class and per-combination/scenario pass rate,
+mean and p95 latency, latency standard deviation, token/cost totals and means,
+retries, baseline revision, and regression reasons. `assertPassed()` throws for
+failed or regressed results so CI and provider-promotion workflows can fail
+closed.
+
+## Recorded mock lane
+
+Run the committed credential-free smoke fixture:
+
+```bash
+pnpm --filter @veritas-kanban/server exec tsx \
+  src/scripts/run-harness-conformance.ts -- \
+  --suite server/src/__fixtures__/harness-conformance/mock-suite.json \
+  --observations server/src/__fixtures__/harness-conformance/mock-observations.json
+```
+
+Add `--json` for the complete normalized result. The recorded executor is
+intentionally inert: it reads bounded observations, runs no arbitrary suite
+command, and exits non-zero when evidence is missing, an assertion fails, or a
+baseline regresses.
+
+Real-provider lanes supply an executor through the service API. A scheduled or
+local caller must add `--allow-credential-gated` or the equivalent service
+option, obtain credentials from the approved runtime secret source, and retain
+only the normalized evidence contract.
+
+## Security and retention
+
+- Suite and observation schemas reject unknown fields and bound every array,
+  string, path, duration, cost, retry, and sequence value.
+- Secret-like suite text is rejected. Executor diagnostics are normalized,
+  redacted, and truncated before inclusion.
+- Observations contain tool names and outcomes, not arguments; hosts, not full
+  URLs; policy decisions, not secrets; and evidence references, not raw logs.
+- Provider output and private task content are not part of the result schema.
+- A failed reset, malformed observation, provider crash, policy block, timeout,
+  or verification failure receives an explicit classification.
+
+## Ownership
+
+This contract owns deterministic scenario execution, reduction, baselines, and
+evidence references. Provider adapters own their mechanics and runtime
+manifests. Buzz composition and the cross-harness compatibility matrix consume
+this runner in their release fixtures rather than creating parallel evaluators.

--- a/server/src/__fixtures__/harness-conformance/mock-observations.json
+++ b/server/src/__fixtures__/harness-conformance/mock-observations.json
@@ -1,0 +1,40 @@
+[
+  {
+    "combinationId": "codex-mock",
+    "scenarioId": "complete-task",
+    "trial": 1,
+    "observation": {
+      "outcome": "passed",
+      "durationMs": 120,
+      "tokens": 90,
+      "costUsd": 0.01,
+      "retries": 0,
+      "files": [
+        {
+          "path": "src/result.txt",
+          "state": "created"
+        }
+      ],
+      "completions": [
+        {
+          "schema": "provider-completion/v1",
+          "valid": true
+        }
+      ],
+      "capabilities": [
+        {
+          "id": "tool.mcp",
+          "state": "supported"
+        }
+      ],
+      "evidence": {
+        "launchManifestDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "providerRuntimeManifestDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "taskId": "task-smoke",
+        "attemptId": "attempt-smoke",
+        "eventSequenceStart": 1,
+        "eventSequenceEnd": 4
+      }
+    }
+  }
+]

--- a/server/src/__fixtures__/harness-conformance/mock-suite.json
+++ b/server/src/__fixtures__/harness-conformance/mock-suite.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": "harness-conformance-suite/v1",
+  "id": "mock-provider-smoke",
+  "revision": 1,
+  "objective": "Exercise a deterministic provider task and retain immutable evidence references.",
+  "fixture": {
+    "id": "seeded-task-repository",
+    "revision": 1,
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "seed": "smoke-1"
+  },
+  "combinations": [
+    {
+      "id": "codex-mock",
+      "provider": "codex-cli",
+      "model": "gpt-5.6-sol",
+      "profileId": "openai-codex-cli",
+      "policyId": "workspace",
+      "sandboxPresetId": "workspace-write",
+      "mode": "mock"
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "complete-task",
+      "objective": "Create the selected fixture output and return a valid completion.",
+      "repetitions": 1,
+      "assertions": [
+        {
+          "kind": "outcome",
+          "expected": "passed"
+        },
+        {
+          "kind": "file",
+          "path": "src/result.txt",
+          "expected": "created"
+        },
+        {
+          "kind": "completion",
+          "expectedSchema": "provider-completion/v1",
+          "valid": true
+        },
+        {
+          "kind": "capability",
+          "capabilityId": "tool.mcp",
+          "expected": "supported"
+        }
+      ]
+    }
+  ],
+  "capabilityClaims": [
+    {
+      "profileId": "openai-codex-cli",
+      "capabilityId": "tool.mcp",
+      "scenarioIds": ["complete-task"]
+    }
+  ],
+  "baselines": [
+    {
+      "revision": 1,
+      "combinationId": "codex-mock",
+      "scenarioId": "complete-task",
+      "minPassRate": 1,
+      "maxMeanLatencyMs": 500,
+      "maxLatencyStdDevMs": 0,
+      "maxMeanTokens": 200,
+      "maxMeanCostUsd": 0.05
+    }
+  ]
+}

--- a/server/src/__tests__/harness-conformance-service.test.ts
+++ b/server/src/__tests__/harness-conformance-service.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  HarnessConformanceExecutionInput,
+  HarnessConformanceExecutor,
+  HarnessConformanceObservation,
+  HarnessConformanceSuite,
+} from '@veritas-kanban/shared';
+import {
+  HarnessConformanceExecutionError,
+  HarnessConformanceService,
+} from '../services/harness-conformance-service.js';
+
+const DIGEST_A = `sha256:${'a'.repeat(64)}`;
+const DIGEST_B = `sha256:${'b'.repeat(64)}`;
+
+function suite(): HarnessConformanceSuite {
+  return {
+    schemaVersion: 'harness-conformance-suite/v1',
+    id: 'provider-parity',
+    revision: 1,
+    objective: 'Prove the same governed task contract across provider profiles.',
+    fixture: {
+      id: 'seeded-task-repository',
+      revision: 1,
+      digest: DIGEST_A,
+      seed: 'task-42',
+    },
+    combinations: [
+      {
+        id: 'codex',
+        provider: 'codex-cli',
+        model: 'gpt-5.6-sol',
+        profileId: 'openai-codex-cli',
+        policyId: 'workspace',
+        sandboxPresetId: 'workspace-write',
+        mode: 'mock',
+      },
+      {
+        id: 'claude',
+        provider: 'claude-code',
+        model: 'claude-sonnet-4-6',
+        profileId: 'claude-code',
+        policyId: 'workspace',
+        sandboxPresetId: 'workspace-write',
+        mode: 'mock',
+      },
+    ],
+    scenarios: [
+      {
+        id: 'governed-change',
+        objective: 'Create the selected file and complete through the governed tool boundary.',
+        repetitions: 2,
+        assertions: [
+          { kind: 'outcome', expected: 'passed' },
+          { kind: 'file', path: 'src/result.txt', expected: 'created' },
+          { kind: 'tool', name: 'workspace/write_file', expected: 'allowed' },
+          { kind: 'approval', expected: 'approved' },
+          { kind: 'network', host: 'metadata.internal', expected: 'denied' },
+          { kind: 'policy', policyId: 'workspace', expected: 'allowed' },
+          { kind: 'completion', expectedSchema: 'provider-completion/v1', valid: true },
+          { kind: 'capability', capabilityId: 'tool.mcp', expected: 'supported' },
+        ],
+      },
+    ],
+    capabilityClaims: [
+      {
+        profileId: 'openai-codex-cli',
+        capabilityId: 'tool.mcp',
+        scenarioIds: ['governed-change'],
+      },
+      {
+        profileId: 'claude-code',
+        capabilityId: 'tool.mcp',
+        scenarioIds: ['governed-change'],
+      },
+    ],
+    baselines: [
+      {
+        revision: 1,
+        combinationId: 'codex',
+        scenarioId: 'governed-change',
+        minPassRate: 1,
+        maxMeanLatencyMs: 150,
+        maxLatencyStdDevMs: 10,
+        maxMeanTokens: 120,
+        maxMeanCostUsd: 0.02,
+      },
+      {
+        revision: 1,
+        combinationId: 'claude',
+        scenarioId: 'governed-change',
+        minPassRate: 1,
+        maxMeanLatencyMs: 150,
+        maxLatencyStdDevMs: 10,
+        maxMeanTokens: 120,
+        maxMeanCostUsd: 0.02,
+      },
+    ],
+  };
+}
+
+function observation(input: HarnessConformanceExecutionInput): HarnessConformanceObservation {
+  return {
+    outcome: 'passed',
+    durationMs: 100 + input.trial,
+    tokens: 100,
+    costUsd: 0.01,
+    retries: 0,
+    files: [{ path: 'src/result.txt', state: 'created' }],
+    tools: [{ name: 'workspace/write_file', outcome: 'allowed' }],
+    approvals: [{ outcome: 'approved' }],
+    network: [{ host: 'metadata.internal', decision: 'denied' }],
+    policies: [{ policyId: 'workspace', decision: 'allowed' }],
+    completions: [{ schema: 'provider-completion/v1', valid: true }],
+    capabilities: [{ id: 'tool.mcp', state: 'supported' }],
+    evidence: {
+      launchManifestDigest: DIGEST_A,
+      providerRuntimeManifestDigest: DIGEST_B,
+      taskId: `task-${input.combination.id}`,
+      attemptId: `attempt-${input.trial}`,
+      eventSequenceStart: 1,
+      eventSequenceEnd: 8,
+    },
+  };
+}
+
+function executor(
+  execute: (input: HarnessConformanceExecutionInput) => HarnessConformanceObservation = observation
+): HarnessConformanceExecutor {
+  return {
+    reset: vi.fn(async () => undefined),
+    execute: vi.fn(async (input) => execute(input)),
+  };
+}
+
+describe('HarnessConformanceService', () => {
+  it('runs one seeded scenario across provider combinations and aggregates reproducible evidence', async () => {
+    const runner = executor();
+    const service = new HarnessConformanceService(() => new Date('2026-07-24T14:00:00.000Z'));
+    const result = await service.run(suite(), runner);
+
+    expect(result).toMatchObject({
+      schemaVersion: 'harness-conformance-result/v1',
+      suiteId: 'provider-parity',
+      suiteRevision: 1,
+      status: 'passed',
+    });
+    expect(result.trials).toHaveLength(4);
+    expect(result.aggregates).toEqual([
+      expect.objectContaining({
+        combinationId: 'codex',
+        trials: 2,
+        passed: 2,
+        passRate: 1,
+        meanLatencyMs: 101.5,
+        p95LatencyMs: 102,
+        totalTokens: 200,
+        totalCostUsd: 0.02,
+        regressions: [],
+      }),
+      expect.objectContaining({
+        combinationId: 'claude',
+        trials: 2,
+        passed: 2,
+        regressions: [],
+      }),
+    ]);
+    expect(runner.reset).toHaveBeenCalledTimes(4);
+    expect(runner.execute).toHaveBeenCalledTimes(4);
+    expect(result.trials[0]?.observation?.evidence).toMatchObject({
+      launchManifestDigest: DIGEST_A,
+      providerRuntimeManifestDigest: DIGEST_B,
+      eventSequenceStart: 1,
+      eventSequenceEnd: 8,
+    });
+    expect(() => service.assertPassed(result)).not.toThrow();
+  });
+
+  it('reports baseline regression and exposes a CI-blocking assertion', async () => {
+    const slower = executor((input) => ({
+      ...observation(input),
+      durationMs: 500,
+      tokens: 400,
+      costUsd: 0.25,
+    }));
+    const service = new HarnessConformanceService();
+    const result = await service.run(suite(), slower);
+
+    expect(result.status).toBe('regression');
+    expect(result.aggregates[0]?.regressions).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Mean latency'),
+        expect.stringContaining('Mean tokens'),
+        expect.stringContaining('Mean cost'),
+      ])
+    );
+    expect(() => service.assertPassed(result)).toThrow(/conformance regression/i);
+  });
+
+  it('classifies reset and provider execution failures without losing later trials', async () => {
+    const candidate = suite();
+    retainFirstCombination(candidate);
+    const reset = vi
+      .fn<HarnessConformanceExecutor['reset']>()
+      .mockRejectedValueOnce(new Error('fixture could not reset'))
+      .mockResolvedValue(undefined);
+    const run = vi
+      .fn<HarnessConformanceExecutor['execute']>()
+      .mockRejectedValueOnce(
+        new HarnessConformanceExecutionError('provider-crash', 'provider exited 9')
+      );
+    const result = await new HarnessConformanceService().run(candidate, { reset, execute: run });
+
+    expect(result.status).toBe('regression');
+    expect(result.trials).toMatchObject([
+      { passed: false, failureClass: 'fixture-reset' },
+      { passed: false, failureClass: 'provider-crash' },
+    ]);
+    expect(reset).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('requires explicit opt-in for credential-gated lanes', async () => {
+    const candidate = suite();
+    retainFirstCombination(candidate);
+    const first = candidate.combinations[0];
+    if (!first) throw new Error('Fixture combination missing.');
+    candidate.combinations = [{ ...first, mode: 'credential-gated' as const }];
+    const runner = executor();
+    const service = new HarnessConformanceService();
+
+    await expect(service.run(candidate, runner)).rejects.toThrow(/explicit.*opt-in/i);
+    await expect(
+      service.run(candidate, runner, { allowCredentialGated: true })
+    ).resolves.toMatchObject({ status: 'passed' });
+  });
+
+  it('rejects unproven claims and secret-bearing suites while redacting executor diagnostics', async () => {
+    const missingProof = suite();
+    const firstScenario = missingProof.scenarios[0];
+    if (!firstScenario) throw new Error('Fixture scenario missing.');
+    firstScenario.assertions = [{ kind: 'outcome', expected: 'passed' }];
+    await expect(new HarnessConformanceService().run(missingProof, executor())).rejects.toThrow(
+      /matching scenario assertion/i
+    );
+
+    const secret = suite();
+    secret.objective = 'api_key=super-sensitive-fixture-value';
+    await expect(new HarnessConformanceService().run(secret, executor())).rejects.toThrow(
+      /credential material/i
+    );
+
+    const diagnostic = executor((input) => ({
+      ...observation(input),
+      diagnostic: 'token=super-sensitive-provider-value',
+    }));
+    const result = await new HarnessConformanceService().run(suite(), diagnostic);
+    expect(result.trials[0]?.diagnostic).toBe('token=[REDACTED]');
+    expect(JSON.stringify(result)).not.toContain('super-sensitive-provider-value');
+  });
+});
+
+function retainFirstCombination(candidate: HarnessConformanceSuite): void {
+  const first = candidate.combinations[0];
+  if (!first) throw new Error('Fixture combination missing.');
+  candidate.combinations = [first];
+  candidate.baselines = candidate.baselines.filter(
+    (baseline) => baseline.combinationId === first.id
+  );
+  candidate.capabilityClaims = candidate.capabilityClaims.filter(
+    (claim) => claim.profileId === first.profileId
+  );
+}

--- a/server/src/schemas/harness-conformance-schemas.ts
+++ b/server/src/schemas/harness-conformance-schemas.ts
@@ -1,0 +1,313 @@
+import { z } from 'zod';
+import {
+  HARNESS_CONFORMANCE_SUITE_SCHEMA_VERSION,
+  KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS,
+} from '@veritas-kanban/shared';
+
+const identifier = z
+  .string()
+  .trim()
+  .min(1)
+  .max(120)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/);
+const digest = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const boundedText = z.string().trim().min(1).max(2000);
+const relativePath = z
+  .string()
+  .trim()
+  .min(1)
+  .max(500)
+  .refine((value) => !value.startsWith('/') && !value.includes('..'), {
+    message: 'Conformance file paths must remain relative and cannot traverse.',
+  });
+const capabilityId = z.enum(KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS);
+const capabilityState = z.enum(['supported', 'advisory', 'unsupported', 'unknown']);
+
+export const harnessConformanceAssertionSchema = z.discriminatedUnion('kind', [
+  z
+    .object({ kind: z.literal('outcome'), expected: z.enum(['passed', 'failed', 'blocked']) })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('file'),
+      path: relativePath,
+      expected: z.enum(['created', 'modified', 'deleted', 'unchanged']),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('tool'),
+      name: identifier,
+      expected: z.enum(['called', 'not-called', 'allowed', 'denied']),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('approval'),
+      expected: z.enum(['requested', 'approved', 'denied', 'not-requested']),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('network'),
+      host: z.string().trim().min(1).max(253),
+      expected: z.enum(['allowed', 'denied', 'not-attempted']),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('policy'),
+      policyId: identifier,
+      expected: z.enum(['allowed', 'denied', 'approval']),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('completion'),
+      expectedSchema: identifier,
+      valid: z.boolean(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('capability'),
+      capabilityId,
+      expected: capabilityState,
+    })
+    .strict(),
+]);
+
+const combinationSchema = z
+  .object({
+    id: identifier,
+    provider: identifier,
+    model: z.string().trim().min(1).max(200).optional(),
+    profileId: identifier,
+    policyId: identifier.optional(),
+    sandboxPresetId: identifier.optional(),
+    mode: z.enum(['mock', 'local', 'credential-gated']),
+  })
+  .strict();
+
+const scenarioSchema = z
+  .object({
+    id: identifier,
+    objective: boundedText,
+    repetitions: z.number().int().min(1).max(20),
+    assertions: z.array(harnessConformanceAssertionSchema).min(1).max(100),
+  })
+  .strict();
+
+export const harnessConformanceSuiteSchema = z
+  .object({
+    schemaVersion: z.literal(HARNESS_CONFORMANCE_SUITE_SCHEMA_VERSION),
+    id: identifier,
+    revision: z.number().int().positive(),
+    objective: boundedText,
+    fixture: z
+      .object({
+        id: identifier,
+        revision: z.number().int().positive(),
+        digest,
+        repository: z.string().url().max(500).optional(),
+        seed: z.string().trim().min(1).max(200).optional(),
+      })
+      .strict(),
+    combinations: z.array(combinationSchema).min(1).max(20),
+    scenarios: z.array(scenarioSchema).min(1).max(50),
+    capabilityClaims: z
+      .array(
+        z
+          .object({
+            profileId: identifier,
+            capabilityId,
+            scenarioIds: z.array(identifier).min(1).max(50),
+          })
+          .strict()
+      )
+      .max(200),
+    baselines: z
+      .array(
+        z
+          .object({
+            revision: z.number().int().positive(),
+            combinationId: identifier,
+            scenarioId: identifier,
+            minPassRate: z.number().min(0).max(1),
+            maxMeanLatencyMs: z.number().nonnegative().optional(),
+            maxLatencyStdDevMs: z.number().nonnegative().optional(),
+            maxMeanTokens: z.number().nonnegative().optional(),
+            maxMeanCostUsd: z.number().nonnegative().optional(),
+          })
+          .strict()
+      )
+      .max(1000),
+  })
+  .strict()
+  .superRefine((suite, context) => {
+    uniqueIds(suite.combinations, ['combinations'], context);
+    uniqueIds(suite.scenarios, ['scenarios'], context);
+    const combinationIds = new Set(suite.combinations.map((item) => item.id));
+    const scenarios = new Map(suite.scenarios.map((item) => [item.id, item]));
+    for (const [index, baseline] of suite.baselines.entries()) {
+      if (!combinationIds.has(baseline.combinationId)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['baselines', index, 'combinationId'],
+          message: 'Baseline references an unknown combination.',
+        });
+      }
+      if (!scenarios.has(baseline.scenarioId)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['baselines', index, 'scenarioId'],
+          message: 'Baseline references an unknown scenario.',
+        });
+      }
+    }
+    for (const [claimIndex, claim] of suite.capabilityClaims.entries()) {
+      const profileExists = suite.combinations.some(
+        (combination) => combination.profileId === claim.profileId
+      );
+      if (!profileExists) {
+        context.addIssue({
+          code: 'custom',
+          path: ['capabilityClaims', claimIndex, 'profileId'],
+          message: 'Capability claim references an unknown profile.',
+        });
+      }
+      for (const [scenarioIndex, scenarioId] of claim.scenarioIds.entries()) {
+        const scenario = scenarios.get(scenarioId);
+        if (!scenario) {
+          context.addIssue({
+            code: 'custom',
+            path: ['capabilityClaims', claimIndex, 'scenarioIds', scenarioIndex],
+            message: 'Capability claim references an unknown scenario.',
+          });
+          continue;
+        }
+        if (
+          !scenario.assertions.some(
+            (assertion) =>
+              assertion.kind === 'capability' && assertion.capabilityId === claim.capabilityId
+          )
+        ) {
+          context.addIssue({
+            code: 'custom',
+            path: ['capabilityClaims', claimIndex, 'scenarioIds', scenarioIndex],
+            message: 'Claimed capability must have a matching scenario assertion.',
+          });
+        }
+      }
+    }
+    const trialCount =
+      suite.combinations.length *
+      suite.scenarios.reduce((total, scenario) => total + scenario.repetitions, 0);
+    if (trialCount > 500) {
+      context.addIssue({
+        code: 'custom',
+        path: ['scenarios'],
+        message: 'A conformance suite is limited to 500 total trials.',
+      });
+    }
+  });
+
+export const harnessConformanceObservationSchema = z
+  .object({
+    outcome: z.enum(['passed', 'failed', 'blocked']),
+    durationMs: z
+      .number()
+      .nonnegative()
+      .max(24 * 60 * 60 * 1000),
+    tokens: z.number().nonnegative().optional(),
+    costUsd: z.number().nonnegative().optional(),
+    retries: z.number().int().nonnegative().max(100).optional(),
+    files: z
+      .array(
+        z
+          .object({
+            path: relativePath,
+            state: z.enum(['created', 'modified', 'deleted', 'unchanged']),
+          })
+          .strict()
+      )
+      .max(2000)
+      .optional(),
+    tools: z
+      .array(z.object({ name: identifier, outcome: z.enum(['allowed', 'denied']) }).strict())
+      .max(2000)
+      .optional(),
+    approvals: z
+      .array(z.object({ outcome: z.enum(['requested', 'approved', 'denied']) }).strict())
+      .max(1000)
+      .optional(),
+    network: z
+      .array(
+        z
+          .object({
+            host: z.string().trim().min(1).max(253),
+            decision: z.enum(['allowed', 'denied']),
+          })
+          .strict()
+      )
+      .max(1000)
+      .optional(),
+    policies: z
+      .array(
+        z
+          .object({
+            policyId: identifier,
+            decision: z.enum(['allowed', 'denied', 'approval']),
+          })
+          .strict()
+      )
+      .max(1000)
+      .optional(),
+    completions: z
+      .array(z.object({ schema: identifier, valid: z.boolean() }).strict())
+      .max(100)
+      .optional(),
+    capabilities: z
+      .array(z.object({ id: capabilityId, state: capabilityState }).strict())
+      .max(KNOWN_PROVIDER_RUNTIME_CAPABILITY_IDS.length)
+      .optional(),
+    evidence: z
+      .object({
+        launchManifestDigest: digest,
+        providerRuntimeManifestDigest: digest,
+        taskId: identifier.optional(),
+        attemptId: identifier.optional(),
+        eventSequenceStart: z.number().int().nonnegative().optional(),
+        eventSequenceEnd: z.number().int().nonnegative().optional(),
+      })
+      .strict(),
+    failureClass: z
+      .enum([
+        'assertion',
+        'fixture-reset',
+        'provider-launch',
+        'provider-timeout',
+        'provider-crash',
+        'policy-block',
+        'malformed-output',
+        'verification',
+        'unknown',
+      ])
+      .optional(),
+    diagnostic: z.string().max(8000).optional(),
+  })
+  .strict();
+
+function uniqueIds(values: Array<{ id: string }>, path: string[], context: z.RefinementCtx): void {
+  const seen = new Set<string>();
+  for (const [index, value] of values.entries()) {
+    if (seen.has(value.id)) {
+      context.addIssue({
+        code: 'custom',
+        path: [...path, index, 'id'],
+        message: 'IDs must be unique within the suite.',
+      });
+    }
+    seen.add(value.id);
+  }
+}

--- a/server/src/scripts/run-harness-conformance.ts
+++ b/server/src/scripts/run-harness-conformance.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type {
+  HarnessConformanceExecutionInput,
+  HarnessConformanceObservation,
+  HarnessConformanceSuite,
+} from '@veritas-kanban/shared';
+import {
+  HarnessConformanceExecutionError,
+  HarnessConformanceService,
+} from '../services/harness-conformance-service.js';
+
+interface RecordedObservation {
+  combinationId: string;
+  scenarioId: string;
+  trial: number;
+  observation: HarnessConformanceObservation;
+}
+
+const MAX_INPUT_BYTES = 3 * 1024 * 1024;
+const args = parseArgs(process.argv.slice(2));
+const suite = await readJson<HarnessConformanceSuite>(args.suite);
+const recorded = await readJson<RecordedObservation[]>(args.observations);
+const byTrial = new Map(
+  recorded.map((item) => [
+    `${item.combinationId}\0${item.scenarioId}\0${item.trial}`,
+    item.observation,
+  ])
+);
+const service = new HarnessConformanceService();
+const result = await service.run(
+  suite,
+  {
+    async reset() {
+      // Recorded fixtures are immutable; production executors provide a real reset.
+    },
+    async execute(input: HarnessConformanceExecutionInput) {
+      const key = `${input.combination.id}\0${input.scenario.id}\0${input.trial}`;
+      const observation = byTrial.get(key);
+      if (!observation) {
+        throw new HarnessConformanceExecutionError(
+          'verification',
+          `Recorded observation is missing for ${input.combination.id}/${input.scenario.id}/${input.trial}.`
+        );
+      }
+      return structuredClone(observation);
+    },
+  },
+  { allowCredentialGated: args.allowCredentialGated }
+);
+
+if (args.json) {
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} else {
+  process.stdout.write(
+    `${result.status.toUpperCase()} ${result.suiteId}@${result.suiteRevision}: ` +
+      `${result.trials.filter((trial) => trial.passed).length}/${result.trials.length} trials passed, ` +
+      `${result.aggregates.reduce((count, aggregate) => count + aggregate.regressions.length, 0)} regressions\n`
+  );
+}
+service.assertPassed(result);
+
+function parseArgs(values: string[]): {
+  suite: string;
+  observations: string;
+  json: boolean;
+  allowCredentialGated: boolean;
+} {
+  let suite: string | undefined;
+  let observations: string | undefined;
+  let json = false;
+  let allowCredentialGated = false;
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (value === '--') continue;
+    if (value === '--suite') suite = values[++index];
+    else if (value === '--observations') observations = values[++index];
+    else if (value === '--json') json = true;
+    else if (value === '--allow-credential-gated') allowCredentialGated = true;
+    else throw new Error(`Unknown conformance option: ${value}`);
+  }
+  if (!suite || !observations) {
+    throw new Error(
+      'Usage: pnpm --filter @veritas-kanban/server exec tsx src/scripts/run-harness-conformance.ts -- --suite <suite.json> --observations <observations.json> [--json] [--allow-credential-gated]'
+    );
+  }
+  const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+  return {
+    suite: path.resolve(repositoryRoot, suite),
+    observations: path.resolve(repositoryRoot, observations),
+    json,
+    allowCredentialGated,
+  };
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  const content = await readFile(filePath, 'utf8');
+  if (Buffer.byteLength(content, 'utf8') > MAX_INPUT_BYTES) {
+    throw new Error(`Conformance input exceeds ${MAX_INPUT_BYTES} bytes: ${filePath}`);
+  }
+  return JSON.parse(content) as T;
+}

--- a/server/src/services/harness-conformance-service.ts
+++ b/server/src/services/harness-conformance-service.ts
@@ -1,0 +1,401 @@
+import { createHash } from 'node:crypto';
+import type {
+  HarnessConformanceAggregate,
+  HarnessConformanceAssertion,
+  HarnessConformanceAssertionResult,
+  HarnessConformanceExecutionInput,
+  HarnessConformanceExecutor,
+  HarnessConformanceFailureClass,
+  HarnessConformanceObservation,
+  HarnessConformanceResult,
+  HarnessConformanceSuite,
+  HarnessConformanceTrialResult,
+} from '@veritas-kanban/shared';
+import { HARNESS_CONFORMANCE_RESULT_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import { ConflictError, ValidationError } from '../middleware/error-handler.js';
+import {
+  harnessConformanceObservationSchema,
+  harnessConformanceSuiteSchema,
+} from '../schemas/harness-conformance-schemas.js';
+import {
+  containsUnredactedProviderRuntimeSecret,
+  sanitizeProviderRuntimeDiagnostic,
+} from '../utils/provider-runtime-manifest-sanitize.js';
+
+export interface HarnessConformanceRunOptions {
+  allowCredentialGated?: boolean;
+}
+
+export class HarnessConformanceExecutionError extends Error {
+  constructor(
+    public readonly failureClass: HarnessConformanceFailureClass,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export class HarnessConformanceService {
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  async run(
+    input: HarnessConformanceSuite,
+    executor: HarnessConformanceExecutor,
+    options: HarnessConformanceRunOptions = {}
+  ): Promise<HarnessConformanceResult> {
+    const suite = harnessConformanceSuiteSchema.parse(input) as HarnessConformanceSuite;
+    if (containsSensitiveValue(suite)) {
+      throw new ValidationError('Conformance suites cannot contain credential material.');
+    }
+    if (
+      !options.allowCredentialGated &&
+      suite.combinations.some((combination) => combination.mode === 'credential-gated')
+    ) {
+      throw new ValidationError(
+        'Credential-gated conformance requires an explicit local or scheduled-lane opt-in.'
+      );
+    }
+
+    const startedAt = this.now().toISOString();
+    const trials: HarnessConformanceTrialResult[] = [];
+    for (const combination of suite.combinations) {
+      for (const scenario of suite.scenarios) {
+        for (let trial = 1; trial <= scenario.repetitions; trial += 1) {
+          const execution: HarnessConformanceExecutionInput = {
+            suite,
+            combination,
+            scenario,
+            trial,
+          };
+          trials.push(await this.executeTrial(execution, executor));
+        }
+      }
+    }
+    const aggregates = this.aggregate(suite, trials);
+    const hasRegression = aggregates.some((aggregate) => aggregate.regressions.length > 0);
+    const status = hasRegression
+      ? 'regression'
+      : trials.every((trial) => trial.passed)
+        ? 'passed'
+        : 'failed';
+    const completedAt = this.now().toISOString();
+    return {
+      schemaVersion: HARNESS_CONFORMANCE_RESULT_SCHEMA_VERSION,
+      id: `hcr_${hashJson({ suite: suite.id, revision: suite.revision, startedAt }).slice(0, 24)}`,
+      suiteId: suite.id,
+      suiteRevision: suite.revision,
+      fixture: structuredClone(suite.fixture),
+      startedAt,
+      completedAt,
+      status,
+      trials,
+      aggregates,
+    };
+  }
+
+  assertPassed(result: HarnessConformanceResult): void {
+    if (result.status === 'passed') return;
+    throw new ConflictError(`Harness conformance ${result.status}.`, {
+      resultId: result.id,
+      regressions: result.aggregates.flatMap((aggregate) =>
+        aggregate.regressions.map((regression) => ({
+          combinationId: aggregate.combinationId,
+          scenarioId: aggregate.scenarioId,
+          detail: regression,
+        }))
+      ),
+      failedTrials: result.trials.filter((trial) => !trial.passed).length,
+    });
+  }
+
+  private async executeTrial(
+    input: HarnessConformanceExecutionInput,
+    executor: HarnessConformanceExecutor
+  ): Promise<HarnessConformanceTrialResult> {
+    try {
+      await executor.reset(structuredClone(input));
+    } catch (error) {
+      return failedTrial(input, 'fixture-reset', error);
+    }
+
+    let observation: HarnessConformanceObservation;
+    try {
+      observation = harnessConformanceObservationSchema.parse(
+        await executor.execute(structuredClone(input))
+      ) as HarnessConformanceObservation;
+    } catch (error) {
+      return failedTrial(
+        input,
+        error instanceof HarnessConformanceExecutionError
+          ? error.failureClass
+          : isSchemaError(error)
+            ? 'malformed-output'
+            : 'unknown',
+        error
+      );
+    }
+    const assertions = input.scenario.assertions.map((assertion) =>
+      evaluateAssertion(assertion, observation)
+    );
+    const passed = assertions.every((assertion) => assertion.passed);
+    const { diagnostic, ...safeObservation } = observation;
+    return {
+      combinationId: input.combination.id,
+      scenarioId: input.scenario.id,
+      trial: input.trial,
+      passed,
+      ...(!passed || observation.failureClass
+        ? { failureClass: observation.failureClass ?? 'assertion' }
+        : {}),
+      ...(diagnostic ? { diagnostic: sanitizeProviderRuntimeDiagnostic(diagnostic) } : {}),
+      observation: safeObservation,
+      assertions,
+    };
+  }
+
+  private aggregate(
+    suite: HarnessConformanceSuite,
+    trials: HarnessConformanceTrialResult[]
+  ): HarnessConformanceAggregate[] {
+    return suite.combinations.flatMap((combination) =>
+      suite.scenarios.map((scenario) => {
+        const matching = trials.filter(
+          (trial) => trial.combinationId === combination.id && trial.scenarioId === scenario.id
+        );
+        const observations = matching.flatMap((trial) =>
+          trial.observation ? [trial.observation] : []
+        );
+        const latencies = observations.map((observation) => observation.durationMs);
+        const tokens = observations.map((observation) => observation.tokens ?? 0);
+        const costs = observations.map((observation) => observation.costUsd ?? 0);
+        const aggregate: HarnessConformanceAggregate = {
+          combinationId: combination.id,
+          scenarioId: scenario.id,
+          trials: matching.length,
+          passed: matching.filter((trial) => trial.passed).length,
+          passRate:
+            matching.length === 0
+              ? 0
+              : matching.filter((trial) => trial.passed).length / matching.length,
+          meanLatencyMs: mean(latencies),
+          p95LatencyMs: percentile(latencies, 0.95),
+          latencyStdDevMs: stdDev(latencies),
+          meanTokens: mean(tokens),
+          totalTokens: sum(tokens),
+          meanCostUsd: mean(costs),
+          totalCostUsd: sum(costs),
+          retries: sum(observations.map((observation) => observation.retries ?? 0)),
+          regressions: [],
+        };
+        const baseline = suite.baselines.find(
+          (candidate) =>
+            candidate.combinationId === combination.id && candidate.scenarioId === scenario.id
+        );
+        if (baseline) {
+          aggregate.baselineRevision = baseline.revision;
+          if (aggregate.passRate < baseline.minPassRate) {
+            aggregate.regressions.push(
+              `Pass rate ${aggregate.passRate.toFixed(3)} is below ${baseline.minPassRate.toFixed(3)}.`
+            );
+          }
+          compareMaximum(
+            aggregate.regressions,
+            'Mean latency',
+            aggregate.meanLatencyMs,
+            baseline.maxMeanLatencyMs,
+            'ms'
+          );
+          compareMaximum(
+            aggregate.regressions,
+            'Latency standard deviation',
+            aggregate.latencyStdDevMs,
+            baseline.maxLatencyStdDevMs,
+            'ms'
+          );
+          compareMaximum(
+            aggregate.regressions,
+            'Mean tokens',
+            aggregate.meanTokens,
+            baseline.maxMeanTokens,
+            'tokens'
+          );
+          compareMaximum(
+            aggregate.regressions,
+            'Mean cost',
+            aggregate.meanCostUsd,
+            baseline.maxMeanCostUsd,
+            'USD'
+          );
+        }
+        return aggregate;
+      })
+    );
+  }
+}
+
+function failedTrial(
+  input: HarnessConformanceExecutionInput,
+  failureClass: HarnessConformanceFailureClass,
+  error: unknown
+): HarnessConformanceTrialResult {
+  return {
+    combinationId: input.combination.id,
+    scenarioId: input.scenario.id,
+    trial: input.trial,
+    passed: false,
+    failureClass,
+    diagnostic: sanitizeProviderRuntimeDiagnostic(
+      error instanceof Error ? error.message : 'Harness conformance execution failed.'
+    ),
+    assertions: [],
+  };
+}
+
+function evaluateAssertion(
+  assertion: HarnessConformanceAssertion,
+  observation: HarnessConformanceObservation
+): HarnessConformanceAssertionResult {
+  let passed = false;
+  let observed = 'not observed';
+  switch (assertion.kind) {
+    case 'outcome':
+      observed = observation.outcome;
+      passed = observation.outcome === assertion.expected;
+      break;
+    case 'file': {
+      const file = observation.files?.find((candidate) => candidate.path === assertion.path);
+      observed = file?.state ?? 'not observed';
+      passed = file?.state === assertion.expected;
+      break;
+    }
+    case 'tool': {
+      const calls =
+        observation.tools?.filter((candidate) => candidate.name === assertion.name) ?? [];
+      observed = calls.length === 0 ? 'not called' : calls.map((call) => call.outcome).join(',');
+      passed =
+        assertion.expected === 'called'
+          ? calls.length > 0
+          : assertion.expected === 'not-called'
+            ? calls.length === 0
+            : calls.some((call) => call.outcome === assertion.expected);
+      break;
+    }
+    case 'approval': {
+      const approvals = observation.approvals ?? [];
+      observed =
+        approvals.length === 0 ? 'not requested' : approvals.map((item) => item.outcome).join(',');
+      passed =
+        assertion.expected === 'not-requested'
+          ? approvals.length === 0
+          : approvals.some((item) => item.outcome === assertion.expected);
+      break;
+    }
+    case 'network': {
+      const attempts =
+        observation.network?.filter((candidate) => candidate.host === assertion.host) ?? [];
+      observed =
+        attempts.length === 0 ? 'not attempted' : attempts.map((item) => item.decision).join(',');
+      passed =
+        assertion.expected === 'not-attempted'
+          ? attempts.length === 0
+          : attempts.some((item) => item.decision === assertion.expected);
+      break;
+    }
+    case 'policy': {
+      const decisions =
+        observation.policies?.filter((candidate) => candidate.policyId === assertion.policyId) ??
+        [];
+      observed =
+        decisions.length === 0 ? 'not observed' : decisions.map((item) => item.decision).join(',');
+      passed = decisions.some((item) => item.decision === assertion.expected);
+      break;
+    }
+    case 'completion': {
+      const completion = observation.completions?.find(
+        (candidate) => candidate.schema === assertion.expectedSchema
+      );
+      observed = completion ? String(completion.valid) : 'not observed';
+      passed = completion?.valid === assertion.valid;
+      break;
+    }
+    case 'capability': {
+      const capability = observation.capabilities?.find(
+        (candidate) => candidate.id === assertion.capabilityId
+      );
+      observed = capability?.state ?? 'not observed';
+      passed = capability?.state === assertion.expected;
+      break;
+    }
+  }
+  return {
+    assertion,
+    passed,
+    detail: passed
+      ? `Observed ${observed}.`
+      : `Expected ${expectedValue(assertion)}; observed ${observed}.`,
+  };
+}
+
+function expectedValue(assertion: HarnessConformanceAssertion): string {
+  if (assertion.kind === 'completion') return String(assertion.valid);
+  return assertion.expected;
+}
+
+function compareMaximum(
+  regressions: string[],
+  label: string,
+  actual: number,
+  maximum: number | undefined,
+  unit: string
+): void {
+  if (maximum !== undefined && actual > maximum) {
+    regressions.push(
+      `${label} ${actual.toFixed(3)} ${unit} exceeds ${maximum.toFixed(3)} ${unit}.`
+    );
+  }
+}
+
+function mean(values: number[]): number {
+  return values.length === 0 ? 0 : sum(values) / values.length;
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function stdDev(values: number[]): number {
+  if (values.length === 0) return 0;
+  const average = mean(values);
+  return Math.sqrt(mean(values.map((value) => (value - average) ** 2)));
+}
+
+function percentile(values: number[], percentileValue: number): number {
+  if (values.length === 0) return 0;
+  const ordered = [...values].sort((left, right) => left - right);
+  const index = Math.max(0, Math.ceil(percentileValue * ordered.length) - 1);
+  return ordered[index] ?? 0;
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function isSchemaError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === 'object' &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'ZodError'
+  );
+}
+
+function containsSensitiveValue(value: unknown): boolean {
+  if (typeof value === 'string') return containsUnredactedProviderRuntimeSecret(value);
+  if (Array.isArray(value)) return value.some(containsSensitiveValue);
+  if (!value || typeof value !== 'object') return false;
+  return Object.entries(value).some(
+    ([key, child]) =>
+      containsUnredactedProviderRuntimeSecret(`${key}=${String(child)}`) ||
+      containsSensitiveValue(child)
+  );
+}

--- a/shared/src/types/harness-conformance.types.ts
+++ b/shared/src/types/harness-conformance.types.ts
@@ -1,0 +1,177 @@
+import type {
+  KnownProviderRuntimeCapabilityId,
+  ProviderRuntimeCapabilityState,
+} from './provider-runtime.types.js';
+
+export const HARNESS_CONFORMANCE_SUITE_SCHEMA_VERSION = 'harness-conformance-suite/v1' as const;
+export const HARNESS_CONFORMANCE_RESULT_SCHEMA_VERSION = 'harness-conformance-result/v1' as const;
+
+export type HarnessConformanceMode = 'mock' | 'local' | 'credential-gated';
+export type HarnessConformanceFailureClass =
+  | 'assertion'
+  | 'fixture-reset'
+  | 'provider-launch'
+  | 'provider-timeout'
+  | 'provider-crash'
+  | 'policy-block'
+  | 'malformed-output'
+  | 'verification'
+  | 'unknown';
+
+export interface HarnessConformanceFixture {
+  id: string;
+  revision: number;
+  digest: string;
+  repository?: string;
+  seed?: string;
+}
+
+export interface HarnessConformanceCombination {
+  id: string;
+  provider: string;
+  model?: string;
+  profileId: string;
+  policyId?: string;
+  sandboxPresetId?: string;
+  mode: HarnessConformanceMode;
+}
+
+export type HarnessConformanceAssertion =
+  | { kind: 'outcome'; expected: 'passed' | 'failed' | 'blocked' }
+  | { kind: 'file'; path: string; expected: 'created' | 'modified' | 'deleted' | 'unchanged' }
+  | { kind: 'tool'; name: string; expected: 'called' | 'not-called' | 'allowed' | 'denied' }
+  | { kind: 'approval'; expected: 'requested' | 'approved' | 'denied' | 'not-requested' }
+  | { kind: 'network'; host: string; expected: 'allowed' | 'denied' | 'not-attempted' }
+  | { kind: 'policy'; policyId: string; expected: 'allowed' | 'denied' | 'approval' }
+  | { kind: 'completion'; expectedSchema: string; valid: boolean }
+  | {
+      kind: 'capability';
+      capabilityId: KnownProviderRuntimeCapabilityId;
+      expected: ProviderRuntimeCapabilityState;
+    };
+
+export interface HarnessConformanceScenario {
+  id: string;
+  objective: string;
+  repetitions: number;
+  assertions: HarnessConformanceAssertion[];
+}
+
+export interface HarnessConformanceCapabilityClaim {
+  profileId: string;
+  capabilityId: KnownProviderRuntimeCapabilityId;
+  scenarioIds: string[];
+}
+
+export interface HarnessConformanceBaseline {
+  revision: number;
+  combinationId: string;
+  scenarioId: string;
+  minPassRate: number;
+  maxMeanLatencyMs?: number;
+  maxLatencyStdDevMs?: number;
+  maxMeanTokens?: number;
+  maxMeanCostUsd?: number;
+}
+
+export interface HarnessConformanceSuite {
+  schemaVersion: typeof HARNESS_CONFORMANCE_SUITE_SCHEMA_VERSION;
+  id: string;
+  revision: number;
+  objective: string;
+  fixture: HarnessConformanceFixture;
+  combinations: HarnessConformanceCombination[];
+  scenarios: HarnessConformanceScenario[];
+  capabilityClaims: HarnessConformanceCapabilityClaim[];
+  baselines: HarnessConformanceBaseline[];
+}
+
+export interface HarnessConformanceEvidenceReference {
+  launchManifestDigest: string;
+  providerRuntimeManifestDigest: string;
+  taskId?: string;
+  attemptId?: string;
+  eventSequenceStart?: number;
+  eventSequenceEnd?: number;
+}
+
+export interface HarnessConformanceObservation {
+  outcome: 'passed' | 'failed' | 'blocked';
+  durationMs: number;
+  tokens?: number;
+  costUsd?: number;
+  retries?: number;
+  files?: Array<{ path: string; state: 'created' | 'modified' | 'deleted' | 'unchanged' }>;
+  tools?: Array<{ name: string; outcome: 'allowed' | 'denied' }>;
+  approvals?: Array<{ outcome: 'requested' | 'approved' | 'denied' }>;
+  network?: Array<{ host: string; decision: 'allowed' | 'denied' }>;
+  policies?: Array<{ policyId: string; decision: 'allowed' | 'denied' | 'approval' }>;
+  completions?: Array<{ schema: string; valid: boolean }>;
+  capabilities?: Array<{
+    id: KnownProviderRuntimeCapabilityId;
+    state: ProviderRuntimeCapabilityState;
+  }>;
+  evidence: HarnessConformanceEvidenceReference;
+  failureClass?: HarnessConformanceFailureClass;
+  diagnostic?: string;
+}
+
+export interface HarnessConformanceAssertionResult {
+  assertion: HarnessConformanceAssertion;
+  passed: boolean;
+  detail: string;
+}
+
+export interface HarnessConformanceTrialResult {
+  combinationId: string;
+  scenarioId: string;
+  trial: number;
+  passed: boolean;
+  failureClass?: HarnessConformanceFailureClass;
+  diagnostic?: string;
+  observation?: Omit<HarnessConformanceObservation, 'diagnostic'>;
+  assertions: HarnessConformanceAssertionResult[];
+}
+
+export interface HarnessConformanceAggregate {
+  combinationId: string;
+  scenarioId: string;
+  trials: number;
+  passed: number;
+  passRate: number;
+  meanLatencyMs: number;
+  p95LatencyMs: number;
+  latencyStdDevMs: number;
+  meanTokens: number;
+  totalTokens: number;
+  meanCostUsd: number;
+  totalCostUsd: number;
+  retries: number;
+  baselineRevision?: number;
+  regressions: string[];
+}
+
+export interface HarnessConformanceResult {
+  schemaVersion: typeof HARNESS_CONFORMANCE_RESULT_SCHEMA_VERSION;
+  id: string;
+  suiteId: string;
+  suiteRevision: number;
+  fixture: HarnessConformanceFixture;
+  startedAt: string;
+  completedAt: string;
+  status: 'passed' | 'failed' | 'regression';
+  trials: HarnessConformanceTrialResult[];
+  aggregates: HarnessConformanceAggregate[];
+}
+
+export interface HarnessConformanceExecutionInput {
+  suite: HarnessConformanceSuite;
+  combination: HarnessConformanceCombination;
+  scenario: HarnessConformanceScenario;
+  trial: number;
+}
+
+export interface HarnessConformanceExecutor {
+  reset(input: HarnessConformanceExecutionInput): Promise<void>;
+  execute(input: HarnessConformanceExecutionInput): Promise<HarnessConformanceObservation>;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -25,6 +25,7 @@ export * from './decision.types.js';
 export * from './run-session.types.js';
 export * from './run-supervisor.types.js';
 export * from './evaluation.types.js';
+export * from './harness-conformance.types.js';
 export * from './policy.types.js';
 export * from './prompt-registry.types.js';
 export * from './provider-runtime.types.js';


### PR DESCRIPTION
## Summary

- add versioned harness-conformance-suite/v1 and harness-conformance-result/v1 contracts for seeded provider/model/profile/policy/sandbox comparisons
- validate bounded declarative assertions, capability-to-scenario proof, immutable evidence references, trial limits, relative paths, and secret-free fixtures
- run deterministic reset/execute trials with explicit failure classes and aggregate pass rate, variance, latency, tokens, cost, retries, and versioned baseline regressions
- require explicit opt-in for credential-gated lanes and provide a CI-blocking assertPassed result gate
- add a committed credential-free recorded fixture plus pnpm conformance:harness for local and CI use
- document ownership, security, evidence, and downstream use by Buzz and cross-harness certification

## Verification

- 5 focused service tests in under one second
- recorded pnpm conformance:harness smoke emitted a normalized passing result
- shared build
- server typecheck and build
- changed-file ESLint and Prettier
- security artifact scan

Closes #859