### PR TITLE
feat: propagate phase authority through launches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,9 +194,13 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   only through `phase-transition-service.ts` with exact attempt, sequence,
   evidence-digest, and launch-manifest compare-and-set guards. Authority
   expansion requires an exact-action approval; an emergency override requires
-  `admin:manage`, expires within 24 hours, and is durably reverted. Until #1036
-  and #1033 land, launch propagation and provider/tool enforcement remain
-  separate delivery boundaries.
+  `admin:manage`, expires within 24 hours, and is durably reverted. Every task
+  launch, workflow step, retry or fallback, resume, follow-up, fork, compaction
+  control, and provider handoff must bind the effective phase before attempt
+  mutation. Descendants inherit and intersect the exact parent launch or
+  transition evidence and cannot widen it. Explicit phases fail closed when any
+  required dimension is not enforceable. Tool-command and external-action
+  enforcement remain the separate #1033 delivery boundary.
 - Credential-bound tool servers persist only exact definition/scope digests and
   safe target names in `run-tool-catalog/v1`. Discovery strips their source
   environment/header values, native provider injection omits them, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Propagated immutable phase authority through task previews and starts,
+  workflow steps, retries and fallbacks, provider changes, conversation resume,
+  follow-up and fork operations, and active-run controls. Every executable
+  entry now resolves the exact parent launch or current transition evidence
+  before attempt mutation, persists the compiled phase digest and source
+  references, intersects descendants monotonically, and returns typed blockers
+  when the selected sandbox, runtime, host, or tool policy cannot enforce a
+  required phase dimension. Legacy launches remain explicit and readable
+  without inventing restrictions (#1036).
 - Added the append-only `phase-transition-record/v1` journal for active runs.
   Every transition is bound to the exact attempt, prior sequence, compiled
   phase evidence, and launch-manifest digest. Narrowing transitions apply

--- a/cli/src/__tests__/agents-runtime-capabilities.test.ts
+++ b/cli/src/__tests__/agents-runtime-capabilities.test.ts
@@ -49,6 +49,10 @@ describe('vk agent runtime capability controls', () => {
         'task_1',
         '--agent',
         'codex',
+        '--phase',
+        'implement',
+        '--parent-attempt',
+        'attempt_parent',
         '--require-capability',
         'tool.mcp',
         'output.structured',
@@ -62,7 +66,42 @@ describe('vk agent runtime capability controls', () => {
       body: JSON.stringify({
         agent: 'codex',
         profileId: undefined,
+        phase: 'implement',
         requiredRuntimeCapabilities: ['tool.mcp', 'output.structured'],
+        parentAttemptId: 'attempt_parent',
+      }),
+    });
+  });
+
+  it('previews one explicit phase against exact parent launch evidence', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerAgentCommands(program);
+
+    await program.parseAsync(
+      [
+        'launch-preview',
+        'task_1',
+        '--agent',
+        'codex',
+        '--phase',
+        'plan',
+        '--parent-attempt',
+        'attempt_parent',
+        '--json',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/launch-preview', {
+      method: 'POST',
+      body: JSON.stringify({
+        agent: 'codex',
+        profileId: undefined,
+        phase: 'plan',
+        requiredRuntimeCapabilities: undefined,
+        commitPolicy: undefined,
+        parentAttemptId: 'attempt_parent',
       }),
     });
   });
