### PR TITLE
feat: aggregate execution tree budgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,13 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   Completion, interruption, cancellation, and start failure release once;
   restart recovery may reclaim only after the durable run supervisor verifies
   the original live process or session.
+- Bind every executable reservation to `execution-tree-identity/v1`. Descendants
+  retain the root objective and exact parent edge across resume, follow-up,
+  fork, retry, fallback, provider handoff, workflow step, and child-agent
+  launches. Claim capacity and aggregate budget in the same repository lock or
+  transaction. Usage events must be idempotent and attributable to one node;
+  never copy cumulative parent or descendant totals into another contributor.
+  Release unused reservation while retaining committed usage.
 - Persist `run-supervisor/v1` before provider dispatch. Restart recovery must
   validate the exact runtime, task-envelope, launch-manifest, worktree, host,
   lease, and process/session identity; replay only after the durable event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added versioned execution-tree identities and aggregate budget reservations
+  to direct attempts, conversation continuations, retries, fallbacks, provider
+  handoffs, child agents, workflow roots, and workflow steps. Capacity and the
+  strictest applicable workspace, agent, workflow, run, and root-objective
+  budgets are now claimed atomically through the same file lock or SQLite
+  transaction. Idempotent usage events convert reservations into attributable
+  committed input/output/total tokens, cost, tool calls, runtime, idle time,
+  retries, and fan-out without counting descendant totals again. Terminal
+  release preserves committed usage and returns unused reservations. REST and
+  `vk admission tree` expose bounded totals, remaining policy capacity,
+  contributors, and the exact blocking policies (#1052).
 - Routed workflow roots and every provider-backed workflow step through the
   durable admission controller. A root now reserves `workflow-control`
   capacity before the run becomes active, while each executable step reserves

--- a/cli/src/__tests__/admission.test.ts
+++ b/cli/src/__tests__/admission.test.ts
@@ -35,6 +35,12 @@ describe('vk admission commands', () => {
       'execute',
       '--root-reservation',
       'admission_root',
+      '--root-objective',
+      'objective-a',
+      '--node',
+      'node-child',
+      '--parent-node',
+      'node-root',
       '--state',
       'active',
       'released',
@@ -44,7 +50,7 @@ describe('vk admission commands', () => {
     ]);
 
     expect(api).toHaveBeenCalledWith(
-      '/api/admission?workspaceId=workspace-a&workflowRunId=run_1234567890_abcdef&workflowStepId=execute&rootReservationId=admission_root&state=active&state=released&limit=25'
+      '/api/admission?workspaceId=workspace-a&workflowRunId=run_1234567890_abcdef&workflowStepId=execute&rootReservationId=admission_root&rootObjectiveId=objective-a&nodeId=node-child&parentNodeId=node-root&state=active&state=released&limit=25'
     );
     expect(JSON.parse(String(output.mock.calls[0][0]))).toEqual({
       generatedAt: '2026-07-25T10:00:00.000Z',
@@ -65,6 +71,34 @@ describe('vk admission commands', () => {
     expect(JSON.parse(String(output.mock.calls[0][0]))).toEqual({
       id: 'admission_1',
       state: 'released',
+    });
+    output.mockRestore();
+  });
+
+  it('inspects an aggregate execution tree as JSON', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'execution-tree-budget-summary/v1',
+      rootObjectiveId: 'objective-a',
+      contributors: [],
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'tree',
+      'objective-a',
+      '--limit',
+      '25',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith('/api/admission/tree/objective-a?limit=25');
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      rootObjectiveId: 'objective-a',
     });
     output.mockRestore();
   });

--- a/cli/src/commands/admission.ts
+++ b/cli/src/commands/admission.ts
@@ -1,6 +1,10 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import type { AdmissionReservation, AdmissionReservationState } from '@veritas-kanban/shared';
+import type {
+  AdmissionReservation,
+  AdmissionReservationState,
+  ExecutionTreeBudgetSummary,
+} from '@veritas-kanban/shared';
 import { api } from '../utils/api.js';
 
 interface AdmissionListResponse {
@@ -24,6 +28,9 @@ export function registerAdmissionCommands(program: Command): void {
     .option('--workflow-run <id>', 'Filter by workflow run')
     .option('--workflow-step <id>', 'Filter by workflow step')
     .option('--root-reservation <id>', 'Filter by workflow root reservation')
+    .option('--root-objective <id>', 'Filter by execution-tree root objective')
+    .option('--node <id>', 'Filter by execution-tree node')
+    .option('--parent-node <id>', 'Filter by execution-tree parent node')
     .option('--state <states...>', 'Filter by state (active, released, expired)')
     .option('--limit <count>', 'Maximum records', '100')
     .option('--json', 'Output as JSON')
@@ -38,6 +45,9 @@ export function registerAdmissionCommands(program: Command): void {
         if (options.workflowRun) query.set('workflowRunId', options.workflowRun);
         if (options.workflowStep) query.set('workflowStepId', options.workflowStep);
         if (options.rootReservation) query.set('rootReservationId', options.rootReservation);
+        if (options.rootObjective) query.set('rootObjectiveId', options.rootObjective);
+        if (options.node) query.set('nodeId', options.node);
+        if (options.parentNode) query.set('parentNodeId', options.parentNode);
         for (const state of (options.state ?? []) as AdmissionReservationState[]) {
           query.append('state', state);
         }
@@ -52,6 +62,27 @@ export function registerAdmissionCommands(program: Command): void {
           return;
         }
         for (const reservation of result.reservations) printReservation(reservation);
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  admission
+    .command('tree <root-objective-id>')
+    .description('Inspect aggregate usage and reservations for one execution tree')
+    .option('--limit <count>', 'Maximum contributors', '100')
+    .option('--json', 'Output as JSON')
+    .action(async (rootObjectiveId, options) => {
+      try {
+        const query = new URLSearchParams({ limit: options.limit });
+        const result = await api<ExecutionTreeBudgetSummary>(
+          `/api/admission/tree/${encodeURIComponent(rootObjectiveId)}?${query.toString()}`
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        printExecutionTreeSummary(result);
       } catch (error) {
         printError(error);
       }
@@ -97,6 +128,13 @@ function printReservation(reservation: AdmissionReservation, verbose = false): v
       )
     );
   }
+  if (reservation.request.executionTree) {
+    console.log(
+      chalk.dim(
+        `  objective=${reservation.request.executionTree.rootObjectiveId} node=${reservation.request.executionTree.nodeId} parent=${reservation.request.executionTree.parentNodeId ?? 'root'} edge=${reservation.request.executionTree.edge}`
+      )
+    );
+  }
   console.log(
     chalk.dim(
       `  capacity runs=${reservation.request.requested.runSlots} processes=${reservation.request.requested.processSlots} memory=${reservation.request.requested.estimatedMemoryMb}MB`
@@ -114,6 +152,28 @@ function printReservation(reservation: AdmissionReservation, verbose = false): v
       chalk.dim(`  released=${reservation.release.reason} at ${reservation.release.releasedAt}`)
     );
   }
+}
+
+function printExecutionTreeSummary(summary: ExecutionTreeBudgetSummary): void {
+  console.log(chalk.bold(`Execution tree ${summary.rootObjectiveId}`));
+  console.log(
+    `  committed tokens=${summary.committed.totalTokens} cost=$${summary.committed.costUsd.toFixed(4)} tools=${summary.committed.toolCalls} runtime=${summary.committed.runtimeSeconds}s retries=${summary.committed.retries} fan-out=${summary.committed.fanOut}`
+  );
+  console.log(
+    chalk.dim(
+      `  reserved tokens=${summary.reserved.totalTokens} cost=$${summary.reserved.costUsd.toFixed(4)} tools=${summary.reserved.toolCalls} runtime=${summary.reserved.runtimeSeconds}s retries=${summary.reserved.retries} fan-out=${summary.reserved.fanOut}`
+    )
+  );
+  for (const status of summary.policies) {
+    console.log(
+      `${status.blocksNextLaunch ? chalk.red('blocked') : chalk.green('available')} ${status.policy.name} (${status.policy.scope}:${status.policy.scopeId})`
+    );
+  }
+  console.log(
+    chalk.dim(
+      `  contributors=${summary.contributorCount}${summary.truncated ? ` (showing ${summary.contributors.length})` : ''}`
+    )
+  );
 }
 
 function printError(error: unknown): void {

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -976,10 +976,21 @@ are released and blocked for operator reconciliation. Caller-supplied
 idempotency values are represented by a stable SHA-256 identity in durable
 records; the original value is not stored.
 
+Every reservation also carries a versioned execution-tree identity. Resume,
+follow-up, fork, retry, fallback, provider handoff, workflow-step, and
+child-agent launches preserve the same root objective and exact parent edge.
+The capacity claim and strictest applicable workspace, agent, workflow, run,
+and root-objective budget claim share one atomic repository operation.
+Idempotent node usage events convert reserved tokens, cost, tool calls,
+runtime, idle time, retries, and fan-out into committed attribution. Release
+returns only unused reservation; committed usage remains in the tree.
+
 Inspect reservations with `vk admission list`, `vk admission get <id>`, or the
-matching read-only REST endpoints. Use `--workflow-run`, `--workflow-step`, or
-`--root-reservation` to follow a workflow tree. Machine consumers should use
-`--json`.
+matching read-only REST endpoints. Use `--workflow-run`, `--workflow-step`,
+`--root-reservation`, or `--root-objective` to follow a tree. Use
+`vk admission tree <root-objective-id>` for aggregate totals, remaining policy
+capacity, blocking policies, and bounded contributors. Machine consumers
+should use `--json`.
 
 ## Local And Cloud Profiles
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4147,14 +4147,16 @@ before attempt persistence or provider dispatch. Workflow roots use the
 `workflow-control` admission provider; child steps use the resolved execution
 provider and selected host. Inspection requires `agent:read`.
 
-| Method | Path                 | Description                                             |
-| ------ | -------------------- | ------------------------------------------------------- |
-| `GET`  | `/api/admission`     | List reservations with optional scope and state filters |
-| `GET`  | `/api/admission/:id` | Inspect one durable reservation                         |
+| Method | Path                                   | Description                                             |
+| ------ | -------------------------------------- | ------------------------------------------------------- |
+| `GET`  | `/api/admission`                       | List reservations with optional scope and state filters |
+| `GET`  | `/api/admission/tree/:rootObjectiveId` | Summarize one aggregate execution tree                  |
+| `GET`  | `/api/admission/:id`                   | Inspect one durable reservation                         |
 
 List filters are `workspaceId`, `taskId`, `rootTaskId`, `provider`, `hostId`,
-`workflowRunId`, `workflowStepId`, `rootReservationId`, repeatable `state`
-(`active`, `released`, `expired`), and `limit` (1-1000).
+`workflowRunId`, `workflowStepId`, `rootReservationId`, `rootObjectiveId`,
+`nodeId`, `parentNodeId`, repeatable `state` (`active`, `released`, `expired`),
+and `limit` (1-1000).
 
 ```http
 GET /api/v1/admission?state=active&provider=codex-cli&limit=25
@@ -4162,6 +4164,10 @@ GET /api/v1/admission?state=active&provider=codex-cli&limit=25
 
 ```http
 GET /api/v1/admission?workflowRunId=run_20260725_abc123&state=active
+```
+
+```http
+GET /api/v1/admission/tree/objective_0123456789abcdef?limit=100
 ```
 
 The response contains `admission-reservation/v1` records with the versioned
@@ -4174,6 +4180,13 @@ root reservation. Overloaded starts return a `409` conflict with
 `ADMISSION_POLICY_DENIED`. A step-level retryable overload blocks the workflow
 without creating a partially active attempt; terminal policy denial fails the
 run and releases its root.
+
+Execution-tree reservations include `execution-tree-identity/v1` and durable
+requested, remaining, committed, released-unused, and idempotent usage-event
+state. The tree summary aggregates each node once and returns committed and
+active reserved usage, per-policy remaining limits, the policy that blocks the
+next launch, bounded contributors, and truncation evidence. Committed usage is
+retained after release; only unused reservation returns to the tree.
 
 Direct `POST /api/v1/agents/:taskId/start` callers may send an opaque
 `X-Idempotency-Key` header (8-240 characters). The header takes precedence

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -601,16 +601,23 @@ vk admission list --state active --provider codex-cli --json
 vk admission list --workflow-run run_20260725_abc123 --json
 vk admission list --workflow-run run_20260725_abc123 --workflow-step implement
 vk admission list --root-reservation admission_0123456789abcdef
+vk admission list --root-objective objective_0123456789abcdef --json
 vk admission get admission_0123456789abcdef --json
+vk admission tree objective_0123456789abcdef
+vk admission tree objective_0123456789abcdef --limit 25 --json
 ```
 
 `admission list` filters by workspace, task, root task, provider, host, state,
-workflow run, workflow step, root reservation, and result limit. Active records
+workflow run, workflow step, root reservation, root objective, node, parent
+node, and result limit. Active records
 show the lease expiry and requested run, process, and estimated-memory
 capacity. Workflow roots use provider `workflow-control`; executable child
 steps show their resolved provider, selected host, and root reservation.
 Released records retain the terminal reason and idempotency identity for
-operator diagnosis. These are read-only commands and require `agent:read`.
+operator diagnosis. `admission tree` reports committed and reserved tokens,
+cost, tool calls, runtime, retries, fan-out, policy availability, and bounded
+contributors without double counting descendant totals. These are read-only
+commands and require `agent:read`.
 
 ---
 

--- a/docs/SQLITE-SCHEMA.md
+++ b/docs/SQLITE-SCHEMA.md
@@ -1065,14 +1065,14 @@ SQLite tables with JSON payload columns plus query indexes. This keeps the v4
 service contracts intact while preventing SQLite mode from writing operational
 state back to `.veritas-kanban/*.json` or telemetry NDJSON files.
 
-| Runtime table            | Stored data                                                                                                                    |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `activity_events`        | Complete activity entries plus type, task, agent, and created-time columns.                                                    |
-| `status_history`         | Complete status transition entries plus previous/new status and task columns.                                                  |
-| `telemetry_events`       | Complete telemetry events plus type, task, project, token, duration, and result columns.                                       |
-| `run_events`             | Complete `run-event/v1` envelopes plus ordered attempt cursor, provider identity, dedupe, and receive columns.                 |
-| `run_supervisors`        | Complete `run-supervisor/v1` snapshots plus task/attempt, state, revision, lease owner/expiry, and recovery indexes.           |
-| `admission_reservations` | Versioned capacity reservations plus task/workspace/root/provider/host scopes, lease state, revision, and idempotency indexes. |
+| Runtime table            | Stored data                                                                                                                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activity_events`        | Complete activity entries plus type, task, agent, and created-time columns.                                                                                                                   |
+| `status_history`         | Complete status transition entries plus previous/new status and task columns.                                                                                                                 |
+| `telemetry_events`       | Complete telemetry events plus type, task, project, token, duration, and result columns.                                                                                                      |
+| `run_events`             | Complete `run-event/v1` envelopes plus ordered attempt cursor, provider identity, dedupe, and receive columns.                                                                                |
+| `run_supervisors`        | Complete `run-supervisor/v1` snapshots plus task/attempt, state, revision, lease owner/expiry, and recovery indexes.                                                                          |
+| `admission_reservations` | Versioned capacity and execution-tree budget reservations plus task/workspace/root/provider/host scopes, root objective/node/parent indexes, lease state, revision, and idempotency evidence. |
 
 `ActivityService`, `StatusHistoryService`, `TelemetryService`,
 `RunEventJournalService`, `RunSupervisorService`, and `AdmissionControlService`

--- a/docs/WORKFLOW_ENGINE_ARCHITECTURE.md
+++ b/docs/WORKFLOW_ENGINE_ARCHITECTURE.md
@@ -2464,6 +2464,14 @@ Retry and fallback attempts release the prior child reservation before
 claiming another. Global, workspace, root-task, provider, and host limits use
 the same durable policies as direct task launches.
 
+The root and every executable step also persist `execution-tree-identity/v1`.
+Step, retry, and fallback edges retain the workflow root objective and exact
+parent node. The admission repository evaluates capacity and the aggregate
+workflow/root budget in the same file lock or SQLite `BEGIN IMMEDIATE`
+transaction. Each step commits only its own provider-reported usage; cumulative
+workflow totals are not copied into child records. This keeps deep, wide, and
+replayed workflows attributable without descendant double counting.
+
 Temporary step overload blocks the workflow with the limiting policy retained
 in the run; an impossible request fails the run. Durable fair queues and
 priority aging are scheduler concerns layered on this controller, not hidden

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -7,6 +7,8 @@ import {
   DEFAULT_FEATURE_SETTINGS,
   type AdmissionCapacityLimit,
   type AdmissionSettings,
+  type ExecutionTreeBudgetPolicy,
+  ZERO_AGENT_BUDGET_USAGE,
 } from '@veritas-kanban/shared';
 import { AdmissionControlService } from '../services/admission-control-service.js';
 import { FileAdmissionReservationRepository } from '../storage/admission-reservation-repository.js';
@@ -74,6 +76,40 @@ async function repositoryFor(backend: 'file' | 'sqlite') {
   database.open();
   databases.push(database);
   return new SqliteAdmissionReservationRepository(database);
+}
+
+const treePolicy: ExecutionTreeBudgetPolicy = {
+  id: 'budget_root_objective',
+  scope: 'root-objective',
+  scopeId: 'objective-a',
+  name: 'Root objective budget',
+  limits: { totalTokens: 100, fanOut: 2 },
+  hardAction: 'pause',
+};
+
+function treeRequest(
+  taskId: string,
+  nodeId: string,
+  parentNodeId?: string,
+  budgetRequest: Partial<typeof ZERO_AGENT_BUDGET_USAGE> = { fanOut: 1 },
+  identity: {
+    edge?: 'child-agent' | 'retry' | 'fallback';
+    depth?: number;
+  } = {}
+) {
+  return {
+    ...request(taskId, `tree:${nodeId}`),
+    executionTree: {
+      schemaVersion: 'execution-tree-identity/v1' as const,
+      rootObjectiveId: 'objective-a',
+      nodeId,
+      ...(parentNodeId ? { parentNodeId } : {}),
+      edge: parentNodeId ? (identity.edge ?? 'child-agent') : ('root' as const),
+      depth: parentNodeId ? (identity.depth ?? 1) : 0,
+    },
+    budgetPolicies: [treePolicy],
+    budgetRequest,
+  };
 }
 
 describe('AdmissionControlService', () => {
@@ -222,6 +258,199 @@ describe('AdmissionControlService', () => {
 });
 
 describe.each(['file', 'sqlite'] as const)('%s admission reservation parity', (backend) => {
+  it('atomically reserves, converts, summarizes, and releases execution-tree budgets', async () => {
+    const repository = await repositoryFor(backend);
+    const service = createService(repository, configuredSettings());
+    const root = await service.admit(treeRequest('task-tree-root', 'node-root'));
+    const rootId = root.reservation?.id as string;
+    await service.bindAttempt(rootId, 'attempt-root');
+    await service.recordBudgetUsage(rootId, {
+      schemaVersion: 'execution-tree-budget-event/v1',
+      id: 'root-launch',
+      mode: 'delta',
+      usage: { ...ZERO_AGENT_BUDGET_USAGE, fanOut: 1 },
+      source: 'test-launch',
+      occurredAt: '2026-07-25T12:00:00.000Z',
+    });
+    await expect(
+      service.admit({
+        ...treeRequest('task-tree-looser-policy', 'node-looser-policy', 'node-root', {
+          totalTokens: 150,
+        }),
+        budgetPolicies: [
+          {
+            ...treePolicy,
+            limits: { totalTokens: 200, fanOut: 2 },
+          },
+        ],
+      })
+    ).resolves.toMatchObject({
+      outcome: 'terminal-policy-denial',
+      limitingBudgetPolicies: [
+        expect.objectContaining({
+          id: treePolicy.id,
+          limits: expect.objectContaining({ totalTokens: 100 }),
+        }),
+      ],
+    });
+
+    const child = await service.admit(
+      treeRequest('task-tree-child', 'node-child', 'node-root', {
+        fanOut: 1,
+        totalTokens: 50,
+      })
+    );
+    expect(child.outcome).toBe('admitted');
+    const childId = child.reservation?.id as string;
+    await service.bindAttempt(childId, 'attempt-child');
+    const usageEvent = {
+      schemaVersion: 'execution-tree-budget-event/v1' as const,
+      id: 'child-usage',
+      mode: 'snapshot' as const,
+      usage: { ...ZERO_AGENT_BUDGET_USAGE, fanOut: 1, totalTokens: 20 },
+      source: 'test-result',
+      occurredAt: '2026-07-25T12:00:01.000Z',
+    };
+    const recorded = await service.recordBudgetUsage(childId, usageEvent);
+    await expect(service.recordBudgetUsage(childId, usageEvent)).resolves.toEqual(recorded);
+    await expect(
+      service.recordBudgetUsage(childId, { ...usageEvent, source: 'conflicting-result' })
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    const released = await service.release(childId, 'completed', 'completed:child');
+    expect(released.executionBudget).toMatchObject({
+      committed: { totalTokens: 20, fanOut: 1 },
+      remaining: { totalTokens: 0, fanOut: 0 },
+      releasedUnused: { totalTokens: 30 },
+    });
+    await expect(service.recordBudgetUsage(childId, usageEvent)).resolves.toEqual(released);
+    await expect(
+      service.recordBudgetUsage(childId, {
+        ...usageEvent,
+        id: 'late-child-usage',
+        occurredAt: '2026-07-25T12:00:02.000Z',
+      })
+    ).rejects.toMatchObject({
+      statusCode: 409,
+    });
+    await expect(service.getExecutionTreeSummary('objective-a')).resolves.toMatchObject({
+      committed: { totalTokens: 20, fanOut: 2 },
+      reserved: { totalTokens: 0, fanOut: 0 },
+      contributorCount: 2,
+      contributors: expect.arrayContaining([
+        expect.objectContaining({
+          identity: expect.objectContaining({ nodeId: 'node-child', parentNodeId: 'node-root' }),
+        }),
+      ]),
+    });
+    await expect(
+      repository.list({ rootObjectiveId: 'objective-a', parentNodeId: 'node-root' })
+    ).resolves.toHaveLength(1);
+
+    await expect(
+      service.admit(treeRequest('task-tree-overflow', 'node-overflow', 'node-root'))
+    ).resolves.toMatchObject({
+      outcome: 'terminal-policy-denial',
+      limitingBudgetPolicies: [{ id: treePolicy.id }],
+    });
+  });
+
+  it('serializes competing execution-tree budget claims under the capacity lock', async () => {
+    const repository = await repositoryFor(backend);
+    const left = createService(repository, configuredSettings(), { ownerId: 'owner-budget-left' });
+    const right = createService(repository, configuredSettings(), {
+      ownerId: 'owner-budget-right',
+    });
+    const root = await left.admit(treeRequest('task-budget-root', 'node-root'));
+    await left.bindAttempt(root.reservation?.id as string, 'attempt-budget-root');
+    const decisions = await Promise.all([
+      left.admit(treeRequest('task-budget-left', 'node-left', 'node-root')),
+      right.admit(treeRequest('task-budget-right', 'node-right', 'node-root')),
+    ]);
+    expect(decisions.map((decision) => decision.outcome).sort()).toEqual([
+      'admitted',
+      'retryable-overload',
+    ]);
+    expect(decisions.find((decision) => decision.outcome === 'retryable-overload')).toMatchObject({
+      limitingBudgetPolicies: [{ id: treePolicy.id }],
+    });
+  });
+
+  it('reuses released capacity across deep retry and fallback branches', async () => {
+    const repository = await repositoryFor(backend);
+    const service = createService(repository, configuredSettings());
+    const branchPolicy: ExecutionTreeBudgetPolicy = {
+      ...treePolicy,
+      id: 'budget_deep_wide_tree',
+      limits: { totalTokens: 100, fanOut: 10 },
+    };
+    const withPolicy = (
+      taskId: string,
+      nodeId: string,
+      parentNodeId?: string,
+      budgetRequest: Partial<typeof ZERO_AGENT_BUDGET_USAGE> = { fanOut: 1 },
+      identity: { edge?: 'child-agent' | 'retry' | 'fallback'; depth?: number } = {}
+    ) => ({
+      ...treeRequest(taskId, nodeId, parentNodeId, budgetRequest, identity),
+      budgetPolicies: [branchPolicy],
+    });
+
+    const root = await service.admit(withPolicy('task-branch-root', 'node-branch-root'));
+    await service.bindAttempt(root.reservation?.id as string, 'attempt-branch-root');
+    const retry = await service.admit(
+      withPolicy(
+        'task-branch-retry',
+        'node-branch-retry',
+        'node-branch-root',
+        { totalTokens: 60, fanOut: 1, retries: 1 },
+        { edge: 'retry' }
+      )
+    );
+    await service.bindAttempt(retry.reservation?.id as string, 'attempt-branch-retry');
+    await service.release(retry.reservation?.id as string, 'failed', 'retry-replaced');
+
+    const fallback = await service.admit(
+      withPolicy(
+        'task-branch-fallback',
+        'node-branch-fallback',
+        'node-branch-retry',
+        { totalTokens: 60, fanOut: 1, retries: 1 },
+        { edge: 'fallback', depth: 2 }
+      )
+    );
+    expect(fallback.outcome).toBe('admitted');
+    await service.bindAttempt(fallback.reservation?.id as string, 'attempt-branch-fallback');
+    const siblings = await Promise.all([
+      service.admit(
+        withPolicy('task-branch-left', 'node-branch-left', 'node-branch-root', {
+          totalTokens: 10,
+          fanOut: 1,
+        })
+      ),
+      service.admit(
+        withPolicy('task-branch-right', 'node-branch-right', 'node-branch-root', {
+          totalTokens: 10,
+          fanOut: 1,
+        })
+      ),
+    ]);
+    expect(siblings.every((decision) => decision.outcome === 'admitted')).toBe(true);
+    await expect(service.getExecutionTreeSummary('objective-a')).resolves.toMatchObject({
+      reserved: { totalTokens: 80, fanOut: 4, retries: 1 },
+      contributorCount: 5,
+      contributors: expect.arrayContaining([
+        expect.objectContaining({
+          identity: expect.objectContaining({
+            nodeId: 'node-branch-fallback',
+            parentNodeId: 'node-branch-retry',
+            edge: 'fallback',
+            depth: 2,
+          }),
+        }),
+      ]),
+    });
+  });
+
   it('serializes competing claims and releases the winner idempotently', async () => {
     const repository = await repositoryFor(backend);
     const settings = configuredSettings({ global: { concurrentRuns: 1 } });

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -182,6 +182,7 @@ import type {
   SandboxPolicyDryRunResult,
   Task,
   TaskAttempt,
+  ExecutionTreeIdentity,
 } from '@veritas-kanban/shared';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 import {
@@ -290,6 +291,8 @@ function testAdmissionControl(): AdmissionControlService {
       reservation: { id: `admission-test-${input.taskId}-${++sequence}` },
     })),
     bindAttempt: vi.fn(async (id: string) => ({ id })),
+    get: vi.fn(async (id: string) => ({ id, request: { budgetPolicies: [] } })),
+    recordBudgetUsage: vi.fn(async (id: string) => ({ id })),
     release: vi.fn(async (id: string) => ({ id })),
     releaseIfUnbound: vi.fn(async (id: string) => ({ id })),
     releaseByAttempt: vi.fn(async () => null),
@@ -692,6 +695,77 @@ describe('ClawdbotAgentService Codex providers', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it('isolates independent roots and preserves identity across provider handoffs', () => {
+    const service = testableService(tmpDir);
+    const buildExecutionTreeIdentity = (
+      service as unknown as {
+        buildExecutionTreeIdentity(input: {
+          taskId: string;
+          workspaceId: string;
+          attemptId: string;
+          parentAttempt?: TaskAttempt;
+          provider: 'codex-cli' | 'claude-code';
+          conversationIntent: 'fresh' | 'follow-up';
+          rootIdempotencyKey?: string;
+        }): ExecutionTreeIdentity;
+      }
+    ).buildExecutionTreeIdentity.bind(service);
+    const first = buildExecutionTreeIdentity({
+      taskId: task.id,
+      workspaceId: 'veritas',
+      attemptId: 'attempt-root-a',
+      provider: 'codex-cli',
+      conversationIntent: 'fresh',
+    });
+    const second = buildExecutionTreeIdentity({
+      taskId: task.id,
+      workspaceId: 'veritas',
+      attemptId: 'attempt-root-b',
+      provider: 'codex-cli',
+      conversationIntent: 'fresh',
+    });
+    expect(second.rootObjectiveId).not.toBe(first.rootObjectiveId);
+    const keyedFirst = buildExecutionTreeIdentity({
+      taskId: task.id,
+      workspaceId: 'veritas',
+      attemptId: 'attempt-keyed-a',
+      provider: 'codex-cli',
+      conversationIntent: 'fresh',
+      rootIdempotencyKey: 'stable-launch-key',
+    });
+    const keyedRetry = buildExecutionTreeIdentity({
+      taskId: task.id,
+      workspaceId: 'veritas',
+      attemptId: 'attempt-keyed-b',
+      provider: 'codex-cli',
+      conversationIntent: 'fresh',
+      rootIdempotencyKey: 'stable-launch-key',
+    });
+    expect(keyedRetry).toEqual(keyedFirst);
+
+    const handoff = buildExecutionTreeIdentity({
+      taskId: task.id,
+      workspaceId: 'veritas',
+      attemptId: 'attempt-handoff',
+      parentAttempt: {
+        id: first.nodeId,
+        agent: 'codex',
+        status: 'complete',
+        started: '2026-07-25T12:00:00.000Z',
+        provider: 'codex-cli',
+        executionTree: first,
+      } as TaskAttempt,
+      provider: 'claude-code',
+      conversationIntent: 'follow-up',
+    });
+    expect(handoff).toMatchObject({
+      rootObjectiveId: first.rootObjectiveId,
+      parentNodeId: first.nodeId,
+      edge: 'provider-handoff',
+      depth: 1,
+    });
+  });
+
   it(
     'runs the Codex CLI adapter against mocked JSONL and records telemetry',
     { timeout: 20_000 },
@@ -699,10 +773,23 @@ describe('ClawdbotAgentService Codex providers', () => {
       const fixture = await fs.readFile(path.join(fixtureDir, 'success.jsonl'), 'utf-8');
       mockSpawn.mockReturnValue(createFakeChild(fixture));
       const service = testableService(tmpDir);
+      const admission = (service as unknown as { admission: AdmissionControlService }).admission;
 
       const status = await service.startAgent(task.id, 'codex');
 
       expect(status.status).toBe('running');
+      expect(status.executionTree).toMatchObject({
+        schemaVersion: 'execution-tree-identity/v1',
+        nodeId: status.attemptId,
+        edge: 'root',
+        depth: 0,
+      });
+      expect(admission.admit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionTree: status.executionTree,
+          budgetRequest: expect.objectContaining({ fanOut: 1, retries: 0 }),
+        })
+      );
       expect(status.runLaunchManifest).toMatchObject({
         schemaVersion: 'run-launch-manifest/v1',
         taskId: task.id,

--- a/server/src/__tests__/helpers/workflow-admission-stub.ts
+++ b/server/src/__tests__/helpers/workflow-admission-stub.ts
@@ -2,17 +2,30 @@ import type { AdmissionControlService } from '../../services/admission-control-s
 
 export function workflowAdmissionStub(): AdmissionControlService {
   const reservationsByAttempt = new Map<string, string>();
+  const requestsByReservation = new Map<
+    string,
+    { budgetPolicies?: import('@veritas-kanban/shared').ExecutionTreeBudgetPolicy[] }
+  >();
   let pendingReservationId = 'admission_workflow_test';
 
   return {
     getExecutionHostId: () => 'test-execution-host',
-    admit: async (input: { workflowRunId?: string; workflowStepId?: string }) => {
+    admit: async (input: {
+      workflowRunId?: string;
+      workflowStepId?: string;
+      budgetPolicies?: import('@veritas-kanban/shared').ExecutionTreeBudgetPolicy[];
+    }) => {
       pendingReservationId = `admission_${input.workflowRunId ?? 'run'}_${input.workflowStepId ?? 'root'}`;
+      requestsByReservation.set(pendingReservationId, {
+        budgetPolicies: input.budgetPolicies,
+      });
       return {
         outcome: 'admitted',
         reservation: { id: pendingReservationId },
       };
     },
+    get: async (id: string) => ({ id, request: requestsByReservation.get(id) ?? {} }),
+    recordBudgetUsage: async (id: string) => ({ id }),
     bindAttempt: async (id: string, attemptId: string) => {
       reservationsByAttempt.set(attemptId, id);
       return { id };

--- a/server/src/__tests__/workflow-admission.test.ts
+++ b/server/src/__tests__/workflow-admission.test.ts
@@ -168,7 +168,25 @@ describe('workflow admission', () => {
           provider: 'codex-sdk',
           hostId: 'local-process',
           rootReservationId: root?.id,
+          executionTree: {
+            rootObjectiveId: root?.request.executionTree?.rootObjectiveId,
+            parentNodeId: root?.request.executionTree?.nodeId,
+            edge: 'workflow-step',
+            depth: 1,
+          },
         },
+      });
+      expect(root?.request.executionTree).toMatchObject({
+        edge: 'root',
+        depth: 0,
+      });
+      await expect(
+        harness.admission.getExecutionTreeSummary(
+          root?.request.executionTree?.rootObjectiveId as string
+        )
+      ).resolves.toMatchObject({
+        committed: { fanOut: 2 },
+        contributorCount: 2,
       });
       await expect(
         harness.admission.admit({

--- a/server/src/routes/admission.ts
+++ b/server/src/routes/admission.ts
@@ -18,6 +18,9 @@ const listQuerySchema = z
     workflowRunId: z.string().trim().min(1).max(240).optional(),
     workflowStepId: z.string().trim().min(1).max(240).optional(),
     rootReservationId: z.string().trim().min(1).max(240).optional(),
+    rootObjectiveId: z.string().trim().min(1).max(240).optional(),
+    nodeId: z.string().trim().min(1).max(240).optional(),
+    parentNodeId: z.string().trim().min(1).max(240).optional(),
     state: z
       .union([z.string(), z.array(z.string())])
       .optional()
@@ -42,6 +45,9 @@ router.get(
         workflowRunId: raw.workflowRunId,
         workflowStepId: raw.workflowStepId,
         rootReservationId: raw.rootReservationId,
+        rootObjectiveId: raw.rootObjectiveId,
+        nodeId: raw.nodeId,
+        parentNodeId: raw.parentNodeId,
         states: raw.state,
         limit: raw.limit,
       });
@@ -49,6 +55,22 @@ router.get(
         generatedAt: new Date().toISOString(),
         reservations: await admission.list(query),
       });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
+
+router.get(
+  '/tree/:rootObjectiveId',
+  asyncHandler(async (req, res) => {
+    try {
+      const rootObjectiveId = z.string().trim().min(1).max(240).parse(req.params.rootObjectiveId);
+      const limit = z.coerce.number().int().min(1).max(1_000).default(100).parse(req.query.limit);
+      res.json(await admission.getExecutionTreeSummary(rootObjectiveId, limit));
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new ValidationError('Validation failed', error.issues);

--- a/server/src/schemas/admission-control-schemas.ts
+++ b/server/src/schemas/admission-control-schemas.ts
@@ -7,12 +7,80 @@ import {
   ADMISSION_RESERVATION_SCHEMA_VERSION,
   ADMISSION_RESERVATION_STATES,
   ADMISSION_SCOPES,
+  EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION,
+  EXECUTION_TREE_EDGE_KINDS,
+  EXECUTION_TREE_IDENTITY_SCHEMA_VERSION,
   EXECUTABLE_AGENT_PROVIDERS,
 } from '@veritas-kanban/shared';
+import { AgentBudgetLimitsSchema, AgentBudgetUsageSchema } from './agent-budget-schemas.js';
 
 const identifier = z.string().trim().min(1).max(240);
 const policyIdentifier = z.string().trim().min(1).max(256);
 const admissionProvider = z.enum([...EXECUTABLE_AGENT_PROVIDERS, ADMISSION_CONTROL_PROVIDER]);
+const executionTreeBudgetPolicyScope = z.enum([
+  'workspace',
+  'agent',
+  'workflow',
+  'run',
+  'root-objective',
+]);
+
+export const ExecutionTreeIdentitySchema = z
+  .object({
+    schemaVersion: z.literal(EXECUTION_TREE_IDENTITY_SCHEMA_VERSION),
+    rootObjectiveId: identifier,
+    nodeId: identifier,
+    parentNodeId: identifier.optional(),
+    edge: z.enum(EXECUTION_TREE_EDGE_KINDS),
+    depth: z.number().int().min(0).max(10_000),
+  })
+  .strict()
+  .superRefine((identity, ctx) => {
+    if (identity.depth === 0 && (identity.parentNodeId || identity.edge !== 'root')) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Execution-tree roots cannot have a parent edge.',
+      });
+    }
+    if (identity.depth > 0 && (!identity.parentNodeId || identity.edge === 'root')) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Execution-tree descendants require a parent node and non-root edge.',
+      });
+    }
+  });
+
+export const ExecutionTreeBudgetPolicySchema = z
+  .object({
+    id: policyIdentifier,
+    scope: executionTreeBudgetPolicyScope,
+    scopeId: identifier,
+    name: z.string().trim().min(1).max(160),
+    limits: AgentBudgetLimitsSchema,
+    hardAction: z.enum(['pause', 'require-approval', 'downgrade', 'cancel']),
+  })
+  .strict();
+
+export const ExecutionTreeBudgetUsageEventSchema = z
+  .object({
+    schemaVersion: z.literal(EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION),
+    id: identifier,
+    mode: z.enum(['delta', 'snapshot']),
+    usage: AgentBudgetUsageSchema,
+    source: z.string().trim().min(1).max(160),
+    occurredAt: z.string().datetime(),
+  })
+  .strict();
+
+export const ExecutionTreeBudgetStateSchema = z
+  .object({
+    requested: AgentBudgetUsageSchema,
+    remaining: AgentBudgetUsageSchema,
+    committed: AgentBudgetUsageSchema,
+    releasedUnused: AgentBudgetUsageSchema,
+    events: z.array(ExecutionTreeBudgetUsageEventSchema).max(10_000),
+  })
+  .strict();
 
 export const AdmissionCapacityRequestSchema = z
   .object({
@@ -61,10 +129,22 @@ export const AdmissionRequestSchema = z
     workflowRunId: identifier.optional(),
     workflowStepId: identifier.optional(),
     rootReservationId: identifier.optional(),
+    executionTree: ExecutionTreeIdentitySchema.optional(),
+    budgetPolicies: z.array(ExecutionTreeBudgetPolicySchema).max(16).optional(),
+    budgetRequest: AgentBudgetUsageSchema.optional(),
     requested: AdmissionCapacityRequestSchema,
     requestedAt: z.string().datetime(),
   })
-  .strict();
+  .strict()
+  .superRefine((request, ctx) => {
+    if ((request.budgetPolicies || request.budgetRequest) && !request.executionTree) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Execution budget requests require execution-tree identity.',
+        path: ['executionTree'],
+      });
+    }
+  });
 
 export const AdmissionReservationLeaseSchema = z
   .object({
@@ -102,6 +182,7 @@ export const AdmissionReservationSchema = z
       })
       .strict()
       .optional(),
+    executionBudget: ExecutionTreeBudgetStateSchema.optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })
@@ -121,6 +202,13 @@ export const AdmissionReservationSchema = z
         path: ['release'],
       });
     }
+    if (record.request.executionTree && !record.executionBudget) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Execution-tree reservations require durable budget state.',
+        path: ['executionBudget'],
+      });
+    }
   });
 
 export const AdmissionDecisionSchema = z
@@ -130,6 +218,7 @@ export const AdmissionDecisionSchema = z
     request: AdmissionRequestSchema,
     reservation: AdmissionReservationSchema.optional(),
     limitingPolicies: z.array(AdmissionLimitPolicySchema).max(6),
+    limitingBudgetPolicies: z.array(ExecutionTreeBudgetPolicySchema).max(16).optional(),
     retryAfterMs: z.number().int().min(250).max(60_000).optional(),
     reason: z.string().min(1).max(1_000),
     decidedAt: z.string().datetime(),
@@ -146,6 +235,9 @@ export const AdmissionReservationListQuerySchema = z
     workflowRunId: identifier.optional(),
     workflowStepId: identifier.optional(),
     rootReservationId: identifier.optional(),
+    rootObjectiveId: identifier.optional(),
+    nodeId: identifier.optional(),
+    parentNodeId: identifier.optional(),
     states: z.array(z.enum(ADMISSION_RESERVATION_STATES)).max(3).optional(),
     limit: z.number().int().min(1).max(1_000).optional(),
   })

--- a/server/src/schemas/agent-budget-schemas.ts
+++ b/server/src/schemas/agent-budget-schemas.ts
@@ -14,6 +14,20 @@ export const AgentBudgetLimitsSchema = z
   })
   .strict();
 
+export const AgentBudgetUsageSchema = z
+  .object({
+    inputTokens: z.number().int().min(0),
+    outputTokens: z.number().int().min(0),
+    totalTokens: z.number().int().min(0),
+    costUsd: z.number().min(0),
+    toolCalls: z.number().int().min(0),
+    runtimeSeconds: z.number().int().min(0),
+    idleRuntimeSeconds: z.number().int().min(0),
+    retries: z.number().int().min(0),
+    fanOut: z.number().int().min(0),
+  })
+  .strict();
+
 export const AgentBudgetPolicySchema = z
   .object({
     enabled: z.boolean().optional(),

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -10,12 +10,18 @@ import type {
   AdmissionReservationListQuery,
   AdmissionReservationRelease,
   AdmissionSettings,
+  AgentBudgetUsage,
+  ExecutionTreeBudgetPolicy,
+  ExecutionTreeBudgetSummary,
+  ExecutionTreeBudgetUsageEvent,
+  ExecutionTreeIdentity,
 } from '@veritas-kanban/shared';
 import {
   ADMISSION_DECISION_SCHEMA_VERSION,
   ADMISSION_REQUEST_SCHEMA_VERSION,
   ADMISSION_RESERVATION_SCHEMA_VERSION,
   DEFAULT_FEATURE_SETTINGS,
+  ZERO_AGENT_BUDGET_USAGE,
 } from '@veritas-kanban/shared';
 import {
   AdmissionDecisionSchema,
@@ -24,6 +30,12 @@ import {
 import type { AdmissionReservationRepository } from '../storage/interfaces.js';
 import { FileAdmissionReservationRepository } from '../storage/admission-reservation-repository.js';
 import { requestExceedsPolicies } from '../storage/admission-capacity.js';
+import {
+  applyExecutionTreeBudgetEvent,
+  initializeExecutionTreeBudget,
+  releaseExecutionTreeBudget,
+  summarizeExecutionTreeBudget,
+} from '../storage/execution-tree-budget.js';
 import { getStorage, getStorageTypeFromEnv } from '../storage/index.js';
 import { ConfigService } from './config-service.js';
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
@@ -39,6 +51,9 @@ export interface AdmissionRequestInput {
   workflowRunId?: string;
   workflowStepId?: string;
   rootReservationId?: string;
+  executionTree?: ExecutionTreeIdentity;
+  budgetPolicies?: ExecutionTreeBudgetPolicy[];
+  budgetRequest?: Partial<AgentBudgetUsage>;
   source?: AdmissionLaunchSource;
   idempotencyKey?: string;
   requested?: Partial<AdmissionCapacityRequest>;
@@ -141,6 +156,16 @@ export class AdmissionControlService {
       ...(input.workflowRunId ? { workflowRunId: input.workflowRunId } : {}),
       ...(input.workflowStepId ? { workflowStepId: input.workflowStepId } : {}),
       ...(input.rootReservationId ? { rootReservationId: input.rootReservationId } : {}),
+      ...(input.executionTree ? { executionTree: input.executionTree } : {}),
+      ...(input.budgetPolicies ? { budgetPolicies: input.budgetPolicies } : {}),
+      ...(input.executionTree
+        ? {
+            budgetRequest: {
+              ...ZERO_AGENT_BUDGET_USAGE,
+              ...input.budgetRequest,
+            },
+          }
+        : {}),
       requested: {
         ...requested,
         runSlots: Math.max(1, requested.runSlots),
@@ -165,11 +190,32 @@ export class AdmissionControlService {
       state: 'active',
       request,
       policies,
+      ...(request.executionTree
+        ? {
+            executionBudget: initializeExecutionTreeBudget(
+              request.budgetRequest ?? { ...ZERO_AGENT_BUDGET_USAGE }
+            ),
+          }
+        : {}),
       lease: this.newLease(now, settings.leaseMs),
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
     });
     const claimed = await this.repository.claim({ record, now: now.toISOString() });
+    if (claimed.limitingBudgetPolicies?.length) {
+      return this.decision(
+        claimed.budgetRetryable ? 'retryable-overload' : 'terminal-policy-denial',
+        request,
+        [],
+        claimed.budgetRetryable
+          ? 'Active execution-tree reservations currently consume the configured budget.'
+          : 'Committed execution-tree usage exhausts a configured budget.',
+        now,
+        claimed.budgetRetryable ? settings.retryAfterMs : undefined,
+        undefined,
+        claimed.limitingBudgetPolicies
+      );
+    }
     if (claimed.limitingPolicies.length > 0) {
       return this.decision(
         'retryable-overload',
@@ -261,6 +307,7 @@ export class AdmissionControlService {
       return {
         ...current,
         state: 'released',
+        executionBudget: releaseExecutionTreeBudget(current.executionBudget),
         release: {
           reason,
           idempotencyKey,
@@ -281,6 +328,7 @@ export class AdmissionControlService {
       return {
         ...current,
         state: 'released',
+        executionBudget: releaseExecutionTreeBudget(current.executionBudget),
         release: {
           reason,
           idempotencyKey,
@@ -323,11 +371,17 @@ export class AdmissionControlService {
       now: now.toISOString(),
       reclaimExpired: true,
     });
-    if (claimed.limitingPolicies.length > 0 || !claimed.record) {
+    if (
+      claimed.limitingPolicies.length > 0 ||
+      claimed.limitingBudgetPolicies?.length ||
+      !claimed.record
+    ) {
       throw new ConflictError('Verified live run could not reclaim admission capacity.', {
         taskId: input.taskId,
         attemptId: input.attemptId,
         limitingPolicies: claimed.limitingPolicies,
+        limitingBudgetPolicies: claimed.limitingBudgetPolicies,
+        budgetRetryable: claimed.budgetRetryable,
       });
     }
     if (claimed.record.state !== 'active') {
@@ -361,6 +415,68 @@ export class AdmissionControlService {
   async list(query: AdmissionReservationListQuery = {}): Promise<AdmissionReservation[]> {
     await this.expireAbandoned();
     return this.repository.list(query);
+  }
+
+  async recordBudgetUsage(
+    reservationId: string,
+    event: ExecutionTreeBudgetUsageEvent
+  ): Promise<AdmissionReservation> {
+    return this.mutate(reservationId, (current, now) => {
+      if (!current.executionBudget) {
+        throw new ConflictError('Admission reservation does not track an execution-tree budget.', {
+          reservationId,
+        });
+      }
+      const isReplay = current.executionBudget.events.some(
+        (candidate) => candidate.id === event.id
+      );
+      if (
+        isReplay &&
+        !current.executionBudget.events.some(
+          (candidate) =>
+            candidate.id === event.id && JSON.stringify(candidate) === JSON.stringify(event)
+        )
+      ) {
+        throw new ConflictError('Execution-tree budget event conflicts with recorded evidence.', {
+          reservationId,
+          eventId: event.id,
+        });
+      }
+      if (current.state !== 'active' && !isReplay) {
+        throw new ConflictError(
+          'Terminal admission reservations reject new execution-tree budget evidence.',
+          {
+            reservationId,
+            reservationState: current.state,
+            eventId: event.id,
+          }
+        );
+      }
+      const executionBudget = applyExecutionTreeBudgetEvent(current.executionBudget, event);
+      if (executionBudget === current.executionBudget) return current;
+      return {
+        ...current,
+        executionBudget,
+        updatedAt: now.toISOString(),
+      };
+    });
+  }
+
+  async getExecutionTreeSummary(
+    rootObjectiveId: string,
+    limit = 100
+  ): Promise<ExecutionTreeBudgetSummary> {
+    await this.expireAbandoned();
+    const records = await this.repository.list({
+      rootObjectiveId,
+      limit: 10_000,
+    });
+    return summarizeExecutionTreeBudget(
+      rootObjectiveId,
+      records,
+      Math.min(Math.max(1, limit), 1_000),
+      this.now().toISOString()
+    );
   }
 
   async findByAttempt(
@@ -422,7 +538,8 @@ export class AdmissionControlService {
     reason: string,
     now: Date,
     retryAfterMs?: number,
-    reservation?: AdmissionReservation
+    reservation?: AdmissionReservation,
+    limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[]
   ): AdmissionDecision {
     return AdmissionDecisionSchema.parse({
       schemaVersion: ADMISSION_DECISION_SCHEMA_VERSION,
@@ -430,6 +547,7 @@ export class AdmissionControlService {
       request,
       reservation,
       limitingPolicies,
+      limitingBudgetPolicies,
       retryAfterMs,
       reason,
       decidedAt: now.toISOString(),
@@ -536,6 +654,9 @@ function sameRequestIdentity(
     left.workflowRunId === right.workflowRunId &&
     left.workflowStepId === right.workflowStepId &&
     left.rootReservationId === right.rootReservationId &&
+    JSON.stringify(left.executionTree) === JSON.stringify(right.executionTree) &&
+    JSON.stringify(left.budgetPolicies) === JSON.stringify(right.budgetPolicies) &&
+    JSON.stringify(left.budgetRequest) === JSON.stringify(right.budgetRequest) &&
     JSON.stringify(left.requested) === JSON.stringify(right.requested)
   );
 }

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -15,6 +15,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { nanoid } from 'nanoid';
 import fs from 'fs/promises';
 import path from 'path';
+import { createHash } from 'node:crypto';
 import { ConfigService } from './config-service.js';
 import { TaskService } from './task-service.js';
 import { getTelemetryService } from './telemetry-service.js';
@@ -128,6 +129,9 @@ import type {
   WorkspaceExecutionTrustEvaluation,
   WorkspaceExecutionTrustScanResult,
   AdmissionReservationRelease,
+  ExecutionTreeBudgetPolicy,
+  ExecutionTreeEdgeKind,
+  ExecutionTreeIdentity,
 } from '@veritas-kanban/shared';
 import { createLogger } from '../lib/logger.js';
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
@@ -331,6 +335,7 @@ export interface AgentStatus {
   conversation: ConversationLifecycleRecord;
   controls: ProviderRuntimeControlSet;
   admissionReservationId?: string;
+  executionTree?: ExecutionTreeIdentity;
 }
 
 export interface AgentOutput {
@@ -393,6 +398,7 @@ interface PendingAgent {
   provider: ExecutableAgentProvider;
   model?: string;
   budget?: AgentBudgetState;
+  executionTreeUsage: AgentBudgetUsage;
   recoveryBudgetBase?: AgentBudgetUsage;
   budgetStopped?: boolean;
   agentProfile?: AgentProfileLaunchMetadata;
@@ -408,6 +414,7 @@ interface PendingAgent {
   conversation: ConversationLifecycleRecord;
   supervisorId?: string;
   admissionReservationId?: string;
+  executionTree?: ExecutionTreeIdentity;
   recoveredControl?: boolean;
   threadId?: string;
   abortController?: AbortController;
@@ -1334,6 +1341,10 @@ export class ClawdbotAgentService {
       provider,
       model: attempt.model,
       budget: supervisor.budget ?? attempt.budget,
+      executionTreeUsage: recoveredAdmission?.executionBudget?.committed ?? {
+        ...ZERO_AGENT_BUDGET_USAGE,
+      },
+      executionTree: attempt.executionTree ?? recoveredAdmission?.request.executionTree,
       recoveryBudgetBase: attempt.runRetry?.cumulativeBudget,
       agentProfile: attempt.agentProfile,
       providerRuntimeManifest: attempt.providerRuntimeManifest,
@@ -2111,6 +2122,35 @@ export class ClawdbotAgentService {
       conversationRequest.forkTurnId,
       conversationRequest.intent
     );
+    const executionTree = this.buildExecutionTreeIdentity({
+      taskId,
+      rootTaskId: options.rootTaskId,
+      workspaceId: taskEnvelope.workspace.workspaceId,
+      attemptId,
+      parentAttempt,
+      provider,
+      conversationIntent: conversation.intent,
+      recoveryAction: options.recovery?.action,
+      rootIdempotencyKey: options.admissionIdempotencyKey,
+    });
+    const inheritedBudgetPolicies = parentAttempt?.admissionReservationId
+      ? ((await this.admission.get(parentAttempt.admissionReservationId)).request.budgetPolicies ??
+        [])
+      : [];
+    const executionBudgetPolicies = mergeExecutionTreeBudgetPolicies([
+      ...inheritedBudgetPolicies.filter(
+        (policy) => policy.scope !== 'agent' || policy.scopeId === agent
+      ),
+      ...this.executionTreeBudgetPolicies({
+        executionTree,
+        workspaceId: taskEnvelope.workspace.workspaceId,
+        agent,
+        attemptId,
+        budgetPolicy,
+        budgetSources,
+        isRoot: !parentAttempt,
+      }),
+    ]);
     const admissionDecision = await this.admission.admit({
       taskId,
       rootTaskId: options.rootTaskId,
@@ -2125,6 +2165,12 @@ export class ClawdbotAgentService {
           ? 'direct'
           : 'conversation',
       idempotencyKey: options.admissionIdempotencyKey,
+      executionTree,
+      budgetPolicies: executionBudgetPolicies,
+      budgetRequest: {
+        fanOut: 1,
+        retries: options.recovery ? 1 : 0,
+      },
     });
     if (admissionDecision.outcome !== 'admitted' || !admissionDecision.reservation) {
       throw new ConflictError(
@@ -2146,6 +2192,18 @@ export class ClawdbotAgentService {
         admissionDecision.reservation.id,
         attemptId
       );
+      await this.admission.recordBudgetUsage(admissionReservation.id, {
+        schemaVersion: 'execution-tree-budget-event/v1',
+        id: `launch_${attemptId}`,
+        mode: 'delta',
+        usage: {
+          ...ZERO_AGENT_BUDGET_USAGE,
+          fanOut: 1,
+          retries: options.recovery ? 1 : 0,
+        },
+        source: 'agent-launch',
+        occurredAt: startedAt,
+      });
     } catch (error) {
       await this.admission
         .releaseIfUnbound(
@@ -2180,6 +2238,12 @@ export class ClawdbotAgentService {
       activePhaseEvidence: runLaunchManifest.phase?.evidence,
       conversation,
       admissionReservationId: admissionReservation.id,
+      executionTree,
+      executionTreeUsage: {
+        ...ZERO_AGENT_BUDGET_USAGE,
+        fanOut: 1,
+        retries: options.recovery ? 1 : 0,
+      },
       filesystemSandboxPlan,
       budget: budgetPolicy
         ? {
@@ -2237,6 +2301,7 @@ export class ClawdbotAgentService {
       runRetry,
       conversation,
       admissionReservationId: admissionReservation.id,
+      executionTree,
     };
 
     const usesManagedWorktree = Boolean(task.git.worktreeManifestId && task.git.worktreeLeaseId);
@@ -2613,6 +2678,7 @@ export class ClawdbotAgentService {
       conversation,
       controls: providerRuntimeControls(providerRuntimeManifest),
       admissionReservationId: admissionReservation.id,
+      executionTree,
     };
   }
 
@@ -3324,7 +3390,7 @@ export class ClawdbotAgentService {
           durationMs: new Date(endedAt).getTime() - new Date(pending.startedAt).getTime(),
         };
       })());
-    if (pending.budget?.enabled && !pending.completionBudgetEvaluated) {
+    if (!pending.completionBudgetEvaluated) {
       // Terminal ownership wins over an older usage report. Waiting behind that
       // report can deadlock when it is itself waiting for this finalization.
       if (!budgetEvaluations.has(pending)) {
@@ -3394,6 +3460,7 @@ export class ClawdbotAgentService {
           runLaunchManifest: pending.runLaunchManifest,
           runSupervisorId: pending.supervisorId,
           admissionReservationId: pending.admissionReservationId,
+          executionTree: pending.executionTree,
           runLaunchManifestTraceId: pending.runLaunchManifestTraceId,
           runLaunchParentAttemptId: pending.runLaunchParentAttemptId,
           runLaunchManifestDrift: pending.runLaunchManifestDrift,
@@ -4161,6 +4228,7 @@ export class ClawdbotAgentService {
         usageAttemptId: attemptId,
       });
     }
+    await this.recordExecutionTreeUsage(pending, delta, actionType);
     if (!pending?.budget?.enabled || !pending.budget.policy) return;
 
     const evaluation = await this.serializeBudgetEvaluation(
@@ -4241,6 +4309,30 @@ export class ClawdbotAgentService {
           .map((event) => event.message)
           .join(' ')}`,
       };
+    });
+  }
+
+  private async recordExecutionTreeUsage(
+    pending: PendingAgent,
+    delta: Partial<AgentBudgetUsage>,
+    source: string
+  ): Promise<void> {
+    if (!pending.admissionReservationId) return;
+    await this.serializeBudgetEvaluation(pending, async () => {
+      const usage = getAgentBudgetService().mergeUsage(pending.executionTreeUsage, delta);
+      const digest = createHash('sha256')
+        .update(`${source}:${JSON.stringify(usage)}`)
+        .digest('hex')
+        .slice(0, 32);
+      await this.admission.recordBudgetUsage(pending.admissionReservationId as string, {
+        schemaVersion: 'execution-tree-budget-event/v1',
+        id: `usage_${digest}`,
+        mode: 'snapshot',
+        usage,
+        source,
+        occurredAt: pending.startedAt,
+      });
+      pending.executionTreeUsage = usage;
     });
   }
 
@@ -8182,6 +8274,8 @@ export class ClawdbotAgentService {
       activePhaseEvidence: pending.activePhaseEvidence,
       conversation: pending.conversation,
       controls: providerRuntimeControls(pending.providerRuntimeManifest),
+      admissionReservationId: pending.admissionReservationId,
+      executionTree: pending.executionTree,
     };
   }
 
