### PR TITLE
chore: enforce sustainable delivery cadence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,9 @@ Do not run `npm install`, `yarn`, or `bun install`. If lockfile conflicts arise,
   a linked issue instead of expanding the active pull request.
 - Re-scope before continuing when an issue no longer fits one coherent review, an unexpected
   subsystem becomes necessary, or verification work is larger than the behavior being changed.
+- At the 45-minute delivery checkpoint, if the issue is not pull-request ready, stop adding scope
+  and report the concrete cause. Split independent remaining work into linked issues, or continue
+  only when the next step is required to preserve correctness of the current behavior.
 - During implementation, run the narrowest useful loop: type-check touched packages, lint changed
   files, and run focused tests for changed behavior and high-risk edges.
 - Run focused Vitest slices with

--- a/scripts/check-delivery-cadence.mjs
+++ b/scripts/check-delivery-cadence.mjs
@@ -18,6 +18,10 @@ export const CADENCE_CONTRACTS = {
       pattern: /run the narrowest useful loop/i,
     },
     {
+      description: '45-minute split or escalate delivery checkpoint',
+      pattern: /45-minute delivery checkpoint/i,
+    },
+    {
       description: 'direct Vitest exact-file invocation',
       pattern: /exec vitest run/i,
     },

--- a/scripts/check-delivery-cadence.test.mjs
+++ b/scripts/check-delivery-cadence.test.mjs
@@ -34,6 +34,22 @@ test('reports a missing canonical cadence rule with its file', () => {
   ]);
 });
 
+test('requires the 45-minute delivery checkpoint in canonical guidance', () => {
+  const files = validContractFiles();
+  files['AGENTS.md'] = files['AGENTS.md'].replace(
+    '45-minute delivery checkpoint',
+    'unbounded delivery loop'
+  );
+
+  assert.deepEqual(findMissingCadenceContracts(files), [
+    {
+      file: 'AGENTS.md',
+      message:
+        'required cadence contract is missing: 45-minute split or escalate delivery checkpoint',
+    },
+  ]);
+});
+
 test('rejects unconditional workspace-wide pnpm test commands', () => {
   assert.deepEqual(
     findUnsafePromptStatements({


### PR DESCRIPTION
## Summary

- Make `gh` the standard GitHub interface and retain reviewed release-note files as publication authority.
- Require one independently shippable behavior per issue and a 45-minute split or escalate checkpoint.
- Use direct exact-file Vitest commands during implementation and reserve complete suites for explicit milestones.
- Keep independent and cross-model review optional and proportional to risk.
- Add pull request verification tiers and linked follow-up fields.
- Enforce the contract with a dependency-free checker wired into path-aware CI.

## Verification

- Delivery-cadence checker: 18 tests passed
- Canonical delivery guidance consistency check
- Security-artifact and diff checks

## Risk

This does not weaken release, integration, or critical-security gates. The `ci:full` label, scheduled CI, and manual full dispatch remain authoritative broad verification paths.

Closes #1068
