### PR TITLE
feat: define phase capability authority compiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,14 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   whose built-in type and command both identify `codex` or `hermes` may infer a
   provider during migration; provider-less or profile/adapter-mismatched records
   fail closed before an attempt is created.
+- Phase authority uses the versioned contracts in
+  `shared/src/types/phase-capability.types.ts`. Compile parent, phase, agent
+  profile, sandbox, tool-catalog, and launch-policy authority only through
+  `phase-capability-service.ts`; never union scopes or infer missing
+  dimensions. The plan artifact exception is one harness-owned exact path and
+  never implies general filesystem write authority. Until #1035, #1036, and
+  #1033 land, this compiler is a contract foundation rather than active
+  transition or runtime enforcement.
 - Credential-bound tool servers persist only exact definition/scope digests and
   safe target names in `run-tool-catalog/v1`. Discovery strips their source
   environment/header values, native provider injection omits them, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the provider-neutral `phase-capability-profile/v1` foundation with
+  strict schemas and built-in explore, plan, implement, verify, and publish
+  profiles. A pure compiler now intersects phase requests with parent, agent,
+  sandbox, tool-catalog, and launch-policy authority without ever widening a
+  scope. Required unsupported or unenforceable dimensions return typed
+  fail-closed blockers, legacy launches are explicit, and the optional plan
+  artifact is restricted to one normalized harness-owned exact path that
+  cannot grant general filesystem or indirect shell-write authority (#1034).
 - Added a provider-neutral workspace execution trust gate that scans the exact
   task worktree for repository-controlled agent instructions, provider
   configuration, MCP servers, hooks, language-server settings, workflows,

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ When the board is working, use [Setup Paths](docs/SETUP-PATHS.md) to choose the 
 - [Agent Guide and `AGENTS.md` Template](docs/AGENTS-TEMPLATE.md) — shared managed-run protocol, external self-reporting template, and unmanaged MCP setup.
 - [Agent Providers](docs/AGENT-PROVIDERS.md) — evidence-backed Buzz, Grok Build, Codex, Claude Code, Copilot CLI, Hermes, OpenClaw, and optional model profiles.
 - [v6 Agent Runtime Control Plane](docs/architecture/V6-AGENT-RUNTIME-CONTROL-PLANE.md) — authority, adapter, lifecycle, approval, tool, credential, Buzz, and certification boundaries.
+- [Phase Capability Profiles](docs/architecture/PHASE-CAPABILITY-PROFILES.md) — versioned execution-phase authority contracts, deterministic intersections, exact-path plan artifacts, and current delivery boundaries.
 - [OpenAI Codex Integration Roadmap](docs/CODEX-INTEGRATION.md) — optional local execution, SDK sessions, cloud delegation, MCP setup, workflows, telemetry, and release QA.
 - [Veritas Cutover Operating Guide](docs/VERITAS-CUTOVER.md) — authority model, HermesAgent roster, QA evidence gate, and GitHub-backed task templates.
 - [Codex Integration SOP](docs/SOP-codex-integration.md) & [Codex Workflow Examples](docs/EXAMPLES-codex-workflows.md) — operational playbooks for using Codex as a first-class Veritas agent.
@@ -248,6 +249,11 @@ Tasks are markdown files. Settings are JSON. Workflows are YAML. No database, no
 - **Team roster routing** — Workspace coordinator/member manifests route tasks by capabilities, reviewers, fallbacks, and escalation posture
 - **Workspace capability discovery** — Trusted workspace capability catalogs let Veritas package delegated work intake before handing work across workspace boundaries
 - **Agent profile packages** — Portable YAML/JSON packages that bundle role, runtime, prompt, tools, permissions, sandbox, budget, workflow, and health metadata for reusable launches
+- **Phase capability contract** — Built-in explore, plan, implement, verify, and
+  publish profiles compile parent, phase, agent, sandbox, tool, and launch
+  authority without widening it. The current slice defines the shared contract
+  and compiler; runtime transition and enforcement work remains explicitly
+  tracked.
 - **Provider-owned task envelopes** — OpenClaw, Codex CLI, Codex SDK, and Hermes render the same immutable task contract through adapter-owned transports with explicit commit policy and completion posture
 - **Decision review sessions** — Multi-participant decision reviews with independent responses, critique rounds, final synthesis packets, work-product attachment, and decision audit links
 - **Shared live run sessions** — Create workspace-scoped view, co-drive, or fork links for active task runs; viewers receive live output and events, editors send attributed messages and mobile-safe approval responses, and forks create linked tasks without mutating the parent run

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -338,6 +338,14 @@ First-class support for autonomous coding agents.
 - **Team roster routing manifests** — Workspace coordinators can define enabled members, capabilities, routing rules, fallbacks, reviewers, and escalation posture before `/api/agents/route` selects an agent
 - **Workspace capability discovery** — Trusted workspace catalogs expose supported task types, SLA/queue posture, intake requirements, and delegated-work packaging so cross-workspace handoffs are explicit
 - **Agent profile packages** — Reusable YAML/JSON packages bundle role, runtime, model, prompt instructions, tools, permissions, sandbox, budget, workflow, and health metadata for portable task launches
+- **Phase capability contract** — Versioned explore, plan, implement, verify,
+  and publish profiles compile a monotonic intersection across parent, agent,
+  sandbox, tool-catalog, and launch policy authority. Unsupported required
+  dimensions fail closed, legacy mode remains explicit, and plan artifacts
+  stay bound to one harness-owned exact path. This is the model/compiler
+  foundation; transition persistence, launch propagation, tool enforcement,
+  and UI remain tracked in #1035, #1036, and #1033. See
+  [Phase Capability Profiles](architecture/PHASE-CAPABILITY-PROFILES.md).
 - **Provider runtime manifests** — Every executable adapter records a versioned, evidence-backed capability snapshot and digest on the attempt, history, trace, and log; provider version skew reruns conformance and unsupported configured providers fail closed instead of falling back to OpenClaw
 - **Cross-harness compatibility matrix** — Buzz, Grok Build, OpenAI Codex app-server, Claude Code, and GitHub Copilot CLI publish exact reviewed builds, source-availability caveats, deterministic fixture identity, capability evidence, limitations, and live support tiers through one API record consumed by Settings, `vk doctor`, telemetry, and [operator guidance](HARNESS-COMPATIBILITY.md)
 - **Harness conformance suites** — Versioned seeded scenarios compare

--- a/docs/architecture/PHASE-CAPABILITY-PROFILES.md
+++ b/docs/architecture/PHASE-CAPABILITY-PROFILES.md
@@ -1,0 +1,120 @@
+# Phase Capability Profiles
+
+Issue #1034 establishes the provider-neutral authority contract for execution
+phases. It defines what a phase may request and how Veritas computes the
+effective result before runtime transition, propagation, and tool enforcement
+are added in the remaining #875 slices.
+
+This foundation is intentionally pure. It does not change an active attempt,
+persist a transition, filter a tool catalog, or claim that a provider enforced
+the result.
+
+## Contract
+
+The versioned contracts are:
+
+- `phase-capability-profile/v1` for built-in and workspace-defined profiles
+- `phase-transition-intent/v1` for a requested move between phase identities
+- `phase-capability-evidence/v1` for the compiled result and blockers
+
+The built-in phase names are `explore`, `plan`, `implement`, `verify`, and
+`publish`. Launches without a profile compile in explicit `legacy` mode. Legacy
+mode preserves the intersection of existing policies and emits a warning; it
+does not silently invent a phase.
+
+## Authority dimensions
+
+The compiler keeps these dimensions independent:
+
+| Dimension             | Scope meaning                                       |
+| --------------------- | --------------------------------------------------- |
+| `filesystem.read`     | Exact logical paths or roots                        |
+| `filesystem.write`    | Exact logical paths or roots                        |
+| `command.execute`     | Trusted command classes, not arbitrary command text |
+| `network.egress`      | Exact destinations or policy-owned destination IDs  |
+| `credential.access`   | Credential definition references, never values      |
+| `external.action`     | Exact external action classes                       |
+| `artifact.plan.write` | The narrow harness-owned plan artifact capability   |
+
+Scopes are exact strings. `*` means that one source does not narrow the
+dimension. It cannot be combined with exact scopes. The compiler does not infer
+path ancestry, destination patterns, credential aliases, or command safety.
+
+In particular, an `inspect` command class is only a policy identifier for a
+trusted, enforceable tool mapping. It does not make arbitrary shell commands
+read-only.
+
+## Built-in profiles
+
+| Phase       | General workspace write | Task credentials   | External mutation  | Plan artifact       |
+| ----------- | ----------------------- | ------------------ | ------------------ | ------------------- |
+| `explore`   | No                      | No                 | No                 | No                  |
+| `plan`      | No                      | No                 | No                 | Optional exact path |
+| `implement` | Yes                     | Separately bounded | No                 | No                  |
+| `verify`    | Yes                     | No                 | No                 | No                  |
+| `publish`   | Yes                     | Separately bounded | Separately bounded | No                  |
+
+Profiles are ceilings, not grants by themselves. Agent, sandbox, tool, and
+launch policy sources can always narrow them.
+
+## Deterministic intersection
+
+Effective authority is the exact intersection of:
+
+1. Parent authority
+2. The selected phase profile
+3. Agent profile authority
+4. Sandbox capability
+5. Tool catalog capability
+6. Launch policy
+
+The compiler never unions scopes. A descendant therefore cannot exceed its
+parent. Every dimension records requested scopes, effective scopes, and the
+sources that narrowed it.
+
+Each non-phase source also reports whether it can enforce every dimension:
+
+- `enforced` allows its exact scopes to participate.
+- `unsupported` removes the dimension and creates a typed blocker when the
+  profile requires it.
+- `unenforceable` also removes the dimension and creates a distinct typed
+  blocker when required.
+
+An enforced source with no matching requested scope produces
+`required-authority-denied` for a required dimension. Optional authority can be
+narrowed away with a warning. Unknown dimensions and malformed source records
+are rejected by strict Zod schemas.
+
+## Plan artifact exception
+
+The plan profile may request one plan artifact through:
+
+```json
+{
+  "exactPath": ".veritas-kanban/plans/task-1034.md",
+  "owner": "veritas-kanban",
+  "transport": "harness-api"
+}
+```
+
+The effective evidence binds that exact normalized repository-relative path.
+The contract records `shellRedirection: false` and `indirectWrites: false`.
+Absolute paths, traversal, backslashes, control characters, and shell syntax
+fail closed. The exception never adds `filesystem.write` authority and cannot
+be requested by another built-in phase.
+
+Only the harness API may perform this write. A provider shell, hook, MCP tool,
+or redirection must not translate the exception into a general filesystem
+grant.
+
+## Delivery boundary
+
+This issue supplies the shared types, strict schemas, built-in profiles, pure
+compiler, and focused matrix coverage. The remaining tracking-epic slices add:
+
+- Durable transition state, approvals, and operator controls in #1035
+- Launch, descendant, retry, resume, and handoff propagation in #1036
+- Tool enforcement, evidence surfaces, and UI in #1033
+
+Until those slices land, compiled phase evidence is an architecture contract,
+not a claim that active runs are phase-restricted.

--- a/server/src/__tests__/phase-capability-service.test.ts
+++ b/server/src/__tests__/phase-capability-service.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PHASE_AUTHORITY_DIMENSIONS,
+  PHASE_TRANSITION_INTENT_SCHEMA_VERSION,
+  type PhaseAuthorityDimension,
+  type PhaseAuthoritySource,
+  type PhaseCapabilityCompilerInput,
+} from '@veritas-kanban/shared';
+import {
+  phaseCapabilityCompilerInputSchema,
+  phaseCapabilityEvidenceSchema,
+  phaseCapabilityProfileSchema,
+  phaseTransitionIntentSchema,
+} from '../schemas/phase-capability-schemas.js';
+import {
+  compilePhaseCapabilityAuthority,
+  getBuiltInPhaseCapabilityProfile,
+  listBuiltInPhaseCapabilityProfiles,
+} from '../services/phase-capability-service.js';
+
+describe('phase capability profiles', () => {
+  it('ships schema-valid built-in profiles for every phase', () => {
+    const profiles = listBuiltInPhaseCapabilityProfiles();
+
+    expect(profiles.map((profile) => profile.phase)).toEqual([
+      'explore',
+      'plan',
+      'implement',
+      'verify',
+      'publish',
+    ]);
+    for (const profile of profiles) {
+      expect(() => phaseCapabilityProfileSchema.parse(profile)).not.toThrow();
+      expect(profile.requiredDimensions).toEqual(PHASE_AUTHORITY_DIMENSIONS);
+    }
+  });
+
+  it.each(['explore', 'plan'] as const)(
+    '%s grants no general workspace mutation, task credentials, or external mutation',
+    (phase) => {
+      const evidence = compilePhaseCapabilityAuthority(
+        compilerInput(getBuiltInPhaseCapabilityProfile(phase))
+      );
+
+      expect(evidence.status).toBe('allowed');
+      expect(evidence.effectiveAuthority['filesystem.write']).toEqual([]);
+      expect(evidence.effectiveAuthority['credential.access']).toEqual([]);
+      expect(evidence.effectiveAuthority['external.action']).not.toContain('mutate');
+      expect(evidence.planArtifact).toBeUndefined();
+      expect(() => phaseCapabilityEvidenceSchema.parse(evidence)).not.toThrow();
+    }
+  );
+
+  it('binds the plan exception to one exact harness-owned path', () => {
+    const evidence = compilePhaseCapabilityAuthority({
+      ...compilerInput(getBuiltInPhaseCapabilityProfile('plan')),
+      planArtifact: {
+        exactPath: '.veritas-kanban/plans/task-1034.md',
+        owner: 'veritas-kanban',
+        transport: 'harness-api',
+      },
+    });
+
+    expect(evidence.status).toBe('allowed');
+    expect(evidence.effectiveAuthority['filesystem.write']).toEqual([]);
+    expect(evidence.effectiveAuthority['artifact.plan.write']).toEqual([
+      '.veritas-kanban/plans/task-1034.md',
+    ]);
+    expect(evidence.planArtifact).toEqual({
+      exactPath: '.veritas-kanban/plans/task-1034.md',
+      owner: 'veritas-kanban',
+      transport: 'harness-api',
+      shellRedirection: false,
+      indirectWrites: false,
+    });
+  });
+
+  it.each([
+    '../plan.md',
+    'plans/../plan.md',
+    '/tmp/plan.md',
+    'C:/tmp/plan.md',
+    'plans\\plan.md',
+    'plans/plan.md;touch-pwned',
+    'plans/$OUTPUT',
+  ])('blocks unsafe or indirect plan-artifact path %s', (exactPath) => {
+    const evidence = compilePhaseCapabilityAuthority({
+      ...compilerInput(getBuiltInPhaseCapabilityProfile('plan')),
+      planArtifact: { exactPath, owner: 'veritas-kanban', transport: 'harness-api' },
+    });
+
+    expect(evidence.status).toBe('blocked');
+    expect(evidence.blockers).toContainEqual(
+      expect.objectContaining({ code: 'plan-artifact-path-invalid' })
+    );
+    expect(evidence.planArtifact).toBeUndefined();
+  });
+
+  it('does not generalize the plan-artifact exception to another phase', () => {
+    const evidence = compilePhaseCapabilityAuthority({
+      ...compilerInput(getBuiltInPhaseCapabilityProfile('implement')),
+      planArtifact: {
+        exactPath: 'plans/task-1034.md',
+        owner: 'veritas-kanban',
+        transport: 'harness-api',
+      },
+    });
+
+    expect(evidence.status).toBe('blocked');
+    expect(evidence.blockers).toContainEqual(
+      expect.objectContaining({ code: 'plan-artifact-not-allowed' })
+    );
+    expect(evidence.effectiveAuthority['artifact.plan.write']).toEqual([]);
+  });
+
+  it('keeps implement, verify, and publish authority dimensions independent', () => {
+    const implement = compilePhaseCapabilityAuthority(
+      compilerInput(getBuiltInPhaseCapabilityProfile('implement'))
+    );
+    const verify = compilePhaseCapabilityAuthority(
+      compilerInput(getBuiltInPhaseCapabilityProfile('verify'))
+    );
+    const publish = compilePhaseCapabilityAuthority(
+      compilerInput(getBuiltInPhaseCapabilityProfile('publish'))
+    );
+
+    expect(implement.effectiveAuthority['filesystem.write']).toEqual(['<workspace>']);
+    expect(implement.effectiveAuthority['credential.access']).toEqual(['*']);
+    expect(implement.effectiveAuthority['external.action']).not.toContain('mutate');
+    expect(verify.effectiveAuthority['credential.access']).toEqual([]);
+    expect(verify.effectiveAuthority['external.action']).not.toContain('mutate');
+    expect(publish.effectiveAuthority['external.action']).toContain('mutate');
+    expect(publish.approvalRequiredDimensions).toEqual(['credential.access', 'external.action']);
+  });
+
+  it('intersects every source monotonically and records narrowing', () => {
+    const input = compilerInput(getBuiltInPhaseCapabilityProfile('implement'));
+    input.sources.parent.authority['command.execute'] = ['inspect', 'test'];
+    input.sources.sandbox.authority['network.egress'] = ['registry.npmjs.org'];
+    input.sources.launchPolicy.authority['credential.access'] = ['npm-publish'];
+
+    const evidence = compilePhaseCapabilityAuthority(input);
+
+    expect(evidence.status).toBe('narrowed');
+    expect(evidence.effectiveAuthority['command.execute']).toEqual(['inspect', 'test']);
+    expect(evidence.effectiveAuthority['network.egress']).toEqual(['registry.npmjs.org']);
+    expect(evidence.effectiveAuthority['credential.access']).toEqual(['npm-publish']);
+    for (const dimension of PHASE_AUTHORITY_DIMENSIONS) {
+      expect(
+        isSubset(evidence.effectiveAuthority[dimension], input.sources.parent.authority[dimension])
+      ).toBe(true);
+    }
+  });
+
+  it('returns a typed blocker when a required scope is denied', () => {
+    const input = compilerInput(getBuiltInPhaseCapabilityProfile('implement'));
+    input.sources.parent.authority['filesystem.write'] = [];
+
+    const evidence = compilePhaseCapabilityAuthority(input);
+
+    expect(evidence.status).toBe('blocked');
+    expect(evidence.blockers).toContainEqual(
+      expect.objectContaining({
+        code: 'required-authority-denied',
+        dimension: 'filesystem.write',
+      })
+    );
+  });
+
+  it.each([
+    ['unsupported', 'required-authority-unsupported'],
+    ['unenforceable', 'required-authority-unenforceable'],
+  ] as const)('fails closed when required authority is %s', (state, code) => {
+    const input = compilerInput(getBuiltInPhaseCapabilityProfile('explore'));
+    input.sources.toolCatalog.enforcement['external.action'] = state;
+
+    const evidence = compilePhaseCapabilityAuthority(input);
+
+    expect(evidence.status).toBe('blocked');
+    expect(evidence.blockers).toContainEqual(
+      expect.objectContaining({
+        code,
+        dimension: 'external.action',
+        sourceId: 'tool-catalog',
+      })
+    );
+    expect(evidence.effectiveAuthority['external.action']).toEqual([]);
+  });
+
+  it('makes legacy behavior explicit without inventing a phase profile', () => {
+    const input = compilerInput();
+    input.sources.parent.authority['filesystem.write'] = ['<workspace>'];
+    input.sources.launchPolicy.authority['filesystem.write'] = ['<workspace>'];
+
+    const evidence = compilePhaseCapabilityAuthority(input);
+
+    expect(evidence.identity).toEqual({ mode: 'legacy', phase: 'legacy' });
+    expect(evidence.warnings).toContain(
+      'Legacy mode applies no phase profile; existing parent, agent, sandbox, tool, and launch policies remain authoritative.'
+    );
+    expect(evidence.effectiveAuthority['filesystem.write']).toEqual(['<workspace>']);
+    expect(evidence.effectiveAuthority['artifact.plan.write']).toEqual([]);
+  });
+
+  it('rejects unknown authority dimensions instead of silently widening', () => {
+    const input = compilerInput(getBuiltInPhaseCapabilityProfile('explore')) as unknown as {
+      sources: { parent: { authority: Record<string, string[]> } };
+    };
+    input.sources.parent.authority['future.unenforced'] = ['*'];
+
+    expect(() => phaseCapabilityCompilerInputSchema.parse(input)).toThrow();
+    expect(() => compilePhaseCapabilityAuthority(input as never)).toThrow();
+  });
+
+  it('validates versioned transition intent without implementing transitions', () => {
+    const plan = getBuiltInPhaseCapabilityProfile('plan');
+    const implement = getBuiltInPhaseCapabilityProfile('implement');
+
+    expect(
+      phaseTransitionIntentSchema.parse({
+        schemaVersion: PHASE_TRANSITION_INTENT_SCHEMA_VERSION,
+        from: {
+          mode: 'profile',
+          phase: plan.phase,
+          profileId: plan.id,
+          profileVersion: plan.version,
+        },
+        to: {
+          mode: 'profile',
+          phase: implement.phase,
+          profileId: implement.id,
+          profileVersion: implement.version,
+        },
+        actor: 'operator:brad',
+        reason: 'The approved plan is ready for implementation.',
+        requestedAt: '2026-07-25T00:00:00.000Z',
+      })
+    ).toBeDefined();
+  });
+});
+
+function compilerInput(
+  profile?: PhaseCapabilityCompilerInput['profile']
+): PhaseCapabilityCompilerInput {
+  return {
+    ...(profile ? { profile } : {}),
+    sources: {
+      parent: source('parent', 'parent'),
+      agentProfile: source('agent-profile', 'agent-profile'),
+      sandbox: source('sandbox', 'sandbox'),
+      toolCatalog: source('tool-catalog', 'tool-catalog'),
+      launchPolicy: source('launch-policy', 'launch-policy'),
+    },
+  };
+}
+
+function source<K extends PhaseAuthoritySource['kind']>(
+  id: string,
+  kind: K
+): PhaseAuthoritySource & { kind: K } {
+  return {
+    id,
+    kind,
+    authority: recordForDimensions(() => ['*']),
+    enforcement: recordForDimensions(() => 'enforced'),
+  };
+}
+
+function recordForDimensions<T>(
+  value: (dimension: PhaseAuthorityDimension) => T
+): Record<PhaseAuthorityDimension, T> {
+  return Object.fromEntries(
+    PHASE_AUTHORITY_DIMENSIONS.map((dimension) => [dimension, value(dimension)])
+  ) as Record<PhaseAuthorityDimension, T>;
+}
+
+function isSubset(scopes: string[], parentScopes: string[]): boolean {
+  if (parentScopes.includes('*')) return true;
+  return scopes.every((scope) => parentScopes.includes(scope));
+}

