### PR TITLE
docs: improve release note readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 - Keep each prose paragraph, blockquote, and list item on one logical Markdown source line.
   Separate blocks with blank lines. Do not hard-wrap release prose or add carriage returns,
   trailing-space hard breaks, literal escaped newlines, or HTML `<br>` tags.
+- Prefer compact, natural paragraphs over bullet-per-sentence formatting. Use lists only for
+  genuinely parallel items, and avoid repeated one-sentence blocks that render as a ragged page.
 - Run `pnpm validate:release -- --version X.Y.Z`; the post-publication `--github` form also
   requires the published GitHub body to match the reviewed file exactly.
 

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -1,39 +1,18 @@
-Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix. It keeps Chat inside a reversible Workbench dock, adds authoritative native version/build information, and makes verification proportional between release milestones.
+Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix. It keeps Chat inside a reversible Workbench dock, adds authoritative native version and build information, and makes verification proportional between release milestones.
 
 > Veritas Kanban 6.0.0 remains a quarantined prerelease. Version 6.0.2 supersedes 6.0.1 as the supported stable v6 release.
 
-## What changed
+## Highlights
 
-### Chat can no longer trap the application window
+**Chat no longer traps the application window.** Board Chat and Squad Chat now open in a right-side Workbench dock. You can switch between Right and Bottom without remounting the conversation, and Chat owns its scrolling without moving the application shell. Close, Escape, browser Back, and Reset Layout all return to a visible board and restore focus. Invalid persisted dimensions recover to the safe right-dock default at startup. See [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
 
-- Board Chat and Squad Chat open in a right-side Workbench dock by default.
-- Switch between Right and Bottom without remounting the active conversation.
-- Width and height clamp to the live viewport, and Chat owns its scrolling without moving the application shell.
-- Close, Escape, browser Back, and Reset Layout return to a visible board and restore focus.
-- Invalid or obsolete persisted dimensions recover to the safe right-dock default on startup.
+**Native version and build information is authoritative.** About Veritas Kanban now uses Electron application metadata, while Copy Version Information creates an offline support record containing the version, embedded release commit, channel, operating system, architecture, and packaged state. The About panel, copied support text, desktop bridge, and updater fallback all consume the same record. See [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
 
-Tracked in [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
-
-### Exact native version and build information
-
-- **About Veritas Kanban** uses Electron's authoritative application metadata.
-- **Copy Version Information** provides an offline support record with version, embedded release commit, channel, OS, architecture, and packaged state.
-- The native About panel, copied support text, desktop bridge, and updater fallback all consume the same record.
-
-Tracked in [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
-
-### Faster, proportional verification
-
-- Documentation-only changes skip workspace suites.
-- Ordinary code changes run affected Vitest coverage.
-- Shared, storage, manifest, desktop, high-risk, and release changes retain the full gate.
-- Reviewed full-suite evidence is reused only when its exact head is an ancestor of the resulting commit.
-
-Tracked in [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
+**Verification is faster and proportional.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, and release changes retain the full gate. Reviewed full-suite evidence is reused only when its exact head is an ancestor of the resulting commit. See [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
 
 ## Install or upgrade
 
-### Homebrew
+Upgrade with Homebrew:
 
 ```bash
 brew update
@@ -46,21 +25,14 @@ For a first installation:
 brew install --cask bradgroux/tap/veritas-kanban
 ```
 
-### Direct download
+You can also download the signed and notarized macOS arm64 DMG or ZIP from the Assets section below. Back up the current workspace before upgrading and keep the backup until the new runtime is accepted.
 
-Download the signed and notarized macOS arm64 DMG or ZIP from this release. Back up the current workspace before upgrading and keep the backup until the new runtime is accepted.
-
-## Compatibility
+## Compatibility and support
 
 The Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts introduced in 6.0.1 are unchanged. Version 6.0.2 adds no data-schema migration over 6.0.1, and the public REST API remains mounted at `v1`.
 
 Linux and Windows desktop artifacts remain unsigned verification previews. Signed and notarized macOS arm64 is the supported desktop distribution.
 
-## Documentation and evidence
+## Documentation
 
-- [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md)
-- [v6 upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md)
-- [Harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md)
-- [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md)
-- [Release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md)
-- [Release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010)
+For full context, see the [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md), [upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md), [harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md), [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md), [release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md), and [release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010).


### PR DESCRIPTION
## Summary

- rewrite the v6.0.2 release notes as compact, natural-width prose
- consolidate issue and documentation links without dropping context
- document the future rule against bullet-per-sentence and repeated one-sentence blocks
- keep the live v6.0.2 release synchronized through `gh release edit --notes-file`

## Verification

- `git diff --check`
- `prettier --check AGENTS.md docs/releases/v6.0.2.md`
- `node scripts/validate-release.mjs --version 6.0.2 --github`
- live release body has zero carriage returns, hard-break spaces, literal escaped newlines, and HTML breaks
- rendered GitHub release: 1,182 px content width, 17 blocks, zero narrower child blocks

Closes #1018