### PR TITLE
fix: make desktop Chat recoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept desktop Chat in a bounded, reversible workbench panel; Escape and browser
+  Back now close it, obsolete persisted panel visibility is discarded, compact
+  window heights preserve the application shell, and the native Navigate menu
+  can reset layout state without deleting application data (#945).
+
 ## [6.0.0] - 2026-07-24
 
 Each release entry below names its tracking issue. The complete issue-to-pull

--- a/desktop/src/main/__tests__/commands.test.ts
+++ b/desktop/src/main/__tests__/commands.test.ts
@@ -93,6 +93,10 @@ describe('desktop command registry', () => {
     expect(DESKTOP_COMMAND_REGISTRY['new-task'].accelerator).toBe('CommandOrControl+N');
     expect(DESKTOP_COMMAND_REGISTRY['open-command-center'].accelerator).toBe('CommandOrControl+K');
     expect(DESKTOP_COMMAND_REGISTRY['open-onboarding'].label).toBe('Setup & Diagnostics');
+    expect(DESKTOP_COMMAND_REGISTRY['reset-layout']).toMatchObject({
+      label: 'Reset Window Layout',
+      nativeAction: 'renderer',
+    });
   });
 
   it('routes renderer commands through the menu command event path', async () => {

--- a/desktop/src/main/__tests__/menu.test.ts
+++ b/desktop/src/main/__tests__/menu.test.ts
@@ -54,6 +54,7 @@ describe('desktop native menu', () => {
     expect(labels).toContain('Search');
     expect(labels).toContain('Settings');
     expect(labels).toContain('Restart Local Server');
+    expect(labels).toContain('Reset Window Layout');
 
     const fileMenu = template.find((item) => item.label === 'File');
     const newTask = Array.isArray(fileMenu?.submenu)

--- a/desktop/src/main/commands.ts
+++ b/desktop/src/main/commands.ts
@@ -60,6 +60,8 @@ function commandLabel(name: DesktopCommandName): string {
       return 'Settings';
     case 'open-command-center':
       return 'Command Center';
+    case 'reset-layout':
+      return 'Reset Window Layout';
     case 'import-data':
       return 'Import';
     case 'export-data':

--- a/desktop/src/main/menu.ts
+++ b/desktop/src/main/menu.ts
@@ -61,7 +61,13 @@ export function createDesktopMenuTemplate(
     { role: 'editMenu' },
     {
       label: 'Navigate',
-      submenu: [command('open-command-center'), command('open-search'), command('open-settings')],
+      submenu: [
+        command('open-command-center'),
+        command('open-search'),
+        command('open-settings'),
+        { type: 'separator' },
+        command('reset-layout'),
+      ],
     },
     {
       label: 'Desktop',

--- a/desktop/src/shared/desktop-bridge-contracts.ts
+++ b/desktop/src/shared/desktop-bridge-contracts.ts
@@ -90,6 +90,7 @@ export const DESKTOP_COMMAND_NAMES = [
   'open-search',
   'open-settings',
   'open-command-center',
+  'reset-layout',
   'import-data',
   'export-data',
   'create-backup',

--- a/web/src/__tests__/desktop-shell-context.test.tsx
+++ b/web/src/__tests__/desktop-shell-context.test.tsx
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  DEFAULT_BOTTOM_PANEL_HEIGHT,
+  DesktopShellProvider,
+  useDesktopShell,
+} from '@/components/layout/DesktopShellContext';
+
+function ShellProbe() {
+  const shell = useDesktopShell();
+
+  return (
+    <div>
+      <output aria-label="left rail">{String(shell.leftRailOpen)}</output>
+      <output aria-label="right rail">{String(shell.rightRailOpen)}</output>
+      <output aria-label="bottom panel">{shell.bottomPanel ?? 'closed'}</output>
+      <output aria-label="bottom panel height">{shell.bottomPanelHeight}</output>
+      <button type="button" onClick={() => shell.openBottomPanel('board-chat')}>
+        Open board chat
+      </button>
+      <button type="button" onClick={() => shell.setLeftRailOpen(false)}>
+        Close left rail
+      </button>
+      <button type="button" onClick={() => shell.setRightRailOpen(true)}>
+        Open right rail
+      </button>
+    </div>
+  );
+}
+
+describe('desktop shell recovery', () => {
+  let menuListener: ((payload: { command: string }) => void) | undefined;
+
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => storage.delete(key),
+        setItem: (key: string, value: string) => storage.set(key, value),
+      } satisfies Storage,
+    });
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/');
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 });
+    Object.defineProperty(window, 'veritasDesktop', {
+      configurable: true,
+      value: {
+        onMenuCommand: vi.fn((listener: (payload: { command: string }) => void) => {
+          menuListener = listener;
+          return vi.fn();
+        }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as Window & { veritasDesktop?: unknown }).veritasDesktop;
+    delete document.documentElement.dataset.client;
+    menuListener = undefined;
+  });
+
+  it('discards obsolete persisted panel visibility and clamps a stale height', () => {
+    window.localStorage.setItem('veritas.desktop.bottomPanel', 'board-chat');
+    window.localStorage.setItem('veritas.workbench.bottomPanelHeight', '9999');
+
+    render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+    expect(screen.getByLabelText('bottom panel height').textContent).toBe('380');
+    expect(window.localStorage.getItem('veritas.desktop.bottomPanel')).toBeNull();
+  });
+
+  it('closes transient chat layout with Escape or browser Back', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('board-chat');
+
+    await user.keyboard('{Escape}');
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+
+    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+    act(() => window.dispatchEvent(new PopStateEvent('popstate', { state: {} })));
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+  });
+
+  it('resets the complete desktop layout from the native recovery command', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close left rail' }));
+    await user.click(screen.getByRole('button', { name: 'Open right rail' }));
+    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+
+    act(() => menuListener?.({ command: 'reset-layout' }));
+
+    expect(screen.getByLabelText('left rail').textContent).toBe('true');
+    expect(screen.getByLabelText('right rail').textContent).toBe('false');
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+    expect(screen.getByLabelText('bottom panel height').textContent).toBe(
+      String(DEFAULT_BOTTOM_PANEL_HEIGHT)
+    );
+    expect(window.localStorage.getItem('veritas.desktop.leftRailOpen')).toBeNull();
+    expect(window.localStorage.getItem('veritas.desktop.rightRailOpen')).toBeNull();
+    expect(window.localStorage.getItem('veritas.workbench.bottomPanelHeight')).toBeNull();
+  });
+});

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -250,7 +250,7 @@ export function ChatPanel({
           </ActionIcon>
         </div>
 
-        <div className="flex items-center gap-2 text-xs">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
           <span className="text-muted-foreground">Mode:</span>
           <Button
             variant={mode === 'ask' ? 'filled' : 'outline'}
@@ -266,7 +266,7 @@ export function ChatPanel({
           >
             Build
           </Button>
-          <span className="text-muted-foreground ml-1">
+          <span className="ml-1 min-w-0 text-muted-foreground">
             {mode === 'ask' ? '· Read-only queries' : '· Changes, files, commands'}
           </span>
         </div>

--- a/web/src/components/layout/DesktopShellContext.tsx
+++ b/web/src/components/layout/DesktopShellContext.tsx
@@ -29,6 +29,9 @@ const LEFT_RAIL_STORAGE_KEY = 'veritas.desktop.leftRailOpen';
 const RIGHT_RAIL_STORAGE_KEY = 'veritas.desktop.rightRailOpen';
 const BOTTOM_PANEL_STORAGE_KEY = 'veritas.desktop.bottomPanel';
 const BOTTOM_PANEL_HEIGHT_STORAGE_KEY = 'veritas.workbench.bottomPanelHeight';
+const BOTTOM_PANEL_HISTORY_STATE_KEY = 'veritasBottomPanel';
+const BOTTOM_PANEL_VIEWPORT_RESERVE = 220;
+const COMPACT_BOTTOM_PANEL_HEIGHT = 200;
 export const DEFAULT_BOTTOM_PANEL_HEIGHT = 340;
 export const MIN_BOTTOM_PANEL_HEIGHT = 320;
 export const MAX_BOTTOM_PANEL_HEIGHT = 640;
@@ -68,26 +71,16 @@ function readStoredBoolean(key: string, fallback: boolean): boolean {
   }
 }
 
-function readStoredBottomPanel(): DesktopBottomPanel | null {
-  if (typeof window === 'undefined') return null;
-
-  try {
-    const value = window.localStorage.getItem(BOTTOM_PANEL_STORAGE_KEY);
-    return value === 'board-chat' || value === 'squad-chat' ? value : null;
-  } catch {
-    return null;
-  }
-}
-
 function clampBottomPanelHeight(height: number): number {
   const viewportMax =
     typeof window === 'undefined'
       ? MAX_BOTTOM_PANEL_HEIGHT
-      : Math.max(MIN_BOTTOM_PANEL_HEIGHT, Math.floor(window.innerHeight * 0.68));
-  return Math.min(
-    Math.min(MAX_BOTTOM_PANEL_HEIGHT, viewportMax),
-    Math.max(MIN_BOTTOM_PANEL_HEIGHT, height)
-  );
+      : Math.min(
+          MAX_BOTTOM_PANEL_HEIGHT,
+          Math.max(COMPACT_BOTTOM_PANEL_HEIGHT, window.innerHeight - BOTTOM_PANEL_VIEWPORT_RESERVE)
+        );
+  const viewportMin = Math.min(MIN_BOTTOM_PANEL_HEIGHT, viewportMax);
+  return Math.min(viewportMax, Math.max(viewportMin, height));
 }
 
 function readStoredBottomPanelHeight(): number {
@@ -111,6 +104,18 @@ function writeStoredValue(key: string, value: string): void {
   }
 }
 
+function removeStoredValue(key: string): void {
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Local storage can be unavailable in hardened test/browser environments.
+  }
+}
+
+function isBottomPanel(value: unknown): value is DesktopBottomPanel {
+  return value === 'board-chat' || value === 'squad-chat';
+}
+
 export function DesktopShellProvider({ children }: { children: ReactNode }) {
   const desktopClient = isDesktopClient();
   const supportsWorkbenchPanel = useMediaQuery('(min-width: 768px)', false);
@@ -121,9 +126,7 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
   const [rightRailOpen, setRightRailOpenState] = useState(() =>
     readStoredBoolean(RIGHT_RAIL_STORAGE_KEY, false)
   );
-  const [bottomPanel, setBottomPanel] = useState<DesktopBottomPanel | null>(() =>
-    readStoredBottomPanel()
-  );
+  const [bottomPanel, setBottomPanel] = useState<DesktopBottomPanel | null>(null);
   const [bottomPanelHeight, setBottomPanelHeightState] = useState(() =>
     readStoredBottomPanelHeight()
   );
@@ -150,28 +153,113 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
     writeStoredValue(BOTTOM_PANEL_HEIGHT_STORAGE_KEY, String(next));
   }, []);
 
-  const openBottomPanel = useCallback((panel: DesktopBottomPanel) => {
-    setBottomPanel(panel);
-    writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, panel);
-  }, []);
-
   const closeBottomPanel = useCallback(() => {
     setBottomPanel(null);
-    writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, 'closed');
+    removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
+    if (typeof window !== 'undefined' && window.history.state?.[BOTTOM_PANEL_HISTORY_STATE_KEY]) {
+      window.history.back();
+    }
   }, []);
 
-  const toggleBottomPanel = useCallback((panel: DesktopBottomPanel = 'board-chat') => {
-    setBottomPanel((current) => {
-      const next = current === panel ? null : panel;
-      writeStoredValue(BOTTOM_PANEL_STORAGE_KEY, next ?? 'closed');
-      return next;
-    });
+  const openBottomPanel = useCallback((panel: DesktopBottomPanel) => {
+    setBottomPanel(panel);
+    removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
+    if (typeof window === 'undefined') return;
+
+    const state = {
+      ...(typeof window.history.state === 'object' && window.history.state
+        ? window.history.state
+        : {}),
+      [BOTTOM_PANEL_HISTORY_STATE_KEY]: panel,
+    };
+    if (window.history.state?.[BOTTOM_PANEL_HISTORY_STATE_KEY]) {
+      window.history.replaceState(state, '', window.location.href);
+    } else {
+      window.history.pushState(state, '', window.location.href);
+    }
+  }, []);
+
+  const toggleBottomPanel = useCallback(
+    (panel: DesktopBottomPanel = 'board-chat') => {
+      if (bottomPanel === panel) {
+        closeBottomPanel();
+        return;
+      }
+      openBottomPanel(panel);
+    },
+    [bottomPanel, closeBottomPanel, openBottomPanel]
+  );
+
+  const resetDesktopLayout = useCallback(() => {
+    setLeftRailOpenState(true);
+    setRightRailOpenState(false);
+    setBottomPanel(null);
+    setBottomPanelHeightState(clampBottomPanelHeight(DEFAULT_BOTTOM_PANEL_HEIGHT));
+    removeStoredValue(LEFT_RAIL_STORAGE_KEY);
+    removeStoredValue(RIGHT_RAIL_STORAGE_KEY);
+    removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
+    removeStoredValue(BOTTOM_PANEL_HEIGHT_STORAGE_KEY);
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.history.state === 'object' &&
+      window.history.state
+    ) {
+      const { [BOTTOM_PANEL_HISTORY_STATE_KEY]: _panel, ...rest } = window.history.state;
+      window.history.replaceState(rest, '', window.location.href);
+    }
   }, []);
 
   useEffect(() => {
     if (!desktopClient || typeof document === 'undefined') return;
     document.documentElement.dataset.client = 'desktop';
   }, [desktopClient]);
+
+  useEffect(() => {
+    removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== 'Escape' || !bottomPanel) return;
+      event.preventDefault();
+      closeBottomPanel();
+    };
+    const handlePopState = (event: PopStateEvent) => {
+      const panel = event.state?.[BOTTOM_PANEL_HISTORY_STATE_KEY];
+      setBottomPanel(isBottomPanel(panel) ? panel : null);
+    };
+    const handleResize = () => {
+      setBottomPanelHeightState((current) => {
+        const next = clampBottomPanelHeight(current);
+        if (next !== current) {
+          writeStoredValue(BOTTOM_PANEL_HEIGHT_STORAGE_KEY, String(next));
+        }
+        return next;
+      });
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('popstate', handlePopState);
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('popstate', handlePopState);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [bottomPanel, closeBottomPanel]);
+
+  useEffect(() => {
+    const desktop = (
+      window as Window & {
+        veritasDesktop?: {
+          onMenuCommand?: (listener: (payload: { command: string }) => void) => () => void;
+        };
+      }
+    ).veritasDesktop;
+    return desktop?.onMenuCommand?.((payload) => {
+      if (payload.command === 'reset-layout') resetDesktopLayout();
+    });
+  }, [resetDesktopLayout]);
 
   const value = useMemo<DesktopShellContextValue>(
     () => ({

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -249,8 +249,8 @@ html[data-client='desktop'] .desktop-main-content {
 .workbench-bottom-panel {
   display: flex;
   height: var(--workbench-bottom-panel-height, 340px);
-  min-height: 320px;
-  max-height: min(68vh, 640px);
+  min-height: 0;
+  max-height: min(max(200px, calc(100vh - 220px)), 640px);
   flex: 0 0 var(--workbench-bottom-panel-height, 340px);
   flex-direction: column;
   overflow: hidden;
@@ -264,8 +264,8 @@ html:not([data-client='desktop']) .workbench-bottom-panel {
 }
 
 html[data-client='desktop'] .workbench-bottom-panel {
-  min-height: 320px;
-  max-height: min(68vh, 640px);
+  min-height: 0;
+  max-height: min(max(200px, calc(100vh - 220px)), 640px);
   flex: 0 0 var(--workbench-bottom-panel-height, 340px);
 }
 


### PR DESCRIPTION
## Summary

- keep Board Chat in a bounded workbench panel that cannot consume the application shell
- make Escape and browser Back close the panel without losing the current route
- discard obsolete persisted panel visibility and clamp stale heights on startup and resize
- add a native Reset Window Layout command that preserves all application data
- wrap Chat mode controls at compact desktop sizes

## Root cause

Panel visibility was persisted across launches, while a fixed 320px minimum could consume the remaining workbench height in compact windows. That combination could restore a chat-dominant layout after relaunch with little or no usable main content.

## Verification

- 13 focused web tests
- 23 focused desktop tests
- web and desktop typecheck
- web and desktop production builds
- scoped ESLint
- desktop Electron artifact check

## Release note

This PR references #945 but intentionally leaves it open until the final signed 6.0.1 package passes the relaunch and invalid-state smoke check.

Refs #945