### PR TITLE
release: prepare Veritas Kanban 6.0.2 desktop hotfix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 > Harness-specific supplements (for example `CLAUDE.md`) extend, never duplicate or contradict,
 > these rules. See `docs/AGENTS-TEMPLATE.md` for the managed-run and external-agent protocols.
 >
-> **Version:** 6.0.1
+> **Version:** 6.0.2
 > **Freshness policy:** update within two working days of any toolchain or architecture change.
 > Stale fields (package manager, Node version, provider list, test commands) are caught by
 > `pnpm check:pnpm-settings` and the smoke-test CI job.
@@ -90,6 +90,13 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   can perform the operation.
 - Fall back only when `gh` is unavailable or cannot support the required operation. Report the
   exact blocker before changing paths.
+- Source every published GitHub release body from `docs/releases/vX.Y.Z.md` and pass that file
+  to `gh release create` or `gh release edit` with `--notes-file`.
+- Keep each prose paragraph, blockquote, and list item on one logical Markdown source line.
+  Separate blocks with blank lines. Do not hard-wrap release prose or add carriage returns,
+  trailing-space hard breaks, literal escaped newlines, or HTML `<br>` tags.
+- Run `pnpm validate:release -- --version X.Y.Z`; the post-publication `--github` form also
+  requires the published GitHub body to match the reviewed file exactly.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.2] - 2026-07-24
+
+Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix. It keeps
+Chat contained within a reversible Workbench dock, adds authoritative native
+version/build information, and makes CI verification proportional to the
+change while retaining full release gates.
+
 ### Changed
 
 - Made CI test scope deterministic and path-aware. Documentation-only changes
