### PR TITLE
ci: make test scope path-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,24 @@ on:
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
+    inputs:
+      test_scope:
+        description: Unit-test verification tier
+        required: true
+        default: focused
+        type: choice
+        options:
+          - focused
+          - full
+      base_sha:
+        description: Optional base commit for a focused run (defaults to HEAD^)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +36,145 @@ env:
   NODE_VERSION: '22'
 
 jobs:
+  # ─── Deterministic Test Scope ───────────────────────────────────
+  select-tests:
+    name: Select Test Scope
+    runs-on: ubuntu-latest
+    outputs:
+      scope: ${{ steps.scope.outputs.scope }}
+      packages: ${{ steps.scope.outputs.packages }}
+      diff_range: ${{ steps.scope.outputs.diff_range }}
+      reason: ${{ steps.scope.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Verify CI scope selector
+        run: node --test scripts/select-ci-test-scope.test.mjs
+
+      - name: Find reviewed full-suite evidence
+        id: reviewed_full
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          reviewed_full=false
+          reviewed_pr=
+          reviewed_head=
+          associated_prs="$(
+            gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+              2>/dev/null ||
+              printf '[]'
+          )"
+          merged_pr="$(
+            jq -c \
+              --arg merge_sha "$GITHUB_SHA" \
+              '[.[] | select(
+                .merged_at != null and
+                .base.ref == "main" and
+                .merge_commit_sha == $merge_sha
+              )] | first // empty' \
+              <<<"$associated_prs"
+          )"
+
+          if [[ -n "$merged_pr" ]]; then
+            reviewed_pr="$(jq -r '.number' <<<"$merged_pr")"
+            reviewed_head="$(jq -r '.head.sha' <<<"$merged_pr")"
+            check_runs="$(
+              gh api \
+                -H 'Accept: application/vnd.github+json' \
+                "repos/${GITHUB_REPOSITORY}/commits/${reviewed_head}/check-runs?per_page=100" \
+                2>/dev/null ||
+                printf '{"check_runs":[]}'
+            )"
+
+            if jq -e '
+              .check_runs |
+              any(.[];
+                .name == "Workspace Unit Tests" and
+                .status == "completed" and
+                .conclusion == "success" and
+                .app.slug == "github-actions"
+              )
+            ' <<<"$check_runs" >/dev/null; then
+              if git cat-file -e "${reviewed_head}^{commit}" 2>/dev/null ||
+                git fetch --no-tags origin "$reviewed_head"; then
+                if git merge-base --is-ancestor "$reviewed_head" "$GITHUB_SHA"; then
+                  reviewed_full=true
+                fi
+              fi
+            fi
+          fi
+
+          {
+            echo "reviewed_full=$reviewed_full"
+            echo "reviewed_pr=$reviewed_pr"
+            echo "reviewed_head=$reviewed_head"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Select verification tier
+        id: scope
+        shell: bash
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_MANUAL_SCOPE: ${{ inputs.test_scope || '' }}
+          CI_PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          CI_REVIEWED_FULL: ${{ steps.reviewed_full.outputs.reviewed_full || 'false' }}
+          CI_REVIEWED_PR: ${{ steps.reviewed_full.outputs.reviewed_pr || '' }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          DISPATCH_BASE_SHA: ${{ inputs.base_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          case "$CI_EVENT_NAME" in
+            pull_request)
+              CI_BASE_SHA="$PR_BASE_SHA"
+              CI_HEAD_SHA="$PR_HEAD_SHA"
+              ;;
+            push)
+              CI_BASE_SHA="$PUSH_BEFORE_SHA"
+              CI_HEAD_SHA="$GITHUB_SHA"
+              if [[ "$CI_BASE_SHA" =~ ^0+$ ]]; then
+                CI_BASE_SHA="$(git rev-parse "${GITHUB_SHA}^")"
+              fi
+              ;;
+            workflow_dispatch)
+              CI_HEAD_SHA="$GITHUB_SHA"
+              if [[ -n "$DISPATCH_BASE_SHA" ]]; then
+                if [[ ! "$DISPATCH_BASE_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+                  echo "::error::base_sha must be a 7-40 character hexadecimal commit ID"
+                  exit 1
+                fi
+                CI_BASE_SHA="$(git rev-parse --verify "${DISPATCH_BASE_SHA}^{commit}")"
+              else
+                CI_BASE_SHA="$(git rev-parse "${GITHUB_SHA}^")"
+              fi
+              ;;
+            schedule)
+              CI_BASE_SHA="$GITHUB_SHA"
+              CI_HEAD_SHA="$GITHUB_SHA"
+              ;;
+            *)
+              echo "::error::Unsupported CI event: $CI_EVENT_NAME"
+              exit 1
+              ;;
+          esac
+
+          export CI_BASE_SHA CI_HEAD_SHA
+          node scripts/select-ci-test-scope.mjs
+
   # ─── Lint & Type Check ───────────────────────────────────────────
   lint-and-typecheck:
     name: Lint & Type Check
@@ -53,109 +210,218 @@ jobs:
       - name: Type check all packages
         run: pnpm typecheck
 
-  # ─── Changed PR Tests ────────────────────────────────────────────
+  # ─── Focused Related Tests ──────────────────────────────────────
   test-changed:
     name: Changed Tests
-    if: github.event_name == 'pull_request'
+    needs: select-tests
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Require a successful scope decision
+        env:
+          SELECTOR_RESULT: ${{ needs.select-tests.result }}
+          SELECTED_SCOPE: ${{ needs.select-tests.outputs.scope }}
+          SELECTED_PACKAGES: ${{ needs.select-tests.outputs.packages }}
+        run: |
+          if [[ "$SELECTOR_RESULT" != "success" ]]; then
+            echo "::error::Select Test Scope did not complete successfully"
+            exit 1
+          fi
+          if [[ ! "$SELECTED_SCOPE" =~ ^(none|focused|full)$ ]]; then
+            echo "::error::Select Test Scope returned an invalid scope"
+            exit 1
+          fi
+          if [[ "$SELECTED_SCOPE" == "focused" && -z "$SELECTED_PACKAGES" ]]; then
+            echo "::error::Focused scope requires at least one workspace"
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
+        if: needs.select-tests.outputs.scope == 'focused'
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v6
+        if: needs.select-tests.outputs.scope == 'focused'
 
       - uses: actions/setup-node@v6
+        if: needs.select-tests.outputs.scope == 'focused'
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
+        if: needs.select-tests.outputs.scope == 'focused'
         run: pnpm install --frozen-lockfile
 
       - name: Build shared test dependency
+        if: needs.select-tests.outputs.scope == 'focused'
         run: pnpm --filter @veritas-kanban/shared build
 
-      - name: Run changed workspace tests
+      - name: Run related tests in affected workspaces
+        if: needs.select-tests.outputs.scope == 'focused'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          DIFF_RANGE: ${{ needs.select-tests.outputs.diff_range }}
+          SELECTED_PACKAGES: ${{ needs.select-tests.outputs.packages }}
+          VERITAS_DISABLE_WATCHERS: '1'
+        shell: bash
         run: |
-          selected_count=0
-          for package_name in server web cli mcp; do
-            package_tests=()
-            while IFS= read -r test_file; do
-              package_tests+=("${test_file#"$package_name/"}")
-            done < <(
-              git diff --name-only --diff-filter=ACMR "$BASE_SHA...HEAD" |
-                grep -E "^${package_name}/.*\\.(test|spec)\\.[cm]?[jt]sx?$" || true
-            )
-            if (( ${#package_tests[@]} > 0 )); then
-              for test_file in "${package_tests[@]}"; do
-                pnpm --filter "@veritas-kanban/${package_name}" exec vitest run \
-                  --passWithNoTests \
-                  "$test_file"
-                selected_count=$((selected_count + 1))
-              done
-            fi
-          done
-          if (( selected_count == 0 )); then
-            echo "No changed server, web, CLI, or MCP test files."
-          fi
+          set -euo pipefail
 
-      - name: Run changed desktop tests
+          IFS=',' read -r -a packages <<< "$SELECTED_PACKAGES"
+          executed_packages=()
+          {
+            echo "### Changed Tests"
+            echo
+            echo "- Diff range: \`$DIFF_RANGE\`"
+            echo "- Selected workspaces: \`$SELECTED_PACKAGES\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for package_name in "${packages[@]}"; do
+            related_files=()
+            while IFS= read -r changed_file; do
+              related_files+=("./${changed_file#"$package_name/"}")
+            done < <(
+              git diff --name-only --diff-filter=ACMR "$DIFF_RANGE" -- "$package_name/"
+            )
+
+            if (( ${#related_files[@]} == 0 )); then
+              continue
+            fi
+
+            case "$package_name" in
+              server|web|cli|mcp)
+                package_filter="@veritas-kanban/${package_name}"
+                extra_args=()
+                if [[ "$package_name" == "web" ]]; then
+                  extra_args+=(--testTimeout 15000)
+                fi
+                ;;
+              desktop)
+                package_filter="@veritas-kanban/desktop"
+                extra_args=(--config vitest.config.ts)
+                ;;
+              *)
+                echo "::error::Unknown selected workspace: $package_name"
+                exit 1
+                ;;
+            esac
+
+            pnpm --filter "$package_filter" exec vitest related \
+              --run \
+              --passWithNoTests \
+              "${extra_args[@]}" \
+              "${related_files[@]}"
+            executed_packages+=("$package_name")
+          done
+
+          {
+            if (( ${#executed_packages[@]} > 0 )); then
+              echo "- Related coverage executed for: \`${executed_packages[*]}\`"
+            else
+              echo "- No added, copied, modified, or renamed workspace inputs required related coverage."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record focused-tier skip
+        if: needs.select-tests.outputs.scope != 'focused'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SELECTED_SCOPE: ${{ needs.select-tests.outputs.scope }}
+          SELECTION_REASON: ${{ needs.select-tests.outputs.reason }}
         run: |
-          desktop_tests=()
-          while IFS= read -r test_file; do
-            desktop_tests+=("$test_file")
-          done < <(
-            git diff --name-only --diff-filter=ACMR "$BASE_SHA...HEAD" |
-              grep -E '^desktop/.*\.(test|spec)\.[cm]?[jt]sx?$' |
-              sed 's#^desktop/##' || true
-          )
-          if (( ${#desktop_tests[@]} == 0 )); then
-            echo "No changed desktop test files."
-          else
-            for test_file in "${desktop_tests[@]}"; do
-              pnpm --filter @veritas-kanban/desktop exec vitest run \
-                --config vitest.config.ts \
-                --passWithNoTests \
-                "$test_file"
-            done
-          fi
+          {
+            echo "### Changed Tests"
+            echo
+            echo "- Decision: skipped related coverage because scope is \`$SELECTED_SCOPE\`."
+            echo "- Selection reason: $SELECTION_REASON"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ─── Full Workspace Unit Tests ───────────────────────────────────
   test-workspace:
     name: Workspace Unit Tests
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full')
+    needs: select-tests
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Require a successful scope decision
+        env:
+          SELECTOR_RESULT: ${{ needs.select-tests.result }}
+          SELECTED_SCOPE: ${{ needs.select-tests.outputs.scope }}
+        run: |
+          if [[ "$SELECTOR_RESULT" != "success" ]]; then
+            echo "::error::Select Test Scope did not complete successfully"
+            exit 1
+          fi
+          if [[ ! "$SELECTED_SCOPE" =~ ^(none|focused|full)$ ]]; then
+            echo "::error::Select Test Scope returned an invalid scope"
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
+        if: needs.select-tests.outputs.scope == 'full'
 
       - uses: pnpm/action-setup@v6
+        if: needs.select-tests.outputs.scope == 'full'
 
       - uses: actions/setup-node@v6
+        if: needs.select-tests.outputs.scope == 'full'
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
+        if: needs.select-tests.outputs.scope == 'full'
         run: pnpm install --frozen-lockfile
 
       - name: Build shared (dependency for workspace tests)
+        if: needs.select-tests.outputs.scope == 'full'
         run: pnpm --filter @veritas-kanban/shared build
 
       - name: Run workspace unit tests
+        if: needs.select-tests.outputs.scope == 'full'
         run: pnpm test:unit
 
       - name: Run desktop readiness regression tests
+        if: needs.select-tests.outputs.scope == 'full'
         run: pnpm desktop:test:readiness
 
       - name: Run dual-storage parity tests
-        run: pnpm --filter @veritas-kanban/server test -- src/__tests__/storage/dual-storage-parity.test.ts
+        if: needs.select-tests.outputs.scope == 'full'
+        run: >-
+          pnpm --filter @veritas-kanban/server exec vitest run
+          src/__tests__/storage/dual-storage-parity.test.ts
+
+      - name: Record full-suite evidence
+        if: >-
+          always() &&
+          needs.select-tests.result == 'success' &&
+          needs.select-tests.outputs.scope == 'full'
+        env:
+          DIFF_RANGE: ${{ needs.select-tests.outputs.diff_range }}
+          SELECTION_REASON: ${{ needs.select-tests.outputs.reason }}
+          CURRENT_JOB_STATUS: ${{ job.status }}
+        run: |
+          {
+            echo "### Workspace Unit Tests"
+            echo
+            echo "- Diff range: \`${DIFF_RANGE:-not required}\`"
+            echo "- Selection reason: $SELECTION_REASON"
+            echo "- Workflow checkout SHA: \`$GITHUB_SHA\`"
+            echo "- Current job status: \`$CURRENT_JOB_STATUS\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record full-tier skip
+        if: needs.select-tests.outputs.scope != 'full'
+        env:
+          SELECTED_SCOPE: ${{ needs.select-tests.outputs.scope }}
+          SELECTION_REASON: ${{ needs.select-tests.outputs.reason }}
+        run: |
+          {
+            echo "### Workspace Unit Tests"
+            echo
+            echo "- Decision: skipped the complete suite because scope is \`$SELECTED_SCOPE\`."
+            echo "- Selection reason: $SELECTION_REASON"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ─── Build ───────────────────────────────────────────────────────
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ pnpm lint:fix
 
 # Smoke checks
 pnpm check:pnpm-settings        # Validates package manager fields match this file
+pnpm test:ci-scope              # Validates path-aware CI test selection
 pnpm smoke:cli-mcp              # CLI ↔ MCP compatibility smoke test
 pnpm test:buzz:compatibility    # Credential-free composed Buzz release gate
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made CI test scope deterministic and path-aware. Documentation-only changes
+  skip workspace suites, ordinary code changes run Vitest related coverage for
+  affected packages, and CI, manifest, shared, storage, or desktop changes
+  conservatively select the full gate. A successful reviewed full-suite head is
+  reused after merge only when it is an ancestor of the merge commit, avoiding
+  a duplicate full run while scheduled and explicit release gates remain
+  authoritative. Dual-storage parity now invokes its exact Vitest file instead
+  of expanding through the package test wrapper, and job summaries retain exact
+  range and selection evidence (#1000).
+
 ## [6.0.1] - 2026-07-24
 
 Veritas Kanban 6.0.1 is the first supported stable v6 release. It supersedes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,9 +250,11 @@ docs: update README with deployment instructions
 2. **Branch naming:** Use descriptive names like `feat/task-filters`, `fix/login-redirect`, `docs/api-reference`.
 3. **Open a PR** against `main`.
 4. **Fill out the PR template** — describe changes, link related issues, include screenshots for UI changes.
-5. **Ensure the PR CI tier passes** — all checks started for the pull request
-   must be green. Full workspace and packaging evidence runs after merge, on
-   explicit dispatch, or when the `ci:full` label is applied.
+5. **Ensure the selected PR CI tier passes** — all checks started for the pull
+   request must be green. The scope selector runs related tests for affected
+   workspaces, escalates high-risk paths to the complete suite, and records its
+   base/head evidence in the job summary. Use `ci:full` for release candidates
+   or other changes that require an explicit complete-suite gate.
 6. **Request review** — a maintainer will review and may request changes.
 7. **Address feedback** — push additional commits as needed.
 8. **Merge** — once approved, a maintainer will merge.
@@ -299,12 +301,36 @@ Follow the existing conventions in `.eslintrc.*`, `.prettierrc`, and `tsconfig.j
 
 ### CI tiers
 
-| Trigger                                                                                                     | Stable checks                                                   | Scope                                                                              |
-| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Pull request                                                                                                | `Lint & Type Check`, `Changed Tests`, `Build`, `Security Audit` | Static gates, full build, and only test files added or changed by the pull request |
-| Pull request with `ci:full`                                                                                 | Default checks plus `Workspace Unit Tests`                      | Complete workspace, desktop readiness regressions, and dual-storage parity         |
-| Push to `main`, nightly 08:00 UTC, or manual `CI` dispatch                                                  | Static gates, `Workspace Unit Tests`, `Build`, `Security Audit` | Complete authoritative workspace suite                                             |
-| Desktop/package/release-workflow pull request, relevant `main` push, or manual `Desktop Artifacts` dispatch | Unsigned macOS, Linux, and Windows artifact jobs                | Cross-platform packaging                                                           |
+| Trigger                                                                                                     | Stable checks                                                   | Scope                                                                                                   |
+| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Documentation-only pull request or merge                                                                    | Static gates; unit-test jobs record skip decisions              | No workspace unit suite                                                                                 |
+| Ordinary code pull request                                                                                  | `Lint & Type Check`, `Changed Tests`, `Build`, `Security Audit` | Vitest `related` coverage for affected server, web, CLI, or MCP workspaces                              |
+| Ordinary code merge to `main`                                                                               | Default static gates plus `Changed Tests`                       | Related coverage limited to affected workspaces                                                         |
+| Pull request with `ci:full`, or a high-risk CI/manifest/shared/storage/desktop change                       | Default checks plus `Workspace Unit Tests`                      | Complete workspace, desktop readiness regressions, and exact dual-storage parity                        |
+| Merge whose reviewed head already passed `Workspace Unit Tests`                                             | Static gates; both unit-test tiers record skip decisions        | Reuses exact successful head evidence when that head is an ancestor of the merge commit                 |
+| Nightly 08:00 UTC or manual `CI` dispatch with `test_scope=full`                                            | Static gates, `Workspace Unit Tests`, `Build`, `Security Audit` | Complete authoritative workspace suite                                                                  |
+| Manual `CI` dispatch with `test_scope=focused` and optional `base_sha`                                      | Static gates plus the selected unit-test tier                   | Classifies `base_sha...HEAD` (or `HEAD^...HEAD`); high-risk paths still conservatively escalate to full |
+| Desktop/package/release-workflow pull request, relevant `main` push, or manual `Desktop Artifacts` dispatch | Unsigned macOS, Linux, and Windows artifact jobs                | Cross-platform packaging                                                                                |
+
+`Select Test Scope` is the decision record for each run. Its summary names the
+event, exact base/head range, changed-path count, selected tier, affected
+workspaces, and why `Changed Tests` or `Workspace Unit Tests` ran or skipped.
+The selector fails safe to the complete suite for unknown non-documentation
+paths and for changes to:
+
+- GitHub Actions workflows and the selector itself
+- package manifests, lockfiles, workspace configuration, and test configuration
+- the shared package
+- storage implementations and storage parity coverage
+- the desktop package and desktop readiness boundary
+- deletion of any non-documentation path, because related selection cannot
+  reconstruct the deleted dependency graph
+
+Run the selector contract locally with:
+
+```bash
+pnpm test:ci-scope
+```
 
 Release validation remains the final authority: clean-clone build, full unit
 and integration suites, applicable E2E, and signed artifact verification.
@@ -312,8 +338,8 @@ and integration suites, applicable E2E, and signed artifact verification.
 The operational target for the default pull-request tier is under 15 minutes,
 with no desktop packaging. This is a target rather than an SLA; dependency
 installation and hosted-runner availability still vary. Behavior changes
-should include a focused test change so the pull-request selector executes
-relevant coverage.
+should include coverage reachable from the changed source so Vitest's related
+test selection can execute it.
 
 ## Questions?
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",
     "test": "vitest run",
     "test:unit": "pnpm -r --workspace-concurrency=1 test",
+    "test:ci-scope": "node --test scripts/select-ci-test-scope.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",

--- a/scripts/select-ci-test-scope.mjs
+++ b/scripts/select-ci-test-scope.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { appendFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WORKSPACE_NAMES = ['server', 'web', 'cli', 'mcp', 'desktop'];
+
+const FULL_SUITE_PATH_PATTERNS = [
+  /^\.github\/workflows\//,
+  /^desktop\//,
+  /^shared\//,
+  /^server\/src\/storage\//,
+  /^server\/src\/__tests__\/storage\//,
+  /^scripts\/select-ci-test-scope(?:\.test)?\.mjs$/,
+  /(^|\/)package\.json$/,
+  /(^|\/)(?:vitest|playwright|electron\.vite)\.config\.[cm]?[jt]s$/,
+  /(^|\/)tsconfig(?:\.[^/]+)?\.json$/,
+  /^eslint\.config\.[cm]?[jt]s$/,
+  /^pnpm-lock\.yaml$/,
+  /^pnpm-workspace\.yaml$/,
+];
+
+const DOCUMENTATION_PATH_PATTERNS = [
+  /\.md$/i,
+  /^docs\//,
+  /^prompt-registry\//,
+  /^\.github\/ISSUE_TEMPLATE\//,
+  /^\.github\/PULL_REQUEST_TEMPLATE\.md$/,
+  /^(?:CODE_OF_CONDUCT|LICENSE|SECURITY)(?:\.[^/]+)?$/,
+];
+
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+
+function normalizeFiles(files) {
+  return [...new Set(files.map((file) => file.trim()).filter(Boolean))].sort();
+}
+
+function summarizePaths(files) {
+  const visible = files.slice(0, 5);
+  const remainder = files.length - visible.length;
+  return `${visible.join(', ')}${remainder > 0 ? `, and ${remainder} more` : ''}`;
+}
+
+export function isDocumentationPath(file) {
+  return DOCUMENTATION_PATH_PATTERNS.some((pattern) => pattern.test(file));
+}
+
+export function requiresFullSuite(file) {
+  return FULL_SUITE_PATH_PATTERNS.some((pattern) => pattern.test(file));
+}
+
+export function affectedWorkspaces(files) {
+  const selected = new Set();
+
+  for (const file of files) {
+    const workspace = WORKSPACE_NAMES.find((name) => file.startsWith(`${name}/`));
+    if (workspace) selected.add(workspace);
+  }
+
+  return WORKSPACE_NAMES.filter((name) => selected.has(name));
+}
+
+export function classifyCiTestScope({
+  eventName,
+  manualScope = '',
+  labels = [],
+  changedFiles = [],
+  deletedFiles = [],
+  reviewedFullSuite = false,
+  reviewedPullRequest = '',
+}) {
+  const files = normalizeFiles(changedFiles);
+  const deleted = normalizeFiles(deletedFiles);
+  const packages = affectedWorkspaces(files);
+
+  if (eventName === 'schedule') {
+    return {
+      scope: 'full',
+      packages: WORKSPACE_NAMES,
+      files,
+      reason: 'Scheduled CI is the authoritative recurring full-suite drift gate.',
+    };
+  }
+
+  if (eventName === 'workflow_dispatch' && manualScope === 'full') {
+    return {
+      scope: 'full',
+      packages: WORKSPACE_NAMES,
+      files,
+      reason: 'Manual dispatch explicitly requested the full verification tier.',
+    };
+  }
+
+  if (eventName === 'pull_request' && labels.includes('ci:full')) {
+    return {
+      scope: 'full',
+      packages: WORKSPACE_NAMES,
+      files,
+      reason: 'The pull request carries the ci:full release or high-risk verification label.',
+    };
+  }
+
+  if (eventName === 'push' && reviewedFullSuite) {
+    const prSuffix = reviewedPullRequest ? ` for PR #${reviewedPullRequest}` : '';
+    return {
+      scope: 'none',
+      packages: [],
+      files,
+      reason: `The reviewed head${prSuffix} already passed Workspace Unit Tests and is an ancestor of this merge commit.`,
+    };
+  }
+
+  const deletedCodePaths = deleted.filter((file) => !isDocumentationPath(file));
+  if (deletedCodePaths.length > 0) {
+    return {
+      scope: 'full',
+      packages: WORKSPACE_NAMES,
+      files,
+      reason: `Deleted non-documentation paths cannot use dependency-graph related selection and require the full suite: ${summarizePaths(
+        deletedCodePaths
+      )}`,
+    };
+  }
+
+  const fullSuitePaths = files.filter(requiresFullSuite);
+  if (fullSuitePaths.length > 0) {
+    return {
+      scope: 'full',
+      packages: WORKSPACE_NAMES,
+      files,
+      reason: `High-risk CI, manifest, shared, storage, or desktop paths require the full suite: ${summarizePaths(
+        fullSuitePaths
+      )}`,
+    };
+  }
+
+  if (files.length === 0) {
+    return {
+      scope: 'none',
+      packages: [],
+      files,
+      reason:
+        'The selected base/head range contains no added, copied, modified, renamed, or deleted files.',
+    };
+  }
+
+  if (files.every(isDocumentationPath)) {
+    return {
+      scope: 'none',
+      packages: [],
+      files,
+      reason: 'Only documentation or issue-template paths changed.',
+    };
+  }
+
+  const unclassifiedCodePaths = files.filter(
+    (file) =>
+      !isDocumentationPath(file) &&
+      !WORKSPACE_NAMES.some((workspace) => file.startsWith(`${workspace}/`))
+  );
+  if (unclassifiedCodePaths.length > 0) {
+    return {
+      scope: 'full',
+      packages: WORKSPACE_NAMES,
+      files,
+      reason: `Non-documentation paths outside a known test workspace fail safe to the full suite: ${summarizePaths(
+        unclassifiedCodePaths
+      )}`,
+    };
+  }
+
+  if (packages.length === 0) {
+    return {
+      scope: 'none',
+      packages: [],
+      files,
+      reason: 'No testable workspace changed.',
+    };
+  }
+
+  return {
+    scope: 'focused',
+    packages,
+    files,
+    reason: `Run Vitest related coverage for affected workspace packages: ${packages.join(', ')}.`,
+  };
+}
+
+export function diffRangeFor(baseSha, headSha, eventName) {
+  if (!baseSha || !headSha || baseSha === headSha) return '';
+  if (!COMMIT_SHA_PATTERN.test(baseSha) || !COMMIT_SHA_PATTERN.test(headSha)) {
+    throw new Error('CI base and head revisions must be hexadecimal commit IDs.');
+  }
+
+  return eventName === 'push' ? `${baseSha}..${headSha}` : `${baseSha}...${headSha}`;
+}
+
+export function changedFilesForRange(baseSha, headSha, eventName, cwd = process.cwd()) {
+  const range = diffRangeFor(baseSha, headSha, eventName);
+  if (!range) return [];
+  const output = execFileSync('git', ['diff', '--name-only', '--diff-filter=ACMRD', range], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  return normalizeFiles(output.split('\n'));
+}
+
+export function deletedFilesForRange(baseSha, headSha, eventName, cwd = process.cwd()) {
+  const range = diffRangeFor(baseSha, headSha, eventName);
+  if (!range) return [];
+  const output = execFileSync('git', ['diff', '--name-only', '--diff-filter=D', range], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  return normalizeFiles(output.split('\n'));
+}
+
+function parseLabels(value) {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((label) => typeof label === 'string') : [];
+  } catch {
+    throw new Error('CI_PR_LABELS must be a JSON array of label names.');
+  }
+}
+
+function githubOutputLines(result, input) {
+  const diffRange = diffRangeFor(input.baseSha, input.headSha, input.eventName);
+  return [
+    `scope=${result.scope}`,
+    `packages=${result.packages.join(',')}`,
+    `diff_range=${diffRange}`,
+    `reason=${result.reason}`,
+  ].join('\n');
+}
+
+function summaryMarkdown(result, input) {
+  const focusedDecision =
+    result.scope === 'focused'
+      ? `run for ${result.packages.map((name) => `\`${name}\``).join(', ')}`
+      : `skip because scope is \`${result.scope}\``;
+  const fullDecision =
+    result.scope === 'full'
+      ? 'run the complete release-grade suite'
+      : `skip because scope is \`${result.scope}\``;
+
+  return [
+    '### CI test scope',
+    '',
+    '| Evidence | Value |',
+    '| --- | --- |',
+    `| Event | \`${input.eventName}\` |`,
+    `| Base | \`${input.baseSha || 'not required'}\` |`,
+    `| Head | \`${input.headSha || 'not required'}\` |`,
+    `| Changed paths | ${result.files.length} |`,
+    `| Selected scope | \`${result.scope}\` |`,
+    `| Reason | ${result.reason.replaceAll('|', '\\|')} |`,
+    '',
+    '| Test tier | Decision |',
+    '| --- | --- |',
+    `| Changed Tests | ${focusedDecision} |`,
+    `| Workspace Unit Tests | ${fullDecision} |`,
+    '',
+  ].join('\n');
+}
+
+async function main() {
+  const input = {
+    eventName: process.env.CI_EVENT_NAME || '',
+    baseSha: process.env.CI_BASE_SHA || '',
+    headSha: process.env.CI_HEAD_SHA || '',
+    manualScope: process.env.CI_MANUAL_SCOPE || '',
+    labels: parseLabels(process.env.CI_PR_LABELS || '[]'),
+    reviewedFullSuite: process.env.CI_REVIEWED_FULL === 'true',
+    reviewedPullRequest: process.env.CI_REVIEWED_PR || '',
+  };
+
+  if (!input.eventName) {
+    throw new Error('CI_EVENT_NAME is required.');
+  }
+
+  const changedFiles = changedFilesForRange(input.baseSha, input.headSha, input.eventName);
+  const deletedFiles = deletedFilesForRange(input.baseSha, input.headSha, input.eventName);
+  const result = classifyCiTestScope({ ...input, changedFiles, deletedFiles });
+
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `${githubOutputLines(result, input)}\n`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, summaryMarkdown(result, input));
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ...result,
+        baseSha: input.baseSha,
+        headSha: input.headSha,
+      },
+      null,
+      2
+    )
+  );
+}
+
+if (path.resolve(process.argv[1] || '') === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/select-ci-test-scope.test.mjs
+++ b/scripts/select-ci-test-scope.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  affectedWorkspaces,
+  classifyCiTestScope,
+  diffRangeFor,
+  isDocumentationPath,
+  requiresFullSuite,
+} from './select-ci-test-scope.mjs';
+
+test('classifies documentation-only pull requests without unit tests', () => {
+  const result = classifyCiTestScope({
+    eventName: 'pull_request',
+    changedFiles: ['README.md', 'docs/AGENTS-TEMPLATE.md'],
+  });
+
+  assert.equal(result.scope, 'none');
+  assert.deepEqual(result.packages, []);
+});
+
+test('selects affected workspaces for ordinary code changes', () => {
+  const result = classifyCiTestScope({
+    eventName: 'pull_request',
+    changedFiles: ['web/src/App.tsx', 'server/src/routes/tasks.ts', 'README.md'],
+  });
+
+  assert.equal(result.scope, 'focused');
+  assert.deepEqual(result.packages, ['server', 'web']);
+});
+
+test('ci:full overrides a documentation-only pull request', () => {
+  const result = classifyCiTestScope({
+    eventName: 'pull_request',
+    labels: ['documentation', 'ci:full'],
+    changedFiles: ['docs/V6-GA-CHECKLIST.md'],
+  });
+
+  assert.equal(result.scope, 'full');
+});
+
+test('selects the full suite for CI, manifest, shared, storage, and desktop paths', () => {
+  const paths = [
+    '.github/workflows/ci.yml',
+    'package.json',
+    'shared/src/types/task.types.ts',
+    'server/src/storage/sqlite/repositories.ts',
+    'desktop/src/main/index.ts',
+  ];
+
+  for (const file of paths) {
+    const result = classifyCiTestScope({
+      eventName: 'pull_request',
+      changedFiles: [file],
+    });
+    assert.equal(result.scope, 'full', file);
+    assert.equal(requiresFullSuite(file), true, file);
+  }
+});
+
+test('scheduled and explicitly full manual runs select the full suite', () => {
+  assert.equal(classifyCiTestScope({ eventName: 'schedule', changedFiles: [] }).scope, 'full');
+  assert.equal(
+    classifyCiTestScope({
+      eventName: 'workflow_dispatch',
+      manualScope: 'full',
+      changedFiles: ['README.md'],
+    }).scope,
+    'full'
+  );
+});
+
+test('focused manual runs still classify the selected range by risk', () => {
+  assert.equal(
+    classifyCiTestScope({
+      eventName: 'workflow_dispatch',
+      manualScope: 'focused',
+      changedFiles: ['server/src/routes/tasks.ts'],
+    }).scope,
+    'focused'
+  );
+  assert.equal(
+    classifyCiTestScope({
+      eventName: 'workflow_dispatch',
+      manualScope: 'focused',
+      changedFiles: ['pnpm-lock.yaml'],
+    }).scope,
+    'full'
+  );
+});
+
+test('a successful reviewed full suite suppresses duplicate post-merge tests', () => {
+  const result = classifyCiTestScope({
+    eventName: 'push',
+    reviewedFullSuite: true,
+    reviewedPullRequest: '1000',
+    changedFiles: ['.github/workflows/ci.yml'],
+  });
+
+  assert.equal(result.scope, 'none');
+  assert.match(result.reason, /PR #1000/);
+});
+
+test('ordinary post-merge pushes remain limited to affected packages', () => {
+  const result = classifyCiTestScope({
+    eventName: 'push',
+    changedFiles: ['cli/src/commands/doctor.ts'],
+  });
+
+  assert.equal(result.scope, 'focused');
+  assert.deepEqual(result.packages, ['cli']);
+});
+
+test('unknown non-documentation paths fail safe to the full suite', () => {
+  const result = classifyCiTestScope({
+    eventName: 'pull_request',
+    changedFiles: ['site/src/runtime.ts'],
+  });
+
+  assert.equal(result.scope, 'full');
+});
+
+test('deleted source fails safe to full while deleted documentation stays lightweight', () => {
+  assert.equal(
+    classifyCiTestScope({
+      eventName: 'pull_request',
+      changedFiles: ['server/src/obsolete.ts'],
+      deletedFiles: ['server/src/obsolete.ts'],
+    }).scope,
+    'full'
+  );
+  assert.equal(
+    classifyCiTestScope({
+      eventName: 'pull_request',
+      changedFiles: ['docs/obsolete.md'],
+      deletedFiles: ['docs/obsolete.md'],
+    }).scope,
+    'none'
+  );
+});
+
+test('empty ranges select no unit-test tier', () => {
+  const result = classifyCiTestScope({
+    eventName: 'push',
+    changedFiles: [],
+  });
+
+  assert.equal(result.scope, 'none');
+});
+
+test('documentation and workspace helpers are deterministic', () => {
+  assert.equal(isDocumentationPath('prompt-registry/review.md'), true);
+  assert.equal(isDocumentationPath('server/src/index.ts'), false);
+  assert.deepEqual(
+    affectedWorkspaces([
+      'desktop/src/main/index.ts',
+      'mcp/src/index.ts',
+      'server/src/index.ts',
+      'server/src/routes/tasks.ts',
+    ]),
+    ['server', 'mcp', 'desktop']
+  );
+});
+
+test('uses two-dot push ranges, three-dot review ranges, and rejects non-SHAs', () => {
+  const base = 'a'.repeat(40);
+  const head = 'b'.repeat(40);
+
+  assert.equal(diffRangeFor(base, head, 'push'), `${base}..${head}`);
+  assert.equal(diffRangeFor(base, head, 'pull_request'), `${base}...${head}`);
+  assert.throws(
+    () => diffRangeFor('--output=/tmp/unsafe', head, 'workflow_dispatch'),
+    /hexadecimal commit IDs/
+  );
+});


### PR DESCRIPTION
Closes #1000.

## What changed

- adds a deterministic `Select Test Scope` job with exact base/head and selection evidence
- skips workspace suites for documentation-only changes
- runs Vitest related coverage for affected workspaces on ordinary code changes
- conservatively selects the complete suite for CI, manifest, shared, storage, desktop, unknown, and deleted code paths
- reuses a successful reviewed full-suite head after merge only when that head is an ancestor of the merge commit
- keeps `Changed Tests` and `Workspace Unit Tests` as stable, fail-closed check names
- adds focused/full manual dispatch controls and records run/skip reasons in job summaries
- fixes the dual-storage parity command so it invokes the exact Vitest file instead of expanding through the package test wrapper
- documents the CI tiers and records the change under `Unreleased`

## Root cause

The previous condition ran the complete workspace suite for every push to `main`, even when the reviewed pull-request head had already passed it or the merge changed only documentation. The focused pull-request job also selected only directly changed test files and did not provide a durable scope decision.

## Verification

- `pnpm test:ci-scope` (13 tests)
- `pnpm exec eslint scripts/select-ci-test-scope.mjs scripts/select-ci-test-scope.test.mjs`
- `pnpm --filter @veritas-kanban/shared build`
- Vitest related web fixture from merged PR #996 (13 files, 57 tests)
- historical classification checks for docs-only PR #1002, focused web PR #996, and full-suite release PR #998
- successful full-suite evidence lookup against PR #998 and merge commit `faeec2752`
- `pnpm check:pnpm-settings`
- `pnpm check:security-artifacts`
- Prettier and `git diff --check`

The complete suite is intentionally delegated to this pull request's `ci:full` GitHub gate because the change modifies CI policy and a workspace manifest. It was not duplicated locally.