@@ -9593,6 +9687,115 @@ export class ClawdbotAgentService {
     );
   }
 
+  private buildExecutionTreeIdentity(input: {
+    taskId: string;
+    rootTaskId?: string;
+    workspaceId: string;
+    attemptId: string;
+    parentAttempt?: TaskAttempt;
+    provider: ExecutableAgentProvider;
+    conversationIntent: ConversationLifecycleRecord['intent'];
+    recoveryAction?: RunRecoveryRecord['action'];
+    rootIdempotencyKey?: string;
+  }): ExecutionTreeIdentity {
+    const parent = input.parentAttempt?.executionTree;
+    const parentNodeId = parent?.nodeId ?? input.parentAttempt?.id;
+    const parentTaskId = input.parentAttempt?.runLaunchManifest?.taskId;
+    const isChildAgent = Boolean(parentTaskId && parentTaskId !== input.taskId);
+    const rootIdempotencyKey = input.rootIdempotencyKey?.trim();
+    const nodeId =
+      !parentNodeId && rootIdempotencyKey
+        ? `node_${createHash('sha256')
+            .update(`idempotency:${rootIdempotencyKey}`)
+            .digest('hex')
+            .slice(0, 32)}`
+        : input.attemptId;
+    let edge: ExecutionTreeEdgeKind = 'root';
+    if (parentNodeId) {
+      edge =
+        input.recoveryAction === 'fallback'
+          ? 'fallback'
+          : input.recoveryAction
+            ? 'retry'
+            : isChildAgent
+              ? 'child-agent'
+              : input.parentAttempt?.provider !== input.provider
+                ? 'provider-handoff'
+                : input.conversationIntent === 'resume'
+                  ? 'resume'
+                  : input.conversationIntent === 'follow-up'
+                    ? 'follow-up'
+                    : input.conversationIntent === 'fork'
+                      ? 'fork'
+                      : 'follow-up';
+    }
+    const objectiveSeed = `${input.workspaceId}:${input.rootTaskId ?? input.taskId}:${
+      parentNodeId ?? nodeId
+    }`;
+    return {
+      schemaVersion: 'execution-tree-identity/v1',
+      rootObjectiveId:
+        parent?.rootObjectiveId ??
+        `objective_${createHash('sha256').update(objectiveSeed).digest('hex').slice(0, 32)}`,
+      nodeId,
+      ...(parentNodeId ? { parentNodeId } : {}),
+      edge,
+      depth: parent ? parent.depth + 1 : parentNodeId ? 1 : 0,
+    };
+  }
+
+  private executionTreeBudgetPolicies(input: {
+    executionTree: ExecutionTreeIdentity;
+    workspaceId: string;
+    agent: AgentType;
+    attemptId: string;
+    budgetPolicy?: AgentBudgetPolicy;
+    budgetSources: {
+      workspaceBudget?: AgentBudgetPolicy;
+      agentBudget?: AgentBudgetPolicy;
+      profileBudget?: AgentBudgetPolicy;
+      runBudget?: AgentBudgetPolicy;
+    };
+    isRoot: boolean;
+  }): ExecutionTreeBudgetPolicy[] {
+    return [
+      executionTreePolicy(
+        input.budgetSources.workspaceBudget,
+        'workspace',
+        input.workspaceId,
+        'Workspace budget'
+      ),
+      executionTreePolicy(
+        input.budgetSources.agentBudget,
+        'agent',
+        input.agent,
+        `Agent ${input.agent} budget`
+      ),
+      executionTreePolicy(
+        input.budgetSources.profileBudget,
+        'agent',
+        input.agent,
+        `Agent profile ${input.agent} budget`,
+        `profile:${input.agent}`
+      ),
+      executionTreePolicy(
+        input.budgetSources.runBudget,
+        'run',
+        input.executionTree.rootObjectiveId,
+        'Run budget',
+        'effective-run'
+      ),
+      input.isRoot
+        ? executionTreePolicy(
+            input.budgetPolicy,
+            'root-objective',
+            input.executionTree.rootObjectiveId,
+            'Root objective budget'
+          )
+        : undefined,
+    ].filter((policy): policy is ExecutionTreeBudgetPolicy => Boolean(policy));
+  }
+
   private async resolveParentAttempt(
     task: Task,
     parentAttemptId?: string
@@ -9984,6 +10187,53 @@ function commandText(value: unknown): string {
     if (candidate) return candidate;
   }
   return '';
+}
+
+function executionTreePolicy(
+  policy: AgentBudgetPolicy | undefined,
+  scope: ExecutionTreeBudgetPolicy['scope'],
+  scopeId: string,
+  fallbackName: string,
+  identitySuffix = ''
+): ExecutionTreeBudgetPolicy | undefined {
+  if (
+    !policy ||
+    policy.enabled === false ||
+    !policy.limits ||
+    Object.keys(policy.limits).length === 0
+  ) {
+    return undefined;
+  }
+  const identity = `${scope}:${scopeId}:${identitySuffix}`;
+  return {
+    id: `budget_${createHash('sha256').update(identity).digest('hex').slice(0, 32)}`,
+    scope,
+    scopeId,
+    name: policy.name?.trim() || fallbackName,
+    limits: { ...policy.limits },
+    hardAction: policy.hardAction ?? 'pause',
+  };
+}
+
+function mergeExecutionTreeBudgetPolicies(
+  policies: ExecutionTreeBudgetPolicy[]
+): ExecutionTreeBudgetPolicy[] {
+  const merged = new Map<string, ExecutionTreeBudgetPolicy>();
+  for (const policy of policies) {
+    const current = merged.get(policy.id);
+    if (!current) {
+      merged.set(policy.id, policy);
+      continue;
+    }
+    const limits = { ...current.limits };
+    for (const [metric, limit] of Object.entries(policy.limits)) {
+      const currentLimit = limits[metric as keyof typeof limits];
+      limits[metric as keyof typeof limits] =
+        currentLimit === undefined ? limit : Math.min(currentLimit, limit);
+    }
+    merged.set(policy.id, { ...current, limits });
+  }
+  return [...merged.values()];
 }
 
 // Export singleton

