### PR TITLE
feat: add runtime hook bus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,10 @@ src/scripts/run-harness-conformance.ts -- --suite <suite.json>
   `docs/HARNESS-COMPATIBILITY.md` must use the reviewed profile capability
   digest, fixture revision, invalidation policy, and source caveats rather than
   defining provider-specific tiers.
+- Runtime extensions use the in-process `runtime-hook/v1` bus. Only documented
+  pre-events may deny, post-events remain passive, and arbitrary executable or
+  HTTP handlers stay unsupported until their filesystem and egress boundaries
+  are enforceable. See `docs/architecture/RUNTIME-HOOK-V1.md`.
 - `vk acp serve --stdio` exposes one Veritas-managed task as an ACP v1 server
   view for editors and other ACP clients. Bind with `--task` or require
   `_meta["veritas/taskId"]` on `session/new`; client-owned MCP catalogs fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the provider-neutral `runtime-hook/v1` in-process hook bus with bounded
+  envelopes, deterministic scope ordering, explicit blocking pre-events,
+  passive post-events, timeout/reentrancy protection, side-effect-free dry-run,
+  and causal run-journal evidence. External executable and HTTP handlers remain
+  fail closed pending their sandbox and egress boundaries (#874).
 - Added `harness-compatibility-matrix/v1` for Buzz, Grok Build, OpenAI Codex
   app-server, Claude Code, and GitHub Copilot CLI. One reviewed record now
   drives exact builds, source caveats, capability and fixture digests,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -296,6 +296,7 @@ First-class support for autonomous coding agents.
 - **Running indicator on cards** — Animated spinner on task cards when an agent is actively working
 - **Agent output stream** — Real-time agent output via WebSocket with auto-scroll and clear
 - **Causal run-event journal** — OpenClaw, Codex CLI, Codex SDK, Codex app-server, Claude Code, ACP stdio, and Hermes map provider output into one bounded, redacted, append-only `run-event/v1` stream with per-attempt ordering, provider deduplication, REST cursor replay, gap-free WebSocket reconnect, and compatible legacy output projections
+- **Provider-neutral runtime hooks** — Trusted in-process features can register bounded `runtime-hook/v1` pre-dispatch decisions and passive post-event observations with deterministic scope ordering, timeouts, reentrancy protection, dry-run, and causal evidence; arbitrary executable and HTTP handlers remain unsupported
 - **Provider-native approval broker** — Provider requests pause on an exact action hash, persist a bounded workspace-scoped review record, and resume only after an authenticated compare-and-set approve/reject decision; expiry, interruption, cancellation, stale evidence, changed arguments, and duplicate decisions fail closed
 - **Run-scoped tool control plane** — Versioned MCP definitions and discovery,
   immutable per-attempt catalogs, required and optional server posture,

--- a/docs/architecture/RUNTIME-HOOK-V1.md
+++ b/docs/architecture/RUNTIME-HOOK-V1.md
@@ -1,0 +1,93 @@
+# Runtime Hook v1
+
+`runtime-hook/v1` is the provider-neutral in-process extension seam for ordered
+runtime decisions and passive observations. It exists so features such as Buzz
+workflow triggers can use one governed contract instead of adding
+provider-specific callbacks.
+
+## Scope
+
+The v1 bus accepts only handlers registered by trusted server code. Executable
+repository scripts, arbitrary plugins, and HTTP/webhook handlers are
+unsupported until the filesystem and egress boundaries in #862 and #855 can
+enforce them.
+
+Initial events:
+
+| Event                           | May deny |
+| ------------------------------- | -------- |
+| `session.pre-start`             | Yes      |
+| `session.post-end`              | No       |
+| `tool.pre-use`                  | Yes      |
+| `tool.post-use`                 | No       |
+| `permission.post-denied`        | No       |
+| `completion.post-recorded`      | No       |
+| `workflow.pre-external-trigger` | Yes      |
+
+Post-event definitions must use `fail-open`. If a post-event handler returns a
+deny decision, the bus records `invalid-post-decision` and leaves the completed
+result unchanged.
+
+## Envelope and definitions
+
+Every envelope contains:
+
+- a version, event ID, event type, and timestamp;
+- optional workspace, profile, workflow, and run scope IDs;
+- opaque source, task, attempt, tool, approval, workflow, and external-event
+  references;
+- a flat, bounded metadata record containing primitives only.
+
+Unknown events, nested or oversized metadata, credential-like fields, and
+recognized secret values are rejected before handler execution. Provider
+credentials and unrestricted host paths are not hook payload fields.
+
+Definitions bind one event to one registered handler, scope, order, timeout,
+enabled state, and fail-open or fail-closed policy. Re-registering the same
+definition ID is the controlled update path. Definitions can be enabled or
+disabled without deleting prior outcomes.
+
+## Deterministic order
+
+Matching definitions execute sequentially in this order:
+
+1. global
+2. workspace
+3. profile
+4. workflow
+5. run
+
+Within a scope, lower explicit order runs first, then definition ID. Disabled
+and non-matching definitions are omitted. The first blocking denial or
+fail-closed failure stops later handlers.
+
+## Failure and reentrancy
+
+Handlers receive an `AbortSignal`. The bus enforces a 10 to 5,000 millisecond
+timeout and rejects recursive dispatch of the same event/hook pair. Missing,
+failed, timed-out, or reentrant pre-event handlers obey their declared failure
+policy. Post-events stay passive regardless of handler failure.
+
+Handlers must stop work when their signal is aborted. The bus cannot make an
+arbitrary in-process side effect reversible after it occurs.
+
+## Evidence and dry-run
+
+Each outcome retains source event ID, hook/handler IDs, execution order,
+timestamps, duration, disposition, blocking state, and a bounded redacted
+diagnostic. When task and attempt references exist, the default recorder appends
+a namespaced `runtime.hook` event to the causal run journal and returns its
+event/sequence reference.
+
+`dryRun()` validates the same envelope and resolves the same effective ordering,
+registered handlers, and fail-closed missing-handler blockers. It never invokes
+a handler or writes evidence.
+
+## Feature integration
+
+Feature code uses the singleton bus only to register a bounded built-in handler
+and versioned definition. It must keep product configuration, authorization,
+and domain persistence in the feature that owns them. For #911, the Buzz
+adapter supplies an authenticated external-event reference, while the workflow
+trigger feature owns its rule, causal key, journal disposition, and exactly-once
+workflow dispatch.

--- a/server/src/__tests__/runtime-hook-bus-service.test.ts
+++ b/server/src/__tests__/runtime-hook-bus-service.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  RUNTIME_HOOK_SCHEMA_VERSION,
+  type RuntimeHookDefinition,
+  type RuntimeHookEnvelope,
+} from '@veritas-kanban/shared';
+import {
+  RuntimeHookDefinitionSchema,
+  RuntimeHookEnvelopeSchema,
+} from '../schemas/runtime-hook-schemas.js';
+import {
+  RunEventRuntimeHookOutcomeRecorder,
+  RuntimeHookBusService,
+} from '../services/runtime-hook-bus-service.js';
+import type { RunEventJournalService } from '../services/run-event-journal-service.js';
+
+const NOW = '2026-07-24T14:00:00.000Z';
+
+function definition(
+  id: string,
+  overrides: Partial<RuntimeHookDefinition> = {}
+): RuntimeHookDefinition {
+  return {
+    schemaVersion: RUNTIME_HOOK_SCHEMA_VERSION,
+    id,
+    event: 'tool.pre-use',
+    handlerId: id,
+    scope: { kind: 'global' },
+    enabled: true,
+    order: 0,
+    timeoutMs: 100,
+    failurePolicy: 'fail-closed',
+    ...overrides,
+  };
+}
+
+function envelope(overrides: Partial<RuntimeHookEnvelope> = {}): RuntimeHookEnvelope {
+  return {
+    schemaVersion: RUNTIME_HOOK_SCHEMA_VERSION,
+    eventId: 'hookevt_1',
+    event: 'tool.pre-use',
+    occurredAt: NOW,
+    scope: {
+      workspaceId: 'workspace_1',
+      profileId: 'profile_1',
+      workflowId: 'workflow_1',
+      runId: 'run_1',
+    },
+    references: {
+      sourceEventId: 'runevt_source_1',
+      taskId: 'task_1',
+      attemptId: 'attempt_1',
+      toolCallId: 'tool_1',
+    },
+    metadata: { toolName: 'task.read', policy: 'allowlisted' },
+    ...overrides,
+  };
+}
+
+describe('RuntimeHookBusService', () => {
+  it('rejects unknown events, credential fields, oversized metadata, and blocking post-hooks', () => {
+    expect(() =>
+      RuntimeHookEnvelopeSchema.parse({ ...envelope(), event: 'provider.unknown' })
+    ).toThrow();
+    expect(() =>
+      RuntimeHookEnvelopeSchema.parse({
+        ...envelope(),
+        metadata: { authorizationToken: 'test-value' },
+      })
+    ).toThrow(/credential fields/);
+    expect(() =>
+      RuntimeHookEnvelopeSchema.parse({
+        ...envelope(),
+        metadata: Object.fromEntries(
+          Array.from({ length: 17 }, (_, index) => [`field${index}`, 'x'.repeat(1000)])
+        ),
+      })
+    ).toThrow(/16384 bytes/);
+    expect(() =>
+      RuntimeHookDefinitionSchema.parse(
+        definition('post', {
+          event: 'tool.post-use',
+          failurePolicy: 'fail-closed',
+        })
+      )
+    ).toThrow(/Passive post-events/);
+  });
+
+  it('resolves enabled hooks by scope precedence, order, and ID', () => {
+    const bus = new RuntimeHookBusService({
+      definitions: [
+        definition('run', { scope: { kind: 'run', id: 'run_1' }, order: -10 }),
+        definition('workspace-b', {
+          scope: { kind: 'workspace', id: 'workspace_1' },
+          order: 5,
+        }),
+        definition('global-b', { order: 10 }),
+        definition('global-a', { order: 10 }),
+        definition('disabled', { enabled: false, order: -100 }),
+        definition('other-profile', {
+          scope: { kind: 'profile', id: 'profile_2' },
+        }),
+      ],
+    });
+
+    expect(bus.dryRun(envelope()).effectiveHooks.map((entry) => entry.hookId)).toEqual([
+      'global-a',
+      'global-b',
+      'workspace-b',
+      'run',
+    ]);
+  });
+
+  it('applies pre-event allow, fail-open, and deny decisions in order', async () => {
+    const after = vi.fn(async () => ({ decision: 'allow' as const }));
+    const bus = new RuntimeHookBusService({
+      definitions: [
+        definition('allow', { order: 0 }),
+        definition('missing-open', { order: 1, failurePolicy: 'fail-open' }),
+        definition('deny', { order: 2 }),
+        definition('after', { order: 3 }),
+      ],
+      handlers: {
+        allow: async () => ({ decision: 'allow' }),
+        deny: async () => ({ decision: 'deny', diagnostic: 'Policy denied the tool.' }),
+        after,
+      },
+    });
+
+    const result = await bus.dispatch(envelope());
+
+    expect(result.allowed).toBe(false);
+    expect(result.outcomes.map((outcome) => [outcome.hookId, outcome.disposition])).toEqual([
+      ['allow', 'allowed'],
+      ['missing-open', 'missing-handler'],
+      ['deny', 'denied'],
+    ]);
+    expect(after).not.toHaveBeenCalled();
+  });
+
+  it('keeps post-events passive when a handler attempts to deny', async () => {
+    const bus = new RuntimeHookBusService({
+      definitions: [
+        definition('post', {
+          event: 'tool.post-use',
+          failurePolicy: 'fail-open',
+        }),
+      ],
+      handlers: {
+        post: async () => ({ decision: 'deny' }),
+      },
+    });
+
+    const result = await bus.dispatch(envelope({ event: 'tool.post-use' }));
+
+    expect(result.allowed).toBe(true);
+    expect(result.outcomes[0]).toMatchObject({
+      disposition: 'invalid-post-decision',
+      blocking: false,
+    });
+  });
+
+  it('rejects recursive dispatch and bounds fail-closed handler timeouts', async () => {
+    let reentrantBus: RuntimeHookBusService;
+    reentrantBus = new RuntimeHookBusService({
+      definitions: [definition('recursive')],
+      handlers: {
+        recursive: async (event) => {
+          const nested = await reentrantBus.dispatch(event);
+          expect(nested.outcomes[0]?.disposition).toBe('reentrant');
+          return { decision: nested.allowed ? 'allow' : 'deny' };
+        },
+      },
+    });
+    expect((await reentrantBus.dispatch(envelope())).allowed).toBe(false);
+
+    const timeoutBus = new RuntimeHookBusService({
+      definitions: [definition('timeout', { timeoutMs: 10 })],
+      handlers: {
+        timeout: async () => new Promise(() => {}),
+      },
+    });
+    const timedOut = await timeoutBus.dispatch(envelope());
+    expect(timedOut).toMatchObject({
+      allowed: false,
+      outcomes: [{ disposition: 'timed-out', blocking: true }],
+    });
+  });
+
+  it('keeps dry-run side-effect free and attaches recorder evidence on dispatch', async () => {
+    const handler = vi.fn(async () => ({ decision: 'allow' as const }));
+    const append = vi.fn(async () => ({
+      appended: true,
+      event: { eventId: 'runevt_recorded_1', sequence: 7 },
+    }));
+    const recorder = new RunEventRuntimeHookOutcomeRecorder({
+      append,
+    } as unknown as RunEventJournalService);
+    const bus = new RuntimeHookBusService({
+      definitions: [definition('recorded')],
+      handlers: { recorded: handler },
+      recorder,
+    });
+
+    expect(bus.dryRun(envelope())).toMatchObject({
+      wouldBlock: false,
+      effectiveHooks: [{ hookId: 'recorded', handlerRegistered: true }],
+    });
+    expect(handler).not.toHaveBeenCalled();
+    expect(append).not.toHaveBeenCalled();
+
+    const result = await bus.dispatch(envelope());
+    expect(handler).toHaveBeenCalledOnce();
+    expect(append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task_1',
+        attemptId: 'attempt_1',
+        causalEventId: 'runevt_source_1',
+        kind: 'runtime.hook',
+        dedupeKey: 'runtime-hook:hookevt_1:recorded',
+      })
+    );
+    expect(result.outcomes[0]?.evidence).toEqual({
+      kind: 'run-event',
+      eventId: 'runevt_recorded_1',
+      sequence: 7,
+    });
+  });
+});

