### PR TITLE
fix: make task drawers and overlays scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Let Archive cards grow with expanded content, clamp collapsed text by whole
   lines with accessible full text, wrap long metadata safely, and keep Restore
   reachable beside long task content (#939).
+- Established one bounded, keyboard-focusable scroll owner for task drawers and
+  shared overlays, kept drawer chrome fixed, and made task description editors
+  taller and vertically resizable (#935).
 
 ## [6.0.0] - 2026-07-24
 

--- a/web/src/__tests__/mantine-theme.test.ts
+++ b/web/src/__tests__/mantine-theme.test.ts
@@ -10,4 +10,35 @@ describe('veritasMantineTheme', () => {
       lockScroll: false,
     });
   });
+
+  it('gives shared overlays one bounded scroll owner', () => {
+    expect(veritasMantineTheme.components?.Modal?.styles).toMatchObject({
+      content: {
+        minHeight: 0,
+        overflow: 'hidden',
+      },
+      body: {
+        minHeight: 0,
+        overflowY: 'auto',
+        overscrollBehavior: 'contain',
+      },
+    });
+    expect(veritasMantineTheme.components?.Drawer?.styles).toMatchObject({
+      content: {
+        minHeight: 0,
+        overflow: 'hidden',
+      },
+      body: {
+        minHeight: 0,
+        overflowY: 'auto',
+        overscrollBehavior: 'contain',
+      },
+    });
+    expect(veritasMantineTheme.components?.Popover?.styles).toMatchObject({
+      dropdown: {
+        overflowY: 'auto',
+        overscrollBehavior: 'contain',
+      },
+    });
+  });
 });

--- a/web/src/__tests__/task-detail-mantine.test.tsx
+++ b/web/src/__tests__/task-detail-mantine.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/re
 import userEvent from '@testing-library/user-event';
 
 import { TaskDetailPanel } from '@/components/task/TaskDetailPanel';
