### PR TITLE
fix: prevent desktop updater downgrades

### DIFF
--- a/desktop/src/main/__tests__/updates.test.ts
+++ b/desktop/src/main/__tests__/updates.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   DesktopUpdateService,
+  ElectronAutoUpdaterAdapter,
   resolveDesktopUpdateChannel,
   type DesktopUpdateAdapter,
   type DesktopUpdateAdapterConfigureOptions,
@@ -36,7 +37,7 @@ class FakeUpdateAdapter implements DesktopUpdateAdapter {
   }
 }
 
-function service(adapter = new FakeUpdateAdapter()) {
+function service(adapter = new FakeUpdateAdapter(), currentVersion = '4.3.2') {
   const emitStatus = vi.fn();
   return {
     adapter,
@@ -44,7 +45,7 @@ function service(adapter = new FakeUpdateAdapter()) {
     service: new DesktopUpdateService({
       adapter,
       packaged: true,
-      currentVersion: '4.3.2',
+      currentVersion,
       channel: 'stable',
       now: () => new Date('2026-05-31T00:00:00.000Z'),
       emitStatus,
@@ -57,6 +58,7 @@ describe('desktop update service', () => {
     const harness = service();
 
     expect(harness.adapter.configure).toHaveBeenCalledWith({
+      allowDowngrade: false,
       allowPrerelease: false,
       autoDownload: false,
       autoInstallOnAppQuit: false,
@@ -88,6 +90,31 @@ describe('desktop update service', () => {
       state: 'ready',
       availableVersion: '4.3.3',
     });
+  });
+
+  it('disables downgrade after assigning the updater channel', () => {
+    const updater = {
+      allowDowngrade: false,
+      allowPrerelease: false,
+      autoDownload: true,
+      autoInstallOnAppQuit: true,
+      forceDevUpdateConfig: false,
+      set channel(_value: string | null) {
+        this.allowDowngrade = true;
+      },
+    };
+    const adapter = new ElectronAutoUpdaterAdapter(updater as never);
+
+    adapter.configure({
+      allowDowngrade: false,
+      allowPrerelease: false,
+      autoDownload: false,
+      autoInstallOnAppQuit: false,
+      channel: 'stable',
+      forceDevUpdateConfig: false,
+    });
+
+    expect(updater.allowDowngrade).toBe(false);
   });
 
   it('keeps dev builds unsupported unless force dev update config is enabled', async () => {

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -14,6 +14,7 @@ type DesktopUpdateEvent =
   | 'error';
 
 export interface DesktopUpdateAdapterConfigureOptions {
+  allowDowngrade: boolean;
   allowPrerelease: boolean;
   autoDownload: boolean;
   autoInstallOnAppQuit: boolean;
@@ -48,6 +49,9 @@ export class ElectronAutoUpdaterAdapter implements DesktopUpdateAdapter {
     this.updater.autoInstallOnAppQuit = options.autoInstallOnAppQuit;
     this.updater.allowPrerelease = options.allowPrerelease;
     this.updater.channel = options.channel === 'stable' ? null : options.channel;
+    // electron-updater sets allowDowngrade=true whenever channel is assigned.
+    // Stable checks must never turn older release metadata into an update.
+    this.updater.allowDowngrade = options.allowDowngrade;
     this.updater.forceDevUpdateConfig = options.forceDevUpdateConfig;
   }
 
@@ -83,6 +87,7 @@ export class DesktopUpdateService {
       : this.createStatus('unsupported', 'Updater checks run only from packaged builds.');
 
     options.adapter.configure({
+      allowDowngrade: false,
       allowPrerelease: options.channel !== 'stable',
       autoDownload: false,
       autoInstallOnAppQuit: false,


### PR DESCRIPTION
## Summary

- force `electron-updater` downgrade support back off after channel assignment
- retain the existing stable, beta, and dev channel behavior
- add a focused regression for the channel setter side effect

## Cause

Assigning `AppUpdater.channel` internally sets `allowDowngrade=true`. The
stable configuration assigned `null` to the channel but did not restore the
safe downgrade setting, so the packaged 6.0.0 candidate offered published
5.2.5 metadata for download.

## Verification

- focused desktop updater test: 6/6 in 203 ms
- desktop typecheck
- focused ESLint
- security artifact scan: 1,585 tracked files

## Risk

Low. The change is limited to updater configuration and preserves the current
manual-download flow for genuinely newer releases.

Closes #983
