### PR TITLE
fix: enforce full-width release notes

### DIFF
--- a/docs/V6-GA-CHECKLIST.md
+++ b/docs/V6-GA-CHECKLIST.md
@@ -53,8 +53,9 @@ Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2.
       scope, while explicit and milestone release gates remain full (#1000).
 - [x] Published release notes are sourced from
       `docs/releases/vX.Y.Z.md`, use one full-width Markdown line per paragraph
-      or list item, and are compared with GitHub during post-publication
-      validation.
+      or list item, use lists rather than blockquotes for grouped changes, and
+      are compared with GitHub during post-publication validation. Run
+      `pnpm test:release-format` and `pnpm validate:release` before publication.
 
 ## Provider Certification
 

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -1,38 +1,20 @@
-Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix. It keeps Chat inside a reversible Workbench dock, adds authoritative native version and build information, and makes verification proportional between release milestones.
+Veritas Kanban 6.0.2 is the supported stable v6 release. This desktop recovery and supportability hotfix keeps Chat inside a reversible Workbench dock, provides authoritative native version and build information, and makes verification proportional between release milestones. It supersedes 6.0.1; v6.0.0 remains a quarantined prerelease.
 
-> Veritas Kanban 6.0.0 remains a quarantined prerelease. Version 6.0.2 supersedes 6.0.1 as the supported stable v6 release.
+## What changed
 
-## Highlights
-
-**Chat no longer traps the application window.** Board Chat and Squad Chat now open in a right-side Workbench dock. You can switch between Right and Bottom without remounting the conversation, and Chat owns its scrolling without moving the application shell. Close, Escape, browser Back, and Reset Layout all return to a visible board and restore focus. Invalid persisted dimensions recover to the safe right-dock default at startup. See [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
-
-**Native version and build information is authoritative.** About Veritas Kanban now uses Electron application metadata, while Copy Version Information creates an offline support record containing the version, embedded release commit, channel, operating system, architecture, and packaged state. The About panel, copied support text, desktop bridge, and updater fallback all consume the same record. See [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
-
-**Verification is faster and proportional.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, and release changes retain the full gate. Reviewed full-suite evidence is reused only when its exact head is an ancestor of the resulting commit. See [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
+- **Chat stays inside the application window.** Board Chat and Squad Chat now open in a reversible Workbench dock, preserve the conversation when switching between Right and Bottom, own their scrolling, and reliably return to a visible board through Close, Escape, browser Back, or Reset Layout. Invalid persisted dimensions recover to a safe default. See [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
+- **Native version and build information is authoritative.** About Veritas Kanban and Copy Version Information now share one offline support record containing the application version, embedded release commit, channel, operating system, architecture, and packaged state. See [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
+- **Verification is faster and proportional.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, and release changes retain the full gate. Reviewed full-suite evidence is reused only when its exact head is an ancestor of the resulting commit. See [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
 
 ## Install or upgrade
-
-Upgrade with Homebrew:
 
 ```bash
 brew update
 brew upgrade --cask bradgroux/tap/veritas-kanban
 ```
 
-For a first installation:
+For a first installation, run `brew install --cask bradgroux/tap/veritas-kanban`. The Assets section also provides the signed and notarized macOS arm64 DMG and ZIP. Back up the current workspace before upgrading and keep the backup until the new runtime is accepted.
 
-```bash
-brew install --cask bradgroux/tap/veritas-kanban
-```
+## Compatibility and documentation
 
-You can also download the signed and notarized macOS arm64 DMG or ZIP from the Assets section below. Back up the current workspace before upgrading and keep the backup until the new runtime is accepted.
-
-## Compatibility and support
-
-The Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts introduced in 6.0.1 are unchanged. Version 6.0.2 adds no data-schema migration over 6.0.1, and the public REST API remains mounted at `v1`.
-
-Linux and Windows desktop artifacts remain unsigned verification previews. Signed and notarized macOS arm64 is the supported desktop distribution.
-
-## Documentation
-
-For full context, see the [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md), [upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md), [harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md), [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md), [release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md), and [release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010).
+The Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts introduced in 6.0.1 are unchanged. Version 6.0.2 adds no data-schema migration over 6.0.1, and the public REST API remains mounted at `v1`. Linux and Windows desktop artifacts remain unsigned verification previews; signed and notarized macOS arm64 is the supported desktop distribution. Full context is available in the [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md), [upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md), [harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md), [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md), [release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md), and [release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010).

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:load:smoke": "k6 run load-tests/k6/smoke.js",
     "test:load": "k6 run load-tests/k6/smoke.js && k6 run load-tests/k6/read-load.js && k6 run load-tests/k6/write-load.js && k6 run load-tests/k6/mixed-load.js && k6 run load-tests/k6/ws-stress.js && k6 run load-tests/k6/v5-remote-mix.js",
     "smoke:cli-mcp": "node scripts/smoke-cli-mcp-compat.mjs",
+    "test:release-format": "node --test scripts/validate-release-format.test.mjs",
     "validate:release": "node scripts/validate-release.mjs",
     "clean": "pnpm -r clean && rm -rf node_modules",
     "audit": "pnpm audit --prod",

--- a/scripts/validate-release-format.test.mjs
+++ b/scripts/validate-release-format.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { releaseBodyFormattingIssues } from './validate-release.mjs';
+
+const cleanBody = `Veritas Kanban 6.0.2 is the supported stable release.
+
+## What changed
+
+- **Chat stays inside the application window.** The Workbench dock is reversible.
+- **Version information is authoritative.** Support data comes from one record.
+
+\`\`\`bash
+brew update
+brew upgrade --cask bradgroux/tap/veritas-kanban
+\`\`\`
+`;
+
+test('accepts full-width release Markdown', () => {
+  assert.deepEqual(releaseBodyFormattingIssues(cleanBody), []);
+});
+
+test('rejects release formatting that forces narrow or manual line breaks', () => {
+  const cases = [
+    ['carriage return', 'First paragraph.\r\n'],
+    ['Markdown hard break', 'First paragraph.  \n'],
+    ['literal escaped newline', String.raw`First paragraph.\nSecond paragraph.`],
+    ['HTML break', 'First paragraph.<br>\n'],
+    ['blockquote', '> Narrow callout.\n'],
+    ['hard-wrapped prose', 'First half of a paragraph\nsecond half of the paragraph.\n'],
+    ['unclosed code fence', '```bash\nbrew update\n'],
+  ];
+
+  for (const [name, body] of cases) {
+    assert.notDeepEqual(releaseBodyFormattingIssues(body), [], name);
+  }
+});

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -38,6 +38,7 @@ const requiredScripts = [
   'test:e2e',
   'test:load',
   'test:load:smoke',
+  'test:release-format',
   'test:unit',
   'typecheck',
 ];
@@ -300,7 +301,7 @@ function normalizeReleaseBody(value) {
   return value.replace(/\r\n?/g, '\n').trim();
 }
 
-function releaseBodyFormattingIssues(value) {
+export function releaseBodyFormattingIssues(value) {
   const issues = [];
 
   if (value.includes('\r')) {
@@ -339,6 +340,10 @@ function releaseBodyFormattingIssues(value) {
 
     if (/\\[rn](?:\\[rn])?/.test(line)) {
       issues.push(`line ${lineNumber} contains a literal escaped line break`);
+    }
+
+    if (/^\s*>/.test(line)) {
+      issues.push(`line ${lineNumber} uses a blockquote instead of a full-width block`);
     }
 
     const blockLine = {
@@ -585,7 +590,9 @@ async function main() {
   console.log('\nRelease validation passed.');
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #1020.

## What changed

- Replaced the fragmented v6.0.2 release source with the compact body now published on GitHub.
- Made the release validator reject blockquotes in addition to carriage returns, forced Markdown breaks, escaped line breaks, HTML breaks, hard-wrapped prose, and unclosed fences.
- Added focused regression coverage and documented the required release-note structure and pre-publication commands.

## Root cause

The existing full-width validator did not treat blockquotes as a formatting failure, so a narrow standalone callout passed validation and was published.

## Verification

- `pnpm test:release-format`
- `pnpm validate:release -- --version 6.0.2 --skip-build-output --github`
- Focused ESLint
- Prettier check
- `git diff --check`
- Headless GitHub render inspection at 1,440px viewport
