### PR TITLE
Fix GitHub release note layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,12 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   exact blocker before changing paths.
 - Source every published GitHub release body from `docs/releases/vX.Y.Z.md` and pass that file
   to `gh release create` or `gh release edit` with `--notes-file`.
-- Keep each prose paragraph, blockquote, and list item on one logical Markdown source line.
-  Separate blocks with blank lines. Do not hard-wrap release prose or add carriage returns,
-  trailing-space hard breaks, literal escaped newlines, or HTML `<br>` tags.
+- Keep each prose paragraph and list item on one logical Markdown source line. Separate blocks
+  with blank lines. Do not hard-wrap release prose or add carriage returns, trailing-space hard
+  breaks, literal escaped newlines, HTML `<br>` tags, or blockquotes.
 - Prefer compact, natural paragraphs over bullet-per-sentence formatting. Use lists only for
-  genuinely parallel items, and avoid repeated one-sentence blocks that render as a ragged page.
+  genuinely parallel items. Keep rendered prose blocks concise so they do not become walls of
+  text on GitHub's release index.
 - Run `pnpm validate:release -- --version X.Y.Z`; the post-publication `--github` form also
   requires the published GitHub body to match the reviewed file exactly.
 

--- a/docs/V6-GA-CHECKLIST.md
+++ b/docs/V6-GA-CHECKLIST.md
@@ -53,9 +53,10 @@ Documentation freshness: 2026-07-24 for Veritas Kanban 6.0.2.
       scope, while explicit and milestone release gates remain full (#1000).
 - [x] Published release notes are sourced from
       `docs/releases/vX.Y.Z.md`, use one full-width Markdown line per paragraph
-      or list item, use lists rather than blockquotes for grouped changes, and
-      are compared with GitHub during post-publication validation. Run
-      `pnpm test:release-format` and `pnpm validate:release` before publication.
+      or list item, reject blockquotes and overlong prose blocks, and are
+      compared with GitHub during post-publication validation. Run
+      `pnpm test:release-format`, `pnpm validate:release`, and the
+      post-publication `pnpm validate:release -- --github` check.
 
 ## Provider Certification
 

--- a/docs/releases/v6.0.1.md
+++ b/docs/releases/v6.0.1.md
@@ -1,6 +1,8 @@
-Veritas Kanban 6.0.1 is the first supported stable v6 release. It adds first-class Buzz integration and gives Grok Build, OpenAI Codex, Claude Code, and GitHub Copilot CLI the same evidence-backed task, worktree, tool, approval, credential, event, and completion boundaries.
+Veritas Kanban 6.0.1 is the first supported stable v6 release.
 
-> Veritas Kanban 6.0.0 remains available as a quarantined prerelease. Install 6.0.1 or newer.
+It adds first-class Buzz integration and gives Grok Build, OpenAI Codex, Claude Code, and GitHub Copilot CLI the same evidence-backed task, worktree, tool, approval, credential, event, and completion boundaries.
+
+**Release status:** Veritas Kanban 6.0.0 remains available as a quarantined prerelease. Install 6.0.1 or newer.
 
 ## Highlights
 
@@ -12,7 +14,9 @@ Veritas Kanban 6.0.1 is the first supported stable v6 release. It adds first-cla
 - Hermes and OpenClaw retain their supported one-shot and gateway transports.
 - Settings, API diagnostics, telemetry, dispatch, and `vk doctor --json` now report the same support tier and redacted readiness evidence.
 
-Equal footing does not mean pretending every provider has the same features. Veritas probes the installed version and capabilities, persists that evidence, and blocks unsupported resume, tool, approval, sandbox, or completion behavior before an attempt starts.
+Equal footing does not mean pretending every provider has the same features. Veritas probes the installed version and capabilities, then persists that evidence.
+
+Unsupported resume, tool, approval, sandbox, or completion behavior is blocked before an attempt starts.
 
 ### First-class Buzz support
 
@@ -61,7 +65,11 @@ brew install --cask bradgroux/tap/veritas-kanban
 
 Download the signed and notarized macOS arm64 DMG or ZIP from the [v6.0.1 release](https://github.com/BradGroux/veritas-kanban/releases/tag/v6.0.1).
 
-Back up the current workspace before upgrading. Keep the v5.2.5 backup until the v6 runtime is accepted. If rollback requires an older schema, restore the pre-upgrade backup instead of opening newer data with an incompatible binary. Follow the [v6 upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md) for the complete migration, remote-access, validation, and rollback procedure.
+Back up the current workspace before upgrading. Keep the v5.2.5 backup until the v6 runtime is accepted.
+
+If rollback requires an older schema, restore the pre-upgrade backup instead of opening newer data with an incompatible binary.
+
+Follow the [v6 upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.1/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md) for migration, remote access, validation, and rollback.
 
 ## Important behavior changes
 

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -1,20 +1,54 @@
-Veritas Kanban 6.0.2 is the supported stable v6 release. This desktop recovery and supportability hotfix keeps Chat inside a reversible Workbench dock, provides authoritative native version and build information, and makes verification proportional between release milestones. It supersedes 6.0.1; v6.0.0 remains a quarantined prerelease.
+Veritas Kanban 6.0.2 is the current supported stable v6 release. It fixes desktop Chat recovery, makes native version information authoritative, and keeps verification proportional between release milestones.
 
-## What changed
+**Release status:** 6.0.2 supersedes 6.0.1. Version 6.0.0 remains a quarantined prerelease.
 
-- **Chat stays inside the application window.** Board Chat and Squad Chat now open in a reversible Workbench dock, preserve the conversation when switching between Right and Bottom, own their scrolling, and reliably return to a visible board through Close, Escape, browser Back, or Reset Layout. Invalid persisted dimensions recover to a safe default. See [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
-- **Native version and build information is authoritative.** About Veritas Kanban and Copy Version Information now share one offline support record containing the application version, embedded release commit, channel, operating system, architecture, and packaged state. See [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
-- **Verification is faster and proportional.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, and release changes retain the full gate. Reviewed full-suite evidence is reused only when its exact head is an ancestor of the resulting commit. See [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
+## Highlights
+
+### Chat stays inside Veritas Kanban
+
+Board Chat and Squad Chat now use a reversible Workbench dock. Conversations remain mounted while switching between Right and Bottom, with bounded dimensions and owned scrolling.
+
+Close, Escape, browser Back, and Reset Layout all return to a visible board. Invalid saved dimensions recover to safe defaults. See [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
+
+### Version information you can trust
+
+About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state. See [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
+
+### Faster, proportional verification
+
+Documentation-only changes skip workspace suites. Ordinary code changes run affected Vitest coverage. Shared, storage, manifest, desktop, high-risk, and release changes retain the full gate.
+
+Full-suite evidence is reused only when its exact tested head is an ancestor of the resulting commit. See [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
 
 ## Install or upgrade
+
+### Upgrade
 
 ```bash
 brew update
 brew upgrade --cask bradgroux/tap/veritas-kanban
 ```
 
-For a first installation, run `brew install --cask bradgroux/tap/veritas-kanban`. The Assets section also provides the signed and notarized macOS arm64 DMG and ZIP. Back up the current workspace before upgrading and keep the backup until the new runtime is accepted.
+### First installation
 
-## Compatibility and documentation
+```bash
+brew install --cask bradgroux/tap/veritas-kanban
+```
 
-The Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts introduced in 6.0.1 are unchanged. Version 6.0.2 adds no data-schema migration over 6.0.1, and the public REST API remains mounted at `v1`. Linux and Windows desktop artifacts remain unsigned verification previews; signed and notarized macOS arm64 is the supported desktop distribution. Full context is available in the [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md), [upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md), [harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md), [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md), [release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md), and [release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010).
+The Assets section also provides the signed and notarized macOS arm64 DMG and ZIP. Back up the current workspace before upgrading and retain the backup until the new runtime is accepted.
+
+## Compatibility
+
+- No data-schema migration is required when upgrading from 6.0.1.
+- The public REST API remains mounted at `v1`.
+- Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts are unchanged.
+- Signed and notarized macOS arm64 is the supported desktop distribution. Linux and Windows artifacts remain unsigned verification previews.
+
+## Documentation
+
+- [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md)
+- [Upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md)
+- [Harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md)
+- [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md)
+- [Release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md)
+- [Release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010)

--- a/scripts/validate-release-format.test.mjs
+++ b/scripts/validate-release-format.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { releaseBodyFormattingIssues } from './validate-release.mjs';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const cleanBody = `Veritas Kanban 6.0.2 is the supported stable release.
 
@@ -28,10 +33,25 @@ test('rejects release formatting that forces narrow or manual line breaks', () =
     ['HTML break', 'First paragraph.<br>\n'],
     ['blockquote', '> Narrow callout.\n'],
     ['hard-wrapped prose', 'First half of a paragraph\nsecond half of the paragraph.\n'],
+    ['overlong prose block', `${'word '.repeat(50)}end\n`],
     ['unclosed code fence', '```bash\nbrew update\n'],
   ];
 
   for (const [name, body] of cases) {
     assert.notDeepEqual(releaseBodyFormattingIssues(body), [], name);
+  }
+});
+
+test('accepts every checked-in GitHub release body', async () => {
+  const releaseBodyDir = path.join(rootDir, 'docs', 'releases');
+  const releaseBodyFiles = (await readdir(releaseBodyDir))
+    .filter((file) => /^v\d+\.\d+\.\d+\.md$/.test(file))
+    .sort();
+
+  assert.ok(releaseBodyFiles.length > 0, 'expected at least one checked-in release body');
+
+  for (const file of releaseBodyFiles) {
+    const body = await readFile(path.join(releaseBodyDir, file), 'utf8');
+    assert.deepEqual(releaseBodyFormattingIssues(body), [], file);
   }
 });

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -301,6 +301,18 @@ function normalizeReleaseBody(value) {
   return value.replace(/\r\n?/g, '\n').trim();
 }
 
+const MAX_RENDERED_RELEASE_BLOCK_LENGTH = 240;
+
+function renderedReleaseBlockText(line) {
+  return line
+    .replace(/!\[[^\]]*]\([^)]*\)/g, '')
+    .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/^\s*(?:[-*+]|\d+\.)\s+/, '')
+    .replace(/[*_~]/g, '')
+    .trim();
+}
+
 export function releaseBodyFormattingIssues(value) {
   const issues = [];
 
@@ -348,9 +360,21 @@ export function releaseBodyFormattingIssues(value) {
 
     const blockLine = {
       lineNumber,
+      heading: /^\s*#{1,6}\s+/.test(line),
       listItem: /^\s*(?:[-*+]|\d+\.)\s+/.test(line),
       tableRow: /^\s*\|.*\|\s*$/.test(line),
     };
+
+    const renderedBlockLength = renderedReleaseBlockText(line).length;
+    if (
+      !blockLine.heading &&
+      !blockLine.tableRow &&
+      renderedBlockLength > MAX_RENDERED_RELEASE_BLOCK_LENGTH
+    ) {
+      issues.push(
+        `line ${lineNumber} renders as ${renderedBlockLength} characters; split it into concise full-width blocks`
+      );
+    }
 
     if (
       previousBlockLine &&


### PR DESCRIPTION
## Summary

- replace the dense v6.0.2 release body with concise full-width sections
- remove the blockquote still present in the canonical and live v6.0.1 notes
- reject release prose blocks that render longer than 240 characters
- validate every checked-in `docs/releases/vX.Y.Z.md` body, not only the current version
- make the repository instructions explicitly prohibit release-note blockquotes

## Root cause

The first guard rejected carriage returns, hard breaks, and blockquotes in the current release source, but it did not validate older checked-in release bodies or constrain visually dense prose. That left v6.0.1 broken on the public releases index and allowed v6.0.2 to pass despite poor visual structure.

## Verification

- `pnpm test:release-format` (3 tests passed)
- Prettier check on all six touched files
- `git diff --check`
- live v6.0.1 and v6.0.2 bodies exactly match their canonical files
- rendered v6.0.2 inspected on GitHub with no blockquote

## Note

The full release validator was not rerun after its formatting checks because this fresh worktree intentionally has no built package outputs. Its release-body and repository checks passed; the only reported failures were the six missing build artifacts.

Closes #1020
