### PR TITLE
feat: add durable task launch admission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,15 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   high-risk environment passthrough are separate classes. Task integration
   credentials fail closed until an accepted tool or egress boundary proves
   brokered, non-bypassable delivery.
+- Atomically persist `admission-reservation/v1` before direct task attempt,
+  pending-run, or provider state. Capacity claims use the storage repository
+  transaction or file lock, not process-local counters. Keep the invariant
+  one-active-run-per-task policy and configured global, workspace, root-task,
+  provider, and host ceilings aligned across dispatch, REST, and `vk`.
+  Persist only a stable digest of caller-supplied idempotency values.
+  Completion, interruption, cancellation, and start failure release once;
+  restart recovery may reclaim only after the durable run supervisor verifies
+  the original live process or session.
 - Persist `run-supervisor/v1` before provider dispatch. Restart recovery must
   validate the exact runtime, task-envelope, launch-manifest, worktree, host,
   lease, and process/session identity; replay only after the durable event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added durable admission reservations for every direct agent task launch. File
+  and SQLite backends atomically enforce one active run per task plus optional
+  global, workspace, root-task, provider, and host ceilings for run slots,
+  process slots, and operator-estimated memory. Versioned decisions distinguish
+  retryable overload from terminal policy denial before attempt persistence or
+  provider dispatch. Lease recovery is bound to verified live supervisors,
+  terminal paths release idempotently, and file heartbeat history compacts
+  atomically. Operators can inspect active and recent reservations through
+  read-scoped REST and `vk admission` JSON commands (#1050).
 - Added a first-class workflow definition browser with deep-linked view, edit, and duplicate routes. Definition detail now exposes agents, ordered steps, phases, inputs, acceptance criteria, gates, loops, parallel branches, outputs, and provenance before execution. Server-owned access evidence distinguishes user-owned, shared, and built-in workflows; read-only definitions explain the restriction and offer duplication when permitted. User-owned edits save through Author with version-bound conflict protection that preserves the draft on failure. Starting a run is now a separate configuration step for optional task association and JSON context (#940).
 - Enforced active phase authority across run tool discovery, mediated
   invocation, approvals, completion evidence, REST, CLI, and the task run

--- a/cli/src/__tests__/admission.test.ts
+++ b/cli/src/__tests__/admission.test.ts
@@ -1,0 +1,65 @@
+import { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const api = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/api.js', () => ({ api }));
+
+import { registerAdmissionCommands } from '../commands/admission.js';
+
+describe('vk admission commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+  });
+
+  it('lists reservations as JSON with all operator filters preserved', async () => {
+    api.mockResolvedValue({
+      generatedAt: '2026-07-25T10:00:00.000Z',
+      reservations: [{ id: 'admission_1', state: 'active' }],
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'list',
+      '--workspace',
+      'workspace-a',
+      '--state',
+      'active',
+      'released',
+      '--limit',
+      '25',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith(
+      '/api/admission?workspaceId=workspace-a&state=active&state=released&limit=25'
+    );
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toEqual({
+      generatedAt: '2026-07-25T10:00:00.000Z',
+      reservations: [{ id: 'admission_1', state: 'active' }],
+    });
+    output.mockRestore();
+  });
+
+  it('inspects one reservation as JSON', async () => {
+    api.mockResolvedValue({ id: 'admission_1', state: 'released' });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync(['node', 'vk', 'admission', 'get', 'admission_1', '--json']);
+
+    expect(api).toHaveBeenCalledWith('/api/admission/admission_1');
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toEqual({
+      id: 'admission_1',
+      state: 'released',
+    });
+    output.mockRestore();
+  });
+});

--- a/cli/src/__tests__/agents-runtime-capabilities.test.ts
+++ b/cli/src/__tests__/agents-runtime-capabilities.test.ts
@@ -16,6 +16,15 @@ import { registerAgentCommands } from '../commands/agents.js';
 
 const temporaryRoots: string[] = [];
 
+function expectLaunchBody(expected: Record<string, unknown>): void {
+  const [url, request] = mockApi.mock.calls.at(-1) as [string, { method: string; body: string }];
+  const { idempotencyKey, ...body } = JSON.parse(request.body) as Record<string, unknown>;
+  expect(url).toBe('/api/agents/task_1/start');
+  expect(request.method).toBe('POST');
+  expect(idempotencyKey).toMatch(/^vk-cli:task_1:[0-9a-f-]{36}$/);
+  expect(body).toEqual(expected);
+}
+
 afterEach(async () => {
   await Promise.all(
     temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))
@@ -61,15 +70,11 @@ describe('vk agent runtime capability controls', () => {
       { from: 'user' }
     );
 
-    expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
-      method: 'POST',
-      body: JSON.stringify({
-        agent: 'codex',
-        profileId: undefined,
-        phase: 'implement',
-        requiredRuntimeCapabilities: ['tool.mcp', 'output.structured'],
-        parentAttemptId: 'attempt_parent',
-      }),
+    expectLaunchBody({
+      agent: 'codex',
+      phase: 'implement',
+      requiredRuntimeCapabilities: ['tool.mcp', 'output.structured'],
+      parentAttemptId: 'attempt_parent',
     });
   });
 
@@ -116,14 +121,9 @@ describe('vk agent runtime capability controls', () => {
       { from: 'user' }
     );
 
-    expect(mockApi).toHaveBeenCalledWith('/api/agents/task_1/start', {
-      method: 'POST',
-      body: JSON.stringify({
-        agent: 'codex',
-        profileId: undefined,
-        requiredRuntimeCapabilities: undefined,
-        commitPolicy: 'forbidden',
-      }),
+    expectLaunchBody({
+      agent: 'codex',
+      commitPolicy: 'forbidden',
     });
   });
 

--- a/cli/src/commands/admission.ts
+++ b/cli/src/commands/admission.ts
@@ -1,0 +1,109 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import type { AdmissionReservation, AdmissionReservationState } from '@veritas-kanban/shared';
+import { api } from '../utils/api.js';
+
+interface AdmissionListResponse {
+  generatedAt: string;
+  reservations: AdmissionReservation[];
+}
+
+export function registerAdmissionCommands(program: Command): void {
+  const admission = program
+    .command('admission')
+    .description('Inspect durable execution admission reservations');
+
+  admission
+    .command('list')
+    .description('List active or recently terminal admission reservations')
+    .option('--workspace <id>', 'Filter by workspace')
+    .option('--task <id>', 'Filter by task')
+    .option('--root-task <id>', 'Filter by root task')
+    .option('--provider <provider>', 'Filter by provider')
+    .option('--host <id>', 'Filter by launch host')
+    .option('--state <states...>', 'Filter by state (active, released, expired)')
+    .option('--limit <count>', 'Maximum records', '100')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const query = new URLSearchParams();
+        if (options.workspace) query.set('workspaceId', options.workspace);
+        if (options.task) query.set('taskId', options.task);
+        if (options.rootTask) query.set('rootTaskId', options.rootTask);
+        if (options.provider) query.set('provider', options.provider);
+        if (options.host) query.set('hostId', options.host);
+        for (const state of (options.state ?? []) as AdmissionReservationState[]) {
+          query.append('state', state);
+        }
+        query.set('limit', options.limit);
+        const result = await api<AdmissionListResponse>(`/api/admission?${query.toString()}`);
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        if (result.reservations.length === 0) {
+          console.log(chalk.dim('No admission reservations matched.'));
+          return;
+        }
+        for (const reservation of result.reservations) printReservation(reservation);
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  admission
+    .command('get <id>')
+    .description('Inspect one admission reservation')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const result = await api<AdmissionReservation>(`/api/admission/${encodeURIComponent(id)}`);
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        printReservation(result, true);
+      } catch (error) {
+        printError(error);
+      }
+    });
+}
+
+function printReservation(reservation: AdmissionReservation, verbose = false): void {
+  const state =
+    reservation.state === 'active'
+      ? chalk.green(reservation.state)
+      : reservation.state === 'released'
+        ? chalk.blue(reservation.state)
+        : chalk.yellow(reservation.state);
+  console.log(
+    `${state} ${chalk.bold(reservation.id)} task=${reservation.request.taskId} provider=${reservation.request.provider}`
+  );
+  console.log(
+    chalk.dim(
+      `  workspace=${reservation.request.workspaceId} root=${reservation.request.rootTaskId} host=${reservation.request.hostId}`
+    )
+  );
+  console.log(
+    chalk.dim(
+      `  capacity runs=${reservation.request.requested.runSlots} processes=${reservation.request.requested.processSlots} memory=${reservation.request.requested.estimatedMemoryMb}MB`
+    )
+  );
+  if (verbose || reservation.state === 'active') {
+    console.log(
+      chalk.dim(
+        `  attempt=${reservation.attemptId ?? 'unbound'} lease=${reservation.lease.expiresAt} revision=${reservation.revision}`
+      )
+    );
+  }
+  if (reservation.release) {
+    console.log(
+      chalk.dim(`  released=${reservation.release.reason} at ${reservation.release.releasedAt}`)
+    );
+  }
+}
+
+function printError(error: unknown): void {
+  console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
+  process.exitCode = 1;
+}

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { randomUUID } from 'node:crypto';
 import chalk from 'chalk';
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
@@ -234,6 +235,7 @@ export function registerAgentCommands(program: Command): void {
             requiredRuntimeCapabilities: options.requireCapability,
             commitPolicy: options.commitPolicy,
             parentAttemptId: options.parentAttempt,
+            idempotencyKey: `vk-cli:${task.id}:${randomUUID()}`,
           }),
         });
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,7 @@ import { registerQueueMonitorCommands } from './commands/queue-monitors.js';
 import { registerSqliteCommands } from './commands/sqlite.js';
 import { registerToolServerCommands } from './commands/tool-servers.js';
 import { registerAcpCommands } from './commands/acp.js';
