### PR TITLE
fix: contain desktop chat in a reversible dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of expanding through the package test wrapper, and job summaries retain exact
   range and selection evidence (#1000).
 
+### Fixed
+
+- Replaced the desktop-only bottom Chat surface with a bounded dock that opens on
+  the right by default and can switch between Right and Bottom without remounting
+  the active conversation. Both dimensions are clamped against the live viewport,
+  chat scrolling cannot move the application shell, wheel input cannot resize the
+  dock, and Close, Escape, Back, or Reset Layout always preserve a visible board
+  and restore focus (#1004).
+
 ## [6.0.1] - 2026-07-24
 
 Veritas Kanban 6.0.1 is the first supported stable v6 release. It supersedes

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Spawn autonomous coding agents on tasks when you choose to connect an agent runn
 
 ![Resizable Workbench panel](docs/assets/v5/v5-workbench-panel.png)
 
+Desktop Board Chat and Squad Chat open in a bounded right-side Workbench dock by
+default. Switch to Bottom when vertical space is preferable; both orientations
+keep the board, header, close control, and keyboard recovery paths reachable.
+
 ![Squad Chat threaded coordination](docs/assets/v5/v5-squad-chat-threaded-coordination.png)
 
 ### 🧭 Veritas Cutover + Hermes Support

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -117,9 +117,9 @@ The Kanban board is the central interface — a drag-and-drop workspace that ref
 - **Markdown storage** — Tasks stored as human-readable `.md` files with YAML frontmatter
 - **Dark/light mode** — Ships dark by default with a toggle in Settings → General → Appearance; persists to localStorage; inline script in `index.html` prevents flash of wrong theme on load
 - **Filter bar** — Search tasks by text, filter by project and task type; filters persist in URL query params
-- **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, view toggles, and left/right/bottom panel controls shared by the web and macOS app shells
+- **Desktop shell controls** — Native-app-style toolbar with workspace selection, health state, view toggles, and bounded left/right/chat dock controls shared by the web and macOS app shells
 - **Mobile shell controls** — Compact navigation uses bounded labels and full accessible names; Board Chat stays fixed above the bottom navigation and device safe area
-- **Resizable Workbench** — Board Chat and Squad Chat live in a collapsible bottom panel that can be resized vertically for longer chat sessions
+- **Resizable Workbench** — Board Chat and Squad Chat open in a right dock by default, can switch to Bottom without losing the active conversation, and clamp their width or height to keep the application shell recoverable
 - **Bulk operations** — Select multiple tasks to move, archive, or delete in batch; select-all toggle
 - **Keyboard shortcuts** — Navigate tasks (j/k, arrows), open (Enter), close (Esc), create (c), move to column (1-4), help (?)
 - **Loading skeleton** — Shimmer placeholders while the board loads
@@ -620,7 +620,7 @@ Real-time agent-to-agent communication channel for multi-agent collaboration. Sh
 | ![v5 Squad Chat coordination](assets/v5/v5-squad-chat-threaded-coordination.png) | ![v5 Squad Chat human reply adapter](assets/v5/v5-squad-chat-human-reply-adapter.png) |
 
 - **WebSocket-powered chat** — Messages broadcast in real time to all connected clients
-- **Resizable Workbench panel** — Board Chat and Squad Chat share the bottom Workbench surface, which can be collapsed or resized vertically instead of floating off-screen
+- **Resizable Workbench dock** — Board Chat and Squad Chat share one dock that defaults Right, optionally moves to Bottom, isolates chat scrolling, and keeps Close, Escape, Back, and Reset Layout recovery available
 - **Local shared log** — Squad Chat stores and streams messages; it does not wake or reply through an external agent unless a webhook, OpenClaw Direct path, or orchestrator is configured
 - **Threaded coordination** — Reply-to links render compact threads for long multi-agent runs
 - **Unread and mentions** — Per-actor unread state persists across refreshes, and mentions create local notifications linked back to messages

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -116,7 +116,7 @@ function DesktopAwareAppShell({
   showDesktopOnboarding: boolean;
   setShowDesktopOnboarding: (open: boolean) => void;
 }) {
-  const { isDesktopClient, bottomPanel } = useDesktopShell();
+  const { isDesktopClient, bottomPanel, dockPosition } = useDesktopShell();
 
   return (
     <Box className="desktop-app-shell min-h-screen bg-background">
@@ -128,23 +128,28 @@ function DesktopAwareAppShell({
       <Suspense fallback={null}>
         <PwaStatusBanner sessionExpiry={authStatus?.sessionExpiry} onRefreshAuth={refreshStatus} />
       </Suspense>
-      <div className="desktop-workbench">
-        <DesktopLeftSidebar />
-        <Box
-          component="main"
-          id="main-content"
-          px={isDesktopClient ? 'md' : { base: 'md', md: '3.5rem' }}
-          pt={isDesktopClient ? 'md' : 'lg'}
-          pb={bottomPanel ? 'md' : isDesktopClient ? 'lg' : { base: '6rem', md: 'lg' }}
-          tabIndex={-1}
-          className="desktop-main-content"
-        >
-          <ErrorBoundary level="section">
-            <MainContent />
-          </ErrorBoundary>
-        </Box>
+      <div
+        className="desktop-workbench-container"
+        data-dock-position={bottomPanel ? dockPosition : undefined}
+      >
+        <div className="desktop-workbench">
+          <DesktopLeftSidebar />
+          <Box
+            component="main"
+            id="main-content"
+            px={isDesktopClient ? 'md' : { base: 'md', md: '3.5rem' }}
+            pt={isDesktopClient ? 'md' : 'lg'}
+            pb={bottomPanel ? 'md' : isDesktopClient ? 'lg' : { base: '6rem', md: 'lg' }}
+            tabIndex={-1}
+            className="desktop-main-content"
+          >
+            <ErrorBoundary level="section">
+              <MainContent />
+            </ErrorBoundary>
+          </Box>
+        </div>
+        <DesktopBottomPanel />
       </div>
-      <DesktopBottomPanel />
       <Toaster />
       <CommandPalette />
       {!isDesktopClient && !bottomPanel && (

--- a/web/src/__tests__/desktop-shell-context.test.tsx
+++ b/web/src/__tests__/desktop-shell-context.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
-  DEFAULT_BOTTOM_PANEL_HEIGHT,
+  DEFAULT_RIGHT_PANEL_WIDTH,
   DesktopShellProvider,
   useDesktopShell,
 } from '@/components/layout/DesktopShellContext';
@@ -16,9 +16,17 @@ function ShellProbe() {
       <output aria-label="left rail">{String(shell.leftRailOpen)}</output>
       <output aria-label="right rail">{String(shell.rightRailOpen)}</output>
       <output aria-label="bottom panel">{shell.bottomPanel ?? 'closed'}</output>
+      <output aria-label="dock position">{shell.dockPosition}</output>
       <output aria-label="bottom panel height">{shell.bottomPanelHeight}</output>
+      <output aria-label="right panel width">{shell.rightPanelWidth}</output>
       <button type="button" onClick={() => shell.openBottomPanel('board-chat')}>
         Open board chat
+      </button>
+      <button type="button" onClick={() => shell.setDockPosition('bottom')}>
+        Dock bottom
+      </button>
+      <button type="button" onClick={() => shell.setDockPosition('right')}>
+        Dock right
       </button>
       <button type="button" onClick={() => shell.setLeftRailOpen(false)}>
         Close left rail
@@ -51,6 +59,7 @@ describe('desktop shell recovery', () => {
     window.localStorage.clear();
     window.history.replaceState({}, '', '/');
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 });
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1180 });
     Object.defineProperty(window, 'veritasDesktop', {
       configurable: true,
       value: {
@@ -69,9 +78,11 @@ describe('desktop shell recovery', () => {
     menuListener = undefined;
   });
 
-  it('discards obsolete persisted panel visibility and clamps a stale height', () => {
+  it('defaults invalid and legacy layout state to a bounded right dock', () => {
     window.localStorage.setItem('veritas.desktop.bottomPanel', 'board-chat');
     window.localStorage.setItem('veritas.workbench.bottomPanelHeight', '9999');
+    window.localStorage.setItem('veritas.workbench.rightPanelWidth', '-20');
+    window.localStorage.setItem('veritas.workbench.dockPosition', 'full-window');
 
     render(
       <DesktopShellProvider>
@@ -80,11 +91,40 @@ describe('desktop shell recovery', () => {
     );
 
     expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
-    expect(screen.getByLabelText('bottom panel height').textContent).toBe('380');
+    expect(screen.getByLabelText('dock position').textContent).toBe('right');
+    expect(screen.getByLabelText('bottom panel height').textContent).toBe('280');
+    expect(screen.getByLabelText('right panel width').textContent).toBe(
+      String(DEFAULT_RIGHT_PANEL_WIDTH)
+    );
     expect(window.localStorage.getItem('veritas.desktop.bottomPanel')).toBeNull();
+    expect(window.localStorage.getItem('veritas.workbench.dockPosition')).toBeNull();
   });
 
-  it('closes transient chat layout with Escape or browser Back', async () => {
+  it('persists a valid dock position without closing the conversation', async () => {
+    const user = userEvent.setup();
+    const view = render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+    await user.click(screen.getByRole('button', { name: 'Dock bottom' }));
+
+    expect(screen.getByLabelText('bottom panel').textContent).toBe('board-chat');
+    expect(screen.getByLabelText('dock position').textContent).toBe('bottom');
+    expect(window.localStorage.getItem('veritas.workbench.dockPosition')).toBe('bottom');
+
+    view.unmount();
+    render(
+      <DesktopShellProvider>
+        <ShellProbe />
+      </DesktopShellProvider>
+    );
+    expect(screen.getByLabelText('dock position').textContent).toBe('bottom');
+  });
+
+  it('closes transient chat layout with Escape or browser Back and restores focus', async () => {
     const user = userEvent.setup();
 
     render(
@@ -93,11 +133,13 @@ describe('desktop shell recovery', () => {
       </DesktopShellProvider>
     );
 
-    await user.click(screen.getByRole('button', { name: 'Open board chat' }));
+    const trigger = screen.getByRole('button', { name: 'Open board chat' });
+    await user.click(trigger);
     expect(screen.getByLabelText('bottom panel').textContent).toBe('board-chat');
 
     await user.keyboard('{Escape}');
     expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
+    await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
 
     await user.click(screen.getByRole('button', { name: 'Open board chat' }));
     act(() => window.dispatchEvent(new PopStateEvent('popstate', { state: {} })));
@@ -122,11 +164,15 @@ describe('desktop shell recovery', () => {
     expect(screen.getByLabelText('left rail').textContent).toBe('true');
     expect(screen.getByLabelText('right rail').textContent).toBe('false');
     expect(screen.getByLabelText('bottom panel').textContent).toBe('closed');
-    expect(screen.getByLabelText('bottom panel height').textContent).toBe(
-      String(DEFAULT_BOTTOM_PANEL_HEIGHT)
+    expect(screen.getByLabelText('dock position').textContent).toBe('right');
+    expect(screen.getByLabelText('bottom panel height').textContent).toBe('280');
+    expect(screen.getByLabelText('right panel width').textContent).toBe(
+      String(DEFAULT_RIGHT_PANEL_WIDTH)
     );
     expect(window.localStorage.getItem('veritas.desktop.leftRailOpen')).toBeNull();
     expect(window.localStorage.getItem('veritas.desktop.rightRailOpen')).toBeNull();
     expect(window.localStorage.getItem('veritas.workbench.bottomPanelHeight')).toBeNull();
+    expect(window.localStorage.getItem('veritas.workbench.rightPanelWidth')).toBeNull();
+    expect(window.localStorage.getItem('veritas.workbench.dockPosition')).toBeNull();
   });
 });

--- a/web/src/__tests__/layout-chrome-mantine.test.tsx
+++ b/web/src/__tests__/layout-chrome-mantine.test.tsx
@@ -256,7 +256,7 @@ describe('layout chrome Mantine migration', () => {
 
     expect(screen.getByRole('button', { name: 'Collapse left sidebar' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Expand right sidebar' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Open bottom panel' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Open chat dock' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Board Chat' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Squad Chat' })).toBeDefined();
 

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -194,7 +194,7 @@ export function ChatPanel({
   const chatContent = (
     <>
       <ScrollArea
-        className="min-h-0 flex-1 px-4"
+        className="chat-dock-scroll-area min-h-0 flex-1 px-4"
         onScrollCapture={handleScroll}
         ref={scrollAreaRef}
       >

--- a/web/src/components/chat/SquadChatPanel.tsx
+++ b/web/src/components/chat/SquadChatPanel.tsx
@@ -372,7 +372,7 @@ export function SquadChatPanel({
 
       {/* Messages */}
       <ScrollArea
-        className="flex-1 min-h-0 px-4"
+        className="chat-dock-scroll-area flex-1 min-h-0 px-4"
         onScrollCapture={handleScroll}
         ref={scrollAreaRef}
       >

--- a/web/src/components/layout/DesktopBottomPanel.tsx
+++ b/web/src/components/layout/DesktopBottomPanel.tsx
@@ -5,15 +5,26 @@ import {
   type CSSProperties,
   type KeyboardEvent,
   type PointerEvent,
+  type WheelEvent,
 } from 'react';
 import { ActionIcon, Group, SegmentedControl, Text } from '@mantine/core';
-import { GripHorizontal, MessageSquare, PanelBottomClose, Users } from 'lucide-react';
+import {
+  GripHorizontal,
+  GripVertical,
+  MessageSquare,
+  PanelBottomClose,
+  PanelRightClose,
+  Users,
+} from 'lucide-react';
 
 import {
   MAX_BOTTOM_PANEL_HEIGHT,
+  MAX_RIGHT_PANEL_WIDTH,
   MIN_BOTTOM_PANEL_HEIGHT,
+  MIN_RIGHT_PANEL_WIDTH,
   useDesktopShell,
   type DesktopBottomPanel as DesktopBottomPanelId,
+  type DesktopDockPosition,
 } from './DesktopShellContext';
 
 const ChatPanel = lazy(() =>
@@ -33,35 +44,54 @@ const PANEL_OPTIONS = [
   { label: 'Squad Chat', value: 'squad-chat' },
 ] satisfies Array<{ label: string; value: DesktopBottomPanelId }>;
 
+const DOCK_OPTIONS = [
+  { label: 'Right', value: 'right' },
+  { label: 'Bottom', value: 'bottom' },
+] satisfies Array<{ label: string; value: DesktopDockPosition }>;
+
 export function DesktopBottomPanel() {
   const {
+    isDesktopClient,
     bottomPanel,
+    dockPosition,
     bottomPanelHeight,
+    rightPanelWidth,
+    setDockPosition,
     setBottomPanelHeight,
+    setRightPanelWidth,
     openBottomPanel,
     closeBottomPanel,
   } = useDesktopShell();
-  const dragStateRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const dragStateRef = useRef<{ startPosition: number; startSize: number } | null>(null);
 
   if (!bottomPanel) return null;
 
   const resizeBy = (delta: number) => {
-    setBottomPanelHeight(bottomPanelHeight + delta);
+    if (dockPosition === 'right') {
+      setRightPanelWidth(rightPanelWidth + delta);
+    } else {
+      setBottomPanelHeight(bottomPanelHeight + delta);
+    }
   };
 
   const handleResizePointerDown = (event: PointerEvent<HTMLButtonElement>) => {
     event.preventDefault();
     dragStateRef.current = {
-      startY: event.clientY,
-      startHeight: bottomPanelHeight,
+      startPosition: dockPosition === 'right' ? event.clientX : event.clientY,
+      startSize: dockPosition === 'right' ? rightPanelWidth : bottomPanelHeight,
     };
     event.currentTarget.setPointerCapture(event.pointerId);
   };
 
   const handleResizePointerMove = (event: PointerEvent<HTMLButtonElement>) => {
     if (!dragStateRef.current) return;
-    const delta = dragStateRef.current.startY - event.clientY;
-    setBottomPanelHeight(dragStateRef.current.startHeight + delta);
+    const currentPosition = dockPosition === 'right' ? event.clientX : event.clientY;
+    const delta = dragStateRef.current.startPosition - currentPosition;
+    if (dockPosition === 'right') {
+      setRightPanelWidth(dragStateRef.current.startSize + delta);
+    } else {
+      setBottomPanelHeight(dragStateRef.current.startSize + delta);
+    }
   };
 
   const handleResizePointerEnd = (event: PointerEvent<HTMLButtonElement>) => {
@@ -72,74 +102,118 @@ export function DesktopBottomPanel() {
   };
 
   const handleResizeKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'ArrowUp') {
+    const growKey = dockPosition === 'right' ? 'ArrowLeft' : 'ArrowUp';
+    const shrinkKey = dockPosition === 'right' ? 'ArrowRight' : 'ArrowDown';
+    if (event.key === growKey) {
       event.preventDefault();
       resizeBy(event.shiftKey ? 80 : 24);
-    } else if (event.key === 'ArrowDown') {
+    } else if (event.key === shrinkKey) {
       event.preventDefault();
       resizeBy(event.shiftKey ? -80 : -24);
     } else if (event.key === 'Home') {
       event.preventDefault();
-      setBottomPanelHeight(MIN_BOTTOM_PANEL_HEIGHT);
+      if (dockPosition === 'right') {
+        setRightPanelWidth(MIN_RIGHT_PANEL_WIDTH);
+      } else {
+        setBottomPanelHeight(MIN_BOTTOM_PANEL_HEIGHT);
+      }
     } else if (event.key === 'End') {
       event.preventDefault();
-      setBottomPanelHeight(MAX_BOTTOM_PANEL_HEIGHT);
+      if (dockPosition === 'right') {
+        setRightPanelWidth(MAX_RIGHT_PANEL_WIDTH);
+      } else {
+        setBottomPanelHeight(MAX_BOTTOM_PANEL_HEIGHT);
+      }
     }
   };
 
+  const handleResizeWheel = (event: WheelEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const orientationLabel = dockPosition === 'right' ? 'right dock' : 'bottom dock';
+
   return (
     <section
-      className="workbench-bottom-panel border-t border-border bg-card"
-      aria-label="Workbench bottom panel"
-      style={{ '--workbench-bottom-panel-height': `${bottomPanelHeight}px` } as CSSProperties}
+      className={`workbench-chat-dock workbench-chat-dock--${dockPosition} bg-card`}
+      aria-label={`Workbench ${orientationLabel}`}
+      data-dock-position={dockPosition}
+      style={
+        {
+          '--workbench-bottom-panel-height': `${bottomPanelHeight}px`,
+          '--workbench-right-panel-width': `${rightPanelWidth}px`,
+        } as CSSProperties
+      }
     >
       <button
         type="button"
-        className="workbench-bottom-panel-resizer desktop-no-drag"
-        aria-label="Resize workbench panel"
-        title="Drag to resize workbench panel"
+        className="workbench-chat-dock-resizer desktop-no-drag"
+        aria-label={`Resize ${orientationLabel}`}
+        aria-orientation={dockPosition === 'right' ? 'vertical' : 'horizontal'}
+        title={`Drag to resize ${orientationLabel}`}
         onPointerDown={handleResizePointerDown}
         onPointerMove={handleResizePointerMove}
         onPointerUp={handleResizePointerEnd}
         onPointerCancel={handleResizePointerEnd}
         onKeyDown={handleResizeKeyDown}
+        onWheel={handleResizeWheel}
       >
-        <GripHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+        {dockPosition === 'right' ? (
+          <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <GripHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
       </button>
-      <Group
-        justify="space-between"
-        wrap="nowrap"
-        className="desktop-no-drag h-11 border-b border-border px-3"
-      >
-        <Group gap="xs" wrap="nowrap">
-          {bottomPanel === 'board-chat' ? (
-            <MessageSquare className="h-4 w-4 text-primary" aria-hidden="true" />
-          ) : (
-            <Users className="h-4 w-4 text-primary" aria-hidden="true" />
-          )}
-          <Text size="sm" fw={600}>
-            Workbench
-          </Text>
+      <div className="desktop-no-drag shrink-0 space-y-2 border-b border-border px-3 py-2">
+        <Group justify="space-between" wrap="nowrap">
+          <Group gap="xs" wrap="nowrap">
+            {bottomPanel === 'board-chat' ? (
+              <MessageSquare className="h-4 w-4 text-primary" aria-hidden="true" />
+            ) : (
+              <Users className="h-4 w-4 text-primary" aria-hidden="true" />
+            )}
+            <Text size="sm" fw={600}>
+              Workbench
+            </Text>
+          </Group>
+          <Group gap={4} wrap="nowrap">
+            {isDesktopClient && (
+              <SegmentedControl
+                size="xs"
+                value={dockPosition}
+                onChange={(value) => setDockPosition(value as DesktopDockPosition)}
+                data={DOCK_OPTIONS}
+                aria-label="Dock position"
+              />
+            )}
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size={30}
+              onClick={closeBottomPanel}
+              aria-label={`Close ${orientationLabel}`}
+              title={`Close ${orientationLabel}`}
+            >
+              {dockPosition === 'right' ? (
+                <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <PanelBottomClose className="h-4 w-4" aria-hidden="true" />
+              )}
+            </ActionIcon>
+          </Group>
+        </Group>
+        <Group wrap="nowrap">
           <SegmentedControl
             size="xs"
             value={bottomPanel}
             onChange={(value) => openBottomPanel(value as DesktopBottomPanelId)}
             data={PANEL_OPTIONS}
-            aria-label="Bottom panel"
+            aria-label="Chat channel"
           />
         </Group>
-        <ActionIcon
-          variant="subtle"
-          color="gray"
-          size={30}
-          onClick={closeBottomPanel}
-          aria-label="Close bottom panel"
-          title="Close bottom panel"
-        >
-          <PanelBottomClose className="h-4 w-4" aria-hidden="true" />
-        </ActionIcon>
-      </Group>
-      <div className="min-h-0 flex-1 overflow-hidden">
+      </div>
+      <div className="workbench-chat-dock-content min-h-0 flex-1 overflow-hidden">
         <Suspense
           fallback={
             <div className="flex h-full items-center justify-center text-sm text-muted-foreground">

--- a/web/src/components/layout/DesktopShellContext.tsx
+++ b/web/src/components/layout/DesktopShellContext.tsx
@@ -4,22 +4,28 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
 import { useMediaQuery } from '@mantine/hooks';
 
 export type DesktopBottomPanel = 'board-chat' | 'squad-chat';
+export type DesktopDockPosition = 'right' | 'bottom';
 
 interface DesktopShellContextValue {
   isDesktopClient: boolean;
   leftRailOpen: boolean;
   rightRailOpen: boolean;
   bottomPanel: DesktopBottomPanel | null;
+  dockPosition: DesktopDockPosition;
   bottomPanelHeight: number;
+  rightPanelWidth: number;
   setLeftRailOpen: (open: boolean) => void;
   setRightRailOpen: (open: boolean) => void;
+  setDockPosition: (position: DesktopDockPosition) => void;
   setBottomPanelHeight: (height: number) => void;
+  setRightPanelWidth: (width: number) => void;
   openBottomPanel: (panel: DesktopBottomPanel) => void;
   closeBottomPanel: () => void;
   toggleBottomPanel: (panel?: DesktopBottomPanel) => void;
@@ -29,22 +35,33 @@ const LEFT_RAIL_STORAGE_KEY = 'veritas.desktop.leftRailOpen';
 const RIGHT_RAIL_STORAGE_KEY = 'veritas.desktop.rightRailOpen';
 const BOTTOM_PANEL_STORAGE_KEY = 'veritas.desktop.bottomPanel';
 const BOTTOM_PANEL_HEIGHT_STORAGE_KEY = 'veritas.workbench.bottomPanelHeight';
+const DOCK_POSITION_STORAGE_KEY = 'veritas.workbench.dockPosition';
+const RIGHT_PANEL_WIDTH_STORAGE_KEY = 'veritas.workbench.rightPanelWidth';
 const BOTTOM_PANEL_HISTORY_STATE_KEY = 'veritasBottomPanel';
-const BOTTOM_PANEL_VIEWPORT_RESERVE = 220;
+const BOTTOM_PANEL_VIEWPORT_RESERVE = 320;
+const RIGHT_PANEL_VIEWPORT_RESERVE = 520;
 const COMPACT_BOTTOM_PANEL_HEIGHT = 200;
+const COMPACT_RIGHT_PANEL_WIDTH = 280;
 export const DEFAULT_BOTTOM_PANEL_HEIGHT = 340;
 export const MIN_BOTTOM_PANEL_HEIGHT = 320;
 export const MAX_BOTTOM_PANEL_HEIGHT = 640;
+export const DEFAULT_RIGHT_PANEL_WIDTH = 420;
+export const MIN_RIGHT_PANEL_WIDTH = 320;
+export const MAX_RIGHT_PANEL_WIDTH = 640;
 
 const DEFAULT_CONTEXT: DesktopShellContextValue = {
   isDesktopClient: false,
   leftRailOpen: false,
   rightRailOpen: false,
   bottomPanel: null,
+  dockPosition: 'right',
   bottomPanelHeight: DEFAULT_BOTTOM_PANEL_HEIGHT,
+  rightPanelWidth: DEFAULT_RIGHT_PANEL_WIDTH,
   setLeftRailOpen: () => undefined,
   setRightRailOpen: () => undefined,
+  setDockPosition: () => undefined,
   setBottomPanelHeight: () => undefined,
+  setRightPanelWidth: () => undefined,
   openBottomPanel: () => undefined,
   closeBottomPanel: () => undefined,
   toggleBottomPanel: () => undefined,
@@ -72,6 +89,7 @@ function readStoredBoolean(key: string, fallback: boolean): boolean {
 }
 
 function clampBottomPanelHeight(height: number): number {
+  const finiteHeight = Number.isFinite(height) ? height : DEFAULT_BOTTOM_PANEL_HEIGHT;
   const viewportMax =
     typeof window === 'undefined'
       ? MAX_BOTTOM_PANEL_HEIGHT
@@ -80,20 +98,63 @@ function clampBottomPanelHeight(height: number): number {
           Math.max(COMPACT_BOTTOM_PANEL_HEIGHT, window.innerHeight - BOTTOM_PANEL_VIEWPORT_RESERVE)
         );
   const viewportMin = Math.min(MIN_BOTTOM_PANEL_HEIGHT, viewportMax);
-  return Math.min(viewportMax, Math.max(viewportMin, height));
+  return Math.min(viewportMax, Math.max(viewportMin, finiteHeight));
+}
+
+function clampRightPanelWidth(width: number): number {
+  const finiteWidth = Number.isFinite(width) ? width : DEFAULT_RIGHT_PANEL_WIDTH;
+  const viewportMax =
+    typeof window === 'undefined'
+      ? MAX_RIGHT_PANEL_WIDTH
+      : Math.min(
+          MAX_RIGHT_PANEL_WIDTH,
+          Math.max(COMPACT_RIGHT_PANEL_WIDTH, window.innerWidth - RIGHT_PANEL_VIEWPORT_RESERVE)
+        );
+  const viewportMin = Math.min(MIN_RIGHT_PANEL_WIDTH, viewportMax);
+  return Math.min(viewportMax, Math.max(viewportMin, finiteWidth));
 }
 
 function readStoredBottomPanelHeight(): number {
   if (typeof window === 'undefined') return DEFAULT_BOTTOM_PANEL_HEIGHT;
 
   try {
-    const value = Number(window.localStorage.getItem(BOTTOM_PANEL_HEIGHT_STORAGE_KEY));
-    return Number.isFinite(value)
+    const stored = window.localStorage.getItem(BOTTOM_PANEL_HEIGHT_STORAGE_KEY);
+    if (stored === null) return clampBottomPanelHeight(DEFAULT_BOTTOM_PANEL_HEIGHT);
+    const value = Number(stored);
+    return Number.isFinite(value) && value > 0
       ? clampBottomPanelHeight(value)
       : clampBottomPanelHeight(DEFAULT_BOTTOM_PANEL_HEIGHT);
   } catch {
     return DEFAULT_BOTTOM_PANEL_HEIGHT;
   }
+}
+
+function readStoredRightPanelWidth(): number {
+  if (typeof window === 'undefined') return DEFAULT_RIGHT_PANEL_WIDTH;
+
+  try {
+    const stored = window.localStorage.getItem(RIGHT_PANEL_WIDTH_STORAGE_KEY);
+    if (stored === null) return clampRightPanelWidth(DEFAULT_RIGHT_PANEL_WIDTH);
+    const value = Number(stored);
+    return Number.isFinite(value) && value > 0
+      ? clampRightPanelWidth(value)
+      : clampRightPanelWidth(DEFAULT_RIGHT_PANEL_WIDTH);
+  } catch {
+    return DEFAULT_RIGHT_PANEL_WIDTH;
+  }
+}
+
+function readStoredDockPosition(): DesktopDockPosition {
+  if (typeof window === 'undefined') return 'right';
+
+  try {
+    const stored = window.localStorage.getItem(DOCK_POSITION_STORAGE_KEY);
+    if (stored === 'right' || stored === 'bottom') return stored;
+    if (stored !== null) window.localStorage.removeItem(DOCK_POSITION_STORAGE_KEY);
+  } catch {
+    // Use the safe desktop default when storage is unavailable.
+  }
+  return 'right';
 }
 
 function writeStoredValue(key: string, value: string): void {
@@ -120,6 +181,7 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
   const desktopClient = isDesktopClient();
   const supportsWorkbenchPanel = useMediaQuery('(min-width: 768px)', false);
   const canUseBottomPanel = desktopClient || supportsWorkbenchPanel;
+  const panelTriggerRef = useRef<HTMLElement | null>(null);
   const [leftRailOpen, setLeftRailOpenState] = useState(() =>
     readStoredBoolean(LEFT_RAIL_STORAGE_KEY, true)
   );
@@ -127,9 +189,13 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
     readStoredBoolean(RIGHT_RAIL_STORAGE_KEY, false)
   );
   const [bottomPanel, setBottomPanel] = useState<DesktopBottomPanel | null>(null);
+  const [dockPosition, setDockPositionState] = useState<DesktopDockPosition>(() =>
+    readStoredDockPosition()
+  );
   const [bottomPanelHeight, setBottomPanelHeightState] = useState(() =>
     readStoredBottomPanelHeight()
   );
+  const [rightPanelWidth, setRightPanelWidthState] = useState(() => readStoredRightPanelWidth());
 
   const setLeftRailOpen = useCallback(
     (open: boolean) => {
@@ -147,37 +213,67 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
     [desktopClient]
   );
 
+  const setDockPosition = useCallback(
+    (position: DesktopDockPosition) => {
+      setDockPositionState(position);
+      if (desktopClient) writeStoredValue(DOCK_POSITION_STORAGE_KEY, position);
+    },
+    [desktopClient]
+  );
+
   const setBottomPanelHeight = useCallback((height: number) => {
     const next = clampBottomPanelHeight(height);
     setBottomPanelHeightState(next);
     writeStoredValue(BOTTOM_PANEL_HEIGHT_STORAGE_KEY, String(next));
   }, []);
 
+  const setRightPanelWidth = useCallback((width: number) => {
+    const next = clampRightPanelWidth(width);
+    setRightPanelWidthState(next);
+    writeStoredValue(RIGHT_PANEL_WIDTH_STORAGE_KEY, String(next));
+  }, []);
+
+  const restorePanelFocus = useCallback(() => {
+    const trigger = panelTriggerRef.current;
+    panelTriggerRef.current = null;
+    if (!trigger) return;
+    requestAnimationFrame(() => {
+      if (trigger.isConnected) trigger.focus();
+    });
+  }, []);
+
   const closeBottomPanel = useCallback(() => {
     setBottomPanel(null);
     removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
+    restorePanelFocus();
     if (typeof window !== 'undefined' && window.history.state?.[BOTTOM_PANEL_HISTORY_STATE_KEY]) {
       window.history.back();
     }
-  }, []);
+  }, [restorePanelFocus]);
 
-  const openBottomPanel = useCallback((panel: DesktopBottomPanel) => {
-    setBottomPanel(panel);
-    removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
-    if (typeof window === 'undefined') return;
+  const openBottomPanel = useCallback(
+    (panel: DesktopBottomPanel) => {
+      if (!bottomPanel && document.activeElement instanceof HTMLElement) {
+        panelTriggerRef.current = document.activeElement;
+      }
+      setBottomPanel(panel);
+      removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
+      if (typeof window === 'undefined') return;
 
-    const state = {
-      ...(typeof window.history.state === 'object' && window.history.state
-        ? window.history.state
-        : {}),
-      [BOTTOM_PANEL_HISTORY_STATE_KEY]: panel,
-    };
-    if (window.history.state?.[BOTTOM_PANEL_HISTORY_STATE_KEY]) {
-      window.history.replaceState(state, '', window.location.href);
-    } else {
-      window.history.pushState(state, '', window.location.href);
-    }
-  }, []);
+      const state = {
+        ...(typeof window.history.state === 'object' && window.history.state
+          ? window.history.state
+          : {}),
+        [BOTTOM_PANEL_HISTORY_STATE_KEY]: panel,
+      };
+      if (window.history.state?.[BOTTOM_PANEL_HISTORY_STATE_KEY]) {
+        window.history.replaceState(state, '', window.location.href);
+      } else {
+        window.history.pushState(state, '', window.location.href);
+      }
+    },
+    [bottomPanel]
+  );
 
   const toggleBottomPanel = useCallback(
     (panel: DesktopBottomPanel = 'board-chat') => {
@@ -194,11 +290,16 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
     setLeftRailOpenState(true);
     setRightRailOpenState(false);
     setBottomPanel(null);
+    setDockPositionState('right');
     setBottomPanelHeightState(clampBottomPanelHeight(DEFAULT_BOTTOM_PANEL_HEIGHT));
+    setRightPanelWidthState(clampRightPanelWidth(DEFAULT_RIGHT_PANEL_WIDTH));
     removeStoredValue(LEFT_RAIL_STORAGE_KEY);
     removeStoredValue(RIGHT_RAIL_STORAGE_KEY);
     removeStoredValue(BOTTOM_PANEL_STORAGE_KEY);
     removeStoredValue(BOTTOM_PANEL_HEIGHT_STORAGE_KEY);
+    removeStoredValue(DOCK_POSITION_STORAGE_KEY);
+    removeStoredValue(RIGHT_PANEL_WIDTH_STORAGE_KEY);
+    restorePanelFocus();
     if (
       typeof window !== 'undefined' &&
       typeof window.history.state === 'object' &&
@@ -207,7 +308,7 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
       const { [BOTTOM_PANEL_HISTORY_STATE_KEY]: _panel, ...rest } = window.history.state;
       window.history.replaceState(rest, '', window.location.href);
     }
-  }, []);
+  }, [restorePanelFocus]);
 
   useEffect(() => {
     if (!desktopClient || typeof document === 'undefined') return;
@@ -227,6 +328,7 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
     const handlePopState = (event: PopStateEvent) => {
       const panel = event.state?.[BOTTOM_PANEL_HISTORY_STATE_KEY];
       setBottomPanel(isBottomPanel(panel) ? panel : null);
+      if (!isBottomPanel(panel)) restorePanelFocus();
     };
     const handleResize = () => {
       setBottomPanelHeightState((current) => {
@@ -236,17 +338,26 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
         }
         return next;
       });
+      setRightPanelWidthState((current) => {
+        const next = clampRightPanelWidth(current);
+        if (next !== current) {
+          writeStoredValue(RIGHT_PANEL_WIDTH_STORAGE_KEY, String(next));
+        }
+        return next;
+      });
     };
 
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('popstate', handlePopState);
     window.addEventListener('resize', handleResize);
+    document.addEventListener('fullscreenchange', handleResize);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('popstate', handlePopState);
       window.removeEventListener('resize', handleResize);
+      document.removeEventListener('fullscreenchange', handleResize);
     };
-  }, [bottomPanel, closeBottomPanel]);
+  }, [bottomPanel, closeBottomPanel, restorePanelFocus]);
 
   useEffect(() => {
     const desktop = (
@@ -267,10 +378,14 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
       leftRailOpen: desktopClient ? leftRailOpen : false,
       rightRailOpen: desktopClient ? rightRailOpen : false,
       bottomPanel: canUseBottomPanel ? bottomPanel : null,
+      dockPosition: desktopClient ? dockPosition : 'bottom',
       bottomPanelHeight,
+      rightPanelWidth,
       setLeftRailOpen,
       setRightRailOpen,
+      setDockPosition,
       setBottomPanelHeight,
+      setRightPanelWidth,
       openBottomPanel,
       closeBottomPanel,
       toggleBottomPanel,
@@ -280,12 +395,16 @@ export function DesktopShellProvider({ children }: { children: ReactNode }) {
       closeBottomPanel,
       canUseBottomPanel,
       desktopClient,
+      dockPosition,
       bottomPanelHeight,
       leftRailOpen,
       openBottomPanel,
+      rightPanelWidth,
       rightRailOpen,
+      setDockPosition,
       setBottomPanelHeight,
       setLeftRailOpen,
+      setRightPanelWidth,
       setRightRailOpen,
       toggleBottomPanel,
     ]

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -160,6 +160,7 @@ export function Header() {
     leftRailOpen,
     rightRailOpen,
     bottomPanel,
+    dockPosition,
     setLeftRailOpen,
     setRightRailOpen,
     openBottomPanel,
@@ -426,14 +427,18 @@ export function Header() {
                   color={bottomPanel ? 'veritas' : 'gray'}
                   size={32}
                   onClick={() => toggleBottomPanel('board-chat')}
-                  aria-label={bottomPanel ? 'Close bottom panel' : 'Open bottom panel'}
+                  aria-label={bottomPanel ? `Close ${dockPosition} chat dock` : 'Open chat dock'}
                   aria-pressed={Boolean(bottomPanel)}
-                  title={bottomPanel ? 'Close bottom panel' : 'Open bottom panel'}
+                  title={bottomPanel ? `Close ${dockPosition} chat dock` : 'Open chat dock'}
                 >
-                  {bottomPanel ? (
+                  {bottomPanel && dockPosition === 'bottom' ? (
                     <PanelBottomClose className="h-4 w-4" aria-hidden="true" />
-                  ) : (
+                  ) : bottomPanel ? (
+                    <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+                  ) : dockPosition === 'bottom' ? (
                     <PanelBottom className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <PanelRight className="h-4 w-4" aria-hidden="true" />
                   )}
                 </ActionIcon>
               </Group>

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -244,9 +244,32 @@ html[data-client='desktop'] .desktop-header-leading {
   padding-left: 6rem;
 }
 
+html:not([data-client='desktop']) .desktop-workbench-container {
+  display: contents;
+}
+
+html[data-client='desktop'] .desktop-workbench-container {
+  display: flex;
+  min-height: 0;
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+html[data-client='desktop'] .desktop-workbench-container[data-dock-position='right'] {
+  flex-direction: row;
+}
+
+html[data-client='desktop'] .desktop-workbench-container[data-dock-position='bottom'],
+html[data-client='desktop'] .desktop-workbench-container:not([data-dock-position]) {
+  flex-direction: column;
+}
+
 html[data-client='desktop'] .desktop-workbench {
   display: flex;
   min-height: 0;
+  min-width: 0;
   flex: 1 1 auto;
   overflow: hidden;
 }
@@ -261,49 +284,88 @@ html[data-client='desktop'] .desktop-main-content {
   min-width: 0;
   flex: 1 1 auto;
   overflow: auto;
+  overscroll-behavior: contain;
 }
 
-.workbench-bottom-panel {
+.workbench-chat-dock {
   display: flex;
-  height: var(--workbench-bottom-panel-height, 340px);
   min-height: 0;
-  max-height: min(max(200px, calc(100vh - 220px)), 640px);
-  flex: 0 0 var(--workbench-bottom-panel-height, 340px);
+  min-width: 0;
   flex-direction: column;
   overflow: hidden;
+  overscroll-behavior: contain;
 }
 
-html:not([data-client='desktop']) .workbench-bottom-panel {
+html:not([data-client='desktop']) .workbench-chat-dock {
   position: sticky;
   bottom: 0;
   z-index: 35;
+  height: var(--workbench-bottom-panel-height, 340px);
+  max-height: min(max(200px, calc(100vh - 320px)), 640px);
+  flex: 0 0 var(--workbench-bottom-panel-height, 340px);
   box-shadow: 0 -12px 32px color-mix(in oklch, var(--foreground) 10%, transparent);
 }
 
-html[data-client='desktop'] .workbench-bottom-panel {
+html[data-client='desktop'] .workbench-chat-dock--bottom {
+  height: var(--workbench-bottom-panel-height, 340px);
   min-height: 0;
-  max-height: min(max(200px, calc(100vh - 220px)), 640px);
+  max-height: min(max(200px, calc(100vh - 320px)), 640px);
   flex: 0 0 var(--workbench-bottom-panel-height, 340px);
+  border-top: 1px solid var(--border);
 }
 
-.workbench-bottom-panel-resizer {
+html[data-client='desktop'] .workbench-chat-dock--right {
+  width: var(--workbench-right-panel-width, 420px);
+  min-width: 0;
+  max-width: min(max(280px, calc(100vw - 520px)), 640px);
+  flex: 0 0 var(--workbench-right-panel-width, 420px);
+  border-left: 1px solid var(--border);
+}
+
+.workbench-chat-dock-resizer {
   display: flex;
-  height: 10px;
-  width: 100%;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  border: 0;
-  border-bottom: 1px solid var(--border);
+  border: 0 solid var(--border);
   background: color-mix(in oklch, var(--card) 92%, var(--muted));
   color: var(--muted-foreground);
-  cursor: ns-resize;
   touch-action: none;
+  overscroll-behavior: none;
 }
 
-.workbench-bottom-panel-resizer:hover,
-.workbench-bottom-panel-resizer:focus-visible {
+.workbench-chat-dock--bottom .workbench-chat-dock-resizer {
+  height: 10px;
+  width: 100%;
+  border-bottom-width: 1px;
+  cursor: ns-resize;
+}
+
+.workbench-chat-dock--right .workbench-chat-dock-resizer {
+  position: absolute;
+  z-index: 2;
+  left: 0;
+  height: 100%;
+  width: 10px;
+  border-right-width: 1px;
+  cursor: ew-resize;
+}
+
+.workbench-chat-dock--right {
+  position: relative;
+}
+
+.workbench-chat-dock-resizer:hover,
+.workbench-chat-dock-resizer:focus-visible {
   background: color-mix(in oklch, var(--primary) 12%, var(--card));
   color: var(--foreground);
+}
+
+.workbench-chat-dock-content,
+.workbench-chat-dock-content > *,
+.workbench-chat-dock .mantine-ScrollArea-viewport,
+.chat-dock-scroll-area .mantine-ScrollArea-viewport {
+  overscroll-behavior: contain;
 }
 
 html[data-client='desktop'] .desktop-board-with-right-rail {


### PR DESCRIPTION
## Summary

- open Board Chat and Squad Chat in a bounded right dock by default
- switch Right and Bottom in place without remounting the active conversation
- clamp both dimensions and isolate chat scrolling from the application shell
- keep Close, Escape, Back, Reset Layout, and focus recovery available
- document the new desktop behavior in the changelog and feature docs

## Focused verification

- `pnpm --filter @veritas-kanban/web typecheck`
- `pnpm --filter @veritas-kanban/web exec vitest run src/__tests__/desktop-shell-context.test.tsx src/__tests__/layout-chrome-mantine.test.tsx` (10 tests)
- `pnpm exec eslint` on the touched web files
- `pnpm --filter @veritas-kanban/web build`
- Playwright desktop smoke at 1180x760: Right and Bottom layouts, visible board/header/close controls, wheel-stable resizer, Escape close, and focus restoration

## Release gate

The signed packaged macOS smoke and asset digest verification remain required at the v6.0.2 milestone boundary. They are not claimed by this source-level PR.

Closes #1004