### PR TITLE
Fix natural wrapping in GitHub release notes

### DIFF
--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -1,43 +1,29 @@
-Veritas Kanban 6.0.2 is the current supported stable v6 release. It fixes desktop Chat recovery, makes native version information authoritative, and keeps verification proportional between release milestones.
+Veritas Kanban 6.0.2 is the current supported stable v6 release. It resolves the two critical desktop regressions tracked in [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004) and [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005), and it adds the proportional verification policy from [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000). **Release status:** 6.0.2 supersedes 6.0.1; version 6.0.0 remains a quarantined prerelease.
 
-**Release status:** 6.0.2 supersedes 6.0.1. Version 6.0.0 remains a quarantined prerelease.
+## What changed
 
-## Highlights
-
-### Chat stays inside Veritas Kanban
-
-Board Chat and Squad Chat now use a reversible Workbench dock. Conversations remain mounted while switching between Right and Bottom, with bounded dimensions and owned scrolling.
-
-Close, Escape, browser Back, and Reset Layout all return to a visible board. Invalid saved dimensions recover to safe defaults. See [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004).
-
-### Version information you can trust
-
-About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state. See [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005).
-
-### Faster, proportional verification
-
-Documentation-only changes skip workspace suites. Ordinary code changes run affected Vitest coverage. Shared, storage, manifest, desktop, high-risk, and release changes retain the full gate.
-
-Full-suite evidence is reused only when its exact tested head is an ancestor of the resulting commit. See [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
+- **Chat recovery and layout safety:** Board Chat and Squad Chat now use a reversible Workbench dock. Conversations remain mounted while switching between Right and Bottom, dimensions are bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
+- **Authoritative native version information:** About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state.
+- **Proportional verification:** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence is reused only when its exact tested head is an ancestor of the resulting commit.
 
 ## Install or upgrade
 
-### Upgrade
+Upgrade an existing Homebrew installation:
 
 ```bash
 brew update
 brew upgrade --cask bradgroux/tap/veritas-kanban
 ```
 
-### First installation
+Install for the first time:
 
 ```bash
 brew install --cask bradgroux/tap/veritas-kanban
 ```
 
-The Assets section also provides the signed and notarized macOS arm64 DMG and ZIP. Back up the current workspace before upgrading and retain the backup until the new runtime is accepted.
+The Assets section provides the signed and notarized macOS arm64 DMG and ZIP. Back up the current workspace before upgrading and retain the backup until the new runtime is accepted.
 
-## Compatibility
+## Compatibility and support
 
 - No data-schema migration is required when upgrading from 6.0.1.
 - The public REST API remains mounted at `v1`.

--- a/scripts/validate-release-format.test.mjs
+++ b/scripts/validate-release-format.test.mjs
@@ -8,7 +8,7 @@ import { releaseBodyFormattingIssues } from './validate-release.mjs';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
-const cleanBody = `Veritas Kanban 6.0.2 is the supported stable release.
+const cleanBody = `Veritas Kanban 6.0.2 is the supported stable release. This paragraph is intentionally longer than the previous 240-character limit because Markdown source should use one logical line per paragraph and let GitHub wrap the rendered text to the available page width instead of forcing narrow manual breaks into the release notes.
 
 ## What changed
 
@@ -33,7 +33,6 @@ test('rejects release formatting that forces narrow or manual line breaks', () =
     ['HTML break', 'First paragraph.<br>\n'],
     ['blockquote', '> Narrow callout.\n'],
     ['hard-wrapped prose', 'First half of a paragraph\nsecond half of the paragraph.\n'],
-    ['overlong prose block', `${'word '.repeat(50)}end\n`],
     ['unclosed code fence', '```bash\nbrew update\n'],
   ];
 

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -301,18 +301,6 @@ function normalizeReleaseBody(value) {
   return value.replace(/\r\n?/g, '\n').trim();
 }
 
-const MAX_RENDERED_RELEASE_BLOCK_LENGTH = 240;
-
-function renderedReleaseBlockText(line) {
-  return line
-    .replace(/!\[[^\]]*]\([^)]*\)/g, '')
-    .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
-    .replace(/`([^`]*)`/g, '$1')
-    .replace(/^\s*(?:[-*+]|\d+\.)\s+/, '')
-    .replace(/[*_~]/g, '')
-    .trim();
-}
-
 export function releaseBodyFormattingIssues(value) {
   const issues = [];
 
@@ -364,17 +352,6 @@ export function releaseBodyFormattingIssues(value) {
       listItem: /^\s*(?:[-*+]|\d+\.)\s+/.test(line),
       tableRow: /^\s*\|.*\|\s*$/.test(line),
     };
-
-    const renderedBlockLength = renderedReleaseBlockText(line).length;
-    if (
-      !blockLine.heading &&
-      !blockLine.tableRow &&
-      renderedBlockLength > MAX_RENDERED_RELEASE_BLOCK_LENGTH
-    ) {
-      issues.push(
-        `line ${lineNumber} renders as ${renderedBlockLength} characters; split it into concise full-width blocks`
-      );
-    }
 
     if (
       previousBlockLine &&


### PR DESCRIPTION
## Summary

- remove the arbitrary 240-character release prose limit
- preserve checks for CR characters, Markdown hard breaks, HTML breaks, escaped line breaks, blockquotes, and source-level hard wrapping
- synchronize the checked-in v6.0.2 release body with the corrected live release
- cover a naturally wrapped paragraph longer than the old limit

## Verification

- `node --test scripts/validate-release-format.test.mjs`
- `node scripts/validate-release.mjs --version 6.0.2 --github --repo BradGroux/veritas-kanban --skip-build-output`
- `git diff --check`

Closes #1020