### PR TITLE
test: add composed Buzz compatibility gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ pnpm lint:fix
 # Smoke checks
 pnpm check:pnpm-settings        # Validates package manager fields match this file
 pnpm smoke:cli-mcp              # CLI ↔ MCP compatibility smoke test
+pnpm test:buzz:compatibility    # Credential-free composed Buzz release gate
 ```
 
 Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise, resolve with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a composed credential-free Buzz compatibility gate and complete
+  machine-readable seam evidence for the pinned Buzz `0.4.24` /
+  `710ed9fff57878a1d69f809b80a6ee0416c53fc4` baseline, plus trigger setup,
+  support dispositions, optional live-smoke boundaries, upgrade, and rollback
+  guidance (#912).
 - Added allowlisted Buzz root-message workflow triggers with bounded predicates,
   provider-neutral pre-dispatch hooks, durable causal keys, replay and echo
   suppression, restart reconciliation, API configuration, and audit history

--- a/docs/BUZZ-INTEGRATION.md
+++ b/docs/BUZZ-INTEGRATION.md
@@ -215,6 +215,53 @@ POST /api/integrations/communication/adapters/:adapterId/buzz/definitions/import
 Reads and preview require `settings:read`. Import requires `settings:write`.
 There is no continuous synchronization and no Buzz write-back endpoint.
 
+## Trigger a Veritas workflow
+
+A `buzz-workflow-trigger/v1` rule can bind one active channel mapping to one
+Veritas workflow. The first supported event is a root kind `9`
+`message.posted`. Replies, edits, deletes, reactions, adapter-originated
+echoes, disabled rules, and predicate mismatches do not launch a run.
+
+Create a rule with the mapping ID returned by the channel-mapping API:
+
+```bash
+curl -X POST \
+  http://localhost:3001/api/integrations/communication/adapters/buzz-default/buzz/workflow-triggers \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: <veritas-api-key>' \
+  --data '{
+    "mappingId": "buzz_map_example",
+    "workflowId": "triage-external-request",
+    "contentIncludes": "help"
+  }'
+```
+
+An exact 64-character author public key may be supplied as `authorPubkey`.
+Content matching is a bounded, case-insensitive substring check. There is no
+regex, expression, code, shell, or arbitrary Nostr-kind filter.
+
+Rule creation requires `settings:write` and execute permission on the
+destination workflow. The mapping alone does not grant workflow or task
+mutation rights.
+
+Veritas persists the accepted causal key
+`buzz:{community}:{eventId}:{ruleId}` before dispatch through the
+provider-neutral `workflow.pre-external-trigger` hook. Workflow context
+retains the community, channel, event, author, mapping, rule, and sanitized
+message. A replay returns the existing run. After restart, Veritas searches
+the destination workflow's run context for the causal key before launching
+another run.
+
+List or disable rules and inspect bounded disposition history:
+
+```text
+GET  /api/integrations/communication/adapters/:adapterId/buzz/workflow-triggers
+POST /api/integrations/communication/adapters/:adapterId/buzz/workflow-triggers/:ruleId/disable
+GET  /api/integrations/communication/adapters/:adapterId/buzz/workflow-trigger-audits
+```
+
+Disabling a rule retains its prior audits and linked workflow runs.
+
 ## Send roots and replies
 
 Send a root and associate it with a local Squad Chat message:
@@ -340,6 +387,67 @@ disabled, payloads are bounded, and requests have fixed timeouts.
 
 Enable only the narrow network class required by the relay.
 
+## Credential-free release gate
+
+Run the composed Buzz gate from the repository root:
+
+```bash
+pnpm test:buzz:compatibility
+```
+
+This command runs the existing credential-free fixtures for:
+
+- pinned relay/community/identity compatibility and secret non-retention;
+- signed root/reply communication, reconnect replay, dedupe, loop prevention,
+  and ambiguous delivery recovery;
+- `buzz-agent` through generic ACP;
+- the opaque run-scoped Veritas MCP bridge;
+- persona/team preview, import, refresh, provenance, and unsafe-source
+  rejection;
+- the typed root-message workflow trigger and causal replay; and
+- the machine-readable compatibility record.
+
+The canonical support record is still
+`GET /api/config/harness-compatibility`. Its Buzz entry pins release `0.4.24`,
+commit `710ed9fff57878a1d69f809b80a6ee0416c53fc4`, `buzz-agent 0.1.0`,
+provider probe revision, fixture revision, and every seam fixture path. A
+provider build, protocol, capability, probe, configuration, or fixture change
+invalidates prior certification.
+
+The green aggregate gate means only the following:
+
+| Capability                                                              | Disposition                                    |
+| ----------------------------------------------------------------------- | ---------------------------------------------- |
+| Relay/community/identity diagnostics                                    | Supported at the pinned baseline               |
+| Mapped roots/replies, replay, dedupe, and loop prevention               | Supported                                      |
+| `buzz-agent` through generic ACP                                        | Supported at the pinned ACP contract           |
+| Run-scoped Veritas MCP                                                  | Supported through the provider-neutral bridge  |
+| Public persona/team import                                              | Supported as explicit one-way materialization  |
+| One typed root message to a Veritas workflow                            | Supported                                      |
+| `buzz-acp` as a Veritas provider                                        | Rejected; it is the inverse Buzz-owned harness |
+| Buzz workflow definition execution and cross-system approvals           | Deferred                                       |
+| NIP-AE memory sync and automatic NIP-34 task mirroring                  | Deferred or rejected                           |
+| Desktop internals, DMs, forums, canvas, moderation, huddles, and mobile | Not implied by this gate                       |
+
+An unknown or changed Buzz build remains unsupported or degraded until the
+baseline, evidence digest, fixtures, and documentation are explicitly
+updated.
+
+### Optional live smoke
+
+Live smoke is supplemental and must target the exact candidate build with a
+dedicated least-privilege identity. It is not normal CI:
+
+1. Run `vk doctor --json` and retain only redacted public build/status fields.
+2. Publish one Veritas root to a dedicated mapped test channel.
+3. Reply from Buzz and verify the reply appears in the correct Squad Chat
+   thread, not merely as an HTTP success or ACP `end_turn`.
+4. Trigger one allowlisted test workflow and verify its causal event/run link.
+5. Disable the test mapping, rule, and profile.
+
+Do not upload raw events, private messages, authorization headers, auth tags,
+private keys, provider keys, or unredacted logs as evidence.
+
 ## Disable, upgrade, and rollback
 
 Disabling a channel mapping closes and rebuilds the worker without deleting
@@ -353,4 +461,11 @@ Buzz Desktop state.
 
 After a Buzz upgrade, run `vk doctor --json`. A version/build change
 invalidates prior compatibility evidence and must pass the pinned contract
-before workers or sends resume.
+and `pnpm test:buzz:compatibility` before workers, sends, or ACP dispatch
+resume. A baseline change updates the release/commit constants, matrix
+evidence digest, fixtures, and this guide together.
+
+If a candidate fails, keep the prior baseline and report the failing facet.
+Disable the affected adapter, mapping, profile, or trigger rule without
+deleting redacted configuration, mappings, cursors, import provenance, trigger
+audits, or workflow-run evidence.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -324,6 +324,10 @@ First-class support for autonomous coding agents.
   reports no persistent session loading or network MCP instead of inventing
   capabilities; selected run tools arrive only through the opaque
   system-owned `veritas-run` bridge
+- **Buzz composed compatibility gate** — One credential-free command verifies
+  pinned relay diagnostics, communication/replay, generic ACP, run-scoped MCP,
+  persona/team import, workflow-trigger, secret-safety, and matrix evidence
+  without treating optional live credentials as certification authority
 - **GitHub Copilot CLI ACP profile** — A disabled-by-default `copilot` runtime
   uses the generic ACP provider with a system-owned stdio/public-preview
   baseline, exact v1.0.74 handshake evidence, bounded restrictive process

--- a/docs/HARNESS-COMPATIBILITY.md
+++ b/docs/HARNESS-COMPATIBILITY.md
@@ -58,6 +58,17 @@ runtime evidence, but it cannot replace or overwrite a deterministic failure.
 Raw observations retain launch-manifest, runtime-manifest, task, attempt, and
 event references through `harness-conformance-result/v1`.
 
+Buzz additionally has a composed credential-free gate:
+
+```bash
+pnpm test:buzz:compatibility
+```
+
+Its matrix record names the relay compatibility, communication/replay, ACP,
+run-scoped MCP, persona/team import, and workflow-trigger fixtures. Live Buzz
+smoke is supplemental and never replaces a deterministic failure. See the
+[Buzz integration guide](BUZZ-INTEGRATION.md#credential-free-release-gate).
+
 ## Operating each harness
 
 Detailed installation, authentication, configuration, permissions, MCP,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
+    "test:buzz:compatibility": "pnpm --filter @veritas-kanban/shared build && pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/buzz-compatibility-integration.test.ts src/__tests__/buzz-communication-adapter-service.test.ts src/__tests__/acp-stdio-provider.test.ts src/__tests__/run-tool-bridge-runtime.test.ts src/__tests__/buzz-definition-import-service.test.ts src/__tests__/buzz-workflow-trigger-service.test.ts src/__tests__/harness-compatibility-matrix-service.test.ts",
     "qa:mantine": "node scripts/check-mantine-qa-gate.mjs",
     "test:load:smoke": "k6 run load-tests/k6/smoke.js",
     "test:load": "k6 run load-tests/k6/smoke.js && k6 run load-tests/k6/read-load.js && k6 run load-tests/k6/write-load.js && k6 run load-tests/k6/mixed-load.js && k6 run load-tests/k6/ws-stress.js && k6 run load-tests/k6/v5-remote-mix.js",

--- a/server/src/__tests__/harness-compatibility-matrix-service.test.ts
+++ b/server/src/__tests__/harness-compatibility-matrix-service.test.ts
@@ -35,6 +35,25 @@ describe('HarnessCompatibilityMatrixService', () => {
       protocolVersion: 'acp/v1',
       testedBuilds: ['94172f2aa4e5'],
     });
+    const buzz = matrix.records.find((record) => record.agentType === 'buzz-agent');
+    expect(buzz).toMatchObject({
+      sourceAvailability: 'open-source',
+      protocolVersion: 'acp/v1',
+      testedVersions: ['buzz-agent 0.1.0'],
+      testedBuilds: ['710ed9fff57878a1d69f809b80a6ee0416c53fc4'],
+      certification: {
+        fixtureRevision: 1,
+        credentialSmokePolicy: 'supplemental-only',
+      },
+    });
+    expect(buzz?.certification.deterministicEvidence.map((entry) => entry.path)).toEqual([
+      'server/src/__tests__/acp-stdio-provider.test.ts',
+      'server/src/__tests__/buzz-compatibility-integration.test.ts',
+      'server/src/__tests__/buzz-communication-adapter-service.test.ts',
+      'server/src/__tests__/run-tool-bridge-runtime.test.ts',
+      'server/src/__tests__/buzz-definition-import-service.test.ts',
+      'server/src/__tests__/buzz-workflow-trigger-service.test.ts',
+    ]);
   });
 
   it('keeps deterministic evidence and all drift keys in the stable record digest', () => {

--- a/server/src/services/harness-compatibility-matrix-service.ts
+++ b/server/src/services/harness-compatibility-matrix-service.ts
@@ -87,10 +87,27 @@ const REVIEWED_HARNESSES: ReviewedHarness[] = [
         'Buzz compatibility contract',
         'server/src/__tests__/buzz-compatibility-integration.test.ts'
       ),
+      fixture(
+        'Buzz communication and replay contract',
+        'server/src/__tests__/buzz-communication-adapter-service.test.ts'
+      ),
+      fixture(
+        'Run-scoped MCP bridge contract',
+        'server/src/__tests__/run-tool-bridge-runtime.test.ts'
+      ),
+      fixture(
+        'Buzz persona and team import contract',
+        'server/src/__tests__/buzz-definition-import-service.test.ts'
+      ),
+      fixture(
+        'Buzz workflow trigger contract',
+        'server/src/__tests__/buzz-workflow-trigger-service.test.ts'
+      ),
     ],
     [
       'Veritas launches buzz-agent as an ACP server; buzz-acp is the inverse relay-side client.',
       'Relay, identity, community, and workflow compatibility are reported separately from task execution.',
+      'Credential-gated live smoke is supplemental; the credential-free composed gate is the release authority.',
     ]
   ),
   reviewedHarness(


### PR DESCRIPTION
Closes #912.

## Summary

- add `pnpm test:buzz:compatibility` as the single credential-free Buzz release gate
- expand the Buzz compatibility record from two fixture pointers to all six required seams
- fail the focused matrix test if the pinned build or any required seam evidence disappears
- document workflow-trigger setup, support dispositions, optional live-smoke boundaries, upgrades, disable, and rollback

## Verification

- `pnpm test:buzz:compatibility`
  - 7 files, 50 tests passed in 2.17 seconds
- `pnpm exec vitest run src/__tests__/harness-compatibility-matrix-service.test.ts` from `server/`
  - 3 tests passed in 585 milliseconds
- `pnpm check:pnpm-settings`
- `pnpm --filter @veritas-kanban/server typecheck`
- changed-file ESLint
- commit security artifact check

## Scope

This composes the already-merged Buzz fixtures instead of creating another fake relay, ACP stack, MCP server, importer, or trigger engine. Live credentials remain supplemental and excluded from normal CI. The full workspace suite remains a final 6.0.0 release gate.
