### PR TITLE
fix: make release note breaks intentional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reworked GitHub release notes to use natural page-width prose instead of
-  fragmented micro-sections, and expanded the release-format gate to reject
-  nested headings and consecutive sentence-sized prose blocks in v6.0.2 and
+- Reworked GitHub release notes to use natural page-width prose and visible
+  lists instead of unmarked stacks of bold-led paragraphs. The release-format
+  gate now rejects nested headings, bold-led prose items, and consecutive
+  sentence-sized blocks even when blank lines separate them in v6.0.2 and
   later release bodies (#1025).
 
 ## [6.0.2] - 2026-07-24

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -193,13 +193,15 @@ policy is tracked in
   `gh release create --notes-file` or `gh release edit --notes-file`. Do not
   hand-author or repair the live body separately.
 - Use one logical source line per prose paragraph and let GitHub wrap it to the
-  available width. Keep release structure to level-two headings, combine
-  sentence-sized fragments into complete paragraphs, and reserve lists for
-  content that is genuinely easier to scan as a list.
+  available width. Keep release structure to level-two headings. Use Markdown
+  lists for parallel changes instead of stacking bold-led paragraphs that look
+  like accidental carriage returns. Combine sentence-sized fragments into
+  complete paragraphs.
 - Run `Desktop Release` only after Developer ID signing secrets and exactly one
   complete notarization credential set are configured.
 - Inspect the rendered release on both the releases index and tag page. Confirm
-  prose uses natural page-width wrapping and no sentence-sized fragments were
+  prose uses natural page-width wrapping, parallel items have visible list
+  markers, and no unmarked paragraph stack or sentence-sized fragment was
   introduced.
 - Confirm notarization succeeds with the intended credential mode and the DMG
   installs without Gatekeeper warnings on a clean Mac.

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -2,11 +2,9 @@ Veritas Kanban 6.0.2 is the supported stable v6 release. It fixes the critical d
 
 ## What changed
 
-**Chat recovery and layout safety.** Board Chat and Squad Chat now stay mounted in a reversible Workbench dock. Switching between Right and Bottom preserves the conversation, dock dimensions remain bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
-
-**Authoritative native version information.** About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state.
-
-**Proportional verification.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence can be reused only when its exact tested head is an ancestor of the resulting commit.
+- **Chat recovery and layout safety.** Board Chat and Squad Chat now stay mounted in a reversible Workbench dock. Switching between Right and Bottom preserves the conversation, dock dimensions remain bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
+- **Authoritative native version information.** About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state.
+- **Proportional verification.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence can be reused only when its exact tested head is an ancestor of the resulting commit.
 
 ## Install or upgrade
 
@@ -31,4 +29,4 @@ No data-schema migration is required when upgrading from 6.0.1, and the public R
 
 ## Documentation
 
-See the [v6 release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md), [upgrade and administration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md), [harness compatibility matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md), [Buzz integration guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md), [release evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md), and [release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010).
+See the [release notes](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RELEASE-NOTES.md), [upgrade guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-UPGRADE-INSTALL-ADMIN-GUIDE.md), [harness matrix](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/HARNESS-COMPATIBILITY.md), [Buzz guide](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/BUZZ-INTEGRATION.md), [evidence packet](https://github.com/BradGroux/veritas-kanban/blob/v6.0.2/docs/V6-RC-EVIDENCE-PACKET.md), and [release issue #1010](https://github.com/BradGroux/veritas-kanban/issues/1010).

--- a/scripts/validate-release-format.test.mjs
+++ b/scripts/validate-release-format.test.mjs
@@ -41,6 +41,10 @@ test('rejects release formatting that forces narrow or manual line breaks', () =
       'consecutive short prose blocks',
       'First short thought.\n\nSecond short thought.\n\nThird short thought.\n',
     ],
+    [
+      'bold-led prose items',
+      '## What changed\n\n**First labeled change.** This long release item looks like a list entry but has no list marker, so its paragraph break appears accidental in the rendered GitHub release even when the source line itself is not manually wrapped.\n\n**Second labeled change.** This second long release item proves the format guard rejects the broken structure based on its semantics rather than an arbitrary character limit.\n',
+    ],
     ['unclosed code fence', '```bash\nbrew update\n'],
   ];
 

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -363,6 +363,12 @@ export function releaseBodyFormattingIssues(value, options = {}) {
       );
     }
 
+    if (compactLayout && !blockLine.listItem && /^\*\*[^*]+\*\*\s+\S/.test(trimmed)) {
+      issues.push(
+        `line ${lineNumber} uses a bold-led prose block; use a Markdown list for parallel release items`
+      );
+    }
+
     const proseBlock =
       !blockLine.heading && !blockLine.listItem && !blockLine.tableRow && trimmed.length < 160;
 


### PR DESCRIPTION
## Summary

- renders parallel release changes as a real Markdown list instead of an unmarked paragraph stack
- shortens the documentation link labels so the final link does not spill onto a stray line
- rejects bold-led prose items in future release bodies and documents the rule

## Verification

- `pnpm test:release-format`
- `pnpm exec prettier --check CHANGELOG.md docs/DESKTOP-RELEASE.md docs/releases/v6.0.2.md scripts/validate-release.mjs scripts/validate-release-format.test.mjs`
- `pnpm exec eslint scripts/validate-release.mjs scripts/validate-release-format.test.mjs`
- `pnpm validate:release -- --version 6.0.2 --github --skip-build-output`
- live v6.0.2 tag-page render inspection

Closes #1025