### PR TITLE
docs: codify sustainable delivery cadence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,16 @@
 
 A clear and concise description of what this PR does.
 
+## Scope
+
+**Linked issue:** Closes #
+
+**In scope:** One independently shippable behavior and the documentation needed
+to use it.
+
+**Linked follow-ups:** List separable UI, integration, refactor, or hardening
+work that was intentionally kept out of this PR, or write `None`.
+
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
@@ -15,6 +25,15 @@ A clear and concise description of what this PR does.
 **How has this been tested?**
 Describe the tests you ran to verify your changes. Provide instructions so reviewers can reproduce.
 
+**Verification tier:**
+
+- [ ] Documentation or static checks only
+- [ ] Focused changed-package tests
+- [ ] Full milestone gate (`ci:full`, critical security, integration, or release)
+
+**Why this tier is sufficient:** Explain the changed behavior, covered failure
+modes, and why broader gates are or are not required.
+
 **Test commands:**
 
 ```bash
@@ -23,9 +42,13 @@ Describe the tests you ran to verify your changes. Provide instructions so revie
 
 ## Checklist
 
+- [ ] This PR contains one coherent, independently shippable behavior
+- [ ] Separable follow-up work is linked instead of folded into this PR
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have updated the documentation accordingly
 - [ ] My changes generate no new warnings
 - [ ] Any breaking changes have been documented in the PR description
+- [ ] I did not rerun unchanged passing gates after documentation or formatting-only edits
+- [ ] Optional desktop, artifact, and release workflows are marked relevant only when this PR touches their product boundary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,29 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 
 ---
 
+## Sustainable execution cadence
+
+- Keep each issue and pull request to one independently shippable behavior. When implementation
+  reveals a separable UI surface, secondary integration, refactor, or hardening follow-up, open
+  a linked issue instead of expanding the active pull request.
+- Re-scope before continuing when an issue no longer fits one coherent review, an unexpected
+  subsystem becomes necessary, or verification work is larger than the behavior being changed.
+- During implementation, run the narrowest useful loop: type-check touched packages, lint changed
+  files, and run focused tests for changed behavior and high-risk edges.
+- Do not rerun an unchanged passing gate after documentation, comments, or formatting-only edits.
+  Rerun only the checks affected by the later change.
+- Use the complete workspace suite once at an explicit integration, critical-security, or release
+  milestone. Pull-request label `ci:full`, scheduled CI, and manual full dispatch are the
+  authoritative broad gates.
+- Trust `scripts/select-ci-test-scope.mjs` and the `Select Test Scope` job to choose the required
+  CI tier. Do not add broader local gates merely to duplicate CI.
+- Do not wait for optional desktop packaging, artifact previews, or release workflows when the
+  change does not touch their product boundary. They are evidence only when declared relevant.
+- Add enough regression coverage to prove the behavior and its meaningful failure modes. Test
+  count is not a quality target.
+
+---
+
 ## Architecture rules
 
 ### Server (Express + TypeScript)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,32 +73,59 @@ veritas-kanban/
 
 2. Make your changes — write code, add tests, update docs.
 
-3. Run type checking, linting, and focused tests before committing:
+3. Run touched-package type checking, changed-file linting, and focused tests
+   before committing:
 
    ```bash
-   pnpm typecheck
-   pnpm lint
+   pnpm --filter @veritas-kanban/server typecheck
+   pnpm exec eslint server/src/path/to/changed.ts
    pnpm --filter @veritas-kanban/server exec vitest run src/path/to/changed.test.ts
    ```
 
-   Use `pnpm test` at integration or release milestones, or when the change
-   affects shared foundations broadly enough that focused selection is unsafe.
+   Build `@veritas-kanban/shared` first and type-check its known consumers when
+   a shared contract changes. Use `pnpm test` at an explicit integration,
+   critical-security, or release milestone, or when the deterministic CI
+   selector classifies the change as high risk.
 
 4. Commit using [conventional commits](#commit-conventions).
 
 5. Push to your fork and open a pull request.
 
+### Scope and Verification Budget
+
+This cadence extends the deterministic CI selector delivered in
+[#1000](https://github.com/BradGroux/veritas-kanban/issues/1000).
+
+- Keep one independently shippable behavior per issue and pull request.
+- Split separable UI work, secondary integrations, refactors, and additional
+  hardening into linked follow-up issues before implementing them.
+- Re-scope when a second unexpected subsystem becomes necessary or the
+  verification effort becomes larger than the changed behavior.
+- Do not rerun an unchanged passing check after documentation, comments, or
+  formatting-only edits.
+- Treat `Select Test Scope` as the CI authority. Focused, full, and no-test
+  selections are recorded in the job summary.
+- Do not wait for optional desktop artifacts, packaging previews, or release
+  workflows unless the pull request changes that product boundary.
+- Test the behavior and meaningful failure modes. Do not use raw test count as
+  a quality measure.
+
 ### Branch Merge Protocol
 
-**Critical:** When merging multiple feature branches, merge **one at a time**. Never batch-merge parallel branches.
+When merging multiple feature branches, merge one at a time so the next branch
+can rebase on the exact result.
 
 **Process:**
 
 1. Merge first branch to `main`
-2. Build all packages: `pnpm build`
-3. Run smoke tests (see [Testing Requirements](#testing-requirements))
-4. Only after smoke tests pass, merge the next branch
-5. Repeat for each branch
+2. Confirm the required GitHub checks for that pull request
+3. Rebase the next branch on the updated `main`
+4. Run only the focused checks affected by conflict resolution
+5. Merge the next branch
+
+The complete build, workspace suite, integration suite, and applicable E2E or
+artifact gates run once at the declared milestone. They are not repeated after
+every unrelated merge. 5. Repeat for each branch
 
 **Why:** Parallel branches often introduce integration issues that are hidden when batch-merging. Sequential merges with testing between each merge catch these immediately.
 
@@ -340,6 +367,11 @@ with no desktop packaging. This is a target rather than an SLA; dependency
 installation and hosted-runner availability still vary. Behavior changes
 should include coverage reachable from the changed source so Vitest's related
 test selection can execute it.
+
+Optional `Desktop Artifacts`, packaging previews, and release workflows are not
+merge blockers outside their path boundary. If one starts without providing
+evidence required by the pull request, continue based on required checks;
+maintainers may cancel the redundant run.
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

- make one independently shippable behavior per issue and pull request the canonical delivery rule
- require re-scoping when a second subsystem or disproportionate verification expands the active change
- standardize touched-package type checks, changed-file linting, focused regression tests, and no reruns of unchanged passing gates
- reserve the full workspace suite for explicit integration, critical-security, scheduled, manual, or release milestones
- stop treating optional desktop, artifact, packaging, and release workflows as blockers outside their product boundary
- add pull-request fields for scope, linked follow-ups, verification tier, and tier justification
- replace the old build-and-smoke-after-every-merge protocol with sequential merges and focused conflict verification

Closes #1030.

## Verification

- Prettier check on `AGENTS.md`, `CONTRIBUTING.md`, and `.github/PULL_REQUEST_TEMPLATE.md`
- `git diff --check`
- commit-time security artifact check

This is a documentation and workflow-contract change. The deterministic CI selector from #1000 remains the executable verification authority.
