### PR TITLE
feat: bridge Buzz messages to workflow triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added allowlisted Buzz root-message workflow triggers with bounded predicates,
+  provider-neutral pre-dispatch hooks, durable causal keys, replay and echo
+  suppression, restart reconciliation, API configuration, and audit history
+  (#911).
 - Added the provider-neutral `runtime-hook/v1` in-process hook bus with bounded
   envelopes, deterministic scope ordering, explicit blocking pre-events,
   passive post-events, timeout/reentrancy protection, side-effect-free dry-run,

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -375,6 +375,23 @@ message. Task execution through the separately configured `buzz-agent` ACP
 profile remains independent of relay delivery and never starts `buzz-acp`. See
 [Buzz Connection Diagnostics](BUZZ-INTEGRATION.md).
 
+An operator can bind one active Buzz channel mapping to one Veritas workflow
+with a `buzz-workflow-trigger/v1` rule. The first supported event is a root
+`message.posted`; replies, adapter-originated echoes, disabled rules, and
+predicate mismatches never launch a run. Each accepted event is journaled
+before dispatch with the causal key
+`buzz:{community}:{eventId}:{ruleId}`. Replays return the existing run, and
+restart recovery reconciles an accepted journal entry against workflow run
+context before attempting dispatch again. The provider-neutral
+`workflow.pre-external-trigger` runtime hook remains the policy boundary.
+
+Rules and their bounded audit history are available under
+`/api/integrations/communication/adapters/:adapterId/buzz/workflow-triggers`
+and
+`/api/integrations/communication/adapters/:adapterId/buzz/workflow-trigger-audits`.
+Rule creation requires both integration settings write access and execute
+permission on the destination workflow.
+
 ## Harness Support Profiles And Tiers
 
 Every configured agent is normalized to a `harness-support-profile/v1` contract.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -629,27 +629,30 @@ Real-time agent-to-agent communication channel for multi-agent collaboration. Sh
 - **OpenClaw Direct gateway wake** — Optional real-time Squad Chat events pushed to OpenClaw gateway for agent orchestration
 - **Human reply adapters** — Configure Teams reply posture, run health checks and test sends, store external thread mappings, and ingest audited human replies back into the correct Squad Chat thread
 - **Buzz channel bridge** — Map a Buzz community channel to Squad Chat, publish and ingest signed roots/replies exactly once, retain source author/timestamp/deep links, resume through a durable cursor with overlap dedupe, and reconcile ambiguous sends before retry
+- **Buzz workflow trigger** — Bind an allowlisted mapped-channel root message to one workflow with bounded author/content predicates, a durable causal key, provider-neutral pre-dispatch hooks, replay/echo suppression, and restart reconciliation
 - **Buzz persona/team import** — List signature-verified NIP-33 persona and team heads, preview mapped/source-only/ignored/rejected fields, resolve collisions explicitly, and create, link, or refresh disabled profile/roster materializations with provenance and optimistic local revisions
 - **Searchable history** — Browse and search past squad chat messages
 
 ### API Endpoints
 
-| Endpoint                                                                       | Method | Description                                       |
-| ------------------------------------------------------------------------------ | ------ | ------------------------------------------------- |
-| `/api/chat/squad`                                                              | POST   | Send a squad chat message                         |
-| `/api/chat/squad`                                                              | GET    | Retrieve squad chat history                       |
-| `/api/chat/squad/search`                                                       | GET    | Search redacted snippets                          |
-| `/api/chat/squad/unread`                                                       | GET    | Get actor-scoped unread state                     |
-| `/api/chat/squad/read`                                                         | POST   | Mark messages read for an actor                   |
-| `/api/chat/squad/:messageId/thread`                                            | GET    | Read a compact thread                             |
-| `/api/chat/squad/:messageId/pin`                                               | POST   | Pin/unpin or mark/unmark a decision               |
-| `/api/chat/squad/:messageId/react`                                             | POST   | Add a lightweight reaction or acknowledgement     |
-| `/api/integrations/communication/adapters/:adapterId/replies`                  | POST   | Ingest an external human reply into Squad Chat    |
-| `/api/integrations/communication/adapters/:adapterId/send`                     | POST   | Publish a mapped Teams/Buzz communication message |
-| `/api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId` | PUT    | Map a Buzz channel to Squad Chat                  |
-| `/api/integrations/communication/adapters/:adapterId/buzz/definitions`         | GET    | List validated Buzz persona/team heads            |
-| `/api/integrations/communication/adapters/:adapterId/buzz/definitions/preview` | POST   | Preview field mappings, diffs, and collisions     |
-| `/api/integrations/communication/adapters/:adapterId/buzz/definitions/import`  | POST   | Explicitly create, link, refresh, or skip import  |
+| Endpoint                                                                           | Method   | Description                                       |
+| ---------------------------------------------------------------------------------- | -------- | ------------------------------------------------- |
+| `/api/chat/squad`                                                                  | POST     | Send a squad chat message                         |
+| `/api/chat/squad`                                                                  | GET      | Retrieve squad chat history                       |
+| `/api/chat/squad/search`                                                           | GET      | Search redacted snippets                          |
+| `/api/chat/squad/unread`                                                           | GET      | Get actor-scoped unread state                     |
+| `/api/chat/squad/read`                                                             | POST     | Mark messages read for an actor                   |
+| `/api/chat/squad/:messageId/thread`                                                | GET      | Read a compact thread                             |
+| `/api/chat/squad/:messageId/pin`                                                   | POST     | Pin/unpin or mark/unmark a decision               |
+| `/api/chat/squad/:messageId/react`                                                 | POST     | Add a lightweight reaction or acknowledgement     |
+| `/api/integrations/communication/adapters/:adapterId/replies`                      | POST     | Ingest an external human reply into Squad Chat    |
+| `/api/integrations/communication/adapters/:adapterId/send`                         | POST     | Publish a mapped Teams/Buzz communication message |
+| `/api/integrations/communication/adapters/:adapterId/buzz/channels/:channelId`     | PUT      | Map a Buzz channel to Squad Chat                  |
+| `/api/integrations/communication/adapters/:adapterId/buzz/workflow-triggers`       | GET/POST | List or create root-message workflow rules        |
+| `/api/integrations/communication/adapters/:adapterId/buzz/workflow-trigger-audits` | GET      | Read bounded trigger disposition history          |
+| `/api/integrations/communication/adapters/:adapterId/buzz/definitions`             | GET      | List validated Buzz persona/team heads            |
+| `/api/integrations/communication/adapters/:adapterId/buzz/definitions/preview`     | POST     | Preview field mappings, diffs, and collisions     |
+| `/api/integrations/communication/adapters/:adapterId/buzz/definitions/import`      | POST     | Explicitly create, link, refresh, or skip import  |
 
 ---
 

--- a/server/src/__tests__/buzz-communication-adapter-service.test.ts
+++ b/server/src/__tests__/buzz-communication-adapter-service.test.ts
@@ -7,6 +7,7 @@ import type { ChatService } from '../services/chat-service.js';
 import type { OutboundIntegrationService } from '../services/outbound-integration-service.js';
 import type { BuzzCompatibilityService } from '../services/buzz-compatibility-service.js';
 import type { BuzzCommunicationService } from '../services/buzz-communication-service.js';
+import type { BuzzWorkflowTriggerService } from '../services/buzz-workflow-trigger-service.js';
 import {
   BUZZ_DELETE_KIND,
   BUZZ_EDIT_KIND,
@@ -86,6 +87,7 @@ describe('Buzz communication adapter', () => {
     eventExists: ReturnType<typeof vi.fn>;
   };
   let workerFactory: FakeWorkerFactory;
+  let buzzWorkflowTriggers: { processEvent: ReturnType<typeof vi.fn> };
   let service: CommunicationAdapterService;
 
   function event(input: {
@@ -162,6 +164,7 @@ describe('Buzz communication adapter', () => {
       eventExists: vi.fn(),
     };
     workerFactory = new FakeWorkerFactory();
+    buzzWorkflowTriggers = { processEvent: vi.fn().mockResolvedValue([]) };
     const options: CommunicationAdapterServiceOptions = {
       storageDir: temporaryDirectory,
       persist: true,
@@ -174,6 +177,7 @@ describe('Buzz communication adapter', () => {
       } as unknown as BuzzCompatibilityService,
       buzzCommunication: buzzCommunication as unknown as BuzzCommunicationService,
       buzzWorkerFactory: workerFactory,
+      buzzWorkflowTriggers: buzzWorkflowTriggers as unknown as BuzzWorkflowTriggerService,
       audit: vi.fn().mockResolvedValue(undefined),
     };
     service = new CommunicationAdapterService(options);
@@ -371,6 +375,15 @@ describe('Buzz communication adapter', () => {
     });
     expect(duplicate.status).toBe('replayed');
     expect(chatService.sendSquadMessage).toHaveBeenCalledTimes(2);
+    expect(buzzWorkflowTriggers.processEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapterId: ADAPTER_ID,
+        mapping,
+        eventId: root.id,
+        content: 'root',
+        rootEventId: undefined,
+      })
+    );
     expect(chatService.sendSquadMessage).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({

--- a/server/src/__tests__/buzz-workflow-trigger-service.test.ts
+++ b/server/src/__tests__/buzz-workflow-trigger-service.test.ts
@@ -1,0 +1,209 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BuzzChannelMapping } from '@veritas-kanban/shared';
+import {
+  BuzzWorkflowTriggerService,
+  type BuzzWorkflowTriggerEvent,
+} from '../services/buzz-workflow-trigger-service.js';
+import { RuntimeHookBusService } from '../services/runtime-hook-bus-service.js';
+import type { WorkflowRunService } from '../services/workflow-run-service.js';
+
+const EVENT_ID = 'a'.repeat(64);
+const AUTHOR = 'b'.repeat(64);
+const mapping: BuzzChannelMapping = {
+  id: 'buzz_map_primary',
+  adapterId: 'buzz-default',
+  community: 'community.example',
+  channelId: '11111111-1111-4111-8111-111111111111',
+  target: { kind: 'squad' },
+  enabled: true,
+  createdAt: '2026-07-24T12:00:00.000Z',
+  updatedAt: '2026-07-24T12:00:00.000Z',
+};
+
+const event: BuzzWorkflowTriggerEvent = {
+  adapterId: 'buzz-default',
+  mapping,
+  eventId: EVENT_ID,
+  authorPubkey: AUTHOR,
+  content: 'ship release candidate',
+  occurredAt: '2026-07-24T12:01:00.000Z',
+};
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true }))
+  );
+});
+
+function workflowRuns(overrides: Partial<WorkflowRunService> = {}): WorkflowRunService {
+  return {
+    listRuns: vi.fn().mockResolvedValue([]),
+    startRun: vi.fn().mockResolvedValue({ id: 'run_1753358460000_trigger1' }),
+    ...overrides,
+  } as unknown as WorkflowRunService;
+}
+
+async function configuredService(options: {
+  persist?: boolean;
+  storageDir?: string;
+  workflowRuns?: WorkflowRunService;
+  runtimeHooks?: RuntimeHookBusService;
+  enabled?: boolean;
+  authorPubkey?: string;
+  contentIncludes?: string;
+}) {
+  const service = new BuzzWorkflowTriggerService({
+    storageDir: options.storageDir ?? '/unused',
+    persist: options.persist ?? false,
+    workflowRuns: options.workflowRuns ?? workflowRuns(),
+    runtimeHooks: options.runtimeHooks ?? new RuntimeHookBusService(),
+  });
+  const rule = await service.createRule(
+    event.adapterId,
+    mapping,
+    {
+      mappingId: mapping.id,
+      workflowId: 'workflow-test',
+      enabled: options.enabled,
+      authorPubkey: options.authorPubkey,
+      contentIncludes: options.contentIncludes,
+    },
+    'operator'
+  );
+  return { service, rule };
+}
+
+describe('BuzzWorkflowTriggerService', () => {
+  it('dispatches one allowlisted root message through the runtime hook bus', async () => {
+    const runs = workflowRuns();
+    const { service, rule } = await configuredService({ workflowRuns: runs });
+
+    const audits = await service.processEvent(event);
+
+    expect(audits.at(-1)).toMatchObject({
+      disposition: 'dispatched',
+      ruleId: rule.id,
+      runId: 'run_1753358460000_trigger1',
+      causalKey: `buzz:${mapping.community}:${EVENT_ID}:${rule.id}`,
+    });
+    expect(runs.startRun).toHaveBeenCalledOnce();
+    expect(runs.startRun).toHaveBeenCalledWith(
+      'workflow-test',
+      undefined,
+      expect.objectContaining({
+        externalTrigger: expect.objectContaining({
+          provider: 'buzz',
+          event: 'message.posted',
+          content: event.content,
+        }),
+      })
+    );
+    expect((await service.listAudits()).map((audit) => audit.disposition)).toEqual([
+      'dispatched',
+      'accepted',
+    ]);
+  });
+
+  it('deduplicates a replay by the durable causal key', async () => {
+    const runs = workflowRuns();
+    const { service } = await configuredService({ workflowRuns: runs });
+
+    await service.processEvent(event);
+    const replay = await service.processEvent(event);
+
+    expect(replay[0]).toMatchObject({
+      disposition: 'duplicate',
+      runId: 'run_1753358460000_trigger1',
+    });
+    expect(runs.startRun).toHaveBeenCalledOnce();
+  });
+
+  it('suppresses replies, echoes, disabled rules, and predicate mismatches', async () => {
+    const runs = workflowRuns();
+    const { service } = await configuredService({
+      workflowRuns: runs,
+      authorPubkey: AUTHOR,
+      contentIncludes: 'release',
+    });
+
+    expect(
+      (await service.processEvent({ ...event, rootEventId: 'c'.repeat(64) }))[0].disposition
+    ).toBe('ignored-policy');
+    expect(
+      (await service.processEvent({ ...event, eventId: 'd'.repeat(64), echo: true }))[0].disposition
+    ).toBe('echo');
+    expect(
+      (
+        await service.processEvent({
+          ...event,
+          eventId: 'e'.repeat(64),
+          content: 'unrelated message',
+        })
+      )[0].disposition
+    ).toBe('ignored-policy');
+
+    const disabled = await configuredService({ workflowRuns: runs, enabled: false });
+    expect((await disabled.service.processEvent(event))[0].disposition).toBe('ignored-policy');
+    expect(runs.startRun).not.toHaveBeenCalled();
+  });
+
+  it('reconciles a persisted accepted dispatch to an existing workflow run after restart', async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-buzz-trigger-'));
+    temporaryDirectories.push(directory);
+    const failingRuns = workflowRuns({
+      startRun: vi.fn().mockRejectedValue(new Error('process stopped before journal update')),
+    });
+    const first = await configuredService({
+      persist: true,
+      storageDir: directory,
+      workflowRuns: failingRuns,
+    });
+    const failed = await first.service.processEvent(event);
+    const causalKey = failed[0].causalKey;
+
+    const recoveredRuns = workflowRuns({
+      listRuns: vi.fn().mockResolvedValue([
+        {
+          id: 'run_1753358460000_recover1',
+          context: { externalTrigger: { causalKey } },
+        },
+      ]),
+    });
+    const recovered = new BuzzWorkflowTriggerService({
+      storageDir: directory,
+      persist: true,
+      workflowRuns: recoveredRuns,
+      runtimeHooks: new RuntimeHookBusService(),
+    });
+    const result = await recovered.processEvent(event);
+
+    expect(result[0]).toMatchObject({
+      disposition: 'dispatched',
+      runId: 'run_1753358460000_recover1',
+    });
+    expect(recoveredRuns.startRun).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the runtime hook policy denies dispatch', async () => {
+    const hooks = {
+      registerHandler: vi.fn(),
+      registerDefinition: vi.fn(),
+      dispatch: vi.fn().mockResolvedValue({ allowed: false, outcomes: [] }),
+    } as unknown as RuntimeHookBusService;
+    const runs = workflowRuns();
+    const { service } = await configuredService({ runtimeHooks: hooks, workflowRuns: runs });
+
+    const audits = await service.processEvent(event);
+
+    expect(audits[0]).toMatchObject({
+      disposition: 'dispatch-failed',
+      detail: expect.stringContaining('policy denied'),
+    });
+    expect(runs.startRun).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/integrations.ts
+++ b/server/src/routes/integrations.ts
@@ -38,6 +38,8 @@ import {
   BuzzDefinitionPreviewBodySchema,
 } from '../schemas/buzz-definition-schemas.js';
 import type { BuzzDefinitionImportInput, BuzzDefinitionPreviewInput } from '@veritas-kanban/shared';
+import type { BuzzWorkflowTriggerRuleInput } from '@veritas-kanban/shared';
+import { assertWorkflowPermission } from '../middleware/workflow-auth.js';
 
 const log = createLogger('integrations');
 const router = Router();
@@ -96,6 +98,19 @@ const buzzChannelMappingSchema = z.object({
   actor: z.string().trim().min(1).max(200).optional(),
 });
 const buzzChannelIdSchema = z.uuid();
+const buzzWorkflowTriggerRuleSchema = z
+  .object({
+    mappingId: z.string().trim().min(1).max(160),
+    workflowId: z.string().trim().min(1).max(160),
+    enabled: z.boolean().optional(),
+    authorPubkey: z
+      .string()
+      .trim()
+      .regex(/^[a-f0-9]{64}$/i)
+      .optional(),
+    contentIncludes: z.string().trim().min(1).max(128).optional(),
+  })
+  .strict();
 
 function adapterIdParam(value: unknown): string {
   return typeof value === 'string' && value.trim() ? value : DEFAULT_ADAPTER_ID;
@@ -382,6 +397,62 @@ router.post(
       if (message.includes('not found')) throw new NotFoundError(message);
       throw error;
     }
+  })
+);
+
+// GET /api/integrations/communication/adapters/:adapterId/buzz/workflow-triggers
+router.get(
+  '/communication/adapters/:adapterId/buzz/workflow-triggers',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    res.json(await communicationAdapters.listBuzzWorkflowTriggerRules(adapterId));
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/buzz/workflow-triggers
+router.post(
+  '/communication/adapters/:adapterId/buzz/workflow-triggers',
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    const input = buzzWorkflowTriggerRuleSchema.parse(req.body) as BuzzWorkflowTriggerRuleInput;
+    const actor = req.auth?.userId || req.auth?.keyName || 'unknown';
+    await assertWorkflowPermission(input.workflowId, actor, 'execute');
+    res
+      .status(201)
+      .json(await communicationAdapters.createBuzzWorkflowTriggerRule(adapterId, input, actor));
+  })
+);
+
+// POST /api/integrations/communication/adapters/:adapterId/buzz/workflow-triggers/:ruleId/disable
+router.post(
+  '/communication/adapters/:adapterId/buzz/workflow-triggers/:ruleId/disable',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    const ruleId = typeof req.params.ruleId === 'string' ? req.params.ruleId : '';
+    if (!ruleId) throw new BadRequestError('Buzz workflow trigger rule ID is required');
+    try {
+      res.json(await communicationAdapters.disableBuzzWorkflowTriggerRule(adapterId, ruleId));
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Buzz workflow trigger update failed';
+      if (message.includes('not found')) throw new NotFoundError(message);
+      throw error;
+    }
+  })
+);
+
+// GET /api/integrations/communication/adapters/:adapterId/buzz/workflow-trigger-audits
+router.get(
+  '/communication/adapters/:adapterId/buzz/workflow-trigger-audits',
+  asyncHandler(async (req, res) => {
+    const adapterId = adapterIdParam(req.params.adapterId);
+    const requested = typeof req.query.limit === 'string' ? Number(req.query.limit) : 100;
+    res.json(
+      await communicationAdapters.listBuzzWorkflowTriggerAudits(
+        adapterId,
+        Number.isFinite(requested) ? requested : 100
+      )
+    );
   })
 );
 

