### PR TITLE
fix(ci): verify executed full-suite steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   checks: read
   pull-requests: read
@@ -70,8 +71,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Verify CI scope selector
-        run: node --test scripts/select-ci-test-scope.test.mjs
+      - name: Verify CI scope controls
+        run: >-
+          node --test
+          scripts/select-ci-test-scope.test.mjs
+          scripts/verify-full-suite-job-evidence.test.mjs
 
       - name: Find reviewed full-suite evidence
         id: reviewed_full
@@ -115,15 +119,35 @@ jobs:
                 printf '{"check_runs":[]}'
             )"
 
-            if jq -e '
-              .check_runs |
-              any(.[];
+            full_suite_check_id="$(
+              jq -r '
+                [
+                  .check_runs[] |
+                  select(
                 .name == "Workspace Unit Tests" and
                 .status == "completed" and
                 .conclusion == "success" and
                 .app.slug == "github-actions"
-              )
-            ' <<<"$check_runs" >/dev/null; then
+                  )
+                ] |
+                sort_by(.completed_at) |
+                last |
+                .id // empty
+              ' <<<"$check_runs"
+            )"
+            full_suite_job="$(
+              if [[ -n "$full_suite_check_id" ]]; then
+                gh api \
+                  -H 'Accept: application/vnd.github+json' \
+                  "repos/${GITHUB_REPOSITORY}/actions/jobs/${full_suite_check_id}" \
+                  2>/dev/null ||
+                  printf '{}'
+              else
+                printf '{}'
+              fi
+            )"
+
+            if node scripts/verify-full-suite-job-evidence.mjs <<<"$full_suite_job"; then
               if git cat-file -e "${reviewed_head}^{commit}" 2>/dev/null ||
                 git fetch --no-tags origin "$reviewed_head"; then
                 if git merge-base --is-ancestor "$reviewed_head" "$GITHUB_SHA"; then

--- a/scripts/select-ci-test-scope.mjs
+++ b/scripts/select-ci-test-scope.mjs
@@ -13,6 +13,7 @@ const FULL_SUITE_PATH_PATTERNS = [
   /^server\/src\/storage\//,
   /^server\/src\/__tests__\/storage\//,
   /^scripts\/select-ci-test-scope(?:\.test)?\.mjs$/,
+  /^scripts\/verify-full-suite-job-evidence(?:\.test)?\.mjs$/,
   /(^|\/)package\.json$/,
   /(^|\/)(?:vitest|playwright|electron\.vite)\.config\.[cm]?[jt]s$/,
   /(^|\/)tsconfig(?:\.[^/]+)?\.json$/,

--- a/scripts/verify-full-suite-job-evidence.mjs
+++ b/scripts/verify-full-suite-job-evidence.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REQUIRED_FULL_SUITE_STEPS = [
+  'Run workspace unit tests',
+  'Run desktop readiness regression tests',
+  'Run dual-storage parity tests',
+];
+
+export function hasSuccessfulFullSuiteEvidence(job) {
+  if (
+    !job ||
+    typeof job !== 'object' ||
+    job.status !== 'completed' ||
+    job.conclusion !== 'success' ||
+    !Array.isArray(job.steps)
+  ) {
+    return false;
+  }
+
+  return REQUIRED_FULL_SUITE_STEPS.every((requiredName) =>
+    job.steps.some(
+      (step) =>
+        step &&
+        typeof step === 'object' &&
+        step.name === requiredName &&
+        step.status === 'completed' &&
+        step.conclusion === 'success'
+    )
+  );
+}
+
+async function main() {
+  let job;
+
+  try {
+    job = JSON.parse(await readFile(0, 'utf8'));
+  } catch {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!hasSuccessfulFullSuiteEvidence(job)) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/verify-full-suite-job-evidence.test.mjs
+++ b/scripts/verify-full-suite-job-evidence.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hasSuccessfulFullSuiteEvidence } from './verify-full-suite-job-evidence.mjs';
+
+function job(overrides = {}) {
+  return {
+    status: 'completed',
+    conclusion: 'success',
+    steps: [
+      {
+        name: 'Run workspace unit tests',
+        status: 'completed',
+        conclusion: 'success',
+      },
+      {
+        name: 'Run desktop readiness regression tests',
+        status: 'completed',
+        conclusion: 'success',
+      },
+      {
+        name: 'Run dual-storage parity tests',
+        status: 'completed',
+        conclusion: 'success',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+test('accepts a successful job only when every full-suite step passed', () => {
+  assert.equal(hasSuccessfulFullSuiteEvidence(job()), true);
+});
+
+test('rejects a successful wrapper job whose workspace suite was skipped', () => {
+  const evidence = job({
+    steps: job().steps.map((step) =>
+      step.name === 'Run workspace unit tests' ? { ...step, conclusion: 'skipped' } : step
+    ),
+  });
+
+  assert.equal(hasSuccessfulFullSuiteEvidence(evidence), false);
+});
+
+test('rejects failed, incomplete, malformed, and missing job evidence', () => {
+  assert.equal(hasSuccessfulFullSuiteEvidence(job({ conclusion: 'failure' })), false);
+  assert.equal(hasSuccessfulFullSuiteEvidence(job({ status: 'in_progress' })), false);
+  assert.equal(hasSuccessfulFullSuiteEvidence(job({ steps: [] })), false);
+  assert.equal(hasSuccessfulFullSuiteEvidence({}), false);
+  assert.equal(hasSuccessfulFullSuiteEvidence(null), false);
+});


### PR DESCRIPTION
Closes #1012.

## Summary

- Require the actual workspace, desktop-readiness, and dual-storage steps to have completed successfully before reusing a reviewed full-suite result.
- Reject successful wrapper jobs whose expensive suite was intentionally skipped.
- Grant the CI selector read-only Actions access for job-step evidence.

## Verification

- `node --test scripts/select-ci-test-scope.test.mjs scripts/verify-full-suite-job-evidence.test.mjs` (17/17)
- Live accepted evidence: full PR #1013 job `89611882881`
- Live rejected evidence: docs-only PR #1014 wrapper job `89614884550`
- Prettier check for all touched files
- YAML parse
- `git diff --check`

## Risk

Evidence reuse remains fail-closed. Missing Actions access, malformed job data, a skipped required step, or any tree/provenance mismatch runs the normal post-merge test tier.