--- a/server/src/schemas/phase-capability-schemas.ts
+++ b/server/src/schemas/phase-capability-schemas.ts
@@ -1,0 +1,279 @@
+import { z } from 'zod';
+import {
+  PHASE_AUTHORITY_DIMENSIONS,
+  PHASE_AUTHORITY_SOURCE_KINDS,
+  PHASE_CAPABILITY_EVIDENCE_SCHEMA_VERSION,
+  PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION,
+  PHASE_NAMES,
+  PHASE_TRANSITION_INTENT_SCHEMA_VERSION,
+} from '@veritas-kanban/shared';
+
+const identifierSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(160)
+  .regex(/^[a-z0-9][a-z0-9._:/-]*$/i);
+const safeTextSchema = z.string().trim().min(1).max(4_096);
+const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const authorityScopeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(1_024)
+  .refine(
+    (scope) => !hasControlCharacters(scope),
+    'Authority scopes cannot contain control characters'
+  );
+const authorityScopesSchema = z
+  .array(authorityScopeSchema)
+  .max(256)
+  .refine((scopes) => new Set(scopes).size === scopes.length, 'Authority scopes must be unique')
+  .refine(
+    (scopes) => !scopes.includes('*') || scopes.length === 1,
+    'Wildcard authority cannot be combined with exact scopes'
+  );
+const effectivePlanArtifactPathSchema = z
+  .string()
+  .min(1)
+  .max(4_096)
+  .refine(isSafeExactArtifactPath, 'Effective plan artifacts require one safe exact path');
+
+export const phaseNameSchema = z.enum(PHASE_NAMES);
+export const phaseAuthorityDimensionSchema = z.enum(PHASE_AUTHORITY_DIMENSIONS);
+export const phaseAuthoritySourceKindSchema = z.enum(PHASE_AUTHORITY_SOURCE_KINDS);
+export const phaseAuthorityEnforcementStateSchema = z.enum([
+  'enforced',
+  'unenforceable',
+  'unsupported',
+]);
+
+export const phaseAuthoritySchema = z
+  .object({
+    'filesystem.read': authorityScopesSchema,
+    'filesystem.write': authorityScopesSchema,
+    'command.execute': authorityScopesSchema,
+    'network.egress': authorityScopesSchema,
+    'credential.access': authorityScopesSchema,
+    'external.action': authorityScopesSchema,
+    'artifact.plan.write': authorityScopesSchema,
+  })
+  .strict();
+
+export const phaseAuthorityEnforcementSchema = z
+  .object({
+    'filesystem.read': phaseAuthorityEnforcementStateSchema,
+    'filesystem.write': phaseAuthorityEnforcementStateSchema,
+    'command.execute': phaseAuthorityEnforcementStateSchema,
+    'network.egress': phaseAuthorityEnforcementStateSchema,
+    'credential.access': phaseAuthorityEnforcementStateSchema,
+    'external.action': phaseAuthorityEnforcementStateSchema,
+    'artifact.plan.write': phaseAuthorityEnforcementStateSchema,
+  })
+  .strict();
+
+export const phaseAuthoritySourceSchema = z
+  .object({
+    id: identifierSchema,
+    kind: phaseAuthoritySourceKindSchema,
+    authority: phaseAuthoritySchema,
+    enforcement: phaseAuthorityEnforcementSchema,
+  })
+  .strict();
+
+const phasePlanArtifactPolicySchema = z.discriminatedUnion('mode', [
+  z
+    .object({
+      mode: z.literal('disabled'),
+      owner: z.literal('veritas-kanban'),
+      maximumPaths: z.literal(0),
+      transport: z.literal('harness-api'),
+      shellRedirection: z.literal(false),
+      indirectWrites: z.literal(false),
+    })
+    .strict(),
+  z
+    .object({
+      mode: z.literal('harness-exact-path'),
+      owner: z.literal('veritas-kanban'),
+      maximumPaths: z.literal(1),
+      transport: z.literal('harness-api'),
+      shellRedirection: z.literal(false),
+      indirectWrites: z.literal(false),
+    })
+    .strict(),
+]);
+
+export const phaseCapabilityProfileSchema = z
+  .object({
+    schemaVersion: z.literal(PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION),
+    id: identifierSchema,
+    version: z.number().int().positive().max(10_000),
+    phase: phaseNameSchema,
+    name: z.string().trim().min(1).max(160),
+    description: safeTextSchema,
+    builtIn: z.boolean().optional(),
+    authority: phaseAuthoritySchema,
+    requiredDimensions: z
+      .array(phaseAuthorityDimensionSchema)
+      .max(PHASE_AUTHORITY_DIMENSIONS.length)
+      .refine(
+        (dimensions) => new Set(dimensions).size === dimensions.length,
+        'Required authority dimensions must be unique'
+      ),
+    approvalRequiredDimensions: z
+      .array(phaseAuthorityDimensionSchema)
+      .max(PHASE_AUTHORITY_DIMENSIONS.length)
+      .refine(
+        (dimensions) => new Set(dimensions).size === dimensions.length,
+        'Approval-required authority dimensions must be unique'
+      ),
+    planArtifactPolicy: phasePlanArtifactPolicySchema,
+  })
+  .strict()
+  .superRefine((profile, context) => {
+    const artifactScopes = profile.authority['artifact.plan.write'];
+    if (profile.planArtifactPolicy.mode === 'disabled' && artifactScopes.length > 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['authority', 'artifact.plan.write'],
+        message: 'Disabled plan-artifact policy cannot grant artifact write authority',
+      });
+    }
+    if (
+      profile.planArtifactPolicy.mode === 'harness-exact-path' &&
+      (artifactScopes.length !== 1 || artifactScopes[0] !== 'harness-exact-path')
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['authority', 'artifact.plan.write'],
+        message: 'Plan-artifact authority must use only the harness-exact-path scope',
+      });
+    }
+  });
+
+export const phaseIdentitySchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('legacy'), phase: z.literal('legacy') }).strict(),
+  z
+    .object({
+      mode: z.literal('profile'),
+      phase: phaseNameSchema,
+      profileId: identifierSchema,
+      profileVersion: z.number().int().positive().max(10_000),
+    })
+    .strict(),
+]);
+
+export const phaseTransitionIntentSchema = z
+  .object({
+    schemaVersion: z.literal(PHASE_TRANSITION_INTENT_SCHEMA_VERSION),
+    from: phaseIdentitySchema,
+    to: phaseIdentitySchema,
+    actor: z.string().trim().min(1).max(240),
+    reason: safeTextSchema,
+    requestedAt: z.string().datetime({ offset: true }),
+    parentEvidenceDigest: digestSchema.optional(),
+  })
+  .strict();
+
+const sourceFor = (kind: (typeof PHASE_AUTHORITY_SOURCE_KINDS)[number]) =>
+  phaseAuthoritySourceSchema.extend({ kind: z.literal(kind) });
+
+export const phaseCapabilityCompilerInputSchema = z
+  .object({
+    profile: phaseCapabilityProfileSchema.optional(),
+    sources: z
+      .object({
+        parent: sourceFor('parent'),
+        agentProfile: sourceFor('agent-profile'),
+        sandbox: sourceFor('sandbox'),
+        toolCatalog: sourceFor('tool-catalog'),
+        launchPolicy: sourceFor('launch-policy'),
+      })
+      .strict(),
+    planArtifact: z
+      .object({
+        exactPath: z.string().min(1).max(4_096),
+        owner: z.literal('veritas-kanban'),
+        transport: z.literal('harness-api'),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export const phaseCapabilityBlockerSchema = z
+  .object({
+    code: z.enum([
+      'required-authority-denied',
+      'required-authority-unsupported',
+      'required-authority-unenforceable',
+      'plan-artifact-not-allowed',
+      'plan-artifact-path-invalid',
+    ]),
+    message: safeTextSchema,
+    dimension: phaseAuthorityDimensionSchema.optional(),
+    sourceId: identifierSchema.optional(),
+  })
+  .strict();
+
+export const phaseCapabilityEvidenceSchema = z
+  .object({
+    schemaVersion: z.literal(PHASE_CAPABILITY_EVIDENCE_SCHEMA_VERSION),
+    digest: digestSchema,
+    status: z.enum(['allowed', 'narrowed', 'blocked']),
+    identity: phaseIdentitySchema,
+    requestedAuthority: phaseAuthoritySchema,
+    effectiveAuthority: phaseAuthoritySchema,
+    requiredDimensions: z.array(phaseAuthorityDimensionSchema),
+    approvalRequiredDimensions: z.array(phaseAuthorityDimensionSchema),
+    evaluations: z.array(
+      z
+        .object({
+          dimension: phaseAuthorityDimensionSchema,
+          requestedScopes: authorityScopesSchema,
+          effectiveScopes: authorityScopesSchema,
+          required: z.boolean(),
+          limitingSourceIds: z.array(identifierSchema).max(16),
+        })
+        .strict()
+    ),
+    blockers: z.array(phaseCapabilityBlockerSchema),
+    warnings: z.array(z.string().min(1).max(4_096)),
+    planArtifact: z
+      .object({
+        exactPath: effectivePlanArtifactPathSchema,
+        owner: z.literal('veritas-kanban'),
+        transport: z.literal('harness-api'),
+        shellRedirection: z.literal(false),
+        indirectWrites: z.literal(false),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+function hasControlCharacters(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
+function isSafeExactArtifactPath(value: string): boolean {
+  if (
+    value !== value.trim() ||
+    value.startsWith('/') ||
+    /^[a-z]:/i.test(value) ||
+    value.includes('\\') ||
+    hasControlCharacters(value) ||
+    /[<>|;&`$]/.test(value)
+  ) {
+    return false;
+  }
+  const segments = value.split('/');
+  return (
+    segments.length > 0 &&
+    segments.every((segment) => segment.length > 0 && segment !== '.' && segment !== '..')
+  );
+}

--- a/server/src/services/phase-capability-service.ts
+++ b/server/src/services/phase-capability-service.ts
@@ -1,0 +1,412 @@
+import {
+  PHASE_AUTHORITY_DIMENSIONS,
+  PHASE_CAPABILITY_EVIDENCE_SCHEMA_VERSION,
+  PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION,
+  type EffectivePhasePlanArtifact,
+  type PhaseAuthority,
+  type PhaseAuthorityDimension,
+  type PhaseAuthorityEvaluation,
+  type PhaseCapabilityBlocker,
+  type PhaseCapabilityCompilerInput,
+  type PhaseCapabilityEvidence,
+  type PhaseCapabilityProfile,
+} from '@veritas-kanban/shared';
+import {
+  phaseCapabilityCompilerInputSchema,
+  phaseCapabilityEvidenceSchema,
+  phaseCapabilityProfileSchema,
+} from '../schemas/phase-capability-schemas.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
+
+const EMPTY_AUTHORITY = emptyAuthority();
+
+const ALL_DIMENSIONS = [...PHASE_AUTHORITY_DIMENSIONS];
+const DISABLED_PLAN_ARTIFACT = {
+  mode: 'disabled',
+  owner: 'veritas-kanban',
+  maximumPaths: 0,
+  transport: 'harness-api',
+  shellRedirection: false,
+  indirectWrites: false,
+} as const;
+const EXACT_PLAN_ARTIFACT = {
+  mode: 'harness-exact-path',
+  owner: 'veritas-kanban',
+  maximumPaths: 1,
+  transport: 'harness-api',
+  shellRedirection: false,
+  indirectWrites: false,
+} as const;
+
+const BUILT_IN_PHASE_CAPABILITY_PROFILES = [
+  profile({
+    id: 'builtin-explore',
+    phase: 'explore',
+    name: 'Explore',
+    description: 'Inspect the workspace without mutation, task credentials, or external changes.',
+    authority: authority({
+      'filesystem.read': ['<workspace>'],
+      'command.execute': ['inspect'],
+      'network.egress': [],
+      'external.action': ['read'],
+    }),
+  }),
+  profile({
+    id: 'builtin-plan',
+    phase: 'plan',
+    name: 'Plan',
+    description:
+      'Inspect and plan without general workspace mutation; an optional plan artifact uses one harness-owned path.',
+    authority: authority({
+      'filesystem.read': ['<workspace>'],
+      'command.execute': ['inspect'],
+      'network.egress': [],
+      'external.action': ['read'],
+      'artifact.plan.write': ['harness-exact-path'],
+    }),
+    planArtifactPolicy: EXACT_PLAN_ARTIFACT,
+  }),
+  profile({
+    id: 'builtin-implement',
+    phase: 'implement',
+    name: 'Implement',
+    description:
+      'Modify the workspace and run implementation commands without publishing external changes.',
+    authority: authority({
+      'filesystem.read': ['<workspace>'],
+      'filesystem.write': ['<workspace>'],
+      'command.execute': ['inspect', 'build', 'test', 'format', 'mutate'],
+      'network.egress': ['*'],
+      'credential.access': ['*'],
+      'external.action': ['read'],
+    }),
+  }),
+  profile({
+    id: 'builtin-verify',
+    phase: 'verify',
+    name: 'Verify',
+    description:
+      'Run bounded build and test commands while keeping credentials and external mutations disabled.',
+    authority: authority({
+      'filesystem.read': ['<workspace>'],
+      'filesystem.write': ['<workspace>'],
+      'command.execute': ['inspect', 'build', 'test'],
+      'network.egress': ['*'],
+      'external.action': ['read'],
+    }),
+  }),
+  profile({
+    id: 'builtin-publish',
+    phase: 'publish',
+    name: 'Publish',
+    description:
+      'Allow separately bounded workspace, command, network, credential, and external publication authority.',
+    authority: authority({
+      'filesystem.read': ['<workspace>'],
+      'filesystem.write': ['<workspace>'],
+      'command.execute': ['inspect', 'build', 'test', 'publish'],
+      'network.egress': ['*'],
+      'credential.access': ['*'],
+      'external.action': ['read', 'mutate'],
+    }),
+    approvalRequiredDimensions: ['credential.access', 'external.action'],
+  }),
+] satisfies PhaseCapabilityProfile[];
+
+export function listBuiltInPhaseCapabilityProfiles(): PhaseCapabilityProfile[] {
+  return BUILT_IN_PHASE_CAPABILITY_PROFILES.map((candidate) => structuredClone(candidate));
+}
+
+export function getBuiltInPhaseCapabilityProfile(
+  phase: PhaseCapabilityProfile['phase']
+): PhaseCapabilityProfile {
+  const candidate = BUILT_IN_PHASE_CAPABILITY_PROFILES.find(
+    (profileCandidate) => profileCandidate.phase === phase
+  );
+  if (!candidate) throw new Error(`Unknown built-in phase: ${phase}`);
+  return structuredClone(candidate);
+}
+
+/**
+ * Compile a monotonic authority intersection. This function is pure: it does
+ * not read configuration, mutate attempts, or infer provider capabilities.
+ */
+export function compilePhaseCapabilityAuthority(
+  input: PhaseCapabilityCompilerInput
+): PhaseCapabilityEvidence {
+  const parsed = phaseCapabilityCompilerInputSchema.parse(input) as PhaseCapabilityCompilerInput;
+  const sources = Object.values(parsed.sources);
+  const identity = parsed.profile
+    ? {
+        mode: 'profile' as const,
+        phase: parsed.profile.phase,
+        profileId: parsed.profile.id,
+        profileVersion: parsed.profile.version,
+      }
+    : {
+        mode: 'legacy' as const,
+        phase: 'legacy' as const,
+      };
+  const requestedAuthority = parsed.profile
+    ? cloneAuthority(parsed.profile.authority)
+    : authority({
+        'filesystem.read': ['*'],
+        'filesystem.write': ['*'],
+        'command.execute': ['*'],
+        'network.egress': ['*'],
+        'credential.access': ['*'],
+        'external.action': ['*'],
+      });
+  const requiredDimensions = parsed.profile ? [...parsed.profile.requiredDimensions] : [];
+  const approvalRequiredDimensions = parsed.profile
+    ? [...parsed.profile.approvalRequiredDimensions]
+    : [];
+  const blockers: PhaseCapabilityBlocker[] = [];
+  const warnings: string[] = [];
+
+  let planArtifact: EffectivePhasePlanArtifact | undefined;
+  if (parsed.planArtifact) {
+    if (parsed.profile?.planArtifactPolicy.mode !== 'harness-exact-path') {
+      requestedAuthority['artifact.plan.write'] = [];
+      blockers.push({
+        code: 'plan-artifact-not-allowed',
+        dimension: 'artifact.plan.write',
+        message: 'The selected phase profile does not allow a plan-artifact exception.',
+      });
+    } else if (!isSafeExactArtifactPath(parsed.planArtifact.exactPath)) {
+      blockers.push({
+        code: 'plan-artifact-path-invalid',
+        dimension: 'artifact.plan.write',
+        message:
+          'The plan artifact must be one normalized repository-relative path without traversal, control characters, backslashes, or shell syntax.',
+      });
+    } else {
+      planArtifact = {
+        exactPath: parsed.planArtifact.exactPath,
+        owner: 'veritas-kanban',
+        transport: 'harness-api',
+        shellRedirection: false,
+        indirectWrites: false,
+      };
+      if (!requiredDimensions.includes('artifact.plan.write')) {
+        requiredDimensions.push('artifact.plan.write');
+      }
+    }
+  } else {
+    requestedAuthority['artifact.plan.write'] = [];
+  }
+
+  const effectiveAuthority = cloneAuthority(EMPTY_AUTHORITY);
+  const evaluations: PhaseAuthorityEvaluation[] = [];
+  for (const dimension of PHASE_AUTHORITY_DIMENSIONS) {
+    const requestedScopes = requestedAuthority[dimension];
+    let effectiveScopes = [...requestedScopes];
+    const limitingSourceIds: string[] = [];
+    const required = requiredDimensions.includes(dimension);
+    let enforcementBlocked = false;
+
+    for (const source of sources) {
+      const enforcement = source.enforcement[dimension];
+      if (enforcement !== 'enforced') {
+        effectiveScopes = [];
+        limitingSourceIds.push(source.id);
+        if (required) {
+          enforcementBlocked = true;
+          blockers.push({
+            code:
+              enforcement === 'unsupported'
+                ? 'required-authority-unsupported'
+                : 'required-authority-unenforceable',
+            dimension,
+            sourceId: source.id,
+            message:
+              enforcement === 'unsupported'
+                ? `${source.id} does not support required ${dimension} enforcement.`
+                : `${source.id} cannot enforce required ${dimension} authority.`,
+          });
+        }
+        continue;
+      }
+
+      const next = intersectScopes(effectiveScopes, source.authority[dimension]);
+      if (!sameScopes(effectiveScopes, next)) limitingSourceIds.push(source.id);
+      effectiveScopes = next;
+    }
+
+    if (
+      required &&
+      requestedScopes.length > 0 &&
+      effectiveScopes.length === 0 &&
+      !enforcementBlocked
+    ) {
+      blockers.push({
+        code: 'required-authority-denied',
+        dimension,
+        message: `The authority intersection denies every requested ${dimension} scope.`,
+      });
+    }
+
+    if (!required && requestedScopes.length > 0 && effectiveScopes.length === 0) {
+      warnings.push(`Optional ${dimension} authority was removed by the effective intersection.`);
+    }
+
+    effectiveAuthority[dimension] = effectiveScopes;
+    evaluations.push({
+      dimension,
+      requestedScopes: [...requestedScopes],
+      effectiveScopes: [...effectiveScopes],
+      required,
+      limitingSourceIds: [...new Set(limitingSourceIds)].sort(),
+    });
+  }
+
+  if (planArtifact) {
+    if (effectiveAuthority['artifact.plan.write'].length === 0) {
+      planArtifact = undefined;
+    } else {
+      effectiveAuthority['artifact.plan.write'] = [planArtifact.exactPath];
+      const evaluation = evaluations.find(
+        (candidate) => candidate.dimension === 'artifact.plan.write'
+      );
+      if (evaluation) evaluation.effectiveScopes = [planArtifact.exactPath];
+    }
+  }
+  if (parsed.planArtifact && !planArtifact) {
+    effectiveAuthority['artifact.plan.write'] = [];
+    const evaluation = evaluations.find(
+      (candidate) => candidate.dimension === 'artifact.plan.write'
+    );
+    if (evaluation) {
+      evaluation.effectiveScopes = [];
+      evaluation.limitingSourceIds = [
+        ...new Set([...evaluation.limitingSourceIds, 'phase-compiler']),
+      ].sort();
+    }
+  }
+
+  if (!parsed.profile) {
+    warnings.push(
+      'Legacy mode applies no phase profile; existing parent, agent, sandbox, tool, and launch policies remain authoritative.'
+    );
+  }
+
+  const narrowed = evaluations.some((evaluation) => {
+    if (
+      evaluation.dimension === 'artifact.plan.write' &&
+      planArtifact &&
+      sameScopes(evaluation.requestedScopes, ['harness-exact-path']) &&
+      sameScopes(evaluation.effectiveScopes, [planArtifact.exactPath])
+    ) {
+      return false;
+    }
+    return !sameScopes(evaluation.requestedScopes, evaluation.effectiveScopes);
+  });
+  const payload: Omit<PhaseCapabilityEvidence, 'digest'> = {
+    schemaVersion: PHASE_CAPABILITY_EVIDENCE_SCHEMA_VERSION,
+    status: blockers.length > 0 ? 'blocked' : narrowed ? 'narrowed' : 'allowed',
+    identity,
+    requestedAuthority,
+    effectiveAuthority,
+    requiredDimensions: sortDimensions(requiredDimensions),
+    approvalRequiredDimensions: sortDimensions(approvalRequiredDimensions),
+    evaluations,
+    blockers: blockers.sort(compareBlockers),
+    warnings: [...new Set(warnings)].sort(),
+    ...(planArtifact ? { planArtifact } : {}),
+  };
+  return phaseCapabilityEvidenceSchema.parse({
+    ...payload,
+    digest: digestRunLaunchValue(payload),
+  }) as PhaseCapabilityEvidence;
+}
+
+function profile(
+  input: Pick<PhaseCapabilityProfile, 'id' | 'phase' | 'name' | 'description' | 'authority'> & {
+    planArtifactPolicy?: PhaseCapabilityProfile['planArtifactPolicy'];
+    approvalRequiredDimensions?: PhaseAuthorityDimension[];
+  }
+): PhaseCapabilityProfile {
+  return phaseCapabilityProfileSchema.parse({
+    schemaVersion: PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION,
+    id: input.id,
+    version: 1,
+    phase: input.phase,
+    name: input.name,
+    description: input.description,
+    builtIn: true,
+    authority: input.authority,
+    requiredDimensions: ALL_DIMENSIONS,
+    approvalRequiredDimensions: input.approvalRequiredDimensions ?? [],
+    planArtifactPolicy: input.planArtifactPolicy ?? DISABLED_PLAN_ARTIFACT,
+  }) as PhaseCapabilityProfile;
+}
+
+function authority(overrides: Partial<PhaseAuthority>): PhaseAuthority {
+  const value = emptyAuthority();
+  for (const dimension of PHASE_AUTHORITY_DIMENSIONS) {
+    if (overrides[dimension]) value[dimension] = [...overrides[dimension]];
+  }
+  return value;
+}
+
+function emptyAuthority(): PhaseAuthority {
+  const value = {} as PhaseAuthority;
+  for (const dimension of PHASE_AUTHORITY_DIMENSIONS) value[dimension] = [];
+  return value;
+}
+
+function cloneAuthority(value: PhaseAuthority): PhaseAuthority {
+  return Object.fromEntries(
+    PHASE_AUTHORITY_DIMENSIONS.map((dimension) => [dimension, [...value[dimension]]])
+  ) as PhaseAuthority;
+}
+
+function intersectScopes(left: string[], right: string[]): string[] {
+  if (left.length === 0 || right.length === 0) return [];
+  if (left[0] === '*') return [...right];
+  if (right[0] === '*') return [...left];
+  const rightScopes = new Set(right);
+  return left.filter((scope) => rightScopes.has(scope));
+}
+
+function sameScopes(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((scope, index) => scope === right[index]);
+}
+
+function sortDimensions(dimensions: PhaseAuthorityDimension[]): PhaseAuthorityDimension[] {
+  const requested = new Set(dimensions);
+  return PHASE_AUTHORITY_DIMENSIONS.filter((dimension) => requested.has(dimension));
+}
+
+function compareBlockers(left: PhaseCapabilityBlocker, right: PhaseCapabilityBlocker): number {
+  return (
+    (left.dimension ?? '').localeCompare(right.dimension ?? '') ||
+    (left.sourceId ?? '').localeCompare(right.sourceId ?? '') ||
+    left.code.localeCompare(right.code)
+  );
+}
+
+function isSafeExactArtifactPath(value: string): boolean {
+  if (
+    value !== value.trim() ||
+    value.startsWith('/') ||
+    /^[a-z]:/i.test(value) ||
+    value.includes('\\') ||
+    hasControlCharacters(value) ||
+    /[<>|;&`$]/.test(value)
+  ) {
+    return false;
+  }
+  const segments = value.split('/');
+  return (
+    segments.length > 0 &&
+    segments.every((segment) => segment.length > 0 && segment !== '.' && segment !== '..')
+  );
+}
+
+function hasControlCharacters(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -65,3 +65,4 @@ export * from './conversation-lifecycle.types.js';
 export * from './tool-control-plane.types.js';
 export * from './acp.types.js';
 export * from './workspace-execution-trust.types.js';
+export * from './phase-capability.types.js';

--- a/shared/src/types/phase-capability.types.ts
+++ b/shared/src/types/phase-capability.types.ts
@@ -1,0 +1,158 @@
+export const PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION = 'phase-capability-profile/v1' as const;
+export const PHASE_CAPABILITY_EVIDENCE_SCHEMA_VERSION = 'phase-capability-evidence/v1' as const;
+export const PHASE_TRANSITION_INTENT_SCHEMA_VERSION = 'phase-transition-intent/v1' as const;
+
+export const PHASE_NAMES = ['explore', 'plan', 'implement', 'verify', 'publish'] as const;
+export type PhaseName = (typeof PHASE_NAMES)[number];
+
+export const PHASE_AUTHORITY_DIMENSIONS = [
+  'filesystem.read',
+  'filesystem.write',
+  'command.execute',
+  'network.egress',
+  'credential.access',
+  'external.action',
+  'artifact.plan.write',
+] as const;
+export type PhaseAuthorityDimension = (typeof PHASE_AUTHORITY_DIMENSIONS)[number];
+
+export const PHASE_AUTHORITY_SOURCE_KINDS = [
+  'parent',
+  'agent-profile',
+  'sandbox',
+  'tool-catalog',
+  'launch-policy',
+] as const;
+export type PhaseAuthoritySourceKind = (typeof PHASE_AUTHORITY_SOURCE_KINDS)[number];
+
+/**
+ * Exact, non-secret authority scopes keyed by dimension.
+ *
+ * `*` means the source does not narrow that dimension. Every other entry is
+ * matched exactly. Paths, destinations, credential definition IDs, command
+ * classes, and external action classes are never inferred from prefixes.
+ */
+export type PhaseAuthority = Record<PhaseAuthorityDimension, string[]>;
+
+export type PhaseAuthorityEnforcementState = 'enforced' | 'unenforceable' | 'unsupported';
+export type PhaseAuthorityEnforcement = Record<
+  PhaseAuthorityDimension,
+  PhaseAuthorityEnforcementState
+>;
+
+export interface PhaseAuthoritySource {
+  id: string;
+  kind: PhaseAuthoritySourceKind;
+  authority: PhaseAuthority;
+  enforcement: PhaseAuthorityEnforcement;
+}
+
+export interface PhaseCapabilityCompilerSources {
+  parent: PhaseAuthoritySource & { kind: 'parent' };
+  agentProfile: PhaseAuthoritySource & { kind: 'agent-profile' };
+  sandbox: PhaseAuthoritySource & { kind: 'sandbox' };
+  toolCatalog: PhaseAuthoritySource & { kind: 'tool-catalog' };
+  launchPolicy: PhaseAuthoritySource & { kind: 'launch-policy' };
+}
+
+export interface PhasePlanArtifactPolicy {
+  mode: 'disabled' | 'harness-exact-path';
+  owner: 'veritas-kanban';
+  maximumPaths: 0 | 1;
+  transport: 'harness-api';
+  shellRedirection: false;
+  indirectWrites: false;
+}
+
+export interface PhaseCapabilityProfile {
+  schemaVersion: typeof PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION;
+  id: string;
+  version: number;
+  phase: PhaseName;
+  name: string;
+  description: string;
+  builtIn?: boolean;
+  authority: PhaseAuthority;
+  requiredDimensions: PhaseAuthorityDimension[];
+  approvalRequiredDimensions: PhaseAuthorityDimension[];
+  planArtifactPolicy: PhasePlanArtifactPolicy;
+}
+
+export type PhaseIdentity =
+  | {
+      mode: 'legacy';
+      phase: 'legacy';
+    }
+  | {
+      mode: 'profile';
+      phase: PhaseName;
+      profileId: string;
+      profileVersion: number;
+    };
+
+export interface PhaseTransitionIntent {
+  schemaVersion: typeof PHASE_TRANSITION_INTENT_SCHEMA_VERSION;
+  from: PhaseIdentity;
+  to: PhaseIdentity;
+  actor: string;
+  reason: string;
+  requestedAt: string;
+  parentEvidenceDigest?: string;
+}
+
+export interface PhasePlanArtifactRequest {
+  exactPath: string;
+  owner: 'veritas-kanban';
+  transport: 'harness-api';
+}
+
+export interface EffectivePhasePlanArtifact {
+  exactPath: string;
+  owner: 'veritas-kanban';
+  transport: 'harness-api';
+  shellRedirection: false;
+  indirectWrites: false;
+}
+
+export type PhaseCapabilityBlockerCode =
+  | 'required-authority-denied'
+  | 'required-authority-unsupported'
+  | 'required-authority-unenforceable'
+  | 'plan-artifact-not-allowed'
+  | 'plan-artifact-path-invalid';
+
+export interface PhaseCapabilityBlocker {
+  code: PhaseCapabilityBlockerCode;
+  message: string;
+  dimension?: PhaseAuthorityDimension;
+  sourceId?: string;
+}
+
+export interface PhaseAuthorityEvaluation {
+  dimension: PhaseAuthorityDimension;
+  requestedScopes: string[];
+  effectiveScopes: string[];
+  required: boolean;
+  limitingSourceIds: string[];
+}
+
+export interface PhaseCapabilityEvidence {
+  schemaVersion: typeof PHASE_CAPABILITY_EVIDENCE_SCHEMA_VERSION;
+  digest: string;
+  status: 'allowed' | 'narrowed' | 'blocked';
+  identity: PhaseIdentity;
+  requestedAuthority: PhaseAuthority;
+  effectiveAuthority: PhaseAuthority;
+  requiredDimensions: PhaseAuthorityDimension[];
+  approvalRequiredDimensions: PhaseAuthorityDimension[];
+  evaluations: PhaseAuthorityEvaluation[];
+  blockers: PhaseCapabilityBlocker[];
+  warnings: string[];
+  planArtifact?: EffectivePhasePlanArtifact;
+}
+
+export interface PhaseCapabilityCompilerInput {
+  profile?: PhaseCapabilityProfile;
+  sources: PhaseCapabilityCompilerSources;
+  planArtifact?: PhasePlanArtifactRequest;
+}


### PR DESCRIPTION
## Summary

- add versioned shared contracts and strict schemas for phase profiles, transition intent, authority sources, blockers, and effective evidence
- ship built-in explore, plan, implement, verify, and publish profiles
- compile a deterministic intersection across parent, phase, agent, sandbox, tool-catalog, and launch-policy authority without widening scopes
- bind the optional plan artifact to one normalized harness-owned exact path with no general filesystem or indirect shell-write grant
- document explicit legacy behavior and the remaining transition, propagation, enforcement, and UI delivery boundaries

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/phase-capability-service.test.ts` (20 tests)
- changed-file ESLint and Prettier checks
- `git diff --check`
- commit security-artifact gate

The focused gate matches this slice: it adds shared contracts and a pure server compiler without changing an active launch path. The repository CI scope selector remains authoritative for broader coverage.

## Delivery boundary

This PR does not persist transitions, propagate phase state into launches, filter runtime tools, or add UI. Those remain in #1035, #1036, and #1033.

Closes #1034