--- a/server/src/services/buzz-workflow-trigger-service.ts
+++ b/server/src/services/buzz-workflow-trigger-service.ts
@@ -1,0 +1,439 @@
+import path from 'path';
+import { nanoid } from 'nanoid';
+import type {
+  BuzzChannelMapping,
+  BuzzWorkflowTriggerAudit,
+  BuzzWorkflowTriggerRule,
+  BuzzWorkflowTriggerRuleInput,
+  RuntimeHookEnvelope,
+} from '@veritas-kanban/shared';
+import {
+  BUZZ_WORKFLOW_TRIGGER_SCHEMA_VERSION,
+  RUNTIME_HOOK_SCHEMA_VERSION,
+} from '@veritas-kanban/shared';
+import { atomicWriteFile, mkdir, readFile } from '../storage/fs-helpers.js';
+import { redactString } from '../lib/redact.js';
+import { ensureWithinBase, validatePathSegment } from '../utils/sanitize.js';
+import { withFileLock } from './file-lock.js';
+import {
+  getRuntimeHookBusService,
+  type RuntimeHookBusService,
+} from './runtime-hook-bus-service.js';
+import { getWorkflowRunService, type WorkflowRunService } from './workflow-run-service.js';
+
+const MAX_AUDITS = 500;
+const HOOK_ID = 'buzz.workflow-trigger.allowlisted/v1';
+const HOOK_HANDLER_ID = 'buzz.workflow-trigger.allowlisted';
+
+interface BuzzWorkflowTriggerDispatch {
+  causalKey: string;
+  workflowId: string;
+  status: 'accepted' | 'dispatched' | 'failed';
+  runId?: string;
+  updatedAt: string;
+}
+
+interface BuzzWorkflowTriggerState {
+  version: 1;
+  rules: Record<string, BuzzWorkflowTriggerRule>;
+  dispatches: Record<string, BuzzWorkflowTriggerDispatch>;
+  audits: BuzzWorkflowTriggerAudit[];
+  updatedAt: string;
+}
+
+export interface BuzzWorkflowTriggerEvent {
+  adapterId: string;
+  mapping: BuzzChannelMapping;
+  eventId: string;
+  authorPubkey: string;
+  content: string;
+  occurredAt: string;
+  rootEventId?: string;
+  echo?: boolean;
+}
+
+export interface BuzzWorkflowTriggerServiceOptions {
+  storageDir: string;
+  persist?: boolean;
+  runtimeHooks?: RuntimeHookBusService;
+  workflowRuns?: WorkflowRunService;
+  now?: () => Date;
+}
+
+export class BuzzWorkflowTriggerService {
+  private readonly storageDir: string;
+  private readonly persist: boolean;
+  private readonly runtimeHooks?: RuntimeHookBusService;
+  private readonly workflowRuns?: WorkflowRunService;
+  private readonly now: () => Date;
+  private readonly inFlight = new Map<string, Promise<BuzzWorkflowTriggerAudit>>();
+  private loaded = false;
+  private hooksReady = false;
+  private state: BuzzWorkflowTriggerState;
+
+  constructor(options: BuzzWorkflowTriggerServiceOptions) {
+    this.storageDir = options.storageDir;
+    this.persist = options.persist ?? true;
+    this.runtimeHooks = options.runtimeHooks;
+    this.workflowRuns = options.workflowRuns;
+    this.now = options.now ?? (() => new Date());
+    this.state = this.emptyState();
+  }
+
+  async listRules(adapterId?: string): Promise<BuzzWorkflowTriggerRule[]> {
+    await this.ensureLoaded();
+    return Object.values(this.state.rules)
+      .filter((rule) => !adapterId || rule.adapterId === adapterId)
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((rule) => structuredClone(rule));
+  }
+
+  async createRule(
+    adapterId: string,
+    mapping: BuzzChannelMapping,
+    input: BuzzWorkflowTriggerRuleInput,
+    createdBy: string
+  ): Promise<BuzzWorkflowTriggerRule> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const timestamp = this.now().toISOString();
+    const authorPubkey = input.authorPubkey?.trim().toLowerCase();
+    const contentIncludes = input.contentIncludes?.trim();
+    const rule: BuzzWorkflowTriggerRule = {
+      schemaVersion: BUZZ_WORKFLOW_TRIGGER_SCHEMA_VERSION,
+      id: `buzz_rule_${nanoid(10)}`,
+      adapterId,
+      mappingId: mapping.id,
+      community: mapping.community,
+      channelId: mapping.channelId,
+      event: 'message.posted',
+      workflowId: input.workflowId.trim(),
+      enabled: input.enabled ?? true,
+      ...(authorPubkey ? { authorPubkey } : {}),
+      ...(contentIncludes ? { contentIncludes } : {}),
+      createdBy: createdBy.trim() || 'unknown',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    this.state.rules[rule.id] = rule;
+    await this.saveState();
+    return structuredClone(rule);
+  }
+
+  async disableRule(adapterId: string, ruleId: string): Promise<BuzzWorkflowTriggerRule> {
+    validatePathSegment(adapterId);
+    validatePathSegment(ruleId);
+    await this.ensureLoaded();
+    const rule = this.state.rules[ruleId];
+    if (!rule || rule.adapterId !== adapterId) {
+      throw new Error(`Buzz workflow trigger rule ${ruleId} not found`);
+    }
+    rule.enabled = false;
+    rule.updatedAt = this.now().toISOString();
+    await this.saveState();
+    return structuredClone(rule);
+  }
+
+  async listAudits(adapterId?: string, limit = 100): Promise<BuzzWorkflowTriggerAudit[]> {
+    await this.ensureLoaded();
+    const safeLimit = Math.max(1, Math.min(Math.floor(limit), MAX_AUDITS));
+    return this.state.audits
+      .filter((audit) => !adapterId || audit.adapterId === adapterId)
+      .slice(-safeLimit)
+      .reverse()
+      .map((audit) => structuredClone(audit));
+  }
+
+  async processEvent(event: BuzzWorkflowTriggerEvent): Promise<BuzzWorkflowTriggerAudit[]> {
+    await this.ensureLoaded();
+    const candidates = Object.values(this.state.rules).filter(
+      (rule) => rule.adapterId === event.adapterId && rule.mappingId === event.mapping.id
+    );
+    const audits: BuzzWorkflowTriggerAudit[] = [];
+    for (const rule of candidates) {
+      const causalKey = this.causalKey(rule, event.eventId);
+      const existing = this.inFlight.get(causalKey);
+      if (existing) {
+        audits.push(await existing);
+        continue;
+      }
+      const pending = this.processRule(rule, event, causalKey).finally(() => {
+        this.inFlight.delete(causalKey);
+      });
+      this.inFlight.set(causalKey, pending);
+      audits.push(await pending);
+    }
+    return audits;
+  }
+
+  private async processRule(
+    rule: BuzzWorkflowTriggerRule,
+    event: BuzzWorkflowTriggerEvent,
+    causalKey: string
+  ): Promise<BuzzWorkflowTriggerAudit> {
+    if (!rule.enabled || event.rootEventId || !this.matchesPredicates(rule, event)) {
+      return this.appendAudit(rule, event, causalKey, 'ignored-policy');
+    }
+    if (event.echo) {
+      return this.appendAudit(rule, event, causalKey, 'echo');
+    }
+
+    const dispatch = this.state.dispatches[causalKey];
+    if (dispatch?.status === 'dispatched') {
+      return this.appendAudit(rule, event, causalKey, 'duplicate', dispatch.runId);
+    }
+
+    this.state.dispatches[causalKey] = {
+      causalKey,
+      workflowId: rule.workflowId,
+      status: 'accepted',
+      updatedAt: this.now().toISOString(),
+    };
+    await this.appendAudit(rule, event, causalKey, 'accepted');
+
+    const existingRun = await this.findExistingRun(rule.workflowId, causalKey);
+    if (existingRun) {
+      return this.recordDispatched(rule, event, causalKey, existingRun.id);
+    }
+
+    try {
+      this.ensureHooks();
+      const hookResult = await this.hooks().dispatch(this.hookEnvelope(rule, event, causalKey));
+      if (!hookResult.allowed) {
+        this.state.dispatches[causalKey].status = 'failed';
+        this.state.dispatches[causalKey].updatedAt = this.now().toISOString();
+        return this.appendAudit(
+          rule,
+          event,
+          causalKey,
+          'dispatch-failed',
+          undefined,
+          'Runtime hook policy denied the external workflow trigger.'
+        );
+      }
+
+      const run = await this.runs().startRun(rule.workflowId, undefined, {
+        externalTrigger: {
+          schemaVersion: BUZZ_WORKFLOW_TRIGGER_SCHEMA_VERSION,
+          provider: 'buzz',
+          event: rule.event,
+          causalKey,
+          ruleId: rule.id,
+          adapterId: rule.adapterId,
+          mappingId: rule.mappingId,
+          community: rule.community,
+          channelId: rule.channelId,
+          eventId: event.eventId,
+          authorPubkey: event.authorPubkey,
+          content: event.content,
+          occurredAt: event.occurredAt,
+        },
+      });
+      return this.recordDispatched(rule, event, causalKey, run.id);
+    } catch (error) {
+      this.state.dispatches[causalKey].status = 'failed';
+      this.state.dispatches[causalKey].updatedAt = this.now().toISOString();
+      return this.appendAudit(
+        rule,
+        event,
+        causalKey,
+        'dispatch-failed',
+        undefined,
+        error instanceof Error
+          ? redactString(error.message).slice(0, 500)
+          : 'Workflow dispatch failed.'
+      );
+    }
+  }
+
+  private matchesPredicates(
+    rule: BuzzWorkflowTriggerRule,
+    event: BuzzWorkflowTriggerEvent
+  ): boolean {
+    if (rule.authorPubkey && rule.authorPubkey !== event.authorPubkey.toLowerCase()) return false;
+    if (
+      rule.contentIncludes &&
+      !event.content.toLowerCase().includes(rule.contentIncludes.toLowerCase())
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  private async findExistingRun(
+    workflowId: string,
+    causalKey: string
+  ): Promise<{ id: string } | undefined> {
+    const runs = await this.runs().listRuns({ workflowId });
+    return runs.find((run) => {
+      const trigger = run.context.externalTrigger;
+      return (
+        trigger &&
+        typeof trigger === 'object' &&
+        (trigger as { causalKey?: unknown }).causalKey === causalKey
+      );
+    });
+  }
+
+  private async recordDispatched(
+    rule: BuzzWorkflowTriggerRule,
+    event: BuzzWorkflowTriggerEvent,
+    causalKey: string,
+    runId: string
+  ): Promise<BuzzWorkflowTriggerAudit> {
+    this.state.dispatches[causalKey] = {
+      causalKey,
+      workflowId: rule.workflowId,
+      status: 'dispatched',
+      runId,
+      updatedAt: this.now().toISOString(),
+    };
+    return this.appendAudit(rule, event, causalKey, 'dispatched', runId);
+  }
+
+  private async appendAudit(
+    rule: BuzzWorkflowTriggerRule,
+    event: BuzzWorkflowTriggerEvent,
+    causalKey: string,
+    disposition: BuzzWorkflowTriggerAudit['disposition'],
+    runId?: string,
+    detail?: string
+  ): Promise<BuzzWorkflowTriggerAudit> {
+    const audit: BuzzWorkflowTriggerAudit = {
+      schemaVersion: BUZZ_WORKFLOW_TRIGGER_SCHEMA_VERSION,
+      id: `buzz_trigger_audit_${nanoid(10)}`,
+      causalKey,
+      adapterId: rule.adapterId,
+      mappingId: rule.mappingId,
+      ruleId: rule.id,
+      workflowId: rule.workflowId,
+      community: rule.community,
+      channelId: rule.channelId,
+      eventId: event.eventId,
+      disposition,
+      occurredAt: this.now().toISOString(),
+      ...(runId ? { runId } : {}),
+      ...(detail ? { detail } : {}),
+    };
+    this.state.audits.push(audit);
+    this.state.audits = this.state.audits.slice(-MAX_AUDITS);
+    await this.saveState();
+    return structuredClone(audit);
+  }
+
+  private hookEnvelope(
+    rule: BuzzWorkflowTriggerRule,
+    event: BuzzWorkflowTriggerEvent,
+    causalKey: string
+  ): RuntimeHookEnvelope {
+    return {
+      schemaVersion: RUNTIME_HOOK_SCHEMA_VERSION,
+      eventId: `buzz-trigger:${event.eventId}:${rule.id}`,
+      event: 'workflow.pre-external-trigger',
+      occurredAt: event.occurredAt,
+      scope: { workflowId: rule.workflowId },
+      references: {
+        sourceEventId: event.eventId,
+        workflowId: rule.workflowId,
+        externalEventId: event.eventId,
+      },
+      metadata: {
+        source: 'buzz',
+        event: rule.event,
+        causalKey,
+        ruleId: rule.id,
+        adapterId: rule.adapterId,
+        mappingId: rule.mappingId,
+      },
+    };
+  }
+
+  private ensureHooks(): void {
+    if (this.hooksReady) return;
+    const hooks = this.hooks();
+    hooks.registerHandler(HOOK_HANDLER_ID, async (envelope) => ({
+      decision: envelope.metadata.source === 'buzz' ? 'allow' : 'observe',
+    }));
+    hooks.registerDefinition({
+      schemaVersion: RUNTIME_HOOK_SCHEMA_VERSION,
+      id: HOOK_ID,
+      event: 'workflow.pre-external-trigger',
+      handlerId: HOOK_HANDLER_ID,
+      scope: { kind: 'global' },
+      enabled: true,
+      order: 0,
+      timeoutMs: 500,
+      failurePolicy: 'fail-closed',
+    });
+    this.hooksReady = true;
+  }
+
+  private hooks(): RuntimeHookBusService {
+    return this.runtimeHooks ?? getRuntimeHookBusService();
+  }
+
+  private runs(): WorkflowRunService {
+    return this.workflowRuns ?? getWorkflowRunService();
+  }
+
+  private causalKey(rule: BuzzWorkflowTriggerRule, eventId: string): string {
+    return `buzz:${rule.community}:${eventId}:${rule.id}`;
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    if (!this.persist) {
+      this.loaded = true;
+      return;
+    }
+    await mkdir(this.storageDir, { recursive: true });
+    try {
+      const parsed = JSON.parse(
+        await readFile(this.statePath, 'utf8')
+      ) as Partial<BuzzWorkflowTriggerState>;
+      this.state = {
+        version: 1,
+        rules:
+          parsed.rules && typeof parsed.rules === 'object'
+            ? (parsed.rules as Record<string, BuzzWorkflowTriggerRule>)
+            : {},
+        dispatches:
+          parsed.dispatches && typeof parsed.dispatches === 'object'
+            ? (parsed.dispatches as Record<string, BuzzWorkflowTriggerDispatch>)
+            : {},
+        audits: Array.isArray(parsed.audits)
+          ? (parsed.audits as BuzzWorkflowTriggerAudit[]).slice(-MAX_AUDITS)
+          : [],
+        updatedAt:
+          typeof parsed.updatedAt === 'string' ? parsed.updatedAt : this.now().toISOString(),
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      this.state = this.emptyState();
+    }
+    this.loaded = true;
+  }
+
+  private async saveState(): Promise<void> {
+    this.state.updatedAt = this.now().toISOString();
+    if (!this.persist) return;
+    await mkdir(this.storageDir, { recursive: true });
+    await withFileLock(this.statePath, async () => {
+      await atomicWriteFile(this.statePath, JSON.stringify(this.state, null, 2));
+    });
+  }
+
+  private get statePath(): string {
+    return ensureWithinBase(this.storageDir, path.join(this.storageDir, 'state.json'));
+  }
+
+  private emptyState(): BuzzWorkflowTriggerState {
+    return {
+      version: 1,
+      rules: {},
+      dispatches: {},
+      audits: [],
+      updatedAt: this.now().toISOString(),
+    };
+  }
+}

--- a/server/src/services/communication-adapter-service.ts
+++ b/server/src/services/communication-adapter-service.ts
@@ -18,6 +18,9 @@ import type {
   BuzzCursor,
   BuzzExternalCoordinate,
   BuzzRuntimeHealth,
+  BuzzWorkflowTriggerAudit,
+  BuzzWorkflowTriggerRule,
+  BuzzWorkflowTriggerRuleInput,
   SquadMessage,
 } from '@veritas-kanban/shared';
 import {
@@ -62,6 +65,10 @@ import {
   buzzAdapterConfigSchema,
   type BuzzAdapterConfig,
 } from '../schemas/communication-adapter-schemas.js';
+import {
+  BuzzWorkflowTriggerService,
+  type BuzzWorkflowTriggerEvent,
+} from './buzz-workflow-trigger-service.js';
 
 const DEFAULT_ADAPTER_ID = 'msteams-default';
 const MAX_DELIVERIES = 500;
@@ -130,6 +137,7 @@ export interface CommunicationAdapterServiceOptions {
   buzzCompatibility?: BuzzCompatibilityService;
   buzzCommunication?: BuzzCommunicationService;
   buzzWorkerFactory?: BuzzSubscriptionWorkerFactory;
+  buzzWorkflowTriggers?: BuzzWorkflowTriggerService;
   audit?: (event: AuditEvent) => Promise<void>;
 }
 
@@ -402,6 +410,7 @@ export class CommunicationAdapterService {
   private readonly buzzCompatibility: BuzzCompatibilityService;
   private readonly buzzCommunication: BuzzCommunicationService;
   private readonly buzzWorkerFactory: BuzzSubscriptionWorkerFactory;
+  private readonly buzzWorkflowTriggers: BuzzWorkflowTriggerService;
   private readonly audit: (event: AuditEvent) => Promise<void>;
   private readonly buzzWorkers = new Map<string, BuzzSubscriptionWorkerHandle>();
   private readonly buzzWorkerGenerations = new Map<string, number>();
@@ -417,6 +426,12 @@ export class CommunicationAdapterService {
     this.buzzCommunication = options.buzzCommunication || new BuzzCommunicationService();
     this.buzzWorkerFactory =
       options.buzzWorkerFactory || new DefaultBuzzSubscriptionWorkerFactory();
+    this.buzzWorkflowTriggers =
+      options.buzzWorkflowTriggers ||
+      new BuzzWorkflowTriggerService({
+        storageDir: path.join(this.storageDir, 'workflow-triggers'),
+        persist: this.persist,
+      });
     this.audit = options.audit || auditLog;
   }
 
@@ -473,6 +488,46 @@ export class CommunicationAdapterService {
     return Object.values(this.state.buzzChannelMappings)
       .filter((mapping) => !adapterId || mapping.adapterId === adapterId)
       .sort((a, b) => a.channelId.localeCompare(b.channelId));
+  }
+
+  async listBuzzWorkflowTriggerRules(adapterId: string): Promise<BuzzWorkflowTriggerRule[]> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    this.requireAdapter(adapterId);
+    return this.buzzWorkflowTriggers.listRules(adapterId);
+  }
+
+  async createBuzzWorkflowTriggerRule(
+    adapterId: string,
+    input: BuzzWorkflowTriggerRuleInput,
+    createdBy: string
+  ): Promise<BuzzWorkflowTriggerRule> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    const adapter = this.requireAdapter(adapterId);
+    if (adapter.kind !== 'buzz') throw new Error('Workflow triggers require a Buzz adapter');
+    const mapping = this.state.buzzChannelMappings[input.mappingId];
+    if (!mapping || mapping.adapterId !== adapterId || !mapping.enabled) {
+      throw new Error('Workflow triggers require an active Buzz channel mapping');
+    }
+    return this.buzzWorkflowTriggers.createRule(adapterId, mapping, input, createdBy);
+  }
+
+  async disableBuzzWorkflowTriggerRule(
+    adapterId: string,
+    ruleId: string
+  ): Promise<BuzzWorkflowTriggerRule> {
+    return this.buzzWorkflowTriggers.disableRule(adapterId, ruleId);
+  }
+
+  async listBuzzWorkflowTriggerAudits(
+    adapterId: string,
+    limit = 100
+  ): Promise<BuzzWorkflowTriggerAudit[]> {
+    validatePathSegment(adapterId);
+    await this.ensureLoaded();
+    this.requireAdapter(adapterId);
+    return this.buzzWorkflowTriggers.listAudits(adapterId, limit);
   }
 
   async configureBuzzChannelMapping(
@@ -976,6 +1031,17 @@ export class CommunicationAdapterService {
     const adapterOrigin = isVeritasBuzzOrigin(inbound.event, adapter.publicKey);
     const existing = this.state.buzzEvents[key];
     if (existing && !outbound && !adapterOrigin) {
+      if (inbound.event.kind === BUZZ_MESSAGE_KIND) {
+        await this.processBuzzWorkflowTrigger({
+          adapterId,
+          mapping,
+          eventId,
+          authorPubkey: coordinate.authorPubkey ?? inbound.event.pubkey,
+          content: cleanInboundMessage(inbound.content),
+          occurredAt: new Date(inbound.event.created_at * 1000).toISOString(),
+          rootEventId: coordinate.rootEventId,
+        });
+      }
       const delivery = this.recordDelivery({
         adapterId,
         operation: 'event-ingest',
@@ -995,6 +1061,18 @@ export class CommunicationAdapterService {
 
     delete this.state.buzzPendingEvents[key];
     if (outbound || adapterOrigin) {
+      if (inbound.event.kind === BUZZ_MESSAGE_KIND) {
+        await this.processBuzzWorkflowTrigger({
+          adapterId,
+          mapping,
+          eventId,
+          authorPubkey: coordinate.authorPubkey ?? inbound.event.pubkey,
+          content: cleanInboundMessage(inbound.content),
+          occurredAt: new Date(inbound.event.created_at * 1000).toISOString(),
+          rootEventId: coordinate.rootEventId,
+          echo: true,
+        });
+      }
       this.recordBuzzEvent({
         key,
         adapterId,
@@ -1099,6 +1177,16 @@ export class CommunicationAdapterService {
       return delivery;
     }
 
+    await this.processBuzzWorkflowTrigger({
+      adapterId,
+      mapping,
+      eventId,
+      authorPubkey: coordinate.authorPubkey ?? inbound.event.pubkey,
+      content: cleanedMessage,
+      occurredAt: new Date(inbound.event.created_at * 1000).toISOString(),
+      rootEventId: coordinate.rootEventId,
+    });
+
     const squadMessage = await this.chatService.sendSquadMessage(
       {
         id: `msg_buzz_${eventId}`,
@@ -1167,6 +1255,20 @@ export class CommunicationAdapterService {
     broadcastSquadMessage(squadMessage);
     await this.replayPendingBuzzReplies(adapterId, mapping, eventId);
     return delivery;
+  }
+
+  private async processBuzzWorkflowTrigger(event: BuzzWorkflowTriggerEvent): Promise<void> {
+    if (!event.content) return;
+    try {
+      await this.buzzWorkflowTriggers.processEvent(event);
+    } catch (error) {
+      await this.audit({
+        action: 'buzz.workflow-trigger.error',
+        actor: 'system',
+        resource: event.adapterId,
+        details: { eventId: event.eventId, error: sanitizeError(error) },
+      }).catch(() => undefined);
+    }
   }
 
   private async sendBuzz(

--- a/shared/src/types/buzz-workflow-trigger.types.ts
+++ b/shared/src/types/buzz-workflow-trigger.types.ts
@@ -1,0 +1,46 @@
+export const BUZZ_WORKFLOW_TRIGGER_SCHEMA_VERSION = 'buzz-workflow-trigger/v1' as const;
+
+export type BuzzWorkflowTriggerDisposition =
+  'accepted' | 'ignored-policy' | 'duplicate' | 'echo' | 'dispatch-failed' | 'dispatched';
+
+export interface BuzzWorkflowTriggerRule {
+  schemaVersion: typeof BUZZ_WORKFLOW_TRIGGER_SCHEMA_VERSION;
+  id: string;
+  adapterId: string;
+  mappingId: string;
+  community: string;
+  channelId: string;
+  event: 'message.posted';
+  workflowId: string;
+  enabled: boolean;
+  authorPubkey?: string;
+  contentIncludes?: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BuzzWorkflowTriggerRuleInput {
+  mappingId: string;
+  workflowId: string;
+  enabled?: boolean;
+  authorPubkey?: string;
+  contentIncludes?: string;
+}
+
+export interface BuzzWorkflowTriggerAudit {
+  schemaVersion: typeof BUZZ_WORKFLOW_TRIGGER_SCHEMA_VERSION;
+  id: string;
+  causalKey: string;
+  adapterId: string;
+  mappingId: string;
+  ruleId: string;
+  workflowId: string;
+  community: string;
+  channelId: string;
+  eventId: string;
+  disposition: BuzzWorkflowTriggerDisposition;
+  occurredAt: string;
+  runId?: string;
+  detail?: string;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -45,6 +45,7 @@ export * from './agent-budget.types.js';
 export * from './agent-profile-package.types.js';
 export * from './team-roster.types.js';
 export * from './buzz-definition.types.js';
+export * from './buzz-workflow-trigger.types.js';
 export * from './workspace-capability.types.js';
 export * from './scheduler.types.js';
 export * from './queue-monitor.types.js';

--- a/web/src/lib/api/integrations.ts
+++ b/web/src/lib/api/integrations.ts
@@ -7,6 +7,9 @@ import type {
   BuzzDefinitionListResult,
   BuzzDefinitionPreview,
   BuzzDefinitionPreviewInput,
+  BuzzWorkflowTriggerAudit,
+  BuzzWorkflowTriggerRule,
+  BuzzWorkflowTriggerRuleInput,
   CommunicationAdapterHealth,
   CommunicationAdapterInput,
   CommunicationAdapterRecord,
@@ -185,6 +188,45 @@ export const integrationsApi = {
     return apiFetch<BuzzChannelMapping>(
       `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/channels/${encodeURIComponent(channelId)}/disable`,
       { method: 'POST' }
+    );
+  },
+
+  buzzWorkflowTriggerRules: async (adapterId: string): Promise<BuzzWorkflowTriggerRule[]> => {
+    return apiFetch<BuzzWorkflowTriggerRule[]>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/workflow-triggers`
+    );
+  },
+
+  createBuzzWorkflowTriggerRule: async (
+    adapterId: string,
+    input: BuzzWorkflowTriggerRuleInput
+  ): Promise<BuzzWorkflowTriggerRule> => {
+    return apiFetch<BuzzWorkflowTriggerRule>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/workflow-triggers`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }
+    );
+  },
+
+  disableBuzzWorkflowTriggerRule: async (
+    adapterId: string,
+    ruleId: string
+  ): Promise<BuzzWorkflowTriggerRule> => {
+    return apiFetch<BuzzWorkflowTriggerRule>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/workflow-triggers/${encodeURIComponent(ruleId)}/disable`,
+      { method: 'POST' }
+    );
+  },
+
+  buzzWorkflowTriggerAudits: async (
+    adapterId: string,
+    limit = 100
+  ): Promise<BuzzWorkflowTriggerAudit[]> => {
+    return apiFetch<BuzzWorkflowTriggerAudit[]>(
+      `${API_BASE}/integrations/communication/adapters/${encodeURIComponent(adapterId)}/buzz/workflow-trigger-audits?limit=${limit}`
     );
   },
 


### PR DESCRIPTION
Closes #911.

## Summary

- add `buzz-workflow-trigger/v1` rules and bounded audit records
- route mapped Buzz root messages through `workflow.pre-external-trigger`
- persist the causal key before workflow dispatch and reconcile existing runs after restart
- suppress replies, echoes, disabled rules, predicate mismatches, and replays
- expose authenticated create/list/disable and audit APIs
- document the supported event and the intentionally deferred rule-management surface

## Verification

- `pnpm exec vitest run src/__tests__/buzz-workflow-trigger-service.test.ts src/__tests__/buzz-communication-adapter-service.test.ts` from `server/`
  - 15 tests passed in 1.13 seconds
- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`
- changed-file ESLint
- commit security artifact check

## Scope

This is the first vertical slice only: one mapped Buzz root `message.posted` event can launch one Veritas workflow. Settings/CLI rule editors, fixture dry-run, fake-relay E2E, retry scheduling, reactions, and broader Buzz workflow parity remain deferred to #912 or typed follow-ups.
