### PR TITLE
perf(ci): suppress cosmetic label runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,19 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{
+      format(
+        '{0}-{1}-{2}',
+        github.workflow,
+        github.ref,
+        github.event_name == 'pull_request' &&
+          contains(fromJSON('["labeled","unlabeled"]'), github.event.action) &&
+          github.event.label.name != 'ci:full' &&
+          format('cosmetic-{0}', github.run_id) ||
+          'authoritative'
+      )
+    }}
   cancel-in-progress: true
 
 env:
@@ -39,6 +51,10 @@ jobs:
   # ─── Deterministic Test Scope ───────────────────────────────────
   select-tests:
     name: Select Test Scope
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'ci:full'
     runs-on: ubuntu-latest
     outputs:
       scope: ${{ steps.scope.outputs.scope }}
@@ -69,6 +85,7 @@ jobs:
           reviewed_full=false
           reviewed_pr=
           reviewed_head=
+          reviewed_mode=
           associated_prs="$(
             gh api \
               -H 'Accept: application/vnd.github+json' \
@@ -111,6 +128,11 @@ jobs:
                 git fetch --no-tags origin "$reviewed_head"; then
                 if git merge-base --is-ancestor "$reviewed_head" "$GITHUB_SHA"; then
                   reviewed_full=true
+                  reviewed_mode=ancestor
+                elif [[ "$(git rev-parse "${reviewed_head}^{tree}")" == \
+                  "$(git rev-parse "${GITHUB_SHA}^{tree}")" ]]; then
+                  reviewed_full=true
+                  reviewed_mode=identical-tree
                 fi
               fi
             fi
@@ -120,6 +142,7 @@ jobs:
             echo "reviewed_full=$reviewed_full"
             echo "reviewed_pr=$reviewed_pr"
             echo "reviewed_head=$reviewed_head"
+            echo "reviewed_mode=$reviewed_mode"
           } >> "$GITHUB_OUTPUT"
 
       - name: Select verification tier
@@ -131,6 +154,7 @@ jobs:
           CI_PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           CI_REVIEWED_FULL: ${{ steps.reviewed_full.outputs.reviewed_full || 'false' }}
           CI_REVIEWED_PR: ${{ steps.reviewed_full.outputs.reviewed_pr || '' }}
+          CI_REVIEWED_MODE: ${{ steps.reviewed_full.outputs.reviewed_mode || '' }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
           PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
@@ -178,6 +202,10 @@ jobs:
   # ─── Lint & Type Check ───────────────────────────────────────────
   lint-and-typecheck:
     name: Lint & Type Check
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'ci:full'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -214,7 +242,13 @@ jobs:
   test-changed:
     name: Changed Tests
     needs: select-tests
-    if: always()
+    if: >-
+      always() &&
+      (
+        github.event_name != 'pull_request' ||
+        !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+        github.event.label.name == 'ci:full'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Require a successful scope decision
@@ -340,7 +374,13 @@ jobs:
   test-workspace:
     name: Workspace Unit Tests
     needs: select-tests
-    if: always()
+    if: >-
+      always() &&
+      (
+        github.event_name != 'pull_request' ||
+        !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+        github.event.label.name == 'ci:full'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Require a successful scope decision
@@ -426,6 +466,10 @@ jobs:
   # ─── Build ───────────────────────────────────────────────────────
   build:
     name: Build
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'ci:full'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -477,6 +521,10 @@ jobs:
   # ─── Security Audit ──────────────────────────────────────────────
   security-audit:
     name: Security Audit
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'ci:full'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/scripts/select-ci-test-scope.mjs
+++ b/scripts/select-ci-test-scope.mjs
@@ -69,6 +69,7 @@ export function classifyCiTestScope({
   deletedFiles = [],
   reviewedFullSuite = false,
   reviewedPullRequest = '',
+  reviewedFullSuiteMode = '',
 }) {
   const files = normalizeFiles(changedFiles);
   const deleted = normalizeFiles(deletedFiles);
@@ -103,11 +104,15 @@ export function classifyCiTestScope({
 
   if (eventName === 'push' && reviewedFullSuite) {
     const prSuffix = reviewedPullRequest ? ` for PR #${reviewedPullRequest}` : '';
+    const evidence =
+      reviewedFullSuiteMode === 'identical-tree'
+        ? 'has the exact Git tree published by this squash merge'
+        : 'is an ancestor of this merge commit';
     return {
       scope: 'none',
       packages: [],
       files,
-      reason: `The reviewed head${prSuffix} already passed Workspace Unit Tests and is an ancestor of this merge commit.`,
+      reason: `The reviewed head${prSuffix} already passed Workspace Unit Tests and ${evidence}.`,
     };
   }
 
@@ -278,6 +283,7 @@ async function main() {
     labels: parseLabels(process.env.CI_PR_LABELS || '[]'),
     reviewedFullSuite: process.env.CI_REVIEWED_FULL === 'true',
     reviewedPullRequest: process.env.CI_REVIEWED_PR || '',
+    reviewedFullSuiteMode: process.env.CI_REVIEWED_MODE || '',
   };
 
   if (!input.eventName) {

--- a/scripts/select-ci-test-scope.test.mjs
+++ b/scripts/select-ci-test-scope.test.mjs
@@ -99,6 +99,21 @@ test('a successful reviewed full suite suppresses duplicate post-merge tests', (
 
   assert.equal(result.scope, 'none');
   assert.match(result.reason, /PR #1000/);
+  assert.match(result.reason, /ancestor/);
+});
+
+test('an exact reviewed tree suppresses duplicate tests after a squash merge', () => {
+  const result = classifyCiTestScope({
+    eventName: 'push',
+    reviewedFullSuite: true,
+    reviewedPullRequest: '1011',
+    reviewedFullSuiteMode: 'identical-tree',
+    changedFiles: ['.github/workflows/ci.yml'],
+  });
+
+  assert.equal(result.scope, 'none');
+  assert.match(result.reason, /PR #1011/);
+  assert.match(result.reason, /exact Git tree/);
 });
 
 test('ordinary post-merge pushes remain limited to affected packages', () => {


### PR DESCRIPTION
Closes #1012.

## Summary

- Skip all CI jobs for cosmetic `labeled` and `unlabeled` pull request events while preserving `ci:full` escalation.
- Isolate cosmetic label events from the authoritative concurrency group so they cannot cancel real verification.
- Reuse a successful reviewed full-suite result after squash merge only when the merged commit and reviewed head have identical Git trees.

## Verification

- `node --test scripts/select-ci-test-scope.test.mjs` (14/14)
- `pnpm exec prettier --check .github/workflows/ci.yml scripts/select-ci-test-scope.mjs scripts/select-ci-test-scope.test.mjs`
- Ruby YAML parse
- `git diff --check`

## Risk

- Cosmetic label events still appear in the Actions history because GitHub cannot filter pull request label names at the workflow trigger. Every CI job is skipped and each event uses an isolated concurrency group.
- Exact-tree reuse remains fail-closed. Any tree difference or missing reviewed check evidence runs the normal post-merge tier.
