### PR TITLE
fix: prevent task Workflow action crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Back now close it, obsolete persisted panel visibility is discarded, compact
   window heights preserve the application shell, and the native Navigate menu
   can reset layout state without deleting application data (#945).
+- Normalized omitted workflow and run collections in the task Workflow action,
+  preventing undefined length crashes and providing a recoverable load error
+  with Retry instead of replacing the task surface with an error boundary
+  (#936).
 
 ## [6.0.0] - 2026-07-24
 

--- a/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-git-workflow-mantine.test.tsx
@@ -407,6 +407,45 @@ describe('task detail Git and workflow Mantine migration', () => {
     });
   });
 
+  it('normalizes omitted workflow collections instead of crashing the task action', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/workflows')) {
+        return createJsonResponse([
+          {
+            id: 'workflow-empty',
+            name: 'Empty Workflow',
+            version: 1,
+            description: 'Definition has no agents or steps yet',
+          },
+        ]);
+      }
+      if (url.includes('/workflows/launch-recommendations')) {
+        return createJsonResponse({ recommendations: [] });
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+        text: vi.fn().mockResolvedValue(''),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderWithProviders(
+      <WorkflowSection
+        task={createMockTask({ id: 'task-without-workflow-run' })}
+        open
+        onOpenChange={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText('Empty Workflow')).toBeDefined();
+    expect(screen.getByText('0 agents')).toBeDefined();
+    expect(screen.getByText('0 steps')).toBeDefined();
+    expect(screen.queryByText('This section encountered an error')).toBeNull();
+  });
+
   it('renders run mode and QA gate controls through direct Mantine primitives', async () => {
     const user = userEvent.setup();
     const onUpdate = vi.fn();

--- a/web/src/components/task/WorkflowSection.tsx
+++ b/web/src/components/task/WorkflowSection.tsx
@@ -40,6 +40,75 @@ interface WorkflowRun {
   startedAt: string;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function unwrapCollection(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  const record = asRecord(value);
+  return Array.isArray(record?.data) ? record.data : [];
+}
+
+function normalizeWorkflows(value: unknown): Workflow[] {
+  return unwrapCollection(value).flatMap((entry) => {
+    const workflow = asRecord(entry);
+    if (
+      !workflow ||
+      typeof workflow.id !== 'string' ||
+      typeof workflow.name !== 'string' ||
+      typeof workflow.version !== 'number'
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        id: workflow.id,
+        name: workflow.name,
+        version: workflow.version,
+        description: typeof workflow.description === 'string' ? workflow.description : '',
+        agents: unwrapCollection(workflow.agents).flatMap((agent) => {
+          const record = asRecord(agent);
+          return record && typeof record.id === 'string' && typeof record.name === 'string'
+            ? [{ id: record.id, name: record.name }]
+            : [];
+        }),
+        steps: unwrapCollection(workflow.steps).flatMap((step) => {
+          const record = asRecord(step);
+          return record && typeof record.id === 'string' && typeof record.name === 'string'
+            ? [{ id: record.id, name: record.name }]
+            : [];
+        }),
+      },
+    ];
+  });
+}
+
+function normalizeActiveRuns(value: unknown): WorkflowRun[] {
+  return unwrapCollection(value).flatMap((entry) => {
+    const run = asRecord(entry);
+    if (
+      !run ||
+      typeof run.id !== 'string' ||
+      typeof run.workflowId !== 'string' ||
+      typeof run.startedAt !== 'string' ||
+      !['pending', 'running', 'blocked', 'completed', 'failed'].includes(String(run.status))
+    ) {
+      return [];
+    }
+
+    const normalized = {
+      id: run.id,
+      workflowId: run.workflowId,
+      status: run.status as WorkflowRun['status'],
+      startedAt: run.startedAt,
+      ...(typeof run.currentStep === 'string' ? { currentStep: run.currentStep } : {}),
+    };
+    return normalized.status === 'running' || normalized.status === 'blocked' ? [normalized] : [];
+  });
+}
+
 function getRunStatusColor(status: WorkflowRun['status']) {
   switch (status) {
     case 'running':
@@ -62,6 +131,8 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
     Record<string, LaunchRecommendation[]>
   >({});
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadRevision, setLoadRevision] = useState(0);
   const [isStarting, setIsStarting] = useState<string | null>(null);
   const { toast } = useToast();
   const { hasPermission } = useIdentity();
@@ -74,47 +145,56 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
 
     const fetchData = async () => {
       setIsLoading(true);
+      setLoadError(null);
+      setWorkflows([]);
+      setActiveRuns([]);
+      setRecommendationsByWorkflow({});
       try {
         // Fetch available workflows
         const workflowsRes = await fetch(`${API_BASE}/workflows`);
-        if (workflowsRes.ok) {
-          const wJson = await workflowsRes.json();
-          const workflowList = (wJson.data ?? wJson) as Workflow[];
-          if (isCancelled) return;
-          setWorkflows(workflowList);
-
-          const recommendationEntries = await Promise.all(
-            workflowList.map(async (workflow) => {
-              try {
-                const result = await workflowsApi.launchRecommendations({
-                  workflowId: workflow.id,
-                  taskId: task.id,
-                  project: task.project,
-                  taskType: task.type,
-                  cwd: task.git?.worktreePath,
-                });
-                return [workflow.id, result.recommendations] as const;
-              } catch {
-                return [workflow.id, []] as const;
-              }
-            })
-          );
-          if (isCancelled) return;
-          setRecommendationsByWorkflow(Object.fromEntries(recommendationEntries));
+        if (!workflowsRes.ok) {
+          throw new Error(`Unable to load workflows (${workflowsRes.status})`);
         }
+        const workflowList = normalizeWorkflows(await workflowsRes.json());
+        if (isCancelled) return;
+        setWorkflows(workflowList);
+
+        const recommendationEntries = await Promise.all(
+          workflowList.map(async (workflow) => {
+            try {
+              const result = await workflowsApi.launchRecommendations({
+                workflowId: workflow.id,
+                taskId: task.id,
+                project: task.project,
+                taskType: task.type,
+                cwd: task.git?.worktreePath,
+              });
+              return [
+                workflow.id,
+                Array.isArray(result.recommendations) ? result.recommendations : [],
+              ] as const;
+            } catch {
+              return [workflow.id, []] as const;
+            }
+          })
+        );
+        if (isCancelled) return;
+        setRecommendationsByWorkflow(Object.fromEntries(recommendationEntries));
 
         // Fetch active runs for this task
         const runsRes = await fetch(`${API_BASE}/workflows/runs?taskId=${task.id}`);
-        if (runsRes.ok) {
-          const rJson = await runsRes.json();
-          const runs = rJson.data ?? rJson;
-          if (isCancelled) return;
-          setActiveRuns(
-            runs.filter((r: WorkflowRun) => r.status === 'running' || r.status === 'blocked')
-          );
+        if (!runsRes.ok) {
+          throw new Error(`Unable to load workflow runs (${runsRes.status})`);
         }
+        const runs = normalizeActiveRuns(await runsRes.json());
+        if (isCancelled) return;
+        setActiveRuns(runs);
       } catch (error) {
-        console.error('Failed to fetch workflows:', error);
+        if (isCancelled) return;
+        const message = error instanceof Error ? error.message : 'Unknown workflow loading error';
+        setLoadError(message);
+        setWorkflows([]);
+        setActiveRuns([]);
       } finally {
         if (!isCancelled) setIsLoading(false);
       }
@@ -124,7 +204,7 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
     return () => {
       isCancelled = true;
     };
-  }, [open, task.id, task.project, task.type, task.git?.worktreePath]);
+  }, [loadRevision, open, task.id, task.project, task.type, task.git?.worktreePath]);
 
   const handleStartWorkflow = async (workflowId: string) => {
     setIsStarting(workflowId);
@@ -174,6 +254,24 @@ export function WorkflowSection({ task, open, onOpenChange }: WorkflowSectionPro
           <Group justify="center" className="py-12">
             <Loader color="gray" size="sm" />
           </Group>
+        ) : loadError ? (
+          <Paper className="bg-card p-4" radius="md" withBorder>
+            <Stack gap="sm" align="flex-start">
+              <Text size="sm" fw={500}>
+                Workflows could not be loaded
+              </Text>
+              <Text size="sm" c="dimmed">
+                {loadError}
+              </Text>
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() => setLoadRevision((value) => value + 1)}
+              >
+                Retry
+              </Button>
+            </Stack>
+          </Paper>
         ) : (
           <ScrollArea.Autosize mah="65vh" type="auto">
             <Stack gap="lg">


### PR DESCRIPTION
## Summary

- normalize workflow definitions and active-run collections before rendering
- default omitted agent and step collections instead of dereferencing undefined values
- show a recoverable load error with Retry for failed workflow API requests
- clear stale workflow state before reloads

## Root cause

The task Workflow surface trusted variable API response shapes. It called `.filter()` on a malformed or omitted run collection and rendered `.length` from omitted workflow `agents` and `steps`, which replaced the task surface with the error boundary.

## Verification

- `pnpm exec vitest run src/__tests__/task-detail-git-workflow-mantine.test.tsx` (7 tests)
- `pnpm exec eslint src/components/task/WorkflowSection.tsx src/__tests__/task-detail-git-workflow-mantine.test.tsx`
- `pnpm typecheck` for shared and web
- `pnpm build` for web

Closes #936