### PR TITLE
chore: prepare v6.0.1 stable release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 > read this file first. Harness-specific supplements (e.g. `CLAUDE.md`) extend, never duplicate
 > or contradict, these rules.
 >
-> **Version:** 6.0.0
+> **Version:** 6.0.1
 > **Freshness policy:** update within two working days of any toolchain or architecture change.
 > Stale fields (package manager, Node version, provider list, test commands) are caught by
 > `pnpm check:pnpm-settings` and the smoke-test CI job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1] - 2026-07-24
+
+Veritas Kanban 6.0.1 is the first supported stable v6 release. It supersedes
+the quarantined 6.0.0 prerelease after closing the post-publication desktop and
+workflow stabilization backlog tracked in #924.
+
 ### Fixed
 
 - Kept desktop Chat in a bounded, reversible workbench panel; Escape and browser
@@ -43,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reporting from Electron's packaged application metadata (#986).
 
 ## [6.0.0] - 2026-07-24
+
+> Quarantined prerelease. Use 6.0.1 or newer. The 6.0.0 artifacts remain
+> available only for investigation and historical release evidence.
 
 Each release entry below names its tracking issue. The complete issue-to-pull
 request mapping, including multi-PR fixes and release engineering, is retained
@@ -2203,7 +2212,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v6.0.0...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v6.0.1...HEAD
+[6.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v6.0.0...v6.0.1
 [6.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.5...v6.0.0
 [5.2.5]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.4...v5.2.5
 [5.2.4]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.3...v5.2.4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-6.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.0.1-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,7 +1,7 @@
 # Veritas Kanban — API Reference
 
-**Version**: 6.0.0
-**Last Updated**: 2026-07-23
+**Version**: 6.0.1
+**Last Updated**: 2026-07-24
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)
 
@@ -1463,7 +1463,7 @@ POST /api/run-sessions/run_share_abc/approvals
   "note": "Use the release branch.",
   "responseData": {
     "answers": {
-      "branch": { "answers": ["release/6.0.0"] }
+      "branch": { "answers": ["release/v6.0.1"] }
     }
   }
 }

--- a/docs/DOC-FRESHNESS.md
+++ b/docs/DOC-FRESHNESS.md
@@ -58,6 +58,7 @@ When a doc is older than the current version, it may need review.
 
 | Date       | Scope                                                               | Agent   |
 | ---------- | ------------------------------------------------------------------- | ------- |
+| 2026-07-24 | v6.0.1 stabilization, release, upgrade, API, MCP, and evidence      | Release |
 | 2026-07-24 | v6.0.0 harness, Buzz, release, upgrade, compatibility, and evidence | Release |
 | 2026-07-12 | v5.2.2 UI-audit fixes, release gates, desktop state, and evidence   | Release |
 | 2026-06-05 | v5.0.0 stable release docs, install paths, release assets, RC notes | Codex   |

--- a/docs/V6-COMPATIBILITY-AND-RELEASE-POLICY.md
+++ b/docs/V6-COMPATIBILITY-AND-RELEASE-POLICY.md
@@ -1,11 +1,11 @@
 # Veritas Kanban v6 Compatibility And Release Policy
 
-This policy defines supported v6.0.0 combinations, harness evidence, release
+This policy defines supported v6.0.1 combinations, harness evidence, release
 channels, and rollback limits. The machine-readable harness record at
 `GET /api/config/harness-compatibility` is authoritative for exact capability
 digests, fixture revisions, and the current host's live state.
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
 
 ## Harness Support Tiers
 
@@ -25,7 +25,7 @@ are incompatible with v6.
 
 | Component                              | Supported v6 combination                                                                    | Detection/evidence                                                                                      | Fail-closed boundary                                                                                                            |
 | -------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Server, web, shared, CLI, MCP, desktop | All release packages are exactly 6.0.0.                                                     | Package manifests, `/api/health.version`, `vk --version`, MCP metadata, desktop bundle/update metadata. | Mixed release packages are unsupported for publication.                                                                         |