@@ -2239,7 +2246,8 @@ Veritas Kanban is an AI-native project management board built for developers and
 
 _Built by [Digital Meld](https://digitalmeld.io) — AI-driven enterprise automation._
 
-[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v6.0.1...HEAD
+[unreleased]: https://github.com/BradGroux/veritas-kanban/compare/v6.0.2...HEAD
+[6.0.2]: https://github.com/BradGroux/veritas-kanban/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/BradGroux/veritas-kanban/compare/v6.0.0...v6.0.1
 [6.0.0]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.5...v6.0.0
 [5.2.5]: https://github.com/BradGroux/veritas-kanban/compare/v5.2.4...v5.2.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 > Claude-specific lessons and common mistakes caught by previous Claude runs. Do not duplicate
 > `AGENTS.md` content here.
 >
-> **Last updated:** 2026-07-24 (v6.0.1 release freshness)
+> **Last updated:** 2026-07-24 (v6.0.2 release freshness)
 > **Freshness check:** Update after mistakes; review monthly.
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start with a visual Kanban board. Add CLI, MCP, OpenClaw, Squad Chat webhooks, w
 
 [![CI](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml/badge.svg)](https://github.com/BradGroux/veritas-kanban/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-6.0.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.0.2-blue.svg)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/cli",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "CLI for Veritas Kanban task management",
   "type": "module",
   "bin": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/desktop",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "homepage": "https://github.com/BradGroux/veritas-kanban",
   "description": "Veritas Kanban native desktop shell",

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,6 +1,6 @@
 # Veritas Kanban — API Reference
 
-**Version**: 6.0.1
+**Version**: 6.0.2
 **Last Updated**: 2026-07-24
 **Base URL**: `http://localhost:3001/api`
 **Canonical prefix**: `/api/v1` (alias: `/api`)
@@ -1463,7 +1463,7 @@ POST /api/run-sessions/run_share_abc/approvals
   "note": "Use the release branch.",
   "responseData": {
     "answers": {
-      "branch": { "answers": ["release/v6.0.1"] }
+      "branch": { "answers": ["release/v6.0.2"] }
     }
   }
 }

--- a/docs/DOC-FRESHNESS.md
+++ b/docs/DOC-FRESHNESS.md
@@ -58,6 +58,7 @@ When a doc is older than the current version, it may need review.
 
 | Date       | Scope                                                               | Agent   |
 | ---------- | ------------------------------------------------------------------- | ------- |
+| 2026-07-24 | v6.0.2 desktop recovery, version support, release, and evidence     | Release |
 | 2026-07-24 | v6.0.1 stabilization, release, upgrade, API, MCP, and evidence      | Release |
 | 2026-07-24 | v6.0.0 harness, Buzz, release, upgrade, compatibility, and evidence | Release |
 | 2026-07-12 | v5.2.2 UI-audit fixes, release gates, desktop state, and evidence   | Release |

--- a/docs/V6-COMPATIBILITY-AND-RELEASE-POLICY.md
+++ b/docs/V6-COMPATIBILITY-AND-RELEASE-POLICY.md
@@ -1,11 +1,11 @@
 # Veritas Kanban v6 Compatibility And Release Policy
 
-This policy defines supported v6.0.1 combinations, harness evidence, release
+This policy defines supported v6.0.2 combinations, harness evidence, release
 channels, and rollback limits. The machine-readable harness record at
 `GET /api/config/harness-compatibility` is authoritative for exact capability
 digests, fixture revisions, and the current host's live state.
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2.
 
 ## Harness Support Tiers
 
@@ -25,7 +25,7 @@ are incompatible with v6.
 
 | Component                              | Supported v6 combination                                                                    | Detection/evidence                                                                                      | Fail-closed boundary                                                                                                            |
 | -------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Server, web, shared, CLI, MCP, desktop | All release packages are exactly 6.0.1.                                                     | Package manifests, `/api/health.version`, `vk --version`, MCP metadata, desktop bundle/update metadata. | Mixed release packages are unsupported for publication.                                                                         |
+| Server, web, shared, CLI, MCP, desktop | All release packages are exactly 6.0.2.                                                     | Package manifests, `/api/health.version`, `vk --version`, MCP metadata, desktop bundle/update metadata. | Mixed release packages are unsupported for publication.                                                                         |
 | Public API                             | REST API remains `v1` at `/api/v1`, with `/api` compatibility aliases where documented.     | `X-API-Version`, OpenAPI/reference docs, CLI/MCP smoke.                                                 | Unknown API versions or incompatible auth fail before mutation.                                                                 |
 | Buzz Agent                             | Buzz v0.4.24 commit `710ed9fff57878a1d69f809b80a6ee0416c53fc4`; `buzz-agent 0.1.0`; ACP v1. | Exact initialize identity, capability digest, probe revision, composed Buzz fixtures.                   | Unknown build, `buzz-acp`, resume, HTTP/SSE MCP, or capability drift blocks.                                                    |
 | Buzz relay integration                 | Buzz v0.4.24; NIP-11, NIP-29, NIP-42; optional NIP-43 membership.                           | Pinned relay compatibility evidence, signed query/event fixtures, mapping state.                        | Host/TLS drift, unsafe URL, bad signature, identity mismatch, replay, or disabled mapping blocks.                               |
@@ -37,7 +37,7 @@ are incompatible with v6.
 | GitHub Copilot CLI                     | v1.0.74 public-preview ACP; tag commit `2b809c84e87dbcc88f897cb4f3fb97c43b77af95`.          | Version and ACP initialize handshake; authentication remains provider-managed.                          | Version drift, broad allow, remote/plugin/config injection, or unsupported controls blocks.                                     |
 | Hermes Agent                           | v2026.7.7.2 one-shot process adapter.                                                       | `hermes --version` and allowlisted boot authentication.                                                 | Resume/follow-up remains unsupported.                                                                                           |
 | OpenClaw                               | v2026.6.11 gateway adapter.                                                                 | Gateway health, runtime manifest, explicit operator tool policy.                                        | Missing `sessions_spawn`/`sessions_send`, unknown evidence, or unsupported task controls blocks.                                |
-| macOS desktop                          | macOS arm64 signed/notarized app with bundled 6.0.1 server/web.                             | Bundle version, signature, Gatekeeper, stapling, `/api/health.version`, update metadata.                | Mixed bundle/runtime, failed readiness, signature, or metadata checks blocks stable publication.                                |
+| macOS desktop                          | macOS arm64 signed/notarized app with bundled 6.0.2 server/web.                             | Bundle version, signature, Gatekeeper, stapling, `/api/health.version`, update metadata.                | Mixed bundle/runtime, failed readiness, signature, or metadata checks blocks stable publication.                                |
 | Linux/Windows desktop                  | Unsigned preview artifacts only.                                                            | Cross-platform packaging workflows.                                                                     | Not a supported stable install or update channel.                                                                               |
 | Desktop SQLite/profile                 | Existing v5.2.5 workspace upgraded in place after a complete backup.                        | Data/profile counts, integrity check, startup normalization, board/runtime smoke.                       | Competing writers, unsafe filesystem, failed migration, or missing recovery evidence blocks acceptance.                         |
 
@@ -73,7 +73,7 @@ Provider-specific opt-in smoke commands are documented in
 - Required filesystem, process, environment, network, MCP, tool, approval,
   budget, and lifecycle controls must be supported by current runtime evidence.
   Advisory controls may proceed with an attributed warning.
-- The fine-grained egress gateway in issue 855 is deferred. v6.0.1 does not
+- The fine-grained egress gateway in issue 855 is deferred. v6.0.2 does not
   claim method/path/domain proxy enforcement that it does not have.
 
 ## Release Channels

--- a/docs/V6-GA-CHECKLIST.md
+++ b/docs/V6-GA-CHECKLIST.md
@@ -1,10 +1,10 @@
 # Veritas Kanban v6 GA Checklist
 
-This checklist is the stable-release gate for Veritas Kanban 6.0.1. Command
+This checklist is the stable-release gate for Veritas Kanban 6.0.2. Command
 results, platform details, workflow links, limitations, and artifact hashes
 belong in [v6 Release Candidate Evidence Packet](V6-RC-EVIDENCE-PACKET.md).
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2.
 
 ## Source And Scope
 
@@ -14,9 +14,9 @@ Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
       through merged, focused pull requests.
 - [x] The release tracker lists the exact main baseline, release branch, release
       PR, deferred v6.x work, and no unresolved release blocker.
-- [x] Root, shared, server, web, CLI, MCP, and desktop manifests are 6.0.1.
+- [x] Root, shared, server, web, CLI, MCP, and desktop manifests are 6.0.2.
 - [x] `AGENTS.md`, README badge, health, CLI, MCP, desktop bundle, artifact
-      names, updater metadata, changelog, and current docs agree on 6.0.1.
+      names, updater metadata, changelog, and current docs agree on 6.0.2.
 - [x] The public API remains intentionally `v1`, with additive v6 contracts and
       tested CLI/MCP compatibility.
 
@@ -37,6 +37,24 @@ Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
 - [x] Desktop setup is version-neutral and the bridge consumes Electron's
       application version; the published bundle, health endpoint, updater, and
       bridge all report 6.0.1 (#986).
+
+## 6.0.2 Desktop Recovery Hotfix
+
+- [x] Board Chat and Squad Chat default to a bounded right-side Workbench dock
+      and can switch between Right and Bottom without remounting the active
+      conversation (#1004).
+- [x] Chat width and height clamp to the live viewport; scrolling, wheel input,
+      Close, Escape, browser Back, Reset Layout, persisted-state recovery, and
+      focus restoration have focused coverage (#1004).
+- [x] Native About, copied support information, the desktop bridge, and updater
+      fallback consume one authoritative version/build/channel/OS/architecture
+      record (#1005).
+- [x] Pull-request verification uses documentation-only, focused, or full test
+      scope, while explicit and milestone release gates remain full (#1000).
+- [x] Published release notes are sourced from
+      `docs/releases/vX.Y.Z.md`, use one full-width Markdown line per paragraph
+      or list item, and are compared with GitHub during post-publication
+      validation.
 
 ## Provider Certification
 
@@ -150,8 +168,8 @@ pnpm desktop:build
 pnpm desktop:check:electron-artifacts
 pnpm desktop:smoke:mac:local
 pnpm desktop:package:mac:unsigned
-pnpm validate:release -- --version 6.0.1
-pnpm validate:release -- --version 6.0.1 --docker-build
+pnpm validate:release -- --version 6.0.2
+pnpm validate:release -- --version 6.0.2 --docker-build
 ```
 
 Provider-specific deterministic suites are part of `pnpm test:unit`; record
@@ -161,26 +179,28 @@ quota are available.
 
 ## Distribution And Post-Publication
 
-- [x] The ready release PR passes required CI and the `ci:full` workspace suite,
-      receives focused standards/spec review, and merges to main.
-- [x] Annotated tag `v6.0.1` peels to the exact release merge commit.
-- [x] The GitHub release is published from reviewed v6 release notes.
-- [x] Desktop Release completes with signed/notarized arm64 DMG and ZIP,
+- [ ] The ready release PR passes required CI and the milestone-wide workspace
+      suite, then merges to main.
+- [ ] Annotated tag `v6.0.2` peels to the exact release merge commit.
+- [ ] The GitHub release is published from reviewed
+      `docs/releases/v6.0.2.md` without hard-wrapped prose.
+- [ ] Desktop Release completes with signed/notarized arm64 DMG and ZIP,
       blockmaps, `latest-mac.yml`, and SHA-256 sidecars.
-- [x] Independent downloads match GitHub digests, sidecars, updater metadata,
+- [ ] Independent downloads match GitHub digests, sidecars, updater metadata,
       byte sizes, and SHA-256 values.
-- [x] DMG and ZIP app signatures, hardened runtime, Gatekeeper, and notarization
+- [ ] DMG and ZIP app signatures, hardened runtime, Gatekeeper, and notarization
       stapling pass.
-- [x] The downloaded signed app launches with an isolated profile, reports
-      6.0.1 through bundle, health, updater, and desktop bridge metadata,
-      verifies Chat recovery, executes a bounded task,
-      and quits cleanly.
-- [x] `pnpm validate:release -- --version 6.0.1 --github --repo BradGroux/veritas-kanban`
+- [ ] The downloaded signed app launches with an isolated profile, reports
+      6.0.2 through bundle, health, updater, native About, copied support
+      information, and desktop bridge metadata; verifies Right and Bottom Chat
+      recovery at the minimum supported window; executes a bounded task; and
+      quits cleanly.
+- [ ] `pnpm validate:release -- --version 6.0.2 --github --repo BradGroux/veritas-kanban`
       passes.
-- [x] The Homebrew cask PR uses the published ZIP checksum, merges, and the
+- [ ] The Homebrew cask PR uses the published ZIP checksum, merges, and the
       registered tap passes style, strict online audit, dry-run install, and
       livecheck.
-- [x] The evidence packet contains release/workflow/asset/Homebrew links,
+- [ ] The evidence packet contains release/workflow/asset/Homebrew links,
       exact hashes, runtime results, limitations, and deferred v6.x issues.
-- [x] The release tracker closes only after every distribution surface above is
+- [ ] The release tracker closes only after every distribution surface above is
       independently verified.

--- a/docs/V6-RC-EVIDENCE-PACKET.md
+++ b/docs/V6-RC-EVIDENCE-PACKET.md
@@ -1,14 +1,36 @@
 # Veritas Kanban v6 Release Candidate Evidence Packet
 
 This packet retains the historical evidence for the quarantined Veritas Kanban
-6.0.0 prerelease and records the 6.0.1 stabilization release. It separates
-merged implementation, deterministic conformance, live provider evidence,
-local runtime proof, signed publication, and Homebrew availability.
+6.0.0 prerelease and the 6.0.1 stabilization release, then records the 6.0.2
+desktop recovery hotfix. It separates merged implementation, deterministic
+conformance, local runtime proof, signed publication, and Homebrew availability.
 
-Veritas Kanban 6.0.1 is the first supported stable v6 release. Do not use
-6.0.0 for installation or upgrade validation.
+Veritas Kanban 6.0.2 supersedes 6.0.1 as the supported stable v6 release. Do
+not use 6.0.0 for installation or upgrade validation.
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2.
+
+## 6.0.2 Desktop Recovery Candidate
+
+| Field               | Value                                                                                                                                                                                                                                                                      |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Release version     | 6.0.2                                                                                                                                                                                                                                                                      |
+| Release tracker     | [#1010](https://github.com/BradGroux/veritas-kanban/issues/1010)                                                                                                                                                                                                           |
+| Source branch       | `release/v6.0.2-1010`                                                                                                                                                                                                                                                      |
+| Source baseline     | `2f18229ff24153ef33b5a21de21f0befb94d8a08`, the merged #1005 main commit with green CI and cross-platform unsigned desktop artifacts                                                                                                                                       |
+| Included issues     | [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000), [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004), [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005), and [#1010](https://github.com/BradGroux/veritas-kanban/issues/1010) |
+| Source verification | Focused tests and rendered smoke per fix; reviewed full workspace evidence on the exact #1005 merge ancestry; one milestone release validation gate                                                                                                                        |
+| Signed runtime gate | Exact 6.0.2 equality across bundle, health, updater, native About, copied support text, and desktop bridge; Right/Bottom Chat recovery at the minimum supported window; bounded task; clean quit                                                                           |
+| Distribution gate   | Annotated tag, reviewed full-width GitHub release body, signed/notarized DMG and ZIP, updater metadata, independent digests, GitHub release validation, and verified Homebrew cask                                                                                         |
+
+### 6.0.2 issue traceability
+
+| Issue                                                            | Pull request                                                   | Outcome                                                                                                  |
+| ---------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000) | [#1003](https://github.com/BradGroux/veritas-kanban/pull/1003) | Deterministic documentation, focused, and full CI test scope                                             |
+| [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004) | [#1008](https://github.com/BradGroux/veritas-kanban/pull/1008) | Bounded right/bottom Chat dock with complete visible recovery paths                                      |
+| [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005) | [#1009](https://github.com/BradGroux/veritas-kanban/pull/1009) | Authoritative native version/build/channel/OS/architecture record and offline copy action                |
+| [#1010](https://github.com/BradGroux/veritas-kanban/issues/1010) | Pending                                                        | Version, documentation, release body, signed publication, downloaded-app verification, and Homebrew gate |
 
 ## 6.0.1 Stabilization Candidate
 
@@ -299,9 +321,10 @@ and Homebrew availability are independent gates.
 - Buzz Agent does not resume in-memory sessions; Buzz communication does not
   project files, reactions, forums, DMs, or destructive edit/delete behavior.
 - [Packaged desktop version reporting](https://github.com/BradGroux/veritas-kanban/issues/986)
-  is fixed in the 6.0.1 source candidate. Exact equality across the downloaded
-  bundle, health endpoint, updater metadata, and desktop bridge remains a
-  signed-publication gate.
+  landed in 6.0.1; [native build and support information](https://github.com/BradGroux/veritas-kanban/issues/1005)
+  is added in 6.0.2. Exact equality across the downloaded bundle, health
+  endpoint, updater metadata, native About, copied support text, and desktop
+  bridge remains a signed-publication gate.
 - Linux and Windows desktop packages remain unsigned previews.
 - Provider and Buzz Settings screenshots were captured from the isolated
   profile. No public-safe active approval existed, so approval visual evidence

--- a/docs/V6-RELEASE-NOTES.md
+++ b/docs/V6-RELEASE-NOTES.md
@@ -1,79 +1,76 @@
-Veritas Kanban 6.0.1 is the first supported stable v6 release. It adds
-first-class Buzz integration and gives Grok Build, OpenAI Codex, Claude Code,
-and GitHub Copilot CLI the same evidence-backed task, worktree, tool, approval,
-credential, event, and completion boundaries.
+# Veritas Kanban 6.0.2 Release Notes
 
-> Veritas Kanban 6.0.0 remains available as a quarantined prerelease. Install
-> 6.0.1 or newer.
+Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix for the
+first stable v6 line. It prevents Chat from trapping the application window,
+adds authoritative native version/build information, and keeps verification
+focused between release milestones.
 
-## Highlights
+> Veritas Kanban 6.0.0 remains a quarantined prerelease. Version 6.0.2
+> supersedes 6.0.1 as the supported stable v6 release.
 
-### One control plane for agent harnesses
+## Desktop Recovery Hotfix
 
-- Buzz Agent, Grok Build, and GitHub Copilot CLI run through the shared ACP v1
-  adapter.
-- OpenAI Codex supports CLI, SDK, and the richer app-server JSON-RPC lifecycle.
-- Claude Code runs through a supervised bare-mode stream.
-- Hermes and OpenClaw retain their supported one-shot and gateway transports.
-- Settings, API diagnostics, telemetry, dispatch, and `vk doctor --json` now
+### Chat stays inside the application shell
+
+Board Chat and Squad Chat now open in a right-side Workbench dock by default.
+The same active conversation can switch between Right and Bottom without
+remounting. The dock clamps its width or height to the live viewport, owns its
+scrolling, and cannot move or cover the entire application shell.
+
+Close, Escape, browser Back, and Reset Layout all return to a visible board and
+restore focus. Invalid or obsolete persisted dimensions recover to the safe
+right-dock default on startup
+([#1004](https://github.com/BradGroux/veritas-kanban/issues/1004)).
+
+### Native About and offline support information
+
+The desktop application now exposes **About Veritas Kanban** and **Copy Version
+Information** in its native application menu. Both use Electron's authoritative
+application record and include:
+
+- application name and identifier;
+- exact semantic version;
+- embedded release commit/build identity;
+- stable, beta, or development channel;
+- operating system version and architecture; and
+- packaged versus development state.
+
+The native About panel, copied support text, desktop bridge, and updater
+fallback all consume the same record. Operators can capture exact diagnostics
+without opening Settings, the renderer, or a network connection
+([#1005](https://github.com/BradGroux/veritas-kanban/issues/1005)).
+
+### Proportional CI verification
+
+CI now selects documentation-only, focused, or full verification from the
+reviewed change range. Ordinary code changes run affected Vitest coverage;
+high-risk, shared, storage, manifest, and release changes retain the full gate.
+A successful reviewed full-suite head can be reused after merge only when it is
+an ancestor of the resulting commit. Scheduled and explicit release gates
+remain authoritative
+([#1000](https://github.com/BradGroux/veritas-kanban/issues/1000)).
+
+## Harness Support
+
+The v6 harness control plane and compatibility claims introduced in 6.0.1 are
+unchanged:
+
+- Buzz Agent, Grok Build, and GitHub Copilot CLI use the shared ACP v1 adapter.
+- OpenAI Codex supports CLI, SDK, and app-server lifecycles.
+- Claude Code uses a supervised bare-mode stream.
+- Hermes and OpenClaw retain their one-shot and gateway transports.
+- Settings, API diagnostics, telemetry, dispatch, and `vk doctor --json`
   report the same support tier and redacted readiness evidence.
 
-Equal footing does not mean pretending every provider has the same features.
+Equal footing does not pretend every provider supports the same controls.
 Veritas probes the installed version and capabilities, persists that evidence,
-and blocks unsupported resume, tool, approval, sandbox, or completion behavior
-before an attempt starts.
+and blocks unsupported lifecycle, tool, approval, sandbox, or completion
+behavior before attempt creation.
 
-### First-class Buzz support
+Buzz communication remains separate from task authority. The relay transports
+signed messages; Veritas owns tasks, attempts, tools, approvals, and completion.
 
-- Connect a pinned Buzz community channel to Squad Chat.
-- Import signed public persona and team definitions as disabled profiles.
-- Run `buzz-agent` through ACP with exact version and capability checks.
-- Expose only the selected run-scoped Veritas tools.
-- Trigger allowlisted Veritas workflows from Buzz root messages with durable
-  replay protection.
-
-Buzz relay delivery remains a communication path. Veritas remains the authority
-for tasks, attempts, tools, approvals, and completion.
-
-### Safer, recoverable runs
-
-- Every run records its task envelope, launch policy, worktree baseline,
-  provider runtime evidence, causal events, approvals, tool catalog, and
-  completion evidence.
-- Restart and reconnect logic verifies ownership before resuming work, avoiding
-  silent duplicate runs.
-- Provider build or capability drift invalidates old certification.
-- Credential-bearing tools use one-shot, exact-action leases instead of
-  exposing raw secrets to provider configuration or logs.
-- The desktop updater rejects older release metadata instead of offering a
-  downgrade.
-
-## Stabilization fixes in 6.0.1
-
-- Chat is a reversible desktop panel with visible close, Escape, browser Back,
-  startup-state recovery, and native layout reset
-  ([#945](https://github.com/BradGroux/veritas-kanban/issues/945)).
-- Task drawers, shared overlays, Archive cards, scoring pages, and the template
-  editor have reachable scrolling and resizing
-  ([#935](https://github.com/BradGroux/veritas-kanban/issues/935),
-  [#938](https://github.com/BradGroux/veritas-kanban/issues/938),
-  [#939](https://github.com/BradGroux/veritas-kanban/issues/939),
-  [#941](https://github.com/BradGroux/veritas-kanban/issues/941)).
-- Workflow actions handle omitted collections and recoverable load failures
-  instead of crashing task detail
-  ([#936](https://github.com/BradGroux/veritas-kanban/issues/936)).
-- Full-page views, task detail, and nested Workflow overlays preserve their
-  actual route origin, browser history, keyboard Back behavior, and scroll
-  position ([#937](https://github.com/BradGroux/veritas-kanban/issues/937)).
-- New scoring profiles open as visible, validated drafts
-  ([#943](https://github.com/BradGroux/veritas-kanban/issues/943)).
-- Operations Digest reconciles board inventory with windowed events and exposes
-  source IDs and metadata-quality findings
-  ([#944](https://github.com/BradGroux/veritas-kanban/issues/944)).
-- The packaged desktop consistently reports its real application version
-  ([#986](https://github.com/BradGroux/veritas-kanban/issues/986)).
-
-## Install or upgrade
+## Install Or Upgrade
 
 ### Homebrew
 
@@ -82,7 +79,7 @@ brew update
 brew upgrade --cask bradgroux/tap/veritas-kanban
 ```
 
-For a first install:
+For a first installation:
 
 ```bash
 brew install --cask bradgroux/tap/veritas-kanban
@@ -91,35 +88,37 @@ brew install --cask bradgroux/tap/veritas-kanban
 ### Direct download
 
 Download the signed and notarized macOS arm64 DMG or ZIP from the
-[v6.0.1 release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.1).
+[v6.0.2 release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.2).
 
-Back up the current workspace before upgrading. Keep the v5.2.5 backup until
-the v6 runtime is accepted. If rollback requires an older schema, restore the
-pre-upgrade backup instead of opening newer data with an incompatible binary.
-Follow the
-[v6 upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md)
-for the complete migration, remote-access, validation, and rollback procedure.
+Back up the current workspace before upgrading. Keep the backup until the new
+runtime is accepted. Follow the
+[v6 upgrade and administration guide](V6-UPGRADE-INSTALL-ADMIN-GUIDE.md) for
+exact readiness, data-preservation, diagnostics, and rollback procedures.
 
-## Important behavior changes
+## Breaking Changes And Migration Warnings
 
-- Provider-less or adapter/profile-mismatched records no longer fall through to
+- Version 6.0.2 does not add a new data-schema migration over 6.0.1.
+- Do not install the quarantined 6.0.0 prerelease.
+- Provider-less or adapter/profile-mismatched records do not fall through to
   OpenClaw.
 - Unknown or changed provider builds lose certification until current probes
   and deterministic fixtures pass.
-- Claude Code no longer launches with `--dangerously-skip-permissions`.
-- Credential-bound MCP servers are not copied into provider-native
-  configuration. They are available only through the mediated run bridge.
-- Conversation controls appear only when the selected provider proves it
-  supports them.
+- Claude Code does not launch with `--dangerously-skip-permissions`.
+- Credential-bound MCP servers are available only through the mediated
+  run-scoped bridge.
 - The public REST API remains mounted at `v1`; the v6 product version does not
   rename API routes.
 
-## Known limitations
+Upgrade from v5.2.5 only after a governed backup. If rollback requires an older
+schema, restore the stopped-writer pre-upgrade backup instead of opening newer
+data with an incompatible binary.
+
+## Known Limitations
 
 - Buzz Agent sessions are in-memory and do not support session load/resume.
   Buzz files, reactions, forums, DMs, and destructive edit/delete projection
   are not bridged.
-- GitHub Copilot CLI ACP is public preview.
+- GitHub Copilot CLI ACP remains public preview.
 - Grok Build's stable artifact self-reports alpha and cannot be fully traced to
   the current public source tree.
 - Claude Code's complete CLI implementation is not public, so certification is
@@ -129,14 +128,31 @@ for the complete migration, remote-access, validation, and rollback procedure.
 - Deterministic compatibility does not prove provider authentication,
   subscription availability, quota, or live inference.
 
-## Documentation and evidence
+## Release Artifacts
 
-- [Agent guide and reusable `AGENTS.md` template](https://github.com/BradGroux/veritas-kanban/blob/main/docs/AGENTS-TEMPLATE.md)
-- [Agent provider setup and operations](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/AGENT-PROVIDERS.md)
-- [Harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/HARNESS-COMPATIBILITY.md)
-- [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/BUZZ-INTEGRATION.md)
-- [v6 runtime architecture](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md)
-- [Release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/main/docs/V6-RC-EVIDENCE-PACKET.md)
-- [Release tracker #924](https://github.com/BradGroux/veritas-kanban/issues/924)
+The supported stable desktop release publishes these assets from the annotated
+`v6.0.2` tag:
+
+- signed and notarized `Veritas-Kanban-6.0.2-mac-arm64.dmg`;
+- signed and notarized `Veritas-Kanban-6.0.2-mac-arm64.zip`;
+- DMG and ZIP blockmaps;
+- SHA-256 sidecars; and
+- `latest-mac.yml` updater metadata.
+
+Linux and Windows builds are verification previews, not stable signed
+distribution artifacts. Exact byte sizes, GitHub digests, signature,
+Gatekeeper, stapling, updater, and downloaded-app evidence are recorded in the
+[v6 release candidate evidence packet](V6-RC-EVIDENCE-PACKET.md).
+
+## Documentation And Evidence
+
+- [Agent guide and reusable `AGENTS.md` template](AGENTS-TEMPLATE.md)
+- [Agent provider setup and operations](AGENT-PROVIDERS.md)
+- [Harness compatibility matrix](HARNESS-COMPATIBILITY.md)
+- [Buzz integration guide](BUZZ-INTEGRATION.md)
+- [v6 runtime architecture](architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md)
+- [v6 compatibility and release policy](V6-COMPATIBILITY-AND-RELEASE-POLICY.md)
+- [v6 GA checklist](V6-GA-CHECKLIST.md)
+- [Release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010)
 - [Buzz epic #904](https://github.com/BradGroux/veritas-kanban/issues/904)
 - [Equal-footing harness epic #915](https://github.com/BradGroux/veritas-kanban/issues/915)

--- a/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md
+++ b/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md
@@ -1,15 +1,15 @@
 # Veritas Kanban v6 Upgrade, Install, Remote, And Admin Guide
 
-This is the release-facing operator guide for Veritas Kanban 6.0.1. The
+This is the release-facing operator guide for Veritas Kanban 6.0.2. The
 detailed provider commands live in [Agent Providers](AGENT-PROVIDERS.md), the
 machine-readable support contract is summarized in
 [Harness Compatibility](HARNESS-COMPATIBILITY.md), and Buzz relay setup lives
 in [Buzz Integration](BUZZ-INTEGRATION.md).
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2.
 
-Do not install 6.0.0. It is retained as a quarantined prerelease; 6.0.1 is the
-first supported stable v6 build.
+Do not install 6.0.0. It is retained as a quarantined prerelease. Version 6.0.2
+is the current supported stable v6 build and supersedes 6.0.1.
 
 ## Fresh Mac Desktop Install
 
@@ -21,8 +21,8 @@ brew install --cask veritas-kanban
 ```
 
 Manual installation uses
-`Veritas-Kanban-6.0.1-mac-arm64.zip` from the
-[v6.0.1 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.1).
+`Veritas-Kanban-6.0.2-mac-arm64.zip` from the
+[v6.0.2 GitHub release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.2).
 Move `Veritas Kanban.app` into `/Applications`, launch it normally, and verify
 Settings -> Maintenance before enabling an agent or external integration.
 
@@ -30,7 +30,7 @@ For a new board:
 
 1. Choose Board Only unless agent execution is required immediately.
 2. Create the local admin password and retain the recovery key securely.
-3. Confirm `/api/health` reports version 6.0.1.
+3. Confirm `/api/health` reports version 6.0.2.
 4. Create a governed backup before adding external credentials or relay
    mappings.
 
@@ -58,14 +58,14 @@ equivalent v5.2.5 self-hosted workspace.
    preferred port are stopped before copying data.
 5. Preserve the complete workspace, not only the SQLite file. Keep the backup
    through release acceptance.
-6. Install v6.0.1 without replacing the workspace.
+6. Install v6.0.2 without replacing the workspace.
 7. Launch with the same profile. If setup appears for a populated database,
    choose **Use Existing Data**. Do not rerun file migration or restore over the
    populated database.
 8. Wait for the exact-version readiness gate:
 
    ```bash
-   EXPECTED_VERSION=6.0.1
+   EXPECTED_VERSION=6.0.2
    pnpm desktop:wait:ready -- --expected-version "$EXPECTED_VERSION"
    ```
 

--- a/docs/V6-VISUAL-TOUR.md
+++ b/docs/V6-VISUAL-TOUR.md
@@ -5,9 +5,10 @@ integration, approvals, and run evidence. The general board, desktop shell,
 Workbench, Squad Chat, Maintenance, and mobile/PWA layouts remain represented
 by the retained [v5 Visual Tour](V5-VISUAL-TOUR.md) and its dummy-data assets.
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1. The retained
-screenshots cover the unchanged v6 provider and Buzz surfaces; 6.0.1
-stabilization behavior is documented in the release notes and evidence packet.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2. The retained
+screenshots cover the unchanged v6 provider and Buzz surfaces; 6.0.2 Chat
+recovery and native version information are documented in the release notes
+and evidence packet.
 
 ## Provider Support
 

--- a/docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md
+++ b/docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md
@@ -1,6 +1,6 @@
 # Veritas Kanban v6 Agent Runtime Control Plane
 
-This document defines the supported v6.0.1 architecture for executable agent
+This document defines the supported v6.0.2 architecture for executable agent
 harnesses and Buzz integration. It is the version-level composition of the
 individual contract documents for
 [ACP](ACP-PROVIDER-V1.md),
@@ -8,7 +8,7 @@ individual contract documents for
 [tool control](TOOL-CONTROL-PLANE-V1.md), and
 [runtime hooks](RUNTIME-HOOK-V1.md).
 
-Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.1.
+Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2.
 
 ## Authority Model
 
@@ -129,5 +129,5 @@ evidence and never hides a failure.
 - Required unsupported filesystem, network, environment, credential, MCP,
   tool, approval, lifecycle, and budget controls block before attempt mutation.
 - Fine-grained HTTP method/path/domain proxy enforcement remains deferred to
-  issue 855. v6.0.1 claims only the network controls proven in current provider
+  issue 855. v6.0.2 claims only the network controls proven in current provider
   runtime evidence.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1239,7 +1239,7 @@
     <div class="hero-content">
       <div class="hero-badge fade-in">
         <span class="pulse"></span>
-        v6.0.1 — First stable v6 release
+        v6.0.2: Desktop recovery hotfix
       </div>
       <h1 class="fade-in fade-in-delay-1">Veritas Kanban</h1>
       <p class="tagline fade-in fade-in-delay-2">Task management built for AI agents — not against them</p>
@@ -1556,36 +1556,36 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
     <div class="container">
       <div class="fade-in">
         <span class="section-label">What's New</span>
-        <h2 class="section-title">v6.0.1 Harness Control Plane</h2>
+        <h2 class="section-title">v6.0.2 Desktop Recovery And Support</h2>
         <span class="version-tag">🚀 Latest Release</span>
       </div>
       <div class="version-grid">
         <div class="version-item fade-in">
-          <span class="version-item-icon">🧭</span>
+          <span class="version-item-icon">💬</span>
           <div>
-            <h3>Evidence-Backed Harness Support</h3>
-            <p>Buzz, Grok Build, OpenAI Codex, Claude Code, and GitHub Copilot CLI use one reviewed support matrix, exact build evidence, and fail-closed dispatch.</p>
+            <h3>Bounded Chat Workbench</h3>
+            <p>Board Chat and Squad Chat default to a right dock, switch to Bottom without remounting, clamp to the viewport, and always preserve visible recovery controls.</p>
           </div>
         </div>
         <div class="version-item fade-in fade-in-delay-1">
-          <span class="version-item-icon">🛡️</span>
+          <span class="version-item-icon">ℹ️</span>
           <div>
-            <h3>Run Authority And Safety</h3>
-            <p>Immutable launch manifests, causal events, supervised runs, exact-action approvals, brokered credentials, and authoritative completion evidence stay provider-neutral.</p>
+            <h3>Exact Native Version Information</h3>
+            <p>About and Copy Version Information expose one authoritative version, release commit, channel, operating system, architecture, and packaged-state record.</p>
           </div>
         </div>
         <div class="version-item fade-in fade-in-delay-2">
-          <span class="version-item-icon">📡</span>
+          <span class="version-item-icon">🧭</span>
           <div>
-            <h3>Native Buzz Integration</h3>
-            <p>Signed Squad Chat bridging, safe persona and team import, generic ACP task execution, run-scoped MCP tools, and replay-safe workflow triggers.</p>
+            <h3>Evidence-Backed Harness Support</h3>
+            <p>Buzz, Grok Build, OpenAI Codex, Claude Code, and GitHub Copilot CLI retain one reviewed support matrix, exact build evidence, and fail-closed dispatch.</p>
           </div>
         </div>
         <div class="version-item fade-in fade-in-delay-3">
-          <span class="version-item-icon">🔌</span>
+          <span class="version-item-icon">⚡</span>
           <div>
-            <h3>ACP And Interactive Lifecycles</h3>
-            <p>Generic ACP stdio support sits beside Codex app-server and Claude stream adapters, with capability-gated resume, fork, steer, interrupt, and close.</p>
+            <h3>Proportional Verification</h3>
+            <p>Ordinary changes run focused coverage, while shared, storage, manifest, desktop, high-risk, and milestone release changes retain the full gate.</p>
           </div>
         </div>
       </div>
@@ -1669,7 +1669,7 @@ curl -X POST .../tasks/&lt;id&gt;/comments \
       </div>
       <div class="proof-stats fade-in">
         <div class="proof-stat">
-          <div class="proof-stat-number">v6.0.1</div>
+          <div class="proof-stat-number">v6.0.2</div>
           <div class="proof-stat-label">Current source line</div>
         </div>
         <div class="proof-stat">

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -843,7 +843,7 @@ Configure telemetry retention in `server/.env`:
 
 | Component          | Version      | Notes                       |
 | ------------------ | ------------ | --------------------------- |
-| MCP server package | `6.0.1`      | Matches VK server version   |
+| MCP server package | `6.0.2`      | Matches VK server version   |
 | MCP SDK            | `1.29.0`     | `@modelcontextprotocol/sdk` |
 | MCP protocol       | `2025-11-25` | Latest stable spec          |
 | Node.js            | `≥ 22`       | Matches the repo runtime    |
@@ -887,4 +887,4 @@ The `findTask` utility matches the last N characters of a task ID (minimum 6). I
 
 ---
 
-_Last updated: 2026-07-24 · VK v6.0.1 · 41 tools / 9 categories_
+_Last updated: 2026-07-24 · VK v6.0.2 · 41 tools / 9 categories_

--- a/docs/releases/v6.0.1.md
+++ b/docs/releases/v6.0.1.md
@@ -1,0 +1,94 @@
+Veritas Kanban 6.0.1 is the first supported stable v6 release. It adds first-class Buzz integration and gives Grok Build, OpenAI Codex, Claude Code, and GitHub Copilot CLI the same evidence-backed task, worktree, tool, approval, credential, event, and completion boundaries.
+
+> Veritas Kanban 6.0.0 remains available as a quarantined prerelease. Install 6.0.1 or newer.
+
+## Highlights
+
+### One control plane for agent harnesses
+
+- Buzz Agent, Grok Build, and GitHub Copilot CLI run through the shared ACP v1 adapter.
+- OpenAI Codex supports CLI, SDK, and the richer app-server JSON-RPC lifecycle.
+- Claude Code runs through a supervised bare-mode stream.
+- Hermes and OpenClaw retain their supported one-shot and gateway transports.
+- Settings, API diagnostics, telemetry, dispatch, and `vk doctor --json` now report the same support tier and redacted readiness evidence.
+
+Equal footing does not mean pretending every provider has the same features. Veritas probes the installed version and capabilities, persists that evidence, and blocks unsupported resume, tool, approval, sandbox, or completion behavior before an attempt starts.
+
+### First-class Buzz support
+
+- Connect a pinned Buzz community channel to Squad Chat.
+- Import signed public persona and team definitions as disabled profiles.
+- Run `buzz-agent` through ACP with exact version and capability checks.
+- Expose only the selected run-scoped Veritas tools.
+- Trigger allowlisted Veritas workflows from Buzz root messages with durable replay protection.
+
+Buzz relay delivery remains a communication path. Veritas remains the authority for tasks, attempts, tools, approvals, and completion.
+
+### Safer, recoverable runs
+
+- Every run records its task envelope, launch policy, worktree baseline, provider runtime evidence, causal events, approvals, tool catalog, and completion evidence.
+- Restart and reconnect logic verifies ownership before resuming work, avoiding silent duplicate runs.
+- Provider build or capability drift invalidates old certification.
+- Credential-bearing tools use one-shot, exact-action leases instead of exposing raw secrets to provider configuration or logs.
+- The desktop updater rejects older release metadata instead of offering a downgrade.
+
+## Stabilization fixes in 6.0.1
+
+- Chat is a reversible desktop panel with visible close, Escape, browser Back, startup-state recovery, and native layout reset ([#945](https://github.com/BradGroux/veritas-kanban/issues/945)).
+- Task drawers, shared overlays, Archive cards, scoring pages, and the template editor have reachable scrolling and resizing ([#935](https://github.com/BradGroux/veritas-kanban/issues/935), [#938](https://github.com/BradGroux/veritas-kanban/issues/938), [#939](https://github.com/BradGroux/veritas-kanban/issues/939), [#941](https://github.com/BradGroux/veritas-kanban/issues/941)).
+- Workflow actions handle omitted collections and recoverable load failures instead of crashing task detail ([#936](https://github.com/BradGroux/veritas-kanban/issues/936)).
+- Full-page views, task detail, and nested Workflow overlays preserve their actual route origin, browser history, keyboard Back behavior, and scroll position ([#937](https://github.com/BradGroux/veritas-kanban/issues/937)).
+- New scoring profiles open as visible, validated drafts ([#943](https://github.com/BradGroux/veritas-kanban/issues/943)).
+- Operations Digest reconciles board inventory with windowed events and exposes source IDs and metadata-quality findings ([#944](https://github.com/BradGroux/veritas-kanban/issues/944)).
+- The packaged desktop consistently reports its real application version ([#986](https://github.com/BradGroux/veritas-kanban/issues/986)).
+
+## Install or upgrade
+
+### Homebrew
+
+```bash
+brew update
+brew upgrade --cask bradgroux/tap/veritas-kanban
+```
+
+For a first install:
+
+```bash
+brew install --cask bradgroux/tap/veritas-kanban
+```
+
+### Direct download
+
+Download the signed and notarized macOS arm64 DMG or ZIP from the [v6.0.1 release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.1).
+
+Back up the current workspace before upgrading. Keep the v5.2.5 backup until the v6 runtime is accepted. If rollback requires an older schema, restore the pre-upgrade backup instead of opening newer data with an incompatible binary. Follow the [v6 upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md) for the complete migration, remote-access, validation, and rollback procedure.
+
+## Important behavior changes
+
+- Provider-less or adapter/profile-mismatched records no longer fall through to OpenClaw.
+- Unknown or changed provider builds lose certification until current probes and deterministic fixtures pass.
+- Claude Code no longer launches with `--dangerously-skip-permissions`.
+- Credential-bound MCP servers are not copied into provider-native configuration. They are available only through the mediated run bridge.
+- Conversation controls appear only when the selected provider proves it supports them.
+- The public REST API remains mounted at `v1`; the v6 product version does not rename API routes.
+
+## Known limitations
+
+- Buzz Agent sessions are in-memory and do not support session load/resume. Buzz files, reactions, forums, DMs, and destructive edit/delete projection are not bridged.
+- GitHub Copilot CLI ACP is public preview.
+- Grok Build's stable artifact self-reports alpha and cannot be fully traced to the current public source tree.
+- Claude Code's complete CLI implementation is not public, so certification is bound to exact release behavior and checked-in fixtures.
+- Linux and Windows desktop artifacts remain unsigned previews. Signed and notarized macOS arm64 is the supported desktop distribution.
+- Deterministic compatibility does not prove provider authentication, subscription availability, quota, or live inference.
+
+## Documentation and evidence
+
+- [Agent guide and reusable `AGENTS.md` template](https://github.com/BradGroux/veritas-kanban/blob/main/docs/AGENTS-TEMPLATE.md)
+- [Agent provider setup and operations](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/AGENT-PROVIDERS.md)
+- [Harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/HARNESS-COMPATIBILITY.md)
+- [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/BUZZ-INTEGRATION.md)
+- [v6 runtime architecture](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md)
+- [Release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/main/docs/V6-RC-EVIDENCE-PACKET.md)
+- [Release tracker #924](https://github.com/BradGroux/veritas-kanban/issues/924)
+- [Buzz epic #904](https://github.com/BradGroux/veritas-kanban/issues/904)
+- [Equal-footing harness epic #915](https://github.com/BradGroux/veritas-kanban/issues/915)

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -1,0 +1,66 @@
+Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix. It keeps Chat inside a reversible Workbench dock, adds authoritative native version/build information, and makes verification proportional between release milestones.
+
+> Veritas Kanban 6.0.0 remains a quarantined prerelease. Version 6.0.2 supersedes 6.0.1 as the supported stable v6 release.
+
+## What changed
+
+### Chat can no longer trap the application window
+
+- Board Chat and Squad Chat open in a right-side Workbench dock by default.
+- Switch between Right and Bottom without remounting the active conversation.
+- Width and height clamp to the live viewport, and Chat owns its scrolling without moving the application shell.
+- Close, Escape, browser Back, and Reset Layout return to a visible board and restore focus.
+- Invalid or obsolete persisted dimensions recover to the safe right-dock default on startup.
+
+Tracked in [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
+
+### Exact native version and build information
+
+- **About Veritas Kanban** uses Electron's authoritative application metadata.
+- **Copy Version Information** provides an offline support record with version, embedded release commit, channel, OS, architecture, and packaged state.
+- The native About panel, copied support text, desktop bridge, and updater fallback all consume the same record.
+
+Tracked in [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
+
+### Faster, proportional verification
+
+- Documentation-only changes skip workspace suites.
+- Ordinary code changes run affected Vitest coverage.
+- Shared, storage, manifest, desktop, high-risk, and release changes retain the full gate.
+- Reviewed full-suite evidence is reused only when its exact head is an ancestor of the resulting commit.
+
+Tracked in [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
+
+## Install or upgrade
+
+### Homebrew
+
+```bash
+brew update
+brew upgrade --cask bradgroux/tap/veritas-kanban
+```
+
+For a first installation:
+
+```bash
+brew install --cask bradgroux/tap/veritas-kanban
+```
+
+### Direct download
+
+Download the signed and notarized macOS arm64 DMG or ZIP from this release. Back up the current workspace before upgrading and keep the backup until the new runtime is accepted.
+
+## Compatibility
+
+The Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts introduced in 6.0.1 are unchanged. Version 6.0.2 adds no data-schema migration over 6.0.1, and the public REST API remains mounted at `v1`.
+
+Linux and Windows desktop artifacts remain unsigned verification previews. Signed and notarized macOS arm64 is the supported desktop distribution.
+
+## Documentation and evidence
+
+- [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md)
+- [v6 upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md)
+- [Harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md)
+- [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md)
+- [Release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md)
+- [Release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010)

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/mcp",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "MCP server for Veritas Kanban",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritas-kanban",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "description": "Local-first task management and AI agent orchestration platform",
   "author": "Brad Groux <brad@digitalmeld.io>",

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -296,6 +296,77 @@ function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function normalizeReleaseBody(value) {
+  return value.replace(/\r\n?/g, '\n').trim();
+}
+
+function releaseBodyFormattingIssues(value) {
+  const issues = [];
+
+  if (value.includes('\r')) {
+    issues.push('contains carriage-return characters');
+  }
+
+  const lines = value.replace(/\r\n?/g, '\n').split('\n');
+  let inFence = false;
+  let previousBlockLine;
+
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1;
+    const trimmed = line.trim();
+    const trimmedStart = line.trimStart();
+
+    if (/^```/.test(trimmedStart)) {
+      inFence = !inFence;
+      previousBlockLine = undefined;
+      continue;
+    }
+
+    if (inFence) continue;
+
+    if (trimmed.length === 0) {
+      previousBlockLine = undefined;
+      continue;
+    }
+
+    if (/\s{2}$/.test(line)) {
+      issues.push(`line ${lineNumber} uses a Markdown hard break`);
+    }
+
+    if (/<br\s*\/?>/i.test(line)) {
+      issues.push(`line ${lineNumber} contains an explicit HTML line break`);
+    }
+
+    if (/\\[rn](?:\\[rn])?/.test(line)) {
+      issues.push(`line ${lineNumber} contains a literal escaped line break`);
+    }
+
+    const blockLine = {
+      lineNumber,
+      listItem: /^\s*(?:[-*+]|\d+\.)\s+/.test(line),
+      tableRow: /^\s*\|.*\|\s*$/.test(line),
+    };
+
+    if (
+      previousBlockLine &&
+      !(previousBlockLine.listItem && blockLine.listItem) &&
+      !(previousBlockLine.tableRow && blockLine.tableRow)
+    ) {
+      issues.push(
+        `lines ${previousBlockLine.lineNumber}-${lineNumber} are not separated by a blank line`
+      );
+    }
+
+    previousBlockLine = blockLine;
+  }
+
+  if (inFence) {
+    issues.push('contains an unclosed fenced code block');
+  }
+
+  return issues;
+}
+
 function parseGithubRepo(repositoryUrl) {
   if (!repositoryUrl) return undefined;
 
@@ -321,6 +392,10 @@ async function main() {
   const rootPackage = packages.find((pkg) => pkg.label === 'root').json;
   const expectedVersion = options.version ?? rootPackage.version;
   const requiredReleaseDocs = releaseDocsForVersion(expectedVersion);
+  const releaseBodyFile = `docs/releases/v${expectedVersion}.md`;
+  const releaseBodyExists = await exists(releaseBodyFile);
+  const releaseBody = releaseBodyExists ? await readText(releaseBodyFile) : '';
+  const releaseBodyIssues = releaseBodyExists ? releaseBodyFormattingIssues(releaseBody) : [];
 
   check(
     'Release version is valid semver',
@@ -331,6 +406,13 @@ async function main() {
   for (const packageFile of requiredFiles) {
     check(`Required file exists: ${packageFile}`, await exists(packageFile));
   }
+
+  check('Reviewed GitHub release body exists', releaseBodyExists, releaseBodyFile);
+  check(
+    'GitHub release body uses full-width Markdown blocks',
+    releaseBodyExists && releaseBodyIssues.length === 0,
+    releaseBodyIssues.slice(0, 3).join('; ') || releaseBodyFile
+  );
 
   for (const pkg of packages) {
     check(
@@ -443,7 +525,7 @@ async function main() {
         '--repo',
         repo,
         '--json',
-        'isDraft,isPrerelease,name,tagName,url',
+        'body,isDraft,isPrerelease,name,tagName,url',
       ]);
 
       if (release.ok) {
@@ -457,6 +539,12 @@ async function main() {
           `GitHub release is published: ${tagName}`,
           releaseJson.isDraft === false,
           releaseJson.isDraft ? 'draft release' : 'published'
+        );
+        check(
+          `GitHub release body matches ${releaseBodyFile}`,
+          releaseBodyExists &&
+            normalizeReleaseBody(releaseJson.body ?? '') === normalizeReleaseBody(releaseBody),
+          releaseBodyFile
         );
       } else {
         fail(`GitHub release exists: ${tagName}`, release.stderr || 'gh release view failed');

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/server",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/shared",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veritas-kanban/web",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump root, shared, server, web, CLI, MCP, and desktop packages to 6.0.2.
- Publish the #1004 bounded Chat Workbench recovery fix and the #1005 authoritative native version/build support fix as one desktop hotfix.
- Promote #1000, #1004, and #1005 into the dated changelog and update current release, upgrade, compatibility, API, MCP, architecture, visual-tour, checklist, and evidence documentation.
- Add reviewed full-width GitHub release body sources for 6.0.1 and 6.0.2.
- Reject carriage returns, hard-wrapped release prose, explicit line breaks, and published release bodies that differ from the reviewed source.
- Correct the already-published v6.0.1 body through `gh`; the rendered body now spans the GitHub Markdown container with zero `<br>` elements.

## Verification

- `pnpm build`
- `pnpm validate:release -- --version 6.0.2 --docker-build`
- `pnpm validate:release -- --version 6.0.2`
- `pnpm check:pnpm-settings`
- `pnpm audit --prod --audit-level high` (no high or critical findings)
- Targeted Prettier checks for every changed JSON, Markdown, and script file
- `git diff --check`
- Exact v6.0.1 GitHub release body comparison against `docs/releases/v6.0.1.md`
- Main commit `2f18229f` has green CI and macOS, Linux, and Windows desktop artifact workflows after #1005

## Release boundary

- No data-schema migration is added over 6.0.1.
- The existing v6 harness support contracts remain unchanged.
- Signed/notarized macOS publication, independent downloaded-app verification, Homebrew update, and final evidence are post-merge gates tracked in #1010.

Tracks #1010.
