### PR TITLE
fix: prevent delivery cadence policy drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,12 @@ jobs:
       - name: Verify CI scope controls
         run: >-
           node --test
+          scripts/check-delivery-cadence.test.mjs
           scripts/select-ci-test-scope.test.mjs
           scripts/verify-full-suite-job-evidence.test.mjs
+
+      - name: Guard delivery cadence
+        run: node scripts/check-delivery-cadence.mjs
 
       - name: Find reviewed full-suite evidence
         id: reviewed_full

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 pnpm check:security-artifacts
+node scripts/check-delivery-cadence.mjs
 npx lint-staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ pnpm lint:fix
 
 # Smoke checks
 pnpm check:pnpm-settings        # Validates package manager fields match this file
+pnpm check:delivery-cadence     # Prevents verification and review policy drift
 pnpm test:ci-scope              # Validates path-aware CI test selection
 pnpm smoke:cli-mcp              # CLI ↔ MCP compatibility smoke test
 pnpm test:buzz:compatibility    # Credential-free composed Buzz release gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,9 @@ This cadence extends the deterministic CI selector delivered in
   workflows unless the pull request changes that product boundary.
 - Test the behavior and meaningful failure modes. Do not use raw test count as
   a quality measure.
+- The dependency-free delivery cadence checker guards these rules in
+  pre-commit and the early CI scope-control job without installing packages or
+  running workspace tests.
 
 ### Branch Merge Protocol
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint:budget": "node scripts/lint-warning-budget.mjs --max-warnings=600",
     "lint:report": "node scripts/lint-warning-budget.mjs --all-rules",
     "lint:fix": "eslint . --fix",
+    "check:delivery-cadence": "node --test scripts/check-delivery-cadence.test.mjs && node scripts/check-delivery-cadence.mjs",
     "check:pnpm-settings": "node scripts/check-pnpm-settings.mjs",
     "check:security-artifacts": "node scripts/check-security-artifacts.mjs",
     "typecheck": "pnpm --filter @veritas-kanban/shared build && pnpm -r typecheck",