+import { registerAdmissionCommands } from './commands/admission.js';
 
 const program = new Command();
 const packageJson = JSON.parse(
@@ -61,5 +62,6 @@ registerQueueMonitorCommands(program);
 registerSqliteCommands(program);
 registerToolServerCommands(program);
 registerAcpCommands(program);
+registerAdmissionCommands(program);
 
 program.parse();

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -923,6 +923,52 @@ Use **Settings -> Agents** and **Settings -> Data & Storage -> Budget Tracking**
 
 Soft thresholds create `budget-policy` governance traces and visible warnings. Hard thresholds can pause for review, require approval, downgrade to a configured model, or cancel the run. Completion packets include the final budget decision, usage, threshold events, related trace IDs, and operator override notes when present.
 
+## Execution Admission
+
+Every direct task launch receives a durable `admission-reservation/v1` record
+before Veritas persists an attempt or calls a provider adapter. Reservations
+account for run slots, process slots, and operator-estimated memory across
+optional global, workspace, root-task, provider, and host ceilings. Estimated
+memory is a configured planning value, not a runtime memory prediction.
+An invariant one-run-per-task policy also prevents concurrent duplicate
+launches across server processes.
+
+Configure ceilings through `PATCH /api/settings/features`:
+
+```json
+{
+  "admission": {
+    "global": {
+      "concurrentRuns": 8,
+      "processSlots": 8,
+      "estimatedMemoryMb": 16384
+    },
+    "providers": {
+      "codex-cli": {
+        "concurrentRuns": 4
+      }
+    },
+    "hosts": {
+      "local-process": {
+        "processSlots": 6
+      }
+    }
+  }
+}
+```
+
+An individual request larger than a ceiling receives a terminal policy denial.
+Temporary exhaustion returns a retryable overload decision with the limiting
+scope and bounded retry guidance. Active leases renew while the verified run is
+live; completion, interruption, cancellation, or launch failure releases the
+reservation idempotently. After restart, only a run verified through its
+durable supervisor may reclaim an expired reservation. Caller-supplied
+idempotency values are represented by a stable SHA-256 identity in durable
+records; the original value is not stored.
+
+Inspect reservations with `vk admission list`, `vk admission get <id>`, or the
+matching read-only REST endpoints. Machine consumers should use `--json`.
+
 ## Local And Cloud Profiles
 
 | Profile            | Provider           | Default command                               | Auth / readiness                                             |

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -62,6 +62,7 @@
 49. [Versioning & Deprecation](#versioning--deprecation)
 50. [Rate Limits](#rate-limits)
 51. [Additional Endpoint Groups](#additional-endpoint-groups)
+52. [Execution Admission](#execution-admission)
 
 ---
 
@@ -4135,6 +4136,40 @@ Settings live under `features.watcherContinuations` and are updated through
 `PATCH /api/settings/features`. Defaults preserve current behavior:
 continuations are disabled and the global kill switch is active until explicitly
 configured.
+
+---
+
+## Execution Admission
+
+Direct task starts atomically reserve configured run, process, and
+estimated-memory capacity before attempt persistence or provider dispatch.
+Inspection requires `agent:read`.
+
+| Method | Path                 | Description                                             |
+| ------ | -------------------- | ------------------------------------------------------- |
+| `GET`  | `/api/admission`     | List reservations with optional scope and state filters |
+| `GET`  | `/api/admission/:id` | Inspect one durable reservation                         |
+
+List filters are `workspaceId`, `taskId`, `rootTaskId`, `provider`, `hostId`,
+repeatable `state` (`active`, `released`, `expired`), and `limit` (1-1000).
+
+```http
+GET /api/v1/admission?state=active&provider=codex-cli&limit=25
+```
+
+The response contains `admission-reservation/v1` records with the versioned
+request, requested capacity, evaluated limit policies, attempt binding, lease,
+revision, and terminal release evidence. It never contains provider
+credentials. Overloaded task-start requests return a `409` conflict with
+`details.code` set to `ADMISSION_OVERLOAD`, the limiting scope, and bounded
+`retryAfterMs`. A request larger than a configured ceiling returns
+`ADMISSION_POLICY_DENIED`.
+
+Direct `POST /api/v1/agents/:taskId/start` callers may send an opaque
+`X-Idempotency-Key` header (8-240 characters). The header takes precedence
+over the equivalent JSON `idempotencyKey` field and lets a retry reuse the same
+reservation without launching a second attempt. Veritas persists only its
+SHA-256 identity, never the supplied value.
 
 ---
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -19,6 +19,7 @@ Comprehensive guide to the `vk` command-line tool for Veritas Kanban.
   - [Agent Status](#agent-status)
   - [Project Management](#project-management)
   - [Agent Commands](#agent-commands)
+  - [Admission Commands](#admission-commands)
   - [Automation Commands](#automation-commands)
   - [Scheduler Commands](#scheduler-commands)
   - [Queue Monitor Commands](#queue-monitor-commands)
@@ -587,6 +588,24 @@ applies immediately. Expansion returns an exact approval; decide it with
 transition with the same `--operation` and `--approval-id`. Emergency expansion
 requires `--override-until` and `--override-reason`; the authenticated caller
 must be an administrator and the expiry cannot exceed 24 hours.
+
+---
+
+### Admission Commands
+
+Inspect the capacity reservation that must exist before a provider can start:
+
+```bash
+vk admission list
+vk admission list --state active --provider codex-cli --json
+vk admission get admission_0123456789abcdef --json
+```
+
+`admission list` filters by workspace, task, root task, provider, host, state,
+and result limit. Active records show the lease expiry and requested run,
+process, and estimated-memory capacity. Released records retain the terminal
+reason and idempotency identity for operator diagnosis. These are read-only
+commands and require `agent:read`.
 
 ---
 

--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -1065,19 +1065,20 @@ SQLite tables with JSON payload columns plus query indexes. This keeps the v4
 service contracts intact while preventing SQLite mode from writing operational
 state back to `.veritas-kanban/*.json` or telemetry NDJSON files.
 
-| Runtime table      | Stored data                                                                                                          |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `activity_events`  | Complete activity entries plus type, task, agent, and created-time columns.                                          |
-| `status_history`   | Complete status transition entries plus previous/new status and task columns.                                        |
-| `telemetry_events` | Complete telemetry events plus type, task, project, token, duration, and result columns.                             |
-| `run_events`       | Complete `run-event/v1` envelopes plus ordered attempt cursor, provider identity, dedupe, and receive columns.       |
-| `run_supervisors`  | Complete `run-supervisor/v1` snapshots plus task/attempt, state, revision, lease owner/expiry, and recovery indexes. |
+| Runtime table            | Stored data                                                                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `activity_events`        | Complete activity entries plus type, task, agent, and created-time columns.                                                    |
+| `status_history`         | Complete status transition entries plus previous/new status and task columns.                                                  |
+| `telemetry_events`       | Complete telemetry events plus type, task, project, token, duration, and result columns.                                       |
+| `run_events`             | Complete `run-event/v1` envelopes plus ordered attempt cursor, provider identity, dedupe, and receive columns.                 |
+| `run_supervisors`        | Complete `run-supervisor/v1` snapshots plus task/attempt, state, revision, lease owner/expiry, and recovery indexes.           |
+| `admission_reservations` | Versioned capacity reservations plus task/workspace/root/provider/host scopes, lease state, revision, and idempotency indexes. |
 
 `ActivityService`, `StatusHistoryService`, `TelemetryService`,
-`RunEventJournalService`, and `RunSupervisorService` select these SQLite repositories when
-`VERITAS_STORAGE=sqlite`. File storage still forces the file-backed services to
-`storageType='file'`, so explicit file mode cannot be accidentally flipped by
-the environment.
+`RunEventJournalService`, `RunSupervisorService`, and `AdmissionControlService`
+select these SQLite repositories when `VERITAS_STORAGE=sqlite`. File storage
+still forces the file-backed services to `storageType='file'`, so explicit file
+mode cannot be accidentally flipped by the environment.
 
 Dashboard metric aggregation uses the same active storage backend. In SQLite
 mode, `/metrics/all`, `/metrics/trends`, agent comparison, task cost, and

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AdmissionReservationRepository } from '../storage/interfaces.js';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type AdmissionCapacityLimit,
+  type AdmissionSettings,
+} from '@veritas-kanban/shared';
+import { AdmissionControlService } from '../services/admission-control-service.js';
+import { FileAdmissionReservationRepository } from '../storage/admission-reservation-repository.js';
+import { SqliteDatabase } from '../storage/sqlite/database.js';
+import { SqliteAdmissionReservationRepository } from '../storage/sqlite/admission-reservation-repository.js';
+
+const roots: string[] = [];
+const services: AdmissionControlService[] = [];
+const databases: SqliteDatabase[] = [];
+
+afterEach(async () => {
+  for (const service of services.splice(0)) service.dispose();
+  for (const database of databases.splice(0)) database.close();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+function configuredSettings(
+  overrides: {
+    global?: AdmissionCapacityLimit;
+    providers?: AdmissionSettings['providers'];
+  } = {}
+): AdmissionSettings {
+  return {
+    ...structuredClone(DEFAULT_FEATURE_SETTINGS.admission),
+    global: overrides.global ?? {},
+    providers: overrides.providers ?? {},
+    heartbeatMs: 20_000,
+  };
+}
+
+function createService(
+  repository: AdmissionReservationRepository,
+  settings: AdmissionSettings,
+  options: { now?: () => Date; ownerId?: string } = {}
+): AdmissionControlService {
+  const service = new AdmissionControlService({
+    repository,
+    settings: async () => structuredClone(settings),
+    hostId: 'execution-host-a',
+    ownerId: options.ownerId ?? 'owner-a',
+    processId: 101,
+    now: options.now,
+  });
+  services.push(service);
+  return service;
+}
+
+function request(taskId: string, idempotencyKey = `launch:${taskId}`) {
+  return {
+    taskId,
+    workspaceId: 'workspace-a',
+    provider: 'codex-cli' as const,
+    hostId: 'local-process',
+    idempotencyKey,
+  };
+}
+
+async function repositoryFor(backend: 'file' | 'sqlite') {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `veritas-admission-${backend}-`));
+  roots.push(root);
+  if (backend === 'file') {
+    return new FileAdmissionReservationRepository(path.join(root, 'admission.jsonl'));
+  }
+  const database = new SqliteDatabase({ databasePath: path.join(root, 'veritas.db') });
+  database.open();
+  databases.push(database);
+  return new SqliteAdmissionReservationRepository(database);
+}
+
+describe('AdmissionControlService', () => {
+  it('distinguishes an impossible policy request from retryable active-capacity overload', async () => {
+    const repository = await repositoryFor('file');
+    const impossible = createService(
+      repository,
+      configuredSettings({ global: { concurrentRuns: 0 } })
+    );
+    await expect(impossible.admit(request('task-impossible'))).resolves.toMatchObject({
+      outcome: 'terminal-policy-denial',
+      limitingPolicies: [{ scope: 'global', scopeId: 'global' }],
+      retryAfterMs: undefined,
+    });
+
+    const settings = configuredSettings({
+      global: { concurrentRuns: 1 },
+      providers: { 'codex-cli': { processSlots: 1 } },
+    });
+    const service = createService(repository, settings);
+    const admitted = await service.admit(request('task-one'));
+    expect(admitted).toMatchObject({
+      outcome: 'admitted',
+      reservation: { state: 'active' },
+    });
+    await expect(
+      service.admit(request('task-one', 'launch:task-one:duplicate'))
+    ).resolves.toMatchObject({
+      outcome: 'retryable-overload',
+      limitingPolicies: expect.arrayContaining([
+        expect.objectContaining({ scope: 'task', scopeId: 'task-one' }),
+      ]),
+    });
+    await expect(service.admit(request('task-two'))).resolves.toMatchObject({
+      outcome: 'retryable-overload',
+      retryAfterMs: settings.retryAfterMs,
+      limitingPolicies: expect.arrayContaining([
+        expect.objectContaining({ scope: 'global', scopeId: 'global' }),
+        expect.objectContaining({ scope: 'provider', scopeId: 'codex-cli' }),
+      ]),
+    });
+  });
+
+  it('admits maximum-length scope identifiers without overflowing generated policy IDs', async () => {
+    const repository = await repositoryFor('file');
+    const service = createService(repository, configuredSettings());
+
+    await expect(service.admit(request('t'.repeat(240)))).resolves.toMatchObject({
+      outcome: 'admitted',
+      reservation: {
+        policies: [expect.objectContaining({ scope: 'task' })],
+      },
+    });
+  });
+
+  it('renews a verified live run after lease expiry without creating a duplicate reservation', async () => {
+    const repository = await repositoryFor('file');
+    let now = new Date('2026-07-25T10:00:00.000Z');
+    const settings = configuredSettings({ global: { concurrentRuns: 1 } });
+    const original = createService(repository, settings, { now: () => now });
+    const decision = await original.admit(request('task-recover'));
+    const bound = await original.bindAttempt(decision.reservation?.id as string, 'attempt-recover');
+    original.dispose();
+
+    now = new Date('2026-07-25T10:00:31.000Z');
+    await original.expireAbandoned();
+    const recovering = createService(repository, settings, {
+      now: () => now,
+      ownerId: 'owner-b',
+    });
+    const recovered = await recovering.recoverVerifiedRun({
+      workspaceId: 'workspace-a',
+      taskId: 'task-recover',
+      attemptId: 'attempt-recover',
+    });
+    expect(recovered).toMatchObject({
+      id: bound.id,
+      state: 'active',
+      attemptId: 'attempt-recover',
+      lease: { ownerId: 'owner-b' },
+    });
+    await expect(
+      recovering.admit(request('task-recover', 'launch:task-recover'))
+    ).resolves.toMatchObject({
+      outcome: 'admitted',
+      reservation: { id: bound.id },
+    });
+    await expect(repository.list({ taskId: 'task-recover' })).resolves.toHaveLength(1);
+  });
+
+  it('does not release another attempt when an idempotent retry loses the bind race', async () => {
+    const repository = await repositoryFor('file');
+    const settings = configuredSettings();
+    const original = createService(repository, settings, { ownerId: 'owner-original' });
+    const retry = createService(repository, settings, { ownerId: 'owner-retry' });
+    const originalDecision = await original.admit(request('task-idempotent'));
+    const retryDecision = await retry.admit(request('task-idempotent'));
+    expect(originalDecision.reservation?.request.idempotencyKey).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(originalDecision.reservation?.request.idempotencyKey).not.toContain(
+      'launch:task-idempotent'
+    );
+
+    const bound = await original.bindAttempt(
+      originalDecision.reservation?.id as string,
+      'attempt-original'
+    );
+    await expect(
+      retry.bindAttempt(retryDecision.reservation?.id as string, 'attempt-retry')
+    ).rejects.toMatchObject({
+      statusCode: 409,
+    });
+    await retry.releaseIfUnbound(
+      retryDecision.reservation?.id as string,
+      'start-failed',
+      'bind-failed:attempt-retry'
+    );
+
+    await expect(repository.get(bound.id)).resolves.toMatchObject({
+      state: 'active',
+      attemptId: 'attempt-original',
+      lease: { ownerId: 'owner-original' },
+    });
+  });
+
+  it('compacts file heartbeat snapshots without losing the latest reservation revision', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'veritas-admission-compact-'));
+    roots.push(root);
+    const logPath = path.join(root, 'admission.jsonl');
+    const repository = new FileAdmissionReservationRepository(logPath, 3);
+    const service = createService(repository, configuredSettings());
+    const decision = await service.admit(request('task-compact'));
+    const bound = await service.bindAttempt(decision.reservation?.id as string, 'attempt-compact');
+    const renewed = await service.renew(bound.id);
+    const compacted = await service.renew(bound.id);
+
+    const lines = (await fs.readFile(logPath, 'utf8')).trim().split('\n');
+    expect(lines).toHaveLength(1);
+    await expect(repository.get(bound.id)).resolves.toMatchObject({
+      revision: compacted.revision,
+      state: 'active',
+      attemptId: 'attempt-compact',
+      lease: { heartbeatAt: compacted.lease.heartbeatAt },
+    });
+    expect(compacted.revision).toBe(renewed.revision + 1);
+  });
+});
+
+describe.each(['file', 'sqlite'] as const)('%s admission reservation parity', (backend) => {
+  it('serializes competing claims and releases the winner idempotently', async () => {
+    const repository = await repositoryFor(backend);
+    const settings = configuredSettings({ global: { concurrentRuns: 1 } });
+    const left = createService(repository, settings, { ownerId: 'owner-left' });
+    const right = createService(repository, settings, { ownerId: 'owner-right' });
+    const decisions = await Promise.all([
+      left.admit(request('task-left')),
+      right.admit(request('task-right')),
+    ]);
+    expect(decisions.map((decision) => decision.outcome).sort()).toEqual([
+      'admitted',
+      'retryable-overload',
+    ]);
+    const admitted = decisions.find((decision) => decision.outcome === 'admitted');
+    const reservation = await left.bindAttempt(
+      admitted?.reservation?.id as string,
+      'attempt-winner'
+    );
+    const released = await left.release(reservation.id, 'completed', 'terminal:attempt-winner');
+    await expect(
+      left.release(reservation.id, 'completed', 'terminal:attempt-winner')
+    ).resolves.toEqual(released);
+    expect(released).toMatchObject({
+      state: 'released',
+      release: {
+        reason: 'completed',
+        idempotencyKey: 'terminal:attempt-winner',
+      },
+    });
+  });
+
+  it('renews and expires leases with equivalent revisioned state transitions', async () => {
+    const repository = await repositoryFor(backend);
+    let now = new Date('2026-07-25T12:00:00.000Z');
+    const service = createService(repository, configuredSettings(), { now: () => now });
+    const decision = await service.admit(request(`task-lease-${backend}`));
+    const bound = await service.bindAttempt(
+      decision.reservation?.id as string,
+      `attempt-lease-${backend}`
+    );
+
+    now = new Date('2026-07-25T12:00:01.000Z');
+    const renewed = await service.renew(bound.id);
+    expect(renewed.revision).toBe(bound.revision + 1);
+    expect(renewed.lease.heartbeatAt).toBe(now.toISOString());
+
+    now = new Date('2026-07-25T12:00:32.000Z');
+    await expect(service.expireAbandoned()).resolves.toEqual([
+      expect.objectContaining({
+        id: bound.id,
+        state: 'expired',
+        revision: renewed.revision + 1,
+      }),
+    ]);
+  });
+});

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -252,7 +252,7 @@ function testableService(
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
   > = testWorkspaceExecutionTrust(),
-  admission?: AdmissionControlService
+  admission: AdmissionControlService = testAdmissionControl()
 ): TestableClawdbotAgentService {
   const completionEvidence = testCompletionEvidence();
   const taskEnvelopes = new TaskEnvelopeService(completionEvidence);
@@ -280,6 +280,22 @@ function testableService(
   ) as unknown as TestableClawdbotAgentService;
   service.logsDir = tmpDir;
   return service;
+}
+
+function testAdmissionControl(): AdmissionControlService {
+  let sequence = 0;
+  return {
+    admit: vi.fn(async (input: { taskId: string }) => ({
+      outcome: 'admitted',
+      reservation: { id: `admission-test-${input.taskId}-${++sequence}` },
+    })),
+    bindAttempt: vi.fn(async (id: string) => ({ id })),
+    release: vi.fn(async (id: string) => ({ id })),
+    releaseIfUnbound: vi.fn(async (id: string) => ({ id })),
+    releaseByAttempt: vi.fn(async () => null),
+    expireAbandoned: vi.fn(async () => []),
+    recoverVerifiedRun: vi.fn(async () => null),
+  } as unknown as AdmissionControlService;
 }
 
 function testWorkspaceExecutionTrust(): Pick<

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -203,6 +203,7 @@ import { calculateRunToolCatalogDigest } from '../utils/tool-control-plane-diges
 import type { FilesystemSandboxService } from '../services/filesystem-sandbox-service.js';
 import type { SandboxPolicyService } from '../services/sandbox-policy-service.js';
 import type { WorkspaceExecutionTrustService } from '../services/workspace-execution-trust-service.js';
+import type { AdmissionControlService } from '../services/admission-control-service.js';
 
 const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'codex');
 
@@ -250,7 +251,8 @@ function testableService(
   workspaceExecutionTrust: Pick<
     WorkspaceExecutionTrustService,
     'scan' | 'evaluateForLaunch' | 'assertFresh'
-  > = testWorkspaceExecutionTrust()
+  > = testWorkspaceExecutionTrust(),
+  admission?: AdmissionControlService
 ): TestableClawdbotAgentService {
   const completionEvidence = testCompletionEvidence();
   const taskEnvelopes = new TaskEnvelopeService(completionEvidence);
@@ -273,7 +275,8 @@ function testableService(
     sandboxPolicies,
     workspaceExecutionTrust,
     undefined,
-    { getCurrent: vi.fn().mockResolvedValue(null) }
+    { getCurrent: vi.fn().mockResolvedValue(null) },
+    admission
   ) as unknown as TestableClawdbotAgentService;
   service.logsDir = tmpDir;
   return service;
@@ -3426,6 +3429,55 @@ describe('ClawdbotAgentService Codex providers', () => {
       }),
     });
     expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('blocks provider dispatch before attempt persistence when admission is overloaded', async () => {
+    const admit = vi.fn().mockResolvedValue({
+      schemaVersion: 'admission-decision/v1',
+      outcome: 'retryable-overload',
+      request: {
+        schemaVersion: 'admission-request/v1',
+        idempotencyKey: 'launch:overloaded-task',
+        source: 'direct',
+        taskId: task.id,
+        rootTaskId: task.id,
+        workspaceId: task.project,
+        provider: 'codex-cli',
+        hostId: 'local-process',
+        requested: { runSlots: 1, processSlots: 1, estimatedMemoryMb: 512 },
+        requestedAt: '2026-07-25T10:00:00.000Z',
+      },
+      limitingPolicies: [
+        {
+          id: 'global:global',
+          scope: 'global',
+          scopeId: 'global',
+          limits: { concurrentRuns: 1 },
+        },
+      ],
+      retryAfterMs: 5_000,
+      reason: 'Active reservations currently consume the configured capacity.',
+      decidedAt: '2026-07-25T10:00:00.000Z',
+    });
+    const admission = { admit } as unknown as AdmissionControlService;
+    const service = testableService(
+      tmpDir,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      testWorkspaceExecutionTrust(),
+      admission
+    );
+
+    await expect(service.startAgent(task.id, 'codex')).rejects.toMatchObject({
+      statusCode: 409,
+      details: expect.objectContaining({ code: 'ADMISSION_OVERLOAD' }),
+    });
+    expect(admit).toHaveBeenCalledOnce();
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockUpdateTask).not.toHaveBeenCalled();
   });
 
   it('records user stop requests as abort trace steps before completing the attempt', async () => {

--- a/server/src/__tests__/routes/admission.test.ts
+++ b/server/src/__tests__/routes/admission.test.ts
@@ -1,0 +1,68 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { errorHandler } from '../../middleware/error-handler.js';
+
+const admission = vi.hoisted(() => ({
+  list: vi.fn(),
+  get: vi.fn(),
+}));
+
+vi.mock('../../services/admission-control-service.js', () => ({
+  getAdmissionControlService: () => admission,
+}));
+
+import { admissionRoutes } from '../../routes/admission.js';
+
+function createApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admission', admissionRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('admission routes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists filtered reservations with stable machine-readable fields', async () => {
+    admission.list.mockResolvedValue([{ id: 'admission_1', state: 'active' }]);
+
+    const response = await request(createApp()).get(
+      '/api/admission?workspaceId=workspace-a&state=active&state=released&limit=25'
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      generatedAt: expect.any(String),
+      reservations: [{ id: 'admission_1', state: 'active' }],
+    });
+    expect(admission.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-a',
+        states: ['active', 'released'],
+        limit: 25,
+      })
+    );
+  });
+
+  it('inspects one reservation and rejects invalid list filters', async () => {
+    admission.get.mockResolvedValue({ id: 'admission_1', state: 'released' });
+
+    const found = await request(createApp()).get('/api/admission/admission_1');
+    const invalid = await request(createApp()).get('/api/admission?state=unknown');
+
+    expect(found.status).toBe(200);
+    expect(found.body).toEqual({ id: 'admission_1', state: 'released' });
+    expect(invalid.status).toBe(400);
+    expect(admission.list).not.toHaveBeenCalled();
+  });
+
+  it('returns a validation error for an invalid reservation identifier', async () => {
+    const invalid = await request(createApp()).get(`/api/admission/${'a'.repeat(241)}`);
+
+    expect(invalid.status).toBe(400);
+    expect(invalid.body).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(admission.get).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/routes/agents-local-capability.test.ts
+++ b/server/src/__tests__/routes/agents-local-capability.test.ts
@@ -234,7 +234,30 @@ describe('agent local capability enforcement', () => {
       commitPolicy: undefined,
       phase: 'implement',
       parentAttemptId: undefined,
+      admissionIdempotencyKey: undefined,
     });
+  });
+
+  it('validates and forwards the idempotency header before agent dispatch', async () => {
+    const app = createApp(auth({ clientMode: 'desktop-local', capabilities: ['desktop:local'] }));
+    const response = await request(app)
+      .post('/api/agents/task_1/start')
+      .set('X-Idempotency-Key', 'launch-request-123')
+      .send({ agent: 'codex', idempotencyKey: 'body-request-456' });
+
+    expect(response.status).toBe(201);
+    expect(mockStartAgent).toHaveBeenCalledWith(
+      'task_1',
+      'codex',
+      expect.objectContaining({ admissionIdempotencyKey: 'launch-request-123' })
+    );
+
+    const invalid = await request(app)
+      .post('/api/agents/task_1/start')
+      .set('X-Idempotency-Key', 'short')
+      .send({ agent: 'codex' });
+    expect(invalid.status).toBe(400);
+    expect(mockStartAgent).toHaveBeenCalledTimes(1);
   });
 
   it('previews launch evidence without dispatching an agent', async () => {

--- a/server/src/__tests__/routes/v1-permission-guards.test.ts
+++ b/server/src/__tests__/routes/v1-permission-guards.test.ts
@@ -3,6 +3,7 @@ import type { NextFunction, Response } from 'express';
 import type { AuthenticatedRequest, AuthPermission } from '../../middleware/auth.js';
 import {
   activityAccess,
+  admissionAccess,
   agentPermissionAccess,
   agentRegistryAccess,
   agentRoutingAccess,
@@ -51,6 +52,21 @@ function runGuard(handler: AccessGuard, req: AuthenticatedRequest) {
 }
 
 describe('v1 REST permission guard presets', () => {
+  it('allows admission inspection but reserves future mutations for administrators', () => {
+    expect(
+      runGuard(admissionAccess, mockRequest('GET', '/', 'agent', ['agent:read'])).next
+    ).toHaveBeenCalled();
+
+    const mutation = runGuard(admissionAccess, mockRequest('POST', '/', 'agent', ['agent:read']));
+    expect(mutation.next).not.toHaveBeenCalled();
+    expect(mutation.res.status).toHaveBeenCalledWith(403);
+    expect(mutation.res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ required: ['admin:manage'] }),
+      })
+    );
+  });
+
   it('blocks read-only callers from task, settings, workflow, comment, and approval mutations', () => {
     const blockedMutations: Array<{
       guard: AccessGuard;

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -405,6 +405,29 @@ describe('Feature Settings Schema', () => {
     expect(result.budget?.enabled).toBe(true);
   });
 
+  it('should validate admission ceilings and lease timing', () => {
+    const result = FeatureSettingsPatchSchema.parse({
+      admission: {
+        leaseMs: 30_000,
+        heartbeatMs: 10_000,
+        global: { concurrentRuns: 8, estimatedMemoryMb: 16_384 },
+        providers: { 'codex-cli': { processSlots: 4 } },
+      },
+    });
+    expect(result.admission?.global?.concurrentRuns).toBe(8);
+    expect(result.admission?.providers?.['codex-cli']?.processSlots).toBe(4);
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        admission: { leaseMs: 10_000, heartbeatMs: 10_000 },
+      })
+    ).toThrow();
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        admission: { defaultRequest: { runSlots: 0 } },
+      })
+    ).toThrow();
+  });
+
   it('should reject unknown keys (strict mode)', () => {
     expect(() => FeatureSettingsPatchSchema.parse({ unknownSection: {} })).toThrow();
   });

