### PR TITLE
feat: inspect admission queues through REST and CLI

### DIFF
--- a/cli/src/__tests__/admission.test.ts
+++ b/cli/src/__tests__/admission.test.ts
@@ -102,4 +102,171 @@ describe('vk admission commands', () => {
     });
     output.mockRestore();
   });
+
+  it('lists the admission queue as JSON with all operator filters preserved', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'admission-queue-list/v1',
+      generatedAt: '2026-07-25T12:00:00.000Z',
+      conditional: true,
+      depth: {
+        global: { current: 2, limit: 1_000 },
+        workspaces: [],
+      },
+      pagination: { page: 2, limit: 25, total: 26, hasMore: false },
+      entries: [{ id: 'admission_queue_1', state: 'queued', position: 26 }],
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'queue',
+      'list',
+      '--workspace',
+      'workspace-a',
+      '--root-objective',
+      'objective-a',
+      '--node',
+      'node-a',
+      '--source',
+      'workflow',
+      '--state',
+      'queued',
+      'requeued',
+      '--priority',
+      '3',
+      '--limiting-scope',
+      'provider',
+      '--min-age',
+      '60000',
+      '--max-age',
+      '3600000',
+      '--page',
+      '2',
+      '--limit',
+      '25',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith(
+      '/api/admission/queue?workspaceId=workspace-a&rootObjectiveId=objective-a&nodeId=node-a&source=workflow&state=queued&state=requeued&priority=3&limitingScope=provider&minAgeMs=60000&maxAgeMs=3600000&page=2&limit=25'
+    );
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      schemaVersion: 'admission-queue-list/v1',
+      conditional: true,
+      entries: [{ id: 'admission_queue_1', position: 26 }],
+    });
+    output.mockRestore();
+  });
+
+  it('inspects one admission queue entry as JSON', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'admission-queue-inspection/v1',
+      generatedAt: '2026-07-25T12:00:00.000Z',
+      conditional: true,
+      depth: {
+        global: { current: 1, limit: 1_000 },
+        workspaces: [],
+      },
+      entry: {
+        schemaVersion: 'admission-queue-inspection/v1',
+        id: 'admission_queue_1',
+        state: 'leased',
+        readiness: 'reserved',
+      },
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'queue',
+      'get',
+      'admission_queue_1',
+      '--json',
+    ]);
+
+    expect(api).toHaveBeenCalledWith('/api/admission/queue/admission_queue_1');
+    expect(JSON.parse(String(output.mock.calls[0][0]))).toMatchObject({
+      schemaVersion: 'admission-queue-inspection/v1',
+      entry: { id: 'admission_queue_1', readiness: 'reserved' },
+    });
+    output.mockRestore();
+  });
+
+  it('prints compact conditional queue output without an exact start promise', async () => {
+    api.mockResolvedValue({
+      schemaVersion: 'admission-queue-list/v1',
+      generatedAt: '2026-07-25T12:00:00.000Z',
+      conditional: true,
+      depth: {
+        global: { current: 1, limit: 1_000 },
+        workspaces: [],
+      },
+      pagination: {
+        page: 1,
+        limit: 1,
+        total: 1,
+        hasMore: false,
+        snapshotTruncated: false,
+      },
+      entries: [
+        {
+          schemaVersion: 'admission-queue-inspection/v1',
+          id: 'admission_queue_1',
+          state: 'queued',
+          position: 1,
+          rawPriority: 1,
+          effectivePriority: 2,
+          agePromotion: 1,
+          ageMs: 60_000,
+          readiness: 'conditional',
+          lease: { posture: 'none' },
+          limitingPolicies: [],
+          conditionalStartFactors: ['capacity-recheck'],
+          launch: {
+            source: 'direct',
+            target: 'direct',
+            taskKey: `sha256:${'a'.repeat(64)}`,
+            rootTaskKey: `sha256:${'b'.repeat(64)}`,
+            workspaceKey: `sha256:${'c'.repeat(64)}`,
+            provider: 'codex-cli',
+            hostKey: `sha256:${'d'.repeat(64)}`,
+          },
+          retry: {
+            count: 0,
+            maximum: 3,
+            availableAt: '2026-07-25T12:00:00.000Z',
+          },
+          createdAt: '2026-07-25T11:59:00.000Z',
+          updatedAt: '2026-07-25T11:59:00.000Z',
+        },
+      ],
+    });
+    const output = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = new Command().exitOverride();
+    registerAdmissionCommands(program);
+
+    await program.parseAsync([
+      'node',
+      'vk',
+      'admission',
+      'queue',
+      'list',
+      '--limit',
+      '1',
+    ]);
+
+    const rendered = output.mock.calls.map(([line]) => String(line)).join('\n');
+    expect(rendered).toContain('priority=1->2 readiness=conditional');
+    expect(rendered).toContain('Conditional snapshot at 2026-07-25T12:00:00.000Z');
+    expect(rendered).not.toMatch(/\bETA\b|starts? at|start time/i);
+    output.mockRestore();
+  });
 });

--- a/cli/src/commands/admission.ts
+++ b/cli/src/commands/admission.ts
@@ -1,8 +1,14 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import type {
+  AdmissionLaunchSource,
+  AdmissionQueueGetResponse,
+  AdmissionQueueInspectionEntry,
+  AdmissionQueueListResponse,
+  AdmissionQueueState,
   AdmissionReservation,
   AdmissionReservationState,
+  AdmissionScope,
   ExecutionTreeBudgetSummary,
 } from '@veritas-kanban/shared';
 import { api } from '../utils/api.js';