--- a/scripts/check-delivery-cadence.mjs
+++ b/scripts/check-delivery-cadence.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const CADENCE_CONTRACTS = {
+  'AGENTS.md': [
+    {
+      description: 'sustainable execution cadence section',
+      pattern: /## Sustainable execution cadence/i,
+    },
+    {
+      description: 'one independently shippable behavior per issue and pull request',
+      pattern: /one independently shippable behavior/i,
+    },
+    {
+      description: 'narrowest useful implementation loop',
+      pattern: /run the narrowest useful loop/i,
+    },
+    {
+      description: 'milestone-only complete workspace suite',
+      pattern:
+        /complete workspace suite once at an explicit integration, critical-security, or release milestone/i,
+    },
+    {
+      description: 'optional independent and cross-model review',
+      pattern: /Independent or cross-model review is optional/i,
+    },
+  ],
+  'CONTRIBUTING.md': [
+    {
+      description: 'scope and verification budget section',
+      pattern: /### Scope and Verification Budget/i,
+    },
+    {
+      description: 'one independently shippable behavior per issue and pull request',
+      pattern: /one independently shippable behavior per issue and pull request/i,
+    },
+    {
+      description: 'deterministic CI scope authority',
+      pattern: /Treat `Select Test Scope` as the CI authority/i,
+    },
+    {
+      description: 'test count is not a quality target',
+      pattern: /Do not use raw test count as a quality measure/i,
+    },
+  ],
+  '.github/PULL_REQUEST_TEMPLATE.md': [
+    {
+      description: 'linked follow-up scope boundary',
+      pattern: /\*\*Linked follow-ups:\*\*/i,
+    },
+    {
+      description: 'verification tier selection',
+      pattern: /\*\*Verification tier:\*\*/i,
+    },
+    {
+      description: 'focused changed-package test tier',
+      pattern: /Focused changed-package tests/i,
+    },
+    {
+      description: 'full milestone gate tier',
+      pattern: /Full milestone gate/i,
+    },
+    {
+      description: 'one coherent independently shippable behavior checklist',
+      pattern: /one coherent, independently shippable behavior/i,
+    },
+  ],
+};
+
+const PROMPT_REGISTRY_EXCLUSIONS = new Set([
+  'prompt-registry/README.md',
+  'prompt-registry/cross-model-review.md',
+]);
+
+function normalizeWhitespace(content) {
+  return content.replace(/\s+/g, ' ').trim();
+}
+
+function sentenceContaining(content, matchIndex, fallbackLength = 240) {
+  const sentenceStart = Math.max(
+    content.lastIndexOf('.', matchIndex - 1),
+    content.lastIndexOf('!', matchIndex - 1),
+    content.lastIndexOf('?', matchIndex - 1)
+  );
+  const punctuation = ['.', '!', '?']
+    .map((mark) => content.indexOf(mark, matchIndex))
+    .filter((index) => index >= 0);
+  const sentenceEnd =
+    punctuation.length > 0 ? Math.min(...punctuation) + 1 : matchIndex + fallbackLength;
+  return content.slice(sentenceStart + 1, sentenceEnd);
+}
+
+function isNarrowlyQualified(sentence) {
+  return (
+    /\bdo not\b/i.test(sentence) ||
+    /\b(?:only|unless)\b/i.test(sentence) ||
+    /\b(?:deterministic CI|integration|critical-security|release) milestone\b/i.test(sentence)
+  );
+}
+
+export function findMissingCadenceContracts(files) {
+  const violations = [];
+
+  for (const [file, rules] of Object.entries(CADENCE_CONTRACTS)) {
+    const content = files[file];
+    if (content === undefined) {
+      violations.push({ file, message: 'required cadence contract file is missing' });
+      continue;
+    }
+
+    const normalized = normalizeWhitespace(content);
+    for (const rule of rules) {
+      if (!rule.pattern.test(normalized)) {
+        violations.push({
+          file,
+          message: `required cadence contract is missing: ${rule.description}`,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+function findUnqualifiedFullSuiteStatements(file, content) {
+  const violations = [];
+  const normalized = normalizeWhitespace(content);
+  const pattern =
+    /\b(?:run|execute)\s+(?:the\s+)?(?:complete|full|entire)\s+(?:workspace\s+)?(?:test\s+)?suite\b/gi;
+
+  for (const match of normalized.matchAll(pattern)) {
+    const matchIndex = match.index ?? 0;
+    const sentence = sentenceContaining(normalized, matchIndex);
+
+    if (!isNarrowlyQualified(sentence)) {
+      violations.push({
+        file,
+        message: `unqualified complete-suite requirement: "${match[0]}"`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function findUnsafePromptStatements(files) {
+  const violations = [];
+
+  for (const [file, content] of Object.entries(files)) {
+    const normalized = normalizeWhitespace(content);
+    const pnpmTestPattern = /\bpnpm\s+test(?=[\s`'"]|$)/gi;
+
+    for (const match of normalized.matchAll(pnpmTestPattern)) {
+      const sentence = sentenceContaining(normalized, match.index ?? 0);
+      if (!isNarrowlyQualified(sentence)) {
+        violations.push({
+          file,
+          message: 'active prompts must not prescribe an unconditional workspace-wide `pnpm test`',
+        });
+      }
+    }
+
+    if (
+      /\bcross-model review\s+(?:is\s+)?(?:required|mandatory)\b/i.test(normalized) ||
+      /\b(?:must|required to|shall)\s+(?:run|complete|obtain|perform)[^.]{0,120}\bcross-model review\b/i.test(
+        normalized
+      )
+    ) {
+      violations.push({
+        file,
+        message: 'active prompts must not make cross-model review unconditional',
+      });
+    }
+
+    violations.push(...findUnqualifiedFullSuiteStatements(file, content));
+  }
+
+  return violations;
+}
+
+function readCadenceFiles(rootDir) {
+  return Object.fromEntries(
+    Object.keys(CADENCE_CONTRACTS).map((file) => {
+      const absolutePath = path.join(rootDir, file);
+      return [file, existsSync(absolutePath) ? readFileSync(absolutePath, 'utf8') : undefined];
+    })
+  );
+}
+
+function readActivePromptFiles(rootDir) {
+  const promptDir = path.join(rootDir, 'prompt-registry');
+  return Object.fromEntries(
+    readdirSync(promptDir)
+      .filter((name) => name.endsWith('.md'))
+      .map((name) => `prompt-registry/${name}`)
+      .filter((file) => !PROMPT_REGISTRY_EXCLUSIONS.has(file))
+      .map((file) => [file, readFileSync(path.join(rootDir, file), 'utf8')])
+  );
+}
+
+export function runDeliveryCadenceCheck(rootDir = process.cwd()) {
+  const violations = [
+    ...findMissingCadenceContracts(readCadenceFiles(rootDir)),
+    ...findUnsafePromptStatements(readActivePromptFiles(rootDir)),
+  ];
+
+  if (violations.length > 0) {
+    for (const violation of violations) {
+      console.error(
+        `::error file=${violation.file}::Delivery cadence check failed: ${violation.message}`
+      );
+    }
+    return false;
+  }
+
+  console.log('Delivery cadence contract and active prompts are consistent.');
+  return true;
+}
+
+function isDirectExecution() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectExecution() && !runDeliveryCadenceCheck()) {
+  process.exitCode = 1;
+}

--- a/scripts/check-delivery-cadence.test.mjs
+++ b/scripts/check-delivery-cadence.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CADENCE_CONTRACTS,
+  findMissingCadenceContracts,
+  findUnsafePromptStatements,
+} from './check-delivery-cadence.mjs';
+
+function validContractFiles() {
+  return Object.fromEntries(
+    Object.entries(CADENCE_CONTRACTS).map(([file, rules]) => [
+      file,
+      rules.map((rule) => rule.pattern.source.replaceAll('\\', '')).join('\n'),
+    ])
+  );
+}
+
+test('reports a missing canonical cadence rule with its file', () => {
+  const files = validContractFiles();
+  files['AGENTS.md'] = files['AGENTS.md'].replace(
+    'one independently shippable behavior',
+    'one oversized behavior'
+  );
+
+  assert.deepEqual(findMissingCadenceContracts(files), [
+    {
+      file: 'AGENTS.md',
+      message:
+        'required cadence contract is missing: one independently shippable behavior per issue and pull request',
+    },
+  ]);
+});
+
+test('rejects unconditional workspace-wide pnpm test commands', () => {
+  assert.deepEqual(
+    findUnsafePromptStatements({
+      'prompt-registry/example.md': 'Before completion, run `pnpm test`.',
+    }),
+    [
+      {
+        file: 'prompt-registry/example.md',
+        message: 'active prompts must not prescribe an unconditional workspace-wide `pnpm test`',
+      },
+    ]
+  );
+});
+
+test('allows explicit guidance not to run the workspace-wide pnpm test command', () => {
+  assert.deepEqual(
+    findUnsafePromptStatements({
+      'prompt-registry/example.md':
+        'Do not run `pnpm test` unless deterministic CI selects the full tier.',
+    }),
+    []
+  );
+});
+
+test('rejects unqualified complete-suite requirements', () => {
+  assert.deepEqual(
+    findUnsafePromptStatements({
+      'prompt-registry/example.md': 'Run the complete workspace suite before opening every PR.',
+    }),
+    [
+      {
+        file: 'prompt-registry/example.md',
+        message: 'unqualified complete-suite requirement: "Run the complete workspace suite"',
+      },
+    ]
+  );
+});
+
+test('allows milestone-qualified complete-suite guidance', () => {
+  assert.deepEqual(
+    findUnsafePromptStatements({
+      'prompt-registry/example.md':
+        'Run the complete workspace suite only at an explicit release milestone.',
+    }),
+    []
+  );
+});
+
+test('rejects mandatory cross-model review language', () => {
+  assert.deepEqual(
+    findUnsafePromptStatements({
+      'prompt-registry/example.md': 'Cross-model review is required for every code change.',
+    }),
+    [
+      {
+        file: 'prompt-registry/example.md',
+        message: 'active prompts must not make cross-model review unconditional',
+      },
+    ]
+  );
+});
+
+test('allows optional cross-model review language', () => {
+  assert.deepEqual(
+    findUnsafePromptStatements({
+      'prompt-registry/example.md':
+        'Cross-model review is optional unless the issue owner explicitly requires it.',
+    }),
+    []
+  );
+});


### PR DESCRIPTION
## Summary

- add a dependency-free checker that protects the canonical one-behavior scope and proportional verification contract
- reject active runtime prompts that restore unconditional workspace-wide tests or mandatory cross-model review
- run the 0.03-second guard directly in pre-commit and in the early CI selector job before dependency installation
- keep focused checker tests beside the guard and expose a manual package command

Closes #1041.

## Scope boundary

Delivery policy drift prevention only. This does not change branch protection, deterministic test selection, or milestone verification requirements.

## Linked follow-ups

None.

## Verification tier

- [ ] Documentation or static checks only
- [x] Focused changed-package tests
- [ ] Full milestone gate (`ci:full`, critical security, integration, or release)

## Why this tier is sufficient

The change is a dependency-free static guard plus its seven focused Node tests. The actual check completed in 0.03 seconds. Because the PR touches the CI workflow, the repository's deterministic selector remains authoritative if it escalates the hosted run.

## Test commands

```bash
node --test scripts/check-delivery-cadence.test.mjs
node scripts/check-delivery-cadence.mjs
prettier --check scripts/check-delivery-cadence.mjs scripts/check-delivery-cadence.test.mjs package.json .github/workflows/ci.yml AGENTS.md CONTRIBUTING.md
git diff --check
```