+import { MarkdownEditor } from '@/components/ui/MarkdownEditor';
 import { renderWithProviders, createMockTask } from './test-utils';
 
 const mocks = vi.hoisted(() => ({
@@ -150,6 +151,14 @@ vi.mock('@/components/task/WorkflowSection', () => ({
   WorkflowSection: () => null,
 }));
 
+vi.mock('@/components/evidence/EvidenceTimelinePanel', () => ({
+  EvidenceTimelinePanel: () => (
+    <div data-testid="long-evidence-content">
+      Long evidence timeline content remains inside the task detail scroll region
+    </div>
+  ),
+}));
+
 vi.mock('@/components/task/SubtasksSection', () => ({
   SubtasksSection: () => <div>Subtasks section</div>,
 }));
@@ -207,6 +216,17 @@ describe('task detail Mantine migration', () => {
       'veritas-overlay'
     );
     expect(screen.getByTestId('task-detail-panel').className).toContain('veritas-overlay-surface');
+    expect(screen.getByTestId('task-detail-panel').className).toContain('min-h-0');
+    const scrollRegion = screen.getByTestId('task-detail-scroll-region');
+    expect(scrollRegion.className).toContain('min-h-0');
+    expect(scrollRegion.className).toContain('overflow-y-scroll');
+    expect(scrollRegion.className).toContain('overscroll-contain');
+    expect(scrollRegion.getAttribute('tabindex')).toBe('0');
+    expect(scrollRegion.contains(screen.getByLabelText('Task title'))).toBe(false);
+    const taskDescription = within(scrollRegion).getByLabelText('Task description');
+    expect(taskDescription.className).toContain('min-h-[180px]');
+    expect(taskDescription.className).toContain('resize-y');
+    expect((taskDescription as HTMLTextAreaElement).style.resize).toBe('vertical');
     expect(container.querySelector('.mantine-Tabs-root')).toBeDefined();
     expect(container.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(container.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(5);
@@ -217,6 +237,35 @@ describe('task detail Mantine migration', () => {
     expect(baseElement.querySelector('[data-slot="select-trigger"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="button"]')).toBeNull();
     expect(baseElement.querySelector('[data-slot="input"]')).toBeNull();
+  });
+
+  it('keeps Details and Evidence in the same desktop viewport scroll region', async () => {
+    const user = userEvent.setup();
+    renderTaskDetail();
+
+    const scrollRegion = screen.getByTestId('task-detail-scroll-region');
+    expect(within(scrollRegion).getByLabelText('Task description')).toBeDefined();
+
+    await user.click(screen.getByRole('tab', { name: 'Evidence' }));
+
+    expect(await within(scrollRegion).findByTestId('long-evidence-content')).toBeDefined();
+    expect(screen.getByTestId('task-detail-scroll-region')).toBe(scrollRegion);
+  });
+
+  it('applies description height and vertical resizing to the textarea input', () => {
+    renderWithProviders(
+      <MarkdownEditor
+        value={'Long task description\n'.repeat(20)}
+        onChange={vi.fn()}
+        minHeight={180}
+        ariaLabel="Resizable task description"
+      />
+    );
+
+    const textarea = screen.getByLabelText('Resizable task description');
+    expect(textarea.className).toContain('resize-y');
+    expect((textarea as HTMLTextAreaElement).style.minHeight).toBe('180px');
+    expect((textarea as HTMLTextAreaElement).style.resize).toBe('vertical');
   });
 
   it('keeps title editing and progress tab behavior wired after the migration', async () => {

--- a/web/src/components/task/TaskDetailPanel.tsx
+++ b/web/src/components/task/TaskDetailPanel.tsx
@@ -200,10 +200,10 @@ export function TaskDetailPanel({
         <Drawer.Content
           aria-label={`Task details: ${localTask.title}`}
           data-testid="task-detail-panel"
-          className="veritas-overlay-surface flex h-full max-h-[100dvh] w-[min(100vw,700px)] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:max-w-[700px]"
+          className="veritas-overlay-surface flex h-full min-h-0 max-h-[100dvh] w-[min(100vw,700px)] flex-col overflow-hidden border-l bg-background bg-clip-padding text-sm shadow-lg sm:max-w-[700px]"
         >
-          <Drawer.Body className="contents">
-            <Stack gap={0} className="h-full overflow-hidden">
+          <Drawer.Body className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
+            <Stack gap={0} className="min-h-0 flex-1 overflow-hidden">
               <header className="flex-shrink-0 border-b px-4 py-4 pr-12 sm:px-6">
                 <Group
                   gap="xs"
@@ -323,7 +323,7 @@ export function TaskDetailPanel({
                 onChange={(value) => {
                   if (isTaskDetailTabId(value)) setActiveTab(value);
                 }}
-                className="flex flex-1 flex-col overflow-hidden px-4 pt-3 pb-6 sm:px-6"
+                className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 pt-3 pb-6 sm:px-6"
               >
                 <Tabs.List className="w-full flex-shrink-0 justify-start overflow-x-auto">
                   {visibleTabs.map((tab) => {
@@ -342,7 +342,12 @@ export function TaskDetailPanel({
                   })}
                 </Tabs.List>
 
-                <div className="mt-4 flex-1 overflow-y-auto pr-1">
+                <div
+                  className="veritas-overlay-scroll mt-4 min-h-0 flex-1 overflow-y-scroll overscroll-contain pr-1"
+                  data-testid="task-detail-scroll-region"
+                  aria-label="Task detail content"
+                  tabIndex={0}
+                >
                   {visibleTabs.map((tab) => {
                     const tabContent = (
                       <Suspense
@@ -357,7 +362,7 @@ export function TaskDetailPanel({
                     );
 
                     return (
-                      <Tabs.Panel key={tab.id} value={tab.id} className="mt-0">
+                      <Tabs.Panel key={tab.id} value={tab.id} className="mt-0 min-h-full">
                         {tab.fallbackTitle ? (
                           <FeatureErrorBoundary fallbackTitle={tab.fallbackTitle}>
                             {tabContent}

--- a/web/src/components/task/detail/TaskDetailsTab.tsx
+++ b/web/src/components/task/detail/TaskDetailsTab.tsx
@@ -85,15 +85,18 @@ export function TaskDetailsTab({
             value={task.description}
             onChange={(value) => onUpdate('description', value)}
             placeholder="Add a description... (supports Markdown)"
-            minHeight={120}
+            minHeight={180}
+            ariaLabel="Task description"
           />
         ) : (
           <Textarea
             value={task.description}
             onChange={(e) => onUpdate('description', e.currentTarget.value)}
             placeholder="Add a description..."
-            rows={4}
-            className="resize-none"
+            aria-label="Task description"
+            rows={8}
+            classNames={{ input: 'min-h-[180px] resize-y' }}
+            styles={{ input: { resize: 'vertical' } }}
           />
         )}
       </Stack>

--- a/web/src/components/ui/MarkdownEditor.tsx
+++ b/web/src/components/ui/MarkdownEditor.tsx
@@ -12,6 +12,7 @@ interface MarkdownEditorProps {
   maxHeight?: number | string;
   onKeyDown?: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   disabled?: boolean;
+  ariaLabel?: string;
 }
 
 type SelectionUpdate = {
@@ -38,6 +39,7 @@ export function MarkdownEditor({
   maxHeight,
   onKeyDown,
   disabled = false,
+  ariaLabel,
 }: MarkdownEditorProps) {
   const [mode, setMode] = useState('edit');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -217,8 +219,15 @@ export function MarkdownEditor({
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className={cn('resize-y')}
-          style={{ minHeight, maxHeight }}
+          aria-label={ariaLabel}
+          classNames={{ input: 'resize-y' }}
+          styles={{
+            input: {
+              minHeight,
+              maxHeight,
+              resize: disabled ? 'none' : 'vertical',
+            },
+          }}
           disabled={disabled}
         />
       </Tabs.Panel>

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -92,6 +92,23 @@
   }
 }
 
+.veritas-overlay-scroll {
+  scrollbar-color: color-mix(in oklch, var(--foreground) 45%, transparent) transparent;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+}
+
+.veritas-overlay-scroll::-webkit-scrollbar {
+  width: 0.625rem;
+}
+
+.veritas-overlay-scroll::-webkit-scrollbar-thumb {
+  border: 0.1875rem solid transparent;
+  border-radius: 9999px;
+  background: color-mix(in oklch, var(--foreground) 45%, transparent);
+  background-clip: content-box;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/web/src/theme/mantine-theme.ts
+++ b/web/src/theme/mantine-theme.ts
@@ -179,6 +179,21 @@ export const veritasMantineTheme = createTheme({
         closeButtonProps: { 'aria-label': 'Close dialog' },
         overlayProps: { blur: 2, opacity: 0.45 },
       },
+      styles: {
+        content: {
+          display: 'flex',
+          maxHeight: 'calc(100dvh - 2rem)',
+          minHeight: 0,
+          flexDirection: 'column',
+          overflow: 'hidden',
+        },
+        body: {
+          minHeight: 0,
+          overflowY: 'auto',
+          overscrollBehavior: 'contain',
+          scrollbarGutter: 'stable',
+        },
+      },
     },
     Drawer: {
       defaultProps: {
@@ -187,6 +202,32 @@ export const veritasMantineTheme = createTheme({
         returnFocus: true,
         closeButtonProps: { 'aria-label': 'Close panel' },
         overlayProps: { blur: 2, opacity: 0.35 },
+      },
+      styles: {
+        content: {
+          display: 'flex',
+          maxHeight: '100dvh',
+          minHeight: 0,
+          flexDirection: 'column',
+          overflow: 'hidden',
+        },
+        body: {
+          minHeight: 0,
+          flex: '1 1 auto',
+          overflowY: 'auto',
+          overscrollBehavior: 'contain',
+          scrollbarGutter: 'stable',
+        },
+      },
+    },
+    Popover: {
+      styles: {
+        dropdown: {
+          maxHeight: 'min(70dvh, 32rem)',
+          overflowY: 'auto',
+          overscrollBehavior: 'contain',
+          scrollbarGutter: 'stable',
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

- make the task tab body the single bounded vertical scroll owner
- keep task title, actions, and tabs outside the scrolling region
- add stable scrollbar styling, overscroll containment, and keyboard focus
- enforce bounded overflow defaults for shared Modal, Drawer, and Popover surfaces
- apply minimum height and vertical resize to the actual description textarea input

## Verification

- focused task detail and overlay theme suites (12 tests)
- scoped ESLint and Prettier checks
- shared build plus web typecheck
- PR CI owns the production build gate

Closes #935