### PR TITLE
fix: keep release notes full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controls. Workflow recovery exposes the same exact-parent cancellation
   through REST (#861).
 
+### Changed
+
+- Reworked GitHub release notes to use natural page-width prose instead of
+  fragmented micro-sections, and expanded the release-format gate to reject
+  nested headings and consecutive sentence-sized prose blocks in v6.0.2 and
+  later release bodies (#1025).
+
 ## [6.0.2] - 2026-07-24
 
 Veritas Kanban 6.0.2 is a desktop recovery and supportability hotfix. It keeps

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -192,6 +192,10 @@ policy is tracked in
   `pnpm validate:release -- --version X.Y.Z`, and publish that exact file with
   `gh release create --notes-file` or `gh release edit --notes-file`. Do not
   hand-author or repair the live body separately.
+- Use one logical source line per prose paragraph and let GitHub wrap it to the
+  available width. Keep release structure to level-two headings, combine
+  sentence-sized fragments into complete paragraphs, and reserve lists for
+  content that is genuinely easier to scan as a list.
 - Run `Desktop Release` only after Developer ID signing secrets and exactly one
   complete notarization credential set are configured.
 - Inspect the rendered release on both the releases index and tag page. Confirm

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -1,10 +1,12 @@
-Veritas Kanban 6.0.2 is the current supported stable v6 release. It fixes the critical desktop regressions tracked in [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004) and [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005), adds the proportional verification policy from [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000), and supersedes v6.0.1. Version 6.0.0 remains a quarantined prerelease.
+Veritas Kanban 6.0.2 is the supported stable v6 release. It fixes the critical desktop regressions tracked in [#1004](https://github.com/BradGroux/veritas-kanban/issues/1004) and [#1005](https://github.com/BradGroux/veritas-kanban/issues/1005), adds the proportional verification policy from [#1000](https://github.com/BradGroux/veritas-kanban/issues/1000), and supersedes v6.0.1. Version 6.0.0 remains a quarantined prerelease.
 
-## Highlights
+## What changed
 
-- **Chat recovery and layout safety:** Board Chat and Squad Chat now stay mounted in a reversible Workbench dock. Switching between Right and Bottom preserves the conversation, dock dimensions remain bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
-- **Authoritative native version information:** About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state.
-- **Proportional verification:** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence can be reused only when its exact tested head is an ancestor of the resulting commit.
+**Chat recovery and layout safety.** Board Chat and Squad Chat now stay mounted in a reversible Workbench dock. Switching between Right and Bottom preserves the conversation, dock dimensions remain bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
+
+**Authoritative native version information.** About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state.
+
+**Proportional verification.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence can be reused only when its exact tested head is an ancestor of the resulting commit.
 
 ## Install or upgrade
 
@@ -25,16 +27,8 @@ The Assets section provides the signed and notarized macOS arm64 DMG and ZIP. Ba
 
 ## Compatibility and support
 
-- No data-schema migration is required when upgrading from 6.0.1.
-- The public REST API remains mounted at `v1`.
-- Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts are unchanged.
-- Signed and notarized macOS arm64 is the supported desktop distribution. Linux and Windows artifacts remain unsigned verification previews.
+No data-schema migration is required when upgrading from 6.0.1, and the public REST API remains mounted at `v1`. Buzz, Grok Build, OpenAI Codex, Claude Code, GitHub Copilot CLI, Hermes, and OpenClaw support contracts are unchanged. Signed and notarized macOS arm64 is the supported desktop distribution; Linux and Windows artifacts remain unsigned verification previews.
 
 ## Documentation
 
-- [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md)
-- [Upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md)
-- [Harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md)
-- [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md)
-- [Release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md)
-- [Release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010)
+See the [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md), [upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md), [harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md), [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md), [release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md), and [release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010).

--- a/scripts/validate-release-format.test.mjs
+++ b/scripts/validate-release-format.test.mjs
@@ -33,6 +33,14 @@ test('rejects release formatting that forces narrow or manual line breaks', () =
     ['HTML break', 'First paragraph.<br>\n'],
     ['blockquote', '> Narrow callout.\n'],
     ['hard-wrapped prose', 'First half of a paragraph\nsecond half of the paragraph.\n'],
+    [
+      'nested heading fragment',
+      '## What changed\n\n### One small change\n\nA complete explanation follows.\n',
+    ],
+    [
+      'consecutive short prose blocks',
+      'First short thought.\n\nSecond short thought.\n\nThird short thought.\n',
+    ],
     ['unclosed code fence', '```bash\nbrew update\n'],
   ];
 
@@ -51,6 +59,12 @@ test('accepts every checked-in GitHub release body', async () => {
 
   for (const file of releaseBodyFiles) {
     const body = await readFile(path.join(releaseBodyDir, file), 'utf8');
-    assert.deepEqual(releaseBodyFormattingIssues(body), [], file);
+    const [major, minor, patch] = file
+      .slice(1, -3)
+      .split('.')
+      .map((part) => Number.parseInt(part, 10));
+    const compactLayout = major > 6 || (major === 6 && (minor > 0 || (minor === 0 && patch >= 2)));
+
+    assert.deepEqual(releaseBodyFormattingIssues(body, { compactLayout }), [], file);
   }
 });

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -301,8 +301,10 @@ function normalizeReleaseBody(value) {
   return value.replace(/\r\n?/g, '\n').trim();
 }
 
-export function releaseBodyFormattingIssues(value) {
+export function releaseBodyFormattingIssues(value, options = {}) {
+  const { compactLayout = true } = options;
   const issues = [];
+  const shortProseBlocks = [];
 
   if (value.includes('\r')) {
     issues.push('contains carriage-return characters');
@@ -320,6 +322,7 @@ export function releaseBodyFormattingIssues(value) {
     if (/^```/.test(trimmedStart)) {
       inFence = !inFence;
       previousBlockLine = undefined;
+      shortProseBlocks.length = 0;
       continue;
     }
 
@@ -349,9 +352,32 @@ export function releaseBodyFormattingIssues(value) {
     const blockLine = {
       lineNumber,
       heading: /^\s*#{1,6}\s+/.test(line),
+      nestedHeading: /^\s*#{3,6}\s+/.test(line),
       listItem: /^\s*(?:[-*+]|\d+\.)\s+/.test(line),
       tableRow: /^\s*\|.*\|\s*$/.test(line),
     };
+
+    if (compactLayout && blockLine.nestedHeading) {
+      issues.push(
+        `line ${lineNumber} uses a nested heading that fragments the GitHub release layout`
+      );
+    }
+
+    const proseBlock =
+      !blockLine.heading && !blockLine.listItem && !blockLine.tableRow && trimmed.length < 160;
+
+    if (compactLayout && proseBlock) {
+      shortProseBlocks.push(lineNumber);
+      if (shortProseBlocks.length === 3) {
+        issues.push(
+          `lines ${shortProseBlocks.join(
+            ', '
+          )} form consecutive short prose blocks; combine them into full-width paragraphs`
+        );
+      }
+    } else {
+      shortProseBlocks.length = 0;
+    }
 
     if (
       previousBlockLine &&
@@ -401,7 +427,18 @@ async function main() {
   const releaseBodyFile = `docs/releases/v${expectedVersion}.md`;
   const releaseBodyExists = await exists(releaseBodyFile);
   const releaseBody = releaseBodyExists ? await readText(releaseBodyFile) : '';
-  const releaseBodyIssues = releaseBodyExists ? releaseBodyFormattingIssues(releaseBody) : [];
+  const releaseVersionParts = expectedVersion
+    .split(/[+-]/, 1)[0]
+    .split('.')
+    .map((part) => Number.parseInt(part, 10));
+  const compactReleaseLayout =
+    releaseVersionParts[0] > 6 ||
+    (releaseVersionParts[0] === 6 &&
+      (releaseVersionParts[1] > 0 ||
+        (releaseVersionParts[1] === 0 && releaseVersionParts[2] >= 2)));
+  const releaseBodyIssues = releaseBodyExists
+    ? releaseBodyFormattingIssues(releaseBody, { compactLayout: compactReleaseLayout })
+    : [];
 
   check(
     'Release version is valid semver',


### PR DESCRIPTION
## Summary

- rewrites the v6.0.2 GitHub release body as compact, full-width prose
- rejects nested micro-headings and consecutive sentence-sized prose blocks in v6.0.2 and later release bodies
- documents the release-note layout rule and records the change in the changelog

## Root cause

The existing release-format guard rejected carriage returns, literal escaped newlines, hard breaks, and manually wrapped prose, but it still allowed a release to be split into many short headings and standalone blocks. GitHub rendered those blocks as a narrow, ragged stack.

The live v6.0.2 body was corrected first and now matches the checked-in source exactly.

## Verification

- `pnpm test:release-format`
- `pnpm exec prettier --check CHANGELOG.md docs/DESKTOP-RELEASE.md docs/releases/v6.0.2.md scripts/validate-release.mjs scripts/validate-release-format.test.mjs`
- `pnpm validate:release -- --version 6.0.2 --github --skip-build-output`
- fresh GitHub tag-page render inspection
- exact live body versus checked-in source comparison

Closes #1025
