### PR TITLE
docs: align runtime prompts with focused verification

### DIFF
--- a/prompt-registry/bug-triage.md
+++ b/prompt-registry/bug-triage.md
@@ -35,12 +35,18 @@ Investigate and fix bug: <BUG-TITLE>
 - [ ] Fix implemented
 - [ ] Regression test added (if applicable)
 - [ ] Related areas checked for similar issues
+- [ ] Touched packages type-check and the focused regression test passes
+
+Follow the verification cadence in `AGENTS.md`. Do not run the complete
+workspace suite unless deterministic CI selects it or this is an explicit
+integration, critical-security, or release milestone.
 
 ## Workflow
 ```bash
 vk begin <TASK-ID>
 # ... investigate and fix ...
-pnpm test
+pnpm --filter <TOUCHED-PACKAGE> typecheck
+pnpm --filter <TOUCHED-PACKAGE> test -- <FOCUSED-TEST>
 vk done <TASK-ID> "Fixed: <ROOT-CAUSE>. Solution: <SUMMARY>"
 ````
 

--- a/prompt-registry/feature-development.md
+++ b/prompt-registry/feature-development.md
@@ -38,13 +38,17 @@ Implement feature: <FEATURE-TITLE>
 - Follow existing code patterns in the codebase
 - All new endpoints need auth middleware
 - Changes affecting shared types go in `shared/src/`
-- Run `pnpm typecheck` before considering complete
+- Follow the verification cadence in `AGENTS.md`: type-check touched packages
+  and run focused regression tests during ordinary implementation
+- Run the complete workspace suite only when deterministic CI selects it or at
+  an explicit integration, critical-security, or release milestone
 
 ## Workflow
 ```bash
 vk begin <TASK-ID>
 # ... implement ...
-pnpm typecheck && pnpm test
+pnpm --filter <TOUCHED-PACKAGE> typecheck
+pnpm --filter <TOUCHED-PACKAGE> test -- <FOCUSED-TEST>
 vk done <TASK-ID> "Implemented <FEATURE>: <SUMMARY>"
 ````
 

--- a/prompt-registry/pm-orchestration.md
+++ b/prompt-registry/pm-orchestration.md
@@ -35,9 +35,11 @@ You are the PM for sprint <SPRINT-ID>: <SPRINT-GOAL>
 
 ### Completing the Sprint
 1. Verify all acceptance criteria met
-2. Ensure cross-model reviews completed
-3. Compile completion summary
-4. Archive completed sprint tasks
+2. Confirm each pull request used the verification tier selected by `AGENTS.md`
+   and deterministic CI
+3. Ensure any explicitly required independent reviews completed
+4. Compile completion summary
+5. Archive completed sprint tasks
 
 ## Worker Handoff Template
 Use `prompt-registry/worker-handoff.md` for each assignment.

--- a/prompt-registry/task-completion.md
+++ b/prompt-registry/task-completion.md
@@ -14,8 +14,9 @@ Complete task <TASK-ID>: <TASK-TITLE>
 ### Work Quality
 - [ ] All acceptance criteria met
 - [ ] All subtasks completed
-- [ ] Code compiles without errors (`pnpm typecheck`)
-- [ ] Tests pass (`pnpm test`)
+- [ ] Touched packages type-check without errors
+- [ ] Focused tests cover the changed behavior and high-risk edges
+- [ ] The pull request records the selected verification tier and justification
 - [ ] No console errors or warnings
 
 ### Documentation
@@ -25,7 +26,8 @@ Complete task <TASK-ID>: <TASK-TITLE>
 
 ### Review
 - [ ] Self-reviewed the diff
-- [ ] Cross-model review completed (if code change)
+- [ ] Any review explicitly required by the task, governance policy, issue
+      owner, or release owner is complete
 - [ ] No TODO comments left unresolved
 
 ### Cleanup
@@ -43,12 +45,17 @@ Write a brief summary covering:
 
 ## Workflow
 ```bash
-# Verify everything passes
-pnpm typecheck && pnpm test
+# Run the narrowest useful verification from AGENTS.md
+pnpm --filter <TOUCHED-PACKAGE> typecheck
+pnpm --filter <TOUCHED-PACKAGE> test -- <FOCUSED-TEST>
 
 # Complete the task
 vk done <TASK-ID> "<SUMMARY>"
 ````
+
+Do not rerun unchanged passing gates after documentation, comment, or
+formatting-only edits. The complete workspace suite belongs to deterministic CI
+escalation or an explicit integration, critical-security, or release milestone.
 
 ```
 

--- a/prompt-registry/worker-handoff.md
+++ b/prompt-registry/worker-handoff.md
@@ -24,7 +24,10 @@ You are assigned task <TASK-ID>: <TASK-TITLE>
 ## Constraints
 - Do not modify scope without PM approval
 - Escalate blockers immediately via `vk block <TASK-ID> "<REASON>"`
-- All code changes require cross-model review before merge
+- Follow the proportional verification cadence in `AGENTS.md`; use focused
+  checks for ordinary work and record the selected pull-request tier
+- Independent or cross-model review is optional unless the task, governance
+  policy, issue owner, or release owner explicitly requires it
 
 ## Resources
 - API: http://localhost:3001/api


### PR DESCRIPTION
## Summary

- replace unconditional complete-suite commands in feature, bug-triage, and completion prompts with touched-package type checks and focused regression tests
- reserve the workspace suite for deterministic CI escalation or explicit integration, critical-security, and release milestones
- make independent and cross-model review optional unless a task or configured owner requires it
- make PM, worker, and completion prompts use the canonical `AGENTS.md` verification cadence

Closes #1039.

## Scope boundary

Execution prompt policy only. This does not remove full milestone verification, branch protection, or the optional cross-model review capability.

## Linked follow-ups

None.

## Verification tier

- [x] Documentation or static checks only
- [ ] Focused changed-package tests
- [ ] Full milestone gate (`ci:full`, critical security, integration, or release)

## Why this tier is sufficient

The change only updates Markdown prompt text. Prettier checked all five changed files, `git diff --check` passed, and an exact-text scan confirmed the stale unconditional commands and review mandates are gone from active prompt templates.
