### PR TITLE
fix: keep release notes full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reworked GitHub release notes to use natural page-width prose and visible
-  lists instead of unmarked stacks of bold-led paragraphs. The release-format
-  gate now rejects nested headings, bold-led prose items, and consecutive
-  sentence-sized blocks even when blank lines separate them in v6.0.2 and
-  later release bodies (#1025).
+- Reworked GitHub release notes to use natural page-width prose and concise
+  lists instead of ragged hanging-indent blocks or unmarked stacks of bold-led
+  paragraphs. The release-format gate now rejects long wrapping list items,
+  nested headings, bold-led prose items, and consecutive sentence-sized blocks
+  in v6.0.2 and later release bodies (#1025).
 
 ## [6.0.2] - 2026-07-24
 

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -193,15 +193,17 @@ policy is tracked in
   `gh release create --notes-file` or `gh release edit --notes-file`. Do not
   hand-author or repair the live body separately.
 - Use one logical source line per prose paragraph and let GitHub wrap it to the
-  available width. Keep release structure to level-two headings. Use Markdown
-  lists for parallel changes instead of stacking bold-led paragraphs that look
-  like accidental carriage returns. Combine sentence-sized fragments into
-  complete paragraphs.
+  available width. Keep release structure to level-two headings. Prefer one
+  cohesive full-width paragraph for a handful of related changes. Use Markdown
+  lists only when every item is concise enough to avoid multi-line hanging
+  indentation; the format gate caps list items at 160 source characters. Never
+  stack bold-led paragraphs or long labeled list items that look like accidental
+  carriage returns.
 - Run `Desktop Release` only after Developer ID signing secrets and exactly one
   complete notarization credential set are configured.
 - Inspect the rendered release on both the releases index and tag page. Confirm
-  prose uses natural page-width wrapping, parallel items have visible list
-  markers, and no unmarked paragraph stack or sentence-sized fragment was
+  prose uses natural page-width wrapping, lists remain compact, and no ragged
+  hanging-indent block, unmarked paragraph stack, or sentence-sized fragment was
   introduced.
 - Confirm notarization succeeds with the intended credential mode and the DMG
   installs without Gatekeeper warnings on a clean Mac.

--- a/docs/releases/v6.0.2.md
+++ b/docs/releases/v6.0.2.md
@@ -2,9 +2,7 @@ Veritas Kanban 6.0.2 is the supported stable v6 release. It fixes the critical d
 
 ## What changed
 
-- **Chat recovery and layout safety.** Board Chat and Squad Chat now stay mounted in a reversible Workbench dock. Switching between Right and Bottom preserves the conversation, dock dimensions remain bounded, scrolling stays inside the dock, and Close, Escape, browser Back, or Reset Layout always returns to a visible board.
-- **Authoritative native version information.** About Veritas Kanban and Copy Version Information now use one offline support record for the app version, release commit, channel, operating system, architecture, and packaged state.
-- **Proportional verification.** Documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence can be reused only when its exact tested head is an ancestor of the resulting commit.
+Board Chat and Squad Chat now stay mounted in a reversible Workbench dock, preserve the conversation when switching between Right and Bottom, keep dock dimensions and scrolling bounded, and return to a visible board after Close, Escape, browser Back, or Reset Layout. About Veritas Kanban and Copy Version Information now share one authoritative offline support record for the app version, release commit, channel, operating system, architecture, and packaged state. CI verification now scales with the change: documentation-only changes skip workspace suites, ordinary code changes run affected Vitest coverage, and shared, storage, manifest, desktop, high-risk, or release changes retain the full gate. Full-suite evidence is reused only when its exact tested head is an ancestor of the resulting commit.
 
 ## Install or upgrade
 

--- a/scripts/validate-release-format.test.mjs
+++ b/scripts/validate-release-format.test.mjs
@@ -45,6 +45,10 @@ test('rejects release formatting that forces narrow or manual line breaks', () =
       'bold-led prose items',
       '## What changed\n\n**First labeled change.** This long release item looks like a list entry but has no list marker, so its paragraph break appears accidental in the rendered GitHub release even when the source line itself is not manually wrapped.\n\n**Second labeled change.** This second long release item proves the format guard rejects the broken structure based on its semantics rather than an arbitrary character limit.\n',
     ],
+    [
+      'long wrapping list item',
+      '- **A long labeled change.** This item is deliberately long enough to wrap across multiple rendered lines with a hanging indent, producing the ragged layout that looks like forced carriage returns instead of using the full release width.\n',
+    ],
     ['unclosed code fence', '```bash\nbrew update\n'],
   ];
 

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -369,6 +369,12 @@ export function releaseBodyFormattingIssues(value, options = {}) {
       );
     }
 
+    if (compactLayout && blockLine.listItem && trimmed.length > 160) {
+      issues.push(
+        `line ${lineNumber} uses a long list item that will render with ragged hanging indentation; shorten it or use a full-width prose paragraph`
+      );
+    }
+
     const proseBlock =
       !blockLine.heading && !blockLine.listItem && !blockLine.tableRow && trimmed.length < 160;
 


### PR DESCRIPTION
## Summary

- Replace the long v6.0.2 change bullets with one full-width prose paragraph.
- Reject release list items longer than 160 source characters so GitHub does not render ragged hanging-indent blocks.
- Document the compact-list rule and update the changelog.
- Keep the checked-in v6.0.2 body identical to the corrected live release.

## Verification

- `node --test scripts/validate-release-format.test.mjs`
- `pnpm exec prettier --check docs/releases/v6.0.2.md scripts/validate-release.mjs scripts/validate-release-format.test.mjs docs/DESKTOP-RELEASE.md CHANGELOG.md`
- `git diff --check`
- Live release body matches `docs/releases/v6.0.2.md` byte-for-byte and contains no carriage returns, Markdown hard breaks, or literal escaped newlines.
- Rendered v6.0.2 tag page inspected after publication.

Closes #1025