### PR TITLE
fix: gate desktop releases on reviewed notes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -41,6 +41,14 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
+      - name: Validate published release body
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          pnpm validate:release -- --version "${version}" --github --skip-build-output
+
       - name: Verify signing and notarization secrets are configured
         id: notarization-secrets
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   exact blocker before changing paths.
 - Source every published GitHub release body from `docs/releases/vX.Y.Z.md` and pass that file
   to `gh release create` or `gh release edit` with `--notes-file`.
+- Never hand-author or repair a release body with `--notes`, the GitHub editor, or a raw API
+  body. Edit the reviewed source file first, validate it, and publish that exact file.
 - Keep each prose paragraph and list item on one logical Markdown source line. Separate blocks
   with blank lines. Do not hard-wrap release prose or add carriage returns, trailing-space hard
   breaks, literal escaped newlines, HTML `<br>` tags, or blockquotes.
@@ -100,6 +102,8 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   text on GitHub's release index.
 - Run `pnpm validate:release -- --version X.Y.Z`; the post-publication `--github` form also
   requires the published GitHub body to match the reviewed file exactly.
+- After publication, inspect both the releases index and tag page. Raw Markdown validation does
+  not replace a rendered-format check.
 
 ---
 

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -67,7 +67,10 @@ targets.
 
 `Desktop Release` runs on manual dispatch or a published GitHub release. It
 requires the signing secrets below, builds signed/notarized macOS artifacts,
-and publishes update metadata with the GitHub provider.
+and publishes update metadata with the GitHub provider. A published-release run
+first verifies that the live GitHub body exactly matches
+`docs/releases/vX.Y.Z.md`; a mismatch stops the workflow before signing or
+packaging.
 
 ## Homebrew Cask
 
@@ -185,8 +188,15 @@ policy is tracked in
   `Desktop Artifacts` Windows job and inspect preview artifact names. This is
   not a v6 GA release gate.
 - Run `Desktop Artifacts` and download the uploaded DMG/ZIP/update metadata.
+- Edit `docs/releases/vX.Y.Z.md`, run
+  `pnpm validate:release -- --version X.Y.Z`, and publish that exact file with
+  `gh release create --notes-file` or `gh release edit --notes-file`. Do not
+  hand-author or repair the live body separately.
 - Run `Desktop Release` only after Developer ID signing secrets and exactly one
   complete notarization credential set are configured.
+- Inspect the rendered release on both the releases index and tag page. Confirm
+  prose uses natural page-width wrapping and no sentence-sized fragments were
+  introduced.
 - Confirm notarization succeeds with the intended credential mode and the DMG
   installs without Gatekeeper warnings on a clean Mac.
 - Confirm a first run creates the profile/workspace app data directories.

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -1,10 +1,10 @@
-Veritas Kanban 6.0.2 is the current supported stable v6 release. It resolves the two critical desktop regressions tracked in [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004) and [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005), and it adds the proportional verification policy from [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000). **Release status:** 6.0.2 supersedes 6.0.1; version 6.0.0 remains a quarantined prerelease.
+Veritas Kanban 6.0.2 is the current supported stable v6 release. It fixes the critical desktop regressions tracked in [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004) and [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005), adds the proportional verification policy from [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000), and supersedes v6.0.1. Version 6.0.0 remains a quarantined prerelease.
 
-## What changed
+## Highlights
 
-- **Chat recovery and layout safety:** Board Chat and Squad Chat now use a reversible Workbench dock. Conversations remain mounted while switching between Right and Bottom, dimensions are bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
+- **Chat recovery and layout safety:** Board Chat and Squad Chat now stay mounted in a reversible Workbench dock. Switching between Right and Bottom preserves the conversation, dock dimensions remain bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
 - **Authoritative native version information:** About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state.
-- **Proportional verification:** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence is reused only when its exact tested head is an ancestor of the resulting commit.
+- **Proportional verification:** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence can be reused only when its exact tested head is an ancestor of the resulting commit.
 
 ## Install or upgrade
 


### PR DESCRIPTION
## Summary

- synchronize the reviewed v6.0.2 release body with the corrected live GitHub notes
- require published Desktop Release runs to verify the live body before signing or packaging
- prohibit manual release-body repairs and require a rendered index and tag-page check

## Verification

- `node --test scripts/validate-release-format.test.mjs` (3 passed)
- `pnpm validate:release -- --version 6.0.2 --github --skip-build-output`
- workflow YAML parse
- Prettier check on the four changed files
- `git diff --check`

No workspace-wide suite was run because this changes release documentation and one preflight step only.

Closes #1020