@@ -320,6 +359,8 @@ describe('vk agent runtime capability controls', () => {
         'Explore the alternate fix',
         '--fork-turn',
         'turn_7',
+        '--phase',
+        'explore',
         '--require-capability',
         'tool.mcp',
         '--json',
@@ -333,6 +374,7 @@ describe('vk agent runtime capability controls', () => {
         sourceAttemptId: 'attempt_parent',
         message: 'Explore the alternate fix',
         forkTurnId: 'turn_7',
+        phase: 'explore',
         requiredRuntimeCapabilities: ['tool.mcp'],
       }),
     });

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -30,6 +30,7 @@ interface ConversationTurnOptions {
   message: string;
   forkTurn?: string;
   profile?: string;
+  phase?: string;
   requireCapability?: string[];
   commitPolicy?: string;
   json?: boolean;
@@ -109,6 +110,7 @@ function registerConversationTurnCommand(
     .requiredOption('--source-attempt <attemptId>', 'Terminal attempt with durable conversation')
     .requiredOption('-m, --message <text>', 'Prompt for the new turn')
     .option('-p, --profile <profileId>', 'Agent profile package to launch')
+    .option('--phase <phase>', 'Execution phase (explore, plan, implement, verify, publish)')
     .option(
       '--require-capability <capabilities...>',
       'Require provider runtime capabilities before launch'
@@ -136,6 +138,7 @@ function registerConversationTurnCommand(
           message: options.message,
           ...(action === 'fork' && options.forkTurn ? { forkTurnId: options.forkTurn } : {}),
           profileId: options.profile,
+          phase: options.phase,
           requiredRuntimeCapabilities: options.requireCapability,
           commitPolicy: options.commitPolicy,
         }),
@@ -187,6 +190,7 @@ export function registerAgentCommands(program: Command): void {
       'claude-code'
     )
     .option('-p, --profile <profileId>', 'Agent profile package to launch')
+    .option('--phase <phase>', 'Execution phase (explore, plan, implement, verify, publish)')
     .option(
       '--require-capability <capabilities...>',
       'Require provider runtime capabilities before launch'
@@ -221,6 +225,7 @@ export function registerAgentCommands(program: Command): void {
           body: JSON.stringify({
             agent: options.profile ? undefined : options.agent,
             profileId: options.profile,
+            phase: options.phase,
             requiredRuntimeCapabilities: options.requireCapability,
             commitPolicy: options.commitPolicy,
             parentAttemptId: options.parentAttempt,
@@ -245,6 +250,7 @@ export function registerAgentCommands(program: Command): void {
     .description('Preview the immutable effective launch manifest without starting an agent')
     .option('-a, --agent <agent>', 'Agent to use', 'codex')
     .option('-p, --profile <profileId>', 'Agent profile package to preview')
+    .option('--phase <phase>', 'Execution phase (explore, plan, implement, verify, publish)')
     .option(
       '--require-capability <capabilities...>',
       'Require provider runtime capabilities before launch'
@@ -266,6 +272,7 @@ export function registerAgentCommands(program: Command): void {
             body: JSON.stringify({
               agent: options.profile ? undefined : options.agent,
               profileId: options.profile,
+              phase: options.phase,
               requiredRuntimeCapabilities: options.requireCapability,
               commitPolicy: options.commitPolicy,
               parentAttemptId: options.parentAttempt,
@@ -280,6 +287,16 @@ export function registerAgentCommands(program: Command): void {
         console.log(`  Digest: ${preview.manifest.digest}`);
         console.log(`  Provider: ${preview.manifest.providerRuntime.provider}`);
         console.log(`  Model: ${preview.manifest.runtime.model ?? 'provider default'}`);
+        console.log(
+          `  Phase: ${
+            preview.manifest.phase?.evidence.identity.mode === 'profile'
+              ? preview.manifest.phase.evidence.identity.phase
+              : 'legacy'
+          }`
+        );
+        if (preview.manifest.phase) {
+          console.log(`  Phase evidence: ${preview.manifest.phase.evidence.digest}`);
+        }
         console.log(`  Workspace trust: ${preview.manifest.workspaceTrust.status}`);
         console.log(chalk.dim(`  ${preview.manifest.workspaceTrust.source}`));
         console.log(

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -724,9 +724,9 @@ its task contract, and records the selected provider/model/transport, redacted
 command and arguments, instruction fingerprints and precedence, environment
 key names and broker references, profile tools/MCP/permissions/health checks,
 sandbox/network posture, readiness and any hashed operator override, budget,
-routing/fallback, workspace trust, and the origin of each effective value.
-Prompt content, override text, and credential values are never stored in this
-manifest.
+routing/fallback, workspace trust, compiled phase evidence and source
+references, and the origin of each effective value. Prompt content, override
+text, and credential values are never stored in this manifest.
 
 `POST /api/agents/:taskId/launch-preview` returns the same compiled contract
 without creating an attempt or dispatching a process. The CLI equivalent is
@@ -735,6 +735,15 @@ A profile restriction that the selected adapter
 cannot enforce is returned as a concrete blocker, and `start` rejects it before
 pending or task attempt state changes. Declaring `tool.calls` support is not
 treated as proof that an adapter can enforce a named allowlist.
+
+Phase authority is resolved at the same pre-mutation boundary for task and
+workflow launches, retries, fallbacks, conversation continuations, compaction
+controls, and provider handoffs. A descendant intersects the exact parent
+launch or current transition evidence, so changing providers or omitting an
+explicit phase cannot widen authority. Explicit phase launches fail closed with
+typed blockers when the runtime, sandbox, host, or tool policy cannot prove a
+required dimension. Tool-command and external-action enforcement support is
+delivered separately in #1033; prompt text is never accepted as enforcement.
 
 Repository-controlled instructions and executable configuration pass through
 the provider-neutral workspace execution trust gate before Veritas reads

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -2370,6 +2370,7 @@ additional runtime capabilities, and compare against a parent attempt:
 {
   "profileId": "docs-reviewer",
   "sandboxPresetId": "codex-repo-contained",
+  "phase": "implement",
   "requiredRuntimeCapabilities": ["tool.mcp", "output.structured"],
   "commitPolicy": "allowed",
   "parentAttemptId": "attempt_parent"
@@ -2387,14 +2388,24 @@ manifest identity, and remediation.
 
 The preview response contains `manifest`, plus optional `parentAttemptId` and
 `drift`. The manifest contains redacted effective runtime inputs, instruction
-fingerprints, per-field origins, and an `enforcement` object. Prompt content,
-readiness override text, credential values, and raw local output paths are
-excluded. Preview and start apply the same readiness gate; an accepted operator
-override is represented by its digest and run-level origin. Start records the
-same contract in the active attempt, history, run log, and a policy governance
-trace before provider dispatch. Named tool/MCP/permission restrictions and
-required profile health checks block launch when the adapter cannot enforce
-them explicitly.
+fingerprints, compiled phase evidence and source references, per-field origins,
+and an `enforcement` object. Prompt content, readiness override text,
+credential values, and raw local output paths are excluded. Preview and start
+apply the same readiness gate; an accepted operator override is represented by
+its digest and run-level origin. Start records the same contract in the active
+attempt, history, run log, and a policy governance trace before provider
+dispatch. Named tool/MCP/permission restrictions and required profile health
+checks block launch when the adapter cannot enforce them explicitly.
+
+`phase` accepts `explore`, `plan`, `implement`, `verify`, or `publish`.
+Compilation intersects the requested profile with the exact parent launch or
+current transition evidence before attempt mutation. Descendants, retries,
+fallbacks, and provider changes cannot widen parent authority. An unsupported
+phase dimension returns `409 Conflict` with typed `phase-*` enforcement
+blockers. Omitting `phase` creates explicit legacy evidence only when no
+profile-authoritative parent exists. During the staged v6.x rollout, explicit
+phase starts remain blocked until #1033 supplies command and external-action
+enforcement; launch preview exposes that blocker without mutation.
 
 Codex app-server and Claude Code accept a positive MCP catalog through native,
 run-scoped configuration. Other task adapters reject non-empty MCP selections.
@@ -2498,6 +2509,7 @@ provider identity:
   "sourceAttemptId": "attempt_parent",
   "message": "Continue from the verified history",
   "forkTurnId": "turn_7",
+  "phase": "verify",
   "commitPolicy": "allowed"
 }
 ```
@@ -2509,6 +2521,11 @@ operation. Unsupported steering fails with an explicit capability error, and
 any recorded-only fallback returns `delivered: false` with a reason. Veritas
 does not claim that recording a message or writing process stdin reached the
 provider.
+
+Resume, follow-up, and fork bind the exact source attempt as the phase parent.
+An optional `phase` may narrow that authority but cannot widen it. Omitting the
+field inherits a profile-authoritative parent; a legacy source remains
+explicitly legacy.
 
 `commitPolicy` accepts `forbidden`, `allowed`, or `required`. A run value
 overrides `task.executionPolicy.commitPolicy`, then the legacy

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -447,8 +447,8 @@ Manage AI agents on code tasks.
 
 | Command                                                                             | Description                                               |
 | ----------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| `vk start <id>`                                                                     | Start an agent; optionally require runtime capabilities   |
-| `vk launch-preview <id>`                                                            | Preview effective launch inputs, blockers, and drift      |
+| `vk start <id> [--phase <phase>]`                                                   | Start an agent; optionally bind an execution phase        |
+| `vk launch-preview <id> [--phase <phase>]`                                          | Preview effective launch inputs, blockers, and drift      |
 | `vk workspace-trust scan <id>`                                                      | Inventory repository-controlled execution configuration   |
 | `vk workspace-trust decide <id> --mode <mode> --inventory <digest> --reason <text>` | Authorize or deny one exact inventory                     |
 | `vk workspace-trust revoke <id> --inventory <digest> --reason <text>`               | Revoke the current exact-inventory decision               |
@@ -458,9 +458,9 @@ Manage AI agents on code tasks.
 | `vk agent:phase <id> --attempt <id>`                                                | Read durable phase state and transition history           |
 | `vk agent:transition-phase <id> ...`                                                | Apply or request approval for one exact phase transition  |
 | `vk agent:decide-phase-approval <approvalId> ...`                                   | Approve or reject an exact pending phase expansion        |
-| `vk agent:resume <id> --source-attempt <id> -m <text>`                              | Resume the exact persisted provider conversation          |
-| `vk agent:follow-up <id> --source-attempt <id> -m <text>`                           | Start a provider-native follow-up turn                    |
-| `vk agent:fork <id> --source-attempt <id> -m <text>`                                | Fork provider history without mutating its source         |
+| `vk agent:resume <id> --source-attempt <id> -m <text> [--phase <phase>]`            | Resume the exact persisted provider conversation          |
+| `vk agent:follow-up <id> --source-attempt <id> -m <text> [--phase <phase>]`         | Start a provider-native follow-up turn                    |
+| `vk agent:fork <id> --source-attempt <id> -m <text> [--phase <phase>]`              | Fork provider history without mutating its source         |
 | `vk agent:steer <id> --attempt <id> -m <text>`                                      | Steer the exact active provider turn                      |
 | `vk agent:interrupt <id> --attempt <id>`                                            | Interrupt the exact active provider turn                  |
 | `vk agent:compact <id> --attempt <id>`                                              | Compact a supported provider conversation                 |
@@ -485,14 +485,31 @@ vk start TASK-001 --agent codex \
 Preview without dispatching, or compare a new launch with a parent attempt:
 
 ```bash
-vk launch-preview TASK-001 --agent codex --parent-attempt attempt_parent --json
-vk start TASK-001 --agent codex --parent-attempt attempt_parent
+vk launch-preview TASK-001 --agent codex \
+  --phase verify \
+  --parent-attempt attempt_parent \
+  --json
+vk start TASK-001 --agent codex \
+  --phase verify \
+  --parent-attempt attempt_parent
 ```
 
 Preview output includes the immutable run-launch digest, redacted command and
-argument plan, per-field origins, enforcement blockers, and material drift.
-It applies the same readiness gate and override rules as start. Attempt IDs and
-probe timestamps do not count as material drift.
+argument plan, phase evidence and source references, per-field origins,
+enforcement blockers, and material drift. It applies the same readiness gate
+and override rules as start. A parent phase binding is material; attempt IDs and
+probe timestamps alone do not count as material drift.
+
+`--phase` accepts `explore`, `plan`, `implement`, `verify`, or `publish`.
+Explicit phases fail closed before attempt mutation when the selected runtime,
+sandbox, host, or tool policy cannot prove every required dimension. Omitting
+the flag creates an explicit legacy phase for a new launch. Resume, follow-up,
+fork, retry, fallback, and provider changes inherit and intersect the exact
+parent phase, so a descendant cannot widen authority by changing providers or
+omitting the flag. In the current staged v6.x delivery, use
+`launch-preview --phase ...` to inspect the evidence; explicit task or workflow
+starts remain blocked until #1033 supplies command and external-action
+enforcement.
 
 Inspect workspace execution trust before launching a newly cloned or changed
 repository:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -346,8 +346,11 @@ First-class support for autonomous coding agents.
   Active runs persist append-only compare-and-set transitions with actor,
   authority delta, policy, approval or override, manifest, and event evidence.
   Expansion requires exact-action approval; administrator overrides expire and
-  durably restore the prior phase. Launch propagation, tool enforcement, and UI
-  remain tracked in #1036 and #1033. See
+  durably restore the prior phase. Task and workflow launches, retries and
+  fallbacks, provider changes, conversation continuations, and active-run
+  controls bind the effective phase and exact parent evidence before attempt
+  mutation. Tool-command and external-action enforcement remain tracked in
+  #1033. See
   [Phase Capability Profiles](architecture/PHASE-CAPABILITY-PROFILES.md) and
   [Phase Transition Journal](architecture/PHASE-TRANSITION-JOURNAL.md).
 - **Provider runtime manifests** — Every executable adapter records a versioned, evidence-backed capability snapshot and digest on the attempt, history, trace, and log; provider version skew reruns conformance and unsupported configured providers fail closed instead of falling back to OpenClaw
@@ -974,6 +977,12 @@ Execute a single agent prompt with configurable retries.
   classes retry; each decision persists causal parents, jittered backoff,
   route and manifest evidence, and cumulative budget. Fallback agents must pass
   runtime capability and sandbox preflight before launch.
+- Optional `phase` values are `explore`, `plan`, `implement`, `verify`, and
+  `publish`. The phase is resolved before the step enters a running state.
+  Retries, fallbacks, reused sessions, and provider changes intersect the exact
+  parent phase and cannot widen its authority. Explicit phase steps remain
+  fail-closed until the selected adapter and tool policy provide the
+  command/external-action enforcement completed in #1033.
 
 #### 2. Loop Steps
 

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -171,6 +171,7 @@ vi.mock('../services/circuit-registry.js', () => ({
 import {
   AgentReadinessError,
   ClawdbotAgentService,
+  type AgentStatus,
   type CredentialLeaseLifecycle,
 } from '../services/clawdbot-agent-service.js';
 import type { ThreadEvent } from '@openai/codex-sdk';
@@ -180,6 +181,7 @@ import type {
   RunApprovalRequest,
   SandboxPolicyDryRunResult,
   Task,
+  TaskAttempt,
 } from '@veritas-kanban/shared';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 import {
@@ -269,7 +271,9 @@ function testableService(
     undefined,
     filesystemSandbox,
     sandboxPolicies,
-    workspaceExecutionTrust
+    workspaceExecutionTrust,
+    undefined,
+    { getCurrent: vi.fn().mockResolvedValue(null) }
   ) as unknown as TestableClawdbotAgentService;
   service.logsDir = tmpDir;
   return service;
@@ -695,7 +699,22 @@ describe('ClawdbotAgentService Codex providers', () => {
           enforceable: true,
           blockers: [],
         },
+        phase: {
+          evidence: {
+            identity: { mode: 'legacy', phase: 'legacy' },
+          },
+          sourceReferences: expect.arrayContaining([
+            expect.objectContaining({ kind: 'parent' }),
+            expect.objectContaining({ kind: 'agent-profile' }),
+            expect.objectContaining({ kind: 'sandbox' }),
+            expect.objectContaining({ kind: 'tool-catalog' }),
+            expect.objectContaining({ kind: 'launch-policy' }),
+          ]),
+        },
       });
+      expect(status.activePhaseEvidence?.digest).toBe(
+        status.runLaunchManifest.phase?.evidence.digest
+      );
       expect(status.runLaunchManifest.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
       expect(mockSpawn).toHaveBeenCalledWith(
         'codex',
@@ -1692,6 +1711,36 @@ describe('ClawdbotAgentService Codex providers', () => {
     expect(mockUpdateTask).not.toHaveBeenCalled();
   });
 
+  it('returns typed phase blockers before dispatch or attempt mutation', async () => {
+    const service = testableService(tmpDir);
+
+    const preview = await service.previewAgentLaunch(task.id, 'codex', {
+      phase: 'explore',
+    });
+
+    expect(preview.manifest.phase?.evidence.identity).toEqual({
+      mode: 'profile',
+      phase: 'explore',
+      profileId: 'builtin-explore',
+      profileVersion: 1,
+    });
+    expect(preview.manifest.enforcement).toMatchObject({
+      enforceable: false,
+      blockers: expect.arrayContaining([
+        expect.objectContaining({
+          code: 'phase-required-authority-unsupported',
+          field: 'phase.evidence.command.execute',
+        }),
+        expect.objectContaining({
+          code: 'phase-required-authority-unsupported',
+          field: 'phase.evidence.external.action',
+        }),
+      ]),
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
   it('compares replay and fork previews with compatible and incompatible parent manifests', async () => {
     const service = testableService(tmpDir);
     const parent = await service.previewAgentLaunch(task.id, 'codex');
@@ -1710,10 +1759,23 @@ describe('ClawdbotAgentService Codex providers', () => {
     const compatible = await service.previewAgentLaunch(task.id, 'codex', {
       parentAttemptId: 'attempt_parent',
     });
-    expect(compatible).toMatchObject({
-      parentAttemptId: 'attempt_parent',
-      drift: { material: false, changes: [] },
+    expect(compatible.parentAttemptId).toBe('attempt_parent');
+    expect(compatible.drift).toMatchObject({
+      material: true,
+      changes: expect.arrayContaining([
+        expect.objectContaining({ field: 'phase' }),
+        expect.objectContaining({ field: 'origins' }),
+      ]),
     });
+    expect(compatible.manifest.phase?.sourceReferences).toContainEqual(
+      expect.objectContaining({
+        kind: 'parent',
+        originScope: 'parent',
+        parentAttemptId: 'attempt_parent',
+        parentManifestDigest: parent.manifest.digest,
+        parentEvidenceDigest: parent.manifest.phase?.evidence.digest,
+      })
+    );
 
     mockGetConfig.mockResolvedValue({
       agents: [
@@ -1737,6 +1799,43 @@ describe('ClawdbotAgentService Codex providers', () => {
     });
     expect(mockSpawn).not.toHaveBeenCalled();
     expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it('binds a resumed conversation to the exact parent phase snapshot', async () => {
+    const service = testableService(tmpDir);
+    const sourceAttempt = {
+      id: 'attempt_parent',
+      agent: 'codex',
+      status: 'complete',
+      threadId: 'thread_parent',
+      providerRuntimeManifest: {},
+      taskEnvelope: {},
+      runLaunchManifest: {},
+    } as TaskAttempt;
+    vi.spyOn(
+      service as unknown as {
+        findAttempt(attemptId: string): Promise<TaskAttempt | undefined>;
+      },
+      'findAttempt'
+    ).mockResolvedValue(sourceAttempt);
+    const startAgent = vi
+      .spyOn(service, 'startAgent')
+      .mockResolvedValue({ attemptId: 'attempt_child' } as AgentStatus);
+
+    await service.resumeConversation(task.id, sourceAttempt.id, 'Continue safely', {
+      phase: 'verify',
+    });
+
+    expect(startAgent).toHaveBeenCalledWith(task.id, 'codex', {
+      phase: 'verify',
+      parentAttemptId: sourceAttempt.id,
+      conversation: {
+        mode: 'resume',
+        intent: 'resume',
+        sourceAttemptId: sourceAttempt.id,
+        message: 'Continue safely',
+      },
+    });
   });
 
   it('compiles transient preview and durable start tool catalogs before enforced launch', async () => {

--- a/server/src/__tests__/issues-778-780-785-786-787.test.ts
+++ b/server/src/__tests__/issues-778-780-785-786-787.test.ts
@@ -23,6 +23,8 @@ import type { WorkflowRunService } from '../services/workflow-run-service.js';
 // ─────────────────────────────────────────────────────────────
 
 const mockLoadWorkflow = vi.fn();
+const mockPrepareStep = vi.fn(async (step: unknown) => ({ kind: 'non-agent', step }));
+const mockApplyPreparation = vi.fn();
 const mockExecuteStep = vi.fn();
 const mockBroadcastWorkflowStatus = vi.fn();
 const mockGetTask = vi.fn();
@@ -40,6 +42,8 @@ vi.mock('../services/workflow-step-executor.js', async (importOriginal) => {
   return {
     HumanGateBlockError: actual.HumanGateBlockError,
     WorkflowStepExecutor: class {
+      prepareStep = mockPrepareStep;
+      applyPreparation = mockApplyPreparation;
       executeStep = mockExecuteStep;
     },
   };

--- a/server/src/__tests__/phase-launch-authority-service.test.ts
+++ b/server/src/__tests__/phase-launch-authority-service.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderRuntimeManifest, SandboxPolicyDryRunResult } from '@veritas-kanban/shared';
+import { PhaseLaunchAuthorityService } from '../services/phase-launch-authority-service.js';
+import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+
+const sandboxPolicy: SandboxPolicyDryRunResult = {
+  decision: 'allow',
+  provider: 'codex-sdk',
+  preset: {
+    id: 'workflow-default',
+    name: 'Workflow default',
+    enabled: true,
+    enforcement: 'required',
+    requiredCapabilities: [],
+    filesystem: {
+      readPaths: ['<workspace>'],
+      writePaths: ['<workspace>'],
+      deniedPaths: [],
+      dotfileMasking: false,
+      localOnlyHandles: true,
+    },
+    network: {
+      defaultEgress: 'allow',
+      allowedHosts: [],
+      allowedMethods: [],
+      allowedPathPrefixes: [],
+      blockPrivateNetwork: true,
+      blockMetadataEndpoints: true,
+      blockLoopback: false,
+    },
+    environment: {
+      passthrough: ['PATH', 'OPENAI_API_KEY'],
+      redactDisplay: true,
+    },
+    credentials: {
+      mode: 'env-passthrough',
+      brokerRefs: [],
+    },
+    createdAt: '2026-07-25T00:00:00.000Z',
+    updatedAt: '2026-07-25T00:00:00.000Z',
+  },
+  effective: {
+    sandboxMode: 'workspace-write',
+    networkAccessEnabled: true,
+    envPassthrough: ['PATH', 'OPENAI_API_KEY'],
+    credentialRefs: [],
+    filesystemBackend: {
+      backend: 'codex-sandbox',
+      state: 'available',
+      capabilityVersion: 'codex-sandbox-state/v1',
+      backendVersion: '1.0.0',
+      platformBackend: 'seatbelt',
+      supported: ['filesystem.read', 'filesystem.write'],
+      reason: 'Fixture filesystem boundary is available.',
+    },
+  },
+  evaluations: [],
+  unsupportedRules: [],
+  warnings: [],
+};
+
+function runtime(provider = 'codex-sdk'): ProviderRuntimeManifest {
+  return providerRuntimeManifestFixture({
+    provider,
+    capabilityStates: {
+      'filesystem.read': 'supported',
+      'filesystem.write': 'supported',
+      'network.disable': 'supported',
+      'network.allowlist': 'supported',
+      'environment.allowlist': 'supported',
+      'credential.broker': 'supported',
+    },
+  });
+}
+
+const enforcedExecution = {
+  commandExecute: 'enforced',
+  externalAction: 'enforced',
+  planArtifactWrite: 'enforced',
+} as const;
+
+describe('PhaseLaunchAuthorityService', () => {
+  it('records explicit legacy evidence without inventing phase restrictions', () => {
+    const phase = new PhaseLaunchAuthorityService().compile({
+      sandboxPolicy,
+      providerRuntimeManifest: runtime(),
+      selectedHost: 'local-process',
+    });
+
+    expect(phase.evidence.identity).toEqual({ mode: 'legacy', phase: 'legacy' });
+    expect(phase.evidence.status).not.toBe('blocked');
+    expect(phase.evidence.warnings).toContain(
+      'Legacy mode applies no phase profile; existing parent, agent, sandbox, tool, and launch policies remain authoritative.'
+    );
+    expect(phase.sourceReferences.map((reference) => reference.kind).sort()).toEqual([
+      'agent-profile',
+      'launch-policy',
+      'parent',
+      'sandbox',
+      'tool-catalog',
+    ]);
+  });
+
+  it('returns typed blockers when command and external enforcement are unavailable', () => {
+    const phase = new PhaseLaunchAuthorityService().compile({
+      requestedPhase: 'explore',
+      sandboxPolicy,
+      providerRuntimeManifest: runtime(),
+      selectedHost: 'local-process',
+    });
+
+    expect(phase.evidence.status).toBe('blocked');
+    expect(phase.evidence.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'required-authority-unsupported',
+          dimension: 'command.execute',
+          sourceId: 'tool-catalog:none',
+        }),
+        expect.objectContaining({
+          code: 'required-authority-unsupported',
+          dimension: 'external.action',
+          sourceId: 'tool-catalog:none',
+        }),
+      ])
+    );
+    expect(() => new PhaseLaunchAuthorityService().assertEnforceable(phase)).toThrow(
+      'effective phase authority cannot be enforced'
+    );
+  });
+
+  it('intersects descendants with the exact parent snapshot across provider changes', () => {
+    const service = new PhaseLaunchAuthorityService();
+    const parent = service.compile({
+      requestedPhase: 'implement',
+      sandboxPolicy,
+      providerRuntimeManifest: runtime('codex-sdk'),
+      selectedHost: 'local-process',
+      executionEnforcement: enforcedExecution,
+    });
+    const child = service.compile({
+      requestedPhase: 'publish',
+      parent: {
+        attemptId: 'run_parent:step:0',
+        manifestDigest: `sha256:${'a'.repeat(64)}`,
+        evidence: parent.evidence,
+      },
+      sandboxPolicy,
+      providerRuntimeManifest: runtime('openclaw'),
+      selectedHost: 'openclaw-gateway',
+      executionEnforcement: enforcedExecution,
+    });
+
+    expect(child.evidence.status).not.toBe('blocked');
+    expect(child.evidence.effectiveAuthority['external.action']).toEqual(['read']);
+    expect(child.evidence.effectiveAuthority['credential.access']).toEqual(
+      parent.evidence.effectiveAuthority['credential.access']
+    );
+    expect(child.sourceReferences.find((reference) => reference.kind === 'parent')).toMatchObject({
+      originScope: 'parent',
+      parentAttemptId: 'run_parent:step:0',
+      parentManifestDigest: `sha256:${'a'.repeat(64)}`,
+      parentEvidenceDigest: parent.evidence.digest,
+    });
+  });
+
+  it('blocks a wider publish retry when the parent denied credential authority', () => {
+    const service = new PhaseLaunchAuthorityService();
+    const parent = service.compile({
+      requestedPhase: 'verify',
+      sandboxPolicy,
+      providerRuntimeManifest: runtime(),
+      selectedHost: 'local-process',
+      executionEnforcement: enforcedExecution,
+    });
+    const child = service.compile({
+      requestedPhase: 'publish',
+      parent: {
+        attemptId: 'run_parent:verify:0',
+        manifestDigest: `sha256:${'b'.repeat(64)}`,
+        evidence: parent.evidence,
+      },
+      sandboxPolicy,
+      providerRuntimeManifest: runtime('openclaw'),
+      selectedHost: 'openclaw-gateway',
+      executionEnforcement: enforcedExecution,
+    });
+
+    expect(child.evidence.status).toBe('blocked');
+    expect(child.evidence.blockers).toContainEqual(
+      expect.objectContaining({
+        code: 'required-authority-denied',
+        dimension: 'credential.access',
+      })
+    );
+    expect(child.evidence.effectiveAuthority['credential.access']).toEqual([]);
+  });
+
+  it('rejects tampered parent evidence before compiling a continuation', () => {
+    const service = new PhaseLaunchAuthorityService();
+    const parent = service.compile({
+      requestedPhase: 'verify',
+      sandboxPolicy,
+      providerRuntimeManifest: runtime(),
+      selectedHost: 'local-process',
+      executionEnforcement: enforcedExecution,
+    });
+
+    expect(() =>
+      service.compile({
+        parent: {
+          attemptId: 'run_parent:verify:0',
+          manifestDigest: `sha256:${'c'.repeat(64)}`,
+          evidence: {
+            ...parent.evidence,
+            warnings: [...parent.evidence.warnings, 'tampered'],
+          },
+        },
+        sandboxPolicy,
+        providerRuntimeManifest: runtime(),
+        selectedHost: 'local-process',
+        executionEnforcement: enforcedExecution,
+      })
+    ).toThrow('Parent phase evidence digest does not match its content');
+  });
+
+  it('narrows concrete sandbox rules before provider launch', () => {
+    const narrowed = new PhaseLaunchAuthorityService().narrowSandboxPreset(
+      sandboxPolicy.preset,
+      'explore'
+    );
+
+    expect(narrowed.filesystem.writePaths).toEqual([]);
+    expect(narrowed.network).toMatchObject({
+      defaultEgress: 'deny',
+      allowedHosts: [],
+      blockLoopback: true,
+    });
+    expect(narrowed.credentials).toEqual({
+      mode: 'none',
+      brokerRefs: [],
+    });
+  });
+});

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -222,7 +222,7 @@ describe('agent local capability enforcement', () => {
       createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }))
     )
       .post('/api/agents/task_1/start')
-      .send({ agent: 'codex' });
+      .send({ agent: 'codex', phase: 'implement' });
 
     expect(response.status).toBe(201);
     expect(mockStartAgent).toHaveBeenCalledWith('task_1', 'codex', {
@@ -232,6 +232,7 @@ describe('agent local capability enforcement', () => {
       budget: undefined,
       requiredRuntimeCapabilities: undefined,
       commitPolicy: undefined,
+      phase: 'implement',
       parentAttemptId: undefined,
     });
   });
@@ -240,7 +241,7 @@ describe('agent local capability enforcement', () => {
     const app = createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }));
     const response = await request(app)
       .post('/api/agents/task_1/launch-preview')
-      .send({ agent: 'codex', parentAttemptId: 'attempt_parent' });
+      .send({ agent: 'codex', phase: 'explore', parentAttemptId: 'attempt_parent' });
 
     expect(response.status).toBe(200);
     expect(response.body.manifest.digest).toBe(`sha256:${'a'.repeat(64)}`);
@@ -251,6 +252,7 @@ describe('agent local capability enforcement', () => {
       budget: undefined,
       requiredRuntimeCapabilities: undefined,
       commitPolicy: undefined,
+      phase: 'explore',
       parentAttemptId: 'attempt_parent',
     });
     expect(mockStartAgent).not.toHaveBeenCalled();
@@ -451,19 +453,21 @@ describe('agent local capability enforcement', () => {
       sourceAttemptId: 'attempt_parent',
       message: 'Continue from the durable provider history',
       commitPolicy: 'forbidden',
+      phase: 'verify',
     });
     expect(resume.status).toBe(201);
     expect(mockResumeConversation).toHaveBeenCalledWith(
       'task_1',
       'attempt_parent',
       'Continue from the durable provider history',
-      expect.objectContaining({ commitPolicy: 'forbidden' })
+      expect.objectContaining({ commitPolicy: 'forbidden', phase: 'verify' })
     );
 
     const fork = await request(app).post('/api/agents/task_1/conversation/fork').send({
       sourceAttemptId: 'attempt_parent',
       message: 'Explore another branch',
       forkTurnId: 'turn_7',
+      phase: 'explore',
     });
     expect(fork.status).toBe(201);
     expect(mockForkConversation).toHaveBeenCalledWith(
@@ -471,7 +475,7 @@ describe('agent local capability enforcement', () => {
       'attempt_parent',
       'Explore another branch',
       'turn_7',
-      expect.any(Object)
+      expect.objectContaining({ phase: 'explore' })
     );
 
     const spoofedSteer = await request(app).post('/api/agents/task_1/conversation/steer').send({
@@ -516,6 +520,7 @@ describe('agent local capability enforcement', () => {
     const response = await request(app).post('/api/agents/task_1/conversation/fresh').send({
       agent: 'codex',
       message: 'Start this task through ACP',
+      phase: 'plan',
     });
 
     expect(response.status).toBe(201);
@@ -523,6 +528,7 @@ describe('agent local capability enforcement', () => {
       'task_1',
       'codex',
       expect.objectContaining({
+        phase: 'plan',
         conversation: {
           mode: 'fresh',
           intent: 'fresh',

--- a/server/src/__tests__/run-launch-manifest-service.test.ts
+++ b/server/src/__tests__/run-launch-manifest-service.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/run-launch-manifest-digest.js';
 import { calculateRunToolCatalogDigest } from '../utils/tool-control-plane-digest.js';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
+import { PhaseLaunchAuthorityService } from '../services/phase-launch-authority-service.js';
 
 const providerRuntimeManifest = providerRuntimeManifestFixture({
   provider: 'codex-cli',
@@ -188,6 +189,12 @@ const workspaceTrust: RunLaunchManifestCompileInput['workspaceTrust'] = {
   restrictionChecks: [],
 };
 
+const legacyPhaseAuthority = new PhaseLaunchAuthorityService().compile({
+  sandboxPolicy,
+  providerRuntimeManifest,
+  selectedHost: 'local-process',
+});
+
 function input(
   overrides: Partial<RunLaunchManifestCompileInput> = {}
 ): RunLaunchManifestCompileInput {
@@ -211,6 +218,7 @@ function input(
       version: '1.0.0',
       role: 'developer',
     },
+    phase: legacyPhaseAuthority,
     readiness: {
       summary: {
         checks: [],
@@ -401,6 +409,22 @@ describe('RunLaunchManifestService', () => {
         enforceable: true,
         blockers: [],
       },
+      phase: {
+        evidence: {
+          identity: {
+            mode: 'legacy',
+            phase: 'legacy',
+          },
+          status: expect.stringMatching(/allowed|narrowed/),
+        },
+        sourceReferences: expect.arrayContaining([
+          expect.objectContaining({ kind: 'parent' }),
+          expect.objectContaining({ kind: 'agent-profile' }),
+          expect.objectContaining({ kind: 'sandbox' }),
+          expect.objectContaining({ kind: 'tool-catalog' }),
+          expect.objectContaining({ kind: 'launch-policy' }),
+        ]),
+      },
       sandbox: {
         filesystem: {
           backend: 'codex-sandbox',
@@ -440,8 +464,9 @@ describe('RunLaunchManifestService', () => {
   it('keeps legacy v1 launch manifests readable without treating them as fresh trust evidence', () => {
     const current = new RunLaunchManifestService().compile(input());
     const { digest: _digest, ...currentPayload } = current;
+    const { phase: _phase, ...legacyPhasePayload } = currentPayload;
     const legacyPayload = {
-      ...currentPayload,
+      ...legacyPhasePayload,
       workspaceTrust: {
         status: 'trusted' as const,
         source: 'Legacy workspace trust evidence.',
@@ -453,6 +478,7 @@ describe('RunLaunchManifestService', () => {
     };
 
     expect(parseRunLaunchManifest(legacy).workspaceTrust).toEqual(legacyPayload.workspaceTrust);
+    expect(parseRunLaunchManifest(legacy).phase).toBeUndefined();
   });
 
   it('rejects filesystem evidence linked to a different provider manifest', () => {
@@ -971,6 +997,21 @@ describe('RunLaunchManifestService', () => {
         },
       })
     ).toThrow(/digest/i);
+
+    expect(() =>
+      parseRunLaunchManifest({
+        ...manifest,
+        phase: manifest.phase
+          ? {
+              ...manifest.phase,
+              evidence: {
+                ...manifest.phase.evidence,
+                warnings: [...manifest.phase.evidence.warnings, 'tampered'],
+              },
+            }
+          : undefined,
+      })
+    ).toThrow(/phase|digest/i);
   });
 
   it('does not change persisted evidence when source configuration mutates after compile', () => {

--- a/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
+++ b/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
@@ -14,6 +14,8 @@ import {
 } from '../../storage/sqlite/test-helpers.js';
 
 const mockExecuteStep = vi.fn();
+const mockPrepareStep = vi.fn(async (step: unknown) => ({ kind: 'non-agent', step }));
+const mockApplyPreparation = vi.fn();
 const mockBroadcastWorkflowStatus = vi.fn();
 const mockGetTask = vi.fn();
 
@@ -22,6 +24,8 @@ vi.mock('../../services/workflow-step-executor.js', async (importOriginal) => {
   return {
     HumanGateBlockError: actual.HumanGateBlockError,
     WorkflowStepExecutor: class {
+      prepareStep = mockPrepareStep;
+      applyPreparation = mockApplyPreparation;
       executeStep = mockExecuteStep;
     },
   };

--- a/server/src/__tests__/workflow-run-service.test.ts
+++ b/server/src/__tests__/workflow-run-service.test.ts
@@ -5,6 +5,8 @@ import path from 'path';
 
 const mockLoadWorkflow = vi.fn();
 const mockListWorkflowsMetadata = vi.fn();
+const mockPrepareStep = vi.fn();
+const mockApplyPreparation = vi.fn();
 const mockExecuteStep = vi.fn();
 const mockValidateFallbackAgent = vi.fn();
 const mockBroadcastWorkflowStatus = vi.fn();
@@ -24,6 +26,8 @@ vi.mock('../services/workflow-step-executor.js', async (importOriginal) => {
   return {
     HumanGateBlockError: actual.HumanGateBlockError,
     WorkflowStepExecutor: class {
+      prepareStep = mockPrepareStep;
+      applyPreparation = mockApplyPreparation;
       executeStep = mockExecuteStep;
       validateFallbackAgent = mockValidateFallbackAgent;
     },
@@ -75,6 +79,8 @@ describe('WorkflowRunService', () => {
     ]);
     mockGetTask.mockResolvedValue({ id: 'task-1', title: 'Task 1' });
     mockCheckWorkflowPermission.mockResolvedValue(true);
+    mockPrepareStep.mockImplementation(async (step: any) => ({ kind: 'non-agent', step }));
+    mockApplyPreparation.mockImplementation(() => undefined);
     mockExecuteStep.mockImplementation(async (step: any) => ({
       output: { done: step.id },
       outputPath: `/tmp/${step.id}.json`,
@@ -105,6 +111,32 @@ describe('WorkflowRunService', () => {
     const snapshot = await fs.readFile(path.join(tmpDir, run.id, 'workflow.yml'), 'utf8');
     expect(snapshot).toContain('wf-1');
     expect(mockBroadcastWorkflowStatus).toHaveBeenCalled();
+  });
+
+  it('resolves phase launch controls before mutating executable step state', async () => {
+    let observed: { currentStep?: string; stepStatus?: string; startedAt?: string } | undefined;
+    mockPrepareStep.mockImplementationOnce(async (_step: any, run: any) => {
+      observed = {
+        currentStep: run.currentStep,
+        stepStatus: run.steps[0]?.status,
+        startedAt: run.steps[0]?.startedAt,
+      };
+      throw new Error('The effective phase authority cannot be enforced.');
+    });
+
+    const run = await service.startRun('wf-1', 'task-1');
+
+    await vi.waitFor(async () => {
+      const saved = await service.getRun(run.id);
+      expect(saved.status).toBe('failed');
+    });
+    expect(observed).toEqual({
+      currentStep: 'step-1',
+      stepStatus: 'pending',
+      startedAt: undefined,
+    });
+    expect(mockApplyPreparation).not.toHaveBeenCalled();
+    expect(mockExecuteStep).not.toHaveBeenCalled();
   });
 
   it('rejects initial context that overrides server-owned workflow run keys', async () => {

--- a/server/src/__tests__/workflow-step-executor-codex.test.ts
+++ b/server/src/__tests__/workflow-step-executor-codex.test.ts
@@ -218,33 +218,119 @@ describe('WorkflowStepExecutor Codex integration', () => {
       workflowId: 'wf-codex',
       workflowVersion: 1,
       status: 'running',
-      context: {},
+      context: {
+        task: {
+          id: 'task_1',
+          title: 'Recover a Codex workflow step',
+          git: { worktreePath: tmpDir },
+        },
+        workflow: {
+          agents: [
+            {
+              id: 'codex',
+              name: 'Codex',
+              role: 'implementer',
+              provider: 'codex-sdk',
+              description: 'Codex implementer',
+            },
+          ],
+        },
+        _sessions: {},
+      },
       startedAt: new Date().toISOString(),
       steps: [{ stepId: 'recover', status: 'running', retries: 1, runRetry: recovery }],
     } as WorkflowRun;
-    const step = { id: 'recover', type: 'agent', agent: 'codex' } as WorkflowStep;
+    const step = {
+      id: 'recover',
+      type: 'agent',
+      agent: 'codex',
+      input: 'Recover the workflow step',
+    } as WorkflowStep;
 
-    await (
-      executor as unknown as {
-        recordRuntimeManifest(
-          run: WorkflowRun,
-          step: WorkflowStep,
-          manifest: typeof manifest,
-          required: string[]
-        ): Promise<void>;
-      }
-    ).recordRuntimeManifest(run, step, manifest, ['run.start', 'artifact.write']);
+    const original = await executor.prepareStep(step, run);
+    expect(original.kind).toBe('agent');
+    executor.applyPreparation(run, original);
+    const parentManifestDigest = run.steps[0].phaseLaunchDigest;
+    const parentEvidenceDigest = run.steps[0].phaseAuthority?.evidence.digest;
+
+    await executor.executeStep(step, run);
 
     expect(run.steps[0]).toMatchObject({
       providerRuntimeManifest: { digest: manifest.digest },
-      requiredRuntimeCapabilities: ['artifact.write', 'run.start'],
+      requiredRuntimeCapabilities: expect.arrayContaining(['artifact.write', 'run.start']),
+      phaseAuthority: {
+        evidence: {
+          identity: { mode: 'legacy', phase: 'legacy' },
+        },
+      },
+      phaseLaunchDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
       runRetry: {
         state: 'launched',
         launchedManifestDigest: manifest.digest,
-        requiredRuntimeCapabilities: ['artifact.write', 'run.start'],
+        requiredRuntimeCapabilities: expect.arrayContaining(['artifact.write', 'run.start']),
       },
     });
+    expect(run.steps[0].phaseAuthority?.sourceReferences).toContainEqual(
+      expect.objectContaining({
+        kind: 'parent',
+        originScope: 'parent',
+        parentAttemptId: `${run.id}:recover:1`,
+        parentManifestDigest,
+        parentEvidenceDigest,
+      })
+    );
     expect(persistRun).toHaveBeenCalledWith(run);
+    expect(persistRun.mock.invocationCallOrder[0]).toBeLessThan(
+      mockStartThread.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('rejects an unenforceable explicit phase before persistence or provider dispatch', async () => {
+    const persistRun = vi.fn().mockResolvedValue(undefined);
+    const executor = new WorkflowStepExecutor(tmpDir, { runtimeManifestResolver, persistRun });
+    const step: WorkflowStep = {
+      id: 'explore',
+      name: 'Explore',
+      type: 'agent',
+      agent: 'codex',
+      phase: 'explore',
+      input: 'Inspect the workflow task',
+    };
+    const run = {
+      id: 'run_1234567890_phase',
+      workflowId: 'wf-codex',
+      workflowVersion: 1,
+      status: 'running',
+      context: {
+        task: {
+          id: 'task_1',
+          title: 'Inspect phase enforcement',
+          git: { worktreePath: tmpDir },
+        },
+        workflow: {
+          agents: [
+            {
+              id: 'codex',
+              name: 'Codex',
+              role: 'researcher',
+              provider: 'codex-sdk',
+              description: 'Codex researcher',
+            },
+          ],
+        },
+      },
+      startedAt: new Date().toISOString(),
+      steps: [{ stepId: 'explore', status: 'pending', retries: 0 }],
+    } as WorkflowRun;
+
+    await expect(executor.executeStep(step, run)).rejects.toThrow(
+      /effective phase authority cannot be enforced/i
+    );
+
+    expect(run.steps[0].phaseAuthority).toBeUndefined();
+    expect(run.steps[0].phaseLaunchDigest).toBeUndefined();
+    expect(persistRun).not.toHaveBeenCalled();
+    expect(mockStartThread).not.toHaveBeenCalled();
   });
 
   it('rejects providers that have no workflow execution adapter before probing or launch', async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -9,6 +9,7 @@ import { getTelemetryService } from '../services/telemetry-service.js';
 import { getTaskService } from '../services/task-service.js';
 import type {
   AgentType,
+  PhaseName,
   ProviderRuntimeCapabilityId,
   TaskCommitPolicy,
   TokenTelemetryEvent,
@@ -33,7 +34,10 @@ import {
   workspaceExecutionTrustRevokeInputSchema,
 } from '../schemas/workspace-execution-trust-schemas.js';
 import { getWorkspaceExecutionTrustService } from '../services/workspace-execution-trust-service.js';
-import { phaseTransitionRequestInputSchema } from '../schemas/phase-capability-schemas.js';
+import {
+  phaseNameSchema,
+  phaseTransitionRequestInputSchema,
+} from '../schemas/phase-capability-schemas.js';
 import {
   getPhaseTransitionService,
   type PhaseTransitionActorContext,
@@ -53,6 +57,7 @@ const startAgentSchema = z.object({
   budget: AgentBudgetPolicySchema.optional(),
   requiredRuntimeCapabilities: z.array(ProviderRuntimeCapabilityIdSchema).max(64).optional(),
   commitPolicy: TaskCommitPolicySchema.optional(),
+  phase: phaseNameSchema.optional(),
   parentAttemptId: z.string().trim().min(1).max(120).optional(),
 });
 
@@ -178,6 +183,7 @@ const conversationTurnSchema = z
     budget: AgentBudgetPolicySchema.optional(),
     requiredRuntimeCapabilities: z.array(ProviderRuntimeCapabilityIdSchema).max(64).optional(),
     commitPolicy: TaskCommitPolicySchema.optional(),
+    phase: phaseNameSchema.optional(),
   })
   .strict();
 
@@ -276,6 +282,7 @@ router.post(
           requiredRuntimeCapabilities: parsed.requiredRuntimeCapabilities as
             ProviderRuntimeCapabilityId[] | undefined,
           commitPolicy: parsed.commitPolicy as TaskCommitPolicy | undefined,
+          phase: parsed.phase,
           parentAttemptId: parsed.parentAttemptId,
         }
       );
@@ -303,6 +310,7 @@ router.post(
     let budget: z.infer<typeof AgentBudgetPolicySchema> | undefined;
     let requiredRuntimeCapabilities: ProviderRuntimeCapabilityId[] | undefined;
     let commitPolicy: TaskCommitPolicy | undefined;
+    let phase: PhaseName | undefined;
     let parentAttemptId: string | undefined;
     try {
       ({
@@ -313,6 +321,7 @@ router.post(
         budget,
         requiredRuntimeCapabilities,
         commitPolicy,
+        phase,
         parentAttemptId,
       } = startAgentSchema.parse(req.body) as {
         agent?: AgentType;
@@ -322,6 +331,7 @@ router.post(
         budget?: z.infer<typeof AgentBudgetPolicySchema>;
         requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
         commitPolicy?: TaskCommitPolicy;
+        phase?: PhaseName;
         parentAttemptId?: string;
       });
     } catch (error) {
@@ -339,6 +349,7 @@ router.post(
         budget,
         requiredRuntimeCapabilities,
         commitPolicy,
+        phase,
         parentAttemptId,
       });
     } catch (error) {
@@ -837,6 +848,7 @@ function conversationStartOptions(
     requiredRuntimeCapabilities: body.requiredRuntimeCapabilities as
       ProviderRuntimeCapabilityId[] | undefined,
     commitPolicy: body.commitPolicy as TaskCommitPolicy | undefined,
+    phase: body.phase,
   };
 }
 

--- a/server/src/schemas/run-launch-manifest-schemas.ts
+++ b/server/src/schemas/run-launch-manifest-schemas.ts
@@ -1,11 +1,13 @@
 import { z } from 'zod';
 import {
   HARNESS_SUPPORT_TIERS,
+  PHASE_AUTHORITY_SOURCE_KINDS,
   RUN_LAUNCH_CREDENTIAL_PLAN_SCHEMA_VERSION,
   RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
   type RunLaunchManifest,
 } from '@veritas-kanban/shared';
 import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
+import { phaseCapabilityEvidenceSchema } from './phase-capability-schemas.js';
 import { calculateRunLaunchManifestDigest } from '../utils/run-launch-manifest-digest.js';
 import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
 import { containsUnredactedProviderRuntimeSecret } from '../utils/provider-runtime-manifest-sanitize.js';
@@ -100,6 +102,37 @@ export const RunLaunchManifestSchema = z
         id: identifierSchema,
         version: identifierSchema,
         role: identifierSchema,
+      })
+      .strict()
+      .optional(),
+    phase: z
+      .object({
+        evidence: phaseCapabilityEvidenceSchema,
+        sourceReferences: z
+          .array(
+            z
+              .object({
+                sourceId: identifierSchema,
+                kind: z.enum(PHASE_AUTHORITY_SOURCE_KINDS),
+                originScope: z.enum([
+                  'run',
+                  'parent',
+                  'task-envelope',
+                  'agent-profile',
+                  'workflow',
+                  'template',
+                  'provider',
+                  'workspace',
+                  'system-default',
+                ]),
+                sourceDigest: digestSchema,
+                parentAttemptId: identifierSchema.optional(),
+                parentManifestDigest: digestSchema.optional(),
+                parentEvidenceDigest: digestSchema.optional(),
+              })
+              .strict()
+          )
+          .length(PHASE_AUTHORITY_SOURCE_KINDS.length),
       })
       .strict()
       .optional(),
@@ -357,6 +390,7 @@ export const RunLaunchManifestSchema = z
             field: identifierSchema,
             scope: z.enum([
               'run',
+              'parent',
               'task-envelope',
               'agent-profile',
               'workflow',
@@ -392,6 +426,53 @@ export const RunLaunchManifestSchema = z
   })
   .strict()
   .superRefine((manifest, context) => {
+    if (manifest.phase) {
+      const { digest, ...phasePayload } = manifest.phase.evidence;
+      if (digest !== digestRunLaunchValue(phasePayload)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['phase', 'evidence', 'digest'],
+          message: 'Phase evidence digest does not match its canonical payload',
+        });
+      }
+      const sourceKinds = manifest.phase.sourceReferences.map((reference) => reference.kind);
+      if (
+        new Set(sourceKinds).size !== PHASE_AUTHORITY_SOURCE_KINDS.length ||
+        PHASE_AUTHORITY_SOURCE_KINDS.some((kind) => !sourceKinds.includes(kind))
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['phase', 'sourceReferences'],
+          message: 'Phase evidence requires exactly one reference for every authority source kind',
+        });
+      }
+      for (const [index, reference] of manifest.phase.sourceReferences.entries()) {
+        const hasParentLink = Boolean(
+          reference.parentAttemptId ||
+          reference.parentManifestDigest ||
+          reference.parentEvidenceDigest
+        );
+        if ((reference.kind === 'parent' && reference.originScope === 'parent') !== hasParentLink) {
+          context.addIssue({
+            code: 'custom',
+            path: ['phase', 'sourceReferences', index],
+            message: 'Parent phase references must carry one complete parent origin link',
+          });
+        }
+        if (
+          reference.kind === 'parent' &&
+          reference.originScope === 'parent' &&
+          (!reference.parentAttemptId || !reference.parentManifestDigest)
+        ) {
+          context.addIssue({
+            code: 'custom',
+            path: ['phase', 'sourceReferences', index],
+            message:
+              'Parent phase references require the attempt, manifest, and applicable evidence digests',
+          });
+        }
+      }
+    }
     if (manifest.credentials) {
       const { digest, ...payload } = manifest.credentials;
       if (digest !== digestRunLaunchValue(payload)) {

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -100,6 +100,9 @@ import type {
   RunLaunchManifestOrigin,
   RunLaunchManifestPreview,
   RunLaunchRuntime,
+  RunLaunchPhaseAuthority,
+  PhaseName,
+  PhaseCapabilityEvidence,
   CredentialRunRevocationRequest,
   CredentialLeaseTerminalReason,
   RunEventEnvelope,
@@ -240,6 +243,15 @@ import {
   getWorkspaceExecutionTrustService,
   type WorkspaceExecutionTrustService,
 } from './workspace-execution-trust-service.js';
+import {
+  PhaseLaunchAuthorityService,
+  type PhaseLaunchParentSnapshot,
+} from './phase-launch-authority-service.js';
+import {
+  getPhaseTransitionService,
+  type PhaseTransitionService,
+} from './phase-transition-service.js';
+import { verifyPhaseCapabilityEvidenceDigest } from './phase-capability-service.js';
 const log = createLogger('clawdbot-agent-service');
 
 const TRACE_SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -306,6 +318,7 @@ export interface AgentStatus {
   runLaunchParentAttemptId?: string;
   runLaunchManifestDrift?: RunLaunchManifestDriftResult;
   runRetry?: RunRecoveryRecord;
+  activePhaseEvidence?: PhaseCapabilityEvidence;
   conversation: ConversationLifecycleRecord;
   controls: ProviderRuntimeControlSet;
 }
@@ -323,6 +336,7 @@ export interface AgentStartOptions {
   budget?: AgentBudgetPolicy;
   requiredRuntimeCapabilities?: ProviderRuntimeCapabilityId[];
   commitPolicy?: TaskCommitPolicy;
+  phase?: PhaseName;
   parentAttemptId?: string;
   conversation?: ConversationLaunchRequest;
   /** Internal durable recovery context. API callers cannot supply this field. */
@@ -378,6 +392,7 @@ interface PendingAgent {
   runLaunchParentAttemptId?: string;
   runLaunchManifestDrift?: RunLaunchManifestDriftResult;
   runRetry?: RunRecoveryRecord;
+  activePhaseEvidence?: PhaseCapabilityEvidence;
   conversation: ConversationLifecycleRecord;
   supervisorId?: string;
   recoveredControl?: boolean;
@@ -499,6 +514,8 @@ export class ClawdbotAgentService {
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
   >;
+  private phaseAuthority: PhaseLaunchAuthorityService;
+  private phaseTransitions?: Pick<PhaseTransitionService, 'getCurrent'>;
   private logsDir: string;
 
   constructor(
@@ -524,7 +541,9 @@ export class ClawdbotAgentService {
     workspaceExecutionTrust: Pick<
       WorkspaceExecutionTrustService,
       'scan' | 'evaluateForLaunch' | 'assertFresh'
-    > = getWorkspaceExecutionTrustService()
+    > = getWorkspaceExecutionTrustService(),
+    phaseAuthority = new PhaseLaunchAuthorityService(),
+    phaseTransitions?: Pick<PhaseTransitionService, 'getCurrent'>
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -551,6 +570,8 @@ export class ClawdbotAgentService {
     this.filesystemSandbox = filesystemSandbox;
     this.sandboxPolicies = sandboxPolicies;
     this.workspaceExecutionTrust = workspaceExecutionTrust;
+    this.phaseAuthority = phaseAuthority;
+    this.phaseTransitions = phaseTransitions;
     this.logsDir = getLogsDir();
     this.ensureLogsDir();
   }
@@ -1266,6 +1287,7 @@ export class ClawdbotAgentService {
       runLaunchParentAttemptId: attempt.runLaunchParentAttemptId,
       runLaunchManifestDrift: attempt.runLaunchManifestDrift,
       runRetry: attempt.runRetry,
+      activePhaseEvidence: attempt.runLaunchManifest.phase?.evidence,
       conversation: recoveredConversation,
       supervisorId: supervisor.id,
       recoveredControl: true,
@@ -1487,7 +1509,9 @@ export class ClawdbotAgentService {
       budgetPolicy,
       options.requiredRuntimeCapabilities
     );
-    const sandboxPolicy = await this.sandboxPolicies.dryRunWithTrace({
+    const parentAttempt = await this.resolveParentAttempt(task, options.parentAttemptId);
+    const parentPhase = await this.resolveParentPhaseSnapshot(parentAttempt);
+    let sandboxPolicy = await this.sandboxPolicies.dryRunWithTrace({
       presetId:
         options.sandboxPresetId ??
         profileLaunch?.sandboxPresetId ??
@@ -1496,6 +1520,18 @@ export class ClawdbotAgentService {
       workspacePath: task.git.worktreePath,
       providerRuntimeManifest,
     });
+    if (options.phase || parentPhase?.evidence?.identity.mode === 'profile') {
+      sandboxPolicy = await this.sandboxPolicies.dryRunWithTrace({
+        preset: this.phaseAuthority.narrowSandboxPreset(
+          sandboxPolicy.result.preset,
+          options.phase,
+          parentPhase
+        ),
+        provider,
+        workspacePath: task.git.worktreePath,
+        providerRuntimeManifest,
+      });
+    }
     const attemptId = `preview_${nanoid(8)}`;
     const startedAt = new Date().toISOString();
     const logPath = path.join(this.logsDir, `${taskId}_${attemptId}.md`);
@@ -1585,8 +1621,8 @@ export class ClawdbotAgentService {
       runToolCatalog,
       filesystemSandboxPlan,
       workspaceTrustEvaluation,
+      parentPhase,
     });
-    const parentAttempt = await this.resolveParentAttempt(task, options.parentAttemptId);
     return {
       manifest,
       ...(parentAttempt
@@ -1758,7 +1794,12 @@ export class ClawdbotAgentService {
         ...conversationLaunchCapabilities(conversationRequest.mode),
       ]
     );
-    const sandboxPolicy = await this.sandboxPolicies.dryRunWithTrace({
+    const parentAttempt = await this.resolveParentAttempt(
+      task,
+      conversationSource?.attempt.id ?? options.parentAttemptId
+    );
+    const parentPhase = await this.resolveParentPhaseSnapshot(parentAttempt);
+    let sandboxPolicy = await this.sandboxPolicies.dryRunWithTrace({
       presetId:
         options.sandboxPresetId ??
         profileLaunch?.sandboxPresetId ??
@@ -1767,6 +1808,18 @@ export class ClawdbotAgentService {
       workspacePath: task.git.worktreePath,
       providerRuntimeManifest,
     });
+    if (options.phase || parentPhase?.evidence?.identity.mode === 'profile') {
+      sandboxPolicy = await this.sandboxPolicies.dryRunWithTrace({
+        preset: this.phaseAuthority.narrowSandboxPreset(
+          sandboxPolicy.result.preset,
+          options.phase,
+          parentPhase
+        ),
+        provider,
+        workspacePath: task.git.worktreePath,
+        providerRuntimeManifest,
+      });
+    }
     const sandboxTrace = await getGovernanceTraceService().record(sandboxPolicy.trace);
 
     if (!readiness.ready && overrideReason) {
@@ -1903,11 +1956,8 @@ export class ClawdbotAgentService {
       runToolCatalog,
       filesystemSandboxPlan,
       workspaceTrustEvaluation,
+      parentPhase,
     });
-    const parentAttempt = await this.resolveParentAttempt(
-      task,
-      conversationSource?.attempt.id ?? options.parentAttemptId
-    );
     const runLaunchManifestDrift = parentAttempt?.runLaunchManifest
       ? diffRunLaunchManifests(runLaunchManifest, parentAttempt.runLaunchManifest)
       : undefined;
@@ -1987,6 +2037,7 @@ export class ClawdbotAgentService {
       runLaunchParentAttemptId: parentAttempt?.id,
       runLaunchManifestDrift,
       runRetry,
+      activePhaseEvidence: runLaunchManifest.phase?.evidence,
       conversation,
       filesystemSandboxPlan,
       budget: budgetPolicy
@@ -2163,6 +2214,8 @@ export class ClawdbotAgentService {
           taskEnvelopeDigest: taskEnvelope.digest,
           runLaunchManifestDigest: runLaunchManifest.digest,
           providerRuntimeManifestDigest: providerRuntimeManifest.digest,
+          phaseEvidenceDigest: runLaunchManifest.phase?.evidence.digest,
+          phaseIdentity: runLaunchManifest.phase?.evidence.identity,
           worktreeManifestId: taskEnvelope.workspace.worktreeManifestId,
         },
         {
@@ -2189,6 +2242,8 @@ export class ClawdbotAgentService {
           parentAttemptId: conversation.parentAttemptId,
           parentConversationId: conversation.parentConversationId,
           forkTurnId: conversation.forkTurnId,
+          phaseEvidenceDigest: runLaunchManifest.phase?.evidence.digest,
+          phaseIdentity: runLaunchManifest.phase?.evidence.identity,
         },
         {
           provider,
@@ -2376,6 +2431,7 @@ export class ClawdbotAgentService {
       runLaunchParentAttemptId: parentAttempt?.id,
       runLaunchManifestDrift,
       runRetry,
+      activePhaseEvidence: runLaunchManifest.phase?.evidence,
       conversation,
       controls: providerRuntimeControls(providerRuntimeManifest),
     };
@@ -3797,6 +3853,8 @@ export class ClawdbotAgentService {
         conversationId: conversation.conversationId,
         turnId: conversation.currentTurnId,
         state: conversation.state,
+        phaseEvidenceDigest: pending.activePhaseEvidence?.digest,
+        phaseIdentity: pending.activePhaseEvidence?.identity,
       },
       {
         provider: 'operator',
@@ -7827,6 +7885,7 @@ export class ClawdbotAgentService {
       runLaunchParentAttemptId: pending.runLaunchParentAttemptId,
       runLaunchManifestDrift: pending.runLaunchManifestDrift,
       runRetry: pending.runRetry,
+      activePhaseEvidence: pending.activePhaseEvidence,
       conversation: pending.conversation,
       controls: providerRuntimeControls(pending.providerRuntimeManifest),
     };
@@ -7948,6 +8007,53 @@ export class ClawdbotAgentService {
     }
     this.runLaunchManifests.assertEnforceable(persistedAttempt.runLaunchManifest);
     this.runLaunchManifests.assertEnforceable(pending.runLaunchManifest);
+    const persistedPhase = persistedAttempt.runLaunchManifest.phase?.evidence;
+    if (!persistedPhase) {
+      pending.activePhaseEvidence = undefined;
+      return;
+    }
+    if (!verifyPhaseCapabilityEvidenceDigest(persistedPhase)) {
+      throw new ConflictError(
+        'Phase authority is stale or invalid: initial launch evidence digest does not match',
+        {
+          action,
+          phaseEvidenceDigest: persistedPhase.digest,
+          remediation:
+            'Terminate the detached provider, reconcile persisted phase evidence, and launch again.',
+        }
+      );
+    }
+    const currentPhase = await this.getCurrentPhase(
+      pending.taskEnvelope.workspace.workspaceId,
+      taskId,
+      pending.attemptId
+    );
+    if (currentPhase && currentPhase.manifestDigest !== persistedAttempt.runLaunchManifest.digest) {
+      throw new ConflictError(
+        'Phase authority is stale or invalid: transition evidence belongs to another launch manifest',
+        {
+          action,
+          phaseTransitionManifestDigest: currentPhase.manifestDigest,
+          runLaunchManifestDigest: persistedAttempt.runLaunchManifest.digest,
+          remediation:
+            'Terminate the detached provider, reconcile the phase transition journal, and launch again.',
+        }
+      );
+    }
+    const activePhase = currentPhase?.effectiveEvidence ?? persistedPhase;
+    if (!verifyPhaseCapabilityEvidenceDigest(activePhase) || activePhase.status === 'blocked') {
+      throw new ConflictError(
+        'Phase authority is stale or invalid: active evidence cannot authorize run control',
+        {
+          action,
+          phaseEvidenceDigest: activePhase.digest,
+          phaseStatus: activePhase.status,
+          remediation:
+            'Terminate the detached provider, reconcile active phase evidence, and launch again.',
+        }
+      );
+    }
+    pending.activePhaseEvidence = activePhase;
   }
 
   /**
@@ -8133,6 +8239,7 @@ export class ClawdbotAgentService {
     runToolCatalog?: RunToolCatalog;
     filesystemSandboxPlan: FilesystemSandboxLaunchPlan;
     workspaceTrustEvaluation: WorkspaceExecutionTrustEvaluation;
+    parentPhase?: PhaseLaunchParentSnapshot;
   }): Promise<RunLaunchManifest> {
     const profile = input.profileLaunch?.profile;
     const toolCatalogDelivery = input.launchAgentConfig
@@ -8160,6 +8267,24 @@ export class ClawdbotAgentService {
         ? [`workflow-entrypoint:${profile.workflow.entrypoint}`]
         : []),
     ];
+    const selectedHost = input.provider === 'openclaw' ? 'openclaw-gateway' : 'local-process';
+    const phase = this.phaseAuthority.compile({
+      requestedPhase: input.options.phase,
+      parent: input.parentPhase,
+      ...(profile
+        ? {
+            agentProfile: {
+              id: profile.id,
+              version: profile.version,
+            },
+          }
+        : {}),
+      sandboxPolicy: input.sandboxPolicy,
+      providerRuntimeManifest: input.providerRuntimeManifest,
+      filesystemSandbox: input.filesystemSandboxPlan.evidence,
+      selectedHost,
+      toolCatalogId: input.runToolCatalog?.digest,
+    });
     const runtime = this.buildRunLaunchRuntime(
       input.provider,
       input.launchAgentConfig,
@@ -8373,6 +8498,35 @@ export class ClawdbotAgentService {
         source: `harness-support:${input.harnessSupport.profileId}`,
         precedence: 100,
       },
+      {
+        field: 'phase.evidence',
+        scope: input.options.phase
+          ? ('run' as const)
+          : input.parentPhase
+            ? ('parent' as const)
+            : ('system-default' as const),
+        source: input.options.phase
+          ? `phase-profile:builtin-${input.options.phase}:1`
+          : input.parentPhase
+            ? `parent-attempt:${input.parentPhase.attemptId}:${input.parentPhase.evidence?.digest ?? 'legacy'}`
+            : 'phase-profile:legacy',
+        precedence: input.options.phase ? 300 : input.parentPhase ? 400 : 0,
+      },
+      ...phase.sourceReferences.map((reference) => ({
+        field: `phase.sources.${reference.kind}`,
+        scope: reference.originScope,
+        source: `phase-source:${reference.kind}:${reference.sourceDigest}`,
+        precedence:
+          reference.originScope === 'parent'
+            ? 400
+            : reference.originScope === 'run'
+              ? 300
+              : reference.originScope === 'agent-profile'
+                ? 200
+                : reference.originScope === 'provider'
+                  ? 100
+                  : 0,
+      })),
       {
         field: 'instructions.effective-task-request',
         scope: 'task-envelope',
@@ -8752,7 +8906,7 @@ export class ClawdbotAgentService {
       routing: {
         requestedAgent: input.requestedAgent,
         selectedAgent: input.agent,
-        selectedHost: input.provider === 'openclaw' ? 'openclaw-gateway' : 'local-process',
+        selectedHost,
         reason: input.routingReason,
         fallbackAgent: input.routingFallback ?? null,
         fallbackAllowed: Boolean(input.routingFallback && input.routingFallbackOnFailure),
@@ -8768,6 +8922,7 @@ export class ClawdbotAgentService {
             },
           }
         : {}),
+      phase,
       readiness: {
         summary: input.readiness,
         overrideReason: input.overrideReason,
@@ -9133,6 +9288,45 @@ export class ClawdbotAgentService {
       });
     }
     return parent as TaskAttempt & { runLaunchManifest: RunLaunchManifest };
+  }
+
+  private async resolveParentPhaseSnapshot(
+    parent:
+      | (TaskAttempt & {
+          runLaunchManifest: RunLaunchManifest;
+        })
+      | undefined
+  ): Promise<PhaseLaunchParentSnapshot | undefined> {
+    if (!parent) return undefined;
+    const manifest = parent.runLaunchManifest;
+    const workspaceId = parent.taskEnvelope?.workspace.workspaceId;
+    const current = workspaceId
+      ? await this.getCurrentPhase(workspaceId, manifest.taskId, parent.id)
+      : null;
+    if (current && current.manifestDigest !== manifest.digest) {
+      throw new ConflictError('Parent phase transition evidence references a different launch.', {
+        parentAttemptId: parent.id,
+        parentManifestDigest: manifest.digest,
+        transitionManifestDigest: current.manifestDigest,
+      });
+    }
+    return {
+      attemptId: parent.id,
+      manifestDigest: manifest.digest,
+      ...(current?.effectiveEvidence
+        ? { evidence: current.effectiveEvidence }
+        : manifest.phase?.evidence
+          ? { evidence: manifest.phase.evidence }
+          : {}),
+    };
+  }
+
+  private getCurrentPhase(workspaceId: string, taskId: string, attemptId: string) {
+    return (this.phaseTransitions ?? getPhaseTransitionService()).getCurrent(
+      workspaceId,
+      taskId,
+      attemptId
+    );
   }
 
   private async findAttempt(attemptId: string): Promise<TaskAttempt | undefined> {

--- a/server/src/services/phase-launch-authority-service.ts
+++ b/server/src/services/phase-launch-authority-service.ts
@@ -1,0 +1,481 @@
+import {
+  PHASE_AUTHORITY_DIMENSIONS,
+  PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION,
+  type PhaseAuthority,
+  type PhaseAuthorityDimension,
+  type PhaseAuthorityEnforcement,
+  type PhaseAuthorityEnforcementState,
+  type PhaseAuthoritySource,
+  type PhaseCapabilityCompilerSources,
+  type PhaseCapabilityEvidence,
+  type PhaseCapabilityProfile,
+  type PhaseName,
+  type ProviderRuntimeCapabilityId,
+  type ProviderRuntimeManifest,
+  type RunLaunchFilesystemSandboxEvidence,
+  type RunLaunchManifestOriginScope,
+  type RunLaunchPhaseAuthority,
+  type RunLaunchPhaseSourceReference,
+  type SandboxPolicyDryRunResult,
+  type SandboxPolicyPreset,
+} from '@veritas-kanban/shared';
+import { ConflictError } from '../middleware/error-handler.js';
+import {
+  phaseCapabilityEvidenceSchema,
+  phaseCapabilityProfileSchema,
+} from '../schemas/phase-capability-schemas.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
+import {
+  compilePhaseCapabilityAuthority,
+  getBuiltInPhaseCapabilityProfile,
+  verifyPhaseCapabilityEvidenceDigest,
+} from './phase-capability-service.js';
+
+const WILDCARD_AUTHORITY = authority(
+  Object.fromEntries(
+    PHASE_AUTHORITY_DIMENSIONS.map((dimension) => [dimension, ['*']])
+  ) as Partial<PhaseAuthority>
+);
+const ENFORCED = enforcement('enforced');
+const DISABLED_PLAN_ARTIFACT = {
+  mode: 'disabled',
+  owner: 'veritas-kanban',
+  maximumPaths: 0,
+  transport: 'harness-api',
+  shellRedirection: false,
+  indirectWrites: false,
+} as const;
+const EXACT_PLAN_ARTIFACT = {
+  mode: 'harness-exact-path',
+  owner: 'veritas-kanban',
+  maximumPaths: 1,
+  transport: 'harness-api',
+  shellRedirection: false,
+  indirectWrites: false,
+} as const;
+
+export interface PhaseLaunchParentSnapshot {
+  attemptId: string;
+  manifestDigest?: string;
+  evidence?: PhaseCapabilityEvidence;
+}
+
+export interface PhaseLaunchExecutionEnforcement {
+  commandExecute?: PhaseAuthorityEnforcementState;
+  externalAction?: PhaseAuthorityEnforcementState;
+  planArtifactWrite?: PhaseAuthorityEnforcementState;
+}
+
+export interface PhaseLaunchAuthorityCompileInput {
+  requestedPhase?: PhaseName;
+  parent?: PhaseLaunchParentSnapshot;
+  agentProfile?: {
+    id: string;
+    version?: string | number;
+  };
+  sandboxPolicy: SandboxPolicyDryRunResult;
+  providerRuntimeManifest: ProviderRuntimeManifest;
+  filesystemSandbox?: RunLaunchFilesystemSandboxEvidence;
+  selectedHost: string;
+  toolCatalogId?: string;
+  executionEnforcement?: PhaseLaunchExecutionEnforcement;
+}
+
+/**
+ * Compiles phase authority from launch-time evidence without mutating attempts
+ * or inferring provider features from provider names.
+ */
+export class PhaseLaunchAuthorityService {
+  compile(input: PhaseLaunchAuthorityCompileInput): RunLaunchPhaseAuthority {
+    const parentEvidence = verifiedParentEvidence(input.parent);
+    const profile = resolvePhaseProfile(input.requestedPhase, parentEvidence);
+    const desired = desiredAuthority(profile, parentEvidence);
+    const explicitPhase = Boolean(profile);
+    const sources = {
+      parent: parentSource(input.parent, parentEvidence),
+      agentProfile: agentProfileSource(input.agentProfile),
+      sandbox: sandboxSource(input, desired),
+      toolCatalog: toolCatalogSource(input, desired, explicitPhase),
+      launchPolicy: launchPolicySource(input),
+    } satisfies PhaseCapabilityCompilerSources;
+    const evidence = compilePhaseCapabilityAuthority({
+      ...(profile ? { profile } : {}),
+      sources,
+    });
+
+    return {
+      evidence,
+      sourceReferences: [
+        referenceFor(
+          sources.parent,
+          input.parent ? 'parent' : 'system-default',
+          input.parent,
+          parentEvidence
+        ),
+        referenceFor(sources.agentProfile, input.agentProfile ? 'agent-profile' : 'system-default'),
+        referenceFor(sources.sandbox, 'run'),
+        referenceFor(sources.toolCatalog, input.toolCatalogId ? 'run' : 'system-default'),
+        referenceFor(sources.launchPolicy, 'provider'),
+      ],
+    };
+  }
+
+  /**
+   * Narrows the concrete sandbox preset before the provider launch is built.
+   * Legacy launches are returned unchanged.
+   */
+  narrowSandboxPreset(
+    preset: SandboxPolicyPreset,
+    requestedPhase?: PhaseName,
+    parent?: PhaseLaunchParentSnapshot
+  ): SandboxPolicyPreset {
+    const parentEvidence = verifiedParentEvidence(parent);
+    const profile = resolvePhaseProfile(requestedPhase, parentEvidence);
+    if (!profile) return structuredClone(preset);
+
+    const desired = desiredAuthority(profile, parentEvidence);
+    const narrowed = structuredClone(preset);
+    narrowed.filesystem.readPaths = narrowScopes(
+      narrowed.filesystem.readPaths,
+      desired['filesystem.read']
+    );
+    narrowed.filesystem.writePaths = narrowScopes(
+      narrowed.filesystem.writePaths,
+      desired['filesystem.write']
+    );
+
+    const network = desired['network.egress'];
+    if (network.length === 0) {
+      narrowed.network.defaultEgress = 'deny';
+      narrowed.network.allowedHosts = [];
+      narrowed.network.allowedMethods = [];
+      narrowed.network.allowedPathPrefixes = [];
+      narrowed.network.blockPrivateNetwork = true;
+      narrowed.network.blockMetadataEndpoints = true;
+      narrowed.network.blockLoopback = true;
+    } else if (!network.includes('*')) {
+      narrowed.network.defaultEgress = 'deny';
+      narrowed.network.allowedHosts = narrowScopes(narrowed.network.allowedHosts, network);
+    }
+
+    const credentials = desired['credential.access'];
+    if (credentials.length === 0) {
+      narrowed.credentials.mode = 'none';
+      narrowed.credentials.brokerRefs = [];
+    } else if (!credentials.includes('*')) {
+      narrowed.credentials.brokerRefs = narrowScopes(narrowed.credentials.brokerRefs, credentials);
+      if (narrowed.credentials.brokerRefs.length === 0) narrowed.credentials.mode = 'none';
+    }
+    return narrowed;
+  }
+
+  assertEnforceable(phase: RunLaunchPhaseAuthority): void {
+    if (phase.evidence.status !== 'blocked') return;
+    throw new ConflictError('The effective phase authority cannot be enforced.', {
+      phaseEvidenceDigest: phase.evidence.digest,
+      phase: phase.evidence.identity,
+      blockers: phase.evidence.blockers,
+    });
+  }
+}
+
+function resolvePhaseProfile(
+  requestedPhase: PhaseName | undefined,
+  parentEvidence: PhaseCapabilityEvidence | undefined
+): PhaseCapabilityProfile | undefined {
+  if (requestedPhase) return getBuiltInPhaseCapabilityProfile(requestedPhase);
+  if (parentEvidence?.identity.mode !== 'profile') return undefined;
+
+  const requestedArtifact = parentEvidence.requestedAuthority['artifact.plan.write'];
+  return phaseCapabilityProfileSchema.parse({
+    schemaVersion: PHASE_CAPABILITY_PROFILE_SCHEMA_VERSION,
+    id: parentEvidence.identity.profileId,
+    version: parentEvidence.identity.profileVersion,
+    phase: parentEvidence.identity.phase,
+    name: `Inherited ${parentEvidence.identity.phase}`,
+    description: 'Inherited from the exact parent phase evidence snapshot.',
+    authority: parentEvidence.requestedAuthority,
+    requiredDimensions: parentEvidence.requiredDimensions,
+    approvalRequiredDimensions: parentEvidence.approvalRequiredDimensions,
+    planArtifactPolicy: requestedArtifact.includes('harness-exact-path')
+      ? EXACT_PLAN_ARTIFACT
+      : DISABLED_PLAN_ARTIFACT,
+  }) as PhaseCapabilityProfile;
+}
+
+function desiredAuthority(
+  profile: PhaseCapabilityProfile | undefined,
+  parentEvidence: PhaseCapabilityEvidence | undefined
+): PhaseAuthority {
+  const requested = profile?.authority ?? WILDCARD_AUTHORITY;
+  if (!parentEvidence) return cloneAuthority(requested);
+  return intersectAuthority(requested, parentEvidence.effectiveAuthority);
+}
+
+function parentSource(
+  parent: PhaseLaunchParentSnapshot | undefined,
+  evidence: PhaseCapabilityEvidence | undefined
+): PhaseCapabilityCompilerSources['parent'] {
+  return {
+    id: parent ? `parent:${safeId(parent.attemptId)}` : 'parent:none',
+    kind: 'parent',
+    authority: evidence
+      ? cloneAuthority(evidence.effectiveAuthority)
+      : cloneAuthority(WILDCARD_AUTHORITY),
+    enforcement: { ...ENFORCED },
+  };
+}
+
+function agentProfileSource(
+  profile: PhaseLaunchAuthorityCompileInput['agentProfile']
+): PhaseCapabilityCompilerSources['agentProfile'] {
+  return {
+    id: profile ? `agent-profile:${safeId(profile.id)}` : 'agent-profile:none',
+    kind: 'agent-profile',
+    authority: cloneAuthority(WILDCARD_AUTHORITY),
+    enforcement: { ...ENFORCED },
+  };
+}
+
+function sandboxSource(
+  input: PhaseLaunchAuthorityCompileInput,
+  desired: PhaseAuthority
+): PhaseCapabilityCompilerSources['sandbox'] {
+  const preset = input.sandboxPolicy.preset;
+  const effective = input.sandboxPolicy.effective;
+  const credentialScopes =
+    preset.credentials.mode === 'none'
+      ? []
+      : preset.credentials.mode === 'brokered'
+        ? [...effective.credentialRefs]
+        : preset.environment.passthrough
+            .filter(isCredentialEnvironmentKey)
+            .map((key) => `env:${key}`);
+  const networkScopes = !effective.networkAccessEnabled
+    ? []
+    : preset.network.defaultEgress === 'allow'
+      ? ['*']
+      : [...preset.network.allowedHosts];
+  const sandboxAuthority = authority({
+    'filesystem.read': [...preset.filesystem.readPaths],
+    'filesystem.write':
+      effective.sandboxMode === 'read-only' ? [] : [...preset.filesystem.writePaths],
+    'command.execute': ['*'],
+    'network.egress': networkScopes,
+    'credential.access': credentialScopes,
+    'external.action': ['*'],
+    'artifact.plan.write': ['*'],
+  });
+
+  return {
+    id: `sandbox:${safeId(preset.id)}`,
+    kind: 'sandbox',
+    authority: sandboxAuthority,
+    enforcement: {
+      'filesystem.read': filesystemEnforcement(input, desired['filesystem.read'], false),
+      'filesystem.write': filesystemEnforcement(input, desired['filesystem.write'], true),
+      'command.execute': 'enforced',
+      'network.egress': networkEnforcement(
+        input.providerRuntimeManifest,
+        desired['network.egress']
+      ),
+      'credential.access': credentialEnforcement(
+        input.providerRuntimeManifest,
+        preset.credentials.mode,
+        desired['credential.access']
+      ),
+      'external.action': 'enforced',
+      'artifact.plan.write': 'enforced',
+    },
+  };
+}
+
+function toolCatalogSource(
+  input: PhaseLaunchAuthorityCompileInput,
+  desired: PhaseAuthority,
+  explicitPhase: boolean
+): PhaseCapabilityCompilerSources['toolCatalog'] {
+  const configured = input.executionEnforcement;
+  return {
+    id: input.toolCatalogId ? `tool-catalog:${safeId(input.toolCatalogId)}` : 'tool-catalog:none',
+    kind: 'tool-catalog',
+    authority: cloneAuthority(WILDCARD_AUTHORITY),
+    enforcement: {
+      ...ENFORCED,
+      'command.execute': configured?.commandExecute ?? (explicitPhase ? 'unsupported' : 'enforced'),
+      'external.action': configured?.externalAction ?? (explicitPhase ? 'unsupported' : 'enforced'),
+      'artifact.plan.write':
+        desired['artifact.plan.write'].length === 0
+          ? 'enforced'
+          : (configured?.planArtifactWrite ?? (explicitPhase ? 'unsupported' : 'enforced')),
+    },
+  };
+}
+
+function launchPolicySource(
+  input: PhaseLaunchAuthorityCompileInput
+): PhaseCapabilityCompilerSources['launchPolicy'] {
+  return {
+    id: `launch-policy:${safeId(input.providerRuntimeManifest.provider)}:${safeId(input.selectedHost)}`,
+    kind: 'launch-policy',
+    authority: cloneAuthority(WILDCARD_AUTHORITY),
+    enforcement: { ...ENFORCED },
+  };
+}
+
+function referenceFor(
+  source: PhaseAuthoritySource,
+  originScope: RunLaunchManifestOriginScope,
+  parent?: PhaseLaunchParentSnapshot,
+  parentEvidence?: PhaseCapabilityEvidence
+): RunLaunchPhaseSourceReference {
+  return {
+    sourceId: source.id,
+    kind: source.kind,
+    originScope,
+    sourceDigest: digestRunLaunchValue(source),
+    ...(parent
+      ? {
+          parentAttemptId: parent.attemptId,
+          ...(parent.manifestDigest ? { parentManifestDigest: parent.manifestDigest } : {}),
+          ...(parentEvidence ? { parentEvidenceDigest: parentEvidence.digest } : {}),
+        }
+      : {}),
+  };
+}
+
+function filesystemEnforcement(
+  input: PhaseLaunchAuthorityCompileInput,
+  desiredScopes: string[],
+  write: boolean
+): PhaseAuthorityEnforcementState {
+  const boundaryState =
+    input.filesystemSandbox?.state ??
+    (input.sandboxPolicy.effective.filesystemBackend.state === 'available'
+      ? 'enforced'
+      : input.sandboxPolicy.effective.filesystemBackend.state);
+  if (boundaryState !== 'enforced' && boundaryState !== 'native') {
+    return boundaryState === 'advisory' ? 'unenforceable' : 'unsupported';
+  }
+  if (write && desiredScopes.length === 0) {
+    return runtimeCapabilityState(input.providerRuntimeManifest, 'filesystem.read');
+  }
+  return runtimeCapabilityState(
+    input.providerRuntimeManifest,
+    write ? 'filesystem.write' : 'filesystem.read'
+  );
+}
+
+function networkEnforcement(
+  manifest: ProviderRuntimeManifest,
+  desiredScopes: string[]
+): PhaseAuthorityEnforcementState {
+  if (desiredScopes.includes('*')) return 'enforced';
+  return runtimeCapabilityState(
+    manifest,
+    desiredScopes.length === 0 ? 'network.disable' : 'network.allowlist'
+  );
+}
+
+function credentialEnforcement(
+  manifest: ProviderRuntimeManifest,
+  mode: SandboxPolicyPreset['credentials']['mode'],
+  desiredScopes: string[]
+): PhaseAuthorityEnforcementState {
+  if (desiredScopes.length === 0 || desiredScopes.includes('*')) return 'enforced';
+  return runtimeCapabilityState(
+    manifest,
+    mode === 'brokered' ? 'credential.broker' : 'environment.allowlist'
+  );
+}
+
+function runtimeCapabilityState(
+  manifest: ProviderRuntimeManifest,
+  capabilityId: ProviderRuntimeCapabilityId
+): PhaseAuthorityEnforcementState {
+  const state = manifest.capabilities.find((capability) => capability.id === capabilityId)?.state;
+  if (state === 'supported') return 'enforced';
+  if (state === 'advisory') return 'unenforceable';
+  return 'unsupported';
+}
+
+function verifiedParentEvidence(
+  parent: PhaseLaunchParentSnapshot | undefined
+): PhaseCapabilityEvidence | undefined {
+  if (!parent?.evidence) return undefined;
+  const evidence = phaseCapabilityEvidenceSchema.parse(parent.evidence) as PhaseCapabilityEvidence;
+  if (!verifyPhaseCapabilityEvidenceDigest(evidence)) {
+    throw new ConflictError('Parent phase evidence digest does not match its content.', {
+      parentAttemptId: parent.attemptId,
+      parentEvidenceDigest: evidence.digest,
+    });
+  }
+  if (evidence.status === 'blocked') {
+    throw new ConflictError('Blocked parent phase evidence cannot authorize a descendant.', {
+      parentAttemptId: parent.attemptId,
+      parentEvidenceDigest: evidence.digest,
+    });
+  }
+  return evidence;
+}
+
+function authority(overrides: Partial<PhaseAuthority> = {}): PhaseAuthority {
+  return Object.fromEntries(
+    PHASE_AUTHORITY_DIMENSIONS.map((dimension) => [dimension, [...(overrides[dimension] ?? [])]])
+  ) as PhaseAuthority;
+}
+
+function enforcement(state: PhaseAuthorityEnforcementState): PhaseAuthorityEnforcement {
+  return Object.fromEntries(
+    PHASE_AUTHORITY_DIMENSIONS.map((dimension) => [dimension, state])
+  ) as PhaseAuthorityEnforcement;
+}
+
+function cloneAuthority(value: PhaseAuthority): PhaseAuthority {
+  return authority(value);
+}
+
+function intersectAuthority(left: PhaseAuthority, right: PhaseAuthority): PhaseAuthority {
+  return Object.fromEntries(
+    PHASE_AUTHORITY_DIMENSIONS.map((dimension) => [
+      dimension,
+      intersectScopes(left[dimension], right[dimension]),
+    ])
+  ) as PhaseAuthority;
+}
+
+function intersectScopes(left: string[], right: string[]): string[] {
+  if (left.length === 0 || right.length === 0) return [];
+  if (left.includes('*')) return [...right];
+  if (right.includes('*')) return [...left];
+  const rightScopes = new Set(right);
+  return left.filter((scope) => rightScopes.has(scope));
+}
+
+function narrowScopes(configured: string[], ceiling: string[]): string[] {
+  if (ceiling.includes('*')) return [...configured];
+  return intersectScopes(configured, ceiling);
+}
+
+function isCredentialEnvironmentKey(key: string): boolean {
+  return /(?:API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|ACCESS_KEY)$/i.test(key);
+}
+
+function safeId(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/[^a-z0-9._:/-]+/gi, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[^a-z0-9]+/i, '')
+    .slice(0, 120);
+  return normalized || 'unknown';
+}
+
+export function phaseAuthorityHasScope(
+  authorityValue: PhaseAuthority,
+  dimension: PhaseAuthorityDimension,
+  scope: string
+): boolean {
+  const scopes = authorityValue[dimension];
+  return scopes.includes('*') || scopes.includes(scope);
+}

--- a/server/src/services/run-launch-manifest-service.ts
+++ b/server/src/services/run-launch-manifest-service.ts
@@ -19,6 +19,7 @@ import type {
   RunLaunchRuntime,
   RunLaunchTools,
   RunLaunchFilesystemSandboxEvidence,
+  RunLaunchPhaseAuthority,
   SandboxPolicyDryRunResult,
   TaskEnvelope,
   TaskReadinessSummary,
@@ -60,6 +61,7 @@ export interface RunLaunchManifestCompileInput {
   harnessSupport: HarnessSupportStatus;
   routing: RunLaunchRouting;
   profile?: RunLaunchProfileReference;
+  phase: RunLaunchPhaseAuthority;
   readiness: {
     summary: TaskReadinessSummary;
     overrideReason?: string;
@@ -86,6 +88,7 @@ const MATERIAL_SECTIONS: Array<keyof RunLaunchManifest> = [
   'harnessSupport',
   'routing',
   'profile',
+  'phase',
   'readiness',
   'instructions',
   'workspace',
@@ -186,6 +189,7 @@ export class RunLaunchManifestService {
         .filter((capability) => capability.advisory)
         .map((capability) => `${capability.id}: ${capability.reason}`),
       ...(input.harnessSupport.supportTier === 'degraded' ? [input.harnessSupport.reason] : []),
+      ...input.phase.evidence.warnings,
     ]).map(sanitizeProviderRuntimeDiagnostic);
     const payload: Omit<RunLaunchManifest, 'digest'> = {
       schemaVersion: RUN_LAUNCH_MANIFEST_SCHEMA_VERSION,
@@ -224,6 +228,7 @@ export class RunLaunchManifestService {
         reason: sanitizeProviderRuntimeDiagnostic(input.routing.reason),
       },
       ...(input.profile ? { profile: { ...input.profile } } : {}),
+      phase: structuredClone(input.phase),
       readiness: {
         ready: input.readiness.summary.ready,
         overridden:
@@ -560,6 +565,16 @@ function collectBlockers({
   const add = (code: string, field: string, detail: string, remediation: string): void => {
     blockers.push({ code, field, detail, remediation });
   };
+  for (const blocker of input.phase.evidence.blockers) {
+    add(
+      `phase-${blocker.code}`,
+      blocker.dimension ? `phase.evidence.${blocker.dimension}` : 'phase.evidence',
+      blocker.message,
+      blocker.sourceId
+        ? `Select launch evidence that enforces ${blocker.dimension ?? 'the required phase authority'} at ${blocker.sourceId}.`
+        : 'Select a compatible phase, provider, host, sandbox, and tool policy before launch.'
+    );
+  }
   if (credentials.brokerState === 'blocked') {
     add(
       'credential-boundary-unavailable',

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -56,6 +56,7 @@ const RESERVED_CONTEXT_KEYS = new Set([
   'run',
   'pipeline',
   '_sessions',
+  '_sessionPhaseAuthority',
   '_retryContext',
   '_gateBlock',
   '_gateApproval',
@@ -75,9 +76,11 @@ export class WorkflowRunService {
     this.runsDir = resolvedOptions.runsDir || getWorkflowRunsDir();
     this.workflowService = resolvedOptions.workflowService ?? getWorkflowService();
     this.runRecoveryPolicy = resolvedOptions.runRecoveryPolicy ?? new RunRecoveryPolicyService();
-    this.stepExecutor = new WorkflowStepExecutor(resolvedOptions.runsDir, {
-      persistRun: (run) => this.saveRun(run),
-    });
+    this.stepExecutor =
+      resolvedOptions.stepExecutor ??
+      new WorkflowStepExecutor(resolvedOptions.runsDir, {
+        persistRun: (run) => this.saveRun(run),
+      });
     const storageType =
       resolvedOptions.storageType ?? (process.env.VERITAS_STORAGE === 'sqlite' ? 'sqlite' : 'file');
 
@@ -460,29 +463,32 @@ export class WorkflowRunService {
           continue;
         }
 
-        // Update current step
-        run.currentStep = step.id;
-        await this.saveRun(run);
-        broadcastWorkflowStatus(run);
-
         const stepRun = existingStepRun;
-        stepRun.agent ??= step.agent;
-        stepRun.status = 'running';
-        stepRun.startedAt = new Date().toISOString();
-        if (stepRun.runRetry?.state === 'launching') {
-          stepRun.runRetry = {
-            ...stepRun.runRetry,
-            state: 'launched',
-            launchedAt: stepRun.startedAt,
-            launchedRunId: `${run.id}:${step.id}:${stepRun.runRetry.sequence}`,
-            selectedAgent: stepRun.agent ?? stepRun.runRetry.selectedAgent,
-          };
-        }
-        this.syncPipelineSummary(run, workflow);
-        await this.saveRun(run);
 
         try {
-          const result = await this.stepExecutor.executeStep(step, run);
+          // Resolve runtime, sandbox, host, and phase authority before creating
+          // or mutating the executable step attempt.
+          const preparation = await this.stepExecutor.prepareStep(step, run);
+          run.currentStep = step.id;
+          stepRun.agent ??= preparation.step.agent ?? step.agent;
+          this.stepExecutor.applyPreparation(run, preparation);
+          stepRun.status = 'running';
+          stepRun.error = undefined;
+          stepRun.startedAt = new Date().toISOString();
+          if (stepRun.runRetry?.state === 'launching') {
+            stepRun.runRetry = {
+              ...stepRun.runRetry,
+              state: 'launched',
+              launchedAt: stepRun.startedAt,
+              launchedRunId: `${run.id}:${step.id}:${stepRun.runRetry.sequence}`,
+              selectedAgent: stepRun.agent ?? stepRun.runRetry.selectedAgent,
+            };
+          }
+          this.syncPipelineSummary(run, workflow);
+          await this.saveRun(run);
+          broadcastWorkflowStatus(run);
+
+          const result = await this.stepExecutor.executeStep(step, run, preparation);
           if (result.budgetUsage) {
             const budgetBlocked = await this.evaluateRunBudget(
               run,
@@ -514,6 +520,7 @@ export class WorkflowRunService {
           await this.saveRun(run);
           broadcastWorkflowStatus(run);
         } catch (err: unknown) {
+          run.currentStep = step.id;
           // --- Gate human-escalation (#778) ---
           // HumanGateBlockError is a clean, expected pause — not a real failure.
           // Handle it before the generic failure path so on_fail is not misapplied.
@@ -1581,6 +1588,7 @@ export interface WorkflowRunServiceOptions {
   sqliteConnectionOptions?: SqliteConnectionOptions;
   workflowService?: ReturnType<typeof getWorkflowService>;
   runRecoveryPolicy?: RunRecoveryPolicyService;
+  stepExecutor?: WorkflowStepExecutor;
 }
 
 // Singleton

--- a/server/src/services/workflow-service.ts
+++ b/server/src/services/workflow-service.ts
@@ -6,6 +6,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import yaml from 'yaml';
+import { PHASE_NAMES, type PhaseName } from '@veritas-kanban/shared';
 import type { WorkflowDefinition, WorkflowACL, WorkflowAuditEvent } from '../types/workflow.js';
 import { ValidationError } from '../types/workflow.js';
 import { getWorkflowsDir } from '../utils/paths.js';
@@ -348,6 +349,12 @@ export class WorkflowService {
     }
 
     for (const step of workflow.steps) {
+      if (step.phase !== undefined && !PHASE_NAMES.includes(step.phase as PhaseName)) {
+        throw new ValidationError(
+          `Step ${step.id} phase must be one of: ${PHASE_NAMES.join(', ')}`
+        );
+      }
+
       // Agent steps must reference a valid agent
       if ((step.type === 'agent' || step.type === 'loop') && !agentIdSet.has(step.agent!)) {
         throw new ValidationError(`Step ${step.id} references unknown agent ${step.agent}`);

--- a/server/src/services/workflow-step-executor.ts
+++ b/server/src/services/workflow-step-executor.ts
@@ -13,6 +13,7 @@ import type {
   ExecutableAgentProvider,
   ProviderRuntimeCapabilityId,
   ProviderRuntimeManifest,
+  RunLaunchPhaseAuthority,
   SandboxPolicyDryRunResult,
 } from '@veritas-kanban/shared';
 import type {
@@ -46,6 +47,11 @@ import {
   BASELINE_LAUNCH_CAPABILITIES,
   providerRuntimeControls,
 } from './provider-runtime-control-service.js';
+import {
+  PhaseLaunchAuthorityService,
+  type PhaseLaunchParentSnapshot,
+} from './phase-launch-authority-service.js';
+import { digestRunLaunchValue } from '../utils/run-launch-manifest-digest.js';
 
 const log = createLogger('workflow-step-executor');
 
@@ -73,15 +79,49 @@ interface WorkflowStepExecutorOptions {
   openClawAdapter?: OpenClawWorkflowAdapter;
   runtimeManifestResolver?: (agent: AgentConfig) => Promise<ProviderRuntimeManifest>;
   persistRun?: (run: WorkflowRun) => Promise<void>;
+  phaseAuthority?: PhaseLaunchAuthorityService;
 }
 
 type WorkflowExecutableProvider = Extract<ExecutableAgentProvider, 'codex-sdk' | 'openclaw'>;
+
+export interface WorkflowAgentStepPreparation {
+  kind: 'agent';
+  step: WorkflowStep;
+  agentDef: WorkflowAgent | null;
+  sessionConfig: StepSessionConfig;
+  sessionContext: Record<string, unknown>;
+  prompt: string;
+  toolPolicyFilter: { allowed?: string[]; denied?: string[] };
+  workingDirectory: string;
+  runtimeProvider: WorkflowExecutableProvider;
+  runtimeManifest: ProviderRuntimeManifest;
+  requiredRuntimeCapabilities: ProviderRuntimeCapabilityId[];
+  sandboxPolicy: SandboxPolicyDryRunResult;
+  hostRouting: AgentHostRoutingDecision;
+  hostRoutingGeneratedAt: string;
+  phaseAuthority: RunLaunchPhaseAuthority;
+  phaseLaunchDigest: string;
+}
+
+export type WorkflowStepExecutionPreparation =
+  | WorkflowAgentStepPreparation
+  | {
+      kind: 'non-agent';
+      step: WorkflowStep;
+    };
+
+interface WorkflowSessionPhaseSnapshot {
+  attemptId: string;
+  manifestDigest: string;
+  phaseAuthority: RunLaunchPhaseAuthority;
+}
 
 export class WorkflowStepExecutor {
   private runsDir: string;
   private openClawAdapter: OpenClawWorkflowAdapter;
   private runtimeManifestResolver: (agent: AgentConfig) => Promise<ProviderRuntimeManifest>;
   private persistRun: (run: WorkflowRun) => Promise<void>;
+  private phaseAuthority: PhaseLaunchAuthorityService;
   private appendCountCache?: Map<string, number>; // Performance: Track append counts to reduce stat() calls
 
   constructor(runsDir?: string, options: WorkflowStepExecutorOptions = {}) {
@@ -94,19 +134,31 @@ export class WorkflowStepExecutor {
         return clawdbotAgentService.probeProviderRuntime(agent, agent.type, 'workflow');
       });
     this.persistRun = options.persistRun ?? (async () => undefined);
+    this.phaseAuthority = options.phaseAuthority ?? new PhaseLaunchAuthorityService();
   }
 
   /**
    * Execute a single workflow step
    */
-  async executeStep(step: WorkflowStep, run: WorkflowRun): Promise<StepExecutionResult> {
+  async executeStep(
+    step: WorkflowStep,
+    run: WorkflowRun,
+    preparation?: WorkflowStepExecutionPreparation
+  ): Promise<StepExecutionResult> {
     log.info({ runId: run.id, stepId: step.id, type: step.type }, 'Executing step');
-    const selectedAgent = run.steps.find((candidate) => candidate.stepId === step.id)?.agent;
-    const effectiveStep = selectedAgent ? { ...step, agent: selectedAgent } : step;
+    const resolved = preparation ?? (await this.prepareStep(step, run));
+    if (!preparation) {
+      this.applyPreparation(run, resolved);
+      await this.persistRun(run);
+    }
+    const effectiveStep = resolved.step;
 
     switch (effectiveStep.type) {
       case 'agent':
-        return this.executeAgentStep(effectiveStep, run);
+        if (resolved.kind !== 'agent') {
+          throw new Error(`Workflow step ${effectiveStep.id} is missing agent launch preparation`);
+        }
+        return this.executeAgentStep(resolved, run);
       case 'loop':
         return this.executeLoopStep(effectiveStep, run);
       case 'gate':
@@ -119,6 +171,53 @@ export class WorkflowStepExecutor {
   }
 
   /**
+   * Resolve every launch control before WorkflowRunService mutates step state.
+   */
+  async prepareStep(
+    step: WorkflowStep,
+    run: WorkflowRun
+  ): Promise<WorkflowStepExecutionPreparation> {
+    const selectedAgent = run.steps.find((candidate) => candidate.stepId === step.id)?.agent;
+    const effectiveStep = selectedAgent ? { ...step, agent: selectedAgent } : step;
+    if (effectiveStep.type !== 'agent') {
+      return { kind: 'non-agent', step: effectiveStep };
+    }
+    return this.prepareAgentStep(effectiveStep, run);
+  }
+
+  /**
+   * Persist the exact prepared evidence only after all phase controls pass.
+   */
+  applyPreparation(run: WorkflowRun, preparation: WorkflowStepExecutionPreparation): void {
+    if (preparation.kind !== 'agent') return;
+    const stepRun = run.steps.find((candidate) => candidate.stepId === preparation.step.id);
+    if (!stepRun) {
+      throw new Error(`Workflow run is missing step state for ${preparation.step.id}`);
+    }
+    stepRun.agent = preparation.step.agent;
+    stepRun.providerRuntimeManifest = preparation.runtimeManifest;
+    stepRun.requiredRuntimeCapabilities = [
+      ...new Set(preparation.requiredRuntimeCapabilities),
+    ].sort((left, right) => left.localeCompare(right));
+    stepRun.runtimeControls = providerRuntimeControls(preparation.runtimeManifest);
+    stepRun.phaseAuthority = structuredClone(preparation.phaseAuthority);
+    stepRun.phaseLaunchDigest = preparation.phaseLaunchDigest;
+    if (stepRun.runRetry?.state === 'launched') {
+      stepRun.runRetry = {
+        ...stepRun.runRetry,
+        launchedManifestDigest: preparation.runtimeManifest.digest,
+        requiredRuntimeCapabilities: [...stepRun.requiredRuntimeCapabilities],
+      };
+    }
+    this.recordAgentHostRouting(
+      run,
+      preparation.step,
+      preparation.hostRouting,
+      preparation.hostRoutingGeneratedAt
+    );
+  }
+
+  /**
    * Probe a fallback through the same capability and sandbox gates used by a
    * real workflow launch, without creating a provider session.
    */
@@ -128,58 +227,21 @@ export class WorkflowStepExecutor {
     agentId: string
   ): Promise<ProviderRuntimeManifest> {
     const effectiveStep = { ...step, agent: agentId };
-    let agentDef = this.getAgentDefinition(run, agentId);
-    if (!agentDef) {
+    if (!this.getAgentDefinition(run, agentId)) {
       throw new Error(`Workflow fallback agent ${agentId} is not defined in the workflow`);
     }
-    if (run.budget?.modelOverride) {
-      agentDef = { ...agentDef, model: run.budget.modelOverride };
-    }
-    const workflowConfig = run.context.workflow as
-      { config?: { fresh_session_default?: boolean } } | undefined;
-    const sessionConfig = this.buildSessionConfig(effectiveStep, run, workflowConfig?.config);
-    const toolPolicyFilter = await this.getToolPolicyForAgent(agentDef);
-    const runtimeProvider = this.resolveWorkflowProvider(effectiveStep, agentDef);
-    const runtimeManifest = await this.resolveRuntimeManifest(
-      effectiveStep,
-      agentDef,
-      runtimeProvider
-    );
-    const requiredRuntimeCapabilities = this.requiredRuntimeCapabilities(
-      effectiveStep,
-      run,
-      agentDef,
-      runtimeProvider,
-      sessionConfig,
-      toolPolicyFilter
-    );
-    assertProviderRuntimeCapabilities(
-      runtimeManifest,
-      requiredRuntimeCapabilities,
-      `workflow fallback ${agentId} for step ${step.id}`
-    );
-    const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
-      presetId: agentDef.sandboxPresetId,
-      provider: runtimeManifest.provider,
-      workspacePath: this.expandPath(this.getWorkflowWorkingDirectory(run)),
-      providerRuntimeManifest: runtimeManifest,
-    });
-    if (sandboxPolicy.result.decision === 'block') {
-      throw new Error(
-        `Workflow fallback ${agentId} cannot enforce sandbox preset ${sandboxPolicy.result.preset.id}`
-      );
-    }
-    return runtimeManifest;
+    const preparation = await this.prepareAgentStep(effectiveStep, run);
+    return preparation.runtimeManifest;
   }
 
   /**
    * Execute an agent step through its configured provider.
    * Integrated features: #108 (progress), #110 (tool policies), #111 (session management)
    */
-  private async executeAgentStep(
+  private async prepareAgentStep(
     step: WorkflowStep,
     run: WorkflowRun
-  ): Promise<StepExecutionResult> {
+  ): Promise<WorkflowAgentStepPreparation> {
     if (!step.agent) {
       throw new Error(`Agent step ${step.id} missing agent`);
     }
@@ -221,13 +283,25 @@ export class WorkflowStepExecutor {
       requiredRuntimeCapabilities,
       `workflow step ${step.id} launch`
     );
-    await this.recordRuntimeManifest(run, step, runtimeManifest, requiredRuntimeCapabilities);
-    const sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
+    const parentPhase = this.resolveWorkflowPhaseParent(step, run, sessionConfig);
+    let sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
       presetId: agentDef?.sandboxPresetId,
       provider: runtimeManifest.provider,
       workspacePath: workingDirectory,
       providerRuntimeManifest: runtimeManifest,
     });
+    if (step.phase || parentPhase?.evidence?.identity.mode === 'profile') {
+      sandboxPolicy = await getSandboxPolicyService().dryRunWithTrace({
+        preset: this.phaseAuthority.narrowSandboxPreset(
+          sandboxPolicy.result.preset,
+          step.phase,
+          parentPhase
+        ),
+        provider: runtimeManifest.provider,
+        workspacePath: workingDirectory,
+        providerRuntimeManifest: runtimeManifest,
+      });
+    }
     const sandboxTrace = await getGovernanceTraceService().record(sandboxPolicy.trace);
     if (sandboxPolicy.result.decision === 'block') {
       throw new Error(
@@ -244,7 +318,38 @@ export class WorkflowStepExecutor {
       verificationGates: step.acceptance_criteria,
       sandboxPresetId: sandboxPolicy.result.preset.id,
     });
-    this.recordAgentHostRouting(run, step, hostPreview.decision, hostPreview.generatedAt);
+    const selectedHost =
+      hostPreview.decision.selectedHostId ??
+      (runtimeProvider === 'openclaw' ? 'openclaw-gateway' : 'local-process');
+    const phaseAuthority = this.phaseAuthority.compile({
+      requestedPhase: step.phase,
+      parent: parentPhase,
+      ...(agentDef
+        ? {
+            agentProfile: {
+              id: agentDef.id,
+              version: run.workflowVersion,
+            },
+          }
+        : {}),
+      sandboxPolicy: sandboxPolicy.result,
+      providerRuntimeManifest: runtimeManifest,
+      selectedHost,
+      toolCatalogId: digestRunLaunchValue(toolPolicyFilter),
+    });
+    this.phaseAuthority.assertEnforceable(phaseAuthority);
+    const phaseLaunchDigest = digestRunLaunchValue({
+      schemaVersion: 'workflow-phase-launch/v1',
+      workflowId: run.workflowId,
+      workflowVersion: run.workflowVersion,
+      runId: run.id,
+      stepId: step.id,
+      agent: step.agent,
+      providerRuntimeManifestDigest: runtimeManifest.digest,
+      selectedHost,
+      phaseEvidenceDigest: phaseAuthority.evidence.digest,
+      phaseSourceReferences: phaseAuthority.sourceReferences,
+    });
 
     log.info(
       {
@@ -262,30 +367,54 @@ export class WorkflowStepExecutor {
       'Agent step execution configured'
     );
 
-    if (runtimeProvider === 'codex-sdk') {
+    return {
+      kind: 'agent',
+      step,
+      agentDef,
+      sessionConfig,
+      sessionContext,
+      prompt,
+      toolPolicyFilter,
+      workingDirectory,
+      runtimeProvider,
+      runtimeManifest,
+      requiredRuntimeCapabilities,
+      sandboxPolicy: sandboxPolicy.result,
+      hostRouting: hostPreview.decision,
+      hostRoutingGeneratedAt: hostPreview.generatedAt,
+      phaseAuthority,
+      phaseLaunchDigest,
+    };
+  }
+
+  private async executeAgentStep(
+    preparation: WorkflowAgentStepPreparation,
+    run: WorkflowRun
+  ): Promise<StepExecutionResult> {
+    if (preparation.runtimeProvider === 'codex-sdk') {
       return this.executeCodexAgentStep(
-        step,
+        preparation.step,
         run,
-        agentDef,
-        prompt,
-        sessionConfig,
-        toolPolicyFilter,
-        hostPreview.decision,
-        sandboxPolicy.result,
-        runtimeManifest
+        preparation.agentDef,
+        preparation.prompt,
+        preparation.sessionConfig,
+        preparation.toolPolicyFilter,
+        preparation.hostRouting,
+        preparation.sandboxPolicy,
+        preparation.runtimeManifest
       );
     }
 
     return this.executeOpenClawAgentStep(
-      step,
+      preparation.step,
       run,
-      agentDef,
-      prompt,
-      sessionConfig,
-      sessionContext,
-      toolPolicyFilter,
-      hostPreview.decision,
-      runtimeManifest
+      preparation.agentDef,
+      preparation.prompt,
+      preparation.sessionConfig,
+      preparation.sessionContext,
+      preparation.toolPolicyFilter,
+      preparation.hostRouting,
+      preparation.runtimeManifest
     );
   }
 
@@ -408,7 +537,74 @@ export class WorkflowStepExecutor {
     const stepRun = run.steps.find((s) => s.stepId === step.id);
     if (stepRun) {
       stepRun.sessionKey = sessionKey;
+      if (stepRun.phaseAuthority && stepRun.phaseLaunchDigest) {
+        run.context._sessionPhaseAuthority = {
+          ...((run.context._sessionPhaseAuthority as
+            Record<string, WorkflowSessionPhaseSnapshot> | undefined) ?? {}),
+          [agentId]: {
+            attemptId: this.workflowStepAttemptId(run, stepRun.stepId),
+            manifestDigest: stepRun.phaseLaunchDigest,
+            phaseAuthority: structuredClone(stepRun.phaseAuthority),
+          },
+        };
+      }
     }
+  }
+
+  private resolveWorkflowPhaseParent(
+    step: WorkflowStep,
+    run: WorkflowRun,
+    sessionConfig: StepSessionConfig
+  ): PhaseLaunchParentSnapshot | undefined {
+    const stepRun = run.steps.find((candidate) => candidate.stepId === step.id);
+    if (stepRun?.phaseAuthority && stepRun.phaseLaunchDigest) {
+      return {
+        attemptId: this.workflowStepAttemptId(run, step.id),
+        manifestDigest: stepRun.phaseLaunchDigest,
+        evidence: stepRun.phaseAuthority.evidence,
+      };
+    }
+
+    if (sessionConfig.mode !== 'reuse') return undefined;
+    const agentId = step.agent ?? step.id;
+    const sessionKey = (run.context._sessions as Record<string, string> | undefined)?.[agentId];
+    if (!sessionKey) return undefined;
+    const sessionPhase = (
+      run.context._sessionPhaseAuthority as Record<string, WorkflowSessionPhaseSnapshot> | undefined
+    )?.[agentId];
+    if (sessionPhase) {
+      if (
+        !sessionPhase.attemptId ||
+        !sessionPhase.manifestDigest ||
+        !sessionPhase.phaseAuthority?.evidence
+      ) {
+        throw new Error(`Workflow session ${agentId} has invalid phase authority evidence`);
+      }
+      return {
+        attemptId: sessionPhase.attemptId,
+        manifestDigest: sessionPhase.manifestDigest,
+        evidence: sessionPhase.phaseAuthority.evidence,
+      };
+    }
+
+    const legacyDigest = digestRunLaunchValue({
+      schemaVersion: 'workflow-legacy-session-phase/v1',
+      workflowId: run.workflowId,
+      workflowVersion: run.workflowVersion,
+      runId: run.id,
+      agentId,
+      sessionKeyDigest: digestRunLaunchValue(sessionKey),
+    });
+    return {
+      attemptId: `legacy-session:${legacyDigest.slice(0, 20)}`,
+      manifestDigest: legacyDigest,
+    };
+  }
+
+  private workflowStepAttemptId(run: WorkflowRun, stepId: string): string {
+    const stepRun = run.steps.find((candidate) => candidate.stepId === stepId);
+    const sequence = stepRun?.runRetry?.sequence ?? stepRun?.retries ?? 0;
+    return `${run.id}:${stepId}:${sequence}`;
   }
 
   private recordAgentHostRouting(
@@ -538,30 +734,6 @@ export class WorkflowStepExecutor {
     }
 
     return [...required].sort((left, right) => left.localeCompare(right));
-  }
-
-  private async recordRuntimeManifest(
-    run: WorkflowRun,
-    step: WorkflowStep,
-    manifest: ProviderRuntimeManifest,
-    requiredRuntimeCapabilities: ProviderRuntimeCapabilityId[]
-  ): Promise<void> {
-    const stepRun = run.steps.find((candidate) => candidate.stepId === step.id);
-    if (stepRun) {
-      stepRun.providerRuntimeManifest = manifest;
-      stepRun.requiredRuntimeCapabilities = [...new Set(requiredRuntimeCapabilities)].sort(
-        (left, right) => left.localeCompare(right)
-      );
-      stepRun.runtimeControls = providerRuntimeControls(manifest);
-      if (stepRun.runRetry?.state === 'launched') {
-        stepRun.runRetry = {
-          ...stepRun.runRetry,
-          launchedManifestDigest: manifest.digest,
-          requiredRuntimeCapabilities: [...stepRun.requiredRuntimeCapabilities],
-        };
-      }
-    }
-    await this.persistRun(run);
   }
 
   private assertOpenClawResult(
@@ -728,10 +900,7 @@ export class WorkflowStepExecutor {
       }
       if (event.type === 'thread.started') {
         threadId = event.thread_id;
-        run.context._sessions = {
-          ...((run.context._sessions as Record<string, string> | undefined) || {}),
-          [sessionKey]: threadId,
-        };
+        this.recordWorkflowSession(run, step, sessionKey, threadId);
       }
       if (event.type === 'item.completed' && event.item.type === 'agent_message') {
         finalResponse = event.item.text;

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -122,6 +122,8 @@ export interface WorkflowStep {
   name: string;
   agent?: string; // agent ID (required for type=agent|loop)
   type: StepType;
+  /** Optional built-in execution phase. Omitted definitions run in explicit legacy mode. */
+  phase?: import('@veritas-kanban/shared').PhaseName;
   fresh_session?: boolean; // Legacy: use session config instead
   session?: StepSessionConfig; // Session configuration (#111)
   input?: string; // Jinja2 template
@@ -230,6 +232,10 @@ export interface StepRun {
   /** Exact runtime capabilities required by the recorded provider launch. */
   requiredRuntimeCapabilities?: import('@veritas-kanban/shared').ProviderRuntimeCapabilityId[];
   runtimeControls?: import('@veritas-kanban/shared').ProviderRuntimeControlSet;
+  /** Exact phase authority resolved before this step launch mutated run state. */
+  phaseAuthority?: import('@veritas-kanban/shared').RunLaunchPhaseAuthority;
+  /** Digest of the immutable workflow step launch snapshot that owns phaseAuthority. */
+  phaseLaunchDigest?: string;
   /** Durable retry/fallback decision for this workflow step. */
   runRetry?: import('@veritas-kanban/shared').RunRecoveryRecord;
 

--- a/shared/src/types/run-launch-manifest.types.ts
+++ b/shared/src/types/run-launch-manifest.types.ts
@@ -1,4 +1,8 @@
 import type { AgentBudgetPolicy } from './agent-budget.types.js';
+import type {
+  PhaseAuthoritySourceKind,
+  PhaseCapabilityEvidence,
+} from './phase-capability.types.js';
 import type { HarnessSupportTier, HarnessTransport } from './provider-runtime.types.js';
 import type { ProviderRuntimeCapabilityState } from './provider-runtime.types.js';
 
@@ -13,6 +17,7 @@ export type RunLaunchManifestInstructionKind =
 
 export type RunLaunchManifestOriginScope =
   | 'run'
+  | 'parent'
   | 'task-envelope'
   | 'agent-profile'
   | 'workflow'
@@ -266,6 +271,25 @@ export interface RunLaunchManifestOrigin {
   precedence: number;
 }
 
+export interface RunLaunchPhaseSourceReference {
+  sourceId: string;
+  kind: PhaseAuthoritySourceKind;
+  originScope: RunLaunchManifestOriginScope;
+  sourceDigest: string;
+  parentAttemptId?: string;
+  parentManifestDigest?: string;
+  parentEvidenceDigest?: string;
+}
+
+/**
+ * Immutable effective phase authority and the exact source snapshots that
+ * produced it. `phase-capability-evidence/v1` carries no credential values.
+ */
+export interface RunLaunchPhaseAuthority {
+  evidence: PhaseCapabilityEvidence;
+  sourceReferences: RunLaunchPhaseSourceReference[];
+}
+
 export interface RunLaunchManifestBlocker {
   code: string;
   field: string;
@@ -297,6 +321,8 @@ export interface RunLaunchManifest {
   harnessSupport: RunLaunchHarnessSupport;
   routing: RunLaunchRouting;
   profile?: RunLaunchProfileReference;
+  /** Present on manifests compiled after phase launch propagation shipped. */
+  phase?: RunLaunchPhaseAuthority;
   readiness: RunLaunchReadiness;
   instructions: RunLaunchInstructionReference[];
   /** Present on newly compiled manifests; absent only on pre-6.0 legacy records. */

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -150,6 +150,8 @@ export interface WorkflowStep {
   name: string;
   agent?: string; // agent ID (required for type=agent|loop)
   type: StepType;
+  /** Optional built-in execution phase. Omitted definitions run in explicit legacy mode. */
+  phase?: import('./phase-capability.types.js').PhaseName;
   fresh_session?: boolean; // Legacy: use session config instead
   session?: StepSessionConfig; // Session configuration (#111)
   input?: string; // Jinja2 template
@@ -257,6 +259,10 @@ export interface StepRun {
   /** Exact runtime capabilities required by the recorded provider launch. */
   requiredRuntimeCapabilities?: import('./provider-runtime.types.js').ProviderRuntimeCapabilityId[];
   runtimeControls?: import('./provider-runtime.types.js').ProviderRuntimeControlSet;
+  /** Exact phase authority resolved before this step launch mutated run state. */
+  phaseAuthority?: import('./run-launch-manifest.types.js').RunLaunchPhaseAuthority;
+  /** Digest of the immutable workflow step launch snapshot that owns phaseAuthority. */
+  phaseLaunchDigest?: string;
   /** Durable retry/fallback decision for this workflow step. */
   runRetry?: import('./run-recovery.types.js').RunRecoveryRecord;
 


### PR DESCRIPTION
## Summary

- bind immutable phase evidence and exact source references into every new task run launch manifest
- resolve parent or current transition authority before task, workflow, retry, fallback, resume, follow-up, fork, and provider-handoff attempt mutation
- narrow concrete sandbox posture before launch and reject unsupported phase dimensions with typed blockers
- persist workflow phase snapshots across retries and reused sessions while retaining explicit legacy compatibility
- expose phase selection through the REST API and CLI and document the staged enforcement boundary

Closes #1036.

## Scope boundary

This PR delivers launch and continuation propagation. Tool-command filtering, external-action enforcement, completion evidence, and operator presentation remain in #1033.

## Verification tier

- [ ] Documentation or static checks only
- [x] Focused changed-package tests
- [ ] Full milestone gate (`ci:full`, critical security, integration, or release)

## Why this tier is sufficient

The focused tests cover task launch and preview, workflow preparation, retry and fallback inheritance, resume plumbing, provider changes, exact parent evidence, tamper rejection, typed blockers, and legacy manifest reads. The deterministic CI selector remains authoritative for any broader hosted gate.

## Test commands

```bash
pnpm --filter @veritas-kanban/server exec vitest run --reporter=dot src/__tests__/phase-launch-authority-service.test.ts src/__tests__/run-launch-manifest-service.test.ts src/__tests__/workflow-step-executor-codex.test.ts src/__tests__/workflow-step-executor-openclaw.test.ts src/__tests__/workflow-run-service.test.ts src/__tests__/routes/agents-local-capability.test.ts src/__tests__/codex-provider-service.test.ts
pnpm --filter @veritas-kanban/cli exec vitest run src/__tests__/agents-runtime-capabilities.test.ts
pnpm --filter @veritas-kanban/shared build
pnpm --filter @veritas-kanban/server typecheck
pnpm --filter @veritas-kanban/cli typecheck
pnpm check:delivery-cadence
git diff --check origin/main
```
