### PR TITLE
fix: reject ambiguous focused test wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,10 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
 - During implementation, run the narrowest useful loop: type-check touched packages, lint changed
   files, and run focused tests for changed behavior and high-risk edges.
 - Run focused Vitest slices with
-  `pnpm --filter <package> exec vitest run <exact-test-files>`. Do not use the ambiguous
-  `pnpm --filter <package> test -- --run <test-files>` form; package wrappers can ignore that
-  file boundary and expand into the entire package suite.
+  `pnpm --filter <package> exec vitest run <exact-test-files>`. Do not use
+  `pnpm --filter <package> test -- <test-files>` or
+  `pnpm --filter <package> test -- --run <test-files>`; package wrappers can ignore that file
+  boundary and expand into the entire package suite.
 - Do not rerun an unchanged passing gate after documentation, comments, or formatting-only edits.
   Rerun only the checks affected by the later change.
 - Use the complete workspace suite once at an explicit integration, critical-security, or release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,9 +121,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardized focused Vitest verification on direct
   `pnpm --filter <package> exec vitest run <exact-test-files>` invocation. The
   dependency-free delivery cadence checker now rejects active guidance that
-  presents the ambiguous package `test -- --run` wrapper as focused
-  verification, preventing an intended file slice from silently expanding into
-  an entire package suite (#1044).
+  presents either of the ambiguous package `test -- <test-files>` or
+  `test -- --run <test-files>` wrappers as focused verification, preventing
+  an intended file slice from silently expanding into an entire package suite
+  (#1044, #1058).
 - Reworked GitHub release notes to use natural page-width prose and concise
   lists instead of ragged hanging-indent blocks or unmarked stacks of bold-led
   paragraphs. The release-format gate now rejects long wrapping list items,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,9 @@ veritas-kanban/
    ```
 
    Use direct `exec vitest run` invocation for exact-file slices. Do not use
-   `pnpm --filter <package> test -- --run <test-files>` as a focused command;
-   package wrappers can ignore that file boundary and expand into the entire
+   `pnpm --filter <package> test -- <test-files>` or
+   `pnpm --filter <package> test -- --run <test-files>` as a focused command.
+   Package wrappers can ignore that file boundary and expand into the entire
    package suite.
 
    Build `@veritas-kanban/shared` first and type-check its known consumers when

--- a/prompt-registry/bug-triage.md
+++ b/prompt-registry/bug-triage.md
@@ -46,7 +46,7 @@ integration, critical-security, or release milestone.
 vk begin <TASK-ID>
 # ... investigate and fix ...
 pnpm --filter <TOUCHED-PACKAGE> typecheck
-pnpm --filter <TOUCHED-PACKAGE> test -- <FOCUSED-TEST>
+pnpm --filter <TOUCHED-PACKAGE> exec vitest run <FOCUSED-TEST>
 vk done <TASK-ID> "Fixed: <ROOT-CAUSE>. Solution: <SUMMARY>"
 ````
 

--- a/prompt-registry/feature-development.md
+++ b/prompt-registry/feature-development.md
@@ -48,7 +48,7 @@ Implement feature: <FEATURE-TITLE>
 vk begin <TASK-ID>
 # ... implement ...
 pnpm --filter <TOUCHED-PACKAGE> typecheck
-pnpm --filter <TOUCHED-PACKAGE> test -- <FOCUSED-TEST>
+pnpm --filter <TOUCHED-PACKAGE> exec vitest run <FOCUSED-TEST>
 vk done <TASK-ID> "Implemented <FEATURE>: <SUMMARY>"
 ````
 

--- a/prompt-registry/task-completion.md
+++ b/prompt-registry/task-completion.md
@@ -47,7 +47,7 @@ Write a brief summary covering:
 ```bash
 # Run the narrowest useful verification from AGENTS.md
 pnpm --filter <TOUCHED-PACKAGE> typecheck
-pnpm --filter <TOUCHED-PACKAGE> test -- <FOCUSED-TEST>
+pnpm --filter <TOUCHED-PACKAGE> exec vitest run <FOCUSED-TEST>
 
 # Complete the task
 vk done <TASK-ID> "<SUMMARY>"

--- a/scripts/check-delivery-cadence.mjs
+++ b/scripts/check-delivery-cadence.mjs
@@ -267,7 +267,8 @@ export function findUnsafeCanonicalCadenceStatements(files) {
 
 export function findAmbiguousFocusedTestCommands(files) {
   const violations = [];
-  const pattern = /\bpnpm\s+--filter\s+\S+\s+test\s+--\s+--run\b/gi;
+  const pattern =
+    /\bpnpm\s+(?:--filter(?:=|\s+)|-F\s+)\S+\s+(?:run\s+)?test\s+--(?=\s)/gi;
 
   for (const [file, content] of Object.entries(files)) {
     const normalized = normalizeWhitespace(content);

--- a/scripts/check-delivery-cadence.test.mjs
+++ b/scripts/check-delivery-cadence.test.mjs
@@ -202,6 +202,28 @@ test('rejects package test wrappers that can expand an intended file slice', () 
   );
 });
 
+test('rejects package test wrappers with a direct file argument', () => {
+  for (const command of [
+    'pnpm --filter @veritas-kanban/server test -- src/example.test.ts',
+    'pnpm --filter=@veritas-kanban/server test -- src/example.test.ts',
+    'pnpm -F @veritas-kanban/server test -- src/example.test.ts',
+    'pnpm --filter @veritas-kanban/server run test -- src/example.test.ts',
+  ]) {
+    assert.deepEqual(
+      findAmbiguousFocusedTestCommands({
+        'prompt-registry/example.md': `Run \`${command}\`.`,
+      }),
+      [
+        {
+          file: 'prompt-registry/example.md',
+          message:
+            'focused Vitest files must use direct `pnpm --filter <package> exec vitest run <exact-test-files>` invocation',
+        },
+      ]
+    );
+  }
+});
+
 test('allows direct Vitest exact-file invocation', () => {
   assert.deepEqual(
     findAmbiguousFocusedTestCommands({
@@ -216,7 +238,7 @@ test('allows an explicit warning against the ambiguous package test wrapper', ()
   assert.deepEqual(
     findAmbiguousFocusedTestCommands({
       'AGENTS.md':
-        'Do not use `pnpm --filter <package> test -- --run <test-files>` for focused verification.',
+        'Do not use `pnpm --filter <package> test -- <test-files>` or `pnpm --filter <package> test -- --run <test-files>` for focused verification.',
     }),
     []
   );


### PR DESCRIPTION
## Summary

- reject focused-test guidance that uses package `test -- <file>` or `test -- --run <file>` wrappers
- cover `--filter`, `--filter=`, `-F`, and explicit `run test` spellings while preserving warning text
- replace the three unsafe active prompt commands with direct exact-file Vitest invocation
- update canonical contributor guidance and the unreleased changelog

## Verification

- `pnpm check:delivery-cadence` (17 passed)
- `git diff --check`

No package or workspace test suite was run or required.

Closes #1058