+| Server, web, shared, CLI, MCP, desktop | All release packages are exactly 6.0.1.                                                     | Package manifests, `/api/health.version`, `vk --version`, MCP metadata, desktop bundle/update metadata. | Mixed release packages are unsupported for publication.                                                                         |
 | Public API                             | REST API remains `v1` at `/api/v1`, with `/api` compatibility aliases where documented.     | `X-API-Version`, OpenAPI/reference docs, CLI/MCP smoke.                                                 | Unknown API versions or incompatible auth fail before mutation.                                                                 |
 | Buzz Agent                             | Buzz v0.4.24 commit `710ed9fff57878a1d69f809b80a6ee0416c53fc4`; `buzz-agent 0.1.0`; ACP v1. | Exact initialize identity, capability digest, probe revision, composed Buzz fixtures.                   | Unknown build, `buzz-acp`, resume, HTTP/SSE MCP, or capability drift blocks.                                                    |
 | Buzz relay integration                 | Buzz v0.4.24; NIP-11, NIP-29, NIP-42; optional NIP-43 membership.                           | Pinned relay compatibility evidence, signed query/event fixtures, mapping state.                        | Host/TLS drift, unsafe URL, bad signature, identity mismatch, replay, or disabled mapping blocks.                               |
@@ -37,7 +37,7 @@ are incompatible with v6.
 | GitHub Copilot CLI                     | v1.0.74 public-preview ACP; tag commit `2b809c84e87dbcc88f897cb4f3fb97c43b77af95`.          | Version and ACP initialize handshake; authentication remains provider-managed.                          | Version drift, broad allow, remote/plugin/config injection, or unsupported controls blocks.                                     |
 | Hermes Agent                           | v2026.7.7.2 one-shot process adapter.                                                       | `hermes --version` and allowlisted boot authentication.                                                 | Resume/follow-up remains unsupported.                                                                                           |
 | OpenClaw                               | v2026.6.11 gateway adapter.                                                                 | Gateway health, runtime manifest, explicit operator tool policy.                                        | Missing `sessions_spawn`/`sessions_send`, unknown evidence, or unsupported task controls blocks.                                |
-| macOS desktop                          | macOS arm64 signed/notarized app with bundled 6.0.0 server/web.                             | Bundle version, signature, Gatekeeper, stapling, `/api/health.version`, update metadata.                | Mixed bundle/runtime, failed readiness, signature, or metadata checks blocks stable publication.                                |
+| macOS desktop                          | macOS arm64 signed/notarized app with bundled 6.0.1 server/web.                             | Bundle version, signature, Gatekeeper, stapling, `/api/health.version`, update metadata.                | Mixed bundle/runtime, failed readiness, signature, or metadata checks blocks stable publication.                                |
 | Linux/Windows desktop                  | Unsigned preview artifacts only.                                                            | Cross-platform packaging workflows.                                                                     | Not a supported stable install or update channel.                                                                               |
 | Desktop SQLite/profile                 | Existing v5.2.5 workspace upgraded in place after a complete backup.                        | Data/profile counts, integrity check, startup normalization, board/runtime smoke.                       | Competing writers, unsafe filesystem, failed migration, or missing recovery evidence blocks acceptance.                         |
 
@@ -73,7 +73,7 @@ Provider-specific opt-in smoke commands are documented in
 - Required filesystem, process, environment, network, MCP, tool, approval,
   budget, and lifecycle controls must be supported by current runtime evidence.
   Advisory controls may proceed with an attributed warning.
-- The fine-grained egress gateway in issue 855 is deferred. v6.0.0 does not
+- The fine-grained egress gateway in issue 855 is deferred. v6.0.1 does not
   claim method/path/domain proxy enforcement that it does not have.
 
 ## Release Channels

--- a/docs/V6-GA-CHECKLIST.md
+++ b/docs/V6-GA-CHECKLIST.md
@@ -1,10 +1,10 @@
 # Veritas Kanban v6 GA Checklist
 
