### PR TITLE
feat: add harness compatibility matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,11 @@ stdio`, and rejects approval bypass, reauthentication, leader, plugin,
 src/scripts/run-harness-conformance.ts -- --suite <suite.json>
 --observations <observations.json>`. Credential-gated lanes require explicit
   opt-in and never commit raw provider output or secrets.
+- Cross-harness compatibility is published as
+  `harness-compatibility-matrix/v1`. API, `vk doctor`, Settings, telemetry, and
+  `docs/HARNESS-COMPATIBILITY.md` must use the reviewed profile capability
+  digest, fixture revision, invalidation policy, and source caveats rather than
+  defining provider-specific tiers.
 - `vk acp serve --stdio` exposes one Veritas-managed task as an ACP v1 server
   view for editors and other ACP clients. Bind with `--task` or require
   `_meta["veritas/taskId"]` on `session/new`; client-owned MCP catalogs fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `harness-compatibility-matrix/v1` for Buzz, Grok Build, OpenAI Codex
+  app-server, Claude Code, and GitHub Copilot CLI. One reviewed record now
+  drives exact builds, source caveats, capability and fixture digests,
+  invalidation policy, live support tiers, API, `vk doctor`, Settings, telemetry,
+  and operator guidance (#918).
 - Added `harness-conformance-suite/v1` and a deterministic runner for seeded,
   repeated provider/model/profile/policy/sandbox comparisons. Explicit
   assertions cover outcomes, files, tools, approvals, network, policy,

--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -19,6 +19,25 @@ function doctorFetch(routes: Record<string, Response>) {
   }) as unknown as typeof fetch;
 }
 
