### PR TITLE
fix: remove nested scoring page scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inclusion and exclusion reasons plus metadata quality findings, bounded
   observed wall time to the selected window, and documented current-state
   versus windowed metrics (#944).
+- Removed competing profile-editor and scorer-list scroll containers so Agent
+  Output Scoring uses the application page scrollbar at compact and full
+  desktop sizes (#938).
 
 ## [6.0.0] - 2026-07-24
 

--- a/web/src/__tests__/governance-surfaces-mantine.test.tsx
+++ b/web/src/__tests__/governance-surfaces-mantine.test.tsx
@@ -510,15 +510,17 @@ describe('governance surfaces Mantine migration', () => {
     expectNoLegacySlots(detail.baseElement);
   });
 
-  it('renders scoring profiles and score explorer with Mantine tabs, selects, and scroll areas', async () => {
+  it('renders scoring profiles and score explorer in the page scroll flow', async () => {
     const user = userEvent.setup();
     const { baseElement } = renderWithProviders(<ScoringProfiles onBack={vi.fn()} />);
 
     expect(screen.getByText('Agent Output Scoring')).toBeDefined();
+    expect(screen.getByTestId('scoring-page').className).not.toContain('h-[100dvh]');
+    expect(screen.getByTestId('scoring-profile-detail').className).not.toContain('overflow-y-auto');
+    expect(screen.getByTestId('scoring-scorer-list').className).not.toContain('h-[440px]');
     expect(baseElement.querySelector('.mantine-Tabs-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-TextInput-root')).toBeDefined();
     expect(baseElement.querySelector('.mantine-Textarea-root')).toBeDefined();
-    expect(baseElement.querySelector('.mantine-ScrollArea-root')).toBeDefined();
     expect(screen.queryByText('Composite Score Trend')).toBeNull();
 
     await user.click(screen.getByRole('tab', { name: /score explorer/i }));
@@ -526,6 +528,42 @@ describe('governance surfaces Mantine migration', () => {
     expect(await screen.findByText('Composite Score Trend')).toBeDefined();
     expect(baseElement.querySelectorAll('.mantine-Select-root').length).toBeGreaterThanOrEqual(2);
     expectNoLegacySlots(baseElement);
+  });
+
+  it('keeps every scorer in document flow and allows keyboard focus to reach the last field', async () => {
+    mocks.useScoringProfiles.mockReturnValue({
+      data: [
+        {
+          id: 'long-profile',
+          name: 'Long Profile',
+          description: 'Exercises a profile with many scorer cards.',
+          compositeMethod: 'weightedAvg',
+          builtIn: false,
+          created: now,
+          updated: now,
+          scorers: Array.from({ length: 12 }, (_, index) => ({
+            id: `keyword-${index + 1}`,
+            name: `Keyword check ${index + 1}`,
+            type: 'KeywordContains',
+            keywords: ['verified'],
+            weight: 1,
+            target: 'output',
+          })),
+        },
+      ],
+      isLoading: false,
+    });
+
+    renderWithProviders(<ScoringProfiles onBack={vi.fn()} />);
+
+    const lastScorer = await screen.findByRole('textbox', { name: 'Scorer 12 name' });
+    expect(screen.getAllByRole('textbox', { name: /Scorer \d+ name/ })).toHaveLength(12);
+    expect(screen.getByTestId('scoring-scorer-list').className).not.toMatch(
+      /overflow-y|h-\[440px\]/
+    );
+
+    lastScorer.focus();
+    expect(document.activeElement).toBe(lastScorer);
   });
 
   it('opens and cancels a focused scoring profile draft from Score Explorer', async () => {

--- a/web/src/components/scoring/ScoringProfiles.tsx
+++ b/web/src/components/scoring/ScoringProfiles.tsx
@@ -11,7 +11,6 @@ import {
   ActionIcon,
   Badge,
   Button,
-  ScrollArea,
   Select,
   Tabs,
   Textarea,
@@ -347,7 +346,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
   };
 
   return (
-    <div className="flex h-[100dvh] min-h-0 flex-col gap-4 bg-background">
+    <div data-testid="scoring-page" className="flex min-h-full flex-col gap-4 bg-background">
       <div className="border-b bg-card px-3 py-4 sm:px-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-3">
@@ -400,12 +399,12 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden px-3 pb-3 sm:px-6 sm:pb-6">
+      <div className="flex-1 px-3 pb-3 sm:px-6 sm:pb-6">
         <Tabs
           value={activeTab}
           onChange={handleTabChange}
           keepMounted={false}
-          className="flex h-full flex-col gap-4"
+          className="flex flex-col gap-4"
         >
           <Tabs.List className="w-full sm:w-fit">
             <Tabs.Tab h={48} value="profiles">
@@ -416,7 +415,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
             </Tabs.Tab>
           </Tabs.List>
 
-          <Tabs.Panel value="profiles" className="m-0 flex min-h-0 min-w-0 flex-1 gap-4">
+          <Tabs.Panel value="profiles" className="m-0 flex min-w-0 items-start gap-4">
             <div
               data-testid="scoring-profile-list"
               className={`${
@@ -429,7 +428,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                   Built-ins are read-only. Duplicate them to customize.
                 </div>
               </div>
-              <ScrollArea className="flex-1">
+              <div>
                 <div className="divide-y">
                   {isLoading ? (
                     <div className="p-4 text-sm text-muted-foreground">Loading profiles…</div>
@@ -469,14 +468,14 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                     ))
                   )}
                 </div>
-              </ScrollArea>
+              </div>
             </div>
 
             <div
               data-testid="scoring-profile-detail"
               className={`${
                 mobileView === 'list' ? 'hidden md:flex' : 'flex'
-              } w-full min-w-0 flex-1 flex-col gap-4 overflow-x-hidden overflow-y-auto`}
+              } w-full min-w-0 flex-1 flex-col gap-4 overflow-x-hidden`}
             >
               <div data-testid="scoring-mobile-back" className="md:hidden">
                 <Button h={48} variant="subtle" onClick={handleBackToProfiles}>
@@ -602,7 +601,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                       </Button>
                     </div>
 
-                    <ScrollArea className="h-[440px] rounded-md border">
+                    <div data-testid="scoring-scorer-list" className="rounded-md border">
                       <div className="space-y-3 p-3">
                         {draft.scorers.map((scorer, index) => (
                           <div
@@ -829,7 +828,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
                           </div>
                         ))}
                       </div>
-                    </ScrollArea>
+                    </div>
                   </div>
                 </div>
 
@@ -926,7 +925,7 @@ export function ScoringProfiles({ onBack }: ScoringProfilesProps) {
             </div>
           </Tabs.Panel>
 
-          <Tabs.Panel value="explorer" className="m-0 min-h-0 flex-1 overflow-auto">
+          <Tabs.Panel value="explorer" className="m-0">
             <Suspense
               fallback={
                 <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- let Agent Output Scoring participate in the application page scroll instead of forcing a viewport-height shell
- remove the profile editor and fixed-height scorer-list vertical scroll containers
- keep long scorer profiles in document order so browser focus scrolling reaches every field

## Verification
- `pnpm exec vitest run web/src/__tests__/governance-surfaces-mantine.test.tsx` (7 tests)
- scoped ESLint
- `pnpm --filter @veritas-kanban/web typecheck`

Closes #938