### PR TITLE
fix: prevent focused test suite expansion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,10 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   subsystem becomes necessary, or verification work is larger than the behavior being changed.
 - During implementation, run the narrowest useful loop: type-check touched packages, lint changed
   files, and run focused tests for changed behavior and high-risk edges.
+- Run focused Vitest slices with
+  `pnpm --filter <package> exec vitest run <exact-test-files>`. Do not use the ambiguous
+  `pnpm --filter <package> test -- --run <test-files>` form; package wrappers can ignore that
+  file boundary and expand into the entire package suite.
 - Do not rerun an unchanged passing gate after documentation, comments, or formatting-only edits.
   Rerun only the checks affected by the later change.
 - Use the complete workspace suite once at an explicit integration, critical-security, or release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Standardized focused Vitest verification on direct
+  `pnpm --filter <package> exec vitest run <exact-test-files>` invocation. The
+  dependency-free delivery cadence checker now rejects active guidance that
+  presents the ambiguous package `test -- --run` wrapper as focused
+  verification, preventing an intended file slice from silently expanding into
+  an entire package suite (#1044).
 - Reworked GitHub release notes to use natural page-width prose and concise
   lists instead of ragged hanging-indent blocks or unmarked stacks of bold-led
   paragraphs. The release-format gate now rejects long wrapping list items,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,11 @@ veritas-kanban/
    pnpm --filter @veritas-kanban/server exec vitest run src/path/to/changed.test.ts
    ```
 
+   Use direct `exec vitest run` invocation for exact-file slices. Do not use
+   `pnpm --filter <package> test -- --run <test-files>` as a focused command;
+   package wrappers can ignore that file boundary and expand into the entire
+   package suite.
+
    Build `@veritas-kanban/shared` first and type-check its known consumers when
    a shared contract changes. Use `pnpm test` at an explicit integration,
    critical-security, or release milestone, or when the deterministic CI

--- a/scripts/check-delivery-cadence.mjs
+++ b/scripts/check-delivery-cadence.mjs
@@ -18,6 +18,10 @@ export const CADENCE_CONTRACTS = {
       pattern: /run the narrowest useful loop/i,
     },
     {
+      description: 'direct Vitest exact-file invocation',
+      pattern: /exec vitest run/i,
+    },
+    {
       description: 'milestone-only complete workspace suite',
       pattern:
         /complete workspace suite once at an explicit integration, critical-security, or release milestone/i,
@@ -43,6 +47,10 @@ export const CADENCE_CONTRACTS = {
     {
       description: 'test count is not a quality target',
       pattern: /Do not use raw test count as a quality measure/i,
+    },
+    {
+      description: 'direct Vitest exact-file invocation',
+      pattern: /exec vitest run/i,
     },
   ],
   '.github/PULL_REQUEST_TEMPLATE.md': [
@@ -180,6 +188,27 @@ export function findUnsafePromptStatements(files) {
   return violations;
 }
 
+export function findAmbiguousFocusedTestCommands(files) {
+  const violations = [];
+  const pattern = /\bpnpm\s+--filter\s+\S+\s+test\s+--\s+--run\b/gi;
+
+  for (const [file, content] of Object.entries(files)) {
+    const normalized = normalizeWhitespace(content);
+    for (const match of normalized.matchAll(pattern)) {
+      const sentence = sentenceContaining(normalized, match.index ?? 0);
+      if (!/\b(?:do not|never|avoid|reject)\b/i.test(sentence)) {
+        violations.push({
+          file,
+          message:
+            'focused Vitest files must use direct `pnpm --filter <package> exec vitest run <exact-test-files>` invocation',
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
 function readCadenceFiles(rootDir) {
   return Object.fromEntries(
     Object.keys(CADENCE_CONTRACTS).map((file) => {
@@ -201,9 +230,12 @@ function readActivePromptFiles(rootDir) {
 }
 
 export function runDeliveryCadenceCheck(rootDir = process.cwd()) {
+  const cadenceFiles = readCadenceFiles(rootDir);
+  const promptFiles = readActivePromptFiles(rootDir);
   const violations = [
-    ...findMissingCadenceContracts(readCadenceFiles(rootDir)),
-    ...findUnsafePromptStatements(readActivePromptFiles(rootDir)),
+    ...findMissingCadenceContracts(cadenceFiles),
+    ...findUnsafePromptStatements(promptFiles),
+    ...findAmbiguousFocusedTestCommands({ ...cadenceFiles, ...promptFiles }),
   ];
 
   if (violations.length > 0) {

--- a/scripts/check-delivery-cadence.test.mjs
+++ b/scripts/check-delivery-cadence.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   CADENCE_CONTRACTS,
+  findAmbiguousFocusedTestCommands,
   findMissingCadenceContracts,
   findUnsafePromptStatements,
 } from './check-delivery-cadence.mjs';
@@ -99,6 +100,42 @@ test('allows optional cross-model review language', () => {
     findUnsafePromptStatements({
       'prompt-registry/example.md':
         'Cross-model review is optional unless the issue owner explicitly requires it.',
+    }),
+    []
+  );
+});
+
+test('rejects package test wrappers that can expand an intended file slice', () => {
+  assert.deepEqual(
+    findAmbiguousFocusedTestCommands({
+      'prompt-registry/example.md':
+        'Run `pnpm --filter @veritas-kanban/server test -- --run src/example.test.ts`.',
+    }),
+    [
+      {
+        file: 'prompt-registry/example.md',
+        message:
+          'focused Vitest files must use direct `pnpm --filter <package> exec vitest run <exact-test-files>` invocation',
+      },
+    ]
+  );
+});
+
+test('allows direct Vitest exact-file invocation', () => {
+  assert.deepEqual(
+    findAmbiguousFocusedTestCommands({
+      'prompt-registry/example.md':
+        'Run `pnpm --filter @veritas-kanban/server exec vitest run src/example.test.ts`.',
+    }),
+    []
+  );
+});
+
+test('allows an explicit warning against the ambiguous package test wrapper', () => {
+  assert.deepEqual(
+    findAmbiguousFocusedTestCommands({
+      'AGENTS.md':
+        'Do not use `pnpm --filter <package> test -- --run <test-files>` for focused verification.',
     }),
     []
   );


### PR DESCRIPTION
## Description

Prevents a focused Vitest command from silently expanding into an entire package suite.

Contributor and agent guidance now standardize exact-file verification on `pnpm --filter <package> exec vitest run <exact-test-files>`. The dependency-free cadence checker rejects active guidance that presents the ambiguous package `test -- --run` wrapper as focused verification while allowing explicit warnings against it.

## Scope

**Linked issue:** Closes #1044

**In scope:** One delivery-process guardrail, its contract tests, canonical guidance, and changelog entry.

**Linked follow-ups:** None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactor

## Testing

**How has this been tested?**

The dependency-free contract suite covers rejected ambiguous wrappers, accepted direct exact-file commands, and accepted negative guidance. All 10 tests pass in approximately 43 ms.

**Verification tier:**

- [x] Documentation or static checks only
- [ ] Focused changed-package tests
- [ ] Full milestone gate (`ci:full`, critical security, integration, or release)

**Why this tier is sufficient:** This PR changes only the static cadence checker and documentation. It has no product runtime or package behavior.

**Test commands:**

```bash
node --test scripts/check-delivery-cadence.test.mjs
node scripts/check-delivery-cadence.mjs
pnpm exec eslint scripts/check-delivery-cadence.mjs scripts/check-delivery-cadence.test.mjs
git diff --check
```

## Checklist

- [x] This PR contains one coherent, independently shippable behavior
- [x] Separable follow-up work is linked instead of folded into this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any breaking changes have been documented in the PR description
- [x] I did not rerun unchanged passing gates after documentation or formatting-only edits
- [x] Optional desktop, artifact, and release workflows are marked relevant only when this PR touches their product boundary