+function compatibilityResponse(supportStatuses: unknown[]): Response {
+  return jsonResponse({
+    schemaVersion: 'harness-compatibility-matrix/v1',
+    generatedAt: '2026-06-04T07:00:00.000Z',
+    probeRevision: 14,
+    digest: 'a'.repeat(64),
+    tierDefinitions: {},
+    records: [
+      {
+        profileId: 'openai-codex-app-server',
+        testedVersions: ['codex-cli 0.145.0'],
+        sourceAvailability: 'open-source',
+        certification: { status: 'not-run' },
+      },
+    ],
+    supportStatuses,
+  });
+}
+
 const baseRoutes: Record<string, Response> = {
   '/api/health': jsonResponse({ ok: true, version: '4.3.2', uptimeMs: 1000 }),
   '/api/auth/context': jsonResponse({
@@ -37,7 +56,7 @@ const baseRoutes: Record<string, Response> = {
       provider: 'codex-cli',
     },
   ]),
-  '/api/config/agent-support': jsonResponse([
+  '/api/config/harness-compatibility': compatibilityResponse([
     {
       agentType: 'codex',
       profileId: 'openai-codex-cli',
@@ -156,7 +175,7 @@ describe('vk doctor', () => {
   it('fails closed for an enabled unsupported harness and preserves safe remediation', async () => {
     const routes = {
       ...baseRoutes,
-      '/api/config/agent-support': jsonResponse([
+      '/api/config/harness-compatibility': compatibilityResponse([
         {
           agentType: 'claude-code',
           profileId: 'claude-code',

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -5,7 +5,11 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { API_BASE, buildApiHeaders } from '../utils/api.js';
-import type { CommunicationAdapterHealth, HarnessSupportStatus } from '@veritas-kanban/shared';
+import type {
+  CommunicationAdapterHealth,
+  HarnessCompatibilityMatrix,
+  HarnessSupportStatus,
+} from '@veritas-kanban/shared';
 
 const execFileAsync = promisify(execFile);
 const CRITICAL_STATUSES = new Set<DoctorCheck['id']>([
@@ -652,6 +656,44 @@ function buildHarnessSupportCheck(statuses: HarnessSupportStatus[] | null): Doct
   );
 }
 
+function buildHarnessCompatibilityCheck(matrix: HarnessCompatibilityMatrix | null): DoctorCheck {
+  if (!matrix) {
+    return check(
+      'harness-compatibility',
+      'Harness compatibility',
+      'skip',
+      'Skipped because compatibility evidence was unavailable'
+    );
+  }
+  const stale = matrix.records.filter(
+    (record) => record.certification.status === 'failed' || record.certification.status === 'stale'
+  );
+  return check(
+    'harness-compatibility',
+    'Harness compatibility',
+    stale.length > 0 ? 'warn' : 'pass',
+    stale.length > 0
+      ? `${stale.length} reviewed harness certification record(s) are stale or failed`
+      : `${matrix.records.length} reviewed harness profiles share matrix ${matrix.digest.slice(0, 12)}`,
+    {
+      schemaVersion: matrix.schemaVersion,
+      digest: matrix.digest,
+      probeRevision: matrix.probeRevision,
+      records: matrix.records.map((record) => ({
+        profileId: record.profileId,
+        testedVersions: record.testedVersions,
+        testedBuilds: record.testedBuilds,
+        sourceAvailability: record.sourceAvailability,
+        certification: record.certification.status,
+        supportTier: record.supportStatus?.supportTier,
+      })),
+    },
+    stale.length > 0
+      ? 'Re-run the pinned deterministic fixtures before treating the affected builds as certified.'
+      : undefined
+  );
+}
+
 export async function runDoctorChecks(
   input: Partial<DoctorOptions> = {},
   depsInput: Partial<DoctorDependencies> = {}
@@ -745,6 +787,7 @@ export async function runDoctorChecks(
 
   let agents: AgentConfigResponse[] | null = null;
   let harnessSupport: HarnessSupportStatus[] | null = null;
+  let harnessCompatibility: HarnessCompatibilityMatrix | null = null;
   let routing: RoutingConfigResponse | null = null;
   let settings: FeatureSettingsResponse | null = null;
 
@@ -804,12 +847,15 @@ export async function runDoctorChecks(
     );
     agents = agentsResponse.ok ? agentsResponse.data : null;
 
-    const harnessSupportResponse = await requestJson<HarnessSupportStatus[]>(
+    const harnessCompatibilityResponse = await requestJson<HarnessCompatibilityMatrix>(
       deps,
       options,
-      '/api/config/agent-support'
+      '/api/config/harness-compatibility'
     );
-    harnessSupport = harnessSupportResponse.ok ? harnessSupportResponse.data : null;
+    harnessCompatibility = harnessCompatibilityResponse.ok
+      ? harnessCompatibilityResponse.data
+      : null;
+    harnessSupport = harnessCompatibility?.supportStatuses ?? null;
 
     const routingResponse = await requestJson<RoutingConfigResponse>(
       deps,
@@ -880,12 +926,23 @@ export async function runDoctorChecks(
     checks.push(
       check('harness-support', 'Harness support', 'skip', 'Skipped because API is unreachable')
     );
+    checks.push(
+      check(
+        'harness-compatibility',
+        'Harness compatibility',
+        'skip',
+        'Skipped because API is unreachable'
+      )
+    );
     checks.push(check('buzz', 'Buzz compatibility', 'skip', 'Skipped because API is unreachable'));
   }
 
   const agentResult = await buildAgentCheck(deps, agents);
   checks.push(agentResult.check);
-  if (apiReachable) checks.push(buildHarnessSupportCheck(harnessSupport));
+  if (apiReachable) {
+    checks.push(buildHarnessSupportCheck(harnessSupport));
+    checks.push(buildHarnessCompatibilityCheck(harnessCompatibility));
+  }
   checks.push(
     buildRoutingCheck(routing, agentResult.availableAgents, agentResult.configuredAgents)
   );

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -407,11 +407,19 @@ The live status projection uses five tiers:
 | `degraded`    | The adapter exists, but installation, authentication, probe, compatibility, or certification evidence is unhealthy or stale. |
 | `unsupported` | The profile has no executable adapter or does not support the current platform.                                              |
 
-Settings -> Agents displays the same tier returned by
-`GET /api/config/agent-support`. `vk doctor` consumes that endpoint unchanged:
+Settings -> Agents displays the same tier returned in
+`GET /api/config/harness-compatibility`. `vk doctor` consumes that compatibility
+record unchanged:
 an enabled `degraded` or `unsupported` profile is a blocking failure, while an
 enabled `configured` profile is a warning until certification is current.
 Reasons and remediation are redacted before leaving the server.
+
+The reviewed builds, capability evidence, source-availability caveats, fixture
+identity, and tier definitions are documented in
+[Harness Compatibility](HARNESS-COMPATIBILITY.md). The legacy
+`GET /api/config/agent-support` endpoint remains available for API
+compatibility, but new operator surfaces use the matrix response so they cannot
+drift.
 
 Task start rechecks the normalized profile before attempt state is created. An
 explicit provider must match the profile's executable adapter. A display-only

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -333,6 +333,7 @@ First-class support for autonomous coding agents.
 - **Workspace capability discovery** — Trusted workspace catalogs expose supported task types, SLA/queue posture, intake requirements, and delegated-work packaging so cross-workspace handoffs are explicit
 - **Agent profile packages** — Reusable YAML/JSON packages bundle role, runtime, model, prompt instructions, tools, permissions, sandbox, budget, workflow, and health metadata for portable task launches
 - **Provider runtime manifests** — Every executable adapter records a versioned, evidence-backed capability snapshot and digest on the attempt, history, trace, and log; provider version skew reruns conformance and unsupported configured providers fail closed instead of falling back to OpenClaw
+- **Cross-harness compatibility matrix** — Buzz, Grok Build, OpenAI Codex app-server, Claude Code, and GitHub Copilot CLI publish exact reviewed builds, source-availability caveats, deterministic fixture identity, capability evidence, limitations, and live support tiers through one API record consumed by Settings, `vk doctor`, telemetry, and [operator guidance](HARNESS-COMPATIBILITY.md)
 - **Harness conformance suites** — Versioned seeded scenarios compare
   provider/model/profile/policy/sandbox combinations across repeated trials,
   retain immutable launch/runtime/event evidence references, assert governed

--- a/docs/HARNESS-COMPATIBILITY.md
+++ b/docs/HARNESS-COMPATIBILITY.md
@@ -1,0 +1,85 @@
+# Harness Compatibility
+
+Veritas publishes one reviewed compatibility record for Buzz, Grok Build,
+OpenAI Codex app-server, Claude Code, and GitHub Copilot CLI. The canonical
+machine-readable form is:
+
+```text
+GET /api/config/harness-compatibility
+```
+
+Settings -> Agents and `vk doctor --json` consume that record. Run telemetry
+stores the same profile capability digest beside the existing support tier,
+provider version/build, runtime-manifest digest, and failure class.
+
+## Reviewed matrix
+
+| Harness            | Profile                   | Tested build                                                                        | Transport              | Source availability    | Important limitation                                                                               |
+| ------------------ | ------------------------- | ----------------------------------------------------------------------------------- | ---------------------- | ---------------------- | -------------------------------------------------------------------------------------------------- |
+| Buzz               | `buzz-agent`              | Buzz v0.4.24, commit `710ed9fff57878a1d69f809b80a6ee0416c53fc4`; `buzz-agent 0.1.0` | ACP v1 stdio           | Open source            | Task execution uses `buzz-agent`; relay, identity, community, and workflow checks remain separate. |
+| Grok Build         | `grok-build`              | v0.2.111, build `94172f2aa4e5`                                                      | ACP v1 stdio           | Partial source lineage | The released artifact self-reports alpha and is not fully traceable to the public source tree.     |
+| OpenAI Codex       | `openai-codex-app-server` | `codex-cli 0.145.0`                                                                 | app-server JSON-RPC v2 | Open source            | Experimental methods remain excluded until pinned schemas and behavior are reviewed.               |
+| Claude Code        | `claude-code`             | `2.1.218 (Claude Code)`                                                             | stream-json process    | Partial source         | The complete CLI implementation is not public; some host enforcement remains provider-dependent.   |
+| GitHub Copilot CLI | `github-copilot-cli`      | v1.0.74, commit `2b809c84e87dbcc88f897cb4f3fb97c43b77af95`                          | ACP v1 stdio           | Partial source         | ACP is public preview and provider-managed authentication has no non-consuming status probe.       |
+
+The API is authoritative for the full capability list, reviewed evidence URLs,
+fixture paths, platform coverage, limitations, live readiness, and matrix
+digest. This table is an operator summary, not a substitute for current probe
+evidence.
+
+## Support tiers
+
+| Tier          | Definition                                                                                                           |
+| ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `certified`   | Installed build, configuration, runtime manifest, probe revision, and deterministic fixtures match passing evidence. |
+| `configured`  | The executable adapter can dispatch, but current deterministic certification evidence is absent.                     |
+| `detected`    | The executable is installed, but the profile is disabled.                                                            |
+| `degraded`    | A readiness, compatibility, policy, or certification check failed.                                                   |
+| `unsupported` | The platform or configured provider has no safe executable adapter for the profile.                                  |
+
+These definitions are emitted in the matrix response. CLI, API, web, and
+telemetry must not maintain provider-specific alternatives.
+
+## Certification and invalidation
+
+Each reviewed profile includes a deterministic fixture set, fixture revision,
+capability digest, evidence paths, and current status. Certification is
+invalidated by any change to:
+
+- provider version or build;
+- profile configuration digest;
+- runtime probe revision;
+- transport protocol version;
+- capability digest; or
+- fixture revision.
+
+Credential-gated smoke evidence is supplemental only. It can add exact-build
+runtime evidence, but it cannot replace or overwrite a deterministic failure.
+Raw observations retain launch-manifest, runtime-manifest, task, attempt, and
+event references through `harness-conformance-result/v1`.
+
+## Operating each harness
+
+Detailed installation, authentication, configuration, permissions, MCP,
+worktree, upgrade, degraded-state, and troubleshooting guidance is maintained
+with each provider:
+
+- [Buzz Agent ACP](AGENT-PROVIDERS.md#buzz-agent-acp)
+- [Grok Build ACP](AGENT-PROVIDERS.md#grok-build-acp)
+- [OpenAI Codex app-server](AGENT-PROVIDERS.md#openai-codex-app-server-v01450)
+- [Claude Code](AGENT-PROVIDERS.md#claude-code-v21218)
+- [GitHub Copilot CLI ACP](AGENT-PROVIDERS.md#github-copilot-cli-acp-public-preview)
+
+The common operating contract is:
+
+1. Install the exact tested build.
+2. Authenticate through the provider's login or an allowlisted boot credential.
+3. Enable the built-in profile without adding provider-owned launch bypasses.
+4. Assign a Veritas sandbox, permission, and approval policy.
+5. Run `vk doctor --json`; fix any degraded or unsupported evidence.
+6. Re-run deterministic certification after an upgrade or evidence revision.
+
+Veritas launches all five harnesses in the assigned task worktree. MCP access is
+limited to the immutable task catalog plus the system-owned `veritas-run`
+bridge. Unsafe launch flags, unexpected versions, stale certification, and
+adapter/profile mismatches fail closed before an attempt is created.

--- a/server/src/__tests__/harness-compatibility-matrix-service.test.ts
+++ b/server/src/__tests__/harness-compatibility-matrix-service.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import type { HarnessSupportStatus } from '@veritas-kanban/shared';
+import {
+  getHarnessCompatibilityRecordDigest,
+  HarnessCompatibilityMatrixService,
+} from '../services/harness-compatibility-matrix-service.js';
+
+const NOW = new Date('2026-07-24T12:00:00.000Z');
+
+describe('HarnessCompatibilityMatrixService', () => {
+  it('publishes the five reviewed harnesses from one versioned contract', () => {
+    const matrix = new HarnessCompatibilityMatrixService(() => NOW).build();
+
+    expect(matrix).toMatchObject({
+      schemaVersion: 'harness-compatibility-matrix/v1',
+      generatedAt: NOW.toISOString(),
+      probeRevision: 14,
+    });
+    expect(matrix.records.map((record) => record.agentType)).toEqual([
+      'buzz-agent',
+      'grok-build',
+      'codex-app-server',
+      'claude-code',
+      'copilot',
+    ]);
+    expect(matrix.records.map((record) => record.testedVersions[0])).toEqual([
+      'buzz-agent 0.1.0',
+      'Grok Build 0.2.111',
+      'codex-cli 0.145.0',
+      '2.1.218 (Claude Code)',
+      'Copilot 1.0.74',
+    ]);
+    expect(matrix.records.find((record) => record.agentType === 'grok-build')).toMatchObject({
+      sourceAvailability: 'partial-source',
+      protocolVersion: 'acp/v1',
+      testedBuilds: ['94172f2aa4e5'],
+    });
+  });
+
+  it('keeps deterministic evidence and all drift keys in the stable record digest', () => {
+    const service = new HarnessCompatibilityMatrixService(() => NOW);
+    const first = service.build();
+    const second = service.build();
+
+    expect(first.digest).toBe(second.digest);
+    for (const record of first.records) {
+      expect(record.certification).toMatchObject({
+        fixtureRevision: 1,
+        credentialSmokePolicy: 'supplemental-only',
+        status: 'not-run',
+      });
+      expect(record.certification.deterministicEvidence.length).toBeGreaterThan(0);
+      expect(record.certification.invalidatedBy).toEqual(
+        expect.arrayContaining([
+          'provider-version',
+          'provider-build',
+          'probe-revision',
+          'protocol-version',
+          'capability-digest',
+          'fixture-revision',
+        ])
+      );
+      expect(getHarnessCompatibilityRecordDigest(record.profileId)).toBe(
+        record.certification.capabilityDigest
+      );
+    }
+  });
+
+  it('projects live support without letting it rewrite deterministic certification identity', () => {
+    const status: HarnessSupportStatus = {
+      agentType: 'copilot',
+      enabled: true,
+      profileId: 'github-copilot-cli',
+      adapterId: 'acp-stdio',
+      transport: 'acp',
+      supportTier: 'degraded',
+      reason: 'The certified provider evidence no longer matches the installed runtime.',
+      failureClass: 'certification-stale',
+      checkedAt: NOW.toISOString(),
+      executableFound: true,
+      authenticated: null,
+      certification: {
+        fixtureSet: 'github-copilot-cli/v1',
+        status: 'stale',
+      },
+      diagnosticCommands: ['copilot --version'],
+      remediation: ['Install the tested release.'],
+    };
+
+    const withoutLiveStatus = new HarnessCompatibilityMatrixService(() => NOW).build();
+    const withLiveStatus = new HarnessCompatibilityMatrixService(() => NOW).build([status]);
+    const record = withLiveStatus.records.find((candidate) => candidate.agentType === 'copilot');
+
+    expect(record?.certification.capabilityDigest).toBe(
+      withoutLiveStatus.records.find((candidate) => candidate.agentType === 'copilot')
+        ?.certification.capabilityDigest
+    );
+    expect(record).toMatchObject({
+      certification: { status: 'stale' },
+      supportStatus: status,
+    });
+    expect(withLiveStatus.supportStatuses).toEqual([status]);
+  });
+});

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -22,10 +22,12 @@ import {
   TeamRosterValidateBodySchema,
 } from '../schemas/team-roster-schemas.js';
 import { HarnessSupportService } from '../services/harness-support-service.js';
+import { HarnessCompatibilityMatrixService } from '../services/harness-compatibility-matrix-service.js';
 
 const router: RouterType = Router();
 const configService = new ConfigService();
 const harnessSupportService = new HarnessSupportService({ configService });
+const harnessCompatibilityMatrixService = new HarnessCompatibilityMatrixService();
 const agentProfilePackageService = new AgentProfilePackageService(configService);
 const teamRosterService = new TeamRosterService(configService);
 
@@ -364,6 +366,15 @@ router.get(
   '/agent-support',
   asyncHandler(async (_req, res) => {
     res.json(await harnessSupportService.list());
+  })
+);
+
+// GET /api/config/harness-compatibility - Reviewed compatibility and live support evidence
+router.get(
+  '/harness-compatibility',
+  asyncHandler(async (_req, res) => {
+    const supportStatuses = await harnessSupportService.list();
+    res.json(harnessCompatibilityMatrixService.build(supportStatuses));
   })
 );
 

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -141,6 +141,7 @@ import {
 } from './provider-runtime-control-service.js';
 import { resolveTaskCommitPolicy, TaskEnvelopeService } from './task-envelope-service.js';
 import { evaluateHarnessSupportStatus } from './harness-support-service.js';
+import { getHarnessCompatibilityRecordDigest } from './harness-compatibility-matrix-service.js';
 import {
   harnessToolCatalogDelivery,
   normalizeHarnessSupportProfile,
@@ -6357,8 +6358,10 @@ export class ClawdbotAgentService {
     status: HarnessSupportStatus,
     failureClass: HarnessSupportTelemetry['failureClass'] = status.failureClass
   ): HarnessSupportTelemetry {
+    const compatibilityDigest = getHarnessCompatibilityRecordDigest(status.profileId);
     return {
       profileId: status.profileId,
+      ...(compatibilityDigest ? { compatibilityDigest } : {}),
       ...(status.adapterId ? { adapterId: status.adapterId } : {}),
       ...(status.providerVersion ? { providerVersion: status.providerVersion } : {}),
       ...(status.providerBuild ? { providerBuild: status.providerBuild } : {}),

--- a/server/src/services/harness-compatibility-matrix-service.ts
+++ b/server/src/services/harness-compatibility-matrix-service.ts
@@ -1,0 +1,332 @@
+import { createHash } from 'node:crypto';
+import type {
+  AgentConfig,
+  ExecutableAgentProvider,
+  HarnessCompatibilityGuide,
+  HarnessCompatibilityMatrix,
+  HarnessCompatibilityRecord,
+  HarnessCompatibilityEvidence,
+  HarnessSourceAvailability,
+  HarnessSupportStatus,
+  HarnessSupportTier,
+} from '@veritas-kanban/shared';
+import {
+  HARNESS_COMPATIBILITY_MATRIX_SCHEMA_VERSION,
+  PROVIDER_RUNTIME_PROBE_REVISION,
+} from '@veritas-kanban/shared';
+import {
+  BUZZ_AGENT_TESTED_COMMIT,
+  BUZZ_AGENT_TESTED_RELEASE,
+  COPILOT_ACP_TESTED_COMMIT,
+  COPILOT_ACP_TESTED_RELEASE,
+  GROK_BUILD_TESTED_BUILD,
+  GROK_BUILD_TESTED_RELEASE,
+} from './acp-stdio-adapter.js';
+import { normalizeHarnessSupportProfile } from './harness-support-profile-registry.js';
+import { getProviderRuntimeAdapterDefinition } from './provider-runtime-adapter-registry.js';
+
+const REVIEWED_AT = '2026-07-24';
+const FIXTURE_REVISION = 1;
+const INVALIDATION_KEYS = [
+  'provider-version',
+  'provider-build',
+  'configuration-digest',
+  'probe-revision',
+  'protocol-version',
+  'capability-digest',
+  'fixture-revision',
+] as const;
+const TESTED_BUILDS: Record<string, string[]> = {
+  'buzz-agent': [BUZZ_AGENT_TESTED_COMMIT],
+  'grok-build': [GROK_BUILD_TESTED_BUILD],
+  'codex-app-server': ['25af12f7e61572b0bc18ddb1008be543b91519b0'],
+  'claude-code': ['2982f951552e94f38cd972764ae94c1d90c41da3'],
+  copilot: [COPILOT_ACP_TESTED_COMMIT],
+};
+
+export const HARNESS_SUPPORT_TIER_DEFINITIONS: Record<HarnessSupportTier, string> = {
+  certified:
+    'The installed build, configuration, runtime manifest, probe revision, and deterministic fixtures match passing evidence.',
+  configured:
+    'The executable adapter is ready to dispatch, but current deterministic certification evidence is absent.',
+  detected: 'The executable is installed, but this profile is disabled.',
+  degraded:
+    'The profile is enabled or detected, but a readiness, compatibility, policy, or certification check failed.',
+  unsupported:
+    'The platform or configured provider has no safe executable adapter for this profile.',
+};
+
+interface ReviewedHarness {
+  agent: AgentConfig;
+  sourceAvailability: HarnessSourceAvailability;
+  evidence: HarnessCompatibilityEvidence[];
+  limitations: string[];
+  guide: Omit<HarnessCompatibilityGuide, 'documentationUrl'>;
+}
+
+const REVIEWED_HARNESSES: ReviewedHarness[] = [
+  reviewedHarness(
+    {
+      type: 'buzz-agent',
+      name: 'Buzz Agent',
+      command: 'buzz-agent',
+      args: [],
+      enabled: false,
+      provider: 'acp-stdio',
+    },
+    'open-source',
+    [
+      source(
+        'Buzz source',
+        `https://github.com/block/buzz/tree/${BUZZ_AGENT_TESTED_COMMIT}`,
+        BUZZ_AGENT_TESTED_COMMIT
+      ),
+      release('Buzz release', 'https://github.com/block/buzz/releases', BUZZ_AGENT_TESTED_RELEASE),
+      fixture('ACP adapter contract', 'server/src/__tests__/acp-stdio-provider.test.ts'),
+      fixture(
+        'Buzz compatibility contract',
+        'server/src/__tests__/buzz-compatibility-integration.test.ts'
+      ),
+    ],
+    [
+      'Veritas launches buzz-agent as an ACP server; buzz-acp is the inverse relay-side client.',
+      'Relay, identity, community, and workflow compatibility are reported separately from task execution.',
+    ]
+  ),
+  reviewedHarness(
+    {
+      type: 'grok-build',
+      name: 'Grok Build',
+      command: 'grok',
+      args: [],
+      enabled: false,
+      provider: 'acp-stdio',
+    },
+    'partial-source',
+    [
+      source('Grok Build source', 'https://github.com/xai-org/grok-build'),
+      release(
+        'Tested Grok Build binary',
+        'https://github.com/xai-org/grok-build/releases',
+        `${GROK_BUILD_TESTED_RELEASE} build ${GROK_BUILD_TESTED_BUILD}`
+      ),
+      fixture('ACP adapter contract', 'server/src/__tests__/acp-stdio-provider.test.ts'),
+    ],
+    [
+      'The public source tree and released binary do not provide a complete one-to-one provenance chain.',
+      'The tested stable artifact self-reports an alpha channel.',
+    ]
+  ),
+  reviewedHarness(
+    {
+      type: 'codex-app-server',
+      name: 'OpenAI Codex app-server',
+      command: 'codex',
+      args: [],
+      enabled: false,
+      provider: 'codex-app-server',
+    },
+    'open-source',
+    [
+      source(
+        'Codex app-server source',
+        'https://github.com/openai/codex/tree/25af12f7e61572b0bc18ddb1008be543b91519b0',
+        '25af12f7e61572b0bc18ddb1008be543b91519b0'
+      ),
+      fixture(
+        'Codex app-server contract',
+        'server/src/__tests__/codex-app-server-provider.test.ts'
+      ),
+    ],
+    [
+      'Experimental app-server methods are excluded until their generated schemas and behavior are pinned.',
+    ]
+  ),
+  reviewedHarness(
+    {
+      type: 'claude-code',
+      name: 'Claude Code',
+      command: 'claude',
+      args: [],
+      enabled: false,
+      provider: 'claude-code',
+    },
+    'partial-source',
+    [
+      source(
+        'Claude Code public repository',
+        'https://github.com/anthropics/claude-code/tree/2982f951552e94f38cd972764ae94c1d90c41da3',
+        '2982f951552e94f38cd972764ae94c1d90c41da3'
+      ),
+      fixture('Claude Code contract', 'server/src/__tests__/claude-code-provider.test.ts'),
+    ],
+    [
+      'The complete Claude Code CLI implementation is not available in the public repository.',
+      'Filesystem and network enforcement remain partly provider-dependent.',
+    ]
+  ),
+  reviewedHarness(
+    {
+      type: 'copilot',
+      name: 'GitHub Copilot CLI',
+      command: 'copilot',
+      args: [],
+      enabled: false,
+      provider: 'acp-stdio',
+    },
+    'partial-source',
+    [
+      source(
+        'Copilot CLI public repository',
+        `https://github.com/github/copilot-cli/tree/${COPILOT_ACP_TESTED_COMMIT}`,
+        COPILOT_ACP_TESTED_COMMIT
+      ),
+      release(
+        'Copilot CLI release',
+        'https://github.com/github/copilot-cli/releases',
+        COPILOT_ACP_TESTED_RELEASE
+      ),
+      fixture('ACP adapter contract', 'server/src/__tests__/acp-stdio-provider.test.ts'),
+    ],
+    [
+      'ACP support is public preview and can change without a stable protocol guarantee.',
+      'The complete Copilot CLI implementation is not public.',
+      'Authentication is provider-managed and has no non-consuming status probe.',
+    ]
+  ),
+];
+
+export class HarnessCompatibilityMatrixService {
+  constructor(private readonly now: () => Date = () => new Date()) {}
+
+  build(supportStatuses: HarnessSupportStatus[] = []): HarnessCompatibilityMatrix {
+    const records = REVIEWED_HARNESSES.map((reviewed) =>
+      buildRecord(
+        reviewed,
+        supportStatuses.find((status) => status.agentType === reviewed.agent.type)
+      )
+    );
+    return {
+      schemaVersion: HARNESS_COMPATIBILITY_MATRIX_SCHEMA_VERSION,
+      generatedAt: this.now().toISOString(),
+      probeRevision: PROVIDER_RUNTIME_PROBE_REVISION,
+      digest: digest(records.map(withoutLiveStatus)),
+      tierDefinitions: { ...HARNESS_SUPPORT_TIER_DEFINITIONS },
+      records,
+      supportStatuses: structuredClone(supportStatuses),
+    };
+  }
+}
+
+export function getHarnessCompatibilityRecordDigest(profileId: string): string | undefined {
+  const reviewed = REVIEWED_HARNESSES.find(
+    (candidate) => normalizeHarnessSupportProfile(candidate.agent).id === profileId
+  );
+  return reviewed ? buildRecord(reviewed).certification.capabilityDigest : undefined;
+}
+
+function buildRecord(
+  reviewed: ReviewedHarness,
+  supportStatus?: HarnessSupportStatus
+): HarnessCompatibilityRecord {
+  const profile = normalizeHarnessSupportProfile(reviewed.agent);
+  if (!profile.adapterId) {
+    throw new Error(`Reviewed harness ${profile.id} has no executable adapter.`);
+  }
+  const adapter = getProviderRuntimeAdapterDefinition(profile.adapterId as ExecutableAgentProvider);
+  const capabilityDigest = digest({
+    profileId: profile.id,
+    adapterId: profile.adapterId,
+    protocolVersion: adapter.protocolVersion,
+    probeRevision: PROVIDER_RUNTIME_PROBE_REVISION,
+    capabilities: adapter.capabilities,
+  });
+  const certificationStatus =
+    supportStatus?.certification?.status ??
+    (supportStatus?.supportTier === 'certified'
+      ? 'passed'
+      : supportStatus?.failureClass === 'certification-stale'
+        ? 'stale'
+        : 'not-run');
+  return {
+    agentType: reviewed.agent.type,
+    profileId: profile.id,
+    displayName: profile.displayName,
+    adapterId: profile.adapterId,
+    transport: profile.transport,
+    protocolVersion: adapter.protocolVersion,
+    platforms: [...profile.platforms],
+    testedVersions: [...profile.compatibility.testedVersions],
+    testedBuilds: [...(TESTED_BUILDS[reviewed.agent.type] ?? [])],
+    reviewedAt: REVIEWED_AT,
+    sourceAvailability: reviewed.sourceAvailability,
+    evidence: structuredClone(reviewed.evidence),
+    capabilities: structuredClone(adapter.capabilities),
+    certification: {
+      fixtureSet: profile.conformance.fixtureSet,
+      fixtureRevision: FIXTURE_REVISION,
+      capabilityDigest,
+      status: certificationStatus,
+      invalidatedBy: [...INVALIDATION_KEYS],
+      deterministicEvidence: reviewed.evidence.filter((entry) => entry.kind === 'fixture'),
+      credentialSmokePolicy: 'supplemental-only',
+    },
+    limitations: [...reviewed.limitations],
+    guide: {
+      documentationUrl: profile.documentationUrl,
+      ...reviewed.guide,
+    },
+    ...(supportStatus ? { supportStatus: structuredClone(supportStatus) } : {}),
+  };
+}
+
+function reviewedHarness(
+  agent: AgentConfig,
+  sourceAvailability: HarnessSourceAvailability,
+  evidence: HarnessCompatibilityEvidence[],
+  limitations: string[]
+): ReviewedHarness {
+  const label = agent.name;
+  return {
+    agent,
+    sourceAvailability,
+    evidence,
+    limitations,
+    guide: {
+      installation: `Install the exact tested ${label} build before enabling the profile.`,
+      authentication: `Use ${label}'s provider-managed login or an allowlisted boot credential.`,
+      configuration: 'Configure the built-in profile; Veritas owns transport and launch arguments.',
+      permissions:
+        'Apply a Veritas sandbox policy and approval policy; unsafe launch flags fail closed.',
+      mcp: 'Veritas exposes only the immutable task catalog and system-owned run bridge.',
+      worktree: 'Each task launches in its assigned Git worktree.',
+      upgrade: 'Re-run probes and deterministic fixtures after any version or build change.',
+      degradedState:
+        'Degraded profiles cannot dispatch until the reported evidence mismatch is fixed.',
+      troubleshooting: 'Run `vk doctor --json` and follow the redacted remediation commands.',
+    },
+  };
+}
+
+function source(label: string, url: string, revision?: string): HarnessCompatibilityEvidence {
+  return { kind: 'source', label, url, ...(revision ? { revision } : {}) };
+}
+
+function release(label: string, url: string, revision: string): HarnessCompatibilityEvidence {
+  return { kind: 'release', label, url, revision };
+}
+
+function fixture(label: string, path: string): HarnessCompatibilityEvidence {
+  return { kind: 'fixture', label, path, revision: String(FIXTURE_REVISION) };
+}
+
+function withoutLiveStatus(
+  record: HarnessCompatibilityRecord
+): Omit<HarnessCompatibilityRecord, 'supportStatus'> {
+  const { supportStatus: _supportStatus, ...staticRecord } = record;
+  return staticRecord;
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}

--- a/server/src/services/harness-support-service.ts
+++ b/server/src/services/harness-support-service.ts
@@ -84,6 +84,7 @@ export function evaluateHarnessSupportStatus(
     ...(providerVersion ? { providerVersion: sanitized(providerVersion) } : {}),
     ...(manifest?.providerBuild ? { providerBuild: sanitized(manifest.providerBuild) } : {}),
     ...(manifest?.digest ? { manifestDigest: manifest.digest } : {}),
+    certification: structuredClone(profile.conformance),
     ...((manifest?.probe.diagnostics.length ?? 0) > 0 || (health.diagnostics?.length ?? 0) > 0
       ? {
           diagnostics: [...(health.diagnostics ?? []), ...(manifest?.probe.diagnostics ?? [])]

--- a/shared/src/types/harness-compatibility.types.ts
+++ b/shared/src/types/harness-compatibility.types.ts
@@ -1,0 +1,76 @@
+import type {
+  HarnessSupportInvalidationKey,
+  HarnessSupportStatus,
+  HarnessSupportTier,
+  HarnessTransport,
+  ProviderRuntimeCapabilityEvidence,
+} from './provider-runtime.types.js';
+
+export const HARNESS_COMPATIBILITY_MATRIX_SCHEMA_VERSION =
+  'harness-compatibility-matrix/v1' as const;
+
+export type HarnessSourceAvailability = 'open-source' | 'partial-source';
+
+export type HarnessCertificationInvalidationKey =
+  HarnessSupportInvalidationKey | 'protocol-version' | 'capability-digest' | 'fixture-revision';
+
+export interface HarnessCompatibilityEvidence {
+  kind: 'source' | 'release' | 'documentation' | 'fixture';
+  label: string;
+  url?: string;
+  path?: string;
+  revision?: string;
+}
+
+export interface HarnessCompatibilityCertification {
+  fixtureSet: string;
+  fixtureRevision: number;
+  capabilityDigest: string;
+  status: 'not-run' | 'passed' | 'failed' | 'stale';
+  invalidatedBy: HarnessCertificationInvalidationKey[];
+  deterministicEvidence: HarnessCompatibilityEvidence[];
+  credentialSmokePolicy: 'supplemental-only';
+}
+
+export interface HarnessCompatibilityGuide {
+  documentationUrl: string;
+  installation: string;
+  authentication: string;
+  configuration: string;
+  permissions: string;
+  mcp: string;
+  worktree: string;
+  upgrade: string;
+  degradedState: string;
+  troubleshooting: string;
+}
+
+export interface HarnessCompatibilityRecord {
+  agentType: string;
+  profileId: string;
+  displayName: string;
+  adapterId: string;
+  transport: HarnessTransport;
+  protocolVersion: string;
+  platforms: Array<'darwin' | 'linux' | 'win32'>;
+  testedVersions: string[];
+  testedBuilds: string[];
+  reviewedAt: string;
+  sourceAvailability: HarnessSourceAvailability;
+  evidence: HarnessCompatibilityEvidence[];
+  capabilities: ProviderRuntimeCapabilityEvidence[];
+  certification: HarnessCompatibilityCertification;
+  limitations: string[];
+  guide: HarnessCompatibilityGuide;
+  supportStatus?: HarnessSupportStatus;
+}
+
+export interface HarnessCompatibilityMatrix {
+  schemaVersion: typeof HARNESS_COMPATIBILITY_MATRIX_SCHEMA_VERSION;
+  generatedAt: string;
+  probeRevision: number;
+  digest: string;
+  tierDefinitions: Record<HarnessSupportTier, string>;
+  records: HarnessCompatibilityRecord[];
+  supportStatuses: HarnessSupportStatus[];
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -26,6 +26,7 @@ export * from './run-session.types.js';
 export * from './run-supervisor.types.js';
 export * from './evaluation.types.js';
 export * from './harness-conformance.types.js';
+export * from './harness-compatibility.types.js';
 export * from './policy.types.js';
 export * from './prompt-registry.types.js';
 export * from './provider-runtime.types.js';

--- a/shared/src/types/provider-runtime.types.ts
+++ b/shared/src/types/provider-runtime.types.ts
@@ -103,6 +103,7 @@ export interface HarnessSupportStatus {
   providerVersion?: string;
   providerBuild?: string;
   manifestDigest?: string;
+  certification?: HarnessCertificationEvidence;
   diagnostics?: string[];
   diagnosticCommands: string[];
   remediation: string[];

--- a/shared/src/types/telemetry.types.ts
+++ b/shared/src/types/telemetry.types.ts
@@ -67,6 +67,7 @@ export interface RunErrorEvent extends TelemetryEvent {
 
 export interface HarnessSupportTelemetry {
   profileId: string;
+  compatibilityDigest?: string;
   adapterId?: string;
   providerVersion?: string;
   providerBuild?: string;

--- a/web/src/__tests__/settings-agents-mantine.test.tsx
+++ b/web/src/__tests__/settings-agents-mantine.test.tsx
@@ -200,8 +200,8 @@ vi.mock('@/hooks/useConfig', () => ({
     isFetching: false,
     refetch: mocks.refetchProviderHealth,
   }),
-  useHarnessSupport: () => ({
-    data: [
+  useHarnessCompatibilityMatrix: () => {
+    const supportStatuses = [
       {
         agentType: 'codex',
         profileId: 'openai-codex-cli',
@@ -231,10 +231,36 @@ vi.mock('@/hooks/useConfig', () => ({
         diagnosticCommands: ['claude --version'],
         remediation: ['Use a supported adapter.'],
       },
-    ],
-    isFetching: false,
-    refetch: vi.fn(),
-  }),
+    ];
+    return {
+      data: {
+        digest: 'a'.repeat(64),
+        probeRevision: 14,
+        supportStatuses,
+        records: [
+          {
+            profileId: 'openai-codex-app-server',
+            displayName: 'OpenAI Codex app-server',
+            testedVersions: ['codex-cli 0.145.0'],
+            testedBuilds: ['25af12f7e61572b0bc18ddb1008be543b91519b0'],
+            limitations: ['Experimental methods remain excluded.'],
+            sourceAvailability: 'open-source',
+          },
+          {
+            profileId: 'claude-code',
+            displayName: 'Claude Code',
+            testedVersions: ['2.1.218 (Claude Code)'],
+            testedBuilds: ['2982f951552e94f38cd972764ae94c1d90c41da3'],
+            limitations: ['The complete implementation is not public.'],
+            sourceAvailability: 'partial-source',
+            supportStatus: supportStatuses[1],
+          },
+        ],
+      },
+      isFetching: false,
+      refetch: vi.fn(),
+    };
+  },
   useUpdateAgents: () => ({
     mutate: mocks.updateAgents,
   }),

--- a/web/src/components/settings/tabs/AgentsTab.tsx
+++ b/web/src/components/settings/tabs/AgentsTab.tsx
@@ -19,7 +19,7 @@ import {
   useConfig,
   useDeleteAgentProfile,
   useExportAgentProfile,
-  useHarnessSupport,
+  useHarnessCompatibilityMatrix,
   useImportAgentProfile,
   useProviderHealth,
   useUpdateAgentProfile,
@@ -76,6 +76,7 @@ import type {
   SandboxPolicyPreset,
   ProviderRuntimeManifest,
   HarnessSupportStatus,
+  HarnessCompatibilityMatrix,
 } from '@veritas-kanban/shared';
 import type {
   CodexHealthStatus,
@@ -123,7 +124,8 @@ export function AgentsTab() {
     refetch: refetchProviderHealth,
   } = useProviderHealth();
   const { data: agentProfiles = [], isLoading: isAgentProfilesLoading } = useAgentProfiles();
-  const { data: harnessSupport = [] } = useHarnessSupport();
+  const { data: harnessCompatibility } = useHarnessCompatibilityMatrix();
+  const harnessSupport = harnessCompatibility?.supportStatuses ?? [];
   const { data: sandboxPresets = [], isLoading: isSandboxPoliciesLoading } = useSandboxPolicies();
   const { settings } = useFeatureSettings();
   const { debouncedUpdate, isPending } = useDebouncedFeatureUpdate();
@@ -234,6 +236,8 @@ export function AgentsTab() {
         )}
       </div>
 
+      <HarnessCompatibilityPanel matrix={harnessCompatibility} />
+
       <AgentProfilePackagesSection
         profiles={agentProfiles}
         agents={config?.agents || []}
@@ -314,6 +318,59 @@ export function AgentsTab() {
       {/* Agent Routing Rules */}
       <RoutingRulesSection agents={config?.agents || []} />
     </div>
+  );
+}
+
+function HarnessCompatibilityPanel({ matrix }: { matrix?: HarnessCompatibilityMatrix }) {
+  if (!matrix) return null;
+
+  return (
+    <section className="space-y-3" aria-labelledby="harness-compatibility-title">
+      <div>
+        <h3 id="harness-compatibility-title" className="text-sm font-medium">
+          Harness Compatibility
+        </h3>
+        <Text size="xs" c="dimmed">
+          Reviewed builds and live support evidence from one compatibility record.
+        </Text>
+      </div>
+      <div className="divide-y rounded-md border">
+        {matrix.records.map((record) => (
+          <div
+            key={record.profileId}
+            className="grid gap-2 p-3 md:grid-cols-[minmax(10rem,1fr)_minmax(11rem,1fr)_auto]"
+          >
+            <div>
+              <Text size="sm" fw={500}>
+                {record.displayName}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {record.testedVersions.join(', ')}
+              </Text>
+              {record.testedBuilds.length > 0 && (
+                <Text size="xs" c="dimmed">
+                  Build {record.testedBuilds.map((build) => build.slice(0, 12)).join(', ')}
+                </Text>
+              )}
+            </div>
+            <Text size="xs" c="dimmed">
+              {record.limitations[0]}
+            </Text>
+            <div className="flex flex-wrap items-start gap-1">
+              <Badge size="xs" variant="light">
+                {record.supportStatus?.supportTier ?? 'not configured'}
+              </Badge>
+              <Badge size="xs" variant="outline">
+                {record.sourceAvailability.replace('-', ' ')}
+              </Badge>
+            </div>
+          </div>
+        ))}
+      </div>
+      <Text size="xs" c="dimmed">
+        Matrix {matrix.digest.slice(0, 12)} · probe revision {matrix.probeRevision}
+      </Text>
+    </section>
   );
 }
 

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -34,6 +34,14 @@ export function useHarnessSupport() {
   });
 }
 
+export function useHarnessCompatibilityMatrix() {
+  return useQuery({
+    queryKey: ['config', 'harness-compatibility'],
+    queryFn: api.config.agents.compatibility,
+    staleTime: 30 * 1000,
+  });
+}
+
 export function useRepos() {
   return useQuery({
     queryKey: ['config', 'repos'],
@@ -97,6 +105,7 @@ export function useUpdateAgents() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['config'] });
       queryClient.invalidateQueries({ queryKey: ['config', 'agent-support'] });
+      queryClient.invalidateQueries({ queryKey: ['config', 'harness-compatibility'] });
     },
   });
 }

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -12,6 +12,7 @@ import type {
   AgentProfilePackageFormat,
   AgentProfilePackageSummary,
   AgentProfileValidationResult,
+  HarnessCompatibilityMatrix,
   HarnessSupportStatus,
 } from '@veritas-kanban/shared';
 import { API_BASE, apiFetch } from './helpers';
@@ -162,6 +163,10 @@ export const configApi = {
   },
 
   agents: {
+    compatibility: async (): Promise<HarnessCompatibilityMatrix> => {
+      return apiFetch<HarnessCompatibilityMatrix>(`${API_BASE}/config/harness-compatibility`);
+    },
+
     support: async (): Promise<HarnessSupportStatus[]> => {
       return apiFetch<HarnessSupportStatus[]>(`${API_BASE}/config/agent-support`);
     },


### PR DESCRIPTION
Closes #918

## Summary
- add one versioned compatibility record for the five v6 harness profiles
- expose exact reviewed builds, source caveats, capabilities, fixture identity, invalidation policy, and live support evidence through API, doctor, Settings, and telemetry
- add concise operator guidance and update canonical provider and feature documentation

## Verification
- shared, server, CLI, and web typechecks
- 3 compatibility matrix contract tests
- 10 harness support regression tests
- 6 doctor tests
- 1 focused Settings render test
- changed-file ESLint and Prettier checks

## Risk
- certification remains not-run until deterministic evidence is attached to an installed runtime; credential-gated smoke evidence is supplemental only