--- a/server/src/services/workflow-run-service.ts
+++ b/server/src/services/workflow-run-service.ts
@@ -20,6 +20,8 @@ import {
   type AdmissionDecision,
   type AdmissionReservation,
   type AdmissionReservationRelease,
+  type ExecutionTreeBudgetPolicy,
+  type ExecutionTreeIdentity,
   type RunRecoveryRecord,
   type Task,
   type WorkflowPipelineRoleStatusPatch,
@@ -377,12 +379,51 @@ export class WorkflowRunService {
 
   private async admitWorkflowRoot(
     run: WorkflowRun,
-    task: Task | null
+    task: Task | null,
+    budgetSources?: {
+      workspaceBudget?: AgentBudgetPolicy;
+      workflowBudget?: AgentBudgetPolicy;
+      runBudget?: AgentBudgetPolicy;
+    }
   ): Promise<NonNullable<WorkflowRun['admission']>> {
     const admissionTaskId = this.rootAdmissionTaskId(run.id);
     const attemptId = admissionTaskId;
     const workspaceId = this.workflowWorkspaceId(task);
     const rootTaskId = run.taskId ?? admissionTaskId;
+    const executionTree: ExecutionTreeIdentity =
+      run.executionTree ??
+      ({
+        schemaVersion: 'execution-tree-identity/v1',
+        rootObjectiveId: `objective_${createHash('sha256')
+          .update(`${workspaceId}:${rootTaskId}:${run.id}`)
+          .digest('hex')
+          .slice(0, 32)}`,
+        nodeId: attemptId,
+        edge: 'root',
+        depth: 0,
+      } as const);
+    run.executionTree = executionTree;
+    const budgetPolicies = mergeWorkflowExecutionTreePolicies([
+      workflowExecutionTreePolicy(
+        budgetSources?.workspaceBudget,
+        'workspace',
+        workspaceId,
+        'Workspace budget'
+      ),
+      workflowExecutionTreePolicy(
+        budgetSources?.workflowBudget,
+        'workflow',
+        run.workflowId,
+        'Workflow budget'
+      ),
+      workflowExecutionTreePolicy(budgetSources?.runBudget, 'run', run.id, 'Workflow run budget'),
+      workflowExecutionTreePolicy(
+        run.budget?.policy,
+        'root-objective',
+        executionTree.rootObjectiveId,
+        'Root objective budget'
+      ),
+    ]);
     const decision = await this.admission.admit({
       taskId: admissionTaskId,
       rootTaskId,
@@ -397,6 +438,9 @@ export class WorkflowRunService {
         processSlots: 0,
         estimatedMemoryMb: 0,
       },
+      executionTree,
+      budgetPolicies,
+      budgetRequest: { fanOut: 1 },
     });
     if (decision.outcome !== 'admitted' || !decision.reservation) {
       throw this.admissionConflict(decision, 'Workflow root');
@@ -404,6 +448,14 @@ export class WorkflowRunService {
     let reservation: AdmissionReservation;
     try {
       reservation = await this.admission.bindAttempt(decision.reservation.id, attemptId);
+      await this.admission.recordBudgetUsage(reservation.id, {
+        schemaVersion: 'execution-tree-budget-event/v1',
+        id: `launch_${attemptId}`,
+        mode: 'delta',
+        usage: { ...ZERO_AGENT_BUDGET_USAGE, fanOut: 1 },
+        source: 'workflow-root-launch',
+        occurredAt: run.startedAt,
+      });
     } catch (error) {
       await this.admission
         .releaseIfUnbound(
@@ -421,6 +473,7 @@ export class WorkflowRunService {
       admissionTaskId,
       attemptId,
       reservationId: reservation.id,
+      executionTree,
     };
   }
 
@@ -443,6 +496,22 @@ export class WorkflowRunService {
         recoveredReservationId: recovered?.id,
       });
     }
+    if (!run.admission.executionTree) {
+      const executionTree: ExecutionTreeIdentity = recovered.request.executionTree ??
+        run.executionTree ?? {
+          schemaVersion: 'execution-tree-identity/v1',
+          rootObjectiveId: `objective_${createHash('sha256')
+            .update(`${run.admission.workspaceId}:${run.admission.rootTaskId}:${run.id}`)
+            .digest('hex')
+            .slice(0, 32)}`,
+          nodeId: run.admission.attemptId,
+          edge: 'root',
+          depth: 0,
+        };
+      run.executionTree = executionTree;
+      run.admission = { ...run.admission, executionTree };
+      await this.saveRun(run);
+    }
   }
 
   private async admitWorkflowStep(
@@ -461,6 +530,21 @@ export class WorkflowRunService {
     const sequence = (stepRun.admission?.sequence ?? 0) + 1;
     const admissionTaskId = this.stepAdmissionTaskId(run.id, step.id, sequence);
     const attemptId = admissionTaskId;
+    const parentExecutionTree = run.admission.executionTree;
+    const executionTree: ExecutionTreeIdentity = {
+      schemaVersion: 'execution-tree-identity/v1',
+      rootObjectiveId: parentExecutionTree.rootObjectiveId,
+      nodeId: attemptId,
+      parentNodeId: parentExecutionTree.nodeId,
+      edge:
+        stepRun.runRetry?.action === 'fallback'
+          ? 'fallback'
+          : stepRun.runRetry
+            ? 'retry'
+            : 'workflow-step',
+      depth: parentExecutionTree.depth + 1,
+    };
+    stepRun.executionTree = executionTree;
     const hostId =
       preparation.hostRouting.selectedHostId ??
       (preparation.runtimeProvider === 'openclaw' ? 'openclaw-gateway' : 'local-process');
@@ -480,6 +564,13 @@ export class WorkflowRunService {
       workflowStepId: step.id,
       rootReservationId: run.admission.reservationId,
       idempotencyKey: `workflow-step:${run.id}:${step.id}:${sequence}:${randomUUID()}`,
+      executionTree,
+      budgetPolicies: (await this.admission.get(run.admission.reservationId)).request
+        .budgetPolicies,
+      budgetRequest: {
+        fanOut: Math.max(1, step.parallel?.steps.length ?? 1),
+        retries: stepRun.runRetry ? 1 : 0,
+      },
     });
     const binding: NonNullable<StepRun['admission']> = {
       schemaVersion: WORKFLOW_ADMISSION_SCHEMA_VERSION,
@@ -487,12 +578,25 @@ export class WorkflowRunService {
       admissionTaskId,
       attemptId,
       decision,
+      executionTree,
     };
     if (decision.outcome !== 'admitted' || !decision.reservation) {
       throw new WorkflowStepAdmissionError(binding);
     }
     try {
       const reservation = await this.admission.bindAttempt(decision.reservation.id, attemptId);
+      await this.admission.recordBudgetUsage(reservation.id, {
+        schemaVersion: 'execution-tree-budget-event/v1',
+        id: `launch_${attemptId}`,
+        mode: 'delta',
+        usage: {
+          ...ZERO_AGENT_BUDGET_USAGE,
+          fanOut: Math.max(1, step.parallel?.steps.length ?? 1),
+          retries: stepRun.runRetry ? 1 : 0,
+        },
+        source: 'workflow-step-launch',
+        occurredAt: run.startedAt,
+      });
       return {
         ...binding,
         reservationId: reservation.id,
@@ -547,12 +651,15 @@ export class WorkflowRunService {
     const safeInitialContext = this.validateExternalContext(initialContext, 'Initial context');
     const config = await getConfigService().getConfig();
     const budgetService = getAgentBudgetService();
-    const budgetPolicy = budgetService.resolve({
+    const budgetSources = {
       workspaceBudget: config.features?.budget?.enabled
         ? config.features.budget.defaultRunBudget
         : undefined,
       workflowBudget: workflow.config?.budget,
       runBudget,
+    };
+    const budgetPolicy = budgetService.resolve({
+      ...budgetSources,
     });
     const hasWorkflowAgentBudget = workflow.agents.some(
       (agent) =>
@@ -641,7 +748,7 @@ export class WorkflowRunService {
     };
 
     try {
-      run.admission = await this.admitWorkflowRoot(run, task);
+      run.admission = await this.admitWorkflowRoot(run, task, budgetSources);
       run.status = 'running';
       await this.saveRun(run);
       await this.snapshotWorkflow(run.id, workflow);
@@ -752,6 +859,25 @@ export class WorkflowRunService {
 
           providerDispatchStarted = preparation.kind === 'agent';
           const result = await this.stepExecutor.executeStep(step, run, preparation);
+          if (stepRun.admission?.reservationId) {
+            const runtimeSeconds = stepRun.startedAt
+              ? Math.max(0, Math.ceil((Date.now() - new Date(stepRun.startedAt).getTime()) / 1_000))
+              : 0;
+            await this.admission.recordBudgetUsage(stepRun.admission.reservationId, {
+              schemaVersion: 'execution-tree-budget-event/v1',
+              id: `usage_${stepRun.admission.attemptId}`,
+              mode: 'snapshot',
+              usage: {
+                ...ZERO_AGENT_BUDGET_USAGE,
+                ...result.budgetUsage,
+                runtimeSeconds: Math.max(runtimeSeconds, result.budgetUsage?.runtimeSeconds ?? 0),
+                fanOut: Math.max(1, step.parallel?.steps.length ?? 1),
+                retries: stepRun.runRetry ? 1 : 0,
+              },
+              source: 'workflow-step-result',
+              occurredAt: stepRun.startedAt ?? run.startedAt,
+            });
+          }
           await this.releaseStepAdmission(
             stepRun,
             'completed',
@@ -1940,6 +2066,52 @@ export interface WorkflowRunServiceOptions {
   runRecoveryPolicy?: RunRecoveryPolicyService;
   stepExecutor?: WorkflowStepExecutor;
   admission?: AdmissionControlService;
+}
+
+function workflowExecutionTreePolicy(
+  policy: AgentBudgetPolicy | undefined,
+  scope: ExecutionTreeBudgetPolicy['scope'],
+  scopeId: string,
+  fallbackName: string
+): ExecutionTreeBudgetPolicy | undefined {
+  if (
+    !policy ||
+    policy.enabled === false ||
+    !policy.limits ||
+    Object.keys(policy.limits).length === 0
+  ) {
+    return undefined;
+  }
+  return {
+    id: `budget_${createHash('sha256').update(`${scope}:${scopeId}`).digest('hex').slice(0, 32)}`,
+    scope,
+    scopeId,
+    name: policy.name?.trim() || fallbackName,
+    limits: { ...policy.limits },
+    hardAction: policy.hardAction ?? 'pause',
+  };
+}
+
+function mergeWorkflowExecutionTreePolicies(
+  policies: Array<ExecutionTreeBudgetPolicy | undefined>
+): ExecutionTreeBudgetPolicy[] {
+  const merged = new Map<string, ExecutionTreeBudgetPolicy>();
+  for (const policy of policies) {
+    if (!policy) continue;
+    const current = merged.get(policy.id);
+    if (!current) {
+      merged.set(policy.id, policy);
+      continue;
+    }
+    const limits = { ...current.limits };
+    for (const [metric, limit] of Object.entries(policy.limits)) {
+      const currentLimit = limits[metric as keyof typeof limits];
+      limits[metric as keyof typeof limits] =
+        currentLimit === undefined ? limit : Math.min(currentLimit, limit);
+    }
+    merged.set(policy.id, { ...current, limits });
+  }
+  return [...merged.values()];
 }
 
 // Singleton

--- a/server/src/storage/admission-reservation-repository.ts
+++ b/server/src/storage/admission-reservation-repository.ts
@@ -15,6 +15,10 @@ import { withFileLock } from '../services/file-lock.js';
 import { getRuntimeDir } from '../utils/paths.js';
 import { ensureWithinBase } from '../utils/sanitize.js';
 import { findLimitingAdmissionPolicies } from './admission-capacity.js';
+import {
+  findLimitingExecutionTreeBudgetPolicies,
+  releaseExecutionTreeBudget,
+} from './execution-tree-budget.js';
 import type { AdmissionReservationRepository } from './interfaces.js';
 
 const MAX_LOG_BYTES = 128 * 1024 * 1024;
@@ -64,6 +68,21 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
         if (limitingPolicies.length > 0) {
           return { created: false, limitingPolicies };
         }
+        const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
+          [...materialized.values()].filter((record) => record.id !== existing.id),
+          reclaimed
+        );
+        if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
+          return {
+            created: false,
+            limitingPolicies: [],
+            limitingBudgetPolicies:
+              limitingBudgets.terminal.length > 0
+                ? limitingBudgets.terminal
+                : limitingBudgets.retryable,
+            budgetRetryable: limitingBudgets.terminal.length === 0,
+          };
+        }
         await this.appendSnapshot(reclaimed, snapshots);
         return {
           record: reclaimed,
@@ -74,6 +93,21 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       }
       const limitingPolicies = findLimitingAdmissionPolicies([...materialized.values()], requested);
       if (limitingPolicies.length > 0) return { created: false, limitingPolicies };
+      const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
+        [...materialized.values()],
+        requested
+      );
+      if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
+        return {
+          created: false,
+          limitingPolicies: [],
+          limitingBudgetPolicies:
+            limitingBudgets.terminal.length > 0
+              ? limitingBudgets.terminal
+              : limitingBudgets.retryable,
+          budgetRetryable: limitingBudgets.terminal.length === 0,
+        };
+      }
       await this.appendSnapshot(requested, snapshots);
       return { record: requested, created: true, limitingPolicies: [] };
     });
@@ -100,6 +134,16 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       .filter(
         (record) =>
           !query.rootReservationId || record.request.rootReservationId === query.rootReservationId
+      )
+      .filter(
+        (record) =>
+          !query.rootObjectiveId ||
+          record.request.executionTree?.rootObjectiveId === query.rootObjectiveId
+      )
+      .filter((record) => !query.nodeId || record.request.executionTree?.nodeId === query.nodeId)
+      .filter(
+        (record) =>
+          !query.parentNodeId || record.request.executionTree?.parentNodeId === query.parentNodeId
       )
       .filter((record) => !states || states.has(record.state))
       .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
@@ -148,6 +192,7 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
         ...current,
         revision: current.revision + 1,
         state: 'expired',
+        executionBudget: releaseExecutionTreeBudget(current.executionBudget),
         updatedAt: now,
       });
       await this.appendSnapshot(next, snapshots);

--- a/server/src/storage/execution-tree-budget.ts
+++ b/server/src/storage/execution-tree-budget.ts
@@ -1,0 +1,276 @@
+import type {
+  AdmissionReservation,
+  AgentBudgetLimits,
+  AgentBudgetMetric,
+  AgentBudgetUsage,
+  ExecutionTreeBudgetPolicy,
+  ExecutionTreeBudgetState,
+  ExecutionTreeBudgetSummary,
+  ExecutionTreeBudgetUsageEvent,
+} from '@veritas-kanban/shared';
+import {
+  EXECUTION_TREE_BUDGET_SUMMARY_SCHEMA_VERSION,
+  ZERO_AGENT_BUDGET_USAGE,
+} from '@veritas-kanban/shared';
+
+const BUDGET_METRICS: readonly AgentBudgetMetric[] = [
+  'inputTokens',
+  'outputTokens',
+  'totalTokens',
+  'costUsd',
+  'toolCalls',
+  'runtimeSeconds',
+  'idleRuntimeSeconds',
+  'retries',
+  'fanOut',
+];
+
+export interface ExecutionTreeBudgetLimits {
+  terminal: ExecutionTreeBudgetPolicy[];
+  retryable: ExecutionTreeBudgetPolicy[];
+}
+
+export function addBudgetUsage(left: AgentBudgetUsage, right: AgentBudgetUsage): AgentBudgetUsage {
+  return Object.fromEntries(
+    BUDGET_METRICS.map((metric) => [metric, left[metric] + right[metric]])
+  ) as unknown as AgentBudgetUsage;
+}
+
+function subtractBudgetUsage(left: AgentBudgetUsage, right: AgentBudgetUsage): AgentBudgetUsage {
+  return Object.fromEntries(
+    BUDGET_METRICS.map((metric) => [metric, Math.max(0, left[metric] - right[metric])])
+  ) as unknown as AgentBudgetUsage;
+}
+
+function snapshotDelta(committed: AgentBudgetUsage, snapshot: AgentBudgetUsage): AgentBudgetUsage {
+  return Object.fromEntries(
+    BUDGET_METRICS.map((metric) => [metric, Math.max(0, snapshot[metric] - committed[metric])])
+  ) as unknown as AgentBudgetUsage;
+}
+
+export function initializeExecutionTreeBudget(
+  requested: AgentBudgetUsage
+): ExecutionTreeBudgetState {
+  return {
+    requested: { ...requested },
+    remaining: { ...requested },
+    committed: { ...ZERO_AGENT_BUDGET_USAGE },
+    releasedUnused: { ...ZERO_AGENT_BUDGET_USAGE },
+    events: [],
+  };
+}
+
+export function applyExecutionTreeBudgetEvent(
+  state: ExecutionTreeBudgetState,
+  event: ExecutionTreeBudgetUsageEvent
+): ExecutionTreeBudgetState {
+  const existing = state.events.find((candidate) => candidate.id === event.id);
+  if (existing) {
+    if (JSON.stringify(existing) !== JSON.stringify(event)) {
+      throw new Error(`Execution budget event ${event.id} has conflicting evidence.`);
+    }
+    return state;
+  }
+  if (state.events.length >= 10_000) {
+    throw new Error('Execution budget event history reached its bounded limit.');
+  }
+  const delta =
+    event.mode === 'snapshot' ? snapshotDelta(state.committed, event.usage) : event.usage;
+  return {
+    ...state,
+    committed: addBudgetUsage(state.committed, delta),
+    remaining: subtractBudgetUsage(state.remaining, delta),
+    events: [...state.events, event],
+  };
+}
+
+export function releaseExecutionTreeBudget(
+  state: ExecutionTreeBudgetState | undefined
+): ExecutionTreeBudgetState | undefined {
+  if (!state) return undefined;
+  return {
+    ...state,
+    releasedUnused: addBudgetUsage(state.releasedUnused, state.remaining),
+    remaining: { ...ZERO_AGENT_BUDGET_USAGE },
+  };
+}
+
+function sameExecutionTree(record: AdmissionReservation, candidate: AdmissionReservation): boolean {
+  return (
+    record.request.executionTree?.rootObjectiveId ===
+    candidate.request.executionTree?.rootObjectiveId
+  );
+}
+
+function carriesPolicy(record: AdmissionReservation, policyId: string): boolean {
+  return Boolean(record.request.budgetPolicies?.some((policy) => policy.id === policyId));
+}
+
+function usageForPolicy(
+  records: AdmissionReservation[],
+  policy: ExecutionTreeBudgetPolicy,
+  field: 'committed' | 'remaining'
+): AgentBudgetUsage {
+  return records
+    .filter((record) => carriesPolicy(record, policy.id))
+    .filter((record) => field === 'committed' || record.state === 'active')
+    .reduce(
+      (total, record) =>
+        addBudgetUsage(total, record.executionBudget?.[field] ?? ZERO_AGENT_BUDGET_USAGE),
+      { ...ZERO_AGENT_BUDGET_USAGE }
+    );
+}
+
+function policyBlocks(
+  used: AgentBudgetUsage,
+  requested: AgentBudgetUsage,
+  limits: AgentBudgetLimits
+): boolean {
+  return BUDGET_METRICS.some((metric) => {
+    const limit = limits[metric];
+    if (limit === undefined) return false;
+    return requested[metric] > 0 ? used[metric] + requested[metric] > limit : used[metric] >= limit;
+  });
+}
+
+function strictestPolicy(
+  candidate: ExecutionTreeBudgetPolicy,
+  records: AdmissionReservation[]
+): ExecutionTreeBudgetPolicy {
+  const limits = { ...candidate.limits };
+  for (const policy of records
+    .flatMap((record) => record.request.budgetPolicies ?? [])
+    .filter((policy) => policy.id === candidate.id)) {
+    for (const metric of BUDGET_METRICS) {
+      const persisted = policy.limits[metric];
+      if (persisted === undefined) continue;
+      const current = limits[metric];
+      limits[metric] = current === undefined ? persisted : Math.min(current, persisted);
+    }
+  }
+  return { ...candidate, limits };
+}
+
+export function findLimitingExecutionTreeBudgetPolicies(
+  records: AdmissionReservation[],
+  candidate: AdmissionReservation
+): ExecutionTreeBudgetLimits {
+  if (!candidate.request.executionTree || !candidate.executionBudget) {
+    return { terminal: [], retryable: [] };
+  }
+  const treeRecords = records.filter((record) => sameExecutionTree(record, candidate));
+  const terminal: ExecutionTreeBudgetPolicy[] = [];
+  const retryable: ExecutionTreeBudgetPolicy[] = [];
+  for (const candidatePolicy of candidate.request.budgetPolicies ?? []) {
+    const policy = strictestPolicy(candidatePolicy, treeRecords);
+    const committed = usageForPolicy(treeRecords, policy, 'committed');
+    if (policyBlocks(committed, candidate.executionBudget.remaining, policy.limits)) {
+      terminal.push(policy);
+      continue;
+    }
+    const reserved = usageForPolicy(treeRecords, policy, 'remaining');
+    if (
+      policyBlocks(
+        addBudgetUsage(committed, reserved),
+        candidate.executionBudget.remaining,
+        policy.limits
+      )
+    ) {
+      retryable.push(policy);
+    }
+  }
+  return { terminal, retryable };
+}
+
+function remainingLimits(limits: AgentBudgetLimits, used: AgentBudgetUsage): AgentBudgetLimits {
+  return Object.fromEntries(
+    BUDGET_METRICS.flatMap((metric) =>
+      limits[metric] === undefined
+        ? []
+        : [[metric, Math.max(0, (limits[metric] as number) - used[metric])]]
+    )
+  );
+}
+
+function reachesAnyLimit(usage: AgentBudgetUsage, limits: AgentBudgetLimits): boolean {
+  return BUDGET_METRICS.some(
+    (metric) => limits[metric] !== undefined && usage[metric] >= (limits[metric] as number)
+  );
+}
+
+function strictestPolicies(records: AdmissionReservation[]): ExecutionTreeBudgetPolicy[] {
+  const policies = new Map<string, ExecutionTreeBudgetPolicy>();
+  for (const policy of records.flatMap((record) => record.request.budgetPolicies ?? [])) {
+    policies.set(policy.id, strictestPolicy(policies.get(policy.id) ?? policy, records));
+  }
+  return [...policies.values()];
+}
+
+export function summarizeExecutionTreeBudget(
+  rootObjectiveId: string,
+  records: AdmissionReservation[],
+  limit = 100,
+  generatedAt = new Date().toISOString()
+): ExecutionTreeBudgetSummary {
+  const treeRecords = records.filter(
+    (record) => record.request.executionTree?.rootObjectiveId === rootObjectiveId
+  );
+  const committed = treeRecords.reduce(
+    (total, record) =>
+      addBudgetUsage(total, record.executionBudget?.committed ?? ZERO_AGENT_BUDGET_USAGE),
+    { ...ZERO_AGENT_BUDGET_USAGE }
+  );
+  const reserved = treeRecords
+    .filter((record) => record.state === 'active')
+    .reduce(
+      (total, record) =>
+        addBudgetUsage(total, record.executionBudget?.remaining ?? ZERO_AGENT_BUDGET_USAGE),
+      { ...ZERO_AGENT_BUDGET_USAGE }
+    );
+  const policies = strictestPolicies(treeRecords).map((policy) => {
+    const used = usageForPolicy(treeRecords, policy, 'committed');
+    const policyReserved = usageForPolicy(treeRecords, policy, 'remaining');
+    const total = addBudgetUsage(used, policyReserved);
+    return {
+      policy,
+      used,
+      reserved: policyReserved,
+      remaining: remainingLimits(policy.limits, total),
+      blocksNextLaunch: reachesAnyLimit(total, policy.limits),
+    };
+  });
+  const contributors = treeRecords
+    .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
+    .slice(0, limit)
+    .flatMap((record) => {
+      const identity = record.request.executionTree;
+      if (!identity) return [];
+      return [
+        {
+          identity,
+          reservationId: record.id,
+          taskId: record.request.taskId,
+          attemptId: record.attemptId,
+          provider: record.request.provider,
+          state: record.state,
+          committed: record.executionBudget?.committed ?? { ...ZERO_AGENT_BUDGET_USAGE },
+          reserved:
+            record.state === 'active'
+              ? (record.executionBudget?.remaining ?? { ...ZERO_AGENT_BUDGET_USAGE })
+              : { ...ZERO_AGENT_BUDGET_USAGE },
+          updatedAt: record.updatedAt,
+        },
+      ];
+    });
+  return {
+    schemaVersion: EXECUTION_TREE_BUDGET_SUMMARY_SCHEMA_VERSION,
+    rootObjectiveId,
+    committed,
+    reserved,
+    policies,
+    contributors,
+    contributorCount: treeRecords.length,
+    truncated: treeRecords.length > contributors.length,
+    generatedAt,
+  };
+}

--- a/server/src/storage/sqlite/admission-reservation-repository.ts
+++ b/server/src/storage/sqlite/admission-reservation-repository.ts
@@ -8,6 +8,10 @@ import type {
 } from '@veritas-kanban/shared';
 import { AdmissionReservationSchema } from '../../schemas/admission-control-schemas.js';
 import { findLimitingAdmissionPolicies } from '../admission-capacity.js';
+import {
+  findLimitingExecutionTreeBudgetPolicies,
+  releaseExecutionTreeBudget,
+} from '../execution-tree-budget.js';
 import type { AdmissionReservationRepository } from '../interfaces.js';
 import type { SqliteDatabase } from './database.js';
 
@@ -52,6 +56,24 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
           connection.exec('COMMIT');
           return { created: false, limitingPolicies };
         }
+        const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
+          this.executionTreeReservations(requested.request.executionTree?.rootObjectiveId).filter(
+            (record) => record.id !== existing.id
+          ),
+          reclaimed
+        );
+        if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
+          connection.exec('COMMIT');
+          return {
+            created: false,
+            limitingPolicies: [],
+            limitingBudgetPolicies:
+              limitingBudgets.terminal.length > 0
+                ? limitingBudgets.terminal
+                : limitingBudgets.retryable,
+            budgetRetryable: limitingBudgets.terminal.length === 0,
+          };
+        }
         this.updateRow(reclaimed, existing.revision);
         connection.exec('COMMIT');
         return {
@@ -66,13 +88,30 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
         connection.exec('COMMIT');
         return { created: false, limitingPolicies };
       }
+      const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
+        this.executionTreeReservations(requested.request.executionTree?.rootObjectiveId),
+        requested
+      );
+      if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
+        connection.exec('COMMIT');
+        return {
+          created: false,
+          limitingPolicies: [],
+          limitingBudgetPolicies:
+            limitingBudgets.terminal.length > 0
+              ? limitingBudgets.terminal
+              : limitingBudgets.retryable,
+          budgetRetryable: limitingBudgets.terminal.length === 0,
+        };
+      }
       connection
         .prepare(
           `INSERT INTO admission_reservations (
              id, workspace_id, task_id, root_task_id, provider, host_id, state, revision,
              idempotency_key, lease_expires_at, workflow_run_id, workflow_step_id,
-             root_reservation_id, reservation_json, created_at, updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             root_reservation_id, root_objective_id, node_id, parent_node_id,
+             reservation_json, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           requested.id,
@@ -88,6 +127,9 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
           requested.request.workflowRunId ?? null,
           requested.request.workflowStepId ?? null,
           requested.request.rootReservationId ?? null,
+          requested.request.executionTree?.rootObjectiveId ?? null,
+          requested.request.executionTree?.nodeId ?? null,
+          requested.request.executionTree?.parentNodeId ?? null,
           JSON.stringify(requested),
           requested.createdAt,
           requested.updatedAt
@@ -123,6 +165,9 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
     if (query.workflowRunId) add('workflow_run_id = ?', query.workflowRunId);
     if (query.workflowStepId) add('workflow_step_id = ?', query.workflowStepId);
     if (query.rootReservationId) add('root_reservation_id = ?', query.rootReservationId);
+    if (query.rootObjectiveId) add('root_objective_id = ?', query.rootObjectiveId);
+    if (query.nodeId) add('node_id = ?', query.nodeId);
+    if (query.parentNodeId) add('parent_node_id = ?', query.parentNodeId);
     if (query.states?.length) {
       clauses.push(`state IN (${query.states.map(() => '?').join(', ')})`);
       parameters.push(...query.states);
@@ -194,6 +239,15 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
     return rows.map((row) => AdmissionReservationSchema.parse(JSON.parse(row.reservation_json)));
   }
 
+  private executionTreeReservations(rootObjectiveId: string | undefined): AdmissionReservation[] {
+    if (!rootObjectiveId) return [];
+    const rows = this.database
+      .getConnection()
+      .prepare('SELECT reservation_json FROM admission_reservations WHERE root_objective_id = ?')
+      .all(rootObjectiveId) as unknown as ReservationRow[];
+    return rows.map((row) => AdmissionReservationSchema.parse(JSON.parse(row.reservation_json)));
+  }
+
   private expireInTransaction(now: string): AdmissionReservation[] {
     const rows = this.database
       .getConnection()
@@ -208,6 +262,7 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
         ...current,
         revision: current.revision + 1,
         state: 'expired',
+        executionBudget: releaseExecutionTreeBudget(current.executionBudget),
         updatedAt: now,
       });
       this.updateRow(expired, current.revision);
@@ -223,6 +278,7 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
          SET workspace_id = ?, task_id = ?, root_task_id = ?, provider = ?, host_id = ?,
              state = ?, revision = ?, idempotency_key = ?, lease_expires_at = ?,
              workflow_run_id = ?, workflow_step_id = ?, root_reservation_id = ?,
+             root_objective_id = ?, node_id = ?, parent_node_id = ?,
              reservation_json = ?, updated_at = ?
          WHERE id = ? AND revision = ?`
       )
@@ -239,6 +295,9 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
         record.request.workflowRunId ?? null,
         record.request.workflowStepId ?? null,
         record.request.rootReservationId ?? null,
+        record.request.executionTree?.rootObjectiveId ?? null,
+        record.request.executionTree?.nodeId ?? null,
+        record.request.executionTree?.parentNodeId ?? null,
         JSON.stringify(record),
         record.updatedAt,
         record.id,

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -1331,6 +1331,21 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON admission_reservations(root_reservation_id, updated_at DESC);
     `,
   },
+  {
+    version: 25,
+    name: '0025_execution_tree_budget_reservations',
+    up: `
+      ALTER TABLE admission_reservations ADD COLUMN root_objective_id TEXT;
+      ALTER TABLE admission_reservations ADD COLUMN node_id TEXT;
+      ALTER TABLE admission_reservations ADD COLUMN parent_node_id TEXT;
+
+      CREATE INDEX idx_admission_reservations_execution_tree
+        ON admission_reservations(root_objective_id, updated_at DESC);
+
+      CREATE INDEX idx_admission_reservations_execution_parent
+        ON admission_reservations(parent_node_id, updated_at DESC);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/server/src/types/workflow.ts
+++ b/server/src/types/workflow.ts
@@ -205,6 +205,7 @@ export interface WorkflowRun {
   workflowVersion: number;
   taskId?: string; // Optional task association
   admission?: import('@veritas-kanban/shared').WorkflowRootAdmissionBinding;
+  executionTree?: import('@veritas-kanban/shared').ExecutionTreeIdentity;
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps
@@ -241,6 +242,7 @@ export interface StepRun {
   runRetry?: import('@veritas-kanban/shared').RunRecoveryRecord;
   /** Durable admission evidence for the latest executable step attempt. */
   admission?: import('@veritas-kanban/shared').WorkflowStepAdmissionBinding;
+  executionTree?: import('@veritas-kanban/shared').ExecutionTreeIdentity;
 
   // Loop-specific state
   loopState?: {

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -1,4 +1,12 @@
 import type { ExecutableAgentProvider } from './config.types.js';
+import type {
+  ExecutionTreeBudgetPolicy,
+  ExecutionTreeBudgetState,
+  ExecutionTreeBudgetSummary,
+  ExecutionTreeBudgetUsageEvent,
+  ExecutionTreeIdentity,
+} from './execution-tree-budget.types.js';
+import type { AgentBudgetUsage } from './agent-budget.types.js';
 
 export const ADMISSION_REQUEST_SCHEMA_VERSION = 'admission-request/v1' as const;
 export const ADMISSION_DECISION_SCHEMA_VERSION = 'admission-decision/v1' as const;
@@ -69,6 +77,9 @@ export interface AdmissionRequest {
   workflowRunId?: string;
   workflowStepId?: string;
   rootReservationId?: string;
+  executionTree?: ExecutionTreeIdentity;
+  budgetPolicies?: ExecutionTreeBudgetPolicy[];
+  budgetRequest?: AgentBudgetUsage;
   requested: AdmissionCapacityRequest;
   requestedAt: string;
 }
@@ -98,6 +109,7 @@ export interface AdmissionReservation {
   attemptId?: string;
   lease: AdmissionReservationLease;
   release?: AdmissionReservationRelease;
+  executionBudget?: ExecutionTreeBudgetState;
   createdAt: string;
   updatedAt: string;
 }
@@ -108,6 +120,7 @@ export interface AdmissionDecision {
   request: AdmissionRequest;
   reservation?: AdmissionReservation;
   limitingPolicies: AdmissionLimitPolicy[];
+  limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[];
   retryAfterMs?: number;
   reason: string;
   decidedAt: string;
@@ -122,6 +135,9 @@ export interface AdmissionReservationListQuery {
   workflowRunId?: string;
   workflowStepId?: string;
   rootReservationId?: string;
+  rootObjectiveId?: string;
+  nodeId?: string;
+  parentNodeId?: string;
   states?: AdmissionReservationState[];
   limit?: number;
 }
@@ -149,7 +165,21 @@ export interface AdmissionReservationClaimResult {
   created: boolean;
   reclaimed?: boolean;
   limitingPolicies: AdmissionLimitPolicy[];
+  limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[];
+  budgetRetryable?: boolean;
 }
+
+export interface AdmissionBudgetUsageInput {
+  reservationId: string;
+  event: ExecutionTreeBudgetUsageEvent;
+}
+
+export interface AdmissionExecutionTreeSummaryInput {
+  rootObjectiveId: string;
+  limit?: number;
+}
+
+export type AdmissionExecutionTreeSummary = ExecutionTreeBudgetSummary;
 
 export interface AdmissionSettings {
   enabled: boolean;

--- a/shared/src/types/execution-tree-budget.types.ts
+++ b/shared/src/types/execution-tree-budget.types.ts
@@ -1,0 +1,93 @@
+import type {
+  AgentBudgetAction,
+  AgentBudgetLimits,
+  AgentBudgetUsage,
+} from './agent-budget.types.js';
+
+export const EXECUTION_TREE_IDENTITY_SCHEMA_VERSION = 'execution-tree-identity/v1' as const;
+export const EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION = 'execution-tree-budget-event/v1' as const;
+export const EXECUTION_TREE_BUDGET_SUMMARY_SCHEMA_VERSION =
+  'execution-tree-budget-summary/v1' as const;
+
+export const EXECUTION_TREE_EDGE_KINDS = [
+  'root',
+  'resume',
+  'follow-up',
+  'fork',
+  'retry',
+  'fallback',
+  'provider-handoff',
+  'workflow-step',
+  'child-agent',
+] as const;
+export type ExecutionTreeEdgeKind = (typeof EXECUTION_TREE_EDGE_KINDS)[number];
+
+export interface ExecutionTreeIdentity {
+  schemaVersion: typeof EXECUTION_TREE_IDENTITY_SCHEMA_VERSION;
+  rootObjectiveId: string;
+  nodeId: string;
+  parentNodeId?: string;
+  edge: ExecutionTreeEdgeKind;
+  depth: number;
+}
+
+export type ExecutionTreeBudgetPolicyScope =
+  'workspace' | 'agent' | 'workflow' | 'run' | 'root-objective';
+
+export interface ExecutionTreeBudgetPolicy {
+  id: string;
+  scope: ExecutionTreeBudgetPolicyScope;
+  scopeId: string;
+  name: string;
+  limits: AgentBudgetLimits;
+  hardAction: Exclude<AgentBudgetAction, 'warn'>;
+}
+
+export interface ExecutionTreeBudgetUsageEvent {
+  schemaVersion: typeof EXECUTION_TREE_BUDGET_EVENT_SCHEMA_VERSION;
+  id: string;
+  mode: 'delta' | 'snapshot';
+  usage: AgentBudgetUsage;
+  source: string;
+  occurredAt: string;
+}
+
+export interface ExecutionTreeBudgetState {
+  requested: AgentBudgetUsage;
+  remaining: AgentBudgetUsage;
+  committed: AgentBudgetUsage;
+  releasedUnused: AgentBudgetUsage;
+  events: ExecutionTreeBudgetUsageEvent[];
+}
+
+export interface ExecutionTreeBudgetPolicyStatus {
+  policy: ExecutionTreeBudgetPolicy;
+  used: AgentBudgetUsage;
+  reserved: AgentBudgetUsage;
+  remaining: AgentBudgetLimits;
+  blocksNextLaunch: boolean;
+}
+
+export interface ExecutionTreeBudgetContributor {
+  identity: ExecutionTreeIdentity;
+  reservationId: string;
+  taskId: string;
+  attemptId?: string;
+  provider: string;
+  state: 'active' | 'released' | 'expired';
+  committed: AgentBudgetUsage;
+  reserved: AgentBudgetUsage;
+  updatedAt: string;
+}
+
+export interface ExecutionTreeBudgetSummary {
+  schemaVersion: typeof EXECUTION_TREE_BUDGET_SUMMARY_SCHEMA_VERSION;
+  rootObjectiveId: string;
+  committed: AgentBudgetUsage;
+  reserved: AgentBudgetUsage;
+  policies: ExecutionTreeBudgetPolicyStatus[];
+  contributors: ExecutionTreeBudgetContributor[];
+  contributorCount: number;
+  truncated: boolean;
+  generatedAt: string;
+}

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -43,6 +43,7 @@ export * from './skill-capability.types.js';
 export * from './skill-security.types.js';
 export * from './sandbox-policy.types.js';
 export * from './agent-budget.types.js';
+export * from './execution-tree-budget.types.js';
 export * from './agent-profile-package.types.js';
 export * from './team-roster.types.js';
 export * from './buzz-definition.types.js';

--- a/shared/src/types/task.types.ts
+++ b/shared/src/types/task.types.ts
@@ -78,6 +78,7 @@ export interface TaskAttempt {
   runLaunchManifest?: import('./run-launch-manifest.types.js').RunLaunchManifest;
   runSupervisorId?: string;
   admissionReservationId?: string;
+  executionTree?: import('./execution-tree-budget.types.js').ExecutionTreeIdentity;
   runRecovery?: import('./run-supervisor.types.js').RunSupervisorRecoveryRecord;
   runLaunchManifestTraceId?: string;
   runLaunchParentAttemptId?: string;

--- a/shared/src/types/workflow.ts
+++ b/shared/src/types/workflow.ts
@@ -252,6 +252,7 @@ export interface WorkflowRootAdmissionBinding {
   admissionTaskId: string;
   attemptId: string;
   reservationId: string;
+  executionTree: import('./execution-tree-budget.types.js').ExecutionTreeIdentity;
 }
 
 export interface WorkflowStepAdmissionBinding {
@@ -261,6 +262,7 @@ export interface WorkflowStepAdmissionBinding {
   attemptId: string;
   reservationId?: string;
   decision: import('./admission-control.types.js').AdmissionDecision;
+  executionTree: import('./execution-tree-budget.types.js').ExecutionTreeIdentity;
 }
 
 export interface WorkflowRun {
@@ -271,6 +273,7 @@ export interface WorkflowRun {
   workflowVersion: number;
   taskId?: string; // Optional task association
   admission?: WorkflowRootAdmissionBinding;
+  executionTree?: import('./execution-tree-budget.types.js').ExecutionTreeIdentity;
   status: WorkflowRunStatus;
   currentStep?: string; // Current step ID
   context: Record<string, unknown>; // Shared context across steps
@@ -306,6 +309,7 @@ export interface StepRun {
   runRetry?: import('./run-recovery.types.js').RunRecoveryRecord;
   /** Durable admission evidence for the latest executable step attempt. */
   admission?: WorkflowStepAdmissionBinding;
+  executionTree?: import('./execution-tree-budget.types.js').ExecutionTreeIdentity;
 
   // Loop-specific state
   loopState?: {


### PR DESCRIPTION
## Summary

- persist versioned root objective and parent-edge identity across direct runs, continuations, retries, fallbacks, provider handoffs, child agents, workflow roots, and workflow steps
- atomically claim the strictest applicable capacity and execution budget through the file lock or SQLite transaction
- convert reserved usage into idempotent, attributable committed usage while releasing only unused capacity
- add bounded REST and `vk admission tree` inspection, query filters, schema documentation, operator guidance, and changelog coverage

## Verification

- `pnpm --filter @veritas-kanban/shared build`
- `pnpm --filter @veritas-kanban/server typecheck`
- `pnpm --filter @veritas-kanban/cli typecheck`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/admission-control-service.test.ts` (15 passed)
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/workflow-admission.test.ts` (5 passed)
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/workflow-run-service.test.ts`
- `pnpm --filter @veritas-kanban/server exec vitest run src/__tests__/codex-provider-service.test.ts` (59 passed)
- `pnpm --filter @veritas-kanban/cli exec vitest run src/__tests__/admission.test.ts` (3 passed)
- changed-file ESLint (0 errors; one pre-existing unused-type warning)
- `pnpm check:delivery-cadence` (16 passed)
- `git diff --check`

## Risk and scope

- SQLite migration 25 adds indexed root, node, and parent columns while retaining the complete versioned reservation JSON.
- Existing reservations without execution-tree identity remain valid and continue using capacity-only admission.
- Queue fairness, root cancellation, provider-hidden accounting, and exact future-use prediction remain out of scope.
- The primary checkout and its existing untracked documentation files were not modified.

Closes #1052