--- a/server/src/__tests__/shared-api-permissions.test.ts
+++ b/server/src/__tests__/shared-api-permissions.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { getApiPermissionRequirement } from '../../../shared/src/utils/api-permissions.js';
 
 describe('shared API permission metadata', () => {
+  it('keeps admission inspection agent-scoped and mutations admin-scoped', () => {
+    expect(getApiPermissionRequirement('/api/v1/admission').permissions).toEqual(['agent:read']);
+    expect(getApiPermissionRequirement('/api/admission', { method: 'POST' }).permissions).toEqual([
+      'admin:manage',
+    ]);
+  });
+
   it('requires agent write permission for local agent start and stop routes', () => {
     expect(
       getApiPermissionRequirement('/api/agents/task_1/start', { method: 'POST' }).permissions

--- a/server/src/routes/admission.ts
+++ b/server/src/routes/admission.ts
@@ -1,0 +1,70 @@
+import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../middleware/async-handler.js';
+import { ValidationError } from '../middleware/error-handler.js';
+import { AdmissionReservationListQuerySchema } from '../schemas/admission-control-schemas.js';
+import { getAdmissionControlService } from '../services/admission-control-service.js';
+
+const router: RouterType = Router();
+const admission = getAdmissionControlService();
+
+const listQuerySchema = z
+  .object({
+    workspaceId: z.string().trim().min(1).max(240).optional(),
+    taskId: z.string().trim().min(1).max(240).optional(),
+    rootTaskId: z.string().trim().min(1).max(240).optional(),
+    provider: z.string().trim().min(1).max(80).optional(),
+    hostId: z.string().trim().min(1).max(240).optional(),
+    state: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .transform((value) =>
+        value === undefined ? undefined : Array.isArray(value) ? value : value.split(',')
+      ),
+    limit: z.coerce.number().int().min(1).max(1_000).optional(),
+  })
+  .strict();
+
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    try {
+      const raw = listQuerySchema.parse(req.query);
+      const query = AdmissionReservationListQuerySchema.parse({
+        workspaceId: raw.workspaceId,
+        taskId: raw.taskId,
+        rootTaskId: raw.rootTaskId,
+        provider: raw.provider,
+        hostId: raw.hostId,
+        states: raw.state,
+        limit: raw.limit,
+      });
+      res.json({
+        generatedAt: new Date().toISOString(),
+        reservations: await admission.list(query),
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    try {
+      const id = z.string().trim().min(1).max(240).parse(req.params.id);
+      res.json(await admission.get(id));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
+
+export { router as admissionRoutes };

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -60,6 +60,7 @@ const startAgentSchema = z.object({
   commitPolicy: TaskCommitPolicySchema.optional(),
   phase: phaseNameSchema.optional(),
   parentAttemptId: z.string().trim().min(1).max(120).optional(),
+  idempotencyKey: z.string().trim().min(8).max(240).optional(),
 });
 
 const completionProvenanceSchema = {
@@ -313,7 +314,9 @@ router.post(
     let commitPolicy: TaskCommitPolicy | undefined;
     let phase: PhaseName | undefined;
     let parentAttemptId: string | undefined;
+    let idempotencyKey: string | undefined;
     try {
+      const headerIdempotencyKey = req.get('x-idempotency-key')?.trim();
       ({
         agent,
         profileId,
@@ -324,7 +327,11 @@ router.post(
         commitPolicy,
         phase,
         parentAttemptId,
-      } = startAgentSchema.parse(req.body) as {
+        idempotencyKey,
+      } = startAgentSchema.parse({
+        ...req.body,
+        ...(headerIdempotencyKey ? { idempotencyKey: headerIdempotencyKey } : {}),
+      }) as {
         agent?: AgentType;
         profileId?: string;
         overrideReason?: string;
@@ -334,6 +341,7 @@ router.post(
         commitPolicy?: TaskCommitPolicy;
         phase?: PhaseName;
         parentAttemptId?: string;
+        idempotencyKey?: string;
       });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -352,6 +360,7 @@ router.post(
         commitPolicy,
         phase,
         parentAttemptId,
+        admissionIdempotencyKey: idempotencyKey,
       });
     } catch (error) {
       if (error instanceof AgentReadinessError) {

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -18,6 +18,7 @@ import { Router, type IRouter, type Request } from 'express';
 import { readRateLimit, writeRateLimit, uploadRateLimit } from '../../middleware/rate-limit.js';
 import {
   activityAccess,
+  admissionAccess,
   adminAccess,
   agentPermissionAccess,
   agentRegistryAccess,
@@ -146,6 +147,7 @@ import { workspaceCapabilityRoutes } from '../workspace-capabilities.js';
 import { schedulerRoutes } from '../scheduler.js';
 import { queueMonitorRoutes } from '../queue-monitors.js';
 import { toolControlPlaneRoutes } from '../tool-control-plane.js';
+import { admissionRoutes } from '../admission.js';
 
 const v1Router: IRouter = Router();
 
@@ -200,6 +202,7 @@ v1Router.use('/agents/register', agentRegistryAccess, agentRegistryRoutes); // B
 v1Router.use('/agents/permissions', agentPermissionAccess, agentPermissionRoutes);
 v1Router.use('/agents', agentRoutingAccess, agentRoutingRoutes); // Must be before agentRoutes (/:taskId would match "route"/"routing")
 v1Router.use('/agents', agentTaskAccess, agentRoutes);
+v1Router.use('/admission', admissionAccess, admissionRoutes);
 v1Router.use('/diff', diffAccess, diffRoutes);
 v1Router.use('/automation', taskAccess, automationRoutes);
 v1Router.use('/summary', reportAccess, summaryRoutes);

--- a/server/src/routes/v1/permissions.ts
+++ b/server/src/routes/v1/permissions.ts
@@ -51,6 +51,7 @@ export const agentTaskAccess = routeAccess('agent:read', 'task:write', [
   },
 ]);
 export const agentStatusAccess = routeAccess('agent:read', 'telemetry:write');
+export const admissionAccess = routeAccess('agent:read', 'admin:manage');
 export const reportAccess = routeAccess('report:read', 'report:read');
 export const telemetryAccess = routeAccess('telemetry:read', 'telemetry:write');
 export const policyAccess = routeAccess('policy:read', 'policy:read', [

--- a/server/src/schemas/admission-control-schemas.ts
+++ b/server/src/schemas/admission-control-schemas.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+import {
+  ADMISSION_DECISION_OUTCOMES,
+  ADMISSION_DECISION_SCHEMA_VERSION,
+  ADMISSION_REQUEST_SCHEMA_VERSION,
+  ADMISSION_RESERVATION_SCHEMA_VERSION,
+  ADMISSION_RESERVATION_STATES,
+  ADMISSION_SCOPES,
+  EXECUTABLE_AGENT_PROVIDERS,
+} from '@veritas-kanban/shared';
+
+const identifier = z.string().trim().min(1).max(240);
+const policyIdentifier = z.string().trim().min(1).max(256);
+
+export const AdmissionCapacityRequestSchema = z
+  .object({
+    runSlots: z.number().int().min(1).max(10_000),
+    processSlots: z.number().int().min(0).max(10_000),
+    estimatedMemoryMb: z.number().int().min(0).max(100_000_000),
+  })
+  .strict();
+
+export const AdmissionCapacityLimitSchema = z
+  .object({
+    concurrentRuns: z.number().int().min(0).max(10_000).optional(),
+    processSlots: z.number().int().min(0).max(10_000).optional(),
+    estimatedMemoryMb: z.number().int().min(0).max(100_000_000).optional(),
+  })
+  .strict();
+
+export const AdmissionLimitPolicySchema = z
+  .object({
+    id: policyIdentifier,
+    scope: z.enum(ADMISSION_SCOPES),
+    scopeId: identifier,
+    limits: AdmissionCapacityLimitSchema,
+  })
+  .strict();
+
+export const AdmissionRequestSchema = z
+  .object({
+    schemaVersion: z.literal(ADMISSION_REQUEST_SCHEMA_VERSION),
+    idempotencyKey: identifier,
+    source: z.enum([
+      'direct',
+      'conversation',
+      'recovery',
+      'fallback',
+      'scheduled',
+      'watcher',
+      'workflow',
+      'child-agent',
+    ]),
+    taskId: identifier,
+    rootTaskId: identifier,
+    workspaceId: identifier,
+    provider: z.enum(EXECUTABLE_AGENT_PROVIDERS),
+    hostId: identifier,
+    requested: AdmissionCapacityRequestSchema,
+    requestedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const AdmissionReservationLeaseSchema = z
+  .object({
+    ownerId: identifier,
+    hostId: identifier,
+    processId: z.number().int().nonnegative(),
+    acquiredAt: z.string().datetime(),
+    heartbeatAt: z.string().datetime(),
+    expiresAt: z.string().datetime(),
+  })
+  .strict();
+
+export const AdmissionReservationSchema = z
+  .object({
+    schemaVersion: z.literal(ADMISSION_RESERVATION_SCHEMA_VERSION),
+    id: identifier,
+    revision: z.number().int().positive(),
+    state: z.enum(ADMISSION_RESERVATION_STATES),
+    request: AdmissionRequestSchema,
+    policies: z.array(AdmissionLimitPolicySchema).max(6),
+    attemptId: identifier.optional(),
+    lease: AdmissionReservationLeaseSchema,
+    release: z
+      .object({
+        reason: z.enum([
+          'start-failed',
+          'completed',
+          'failed',
+          'cancelled',
+          'interrupted',
+          'reconciled',
+        ]),
+        idempotencyKey: identifier,
+        releasedAt: z.string().datetime(),
+      })
+      .strict()
+      .optional(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict()
+  .superRefine((record, ctx) => {
+    if (record.state === 'released' && !record.release) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Released admission reservations require release evidence.',
+        path: ['release'],
+      });
+    }
+    if (record.state !== 'released' && record.release) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Only released admission reservations may contain release evidence.',
+        path: ['release'],
+      });
+    }
+  });
+
+export const AdmissionDecisionSchema = z
+  .object({
+    schemaVersion: z.literal(ADMISSION_DECISION_SCHEMA_VERSION),
+    outcome: z.enum(ADMISSION_DECISION_OUTCOMES),
+    request: AdmissionRequestSchema,
+    reservation: AdmissionReservationSchema.optional(),
+    limitingPolicies: z.array(AdmissionLimitPolicySchema).max(6),
+    retryAfterMs: z.number().int().min(250).max(60_000).optional(),
+    reason: z.string().min(1).max(1_000),
+    decidedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const AdmissionReservationListQuerySchema = z
+  .object({
+    workspaceId: identifier.optional(),
+    taskId: identifier.optional(),
+    rootTaskId: identifier.optional(),
+    provider: z.enum(EXECUTABLE_AGENT_PROVIDERS).optional(),
+    hostId: identifier.optional(),
+    states: z.array(z.enum(ADMISSION_RESERVATION_STATES)).max(3).optional(),
+    limit: z.number().int().min(1).max(1_000).optional(),
+  })
+  .strict();

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
-import { BOARD_COLUMN_ID_PATTERN } from '@veritas-kanban/shared';
+import { BOARD_COLUMN_ID_PATTERN, EXECUTABLE_AGENT_PROVIDERS } from '@veritas-kanban/shared';
 
 // Dangerous keys check
 const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
@@ -211,6 +211,54 @@ const BudgetSettingsSchema = z
   .strict()
   .optional();
 
+const AdmissionCapacityRequestSchema = z
+  .object({
+    runSlots: z.number().int().min(1).max(10_000).optional(),
+    processSlots: z.number().int().min(0).max(10_000).optional(),
+    estimatedMemoryMb: z.number().int().min(0).max(100_000_000).optional(),
+  })
+  .strict()
+  .optional();
+
+const AdmissionCapacityLimitSchema = z
+  .object({
+    concurrentRuns: z.number().int().min(0).max(10_000).optional(),
+    processSlots: z.number().int().min(0).max(10_000).optional(),
+    estimatedMemoryMb: z.number().int().min(0).max(100_000_000).optional(),
+  })
+  .strict();
+
+const AdmissionSettingsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    leaseMs: z.number().int().min(5_000).max(300_000).optional(),
+    heartbeatMs: z.number().int().min(1_000).max(100_000).optional(),
+    retryAfterMs: z.number().int().min(250).max(60_000).optional(),
+    defaultRequest: AdmissionCapacityRequestSchema,
+    global: AdmissionCapacityLimitSchema.optional(),
+    workspaces: z.record(z.string().min(1).max(240), AdmissionCapacityLimitSchema).optional(),
+    rootTasks: z.record(z.string().min(1).max(240), AdmissionCapacityLimitSchema).optional(),
+    providers: z
+      .partialRecord(z.enum(EXECUTABLE_AGENT_PROVIDERS), AdmissionCapacityLimitSchema)
+      .optional(),
+    hosts: z.record(z.string().min(1).max(240), AdmissionCapacityLimitSchema).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (
+      value.heartbeatMs !== undefined &&
+      value.leaseMs !== undefined &&
+      value.heartbeatMs >= value.leaseMs
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'admission.heartbeatMs must be less than admission.leaseMs',
+        path: ['heartbeatMs'],
+      });
+    }
+  })
+  .optional();
+
 const EnforcementSettingsSchema = z
   .object({
     squadChat: z.boolean().optional(),
@@ -351,6 +399,7 @@ const FeatureSettingsPatchObjectSchema = z
     notifications: NotificationSettingsSchema,
     archive: ArchiveSettingsSchema,
     budget: BudgetSettingsSchema,
+    admission: AdmissionSettingsSchema,
     enforcement: EnforcementSettingsSchema,
     hooks: HooksSettingsSchema,
     sharedResources: SharedResourcesSettingsSchema,

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -1,0 +1,533 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
+import type {
+  AdmissionCapacityRequest,
+  AdmissionDecision,
+  AdmissionLaunchSource,
+  AdmissionLimitPolicy,
+  AdmissionReservation,
+  AdmissionReservationListQuery,
+  AdmissionReservationRelease,
+  AdmissionSettings,
+  ExecutableAgentProvider,
+} from '@veritas-kanban/shared';
+import {
+  ADMISSION_DECISION_SCHEMA_VERSION,
+  ADMISSION_REQUEST_SCHEMA_VERSION,
+  ADMISSION_RESERVATION_SCHEMA_VERSION,
+  DEFAULT_FEATURE_SETTINGS,
+} from '@veritas-kanban/shared';
+import {
+  AdmissionDecisionSchema,
+  AdmissionReservationSchema,
+} from '../schemas/admission-control-schemas.js';
+import type { AdmissionReservationRepository } from '../storage/interfaces.js';
+import { FileAdmissionReservationRepository } from '../storage/admission-reservation-repository.js';
+import { requestExceedsPolicies } from '../storage/admission-capacity.js';
+import { getStorage, getStorageTypeFromEnv } from '../storage/index.js';
+import { ConfigService } from './config-service.js';
+import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
+
+const MAX_CAS_ATTEMPTS = 8;
+
+export interface AdmissionRequestInput {
+  taskId: string;
+  rootTaskId?: string;
+  workspaceId: string;
+  provider: ExecutableAgentProvider;
+  hostId: string;
+  source?: AdmissionLaunchSource;
+  idempotencyKey?: string;
+  requested?: Partial<AdmissionCapacityRequest>;
+}
+
+export interface RecoverAdmissionInput {
+  workspaceId: string;
+  taskId: string;
+  attemptId: string;
+}
+
+export interface AdmissionControlServiceOptions {
+  repository?: AdmissionReservationRepository;
+  settings?: () => Promise<AdmissionSettings>;
+  now?: () => Date;
+  ownerId?: string;
+  hostId?: string;
+  processId?: number;
+}
+
+let fileRepository: FileAdmissionReservationRepository | undefined;
+let singleton: AdmissionControlService | undefined;
+
+function defaultRepository(): AdmissionReservationRepository {
+  if (getStorageTypeFromEnv() === 'sqlite') return getStorage().admissionReservations;
+  fileRepository ??= new FileAdmissionReservationRepository();
+  return fileRepository;
+}
+
+function defaultExecutionHostId(): string {
+  return `host-${createHash('sha256').update(hostname()).digest('hex').slice(0, 24)}`;
+}
+
+function reservationId(idempotencyKey: string): string {
+  return `admission_${createHash('sha256').update(idempotencyKey).digest('hex').slice(0, 32)}`;
+}
+
+function idempotencyIdentity(idempotencyKey: string): string {
+  return `sha256:${createHash('sha256').update(idempotencyKey).digest('hex')}`;
+}
+
+export class AdmissionControlService {
+  private readonly repositoryOverride?: AdmissionReservationRepository;
+  private readonly settingsOverride?: () => Promise<AdmissionSettings>;
+  private readonly configService = new ConfigService();
+  private readonly now: () => Date;
+  private readonly ownerId: string;
+  private readonly executionHostId: string;
+  private readonly processId: number;
+  private readonly heartbeatTimers = new Map<string, NodeJS.Timeout>();
+  private readonly heartbeatEligible = new Set<string>();
+
+  constructor(options: AdmissionControlServiceOptions = {}) {
+    this.repositoryOverride = options.repository;
+    this.settingsOverride = options.settings;
+    this.now = options.now ?? (() => new Date());
+    this.processId = options.processId ?? process.pid;
+    this.executionHostId = options.hostId ?? defaultExecutionHostId();
+    this.ownerId =
+      options.ownerId ?? `admission-${this.processId}-${randomUUID().replaceAll('-', '')}`;
+  }
+
+  private get repository(): AdmissionReservationRepository {
+    return this.repositoryOverride ?? defaultRepository();
+  }
+
+  private async settings(): Promise<AdmissionSettings> {
+    const settings = this.settingsOverride
+      ? await this.settingsOverride()
+      : ((await this.configService.getFeatureSettings()).admission ??
+        DEFAULT_FEATURE_SETTINGS.admission);
+    if (settings.heartbeatMs >= settings.leaseMs) {
+      throw new ConflictError('Admission heartbeat must be shorter than its lease.', {
+        heartbeatMs: settings.heartbeatMs,
+        leaseMs: settings.leaseMs,
+      });
+    }
+    return settings;
+  }
+
+  async admit(input: AdmissionRequestInput): Promise<AdmissionDecision> {
+    const settings = await this.settings();
+    const now = this.now();
+    const idempotencyKey = idempotencyIdentity(
+      input.idempotencyKey?.trim() || `direct:${input.taskId}:${randomUUID()}`
+    );
+    const requested = {
+      ...settings.defaultRequest,
+      ...input.requested,
+    };
+    const request = {
+      schemaVersion: ADMISSION_REQUEST_SCHEMA_VERSION,
+      idempotencyKey,
+      source: input.source ?? 'direct',
+      taskId: input.taskId,
+      rootTaskId: input.rootTaskId?.trim() || input.taskId,
+      workspaceId: input.workspaceId,
+      provider: input.provider,
+      hostId: input.hostId,
+      requested: {
+        ...requested,
+        runSlots: Math.max(1, requested.runSlots),
+      },
+      requestedAt: now.toISOString(),
+    } as const;
+    const policies = this.policiesFor(request, settings);
+    const impossible = requestExceedsPolicies(request.requested, policies);
+    if (impossible.length > 0) {
+      return this.decision(
+        'terminal-policy-denial',
+        request,
+        impossible,
+        'The launch request exceeds a configured capacity ceiling.',
+        now
+      );
+    }
+    const record = AdmissionReservationSchema.parse({
+      schemaVersion: ADMISSION_RESERVATION_SCHEMA_VERSION,
+      id: reservationId(idempotencyKey),
+      revision: 1,
+      state: 'active',
+      request,
+      policies,
+      lease: this.newLease(now, settings.leaseMs),
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    });
+    const claimed = await this.repository.claim({ record, now: now.toISOString() });
+    if (claimed.limitingPolicies.length > 0) {
+      return this.decision(
+        'retryable-overload',
+        request,
+        claimed.limitingPolicies,
+        'Active reservations currently consume the configured capacity.',
+        now,
+        settings.retryAfterMs
+      );
+    }
+    if (!claimed.record) {
+      throw new Error('Admission repository returned no reservation or limiting policy.');
+    }
+    if (!sameRequestIdentity(claimed.record.request, request)) {
+      return this.decision(
+        'terminal-policy-denial',
+        request,
+        [],
+        'The idempotency key is already bound to a different launch request.',
+        now
+      );
+    }
+    if (claimed.record.state !== 'active') {
+      return this.decision(
+        'terminal-policy-denial',
+        request,
+        [],
+        `The idempotency key already belongs to a ${claimed.record.state} reservation.`,
+        now
+      );
+    }
+    return this.decision(
+      'admitted',
+      request,
+      [],
+      claimed.created ? 'Capacity reserved.' : 'Existing active reservation reused.',
+      now,
+      undefined,
+      claimed.record
+    );
+  }
+
+  async bindAttempt(id: string, attemptId: string): Promise<AdmissionReservation> {
+    const settings = await this.settings();
+    const bound = await this.mutate(id, (current, now) => {
+      if (current.state !== 'active') {
+        throw new ConflictError('Cannot bind an attempt to an inactive admission reservation.', {
+          reservationId: id,
+          state: current.state,
+        });
+      }
+      if (current.attemptId && current.attemptId !== attemptId) {
+        throw new ConflictError('Admission reservation already belongs to another attempt.', {
+          reservationId: id,
+          currentAttemptId: current.attemptId,
+          requestedAttemptId: attemptId,
+        });
+      }
+      return {
+        ...current,
+        attemptId,
+        lease: this.refreshLease(current, now),
+        updatedAt: now.toISOString(),
+      };
+    });
+    this.startHeartbeat(bound, settings.heartbeatMs);
+    return bound;
+  }
+
+  async renew(id: string): Promise<AdmissionReservation> {
+    return this.mutate(id, (current, now) => {
+      if (current.state !== 'active') return current;
+      return {
+        ...current,
+        lease: this.refreshLease(current, now),
+        updatedAt: now.toISOString(),
+      };
+    });
+  }
+
+  async release(
+    id: string,
+    reason: AdmissionReservationRelease['reason'],
+    idempotencyKey: string
+  ): Promise<AdmissionReservation> {
+    this.stopHeartbeat(id);
+    return this.mutate(id, (current, now) => {
+      if (current.state === 'released') return current;
+      return {
+        ...current,
+        state: 'released',
+        release: {
+          reason,
+          idempotencyKey,
+          releasedAt: now.toISOString(),
+        },
+        updatedAt: now.toISOString(),
+      };
+    });
+  }
+
+  async releaseIfUnbound(
+    id: string,
+    reason: AdmissionReservationRelease['reason'],
+    idempotencyKey: string
+  ): Promise<AdmissionReservation> {
+    const record = await this.mutate(id, (current, now) => {
+      if (current.state !== 'active' || current.attemptId) return current;
+      return {
+        ...current,
+        state: 'released',
+        release: {
+          reason,
+          idempotencyKey,
+          releasedAt: now.toISOString(),
+        },
+        updatedAt: now.toISOString(),
+      };
+    });
+    if (record.state !== 'active') this.stopHeartbeat(id);
+    return record;
+  }
+
+  async releaseByAttempt(
+    workspaceId: string,
+    taskId: string,
+    attemptId: string,
+    reason: AdmissionReservationRelease['reason'],
+    idempotencyKey: string
+  ): Promise<AdmissionReservation | null> {
+    const reservation = await this.findByAttempt(workspaceId, taskId, attemptId);
+    return reservation ? this.release(reservation.id, reason, idempotencyKey) : null;
+  }
+
+  async recoverVerifiedRun(input: RecoverAdmissionInput): Promise<AdmissionReservation | null> {
+    const existing = await this.findByAttempt(input.workspaceId, input.taskId, input.attemptId);
+    if (!existing) return null;
+    const settings = await this.settings();
+    const now = this.now();
+    const refreshed = AdmissionReservationSchema.parse({
+      ...existing,
+      revision: 1,
+      state: 'active',
+      release: undefined,
+      policies: this.policiesFor(existing.request, settings),
+      lease: this.newLease(now, settings.leaseMs),
+      updatedAt: now.toISOString(),
+    });
+    const claimed = await this.repository.claim({
+      record: refreshed,
+      now: now.toISOString(),
+      reclaimExpired: true,
+    });
+    if (claimed.limitingPolicies.length > 0 || !claimed.record) {
+      throw new ConflictError('Verified live run could not reclaim admission capacity.', {
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        limitingPolicies: claimed.limitingPolicies,
+      });
+    }
+    if (claimed.record.state !== 'active') {
+      throw new ConflictError('Verified live run has a terminal admission reservation.', {
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        reservationId: claimed.record.id,
+        reservationState: claimed.record.state,
+      });
+    }
+    const recovered = await this.renew(claimed.record.id);
+    this.startHeartbeat(recovered, settings.heartbeatMs);
+    return recovered;
+  }
+
+  async expireAbandoned(): Promise<AdmissionReservation[]> {
+    return this.repository.expireLeases(this.now().toISOString());
+  }
+
+  async get(id: string): Promise<AdmissionReservation> {
+    await this.expireAbandoned();
+    const record = await this.repository.get(id);
+    if (!record) throw new NotFoundError('Admission reservation not found.');
+    return record;
+  }
+
+  async list(query: AdmissionReservationListQuery = {}): Promise<AdmissionReservation[]> {
+    await this.expireAbandoned();
+    return this.repository.list(query);
+  }
+
+  async findByAttempt(
+    workspaceId: string,
+    taskId: string,
+    attemptId: string
+  ): Promise<AdmissionReservation | null> {
+    const records = await this.repository.list({
+      workspaceId,
+      taskId,
+      limit: 1_000,
+    });
+    return records.find((record) => record.attemptId === attemptId) ?? null;
+  }
+
+  dispose(): void {
+    for (const id of this.heartbeatTimers.keys()) this.stopHeartbeat(id);
+    this.heartbeatEligible.clear();
+    this.configService.dispose();
+  }
+
+  private policiesFor(
+    request: Pick<
+      AdmissionReservation['request'],
+      'taskId' | 'workspaceId' | 'rootTaskId' | 'provider' | 'hostId'
+    >,
+    settings: AdmissionSettings
+  ): AdmissionLimitPolicy[] {
+    const taskExclusivity: AdmissionLimitPolicy = {
+      id: `task:${request.taskId}`,
+      scope: 'task',
+      scopeId: request.taskId,
+      limits: { concurrentRuns: 1 },
+    };
+    if (!settings.enabled) return [taskExclusivity];
+    const candidates: Array<
+      [AdmissionLimitPolicy['scope'], string, AdmissionLimitPolicy['limits'] | undefined]
+    > = [
+      ['global', 'global', settings.global],
+      ['workspace', request.workspaceId, settings.workspaces[request.workspaceId]],
+      ['root-task', request.rootTaskId, settings.rootTasks[request.rootTaskId]],
+      ['provider', request.provider, settings.providers[request.provider]],
+      ['host', request.hostId, settings.hosts[request.hostId]],
+    ];
+    return [
+      taskExclusivity,
+      ...candidates.flatMap(([scope, scopeId, limits]) =>
+        limits && Object.keys(limits).length > 0
+          ? [{ id: `${scope}:${scopeId}`, scope, scopeId, limits }]
+          : []
+      ),
+    ];
+  }
+
+  private decision(
+    outcome: AdmissionDecision['outcome'],
+    request: AdmissionDecision['request'],
+    limitingPolicies: AdmissionLimitPolicy[],
+    reason: string,
+    now: Date,
+    retryAfterMs?: number,
+    reservation?: AdmissionReservation
+  ): AdmissionDecision {
+    return AdmissionDecisionSchema.parse({
+      schemaVersion: ADMISSION_DECISION_SCHEMA_VERSION,
+      outcome,
+      request,
+      reservation,
+      limitingPolicies,
+      retryAfterMs,
+      reason,
+      decidedAt: now.toISOString(),
+    });
+  }
+
+  private newLease(now: Date, leaseMs: number): AdmissionReservation['lease'] {
+    return {
+      ownerId: this.ownerId,
+      hostId: this.executionHostId,
+      processId: this.processId,
+      acquiredAt: now.toISOString(),
+      heartbeatAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + leaseMs).toISOString(),
+    };
+  }
+
+  private refreshLease(current: AdmissionReservation, now: Date): AdmissionReservation['lease'] {
+    return {
+      ...current.lease,
+      ownerId: this.ownerId,
+      hostId: this.executionHostId,
+      processId: this.processId,
+      heartbeatAt: now.toISOString(),
+      expiresAt: new Date(
+        now.getTime() +
+          Math.max(1, Date.parse(current.lease.expiresAt) - Date.parse(current.lease.heartbeatAt))
+      ).toISOString(),
+    };
+  }
+
+  private async mutate(
+    id: string,
+    update: (current: AdmissionReservation, now: Date) => AdmissionReservation
+  ): Promise<AdmissionReservation> {
+    for (let attempt = 1; attempt <= MAX_CAS_ATTEMPTS; attempt++) {
+      const current = await this.repository.get(id);
+      if (!current) throw new NotFoundError('Admission reservation not found.');
+      const candidate = update(current, this.now());
+      if (candidate === current) return current;
+      const next = AdmissionReservationSchema.parse({
+        ...candidate,
+        revision: current.revision + 1,
+      });
+      const result = await this.repository.compareAndSet({
+        id,
+        expectedRevision: current.revision,
+        next,
+      });
+      if (result.updated && result.record) return result.record;
+      if (result.reason !== 'stale-revision') {
+        throw new ConflictError('Admission reservation update failed.', {
+          reservationId: id,
+          reason: result.reason,
+        });
+      }
+    }
+    throw new ConflictError('Admission reservation changed too many times.', {
+      reservationId: id,
+    });
+  }
+
+  private startHeartbeat(record: AdmissionReservation, configuredHeartbeatMs: number): void {
+    const id = record.id;
+    this.heartbeatEligible.add(id);
+    if (this.heartbeatTimers.has(id)) return;
+    const leaseDurationMs =
+      Date.parse(record.lease.expiresAt) - Date.parse(record.lease.heartbeatAt);
+    const heartbeatMs = Math.min(
+      configuredHeartbeatMs,
+      Math.max(1_000, Math.floor(leaseDurationMs / 2))
+    );
+    const timer = setInterval(() => {
+      void this.renew(id)
+        .then((renewed) => {
+          if (renewed.state !== 'active') this.stopHeartbeat(id);
+        })
+        .catch(() => this.stopHeartbeat(id));
+    }, heartbeatMs);
+    timer.unref();
+    this.heartbeatTimers.set(id, timer);
+  }
+
+  private stopHeartbeat(id: string): void {
+    this.heartbeatEligible.delete(id);
+    const timer = this.heartbeatTimers.get(id);
+    if (timer) clearInterval(timer);
+    this.heartbeatTimers.delete(id);
+  }
+}
+
+function sameRequestIdentity(
+  left: AdmissionReservation['request'],
+  right: AdmissionReservation['request']
+): boolean {
+  return (
+    left.idempotencyKey === right.idempotencyKey &&
+    left.source === right.source &&
+    left.taskId === right.taskId &&
+    left.rootTaskId === right.rootTaskId &&
+    left.workspaceId === right.workspaceId &&
+    left.provider === right.provider &&
+    left.hostId === right.hostId &&
+    JSON.stringify(left.requested) === JSON.stringify(right.requested)
+  );
+}
+
+export function getAdmissionControlService(): AdmissionControlService {
+  singleton ??= new AdmissionControlService();
+  return singleton;
+}

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -127,6 +127,7 @@ import type {
   RunApprovalRiskClass,
   WorkspaceExecutionTrustEvaluation,
   WorkspaceExecutionTrustScanResult,
+  AdmissionReservationRelease,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
@@ -209,6 +210,10 @@ import {
   type RunApprovalBrokerService,
 } from './run-approval-broker-service.js';
 import { getRunSupervisorService, type RunSupervisorService } from './run-supervisor-service.js';
+import {
+  getAdmissionControlService,
+  type AdmissionControlService,
+} from './admission-control-service.js';
 import {
   ConversationLifecycleService,
   type ConversationSource,
@@ -325,6 +330,7 @@ export interface AgentStatus {
   activePhaseEvidence?: PhaseCapabilityEvidence;
   conversation: ConversationLifecycleRecord;
   controls: ProviderRuntimeControlSet;
+  admissionReservationId?: string;
 }
 
 export interface AgentOutput {
@@ -345,6 +351,8 @@ export interface AgentStartOptions {
   conversation?: ConversationLaunchRequest;
   /** Internal durable recovery context. API callers cannot supply this field. */
   recovery?: RunRecoveryRecord;
+  admissionIdempotencyKey?: string;
+  rootTaskId?: string;
 }
 
 export interface AgentMessageOptions {
@@ -399,6 +407,7 @@ interface PendingAgent {
   activePhaseEvidence?: PhaseCapabilityEvidence;
   conversation: ConversationLifecycleRecord;
   supervisorId?: string;
+  admissionReservationId?: string;
   recoveredControl?: boolean;
   threadId?: string;
   abortController?: AbortController;
@@ -505,6 +514,7 @@ export class ClawdbotAgentService {
   private runEvents: RunEventJournalService;
   private approvalBroker: RunApprovalBrokerService;
   private runSupervisor: RunSupervisorService;
+  private admission: AdmissionControlService;
   private conversationLifecycle: ConversationLifecycleService;
   private toolControlPlane: ToolControlPlaneService;
   private runToolBridge: RunToolBridgeService;
@@ -550,7 +560,8 @@ export class ClawdbotAgentService {
     > = getWorkspaceExecutionTrustService(),
     phaseAuthority = new PhaseLaunchAuthorityService(),
     phaseTransitions?: Pick<PhaseTransitionService, 'getCurrent'> &
-      Partial<Pick<PhaseTransitionService, 'list'>>
+      Partial<Pick<PhaseTransitionService, 'list'>>,
+    admission: AdmissionControlService = getAdmissionControlService()
   ) {
     this.configService = new ConfigService();
     this.taskService = new TaskService();
@@ -570,6 +581,7 @@ export class ClawdbotAgentService {
     this.runEvents = runEvents;
     this.approvalBroker = approvalBroker;
     this.runSupervisor = runSupervisor;
+    this.admission = admission;
     this.conversationLifecycle = conversationLifecycle;
     this.toolControlPlane = toolControlPlane;
     this.runToolBridge = runToolBridge;
@@ -619,6 +631,7 @@ export class ClawdbotAgentService {
    * and whose taskId is NOT in `pendingAgents` are touched.
    */
   async reconcileRunningAttempts(): Promise<void> {
+    await this.admission.expireAbandoned();
     let tasks: Task[];
     try {
       tasks = await this.taskService.listTasks();
@@ -1293,6 +1306,25 @@ export class ClawdbotAgentService {
           ? supervisor.control.sessionId
           : undefined;
     const recoveredConversation = this.conversationLifecycle.recover(attempt, sessionId);
+    const recoveredAdmission = await this.admission.recoverVerifiedRun({
+      workspaceId: attempt.taskEnvelope.workspace.workspaceId,
+      taskId: task.id,
+      attemptId: attempt.id,
+    });
+    if (
+      attempt.admissionReservationId &&
+      recoveredAdmission?.id !== attempt.admissionReservationId
+    ) {
+      throw new CompletionOwnershipError(
+        'Recovered attempt admission binding does not match the durable reservation.',
+        {
+          taskId: task.id,
+          attemptId: attempt.id,
+          expectedReservationId: attempt.admissionReservationId,
+          recoveredReservationId: recoveredAdmission?.id,
+        }
+      );
+    }
     const pending: PendingAgent = {
       taskId: task.id,
       attemptId: attempt.id,
@@ -1316,6 +1348,7 @@ export class ClawdbotAgentService {
       activePhaseEvidence: attempt.runLaunchManifest.phase?.evidence,
       conversation: recoveredConversation,
       supervisorId: supervisor.id,
+      admissionReservationId: recoveredAdmission?.id,
       recoveredControl: true,
       threadId: attempt.threadId ?? sessionId,
       openclawSessionKey: provider === 'openclaw' ? (attempt.sessionKey ?? sessionId) : undefined,
@@ -1712,6 +1745,14 @@ export class ClawdbotAgentService {
     if (!task.git?.worktreePath) {
       throw new Error('Task must have an active worktree to start an agent');
     }
+    if (task.attempt?.status === 'running') {
+      throw new ConflictError('Task already has a persisted running attempt.', {
+        taskId,
+        attemptId: task.attempt.id,
+        runSupervisorId: task.attempt.runSupervisorId,
+        admissionReservationId: task.attempt.admissionReservationId,
+      });
+    }
 
     const conversationRequest = this.normalizeConversationLaunch(options.conversation);
     const conversationSource =
@@ -2070,6 +2111,51 @@ export class ClawdbotAgentService {
       conversationRequest.forkTurnId,
       conversationRequest.intent
     );
+    const admissionDecision = await this.admission.admit({
+      taskId,
+      rootTaskId: options.rootTaskId,
+      workspaceId: taskEnvelope.workspace.workspaceId,
+      provider,
+      hostId: runLaunchManifest.routing.selectedHost,
+      source: options.recovery
+        ? options.recovery.action === 'fallback'
+          ? 'fallback'
+          : 'recovery'
+        : conversationRequest.mode === 'fresh'
+          ? 'direct'
+          : 'conversation',
+      idempotencyKey: options.admissionIdempotencyKey,
+    });
+    if (admissionDecision.outcome !== 'admitted' || !admissionDecision.reservation) {
+      throw new ConflictError(
+        admissionDecision.outcome === 'retryable-overload'
+          ? 'Agent launch is waiting for admission capacity.'
+          : 'Agent launch violates an admission policy.',
+        {
+          code:
+            admissionDecision.outcome === 'retryable-overload'
+              ? 'ADMISSION_OVERLOAD'
+              : 'ADMISSION_POLICY_DENIED',
+          decision: admissionDecision,
+        }
+      );
+    }
+    let admissionReservation;
+    try {
+      admissionReservation = await this.admission.bindAttempt(
+        admissionDecision.reservation.id,
+        attemptId
+      );
+    } catch (error) {
+      await this.admission
+        .releaseIfUnbound(
+          admissionDecision.reservation.id,
+          'start-failed',
+          `bind-failed:${attemptId}`
+        )
+        .catch(() => {});
+      throw error;
+    }
     // Create event emitter for status updates
     const emitter = new EventEmitter();
 
@@ -2093,6 +2179,7 @@ export class ClawdbotAgentService {
       runRetry,
       activePhaseEvidence: runLaunchManifest.phase?.evidence,
       conversation,
+      admissionReservationId: admissionReservation.id,
       filesystemSandboxPlan,
       budget: budgetPolicy
         ? {
@@ -2110,15 +2197,25 @@ export class ClawdbotAgentService {
 
     // Initialize log file (ensure it stays within logs dir)
     ensureWithinBase(this.logsDir, logPath);
-    await this.initLogFile(
-      logPath,
-      task,
-      agent,
-      providerTransport.content,
-      providerRuntimeManifest,
-      taskEnvelope,
-      runLaunchManifest
-    );
+    try {
+      await this.initLogFile(
+        logPath,
+        task,
+        agent,
+        providerTransport.content,
+        providerRuntimeManifest,
+        taskEnvelope,
+        runLaunchManifest
+      );
+    } catch (error) {
+      pendingAgents.delete(taskId);
+      await this.releaseAdmission(
+        admissionReservation.id,
+        'start-failed',
+        `log-init-failed:${attemptId}`
+      );
+      throw error;
+    }
 
     // Update task with attempt info
     const attempt: TaskAttempt = {
@@ -2139,6 +2236,7 @@ export class ClawdbotAgentService {
       runLaunchManifestDrift,
       runRetry,
       conversation,
+      admissionReservationId: admissionReservation.id,
     };
 
     const usesManagedWorktree = Boolean(task.git.worktreeManifestId && task.git.worktreeLeaseId);
@@ -2147,11 +2245,22 @@ export class ClawdbotAgentService {
         await this.worktrees.claimOwnership(taskId, attemptId);
       } catch (error) {
         pendingAgents.delete(taskId);
+        await this.releaseAdmission(
+          admissionReservation.id,
+          'start-failed',
+          `worktree-claim-failed:${attemptId}`
+        );
         throw error;
       }
       const claimedTask = await this.taskService.getTask(taskId);
       if (!claimedTask) {
         await this.worktrees.releaseOwnership(taskId, attemptId);
+        pendingAgents.delete(taskId);
+        await this.releaseAdmission(
+          admissionReservation.id,
+          'start-failed',
+          `task-missing:${attemptId}`
+        );
         throw new Error(`Task "${taskId}" disappeared while claiming its worktree`);
       }
       task = claimedTask;
@@ -2165,6 +2274,11 @@ export class ClawdbotAgentService {
         claimedRecovery.parentRunId !== options.recovery.parentRunId
       ) {
         pendingAgents.delete(taskId);
+        await this.releaseAdmission(
+          admissionReservation.id,
+          'start-failed',
+          `recovery-binding-failed:${attemptId}`
+        );
         throw new ConflictError('Recovery launch no longer matches the claimed parent attempt', {
           taskId,
           activeAttemptId: task.attempt?.id,
@@ -2202,6 +2316,11 @@ export class ClawdbotAgentService {
     } catch (error) {
       pendingAgents.delete(taskId);
       this.runToolBridge.revokeRun(taskId, attemptId);
+      await this.releaseAdmission(
+        admissionReservation.id,
+        'start-failed',
+        `attempt-persistence-failed:${attemptId}`
+      );
       if (usesManagedWorktree) {
         await this.worktrees.releaseOwnership(taskId, attemptId).catch((releaseError) => {
           log.error(
@@ -2358,6 +2477,11 @@ export class ClawdbotAgentService {
       });
     } catch (error: unknown) {
       const startError = error instanceof Error ? error : new Error(String(error));
+      await this.releaseAdmission(
+        admissionReservation.id,
+        'start-failed',
+        `provider-start-failed:${attemptId}`
+      );
       await this.appendRunEvent(
         taskId,
         attemptId,
@@ -2488,6 +2612,7 @@ export class ClawdbotAgentService {
       activePhaseEvidence: runLaunchManifest.phase?.evidence,
       conversation,
       controls: providerRuntimeControls(providerRuntimeManifest),
+      admissionReservationId: admissionReservation.id,
     };
   }
 
@@ -2585,6 +2710,17 @@ export class ClawdbotAgentService {
         if (persistedAttempt.completionResult) {
           const persistedCompletion = this.parsePersistedCompletion(persistedAttempt);
           if (persistedCompletion.idempotencyKey === idempotencyKey) {
+            await this.admission.releaseByAttempt(
+              persistedAttempt.taskEnvelope.workspace.workspaceId,
+              taskId,
+              persistedAttempt.id,
+              persistedCompletion.status === 'success'
+                ? 'completed'
+                : persistedCompletion.status === 'interrupted'
+                  ? 'interrupted'
+                  : 'failed',
+              `duplicate-completion:${persistedCompletion.idempotencyKey}`
+            );
             await this.revokeRunCredentialLeases(
               taskId,
               persistedAttempt.id,
@@ -2861,6 +2997,13 @@ export class ClawdbotAgentService {
       }
     }
     if (lastError) throw lastError;
+    await this.admission.releaseByAttempt(
+      attempt.taskEnvelope.workspace.workspaceId,
+      task.id,
+      attempt.id,
+      admissionReleaseReason(completionResult.status),
+      `recovered-completion:${completionResult.idempotencyKey}`
+    );
     await this.revokeRunCredentialLeases(
       task.id,
       attempt.id,
@@ -3041,6 +3184,13 @@ export class ClawdbotAgentService {
     }
     if (lastError) throw lastError;
 
+    await this.admission.releaseByAttempt(
+      attempt.taskEnvelope.workspace.workspaceId,
+      task.id,
+      attempt.id,
+      admissionReleaseReason(completionResult.status),
+      `restart-completion:${completionResult.idempotencyKey}`
+    );
     await this.revokeRunCredentialLeases(
       task.id,
       attempt.id,
@@ -3138,6 +3288,14 @@ export class ClawdbotAgentService {
     try {
       await finalization;
     } catch (error) {
+      const prepared = pending.preparedFinalizationResult;
+      if (prepared && pending.terminalClaimIdempotencyKey) {
+        await this.releaseAdmission(
+          pending.admissionReservationId,
+          admissionReleaseReason(prepared.status, prepared.success),
+          `finalization-failed:${pending.terminalClaimIdempotencyKey}`
+        );
+      }
       if (error instanceof CompletionOwnershipError && pendingAgents.get(taskId) === pending) {
         pendingAgents.delete(taskId);
       }
@@ -3235,6 +3393,7 @@ export class ClawdbotAgentService {
           taskEnvelope: pending.taskEnvelope,
           runLaunchManifest: pending.runLaunchManifest,
           runSupervisorId: pending.supervisorId,
+          admissionReservationId: pending.admissionReservationId,
           runLaunchManifestTraceId: pending.runLaunchManifestTraceId,
           runLaunchParentAttemptId: pending.runLaunchParentAttemptId,
           runLaunchManifestDrift: pending.runLaunchManifestDrift,
@@ -3311,6 +3470,11 @@ export class ClawdbotAgentService {
       pendingAgents.delete(taskId);
     }
     this.clearRecoveredProcessMonitor(taskId);
+    await this.releaseAdmission(
+      pending.admissionReservationId,
+      admissionReleaseReason(completionResult.status),
+      `completion:${completionResult.idempotencyKey}`
+    );
     if (!persistedHere) return;
 
     const logPath = path.join(this.logsDir, `${taskId}_${attemptId}.md`);
@@ -3458,6 +3622,22 @@ export class ClawdbotAgentService {
       });
     } finally {
       this.runToolBridge.revokeRun(taskId, attemptId);
+    }
+  }
+
+  private async releaseAdmission(
+    reservationId: string | undefined,
+    reason: AdmissionReservationRelease['reason'],
+    idempotencyKey: string
+  ): Promise<void> {
+    if (!reservationId) return;
+    try {
+      await this.admission.release(reservationId, reason, idempotencyKey);
+    } catch (error) {
+      log.error(
+        { err: error, reservationId, reason },
+        '[ClawdbotAgent] Failed to release admission reservation'
+      );
     }
   }
 
@@ -9879,6 +10059,14 @@ function taskStatusForCompletion(status: TaskCompletionStatus): 'done' | 'blocke
   if (status === 'success') return 'done';
   if (status === 'blocked') return 'blocked';
   return 'in-progress';
+}
+
+function admissionReleaseReason(
+  status: TaskCompletionStatus | undefined,
+  success?: boolean
+): AdmissionReservationRelease['reason'] {
+  if (status === 'success' || success === true) return 'completed';
+  return status === 'interrupted' ? 'interrupted' : 'failed';
 }
 
 function upsertAttemptHistory(

--- a/server/src/storage/admission-capacity.ts
+++ b/server/src/storage/admission-capacity.ts
@@ -1,0 +1,68 @@
+import type {
+  AdmissionCapacityRequest,
+  AdmissionLimitPolicy,
+  AdmissionReservation,
+} from '@veritas-kanban/shared';
+
+function policyApplies(policy: AdmissionLimitPolicy, record: AdmissionReservation): boolean {
+  const request = record.request;
+  switch (policy.scope) {
+    case 'global':
+      return true;
+    case 'task':
+      return request.taskId === policy.scopeId;
+    case 'workspace':
+      return request.workspaceId === policy.scopeId;
+    case 'root-task':
+      return request.rootTaskId === policy.scopeId;
+    case 'provider':
+      return request.provider === policy.scopeId;
+    case 'host':
+      return request.hostId === policy.scopeId;
+  }
+}
+
+function addCapacity(
+  total: AdmissionCapacityRequest,
+  requested: AdmissionCapacityRequest
+): AdmissionCapacityRequest {
+  return {
+    runSlots: total.runSlots + requested.runSlots,
+    processSlots: total.processSlots + requested.processSlots,
+    estimatedMemoryMb: total.estimatedMemoryMb + requested.estimatedMemoryMb,
+  };
+}
+
+function exceeds(requested: AdmissionCapacityRequest, policy: AdmissionLimitPolicy): boolean {
+  return (
+    (policy.limits.concurrentRuns !== undefined &&
+      requested.runSlots > policy.limits.concurrentRuns) ||
+    (policy.limits.processSlots !== undefined &&
+      requested.processSlots > policy.limits.processSlots) ||
+    (policy.limits.estimatedMemoryMb !== undefined &&
+      requested.estimatedMemoryMb > policy.limits.estimatedMemoryMb)
+  );
+}
+
+export function requestExceedsPolicies(
+  requested: AdmissionCapacityRequest,
+  policies: AdmissionLimitPolicy[]
+): AdmissionLimitPolicy[] {
+  return policies.filter((policy) => exceeds(requested, policy));
+}
+
+export function findLimitingAdmissionPolicies(
+  active: AdmissionReservation[],
+  candidate: AdmissionReservation
+): AdmissionLimitPolicy[] {
+  return candidate.policies.filter((policy) => {
+    const used = active
+      .filter((record) => record.state === 'active' && policyApplies(policy, record))
+      .reduce((total, record) => addCapacity(total, record.request.requested), {
+        runSlots: 0,
+        processSlots: 0,
+        estimatedMemoryMb: 0,
+      });
+    return exceeds(addCapacity(used, candidate.request.requested), policy);
+  });
+}

--- a/server/src/storage/admission-reservation-repository.ts
+++ b/server/src/storage/admission-reservation-repository.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from 'node:crypto';
+import { constants } from 'node:fs';
+import { lstat, mkdir, open, rename, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  AdmissionReservation,
+  AdmissionReservationClaimInput,
+  AdmissionReservationClaimResult,
+  AdmissionReservationCompareAndSetInput,
+  AdmissionReservationCompareAndSetResult,
+  AdmissionReservationListQuery,
+} from '@veritas-kanban/shared';
+import { AdmissionReservationSchema } from '../schemas/admission-control-schemas.js';
+import { withFileLock } from '../services/file-lock.js';
+import { getRuntimeDir } from '../utils/paths.js';
+import { ensureWithinBase } from '../utils/sanitize.js';
+import { findLimitingAdmissionPolicies } from './admission-capacity.js';
+import type { AdmissionReservationRepository } from './interfaces.js';
+
+const MAX_LOG_BYTES = 128 * 1024 * 1024;
+const MAX_SNAPSHOTS = 100_000;
+const COMPACT_LOG_BYTES = 16 * 1024 * 1024;
+const COMPACT_SNAPSHOTS = 10_000;
+
+export function getAdmissionReservationsPath(): string {
+  return path.join(getRuntimeDir(), 'admission-reservations.jsonl');
+}
+
+export class FileAdmissionReservationRepository implements AdmissionReservationRepository {
+  constructor(
+    private readonly filePath = getAdmissionReservationsPath(),
+    private readonly compactSnapshots = COMPACT_SNAPSHOTS
+  ) {
+    ensureWithinBase(path.dirname(filePath), filePath);
+  }
+
+  async claim(input: AdmissionReservationClaimInput): Promise<AdmissionReservationClaimResult> {
+    const requested = AdmissionReservationSchema.parse(input.record);
+    if (requested.revision !== 1) {
+      throw new Error('New admission reservations must start at revision 1.');
+    }
+    await this.prepareParent();
+    return withFileLock(this.filePath, async () => {
+      const snapshots = await this.readSnapshots();
+      const materialized = this.materialize(snapshots);
+      await this.expireMaterialized(materialized, input.now, snapshots);
+      const existing = materialized.get(requested.id);
+      if (existing) {
+        if (existing.request.idempotencyKey !== requested.request.idempotencyKey) {
+          throw new Error(`Admission reservation ${requested.id} has conflicting identity.`);
+        }
+        if (existing.state !== 'expired' || !input.reclaimExpired) {
+          return { record: existing, created: false, limitingPolicies: [] };
+        }
+        const reclaimed = AdmissionReservationSchema.parse({
+          ...requested,
+          revision: existing.revision + 1,
+          createdAt: existing.createdAt,
+        });
+        const limitingPolicies = findLimitingAdmissionPolicies(
+          [...materialized.values()].filter((record) => record.id !== existing.id),
+          reclaimed
+        );
+        if (limitingPolicies.length > 0) {
+          return { created: false, limitingPolicies };
+        }
+        await this.appendSnapshot(reclaimed, snapshots);
+        return {
+          record: reclaimed,
+          created: false,
+          reclaimed: true,
+          limitingPolicies: [],
+        };
+      }
+      const limitingPolicies = findLimitingAdmissionPolicies([...materialized.values()], requested);
+      if (limitingPolicies.length > 0) return { created: false, limitingPolicies };
+      await this.appendSnapshot(requested, snapshots);
+      return { record: requested, created: true, limitingPolicies: [] };
+    });
+  }
+
+  async get(id: string): Promise<AdmissionReservation | null> {
+    return this.materialize(await this.readSnapshots()).get(id) ?? null;
+  }
+
+  async list(query: AdmissionReservationListQuery): Promise<AdmissionReservation[]> {
+    const states = query.states ? new Set(query.states) : undefined;
+    return [...this.materialize(await this.readSnapshots()).values()]
+      .filter((record) => !query.workspaceId || record.request.workspaceId === query.workspaceId)
+      .filter((record) => !query.taskId || record.request.taskId === query.taskId)
+      .filter((record) => !query.rootTaskId || record.request.rootTaskId === query.rootTaskId)
+      .filter((record) => !query.provider || record.request.provider === query.provider)
+      .filter((record) => !query.hostId || record.request.hostId === query.hostId)
+      .filter((record) => !states || states.has(record.state))
+      .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
+      .slice(0, query.limit ?? 100);
+  }
+
+  async compareAndSet(
+    input: AdmissionReservationCompareAndSetInput
+  ): Promise<AdmissionReservationCompareAndSetResult> {
+    await this.prepareParent();
+    return withFileLock(this.filePath, async () => {
+      const snapshots = await this.readSnapshots();
+      const current = this.materialize(snapshots).get(input.id);
+      if (!current) return { updated: false, reason: 'not-found' };
+      if (current.revision !== input.expectedRevision) {
+        return { record: current, updated: false, reason: 'stale-revision' };
+      }
+      if (input.next.revision !== input.expectedRevision + 1 || input.next.id !== input.id) {
+        return { record: current, updated: false, reason: 'invalid-revision' };
+      }
+      const next = AdmissionReservationSchema.parse(input.next);
+      await this.appendSnapshot(next, snapshots);
+      return { record: next, updated: true };
+    });
+  }
+
+  async expireLeases(now: string): Promise<AdmissionReservation[]> {
+    await this.prepareParent();
+    return withFileLock(this.filePath, async () => {
+      const snapshots = await this.readSnapshots();
+      return this.expireMaterialized(this.materialize(snapshots), now, snapshots);
+    });
+  }
+
+  private async expireMaterialized(
+    materialized: Map<string, AdmissionReservation>,
+    now: string,
+    snapshots: AdmissionReservation[]
+  ): Promise<AdmissionReservation[]> {
+    const expired: AdmissionReservation[] = [];
+    for (const current of materialized.values()) {
+      if (current.state !== 'active' || Date.parse(current.lease.expiresAt) > Date.parse(now)) {
+        continue;
+      }
+      const next = AdmissionReservationSchema.parse({
+        ...current,
+        revision: current.revision + 1,
+        state: 'expired',
+        updatedAt: now,
+      });
+      await this.appendSnapshot(next, snapshots);
+      snapshots.push(next);
+      materialized.set(next.id, next);
+      expired.push(next);
+    }
+    return expired;
+  }
+
+  private async prepareParent(): Promise<void> {
+    const parent = path.dirname(this.filePath);
+    await mkdir(parent, { recursive: true, mode: 0o700 });
+    const stat = await lstat(parent);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error('Admission reservation directory is not a private regular directory.');
+    }
+  }
+
+  private async readSnapshots(): Promise<AdmissionReservation[]> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(this.filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size > MAX_LOG_BYTES) {
+        throw new Error('Admission reservation log is not a bounded regular file.');
+      }
+      const lines = (await handle.readFile({ encoding: 'utf8' })).split(/\r?\n/).filter(Boolean);
+      if (lines.length > MAX_SNAPSHOTS) {
+        throw new Error('Admission reservation log reached its bounded snapshot limit.');
+      }
+      return lines.map((line) => AdmissionReservationSchema.parse(JSON.parse(line)));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+        throw new Error('Admission reservation log is not a bounded regular file.', {
+          cause: error,
+        });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private materialize(snapshots: AdmissionReservation[]): Map<string, AdmissionReservation> {
+    const byId = new Map<string, AdmissionReservation>();
+    for (const snapshot of snapshots) {
+      const current = byId.get(snapshot.id);
+      if (!current || snapshot.revision > current.revision) byId.set(snapshot.id, snapshot);
+    }
+    return byId;
+  }
+
+  private async appendSnapshot(
+    snapshot: AdmissionReservation,
+    existing: AdmissionReservation[]
+  ): Promise<void> {
+    const line = `${JSON.stringify(snapshot)}\n`;
+    const existingBytes = existing.reduce(
+      (total, candidate) => total + Buffer.byteLength(JSON.stringify(candidate), 'utf8') + 1,
+      0
+    );
+    if (
+      existing.length >= this.compactSnapshots ||
+      existingBytes + Buffer.byteLength(line, 'utf8') > COMPACT_LOG_BYTES
+    ) {
+      const materialized = this.materialize(existing);
+      materialized.set(snapshot.id, snapshot);
+      await this.replaceSnapshots([...materialized.values()]);
+      return;
+    }
+    if (existing.length >= MAX_SNAPSHOTS) {
+      throw new Error('Admission reservation log reached its bounded snapshot limit.');
+    }
+    if (existingBytes + Buffer.byteLength(line, 'utf8') > MAX_LOG_BYTES) {
+      throw new Error('Admission reservation log reached its bounded byte limit.');
+    }
+    const handle = await open(
+      this.filePath,
+      constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW,
+      0o600
+    );
+    try {
+      await handle.write(line, undefined, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private async replaceSnapshots(snapshots: AdmissionReservation[]): Promise<void> {
+    if (snapshots.length > MAX_SNAPSHOTS) {
+      throw new Error('Admission reservation log reached its bounded snapshot limit.');
+    }
+    const content = snapshots.map((snapshot) => JSON.stringify(snapshot)).join('\n') + '\n';
+    if (Buffer.byteLength(content, 'utf8') > MAX_LOG_BYTES) {
+      throw new Error('Admission reservation log reached its bounded byte limit.');
+    }
+    const temporaryPath = `${this.filePath}.compact-${process.pid}-${randomUUID()}`;
+    ensureWithinBase(path.dirname(this.filePath), temporaryPath);
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(
+        temporaryPath,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+        0o600
+      );
+      await handle.writeFile(content, 'utf8');
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      await rename(temporaryPath, this.filePath);
+    } catch (error) {
+      await handle?.close().catch(() => {});
+      await unlink(temporaryPath).catch(() => {});
+      throw error;
+    }
+  }
+}

--- a/server/src/storage/file-storage.ts
+++ b/server/src/storage/file-storage.ts
@@ -43,6 +43,7 @@ import type {
   RunApprovalRepository,
   PhaseTransitionRepository,
   RunSupervisorRepository,
+  AdmissionReservationRepository,
   ToolControlPlaneRepository,
 } from './interfaces.js';
 import { TaskService, type TaskServiceOptions } from '../services/task-service.js';
@@ -71,6 +72,7 @@ import { FileRunEventRepository } from './run-event-repository.js';
 import { FileRunApprovalRepository } from './run-approval-repository.js';
 import { FilePhaseTransitionRepository } from './phase-transition-repository.js';
 import { FileRunSupervisorRepository } from './run-supervisor-repository.js';
+import { FileAdmissionReservationRepository } from './admission-reservation-repository.js';
 import { FileToolControlPlaneRepository } from './tool-control-plane-repository.js';
 
 // ---------------------------------------------------------------------------
@@ -492,6 +494,7 @@ export interface FileStorageOptions {
   runApprovalsPath?: string;
   phaseTransitionsPath?: string;
   runSupervisorsPath?: string;
+  admissionReservationsPath?: string;
   toolControlPlanePath?: string;
 }
 
@@ -508,6 +511,7 @@ export class FileStorageProvider implements StorageProvider {
   readonly runApprovals: RunApprovalRepository;
   readonly phaseTransitions: PhaseTransitionRepository;
   readonly runSupervisors: RunSupervisorRepository;
+  readonly admissionReservations: AdmissionReservationRepository;
   readonly toolControlPlane: ToolControlPlaneRepository;
 
   private taskService: TaskService;
@@ -562,6 +566,9 @@ export class FileStorageProvider implements StorageProvider {
     this.runApprovals = new FileRunApprovalRepository(options.runApprovalsPath);
     this.phaseTransitions = new FilePhaseTransitionRepository(options.phaseTransitionsPath);
     this.runSupervisors = new FileRunSupervisorRepository(options.runSupervisorsPath);
+    this.admissionReservations = new FileAdmissionReservationRepository(
+      options.admissionReservationsPath
+    );
     this.toolControlPlane = new FileToolControlPlaneRepository(options.toolControlPlanePath);
   }
 

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -27,6 +27,7 @@ export type {
   RunEventRepositoryAppendInput,
   RunApprovalRepository,
   PhaseTransitionRepository,
+  AdmissionReservationRepository,
   ToolControlPlaneRepository,
   SetupContextRepository,
   WorkspaceFileRepository,
@@ -62,6 +63,10 @@ export {
   InMemoryPhaseTransitionRepository,
   getPhaseTransitionsPath,
 } from './phase-transition-repository.js';
+export {
+  FileAdmissionReservationRepository,
+  getAdmissionReservationsPath,
+} from './admission-reservation-repository.js';
 export type { FileStorageOptions } from './file-storage.js';
 export {
   DEFAULT_SQLITE_FILENAME,
@@ -90,6 +95,7 @@ export { SqliteTelemetryRepository } from './sqlite/telemetry-repository.js';
 export { SqliteRunEventRepository } from './sqlite/run-event-repository.js';
 export { SqliteRunApprovalRepository } from './sqlite/run-approval-repository.js';
 export { SqlitePhaseTransitionRepository } from './sqlite/phase-transition-repository.js';
+export { SqliteAdmissionReservationRepository } from './sqlite/admission-reservation-repository.js';
 export {
   FileToolControlPlaneRepository,
   InMemoryToolControlPlaneRepository,

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -44,6 +44,12 @@ import type {
   RunSupervisorCompareAndSetResult,
   RunSupervisorListQuery,
   RunSupervisorRecord,
+  AdmissionReservation,
+  AdmissionReservationClaimInput,
+  AdmissionReservationClaimResult,
+  AdmissionReservationCompareAndSetInput,
+  AdmissionReservationCompareAndSetResult,
+  AdmissionReservationListQuery,
   RunToolCatalog,
   ToolServerDefinition,
   ToolServerDiscovery,
@@ -422,6 +428,21 @@ export interface RunSupervisorRepository {
 }
 
 // ---------------------------------------------------------------------------
+// Durable Admission Reservation Repository
+// ---------------------------------------------------------------------------
+
+export interface AdmissionReservationRepository {
+  /** Atomically expire stale leases, evaluate aggregate policies, and reserve capacity. */
+  claim(input: AdmissionReservationClaimInput): Promise<AdmissionReservationClaimResult>;
+  get(id: string): Promise<AdmissionReservation | null>;
+  list(query: AdmissionReservationListQuery): Promise<AdmissionReservation[]>;
+  compareAndSet(
+    input: AdmissionReservationCompareAndSetInput
+  ): Promise<AdmissionReservationCompareAndSetResult>;
+  expireLeases(now: string): Promise<AdmissionReservation[]>;
+}
+
+// ---------------------------------------------------------------------------
 // Run-scoped Tool Control Plane Repository
 // ---------------------------------------------------------------------------
 
@@ -453,6 +474,7 @@ export interface StorageProvider {
   readonly runApprovals: RunApprovalRepository;
   readonly phaseTransitions: PhaseTransitionRepository;
   readonly runSupervisors: RunSupervisorRepository;
+  readonly admissionReservations: AdmissionReservationRepository;
   readonly toolControlPlane: ToolControlPlaneRepository;
   readonly setupContext?: SetupContextRepository;
 

--- a/server/src/storage/sqlite/admission-reservation-repository.ts
+++ b/server/src/storage/sqlite/admission-reservation-repository.ts
@@ -1,0 +1,240 @@
+import type {
+  AdmissionReservation,
+  AdmissionReservationClaimInput,
+  AdmissionReservationClaimResult,
+  AdmissionReservationCompareAndSetInput,
+  AdmissionReservationCompareAndSetResult,
+  AdmissionReservationListQuery,
+} from '@veritas-kanban/shared';
+import { AdmissionReservationSchema } from '../../schemas/admission-control-schemas.js';
+import { findLimitingAdmissionPolicies } from '../admission-capacity.js';
+import type { AdmissionReservationRepository } from '../interfaces.js';
+import type { SqliteDatabase } from './database.js';
+
+interface ReservationRow {
+  reservation_json: string;
+}
+
+export class SqliteAdmissionReservationRepository implements AdmissionReservationRepository {
+  constructor(private readonly database: SqliteDatabase) {}
+
+  async claim(input: AdmissionReservationClaimInput): Promise<AdmissionReservationClaimResult> {
+    const requested = AdmissionReservationSchema.parse(input.record);
+    if (requested.revision !== 1) {
+      throw new Error('New admission reservations must start at revision 1.');
+    }
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      this.expireInTransaction(input.now);
+      const existingRow = connection
+        .prepare('SELECT reservation_json FROM admission_reservations WHERE id = ?')
+        .get(requested.id) as ReservationRow | undefined;
+      if (existingRow) {
+        const existing = AdmissionReservationSchema.parse(JSON.parse(existingRow.reservation_json));
+        if (existing.request.idempotencyKey !== requested.request.idempotencyKey) {
+          throw new Error(`Admission reservation ${requested.id} has conflicting identity.`);
+        }
+        if (existing.state !== 'expired' || !input.reclaimExpired) {
+          connection.exec('COMMIT');
+          return { record: existing, created: false, limitingPolicies: [] };
+        }
+        const reclaimed = AdmissionReservationSchema.parse({
+          ...requested,
+          revision: existing.revision + 1,
+          createdAt: existing.createdAt,
+        });
+        const limitingPolicies = findLimitingAdmissionPolicies(
+          this.activeReservations().filter((record) => record.id !== existing.id),
+          reclaimed
+        );
+        if (limitingPolicies.length > 0) {
+          connection.exec('COMMIT');
+          return { created: false, limitingPolicies };
+        }
+        this.updateRow(reclaimed, existing.revision);
+        connection.exec('COMMIT');
+        return {
+          record: reclaimed,
+          created: false,
+          reclaimed: true,
+          limitingPolicies: [],
+        };
+      }
+      const limitingPolicies = findLimitingAdmissionPolicies(this.activeReservations(), requested);
+      if (limitingPolicies.length > 0) {
+        connection.exec('COMMIT');
+        return { created: false, limitingPolicies };
+      }
+      connection
+        .prepare(
+          `INSERT INTO admission_reservations (
+             id, workspace_id, task_id, root_task_id, provider, host_id, state, revision,
+             idempotency_key, lease_expires_at, reservation_json, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          requested.id,
+          requested.request.workspaceId,
+          requested.request.taskId,
+          requested.request.rootTaskId,
+          requested.request.provider,
+          requested.request.hostId,
+          requested.state,
+          requested.revision,
+          requested.request.idempotencyKey,
+          requested.lease.expiresAt,
+          JSON.stringify(requested),
+          requested.createdAt,
+          requested.updatedAt
+        );
+      connection.exec('COMMIT');
+      return { record: requested, created: true, limitingPolicies: [] };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async get(id: string): Promise<AdmissionReservation | null> {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT reservation_json FROM admission_reservations WHERE id = ?')
+      .get(id) as ReservationRow | undefined;
+    return row ? AdmissionReservationSchema.parse(JSON.parse(row.reservation_json)) : null;
+  }
+
+  async list(query: AdmissionReservationListQuery): Promise<AdmissionReservation[]> {
+    const clauses: string[] = [];
+    const parameters: Array<string | number> = [];
+    const add = (clause: string, value: string) => {
+      clauses.push(clause);
+      parameters.push(value);
+    };
+    if (query.workspaceId) add('workspace_id = ?', query.workspaceId);
+    if (query.taskId) add('task_id = ?', query.taskId);
+    if (query.rootTaskId) add('root_task_id = ?', query.rootTaskId);
+    if (query.provider) add('provider = ?', query.provider);
+    if (query.hostId) add('host_id = ?', query.hostId);
+    if (query.states?.length) {
+      clauses.push(`state IN (${query.states.map(() => '?').join(', ')})`);
+      parameters.push(...query.states);
+    }
+    parameters.push(query.limit ?? 100);
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `SELECT reservation_json
+         FROM admission_reservations
+         ${clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : ''}
+         ORDER BY updated_at DESC
+         LIMIT ?`
+      )
+      .all(...parameters) as unknown as ReservationRow[];
+    return rows.map((row) => AdmissionReservationSchema.parse(JSON.parse(row.reservation_json)));
+  }
+
+  async compareAndSet(
+    input: AdmissionReservationCompareAndSetInput
+  ): Promise<AdmissionReservationCompareAndSetResult> {
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const row = connection
+        .prepare('SELECT reservation_json FROM admission_reservations WHERE id = ?')
+        .get(input.id) as ReservationRow | undefined;
+      if (!row) {
+        connection.exec('COMMIT');
+        return { updated: false, reason: 'not-found' };
+      }
+      const current = AdmissionReservationSchema.parse(JSON.parse(row.reservation_json));
+      if (current.revision !== input.expectedRevision) {
+        connection.exec('COMMIT');
+        return { record: current, updated: false, reason: 'stale-revision' };
+      }
+      if (input.next.revision !== input.expectedRevision + 1 || input.next.id !== input.id) {
+        connection.exec('COMMIT');
+        return { record: current, updated: false, reason: 'invalid-revision' };
+      }
+      const next = AdmissionReservationSchema.parse(input.next);
+      this.updateRow(next, input.expectedRevision);
+      connection.exec('COMMIT');
+      return { record: next, updated: true };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async expireLeases(now: string): Promise<AdmissionReservation[]> {
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const expired = this.expireInTransaction(now);
+      connection.exec('COMMIT');
+      return expired;
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  private activeReservations(): AdmissionReservation[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(`SELECT reservation_json FROM admission_reservations WHERE state = 'active'`)
+      .all() as unknown as ReservationRow[];
+    return rows.map((row) => AdmissionReservationSchema.parse(JSON.parse(row.reservation_json)));
+  }
+
+  private expireInTransaction(now: string): AdmissionReservation[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `SELECT reservation_json FROM admission_reservations
+         WHERE state = 'active' AND lease_expires_at <= ?`
+      )
+      .all(now) as unknown as ReservationRow[];
+    return rows.map((row) => {
+      const current = AdmissionReservationSchema.parse(JSON.parse(row.reservation_json));
+      const expired = AdmissionReservationSchema.parse({
+        ...current,
+        revision: current.revision + 1,
+        state: 'expired',
+        updatedAt: now,
+      });
+      this.updateRow(expired, current.revision);
+      return expired;
+    });
+  }
+
+  private updateRow(record: AdmissionReservation, expectedRevision: number): void {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `UPDATE admission_reservations
+         SET workspace_id = ?, task_id = ?, root_task_id = ?, provider = ?, host_id = ?,
+             state = ?, revision = ?, idempotency_key = ?, lease_expires_at = ?,
+             reservation_json = ?, updated_at = ?
+         WHERE id = ? AND revision = ?`
+      )
+      .run(
+        record.request.workspaceId,
+        record.request.taskId,
+        record.request.rootTaskId,
+        record.request.provider,
+        record.request.hostId,
+        record.state,
+        record.revision,
+        record.request.idempotencyKey,
+        record.lease.expiresAt,
+        JSON.stringify(record),
+        record.updatedAt,
+        record.id,
+        expectedRevision
+      );
+    if (result.changes !== 1) {
+      throw new Error('Admission reservation compare-and-set changed unexpectedly.');
+    }
+  }
+}

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -1284,6 +1284,38 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON phase_transitions(workspace_id, created_at DESC);
     `,
   },
+  {
+    version: 23,
+    name: '0023_durable_admission_reservations',
+    up: `
+      CREATE TABLE admission_reservations (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL DEFAULT 'local',
+        task_id TEXT NOT NULL,
+        root_task_id TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        host_id TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('active', 'released', 'expired')),
+        revision INTEGER NOT NULL CHECK (revision > 0),
+        idempotency_key TEXT NOT NULL UNIQUE,
+        lease_expires_at TEXT NOT NULL,
+        reservation_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX idx_admission_reservations_scope_state
+        ON admission_reservations(
+          workspace_id, root_task_id, provider, host_id, state, updated_at DESC
+        );
+
+      CREATE INDEX idx_admission_reservations_task
+        ON admission_reservations(task_id, updated_at DESC);
+
+      CREATE INDEX idx_admission_reservations_lease
+        ON admission_reservations(state, lease_expires_at);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/storage/sqlite/sqlite-storage.ts
+++ b/server/src/storage/sqlite/sqlite-storage.ts
@@ -15,6 +15,7 @@ import { SqliteRunEventRepository } from './run-event-repository.js';
 import { SqliteRunApprovalRepository } from './run-approval-repository.js';
 import { SqlitePhaseTransitionRepository } from './phase-transition-repository.js';
 import { SqliteRunSupervisorRepository } from './run-supervisor-repository.js';
+import { SqliteAdmissionReservationRepository } from './admission-reservation-repository.js';
 import { SqliteToolControlPlaneRepository } from './tool-control-plane-repository.js';
 import { createDefaultConfig, normalizeAppConfig } from '../../services/config-service.js';
 
@@ -38,6 +39,7 @@ export class SqliteStorageProvider implements StorageProvider {
   readonly runApprovals: SqliteRunApprovalRepository;
   readonly phaseTransitions: SqlitePhaseTransitionRepository;
   readonly runSupervisors: SqliteRunSupervisorRepository;
+  readonly admissionReservations: SqliteAdmissionReservationRepository;
   readonly toolControlPlane: SqliteToolControlPlaneRepository;
 
   private readonly sqlite: SqliteDatabase;
@@ -62,6 +64,7 @@ export class SqliteStorageProvider implements StorageProvider {
     this.runApprovals = new SqliteRunApprovalRepository(this.sqlite);
     this.phaseTransitions = new SqlitePhaseTransitionRepository(this.sqlite);
     this.runSupervisors = new SqliteRunSupervisorRepository(this.sqlite);
+    this.admissionReservations = new SqliteAdmissionReservationRepository(this.sqlite);
     this.toolControlPlane = new SqliteToolControlPlaneRepository(this.sqlite);
   }
 

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -1,0 +1,157 @@
+import type { ExecutableAgentProvider } from './config.types.js';
+
+export const ADMISSION_REQUEST_SCHEMA_VERSION = 'admission-request/v1' as const;
+export const ADMISSION_DECISION_SCHEMA_VERSION = 'admission-decision/v1' as const;
+export const ADMISSION_RESERVATION_SCHEMA_VERSION = 'admission-reservation/v1' as const;
+
+export const ADMISSION_SCOPES = [
+  'global',
+  'task',
+  'workspace',
+  'root-task',
+  'provider',
+  'host',
+] as const;
+export type AdmissionScope = (typeof ADMISSION_SCOPES)[number];
+
+export const ADMISSION_RESERVATION_STATES = ['active', 'released', 'expired'] as const;
+export type AdmissionReservationState = (typeof ADMISSION_RESERVATION_STATES)[number];
+
+export const ADMISSION_DECISION_OUTCOMES = [
+  'admitted',
+  'retryable-overload',
+  'terminal-policy-denial',
+] as const;
+export type AdmissionDecisionOutcome = (typeof ADMISSION_DECISION_OUTCOMES)[number];
+
+/** Capacity requested by one launch. Memory is an operator estimate, not a prediction. */
+export interface AdmissionCapacityRequest {
+  runSlots: number;
+  processSlots: number;
+  estimatedMemoryMb: number;
+}
+
+/** Omitted ceilings are unlimited. */
+export interface AdmissionCapacityLimit {
+  concurrentRuns?: number;
+  processSlots?: number;
+  estimatedMemoryMb?: number;
+}
+
+export interface AdmissionLimitPolicy {
+  id: string;
+  scope: AdmissionScope;
+  scopeId: string;
+  limits: AdmissionCapacityLimit;
+}
+
+export type AdmissionLaunchSource =
+  | 'direct'
+  | 'conversation'
+  | 'recovery'
+  | 'fallback'
+  | 'scheduled'
+  | 'watcher'
+  | 'workflow'
+  | 'child-agent';
+
+export interface AdmissionRequest {
+  schemaVersion: typeof ADMISSION_REQUEST_SCHEMA_VERSION;
+  idempotencyKey: string;
+  source: AdmissionLaunchSource;
+  taskId: string;
+  rootTaskId: string;
+  workspaceId: string;
+  provider: ExecutableAgentProvider;
+  hostId: string;
+  requested: AdmissionCapacityRequest;
+  requestedAt: string;
+}
+
+export interface AdmissionReservationLease {
+  ownerId: string;
+  hostId: string;
+  processId: number;
+  acquiredAt: string;
+  heartbeatAt: string;
+  expiresAt: string;
+}
+
+export interface AdmissionReservationRelease {
+  reason: 'start-failed' | 'completed' | 'failed' | 'cancelled' | 'interrupted' | 'reconciled';
+  idempotencyKey: string;
+  releasedAt: string;
+}
+
+export interface AdmissionReservation {
+  schemaVersion: typeof ADMISSION_RESERVATION_SCHEMA_VERSION;
+  id: string;
+  revision: number;
+  state: AdmissionReservationState;
+  request: AdmissionRequest;
+  policies: AdmissionLimitPolicy[];
+  attemptId?: string;
+  lease: AdmissionReservationLease;
+  release?: AdmissionReservationRelease;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AdmissionDecision {
+  schemaVersion: typeof ADMISSION_DECISION_SCHEMA_VERSION;
+  outcome: AdmissionDecisionOutcome;
+  request: AdmissionRequest;
+  reservation?: AdmissionReservation;
+  limitingPolicies: AdmissionLimitPolicy[];
+  retryAfterMs?: number;
+  reason: string;
+  decidedAt: string;
+}
+
+export interface AdmissionReservationListQuery {
+  workspaceId?: string;
+  taskId?: string;
+  rootTaskId?: string;
+  provider?: ExecutableAgentProvider;
+  hostId?: string;
+  states?: AdmissionReservationState[];
+  limit?: number;
+}
+
+export interface AdmissionReservationCompareAndSetInput {
+  id: string;
+  expectedRevision: number;
+  next: AdmissionReservation;
+}
+
+export interface AdmissionReservationCompareAndSetResult {
+  record?: AdmissionReservation;
+  updated: boolean;
+  reason?: 'not-found' | 'stale-revision' | 'invalid-revision';
+}
+
+export interface AdmissionReservationClaimInput {
+  record: AdmissionReservation;
+  now: string;
+  reclaimExpired?: boolean;
+}
+
+export interface AdmissionReservationClaimResult {
+  record?: AdmissionReservation;
+  created: boolean;
+  reclaimed?: boolean;
+  limitingPolicies: AdmissionLimitPolicy[];
+}
+
+export interface AdmissionSettings {
+  enabled: boolean;
+  leaseMs: number;
+  heartbeatMs: number;
+  retryAfterMs: number;
+  defaultRequest: AdmissionCapacityRequest;
+  global: AdmissionCapacityLimit;
+  workspaces: Record<string, AdmissionCapacityLimit>;
+  rootTasks: Record<string, AdmissionCapacityLimit>;
+  providers: Partial<Record<ExecutableAgentProvider, AdmissionCapacityLimit>>;
+  hosts: Record<string, AdmissionCapacityLimit>;
+}

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -12,6 +12,7 @@ import type {
   WorkspaceCapabilityManifest,
   WorkspaceDelegationRecord,
 } from './workspace-capability.types.js';
+import type { AdmissionSettings } from './admission-control.types.js';
 
 export interface DevServerConfig {
   command: string; // e.g., "pnpm dev" or "npm run dev"
@@ -445,6 +446,7 @@ export interface FeatureSettings {
   notifications: NotificationSettings;
   archive: ArchiveSettings;
   budget: BudgetSettings;
+  admission: AdmissionSettings;
   enforcement: EnforcementSettings;
   hooks: HooksSettings;
   sharedResources: SharedResourcesSettings;
@@ -548,6 +550,22 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
       softThresholdPercent: 80,
       hardAction: 'require-approval',
     },
+  },
+  admission: {
+    enabled: true,
+    leaseMs: 30_000,
+    heartbeatMs: 10_000,
+    retryAfterMs: 5_000,
+    defaultRequest: {
+      runSlots: 1,
+      processSlots: 1,
+      estimatedMemoryMb: 512,
+    },
+    global: {},
+    workspaces: {},
+    rootTasks: {},
+    providers: {},
+    hosts: {},
   },
   enforcement: {
     squadChat: false,

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -24,6 +24,7 @@ export * from './drift.types.js';
 export * from './decision.types.js';
 export * from './run-session.types.js';
 export * from './run-supervisor.types.js';
+export * from './admission-control.types.js';
 export * from './evaluation.types.js';
 export * from './harness-conformance.types.js';
 export * from './harness-compatibility.types.js';

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -77,6 +77,7 @@ export interface TaskAttempt {
   taskEnvelope?: import('./task-envelope.types.js').TaskEnvelope;
   runLaunchManifest?: import('./run-launch-manifest.types.js').RunLaunchManifest;
   runSupervisorId?: string;
+  admissionReservationId?: string;
   runRecovery?: import('./run-supervisor.types.js').RunSupervisorRecoveryRecord;
   runLaunchManifestTraceId?: string;
   runLaunchParentAttemptId?: string;

--- a/shared/src/utils/api-permissions.ts
+++ b/shared/src/utils/api-permissions.ts
@@ -198,6 +198,7 @@ const ROUTE_PERMISSIONS: RoutePermissionConfig[] = [
       },
     ],
   },
+  { prefix: '/api/admission', read: 'agent:read', write: 'admin:manage' },
   {
     prefix: '/api/diff',
     read: 'task:read',


### PR DESCRIPTION
## Description

Adds one durable admission path for direct agent task launches. Every launch now reserves capacity before attempt persistence, pending-run state, run-supervisor creation, or provider dispatch.

File and SQLite repositories atomically apply an invariant one-active-run-per-task policy and optional global, workspace, root-task, provider, and host ceilings for run slots, process slots, and operator-estimated memory. Versioned decisions distinguish admitted requests, retryable overload, and terminal policy denial with limiting-scope evidence and bounded retry guidance.

Reservations use renewable leases, release idempotently on terminal and launch-failure paths, and can be reclaimed after restart only for a run verified through its durable supervisor. The file backend compacts heartbeat snapshots atomically before its bounded log can be exhausted. Caller idempotency values are persisted only as SHA-256 identities.

Operators can list and inspect active, released, or expired reservations through read-scoped REST endpoints and `vk admission` commands with JSON output.

## Scope

**Linked issue:** Closes #1050

**In scope:** Direct task launch admission, file and SQLite persistence, capacity settings, restart recovery, terminal cleanup, REST and CLI inspection, canonical docs, API docs, CLI docs, SQLite docs, and changelog context.

**Linked follow-ups:** #1051 extends the same reservation boundary to workflow roots and steps. Queueing, aggregate execution-tree budgets, fairness, and fan-out cancellation remain in their dedicated issues.

## Testing

**Verification tier:** Focused changed-package tests locally. Shared and storage paths intentionally select the full CI integration tier.

**Commands:**

```bash
pnpm --filter @veritas-kanban/shared build
pnpm --filter @veritas-kanban/server typecheck
pnpm --filter @veritas-kanban/cli typecheck
pnpm --filter @veritas-kanban/server exec vitest run <7 exact affected files> -t <affected admission, route, permission, schema, and launch cases>
pnpm --filter @veritas-kanban/cli exec vitest run src/__tests__/admission.test.ts src/__tests__/api-permissions.test.ts src/__tests__/agents-runtime-capabilities.test.ts
pnpm exec eslint <changed TypeScript files>
git diff --check
```

Focused results: 60 server assertions and 25 CLI assertions passed. Typechecks, shared build, changed-file lint, and diff validation passed. Lint reported only three pre-existing warnings in untouched lines.

## Review

- Standards: no remaining findings after consolidating terminal release mapping, validating header precedence, and adding bounded atomic file compaction.
- Specification: no remaining findings after hardening idempotent bind races, failure-path release, dual-backend lease transitions, settings validation, permissions, and persisted idempotency redaction.

## Risk and migration

SQLite migration 23 creates `admission_reservations`. Admission is enabled by default, but no aggregate ceilings are configured by default. The invariant one-active-run-per-task policy is always retained to prevent cross-process duplicate launches. Existing pre-admission attempts remain readable and recover through the legacy compatibility path without invented reservation evidence.
