### PR TITLE
feat: admit workflow execution capacity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,11 +224,15 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   high-risk environment passthrough are separate classes. Task integration
   credentials fail closed until an accepted tool or egress boundary proves
   brokered, non-bypassable delivery.
-- Atomically persist `admission-reservation/v1` before direct task attempt,
-  pending-run, or provider state. Capacity claims use the storage repository
-  transaction or file lock, not process-local counters. Keep the invariant
-  one-active-run-per-task policy and configured global, workspace, root-task,
-  provider, and host ceilings aligned across dispatch, REST, and `vk`.
+- Atomically persist `admission-reservation/v1` before direct task attempts,
+  workflow roots, executable workflow steps, pending-run state, or provider
+  state. Workflow roots use the explicit `workflow-control` admission provider;
+  provider-backed steps bind the resolved provider, selected host, root
+  reservation, run, and step before attempt mutation. Capacity claims use the
+  storage repository transaction or file lock, never process-local counters.
+  Keep the invariant one-active-run-per-task policy and configured global,
+  workspace, root-task, provider, and host ceilings aligned across dispatch,
+  REST, and `vk`.
   Persist only a stable digest of caller-supplied idempotency values.
   Completion, interruption, cancellation, and start failure release once;
   restart recovery may reclaim only after the durable run supervisor verifies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Routed workflow roots and every provider-backed workflow step through the