-This checklist is the stable-release gate for Veritas Kanban 6.0.0. Command
+This checklist is the stable-release gate for Veritas Kanban 6.0.1. Command
 results, platform details, workflow links, limitations, and artifact hashes
 belong in [v6 Release Candidate Evidence Packet](V6-RC-EVIDENCE-PACKET.md).
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
 
 ## Source And Scope
 
@@ -14,11 +14,29 @@ Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0.
       through merged, focused pull requests.
 - [ ] The release tracker lists the exact main baseline, release branch, release
       PR, deferred v6.x work, and no unresolved release blocker.
-- [x] Root, shared, server, web, CLI, MCP, and desktop manifests are 6.0.0.
+- [x] Root, shared, server, web, CLI, MCP, and desktop manifests are 6.0.1.
 - [x] `AGENTS.md`, README badge, health, CLI, MCP, desktop bundle, artifact
-      names, updater metadata, changelog, and current docs agree on 6.0.0.
+      names, updater metadata, changelog, and current docs agree on 6.0.1.
 - [x] The public API remains intentionally `v1`, with additive v6 contracts and
       tested CLI/MCP compatibility.
+
+## 6.0.1 Stabilization
+
+- [x] Task drawers, shared overlays, Archive cards, scoring profiles, and
+      template authoring have focused scroll, resize, compact-window, and
+      keyboard coverage (#935, #938, #939, #941).
+- [x] Workflow loading, route/task/overlay history, and scoring-profile
+      creation have focused recovery and state-transition coverage
+      (#936, #937, #943).
+- [x] Operations Digest inventory, filters, exclusions, source IDs, window
+      semantics, run de-duplication, and data quality reconcile in JSON,
+      Markdown, scheduled snapshots, and UI tests (#944).
+- [x] Chat has visible, Escape, browser Back, persisted-state, compact-window,
+      and native menu recovery coverage; signed-app validation remains a
+      publication gate (#945).
+- [x] Desktop setup is version-neutral and the bridge consumes Electron's
+      application version; bundle, health, updater, and bridge equality remains
+      a signed-app publication gate (#986).
 
 ## Provider Certification
 
@@ -132,8 +150,8 @@ pnpm desktop:build
 pnpm desktop:check:electron-artifacts
 pnpm desktop:smoke:mac:local
 pnpm desktop:package:mac:unsigned
-pnpm validate:release -- --version 6.0.0
-pnpm validate:release -- --version 6.0.0 --docker-build
+pnpm validate:release -- --version 6.0.1
+pnpm validate:release -- --version 6.0.1 --docker-build
 ```
 
 Provider-specific deterministic suites are part of `pnpm test:unit`; record
@@ -143,25 +161,26 @@ quota are available.
 
 ## Distribution And Post-Publication
 
-- [x] The ready release PR passes required CI and the `ci:full` workspace suite,
+- [ ] The ready release PR passes required CI and the `ci:full` workspace suite,
       receives focused standards/spec review, and merges to main.
-- [x] Annotated tag `v6.0.0` peels to the exact release merge commit.
-- [x] The GitHub release is published from reviewed v6 release notes.
-- [x] Desktop Release completes with signed/notarized arm64 DMG and ZIP,
+- [ ] Annotated tag `v6.0.1` peels to the exact release merge commit.
+- [ ] The GitHub release is published from reviewed v6 release notes.
+- [ ] Desktop Release completes with signed/notarized arm64 DMG and ZIP,
       blockmaps, `latest-mac.yml`, and SHA-256 sidecars.
-- [x] Independent downloads match GitHub digests, sidecars, updater metadata,
+- [ ] Independent downloads match GitHub digests, sidecars, updater metadata,
       byte sizes, and SHA-256 values.
-- [x] DMG and ZIP app signatures, hardened runtime, Gatekeeper, and notarization
+- [ ] DMG and ZIP app signatures, hardened runtime, Gatekeeper, and notarization
       stapling pass.
-- [x] The downloaded signed app launches with an isolated profile, reports
-      6.0.0, verifies provider support, checks updates, executes a bounded task,
+- [ ] The downloaded signed app launches with an isolated profile, reports
+      6.0.1 through bundle, health, updater, and desktop bridge metadata,
+      verifies Chat recovery, executes a bounded task,
       and quits cleanly.
-- [x] `pnpm validate:release -- --version 6.0.0 --github --repo BradGroux/veritas-kanban`
+- [ ] `pnpm validate:release -- --version 6.0.1 --github --repo BradGroux/veritas-kanban`
       passes.
-- [x] The Homebrew cask PR uses the published ZIP checksum, merges, and the
+- [ ] The Homebrew cask PR uses the published ZIP checksum, merges, and the
       registered tap passes style, strict online audit, dry-run install, and
       livecheck.
-- [x] The evidence packet contains release/workflow/asset/Homebrew links,
+- [ ] The evidence packet contains release/workflow/asset/Homebrew links,
       exact hashes, runtime results, limitations, and deferred v6.x issues.
-- [x] The release tracker closes only after every distribution surface above is
+- [ ] The release tracker closes only after every distribution surface above is
       independently verified.

--- a/docs/V6-RC-EVIDENCE-PACKET.md
+++ b/docs/V6-RC-EVIDENCE-PACKET.md
@@ -1,12 +1,44 @@
 # Veritas Kanban v6 Release Candidate Evidence Packet
 
-This packet is the retained evidence target for Veritas Kanban 6.0.0. It
-separates merged implementation, deterministic conformance, live provider
-evidence, local runtime proof, signed publication, and Homebrew availability.
+This packet retains the historical evidence for the quarantined Veritas Kanban
+6.0.0 prerelease and records the 6.0.1 stabilization release. It separates
+merged implementation, deterministic conformance, live provider evidence,
+local runtime proof, signed publication, and Homebrew availability.
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0.
+Veritas Kanban 6.0.1 is the first supported stable v6 release. Do not use
+6.0.0 for installation or upgrade validation.
 
-## Release Scope
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
+
+## 6.0.1 Stabilization Candidate
+
+| Field                  | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Release version        | 6.0.1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Stabilization tracker  | [#924](https://github.com/BradGroux/veritas-kanban/issues/924)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Source branch          | `release/v6.0.1`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Superseded publication | [`v6.0.0`](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.0), retained as a quarantined prerelease                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Stabilization issues   | [#935](https://github.com/BradGroux/veritas-kanban/issues/935), [#936](https://github.com/BradGroux/veritas-kanban/issues/936), [#937](https://github.com/BradGroux/veritas-kanban/issues/937), [#938](https://github.com/BradGroux/veritas-kanban/issues/938), [#939](https://github.com/BradGroux/veritas-kanban/issues/939), [#941](https://github.com/BradGroux/veritas-kanban/issues/941), [#943](https://github.com/BradGroux/veritas-kanban/issues/943), [#944](https://github.com/BradGroux/veritas-kanban/issues/944), [#945](https://github.com/BradGroux/veritas-kanban/issues/945), and [#986](https://github.com/BradGroux/veritas-kanban/issues/986) |
+| Source verification    | Focused tests plus changed-file CI per issue; one full workspace suite is reserved for the release PR                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Signed runtime gate    | Exact 6.0.1 equality across bundle, health, updater, and desktop bridge metadata; Chat recovery; bounded task; clean quit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Distribution gate      | Signed/notarized DMG and ZIP, updater metadata, independent checksums, GitHub release validation, and verified Homebrew cask                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+
+### Stabilization issue traceability
+
+| Issue                                                          | Pull request                                                 | Outcome                                                                                                      |
+| -------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| [#935](https://github.com/BradGroux/veritas-kanban/issues/935) | [#992](https://github.com/BradGroux/veritas-kanban/pull/992) | Task drawers and shared overlays remain usable at compact heights                                            |
+| [#936](https://github.com/BradGroux/veritas-kanban/issues/936) | [#989](https://github.com/BradGroux/veritas-kanban/pull/989) | Workflow actions normalize omitted collections and surface recoverable failures                              |
+| [#937](https://github.com/BradGroux/veritas-kanban/issues/937) | [#993](https://github.com/BradGroux/veritas-kanban/pull/993) | Navigation and nested overlays preserve the actual route origin and scroll state                             |
+| [#938](https://github.com/BradGroux/veritas-kanban/issues/938) | [#995](https://github.com/BradGroux/veritas-kanban/pull/995) | Scoring profile content has intentional nested scroll ownership                                              |
+| [#939](https://github.com/BradGroux/veritas-kanban/issues/939) | [#991](https://github.com/BradGroux/veritas-kanban/pull/991) | Archive cards and layout remain reachable at compact sizes                                                   |
+| [#941](https://github.com/BradGroux/veritas-kanban/issues/941) | [#996](https://github.com/BradGroux/veritas-kanban/pull/996) | Template editing is a complete visible authoring flow                                                        |
+| [#943](https://github.com/BradGroux/veritas-kanban/issues/943) | [#990](https://github.com/BradGroux/veritas-kanban/pull/990) | New scoring profiles open as visible validated drafts                                                        |
+| [#944](https://github.com/BradGroux/veritas-kanban/issues/944) | [#994](https://github.com/BradGroux/veritas-kanban/pull/994) | Operations Digest reconciles current state, windowed events, exclusions, and source evidence                 |
+| [#945](https://github.com/BradGroux/veritas-kanban/issues/945) | [#988](https://github.com/BradGroux/veritas-kanban/pull/988) | Chat has visible, keyboard, browser-history, persisted-state, compact-window, and native-menu recovery paths |
+| [#986](https://github.com/BradGroux/veritas-kanban/issues/986) | [#997](https://github.com/BradGroux/veritas-kanban/pull/997) | Desktop setup is version-neutral and the bridge consumes Electron's application version                      |
+
+## Historical 6.0.0 Release Scope
 
 | Field                    | Value                                                                                                                                     |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -215,7 +247,21 @@ test.
 No private data, credential value, raw provider conversation, or unrestricted
 runtime profile is retained in this packet.
 
-## Publication Evidence
+## 6.0.1 Publication Evidence
+
+Publication evidence remains incomplete until the release PR merges, the
+annotated tag is pushed, the signed desktop workflow succeeds, independent
+artifact inspection passes, and the Homebrew cask is restored to 6.0.1.
+
+| Publication item                                      | Result                                                             |
+| ----------------------------------------------------- | ------------------------------------------------------------------ |
+| Release merge SHA                                     | Pending release PR                                                 |
+| Annotated `v6.0.1` tag and GitHub release             | Pending release PR                                                 |
+| Signed/notarized macOS artifacts and updater metadata | Pending tag-triggered workflow                                     |
+| Downloaded signed-app isolated launch                 | Pending exact-version and Chat recovery smoke                      |
+| Homebrew cask                                         | Intentionally held at 5.2.5 until signed 6.0.1 verification passes |
+
+## Historical 6.0.0 Publication Evidence
 
 Source publication completed from reviewed release PR #985. The tag-triggered
 workflow, independent artifact verification, signed-app runtime check, and
@@ -248,9 +294,9 @@ and Homebrew availability are independent gates.
 - Buzz Agent does not resume in-memory sessions; Buzz communication does not
   project files, reactions, forums, DMs, or destructive edit/delete behavior.
 - [Packaged desktop version reporting](https://github.com/BradGroux/veritas-kanban/issues/986)
-  is a v6.0.1 follow-up: health, updater, and bundle metadata report 6.0.0,
-  while the first-run heading retains `v5` wording and the desktop bridge
-  reports `0.0.0`.
+  is fixed in the 6.0.1 source candidate. Exact equality across the downloaded
+  bundle, health endpoint, updater metadata, and desktop bridge remains a
+  signed-publication gate.
 - Linux and Windows desktop packages remain unsigned previews.
 - Provider and Buzz Settings screenshots were captured from the isolated
   profile. No public-safe active approval existed, so approval visual evidence

--- a/docs/V6-RELEASE-NOTES.md
+++ b/docs/V6-RELEASE-NOTES.md
@@ -1,12 +1,17 @@
 # Veritas Kanban v6 Release Notes
 
-Veritas Kanban 6.0.0 makes agent runtimes explicit, evidence-backed, and
-fail-closed. It adds first-class Buzz integration and puts Grok Build, OpenAI
-Codex, Claude Code, and GitHub Copilot CLI behind the same provider-neutral run,
-approval, credential, tool, worktree, event, and completion contracts.
+Veritas Kanban 6.0.1 is the first supported stable v6 release. It makes agent
+runtimes explicit, evidence-backed, and fail-closed, adds first-class Buzz
+integration, and puts Grok Build, OpenAI Codex, Claude Code, and GitHub Copilot
+CLI behind the same provider-neutral run, approval, credential, tool, worktree,
+event, and completion contracts.
+
+The 6.0.0 publication is retained as a quarantined prerelease after unresolved
+desktop and workflow issues were found in the live backlog. Install 6.0.1 or
+newer.
 
 - Release tracker:
-  [Veritas Kanban 6.0.0 harness parity and Buzz integration](https://github.com/BradGroux/veritas-kanban/issues/924)
+  [Stabilize Veritas Kanban 6.0.1 after quarantined 6.0.0](https://github.com/BradGroux/veritas-kanban/issues/924)
 - Buzz epic:
   [First-class Buzz integration](https://github.com/BradGroux/veritas-kanban/issues/904)
 - Harness epic:
@@ -15,7 +20,7 @@ approval, credential, tool, worktree, event, and completion contracts.
 - Versioned architecture:
   [v6 Agent Runtime Control Plane](architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md)
 - Retained validation record: [v6 Release Candidate Evidence Packet](V6-RC-EVIDENCE-PACKET.md)
-- Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0
+- Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1
 
 ## What Changed For Users
 
@@ -38,6 +43,26 @@ approval, credential, tool, worktree, event, and completion contracts.
 - Packaged SQLite startup now defers run-supervisor repository lookup until
   storage is initialized, and the desktop updater refuses older release
   metadata instead of offering a downgrade.
+
+## Stabilization In 6.0.1
+
+- Chat remains a reversible, bounded desktop panel with visible, Escape,
+  browser Back, startup-state, and native menu recovery paths (#945).
+- Task drawers, shared overlays, Archive cards, scoring profiles, and the
+  template editor use intentional, reachable scroll and resize behavior
+  (#935, #938, #939, #941).
+- Workflow actions normalize omitted collections and show recoverable load
+  failures instead of crashing task detail (#936).
+- Full-page views, task detail, and nested Workflow overlays preserve their
+  actual route origin, browser history, keyboard Back, and scroll position
+  (#937).
+- New scoring profiles open as visible, validated drafts from Profiles and
+  Score Explorer (#943).
+- Operations Digest distinguishes current task state from windowed events,
+  reconciles board inventory and exclusions, bounds observed wall time, and
+  exposes source IDs and metadata-quality findings (#944).
+- Desktop setup is version-neutral and the bridge reports Electron's packaged
+  application version instead of an absent npm environment value (#986).
 
 ## Tested Harness Baselines
 
@@ -99,7 +124,7 @@ task or completion authority.
   says the provider supports them.
 - The public REST API remains `v1`; v6 adds contracts and endpoints without
   renaming the API mount. CLI, MCP, server, web, shared, and desktop package
-  versions must all be 6.0.0.
+  versions must all be 6.0.1.
 
 Back up the current workspace before upgrading. Keep the complete v5.2.5
 backup until v6 runtime verification is accepted. App rollback is safe only
@@ -145,11 +170,11 @@ restore the pre-upgrade backup. See the
 
 ## Release Artifacts
 
-The supported v6.0.0 publication set is:
+The supported v6.0.1 publication set is:
 
-- annotated source tag and GitHub release `v6.0.0`;
-- signed and notarized `Veritas-Kanban-6.0.0-mac-arm64.dmg`;
-- signed and notarized `Veritas-Kanban-6.0.0-mac-arm64.zip`;
+- annotated source tag and GitHub release `v6.0.1`;
+- signed and notarized `Veritas-Kanban-6.0.1-mac-arm64.dmg`;
+- signed and notarized `Veritas-Kanban-6.0.1-mac-arm64.zip`;
 - DMG and ZIP blockmaps;
 - `latest-mac.yml`;
 - SHA-256 sidecars; and
@@ -164,5 +189,5 @@ publication. Source preparation does not count as signed distribution proof.
 
 - [Run-scoped egress gateway](https://github.com/BradGroux/veritas-kanban/issues/855)
   remains a v6.x enhancement for fine-grained outbound HTTP enforcement.
-  v6.0.0 already blocks any required rule that the selected provider cannot
+  v6.0.1 already blocks any required rule that the selected provider cannot
   prove it enforces.

--- a/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -1,12 +1,15 @@
 # Veritas Kanban v6 Upgrade, Install, Remote, And Admin Guide
 
-This is the release-facing operator guide for Veritas Kanban 6.0.0. The
+This is the release-facing operator guide for Veritas Kanban 6.0.1. The
 detailed provider commands live in [Agent Providers](AGENT-PROVIDERS.md), the
 machine-readable support contract is summarized in
 [Harness Compatibility](HARNESS-COMPATIBILITY.md), and Buzz relay setup lives
 in [Buzz Integration](BUZZ-INTEGRATION.md).
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
+
+Do not install 6.0.0. It is retained as a quarantined prerelease; 6.0.1 is the
+first supported stable v6 build.
 
 ## Fresh Mac Desktop Install
 
@@ -18,8 +21,8 @@ brew install --cask veritas-kanban
 ```
 
 Manual installation uses
-`Veritas-Kanban-6.0.0-mac-arm64.zip` from the
-[v6.0.0 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.0).
+`Veritas-Kanban-6.0.1-mac-arm64.zip` from the
+[v6.0.1 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.1).
 Move `Veritas Kanban.app` into `/Applications`, launch it normally, and verify
 Settings -> Maintenance before enabling an agent or external integration.
 
@@ -27,7 +30,7 @@ For a new board:
 
 1. Choose Board Only unless agent execution is required immediately.
 2. Create the local admin password and retain the recovery key securely.
-3. Confirm `/api/health` reports version 6.0.0.
+3. Confirm `/api/health` reports version 6.0.1.
 4. Create a governed backup before adding external credentials or relay
    mappings.
 
@@ -55,14 +58,14 @@ equivalent v5.2.5 self-hosted workspace.
    preferred port are stopped before copying data.
 5. Preserve the complete workspace, not only the SQLite file. Keep the backup
    through release acceptance.
-6. Install v6.0.0 without replacing the workspace.
+6. Install v6.0.1 without replacing the workspace.
 7. Launch with the same profile. If setup appears for a populated database,
    choose **Use Existing Data**. Do not rerun file migration or restore over the
    populated database.
 8. Wait for the exact-version readiness gate:
 
    ```bash
-   EXPECTED_VERSION=6.0.0
+   EXPECTED_VERSION=6.0.1
    pnpm desktop:wait:ready -- --expected-version "$EXPECTED_VERSION"
    ```
 

--- a/docs/V6-VISUAL-TOUR.md
+++ b/docs/V6-VISUAL-TOUR.md
@@ -5,7 +5,9 @@ integration, approvals, and run evidence. The general board, desktop shell,
 Workbench, Squad Chat, Maintenance, and mobile/PWA layouts remain represented
 by the retained [v5 Visual Tour](V5-VISUAL-TOUR.md) and its dummy-data assets.
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1. The retained
+screenshots cover the unchanged v6 provider and Buzz surfaces; 6.0.1
+stabilization behavior is documented in the release notes and evidence packet.
 
 ## Provider Support
 

--- a/docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md
+++ b/docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md
@@ -1,6 +1,6 @@
 # Veritas Kanban v6 Agent Runtime Control Plane
 
-This document defines the shipped v6.0.0 architecture for executable agent
+This document defines the supported v6.0.1 architecture for executable agent
 harnesses and Buzz integration. It is the version-level composition of the
 individual contract documents for
 [ACP](ACP-PROVIDER-V1.md),
@@ -8,7 +8,7 @@ individual contract documents for
 [tool control](TOOL-CONTROL-PLANE-V1.md), and
 [runtime hooks](RUNTIME-HOOK-V1.md).
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.0.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
 
 ## Authority Model
 
@@ -129,5 +129,5 @@ evidence and never hides a failure.
 - Required unsupported filesystem, network, environment, credential, MCP,
   tool, approval, lifecycle, and budget controls block before attempt mutation.
 - Fine-grained HTTP method/path/domain proxy enforcement remains deferred to
-  issue 855. v6.0.0 claims only the network controls proven in current provider
+  issue 855. v6.0.1 claims only the network controls proven in current provider
   runtime evidence.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1239,7 +1239,7 @@
     <div class="hero-content">
       <div class="hero-badge fade-in">
         <span class="pulse"></span>
-        v6.0.0 — Buzz and evidence-backed agent harnesses
+        v6.0.1 — First stable v6 release
       </div>
       <h1 class="fade-in fade-in-delay-1">Veritas Kanban</h1>
       <p class="tagline fade-in fade-in-delay-2">Task management built for AI agents — not against them</p>
@@ -1556,7 +1556,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
     <div class="container">
       <div class="fade-in">
         <span class="section-label">What's New</span>
-        <h2 class="section-title">v6.0.0 Harness Control Plane</h2>
+        <h2 class="section-title">v6.0.1 Harness Control Plane</h2>
         <span class="version-tag">🚀 Latest Release</span>
       </div>
       <div class="version-grid">
@@ -1669,7 +1669,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">v6.0.0</div>
+          <div class="proof-stat-number">v6.0.1</div>
           <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -843,7 +843,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `6.0.0`      | Matches VK server version   |
+| MCP server package | `6.0.1`      | Matches VK server version   |
 | MCP SDK            | `1.29.0`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2025-11-25` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -887,4 +887,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-07-24 · VK v6.0.0 · 41 tools / 9 categories_
+_Last updated: 2026-07-24 · VK v6.0.1 · 41 tools / 9 categories_

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps root, shared, server, web, CLI, MCP, and desktop packages to 6.0.1.
- Marks 6.0.1 as the first supported stable v6 release and quarantines 6.0.0 in release-facing documentation.
- Records the merged stabilization work for #935, #936, #937, #938, #939, #941, #943, #944, #945, and #986.
- Updates the changelog, release notes, compatibility policy, upgrade guide, GA checklist, evidence packet, API and MCP references, architecture record, documentation landing page, README, and instruction freshness.
- Resets publication evidence to pending so signed artifacts and Homebrew are not claimed before independent verification.

Tracks #924. Issue #945 remains open until the downloaded signed 6.0.1 app passes the Chat recovery smoke.

## Verification

- `pnpm check:pnpm-settings`
- `node scripts/validate-release.mjs --version 6.0.1 --skip-build-output`
- `git diff --check`
- Focused standards review: no findings after correcting stale current-version documentation.
- Focused specification review against #924: no remaining source-preparation gaps.

The `ci:full` label is applied so this PR runs the one authoritative full workspace suite for the release, instead of repeating that suite on every stabilization PR.

## Publication boundary

Merging this PR prepares source only. The v6.0.1 tag, GitHub release, signed/notarized artifacts, independent download inspection, exact packaged-version checks, Chat recovery smoke, and Homebrew restoration remain separate required gates.