@@ -16,6 +22,89 @@ export function registerAdmissionCommands(program: Command): void {
   const admission = program
     .command('admission')
     .description('Inspect durable execution admission reservations');
+
+  const queue = admission.command('queue').description('Inspect the durable admission queue');
+
+  queue
+    .command('list')
+    .description('List queued, leased, dispatched, or terminal admission entries')
+    .option('--workspace <id>', 'Filter by workspace')
+    .option('--root-objective <id>', 'Filter by execution-tree root objective')
+    .option('--node <id>', 'Filter by execution-tree node')
+    .option('--source <sources...>', 'Filter by launch source')
+    .option('--state <states...>', 'Filter by queue state')
+    .option('--priority <level>', 'Filter by raw numeric priority')
+    .option('--limiting-scope <scopes...>', 'Filter by limiting scope')
+    .option('--min-age <milliseconds>', 'Minimum queue age in milliseconds')
+    .option('--max-age <milliseconds>', 'Maximum queue age in milliseconds')
+    .option('--page <number>', 'Result page', '1')
+    .option('--limit <count>', 'Maximum entries per page', '100')
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+      try {
+        const query = new URLSearchParams();
+        if (options.workspace) query.set('workspaceId', options.workspace);
+        if (options.rootObjective) query.set('rootObjectiveId', options.rootObjective);
+        if (options.node) query.set('nodeId', options.node);
+        for (const source of (options.source ?? []) as AdmissionLaunchSource[]) {
+          query.append('source', source);
+        }
+        for (const state of (options.state ?? []) as AdmissionQueueState[]) {
+          query.append('state', state);
+        }
+        if (options.priority) query.set('priority', options.priority);
+        for (const scope of (options.limitingScope ?? []) as AdmissionScope[]) {
+          query.append('limitingScope', scope);
+        }
+        if (options.minAge) query.set('minAgeMs', options.minAge);
+        if (options.maxAge) query.set('maxAgeMs', options.maxAge);
+        query.set('page', options.page);
+        query.set('limit', options.limit);
+        const result = await api<AdmissionQueueListResponse>(
+          `/api/admission/queue?${query.toString()}`
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        if (result.entries.length === 0) {
+          console.log(chalk.dim('No admission queue entries matched.'));
+          return;
+        }
+        for (const entry of result.entries) printQueueEntry(entry);
+        console.log(
+          chalk.dim(
+            `Conditional snapshot at ${result.generatedAt}; ${result.depth.global.current}/${result.depth.global.limit} global queue slots used.`
+          )
+        );
+      } catch (error) {
+        printError(error);
+      }
+    });
+
+  queue
+    .command('get <id>')
+    .description('Inspect one admission queue entry')
+    .option('--json', 'Output as JSON')
+    .action(async (id, options) => {
+      try {
+        const result = await api<AdmissionQueueGetResponse>(
+          `/api/admission/queue/${encodeURIComponent(id)}`
+        );
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        printQueueEntry(result.entry, true);
+        console.log(
+          chalk.dim(
+            `Conditional snapshot at ${result.generatedAt}; capacity, policy, arrivals, and leases may change position.`
+          )
+        );
+      } catch (error) {
+        printError(error);
+      }
+    });
 
   admission
     .command('list')
@@ -104,6 +193,27 @@ export function registerAdmissionCommands(program: Command): void {
         printError(error);
       }
     });