+  durable admission controller. A root now reserves `workflow-control`
+  capacity before the run becomes active, while each executable step reserves
+  against its resolved provider and selected host before step-attempt
+  mutation or adapter dispatch. Retry and fallback attempts use new child
+  reservations only after the prior reservation releases. Terminal,
+  cancellation, and restart-reconciliation paths release idempotently, and
+  restart recovery reclaims only the exact persisted root binding. Workflow
+  run, step, and root-reservation filters are available through REST and
+  `vk admission`; file and SQLite storage preserve the same inspection
+  contract (#1051).
 - Added durable admission reservations for every direct agent task launch. File
   and SQLite backends atomically enforce one active run per task plus optional
   global, workspace, root-task, provider, and host ceilings for run slots,

--- a/cli/src/__tests__/admission.test.ts
+++ b/cli/src/__tests__/admission.test.ts
@@ -29,6 +29,12 @@ describe('vk admission commands', () => {
       'list',
       '--workspace',
       'workspace-a',
+      '--workflow-run',
+      'run_1234567890_abcdef',
+      '--workflow-step',
+      'execute',
+      '--root-reservation',
+      'admission_root',
       '--state',
       'active',
       'released',
@@ -38,7 +44,7 @@ describe('vk admission commands', () => {
     ]);
 
     expect(api).toHaveBeenCalledWith(
-      '/api/admission?workspaceId=workspace-a&state=active&state=released&limit=25'
+      '/api/admission?workspaceId=workspace-a&workflowRunId=run_1234567890_abcdef&workflowStepId=execute&rootReservationId=admission_root&state=active&state=released&limit=25'
     );
     expect(JSON.parse(String(output.mock.calls[0][0]))).toEqual({
       generatedAt: '2026-07-25T10:00:00.000Z',

--- a/cli/src/commands/admission.ts
+++ b/cli/src/commands/admission.ts
@@ -21,6 +21,9 @@ export function registerAdmissionCommands(program: Command): void {
     .option('--root-task <id>', 'Filter by root task')
     .option('--provider <provider>', 'Filter by provider')
     .option('--host <id>', 'Filter by launch host')
+    .option('--workflow-run <id>', 'Filter by workflow run')
+    .option('--workflow-step <id>', 'Filter by workflow step')
+    .option('--root-reservation <id>', 'Filter by workflow root reservation')
     .option('--state <states...>', 'Filter by state (active, released, expired)')
     .option('--limit <count>', 'Maximum records', '100')
     .option('--json', 'Output as JSON')
@@ -32,6 +35,9 @@ export function registerAdmissionCommands(program: Command): void {
         if (options.rootTask) query.set('rootTaskId', options.rootTask);
         if (options.provider) query.set('provider', options.provider);
         if (options.host) query.set('hostId', options.host);
+        if (options.workflowRun) query.set('workflowRunId', options.workflowRun);
+        if (options.workflowStep) query.set('workflowStepId', options.workflowStep);
+        if (options.rootReservation) query.set('rootReservationId', options.rootReservation);
         for (const state of (options.state ?? []) as AdmissionReservationState[]) {
           query.append('state', state);
         }
@@ -84,6 +90,13 @@ function printReservation(reservation: AdmissionReservation, verbose = false): v
       `  workspace=${reservation.request.workspaceId} root=${reservation.request.rootTaskId} host=${reservation.request.hostId}`
     )
   );
+  if (reservation.request.workflowRunId) {
+    console.log(
+      chalk.dim(
+        `  workflow=${reservation.request.workflowRunId} step=${reservation.request.workflowStepId ?? 'root'} root-reservation=${reservation.request.rootReservationId ?? reservation.id}`
+      )
+    );
+  }
   console.log(
     chalk.dim(
       `  capacity runs=${reservation.request.requested.runSlots} processes=${reservation.request.requested.processSlots} memory=${reservation.request.requested.estimatedMemoryMb}MB`

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -925,13 +925,17 @@ Soft thresholds create `budget-policy` governance traces and visible warnings. H
 
 ## Execution Admission
 
-Every direct task launch receives a durable `admission-reservation/v1` record
-before Veritas persists an attempt or calls a provider adapter. Reservations
-account for run slots, process slots, and operator-estimated memory across
-optional global, workspace, root-task, provider, and host ceilings. Estimated
-memory is a configured planning value, not a runtime memory prediction.
-An invariant one-run-per-task policy also prevents concurrent duplicate
-launches across server processes.
+Every direct task launch, workflow root, and provider-backed workflow step
+receives a durable `admission-reservation/v1` record before Veritas persists
+an executable attempt or calls a provider adapter. Workflow roots use the
+explicit `workflow-control` admission provider and reserve no provider process
+or memory estimate. Each executable child step uses its resolved provider,
+selected host, workflow run, step, and root reservation. Reservations account
+for run slots, process slots, and operator-estimated memory across optional
+global, workspace, root-task, provider, and host ceilings. Estimated memory is
+a configured planning value, not a runtime memory prediction. An invariant
+one-run-per-admission-task policy also prevents concurrent duplicate launches
+across server processes.
 
 Configure ceilings through `PATCH /api/settings/features`:
 
@@ -945,6 +949,9 @@ Configure ceilings through `PATCH /api/settings/features`:
     },
     "providers": {
       "codex-cli": {
+        "concurrentRuns": 4
+      },
+      "workflow-control": {
         "concurrentRuns": 4
       }
     },
@@ -961,13 +968,18 @@ An individual request larger than a ceiling receives a terminal policy denial.
 Temporary exhaustion returns a retryable overload decision with the limiting
 scope and bounded retry guidance. Active leases renew while the verified run is
 live; completion, interruption, cancellation, or launch failure releases the
-reservation idempotently. After restart, only a run verified through its
-durable supervisor may reclaim an expired reservation. Caller-supplied
+reservation idempotently. Workflow retry and fallback attempts release the
+prior step reservation before acquiring another. After restart, task runs use
+their durable supervisor and workflow runs use the exact persisted root
+binding before reclaiming a reservation. Unverified in-flight workflow steps
+are released and blocked for operator reconciliation. Caller-supplied
 idempotency values are represented by a stable SHA-256 identity in durable
 records; the original value is not stored.
 
 Inspect reservations with `vk admission list`, `vk admission get <id>`, or the
-matching read-only REST endpoints. Machine consumers should use `--json`.
+matching read-only REST endpoints. Use `--workflow-run`, `--workflow-step`, or
+`--root-reservation` to follow a workflow tree. Machine consumers should use
+`--json`.
 
 ## Local And Cloud Profiles
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4141,9 +4141,11 @@ configured.
 
 ## Execution Admission
 
-Direct task starts atomically reserve configured run, process, and
-estimated-memory capacity before attempt persistence or provider dispatch.
-Inspection requires `agent:read`.
+Direct task starts, workflow roots, and provider-backed workflow steps
+atomically reserve configured run, process, and estimated-memory capacity
+before attempt persistence or provider dispatch. Workflow roots use the
+`workflow-control` admission provider; child steps use the resolved execution
+provider and selected host. Inspection requires `agent:read`.
 
 | Method | Path                 | Description                                             |
 | ------ | -------------------- | ------------------------------------------------------- |
@@ -4151,19 +4153,27 @@ Inspection requires `agent:read`.
 | `GET`  | `/api/admission/:id` | Inspect one durable reservation                         |
 
 List filters are `workspaceId`, `taskId`, `rootTaskId`, `provider`, `hostId`,
-repeatable `state` (`active`, `released`, `expired`), and `limit` (1-1000).
+`workflowRunId`, `workflowStepId`, `rootReservationId`, repeatable `state`
+(`active`, `released`, `expired`), and `limit` (1-1000).
 
 ```http
 GET /api/v1/admission?state=active&provider=codex-cli&limit=25
 ```
 
+```http
+GET /api/v1/admission?workflowRunId=run_20260725_abc123&state=active
+```
+
 The response contains `admission-reservation/v1` records with the versioned
 request, requested capacity, evaluated limit policies, attempt binding, lease,
 revision, and terminal release evidence. It never contains provider
-credentials. Overloaded task-start requests return a `409` conflict with
+credentials or prompts. Workflow records identify the run, optional step, and
+root reservation. Overloaded starts return a `409` conflict with
 `details.code` set to `ADMISSION_OVERLOAD`, the limiting scope, and bounded
 `retryAfterMs`. A request larger than a configured ceiling returns
-`ADMISSION_POLICY_DENIED`.
+`ADMISSION_POLICY_DENIED`. A step-level retryable overload blocks the workflow
+without creating a partially active attempt; terminal policy denial fails the
+run and releases its root.
 
 Direct `POST /api/v1/agents/:taskId/start` callers may send an opaque
 `X-Idempotency-Key` header (8-240 characters). The header takes precedence

--- a/docs/API-WORKFLOWS.md
+++ b/docs/API-WORKFLOWS.md
@@ -557,6 +557,14 @@ using the strictest positive limit. Soft thresholds write `budget-policy`
 governance traces. Hard thresholds pause/block, require approval, downgrade the
 model route, or cancel according to the effective policy.
 
+The workflow root reserves durable admission capacity before the run becomes
+active. Every provider-backed step then obtains a child reservation against
+its resolved provider and selected host before its attempt becomes running.
+The response exposes the root binding and the latest step decision without
+including prompts or credentials. Use `/api/admission?workflowRunId=<run-id>`
+or `vk admission list --workflow-run <run-id>` for current lease and limiting
+policy details.
+
 **Response**:
 
 ```json
@@ -2139,6 +2147,7 @@ export interface WorkflowRun {
   workflowId: string;
   workflowVersion: number;
   taskId?: string; // optional task association
+  admission?: WorkflowRootAdmissionBinding; // durable root reservation identity
   status: WorkflowRunStatus;
   currentStep?: string; // current step ID
   context: Record<string, unknown>; // shared context across steps
@@ -2167,6 +2176,7 @@ export interface StepRun {
   retries: number;
   output?: string; // path to output file
   error?: string;
+  admission?: WorkflowStepAdmissionBinding; // latest executable attempt decision
 
   // Loop-specific state
   loopState?: {

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -598,14 +598,19 @@ Inspect the capacity reservation that must exist before a provider can start:
 ```bash
 vk admission list
 vk admission list --state active --provider codex-cli --json
+vk admission list --workflow-run run_20260725_abc123 --json
+vk admission list --workflow-run run_20260725_abc123 --workflow-step implement
+vk admission list --root-reservation admission_0123456789abcdef
 vk admission get admission_0123456789abcdef --json
 ```
 
 `admission list` filters by workspace, task, root task, provider, host, state,
-and result limit. Active records show the lease expiry and requested run,
-process, and estimated-memory capacity. Released records retain the terminal
-reason and idempotency identity for operator diagnosis. These are read-only
-commands and require `agent:read`.
+workflow run, workflow step, root reservation, and result limit. Active records
+show the lease expiry and requested run, process, and estimated-memory
+capacity. Workflow roots use provider `workflow-control`; executable child
+steps show their resolved provider, selected host, and root reservation.
+Released records retain the terminal reason and idempotency identity for
+operator diagnosis. These are read-only commands and require `agent:read`.
 
 ---
 

--- a/docs/WORKFLOW_ENGINE_ARCHITECTURE.md
+++ b/docs/WORKFLOW_ENGINE_ARCHITECTURE.md
@@ -2450,113 +2450,24 @@ async function getDirSize(dirPath: string): Promise<number> {
 }
 ```
 
-**Concurrency Limits**:
+**Concurrency and Capacity Admission**:
 
-```typescript
-// server/src/config/workflow-config.ts
+Workflow concurrency is not authorized by process-local sets, counters, or
+queues. `WorkflowRunService` obtains an atomic
+`admission-reservation/v1` root claim before a run becomes active. The root
+uses admission provider `workflow-control` and binds its workspace, root task,
+run ID, host, and lease.
 
-export const WORKFLOW_CONCURRENCY_CONFIG = {
-  // Maximum concurrent workflow runs globally
-  maxConcurrentRuns: 5,
+Every provider-backed step resolves its runtime and host first, then obtains a
+child reservation before mutating the step attempt or dispatching the adapter.
+Retry and fallback attempts release the prior child reservation before
+claiming another. Global, workspace, root-task, provider, and host limits use
+the same durable policies as direct task launches.
 
-  // Maximum concurrent runs per workflow
-  maxConcurrentRunsPerWorkflow: 2,
-
-  // Maximum concurrent steps per workflow run (for parallel steps)
-  maxConcurrentStepsPerRun: 3,
-
-  // Queue size (pending runs waiting for a slot)
-  maxQueueSize: 20,
-};
-```
-
-**Concurrency Enforcement**:
-
-```typescript
-// server/src/services/workflow-run-service.ts (updated)
-
-import { WORKFLOW_CONCURRENCY_CONFIG } from '../config/workflow-config.js';
-
-export class WorkflowRunService {
-  private activeRuns: Set<string> = new Set(); // Run IDs currently executing
-  private runQueue: Array<{ runId: string; workflowId: string }> = [];
-
-  async startRun(
-    workflowId: string,
-    taskId?: string,
-    initialContext?: Record<string, any>
-  ): Promise<WorkflowRun> {
-    // Check global concurrency limit
-    if (this.activeRuns.size >= WORKFLOW_CONCURRENCY_CONFIG.maxConcurrentRuns) {
-      // Queue the run
-      if (this.runQueue.length >= WORKFLOW_CONCURRENCY_CONFIG.maxQueueSize) {
-        throw new Error('Workflow run queue is full — try again later');
-      }
-
-      const run = await this.createRun(workflowId, taskId, initialContext);
-      run.status = 'pending';
-      await this.saveRun(run);
-
-      this.runQueue.push({ runId: run.id, workflowId });
-
-      log.info({ runId: run.id, queuePosition: this.runQueue.length }, 'Run queued');
-      return run;
-    }
-
-    // Check per-workflow concurrency limit
-    let activeRunsForWorkflow = 0;
-    for (const runId of this.activeRuns) {
-      const existingRun = await this.getRun(runId);
-      if (existingRun?.workflowId === workflowId) {
-        activeRunsForWorkflow++;
-      }
-    }
-
-    if (activeRunsForWorkflow >= WORKFLOW_CONCURRENCY_CONFIG.maxConcurrentRunsPerWorkflow) {
-      throw new Error(`Workflow ${workflowId} has too many active runs`);
-    }
-
-    // Start the run
-    const run = await this.createRun(workflowId, taskId, initialContext);
-    this.activeRuns.add(run.id);
-
-    // Execute (async)
-    this.executeRun(run, workflow).finally(() => {
-      this.activeRuns.delete(run.id);
-      this.processQueue(); // Start next queued run
-    });
-
-    return run;
-  }
-
-  private async processQueue(): Promise<void> {
-    if (this.runQueue.length === 0) return;
-    if (this.activeRuns.size >= WORKFLOW_CONCURRENCY_CONFIG.maxConcurrentRuns) return;
-
-    const { runId, workflowId } = this.runQueue.shift()!;
-    const run = await this.getRun(runId);
-    if (!run) return;
-
-    // Update status and start execution
-    run.status = 'running';
-    await this.saveRun(run);
-    broadcastWorkflowStatus(run);
-
-    this.activeRuns.add(run.id);
-
-    const workflow = await this.workflowService.loadWorkflow(workflowId);
-    if (!workflow) {
-      log.error({ runId, workflowId }, 'Workflow not found for queued run');
-      return;
-    }
-
-    this.executeRun(run, workflow).finally(() => {
-      this.activeRuns.delete(run.id);
-      this.processQueue();
-    });
-  }
-}
-```
+Temporary step overload blocks the workflow with the limiting policy retained
+in the run; an impossible request fails the run. Durable fair queues and
+priority aging are scheduler concerns layered on this controller, not hidden
+inside the workflow service.
 
 **OpenClaw Session Cleanup**:
 

--- a/server/src/__tests__/helpers/workflow-admission-stub.ts
+++ b/server/src/__tests__/helpers/workflow-admission-stub.ts
@@ -1,0 +1,28 @@
+import type { AdmissionControlService } from '../../services/admission-control-service.js';
+
+export function workflowAdmissionStub(): AdmissionControlService {
+  const reservationsByAttempt = new Map<string, string>();
+  let pendingReservationId = 'admission_workflow_test';
+
+  return {
+    getExecutionHostId: () => 'test-execution-host',
+    admit: async (input: { workflowRunId?: string; workflowStepId?: string }) => {
+      pendingReservationId = `admission_${input.workflowRunId ?? 'run'}_${input.workflowStepId ?? 'root'}`;
+      return {
+        outcome: 'admitted',
+        reservation: { id: pendingReservationId },
+      };
+    },
+    bindAttempt: async (id: string, attemptId: string) => {
+      reservationsByAttempt.set(attemptId, id);
+      return { id };
+    },
+    recoverVerifiedRun: async (input: { attemptId: string }) => {
+      const id = reservationsByAttempt.get(input.attemptId);
+      return id ? { id } : null;
+    },
+    release: async (id: string) => ({ id }),
+    releaseIfUnbound: async (id: string) => ({ id }),
+    expireAbandoned: async () => [],
+  } as unknown as AdmissionControlService;
+}

--- a/server/src/__tests__/issues-778-780-785-786-787.test.ts
+++ b/server/src/__tests__/issues-778-780-785-786-787.test.ts
@@ -16,6 +16,7 @@ import { BlockingService } from '../services/blocking-service.js';
 import { HumanGateBlockError } from '../services/workflow-step-executor.js';
 import type { Task, WorkflowAgent } from '@veritas-kanban/shared';
 import type { WorkflowRunService } from '../services/workflow-run-service.js';
+import { workflowAdmissionStub } from './helpers/workflow-admission-stub.js';
 
 // ─────────────────────────────────────────────────────────────
 // Module-level mock state shared across workflow service tests.
@@ -141,7 +142,10 @@ describe('#778 — Human gate blocking', () => {
     );
     mockExecuteStep.mockImplementation(gateAwareImpl);
     const mod = await import('../services/workflow-run-service.js');
-    service = new mod.WorkflowRunService(tmpDir);
+    service = new mod.WorkflowRunService({
+      runsDir: tmpDir,
+      admission: workflowAdmissionStub(),
+    });
   });
 
   afterEach(async () => {
@@ -289,7 +293,10 @@ describe('#780 — Bounded retry_step cycles', () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-780-'));
     mockGetTask.mockResolvedValue(null);
     const mod = await import('../services/workflow-run-service.js');
-    service = new mod.WorkflowRunService(tmpDir);
+    service = new mod.WorkflowRunService({
+      runsDir: tmpDir,
+      admission: workflowAdmissionStub(),
+    });
   });
 
   afterEach(async () => {
@@ -350,7 +357,10 @@ describe('#780 — Bounded retry_step cycles', () => {
     });
 
     const mod = await import('../services/workflow-run-service.js');
-    const service2 = new mod.WorkflowRunService(tmpDir);
+    const service2 = new mod.WorkflowRunService({
+      runsDir: tmpDir,
+      admission: workflowAdmissionStub(),
+    });
     const persisted = await service2.getRun(run.id);
     expect(persisted?.retryRouteCount).toBeGreaterThan(0);
   });
@@ -417,7 +427,10 @@ describe('#785 — WorkflowRunService errors extend AppError', () => {
     mockGetTask.mockResolvedValue(null);
     mockLoadWorkflow.mockResolvedValue(null);
     const mod = await import('../services/workflow-run-service.js');
-    service = new mod.WorkflowRunService(tmpDir);
+    service = new mod.WorkflowRunService({
+      runsDir: tmpDir,
+      admission: workflowAdmissionStub(),
+    });
   });
 
   afterEach(async () => {

--- a/server/src/__tests__/routes/admission.test.ts
+++ b/server/src/__tests__/routes/admission.test.ts
@@ -29,7 +29,7 @@ describe('admission routes', () => {
     admission.list.mockResolvedValue([{ id: 'admission_1', state: 'active' }]);
 
     const response = await request(createApp()).get(
-      '/api/admission?workspaceId=workspace-a&state=active&state=released&limit=25'
+      '/api/admission?workspaceId=workspace-a&workflowRunId=run_1234567890_abcdef&workflowStepId=execute&rootReservationId=admission_root&state=active&state=released&limit=25'
     );
 
     expect(response.status).toBe(200);
@@ -40,6 +40,9 @@ describe('admission routes', () => {
     expect(admission.list).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: 'workspace-a',
+        workflowRunId: 'run_1234567890_abcdef',
+        workflowStepId: 'execute',
+        rootReservationId: 'admission_root',
         states: ['active', 'released'],
         limit: 25,
       })

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -411,11 +411,15 @@ describe('Feature Settings Schema', () => {
         leaseMs: 30_000,
         heartbeatMs: 10_000,
         global: { concurrentRuns: 8, estimatedMemoryMb: 16_384 },
-        providers: { 'codex-cli': { processSlots: 4 } },
+        providers: {
+          'codex-cli': { processSlots: 4 },
+          'workflow-control': { concurrentRuns: 3 },
+        },
       },
     });
     expect(result.admission?.global?.concurrentRuns).toBe(8);
     expect(result.admission?.providers?.['codex-cli']?.processSlots).toBe(4);
+    expect(result.admission?.providers?.['workflow-control']?.concurrentRuns).toBe(3);
     expect(() =>
       FeatureSettingsPatchSchema.parse({
         admission: { leaseMs: 10_000, heartbeatMs: 10_000 },

--- a/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
+++ b/server/src/__tests__/storage/sqlite-workflow-run-execution.test.ts
@@ -12,6 +12,7 @@ import {
   createTestSqliteDatabase,
   type TestSqliteDatabase,
 } from '../../storage/sqlite/test-helpers.js';
+import { workflowAdmissionStub } from '../helpers/workflow-admission-stub.js';
 
 const mockExecuteStep = vi.fn();
 const mockPrepareStep = vi.fn(async (step: unknown) => ({ kind: 'non-agent', step }));
@@ -167,17 +168,20 @@ describe('SQLite workflow run execution', () => {
     const definition = workflow();
     await workflowService.saveWorkflow(definition);
     const runsDir = path.join(testRoot, 'storage', 'workflow-runs');
+    const admission = workflowAdmissionStub();
     const first = new WorkflowRunService({
       runsDir,
       storageType: 'sqlite',
       sqliteDatabase: fixture.database,
       workflowService,
+      admission,
     });
     const second = new WorkflowRunService({
       runsDir,
       storageType: 'sqlite',
       sqliteDatabase: fixture.database,
       workflowService,
+      admission,
     });
     const recovery: RunRecoveryRecord = {
       schemaVersion: 'run-recovery/v1',
@@ -246,12 +250,12 @@ describe('SQLite workflow run execution', () => {
 
     expect(executeFirst.mock.calls.length + executeSecond.mock.calls.length).toBe(1);
     expect(await first.getRun(run.id)).toMatchObject({
-      revision: 2,
-      status: 'running',
+      revision: 3,
+      status: 'pending',
       steps: [
         expect.objectContaining({
           runRetry: expect.objectContaining({
-            state: 'launched',
+            state: 'launching',
             parentRunId: recovery.parentRunId,
             sequence: recovery.sequence,
           }),

--- a/server/src/__tests__/workflow-admission.test.ts
+++ b/server/src/__tests__/workflow-admission.test.ts
@@ -1,0 +1,332 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_FEATURE_SETTINGS,
+  type AdmissionSettings,
+  type WorkflowDefinition,
+} from '@veritas-kanban/shared';
+import { AdmissionControlService } from '../services/admission-control-service.js';
+import { WorkflowRunService } from '../services/workflow-run-service.js';
+import type {
+  WorkflowAgentStepPreparation,
+  WorkflowStepExecutor,
+} from '../services/workflow-step-executor.js';
+import { FileAdmissionReservationRepository } from '../storage/admission-reservation-repository.js';
+import { SqliteAdmissionReservationRepository } from '../storage/sqlite/admission-reservation-repository.js';
+import { SqliteDatabase } from '../storage/sqlite/database.js';
+
+const roots: string[] = [];
+const admissions: AdmissionControlService[] = [];
+const runs: WorkflowRunService[] = [];
+const databases: SqliteDatabase[] = [];
+
+afterEach(async () => {
+  for (const run of runs.splice(0)) run.dispose();
+  for (const admission of admissions.splice(0)) admission.dispose();
+  for (const database of databases.splice(0)) database.close();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+function workflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    id: 'workflow-admission',
+    name: 'Workflow admission',
+    version: 1,
+    description: 'Exercises root and executable step admission.',
+    agents: [
+      {
+        id: 'agent',
+        name: 'Agent',
+        role: 'implementation',
+        provider: 'codex-sdk',
+        description: 'Test agent',
+      },
+    ],
+    steps: [
+      {
+        id: 'execute',
+        name: 'Execute',
+        type: 'agent',
+        agent: 'agent',
+        input: 'Run the test.',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function settings(overrides: Partial<AdmissionSettings> = {}): AdmissionSettings {
+  return {
+    ...structuredClone(DEFAULT_FEATURE_SETTINGS.admission),
+    global: { concurrentRuns: 2 },
+    workspaces: { local: { estimatedMemoryMb: 512 } },
+    providers: { 'codex-sdk': { processSlots: 1 } },
+    hosts: { 'local-process': { processSlots: 1 } },
+    heartbeatMs: 20_000,
+    ...overrides,
+  };
+}
+
+function preparation(step: WorkflowDefinition['steps'][number]): WorkflowAgentStepPreparation {
+  return {
+    kind: 'agent',
+    step,
+    runtimeProvider: 'codex-sdk',
+    hostRouting: {
+      selectedHostId: 'local-process',
+    },
+  } as WorkflowAgentStepPreparation;
+}
+
+function executor(
+  executeStep: (step: WorkflowDefinition['steps'][number]) => Promise<{
+    output: unknown;
+    outputPath: string;
+  }>
+): WorkflowStepExecutor {
+  return {
+    prepareStep: async (step: WorkflowDefinition['steps'][number]) => preparation(step),
+    applyPreparation: () => undefined,
+    executeStep,
+    validateFallbackAgent: async () => ({}),
+  } as unknown as WorkflowStepExecutor;
+}
+
+async function createHarness(
+  backend: 'file' | 'sqlite',
+  admissionSettings: AdmissionSettings,
+  stepExecutor: WorkflowStepExecutor,
+  ownerId = `owner-${backend}`
+) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `workflow-admission-${backend}-`));
+  roots.push(root);
+  let database: SqliteDatabase | undefined;
+  const repository =
+    backend === 'file'
+      ? new FileAdmissionReservationRepository(path.join(root, 'admission.jsonl'))
+      : (() => {
+          database = new SqliteDatabase({ databasePath: path.join(root, 'veritas.db') });
+          database.open();
+          databases.push(database);
+          return new SqliteAdmissionReservationRepository(database);
+        })();
+  const admission = new AdmissionControlService({
+    repository,
+    settings: async () => structuredClone(admissionSettings),
+    hostId: 'workflow-host',
+    ownerId,
+    processId: backend === 'file' ? 101 : 202,
+  });
+  admissions.push(admission);
+  const definition = workflow();
+  const service = new WorkflowRunService({
+    runsDir: path.join(root, 'runs'),
+    storageType: backend,
+    sqliteDatabase: database,
+    workflowService: {
+      loadWorkflow: async (id: string) => (id === definition.id ? definition : null),
+    } as never,
+    stepExecutor,
+    admission,
+  });
+  runs.push(service);
+  return { root, database, repository, admission, definition, service };
+}
+
+describe('workflow admission', () => {
+  it.each(['file', 'sqlite'] as const)(
+    'reserves roots and provider steps atomically with %s storage',
+    async (backend) => {
+      let finishStep: (() => void) | undefined;
+      const stepPending = new Promise<void>((resolve) => {
+        finishStep = resolve;
+      });
+      const harness = await createHarness(
+        backend,
+        settings(),
+        executor(async (step) => {
+          await stepPending;
+          return { output: { completed: true }, outputPath: `/tmp/${step.id}.json` };
+        })
+      );
+
+      const run = await harness.service.startRun(harness.definition.id);
+      await vi.waitFor(async () => {
+        const reservations = await harness.admission.list({ workflowRunId: run.id });
+        expect(reservations).toHaveLength(2);
+        expect(reservations.every((reservation) => reservation.state === 'active')).toBe(true);
+      });
+
+      const active = await harness.admission.list({ workflowRunId: run.id });
+      const root = active.find((reservation) => !reservation.request.workflowStepId);
+      const step = active.find((reservation) => reservation.request.workflowStepId === 'execute');
+      expect(root?.request.provider).toBe('workflow-control');
+      expect(step).toMatchObject({
+        request: {
+          provider: 'codex-sdk',
+          hostId: 'local-process',
+          rootReservationId: root?.id,
+        },
+      });
+      await expect(
+        harness.admission.admit({
+          taskId: 'direct-task',
+          workspaceId: 'local',
+          provider: 'codex-sdk',
+          hostId: 'local-process',
+          idempotencyKey: `direct:${backend}`,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'retryable-overload',
+        limitingPolicies: expect.arrayContaining([
+          expect.objectContaining({ scope: 'global' }),
+          expect.objectContaining({ scope: 'workspace', scopeId: 'local' }),
+          expect.objectContaining({ scope: 'provider', scopeId: 'codex-sdk' }),
+          expect.objectContaining({ scope: 'host', scopeId: 'local-process' }),
+        ]),
+      });
+
+      finishStep?.();
+      await vi.waitFor(async () => {
+        expect((await harness.service.getRun(run.id))?.status).toBe('completed');
+      });
+      expect(
+        (await harness.admission.list({ workflowRunId: run.id })).map(
+          (reservation) => reservation.state
+        )
+      ).toEqual(['released', 'released']);
+    }
+  );
+
+  it('fails closed before provider dispatch when a step exceeds its provider ceiling', async () => {
+    const executeStep = vi.fn(async () => ({
+      output: { completed: true },
+      outputPath: '/tmp/execute.json',
+    }));
+    const harness = await createHarness(
+      'file',
+      settings({ providers: { 'codex-sdk': { processSlots: 0 } } }),
+      executor(executeStep)
+    );
+
+    const run = await harness.service.startRun(harness.definition.id);
+    await vi.waitFor(async () => {
+      expect((await harness.service.getRun(run.id))?.status).toBe('failed');
+    });
+
+    const persisted = await harness.service.getRun(run.id);
+    expect(persisted?.steps[0]).toMatchObject({
+      status: 'failed',
+      admission: {
+        decision: {
+          outcome: 'terminal-policy-denial',
+          limitingPolicies: [expect.objectContaining({ scope: 'provider', scopeId: 'codex-sdk' })],
+        },
+      },
+    });
+    expect(executeStep).not.toHaveBeenCalled();
+    expect(
+      (await harness.admission.list({ workflowRunId: run.id })).map(
+        (reservation) => reservation.state
+      )
+    ).toEqual(['released']);
+  });
+
+  it('recovers the exact root lease before resuming a blocked run after restart', async () => {
+    const first = await createHarness(
+      'file',
+      settings(),
+      executor(async () => {
+        throw new Error('permanent provider failure');
+      }),
+      'owner-before-restart'
+    );
+    first.definition.steps[0].on_fail = {
+      retry: 0,
+      escalate_to: 'human',
+      escalate_message: 'Operator review required',
+    };
+    const run = await first.service.startRun(first.definition.id);
+    await vi.waitFor(async () => {
+      expect((await first.service.getRun(run.id))?.status).toBe('blocked');
+    });
+    const rootBinding = (await first.service.getRun(run.id))?.admission;
+    expect(rootBinding).toBeDefined();
+    first.admission.dispose();
+
+    const restartedAdmission = new AdmissionControlService({
+      repository: first.repository,
+      settings: async () => settings(),
+      hostId: 'workflow-host',
+      ownerId: 'owner-after-restart',
+      processId: 303,
+    });
+    admissions.push(restartedAdmission);
+    const restarted = new WorkflowRunService({
+      runsDir: path.join(first.root, 'runs'),
+      workflowService: {
+        loadWorkflow: async (id: string) => (id === first.definition.id ? first.definition : null),
+      } as never,
+      stepExecutor: executor(async () => ({
+        output: { completed: true },
+        outputPath: '/tmp/execute.json',
+      })),
+      admission: restartedAdmission,
+    });
+    runs.push(restarted);
+
+    await restarted.resumeRun(run.id, { approved: true });
+    await vi.waitFor(async () => {
+      expect((await restarted.getRun(run.id))?.status).toBe('completed');
+    });
+    if (!rootBinding) throw new Error('Expected the workflow root admission binding');
+    expect(await restartedAdmission.get(rootBinding.reservationId)).toMatchObject({
+      state: 'released',
+      lease: { ownerId: 'owner-after-restart' },
+    });
+  });
+
+  it('releases the failed child once when recovery cancellation races', async () => {
+    const executeStep = vi.fn(async () => {
+      throw new Error('ETIMEDOUT');
+    });
+    const harness = await createHarness('file', settings(), executor(executeStep));
+    harness.definition.steps[0].on_fail = {
+      retry: 2,
+      retry_delay_ms: 10_000,
+    };
+
+    const run = await harness.service.startRun(harness.definition.id);
+    const pending = await vi.waitFor(async () => {
+      const persisted = await harness.service.getRun(run.id);
+      expect(persisted?.status).toBe('pending');
+      expect(persisted?.steps[0].runRetry?.state).toBe('scheduled');
+      if (!persisted) throw new Error('Expected the pending workflow run');
+      return persisted;
+    });
+    const pendingRecovery = pending.steps[0]?.runRetry;
+    if (!pendingRecovery) throw new Error('Expected the scheduled workflow recovery');
+    const parentRunId = pendingRecovery.parentRunId;
+    const cancellations = await Promise.allSettled([
+      harness.service.cancelPendingRecovery(run.id, 'execute', parentRunId, 'operator-one'),
+      harness.service.cancelPendingRecovery(run.id, 'execute', parentRunId, 'operator-two'),
+    ]);
+
+    expect(cancellations.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(cancellations.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect((await harness.service.getRun(run.id))?.status).toBe('blocked');
+    const reservations = await harness.admission.list({ workflowRunId: run.id });
+    expect(
+      reservations.find((reservation) => reservation.request.workflowStepId === 'execute')
+    ).toMatchObject({
+      state: 'released',
+      release: { reason: 'failed' },
+    });
+    expect(reservations.find((reservation) => !reservation.request.workflowStepId)).toMatchObject({
+      state: 'active',
+    });
+    expect(executeStep).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/__tests__/workflow-run-service.test.ts
+++ b/server/src/__tests__/workflow-run-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { workflowAdmissionStub } from './helpers/workflow-admission-stub.js';
 
 const mockLoadWorkflow = vi.fn();
 const mockListWorkflowsMetadata = vi.fn();
@@ -88,7 +89,10 @@ describe('WorkflowRunService', () => {
     mockValidateFallbackAgent.mockResolvedValue({});
     mockGetFallback.mockResolvedValue(null);
     const mod = await import('../services/workflow-run-service.js');
-    service = new mod.WorkflowRunService(tmpDir);
+    service = new mod.WorkflowRunService({
+      runsDir: tmpDir,
+      admission: workflowAdmissionStub(),
+    });
   });
 
   afterEach(async () => {

--- a/server/src/routes/admission.ts
+++ b/server/src/routes/admission.ts
@@ -15,6 +15,9 @@ const listQuerySchema = z
     rootTaskId: z.string().trim().min(1).max(240).optional(),
     provider: z.string().trim().min(1).max(80).optional(),
     hostId: z.string().trim().min(1).max(240).optional(),
+    workflowRunId: z.string().trim().min(1).max(240).optional(),
+    workflowStepId: z.string().trim().min(1).max(240).optional(),
+    rootReservationId: z.string().trim().min(1).max(240).optional(),
     state: z
       .union([z.string(), z.array(z.string())])
       .optional()
@@ -36,6 +39,9 @@ router.get(
         rootTaskId: raw.rootTaskId,
         provider: raw.provider,
         hostId: raw.hostId,
+        workflowRunId: raw.workflowRunId,
+        workflowStepId: raw.workflowStepId,
+        rootReservationId: raw.rootReservationId,
         states: raw.state,
         limit: raw.limit,
       });

--- a/server/src/schemas/admission-control-schemas.ts
+++ b/server/src/schemas/admission-control-schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import {
   ADMISSION_DECISION_OUTCOMES,
   ADMISSION_DECISION_SCHEMA_VERSION,
+  ADMISSION_CONTROL_PROVIDER,
   ADMISSION_REQUEST_SCHEMA_VERSION,
   ADMISSION_RESERVATION_SCHEMA_VERSION,
   ADMISSION_RESERVATION_STATES,
@@ -11,6 +12,7 @@ import {
 
 const identifier = z.string().trim().min(1).max(240);
 const policyIdentifier = z.string().trim().min(1).max(256);
+const admissionProvider = z.enum([...EXECUTABLE_AGENT_PROVIDERS, ADMISSION_CONTROL_PROVIDER]);
 
 export const AdmissionCapacityRequestSchema = z
   .object({
@@ -54,8 +56,11 @@ export const AdmissionRequestSchema = z
     taskId: identifier,
     rootTaskId: identifier,
     workspaceId: identifier,
-    provider: z.enum(EXECUTABLE_AGENT_PROVIDERS),
+    provider: admissionProvider,
     hostId: identifier,
+    workflowRunId: identifier.optional(),
+    workflowStepId: identifier.optional(),
+    rootReservationId: identifier.optional(),
     requested: AdmissionCapacityRequestSchema,
     requestedAt: z.string().datetime(),
   })
@@ -136,8 +141,11 @@ export const AdmissionReservationListQuerySchema = z
     workspaceId: identifier.optional(),
     taskId: identifier.optional(),
     rootTaskId: identifier.optional(),
-    provider: z.enum(EXECUTABLE_AGENT_PROVIDERS).optional(),
+    provider: admissionProvider.optional(),
     hostId: identifier.optional(),
+    workflowRunId: identifier.optional(),
+    workflowStepId: identifier.optional(),
+    rootReservationId: identifier.optional(),
     states: z.array(z.enum(ADMISSION_RESERVATION_STATES)).max(3).optional(),
     limit: z.number().int().min(1).max(1_000).optional(),
   })

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { AgentBudgetPolicySchema } from './agent-budget-schemas.js';
-import { BOARD_COLUMN_ID_PATTERN, EXECUTABLE_AGENT_PROVIDERS } from '@veritas-kanban/shared';
+import {
+  ADMISSION_CONTROL_PROVIDER,
+  BOARD_COLUMN_ID_PATTERN,
+  EXECUTABLE_AGENT_PROVIDERS,
+} from '@veritas-kanban/shared';
 
 // Dangerous keys check
 const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
@@ -239,7 +243,10 @@ const AdmissionSettingsSchema = z
     workspaces: z.record(z.string().min(1).max(240), AdmissionCapacityLimitSchema).optional(),
     rootTasks: z.record(z.string().min(1).max(240), AdmissionCapacityLimitSchema).optional(),
     providers: z
-      .partialRecord(z.enum(EXECUTABLE_AGENT_PROVIDERS), AdmissionCapacityLimitSchema)
+      .partialRecord(
+        z.enum([...EXECUTABLE_AGENT_PROVIDERS, ADMISSION_CONTROL_PROVIDER]),
+        AdmissionCapacityLimitSchema
+      )
       .optional(),
     hosts: z.record(z.string().min(1).max(240), AdmissionCapacityLimitSchema).optional(),
   })

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -5,11 +5,11 @@ import type {
   AdmissionDecision,
   AdmissionLaunchSource,
   AdmissionLimitPolicy,
+  AdmissionProvider,
   AdmissionReservation,
   AdmissionReservationListQuery,
   AdmissionReservationRelease,
   AdmissionSettings,
-  ExecutableAgentProvider,
 } from '@veritas-kanban/shared';
 import {
   ADMISSION_DECISION_SCHEMA_VERSION,
@@ -34,8 +34,11 @@ export interface AdmissionRequestInput {
   taskId: string;
   rootTaskId?: string;
   workspaceId: string;
-  provider: ExecutableAgentProvider;
+  provider: AdmissionProvider;
   hostId: string;
+  workflowRunId?: string;
+  workflowStepId?: string;
+  rootReservationId?: string;
   source?: AdmissionLaunchSource;
   idempotencyKey?: string;
   requested?: Partial<AdmissionCapacityRequest>;
@@ -135,6 +138,9 @@ export class AdmissionControlService {
       workspaceId: input.workspaceId,
       provider: input.provider,
       hostId: input.hostId,
+      ...(input.workflowRunId ? { workflowRunId: input.workflowRunId } : {}),
+      ...(input.workflowStepId ? { workflowStepId: input.workflowStepId } : {}),
+      ...(input.rootReservationId ? { rootReservationId: input.rootReservationId } : {}),
       requested: {
         ...requested,
         runSlots: Math.max(1, requested.runSlots),
@@ -341,6 +347,10 @@ export class AdmissionControlService {
     return this.repository.expireLeases(this.now().toISOString());
   }
 
+  getExecutionHostId(): string {
+    return this.executionHostId;
+  }
+
   async get(id: string): Promise<AdmissionReservation> {
     await this.expireAbandoned();
     const record = await this.repository.get(id);
@@ -523,6 +533,9 @@ function sameRequestIdentity(
     left.workspaceId === right.workspaceId &&
     left.provider === right.provider &&
     left.hostId === right.hostId &&
+    left.workflowRunId === right.workflowRunId &&
+    left.workflowStepId === right.workflowStepId &&
+    left.rootReservationId === right.rootReservationId &&
     JSON.stringify(left.requested) === JSON.stringify(right.requested)
   );
 }

--- a/server/src/services/task-envelope-service.ts
+++ b/server/src/services/task-envelope-service.ts
@@ -815,7 +815,7 @@ function isPathWithin(basePath: string, targetPath: string): boolean {
   );
 }
 
-function normalizeWorkspaceId(value: string): string {
+export function normalizeWorkspaceId(value: string): string {
   const normalized = value.trim();
   if (normalized.length <= 160) return normalized;
   const suffix = createHash('sha256').update(normalized).digest('hex').slice(0, 16);

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -5,8 +5,10 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import { createHash, randomUUID } from 'node:crypto';
 import { nanoid } from 'nanoid';
 import {
+  ADMISSION_CONTROL_PROVIDER,
   buildWorkflowPipelineSummary,
   DEFAULT_ROUTING_CONFIG,
   ZERO_AGENT_BUDGET_USAGE,
@@ -15,14 +17,23 @@ import {
   type AgentBudgetThresholdEvent,
   type AgentBudgetUsage,
   type AgentType,
+  type AdmissionDecision,
+  type AdmissionReservation,
+  type AdmissionReservationRelease,
   type RunRecoveryRecord,
+  type Task,
   type WorkflowPipelineRoleStatusPatch,
   type WorkflowSubagentRunStatus,
   type WorkflowSubagentTelemetry,
+  WORKFLOW_ADMISSION_SCHEMA_VERSION,
 } from '@veritas-kanban/shared';
 import type { WorkflowRun, StepRun, WorkflowDefinition, WorkflowStep } from '../types/workflow.js';
 import { getWorkflowService } from './workflow-service.js';
-import { WorkflowStepExecutor, HumanGateBlockError } from './workflow-step-executor.js';
+import {
+  WorkflowStepExecutor,
+  HumanGateBlockError,
+  type WorkflowAgentStepPreparation,
+} from './workflow-step-executor.js';
 import { getWorkflowRunsDir } from '../utils/paths.js';
 import { createLogger } from '../lib/logger.js';
 import { broadcastWorkflowStatus } from './broadcast-service.js';
@@ -37,19 +48,22 @@ import { RunRecoveryPolicyService } from './run-recovery-policy-service.js';
 import { getAgentRoutingService } from './agent-routing-service.js';
 import { atomicWriteFile } from '../storage/fs-helpers.js';
 import { withFileLock } from './file-lock.js';
+import {
+  AdmissionControlService,
+  getAdmissionControlService,
+} from './admission-control-service.js';
+import { normalizeWorkspaceId } from './task-envelope-service.js';
 
 const log = createLogger('workflow-run');
 
-// Concurrency limits
-const MAX_CONCURRENT_RUNS = 10;
 /** Default maximum cross-step reroutes per run before exhaustion policy fires (#780) */
 const MAX_REROUTES_DEFAULT = 10;
-let activeRunCount = 0;
 const scheduledWorkflowRecoveries = new Map<
   string,
   { stepId: string; timer: ReturnType<typeof setTimeout> }
 >();
 const RUN_ID_PATTERN = /^run_\d{10,}_[a-zA-Z0-9_-]{6,}$/;
+const WORKFLOW_ADMISSION_ID_PREFIX = 'workflow';
 const RESERVED_CONTEXT_KEYS = new Set([
   'task',
   'workflow',
@@ -62,6 +76,32 @@ const RESERVED_CONTEXT_KEYS = new Set([
   '_gateApproval',
 ]);
 
+class WorkflowStepAdmissionError extends Error {
+  readonly decision: AdmissionDecision;
+
+  constructor(readonly binding: NonNullable<StepRun['admission']>) {
+    const decision = binding.decision;
+    super(
+      decision.outcome === 'retryable-overload'
+        ? 'Workflow step is waiting for admission capacity.'
+        : 'Workflow step violates an admission policy.'
+    );
+    this.name = 'WorkflowStepAdmissionError';
+    this.decision = decision;
+  }
+}
+
+class WorkflowRunChangedError extends ConflictError {
+  constructor(runId: string, expectedRevision: number, currentRevision?: number) {
+    super('Workflow run changed during persistence', {
+      runId,
+      expectedRevision,
+      currentRevision,
+    });
+    this.name = 'WorkflowRunChangedError';
+  }
+}
+
 export class WorkflowRunService {
   private runsDir: string;
   private workflowService: ReturnType<typeof getWorkflowService>;
@@ -70,12 +110,14 @@ export class WorkflowRunService {
   private readonly sqliteDatabase: SqliteDatabase | null = null;
   private readonly ownsSqliteDatabase: boolean = false;
   private readonly runRecoveryPolicy: RunRecoveryPolicyService;
+  private readonly admission: AdmissionControlService;
 
   constructor(options: string | WorkflowRunServiceOptions = {}) {
     const resolvedOptions = typeof options === 'string' ? { runsDir: options } : options;
     this.runsDir = resolvedOptions.runsDir || getWorkflowRunsDir();
     this.workflowService = resolvedOptions.workflowService ?? getWorkflowService();
     this.runRecoveryPolicy = resolvedOptions.runRecoveryPolicy ?? new RunRecoveryPolicyService();
+    this.admission = resolvedOptions.admission ?? getAdmissionControlService();
     this.stepExecutor =
       resolvedOptions.stepExecutor ??
       new WorkflowStepExecutor(resolvedOptions.runsDir, {
@@ -301,6 +343,190 @@ export class WorkflowRunService {
     }
   }
 
+  private rootAdmissionTaskId(runId: string): string {
+    return `${WORKFLOW_ADMISSION_ID_PREFIX}-root:${runId}`;
+  }
+
+  private stepAdmissionTaskId(runId: string, stepId: string, sequence: number): string {
+    const digest = createHash('sha256')
+      .update(`${runId}:${stepId}:${sequence}`)
+      .digest('hex')
+      .slice(0, 32);
+    return `${WORKFLOW_ADMISSION_ID_PREFIX}-step:${digest}`;
+  }
+
+  private workflowWorkspaceId(task: Task | null): string {
+    if (!task) return 'local';
+    return normalizeWorkspaceId(task.project?.trim() || task.git?.repo || task.id);
+  }
+
+  private admissionConflict(decision: AdmissionDecision, subject: string): ConflictError {
+    return new ConflictError(
+      decision.outcome === 'retryable-overload'
+        ? `${subject} is waiting for admission capacity.`
+        : `${subject} violates an admission policy.`,
+      {
+        code:
+          decision.outcome === 'retryable-overload'
+            ? 'ADMISSION_OVERLOAD'
+            : 'ADMISSION_POLICY_DENIED',
+        decision,
+      }
+    );
+  }
+
+  private async admitWorkflowRoot(
+    run: WorkflowRun,
+    task: Task | null
+  ): Promise<NonNullable<WorkflowRun['admission']>> {
+    const admissionTaskId = this.rootAdmissionTaskId(run.id);
+    const attemptId = admissionTaskId;
+    const workspaceId = this.workflowWorkspaceId(task);
+    const rootTaskId = run.taskId ?? admissionTaskId;
+    const decision = await this.admission.admit({
+      taskId: admissionTaskId,
+      rootTaskId,
+      workspaceId,
+      provider: ADMISSION_CONTROL_PROVIDER,
+      hostId: this.admission.getExecutionHostId(),
+      source: 'workflow',
+      workflowRunId: run.id,
+      idempotencyKey: `workflow-root:${run.id}:${randomUUID()}`,
+      requested: {
+        runSlots: 1,
+        processSlots: 0,
+        estimatedMemoryMb: 0,
+      },
+    });
+    if (decision.outcome !== 'admitted' || !decision.reservation) {
+      throw this.admissionConflict(decision, 'Workflow root');
+    }
+    let reservation: AdmissionReservation;
+    try {
+      reservation = await this.admission.bindAttempt(decision.reservation.id, attemptId);
+    } catch (error) {
+      await this.admission
+        .releaseIfUnbound(
+          decision.reservation.id,
+          'start-failed',
+          `workflow-root-bind-failed:${run.id}`
+        )
+        .catch(() => {});
+      throw error;
+    }
+    return {
+      schemaVersion: WORKFLOW_ADMISSION_SCHEMA_VERSION,
+      workspaceId,
+      rootTaskId,
+      admissionTaskId,
+      attemptId,
+      reservationId: reservation.id,
+    };
+  }
+
+  private async ensureWorkflowRootAdmission(run: WorkflowRun): Promise<void> {
+    if (!run.admission) {
+      const task = run.taskId ? await getTaskService().getTask(run.taskId) : null;
+      run.admission = await this.admitWorkflowRoot(run, task);
+      await this.saveRun(run);
+      return;
+    }
+    const recovered = await this.admission.recoverVerifiedRun({
+      workspaceId: run.admission.workspaceId,
+      taskId: run.admission.admissionTaskId,
+      attemptId: run.admission.attemptId,
+    });
+    if (!recovered || recovered.id !== run.admission.reservationId) {
+      throw new ConflictError('Workflow root admission could not be recovered.', {
+        runId: run.id,
+        expectedReservationId: run.admission.reservationId,
+        recoveredReservationId: recovered?.id,
+      });
+    }
+  }
+
+  private async admitWorkflowStep(
+    run: WorkflowRun,
+    step: WorkflowStep,
+    preparation: WorkflowAgentStepPreparation
+  ): Promise<NonNullable<StepRun['admission']>> {
+    if (!run.admission) {
+      throw new ConflictError('Workflow root admission is missing before step launch.', {
+        runId: run.id,
+        stepId: step.id,
+      });
+    }
+    const stepRun = run.steps.find((candidate) => candidate.stepId === step.id);
+    if (!stepRun) throw new Error(`Workflow run is missing step state for ${step.id}`);
+    const sequence = (stepRun.admission?.sequence ?? 0) + 1;
+    const admissionTaskId = this.stepAdmissionTaskId(run.id, step.id, sequence);
+    const attemptId = admissionTaskId;
+    const hostId =
+      preparation.hostRouting.selectedHostId ??
+      (preparation.runtimeProvider === 'openclaw' ? 'openclaw-gateway' : 'local-process');
+    const decision = await this.admission.admit({
+      taskId: admissionTaskId,
+      rootTaskId: run.admission.rootTaskId,
+      workspaceId: run.admission.workspaceId,
+      provider: preparation.runtimeProvider,
+      hostId,
+      source:
+        stepRun.runRetry?.action === 'fallback'
+          ? 'fallback'
+          : stepRun.runRetry
+            ? 'recovery'
+            : 'workflow',
+      workflowRunId: run.id,
+      workflowStepId: step.id,
+      rootReservationId: run.admission.reservationId,
+      idempotencyKey: `workflow-step:${run.id}:${step.id}:${sequence}:${randomUUID()}`,
+    });
+    const binding: NonNullable<StepRun['admission']> = {
+      schemaVersion: WORKFLOW_ADMISSION_SCHEMA_VERSION,
+      sequence,
+      admissionTaskId,
+      attemptId,
+      decision,
+    };
+    if (decision.outcome !== 'admitted' || !decision.reservation) {
+      throw new WorkflowStepAdmissionError(binding);
+    }
+    try {
+      const reservation = await this.admission.bindAttempt(decision.reservation.id, attemptId);
+      return {
+        ...binding,
+        reservationId: reservation.id,
+      };
+    } catch (error) {
+      await this.admission
+        .releaseIfUnbound(
+          decision.reservation.id,
+          'start-failed',
+          `workflow-step-bind-failed:${attemptId}`
+        )
+        .catch(() => {});
+      throw error;
+    }
+  }
+
+  private async releaseStepAdmission(
+    stepRun: StepRun,
+    reason: AdmissionReservationRelease['reason'],
+    idempotencyKey: string
+  ): Promise<void> {
+    if (!stepRun.admission?.reservationId) return;
+    await this.admission.release(stepRun.admission.reservationId, reason, idempotencyKey);
+  }
+
+  private async releaseRootAdmission(
+    run: WorkflowRun,
+    reason: AdmissionReservationRelease['reason'],
+    idempotencyKey: string
+  ): Promise<void> {
+    if (!run.admission?.reservationId) return;
+    await this.admission.release(run.admission.reservationId, reason, idempotencyKey);
+  }
+
   /**
    * Start a new workflow run
    */
@@ -310,13 +536,6 @@ export class WorkflowRunService {
     initialContext?: Record<string, unknown>,
     runBudget?: AgentBudgetPolicy
   ): Promise<WorkflowRun> {
-    // Check concurrency limit
-    if (activeRunCount >= MAX_CONCURRENT_RUNS) {
-      throw new ValidationError(
-        `Maximum concurrent workflow runs (${MAX_CONCURRENT_RUNS}) exceeded. Wait for active runs to complete.`
-      );
-    }
-
     const workflow = await this.workflowService.loadWorkflow(workflowId);
     if (!workflow) {
       throw new NotFoundError(`Workflow ${workflowId} not found`);
@@ -368,8 +587,8 @@ export class WorkflowRunService {
       workflowId: workflow.id,
       workflowVersion: workflow.version,
       taskId,
-      status: 'running',
-      currentStep: workflow.steps[0].id,
+      status: 'pending',
+      currentStep: workflow.steps[0]?.id,
       context: {
         // Workflow variables
         ...workflow.variables,
@@ -421,11 +640,29 @@ export class WorkflowRunService {
       })),
     };
 
-    // Persist initial run state
-    await this.saveRun(run);
-
-    // Snapshot workflow YAML into run directory (for version immutability)
-    await this.snapshotWorkflow(run.id, workflow);
+    try {
+      run.admission = await this.admitWorkflowRoot(run, task);
+      run.status = 'running';
+      await this.saveRun(run);
+      await this.snapshotWorkflow(run.id, workflow);
+    } catch (error) {
+      if (run.admission) {
+        if (run.revision) {
+          run.status = 'failed';
+          run.error = error instanceof Error ? error.message : 'Workflow start failed';
+          run.completedAt = new Date().toISOString();
+          await this.saveRun(run).catch((saveError) => {
+            log.error({ err: saveError, runId }, 'Failed to persist workflow start failure');
+          });
+        }
+        await this.releaseRootAdmission(run, 'start-failed', `start-failed:${run.id}`).catch(
+          (releaseError) => {
+            log.error({ err: releaseError, runId }, 'Failed to release workflow root admission');
+          }
+        );
+      }
+      throw error;
+    }
 
     log.info({ runId, workflowId, workflowVersion: workflow.version }, 'Workflow run started');
 
@@ -441,34 +678,50 @@ export class WorkflowRunService {
    * Execute the workflow run (iterates through steps with retry logic)
    */
   private async executeRun(run: WorkflowRun, workflow: WorkflowDefinition): Promise<void> {
-    // Increment active run counter
-    activeRunCount++;
-
     try {
       // Build initial step queue (skip already completed/skipped steps on resume)
       const stepQueue: string[] = this.buildStepQueue(run, workflow);
 
       while (stepQueue.length > 0) {
-        const stepId = stepQueue.shift()!;
-        const step = workflow.steps.find((s) => s.id === stepId)!;
+        const stepId = stepQueue.shift();
+        if (!stepId) break;
+        const step = workflow.steps.find((s) => s.id === stepId);
+        if (!step) {
+          throw new Error(`Workflow definition is missing queued step ${stepId}`);
+        }
         if (await this.evaluateRunBudget(run, workflow, step, 'workflow.step.start', true)) {
           await this.saveRun(run);
           broadcastWorkflowStatus(run);
+          if (run.status === 'failed') {
+            await this.releaseRootAdmission(
+              run,
+              'failed',
+              `workflow-budget-start:${run.id}:${step.id}`
+            );
+          }
           return;
         }
 
         // Skip if step already completed/skipped (defensive when retry_step rebuilds queue)
-        const existingStepRun = run.steps.find((s) => s.stepId === step.id)!;
+        const existingStepRun = run.steps.find((s) => s.stepId === step.id);
+        if (!existingStepRun) {
+          throw new Error(`Workflow run is missing step state for ${step.id}`);
+        }
         if (existingStepRun.status === 'completed' || existingStepRun.status === 'skipped') {
           continue;
         }
 
         const stepRun = existingStepRun;
+        let providerDispatchStarted = false;
 
         try {
           // Resolve runtime, sandbox, host, and phase authority before creating
           // or mutating the executable step attempt.
           const preparation = await this.stepExecutor.prepareStep(step, run);
+          if (preparation.kind === 'agent') {
+            stepRun.admission = await this.admitWorkflowStep(run, step, preparation);
+          }
+          run.status = 'running';
           run.currentStep = step.id;
           stepRun.agent ??= preparation.step.agent ?? step.agent;
           this.stepExecutor.applyPreparation(run, preparation);
@@ -485,10 +738,25 @@ export class WorkflowRunService {
             };
           }
           this.syncPipelineSummary(run, workflow);
-          await this.saveRun(run);
+          try {
+            await this.saveRun(run);
+          } catch (error) {
+            await this.releaseStepAdmission(
+              stepRun,
+              'start-failed',
+              `workflow-step-persist-failed:${run.id}:${step.id}:${stepRun.admission?.sequence ?? 0}`
+            );
+            throw error;
+          }
           broadcastWorkflowStatus(run);
 
+          providerDispatchStarted = preparation.kind === 'agent';
           const result = await this.stepExecutor.executeStep(step, run, preparation);
+          await this.releaseStepAdmission(
+            stepRun,
+            'completed',
+            `workflow-step-completed:${run.id}:${step.id}:${stepRun.admission?.sequence ?? 0}`
+          );
           if (result.budgetUsage) {
             const budgetBlocked = await this.evaluateRunBudget(
               run,
@@ -501,15 +769,24 @@ export class WorkflowRunService {
             if (budgetBlocked) {
               await this.saveRun(run);
               broadcastWorkflowStatus(run);
+              if ((run.status as WorkflowRun['status']) === 'failed') {
+                await this.releaseRootAdmission(
+                  run,
+                  'failed',
+                  `workflow-budget-usage:${run.id}:${step.id}`
+                );
+              }
               return;
             }
           }
 
           stepRun.status = 'completed';
           stepRun.completedAt = new Date().toISOString();
+          if (!stepRun.startedAt) {
+            throw new Error(`Workflow step ${step.id} completed without a start timestamp`);
+          }
           stepRun.duration = Math.floor(
-            (new Date(stepRun.completedAt).getTime() - new Date(stepRun.startedAt!).getTime()) /
-              1000
+            (new Date(stepRun.completedAt).getTime() - new Date(stepRun.startedAt).getTime()) / 1000
           );
           stepRun.output = result.outputPath;
 
@@ -521,6 +798,38 @@ export class WorkflowRunService {
           broadcastWorkflowStatus(run);
         } catch (err: unknown) {
           run.currentStep = step.id;
+          if (err instanceof WorkflowStepAdmissionError) {
+            stepRun.admission = err.binding;
+            stepRun.error = err.message;
+            run.error = err.message;
+            if (err.decision.outcome === 'retryable-overload') {
+              stepRun.status = 'pending';
+              stepRun.completedAt = undefined;
+              run.status = 'blocked';
+            } else {
+              stepRun.status = 'failed';
+              stepRun.completedAt = new Date().toISOString();
+              run.status = 'failed';
+              run.completedAt = stepRun.completedAt;
+            }
+            this.syncPipelineSummary(run, workflow);
+            await this.saveRun(run);
+            broadcastWorkflowStatus(run);
+            if (run.status === 'failed') {
+              await this.releaseRootAdmission(
+                run,
+                'failed',
+                `workflow-step-admission-denied:${run.id}:${step.id}`
+              );
+            }
+            return;
+          }
+
+          await this.releaseStepAdmission(
+            stepRun,
+            providerDispatchStarted ? 'failed' : 'start-failed',
+            `workflow-step-error:${run.id}:${step.id}:${stepRun.admission?.sequence ?? 0}`
+          );
           // --- Gate human-escalation (#778) ---
           // HumanGateBlockError is a clean, expected pause — not a real failure.
           // Handle it before the generic failure path so on_fail is not misapplied.
@@ -600,20 +909,26 @@ export class WorkflowRunService {
       this.syncPipelineSummary(run, workflow);
       await this.saveRun(run);
       broadcastWorkflowStatus(run);
+      await this.releaseRootAdmission(run, 'completed', `workflow-completed:${run.id}`);
 
       log.info({ runId: run.id, workflowId: run.workflowId }, 'Workflow run completed');
     } catch (err: unknown) {
+      if (err instanceof WorkflowRunChangedError) {
+        log.info({ runId: run.id }, 'Workflow execution ownership changed before persistence');
+        return;
+      }
       run.status = 'failed';
       run.error = err instanceof Error ? err.message : 'Unknown error';
       run.completedAt = new Date().toISOString();
       this.syncPipelineSummary(run, workflow);
-      await this.saveRun(run);
-      broadcastWorkflowStatus(run);
+      try {
+        await this.saveRun(run);
+        broadcastWorkflowStatus(run);
+      } finally {
+        await this.releaseRootAdmission(run, 'failed', `workflow-failed:${run.id}`);
+      }
 
       log.error({ runId: run.id, err }, 'Workflow run failed');
-    } finally {
-      // Decrement active run counter
-      activeRunCount--;
     }
   }
 
@@ -788,7 +1103,10 @@ export class WorkflowRunService {
       }
 
       // Reset the retry step's state
-      const retryStepRun = run.steps.find((s) => s.stepId === retryStep.id)!;
+      const retryStepRun = run.steps.find((s) => s.stepId === retryStep.id);
+      if (!retryStepRun) {
+        throw new Error(`Workflow run is missing retry step state for ${retryStep.id}`);
+      }
       retryStepRun.status = 'pending';
       retryStepRun.retries = 0;
       retryStepRun.error = undefined;
@@ -845,36 +1163,60 @@ export class WorkflowRunService {
   }
 
   async reconcilePendingRecoveries(): Promise<void> {
+    await this.admission.expireAbandoned();
     const runs = (await this.listRuns()).filter(
       (run) => run.status === 'pending' || run.status === 'running'
     );
     let scheduledCount = 0;
     for (const run of runs) {
-      const stepRun = run.steps.find((step) => step.stepId === run.currentStep);
-      const recovery = stepRun?.runRetry;
-      if (!stepRun || !recovery) {
-        continue;
-      }
-      if (recovery.state === 'launched' && run.status === 'running') {
-        stepRun.runRetry = {
-          ...recovery,
-          state: 'approval-required',
-          action: 'approval',
-          reason:
-            'The server restarted after recovery launch and cannot prove the provider terminal state.',
-          backoffMs: 0,
-          handoff: {
-            summary: 'Workflow recovery requires operator reconciliation after restart.',
-            nextActions: [
-              'Inspect the provider session and persisted step output.',
-              'Confirm no provider work remains before resuming or replacing the run.',
-            ],
-          },
-        };
+      try {
+        await this.ensureWorkflowRootAdmission(run);
+      } catch (error) {
         run.status = 'blocked';
-        run.error = stepRun.runRetry.handoff?.summary ?? stepRun.runRetry.reason;
+        run.error =
+          error instanceof Error
+            ? `Workflow root admission recovery failed: ${error.message}`
+            : 'Workflow root admission recovery failed.';
         await this.saveRun(run);
         broadcastWorkflowStatus(run);
+        continue;
+      }
+      const stepRun = run.steps.find((step) => step.stepId === run.currentStep);
+      const recovery = stepRun?.runRetry;
+      if (stepRun?.status === 'running') {
+        await this.releaseStepAdmission(
+          stepRun,
+          'reconciled',
+          `workflow-step-restart:${run.id}:${stepRun.stepId}:${stepRun.admission?.sequence ?? 0}`
+        );
+        if (recovery?.state === 'launched') {
+          stepRun.runRetry = {
+            ...recovery,
+            state: 'approval-required',
+            action: 'approval',
+            reason:
+              'The server restarted after recovery launch and cannot prove the provider terminal state.',
+            backoffMs: 0,
+            handoff: {
+              summary: 'Workflow recovery requires operator reconciliation after restart.',
+              nextActions: [
+                'Inspect the provider session and persisted step output.',
+                'Confirm no provider work remains before resuming or replacing the run.',
+              ],
+            },
+          };
+        }
+        stepRun.status = 'failed';
+        stepRun.error =
+          stepRun.runRetry?.handoff?.summary ??
+          'Workflow step requires operator reconciliation after server restart.';
+        run.status = 'blocked';
+        run.error = stepRun.error;
+        await this.saveRun(run);
+        broadcastWorkflowStatus(run);
+        continue;
+      }
+      if (!stepRun || !recovery) {
         continue;
       }
       if (!['scheduled', 'launching'].includes(recovery.state)) continue;
@@ -936,6 +1278,11 @@ export class WorkflowRunService {
     run.status = 'blocked';
     run.error = cancelled.handoff?.summary ?? cancelled.reason;
     await this.saveRun(run);
+    await this.releaseStepAdmission(
+      stepRun,
+      'cancelled',
+      `workflow-recovery-cancelled:${run.id}:${stepId}:${cancelled.sequence}`
+    );
     this.clearScheduledWorkflowRecovery(runId, stepId);
     broadcastWorkflowStatus(run);
     return run;
@@ -984,32 +1331,10 @@ export class WorkflowRunService {
       this.scheduleWorkflowRecovery(runId, stepId, recoveryToReschedule);
       return;
     }
-    const launchedAt = new Date().toISOString();
-    stepRun.runRetry = {
-      ...recovery,
-      state: 'launched',
-      launchedAt,
-      launchedRunId: `${run.id}:${stepId}:${recovery.sequence}`,
-      selectedAgent: stepRun.agent ?? recovery.selectedAgent,
-    };
-    stepRun.status = 'pending';
-    stepRun.error = undefined;
-    run.status = 'running';
-    run.error = undefined;
-    try {
-      await this.saveRun(run);
-    } catch (error) {
-      if (error instanceof ConflictError) {
-        log.info({ runId, stepId }, 'Workflow recovery claim lost to another process');
-        return;
-      }
-      throw error;
-    }
-
     const workflow = await this.workflowService.loadWorkflow(run.workflowId);
     if (!workflow) {
       stepRun.runRetry = {
-        ...stepRun.runRetry,
+        ...recovery,
         state: 'exhausted',
         action: 'terminal',
         reason: `Workflow ${run.workflowId} no longer exists.`,
@@ -1023,8 +1348,39 @@ export class WorkflowRunService {
       run.error = stepRun.runRetry.reason;
       run.completedAt = new Date().toISOString();
       await this.saveRun(run);
+      await this.releaseRootAdmission(
+        run,
+        'failed',
+        `workflow-recovery-definition-missing:${run.id}`
+      );
       broadcastWorkflowStatus(run);
       return;
+    }
+    try {
+      await this.ensureWorkflowRootAdmission(run);
+    } catch (error) {
+      if (error instanceof WorkflowRunChangedError) {
+        log.info({ runId, stepId }, 'Workflow recovery admission claim lost to another process');
+        return;
+      }
+      throw error;
+    }
+    stepRun.runRetry = {
+      ...recovery,
+      state: 'launching',
+      selectedAgent: stepRun.agent ?? recovery.selectedAgent,
+    };
+    stepRun.status = 'pending';
+    stepRun.error = undefined;
+    run.error = undefined;
+    try {
+      await this.saveRun(run);
+    } catch (error) {
+      if (error instanceof ConflictError) {
+        log.info({ runId, stepId }, 'Workflow recovery claim lost to another process');
+        return;
+      }
+      throw error;
     }
 
     void this.executeRun(run, workflow).catch((error) => {
@@ -1199,6 +1555,12 @@ export class WorkflowRunService {
       throw new ValidationError(`Run ${runId} is not blocked (status: ${run.status})`);
     }
 
+    const workflow = await this.workflowService.loadWorkflow(run.workflowId);
+    if (!workflow) {
+      throw new NotFoundError(`Workflow ${run.workflowId} not found`);
+    }
+    await this.ensureWorkflowRootAdmission(run);
+
     // Merge resume context after rejecting attempts to replace server-owned context.
     run.context = {
       ...run.context,
@@ -1209,12 +1571,6 @@ export class WorkflowRunService {
     run.status = 'running';
     run.error = undefined;
     await this.saveRun(run);
-
-    // Resume execution
-    const workflow = await this.workflowService.loadWorkflow(run.workflowId);
-    if (!workflow) {
-      throw new NotFoundError(`Workflow ${run.workflowId} not found`);
-    }
 
     this.syncPipelineSummary(run, workflow);
     await this.saveRun(run);
@@ -1329,6 +1685,7 @@ export class WorkflowRunService {
       this.syncPipelineSummary(run, workflow);
     }
     await this.saveRun(run);
+    await this.releaseRootAdmission(run, 'failed', `workflow-gate-rejected:${run.id}:${stepId}`);
     broadcastWorkflowStatus(run);
 
     log.warn({ runId, stepId, rejectedBy }, 'Gate step rejected — run failed');
@@ -1519,10 +1876,7 @@ export class WorkflowRunService {
 
     if (this.repository) {
       if (!this.repository.save(nextRun, expectedRevision)) {
-        throw new ConflictError('Workflow run changed during persistence', {
-          runId: run.id,
-          expectedRevision,
-        });
+        throw new WorkflowRunChangedError(run.id, expectedRevision);
       }
       Object.assign(run, nextRun);
       return;
@@ -1546,11 +1900,7 @@ export class WorkflowRunService {
         (current && currentRevision !== expectedRevision) ||
         (!current && expectedRevision !== 0)
       ) {
-        throw new ConflictError('Workflow run changed during persistence', {
-          runId: run.id,
-          expectedRevision,
-          currentRevision: current?.revision,
-        });
+        throw new WorkflowRunChangedError(run.id, expectedRevision, current?.revision);
       }
       await atomicWriteFile(runPath, JSON.stringify(nextRun, null, 2));
     });
@@ -1589,6 +1939,7 @@ export interface WorkflowRunServiceOptions {
   workflowService?: ReturnType<typeof getWorkflowService>;
   runRecoveryPolicy?: RunRecoveryPolicyService;
   stepExecutor?: WorkflowStepExecutor;
+  admission?: AdmissionControlService;
 }
 
 // Singleton

--- a/server/src/storage/admission-reservation-repository.ts
+++ b/server/src/storage/admission-reservation-repository.ts
@@ -91,6 +91,16 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       .filter((record) => !query.rootTaskId || record.request.rootTaskId === query.rootTaskId)
       .filter((record) => !query.provider || record.request.provider === query.provider)
       .filter((record) => !query.hostId || record.request.hostId === query.hostId)
+      .filter(
+        (record) => !query.workflowRunId || record.request.workflowRunId === query.workflowRunId
+      )
+      .filter(
+        (record) => !query.workflowStepId || record.request.workflowStepId === query.workflowStepId
+      )
+      .filter(
+        (record) =>
+          !query.rootReservationId || record.request.rootReservationId === query.rootReservationId
+      )
       .filter((record) => !states || states.has(record.state))
       .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
       .slice(0, query.limit ?? 100);

--- a/server/src/storage/sqlite/admission-reservation-repository.ts
+++ b/server/src/storage/sqlite/admission-reservation-repository.ts
@@ -70,8 +70,9 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
         .prepare(
           `INSERT INTO admission_reservations (
              id, workspace_id, task_id, root_task_id, provider, host_id, state, revision,
-             idempotency_key, lease_expires_at, reservation_json, created_at, updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             idempotency_key, lease_expires_at, workflow_run_id, workflow_step_id,
+             root_reservation_id, reservation_json, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           requested.id,
@@ -84,6 +85,9 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
           requested.revision,
           requested.request.idempotencyKey,
           requested.lease.expiresAt,
+          requested.request.workflowRunId ?? null,
+          requested.request.workflowStepId ?? null,
+          requested.request.rootReservationId ?? null,
           JSON.stringify(requested),
           requested.createdAt,
           requested.updatedAt
@@ -116,6 +120,9 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
     if (query.rootTaskId) add('root_task_id = ?', query.rootTaskId);
     if (query.provider) add('provider = ?', query.provider);
     if (query.hostId) add('host_id = ?', query.hostId);
+    if (query.workflowRunId) add('workflow_run_id = ?', query.workflowRunId);
+    if (query.workflowStepId) add('workflow_step_id = ?', query.workflowStepId);
+    if (query.rootReservationId) add('root_reservation_id = ?', query.rootReservationId);
     if (query.states?.length) {
       clauses.push(`state IN (${query.states.map(() => '?').join(', ')})`);
       parameters.push(...query.states);
@@ -215,6 +222,7 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
         `UPDATE admission_reservations
          SET workspace_id = ?, task_id = ?, root_task_id = ?, provider = ?, host_id = ?,
              state = ?, revision = ?, idempotency_key = ?, lease_expires_at = ?,
+             workflow_run_id = ?, workflow_step_id = ?, root_reservation_id = ?,
              reservation_json = ?, updated_at = ?
          WHERE id = ? AND revision = ?`
       )
@@ -228,6 +236,9 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
         record.revision,
         record.request.idempotencyKey,
         record.lease.expiresAt,
+        record.request.workflowRunId ?? null,
+        record.request.workflowStepId ?? null,
+        record.request.rootReservationId ?? null,
         JSON.stringify(record),
         record.updatedAt,
         record.id,

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -1316,6 +1316,21 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON admission_reservations(state, lease_expires_at);
     `,
   },
+  {
+    version: 24,
+    name: '0024_workflow_admission_reservations',
+    up: `
+      ALTER TABLE admission_reservations ADD COLUMN workflow_run_id TEXT;
+      ALTER TABLE admission_reservations ADD COLUMN workflow_step_id TEXT;
+      ALTER TABLE admission_reservations ADD COLUMN root_reservation_id TEXT;
+
+      CREATE INDEX idx_admission_reservations_workflow
+        ON admission_reservations(workflow_run_id, workflow_step_id, updated_at DESC);
+
+      CREATE INDEX idx_admission_reservations_root_reservation
+        ON admission_reservations(root_reservation_id, updated_at DESC);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -204,6 +204,7 @@ export interface WorkflowRun {
   workflowId: string;
   workflowVersion: number;
   taskId?: string; // Optional task association
+  admission?: import('@veritas-kanban/shared').WorkflowRootAdmissionBinding;
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps
@@ -238,6 +239,8 @@ export interface StepRun {
   phaseLaunchDigest?: string;
   /** Durable retry/fallback decision for this workflow step. */
   runRetry?: import('@veritas-kanban/shared').RunRecoveryRecord;
+  /** Durable admission evidence for the latest executable step attempt. */
+  admission?: import('@veritas-kanban/shared').WorkflowStepAdmissionBinding;
 
   // Loop-specific state
   loopState?: {

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -3,6 +3,8 @@ import type { ExecutableAgentProvider } from './config.types.js';
 export const ADMISSION_REQUEST_SCHEMA_VERSION = 'admission-request/v1' as const;
 export const ADMISSION_DECISION_SCHEMA_VERSION = 'admission-decision/v1' as const;
 export const ADMISSION_RESERVATION_SCHEMA_VERSION = 'admission-reservation/v1' as const;
+export const ADMISSION_CONTROL_PROVIDER = 'workflow-control' as const;
+export type AdmissionProvider = ExecutableAgentProvider | typeof ADMISSION_CONTROL_PROVIDER;
 
 export const ADMISSION_SCOPES = [
   'global',
@@ -62,8 +64,11 @@ export interface AdmissionRequest {
   taskId: string;
   rootTaskId: string;
   workspaceId: string;
-  provider: ExecutableAgentProvider;
+  provider: AdmissionProvider;
   hostId: string;
+  workflowRunId?: string;
+  workflowStepId?: string;
+  rootReservationId?: string;
   requested: AdmissionCapacityRequest;
   requestedAt: string;
 }
@@ -112,8 +117,11 @@ export interface AdmissionReservationListQuery {
   workspaceId?: string;
   taskId?: string;
   rootTaskId?: string;
-  provider?: ExecutableAgentProvider;
+  provider?: AdmissionProvider;
   hostId?: string;
+  workflowRunId?: string;
+  workflowStepId?: string;
+  rootReservationId?: string;
   states?: AdmissionReservationState[];
   limit?: number;
 }
@@ -152,6 +160,6 @@ export interface AdmissionSettings {
   global: AdmissionCapacityLimit;
   workspaces: Record<string, AdmissionCapacityLimit>;
   rootTasks: Record<string, AdmissionCapacityLimit>;
-  providers: Partial<Record<ExecutableAgentProvider, AdmissionCapacityLimit>>;
+  providers: Partial<Record<AdmissionProvider, AdmissionCapacityLimit>>;
   hosts: Record<string, AdmissionCapacityLimit>;
 }

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -243,6 +243,25 @@ export interface ParallelSubStep {
 
 export type WorkflowRunStatus = 'pending' | 'running' | 'blocked' | 'completed' | 'failed';
 export type StepRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+export const WORKFLOW_ADMISSION_SCHEMA_VERSION = 'workflow-admission/v1' as const;
+
+export interface WorkflowRootAdmissionBinding {
+  schemaVersion: typeof WORKFLOW_ADMISSION_SCHEMA_VERSION;
+  workspaceId: string;
+  rootTaskId: string;
+  admissionTaskId: string;
+  attemptId: string;
+  reservationId: string;
+}
+
+export interface WorkflowStepAdmissionBinding {
+  schemaVersion: typeof WORKFLOW_ADMISSION_SCHEMA_VERSION;
+  sequence: number;
+  admissionTaskId: string;
+  attemptId: string;
+  reservationId?: string;
+  decision: import('./admission-control.types.js').AdmissionDecision;
+}
 
 export interface WorkflowRun {
   id: string; // run_<timestamp>_<nanoid>
@@ -251,6 +270,7 @@ export interface WorkflowRun {
   workflowId: string;
   workflowVersion: number;
   taskId?: string; // Optional task association
+  admission?: WorkflowRootAdmissionBinding;
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps
@@ -284,6 +304,8 @@ export interface StepRun {
   phaseLaunchDigest?: string;
   /** Durable retry/fallback decision for this workflow step. */
   runRetry?: import('./run-recovery.types.js').RunRecoveryRecord;
+  /** Durable admission evidence for the latest executable step attempt. */
+  admission?: WorkflowStepAdmissionBinding;
 
   // Loop-specific state
   loopState?: {


### PR DESCRIPTION
## Summary

- reserve durable `workflow-control` capacity before a workflow root becomes active
- reserve each provider-backed step against its resolved provider, selected host, workspace, and root before step-attempt mutation or adapter dispatch
- release step and root reservations through completion, failure, retry, fallback, cancellation, and restart reconciliation paths
- add workflow run, step, and root-reservation filters to REST and `vk admission`
- add SQLite migration 24 and preserve file/SQLite inspection parity
- replace stale process-local concurrency documentation with the durable admission contract

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/cli typecheck`
- 194 focused server tests across workflow, admission, schema, and route boundaries
- 2 focused CLI admission tests
- changed-TypeScript ESLint with no errors
- `pnpm check:pnpm-settings`
- `pnpm check:delivery-cadence`
- `git diff --check`

## Risk and follow-up

- Migration 24 adds nullable workflow identity columns and indexes to the existing admission table.
- Durable queue fairness and aggregate execution-tree budget conversion remain in the dependency-linked follow-up issues.
- A retryable step overload blocks the workflow for explicit resume; automatic durable queueing is intentionally outside this issue.

Closes #1051
