### PR TITLE
feat: queue saturated direct agent launches

### DIFF
--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -959,6 +959,14 @@ Configure ceilings through `PATCH /api/settings/features`:
       "local-process": {
         "processSlots": 6
       }
+    },
+    "queue": {
+      "enabled": true,
+      "globalLimit": 1000,
+      "workspaceLimit": 100,
+      "leaseMs": 30000,
+      "retryBackoffMs": 5000,
+      "maxRetries": 3
     }
   }
 }
@@ -966,15 +974,31 @@ Configure ceilings through `PATCH /api/settings/features`:
 
 An individual request larger than a ceiling receives a terminal policy denial.
 Temporary exhaustion returns a retryable overload decision with the limiting
-scope and bounded retry guidance. Active leases renew while the verified run is
-live; completion, interruption, cancellation, or launch failure releases the
-reservation idempotently. Workflow retry and fallback attempts release the
-prior step reservation before acquiring another. After restart, task runs use
-their durable supervisor and workflow runs use the exact persisted root
-binding before reclaiming a reservation. Unverified in-flight workflow steps
-are released and blocked for operator reconciliation. Caller-supplied
-idempotency values are represented by a stable SHA-256 identity in durable
-records; the original value is not stored.
+scope and bounded retry guidance. A fresh direct task start with no transient
+operator message or per-request policy override is instead persisted as one
+bounded `admission-queue-entry/v1` record. The start response has
+`status: "queued"`, `queueId`, the reserved `attemptId`, `retryAfterMs`, and
+redacted limiting scopes. Harnesses must treat that response as accepted work,
+not as a failed attempt, and must not submit a duplicate start.
+
+The queue uses deterministic FIFO order. A worker claims the queue lease and
+admission capacity atomically, then reruns provider, sandbox, budget, workspace
+trust, and launch-manifest checks before any attempt is persisted. Durable
+supervisor ownership changes the entry to `dispatched`; after that point only
+run recovery may restart or finish the work. Abandoned pre-dispatch leases
+requeue with bounded backoff. Terminal drift, retry exhaustion, and queue
+overflow fail closed. Queue records retain task, workspace, agent, execution
+tree, and limiting-scope evidence, but never prompts, messages, tool arguments,
+credentials, or raw idempotency keys.
+
+Active leases renew while the verified run is live; completion, interruption,
+cancellation, or launch failure releases the reservation idempotently.
+Workflow retry and fallback attempts release the prior step reservation before
+acquiring another. After restart, task runs use their durable supervisor and
+workflow runs use the exact persisted root binding before reclaiming a
+reservation. Unverified in-flight workflow steps are released and blocked for
+operator reconciliation. Caller-supplied idempotency values are represented by
+a stable SHA-256 identity in durable records; the original value is not stored.
 
 Every reservation also carries a versioned execution-tree identity. Resume,
 follow-up, fork, retry, fallback, provider handoff, workflow-step, and

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4194,6 +4194,31 @@ over the equivalent JSON `idempotencyKey` field and lets a retry reuse the same
 reservation without launching a second attempt. Veritas persists only its
 SHA-256 identity, never the supplied value.
 
