### PR TITLE
fix: report packaged desktop version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded the template editor into a responsive authoring surface with one
   bounded scroll region, fixed actions, a resizable Markdown editor, inline
   validation, and unsaved-change protection (#941).
+- Made first-run setup version-neutral and sourced desktop bridge version
+  reporting from Electron's packaged application metadata (#986).
 
 ## [6.0.0] - 2026-07-24
 

--- a/desktop/src/main/__tests__/bridge-contracts.test.ts
+++ b/desktop/src/main/__tests__/bridge-contracts.test.ts
@@ -93,7 +93,7 @@ function shell(): Shell {
 }
 
 function handlers(): DesktopBridgeHandlerMap {
-  return createDesktopBridgeHandlers(runtime(), shell(), false);
+  return createDesktopBridgeHandlers(runtime(), shell(), false, '6.0.1');
 }
 
 describe('desktop bridge contracts', () => {
@@ -124,12 +124,22 @@ describe('desktop bridge contracts', () => {
       }),
     } as unknown as IpcMain;
 
-    registerDesktopBridge(ipcMain, runtime(), shell(), false);
+    registerDesktopBridge(ipcMain, runtime(), shell(), false, '6.0.1');
 
     expect([...registered.keys()].sort()).toEqual(
       DESKTOP_BRIDGE_METHOD_NAMES.map((method) => DESKTOP_BRIDGE_METHODS[method].channel).sort()
     );
     expect(registered.size).toBe(DESKTOP_BRIDGE_METHOD_NAMES.length);
+  });
+
+  it('reports the Electron application version through the desktop bridge', () => {
+    const bridgeHandlers = createDesktopBridgeHandlers(runtime(), shell(), true, '6.0.1');
+
+    expect(bridgeHandlers.getAppInfo(undefined)).toMatchObject({
+      name: 'Veritas Kanban',
+      version: '6.0.1',
+      packaged: true,
+    });
   });
 
   it('keeps the preload API method list aligned to invoke and event contracts', () => {
@@ -172,7 +182,8 @@ describe('desktop bridge contracts', () => {
     const bridgeHandlers: DesktopBridgeHandlerMap = createDesktopBridgeHandlers(
       runtime(),
       fakeShell,
-      false
+      false,
+      '6.0.1'
     );
 
     await expect(
@@ -193,7 +204,7 @@ describe('desktop bridge contracts', () => {
 
   it('validates restart confirmation before restarting the local server', async () => {
     const fakeRuntime = runtime();
-    const bridgeHandlers = createDesktopBridgeHandlers(fakeRuntime, shell(), false);
+    const bridgeHandlers = createDesktopBridgeHandlers(fakeRuntime, shell(), false, '6.0.1');
 
     expect(() => bridgeHandlers.restartLocalServer({ confirmation: 'restart' } as never)).toThrow(
       'explicit restart confirmation'

--- a/desktop/src/main/bridge.ts
+++ b/desktop/src/main/bridge.ts
@@ -204,6 +204,7 @@ export function createDesktopBridgeHandlers(
   runtime: DesktopRuntime,
   shell: Shell,
   packaged: boolean,
+  appVersion: string,
   commandDispatcher?: DesktopCommandDispatcher,
   updateService?: DesktopUpdateService,
   windowControls?: DesktopWindowControls
@@ -211,7 +212,7 @@ export function createDesktopBridgeHandlers(
   const appInfo = (): DesktopAppInfo => ({
     name: DESKTOP_APP_NAME,
     appId: DESKTOP_APP_ID,
-    version: process.env.npm_package_version || '0.0.0',
+    version: appVersion,
     platform: process.platform,
     packaged,
   });
@@ -304,6 +305,7 @@ export function registerDesktopBridge(
   runtime: DesktopRuntime,
   shell: Shell,
   packaged: boolean,
+  appVersion: string,
   commandDispatcher?: DesktopCommandDispatcher,
   updateService?: DesktopUpdateService,
   windowControls?: DesktopWindowControls
@@ -312,6 +314,7 @@ export function registerDesktopBridge(
     runtime,
     shell,
     packaged,
+    appVersion,
     commandDispatcher,
     updateService,
     windowControls

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -309,20 +309,29 @@ async function boot(): Promise<void> {
     },
   });
 
-  registerDesktopBridge(ipcMain, runtime, shell, packaged, commandDispatcher, updateService, {
-    toggleMaximize: () => {
-      const window = activeMainWindow();
-      if (!window) {
-        return { maximized: false };
-      }
-      if (window.isMaximized()) {
-        window.unmaximize();
-      } else {
-        window.maximize();
-      }
-      return { maximized: window.isMaximized() };
-    },
-  });
+  registerDesktopBridge(
+    ipcMain,
+    runtime,
+    shell,
+    packaged,
+    app.getVersion(),
+    commandDispatcher,
+    updateService,
+    {
+      toggleMaximize: () => {
+        const window = activeMainWindow();
+        if (!window) {
+          return { maximized: false };
+        }
+        if (window.isMaximized()) {
+          window.unmaximize();
+        } else {
+          window.maximize();
+        }
+        return { maximized: window.isMaximized() };
+      },
+    }
+  );
   refreshDesktopMenu();
   runtime.on('status', (status) => {
     activeMainWindow()?.webContents.send(DESKTOP_BRIDGE_EVENTS.serverStatus.channel, status);

--- a/web/src/__tests__/desktop-onboarding.test.tsx
+++ b/web/src/__tests__/desktop-onboarding.test.tsx
@@ -57,6 +57,8 @@ describe('desktop onboarding', () => {
     );
 
     expect(await screen.findByText('Choose setup path')).toBeDefined();
+    expect(screen.getByText('Desktop Setup')).toBeDefined();
+    expect(screen.queryByText('v5 Desktop Setup')).toBeNull();
     expect(screen.getByTestId('setup-mode-board').getAttribute('aria-pressed')).toBe('true');
     fireEvent.click(screen.getByTestId('setup-mode-board'));
     fireEvent.click(screen.getByRole('button', { name: 'Continue to Password' }));

--- a/web/src/components/auth/DesktopOnboarding.tsx
+++ b/web/src/components/auth/DesktopOnboarding.tsx
@@ -375,7 +375,7 @@ export function DesktopOnboardingPanel({
       <section className="min-w-0 space-y-5">
         <div className="space-y-3">
           <Badge variant="outline" color="cyan" tt="none">
-            v5 Desktop Setup
+            Desktop Setup
           </Badge>
           <div className="space-y-2">
             <h1


### PR DESCRIPTION
## Summary
- pass Electron `app.getVersion()` into the desktop bridge as the authoritative packaged version
- remove the npm environment fallback that reported `0.0.0` in packaged builds
- make the first-run Desktop Setup badge version-neutral

## Verification
- `pnpm --dir desktop exec vitest run src/main/__tests__/bridge-contracts.test.ts` (17 tests)
- `pnpm exec vitest run web/src/__tests__/desktop-onboarding.test.tsx` (6 tests)
- scoped ESLint
- desktop and web typechecks

The final 6.0.1 packaged smoke will compare bundle metadata, health, updater metadata, and the bridge together.

Closes #986