+}
+
+function printQueueEntry(entry: AdmissionQueueInspectionEntry, verbose = false): void {
+  console.log(
+    `${entry.position ?? '-'} ${entry.state} ${chalk.bold(entry.id)} priority=${entry.rawPriority}->${entry.effectivePriority} readiness=${entry.readiness}`
+  );
+  console.log(
+    chalk.dim(
+      `  source=${entry.launch.source} target=${entry.launch.target} age=${entry.ageMs}ms lease=${entry.lease.posture}`
+    )
+  );
+  if (verbose) {
+    console.log(
+      chalk.dim(
+        `  retries=${entry.retry.count}/${entry.retry.maximum} available=${entry.retry.availableAt}`
+      )
+    );
+    console.log(
+      chalk.dim(`  conditional=${entry.conditionalStartFactors.join(',') || 'capacity-recheck'}`)
+    );
+  }
 }
 
 function printReservation(reservation: AdmissionReservation, verbose = false): void {

--- a/docs/AGENT-PROVIDERS.md
+++ b/docs/AGENT-PROVIDERS.md
@@ -1042,7 +1042,12 @@ matching read-only REST endpoints. Use `--workflow-run`, `--workflow-step`,
 `--root-reservation`, or `--root-objective` to follow a tree. Use
 `vk admission tree <root-objective-id>` for aggregate totals, remaining policy
 capacity, blocking policies, and bounded contributors. Machine consumers
-should use `--json`.
+should use `--json`. Inspect the conditional, redacted queue view with
+`vk admission queue list`, `vk admission queue get <queue-id>`, or the matching
+`/api/v1/admission/queue` endpoints. Queue position is evidence at the response
+generation time, never an exact start-time promise. Machine consumers may use
+the safe `navigation` identifiers to open related task, attempt, workflow, and
+execution-tree views without accessing the redacted launch payload.
 
 ## Local And Cloud Profiles
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4150,6 +4150,8 @@ provider and selected host. Inspection requires `agent:read`.
 | Method | Path                                   | Description                                             |
 | ------ | -------------------------------------- | ------------------------------------------------------- |
 | `GET`  | `/api/admission`                       | List reservations with optional scope and state filters |
+| `GET`  | `/api/admission/queue`                 | List the bounded, redacted admission queue view         |
+| `GET`  | `/api/admission/queue/:id`             | Inspect one redacted queue entry                        |
 | `GET`  | `/api/admission/tree/:rootObjectiveId` | Summarize one aggregate execution tree                  |
 | `GET`  | `/api/admission/:id`                   | Inspect one durable reservation                         |
 
@@ -4157,6 +4159,34 @@ List filters are `workspaceId`, `taskId`, `rootTaskId`, `provider`, `hostId`,
 `workflowRunId`, `workflowStepId`, `rootReservationId`, `rootObjectiveId`,
 `nodeId`, `parentNodeId`, repeatable `state` (`active`, `released`, `expired`),
 and `limit` (1-1000).
+
+Queue-list filters are `workspaceId`, `rootObjectiveId`, `nodeId`, repeatable
+`source`, repeatable `state`, raw numeric `priority`, repeatable
+`limitingScope`, `minAgeMs`, `maxAgeMs`, `page`, and `limit` (1-200).
+
+```http
+GET /api/v1/admission/queue?state=queued&source=workflow&minAgeMs=60000&page=1&limit=25
+```
+
+Queue list responses use `admission-queue-list/v1`; individual entries and
+get responses use `admission-queue-inspection/v1`. Every response carries a
+generation timestamp and `conditional: true`. Entries report current
+scheduler position, raw and effective priority, age promotion, readiness,
+lease posture, redacted limiting policies, conditional start factors, and
+persisted selection evidence. Global and per-workspace depth are reported
+against configured queue bounds. Workspace depth includes both the operator
+workspace identifier and its stable redacted key. Safe navigation fields expose
+the workspace, task, attempt, workflow run, workflow step, root objective, and
+execution-tree node identifiers that exist for the entry. Host and root-task
+identities remain hashed.
+
+Pagination is deterministic for the bounded snapshot. `snapshotTruncated`
+signals that older terminal history fell outside the 1,000-entry inspection
+window. Position and readiness can change after generation because arrivals,
+capacity, policy, backoff, and lease state can change. Responses never promise
+an exact start time and never contain raw host or root-task identities, full
+launch payloads, idempotency material, prompts, messages, tool arguments, or
+credentials.
 
 ```http
 GET /api/v1/admission?state=active&provider=codex-cli&limit=25
@@ -4217,7 +4247,8 @@ profile, readiness override, sandbox or budget override, explicit runtime
 capability, commit policy, phase, recovery, or parent attempt are not
 reconstructable from durable task configuration and continue to fail closed
 with `ADMISSION_OVERLOAD`. Queue bounds and retry behavior are configured under
-`features.admission.queue`. Queue inspection endpoints are added separately;
+`features.admission.queue`. Queue inspection is available through
+`GET /api/v1/admission/queue` and `GET /api/v1/admission/queue/:id`;
 reservation inspection remains unchanged.
 
 Workflow roots and provider-backed steps use the same durable queue internally.

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -605,6 +605,10 @@ vk admission list --root-objective objective_0123456789abcdef --json
 vk admission get admission_0123456789abcdef --json
 vk admission tree objective_0123456789abcdef
 vk admission tree objective_0123456789abcdef --limit 25 --json
+vk admission queue list
+vk admission queue list --state queued requeued --source workflow --min-age 60000 --json
+vk admission queue get admission_queue_0123456789abcdef
+vk admission queue get admission_queue_0123456789abcdef --json
 ```
 
 `admission list` filters by workspace, task, root task, provider, host, state,
@@ -618,6 +622,14 @@ operator diagnosis. `admission tree` reports committed and reserved tokens,
 cost, tool calls, runtime, retries, fan-out, policy availability, and bounded
 contributors without double counting descendant totals. These are read-only
 commands and require `agent:read`.
+
+`admission queue list` filters by workspace, root objective, node, launch
+source, queue state, raw numeric priority, limiting scope, age window, page,
+and result limit. `admission queue get` shows one entry with position,
+priority aging, readiness, lease posture, redacted launch identity, limiting
+policy, conditional start factors, selection evidence, and safe navigation
+identifiers. Human output labels the snapshot as conditional and never presents
+an ETA or exact start time. Use `--json` for the complete versioned REST shape.
 
 ---
 

--- a/server/src/__tests__/admission-control-service.test.ts
+++ b/server/src/__tests__/admission-control-service.test.ts
@@ -587,6 +587,166 @@ describe.each(['file', 'sqlite'] as const)('%s admission reservation parity', (b
     expect(stillQueued.selectionEvidence).toBeUndefined();
   });
 
+  it('projects a filtered, redacted queue view and inspects leased evidence', async () => {
+    const repository = await repositoryFor(backend);
+    let now = new Date('2026-07-25T12:00:00.000Z');
+    const settings = configuredSettings({ global: { concurrentRuns: 1 } });
+    const service = createService(repository, settings, {
+      now: () => now,
+      ownerId: `owner-inspection-${backend}`,
+    });
+    await expect(service.inspectQueue({ page: 1, limit: 1 })).resolves.toMatchObject({
+      depth: { global: { current: 0, limit: 1_000 }, workspaces: [] },
+      pagination: {
+        page: 1,
+        limit: 1,
+        total: 0,
+        hasMore: false,
+        snapshotTruncated: false,
+      },
+      entries: [],
+    });
+    const active = await service.admit(request(`task-inspection-active-${backend}`));
+    const low = await service.admitOrQueue(
+      treeRequest(`task-inspection-low-${backend}`, 'node-low'),
+      {
+        agent: 'codex',
+        attemptId: `attempt-inspection-low-${backend}`,
+        priority: 'low',
+      }
+    );
+    const high = await service.admitOrQueue(
+      {
+        ...request(`task-inspection-high-${backend}`),
+        workspaceId: 'workspace-b',
+      },
+      {
+        agent: 'codex',
+        attemptId: `attempt-inspection-high-${backend}`,
+        priority: 'critical',
+      }
+    );
+    now = new Date('2026-07-25T12:02:00.000Z');
+
+    const listed = await service.inspectQueue({
+      workspaceId: 'workspace-a',
+      rootObjectiveId: 'objective-a',
+      nodeId: 'node-low',
+      sources: ['direct'],
+      states: ['queued'],
+      priority: 0,
+      limitingScopes: ['global'],
+      minAgeMs: 60_000,
+      maxAgeMs: 180_000,
+      page: 1,
+      limit: 10,
+    });
+
+    expect(listed).toMatchObject({
+      schemaVersion: 'admission-queue-list/v1',
+      generatedAt: now.toISOString(),
+      conditional: true,
+      depth: {
+        global: { current: 2, limit: 1_000 },
+        workspaces: expect.arrayContaining([
+          expect.objectContaining({
+            workspaceId: 'workspace-a',
+            workspaceKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+            current: 1,
+            limit: 100,
+          }),
+        ]),
+      },
+      pagination: { page: 1, limit: 10, total: 1, hasMore: false },
+      entries: [
+        {
+          id: low.queueEntry?.id,
+          state: 'queued',
+          position: 2,
+          rawPriority: 0,
+          effectivePriority: 2,
+          agePromotion: 2,
+          ageMs: 120_000,
+          readiness: 'conditional',
+          lease: { posture: 'none' },
+          launch: {
+            source: 'direct',
+            target: 'direct',
+            provider: 'codex-cli',
+            workspaceId: 'workspace-a',
+            taskKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+            workspaceKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+            rootObjectiveKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+            nodeKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          },
+          navigation: {
+            taskId: `task-inspection-low-${backend}`,
+            attemptId: `attempt-inspection-low-${backend}`,
+            executionTree: {
+              rootObjectiveId: 'objective-a',
+              nodeId: 'node-low',
+              edge: 'root',
+              depth: 0,
+            },
+          },
+          limitingPolicies: [
+            {
+              scope: 'global',
+              scopeKey: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+              limits: { concurrentRuns: 1 },
+            },
+          ],
+          conditionalStartFactors: expect.arrayContaining([
+            'queue-eligibility',
+            'active-reservation-release',
+            'policy-recheck',
+          ]),
+        },
+      ],
+    });
+    const serialized = JSON.stringify(listed);
+    expect(serialized).toContain('workspace-a');
+    expect(serialized).toContain(`task-inspection-low-${backend}`);
+    expect(serialized).not.toContain(`tree:node-low`);
+    expect(serialized).not.toContain('idempotencyKey');
+
+    const firstPage = await service.inspectQueue({ page: 1, limit: 1 });
+    const secondPage = await service.inspectQueue({ page: 2, limit: 1 });
+    expect(firstPage).toMatchObject({
+      pagination: { page: 1, limit: 1, total: 2, hasMore: true },
+      entries: [{ id: high.queueEntry?.id, position: 1 }],
+    });
+    expect(secondPage).toMatchObject({
+      pagination: { page: 2, limit: 1, total: 2, hasMore: false },
+      entries: [{ id: low.queueEntry?.id, position: 2 }],
+    });
+
+    await service.release(
+      active.reservation?.id as string,
+      'completed',
+      `release-inspection-active-${backend}`
+    );
+    const claim = await service.claimNextQueued();
+    expect(claim?.entry.id).toBe(high.queueEntry?.id);
+
+    const inspected = await service.inspectQueueEntry(high.queueEntry?.id as string);
+    expect(inspected).toMatchObject({
+      schemaVersion: 'admission-queue-inspection/v1',
+      conditional: true,
+      entry: {
+        id: high.queueEntry?.id,
+        state: 'leased',
+        readiness: 'reserved',
+        lease: { posture: 'active', expiresAt: claim?.entry.lease?.expiresAt },
+        selectionEvidence: {
+          selectedQueueEntryId: high.queueEntry?.id,
+          capacityReadiness: 'ready',
+        },
+      },
+    });
+    expect(inspected.entry.position).toBeUndefined();
+  });
+
   it('reactivates a released pre-dispatch reservation when the queue retries', async () => {
     const repository = await repositoryFor(backend);
     let now = new Date('2026-07-25T12:00:00.000Z');

--- a/server/src/__tests__/routes/admission.test.ts
+++ b/server/src/__tests__/routes/admission.test.ts
@@ -6,6 +6,8 @@ import { errorHandler } from '../../middleware/error-handler.js';
 const admission = vi.hoisted(() => ({
   list: vi.fn(),
   get: vi.fn(),
+  inspectQueue: vi.fn(),
+  inspectQueueEntry: vi.fn(),
 }));
 
 vi.mock('../../services/admission-control-service.js', () => ({
@@ -49,6 +51,45 @@ describe('admission routes', () => {
     );
   });
 
+  it('lists the versioned queue view with bounded operator filters', async () => {
+    admission.inspectQueue.mockResolvedValue({
+      schemaVersion: 'admission-queue-list/v1',
+      generatedAt: '2026-07-25T12:00:00.000Z',
+      conditional: true,
+      depth: {
+        global: { current: 2, limit: 1_000 },
+        workspaces: [{ workspaceKey: `sha256:${'a'.repeat(64)}`, current: 2, limit: 100 }],
+      },
+      pagination: { page: 1, limit: 25, total: 1, hasMore: false },
+      entries: [{ id: 'admission_queue_1', state: 'queued', position: 1 }],
+    });
+
+    const response = await request(createApp()).get(
+      '/api/admission/queue?workspaceId=workspace-a&rootObjectiveId=objective-a&nodeId=node-a&source=workflow&state=queued&state=requeued&priority=3&limitingScope=provider&minAgeMs=60000&maxAgeMs=3600000&page=1&limit=25'
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      schemaVersion: 'admission-queue-list/v1',
+      conditional: true,
+      pagination: { page: 1, limit: 25, total: 1, hasMore: false },
+      entries: [{ id: 'admission_queue_1', position: 1 }],
+    });
+    expect(admission.inspectQueue).toHaveBeenCalledWith({
+      workspaceId: 'workspace-a',
+      rootObjectiveId: 'objective-a',
+      nodeId: 'node-a',
+      sources: ['workflow'],
+      states: ['queued', 'requeued'],
+      priority: 3,
+      limitingScopes: ['provider'],
+      minAgeMs: 60_000,
+      maxAgeMs: 3_600_000,
+      page: 1,
+      limit: 25,
+    });
+  });
+
   it('inspects one reservation and rejects invalid list filters', async () => {
     admission.get.mockResolvedValue({ id: 'admission_1', state: 'released' });
 
@@ -59,6 +100,27 @@ describe('admission routes', () => {
     expect(found.body).toEqual({ id: 'admission_1', state: 'released' });
     expect(invalid.status).toBe(400);
     expect(admission.list).not.toHaveBeenCalled();
+  });
+
+  it('inspects one queue entry and rejects invalid queue filters', async () => {
+    admission.inspectQueueEntry.mockResolvedValue({
+      schemaVersion: 'admission-queue-inspection/v1',
+      entry: { id: 'admission_queue_1', state: 'leased' },
+    });
+
+    const found = await request(createApp()).get('/api/admission/queue/admission_queue_1');
+    const invalid = await request(createApp()).get(
+      '/api/admission/queue?minAgeMs=5000&maxAgeMs=1000'
+    );
+
+    expect(found.status).toBe(200);
+    expect(found.body).toMatchObject({
+      schemaVersion: 'admission-queue-inspection/v1',
+      entry: { id: 'admission_queue_1', state: 'leased' },
+    });
+    expect(admission.inspectQueueEntry).toHaveBeenCalledWith('admission_queue_1');
+    expect(invalid.status).toBe(400);
+    expect(admission.inspectQueue).not.toHaveBeenCalled();
   });
 
   it('returns a validation error for an invalid reservation identifier', async () => {

--- a/server/src/routes/admission.ts
+++ b/server/src/routes/admission.ts
@@ -1,5 +1,10 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
+import {
+  ADMISSION_LAUNCH_SOURCES,
+  ADMISSION_QUEUE_STATES,
+  ADMISSION_SCOPES,
+} from '@veritas-kanban/shared';
 import { asyncHandler } from '../middleware/async-handler.js';
 import { ValidationError } from '../middleware/error-handler.js';
 import { AdmissionReservationListQuerySchema } from '../schemas/admission-control-schemas.js';
@@ -30,6 +35,99 @@ const listQuerySchema = z
     limit: z.coerce.number().int().min(1).max(1_000).optional(),
   })
   .strict();
+
+const queueListQuerySchema = z
+  .object({
+    workspaceId: z.string().trim().min(1).max(240).optional(),
+    rootObjectiveId: z.string().trim().min(1).max(240).optional(),
+    nodeId: z.string().trim().min(1).max(240).optional(),
+    source: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .transform((value) =>
+        value === undefined ? undefined : Array.isArray(value) ? value : value.split(',')
+      )
+      .pipe(
+        z.array(z.enum(ADMISSION_LAUNCH_SOURCES)).max(ADMISSION_LAUNCH_SOURCES.length).optional()
+      ),
+    state: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .transform((value) =>
+        value === undefined ? undefined : Array.isArray(value) ? value : value.split(',')
+      )
+      .pipe(z.array(z.enum(ADMISSION_QUEUE_STATES)).max(ADMISSION_QUEUE_STATES.length).optional()),
+    priority: z.coerce.number().int().min(0).max(15).optional(),
+    limitingScope: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .transform((value) =>
+        value === undefined ? undefined : Array.isArray(value) ? value : value.split(',')
+      )
+      .pipe(z.array(z.enum(ADMISSION_SCOPES)).max(ADMISSION_SCOPES.length).optional()),
+    minAgeMs: z.coerce.number().int().min(0).max(31_536_000_000).optional(),
+    maxAgeMs: z.coerce.number().int().min(0).max(31_536_000_000).optional(),
+    page: z.coerce.number().int().min(1).max(100_000).default(1),
+    limit: z.coerce.number().int().min(1).max(200).default(100),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (
+      value.minAgeMs !== undefined &&
+      value.maxAgeMs !== undefined &&
+      value.minAgeMs > value.maxAgeMs
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'minAgeMs must be less than or equal to maxAgeMs',
+        path: ['minAgeMs'],
+      });
+    }
+  });
+
+router.get(
+  '/queue',
+  asyncHandler(async (req, res) => {
+    try {
+      const query = queueListQuerySchema.parse(req.query);
+      res.json(
+        await admission.inspectQueue({
+          workspaceId: query.workspaceId,
+          rootObjectiveId: query.rootObjectiveId,
+          nodeId: query.nodeId,
+          sources: query.source,
+          states: query.state,
+          priority: query.priority,
+          limitingScopes: query.limitingScope,
+          minAgeMs: query.minAgeMs,
+          maxAgeMs: query.maxAgeMs,
+          page: query.page,
+          limit: query.limit,
+        })
+      );
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
+
+router.get(
+  '/queue/:id',
+  asyncHandler(async (req, res) => {
+    try {
+      const id = z.string().trim().min(1).max(240).parse(req.params.id);
+      res.json(await admission.inspectQueueEntry(id));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Validation failed', error.issues);
+      }
+      throw error;
+    }
+  })
+);
 
 router.get(
   '/',

--- a/server/src/services/admission-control-service.ts
+++ b/server/src/services/admission-control-service.ts
@@ -7,8 +7,13 @@ import type {
   AdmissionLimitPolicy,
   AdmissionProvider,
   AdmissionQueueClaim,
+  AdmissionQueueDepth,
   AdmissionQueueEntry,
+  AdmissionQueueGetResponse,
+  AdmissionQueueInspectionEntry,
+  AdmissionQueueInspectionQuery,
   AdmissionQueueListQuery,
+  AdmissionQueueListResponse,
   AdmissionQueuePriority,
   AdmissionQueueSelectionEvidence,
   AdmissionQueueTarget,
@@ -26,6 +31,8 @@ import type {
 } from '@veritas-kanban/shared';
 import {
   ADMISSION_DECISION_SCHEMA_VERSION,
+  ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION,
+  ADMISSION_QUEUE_LIST_SCHEMA_VERSION,
   ADMISSION_QUEUE_SCHEDULER_POLICY_VERSION,
   ADMISSION_QUEUE_SELECTION_SCHEMA_VERSION,
   ADMISSION_REQUEST_SCHEMA_VERSION,
@@ -52,11 +59,25 @@ import { ConflictError, NotFoundError } from '../middleware/error-handler.js';
 import {
   admissionScopeKey,
   assertSchedulerSettings,
+  orderAdmissionQueueEntries,
   rankAdmissionQueueEntries,
   resolveAdmissionQueuePriority,
+  scoreAdmissionQueueEntry,
+  workspaceKey,
 } from './admission-queue-scheduler.js';
 
 const MAX_CAS_ATTEMPTS = 8;
+const ACTIVE_INSPECTION_SNAPSHOT_LIMIT = 100_000;
+const TERMINAL_INSPECTION_SNAPSHOT_LIMIT = 1_000;
+const ACTIVE_QUEUE_STATES = ['queued', 'leased', 'requeued', 'dispatched'] as const;
+
+interface AdmissionQueueInspectionContext {
+  settings: AdmissionSettings;
+  now: Date;
+  activeEntries: AdmissionQueueEntry[];
+  positions: Map<string, number>;
+  depth: AdmissionQueueDepth;
+}
 
 export interface AdmissionRequestInput {
   taskId: string;
@@ -544,6 +565,280 @@ export class AdmissionControlService {
   async listQueue(query: AdmissionQueueListQuery = {}): Promise<AdmissionQueueEntry[]> {
     await this.repository.expireQueueLeases(this.now().toISOString());
     return this.repository.listQueue(query);
+  }
+
+  async inspectQueue(
+    query: AdmissionQueueInspectionQuery = {}
+  ): Promise<AdmissionQueueListResponse> {
+    const context = await this.queueInspectionContext();
+    const requestedStates = new Set(query.states ?? ACTIVE_QUEUE_STATES);
+    const includeTerminal = requestedStates.has('terminal');
+    const terminalSnapshot = includeTerminal
+      ? await this.repository.listQueue({
+          states: ['terminal'],
+          order: 'updated-desc',
+          limit: TERMINAL_INSPECTION_SNAPSHOT_LIMIT + 1,
+        })
+      : [];
+    const snapshotTruncated = terminalSnapshot.length > TERMINAL_INSPECTION_SNAPSHOT_LIMIT;
+    const records = [
+      ...context.activeEntries,
+      ...terminalSnapshot.slice(0, TERMINAL_INSPECTION_SNAPSHOT_LIMIT),
+    ];
+    const filtered = records
+      .map((entry) => ({
+        entry,
+        inspection: this.projectQueueInspection(entry, context),
+      }))
+      .filter(({ entry }) => requestedStates.has(entry.state))
+      .filter(({ entry }) => !query.workspaceId || entry.request.workspaceId === query.workspaceId)
+      .filter(
+        ({ entry }) =>
+          !query.rootObjectiveId ||
+          entry.request.executionTree?.rootObjectiveId === query.rootObjectiveId
+      )
+      .filter(({ entry }) => !query.nodeId || entry.request.executionTree?.nodeId === query.nodeId)
+      .filter(({ entry }) => !query.sources?.length || query.sources.includes(entry.request.source))
+      .filter(
+        ({ inspection }) =>
+          query.priority === undefined || inspection.rawPriority === query.priority
+      )
+      .filter(
+        ({ entry }) =>
+          !query.limitingScopes?.length ||
+          entry.limitingPolicies.some((policy) => query.limitingScopes?.includes(policy.scope))
+      )
+      .filter(
+        ({ inspection }) => query.minAgeMs === undefined || inspection.ageMs >= query.minAgeMs
+      )
+      .filter(
+        ({ inspection }) => query.maxAgeMs === undefined || inspection.ageMs <= query.maxAgeMs
+      )
+      .sort(
+        (left, right) =>
+          (left.inspection.position ?? Number.MAX_SAFE_INTEGER) -
+            (right.inspection.position ?? Number.MAX_SAFE_INTEGER) ||
+          left.entry.enqueueSequence - right.entry.enqueueSequence ||
+          left.entry.id.localeCompare(right.entry.id)
+      );
+    const page = Math.max(1, Math.floor(query.page ?? 1));
+    const limit = Math.min(200, Math.max(1, Math.floor(query.limit ?? 100)));
+    const offset = (page - 1) * limit;
+
+    return {
+      schemaVersion: ADMISSION_QUEUE_LIST_SCHEMA_VERSION,
+      generatedAt: context.now.toISOString(),
+      conditional: true,
+      depth: context.depth,
+      pagination: {
+        page,
+        limit,
+        total: filtered.length,
+        hasMore: offset + limit < filtered.length,
+        snapshotTruncated,
+      },
+      entries: filtered.slice(offset, offset + limit).map(({ inspection }) => inspection),
+    };
+  }
+
+  async inspectQueueEntry(id: string): Promise<AdmissionQueueGetResponse> {
+    const context = await this.queueInspectionContext();
+    const entry =
+      context.activeEntries.find((candidate) => candidate.id === id) ??
+      (await this.repository.getQueueEntry(id));
+    if (!entry) throw new NotFoundError('Admission queue entry not found.');
+    return {
+      schemaVersion: ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION,
+      generatedAt: context.now.toISOString(),
+      conditional: true,
+      depth: context.depth,
+      entry: this.projectQueueInspection(entry, context),
+    };
+  }
+
+  private async queueInspectionContext(): Promise<AdmissionQueueInspectionContext> {
+    const settings = await this.settings();
+    const now = this.now();
+    await this.repository.expireQueueLeases(now.toISOString());
+    const activeEntries = await this.repository.listQueue({
+      states: [...ACTIVE_QUEUE_STATES],
+      limit: ACTIVE_INSPECTION_SNAPSHOT_LIMIT,
+    });
+    const history = (
+      await this.repository.listQueue({
+        limit: Math.max(settings.queue.scheduler.workspaceBurstLimit, 1),
+        order: 'updated-desc',
+        withSelectionEvidence: true,
+      })
+    )
+      .map((entry) => entry.selectionEvidence)
+      .filter((evidence): evidence is AdmissionQueueSelectionEvidence => Boolean(evidence));
+    const pending = activeEntries.filter((entry) => ['queued', 'requeued'].includes(entry.state));
+    const ordering = orderAdmissionQueueEntries({
+      entries: pending,
+      history,
+      now: now.toISOString(),
+      settings: settings.queue.scheduler,
+    });
+    const positioned = new Set(ordering.candidates.map(({ entry }) => entry.id));
+    const delayed = pending
+      .filter((entry) => !positioned.has(entry.id))
+      .sort(
+        (left, right) =>
+          left.enqueueSequence - right.enqueueSequence || left.id.localeCompare(right.id)
+      );
+    const positions = new Map(
+      [...ordering.candidates.map(({ entry }) => entry), ...delayed].map((entry, index) => [
+        entry.id,
+        index + 1,
+      ])
+    );
+    const workspaceDepth = new Map<string, number>();
+    for (const entry of activeEntries) {
+      workspaceDepth.set(
+        entry.request.workspaceId,
+        (workspaceDepth.get(entry.request.workspaceId) ?? 0) + 1
+      );
+    }
+    const depth: AdmissionQueueDepth = {
+      global: {
+        current: activeEntries.length,
+        limit: settings.queue.globalLimit,
+      },
+      workspaces: [...workspaceDepth.entries()]
+        .map(([workspaceId, current]) => ({
+          workspaceId,
+          workspaceKey: workspaceKey(workspaceId),
+          current,
+          limit: settings.queue.workspaceLimit,
+        }))
+        .sort((left, right) => left.workspaceKey.localeCompare(right.workspaceKey)),
+    };
+    return { settings, now, activeEntries, positions, depth };
+  }
+
+  private projectQueueInspection(
+    entry: AdmissionQueueEntry,
+    context: AdmissionQueueInspectionContext
+  ): AdmissionQueueInspectionEntry {
+    const score = scoreAdmissionQueueEntry(
+      entry,
+      context.now.toISOString(),
+      context.settings.queue.scheduler
+    );
+    const available = Date.parse(entry.availableAt) <= context.now.getTime();
+    const readiness: AdmissionQueueInspectionEntry['readiness'] =
+      entry.state === 'leased'
+        ? 'reserved'
+        : entry.state === 'dispatched'
+          ? 'dispatched'
+          : entry.state === 'terminal'
+            ? 'terminal'
+            : available
+              ? 'conditional'
+              : 'delayed';
+    const leasePosture: AdmissionQueueInspectionEntry['lease']['posture'] =
+      entry.state === 'dispatched'
+        ? 'dispatched'
+        : entry.state === 'terminal'
+          ? 'terminal'
+          : entry.lease
+            ? Date.parse(entry.lease.expiresAt) > context.now.getTime()
+              ? 'active'
+              : 'expired'
+            : 'none';
+    const conditionalStartFactors = new Set<
+      AdmissionQueueInspectionEntry['conditionalStartFactors'][number]
+    >(entry.selectionEvidence?.conditionalStartFactors ?? []);
+    if (entry.state === 'queued' || entry.state === 'requeued') {
+      conditionalStartFactors.add('queue-eligibility');
+      conditionalStartFactors.add(available ? 'capacity-recheck' : 'retry-backoff');
+      conditionalStartFactors.add('policy-recheck');
+      if (entry.limitingPolicies.length > 0) {
+        conditionalStartFactors.add('active-reservation-release');
+      }
+    }
+    if (entry.state === 'leased') conditionalStartFactors.add('lease-expiry');
+    const target = entry.target?.kind ?? 'legacy-direct';
+    const taskId =
+      entry.target?.kind === 'workflow-root'
+        ? entry.target.associatedTaskId
+        : entry.target?.kind === 'workflow-step'
+          ? undefined
+          : entry.request.taskId;
+    const workflowRunId =
+      entry.request.workflowRunId ??
+      (entry.target?.kind === 'workflow-root' || entry.target?.kind === 'workflow-step'
+        ? entry.target.workflowRunId
+        : undefined);
+    const workflowStepId =
+      entry.request.workflowStepId ??
+      (entry.target?.kind === 'workflow-step' ? entry.target.workflowStepId : undefined);
+
+    return {
+      schemaVersion: ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION,
+      id: entry.id,
+      state: entry.state,
+      ...(context.positions.has(entry.id) ? { position: context.positions.get(entry.id) } : {}),
+      rawPriority: score.rawPriority,
+      effectivePriority: score.effectivePriority,
+      agePromotion: score.agePromotion,
+      ageMs: score.ageMs,
+      readiness,
+      lease: {
+        posture: leasePosture,
+        ...(entry.lease ? { expiresAt: entry.lease.expiresAt } : {}),
+      },
+      limitingPolicies: entry.limitingPolicies.map((policy) => ({
+        scope: policy.scope,
+        scopeKey: admissionScopeKey(policy.scope, policy.scopeId),
+        limits: policy.limits,
+      })),
+      conditionalStartFactors: [...conditionalStartFactors],
+      launch: {
+        source: entry.request.source,
+        target,
+        workspaceId: entry.request.workspaceId,
+        taskKey: queueInspectionKey('task', entry.request.taskId),
+        rootTaskKey: queueInspectionKey('root-task', entry.request.rootTaskId),
+        workspaceKey: workspaceKey(entry.request.workspaceId),
+        provider: entry.request.provider,
+        hostKey: queueInspectionKey('host', entry.request.hostId),
+        ...(entry.request.workflowRunId
+          ? { workflowRunKey: queueInspectionKey('workflow-run', entry.request.workflowRunId) }
+          : {}),
+        ...(entry.request.workflowStepId
+          ? { workflowStepKey: queueInspectionKey('workflow-step', entry.request.workflowStepId) }
+          : {}),
+        ...(entry.request.executionTree
+          ? {
+              rootObjectiveKey: queueInspectionKey(
+                'root-objective',
+                entry.request.executionTree.rootObjectiveId
+              ),
+              nodeKey: queueInspectionKey('node', entry.request.executionTree.nodeId),
+            }
+          : {}),
+      },
+      navigation: {
+        ...(taskId ? { taskId } : {}),
+        attemptId: entry.attemptId,
+        ...(entry.target?.kind === 'workflow-root' || entry.target?.kind === 'workflow-step'
+          ? { workflowId: entry.target.workflowId }
+          : {}),
+        ...(workflowRunId ? { workflowRunId } : {}),
+        ...(workflowStepId ? { workflowStepId } : {}),
+        ...(entry.request.executionTree ? { executionTree: entry.request.executionTree } : {}),
+      },
+      ...(entry.selectionEvidence ? { selectionEvidence: entry.selectionEvidence } : {}),
+      retry: {
+        count: entry.retryCount,
+        maximum: entry.maxRetries,
+        availableAt: entry.availableAt,
+      },
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+    };
   }
 
   async markQueueDispatched(id: string, attemptId: string): Promise<AdmissionQueueEntry> {
@@ -1181,6 +1476,10 @@ function sameRequestIdentity(
     JSON.stringify(left.budgetRequest) === JSON.stringify(right.budgetRequest) &&
     JSON.stringify(left.requested) === JSON.stringify(right.requested)
   );
+}
+
+function queueInspectionKey(kind: string, value: string): string {
+  return `sha256:${createHash('sha256').update(`${kind}:${value}`).digest('hex')}`;
 }
 
 export function getAdmissionControlService(): AdmissionControlService {

--- a/server/src/services/admission-queue-scheduler.ts
+++ b/server/src/services/admission-queue-scheduler.ts
@@ -23,6 +23,12 @@ export interface AdmissionQueueRanking {
   deferredWorkspaceKey?: string;
 }
 
+export interface AdmissionQueueOrdering {
+  candidates: RankedAdmissionQueueCandidate[];
+  snapshotSize: number;
+  deferredWorkspaceKey?: string;
+}
+
 export interface RankAdmissionQueueEntriesInput {
   entries: AdmissionQueueEntry[];
   history: AdmissionQueueSelectionEvidence[];
@@ -33,6 +39,20 @@ export interface RankAdmissionQueueEntriesInput {
 export function rankAdmissionQueueEntries(
   input: RankAdmissionQueueEntriesInput
 ): AdmissionQueueRanking {
+  const ordered = orderAdmissionQueueEntries(input);
+  const evaluated = ordered.candidates.slice(0, input.settings.evaluationLimit);
+
+  return {
+    candidates: evaluated,
+    snapshotSize: ordered.snapshotSize,
+    evaluatedCount: evaluated.length,
+    ...(ordered.deferredWorkspaceKey ? { deferredWorkspaceKey: ordered.deferredWorkspaceKey } : {}),
+  };
+}
+
+export function orderAdmissionQueueEntries(
+  input: RankAdmissionQueueEntriesInput
+): AdmissionQueueOrdering {
   assertSchedulerSettings(input.settings);
   const nowMs = Date.parse(input.now);
   if (!Number.isFinite(nowMs)) throw new Error('Admission scheduler requires a valid timestamp.');
@@ -49,26 +69,9 @@ export function rankAdmissionQueueEntries(
       left.selectedQueueEntryId.localeCompare(right.selectedQueueEntryId)
   );
   const deferredWorkspaceKey = workspaceAtBurstLimit(history, input.settings.workspaceBurstLimit);
-  const candidates: RankedAdmissionQueueCandidate[] = eligible.map((entry) => {
-    const rawPriority = normalizeNumericPriority(
-      entry.priority ?? input.settings.defaultPriority,
-      input.settings
-    );
-    const ageMs = Math.max(0, nowMs - Date.parse(entry.createdAt));
-    const agePromotion = Math.min(
-      input.settings.maxAgePromotion,
-      Math.floor(ageMs / input.settings.agingIntervalMs)
-    );
-    return {
-      entry,
-      workspaceKey: workspaceKey(entry.request.workspaceId),
-      rawPriority,
-      ageMs,
-      agePromotion,
-      effectivePriority: Math.min(input.settings.priorityLevels - 1, rawPriority + agePromotion),
-      workspaceTurn: 'normal',
-    };
-  });
+  const candidates = eligible.map((entry) =>
+    scoreAdmissionQueueEntryAt(entry, nowMs, input.settings)
+  );
   const fairnessApplies =
     deferredWorkspaceKey !== undefined &&
     candidates.some((candidate) => candidate.workspaceKey !== deferredWorkspaceKey);
@@ -92,13 +95,46 @@ export function rankAdmissionQueueEntries(
       candidates[index] = { ...candidates[index], workspaceTurn: 'fairness-promoted' };
     }
   }
-  const evaluated = candidates.slice(0, input.settings.evaluationLimit);
-
   return {
-    candidates: evaluated,
+    candidates,
     snapshotSize: eligible.length,
-    evaluatedCount: evaluated.length,
     ...(fairnessApplies ? { deferredWorkspaceKey } : {}),
+  };
+}
+
+export function scoreAdmissionQueueEntry(
+  entry: AdmissionQueueEntry,
+  now: string,
+  settings: AdmissionQueueSchedulerSettings
+): RankedAdmissionQueueCandidate {
+  assertSchedulerSettings(settings);
+  const nowMs = Date.parse(now);
+  if (!Number.isFinite(nowMs)) throw new Error('Admission scheduler requires a valid timestamp.');
+  return scoreAdmissionQueueEntryAt(entry, nowMs, settings);
+}
+
+function scoreAdmissionQueueEntryAt(
+  entry: AdmissionQueueEntry,
+  nowMs: number,
+  settings: AdmissionQueueSchedulerSettings
+): RankedAdmissionQueueCandidate {
+  const rawPriority = normalizeNumericPriority(
+    entry.priority ?? settings.defaultPriority,
+    settings
+  );
+  const ageMs = Math.max(0, nowMs - Date.parse(entry.createdAt));
+  const agePromotion = Math.min(
+    settings.maxAgePromotion,
+    Math.floor(ageMs / settings.agingIntervalMs)
+  );
+  return {
+    entry,
+    workspaceKey: workspaceKey(entry.request.workspaceId),
+    rawPriority,
+    ageMs,
+    agePromotion,
+    effectivePriority: Math.min(settings.priorityLevels - 1, rawPriority + agePromotion),
+    workspaceTurn: 'normal',
   };
 }
 

--- a/shared/src/types/admission-control.types.ts
+++ b/shared/src/types/admission-control.types.ts
@@ -15,6 +15,8 @@ export const ADMISSION_RESERVATION_SCHEMA_VERSION = 'admission-reservation/v1' a
 export const ADMISSION_QUEUE_ENTRY_SCHEMA_VERSION = 'admission-queue-entry/v1' as const;
 export const ADMISSION_QUEUE_SELECTION_SCHEMA_VERSION = 'admission-queue-selection/v1' as const;
 export const ADMISSION_QUEUE_SCHEDULER_POLICY_VERSION = 'admission-queue-scheduler/v1' as const;
+export const ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION = 'admission-queue-inspection/v1' as const;
+export const ADMISSION_QUEUE_LIST_SCHEMA_VERSION = 'admission-queue-list/v1' as const;
 export const ADMISSION_CONTROL_PROVIDER = 'workflow-control' as const;
 export type AdmissionProvider = ExecutableAgentProvider | typeof ADMISSION_CONTROL_PROVIDER;
 
@@ -70,15 +72,17 @@ export interface AdmissionLimitPolicy {
   limits: AdmissionCapacityLimit;
 }
 
-export type AdmissionLaunchSource =
-  | 'direct'
-  | 'conversation'
-  | 'recovery'
-  | 'fallback'
-  | 'scheduled'
-  | 'watcher'
-  | 'workflow'
-  | 'child-agent';
+export const ADMISSION_LAUNCH_SOURCES = [
+  'direct',
+  'conversation',
+  'recovery',
+  'fallback',
+  'scheduled',
+  'watcher',
+  'workflow',
+  'child-agent',
+] as const;
+export type AdmissionLaunchSource = (typeof ADMISSION_LAUNCH_SOURCES)[number];
 
 export interface AdmissionRequest {
   schemaVersion: typeof ADMISSION_REQUEST_SCHEMA_VERSION;
@@ -266,6 +270,116 @@ export interface AdmissionQueueListQuery {
   limit?: number;
   order?: 'fifo' | 'updated-desc';
   withSelectionEvidence?: boolean;
+}
+
+export interface AdmissionQueueInspectionQuery {
+  workspaceId?: string;
+  rootObjectiveId?: string;
+  nodeId?: string;
+  sources?: AdmissionLaunchSource[];
+  states?: AdmissionQueueState[];
+  priority?: number;
+  limitingScopes?: AdmissionScope[];
+  minAgeMs?: number;
+  maxAgeMs?: number;
+  page?: number;
+  limit?: number;
+}
+
+export interface AdmissionQueueInspectionEntry {
+  schemaVersion: typeof ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION;
+  id: string;
+  state: AdmissionQueueState;
+  position?: number;
+  rawPriority: number;
+  effectivePriority: number;
+  agePromotion: number;
+  ageMs: number;
+  readiness: 'conditional' | 'delayed' | 'reserved' | 'dispatched' | 'terminal';
+  lease: {
+    posture: 'none' | 'active' | 'expired' | 'dispatched' | 'terminal';
+    expiresAt?: string;
+  };
+  limitingPolicies: Array<{
+    scope: AdmissionScope;
+    scopeKey: string;
+    limits: AdmissionCapacityLimit;
+  }>;
+  conditionalStartFactors: Array<
+    | 'queue-eligibility'
+    | 'capacity-available'
+    | 'capacity-recheck'
+    | 'active-reservation-release'
+    | 'policy-recheck'
+    | 'lease-expiry'
+    | 'retry-backoff'
+  >;
+  launch: {
+    source: AdmissionLaunchSource;
+    target: 'direct' | 'workflow-root' | 'workflow-step' | 'legacy-direct';
+    workspaceId: string;
+    taskKey: string;
+    rootTaskKey: string;
+    workspaceKey: string;
+    provider: AdmissionProvider;
+    hostKey: string;
+    workflowRunKey?: string;
+    workflowStepKey?: string;
+    rootObjectiveKey?: string;
+    nodeKey?: string;
+  };
+  navigation: {
+    taskId?: string;
+    attemptId: string;
+    workflowId?: string;
+    workflowRunId?: string;
+    workflowStepId?: string;
+    executionTree?: ExecutionTreeIdentity;
+  };
+  selectionEvidence?: AdmissionQueueSelectionEvidence;
+  retry: {
+    count: number;
+    maximum: number;
+    availableAt: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AdmissionQueueDepth {
+  global: {
+    current: number;
+    limit: number;
+  };
+  workspaces: Array<{
+    workspaceId: string;
+    workspaceKey: string;
+    current: number;
+    limit: number;
+  }>;
+}
+
+export interface AdmissionQueueListResponse {
+  schemaVersion: typeof ADMISSION_QUEUE_LIST_SCHEMA_VERSION;
+  generatedAt: string;
+  conditional: true;
+  depth: AdmissionQueueDepth;
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    hasMore: boolean;
+    snapshotTruncated: boolean;
+  };
+  entries: AdmissionQueueInspectionEntry[];
+}
+
+export interface AdmissionQueueGetResponse {
+  schemaVersion: typeof ADMISSION_QUEUE_INSPECTION_SCHEMA_VERSION;
+  generatedAt: string;
+  conditional: true;
+  depth: AdmissionQueueDepth;
+  entry: AdmissionQueueInspectionEntry;
 }
 
 export interface AdmissionQueueDraft {


### PR DESCRIPTION
Closes #1064

## Summary

- add versioned, bounded admission queue list and detail responses with deterministic pagination and operator filters
- expose raw and effective priority, age promotion, readiness, lease posture, limiting policies, queue depth, conditional factors, and redacted selection evidence
- add `vk admission queue list` and `vk admission queue get` with compact human output and complete `--json` output
- preserve safe task, attempt, workflow, workspace, and execution-tree navigation identifiers while hashing or omitting request payloads, prompts, tools, credentials, hosts, and idempotency identities
- document the REST and CLI contracts, conditional semantics, and redaction boundary

## Verification

- focused admission service tests: 29 passed
- focused CLI and scheduler tests: 42 passed
- shared and server TypeScript checks passed
- changed-file lint, formatting, security artifact, and delivery cadence checks passed

## Note

The local route integration harness cannot bind a listener in the managed sandbox. CI owns that route-level gate. The Operations surface remains in #1065.