+When capacity is temporarily exhausted, a reconstructable fresh direct start
+returns `201` with `status: "queued"` instead of `ADMISSION_OVERLOAD`:
+
+```json
+{
+  "taskId": "task_0123456789abcdef",
+  "attemptId": "attempt_01234567",
+  "queueId": "admission_queue_0123456789abcdef",
+  "agent": "codex",
+  "status": "queued",
+  "enqueuedAt": "2026-07-25T12:00:00.000Z",
+  "retryAfterMs": 5000,
+  "limitingScopes": [{ "scope": "global", "scopeId": "global" }]
+}
+```
+
+The response means Veritas durably accepted ownership. Clients and harnesses
+must not create a second launch. Starts containing a conversation message,
+profile, readiness override, sandbox or budget override, explicit runtime
+capability, commit policy, phase, recovery, or parent attempt are not
+reconstructable from durable task configuration and continue to fail closed
+with `ADMISSION_OVERLOAD`. Queue bounds and retry behavior are configured under
+`features.admission.queue`. Queue inspection endpoints are added separately;
+reservation inspection remains unchanged.
+
 ---
 
 ## Traces

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -279,8 +279,14 @@ describe('AdmissionControlService', () => {
       'release-heartbeat-active'
     );
     const claim = await service.claimNextQueued();
+    await service.bindQueuedAttempt(
+      claim?.entry.id as string,
+      claim?.reservation.id as string,
+      claim?.entry.attemptId as string
+    );
     const initialQueueRevision = claim?.entry.revision as number;
-    const initialReservationRevision = claim?.reservation.revision as number;
+    const initialReservationRevision = (await repository.get(claim?.reservation.id as string))
+      ?.revision as number;
 
     await vi.waitFor(
       async () => {

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AdmissionReservationRepository } from '../storage/interfaces.js';
 import {
   DEFAULT_FEATURE_SETTINGS,
@@ -29,12 +29,17 @@ function configuredSettings(
   overrides: {
     global?: AdmissionCapacityLimit;
     providers?: AdmissionSettings['providers'];
+    queue?: Partial<AdmissionSettings['queue']>;
   } = {}
 ): AdmissionSettings {
   return {
     ...structuredClone(DEFAULT_FEATURE_SETTINGS.admission),
     global: overrides.global ?? {},
     providers: overrides.providers ?? {},
+    queue: {
+      ...DEFAULT_FEATURE_SETTINGS.admission.queue,
+      ...overrides.queue,
+    },
     heartbeatMs: 20_000,
   };
 }
@@ -255,9 +260,223 @@ describe('AdmissionControlService', () => {
     });
     expect(compacted.revision).toBe(renewed.revision + 1);
   });
+
+  it('renews a leased queue claim until dispatch ownership takes over', async () => {
+    const repository = await repositoryFor('file');
+    const settings = {
+      ...configuredSettings({ global: { concurrentRuns: 1 } }),
+      heartbeatMs: 10,
+    };
+    const service = createService(repository, settings, { ownerId: 'owner-heartbeat' });
+    const active = await service.admit(request('task-heartbeat-active'));
+    const queued = await service.admitOrQueue(request('task-heartbeat-queued'), {
+      agent: 'codex',
+      attemptId: 'attempt-heartbeat-queued',
+    });
+    await service.release(
+      active.reservation?.id as string,
+      'completed',
+      'release-heartbeat-active'
+    );
+    const claim = await service.claimNextQueued();
+    const initialQueueRevision = claim?.entry.revision as number;
+    const initialReservationRevision = claim?.reservation.revision as number;
+
+    await vi.waitFor(
+      async () => {
+        const queueEntry = await service.getQueueEntry(queued.queueEntry?.id as string);
+        const reservation = await repository.get(claim?.reservation.id as string);
+        expect(queueEntry.state).toBe('leased');
+        expect(queueEntry.revision).toBeGreaterThan(initialQueueRevision);
+        expect(reservation).toMatchObject({ state: 'active' });
+        expect(reservation?.revision).toBeGreaterThan(initialReservationRevision);
+      },
+      { timeout: 500, interval: 10 }
+    );
+
+    const dispatched = await service.markQueueDispatched(
+      claim?.entry.id as string,
+      claim?.entry.attemptId as string
+    );
+    await new Promise((resolve) => setTimeout(resolve, settings.heartbeatMs * 3));
+    await expect(service.getQueueEntry(dispatched.id)).resolves.toEqual(dispatched);
+    service.dispose();
+  });
 });
 
 describe.each(['file', 'sqlite'] as const)('%s admission reservation parity', (backend) => {
+  it('durably queues and atomically claims a saturated direct launch', async () => {
+    const repository = await repositoryFor(backend);
+    const settings = configuredSettings({ global: { concurrentRuns: 1 } });
+    const original = createService(repository, settings, { ownerId: 'owner-original' });
+    const active = await original.admit(request(`task-active-${backend}`));
+
+    const queued = await original.admitOrQueue(request(`task-queued-${backend}`), {
+      agent: 'codex',
+      attemptId: `attempt-queued-${backend}`,
+    });
+    expect(queued).toMatchObject({
+      outcome: 'queued',
+      queueEntry: {
+        state: 'queued',
+        revision: 1,
+        agent: 'codex',
+        attemptId: `attempt-queued-${backend}`,
+      },
+    });
+
+    await original.release(
+      active.reservation?.id as string,
+      'completed',
+      `release-active-${backend}`
+    );
+    original.dispose();
+
+    const restarted = createService(repository, settings, { ownerId: 'owner-restarted' });
+    const claimed = await restarted.claimNextQueued();
+    expect(claimed).toMatchObject({
+      entry: {
+        id: queued.queueEntry?.id,
+        state: 'leased',
+        revision: 2,
+        lease: { ownerId: 'owner-restarted' },
+      },
+      reservation: {
+        state: 'active',
+        request: { taskId: `task-queued-${backend}` },
+        lease: { ownerId: 'owner-restarted' },
+      },
+    });
+    await expect(restarted.claimNextQueued()).resolves.toBeNull();
+  });
+
+  it('fails closed on terminal policy, queue bounds, and sensitive idempotency input', async () => {
+    const repository = await repositoryFor(backend);
+    const terminal = createService(
+      repository,
+      configuredSettings({ global: { concurrentRuns: 0 } })
+    );
+    await expect(
+      terminal.admitOrQueue(request(`task-terminal-${backend}`), {
+        agent: 'codex',
+        attemptId: `attempt-terminal-${backend}`,
+      })
+    ).resolves.toMatchObject({ outcome: 'terminal-policy-denial', queueEntry: undefined });
+    await expect(terminal.listQueue()).resolves.toEqual([]);
+
+    const settings = configuredSettings({
+      global: { concurrentRuns: 1 },
+      queue: { globalLimit: 1, workspaceLimit: 1 },
+    });
+    const service = createService(repository, settings);
+    await service.admit(request(`task-active-bound-${backend}`));
+    const rawIdempotencyKey = `operator-secret-${backend}`;
+    const queued = await service.admitOrQueue(
+      request(`task-bounded-${backend}`, rawIdempotencyKey),
+      {
+        agent: 'codex',
+        attemptId: `attempt-bounded-${backend}`,
+      }
+    );
+    expect(queued.outcome).toBe('queued');
+    expect(JSON.stringify(queued.queueEntry)).not.toContain(rawIdempotencyKey);
+
+    const duplicate = await service.admitOrQueue(
+      request(`task-bounded-${backend}`, `different-${rawIdempotencyKey}`),
+      {
+        agent: 'codex',
+        attemptId: `attempt-bounded-duplicate-${backend}`,
+      }
+    );
+    expect(duplicate.queueEntry?.id).toBe(queued.queueEntry?.id);
+    await expect(
+      service.admitOrQueue(
+        request(`task-bounded-${backend}`, `different-agent-${rawIdempotencyKey}`),
+        {
+          agent: 'copilot',
+          attemptId: `attempt-bounded-agent-change-${backend}`,
+        }
+      )
+    ).resolves.toMatchObject({
+      outcome: 'terminal-policy-denial',
+      queueEntry: undefined,
+    });
+    await expect(
+      service.admitOrQueue(request(`task-overflow-${backend}`), {
+        agent: 'codex',
+        attemptId: `attempt-overflow-${backend}`,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'queue-overflow',
+      retryAfterMs: settings.retryAfterMs,
+      queueEntry: undefined,
+    });
+    await expect(service.listQueue()).resolves.toHaveLength(1);
+  });
+
+  it('preserves FIFO under competing claims and recovers an abandoned lease once', async () => {
+    const repository = await repositoryFor(backend);
+    let now = new Date('2026-07-25T12:00:00.000Z');
+    const settings = configuredSettings({
+      global: { concurrentRuns: 1 },
+      queue: { retryBackoffMs: 250 },
+    });
+    const original = createService(repository, settings, {
+      now: () => now,
+      ownerId: 'owner-original',
+    });
+    const active = await original.admit(request(`task-fifo-active-${backend}`));
+    const first = await original.admitOrQueue(request(`task-fifo-first-${backend}`), {
+      agent: 'codex',
+      attemptId: `attempt-fifo-first-${backend}`,
+    });
+    const second = await original.admitOrQueue(request(`task-fifo-second-${backend}`), {
+      agent: 'codex',
+      attemptId: `attempt-fifo-second-${backend}`,
+    });
+    await original.release(
+      active.reservation?.id as string,
+      'completed',
+      `release-fifo-active-${backend}`
+    );
+
+    const left = createService(repository, settings, { now: () => now, ownerId: 'owner-left' });
+    const right = createService(repository, settings, { now: () => now, ownerId: 'owner-right' });
+    const competing = await Promise.all([left.claimNextQueued(), right.claimNextQueued()]);
+    const winners = competing.filter((claim) => claim !== null);
+    expect(winners).toHaveLength(1);
+    expect(winners[0]?.entry.id).toBe(first.queueEntry?.id);
+    await left.markQueueDispatched(
+      winners[0]?.entry.id as string,
+      winners[0]?.entry.attemptId as string
+    );
+    await left.release(
+      winners[0]?.reservation.id as string,
+      'completed',
+      `release-fifo-first-${backend}`
+    );
+
+    const leasedSecond = await right.claimNextQueued();
+    expect(leasedSecond?.entry.id).toBe(second.queueEntry?.id);
+    now = new Date('2026-07-25T12:00:31.000Z');
+    await expect(right.claimNextQueued()).resolves.toBeNull();
+    now = new Date('2026-07-25T12:00:31.300Z');
+    const recovered = createService(repository, settings, {
+      now: () => now,
+      ownerId: 'owner-recovered',
+    });
+    await expect(recovered.claimNextQueued()).resolves.toMatchObject({
+      entry: {
+        id: second.queueEntry?.id,
+        state: 'leased',
+        retryCount: 1,
+        lease: { ownerId: 'owner-recovered' },
+      },
+      reservation: { lease: { ownerId: 'owner-recovered' } },
+    });
+    await expect(recovered.claimNextQueued()).resolves.toBeNull();
+  });
+
   it('atomically reserves, converts, summarizes, and releases execution-tree budgets', async () => {
     const repository = await repositoryFor(backend);
     const service = createService(repository, configuredSettings());

--- a/server/src/__tests__/codex-provider-service.test.ts
+++ b/server/src/__tests__/codex-provider-service.test.ts
@@ -183,6 +183,7 @@ import type {
   Task,
   TaskAttempt,
   ExecutionTreeIdentity,
+  AdmissionQueueClaim,
 } from '@veritas-kanban/shared';
 import { providerRuntimeManifestFixture } from './fixtures/provider-runtime-manifest.js';
 import {
@@ -285,12 +286,15 @@ function testableService(
 
 function testAdmissionControl(): AdmissionControlService {
   let sequence = 0;
+  const admit = vi.fn(async (input: { taskId: string }) => ({
+    outcome: 'admitted',
+    reservation: { id: `admission-test-${input.taskId}-${++sequence}` },
+  }));
   return {
-    admit: vi.fn(async (input: { taskId: string }) => ({
-      outcome: 'admitted',
-      reservation: { id: `admission-test-${input.taskId}-${++sequence}` },
-    })),
+    admit,
+    admitOrQueue: admit,
     bindAttempt: vi.fn(async (id: string) => ({ id })),
+    bindQueuedAttempt: vi.fn(async (_queueId: string, id: string) => ({ id })),
     get: vi.fn(async (id: string) => ({ id, request: { budgetPolicies: [] } })),
     recordBudgetUsage: vi.fn(async (id: string) => ({ id })),
     release: vi.fn(async (id: string) => ({ id })),
@@ -298,6 +302,7 @@ function testAdmissionControl(): AdmissionControlService {
     releaseByAttempt: vi.fn(async () => null),
     expireAbandoned: vi.fn(async () => []),
     recoverVerifiedRun: vi.fn(async () => null),
+    claimNextQueued: vi.fn(async () => null),
   } as unknown as AdmissionControlService;
 }
 
@@ -766,6 +771,142 @@ describe('ClawdbotAgentService Codex providers', () => {
     });
   });
 
+  it('queues a reconstructable direct launch and dispatches its claim exactly once', async () => {
+    const fixture = await fs.readFile(path.join(fixtureDir, 'success.jsonl'), 'utf-8');
+    mockSpawn.mockReturnValue(createFakeChild(fixture));
+    const admission = testAdmissionControl();
+    let claim: AdmissionQueueClaim | undefined;
+    let currentEntry: AdmissionQueueClaim['entry'] | undefined;
+    vi.mocked(admission.admitOrQueue).mockImplementation(async (input, queue) => {
+      const now = '2026-07-25T12:00:00.000Z';
+      const request = {
+        schemaVersion: 'admission-request/v1',
+        idempotencyKey: `sha256:${'a'.repeat(64)}`,
+        source: 'direct',
+        taskId: input.taskId,
+        rootTaskId: input.rootTaskId ?? input.taskId,
+        workspaceId: input.workspaceId,
+        provider: input.provider,
+        hostId: input.hostId,
+        executionTree: input.executionTree,
+        budgetPolicies: input.budgetPolicies,
+        budgetRequest: input.budgetRequest,
+        requested: { runSlots: 1, processSlots: 1, estimatedMemoryMb: 512 },
+        requestedAt: now,
+      } as AdmissionQueueClaim['entry']['request'];
+      const queuedEntry = {
+        schemaVersion: 'admission-queue-entry/v1',
+        id: 'admission_queue_direct_fixture',
+        revision: 1,
+        state: 'queued',
+        enqueueSequence: 1,
+        agent: queue.agent,
+        attemptId: queue.attemptId,
+        request,
+        policies: [],
+        limitingPolicies: [
+          {
+            id: 'global:global',
+            scope: 'global',
+            scopeId: 'global',
+            limits: { concurrentRuns: 1 },
+          },
+        ],
+        retryAfterMs: 250,
+        retryCount: 0,
+        maxRetries: 3,
+        availableAt: now,
+        createdAt: now,
+        updatedAt: now,
+      } as AdmissionQueueClaim['entry'];
+      const lease = {
+        ownerId: 'queue-worker',
+        hostId: 'execution-host-a',
+        processId: 101,
+        acquiredAt: now,
+        heartbeatAt: now,
+        expiresAt: '2026-07-25T12:00:30.000Z',
+      };
+      currentEntry = {
+        ...queuedEntry,
+        revision: 2,
+        state: 'leased',
+        lease,
+        reservationId: 'admission_direct_fixture',
+      };
+      claim = {
+        entry: currentEntry,
+        reservation: {
+          schemaVersion: 'admission-reservation/v1',
+          id: 'admission_direct_fixture',
+          revision: 1,
+          state: 'active',
+          request,
+          policies: [],
+          lease,
+          createdAt: now,
+          updatedAt: now,
+        },
+      };
+      return {
+        schemaVersion: 'admission-decision/v1',
+        outcome: 'queued',
+        request,
+        queueEntry: queuedEntry,
+        limitingPolicies: queuedEntry.limitingPolicies,
+        retryAfterMs: queuedEntry.retryAfterMs,
+        reason: 'Queued for test.',
+        decidedAt: now,
+      };
+    });
+    admission.getQueueEntry = vi.fn(async () => currentEntry as AdmissionQueueClaim['entry']);
+    admission.markQueueDispatched = vi.fn(async (_id, attemptId) => {
+      currentEntry = {
+        ...(currentEntry as AdmissionQueueClaim['entry']),
+        revision: (currentEntry?.revision ?? 0) + 1,
+        state: 'dispatched',
+        dispatchedAttemptId: attemptId,
+      };
+      return currentEntry;
+    });
+    admission.requeueQueueEntry = vi.fn();
+    admission.terminateQueueEntry = vi.fn();
+    const service = testableService(
+      tmpDir,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      testWorkspaceExecutionTrust(),
+      admission
+    );
+
+    const queued = await service.startAgent(task.id, 'codex');
+    expect(queued).toMatchObject({
+      taskId: task.id,
+      status: 'queued',
+      queueId: 'admission_queue_direct_fixture',
+      retryAfterMs: 250,
+      limitingScopes: [{ scope: 'global', scopeId: 'global' }],
+    });
+    expect(admission.bindAttempt).not.toHaveBeenCalled();
+    expect(task.attempt).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    vi.mocked(admission.claimNextQueued).mockReset();
+    vi.mocked(admission.claimNextQueued)
+      .mockResolvedValueOnce(claim as AdmissionQueueClaim)
+      .mockResolvedValue(null);
+    await service.reconcileQueuedLaunches();
+    await service.reconcileQueuedLaunches();
+
+    expect(admission.markQueueDispatched).toHaveBeenCalledTimes(1);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(task.attempt?.id).toBe(claim?.entry.attemptId);
+    await waitFor(() => expect(task.attempt?.status).toBe('complete'));
+  });
+
   it(
     'runs the Codex CLI adapter against mocked JSONL and records telemetry',
     { timeout: 20_000 },
@@ -784,10 +925,14 @@ describe('ClawdbotAgentService Codex providers', () => {
         edge: 'root',
         depth: 0,
       });
-      expect(admission.admit).toHaveBeenCalledWith(
+      expect(admission.admitOrQueue).toHaveBeenCalledWith(
         expect.objectContaining({
           executionTree: status.executionTree,
           budgetRequest: expect.objectContaining({ fanOut: 1, retries: 0 }),
+        }),
+        expect.objectContaining({
+          agent: 'codex',
+          attemptId: status.attemptId,
         })
       );
       expect(status.runLaunchManifest).toMatchObject({
@@ -3534,7 +3679,7 @@ describe('ClawdbotAgentService Codex providers', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('blocks provider dispatch before attempt persistence when admission is overloaded', async () => {
+  it('blocks a non-reconstructable launch before attempt persistence when admission is overloaded', async () => {
     const admit = vi.fn().mockResolvedValue({
       schemaVersion: 'admission-decision/v1',
       outcome: 'retryable-overload',
@@ -3574,7 +3719,9 @@ describe('ClawdbotAgentService Codex providers', () => {
       admission
     );
 
-    await expect(service.startAgent(task.id, 'codex')).rejects.toMatchObject({
+    await expect(
+      service.startAgent(task.id, 'codex', { commitPolicy: 'forbidden' })
+    ).rejects.toMatchObject({
       statusCode: 409,
       details: expect.objectContaining({ code: 'ADMISSION_OVERLOAD' }),
     });

--- a/server/src/__tests__/schemas.test.ts
+++ b/server/src/__tests__/schemas.test.ts
@@ -415,11 +415,19 @@ describe('Feature Settings Schema', () => {
           'codex-cli': { processSlots: 4 },
           'workflow-control': { concurrentRuns: 3 },
         },
+        queue: {
+          globalLimit: 1_000,
+          workspaceLimit: 100,
+          leaseMs: 30_000,
+          retryBackoffMs: 5_000,
+          maxRetries: 3,
+        },
       },
     });
     expect(result.admission?.global?.concurrentRuns).toBe(8);
     expect(result.admission?.providers?.['codex-cli']?.processSlots).toBe(4);
     expect(result.admission?.providers?.['workflow-control']?.concurrentRuns).toBe(3);
+    expect(result.admission?.queue?.workspaceLimit).toBe(100);
     expect(() =>
       FeatureSettingsPatchSchema.parse({
         admission: { leaseMs: 10_000, heartbeatMs: 10_000 },
@@ -428,6 +436,19 @@ describe('Feature Settings Schema', () => {
     expect(() =>
       FeatureSettingsPatchSchema.parse({
         admission: { defaultRequest: { runSlots: 0 } },
+      })
+    ).toThrow();
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        admission: { queue: { globalLimit: -1 } },
+      })
+    ).toThrow();
+    expect(() =>
+      FeatureSettingsPatchSchema.parse({
+        admission: {
+          heartbeatMs: 10_000,
+          queue: { leaseMs: 10_000 },
+        },
       })
     ).toThrow();
   });

--- a/server/src/schemas/admission-control-schemas.ts
+++ b/server/src/schemas/admission-control-schemas.ts
@@ -3,6 +3,8 @@ import {
   ADMISSION_DECISION_OUTCOMES,
   ADMISSION_DECISION_SCHEMA_VERSION,
   ADMISSION_CONTROL_PROVIDER,
+  ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION,
+  ADMISSION_QUEUE_STATES,
   ADMISSION_REQUEST_SCHEMA_VERSION,
   ADMISSION_RESERVATION_SCHEMA_VERSION,
   ADMISSION_RESERVATION_STATES,
@@ -211,12 +213,76 @@ export const AdmissionReservationSchema = z
     }
   });
 
+export const AdmissionQueueEntrySchema = z
+  .object({
+    schemaVersion: z.literal(ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION),
+    id: identifier,
+    revision: z.number().int().positive(),
+    state: z.enum(ADMISSION_QUEUE_STATES),
+    enqueueSequence: z.number().int().positive(),
+    agent: identifier,
+    attemptId: identifier,
+    request: AdmissionRequestSchema,
+    policies: z.array(AdmissionLimitPolicySchema).max(6),
+    limitingPolicies: z.array(AdmissionLimitPolicySchema).max(6),
+    limitingBudgetPolicies: z.array(ExecutionTreeBudgetPolicySchema).max(16).optional(),
+    retryAfterMs: z.number().int().min(250).max(60_000),
+    retryCount: z.number().int().min(0).max(100),
+    maxRetries: z.number().int().min(0).max(100),
+    availableAt: z.string().datetime(),
+    lease: AdmissionReservationLeaseSchema.optional(),
+    reservationId: identifier.optional(),
+    dispatchedAttemptId: identifier.optional(),
+    terminal: z
+      .object({
+        code: z.string().trim().min(1).max(160),
+        reason: z.string().trim().min(1).max(1_000),
+        recordedAt: z.string().datetime(),
+      })
+      .strict()
+      .optional(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict()
+  .superRefine((entry, ctx) => {
+    if (entry.state === 'leased' && (!entry.lease || !entry.reservationId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Leased queue entries require lease and reservation evidence.',
+        path: ['lease'],
+      });
+    }
+    if (entry.state === 'dispatched' && (!entry.reservationId || !entry.dispatchedAttemptId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Dispatched queue entries require reservation and attempt evidence.',
+        path: ['dispatchedAttemptId'],
+      });
+    }
+    if (entry.state === 'terminal' && !entry.terminal) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Terminal queue entries require terminal evidence.',
+        path: ['terminal'],
+      });
+    }
+    if (entry.state !== 'terminal' && entry.terminal) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Only terminal queue entries may contain terminal evidence.',
+        path: ['terminal'],
+      });
+    }
+  });
+
 export const AdmissionDecisionSchema = z
   .object({
     schemaVersion: z.literal(ADMISSION_DECISION_SCHEMA_VERSION),
     outcome: z.enum(ADMISSION_DECISION_OUTCOMES),
     request: AdmissionRequestSchema,
     reservation: AdmissionReservationSchema.optional(),
+    queueEntry: AdmissionQueueEntrySchema.optional(),
     limitingPolicies: z.array(AdmissionLimitPolicySchema).max(6),
     limitingBudgetPolicies: z.array(ExecutionTreeBudgetPolicySchema).max(16).optional(),
     retryAfterMs: z.number().int().min(250).max(60_000).optional(),

--- a/server/src/schemas/feature-settings-schema.ts
+++ b/server/src/schemas/feature-settings-schema.ts
@@ -249,6 +249,17 @@ const AdmissionSettingsSchema = z
       )
       .optional(),
     hosts: z.record(z.string().min(1).max(240), AdmissionCapacityLimitSchema).optional(),
+    queue: z
+      .object({
+        enabled: z.boolean().optional(),
+        globalLimit: z.number().int().min(0).max(100_000).optional(),
+        workspaceLimit: z.number().int().min(0).max(100_000).optional(),
+        leaseMs: z.number().int().min(5_000).max(300_000).optional(),
+        retryBackoffMs: z.number().int().min(250).max(60_000).optional(),
+        maxRetries: z.number().int().min(0).max(100).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -260,6 +271,17 @@ const AdmissionSettingsSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'admission.heartbeatMs must be less than admission.leaseMs',
+        path: ['heartbeatMs'],
+      });
+    }
+    if (
+      value.heartbeatMs !== undefined &&
+      value.queue?.leaseMs !== undefined &&
+      value.heartbeatMs >= value.queue.leaseMs
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'admission.heartbeatMs must be less than admission.queue.leaseMs',
         path: ['heartbeatMs'],
       });
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -533,7 +533,9 @@ app.use(errorHandler);
 let configService: ConfigService | null = null;
 let storageInitialized = false;
 let credentialReconciliationInterval: ReturnType<typeof setInterval> | undefined;
+let admissionQueueInterval: ReturnType<typeof setInterval> | undefined;
 const CREDENTIAL_RECONCILIATION_INTERVAL_MS = 60_000;
+const ADMISSION_QUEUE_INTERVAL_MS = 5_000;
 
 async function reconcileCredentialLeases(context: 'startup' | 'periodic'): Promise<void> {
   try {
@@ -596,6 +598,7 @@ async function initializeServices(): Promise<void> {
     await agentService.reconcileRunningAttempts();
     await agentService.reconcilePendingRecoveries();
     await getWorkflowRunService().reconcilePendingRecoveries();
+    await agentService.reconcileQueuedLaunches();
   } catch (reconcileErr) {
     // Non-fatal: log and continue — the server can still serve requests.
     log.warn({ err: reconcileErr }, 'Startup: agent run reconciliation failed');
@@ -606,6 +609,14 @@ async function initializeServices(): Promise<void> {
     CREDENTIAL_RECONCILIATION_INTERVAL_MS
   );
   credentialReconciliationInterval.unref();
+  admissionQueueInterval ??= setInterval(
+    () =>
+      void agentService
+        .reconcileQueuedLaunches()
+        .catch((error) => log.warn({ err: error }, 'Admission queue reconciliation failed')),
+    ADMISSION_QUEUE_INTERVAL_MS
+  );
+  admissionQueueInterval.unref();
 }
 
 // Create HTTP server
@@ -1184,6 +1195,10 @@ async function gracefulShutdown(signal: string) {
   if (credentialReconciliationInterval) {
     clearInterval(credentialReconciliationInterval);
     credentialReconciliationInterval = undefined;
+  }
+  if (admissionQueueInterval) {
+    clearInterval(admissionQueueInterval);
+    admissionQueueInterval = undefined;
   }
   log.info({ clients: wss.clients.size }, 'Closing WebSocket connections');
   wss.clients.forEach((client) => {

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -6,7 +6,11 @@ import type {
   AdmissionLaunchSource,
   AdmissionLimitPolicy,
   AdmissionProvider,
+  AdmissionQueueClaim,
+  AdmissionQueueEntry,
+  AdmissionQueueListQuery,
   AdmissionReservation,
+  AdmissionReservationClaimOrQueueResult,
   AdmissionReservationListQuery,
   AdmissionReservationRelease,
   AdmissionSettings,
@@ -15,6 +19,7 @@ import type {
   ExecutionTreeBudgetSummary,
   ExecutionTreeBudgetUsageEvent,
   ExecutionTreeIdentity,
+  AgentType,
 } from '@veritas-kanban/shared';
 import {
   ADMISSION_DECISION_SCHEMA_VERSION,
@@ -59,6 +64,11 @@ export interface AdmissionRequestInput {
   requested?: Partial<AdmissionCapacityRequest>;
 }
 
+export interface DirectAdmissionQueueInput {
+  agent: AgentType;
+  attemptId: string;
+}
+
 export interface RecoverAdmissionInput {
   workspaceId: string;
   taskId: string;
@@ -91,6 +101,10 @@ function reservationId(idempotencyKey: string): string {
   return `admission_${createHash('sha256').update(idempotencyKey).digest('hex').slice(0, 32)}`;
 }
 
+function queueEntryId(idempotencyKey: string): string {
+  return `admission_queue_${createHash('sha256').update(idempotencyKey).digest('hex').slice(0, 32)}`;
+}
+
 function idempotencyIdentity(idempotencyKey: string): string {
   return `sha256:${createHash('sha256').update(idempotencyKey).digest('hex')}`;
 }
@@ -105,6 +119,8 @@ export class AdmissionControlService {
   private readonly processId: number;
   private readonly heartbeatTimers = new Map<string, NodeJS.Timeout>();
   private readonly heartbeatEligible = new Set<string>();
+  private readonly queueHeartbeatTimers = new Map<string, NodeJS.Timeout>();
+  private readonly capacityListeners = new Set<() => void>();
 
   constructor(options: AdmissionControlServiceOptions = {}) {
     this.repositoryOverride = options.repository;
@@ -131,10 +147,30 @@ export class AdmissionControlService {
         leaseMs: settings.leaseMs,
       });
     }
+    if (settings.heartbeatMs >= settings.queue.leaseMs) {
+      throw new ConflictError('Admission heartbeat must be shorter than the queue lease.', {
+        heartbeatMs: settings.heartbeatMs,
+        queueLeaseMs: settings.queue.leaseMs,
+      });
+    }
     return settings;
   }
 
   async admit(input: AdmissionRequestInput): Promise<AdmissionDecision> {
+    return this.admitInternal(input);
+  }
+
+  async admitOrQueue(
+    input: AdmissionRequestInput,
+    queue: DirectAdmissionQueueInput
+  ): Promise<AdmissionDecision> {
+    return this.admitInternal(input, queue);
+  }
+
+  private async admitInternal(
+    input: AdmissionRequestInput,
+    queue?: DirectAdmissionQueueInput
+  ): Promise<AdmissionDecision> {
     const settings = await this.settings();
     const now = this.now();
     const idempotencyKey = idempotencyIdentity(
@@ -201,7 +237,59 @@ export class AdmissionControlService {
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
     });
-    const claimed = await this.repository.claim({ record, now: now.toISOString() });
+    const queueable = Boolean(queue && settings.queue.enabled && request.source === 'direct');
+    const claimed: AdmissionReservationClaimOrQueueResult = queueable
+      ? await this.repository.claimOrEnqueue({
+          record,
+          queue: {
+            id: queueEntryId(idempotencyKey),
+            agent: queue?.agent as AgentType,
+            attemptId: queue?.attemptId as string,
+            request,
+            policies,
+            limitingPolicies: [],
+            retryAfterMs: settings.queue.retryBackoffMs,
+            maxRetries: settings.queue.maxRetries,
+            availableAt: now.toISOString(),
+            createdAt: now.toISOString(),
+          },
+          now: now.toISOString(),
+          globalQueueLimit: settings.queue.globalLimit,
+          workspaceQueueLimit: settings.queue.workspaceLimit,
+        })
+      : await this.repository.claim({ record, now: now.toISOString() });
+    if (claimed.queueConflict) {
+      return this.decision(
+        'terminal-policy-denial',
+        request,
+        claimed.limitingPolicies,
+        'The task already has a queued launch with a different agent selection.',
+        now
+      );
+    }
+    if (claimed.queueOverflow) {
+      return this.decision(
+        'queue-overflow',
+        request,
+        claimed.limitingPolicies,
+        `The ${claimed.queueOverflow} admission queue reached its configured bound.`,
+        now,
+        settings.retryAfterMs
+      );
+    }
+    if (claimed.queueEntry) {
+      return this.decision(
+        'queued',
+        request,
+        claimed.queueEntry.limitingPolicies,
+        'The launch is durably queued until admission capacity becomes available.',
+        now,
+        claimed.queueEntry.retryAfterMs,
+        undefined,
+        claimed.queueEntry.limitingBudgetPolicies,
+        claimed.queueEntry
+      );
+    }
     if (claimed.limitingBudgetPolicies?.length) {
       return this.decision(
         claimed.budgetRetryable ? 'retryable-overload' : 'terminal-policy-denial',
@@ -258,6 +346,174 @@ export class AdmissionControlService {
     );
   }
 
+  async claimNextQueued(): Promise<AdmissionQueueClaim | null> {
+    const settings = await this.settings();
+    for (let attempt = 1; attempt <= MAX_CAS_ATTEMPTS; attempt++) {
+      const now = this.now();
+      await this.repository.expireLeases(now.toISOString());
+      await this.repository.expireQueueLeases(now.toISOString());
+      const [entry] = await this.repository.listQueue({
+        states: ['queued', 'requeued'],
+        eligibleAt: now.toISOString(),
+        limit: 1,
+      });
+      if (!entry) return null;
+      const policies = this.policiesFor(entry.request, settings);
+      const impossible = requestExceedsPolicies(entry.request.requested, policies);
+      if (impossible.length > 0) {
+        await this.terminateQueueEntry(
+          entry.id,
+          'ADMISSION_POLICY_DRIFT',
+          'The queued launch exceeds the current admission policy.'
+        );
+        continue;
+      }
+      const record = AdmissionReservationSchema.parse({
+        schemaVersion: ADMISSION_RESERVATION_SCHEMA_VERSION,
+        id: reservationId(entry.request.idempotencyKey),
+        revision: 1,
+        state: 'active',
+        request: entry.request,
+        policies,
+        ...(entry.request.executionTree
+          ? {
+              executionBudget: initializeExecutionTreeBudget(
+                entry.request.budgetRequest ?? { ...ZERO_AGENT_BUDGET_USAGE }
+              ),
+            }
+          : {}),
+        lease: this.newLease(now, Math.min(settings.leaseMs, settings.queue.leaseMs)),
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      });
+      const claimed = await this.repository.claimQueued({
+        queueId: entry.id,
+        expectedRevision: entry.revision,
+        record,
+        now: now.toISOString(),
+      });
+      if (claimed.stale) continue;
+      if (claimed.limitingBudgetPolicies?.length && claimed.budgetRetryable === false) {
+        await this.terminateQueueEntry(
+          entry.id,
+          'ADMISSION_BUDGET_EXHAUSTED',
+          'Committed execution-tree usage exhausts the current budget.'
+        );
+        continue;
+      }
+      if (
+        claimed.limitingPolicies.length > 0 ||
+        claimed.limitingBudgetPolicies?.length ||
+        !claimed.entry ||
+        !claimed.reservation
+      ) {
+        return null;
+      }
+      const queueClaim = { entry: claimed.entry, reservation: claimed.reservation };
+      this.startQueueHeartbeat(queueClaim, settings.heartbeatMs);
+      return queueClaim;
+    }
+    return null;
+  }
+
+  async getQueueEntry(id: string): Promise<AdmissionQueueEntry> {
+    const entry = await this.repository.getQueueEntry(id);
+    if (!entry) throw new NotFoundError('Admission queue entry not found.');
+    return entry;
+  }
+
+  async listQueue(query: AdmissionQueueListQuery = {}): Promise<AdmissionQueueEntry[]> {
+    await this.repository.expireQueueLeases(this.now().toISOString());
+    return this.repository.listQueue(query);
+  }
+
+  async markQueueDispatched(id: string, attemptId: string): Promise<AdmissionQueueEntry> {
+    this.stopQueueHeartbeat(id);
+    return this.mutateQueue(id, (current, now) => {
+      if (current.state === 'dispatched' && current.dispatchedAttemptId === attemptId) {
+        return current;
+      }
+      if (current.state !== 'leased' || current.attemptId !== attemptId) {
+        throw new ConflictError('Queue dispatch no longer matches its leased launch.', {
+          queueId: id,
+          queueState: current.state,
+          queuedAttemptId: current.attemptId,
+          attemptId,
+        });
+      }
+      return {
+        ...current,
+        state: 'dispatched',
+        dispatchedAttemptId: attemptId,
+        updatedAt: now.toISOString(),
+      };
+    });
+  }
+
+  async requeueQueueEntry(id: string, code: string, reason: string): Promise<AdmissionQueueEntry> {
+    this.stopQueueHeartbeat(id);
+    const settings = await this.settings();
+    return this.mutateQueue(id, (current, now) => {
+      if (current.state !== 'leased') return current;
+      const retryCount = current.retryCount + 1;
+      if (retryCount > current.maxRetries) {
+        return {
+          ...current,
+          state: 'terminal',
+          retryCount,
+          lease: undefined,
+          reservationId: undefined,
+          terminal: {
+            code: code.trim().slice(0, 160) || 'QUEUE_RETRY_EXHAUSTED',
+            reason:
+              `Queue retry limit exhausted. ${reason}`.trim().slice(0, 1_000) ||
+              'Queue retry limit exhausted.',
+            recordedAt: now.toISOString(),
+          },
+          updatedAt: now.toISOString(),
+        };
+      }
+      return {
+        ...current,
+        state: 'requeued',
+        retryCount,
+        availableAt: new Date(now.getTime() + settings.queue.retryBackoffMs).toISOString(),
+        lease: undefined,
+        reservationId: undefined,
+        updatedAt: now.toISOString(),
+      };
+    });
+  }
+
+  async terminateQueueEntry(
+    id: string,
+    code: string,
+    reason: string
+  ): Promise<AdmissionQueueEntry> {
+    this.stopQueueHeartbeat(id);
+    return this.mutateQueue(id, (current, now) => {
+      if (current.state === 'terminal') return current;
+      if (current.state === 'dispatched') {
+        throw new ConflictError('Dispatched queue entries are owned by run recovery.', {
+          queueId: id,
+          dispatchedAttemptId: current.dispatchedAttemptId,
+        });
+      }
+      return {
+        ...current,
+        state: 'terminal',
+        lease: undefined,
+        reservationId: undefined,
+        terminal: {
+          code: code.trim().slice(0, 160) || 'QUEUE_TERMINAL',
+          reason: reason.trim().slice(0, 1_000) || 'Queued launch terminated.',
+          recordedAt: now.toISOString(),
+        },
+        updatedAt: now.toISOString(),
+      };
+    });
+  }
+
   async bindAttempt(id: string, attemptId: string): Promise<AdmissionReservation> {
     const settings = await this.settings();
     const bound = await this.mutate(id, (current, now) => {
@@ -285,6 +541,15 @@ export class AdmissionControlService {
     return bound;
   }
 
+  async bindQueuedAttempt(
+    queueId: string,
+    reservationId: string,
+    attemptId: string
+  ): Promise<AdmissionReservation> {
+    this.stopQueueHeartbeat(queueId);
+    return this.bindAttempt(reservationId, attemptId);
+  }
+
   async renew(id: string): Promise<AdmissionReservation> {
     return this.mutate(id, (current, now) => {
       if (current.state !== 'active') return current;
@@ -302,7 +567,7 @@ export class AdmissionControlService {
     idempotencyKey: string
   ): Promise<AdmissionReservation> {
     this.stopHeartbeat(id);
-    return this.mutate(id, (current, now) => {
+    const released = await this.mutate(id, (current, now) => {
       if (current.state === 'released') return current;
       return {
         ...current,
@@ -316,6 +581,8 @@ export class AdmissionControlService {
         updatedAt: now.toISOString(),
       };
     });
+    this.notifyCapacityAvailable();
+    return released;
   }
 
   async releaseIfUnbound(
@@ -398,7 +665,16 @@ export class AdmissionControlService {
   }
 
   async expireAbandoned(): Promise<AdmissionReservation[]> {
-    return this.repository.expireLeases(this.now().toISOString());
+    const now = this.now().toISOString();
+    const expired = await this.repository.expireLeases(now);
+    await this.repository.expireQueueLeases(now);
+    if (expired.length > 0) this.notifyCapacityAvailable();
+    return expired;
+  }
+
+  onCapacityAvailable(listener: () => void): () => void {
+    this.capacityListeners.add(listener);
+    return () => this.capacityListeners.delete(listener);
   }
 
   getExecutionHostId(): string {
@@ -494,8 +770,22 @@ export class AdmissionControlService {
 
   dispose(): void {
     for (const id of this.heartbeatTimers.keys()) this.stopHeartbeat(id);
+    for (const id of this.queueHeartbeatTimers.keys()) this.stopQueueHeartbeat(id);
     this.heartbeatEligible.clear();
+    this.capacityListeners.clear();
     this.configService.dispose();
+  }
+
+  private notifyCapacityAvailable(): void {
+    for (const listener of this.capacityListeners) {
+      queueMicrotask(() => {
+        try {
+          listener();
+        } catch {
+          // Capacity notifications are best-effort wakeups; durable queue state remains authoritative.
+        }
+      });
+    }
   }
 
   private policiesFor(
@@ -539,13 +829,15 @@ export class AdmissionControlService {
     now: Date,
     retryAfterMs?: number,
     reservation?: AdmissionReservation,
-    limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[]
+    limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[],
+    queueEntry?: AdmissionQueueEntry
   ): AdmissionDecision {
     return AdmissionDecisionSchema.parse({
       schemaVersion: ADMISSION_DECISION_SCHEMA_VERSION,
       outcome,
       request,
       reservation,
+      queueEntry,
       limitingPolicies,
       limitingBudgetPolicies,
       retryAfterMs,
@@ -608,6 +900,93 @@ export class AdmissionControlService {
     throw new ConflictError('Admission reservation changed too many times.', {
       reservationId: id,
     });
+  }
+
+  private async mutateQueue(
+    id: string,
+    update: (current: AdmissionQueueEntry, now: Date) => AdmissionQueueEntry
+  ): Promise<AdmissionQueueEntry> {
+    for (let attempt = 1; attempt <= MAX_CAS_ATTEMPTS; attempt++) {
+      const current = await this.repository.getQueueEntry(id);
+      if (!current) throw new NotFoundError('Admission queue entry not found.');
+      const candidate = update(current, this.now());
+      if (candidate === current) return current;
+      const next = {
+        ...candidate,
+        revision: current.revision + 1,
+      };
+      const result = await this.repository.compareAndSetQueue({
+        id,
+        expectedRevision: current.revision,
+        next,
+      });
+      if (result.updated && result.record) return result.record;
+      if (result.reason !== 'stale-revision') {
+        throw new ConflictError('Admission queue update failed.', {
+          queueId: id,
+          reason: result.reason,
+        });
+      }
+    }
+    throw new ConflictError('Admission queue entry changed too many times.', { queueId: id });
+  }
+
+  private startQueueHeartbeat(claim: AdmissionQueueClaim, configuredHeartbeatMs: number): void {
+    const queueId = claim.entry.id;
+    if (this.queueHeartbeatTimers.has(queueId)) return;
+    const leaseDurationMs =
+      Date.parse(claim.entry.lease?.expiresAt ?? '') -
+      Date.parse(claim.entry.lease?.heartbeatAt ?? '');
+    const heartbeatMs = Math.min(
+      configuredHeartbeatMs,
+      Math.max(250, Math.floor(leaseDurationMs / 3))
+    );
+    const timer = setInterval(() => {
+      void this.renewQueueClaim(queueId, claim.reservation.id).catch(() => {
+        this.stopQueueHeartbeat(queueId);
+      });
+    }, heartbeatMs);
+    timer.unref();
+    this.queueHeartbeatTimers.set(queueId, timer);
+  }
+
+  private async renewQueueClaim(
+    queueId: string,
+    reservationId: string
+  ): Promise<AdmissionQueueEntry> {
+    const entry = await this.mutateQueue(queueId, (current, now) => {
+      if (
+        current.state !== 'leased' ||
+        current.reservationId !== reservationId ||
+        current.lease?.ownerId !== this.ownerId
+      ) {
+        throw new ConflictError('Admission queue lease ownership changed.', {
+          queueId,
+          reservationId,
+          queueState: current.state,
+          queueReservationId: current.reservationId,
+        });
+      }
+      const leaseDurationMs =
+        Date.parse(current.lease.expiresAt) - Date.parse(current.lease.heartbeatAt);
+      return {
+        ...current,
+        lease: {
+          ...current.lease,
+          heartbeatAt: now.toISOString(),
+          expiresAt: new Date(now.getTime() + Math.max(1, leaseDurationMs)).toISOString(),
+        },
+        updatedAt: now.toISOString(),
+      };
+    });
+    await this.renew(reservationId);
+    return entry;
+  }
+
+  private stopQueueHeartbeat(queueId: string): void {
+    const timer = this.queueHeartbeatTimers.get(queueId);
+    if (timer) clearInterval(timer);
+    this.queueHeartbeatTimers.delete(queueId);
   }
 
   private startHeartbeat(record: AdmissionReservation, configuredHeartbeatMs: number): void {

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -542,11 +542,10 @@ export class AdmissionControlService {
   }
 
   async bindQueuedAttempt(
-    queueId: string,
+    _queueId: string,
     reservationId: string,
     attemptId: string
   ): Promise<AdmissionReservation> {
-    this.stopQueueHeartbeat(queueId);
     return this.bindAttempt(reservationId, attemptId);
   }
 

--- a/server/src/services/clawdbot-agent-service.ts
+++ b/server/src/services/clawdbot-agent-service.ts
@@ -129,6 +129,7 @@ import type {
   WorkspaceExecutionTrustEvaluation,
   WorkspaceExecutionTrustScanResult,
   AdmissionReservationRelease,
+  AdmissionQueueClaim,
   ExecutionTreeBudgetPolicy,
   ExecutionTreeEdgeKind,
   ExecutionTreeIdentity,
@@ -338,6 +339,22 @@ export interface AgentStatus {
   executionTree?: ExecutionTreeIdentity;
 }
 
+export interface AgentQueueStatus {
+  taskId: string;
+  attemptId: string;
+  queueId: string;
+  agent: AgentType;
+  status: 'queued';
+  enqueuedAt: string;
+  retryAfterMs: number;
+  limitingScopes: Array<{
+    scope: string;
+    scopeId: string;
+  }>;
+}
+
+export type AgentLaunchStatus = AgentStatus | AgentQueueStatus;
+
 export interface AgentOutput {
   type: 'stdout' | 'stderr' | 'stdin' | 'system';
   content: string;
@@ -358,6 +375,8 @@ export interface AgentStartOptions {
   recovery?: RunRecoveryRecord;
   admissionIdempotencyKey?: string;
   rootTaskId?: string;
+  /** Internal durable queue claim. API callers cannot supply this field. */
+  admissionQueueClaim?: AdmissionQueueClaim;
 }
 
 export interface AgentMessageOptions {
@@ -522,6 +541,7 @@ export class ClawdbotAgentService {
   private approvalBroker: RunApprovalBrokerService;
   private runSupervisor: RunSupervisorService;
   private admission: AdmissionControlService;
+  private admissionQueueDrain?: Promise<void>;
   private conversationLifecycle: ConversationLifecycleService;
   private toolControlPlane: ToolControlPlaneService;
   private runToolBridge: RunToolBridgeService;
@@ -623,6 +643,134 @@ export class ClawdbotAgentService {
 
   private async ensureLogsDir(): Promise<void> {
     await fs.mkdir(this.logsDir, { recursive: true });
+  }
+
+  async reconcileQueuedLaunches(): Promise<void> {
+    if (this.admissionQueueDrain) return this.admissionQueueDrain;
+    let continueDraining = false;
+    this.admissionQueueDrain = this.drainAdmissionQueue().then((hasMore) => {
+      continueDraining = hasMore;
+    });
+    try {
+      await this.admissionQueueDrain;
+    } finally {
+      this.admissionQueueDrain = undefined;
+    }
+    if (continueDraining) this.scheduleAdmissionQueueDrain();
+  }
+
+  private scheduleAdmissionQueueDrain(): void {
+    queueMicrotask(() => {
+      void this.reconcileQueuedLaunches().catch((error) => {
+        log.error({ err: error }, '[ClawdbotAgent] Admission queue drain failed');
+      });
+    });
+  }
+
+  private async drainAdmissionQueue(): Promise<boolean> {
+    for (let index = 0; index < 100; index++) {
+      const claim = await this.admission.claimNextQueued();
+      if (!claim) return false;
+      const { entry, reservation } = claim;
+      if (startingAgents.has(entry.request.taskId) || pendingAgents.has(entry.request.taskId)) {
+        await this.admission
+          .release(reservation.id, 'start-failed', `queue-task-busy:${entry.id}`)
+          .catch(() => {});
+        await this.admission.requeueQueueEntry(
+          entry.id,
+          'QUEUE_TASK_BUSY',
+          'The task already has a launch owner.'
+        );
+        continue;
+      }
+
+      startingAgents.add(entry.request.taskId);
+      try {
+        const result = await this.startReservedAgent(entry.request.taskId, entry.agent, {
+          rootTaskId: entry.request.rootTaskId,
+          admissionQueueClaim: claim,
+        });
+        if (result.status === 'queued') {
+          throw new ConflictError('A leased queue entry cannot enqueue itself again.', {
+            code: 'ADMISSION_QUEUE_RECURSION',
+            queueId: entry.id,
+          });
+        }
+      } catch (error) {
+        const current = await this.admission.getQueueEntry(entry.id);
+        const task = await this.taskService.getTask(entry.request.taskId);
+        if (current.state === 'dispatched' || task?.attempt?.id === entry.attemptId) {
+          if (current.state !== 'dispatched') {
+            await this.admission
+              .release(reservation.id, 'start-failed', `queue-attempt-persisted:${entry.id}`)
+              .catch(() => {});
+            await this.admission.terminateQueueEntry(
+              entry.id,
+              'QUEUE_ATTEMPT_PERSISTED',
+              'Attempt state became durable before dispatch ownership could be confirmed.'
+            );
+          }
+          continue;
+        }
+        await this.admission
+          .release(reservation.id, 'start-failed', `queue-launch-failed:${entry.id}`)
+          .catch(() => {});
+        const failure = this.queueDispatchFailure(error);
+        if (failure.terminal) {
+          await this.admission.terminateQueueEntry(entry.id, failure.code, failure.reason);
+        } else {
+          await this.admission.requeueQueueEntry(entry.id, failure.code, failure.reason);
+        }
+      } finally {
+        startingAgents.delete(entry.request.taskId);
+      }
+    }
+    return true;
+  }
+
+  private queueDispatchFailure(error: unknown): {
+    terminal: boolean;
+    code: string;
+    reason: string;
+  } {
+    const candidate = error as {
+      message?: unknown;
+      statusCode?: unknown;
+      details?: unknown;
+    };
+    const details =
+      candidate.details && typeof candidate.details === 'object'
+        ? (candidate.details as Record<string, unknown>)
+        : {};
+    const detailCode = typeof details.code === 'string' ? details.code : undefined;
+    const statusCode = typeof candidate.statusCode === 'number' ? candidate.statusCode : undefined;
+    const redactedReason = this.redactTraceText(
+      typeof candidate.message === 'string'
+        ? candidate.message
+        : 'Queued launch failed before dispatch.'
+    );
+    const terminal =
+      error instanceof AgentReadinessError ||
+      detailCode === 'ADMISSION_QUEUE_DRIFT' ||
+      detailCode === 'ADMISSION_QUEUE_RECURSION' ||
+      statusCode === 400 ||
+      statusCode === 403 ||
+      statusCode === 404;
+    return {
+      terminal,
+      code: (
+        detailCode ?? (terminal ? 'QUEUE_AUTHORITY_REJECTED' : 'QUEUE_TRANSIENT_FAILURE')
+      ).slice(0, 160),
+      reason: redactedReason.trim().slice(0, 1_000) || 'Queued launch failed before dispatch.',
+    };
+  }
+
+  private requireRunningLaunch(result: AgentLaunchStatus): AgentStatus {
+    if (result.status !== 'queued') return result;
+    throw new ConflictError('This launch source cannot enter the direct admission queue.', {
+      code: 'ADMISSION_QUEUE_SOURCE_DENIED',
+      queueId: result.queueId,
+    });
   }
 
   /**
@@ -1244,10 +1392,12 @@ export class ClawdbotAgentService {
     );
 
     try {
-      const child = await this.startAgent(
-        taskId,
-        launching.selectedAgent,
-        this.recoveryLaunchOptions(claimedAttempt, launching)
+      const child = this.requireRunningLaunch(
+        await this.startAgent(
+          taskId,
+          launching.selectedAgent,
+          this.recoveryLaunchOptions(claimedAttempt, launching)
+        )
       );
       await this.appendRunEvent(
         taskId,
@@ -1725,7 +1875,7 @@ export class ClawdbotAgentService {
     taskId: string,
     agentType?: AgentType,
     options: AgentStartOptions = {}
-  ): Promise<AgentStatus> {
+  ): Promise<AgentLaunchStatus> {
     if (startingAgents.has(taskId) || pendingAgents.has(taskId)) {
       throw new ConflictError('An agent is already running or starting for this task');
     }
@@ -1742,7 +1892,7 @@ export class ClawdbotAgentService {
     taskId: string,
     agentType?: AgentType,
     options: AgentStartOptions = {}
-  ): Promise<AgentStatus> {
+  ): Promise<AgentLaunchStatus> {
     // Get task
     let task = await this.taskService.getTask(taskId);
     if (!task) {
@@ -1934,7 +2084,7 @@ export class ClawdbotAgentService {
     }
 
     // Create attempt
-    const attemptId = `attempt_${nanoid(8)}`;
+    const attemptId = options.admissionQueueClaim?.entry.attemptId ?? `attempt_${nanoid(8)}`;
     const startedAt = new Date().toISOString();
     if (!task.git?.worktreePath) {
       throw new Error(`Task "${taskId}" lost its worktree allocation before launch`);
@@ -2122,17 +2272,19 @@ export class ClawdbotAgentService {
       conversationRequest.forkTurnId,
       conversationRequest.intent
     );
-    const executionTree = this.buildExecutionTreeIdentity({
-      taskId,
-      rootTaskId: options.rootTaskId,
-      workspaceId: taskEnvelope.workspace.workspaceId,
-      attemptId,
-      parentAttempt,
-      provider,
-      conversationIntent: conversation.intent,
-      recoveryAction: options.recovery?.action,
-      rootIdempotencyKey: options.admissionIdempotencyKey,
-    });
+    const executionTree =
+      options.admissionQueueClaim?.entry.request.executionTree ??
+      this.buildExecutionTreeIdentity({
+        taskId,
+        rootTaskId: options.rootTaskId,
+        workspaceId: taskEnvelope.workspace.workspaceId,
+        attemptId,
+        parentAttempt,
+        provider,
+        conversationIntent: conversation.intent,
+        recoveryAction: options.recovery?.action,
+        rootIdempotencyKey: options.admissionIdempotencyKey,
+      });
     const inheritedBudgetPolicies = parentAttempt?.admissionReservationId
       ? ((await this.admission.get(parentAttempt.admissionReservationId)).request.budgetPolicies ??
         [])
@@ -2151,7 +2303,7 @@ export class ClawdbotAgentService {
         isRoot: !parentAttempt,
       }),
     ]);
-    const admissionDecision = await this.admission.admit({
+    const admissionInput = {
       taskId,
       rootTaskId: options.rootTaskId,
       workspaceId: taskEnvelope.workspace.workspaceId,
@@ -2171,27 +2323,117 @@ export class ClawdbotAgentService {
         fanOut: 1,
         retries: options.recovery ? 1 : 0,
       },
-    });
-    if (admissionDecision.outcome !== 'admitted' || !admissionDecision.reservation) {
+    } as const;
+    const queueableDirectLaunch =
+      !options.admissionQueueClaim &&
+      conversationRequest.mode === 'fresh' &&
+      !conversationRequest.message &&
+      !options.recovery &&
+      !options.parentAttemptId &&
+      !options.profileId &&
+      !options.overrideReason &&
+      !options.sandboxPresetId &&
+      !options.budget &&
+      !options.requiredRuntimeCapabilities?.length &&
+      !options.commitPolicy &&
+      !options.phase;
+    const admissionDecision = options.admissionQueueClaim
+      ? undefined
+      : queueableDirectLaunch
+        ? await this.admission.admitOrQueue(admissionInput, { agent, attemptId })
+        : await this.admission.admit(admissionInput);
+    if (admissionDecision?.outcome === 'queued' && admissionDecision.queueEntry) {
+      try {
+        await this.filesystemSandbox.cleanup(filesystemSandboxPlan);
+      } catch {
+        // The queue is durable; best-effort cleanup must not discard the launch request.
+      }
+      this.scheduleAdmissionQueueDrain();
+      return {
+        taskId,
+        attemptId: admissionDecision.queueEntry.attemptId,
+        queueId: admissionDecision.queueEntry.id,
+        agent,
+        status: 'queued',
+        enqueuedAt: admissionDecision.queueEntry.createdAt,
+        retryAfterMs: admissionDecision.queueEntry.retryAfterMs,
+        limitingScopes: admissionDecision.queueEntry.limitingPolicies.map((policy) => ({
+          scope: policy.scope,
+          scopeId: policy.scopeId,
+        })),
+      };
+    }
+    if (
+      admissionDecision &&
+      (admissionDecision.outcome !== 'admitted' || !admissionDecision.reservation)
+    ) {
       throw new ConflictError(
         admissionDecision.outcome === 'retryable-overload'
           ? 'Agent launch is waiting for admission capacity.'
-          : 'Agent launch violates an admission policy.',
+          : admissionDecision.outcome === 'queue-overflow'
+            ? 'The admission queue is full.'
+            : 'Agent launch violates an admission policy.',
         {
           code:
             admissionDecision.outcome === 'retryable-overload'
               ? 'ADMISSION_OVERLOAD'
-              : 'ADMISSION_POLICY_DENIED',
+              : admissionDecision.outcome === 'queue-overflow'
+                ? 'ADMISSION_QUEUE_OVERFLOW'
+                : 'ADMISSION_POLICY_DENIED',
           decision: admissionDecision,
         }
       );
     }
+    const queuedClaim = options.admissionQueueClaim;
+    if (queuedClaim) {
+      const queuedRequest = queuedClaim.reservation.request;
+      const driftFields = [
+        queuedClaim.entry.state !== 'leased' ? 'queueState' : undefined,
+        queuedClaim.entry.attemptId !== attemptId ? 'attemptId' : undefined,
+        queuedClaim.entry.agent !== agent ? 'agent' : undefined,
+        queuedClaim.entry.reservationId !== queuedClaim.reservation.id
+          ? 'reservationId'
+          : undefined,
+        queuedRequest.source !== 'direct' ? 'source' : undefined,
+        queuedRequest.taskId !== taskId ? 'taskId' : undefined,
+        queuedRequest.rootTaskId !== (options.rootTaskId ?? taskId) ? 'rootTaskId' : undefined,
+        queuedRequest.workspaceId !== taskEnvelope.workspace.workspaceId
+          ? 'workspaceId'
+          : undefined,
+        queuedRequest.provider !== provider ? 'provider' : undefined,
+        queuedRequest.hostId !== runLaunchManifest.routing.selectedHost ? 'hostId' : undefined,
+        JSON.stringify(queuedRequest.executionTree) !== JSON.stringify(executionTree)
+          ? 'executionTree'
+          : undefined,
+        JSON.stringify(queuedRequest.budgetPolicies ?? []) !==
+        JSON.stringify(executionBudgetPolicies)
+          ? 'budgetPolicies'
+          : undefined,
+      ].filter((field): field is string => Boolean(field));
+      if (driftFields.length > 0) {
+        throw new ConflictError('Queued launch authority changed before dispatch.', {
+          code: 'ADMISSION_QUEUE_DRIFT',
+          queueId: queuedClaim.entry.id,
+          driftFields,
+        });
+      }
+    }
+    const admissionReservationCandidate =
+      queuedClaim?.reservation ?? admissionDecision?.reservation;
+    if (!admissionReservationCandidate) {
+      throw new ConflictError('Agent launch has no admission reservation.', {
+        code: 'ADMISSION_RESERVATION_MISSING',
+      });
+    }
     let admissionReservation;
     try {
-      admissionReservation = await this.admission.bindAttempt(
-        admissionDecision.reservation.id,
-        attemptId
-      );
+      admissionReservation = queuedClaim
+        ? await this.admission.bindQueuedAttempt(
+            queuedClaim.entry.id,
+            admissionReservationCandidate.id,
+            attemptId
+          )
+        : await this.admission.bindAttempt(admissionReservationCandidate.id, attemptId);
       await this.admission.recordBudgetUsage(admissionReservation.id, {
         schemaVersion: 'execution-tree-budget-event/v1',
         id: `launch_${attemptId}`,
@@ -2207,7 +2449,7 @@ export class ClawdbotAgentService {
     } catch (error) {
       await this.admission
         .releaseIfUnbound(
-          admissionDecision.reservation.id,
+          admissionReservationCandidate.id,
           'start-failed',
           `bind-failed:${attemptId}`
         )
@@ -2443,6 +2685,9 @@ export class ClawdbotAgentService {
       await this.taskService.patchTaskAttempt(taskId, attemptId, {
         runSupervisorId: supervisorId,
       });
+      if (queuedClaim) {
+        await this.admission.markQueueDispatched(queuedClaim.entry.id, attemptId);
+      }
       const startedEvent = await this.appendRunEvent(
         taskId,
         attemptId,
@@ -3700,6 +3945,7 @@ export class ClawdbotAgentService {
     if (!reservationId) return;
     try {
       await this.admission.release(reservationId, reason, idempotencyKey);
+      this.scheduleAdmissionQueueDrain();
     } catch (error) {
       log.error(
         { err: error, reservationId, reason },
@@ -3954,11 +4200,13 @@ export class ClawdbotAgentService {
       await this.findAttempt(sourceAttemptId),
       'resume'
     );
-    return this.startAgent(taskId, source.attempt.agent, {
-      ...options,
-      parentAttemptId: source.attempt.id,
-      conversation: { mode: 'resume', intent: 'resume', sourceAttemptId, message },
-    });
+    return this.requireRunningLaunch(
+      await this.startAgent(taskId, source.attempt.agent, {
+        ...options,
+        parentAttemptId: source.attempt.id,
+        conversation: { mode: 'resume', intent: 'resume', sourceAttemptId, message },
+      })
+    );
   }
 
   async followUpConversation(
@@ -3971,16 +4219,18 @@ export class ClawdbotAgentService {
       await this.findAttempt(sourceAttemptId),
       'resume'
     );
-    return this.startAgent(taskId, source.attempt.agent, {
-      ...options,
-      parentAttemptId: source.attempt.id,
-      conversation: {
-        mode: 'resume',
-        intent: 'follow-up',
-        sourceAttemptId,
-        message,
-      },
-    });
+    return this.requireRunningLaunch(
+      await this.startAgent(taskId, source.attempt.agent, {
+        ...options,
+        parentAttemptId: source.attempt.id,
+        conversation: {
+          mode: 'resume',
+          intent: 'follow-up',
+          sourceAttemptId,
+          message,
+        },
+      })
+    );
   }
 
   async forkConversation(
@@ -3994,17 +4244,19 @@ export class ClawdbotAgentService {
       await this.findAttempt(sourceAttemptId),
       'fork'
     );
-    return this.startAgent(taskId, source.attempt.agent, {
-      ...options,
-      parentAttemptId: source.attempt.id,
-      conversation: {
-        mode: 'fork',
-        intent: 'fork',
-        sourceAttemptId,
-        message,
-        ...(forkTurnId ? { forkTurnId } : {}),
-      },
-    });
+    return this.requireRunningLaunch(
+      await this.startAgent(taskId, source.attempt.agent, {
+        ...options,
+        parentAttemptId: source.attempt.id,
+        conversation: {
+          mode: 'fork',
+          intent: 'fork',
+          sourceAttemptId,
+          message,
+          ...(forkTurnId ? { forkTurnId } : {}),
+        },
+      })
+    );
   }
 
   async compactConversation(

--- a/server/src/storage/admission-reservation-repository.ts
+++ b/server/src/storage/admission-reservation-repository.ts
@@ -3,14 +3,26 @@ import { constants } from 'node:fs';
 import { lstat, mkdir, open, rename, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import type {
+  AdmissionQueueCompareAndSetInput,
+  AdmissionQueueCompareAndSetResult,
+  AdmissionQueueEntry,
+  AdmissionQueueListQuery,
+  AdmissionQueuedClaimInput,
+  AdmissionQueuedClaimResult,
   AdmissionReservation,
   AdmissionReservationClaimInput,
+  AdmissionReservationClaimOrQueueInput,
+  AdmissionReservationClaimOrQueueResult,
   AdmissionReservationClaimResult,
   AdmissionReservationCompareAndSetInput,
   AdmissionReservationCompareAndSetResult,
   AdmissionReservationListQuery,
 } from '@veritas-kanban/shared';
-import { AdmissionReservationSchema } from '../schemas/admission-control-schemas.js';
+import { ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import {
+  AdmissionQueueEntrySchema,
+  AdmissionReservationSchema,
+} from '../schemas/admission-control-schemas.js';
 import { withFileLock } from '../services/file-lock.js';
 import { getRuntimeDir } from '../utils/paths.js';
 import { ensureWithinBase } from '../utils/sanitize.js';
@@ -31,11 +43,15 @@ export function getAdmissionReservationsPath(): string {
 }
 
 export class FileAdmissionReservationRepository implements AdmissionReservationRepository {
+  private readonly queueFilePath: string;
+
   constructor(
     private readonly filePath = getAdmissionReservationsPath(),
     private readonly compactSnapshots = COMPACT_SNAPSHOTS
   ) {
     ensureWithinBase(path.dirname(filePath), filePath);
+    this.queueFilePath = `${filePath}.queue`;
+    ensureWithinBase(path.dirname(filePath), this.queueFilePath);
   }
 
   async claim(input: AdmissionReservationClaimInput): Promise<AdmissionReservationClaimResult> {
@@ -48,54 +64,167 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       const snapshots = await this.readSnapshots();
       const materialized = this.materialize(snapshots);
       await this.expireMaterialized(materialized, input.now, snapshots);
-      const existing = materialized.get(requested.id);
+      return this.claimMaterialized(requested, input, materialized, snapshots);
+    });
+  }
+
+  async claimOrEnqueue(
+    input: AdmissionReservationClaimOrQueueInput
+  ): Promise<AdmissionReservationClaimOrQueueResult> {
+    const requested = AdmissionReservationSchema.parse(input.record);
+    if (requested.revision !== 1) {
+      throw new Error('New admission reservations must start at revision 1.');
+    }
+    await this.prepareParent();
+    return withFileLock(this.filePath, async () => {
+      const snapshots = await this.readSnapshots();
+      const materialized = this.materialize(snapshots);
+      await this.expireMaterialized(materialized, input.now, snapshots);
+      const claimed = await this.claimMaterialized(requested, input, materialized, snapshots);
+      if (
+        claimed.record ||
+        (claimed.limitingBudgetPolicies?.length && claimed.budgetRetryable === false)
+      ) {
+        return claimed;
+      }
+
+      const queue = await this.readQueueEntries();
+      const expired = this.expireQueueMaterialized(queue, input.now);
+      const activeStates = new Set(['queued', 'requeued', 'leased']);
+      const existing = [...queue.values()].find(
+        (entry) =>
+          entry.request.taskId === input.queue.request.taskId && activeStates.has(entry.state)
+      );
       if (existing) {
-        if (existing.request.idempotencyKey !== requested.request.idempotencyKey) {
-          throw new Error(`Admission reservation ${requested.id} has conflicting identity.`);
+        if (expired.length > 0) await this.replaceQueueEntries([...queue.values()]);
+        if (existing.agent !== input.queue.agent) {
+          return { ...claimed, queueConflict: true };
         }
-        if (existing.state !== 'expired' || !input.reclaimExpired) {
-          return { record: existing, created: false, limitingPolicies: [] };
-        }
-        const reclaimed = AdmissionReservationSchema.parse({
-          ...requested,
-          revision: existing.revision + 1,
-          createdAt: existing.createdAt,
-        });
-        const limitingPolicies = findLimitingAdmissionPolicies(
-          [...materialized.values()].filter((record) => record.id !== existing.id),
-          reclaimed
+        return { ...claimed, queueEntry: existing };
+      }
+      const active = [...queue.values()].filter((entry) => activeStates.has(entry.state));
+      if (active.length >= input.globalQueueLimit) {
+        if (expired.length > 0) await this.replaceQueueEntries([...queue.values()]);
+        return { ...claimed, queueOverflow: 'global' };
+      }
+      if (
+        active.filter((entry) => entry.request.workspaceId === input.queue.request.workspaceId)
+          .length >= input.workspaceQueueLimit
+      ) {
+        if (expired.length > 0) await this.replaceQueueEntries([...queue.values()]);
+        return { ...claimed, queueOverflow: 'workspace' };
+      }
+      const enqueueSequence =
+        Math.max(0, ...[...queue.values()].map((entry) => entry.enqueueSequence)) + 1;
+      const entry = AdmissionQueueEntrySchema.parse({
+        schemaVersion: ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION,
+        ...input.queue,
+        limitingPolicies: claimed.limitingPolicies,
+        limitingBudgetPolicies: claimed.limitingBudgetPolicies,
+        revision: 1,
+        state: 'queued',
+        enqueueSequence,
+        retryCount: 0,
+        updatedAt: input.now,
+      });
+      queue.set(entry.id, entry);
+      await this.replaceQueueEntries([...queue.values()]);
+      return { ...claimed, queueEntry: entry };
+    });
+  }
+
+  async claimQueued(input: AdmissionQueuedClaimInput): Promise<AdmissionQueuedClaimResult> {
+    const requested = AdmissionReservationSchema.parse(input.record);
+    await this.prepareParent();
+    return withFileLock(this.filePath, async () => {
+      const snapshots = await this.readSnapshots();
+      const reservations = this.materialize(snapshots);
+      await this.expireMaterialized(reservations, input.now, snapshots);
+      const queue = await this.readQueueEntries();
+      const expired = this.expireQueueMaterialized(queue, input.now);
+      const current = queue.get(input.queueId);
+      const eligible = [...queue.values()]
+        .filter(
+          (entry) =>
+            ['queued', 'requeued'].includes(entry.state) &&
+            Date.parse(entry.availableAt) <= Date.parse(input.now)
+        )
+        .sort(
+          (left, right) =>
+            left.enqueueSequence - right.enqueueSequence || left.id.localeCompare(right.id)
         );
-        if (limitingPolicies.length > 0) {
-          return { created: false, limitingPolicies };
-        }
-        const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
-          [...materialized.values()].filter((record) => record.id !== existing.id),
-          reclaimed
-        );
-        if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
-          return {
-            created: false,
-            limitingPolicies: [],
-            limitingBudgetPolicies:
-              limitingBudgets.terminal.length > 0
-                ? limitingBudgets.terminal
-                : limitingBudgets.retryable,
-            budgetRetryable: limitingBudgets.terminal.length === 0,
-          };
-        }
-        await this.appendSnapshot(reclaimed, snapshots);
+      if (
+        !current ||
+        current.revision !== input.expectedRevision ||
+        eligible[0]?.id !== current.id
+      ) {
+        if (expired.length > 0) await this.replaceQueueEntries([...queue.values()]);
+        return { stale: true, limitingPolicies: [] };
+      }
+      const claimed = await this.claimMaterialized(
+        requested,
+        { record: requested, now: input.now, reclaimExpired: true },
+        reservations,
+        snapshots
+      );
+      if (!claimed.record) {
+        if (expired.length > 0) await this.replaceQueueEntries([...queue.values()]);
         return {
-          record: reclaimed,
-          created: false,
-          reclaimed: true,
-          limitingPolicies: [],
+          stale: false,
+          limitingPolicies: claimed.limitingPolicies,
+          limitingBudgetPolicies: claimed.limitingBudgetPolicies,
+          budgetRetryable: claimed.budgetRetryable,
         };
       }
-      const limitingPolicies = findLimitingAdmissionPolicies([...materialized.values()], requested);
-      if (limitingPolicies.length > 0) return { created: false, limitingPolicies };
+      const entry = AdmissionQueueEntrySchema.parse({
+        ...current,
+        revision: current.revision + 1,
+        state: 'leased',
+        policies: claimed.record.policies,
+        lease: claimed.record.lease,
+        reservationId: claimed.record.id,
+        updatedAt: input.now,
+      });
+      queue.set(entry.id, entry);
+      await this.replaceQueueEntries([...queue.values()]);
+      return {
+        entry,
+        reservation: claimed.record,
+        stale: false,
+        limitingPolicies: [],
+      };
+    });
+  }
+
+  private async claimMaterialized(
+    requested: AdmissionReservation,
+    input: AdmissionReservationClaimInput,
+    materialized: Map<string, AdmissionReservation>,
+    snapshots: AdmissionReservation[]
+  ): Promise<AdmissionReservationClaimResult> {
+    const existing = materialized.get(requested.id);
+    if (existing) {
+      if (existing.request.idempotencyKey !== requested.request.idempotencyKey) {
+        throw new Error(`Admission reservation ${requested.id} has conflicting identity.`);
+      }
+      if (existing.state !== 'expired' || !input.reclaimExpired) {
+        return { record: existing, created: false, limitingPolicies: [] };
+      }
+      const reclaimed = AdmissionReservationSchema.parse({
+        ...requested,
+        revision: existing.revision + 1,
+        createdAt: existing.createdAt,
+      });
+      const limitingPolicies = findLimitingAdmissionPolicies(
+        [...materialized.values()].filter((record) => record.id !== existing.id),
+        reclaimed
+      );
+      if (limitingPolicies.length > 0) {
+        return { created: false, limitingPolicies };
+      }
       const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
-        [...materialized.values()],
-        requested
+        [...materialized.values()].filter((record) => record.id !== existing.id),
+        reclaimed
       );
       if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
         return {
@@ -108,9 +237,33 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
           budgetRetryable: limitingBudgets.terminal.length === 0,
         };
       }
-      await this.appendSnapshot(requested, snapshots);
-      return { record: requested, created: true, limitingPolicies: [] };
-    });
+      await this.appendSnapshot(reclaimed, snapshots);
+      return {
+        record: reclaimed,
+        created: false,
+        reclaimed: true,
+        limitingPolicies: [],
+      };
+    }
+    const limitingPolicies = findLimitingAdmissionPolicies([...materialized.values()], requested);
+    if (limitingPolicies.length > 0) return { created: false, limitingPolicies };
+    const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
+      [...materialized.values()],
+      requested
+    );
+    if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
+      return {
+        created: false,
+        limitingPolicies: [],
+        limitingBudgetPolicies:
+          limitingBudgets.terminal.length > 0
+            ? limitingBudgets.terminal
+            : limitingBudgets.retryable,
+        budgetRetryable: limitingBudgets.terminal.length === 0,
+      };
+    }
+    await this.appendSnapshot(requested, snapshots);
+    return { record: requested, created: true, limitingPolicies: [] };
   }
 
   async get(id: string): Promise<AdmissionReservation | null> {
@@ -148,6 +301,58 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       .filter((record) => !states || states.has(record.state))
       .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
       .slice(0, query.limit ?? 100);
+  }
+
+  async getQueueEntry(id: string): Promise<AdmissionQueueEntry | null> {
+    return (await this.readQueueEntries()).get(id) ?? null;
+  }
+
+  async listQueue(query: AdmissionQueueListQuery): Promise<AdmissionQueueEntry[]> {
+    const states = query.states ? new Set(query.states) : undefined;
+    return [...(await this.readQueueEntries()).values()]
+      .filter((entry) => !query.workspaceId || entry.request.workspaceId === query.workspaceId)
+      .filter((entry) => !query.taskId || entry.request.taskId === query.taskId)
+      .filter((entry) => !states || states.has(entry.state))
+      .filter(
+        (entry) =>
+          !query.eligibleAt || Date.parse(entry.availableAt) <= Date.parse(query.eligibleAt)
+      )
+      .sort(
+        (left, right) =>
+          left.enqueueSequence - right.enqueueSequence || left.id.localeCompare(right.id)
+      )
+      .slice(0, query.limit ?? 100);
+  }
+
+  async compareAndSetQueue(
+    input: AdmissionQueueCompareAndSetInput
+  ): Promise<AdmissionQueueCompareAndSetResult> {
+    await this.prepareParent();
+    return withFileLock(this.filePath, async () => {
+      const queue = await this.readQueueEntries();
+      const current = queue.get(input.id);
+      if (!current) return { updated: false, reason: 'not-found' };
+      if (current.revision !== input.expectedRevision) {
+        return { record: current, updated: false, reason: 'stale-revision' };
+      }
+      if (input.next.revision !== input.expectedRevision + 1 || input.next.id !== input.id) {
+        return { record: current, updated: false, reason: 'invalid-revision' };
+      }
+      const next = AdmissionQueueEntrySchema.parse(input.next);
+      queue.set(next.id, next);
+      await this.replaceQueueEntries([...queue.values()]);
+      return { record: next, updated: true };
+    });
+  }
+
+  async expireQueueLeases(now: string): Promise<AdmissionQueueEntry[]> {
+    await this.prepareParent();
+    return withFileLock(this.filePath, async () => {
+      const queue = await this.readQueueEntries();
+      const expired = this.expireQueueMaterialized(queue, now);
+      if (expired.length > 0) await this.replaceQueueEntries([...queue.values()]);
+      return expired;
+    });
   }
 
   async compareAndSet(
@@ -235,6 +440,111 @@ export class FileAdmissionReservationRepository implements AdmissionReservationR
       throw error;
     } finally {
       await handle?.close();
+    }
+  }
+
+  private async readQueueEntries(): Promise<Map<string, AdmissionQueueEntry>> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(this.queueFilePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size > MAX_LOG_BYTES) {
+        throw new Error('Admission queue is not a bounded regular file.');
+      }
+      const lines = (await handle.readFile({ encoding: 'utf8' })).split(/\r?\n/).filter(Boolean);
+      if (lines.length > MAX_SNAPSHOTS) {
+        throw new Error('Admission queue reached its bounded entry limit.');
+      }
+      return new Map(
+        lines.map((line) => {
+          const entry = AdmissionQueueEntrySchema.parse(JSON.parse(line));
+          return [entry.id, entry];
+        })
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return new Map();
+      if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+        throw new Error('Admission queue is not a bounded regular file.', { cause: error });
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private expireQueueMaterialized(
+    queue: Map<string, AdmissionQueueEntry>,
+    now: string
+  ): AdmissionQueueEntry[] {
+    const expired: AdmissionQueueEntry[] = [];
+    for (const current of queue.values()) {
+      if (
+        current.state !== 'leased' ||
+        !current.lease ||
+        Date.parse(current.lease.expiresAt) > Date.parse(now)
+      ) {
+        continue;
+      }
+      const retryCount = current.retryCount + 1;
+      const terminal = retryCount > current.maxRetries;
+      const next = AdmissionQueueEntrySchema.parse({
+        ...current,
+        revision: current.revision + 1,
+        state: terminal ? 'terminal' : 'requeued',
+        retryCount,
+        availableAt: new Date(Date.parse(now) + current.retryAfterMs).toISOString(),
+        lease: undefined,
+        reservationId: undefined,
+        ...(terminal
+          ? {
+              terminal: {
+                code: 'QUEUE_LEASE_EXPIRED',
+                reason: 'The queue lease expired before dispatch ownership became durable.',
+                recordedAt: now,
+              },
+            }
+          : {}),
+        updatedAt: now,
+      });
+      queue.set(next.id, next);
+      expired.push(next);
+    }
+    return expired;
+  }
+
+  private async replaceQueueEntries(entries: AdmissionQueueEntry[]): Promise<void> {
+    if (entries.length > MAX_SNAPSHOTS) {
+      throw new Error('Admission queue reached its bounded entry limit.');
+    }
+    const content =
+      entries
+        .sort(
+          (left, right) =>
+            left.enqueueSequence - right.enqueueSequence || left.id.localeCompare(right.id)
+        )
+        .map((entry) => JSON.stringify(entry))
+        .join('\n') + (entries.length > 0 ? '\n' : '');
+    if (Buffer.byteLength(content, 'utf8') > MAX_LOG_BYTES) {
+      throw new Error('Admission queue reached its bounded byte limit.');
+    }
+    const temporaryPath = `${this.queueFilePath}.replace-${process.pid}-${randomUUID()}`;
+    ensureWithinBase(path.dirname(this.queueFilePath), temporaryPath);
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(
+        temporaryPath,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+        0o600
+      );
+      await handle.writeFile(content, 'utf8');
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      await rename(temporaryPath, this.queueFilePath);
+    } catch (error) {
+      await handle?.close().catch(() => {});
+      await unlink(temporaryPath).catch(() => {});
+      throw error;
     }
   }
 

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -47,9 +47,17 @@ import type {
   AdmissionReservation,
   AdmissionReservationClaimInput,
   AdmissionReservationClaimResult,
+  AdmissionReservationClaimOrQueueInput,
+  AdmissionReservationClaimOrQueueResult,
   AdmissionReservationCompareAndSetInput,
   AdmissionReservationCompareAndSetResult,
   AdmissionReservationListQuery,
+  AdmissionQueuedClaimInput,
+  AdmissionQueuedClaimResult,
+  AdmissionQueueCompareAndSetInput,
+  AdmissionQueueCompareAndSetResult,
+  AdmissionQueueEntry,
+  AdmissionQueueListQuery,
   RunToolCatalog,
   ToolServerDefinition,
   ToolServerDiscovery,
@@ -434,12 +442,24 @@ export interface RunSupervisorRepository {
 export interface AdmissionReservationRepository {
   /** Atomically expire stale leases, evaluate aggregate policies, and reserve capacity. */
   claim(input: AdmissionReservationClaimInput): Promise<AdmissionReservationClaimResult>;
+  /** Atomically reserve capacity or persist one bounded queue entry. */
+  claimOrEnqueue(
+    input: AdmissionReservationClaimOrQueueInput
+  ): Promise<AdmissionReservationClaimOrQueueResult>;
+  /** Atomically claim the FIFO head and its admission capacity. */
+  claimQueued(input: AdmissionQueuedClaimInput): Promise<AdmissionQueuedClaimResult>;
   get(id: string): Promise<AdmissionReservation | null>;
   list(query: AdmissionReservationListQuery): Promise<AdmissionReservation[]>;
   compareAndSet(
     input: AdmissionReservationCompareAndSetInput
   ): Promise<AdmissionReservationCompareAndSetResult>;
   expireLeases(now: string): Promise<AdmissionReservation[]>;
+  getQueueEntry(id: string): Promise<AdmissionQueueEntry | null>;
+  listQueue(query: AdmissionQueueListQuery): Promise<AdmissionQueueEntry[]>;
+  compareAndSetQueue(
+    input: AdmissionQueueCompareAndSetInput
+  ): Promise<AdmissionQueueCompareAndSetResult>;
+  expireQueueLeases(now: string): Promise<AdmissionQueueEntry[]>;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/storage/sqlite/admission-reservation-repository.ts
+++ b/server/src/storage/sqlite/admission-reservation-repository.ts
@@ -1,12 +1,24 @@
 import type {
+  AdmissionQueueCompareAndSetInput,
+  AdmissionQueueCompareAndSetResult,
+  AdmissionQueueEntry,
+  AdmissionQueueListQuery,
+  AdmissionQueuedClaimInput,
+  AdmissionQueuedClaimResult,
   AdmissionReservation,
   AdmissionReservationClaimInput,
+  AdmissionReservationClaimOrQueueInput,
+  AdmissionReservationClaimOrQueueResult,
   AdmissionReservationClaimResult,
   AdmissionReservationCompareAndSetInput,
   AdmissionReservationCompareAndSetResult,
   AdmissionReservationListQuery,
 } from '@veritas-kanban/shared';
-import { AdmissionReservationSchema } from '../../schemas/admission-control-schemas.js';
+import { ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION } from '@veritas-kanban/shared';
+import {
+  AdmissionQueueEntrySchema,
+  AdmissionReservationSchema,
+} from '../../schemas/admission-control-schemas.js';
 import { findLimitingAdmissionPolicies } from '../admission-capacity.js';
 import {
   findLimitingExecutionTreeBudgetPolicies,
@@ -17,6 +29,10 @@ import type { SqliteDatabase } from './database.js';
 
 interface ReservationRow {
   reservation_json: string;
+}
+
+interface QueueRow {
+  queue_json: string;
 }
 
 export class SqliteAdmissionReservationRepository implements AdmissionReservationRepository {
@@ -31,111 +47,154 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
     connection.exec('BEGIN IMMEDIATE');
     try {
       this.expireInTransaction(input.now);
-      const existingRow = connection
-        .prepare('SELECT reservation_json FROM admission_reservations WHERE id = ?')
-        .get(requested.id) as ReservationRow | undefined;
-      if (existingRow) {
-        const existing = AdmissionReservationSchema.parse(JSON.parse(existingRow.reservation_json));
-        if (existing.request.idempotencyKey !== requested.request.idempotencyKey) {
-          throw new Error(`Admission reservation ${requested.id} has conflicting identity.`);
-        }
-        if (existing.state !== 'expired' || !input.reclaimExpired) {
-          connection.exec('COMMIT');
-          return { record: existing, created: false, limitingPolicies: [] };
-        }
-        const reclaimed = AdmissionReservationSchema.parse({
-          ...requested,
-          revision: existing.revision + 1,
-          createdAt: existing.createdAt,
-        });
-        const limitingPolicies = findLimitingAdmissionPolicies(
-          this.activeReservations().filter((record) => record.id !== existing.id),
-          reclaimed
-        );
-        if (limitingPolicies.length > 0) {
-          connection.exec('COMMIT');
-          return { created: false, limitingPolicies };
-        }
-        const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
-          this.executionTreeReservations(requested.request.executionTree?.rootObjectiveId).filter(
-            (record) => record.id !== existing.id
-          ),
-          reclaimed
-        );
-        if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
-          connection.exec('COMMIT');
-          return {
-            created: false,
-            limitingPolicies: [],
-            limitingBudgetPolicies:
-              limitingBudgets.terminal.length > 0
-                ? limitingBudgets.terminal
-                : limitingBudgets.retryable,
-            budgetRetryable: limitingBudgets.terminal.length === 0,
-          };
-        }
-        this.updateRow(reclaimed, existing.revision);
-        connection.exec('COMMIT');
-        return {
-          record: reclaimed,
-          created: false,
-          reclaimed: true,
-          limitingPolicies: [],
-        };
-      }
-      const limitingPolicies = findLimitingAdmissionPolicies(this.activeReservations(), requested);
-      if (limitingPolicies.length > 0) {
-        connection.exec('COMMIT');
-        return { created: false, limitingPolicies };
-      }
-      const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
-        this.executionTreeReservations(requested.request.executionTree?.rootObjectiveId),
-        requested
-      );
-      if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
-        connection.exec('COMMIT');
-        return {
-          created: false,
-          limitingPolicies: [],
-          limitingBudgetPolicies:
-            limitingBudgets.terminal.length > 0
-              ? limitingBudgets.terminal
-              : limitingBudgets.retryable,
-          budgetRetryable: limitingBudgets.terminal.length === 0,
-        };
-      }
-      connection
-        .prepare(
-          `INSERT INTO admission_reservations (
-             id, workspace_id, task_id, root_task_id, provider, host_id, state, revision,
-             idempotency_key, lease_expires_at, workflow_run_id, workflow_step_id,
-             root_reservation_id, root_objective_id, node_id, parent_node_id,
-             reservation_json, created_at, updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-        )
-        .run(
-          requested.id,
-          requested.request.workspaceId,
-          requested.request.taskId,
-          requested.request.rootTaskId,
-          requested.request.provider,
-          requested.request.hostId,
-          requested.state,
-          requested.revision,
-          requested.request.idempotencyKey,
-          requested.lease.expiresAt,
-          requested.request.workflowRunId ?? null,
-          requested.request.workflowStepId ?? null,
-          requested.request.rootReservationId ?? null,
-          requested.request.executionTree?.rootObjectiveId ?? null,
-          requested.request.executionTree?.nodeId ?? null,
-          requested.request.executionTree?.parentNodeId ?? null,
-          JSON.stringify(requested),
-          requested.createdAt,
-          requested.updatedAt
-        );
+      const result = this.claimInTransaction(requested, input);
       connection.exec('COMMIT');
-      return { record: requested, created: true, limitingPolicies: [] };
+      return result;
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async claimOrEnqueue(
+    input: AdmissionReservationClaimOrQueueInput
+  ): Promise<AdmissionReservationClaimOrQueueResult> {
+    const requested = AdmissionReservationSchema.parse(input.record);
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      this.expireInTransaction(input.now);
+      this.expireQueueInTransaction(input.now);
+      const claimed = this.claimInTransaction(requested, input);
+      if (
+        claimed.record ||
+        (claimed.limitingBudgetPolicies?.length && claimed.budgetRetryable === false)
+      ) {
+        connection.exec('COMMIT');
+        return claimed;
+      }
+
+      const existingRow = connection
+        .prepare(
+          `SELECT queue_json FROM admission_queue
+           WHERE task_id = ? AND state IN ('queued', 'leased', 'requeued')
+           LIMIT 1`
+        )
+        .get(input.queue.request.taskId) as QueueRow | undefined;
+      if (existingRow) {
+        const existing = AdmissionQueueEntrySchema.parse(JSON.parse(existingRow.queue_json));
+        connection.exec('COMMIT');
+        if (existing.agent !== input.queue.agent) {
+          return { ...claimed, queueConflict: true };
+        }
+        return {
+          ...claimed,
+          queueEntry: existing,
+        };
+      }
+      const globalCount = (
+        connection
+          .prepare(
+            `SELECT COUNT(*) AS count FROM admission_queue
+             WHERE state IN ('queued', 'leased', 'requeued')`
+          )
+          .get() as { count: number }
+      ).count;
+      if (globalCount >= input.globalQueueLimit) {
+        connection.exec('COMMIT');
+        return { ...claimed, queueOverflow: 'global' };
+      }
+      const workspaceCount = (
+        connection
+          .prepare(
+            `SELECT COUNT(*) AS count FROM admission_queue
+             WHERE workspace_id = ? AND state IN ('queued', 'leased', 'requeued')`
+          )
+          .get(input.queue.request.workspaceId) as { count: number }
+      ).count;
+      if (workspaceCount >= input.workspaceQueueLimit) {
+        connection.exec('COMMIT');
+        return { ...claimed, queueOverflow: 'workspace' };
+      }
+      const enqueueSequence =
+        (
+          connection
+            .prepare('SELECT MAX(enqueue_sequence) AS sequence FROM admission_queue')
+            .get() as { sequence: number | null }
+        ).sequence ?? 0;
+      const entry = AdmissionQueueEntrySchema.parse({
+        schemaVersion: ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION,
+        ...input.queue,
+        limitingPolicies: claimed.limitingPolicies,
+        limitingBudgetPolicies: claimed.limitingBudgetPolicies,
+        revision: 1,
+        state: 'queued',
+        enqueueSequence: enqueueSequence + 1,
+        retryCount: 0,
+        updatedAt: input.now,
+      });
+      this.insertQueueRow(entry);
+      connection.exec('COMMIT');
+      return { ...claimed, queueEntry: entry };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async claimQueued(input: AdmissionQueuedClaimInput): Promise<AdmissionQueuedClaimResult> {
+    const requested = AdmissionReservationSchema.parse(input.record);
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      this.expireInTransaction(input.now);
+      this.expireQueueInTransaction(input.now);
+      const headRow = connection
+        .prepare(
+          `SELECT queue_json FROM admission_queue
+           WHERE state IN ('queued', 'requeued') AND available_at <= ?
+           ORDER BY enqueue_sequence ASC, id ASC
+           LIMIT 1`
+        )
+        .get(input.now) as QueueRow | undefined;
+      const head = headRow
+        ? AdmissionQueueEntrySchema.parse(JSON.parse(headRow.queue_json))
+        : undefined;
+      if (!head || head.id !== input.queueId || head.revision !== input.expectedRevision) {
+        connection.exec('COMMIT');
+        return { stale: true, limitingPolicies: [] };
+      }
+      const claimed = this.claimInTransaction(requested, {
+        record: requested,
+        now: input.now,
+        reclaimExpired: true,
+      });
+      if (!claimed.record) {
+        connection.exec('COMMIT');
+        return {
+          stale: false,
+          limitingPolicies: claimed.limitingPolicies,
+          limitingBudgetPolicies: claimed.limitingBudgetPolicies,
+          budgetRetryable: claimed.budgetRetryable,
+        };
+      }
+      const entry = AdmissionQueueEntrySchema.parse({
+        ...head,
+        revision: head.revision + 1,
+        state: 'leased',
+        policies: claimed.record.policies,
+        lease: claimed.record.lease,
+        reservationId: claimed.record.id,
+        updatedAt: input.now,
+      });
+      this.updateQueueRow(entry, head.revision);
+      connection.exec('COMMIT');
+      return {
+        entry,
+        reservation: claimed.record,
+        stale: false,
+        limitingPolicies: [],
+      };
     } catch (error) {
       connection.exec('ROLLBACK');
       throw error;
@@ -186,6 +245,91 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
     return rows.map((row) => AdmissionReservationSchema.parse(JSON.parse(row.reservation_json)));
   }
 
+  async getQueueEntry(id: string): Promise<AdmissionQueueEntry | null> {
+    const row = this.database
+      .getConnection()
+      .prepare('SELECT queue_json FROM admission_queue WHERE id = ?')
+      .get(id) as QueueRow | undefined;
+    return row ? AdmissionQueueEntrySchema.parse(JSON.parse(row.queue_json)) : null;
+  }
+
+  async listQueue(query: AdmissionQueueListQuery): Promise<AdmissionQueueEntry[]> {
+    const clauses: string[] = [];
+    const parameters: Array<string | number> = [];
+    if (query.workspaceId) {
+      clauses.push('workspace_id = ?');
+      parameters.push(query.workspaceId);
+    }
+    if (query.taskId) {
+      clauses.push('task_id = ?');
+      parameters.push(query.taskId);
+    }
+    if (query.states?.length) {
+      clauses.push(`state IN (${query.states.map(() => '?').join(', ')})`);
+      parameters.push(...query.states);
+    }
+    if (query.eligibleAt) {
+      clauses.push('available_at <= ?');
+      parameters.push(query.eligibleAt);
+    }
+    parameters.push(query.limit ?? 100);
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `SELECT queue_json FROM admission_queue
+         ${clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : ''}
+         ORDER BY enqueue_sequence ASC, id ASC
+         LIMIT ?`
+      )
+      .all(...parameters) as unknown as QueueRow[];
+    return rows.map((row) => AdmissionQueueEntrySchema.parse(JSON.parse(row.queue_json)));
+  }
+
+  async compareAndSetQueue(
+    input: AdmissionQueueCompareAndSetInput
+  ): Promise<AdmissionQueueCompareAndSetResult> {
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const row = connection
+        .prepare('SELECT queue_json FROM admission_queue WHERE id = ?')
+        .get(input.id) as QueueRow | undefined;
+      if (!row) {
+        connection.exec('COMMIT');
+        return { updated: false, reason: 'not-found' };
+      }
+      const current = AdmissionQueueEntrySchema.parse(JSON.parse(row.queue_json));
+      if (current.revision !== input.expectedRevision) {
+        connection.exec('COMMIT');
+        return { record: current, updated: false, reason: 'stale-revision' };
+      }
+      if (input.next.revision !== input.expectedRevision + 1 || input.next.id !== input.id) {
+        connection.exec('COMMIT');
+        return { record: current, updated: false, reason: 'invalid-revision' };
+      }
+      const next = AdmissionQueueEntrySchema.parse(input.next);
+      this.updateQueueRow(next, input.expectedRevision);
+      connection.exec('COMMIT');
+      return { record: next, updated: true };
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async expireQueueLeases(now: string): Promise<AdmissionQueueEntry[]> {
+    const connection = this.database.getConnection();
+    connection.exec('BEGIN IMMEDIATE');
+    try {
+      const expired = this.expireQueueInTransaction(now);
+      connection.exec('COMMIT');
+      return expired;
+    } catch (error) {
+      connection.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
   async compareAndSet(
     input: AdmissionReservationCompareAndSetInput
   ): Promise<AdmissionReservationCompareAndSetResult> {
@@ -228,6 +372,199 @@ export class SqliteAdmissionReservationRepository implements AdmissionReservatio
     } catch (error) {
       connection.exec('ROLLBACK');
       throw error;
+    }
+  }
+
+  private claimInTransaction(
+    requested: AdmissionReservation,
+    input: AdmissionReservationClaimInput
+  ): AdmissionReservationClaimResult {
+    const connection = this.database.getConnection();
+    const existingRow = connection
+      .prepare('SELECT reservation_json FROM admission_reservations WHERE id = ?')
+      .get(requested.id) as ReservationRow | undefined;
+    if (existingRow) {
+      const existing = AdmissionReservationSchema.parse(JSON.parse(existingRow.reservation_json));
+      if (existing.request.idempotencyKey !== requested.request.idempotencyKey) {
+        throw new Error(`Admission reservation ${requested.id} has conflicting identity.`);
+      }
+      if (existing.state !== 'expired' || !input.reclaimExpired) {
+        return { record: existing, created: false, limitingPolicies: [] };
+      }
+      const reclaimed = AdmissionReservationSchema.parse({
+        ...requested,
+        revision: existing.revision + 1,
+        createdAt: existing.createdAt,
+      });
+      const limitingPolicies = findLimitingAdmissionPolicies(
+        this.activeReservations().filter((record) => record.id !== existing.id),
+        reclaimed
+      );
+      if (limitingPolicies.length > 0) return { created: false, limitingPolicies };
+      const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
+        this.executionTreeReservations(requested.request.executionTree?.rootObjectiveId).filter(
+          (record) => record.id !== existing.id
+        ),
+        reclaimed
+      );
+      if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
+        return {
+          created: false,
+          limitingPolicies: [],
+          limitingBudgetPolicies:
+            limitingBudgets.terminal.length > 0
+              ? limitingBudgets.terminal
+              : limitingBudgets.retryable,
+          budgetRetryable: limitingBudgets.terminal.length === 0,
+        };
+      }
+      this.updateRow(reclaimed, existing.revision);
+      return {
+        record: reclaimed,
+        created: false,
+        reclaimed: true,
+        limitingPolicies: [],
+      };
+    }
+    const limitingPolicies = findLimitingAdmissionPolicies(this.activeReservations(), requested);
+    if (limitingPolicies.length > 0) return { created: false, limitingPolicies };
+    const limitingBudgets = findLimitingExecutionTreeBudgetPolicies(
+      this.executionTreeReservations(requested.request.executionTree?.rootObjectiveId),
+      requested
+    );
+    if (limitingBudgets.terminal.length > 0 || limitingBudgets.retryable.length > 0) {
+      return {
+        created: false,
+        limitingPolicies: [],
+        limitingBudgetPolicies:
+          limitingBudgets.terminal.length > 0
+            ? limitingBudgets.terminal
+            : limitingBudgets.retryable,
+        budgetRetryable: limitingBudgets.terminal.length === 0,
+      };
+    }
+    this.insertReservationRow(requested);
+    return { record: requested, created: true, limitingPolicies: [] };
+  }
+
+  private insertReservationRow(record: AdmissionReservation): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `INSERT INTO admission_reservations (
+           id, workspace_id, task_id, root_task_id, provider, host_id, state, revision,
+           idempotency_key, lease_expires_at, workflow_run_id, workflow_step_id,
+           root_reservation_id, root_objective_id, node_id, parent_node_id,
+           reservation_json, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        record.id,
+        record.request.workspaceId,
+        record.request.taskId,
+        record.request.rootTaskId,
+        record.request.provider,
+        record.request.hostId,
+        record.state,
+        record.revision,
+        record.request.idempotencyKey,
+        record.lease.expiresAt,
+        record.request.workflowRunId ?? null,
+        record.request.workflowStepId ?? null,
+        record.request.rootReservationId ?? null,
+        record.request.executionTree?.rootObjectiveId ?? null,
+        record.request.executionTree?.nodeId ?? null,
+        record.request.executionTree?.parentNodeId ?? null,
+        JSON.stringify(record),
+        record.createdAt,
+        record.updatedAt
+      );
+  }
+
+  private expireQueueInTransaction(now: string): AdmissionQueueEntry[] {
+    const rows = this.database
+      .getConnection()
+      .prepare(
+        `SELECT queue_json FROM admission_queue
+         WHERE state = 'leased' AND lease_expires_at <= ?`
+      )
+      .all(now) as unknown as QueueRow[];
+    return rows.map((row) => {
+      const current = AdmissionQueueEntrySchema.parse(JSON.parse(row.queue_json));
+      const retryCount = current.retryCount + 1;
+      const terminal = retryCount > current.maxRetries;
+      const next = AdmissionQueueEntrySchema.parse({
+        ...current,
+        revision: current.revision + 1,
+        state: terminal ? 'terminal' : 'requeued',
+        retryCount,
+        availableAt: new Date(Date.parse(now) + current.retryAfterMs).toISOString(),
+        lease: undefined,
+        reservationId: undefined,
+        ...(terminal
+          ? {
+              terminal: {
+                code: 'QUEUE_LEASE_EXPIRED',
+                reason: 'The queue lease expired before dispatch ownership became durable.',
+                recordedAt: now,
+              },
+            }
+          : {}),
+        updatedAt: now,
+      });
+      this.updateQueueRow(next, current.revision);
+      return next;
+    });
+  }
+
+  private insertQueueRow(entry: AdmissionQueueEntry): void {
+    this.database
+      .getConnection()
+      .prepare(
+        `INSERT INTO admission_queue (
+           id, workspace_id, task_id, state, revision, enqueue_sequence, available_at,
+           lease_expires_at, queue_json, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        entry.id,
+        entry.request.workspaceId,
+        entry.request.taskId,
+        entry.state,
+        entry.revision,
+        entry.enqueueSequence,
+        entry.availableAt,
+        entry.lease?.expiresAt ?? null,
+        JSON.stringify(entry),
+        entry.createdAt,
+        entry.updatedAt
+      );
+  }
+
+  private updateQueueRow(entry: AdmissionQueueEntry, expectedRevision: number): void {
+    const result = this.database
+      .getConnection()
+      .prepare(
+        `UPDATE admission_queue
+         SET workspace_id = ?, task_id = ?, state = ?, revision = ?, enqueue_sequence = ?,
+             available_at = ?, lease_expires_at = ?, queue_json = ?, updated_at = ?
+         WHERE id = ? AND revision = ?`
+      )
+      .run(
+        entry.request.workspaceId,
+        entry.request.taskId,
+        entry.state,
+        entry.revision,
+        entry.enqueueSequence,
+        entry.availableAt,
+        entry.lease?.expiresAt ?? null,
+        JSON.stringify(entry),
+        entry.updatedAt,
+        entry.id,
+        expectedRevision
+      );
+    if (result.changes !== 1) {
+      throw new Error('Admission queue compare-and-set changed unexpectedly.');
     }
   }
 

--- a/server/src/storage/sqlite/migrations.ts
+++ b/server/src/storage/sqlite/migrations.ts
@@ -1346,6 +1346,39 @@ export const SQLITE_BASE_MIGRATIONS: readonly SqliteMigration[] = [
         ON admission_reservations(parent_node_id, updated_at DESC);
     `,
   },
+  {
+    version: 26,
+    name: '0026_durable_admission_queue',
+    up: `
+      CREATE TABLE admission_queue (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        task_id TEXT NOT NULL,
+        state TEXT NOT NULL
+          CHECK (state IN ('queued', 'leased', 'requeued', 'dispatched', 'terminal')),
+        revision INTEGER NOT NULL CHECK (revision > 0),
+        enqueue_sequence INTEGER NOT NULL CHECK (enqueue_sequence > 0),
+        available_at TEXT NOT NULL,
+        lease_expires_at TEXT,
+        queue_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE UNIQUE INDEX idx_admission_queue_active_task
+        ON admission_queue(task_id)
+        WHERE state IN ('queued', 'leased', 'requeued');
+
+      CREATE INDEX idx_admission_queue_fifo
+        ON admission_queue(state, available_at, enqueue_sequence, id);
+
+      CREATE INDEX idx_admission_queue_workspace
+        ON admission_queue(workspace_id, state, enqueue_sequence);
+
+      CREATE INDEX idx_admission_queue_lease
+        ON admission_queue(state, lease_expires_at);
+    `,
+  },
 ];
 
 export function sortedMigrations(migrations: readonly SqliteMigration[]): SqliteMigration[] {

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -1,4 +1,5 @@
 import type { ExecutableAgentProvider } from './config.types.js';
+import type { AgentType } from './task.types.js';
 import type {
   ExecutionTreeBudgetPolicy,
   ExecutionTreeBudgetState,
@@ -11,6 +12,7 @@ import type { AgentBudgetUsage } from './agent-budget.types.js';
 export const ADMISSION_REQUEST_SCHEMA_VERSION = 'admission-request/v1' as const;
 export const ADMISSION_DECISION_SCHEMA_VERSION = 'admission-decision/v1' as const;
 export const ADMISSION_RESERVATION_SCHEMA_VERSION = 'admission-reservation/v1' as const;
+export const ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION = 'admission-queue-entry/v1' as const;
 export const ADMISSION_CONTROL_PROVIDER = 'workflow-control' as const;
 export type AdmissionProvider = ExecutableAgentProvider | typeof ADMISSION_CONTROL_PROVIDER;
 
@@ -27,8 +29,19 @@ export type AdmissionScope = (typeof ADMISSION_SCOPES)[number];
 export const ADMISSION_RESERVATION_STATES = ['active', 'released', 'expired'] as const;
 export type AdmissionReservationState = (typeof ADMISSION_RESERVATION_STATES)[number];
 
+export const ADMISSION_QUEUE_STATES = [
+  'queued',
+  'leased',
+  'requeued',
+  'dispatched',
+  'terminal',
+] as const;
+export type AdmissionQueueState = (typeof ADMISSION_QUEUE_STATES)[number];
+
 export const ADMISSION_DECISION_OUTCOMES = [
   'admitted',
+  'queued',
+  'queue-overflow',
   'retryable-overload',
   'terminal-policy-denial',
 ] as const;
@@ -114,16 +127,69 @@ export interface AdmissionReservation {
   updatedAt: string;
 }
 
+export interface AdmissionQueueTerminalEvidence {
+  code: string;
+  reason: string;
+  recordedAt: string;
+}
+
+export interface AdmissionQueueEntry {
+  schemaVersion: typeof ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION;
+  id: string;
+  revision: number;
+  state: AdmissionQueueState;
+  enqueueSequence: number;
+  agent: AgentType;
+  attemptId: string;
+  request: AdmissionRequest;
+  policies: AdmissionLimitPolicy[];
+  limitingPolicies: AdmissionLimitPolicy[];
+  limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[];
+  retryAfterMs: number;
+  retryCount: number;
+  maxRetries: number;
+  availableAt: string;
+  lease?: AdmissionReservationLease;
+  reservationId?: string;
+  dispatchedAttemptId?: string;
+  terminal?: AdmissionQueueTerminalEvidence;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface AdmissionDecision {
   schemaVersion: typeof ADMISSION_DECISION_SCHEMA_VERSION;
   outcome: AdmissionDecisionOutcome;
   request: AdmissionRequest;
   reservation?: AdmissionReservation;
+  queueEntry?: AdmissionQueueEntry;
   limitingPolicies: AdmissionLimitPolicy[];
   limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[];
   retryAfterMs?: number;
   reason: string;
   decidedAt: string;
+}
+
+export interface AdmissionQueueListQuery {
+  workspaceId?: string;
+  taskId?: string;
+  states?: AdmissionQueueState[];
+  eligibleAt?: string;
+  limit?: number;
+}
+
+export interface AdmissionQueueDraft {
+  id: string;
+  agent: AgentType;
+  attemptId: string;
+  request: AdmissionRequest;
+  policies: AdmissionLimitPolicy[];
+  limitingPolicies: AdmissionLimitPolicy[];
+  limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[];
+  retryAfterMs: number;
+  maxRetries: number;
+  availableAt: string;
+  createdAt: string;
 }
 
 export interface AdmissionReservationListQuery {
@@ -169,6 +235,53 @@ export interface AdmissionReservationClaimResult {
   budgetRetryable?: boolean;
 }
 
+export interface AdmissionReservationClaimOrQueueInput {
+  record: AdmissionReservation;
+  queue: AdmissionQueueDraft;
+  now: string;
+  globalQueueLimit: number;
+  workspaceQueueLimit: number;
+}
+
+export interface AdmissionReservationClaimOrQueueResult extends AdmissionReservationClaimResult {
+  queueEntry?: AdmissionQueueEntry;
+  queueOverflow?: 'global' | 'workspace';
+  queueConflict?: boolean;
+}
+
+export interface AdmissionQueuedClaimInput {
+  queueId: string;
+  expectedRevision: number;
+  record: AdmissionReservation;
+  now: string;
+}
+
+export interface AdmissionQueuedClaimResult {
+  entry?: AdmissionQueueEntry;
+  reservation?: AdmissionReservation;
+  stale: boolean;
+  limitingPolicies: AdmissionLimitPolicy[];
+  limitingBudgetPolicies?: ExecutionTreeBudgetPolicy[];
+  budgetRetryable?: boolean;
+}
+
+export interface AdmissionQueueCompareAndSetInput {
+  id: string;
+  expectedRevision: number;
+  next: AdmissionQueueEntry;
+}
+
+export interface AdmissionQueueCompareAndSetResult {
+  record?: AdmissionQueueEntry;
+  updated: boolean;
+  reason?: 'not-found' | 'stale-revision' | 'invalid-revision';
+}
+
+export interface AdmissionQueueClaim {
+  entry: AdmissionQueueEntry;
+  reservation: AdmissionReservation;
+}
+
 export interface AdmissionBudgetUsageInput {
   reservationId: string;
   event: ExecutionTreeBudgetUsageEvent;
@@ -192,4 +305,12 @@ export interface AdmissionSettings {
   rootTasks: Record<string, AdmissionCapacityLimit>;
   providers: Partial<Record<AdmissionProvider, AdmissionCapacityLimit>>;
   hosts: Record<string, AdmissionCapacityLimit>;
+  queue: {
+    enabled: boolean;
+    globalLimit: number;
+    workspaceLimit: number;
+    leaseMs: number;
+    retryBackoffMs: number;
+    maxRetries: number;
+  };
 }

--- a/shared/src/types/config.types.ts
+++ b/shared/src/types/config.types.ts
@@ -566,6 +566,14 @@ export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
     rootTasks: {},
     providers: {},
     hosts: {},
+    queue: {
+      enabled: true,
+      globalLimit: 1_000,
+      workspaceLimit: 100,
+      leaseMs: 30_000,
+      retryBackoffMs: 5_000,
+      maxRetries: 3,
+    },
   },
   enforcement: {
     squadChat: false,


### PR DESCRIPTION
## Summary

- Persist one bounded FIFO queue entry when a reconstructable direct agent launch is temporarily capacity-limited.
- Claim queue order, admission capacity, and lease ownership atomically across file and SQLite storage.
- Revalidate task, provider, sandbox, budget, workspace trust, and immutable launch evidence before creating an attempt.
- Keep pre-dispatch retries bounded and transfer post-dispatch ownership to run recovery.
- Preserve compatibility with legacy queue records while redacting raw idempotency values and transient launch input.

## Verification

- Shared package build
- Server typecheck
- Exact admission-control and schema test files: 152 tests passed
- Exact direct-provider dispatch test file: 60 tests passed
- Changed-file formatting, lint, security-artifact, and diff checks

## Risk

Only fresh direct starts that can be reconstructed from durable task configuration enter the queue. Launches with transient messages or request-specific overrides continue to fail closed.

Closes #1061
