### PR TITLE
fix: defer SQLite run supervisor storage binding

### DIFF
--- a/server/src/__tests__/run-supervisor-service.test.ts
+++ b/server/src/__tests__/run-supervisor-service.test.ts
@@ -27,6 +27,7 @@ const SHA_C = `sha256:${'c'.repeat(64)}`;
 const HOST_A = '1'.repeat(64);
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   for (const service of services.splice(0)) service.dispose();
   await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
 });
@@ -133,6 +134,21 @@ function recoveryBindings() {
 }
 
 describe('RunSupervisorService', () => {
+  it('defers the default SQLite repository until storage bootstrap completes', () => {
+    vi.stubEnv('VERITAS_STORAGE', 'sqlite');
+
+    expect(() => {
+      services.push(
+        new RunSupervisorService({
+          hostId: HOST_A,
+          ownerId: 'bootstrap-owner',
+          processId: 101,
+          heartbeatMs: 60_000,
+        })
+      );
+    }).not.toThrow();
+  });
+
   it('persists exact bindings, process control, event cursor, budget, and an idempotent terminal state', async () => {
     const repository = new InMemoryRunSupervisorRepository();
     const supervisor = service(repository);

--- a/server/src/services/run-supervisor-service.ts
+++ b/server/src/services/run-supervisor-service.ts
@@ -98,7 +98,7 @@ function defaultRepository(): RunSupervisorRepository {
 export class RunSupervisorService {
   readonly hostId: string;
   readonly ownerId: string;
-  private readonly repository: RunSupervisorRepository;
+  private readonly repositoryOverride?: RunSupervisorRepository;
   private readonly now: () => Date;
   private readonly processId: number;
   private readonly leaseMs: number;
@@ -113,7 +113,7 @@ export class RunSupervisorService {
   private readonly heartbeatTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(options: RunSupervisorServiceOptions = {}) {
-    this.repository = options.repository ?? defaultRepository();
+    this.repositoryOverride = options.repository;
     this.now = options.now ?? (() => new Date());
     this.processId = options.processId ?? process.pid;
     this.leaseMs = options.leaseMs ?? DEFAULT_LEASE_MS;
@@ -124,6 +124,10 @@ export class RunSupervisorService {
     this.processProbe = options.processProbe ?? defaultProcessProbe;
     this.signalProcess = options.signalProcess ?? signalProcessGroup;
     this.sessionProbe = options.sessionProbe;
+  }
+
+  private get repository(): RunSupervisorRepository {
+    return this.repositoryOverride ?? defaultRepository();
   }
 
   async register(input: RegisterRunSupervisorInput): Promise<RunSupervisorRecord> {


### PR DESCRIPTION
## Summary

- defer the default run-supervisor repository until the first supervisor operation;
- preserve explicitly injected repositories and existing supervisor behavior;
- add a regression for constructing the service before SQLite bootstrap.

Fixes #981.

## Cause

The desktop server imports agent routes before `initializeServices()` calls
`initStorage('sqlite')`. The run-supervisor constructor eagerly resolved
`getStorage().runSupervisors`, so the packaged server exited during module
evaluation.

## Verification

- regression test red before the fix with `Storage has not been initialised`
- `run-supervisor-service.test.ts`: 10/10 passed in 1.03s
- focused ESLint: passed
- server typecheck: passed
- server build: passed
- production import with `VERITAS_STORAGE=sqlite`: passed
- security artifact scan: 1,585 tracked files passed

## Risk

Low. Repository selection moves from construction time to operation time. No
schema, API, migration, or persisted-data contract changes.
