### PR TITLE
fix: reconcile Operations Digest inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserved in-app route origins, scroll positions, and task return paths across
   full-page navigation, added browser Back and `Cmd+[` support, and made direct
   links fall back safely to Board (#937).
+- Reconciled Operations Digest totals with board inventory, exposed auditable
+  inclusion and exclusion reasons plus metadata quality findings, bounded
+  observed wall time to the selected window, and documented current-state
+  versus windowed metrics (#944).
 
 ## [6.0.0] - 2026-07-24
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1880,6 +1880,32 @@ Runs all due standard schedules and refuses overlapping due-run passes.
 
 ---
 
+## Operations Digest
+
+`GET /api/digest/operations` returns the deterministic operations source bundle.
+Use `hours`, `from`, `to`, `project`, `repo`, and `cwd` to scope both JSON and
+Markdown output. `format=markdown` returns the briefing generated from the same
+filtered bundle.
+
+The response distinguishes two time models:
+
+- `active`, `blocked`, and `stuck` are current task-state snapshots. `stuck` is
+  the active subset whose task `updated` timestamp is at least two hours before
+  the selected window end.
+- `completed`, `failed`, `runs`, token usage/cost, active runtime, and observed
+  wall time are restricted to the selected window. Observed wall time is the
+  span between included signals, never task age.
+
+`inventory` reconciles all board tasks into included tasks or one mutually
+exclusive exclusion reason: filter mismatch, current status, time window, or
+missing metadata required by a selected filter. Every count includes task
+source IDs. `dataQuality` separately identifies matching tasks grouped under an
+unassigned project, unknown repository, or missing CWD so operators can drill
+into incomplete records. Run counts are deduplicated by attempt ID when
+available, otherwise by event ID.
+
+---
+
 ## Queue Intake Monitors
 
 Scan bounded GitHub issue and PR queues, build candidate packets, and gate assign/execute actions through policy, budget, sandbox, auth, and workflow preflight checks.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1675,6 +1675,10 @@ New endpoints for advanced metrics and visualization (v1.6):
 - **Status timeline** — Daily Activity (75%) + Recent Status Changes (25%) side-by-side layout
 - **Section collapsing** — Dashboard sections apply `overflow-hidden` only when collapsed
 - **Daily digest** — Summary of the day's activity: tasks completed/created, agent runs, token usage, failures and issues
+- **Reconciled Operations Digest** — Current active/blocked/stuck state is
+  labeled separately from windowed completions, runs, tokens, and observed
+  runtime; board inventory, exclusion reasons, source IDs, and unknown metadata
+  findings make every headline count auditable
 - **Task-level metrics** — Per-task panel showing attempt history, token counts, duration, cost, and status timeline
 - **Export dialog** — Export dashboard data for external analysis
 

--- a/server/src/__tests__/digest-service.test.ts
+++ b/server/src/__tests__/digest-service.test.ts
@@ -263,6 +263,139 @@ describe('DigestService', () => {
         action: 'push_branch',
       });
       expect(digest.totals.openApprovals).toBe(1);
+      expect(digest.inventory).toMatchObject({
+        totalBoardTasks: 3,
+        matchingFilters: 3,
+        includedTasks: 3,
+        excludedTasks: 0,
+      });
+      expect(digest.totals.active + digest.totals.blocked + digest.totals.completed).toBe(
+        digest.inventory.includedTasks
+      );
+      expect(digest.semantics.observedWallTime).toContain('inside the window');
+    });
+
+    it('reconciles old tasks, current state, windowed activity, metadata gaps, and duplicate runs', async () => {
+      const makeTask = (
+        id: string,
+        status: Task['status'],
+        updated: string,
+        overrides: Partial<Task> = {}
+      ): Task => ({
+        id,
+        title: id,
+        description: id,
+        type: 'feature',
+        status,
+        priority: 'medium',
+        project: 'platform',
+        created: '2026-06-01T00:00:00.000Z',
+        updated,
+        git: {
+          repo: 'veritas-kanban',
+          branch: `test/${id}`,
+          baseBranch: 'main',
+          worktreePath: '/worktrees/platform',
+        },
+        ...overrides,
+      });
+      const tasks = [
+        makeTask('task_old_active', 'in-progress', '2026-05-01T00:00:00.000Z'),
+        makeTask('task_recent_blocked', 'blocked', '2026-06-04T10:00:00.000Z'),
+        makeTask('task_recent_done', 'done', '2026-06-04T11:00:00.000Z'),
+        makeTask('task_old_done', 'done', '2026-05-01T00:00:00.000Z'),
+        makeTask('task_todo', 'todo', '2026-06-04T11:15:00.000Z'),
+        makeTask('task_unknown', 'in-progress', '2026-06-04T09:00:00.000Z', {
+          project: undefined,
+          git: undefined,
+        }),
+      ];
+      const telemetry = {
+        getEvents: vi.fn().mockResolvedValue([
+          {
+            id: 'run_error_duplicate',
+            type: 'run.error',
+            timestamp: '2026-06-04T10:30:00.000Z',
+            taskId: 'task_old_active',
+            agent: 'codex',
+            success: false,
+            error: 'Intermediate error',
+            attemptId: 'attempt_shared',
+          } satisfies RunTelemetryEvent,
+          {
+            id: 'run_complete',
+            type: 'run.completed',
+            timestamp: '2026-06-04T11:30:00.000Z',
+            taskId: 'task_old_active',
+            agent: 'codex',
+            success: true,
+            durationMs: 120_000,
+            attemptId: 'attempt_shared',
+          } satisfies RunTelemetryEvent,
+          {
+            id: 'tokens_1',
+            type: 'run.tokens',
+            timestamp: '2026-06-04T11:45:00.000Z',
+            taskId: 'task_old_active',
+            agent: 'codex',
+            inputTokens: 40,
+            outputTokens: 10,
+            totalTokens: 50,
+            cost: 0.005,
+          } satisfies TokenTelemetryEvent,
+        ]),
+      };
+      const taskService = { listTasks: vi.fn().mockResolvedValue(tasks) };
+      const serviceOverrides = service as unknown as {
+        telemetry: typeof telemetry;
+        taskService: typeof taskService;
+      };
+      serviceOverrides.telemetry = telemetry;
+      serviceOverrides.taskService = taskService;
+
+      const digest = await service.generateOperationsDigest({
+        from: '2026-06-04T00:00:00.000Z',
+        to: '2026-06-04T12:00:00.000Z',
+      });
+      const markdown = service.formatOperationsDigestMarkdown(digest).markdown;
+
+      expect(digest.inventory).toMatchObject({
+        totalBoardTasks: 6,
+        matchingFilters: 6,
+        includedTasks: 4,
+        excludedTasks: 2,
+        excludedBy: {
+          filterMismatch: 0,
+          status: 1,
+          timeWindow: 1,
+          missingSourceMetadata: 0,
+        },
+      });
+      expect(digest.totals).toMatchObject({
+        active: 2,
+        blocked: 1,
+        stuck: 2,
+        completed: 1,
+        failed: 0,
+        runs: 1,
+        activeTimeMs: 120_000,
+        totalTokens: 50,
+      });
+      expect(digest.totals.wallTimeMs).toBeLessThanOrEqual(12 * 60 * 60 * 1000);
+      expect(digest.dataQuality.map((issue) => issue.code)).toEqual([
+        'unknown-project',
+        'unknown-repository',
+        'missing-cwd',
+      ]);
+      expect(
+        digest.dataQuality.find((issue) => issue.code === 'unknown-repository')?.sourceLinks[0]?.id
+      ).toBe('task_unknown');
+      expect(digest.inventory.sourceLinks.excludedBy.timeWindow[0]?.id).toBe('task_old_done');
+      expect(markdown).toContain(
+        'Inventory: 6 board tasks, 6 match filters, 4 included, 2 excluded'
+      );
+      expect(markdown).toContain('Semantics: active, blocked, and stuck are current task state');
+      expect(markdown).toContain('Data quality');
     });
 
     it('includes queue monitor activity and skipped reasons', async () => {
@@ -338,6 +471,10 @@ describe('DigestService', () => {
       const tasks = [
         makeTask('task_match', 'veritas-kanban', '/worktrees/platform'),
         makeTask('task_other', 'other-repo', '/worktrees/other'),
+        {
+          ...makeTask('task_missing', 'placeholder', '/worktrees/missing'),
+          git: undefined,
+        },
       ];
       const telemetry = {
         getEvents: vi.fn().mockResolvedValue([
@@ -394,6 +531,19 @@ describe('DigestService', () => {
       expect(digest.groups[0].sourceLinks.activeTasks).toHaveLength(1);
       expect(digest.groups[0].sourceLinks.tokenEvents[0]?.id).toBe('tokens_match');
       expect(digest.totals.totalTokens).toBe(40);
+      expect(digest.inventory).toMatchObject({
+        totalBoardTasks: 3,
+        matchingFilters: 1,
+        includedTasks: 1,
+        excludedTasks: 2,
+        excludedBy: {
+          filterMismatch: 1,
+          missingSourceMetadata: 1,
+        },
+      });
+      expect(digest.inventory.sourceLinks.excludedBy.missingSourceMetadata[0]?.id).toBe(
+        'task_missing'
+      );
     });
   });
 

--- a/server/src/__tests__/scheduled-deliverables-runner-service.test.ts
+++ b/server/src/__tests__/scheduled-deliverables-runner-service.test.ts
@@ -287,6 +287,40 @@ function makeOperationsDigest(): AgentOperationsDigest {
     },
     generatedAt: '2026-06-05T09:00:00.000Z',
     hasActivity: true,
+    filters: {},
+    inventory: {
+      totalBoardTasks: 8,
+      matchingFilters: 8,
+      includedTasks: 8,
+      excludedTasks: 0,
+      excludedBy: {
+        filterMismatch: 0,
+        status: 0,
+        timeWindow: 0,
+        missingSourceMetadata: 0,
+      },
+      sourceLinks: {
+        includedTasks: [],
+        excludedBy: {
+          filterMismatch: [],
+          status: [],
+          timeWindow: [],
+          missingSourceMetadata: [],
+        },
+      },
+    },
+    dataQuality: [],
+    semantics: {
+      active: 'Current snapshot active tasks.',
+      blocked: 'Current snapshot blocked tasks.',
+      stuck: 'Current snapshot stuck tasks.',
+      completed: 'Windowed completed tasks.',
+      failed: 'Windowed failed runs.',
+      runs: 'Windowed unique runs.',
+      activeTime: 'Windowed completed run duration.',
+      observedWallTime: 'Windowed signal span.',
+      tokenCost: 'Windowed reported cost.',
+    },
     groups: [
       {
         key: 'platform::veritas-kanban::/worktrees/veritas',

--- a/server/src/services/digest-service.ts
+++ b/server/src/services/digest-service.ts
@@ -147,6 +147,14 @@ export interface AgentOperationsDigest {
   };
   generatedAt: string;
   hasActivity: boolean;
+  filters: {
+    project?: string;
+    repo?: string;
+    cwd?: string;
+  };
+  inventory: AgentOperationsInventory;
+  dataQuality: AgentOperationsDataQualityIssue[];
+  semantics: AgentOperationsSemantics;
   groups: AgentOperationsDigestGroup[];
   totals: AgentOperationsDigestGroup['totals'] & {
     openApprovals: number;
@@ -159,6 +167,40 @@ export interface AgentOperationsDigest {
   };
 }
 
+export type AgentOperationsExclusionReason =
+  'filterMismatch' | 'status' | 'timeWindow' | 'missingSourceMetadata';
+
+export interface AgentOperationsInventory {
+  totalBoardTasks: number;
+  matchingFilters: number;
+  includedTasks: number;
+  excludedTasks: number;
+  excludedBy: Record<AgentOperationsExclusionReason, number>;
+  sourceLinks: {
+    includedTasks: AgentOperationsSourceLink[];
+    excludedBy: Record<AgentOperationsExclusionReason, AgentOperationsSourceLink[]>;
+  };
+}
+
+export interface AgentOperationsDataQualityIssue {
+  code: 'unknown-project' | 'unknown-repository' | 'missing-cwd';
+  label: string;
+  count: number;
+  sourceLinks: AgentOperationsSourceLink[];
+}
+
+export interface AgentOperationsSemantics {
+  active: string;
+  blocked: string;
+  stuck: string;
+  completed: string;
+  failed: string;
+  runs: string;
+  activeTime: string;
+  observedWallTime: string;
+  tokenCost: string;
+}
+
 export interface DigestMarkdownMessage {
   markdown: string;
   isEmpty: boolean;
@@ -168,6 +210,22 @@ const DEFAULT_OPERATIONS_WINDOW_HOURS = 24;
 const MAX_OPERATIONS_WINDOW_HOURS = 24 * 30;
 const STUCK_TASK_MS = 2 * 60 * 60 * 1000;
 const MONITOR_PROJECT = 'operations';
+const OPERATIONS_SEMANTICS: AgentOperationsSemantics = {
+  active: 'Current snapshot: tasks whose current status is in-progress.',
+  blocked: 'Current snapshot: tasks whose current status is blocked.',
+  stuck:
+    'Current snapshot subset of active tasks whose task updated timestamp is at least 2 hours before the window end.',
+  completed: 'Tasks whose current status is done and whose updated timestamp is inside the window.',
+  failed:
+    'Unique terminal run attempts inside the window that ended unsuccessfully or have an error event without a completion event.',
+  runs: 'Unique terminal run attempts inside the window, deduplicated by attempt ID when available and otherwise by event ID.',
+  activeTime:
+    'Sum of positive durationMs values from unique completed run events inside the window.',
+  observedWallTime:
+    'Elapsed span between the earliest and latest included signals inside the window for each source group; it is not task age.',
+  tokenCost:
+    'Sum of positive reported token-event cost values inside the window; no cost is inferred when telemetry omits it.',
+};
 
 /**
  * Service for generating daily digest summaries
@@ -315,6 +373,12 @@ export class DigestService {
     const monitorById = new Map(queueMonitorList.monitors.map((monitor) => [monitor.id, monitor]));
     const groups = new Map<string, AgentOperationsDigestGroup>();
     const signalTimesByGroup = new Map<string, number[]>();
+    const inventory = emptyOperationsInventory(tasks.length);
+    const dataQualityLinks = {
+      unknownProject: [] as AgentOperationsSourceLink[],
+      unknownRepository: [] as AgentOperationsSourceLink[],
+      missingCwd: [] as AgentOperationsSourceLink[],
+    };
 
     const getGroup = (project: string | undefined, repo: string | undefined, cwd?: string) => {
       const normalizedProject = project || 'unassigned';
@@ -349,15 +413,39 @@ export class DigestService {
 
     const recordSignal = (group: AgentOperationsDigestGroup, timestamp?: string) => {
       const parsed = timestamp ? Date.parse(timestamp) : Number.NaN;
-      if (Number.isFinite(parsed)) {
+      if (
+        Number.isFinite(parsed) &&
+        parsed >= Date.parse(period.start) &&
+        parsed <= Date.parse(period.end)
+      ) {
         signalTimesByGroup.get(group.key)?.push(parsed);
       }
     };
 
     for (const task of tasks) {
-      if (!matchesOperationsFilters(taskOperationsContext(task), filters)) continue;
-      const group = getGroup(task.project, task.git?.repo, task.git?.worktreePath);
       const taskLink = taskSourceLink(task);
+      const context = taskOperationsContext(task);
+      const missingRequiredMetadata = missingRequiredOperationsMetadata(context, filters);
+      if (missingRequiredMetadata) {
+        recordInventoryExclusion(inventory, 'missingSourceMetadata', taskLink);
+        continue;
+      }
+      if (!matchesOperationsFilters(context, filters)) {
+        recordInventoryExclusion(inventory, 'filterMismatch', taskLink);
+        continue;
+      }
+      inventory.matchingFilters++;
+      recordTaskDataQuality(task, taskLink, dataQualityLinks);
+
+      const inclusion = taskInventoryInclusion(task, period);
+      if (inclusion !== 'included') {
+        recordInventoryExclusion(inventory, inclusion, taskLink);
+        continue;
+      }
+      inventory.includedTasks++;
+      pushUnique(inventory.sourceLinks.includedTasks, taskLink);
+
+      const group = getGroup(task.project, task.git?.repo, task.git?.worktreePath);
 
       if (task.status === 'in-progress') {
         group.totals.active++;
@@ -384,6 +472,14 @@ export class DigestService {
       }
     }
 
+    const completedRunKeys = new Set(
+      events
+        .filter((event): event is RunTelemetryEvent => event.type === 'run.completed')
+        .map(runIdentity)
+    );
+    const countedRunKeys = new Set<string>();
+    const countedTokenEventIds = new Set<string>();
+
     for (const event of events) {
       const task = event.taskId ? taskById.get(event.taskId) : undefined;
       if (
@@ -403,10 +499,13 @@ export class DigestService {
         task?.git?.repo,
         task?.git?.worktreePath
       );
-      recordSignal(group, event.timestamp);
 
       if (event.type === 'run.completed') {
         const runEvent = event as RunTelemetryEvent;
+        const runKey = runIdentity(runEvent);
+        if (countedRunKeys.has(runKey)) continue;
+        countedRunKeys.add(runKey);
+        recordSignal(group, event.timestamp);
         group.totals.runs++;
         group.totals.activeTimeMs += positiveNumber(runEvent.durationMs);
         if (isRunSuccess(runEvent)) {
@@ -421,6 +520,10 @@ export class DigestService {
 
       if (event.type === 'run.error') {
         const runEvent = event as RunTelemetryEvent;
+        const runKey = runIdentity(runEvent);
+        if (completedRunKeys.has(runKey) || countedRunKeys.has(runKey)) continue;
+        countedRunKeys.add(runKey);
+        recordSignal(group, event.timestamp);
         group.totals.runs++;
         group.totals.failed++;
         const failure = runFailureLink(runEvent);
@@ -430,6 +533,9 @@ export class DigestService {
 
       if (event.type === 'run.tokens') {
         const tokenEvent = event as TokenTelemetryEvent;
+        if (countedTokenEventIds.has(tokenEvent.id)) continue;
+        countedTokenEventIds.add(tokenEvent.id);
+        recordSignal(group, event.timestamp);
         group.totals.inputTokens += positiveNumber(tokenEvent.inputTokens);
         group.totals.outputTokens += positiveNumber(tokenEvent.outputTokens);
         group.totals.totalTokens +=
@@ -470,7 +576,6 @@ export class DigestService {
       group.totals.wallTimeMs = observedWallTime(signals);
       group.topPlanCompletions = group.topPlanCompletions.slice(0, 5);
       group.notableFailures = group.notableFailures.slice(0, 5);
-      group.openApprovals = group.openApprovals.slice(0, 10);
       group.queueMonitors = group.queueMonitors.slice(0, 10);
     }
 
@@ -478,11 +583,20 @@ export class DigestService {
       .filter((group) => groupHasActivity(group))
       .sort((a, b) => groupActivityRank(b) - groupActivityRank(a) || a.key.localeCompare(b.key));
     const totals = rollupOperationsTotals(sortedGroups);
+    const dataQuality = operationsDataQualityIssues(dataQualityLinks);
 
     return {
       period,
       generatedAt: new Date().toISOString(),
-      hasActivity: sortedGroups.length > 0,
+      hasActivity: sortedGroups.length > 0 || inventory.totalBoardTasks > 0,
+      filters: {
+        project: filters.project,
+        repo: filters.repo,
+        cwd: filters.cwd,
+      },
+      inventory,
+      dataQuality,
+      semantics: OPERATIONS_SEMANTICS,
       groups: sortedGroups,
       totals,
       refresh: {
@@ -506,7 +620,19 @@ export class DigestService {
     lines.push('');
     lines.push(`Window: ${digest.period.start} to ${digest.period.end}`);
     lines.push(
+      `Scope: project=${digest.filters.project ?? 'all'}, repo=${digest.filters.repo ?? 'all'}, cwd=${digest.filters.cwd ?? 'all'}`
+    );
+    lines.push(
+      `Inventory: ${digest.inventory.totalBoardTasks} board tasks, ${digest.inventory.matchingFilters} match filters, ${digest.inventory.includedTasks} included, ${digest.inventory.excludedTasks} excluded`
+    );
+    lines.push(
+      `Excluded: ${digest.inventory.excludedBy.filterMismatch} filter mismatch, ${digest.inventory.excludedBy.status} status, ${digest.inventory.excludedBy.timeWindow} time window, ${digest.inventory.excludedBy.missingSourceMetadata} missing source metadata`
+    );
+    lines.push(
       `Totals: ${digest.totals.active} active, ${digest.totals.blocked} blocked, ${digest.totals.stuck} stuck, ${digest.totals.completed} completed, ${digest.totals.failed} failed`
+    );
+    lines.push(
+      'Semantics: active, blocked, and stuck are current task state; completed, failed, runs, tokens, and observed wall time are windowed.'
     );
     if (digest.totals.totalTokens > 0) {
       lines.push(
@@ -515,13 +641,21 @@ export class DigestService {
     }
     lines.push('');
 
-    for (const group of digest.groups.slice(0, 10)) {
+    if (digest.dataQuality.length > 0) {
+      lines.push('## Data quality');
+      for (const issue of digest.dataQuality) {
+        lines.push(`- ${issue.label}: ${issue.count} task${issue.count === 1 ? '' : 's'}`);
+      }
+      lines.push('');
+    }
+
+    for (const group of digest.groups) {
       lines.push(`## ${group.project} / ${group.repo}${group.cwd ? ` / ${group.cwd}` : ''}`);
       lines.push(
         `- Counts: ${group.totals.active} active, ${group.totals.blocked} blocked, ${group.totals.stuck} stuck, ${group.totals.completed} completed, ${group.totals.failed} failed`
       );
       lines.push(
-        `- Runtime: ${formatDurationMs(group.totals.activeTimeMs)} active, ${formatDurationMs(group.totals.wallTimeMs)} observed wall`
+        `- Runtime: ${formatDurationMs(group.totals.activeTimeMs)} completed-run time, ${formatDurationMs(group.totals.wallTimeMs)} observed in-window wall`
       );
       if (group.totals.totalTokens > 0) {
         lines.push(
@@ -725,6 +859,102 @@ function emptyOperationsTotals(): AgentOperationsDigestGroup['totals'] {
   };
 }
 
+function emptyOperationsInventory(totalBoardTasks: number): AgentOperationsInventory {
+  return {
+    totalBoardTasks,
+    matchingFilters: 0,
+    includedTasks: 0,
+    excludedTasks: 0,
+    excludedBy: {
+      filterMismatch: 0,
+      status: 0,
+      timeWindow: 0,
+      missingSourceMetadata: 0,
+    },
+    sourceLinks: {
+      includedTasks: [],
+      excludedBy: {
+        filterMismatch: [],
+        status: [],
+        timeWindow: [],
+        missingSourceMetadata: [],
+      },
+    },
+  };
+}
+
+function recordInventoryExclusion(
+  inventory: AgentOperationsInventory,
+  reason: AgentOperationsExclusionReason,
+  task: AgentOperationsSourceLink
+) {
+  inventory.excludedTasks++;
+  inventory.excludedBy[reason]++;
+  pushUnique(inventory.sourceLinks.excludedBy[reason], task);
+}
+
+function taskInventoryInclusion(
+  task: Task,
+  period: AgentOperationsDigest['period']
+): 'included' | 'status' | 'timeWindow' {
+  if (task.status === 'in-progress' || task.status === 'blocked') return 'included';
+  if (task.status === 'done') {
+    return inPeriod(task.updated, period.start, period.end) ? 'included' : 'timeWindow';
+  }
+  return 'status';
+}
+
+function missingRequiredOperationsMetadata(
+  candidate: { project?: string; repo?: string; cwd?: string },
+  filters: AgentOperationsDigestOptions
+): boolean {
+  return Boolean(
+    (filters.project && !normalizeOptionalFilter(candidate.project)) ||
+    (filters.repo && !normalizeOptionalFilter(candidate.repo)) ||
+    (filters.cwd && !normalizeOptionalFilter(candidate.cwd))
+  );
+}
+
+function recordTaskDataQuality(
+  task: Task,
+  taskLink: AgentOperationsSourceLink,
+  links: {
+    unknownProject: AgentOperationsSourceLink[];
+    unknownRepository: AgentOperationsSourceLink[];
+    missingCwd: AgentOperationsSourceLink[];
+  }
+) {
+  if (!normalizeOptionalFilter(task.project)) pushUnique(links.unknownProject, taskLink);
+  if (!normalizeOptionalFilter(task.git?.repo)) pushUnique(links.unknownRepository, taskLink);
+  if (!normalizeOptionalFilter(task.git?.worktreePath)) pushUnique(links.missingCwd, taskLink);
+}
+
+function operationsDataQualityIssues(links: {
+  unknownProject: AgentOperationsSourceLink[];
+  unknownRepository: AgentOperationsSourceLink[];
+  missingCwd: AgentOperationsSourceLink[];
+}): AgentOperationsDataQualityIssue[] {
+  return [
+    {
+      code: 'unknown-project' as const,
+      label: 'Tasks grouped under unassigned project',
+      sourceLinks: links.unknownProject,
+    },
+    {
+      code: 'unknown-repository' as const,
+      label: 'Tasks grouped under unknown repository',
+      sourceLinks: links.unknownRepository,
+    },
+    {
+      code: 'missing-cwd' as const,
+      label: 'Tasks missing CWD/worktree metadata',
+      sourceLinks: links.missingCwd,
+    },
+  ]
+    .filter((issue) => issue.sourceLinks.length > 0)
+    .map((issue) => ({ ...issue, count: issue.sourceLinks.length }));
+}
+
 function groupHasActivity(group: AgentOperationsDigestGroup): boolean {
   return (
     groupActivityRank(group) > 0 ||
@@ -893,7 +1123,16 @@ function queueMonitorSourceLink(event: QueueMonitorEvent): AgentOperationsQueueM
 }
 
 function inPeriod(timestamp: string, start: string, end: string): boolean {
-  return timestamp >= start && timestamp <= end;
+  const value = Date.parse(timestamp);
+  const periodStart = Date.parse(start);
+  const periodEnd = Date.parse(end);
+  return (
+    Number.isFinite(value) &&
+    Number.isFinite(periodStart) &&
+    Number.isFinite(periodEnd) &&
+    value >= periodStart &&
+    value <= periodEnd
+  );
 }
 
 function positiveNumber(value: number | undefined): number {
@@ -904,6 +1143,10 @@ function isRunSuccess(event: RunTelemetryEvent): boolean {
   return (
     event.success === true || (event as unknown as Record<string, unknown>).status === 'success'
   );
+}
+
+function runIdentity(event: RunTelemetryEvent): string {
+  return event.attemptId ?? event.id;
 }
 
 function observedWallTime(timestamps: number[]): number {

--- a/server/src/services/scheduled-deliverables-runner-service.ts
+++ b/server/src/services/scheduled-deliverables-runner-service.ts
@@ -242,6 +242,15 @@ function operationsDigestMetadata(
     runs: digest.totals.runs,
     openApprovals: digest.totals.openApprovals,
     totalTokens: digest.totals.totalTokens,
+    totalBoardTasks: digest.inventory.totalBoardTasks,
+    matchingFilters: digest.inventory.matchingFilters,
+    includedTasks: digest.inventory.includedTasks,
+    excludedTasks: digest.inventory.excludedTasks,
+    excludedFilterMismatch: digest.inventory.excludedBy.filterMismatch,
+    excludedStatus: digest.inventory.excludedBy.status,
+    excludedTimeWindow: digest.inventory.excludedBy.timeWindow,
+    excludedMissingSourceMetadata: digest.inventory.excludedBy.missingSourceMetadata,
+    dataQualityIssues: digest.dataQuality.length,
     markdownBytes: message.markdown?.length ?? 0,
   };
 }

--- a/web/src/__tests__/operations-digest-mantine.test.tsx
+++ b/web/src/__tests__/operations-digest-mantine.test.tsx
@@ -48,6 +48,82 @@ const digest: AgentOperationsDigest = {
   },
   generatedAt: '2026-06-05T00:01:00.000Z',
   hasActivity: true,
+  filters: {},
+  inventory: {
+    totalBoardTasks: 8,
+    matchingFilters: 6,
+    includedTasks: 4,
+    excludedTasks: 4,
+    excludedBy: {
+      filterMismatch: 2,
+      status: 1,
+      timeWindow: 1,
+      missingSourceMetadata: 0,
+    },
+    sourceLinks: {
+      includedTasks: [
+        {
+          kind: 'task',
+          id: 'task_active',
+          label: 'Active task',
+          taskId: 'task_active',
+        },
+      ],
+      excludedBy: {
+        filterMismatch: [
+          {
+            kind: 'task',
+            id: 'task_other',
+            label: 'Other task',
+            taskId: 'task_other',
+          },
+        ],
+        status: [
+          {
+            kind: 'task',
+            id: 'task_todo',
+            label: 'Todo task',
+            taskId: 'task_todo',
+          },
+        ],
+        timeWindow: [
+          {
+            kind: 'task',
+            id: 'task_old_done',
+            label: 'Old done task',
+            taskId: 'task_old_done',
+          },
+        ],
+        missingSourceMetadata: [],
+      },
+    },
+  },
+  dataQuality: [
+    {
+      code: 'unknown-repository',
+      label: 'Tasks grouped under unknown repository',
+      count: 1,
+      sourceLinks: [
+        {
+          kind: 'task',
+          id: 'task_unknown',
+          label: 'Unknown repository task',
+          taskId: 'task_unknown',
+        },
+      ],
+    },
+  ],
+  semantics: {
+    active: 'Current snapshot active.',
+    blocked: 'Current snapshot blocked.',
+    stuck: 'Current snapshot stuck.',
+    completed: 'Completed inside the window.',
+    failed: 'Failed inside the window.',
+    runs: 'Unique terminal runs.',
+    activeTime: 'Completed run duration.',
+    observedWallTime: 'Signals inside the window.',
+    tokenCost: 'Reported token cost.',
+  },
   totals: {
     active: 1,
     blocked: 1,
@@ -242,6 +318,13 @@ describe('OperationsDigestPage', () => {
     expect(screen.getByText('platform / veritas-kanban / /worktrees/platform')).toBeDefined();
     expect(screen.getByText('Daily Delivery')).toBeDefined();
     expect(screen.getByText('Configured')).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Board Inventory Reconciliation' })).toBeDefined();
+    expect(screen.getByText(/8 total board tasks/)).toBeDefined();
+    expect(screen.getByRole('button', { name: /Outside window: 1/i })).toBeDefined();
+    expect(
+      screen.getByRole('button', { name: /Tasks grouped under unknown repository: 1/i })
+    ).toBeDefined();
+    expect(screen.getByText('Completed in window')).toBeDefined();
     expect(screen.getByTestId('markdown').textContent).toContain('Agent Operations Digest');
     expect(container.querySelectorAll('.mantine-Button-root').length).toBeGreaterThan(4);
     expect(container.querySelector('[data-slot="button"]')).toBeNull();

--- a/web/src/components/digest/OperationsDigestPage.tsx
+++ b/web/src/components/digest/OperationsDigestPage.tsx
@@ -308,12 +308,39 @@ export function OperationsDigestPage({ onBack, onTaskClick }: OperationsDigestPa
         </Alert>
       ) : null}
 
+      {digest ? <InventoryReconciliation digest={digest} onOpenSources={openSources} /> : null}
+
       <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
-        <Metric label="Active" value={digest?.totals.active} tone="green" />
-        <Metric label="Blocked" value={digest?.totals.blocked} tone="orange" />
-        <Metric label="Stuck" value={digest?.totals.stuck} tone="yellow" />
-        <Metric label="Completed" value={digest?.totals.completed} tone="blue" />
-        <Metric label="Failed" value={digest?.totals.failed} tone="red" />
+        <Metric
+          label="Active now"
+          value={digest?.totals.active}
+          tone="green"
+          description={digest?.semantics.active}
+        />
+        <Metric
+          label="Blocked now"
+          value={digest?.totals.blocked}
+          tone="orange"
+          description={digest?.semantics.blocked}
+        />
+        <Metric
+          label="Stuck now"
+          value={digest?.totals.stuck}
+          tone="yellow"
+          description={digest?.semantics.stuck}
+        />
+        <Metric
+          label="Completed in window"
+          value={digest?.totals.completed}
+          tone="blue"
+          description={digest?.semantics.completed}
+        />
+        <Metric
+          label="Failed in window"
+          value={digest?.totals.failed}
+          tone="red"
+          description={digest?.semantics.failed}
+        />
         <Metric label="Open approvals" value={digest?.totals.openApprovals} tone="violet" />
       </section>
 
@@ -463,17 +490,100 @@ function Metric({
   label,
   value,
   tone,
+  description,
 }: {
   label: string;
   value?: number;
   tone: 'green' | 'orange' | 'yellow' | 'blue' | 'red' | 'violet';
+  description?: string;
 }) {
   return (
-    <div className="rounded-lg border bg-card p-4">
+    <div className="rounded-lg border bg-card p-4" title={description}>
       <div className="text-sm text-muted-foreground">{label}</div>
       <div className="mt-2 text-2xl font-semibold tabular-nums">{formatNumber(value ?? 0)}</div>
       <div className={cn('mt-3 h-1 rounded-full', toneClass(tone))} />
     </div>
+  );
+}
+
+function InventoryReconciliation({
+  digest,
+  onOpenSources,
+}: {
+  digest: AgentOperationsDigest;
+  onOpenSources: (items: AgentOperationsSourceLink[]) => void;
+}) {
+  const inventory = digest.inventory;
+  return (
+    <section className="rounded-lg border bg-card p-4" aria-labelledby="inventory-heading">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 id="inventory-heading" className="text-lg font-semibold">
+            Board Inventory Reconciliation
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {formatNumber(inventory.totalBoardTasks)} total board tasks,{' '}
+            {formatNumber(inventory.matchingFilters)} match the selected source filters,{' '}
+            {formatNumber(inventory.includedTasks)} included and{' '}
+            {formatNumber(inventory.excludedTasks)} excluded.
+          </p>
+        </div>
+        <Group gap="xs" wrap="wrap">
+          <SourceButton
+            label="Included"
+            count={inventory.includedTasks}
+            items={inventory.sourceLinks.includedTasks}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Filter mismatch"
+            count={inventory.excludedBy.filterMismatch}
+            items={inventory.sourceLinks.excludedBy.filterMismatch}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Status"
+            count={inventory.excludedBy.status}
+            items={inventory.sourceLinks.excludedBy.status}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Outside window"
+            count={inventory.excludedBy.timeWindow}
+            items={inventory.sourceLinks.excludedBy.timeWindow}
+            onOpenSources={onOpenSources}
+          />
+          <SourceButton
+            label="Missing metadata"
+            count={inventory.excludedBy.missingSourceMetadata}
+            items={inventory.sourceLinks.excludedBy.missingSourceMetadata}
+            onOpenSources={onOpenSources}
+          />
+        </Group>
+      </div>
+
+      {digest.dataQuality.length > 0 ? (
+        <Alert
+          mt="md"
+          color="yellow"
+          variant="light"
+          icon={<AlertTriangle className="h-4 w-4" />}
+          title="Source metadata needs attention"
+        >
+          <Group gap="xs" wrap="wrap">
+            {digest.dataQuality.map((issue) => (
+              <SourceButton
+                key={issue.code}
+                label={issue.label}
+                count={issue.count}
+                items={issue.sourceLinks}
+                onOpenSources={onOpenSources}
+              />
+            ))}
+          </Group>
+        </Alert>
+      ) : null}
+    </section>
   );
 }
 
@@ -493,9 +603,9 @@ function DigestGroupCard({
         <div className="min-w-0">
           <h3 className="truncate text-base font-semibold">{heading}</h3>
           <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
-            <span>{formatNumber(totals.runs)} runs</span>
-            <span>{formatDuration(totals.activeTimeMs)} active</span>
-            <span>{formatDuration(totals.wallTimeMs)} observed</span>
+            <span>{formatNumber(totals.runs)} windowed runs</span>
+            <span>{formatDuration(totals.activeTimeMs)} run time</span>
+            <span>{formatDuration(totals.wallTimeMs)} observed in window</span>
             <span>{formatNumber(totals.totalTokens)} tokens</span>
             <span>${totals.tokenCost.toFixed(4)}</span>
           </div>
@@ -712,6 +822,15 @@ function digestSnapshotMetadata(
     runs: digest.totals.runs,
     totalTokens: digest.totals.totalTokens,
     tokenCost: digest.totals.tokenCost,
+    totalBoardTasks: digest.inventory.totalBoardTasks,
+    matchingFilters: digest.inventory.matchingFilters,
+    includedTasks: digest.inventory.includedTasks,
+    excludedTasks: digest.inventory.excludedTasks,
+    excludedFilterMismatch: digest.inventory.excludedBy.filterMismatch,
+    excludedStatus: digest.inventory.excludedBy.status,
+    excludedTimeWindow: digest.inventory.excludedBy.timeWindow,
+    excludedMissingSourceMetadata: digest.inventory.excludedBy.missingSourceMetadata,
+    dataQualityIssues: digest.dataQuality.length,
     project: filters.project ?? null,
     repo: filters.repo ?? null,
     cwd: filters.cwd ?? null,

--- a/web/src/lib/api/digest.ts
+++ b/web/src/lib/api/digest.ts
@@ -75,6 +75,39 @@ export interface AgentOperationsDigest {
   };
   generatedAt: string;
   hasActivity: boolean;
+  filters: {
+    project?: string;
+    repo?: string;
+    cwd?: string;
+  };
+  inventory: {
+    totalBoardTasks: number;
+    matchingFilters: number;
+    includedTasks: number;
+    excludedTasks: number;
+    excludedBy: Record<AgentOperationsExclusionReason, number>;
+    sourceLinks: {
+      includedTasks: AgentOperationsSourceLink[];
+      excludedBy: Record<AgentOperationsExclusionReason, AgentOperationsSourceLink[]>;
+    };
+  };
+  dataQuality: Array<{
+    code: 'unknown-project' | 'unknown-repository' | 'missing-cwd';
+    label: string;
+    count: number;
+    sourceLinks: AgentOperationsSourceLink[];
+  }>;
+  semantics: {
+    active: string;
+    blocked: string;
+    stuck: string;
+    completed: string;
+    failed: string;
+    runs: string;
+    activeTime: string;
+    observedWallTime: string;
+    tokenCost: string;
+  };
   groups: AgentOperationsDigestGroup[];
   totals: AgentOperationsDigestGroup['totals'] & {
     openApprovals: number;
@@ -86,6 +119,9 @@ export interface AgentOperationsDigest {
     narrative: 'deterministic-only';
   };
 }
+
+export type AgentOperationsExclusionReason =
+  'filterMismatch' | 'status' | 'timeWindow' | 'missingSourceMetadata';
 
 export interface AgentOperationsMarkdown {
   isEmpty: boolean;


### PR DESCRIPTION
## Summary
- reconcile every board task as included or excluded for one explicit reason, with source IDs for drill-down
- distinguish current active, blocked, and stuck state from windowed completions, runs, tokens, and observed wall time
- bound observed wall time to the selected window, deduplicate terminal runs, and surface unknown metadata as data-quality findings
- use the same normalized filters and reconciliation contract in JSON, Markdown, scheduled snapshots, and the UI

## Verification
- `pnpm exec vitest run server/src/__tests__/digest-service.test.ts server/src/__tests__/scheduled-deliverables-runner-service.test.ts web/src/__tests__/operations-digest-mantine.test.tsx` (26 tests)
- scoped ESLint for changed TypeScript and TSX files
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/web typecheck`

Closes #944