--- a/server/src/schemas/runtime-hook-schemas.ts
+++ b/server/src/schemas/runtime-hook-schemas.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod';
+import {
+  RUNTIME_HOOK_EVENT_IDS,
+  RUNTIME_HOOK_SCHEMA_VERSION,
+  isBlockingRuntimeHookEvent,
+  type RuntimeHookDefinition,
+  type RuntimeHookDryRunResult,
+  type RuntimeHookEnvelope,
+  type RuntimeHookOutcome,
+} from '@veritas-kanban/shared';
+
+const MAX_METADATA_BYTES = 16 * 1024;
+const identifier = z
+  .string()
+  .trim()
+  .min(1)
+  .max(160)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/);
+const metadataValue = z.union([z.string().max(1000), z.number().finite(), z.boolean(), z.null()]);
+const scope = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('global') }).strict(),
+  z
+    .object({
+      kind: z.enum(['workspace', 'profile', 'workflow', 'run']),
+      id: identifier,
+    })
+    .strict(),
+]);
+
+export const RuntimeHookDefinitionSchema: z.ZodType<RuntimeHookDefinition> = z
+  .object({
+    schemaVersion: z.literal(RUNTIME_HOOK_SCHEMA_VERSION),
+    id: identifier,
+    event: z.enum(RUNTIME_HOOK_EVENT_IDS),
+    handlerId: identifier,
+    scope,
+    enabled: z.boolean(),
+    order: z.number().int().min(-1000).max(1000),
+    timeoutMs: z.number().int().min(10).max(5000),
+    failurePolicy: z.enum(['fail-open', 'fail-closed']),
+  })
+  .strict()
+  .superRefine((definition, context) => {
+    if (!isBlockingRuntimeHookEvent(definition.event) && definition.failurePolicy !== 'fail-open') {
+      context.addIssue({
+        code: 'custom',
+        path: ['failurePolicy'],
+        message: 'Passive post-events must use fail-open policy.',
+      });
+    }
+  });
+
+export const RuntimeHookEnvelopeSchema: z.ZodType<RuntimeHookEnvelope> = z
+  .object({
+    schemaVersion: z.literal(RUNTIME_HOOK_SCHEMA_VERSION),
+    eventId: identifier,
+    event: z.enum(RUNTIME_HOOK_EVENT_IDS),
+    occurredAt: z.string().datetime(),
+    scope: z
+      .object({
+        workspaceId: identifier.optional(),
+        profileId: identifier.optional(),
+        workflowId: identifier.optional(),
+        runId: identifier.optional(),
+      })
+      .strict(),
+    references: z
+      .object({
+        sourceEventId: identifier,
+        taskId: identifier.optional(),
+        attemptId: identifier.optional(),
+        toolCallId: identifier.optional(),
+        approvalId: identifier.optional(),
+        workflowId: identifier.optional(),
+        externalEventId: identifier.optional(),
+      })
+      .strict(),
+    metadata: z.record(z.string().min(1).max(80), metadataValue),
+  })
+  .strict()
+  .superRefine((envelope, context) => {
+    const credentialKey = Object.keys(envelope.metadata).find((key) =>
+      /(?:api.?key|authorization|credential|password|secret|token)/i.test(key)
+    );
+    if (credentialKey) {
+      context.addIssue({
+        code: 'custom',
+        path: ['metadata', credentialKey],
+        message: 'Runtime hook metadata cannot contain credential fields.',
+      });
+    }
+    if (Buffer.byteLength(JSON.stringify(envelope.metadata), 'utf8') > MAX_METADATA_BYTES) {
+      context.addIssue({
+        code: 'custom',
+        path: ['metadata'],
+        message: `Runtime hook metadata cannot exceed ${MAX_METADATA_BYTES} bytes.`,
+      });
+    }
+  });
+
+export const RuntimeHookOutcomeSchema: z.ZodType<RuntimeHookOutcome> = z
+  .object({
+    schemaVersion: z.literal(RUNTIME_HOOK_SCHEMA_VERSION),
+    eventId: identifier,
+    sourceEventId: identifier,
+    hookId: identifier,
+    handlerId: identifier,
+    event: z.enum(RUNTIME_HOOK_EVENT_IDS),
+    order: z.number().int().min(-1000).max(1000),
+    startedAt: z.string().datetime(),
+    completedAt: z.string().datetime(),
+    durationMs: z.number().int().nonnegative(),
+    disposition: z.enum([
+      'allowed',
+      'denied',
+      'failed-open',
+      'failed-closed',
+      'timed-out',
+      'reentrant',
+      'missing-handler',
+      'invalid-post-decision',
+    ]),
+    blocking: z.boolean(),
+    diagnostic: z.string().max(1000).optional(),
+    evidence: z
+      .object({
+        kind: z.literal('run-event'),
+        eventId: identifier,
+        sequence: z.number().int().positive(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export const RuntimeHookDryRunResultSchema: z.ZodType<RuntimeHookDryRunResult> = z
+  .object({
+    schemaVersion: z.literal(RUNTIME_HOOK_SCHEMA_VERSION),
+    eventId: identifier,
+    event: z.enum(RUNTIME_HOOK_EVENT_IDS),
+    effectiveHooks: z.array(
+      z
+        .object({
+          hookId: identifier,
+          handlerId: identifier,
+          scope,
+          order: z.number().int().min(-1000).max(1000),
+          blocking: z.boolean(),
+          handlerRegistered: z.boolean(),
+          blocker: z.string().max(1000).optional(),
+        })
+        .strict()
+    ),
+    wouldBlock: z.boolean(),
+    blockers: z.array(z.string().max(1000)),
+  })
+  .strict();

--- a/server/src/services/runtime-hook-bus-service.ts
+++ b/server/src/services/runtime-hook-bus-service.ts
@@ -1,0 +1,371 @@
+import type {
+  RuntimeHookDefinition,
+  RuntimeHookDispatchResult,
+  RuntimeHookDryRunEntry,
+  RuntimeHookDryRunResult,
+  RuntimeHookEnvelope,
+  RuntimeHookEvidenceReference,
+  RuntimeHookHandler,
+  RuntimeHookHandlerResult,
+  RuntimeHookOutcome,
+  RuntimeHookOutcomeRecorder,
+  RuntimeHookScope,
+} from '@veritas-kanban/shared';
+import { RUNTIME_HOOK_SCHEMA_VERSION, isBlockingRuntimeHookEvent } from '@veritas-kanban/shared';
+import { ValidationError } from '../middleware/error-handler.js';
+import {
+  RuntimeHookDefinitionSchema,
+  RuntimeHookDryRunResultSchema,
+  RuntimeHookEnvelopeSchema,
+  RuntimeHookOutcomeSchema,
+} from '../schemas/runtime-hook-schemas.js';
+import {
+  containsUnredactedProviderRuntimeSecret,
+  sanitizeProviderRuntimeDiagnostic,
+} from '../utils/provider-runtime-manifest-sanitize.js';
+import {
+  getRunEventJournalService,
+  type RunEventJournalService,
+} from './run-event-journal-service.js';
+
+const SCOPE_ORDER: Record<RuntimeHookScope['kind'], number> = {
+  global: 0,
+  workspace: 1,
+  profile: 2,
+  workflow: 3,
+  run: 4,
+};
+
+export interface RuntimeHookBusOptions {
+  definitions?: RuntimeHookDefinition[];
+  handlers?: Record<string, RuntimeHookHandler>;
+  recorder?: RuntimeHookOutcomeRecorder;
+  now?: () => Date;
+  clockMs?: () => number;
+}
+
+export class RuntimeHookBusService {
+  private readonly definitions = new Map<string, RuntimeHookDefinition>();
+  private readonly handlers = new Map<string, RuntimeHookHandler>();
+  private readonly active = new Set<string>();
+  private readonly recorder?: RuntimeHookOutcomeRecorder;
+  private readonly now: () => Date;
+  private readonly clockMs: () => number;
+
+  constructor(options: RuntimeHookBusOptions = {}) {
+    this.recorder = options.recorder;
+    this.now = options.now ?? (() => new Date());
+    this.clockMs = options.clockMs ?? Date.now;
+    for (const [handlerId, handler] of Object.entries(options.handlers ?? {})) {
+      this.registerHandler(handlerId, handler);
+    }
+    for (const definition of options.definitions ?? []) {
+      this.registerDefinition(definition);
+    }
+  }
+
+  registerHandler(handlerId: string, handler: RuntimeHookHandler): void {
+    assertIdentifier(handlerId, 'handler ID');
+    this.handlers.set(handlerId, handler);
+  }
+
+  registerDefinition(input: RuntimeHookDefinition): RuntimeHookDefinition {
+    const definition = RuntimeHookDefinitionSchema.parse(input);
+    this.definitions.set(definition.id, structuredClone(definition));
+    return structuredClone(definition);
+  }
+
+  setDefinitionEnabled(id: string, enabled: boolean): RuntimeHookDefinition {
+    const current = this.definitions.get(id);
+    if (!current) throw new ValidationError(`Runtime hook ${id} does not exist.`);
+    return this.registerDefinition({ ...current, enabled });
+  }
+
+  listDefinitions(): RuntimeHookDefinition[] {
+    return [...this.definitions.values()].map((definition) => structuredClone(definition));
+  }
+
+  dryRun(input: RuntimeHookEnvelope): RuntimeHookDryRunResult {
+    const envelope = this.parseEnvelope(input);
+    const effectiveHooks = this.effectiveDefinitions(envelope).map<RuntimeHookDryRunEntry>(
+      (definition) => {
+        const blocking = isBlockingRuntimeHookEvent(definition.event);
+        const handlerRegistered = this.handlers.has(definition.handlerId);
+        const blocker =
+          blocking && !handlerRegistered && definition.failurePolicy === 'fail-closed'
+            ? `Handler ${definition.handlerId} is not registered.`
+            : undefined;
+        return {
+          hookId: definition.id,
+          handlerId: definition.handlerId,
+          scope: structuredClone(definition.scope),
+          order: definition.order,
+          blocking,
+          handlerRegistered,
+          ...(blocker ? { blocker } : {}),
+        };
+      }
+    );
+    const blockers = effectiveHooks.flatMap((entry) => (entry.blocker ? [entry.blocker] : []));
+    return RuntimeHookDryRunResultSchema.parse({
+      schemaVersion: RUNTIME_HOOK_SCHEMA_VERSION,
+      eventId: envelope.eventId,
+      event: envelope.event,
+      effectiveHooks,
+      wouldBlock: blockers.length > 0,
+      blockers,
+    });
+  }
+
+  async dispatch(input: RuntimeHookEnvelope): Promise<RuntimeHookDispatchResult> {
+    const envelope = deepFreeze(this.parseEnvelope(input));
+    const outcomes: RuntimeHookOutcome[] = [];
+    let allowed = true;
+
+    for (const definition of this.effectiveDefinitions(envelope)) {
+      const outcome = await this.executeDefinition(definition, envelope);
+      outcomes.push(outcome);
+      if (outcome.blocking) {
+        allowed = false;
+        break;
+      }
+    }
+
+    return {
+      schemaVersion: RUNTIME_HOOK_SCHEMA_VERSION,
+      eventId: envelope.eventId,
+      event: envelope.event,
+      allowed,
+      outcomes,
+    };
+  }
+
+  private parseEnvelope(input: RuntimeHookEnvelope): RuntimeHookEnvelope {
+    const envelope = RuntimeHookEnvelopeSchema.parse(input);
+    if (containsUnredactedProviderRuntimeSecret(JSON.stringify(envelope.metadata))) {
+      throw new ValidationError('Runtime hook metadata contains credential material.');
+    }
+    return structuredClone(envelope);
+  }
+
+  private effectiveDefinitions(envelope: RuntimeHookEnvelope): RuntimeHookDefinition[] {
+    return [...this.definitions.values()]
+      .filter(
+        (definition) =>
+          definition.enabled &&
+          definition.event === envelope.event &&
+          scopeMatches(definition.scope, envelope)
+      )
+      .sort(
+        (left, right) =>
+          SCOPE_ORDER[left.scope.kind] - SCOPE_ORDER[right.scope.kind] ||
+          left.order - right.order ||
+          left.id.localeCompare(right.id)
+      );
+  }
+
+  private async executeDefinition(
+    definition: RuntimeHookDefinition,
+    envelope: RuntimeHookEnvelope
+  ): Promise<RuntimeHookOutcome> {
+    const startedAt = this.now().toISOString();
+    const startedMs = this.clockMs();
+    const activeKey = `${envelope.eventId}:${definition.id}`;
+    const handler = this.handlers.get(definition.handlerId);
+    let disposition: RuntimeHookOutcome['disposition'];
+    let blocking: boolean;
+    let diagnostic: string | undefined;
+
+    if (!handler) {
+      disposition = 'missing-handler';
+      blocking =
+        isBlockingRuntimeHookEvent(definition.event) && definition.failurePolicy === 'fail-closed';
+      diagnostic = `Handler ${definition.handlerId} is not registered.`;
+    } else if (this.active.has(activeKey)) {
+      disposition = 'reentrant';
+      blocking =
+        isBlockingRuntimeHookEvent(definition.event) && definition.failurePolicy === 'fail-closed';
+      diagnostic = 'Recursive dispatch of the same event and hook was rejected.';
+    } else {
+      this.active.add(activeKey);
+      const controller = new AbortController();
+      try {
+        const result = await withTimeout(
+          handler(envelope, { signal: controller.signal }),
+          definition.timeoutMs,
+          controller
+        );
+        ({ disposition, blocking, diagnostic } = evaluateResult(
+          definition,
+          assertHandlerResult(result)
+        ));
+      } catch (error) {
+        const timedOut = error instanceof RuntimeHookTimeoutError;
+        disposition = timedOut
+          ? 'timed-out'
+          : definition.failurePolicy === 'fail-closed'
+            ? 'failed-closed'
+            : 'failed-open';
+        blocking =
+          isBlockingRuntimeHookEvent(definition.event) &&
+          definition.failurePolicy === 'fail-closed';
+        diagnostic = timedOut
+          ? `Handler exceeded ${definition.timeoutMs}ms.`
+          : error instanceof Error
+            ? error.message
+            : 'Runtime hook handler failed.';
+      } finally {
+        this.active.delete(activeKey);
+      }
+    }
+
+    const completedAt = this.now().toISOString();
+    const outcome = RuntimeHookOutcomeSchema.parse({
+      schemaVersion: RUNTIME_HOOK_SCHEMA_VERSION,
+      eventId: envelope.eventId,
+      sourceEventId: envelope.references.sourceEventId,
+      hookId: definition.id,
+      handlerId: definition.handlerId,
+      event: envelope.event,
+      order: definition.order,
+      startedAt,
+      completedAt,
+      durationMs: Math.max(0, this.clockMs() - startedMs),
+      disposition,
+      blocking,
+      ...(diagnostic ? { diagnostic: sanitizeProviderRuntimeDiagnostic(diagnostic) } : {}),
+    });
+    const evidence = await this.recorder?.record(envelope, structuredClone(outcome));
+    return evidence ? { ...outcome, evidence } : outcome;
+  }
+}
+
+export class RunEventRuntimeHookOutcomeRecorder implements RuntimeHookOutcomeRecorder {
+  constructor(private readonly journal: RunEventJournalService = getRunEventJournalService()) {}
+
+  async record(
+    envelope: RuntimeHookEnvelope,
+    outcome: RuntimeHookOutcome
+  ): Promise<RuntimeHookEvidenceReference | undefined> {
+    const { taskId, attemptId, sourceEventId } = envelope.references;
+    if (!taskId || !attemptId) return undefined;
+    const result = await this.journal.append({
+      taskId,
+      attemptId,
+      causalEventId: sourceEventId,
+      kind: 'runtime.hook',
+      source: { provider: 'system', adapter: 'runtime-hook-bus' },
+      payload: {
+        schemaVersion: outcome.schemaVersion,
+        hookId: outcome.hookId,
+        handlerId: outcome.handlerId,
+        event: outcome.event,
+        order: outcome.order,
+        disposition: outcome.disposition,
+        blocking: outcome.blocking,
+        durationMs: outcome.durationMs,
+        ...(outcome.diagnostic ? { diagnostic: outcome.diagnostic } : {}),
+      },
+      dedupeKey: `runtime-hook:${outcome.eventId}:${outcome.hookId}`,
+    });
+    return {
+      kind: 'run-event',
+      eventId: result.event.eventId,
+      sequence: result.event.sequence,
+    };
+  }
+}
+
+function evaluateResult(
+  definition: RuntimeHookDefinition,
+  result: RuntimeHookHandlerResult
+): Pick<RuntimeHookOutcome, 'disposition' | 'blocking' | 'diagnostic'> {
+  if (!isBlockingRuntimeHookEvent(definition.event) && result.decision === 'deny') {
+    return {
+      disposition: 'invalid-post-decision',
+      blocking: false,
+      diagnostic: 'Passive post-event handlers cannot deny or mutate completed outcomes.',
+    };
+  }
+  if (result.decision === 'deny') {
+    return {
+      disposition: 'denied',
+      blocking: true,
+      ...(result.diagnostic ? { diagnostic: result.diagnostic } : {}),
+    };
+  }
+  return {
+    disposition: 'allowed',
+    blocking: false,
+    ...(result.diagnostic ? { diagnostic: result.diagnostic } : {}),
+  };
+}
+
+function scopeMatches(scope: RuntimeHookScope, envelope: RuntimeHookEnvelope): boolean {
+  if (scope.kind === 'global') return true;
+  const key = `${scope.kind}Id` as keyof RuntimeHookEnvelope['scope'];
+  return envelope.scope[key] === scope.id;
+}
+
+async function withTimeout(
+  promise: Promise<RuntimeHookHandlerResult>,
+  timeoutMs: number,
+  controller: AbortController
+): Promise<RuntimeHookHandlerResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          controller.abort();
+          reject(new RuntimeHookTimeoutError());
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+class RuntimeHookTimeoutError extends Error {}
+
+function assertHandlerResult(result: RuntimeHookHandlerResult): RuntimeHookHandlerResult {
+  if (
+    !result ||
+    !['allow', 'deny', 'observe'].includes(result.decision) ||
+    (result.diagnostic !== undefined && typeof result.diagnostic !== 'string')
+  ) {
+    throw new ValidationError('Runtime hook handler returned an invalid result.');
+  }
+  return result;
+}
+
+function assertIdentifier(value: string, label: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:/-]{0,159}$/.test(value)) {
+    throw new ValidationError(`Invalid runtime hook ${label}.`);
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object') {
+    Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(child);
+    }
+  }
+  return value;
+}
+
+let runtimeHookBusService: RuntimeHookBusService | undefined;
+
+export function getRuntimeHookBusService(): RuntimeHookBusService {
+  runtimeHookBusService ??= new RuntimeHookBusService({
+    recorder: new RunEventRuntimeHookOutcomeRecorder(),
+  });
+  return runtimeHookBusService;
+}
+
+export function resetRuntimeHookBusServiceForTests(): void {
+  runtimeHookBusService = undefined;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -54,6 +54,7 @@ export * from './time-breakdown.types.js';
 export * from './task-envelope.types.js';
 export * from './run-launch-manifest.types.js';
 export * from './run-event.types.js';
+export * from './runtime-hook.types.js';
 export * from './auth.types.js';
 export * from './credential-broker.types.js';
 export * from './worktree-manifest.types.js';

--- a/shared/src/types/runtime-hook.types.ts
+++ b/shared/src/types/runtime-hook.types.ts
@@ -1,0 +1,148 @@
+export const RUNTIME_HOOK_SCHEMA_VERSION = 'runtime-hook/v1' as const;
+
+export const RUNTIME_HOOK_EVENT_IDS = [
+  'session.pre-start',
+  'session.post-end',
+  'tool.pre-use',
+  'tool.post-use',
+  'permission.post-denied',
+  'completion.post-recorded',
+  'workflow.pre-external-trigger',
+] as const;
+
+export type RuntimeHookEventId = (typeof RUNTIME_HOOK_EVENT_IDS)[number];
+
+export const BLOCKING_RUNTIME_HOOK_EVENT_IDS = [
+  'session.pre-start',
+  'tool.pre-use',
+  'workflow.pre-external-trigger',
+] as const;
+
+export type BlockingRuntimeHookEventId = (typeof BLOCKING_RUNTIME_HOOK_EVENT_IDS)[number];
+export type RuntimeHookFailurePolicy = 'fail-open' | 'fail-closed';
+export type RuntimeHookScopeKind = 'global' | 'workspace' | 'profile' | 'workflow' | 'run';
+
+export type RuntimeHookScope =
+  { kind: 'global' } | { kind: Exclude<RuntimeHookScopeKind, 'global'>; id: string };
+
+export interface RuntimeHookDefinition {
+  schemaVersion: typeof RUNTIME_HOOK_SCHEMA_VERSION;
+  id: string;
+  event: RuntimeHookEventId;
+  handlerId: string;
+  scope: RuntimeHookScope;
+  enabled: boolean;
+  order: number;
+  timeoutMs: number;
+  failurePolicy: RuntimeHookFailurePolicy;
+}
+
+export interface RuntimeHookScopeContext {
+  workspaceId?: string;
+  profileId?: string;
+  workflowId?: string;
+  runId?: string;
+}
+
+export interface RuntimeHookReferences {
+  sourceEventId: string;
+  taskId?: string;
+  attemptId?: string;
+  toolCallId?: string;
+  approvalId?: string;
+  workflowId?: string;
+  externalEventId?: string;
+}
+
+export interface RuntimeHookEnvelope {
+  schemaVersion: typeof RUNTIME_HOOK_SCHEMA_VERSION;
+  eventId: string;
+  event: RuntimeHookEventId;
+  occurredAt: string;
+  scope: RuntimeHookScopeContext;
+  references: RuntimeHookReferences;
+  metadata: Record<string, string | number | boolean | null>;
+}
+
+export interface RuntimeHookHandlerResult {
+  decision: 'allow' | 'deny' | 'observe';
+  diagnostic?: string;
+}
+
+export type RuntimeHookDisposition =
+  | 'allowed'
+  | 'denied'
+  | 'failed-open'
+  | 'failed-closed'
+  | 'timed-out'
+  | 'reentrant'
+  | 'missing-handler'
+  | 'invalid-post-decision';
+
+export interface RuntimeHookEvidenceReference {
+  kind: 'run-event';
+  eventId: string;
+  sequence: number;
+}
+
+export interface RuntimeHookOutcome {
+  schemaVersion: typeof RUNTIME_HOOK_SCHEMA_VERSION;
+  eventId: string;
+  sourceEventId: string;
+  hookId: string;
+  handlerId: string;
+  event: RuntimeHookEventId;
+  order: number;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  disposition: RuntimeHookDisposition;
+  blocking: boolean;
+  diagnostic?: string;
+  evidence?: RuntimeHookEvidenceReference;
+}
+
+export interface RuntimeHookDispatchResult {
+  schemaVersion: typeof RUNTIME_HOOK_SCHEMA_VERSION;
+  eventId: string;
+  event: RuntimeHookEventId;
+  allowed: boolean;
+  outcomes: RuntimeHookOutcome[];
+}
+
+export interface RuntimeHookDryRunEntry {
+  hookId: string;
+  handlerId: string;
+  scope: RuntimeHookScope;
+  order: number;
+  blocking: boolean;
+  handlerRegistered: boolean;
+  blocker?: string;
+}
+
+export interface RuntimeHookDryRunResult {
+  schemaVersion: typeof RUNTIME_HOOK_SCHEMA_VERSION;
+  eventId: string;
+  event: RuntimeHookEventId;
+  effectiveHooks: RuntimeHookDryRunEntry[];
+  wouldBlock: boolean;
+  blockers: string[];
+}
+
+export type RuntimeHookHandler = (
+  envelope: Readonly<RuntimeHookEnvelope>,
+  context: { signal: AbortSignal }
+) => Promise<RuntimeHookHandlerResult>;
+
+export interface RuntimeHookOutcomeRecorder {
+  record(
+    envelope: RuntimeHookEnvelope,
+    outcome: RuntimeHookOutcome
+  ): Promise<RuntimeHookEvidenceReference | undefined>;
+}
+
+export function isBlockingRuntimeHookEvent(
+  event: RuntimeHookEventId
+): event is BlockingRuntimeHookEventId {
+  return (BLOCKING_RUNTIME_HOOK_EVENT_IDS as readonly RuntimeHookEventId[]).includes(event);
+}


### PR DESCRIPTION
Closes #874

## Summary
- add the versioned in-process runtime hook envelope, definition, outcome, and dry-run contracts
- enforce deterministic scope ordering, explicit blocking pre-events, passive post-events, timeouts, reentrancy guards, and secret-safe bounded metadata
- append hook outcomes to the causal run journal when task and attempt evidence is available
- keep executable and HTTP handlers explicitly unsupported pending their sandbox and egress boundaries

## Verification
- shared build
- server typecheck
- 6 focused runtime hook contract tests
- changed-file ESLint and Prettier checks

## Risk
- in-process handlers must honor the supplied abort signal; timed-out work cannot be made reversible after a handler has already performed a side effect